### PR TITLE
reply to

### DIFF
--- a/app/inc/mail/_toolmailhandler.php
+++ b/app/inc/mail/_toolmailhandler.php
@@ -888,6 +888,10 @@ class mailHandler
 
             // Prepend ReplyTo information to body for visibility (in case email client doesn't respect Reply-To header)
             if ($replyTo !== '') {
+                Tools::debugCronLog('[REPLYTO] Adding ReplyTo line to body: ' . $replyTo . "\n");
+                Tools::debugCronLog('[REPLYTO] Plain text before: ' . substr($plain, 0, 100) . "\n");
+                Tools::debugCronLog('[REPLYTO] HTML before: ' . substr($html, 0, 200) . "\n");
+
                 $replyToLine = 'ReplyTo: ' . $replyTo . "\n\n";
                 $plain = $replyToLine . $plain;
 
@@ -897,11 +901,18 @@ class mailHandler
                     // Insert after opening body tag if it exists
                     if (stripos($html, '<body') !== false) {
                         $html = preg_replace('/(<body[^>]*>)/i', '$1' . $replyToHtml, $html);
+                        Tools::debugCronLog('[REPLYTO] Inserted into HTML after <body> tag' . "\n");
                     } else {
                         // If no body tag, just prepend
                         $html = $replyToHtml . $html;
+                        Tools::debugCronLog('[REPLYTO] Prepended to HTML (no body tag found)' . "\n");
                     }
                 }
+
+                Tools::debugCronLog('[REPLYTO] Plain text after: ' . substr($plain, 0, 100) . "\n");
+                Tools::debugCronLog('[REPLYTO] HTML after: ' . substr($html, 0, 300) . "\n");
+            } else {
+                Tools::debugCronLog('[REPLYTO] No replyTo address found!' . "\n");
             }
 
             $attachPath = '';
@@ -1273,6 +1284,10 @@ class mailHandler
 
             // Prepend ReplyTo information to body for visibility (in case email client doesn't respect Reply-To header)
             if ($replyTo !== '') {
+                Tools::debugCronLog('[REPLYTO] Adding ReplyTo line to body: ' . $replyTo . "\n");
+                Tools::debugCronLog('[REPLYTO] Plain text before: ' . substr($plain, 0, 100) . "\n");
+                Tools::debugCronLog('[REPLYTO] HTML before: ' . substr($html, 0, 200) . "\n");
+
                 $replyToLine = 'ReplyTo: ' . $replyTo . "\n\n";
                 $plain = $replyToLine . $plain;
 
@@ -1282,11 +1297,18 @@ class mailHandler
                     // Insert after opening body tag if it exists
                     if (stripos($html, '<body') !== false) {
                         $html = preg_replace('/(<body[^>]*>)/i', '$1' . $replyToHtml, $html);
+                        Tools::debugCronLog('[REPLYTO] Inserted into HTML after <body> tag' . "\n");
                     } else {
                         // If no body tag, just prepend
                         $html = $replyToHtml . $html;
+                        Tools::debugCronLog('[REPLYTO] Prepended to HTML (no body tag found)' . "\n");
                     }
                 }
+
+                Tools::debugCronLog('[REPLYTO] Plain text after: ' . substr($plain, 0, 100) . "\n");
+                Tools::debugCronLog('[REPLYTO] HTML after: ' . substr($html, 0, 300) . "\n");
+            } else {
+                Tools::debugCronLog('[REPLYTO] No replyTo address found!' . "\n");
             }
 
             $attachPaths = [];


### PR DESCRIPTION
simple reply to improvements in the mailhandler.php

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add `debugCronLog` instrumentation around Reply-To handling in `imapForwardMessage` and `imapForwardMessageAll` to log before/after body states and insertion behavior.
> 
> - **Mailhandler (`app/inc/mail/_toolmailhandler.php`)**:
>   - **Reply-To handling**:
>     - Add `Tools::debugCronLog` messages when prepending Reply-To to plain text and inserting into HTML.
>     - Log snippets of plain/HTML bodies before/after modification and whether insertion occurred after `<body>` or via prepend.
>     - Log when no Reply-To address is found.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a138e900ea6943c5c931d4851ac7cf2e65be4b14. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->