### PR TITLE
Integrate Tika-first document extraction + PDF OCR fallback (Vision)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -96,3 +96,19 @@ COMPOSER_PROCESS_TIMEOUT=1600
 # OIDC_SSL_VERIFY=false
 
 # Note: Add any additional environment variables your application needs below
+# Apache Tika (Docker local)
+TIKA_URL=http://tika:9998
+
+# Optional tuning (recommended defaults)
+TIKA_ENABLED=true
+TIKA_TIMEOUT_MS=20000
+TIKA_RETRIES=2
+TIKA_RETRY_BACKOFF_MS=500
+TIKA_MIN_LENGTH=200
+TIKA_MIN_ENTROPY=2.5
+TIKA_OCR_SIGNAL_MIN=1
+RASTERIZE_DPI=150
+RASTERIZE_PAGE_CAP=5
+RASTERIZE_TIMEOUT_MS=60000
+TIKA_MIN_CHAR_PER_KB=10
+

--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,9 @@ DB_PASSWORD=synaplan          # Database password
 
 OLLAMA_SERVER=localhost:11434
 
+# Optional triton server - integrated for a customer project
+# TRITON_SERVER=localhost:8001
+
 # ==========================================
 # AI Service API Keys
 # ==========================================
@@ -97,10 +100,17 @@ COMPOSER_PROCESS_TIMEOUT=1600
 
 # Note: Add any additional environment variables your application needs below
 # Apache Tika (Docker local)
+TIKA_ENABLED=true
+
+# Tika URL
 TIKA_URL=http://tika:9998
 
+# Optional: HTTP Basic Authentication for Tika
+# Leave both empty to disable authentication
+TIKA_HTTP_USER=
+TIKA_HTTP_PASS=
+
 # Optional tuning (recommended defaults)
-TIKA_ENABLED=true
 TIKA_TIMEOUT_MS=20000
 TIKA_RETRIES=2
 TIKA_RETRY_BACKOFF_MS=500
@@ -111,4 +121,3 @@ RASTERIZE_DPI=150
 RASTERIZE_PAGE_CAP=5
 RASTERIZE_TIMEOUT_MS=60000
 TIKA_MIN_CHAR_PER_KB=10
-

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ testing/reports/
 
 
 app/inc/ai/grpc-triton/
+dev/ai_readme.md

--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ OPENAI_API_KEY=your_openai_api_key_here
 GOOGLE_GEMINI_API_KEY=your_gemini_api_key_here
 OLLAMA_URL=http://localhost:11434  # If using local Ollama
 
+# Optional: Document extraction via Apache Tika
+TIKA_ENABLED=true
+TIKA_URL=http://localhost:9998
+
 # Database Configuration (if different from defaults)
 DB_HOST=localhost
 DB_NAME=synaplan
@@ -121,6 +125,7 @@ You can also deploy Synaplan on a regular Linux server using Apache, PHP 8.3, an
 - Vector search (MariaDB 11.7+), built-in RAG
 - Local audio transcription via whisper.cpp
 - Full message logging and usage tracking
+- Tika‑first document text extraction with automatic PDF OCR fallback (Vision AI)
 
 ### Architecture (brief)
 ```
@@ -167,6 +172,7 @@ Configuration-driven AI selection via `$GLOBALS` and centralized key management 
 - Uploads: check `public/up/` permissions
 - AI calls: verify API keys in `.env` (project root)
 - DB errors: verify credentials and service status
+- PDFs: if text extraction is empty, ensure Tika is reachable (`TIKA_ENABLED/TIKA_URL`); PDF OCR fallback runs automatically.
 - **Whisper models:** If you need to re-download models, delete the volume and restart:
   ```bash
   docker compose down

--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ OLLAMA_URL=http://localhost:11434  # If using local Ollama
 # Optional: Document extraction via Apache Tika
 TIKA_ENABLED=true
 TIKA_URL=http://localhost:9998
+# Optional: HTTP Basic Auth for Tika (leave empty to disable)
+TIKA_HTTP_USER=
+TIKA_HTTP_PASS=
 
 # Database Configuration (if different from defaults)
 DB_HOST=localhost
@@ -126,6 +129,7 @@ You can also deploy Synaplan on a regular Linux server using Apache, PHP 8.3, an
 - Local audio transcription via whisper.cpp
 - Full message logging and usage tracking
 - Tika‑first document text extraction with automatic PDF OCR fallback (Vision AI)
+  - Optional HTTP Basic Authentication supported for Tika via `TIKA_HTTP_USER` and `TIKA_HTTP_PASS`.
 
 ### Architecture (brief)
 ```
@@ -173,6 +177,7 @@ Configuration-driven AI selection via `$GLOBALS` and centralized key management 
 - AI calls: verify API keys in `.env` (project root)
 - DB errors: verify credentials and service status
 - PDFs: if text extraction is empty, ensure Tika is reachable (`TIKA_ENABLED/TIKA_URL`); PDF OCR fallback runs automatically.
+  - If Tika uses HTTP Basic Auth, set `TIKA_HTTP_USER` and `TIKA_HTTP_PASS` (both optional). Leaving them empty disables auth.
 - **Whisper models:** If you need to re-download models, delete the volume and restart:
   ```bash
   docker compose down

--- a/app/inc/_coreincludes.php
+++ b/app/inc/_coreincludes.php
@@ -29,6 +29,10 @@ require_once(__DIR__ . '/auth/apikeymanager.php');
 require_once(__DIR__ . '/auth/userregistration.php');
 // file management classes
 require_once(__DIR__ . '/domain/files/filemanager.php');
+// document extraction (tika-first + rasterize/vision fallback)
+require_once(__DIR__ . '/domain/files/tika_client.php');
+require_once(__DIR__ . '/domain/files/rasterizer.php');
+require_once(__DIR__ . '/domain/files/universal_file_handler.php');
 // service classes
 require_once(__DIR__ . '/mail/emailservice.php');
 // api classes (only classes here; procedural API files are loaded by public/api.php)

--- a/app/inc/_frontend.php
+++ b/app/inc/_frontend.php
@@ -612,7 +612,18 @@ Class Frontend {
         foreach($lastIds as $msgId) {
             $msgArr = Central::getMsgById(intval($msgId));
             if($msgArr['BFILE'] > 0) {
-                $msgArr = Central::parseFile($msgArr, true);
+                try {
+                    $msgArr = Central::parseFile($msgArr, true);
+                } catch (\Throwable $e) {
+                    error_log("SSE parseFile error: " . $e->getMessage());
+                    $send([
+                        'msgId' => $msgId,
+                        'status' => 'error',
+                        'message' => 'File preprocessing failed: ' . $e->getMessage(),
+                        'timestamp' => time()
+                    ]);
+                    exit;
+                }
             } else {
                 $send([
                     'msgId' => $msgId,

--- a/app/inc/ai/providers/_aigoogle.php
+++ b/app/inc/ai/providers/_aigoogle.php
@@ -932,7 +932,8 @@ class AIGoogle {
                 ];
                 Frontend::printToStream($update);
             }
-            return $errorStop;
+            $msgArr['BFILETEXT'] = $errorStop;
+            return $msgArr;
         }
 
         // Get file information
@@ -1022,7 +1023,8 @@ class AIGoogle {
                 ];
                 Frontend::printToStream($update);
             }
-            return $errorStop;
+            $msgArr['BFILETEXT'] = $errorStop;
+            return $msgArr;
         }
 
         try {
@@ -1108,9 +1110,10 @@ class AIGoogle {
                             ];
                             Frontend::printToStream($update);
                             
-                            // Check if parent process is still running
-                            if (!file_exists('/proc/' . getppid())) {
-                                break;
+                            // Optional: break if parent likely gone (POSIX only)
+                            if (function_exists('posix_getppid')) {
+                                $ppid = posix_getppid();
+                                if ($ppid <= 1) { break; }
                             }
                         }
                         exit(0);

--- a/app/inc/config/_confkeys.php
+++ b/app/inc/config/_confkeys.php
@@ -95,6 +95,19 @@ class ApiKeys {
             'APP_DEBUG',
             'APP_ENV',
             'APP_URL',
+            // Tika / Document extraction
+            'TIKA_ENABLED',
+            'TIKA_URL',
+            'TIKA_TIMEOUT_MS',
+            'TIKA_RETRIES',
+            'TIKA_RETRY_BACKOFF_MS',
+            // Rasterizer / Vision fallback
+            'RASTERIZE_DPI',
+            'RASTERIZE_PAGE_CAP',
+            'RASTERIZE_TIMEOUT_MS',
+            // Quality thresholds
+            'TIKA_MIN_LENGTH',
+            'TIKA_MIN_ENTROPY',
         ];
 
         foreach ($keyConfig as $envKey) {
@@ -122,6 +135,52 @@ class ApiKeys {
     public static function get($key) {
         self::init();
         return self::$keys[$key] ?? null;
+    }
+
+    // ------------------------- TIKA CONFIG -------------------------
+    public static function isTikaEnabled(): bool {
+        $val = self::get('TIKA_ENABLED');
+        if ($val === null) return true; // default enabled
+        $v = strtolower(trim(strval($val)));
+        return !in_array($v, ['0','false','off','no'], true);
+    }
+    public static function getTikaUrl(): ?string {
+        return self::get('TIKA_URL') ?: null;
+    }
+    public static function getTikaTimeoutMs(): int {
+        $v = intval(self::get('TIKA_TIMEOUT_MS'));
+        return $v > 0 ? $v : 15000;
+    }
+    public static function getTikaRetries(): int {
+        $v = intval(self::get('TIKA_RETRIES'));
+        return $v >= 0 ? $v : 1;
+    }
+    public static function getTikaRetryBackoffMs(): int {
+        $v = intval(self::get('TIKA_RETRY_BACKOFF_MS'));
+        return $v >= 0 ? $v : 300;
+    }
+    public static function getTikaMinLength(): int {
+        $v = intval(self::get('TIKA_MIN_LENGTH'));
+        return $v > 0 ? $v : 32;
+    }
+    public static function getTikaMinEntropy(): float {
+        $v = self::get('TIKA_MIN_ENTROPY');
+        $f = $v !== null ? floatval($v) : 2.5;
+        return $f;
+    }
+
+    // ------------------------- RASTERIZER CONFIG -------------------------
+    public static function getRasterizeDpi(): int {
+        $v = intval(self::get('RASTERIZE_DPI'));
+        return $v > 0 ? $v : 150;
+    }
+    public static function getRasterizePageCap(): int {
+        $v = intval(self::get('RASTERIZE_PAGE_CAP'));
+        return $v > 0 ? $v : 5;
+    }
+    public static function getRasterizeTimeoutMs(): int {
+        $v = intval(self::get('RASTERIZE_TIMEOUT_MS'));
+        return $v > 0 ? $v : 20000;
     }
 
     /**

--- a/app/inc/config/_confkeys.php
+++ b/app/inc/config/_confkeys.php
@@ -101,6 +101,8 @@ class ApiKeys {
             'TIKA_TIMEOUT_MS',
             'TIKA_RETRIES',
             'TIKA_RETRY_BACKOFF_MS',
+            'TIKA_HTTP_USER',
+            'TIKA_HTTP_PASS',
             // Rasterizer / Vision fallback
             'RASTERIZE_DPI',
             'RASTERIZE_PAGE_CAP',
@@ -167,6 +169,15 @@ class ApiKeys {
         $v = self::get('TIKA_MIN_ENTROPY');
         $f = $v !== null ? floatval($v) : 2.5;
         return $f;
+    }
+
+    public static function getTikaHttpUser(): ?string {
+        $v = self::get('TIKA_HTTP_USER');
+        return ($v !== null && $v !== '') ? $v : null;
+    }
+    public static function getTikaHttpPass(): ?string {
+        $v = self::get('TIKA_HTTP_PASS');
+        return ($v !== null) ? $v : null;
     }
 
     // ------------------------- RASTERIZER CONFIG -------------------------

--- a/app/inc/domain/files/rasterizer.php
+++ b/app/inc/domain/files/rasterizer.php
@@ -1,0 +1,102 @@
+<?php
+
+class Rasterizer {
+	public static string $lastEngine = '';
+	public static int $lastDpi = 0;
+	public static int $lastPages = 0;
+	/**
+	 * Rasterize PDF to PNG images and return absolute paths of generated PNGs.
+	 * Tries Imagick first, then falls back to pdftoppm.
+	 */
+	public static function pdfToPng(string $absolutePdfPath): array {
+		$dpi = ApiKeys::getRasterizeDpi();
+		$pageCap = ApiKeys::getRasterizePageCap();
+		$timeoutMs = ApiKeys::getRasterizeTimeoutMs();
+
+		if (!is_file($absolutePdfPath) || filesize($absolutePdfPath) === 0) {
+			return [];
+		}
+		$targetDir = self::resolveTargetDir($absolutePdfPath);
+		$basename = pathinfo($absolutePdfPath, PATHINFO_FILENAME);
+
+		$images = [];
+		// Try Imagick if available
+		if (class_exists('\\Imagick')) {
+			try {
+				$className = 'Imagick';
+				$im = new $className();
+				$im->setResolution($dpi, $dpi);
+				$im->readImage($absolutePdfPath);
+				$pages = min($pageCap, $im->getNumberImages());
+				$im->setIteratorIndex(0);
+				for ($i = 0; $i < $pages; $i++) {
+					$im->setIteratorIndex($i);
+					$im->setImageFormat('png');
+					$out = $targetDir . '/' . $basename . '-' . ($i+1) . '.png';
+					$ok = $im->writeImage($out);
+					if ($ok && is_file($out) && filesize($out) > 0) {
+						$images[] = $out;
+					} else {
+						@error_log('Rasterizer Imagick write failed for ' . $out);
+					}
+				}
+				$im->clear();
+				$im->destroy();
+				if (!empty($images)) {
+					self::$lastEngine = 'imagick';
+					self::$lastDpi = (int)$dpi;
+					self::$lastPages = (int)count($images);
+					@error_log('Rasterizer: engine=imagick pages=' . self::$lastPages . ' dpi=' . self::$lastDpi);
+					return $images;
+				}
+			} catch (\Throwable $e) {
+				@error_log('Rasterizer Imagick fallback: ' . $e->getMessage());
+			}
+		}
+
+		// Fallback to pdftoppm
+		$prefix = $targetDir . '/' . $basename;
+		$cmd = 'pdftoppm -png -r ' . (int)$dpi . ' -f 1 -l ' . (int)$pageCap . ' ' . escapeshellarg($absolutePdfPath) . ' ' . escapeshellarg($prefix);
+		self::execWithTimeout($cmd, $timeoutMs);
+		for ($i = 1; $i <= $pageCap; $i++) {
+			$file = $prefix . '-' . $i . '.png';
+			if (is_file($file) && filesize($file) > 0) { $images[] = $file; }
+		}
+		if (!empty($images)) {
+			self::$lastEngine = 'pdftoppm';
+			self::$lastDpi = (int)$dpi;
+			self::$lastPages = (int)count($images);
+			@error_log('Rasterizer: engine=pdftoppm pages=' . self::$lastPages . ' dpi=' . self::$lastDpi);
+		}
+		return $images;
+	}
+
+	private static function ensureTempDir(): string {
+		$dir = rtrim(UPLOAD_DIR, '/') . '/tmp';
+		if (!is_dir($dir)) @mkdir($dir, 0755, true);
+		return $dir;
+	}
+
+	private static function resolveTargetDir(string $absolutePdfPath): string {
+		$uploadBase = rtrim(UPLOAD_DIR, '/') . '/';
+		// If the PDF is already inside the public uploads tree, write PNGs next to it
+		if (strpos($absolutePdfPath, $uploadBase) === 0) {
+			$dir = dirname($absolutePdfPath);
+			if (!is_dir($dir)) @mkdir($dir, 0755, true);
+			return $dir;
+		}
+		// Otherwise, fall back to a temp folder under uploads
+		return self::ensureTempDir();
+	}
+
+	private static function execWithTimeout(string $cmd, int $timeoutMs): void {
+		$timeoutSec = max(1, (int)ceil($timeoutMs / 1000));
+		$full = 'timeout ' . $timeoutSec . 's ' . $cmd . ' 2>&1';
+		@exec($full, $out, $code);
+		if ($code !== 0) {
+			@error_log('Rasterizer exec failed code=' . $code . ' cmd=' . $cmd);
+		}
+	}
+}
+
+

--- a/app/inc/domain/files/tika_client.php
+++ b/app/inc/domain/files/tika_client.php
@@ -1,0 +1,145 @@
+<?php
+
+class TikaClient {
+    private static $didHealthCheck = false;
+	/**
+	 * Resolve Tika base URL from environment with documented default.
+	 */
+	public static function resolveBaseUrl(): string {
+		$envUrl = ApiKeys::getTikaUrl();
+		$base = $envUrl && strlen(trim($envUrl)) > 0 ? trim($envUrl) : 'http://tika:9998';
+		return rtrim($base, '/');
+	}
+
+	/**
+	 * Extract plain text via Apache Tika. Returns [text, meta] or [null, meta] on failure.
+	 */
+	public static function extractText(string $absoluteFilePath, ?string $mimeType = null): array {
+		$baseUrl = self::resolveBaseUrl();
+		$endpoint = $baseUrl . '/tika';
+		$timeoutMs = ApiKeys::getTikaTimeoutMs();
+		$retries = ApiKeys::getTikaRetries();
+		$backoffMs = ApiKeys::getTikaRetryBackoffMs();
+
+		// One-time lightweight health check
+		self::maybePingHealth($baseUrl);
+
+		$headers = [
+			'Accept: text/plain',
+			'User-Agent: synaplan-tika-client'
+		];
+		if ($mimeType) {
+			$headers[] = 'Content-Type: ' . $mimeType;
+		}
+		// Avoid 100-continue delay
+		$headers[] = 'Expect:';
+
+		// Debug pre-call info
+		if (!empty($GLOBALS['debug'])) {
+			$sanitized = self::sanitizeUrl($endpoint);
+			$size = is_file($absoluteFilePath) ? filesize($absoluteFilePath) : 0;
+			@error_log('Tika pre-call endpoint=' . $sanitized . ' ct=' . ($mimeType ?: '') . ' size=' . $size . ' file=' . basename($absoluteFilePath));
+		}
+
+		$attempt = 0;
+		$startTs = microtime(true);
+		$lastError = '';
+		while ($attempt <= $retries) {
+			$attempt++;
+			try {
+				list($result, $httpCode) = self::curlPutFile($endpoint, $headers, $absoluteFilePath, $timeoutMs);
+				$elapsedMs = (int)((microtime(true) - $startTs) * 1000);
+				self::logCall($endpoint, $attempt, true, $elapsedMs, strlen($result), '', $httpCode);
+				return [$result, ['endpoint' => $baseUrl, 'attempts' => $attempt, 'elapsed_ms' => $elapsedMs, 'http' => $httpCode]];
+			} catch (\Throwable $e) {
+				$lastError = $e->getMessage();
+				$elapsedMs = (int)((microtime(true) - $startTs) * 1000);
+				self::logCall($endpoint, $attempt, false, $elapsedMs, 0, $lastError, 0);
+				if ($attempt <= $retries && $backoffMs > 0) {
+					usleep($backoffMs * 1000);
+				}
+			}
+		}
+
+		return [null, ['endpoint' => $baseUrl, 'error' => $lastError]];
+	}
+
+	private static function curlPutFile(string $url, array $headers, string $filePath, int $timeoutMs): array {
+		if (!is_file($filePath) || filesize($filePath) === 0) {
+			throw new \RuntimeException('Input file missing or empty: ' . $filePath);
+		}
+		$fp = fopen($filePath, 'rb');
+		if (!$fp) {
+			throw new \RuntimeException('Unable to open file: ' . $filePath);
+		}
+		$ch = curl_init();
+		curl_setopt($ch, CURLOPT_URL, $url);
+		curl_setopt($ch, CURLOPT_PUT, true);
+		curl_setopt($ch, CURLOPT_INFILE, $fp);
+		curl_setopt($ch, CURLOPT_INFILESIZE, filesize($filePath));
+		curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+		curl_setopt($ch, CURLOPT_ENCODING, 'gzip');
+		if (function_exists('curl_setopt') && defined('CURLOPT_TIMEOUT_MS')) {
+			curl_setopt($ch, CURLOPT_TIMEOUT_MS, max(1000, $timeoutMs));
+		} else {
+			curl_setopt($ch, CURLOPT_TIMEOUT, max(1, (int)ceil($timeoutMs / 1000)));
+		}
+		$response = curl_exec($ch);
+		$errNo = curl_errno($ch);
+		$err = $errNo ? curl_error($ch) : '';
+		$httpCode = (int)curl_getinfo($ch, CURLINFO_HTTP_CODE);
+		curl_close($ch);
+		fclose($fp);
+
+		if ($errNo) {
+			throw new \RuntimeException('Curl error: ' . $err);
+		}
+		if ($httpCode < 200 || $httpCode >= 300) {
+			throw new \RuntimeException('HTTP ' . $httpCode . ' from Tika');
+		}
+		if (!is_string($response)) {
+			throw new \RuntimeException('Empty response from Tika');
+		}
+		return [$response, $httpCode];
+	}
+
+	private static function logCall(string $endpoint, int $attempt, bool $success, int $elapsedMs, int $bytes, string $error = '', int $httpCode = 0): void {
+		// Sanitize URL (strip credentials)
+		$sanitized = self::sanitizeUrl($endpoint);
+		$msg = 'TikaCall endpoint=' . $sanitized . ' attempt=' . $attempt . ' success=' . ($success ? '1' : '0') . ' http=' . $httpCode . ' elapsed_ms=' . $elapsedMs . ' bytes=' . $bytes;
+		if (!$success && $error) { $msg .= ' error=' . $error; }
+		if (!empty($GLOBALS['debug'])) { @error_log($msg); }
+	}
+
+	public static function sanitizeUrl(string $url): string {
+		$parts = parse_url($url);
+		if ($parts === false) { return $url; }
+		$scheme = $parts['scheme'] ?? 'http';
+		$host = $parts['host'] ?? '';
+		$port = isset($parts['port']) ? (':' . $parts['port']) : '';
+		$path = $parts['path'] ?? '';
+		return $scheme . '://' . $host . $port . $path;
+	}
+
+	private static function maybePingHealth(string $baseUrl): void {
+		if (self::$didHealthCheck) return;
+		self::$didHealthCheck = true;
+		$healthUrl = rtrim($baseUrl, '/') . '/version';
+		$ch = curl_init();
+		curl_setopt($ch, CURLOPT_URL, $healthUrl);
+		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+		curl_setopt($ch, CURLOPT_TIMEOUT, 3);
+		$start = microtime(true);
+		$response = curl_exec($ch);
+		$code = (int)curl_getinfo($ch, CURLINFO_HTTP_CODE);
+		curl_close($ch);
+		if (!empty($GLOBALS['debug'])) {
+			$elapsed = (int)((microtime(true) - $start) * 1000);
+			$san = self::sanitizeUrl($healthUrl);
+			@error_log('Tika health endpoint=' . $san . ' http=' . $code . ' elapsed_ms=' . $elapsed);
+		}
+	}
+}
+
+

--- a/app/inc/domain/files/universal_file_handler.php
+++ b/app/inc/domain/files/universal_file_handler.php
@@ -1,0 +1,180 @@
+<?php
+
+class UniversalFileHandler {
+	/**
+	 * Extract text using strategy: Native (when trivial) -> Tika -> Rasterize+Vision fallback.
+	 * Returns extracted text, quality meta, and strategy used.
+	 */
+	public static function extract(string $relativePath, string $fileTypeExtension): array {
+		$abs = self::resolveAbsolutePath($relativePath);
+		$mime = mime_content_type($abs) ?: '';
+		$ext = strtolower($fileTypeExtension);
+		$mime = self::ensureOfficeMime($mime, $ext);
+		$meta = [
+			'mime' => $mime,
+			'ext' => $ext
+		];
+
+		// 1) Native trivial types
+		if (self::isPlainTextMime($mime)) {
+			$text = @file_get_contents($abs) ?: '';
+			return [self::clean($text), ['strategy' => 'native_text'] + $meta];
+		}
+
+		// If Tika is disabled, support PDFs via vision; others return empty
+		if (!ApiKeys::isTikaEnabled()) {
+			if (self::isPdfMime($mime) || $ext === 'pdf') {
+				$images = Rasterizer::pdfToPng($abs);
+				if (!empty($images)) {
+					$text = self::visionAggregate($images);
+					$text = self::clean($text);
+					return [$text, ['strategy' => 'rasterize_vision', 'pages' => count($images)] + $meta];
+				}
+				return ['', ['strategy' => 'rasterize_vision'] + $meta];
+			}
+			// Office/unknown without Tika: no extraction
+			return ['', ['strategy' => 'tika_disabled'] + $meta];
+		}
+
+		// 2) Tika first for documents (office, pdf, html, etc.)
+		list($tikaText, $tikaMeta) = TikaClient::extractText($abs, $mime);
+		if (is_string($tikaText)) {
+			$tikaText = self::clean($tikaText);
+			$trim = trim($tikaText);
+			$len = mb_strlen($trim);
+			// For PDFs, consider low-quality Tika text as unusable
+			$isPdf = (self::isPdfMime($mime) || $ext === 'pdf');
+			$lowQuality = $isPdf ? self::isLowQuality($trim) : false;
+			if ($len > 0 && !$lowQuality) {
+				// Prefer Tika whenever it yields usable content
+				return [$tikaText, ['strategy' => 'tika'] + $meta + $tikaMeta];
+			}
+			// If Tika produced empty or low-quality output and this is a PDF, fallback to vision
+			if ($isPdf) {
+				$images = Rasterizer::pdfToPng($abs);
+				if (!empty($images)) {
+					$text = self::visionAggregate($images);
+					$text = self::clean($text);
+					if (mb_strlen(trim($text)) > 0) {
+						return [$text, ['strategy' => 'rasterize_vision', 'pages' => count($images)] + $meta];
+					}
+				}
+			}
+		}
+
+		// If Tika failed or produced unusable output for non-PDF, return empty with strategy marker
+		return ['', ['strategy' => 'tika'] + $meta];
+	}
+
+	private static function isPlainTextMime(string $mime): bool {
+		return $mime === 'text/plain' || $mime === 'text/markdown' || $mime === 'text/csv';
+	}
+
+	private static function isPdfMime(string $mime): bool {
+		return $mime === 'application/pdf' || $mime === 'application/x-pdf';
+	}
+
+	private static function clean(string $text): string {
+		return Tools::cleanTextBlock($text);
+	}
+
+	private static function resolveAbsolutePath(string $relative): string {
+		$base = rtrim(UPLOAD_DIR, '/') . '/';
+		$candidates = [
+			$base . $relative,
+			(PROJECT_ROOT . '/public/up/' . $relative),
+			(PROJECT_ROOT . '/up/' . $relative)
+		];
+		foreach ($candidates as $p) { if (is_file($p)) return $p; }
+		if (!empty($GLOBALS['debug'])) { @error_log('UniversalFileHandler: file not found, tried: ' . implode(';', $candidates)); }
+		return $candidates[0];
+	}
+
+	private static function isLowQuality(string $text): bool {
+		$minLen = ApiKeys::getTikaMinLength();
+		$minEntropy = ApiKeys::getTikaMinEntropy();
+		if (mb_strlen($text) < $minLen) return true;
+		$entropy = self::shannonEntropy($text);
+		return $entropy < $minEntropy;
+	}
+
+	private static function shannonEntropy(string $s): float {
+		$len = strlen($s);
+		if ($len === 0) return 0.0;
+		$freq = [];
+		for ($i = 0; $i < $len; $i++) {
+			$c = $s[$i];
+			$freq[$c] = ($freq[$c] ?? 0) + 1;
+		}
+		$entropy = 0.0;
+		foreach ($freq as $count) {
+			$p = $count / $len;
+			$entropy -= $p * log($p, 2);
+		}
+		return $entropy;
+	}
+
+	private static function visionAggregate(array $imageAbsolutePaths): string {
+		$service = $GLOBALS["AI_PIC2TEXT"]["SERVICE"] ?? null;
+		if (!$service || !class_exists($service)) {
+			return '';
+		}
+		$fullText = '';
+		foreach ($imageAbsolutePaths as $imgAbs) {
+			$relPath = self::absoluteToRelativeUp($imgAbs);
+			$tmpMsg = [
+				'BID' => 0,
+				'BUSERID' => $_SESSION['USERPROFILE']['BID'] ?? 0,
+				'BFILEPATH' => $relPath,
+				'BFILETYPE' => 'png',
+				'BFILE' => 1,
+				'BTEXT' => ''
+			];
+			try {
+				$res = $service::explainImage($tmpMsg);
+				if (!empty($res['BFILETEXT'])) {
+					if (strlen($fullText) > 0) { $fullText .= "\n\n"; }
+					$fullText .= $res['BFILETEXT'];
+				}
+			} catch (\Throwable $e) {
+				@error_log('Vision fallback error: ' . $e->getMessage());
+			}
+		}
+		return $fullText;
+	}
+
+	private static function absoluteToRelativeUp(string $abs): string {
+		$uploadBase = rtrim(UPLOAD_DIR, '/') . '/';
+		if (strpos($abs, $uploadBase) === 0) {
+			return substr($abs, strlen($uploadBase));
+		}
+		// Fallbacks for unusual paths
+		$projectRoot = dirname(__DIR__, 3);
+		$prefix1 = $projectRoot . '/public/up/';
+		$prefix2 = $projectRoot . '/up/';
+		if (strpos($abs, $prefix1) === 0) return substr($abs, strlen($prefix1));
+		if (strpos($abs, $prefix2) === 0) return substr($abs, strlen($prefix2));
+		return basename($abs);
+	}
+
+	private static function ensureOfficeMime(string $mime, string $ext): string {
+		// Some environments report XLSX/DOCX/PPTX as application/zip; fix by extension
+		$map = [
+			'xls'  => 'application/vnd.ms-excel',
+			'xlsx' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+			'doc'  => 'application/msword',
+			'docx' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+			'ppt'  => 'application/vnd.ms-powerpoint',
+			'pptx' => 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+			'csv'  => 'text/csv'
+		];
+		if (isset($map[$ext])) {
+			if ($mime === '' || $mime === 'application/zip' || $mime === 'application/octet-stream') {
+				return $map[$ext];
+			}
+		}
+		return $mime;
+	}
+}
+
+

--- a/app/inc/support/_central.php
+++ b/app/inc/support/_central.php
@@ -868,20 +868,7 @@ class Central {
                 db::Query($updateSQL);
             }
         }
-        
-        // documents (tika-first, with pdf rasterize→vision fallback via UniversalFileHandler)
-        elseif ($arrMessage['BFILETYPE'] == "pdf" || $arrMessage['BFILETYPE'] == "doc" || $arrMessage['BFILETYPE'] == "docx" || $arrMessage['BFILETYPE'] == "xls" || $arrMessage['BFILETYPE'] == "xlsx" || $arrMessage['BFILETYPE'] == "ppt" || $arrMessage['BFILETYPE'] == "pptx" || $arrMessage['BFILETYPE'] == "csv" || $arrMessage['BFILETYPE'] == "html" || $arrMessage['BFILETYPE'] == "htm" || $arrMessage['BFILETYPE'] == "txt") {
-            $fileType = ($arrMessage['BFILETYPE'] == 'pdf') ? 3 : (($arrMessage['BFILETYPE'] == 'doc' || $arrMessage['BFILETYPE'] == 'docx') ? 4 : (($arrMessage['BFILETYPE'] == 'txt') ? 5 : 0));
-            list($extractedText, $meta) = \UniversalFileHandler::extract($arrMessage['BFILEPATH'], $arrMessage['BFILETYPE']);
-            if (!empty($GLOBALS['debug']) && !empty($meta['strategy'])) {
-                @error_log('DocExtract strategy=' . $meta['strategy'] . ' type=' . $arrMessage['BFILETYPE'] . ' file=' . basename($arrMessage['BFILEPATH']));
-            }
-            $arrMessage['BFILETEXT'] = is_string($extractedText) ? $extractedText : '';
-            if($arrMessage['BID'] > 0) {
-                $updateSQL = "update BMESSAGES set BFILETEXT = '" . db::EscString($arrMessage['BFILETEXT']) . "' where BID = " . ($arrMessage['BID']);
-                db::Query($updateSQL);
-            }
-        }
+
         
         return $arrMessage;
     }

--- a/dev/docker/Dockerfile
+++ b/dev/docker/Dockerfile
@@ -13,6 +13,11 @@ RUN apt-get update && apt-get install -y \
     libjpeg62-turbo-dev \
     libwebp-dev \
     libsodium-dev \
+    ghostscript \
+    # Image/PDF processing dependencies
+    imagemagick \
+    libmagickwand-dev \
+    poppler-utils \
     zip \
     unzip \
     libffi-dev \
@@ -77,11 +82,15 @@ RUN install-php-extensions \
         pcntl \
         bcmath \
         gd \
+        imagick \
         zip \
         sodium \
         ffi \
         xdebug \
         grpc
+
+# Increase PHP upload limits inside the container
+RUN printf "upload_max_filesize=128M\npost_max_size=128M\nmax_file_uploads=50\n" > /usr/local/etc/php/conf.d/zz-uploads.ini
 
 # Install Composer
 COPY --from=composer:latest /usr/bin/composer /usr/bin/composer

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,8 @@ services:
       - DB_PASSWORD=synaplan_password
       - OLLAMA_SERVER=ollama:11434
       - TIKA_URL=${TIKA_URL:-http://tika:9998}
+      - TIKA_HTTP_USER=${TIKA_HTTP_USER:-}
+      - TIKA_HTTP_PASS=${TIKA_HTTP_PASS:-}
       - XDEBUG_MODE=debug
       - XDEBUG_CONFIG=client_host=host.docker.internal client_port=9003
       - OIDC_PROVIDER_URL=${OIDC_PROVIDER_URL:-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       - DB_USER=synaplan_user
       - DB_PASSWORD=synaplan_password
       - OLLAMA_SERVER=ollama:11434
+      - TIKA_URL=${TIKA_URL:-http://tika:9998}
       - XDEBUG_MODE=debug
       - XDEBUG_CONFIG=client_host=host.docker.internal client_port=9003
       - OIDC_PROVIDER_URL=${OIDC_PROVIDER_URL:-}
@@ -129,6 +130,7 @@ services:
       - ollama_data:/root/.ollama
     environment:
       - OLLAMA_HOST=0.0.0.0
+      - OLLAMA_PULL_MODELS=llava:13b,llama3.2:3b,mistral:7b,codellama:7b,deepseek-r1:14b,deepseek-r1:32b,bge-m3
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:11434/api/tags"]
@@ -205,10 +207,32 @@ services:
     networks:
       - synaplan-network
 
+  # Apache Tika (optional;)
+  tika:
+    image: apache/tika:2.9.2.0
+    container_name: synaplan-tika
+    restart: unless-stopped
+    command: -h 0.0.0.0 -p 9998
+    ports:
+      - "9998:9998"
+    healthcheck:
+      test: ["CMD", "sh", "-lc", "wget -qO- http://localhost:9998/version >/dev/null 2>&1 || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 20s
+    logging:
+      options:
+        max-size: "10m"
+        max-file: "3"
+    networks:
+      - synaplan-network
+
 volumes:
   mysql_data:
   ollama_data:
   whisper_models:
+    name: synaplan_whisper_models
 
 networks:
   synaplan-network:

--- a/public/api.php
+++ b/public/api.php
@@ -22,8 +22,7 @@ if (function_exists('session_set_cookie_params')) {
         'domain' => '',
         'secure' => $isHttps ? true : false,
         'httponly' => true,
-        // In non-HTTPS dev, avoid SameSite=None without Secure (rejected by modern browsers)
-        'samesite' => $isHttps ? 'None' : 'Lax'
+        'samesite' => 'None'
     ];
     @session_set_cookie_params($cookieParams);
 }

--- a/public/api.php
+++ b/public/api.php
@@ -22,7 +22,8 @@ if (function_exists('session_set_cookie_params')) {
         'domain' => '',
         'secure' => $isHttps ? true : false,
         'httponly' => true,
-        'samesite' => 'None'
+        // In non-HTTPS dev, avoid SameSite=None without Secure (rejected by modern browsers)
+        'samesite' => $isHttps ? 'None' : 'Lax'
     ];
     @session_set_cookie_params($cookieParams);
 }


### PR DESCRIPTION
This PR replaces the per-type document parsers with a single flow: **Tika-first**, falling back to **PDF rasterize → Vision** when needed. Public APIs and response shapes stay the same; `BFILETEXT` remains the source of truth.

**What changed**

* Add: `app/inc/domain/files/{tika_client.php,rasterizer.php,universal_file_handler.php}`
* Wire: use `UniversalFileHandler::extract(...)` in `Central::parseFile(...)` and `Central::extractFileContent(...)`
* Config: add `TIKA_*` and `RASTERIZE_*` to `.env.example`
* Docs: brief README updates

**Why**

* More robust & broader doc support (PDF/Office/HTML/CSV/TXT)
* Automatic OCR path for scanned PDFs without touching downstream logic

**Ops notes**

* Point `TIKA_URL` to the Tika server; toggle via `TIKA_ENABLED=true/false`
* If Tika is disabled/unreachable: PDFs still go via rasterize→Vision; other Office types return empty (current design)

**Risk/compat**

* Needs Imagick *or* `pdftoppm` (already present) for PDF rasterize
* Timeouts/retries are configurable; no DB or API migrations

**Test checklist**

* Born-digital PDF → text via Tika
* Scanned PDF → text via rasterize→Vision
* DOCX/XLSX/PPTX → text via Tika
* TXT/CSV/MD → native fast path
* Tika down (PDF) → rasterize→Vision; others empty, no crash

**Rollback**

* Set `TIKA_ENABLED=false` (keeps PDF via Vision fallback)
