### PR TITLE
fix(google): update Gemini model to stable 2.5 Pro version

### DIFF
--- a/backend/src/AI/Provider/GoogleProvider.php
+++ b/backend/src/AI/Provider/GoogleProvider.php
@@ -636,7 +636,7 @@ class GoogleProvider implements ChatProviderInterface, ImageGenerationProviderIn
             $mimeType1 = mime_content_type($fullPath1);
             $mimeType2 = mime_content_type($fullPath2);
 
-            $model = 'gemini-2.5-pro-preview-06-05';
+            $model = 'gemini-2.5-pro';
             $url = self::API_BASE."/models/{$model}:generateContent";
 
             $payload = [
@@ -693,7 +693,7 @@ class GoogleProvider implements ChatProviderInterface, ImageGenerationProviderIn
         }
 
         try {
-            $model = $options['model'] ?? 'gemini-2.5-pro-preview-06-05';
+            $model = $options['model'] ?? 'gemini-2.5-pro';
 
             $fullPath = $this->uploadDir.'/'.ltrim($imagePath, '/');
 

--- a/backend/src/DataFixtures/ModelFixtures.php
+++ b/backend/src/DataFixtures/ModelFixtures.php
@@ -671,7 +671,7 @@ class ModelFixtures extends Fixture
                 'tag' => 'chat',
                 'selectable' => 1,
                 'active' => 1,
-                'providerId' => 'gemini-2.5-pro-preview-06-05',
+                'providerId' => 'gemini-2.5-pro',
                 'priceIn' => 2.5,
                 'inUnit' => 'per1M',
                 'priceOut' => 15,
@@ -681,7 +681,7 @@ class ModelFixtures extends Fixture
                 'json' => [
                     'description' => 'Googles Answer to the other LLM models',
                     'params' => [
-                        'model' => 'gemini-2.5-pro-preview-06-05',
+                        'model' => 'gemini-2.5-pro',
                     ],
                 ],
             ],
@@ -692,7 +692,7 @@ class ModelFixtures extends Fixture
                 'tag' => 'pic2text',
                 'selectable' => 1,
                 'active' => 1,
-                'providerId' => 'gemini-2.5-pro-preview-06-05',
+                'providerId' => 'gemini-2.5-pro',
                 'priceIn' => 2.5,
                 'inUnit' => 'per1M',
                 'priceOut' => 15,
@@ -703,7 +703,7 @@ class ModelFixtures extends Fixture
                     'description' => 'Googles Powerhouse can also process images, not just text',
                     'prompt' => 'Describe the image in detail. Extract any text you see.',
                     'params' => [
-                        'model' => 'gemini-2.5-pro-preview-06-05',
+                        'model' => 'gemini-2.5-pro',
                     ],
                 ],
             ],
@@ -1036,9 +1036,9 @@ class ModelFixtures extends Fixture
             // Convert JSON array to string
             $jsonData = json_encode($data['json']);
 
-            $sql = 'INSERT INTO BMODELS (BID, BSERVICE, BNAME, BTAG, BSELECTABLE, BACTIVE, BPROVID, BPRICEIN, BINUNIT, BPRICEOUT, BOUTUNIT, BQUALITY, BRATING, BJSON) 
+            $sql = 'INSERT INTO BMODELS (BID, BSERVICE, BNAME, BTAG, BSELECTABLE, BACTIVE, BPROVID, BPRICEIN, BINUNIT, BPRICEOUT, BOUTUNIT, BQUALITY, BRATING, BJSON)
                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                    ON DUPLICATE KEY UPDATE 
+                    ON DUPLICATE KEY UPDATE
                         BSERVICE = VALUES(BSERVICE),
                         BNAME = VALUES(BNAME),
                         BTAG = VALUES(BTAG),


### PR DESCRIPTION
## Summary
Updates Google Gemini model name from deprecated preview version to stable release, fixing HTTP 404 errors.

## Changes
- Updated `GoogleProvider.php` to use `gemini-2.5-pro` instead of `gemini-2.5-pro-preview-06-05` (2 occurrences)
- Updated `ModelFixtures.php` to use stable model name for both chat and vision models (4 occurrences)

## Verification
- [x] Manual - Verified that the model name matches Google's current stable API
- [ ] Tests added/updated - Existing tests still pass, no new tests needed for model name update

## Notes
- Fixes #262
- Google deprecated `gemini-2.5-pro-preview-06-05` on June 17, 2025
- The stable version `gemini-2.5-pro` replaced the preview model
- This resolves the "HTTP/2 404" error when using Gemini models
- Database fixtures need to be reloaded after this change to update model definitions

**After fix:**
- Model now uses `gemini-2.5-pro` endpoint
- HTTP 404 errors resolved