### PR TITLE
fix: docker-entrypoint.sh improvements

### DIFF
--- a/_docker/backend/docker-entrypoint.sh
+++ b/_docker/backend/docker-entrypoint.sh
@@ -3,6 +3,23 @@ set -euo pipefail
 
 echo "🚀 Starting Synaplan Backend..."
 
+# Source .env file if it exists
+if [ -f /var/www/backend/.env ]; then
+    echo "📄 Loading environment from .env file..."
+    set -a  # automatically export all variables
+    source /var/www/backend/.env
+    set +a
+fi
+
+# Validate required environment variables
+if [ -z "${APP_URL:-}" ]; then
+    echo "❌ ERROR: APP_URL is not set!"
+    echo "   APP_URL is required for the application to work correctly."
+    echo "   Please set it in your environment or .env file."
+    echo "   Example: APP_URL=https://synaplan.example.com"
+    exit 1
+fi
+
 # Build DATABASE URLs from environment variables if not already set
 # Fallback for deployments that provide DB credentials as separate env vars
 if [ -z "${DATABASE_WRITE_URL:-}" ] && [ -n "${DB_HOST:-}" ]; then


### PR DESCRIPTION
## Changes

- Make OLLAMA_BASE_URL optional to fix unbound variable error with `set -euo pipefail`
- Use APP_URL in startup message (required, no fallback)
- Remove redundant SYNAPLAN_URL variable

## Details

### Fix OLLAMA_BASE_URL requirement
Changed to use `${OLLAMA_BASE_URL:-}` and `${AUTO_DOWNLOAD_MODELS:-false}` patterns to prevent script exit when these variables are not set. Ollama integration is optional and should not cause startup failure.

### Simplify URL configuration  
- Startup message now displays `${APP_URL}` directly (required, no fallback to localhost)
- Removed redundant `SYNAPLAN_URL` from helm values - use `APP_URL` instead
- Makes it clear that APP_URL must be set for proper operation