### PR TITLE
feat: add .git-blame-ignore-revs file for ignoring formatting commits

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,8 @@
+# .git-blame-ignore-revs
+# This file contains a list of commits that should be ignored by git blame.
+# To configure git to use this file locally, run:
+# git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+# Formatting changes from PR #92
+489d28638ddcc0fbee45c59969a5a12e24ec3cb0 # Merge pull request #92 from metadist/feat/formatter-applied
+4a54fbb7995903649be275a07363c8abddc46aac # chore: apply format

--- a/README.md
+++ b/README.md
@@ -218,6 +218,15 @@ Configuration-driven AI selection via `$GLOBALS` and centralized key management 
 ### Contributing
 PRs welcome for providers, channels, docs, and performance. Start from `app/Director.php` and `frontend/` components, and follow existing patterns.
 
+#### Git Blame Configuration
+This repository includes a `.git-blame-ignore-revs` file to ignore formatting commits in git blame. To configure your local git to use this file:
+
+```bash
+git config blame.ignoreRevsFile .git-blame-ignore-revs
+```
+
+This will help you see the actual code changes instead of formatting commits when using `git blame`.
+
 ### License
 See "LICENSE": Apache 2.0 real open core, because we love it!
 


### PR DESCRIPTION
compare https://github.com/metadist/synaplan/blame/489d28638ddcc0fbee45c59969a5a12e24ec3cb0/app/director.php
vs
https://github.com/metadist/synaplan/blame/f4e34cbdf08a6868c1e1ec652b669f22fa2bcae5/app/director.php