### PR TITLE
swapping defaults, full scale image for more power

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,18 +30,49 @@ git reset --hard
 
 | Mode | Download Size | Best For | Command |
 |------|---------------|----------|---------|
-| ⚡ **Standard** (Default) | ~5 GB | Quick start, cloud AI (Groq/OpenAI) | `docker compose up -d` |
-| 🔧 **Full-Scale** | ~9 GB | Local AI, audio transcription | `docker compose -f docker-compose-full-scale.yml up -d` |
+| 🔧 **Standard** (Default) | ~9 GB | Full features, local AI, audio transcription | `docker compose up -d` |
+| ⚡ **Minimal** | ~5 GB | Quick start, cloud AI (Groq/OpenAI) | `docker compose -f docker-compose-minimal.yml up -d` |
 
 ---
 
-### ⚡ Standard Install (Recommended for First-Time Users)
+### 🔧 Standard Install (Recommended)
+
+The default installation with all features including local AI models and Whisper audio transcription.
+
+**Windows users:** Please use **WSL2** (Windows Subsystem for Linux) and run the Linux script.
+
+```bash
+# Option 1: Use docker-compose directly
+docker compose up -d
+
+# Option 2: Use the first-install script (Linux / macOS / Windows WSL2)
+./_1st_install_linux.sh
+```
+
+**What's included:**
+- ✅ Full web app and API
+- ✅ Document processing (Tika)
+- ✅ Database (MariaDB)
+- ✅ Local Ollama AI models (gpt-oss:20b, bge-m3)
+- ✅ Whisper audio transcription
+- ✅ Cloud AI support (Groq, OpenAI, Anthropic, Gemini)
+- ✅ Dev tools (phpMyAdmin, MailHog)
+
+After the initial install, subsequent restarts only need:
+
+```bash
+docker compose up -d
+```
+
+---
+
+### ⚡ Minimal Install (Cloud AI Only)
 
 **Fastest way to get started** - uses cloud AI providers, skips large local models and Whisper compilation.
 
 ```bash
 # 1. Start services (~5 GB download, ~2-3 min)
-docker compose up -d
+docker compose -f docker-compose-minimal.yml up -d
 
 # 2. Set your AI API key (get free key at https://console.groq.com)
 echo "GROQ_API_KEY=your_key_here" >> backend/.env
@@ -62,36 +93,10 @@ docker compose restart backend
 - ❌ Whisper models (audio transcription)
 - ❌ Local embedding models
 
-**Upgrade to Full-Scale Install later:**
+**Upgrade to Standard Install later:**
 ```bash
-docker compose down
-docker compose -f docker-compose-full-scale.yml up -d  # Starts full stack with Ollama + Whisper
-```
-
----
-
-### 🔧 Full-Scale Install (Local AI + Audio Transcription)
-
-For the complete experience with local AI models and Whisper audio transcription.
-
-**Windows users:** Please use **WSL2** (Windows Subsystem for Linux) and run the Linux script.
-
-```bash
-# Option 1: Use full-scale docker-compose directly
-docker compose -f docker-compose-full-scale.yml up -d
-
-# Option 2: Use the first-install script (Linux / macOS / Windows WSL2)
-./_1st_install_linux.sh
-```
-
-After the initial install, subsequent restarts only need:
-
-```bash
-# For standard install
-docker compose up -d
-
-# For full-scale install
-docker compose -f docker-compose-full-scale.yml up -d
+docker compose -f docker-compose-minimal.yml down
+docker compose up -d  # Starts full stack with Ollama + Whisper
 ```
 
 **What happens automatically:**
@@ -124,7 +129,7 @@ docker compose -f docker-compose-full-scale.yml up -d
 
 Progress (downloads or schema work) streams directly in the script output, so you always know what’s happening.
 
-**Option 1: Default Auto Download (Recommended)**
+**Using the Install Script (Recommended)**
 ```bash
 ./_1st_install_linux.sh
 ```
@@ -133,7 +138,7 @@ Progress (downloads or schema work) streams directly in the script output, so yo
 - ✅ **AI chat + RAG ready** as soon as the selected provider is configured
 - 💡 **Best for**: Development/prod setups that either have local GPU (option 1) or prefer Groq's hosted models (option 2)
 
-**Option 2: On-demand Downloads**
+**On-demand Downloads (Alternative)**
 ```bash
 AUTO_DOWNLOAD_MODELS=false docker compose up -d
 ```
@@ -144,14 +149,14 @@ AUTO_DOWNLOAD_MODELS=false docker compose up -d
 
 ## 🌐 Access
 
-| Service | URL | Description | Standard | Full-Scale |
-|---------|-----|-------------|:--------:|:----------:|
+| Service | URL | Description | Standard | Minimal |
+|---------|-----|-------------|:--------:|:-------:|
 | Frontend | http://localhost:5173 | Vue.js Web App | ✅ | ✅ |
 | Backend API | http://localhost:8000 | Symfony REST API | ✅ | ✅ |
 | API Docs | http://localhost:8000/api/doc | Swagger UI / OpenAPI | ✅ | ✅ |
 | phpMyAdmin | http://localhost:8082 | Database Management | ✅ | ✅ |
 | MailHog | http://localhost:8025 | Email Testing | ✅ | ✅ |
-| Ollama | http://localhost:11435 | AI Models API | ❌ | ✅ |
+| Ollama | http://localhost:11435 | AI Models API | ✅ | ❌ |
 
 ## 👤 Test Users
 
@@ -348,8 +353,8 @@ synaplan-dev/
 │   └── frontend/            # Frontend Dockerfile & nginx
 ├── backend/                 # Symfony Backend (PHP 8.3)
 ├── frontend/                # Vue.js Frontend
-├── docker-compose.yml       # Standard install (cloud AI only, recommended)
-└── docker-compose-full-scale.yml # Full-scale install (Ollama + Whisper)
+├── docker-compose.yml       # Standard install (Ollama + Whisper, recommended)
+└── docker-compose-minimal.yml # Minimal install (cloud AI only)
 ```
 
 ## ⚙️ Environment Configuration
@@ -407,11 +412,7 @@ docker compose exec frontend npm install <package>
 
 Disable the auto download by running:
 ```bash
-# For standard install
 AUTO_DOWNLOAD_MODELS=false docker compose up -d
-
-# For full-scale install
-AUTO_DOWNLOAD_MODELS=false docker compose -f docker-compose-full-scale.yml up -d
 ```
 
 ## ✨ Features

--- a/docker-compose-minimal.yml
+++ b/docker-compose-minimal.yml
@@ -1,17 +1,16 @@
-# Synaplan - Full-Scale Installation (Local AI + Audio Transcription)
+# Synaplan - Minimal Installation (Cloud AI only)
 #
-# This full-scale configuration includes:
-# - Local Ollama AI models (gpt-oss:20b, bge-m3)
-# - Whisper audio transcription with model downloads
-# - All features enabled
-# - Larger download size (~9GB vs ~5GB for standard)
-# - Slower first-time startup due to Whisper model downloads
+# This is a lightweight configuration for Synaplan:
+# - Uses cloud AI providers (Groq, OpenAI, Anthropic) instead of local Ollama
+# - Skips Whisper audio transcription (faster startup)
+# - Downloads ~4GB less than standard install
+# - Faster startup for first-time users
 #
 # Usage:
-#   docker compose -f docker-compose-full-scale.yml up -d
+#   docker compose -f docker-compose-minimal.yml up -d
 #
-# To switch to standard install (cloud AI only):
-#   docker compose -f docker-compose-full-scale.yml down
+# To switch to standard install (with Ollama + Whisper):
+#   docker compose -f docker-compose-minimal.yml down
 #   docker compose up -d
 #
 services:
@@ -75,8 +74,8 @@ services:
       - ./plugins:/plugins:ro
       - ./_docker/backend/Caddyfile:/etc/caddy/Caddyfile:ro
       - ./_docker/backend/docker-entrypoint.sh:/usr/local/bin/docker-entrypoint.sh:ro
-      - whisper_models:/var/www/backend/var/whisper:ro
       - ./_devextras/backend/docker-entrypoint.d:/docker-entrypoint.d:ro
+      # Note: No whisper_models volume - audio transcription disabled
     environment:
       APP_ENV: dev
       # APP_SECRET loaded from backend/.env (env_file above)
@@ -86,10 +85,12 @@ services:
       SYNAPLAN_URL: http://localhost:8000
       DATABASE_WRITE_URL: mysql://synaplan_user:synaplan_password@db:3306/synaplan?serverVersion=11.8&charset=utf8mb4
       DATABASE_READ_URL: mysql://synaplan_user:synaplan_password@db:3306/synaplan?serverVersion=11.8&charset=utf8mb4
-      OLLAMA_BASE_URL: http://ollama:11434
+      # No Ollama - use external AI providers
+      OLLAMA_BASE_URL: ""
       TRITON_SERVER_URL: ${TRITON_SERVER_URL:-}
       TIKA_BASE_URL: http://tika:9998
-      AI_DEFAULT_PROVIDER: ollama
+      # Default to Groq (free tier available) - user should set GROQ_API_KEY in backend/.env
+      AI_DEFAULT_PROVIDER: groq
       # Token Configuration
       TOKEN_SECRET: 'change_me_in_production_use_openssl_rand_hex_32'
       # Mailer (Mailhog for development)
@@ -100,21 +101,19 @@ services:
       WHATSAPP_WEBHOOK_VERIFY_TOKEN: ${WHATSAPP_WEBHOOK_VERIFY_TOKEN:-}
       WHATSAPP_ENABLED: ${WHATSAPP_ENABLED:-false}
       # AI Provider API Keys (loaded from backend/.env via env_file above)
-      # GROQ_API_KEY is automatically loaded from backend/.env
-      AUTO_DOWNLOAD_MODELS: ${AUTO_DOWNLOAD_MODELS:-false}
-      ENABLE_LOCAL_GPT_OSS: ${ENABLE_LOCAL_GPT_OSS:-true}
+      AUTO_DOWNLOAD_MODELS: "false"
+      ENABLE_LOCAL_GPT_OSS: "false"
       # reCAPTCHA (optional - disabled by default)
       RECAPTCHA_SITE_KEY: ${RECAPTCHA_SITE_KEY:-}
       RECAPTCHA_SECRET_KEY: ${RECAPTCHA_SECRET_KEY:-}
       RECAPTCHA_ENABLED: ${RECAPTCHA_ENABLED:-false}
       # Stripe Payment Integration - loaded from backend/.env via env_file
-      # (STRIPE_SECRET_KEY, STRIPE_PUBLISHABLE_KEY, STRIPE_WEBHOOK_SECRET, STRIPE_PRICE_*)
       # OAuth Social Login Providers (loaded from backend/.env via env_file)
-      # Whisper.cpp Service (Audio Transcription)
+      # Whisper.cpp - DISABLED in light mode (no models downloaded)
       WHISPER_BINARY: /usr/local/bin/whisper
       WHISPER_MODELS_PATH: /var/www/backend/var/whisper
       WHISPER_DEFAULT_MODEL: base
-      WHISPER_ENABLED: "true"
+      WHISPER_ENABLED: "false"
       FFMPEG_BINARY: /usr/bin/ffmpeg
     depends_on:
       db:
@@ -154,26 +153,6 @@ services:
     networks:
       - synaplan-network
 
-  # Ollama - Local AI Models
-  ollama:
-    image: ollama/ollama:latest
-    container_name: synaplan-ollama
-    ports:
-      - "11435:11434"
-    volumes:
-      - ollama_data:/root/.ollama
-    environment:
-      OLLAMA_HOST: 0.0.0.0
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:11434/api/tags"]
-      interval: 30s
-      timeout: 10s
-      retries: 5
-      start_period: 60s
-    restart: unless-stopped
-    networks:
-      - synaplan-network
-
   # Apache Tika - Document Text Extraction
   tika:
     image: apache/tika:2.9.2.0
@@ -188,31 +167,6 @@ services:
       retries: 5
       start_period: 20s
     restart: unless-stopped
-    networks:
-      - synaplan-network
-
-  # Whisper Models Download (runs once)
-  whisper-models:
-    image: alpine:3.20
-    container_name: synaplan-whisper-models
-    command: >
-      sh -c '
-        apk add --no-cache curl ca-certificates &&
-        mkdir -p /models &&
-        if [ ! -f "/models/ggml-base.bin" ]; then
-          echo "Downloading Whisper base model..." &&
-          curl -fL --retry 3 --retry-delay 5 --max-time 600 \
-            -o "/models/ggml-base.bin" \
-            "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.bin" &&
-          chmod 644 /models/*.bin &&
-          echo "Whisper model downloaded successfully"
-        else
-          echo "Whisper model already exists, skipping download"
-        fi
-      '
-    volumes:
-      - whisper_models:/models
-    restart: "no"
     networks:
       - synaplan-network
 
@@ -246,10 +200,8 @@ services:
 
 volumes:
   mysql_data:
-  ollama_data:
-  whisper_models:
+  # Note: No ollama_data or whisper_models volumes in standard mode
 
 networks:
   synaplan-network:
     driver: bridge
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,17 @@
 # Synaplan - Standard Installation (Recommended)
 #
-# This is the default configuration for Synaplan:
-# - Uses cloud AI providers (Groq, OpenAI, Anthropic) instead of local Ollama
-# - Skips Whisper audio transcription (faster startup)
-# - Downloads ~4GB less than full-scale install
-# - Faster startup for first-time users
+# This is the default configuration for Synaplan with all features:
+# - Local Ollama AI models (gpt-oss:20b, bge-m3)
+# - Whisper audio transcription with model downloads
+# - All features enabled
+# - Download size: ~9GB
 #
 # Usage:
 #   docker compose up -d
 #
-# To switch to full-scale install (with Ollama + Whisper):
+# To switch to minimal install (cloud AI only, smaller footprint):
 #   docker compose down
-#   docker compose -f docker-compose-full-scale.yml up -d
+#   docker compose -f docker-compose-minimal.yml up -d
 #
 services:
   # Vue.js Frontend
@@ -74,8 +74,8 @@ services:
       - ./plugins:/plugins:ro
       - ./_docker/backend/Caddyfile:/etc/caddy/Caddyfile:ro
       - ./_docker/backend/docker-entrypoint.sh:/usr/local/bin/docker-entrypoint.sh:ro
+      - whisper_models:/var/www/backend/var/whisper:ro
       - ./_devextras/backend/docker-entrypoint.d:/docker-entrypoint.d:ro
-      # Note: No whisper_models volume - audio transcription disabled
     environment:
       APP_ENV: dev
       # APP_SECRET loaded from backend/.env (env_file above)
@@ -85,12 +85,10 @@ services:
       SYNAPLAN_URL: http://localhost:8000
       DATABASE_WRITE_URL: mysql://synaplan_user:synaplan_password@db:3306/synaplan?serverVersion=11.8&charset=utf8mb4
       DATABASE_READ_URL: mysql://synaplan_user:synaplan_password@db:3306/synaplan?serverVersion=11.8&charset=utf8mb4
-      # No Ollama - use external AI providers
-      OLLAMA_BASE_URL: ""
+      OLLAMA_BASE_URL: http://ollama:11434
       TRITON_SERVER_URL: ${TRITON_SERVER_URL:-}
       TIKA_BASE_URL: http://tika:9998
-      # Default to Groq (free tier available) - user should set GROQ_API_KEY in backend/.env
-      AI_DEFAULT_PROVIDER: groq
+      AI_DEFAULT_PROVIDER: ollama
       # Token Configuration
       TOKEN_SECRET: 'change_me_in_production_use_openssl_rand_hex_32'
       # Mailer (Mailhog for development)
@@ -101,19 +99,21 @@ services:
       WHATSAPP_WEBHOOK_VERIFY_TOKEN: ${WHATSAPP_WEBHOOK_VERIFY_TOKEN:-}
       WHATSAPP_ENABLED: ${WHATSAPP_ENABLED:-false}
       # AI Provider API Keys (loaded from backend/.env via env_file above)
-      AUTO_DOWNLOAD_MODELS: "false"
-      ENABLE_LOCAL_GPT_OSS: "false"
+      # GROQ_API_KEY is automatically loaded from backend/.env
+      AUTO_DOWNLOAD_MODELS: ${AUTO_DOWNLOAD_MODELS:-false}
+      ENABLE_LOCAL_GPT_OSS: ${ENABLE_LOCAL_GPT_OSS:-true}
       # reCAPTCHA (optional - disabled by default)
       RECAPTCHA_SITE_KEY: ${RECAPTCHA_SITE_KEY:-}
       RECAPTCHA_SECRET_KEY: ${RECAPTCHA_SECRET_KEY:-}
       RECAPTCHA_ENABLED: ${RECAPTCHA_ENABLED:-false}
       # Stripe Payment Integration - loaded from backend/.env via env_file
+      # (STRIPE_SECRET_KEY, STRIPE_PUBLISHABLE_KEY, STRIPE_WEBHOOK_SECRET, STRIPE_PRICE_*)
       # OAuth Social Login Providers (loaded from backend/.env via env_file)
-      # Whisper.cpp - DISABLED in light mode (no models downloaded)
+      # Whisper.cpp Service (Audio Transcription)
       WHISPER_BINARY: /usr/local/bin/whisper
       WHISPER_MODELS_PATH: /var/www/backend/var/whisper
-      WHISPER_DEFAULT_MODEL: base
-      WHISPER_ENABLED: "false"
+      WHISPER_DEFAULT_MODEL: tiny
+      WHISPER_ENABLED: "true"
       FFMPEG_BINARY: /usr/bin/ffmpeg
     depends_on:
       db:
@@ -153,6 +153,34 @@ services:
     networks:
       - synaplan-network
 
+  # Ollama - Local AI Models (GPU-accelerated if NVIDIA available)
+  ollama:
+    image: ollama/ollama:latest
+    container_name: synaplan-ollama
+    ports:
+      - "11435:11434"
+    volumes:
+      - ollama_data:/root/.ollama
+    environment:
+      OLLAMA_HOST: 0.0.0.0
+    # GPU support - requires NVIDIA Container Toolkit
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:11434/api/tags"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
+    restart: unless-stopped
+    networks:
+      - synaplan-network
+
   # Apache Tika - Document Text Extraction
   tika:
     image: apache/tika:2.9.2.0
@@ -167,6 +195,31 @@ services:
       retries: 5
       start_period: 20s
     restart: unless-stopped
+    networks:
+      - synaplan-network
+
+  # Whisper Models Download (runs once)
+  whisper-models:
+    image: alpine:3.20
+    container_name: synaplan-whisper-models
+    command: >
+      sh -c '
+        apk add --no-cache curl ca-certificates &&
+        mkdir -p /models &&
+        if [ ! -f "/models/ggml-tiny.bin" ]; then
+          echo "Downloading Whisper tiny model..." &&
+          curl -fL --retry 3 --retry-delay 5 --max-time 600 \
+            -o "/models/ggml-tiny.bin" \
+            "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-tiny.bin" &&
+          chmod 644 /models/*.bin &&
+          echo "Whisper model downloaded successfully"
+        else
+          echo "Whisper model already exists, skipping download"
+        fi
+      '
+    volumes:
+      - whisper_models:/models
+    restart: "no"
     networks:
       - synaplan-network
 
@@ -200,8 +253,10 @@ services:
 
 volumes:
   mysql_data:
-  # Note: No ollama_data or whisper_models volumes in standard mode
+  ollama_data:
+  whisper_models:
 
 networks:
   synaplan-network:
     driver: bridge
+


### PR DESCRIPTION
## Summary
Changed the standard setup

## Changes
The docker-compose renaming is complete and all CI tests pass:
Standard (docker-compose.yml) - Full features with Ollama + Whisper (~9GB)
Minimal (docker-compose-minimal.yml) - Cloud AI only (~5GB)

## Verification
- [ ] Not tested (explain)
- [x] Manual
- [ ] Tests added/updated

## Screenshots/Logs
<img width="1055" height="900" alt="image" src="https://github.com/user-attachments/assets/d1bda520-8d90-4bd8-86ff-cb3e60ef4ac1" />
