### PR TITLE
fix: use pull_request instead of pull_request_target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main, develop]
     tags: ['v*']
-  pull_request_target:
+  pull_request:
     branches: [main, develop]
 
 env:


### PR DESCRIPTION
## Summary
- Change CI workflow trigger from `pull_request_target` to `pull_request`

## Problem
`pull_request_target` checks out the **base branch code** (main), not the PR code. This meant CI was testing main instead of the actual PR changes, causing confusing test failures.

## Solution
Use `pull_request` which:
- Reads workflow definition from base branch (main) ✅ 
- Checks out and tests the **PR code** ✅ 

Since we don't have external forks and the workflow changes are already merged to main, `pull_request` is the correct trigger.

## Context
`pull_request_target` is only needed when:
- Accepting PRs from external forks
- AND needing repository secrets
- BUT running trusted code from base branch

For normal CI testing, `pull_request` is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)