### PR TITLE
Set PHP values to production ready

### DIFF
--- a/_docker/backend/Dockerfile
+++ b/_docker/backend/Dockerfile
@@ -39,10 +39,12 @@ RUN install-php-extensions \
 
 # PHP Configuration
 RUN mkdir -p /var/www/uploads && chmod 777 /var/www/uploads && \
-    printf "upload_max_filesize=128M\npost_max_size=128M\nmax_file_uploads=50\nmemory_limit=512M\nupload_tmp_dir=/var/www/uploads\nsys_temp_dir=/var/www/uploads\n" \
+    printf "upload_max_filesize=512M\npost_max_size=512M\nmax_file_uploads=50\nmemory_limit=512M\nupload_tmp_dir=/var/www/uploads\nsys_temp_dir=/var/www/uploads\nmax_execution_time=300\n" \
     > /usr/local/etc/php/conf.d/uploads.ini && \
     printf "opcache.enable=1\nopcache.memory_consumption=256\nopcache.max_accelerated_files=20000\n" \
-    > /usr/local/etc/php/conf.d/opcache.ini
+    > /usr/local/etc/php/conf.d/opcache.ini && \
+    printf "display_errors=Off\ndisplay_startup_errors=Off\nlog_errors=On\nerror_reporting=E_ALL & ~E_DEPRECATED & ~E_STRICT\n" \
+    > /usr/local/etc/php/conf.d/production.ini
 
 # Install Composer
 COPY --from=composer:latest /usr/bin/composer /usr/bin/composer


### PR DESCRIPTION
Just updating the PHP settings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Increase PHP upload limits and add production error/logging and execution timeout settings in `_docker/backend/Dockerfile`.
> 
> - **Backend Docker image (`_docker/backend/Dockerfile`)**:
>   - Increase PHP upload limits: `upload_max_filesize` and `post_max_size` to `512M`.
>   - Add `max_execution_time=300`.
>   - Add `production.ini` with `display_errors=Off`, `display_startup_errors=Off`, `log_errors=On`, and adjusted `error_reporting`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ed20a5d1ce9fb00b48d73723b09c1d5cb9ad3d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->