### PR TITLE
refactor: reduce docker image size

### DIFF
--- a/_docker/backend/Dockerfile
+++ b/_docker/backend/Dockerfile
@@ -1,27 +1,71 @@
-# Synaplan Symfony Backend - FrankenPHP + PHP 8.3
-# Using bookworm (Debian 12) because Trixie (Debian 13) removed libc-client-dev needed for IMAP
+# ============================================================================
+# Stage 1: Builder - Compile whisper.cpp
+# ============================================================================
+FROM debian:bookworm-slim AS whisper-builder
+
+# Install only build dependencies needed for whisper.cpp
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates git cmake build-essential pkg-config \
+        libopenblas-dev liblapack-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+# Build whisper.cpp
+# Using v1.7.4 - newer versions have better cross-platform SIMD support
+# Note: In 1.6+ the binary is 'whisper-cli' (was 'main') and 'whisper-quantize' (was 'quantize')
+# GGML_NATIVE=OFF disables -mcpu=native which fails under QEMU emulation (Apple Silicon -> x86_64)
+RUN git clone https://github.com/ggerganov/whisper.cpp.git /tmp/whisper.cpp && \
+    cd /tmp/whisper.cpp && \
+    git checkout v1.7.4 && \
+    cmake -B build -DCMAKE_BUILD_TYPE=Release -DGGML_NATIVE=OFF && \
+    cmake --build build --config Release -j$(nproc)
+
+# ============================================================================
+# Stage 2: Final Image - FrankenPHP + PHP 8.3
+# ============================================================================
 FROM dunglas/frankenphp:php8.3-bookworm
 
-# Install system dependencies
-# Retry logic for network resilience (common issue with deb.debian.org connectivity)
+# Install runtime and build dependencies, build PHP extensions, then cleanup
+# This is done in a single RUN to minimize layer size
 RUN set -eux; \
+    # Retry logic for network resilience
     for i in 1 2 3; do \
         apt-get update && \
         apt-get install -y --fix-missing --no-install-recommends \
+            # Runtime dependencies (kept)
             git curl unzip jq \
+            libpng16-16 libonig5 libxml2 libzip4 \
+            libfreetype6 libjpeg62-turbo libwebp7 \
+            libsodium23 libffi8 \
+            ghostscript imagemagick libmagickwand-6.q16-6 poppler-utils \
+            libopenblas0-pthread \
+            ffmpeg libavcodec-extra59 \
+            libc-client2007e libkrb5-3 \
+            # Build dependencies (will be removed)
             libpng-dev libonig-dev libxml2-dev libzip-dev \
             libfreetype6-dev libjpeg62-turbo-dev libwebp-dev \
             libsodium-dev libffi-dev \
-            ghostscript imagemagick libmagickwand-dev poppler-utils \
-            build-essential cmake pkg-config \
-            libopenblas-dev liblapack-dev gfortran \
-            ffmpeg libavcodec-extra libavformat-dev libavutil-dev \
-            libswscale-dev libavfilter-dev libswresample-dev \
-            libx264-dev libx265-dev libvpx-dev libmp3lame-dev libopus-dev \
+            libmagickwand-dev \
             libc-client-dev libkrb5-dev && \
         rm -rf /var/lib/apt/lists/* && \
         break || sleep 10; \
-    done
+    done && \
+    # Install PHP extensions (requires -dev packages)
+    install-php-extensions \
+        pdo_mysql mysqli \
+        exif pcntl bcmath gd imagick zip sodium ffi \
+        grpc intl opcache imap && \
+    # Remove build dependencies to save space (~350-400MB)
+    apt-get purge -y --auto-remove \
+        libpng-dev libonig-dev libxml2-dev libzip-dev \
+        libfreetype6-dev libjpeg62-turbo-dev libwebp-dev \
+        libsodium-dev libffi-dev \
+        libmagickwand-dev \
+        libc-client-dev libkrb5-dev \
+        # Also remove compiler tools pulled in as dependencies
+        gcc g++ cpp libgcc-*-dev libstdc++-*-dev libc6-dev \
+        libssl-dev libicu-dev && \
+    rm -rf /var/lib/apt/lists/*
 
 # Install protoc (pinned version for consistent proto generation)
 # This version is also used in CI (.github/workflows/ci.yml extracts it via grep)
@@ -31,39 +75,21 @@ RUN curl -Lo /tmp/protoc.zip "https://github.com/protocolbuffers/protobuf/releas
     && chmod +x /usr/local/bin/protoc \
     && rm /tmp/protoc.zip
 
-WORKDIR /var/www/backend
+# Copy whisper.cpp binaries and libraries from builder stage
+COPY --from=whisper-builder /tmp/whisper.cpp/build/bin/whisper-cli /usr/local/bin/whisper
+COPY --from=whisper-builder /tmp/whisper.cpp/build/bin/quantize /usr/local/bin/whisper-quantize
+COPY --from=whisper-builder /tmp/whisper.cpp/build/src/libwhisper.so.1.7.4 /usr/local/lib/
+COPY --from=whisper-builder /tmp/whisper.cpp/build/ggml/src/libggml.so /usr/local/lib/
+COPY --from=whisper-builder /tmp/whisper.cpp/build/ggml/src/libggml-cpu.so /usr/local/lib/
+COPY --from=whisper-builder /tmp/whisper.cpp/build/ggml/src/libggml-base.so /usr/local/lib/
 
-# Install whisper.cpp
-# Using v1.7.4 - newer versions have better cross-platform SIMD support
-# Note: In 1.6+ the binary is 'whisper-cli' (was 'main') and 'whisper-quantize' (was 'quantize')
-# GGML_NATIVE=OFF disables -mcpu=native which fails under QEMU emulation (Apple Silicon -> x86_64)
-# CRITICAL: Must copy shared libraries (libwhisper.so, libggml*.so) AND run ldconfig!
-RUN cd /tmp && \
-    git clone https://github.com/ggerganov/whisper.cpp.git && \
-    cd whisper.cpp && \
-    git checkout v1.7.4 && \
-    cmake -B build -DCMAKE_BUILD_TYPE=Release -DGGML_NATIVE=OFF && \
-    cmake --build build --config Release -j$(nproc) && \
-    # Copy binaries
-    cp build/bin/whisper-cli /usr/local/bin/whisper && \
-    cp build/bin/quantize /usr/local/bin/whisper-quantize && \
-    chmod +x /usr/local/bin/whisper* && \
-    # Copy shared libraries (required for binaries to work!)
-    cp build/src/libwhisper.so.1.7.4 /usr/local/lib/ && \
+# Set up whisper binaries and libraries
+RUN chmod +x /usr/local/bin/whisper* && \
     ln -sf libwhisper.so.1.7.4 /usr/local/lib/libwhisper.so.1 && \
     ln -sf libwhisper.so.1 /usr/local/lib/libwhisper.so && \
-    cp build/ggml/src/libggml.so /usr/local/lib/ && \
-    cp build/ggml/src/libggml-cpu.so /usr/local/lib/ && \
-    cp build/ggml/src/libggml-base.so /usr/local/lib/ && \
-    # Update library cache so binaries can find the libs
-    ldconfig && \
-    cd / && rm -rf /tmp/whisper.cpp
+    ldconfig
 
-# Install PHP extensions
-RUN install-php-extensions \
-    pdo_mysql mysqli \
-    exif pcntl bcmath gd imagick zip sodium ffi \
-    grpc intl opcache imap
+WORKDIR /var/www/backend
 
 # PHP Configuration
 RUN mkdir -p /var/www/uploads && chmod 777 /var/www/uploads && \
@@ -99,11 +125,16 @@ ENV WHISPER_BINARY=/usr/local/bin/whisper \
     RASTERIZE_TIMEOUT_MS=30000
 
 # Copy application (exclude .env files - use environment variables instead)
-COPY backend/ .
+COPY --chown=www-data:www-data backend/ .
 RUN rm -f .env .env.example .env.local .env.*.local
 
 # Generate gRPC proto files using composer script (single source of truth)
 RUN composer proto:generate
+
+# Create directories before composer install to avoid permission layer duplication
+RUN mkdir -p /var/www/backend/var/cache /var/www/backend/var/log /var/www/backend/var/uploads /var/www/backend/var/whisper /var/www/backend/public/up && \
+    chown -R www-data:www-data /var/www/backend/var /var/www/backend/public/up && \
+    chmod -R 775 /var/www/backend/var /var/www/backend/public/up
 
 # Install dependencies with production optimizations
 # Flags explained:
@@ -114,12 +145,8 @@ RUN composer proto:generate
 #   This is safe for Symfony apps where all classes are autoloaded via composer
 #   Provides significant performance improvement by eliminating file_exists() calls
 # Cache is cleared on container startup anyway via docker-entrypoint.sh
-RUN composer install --prefer-dist --no-interaction --no-dev --no-scripts --optimize-autoloader --classmap-authoritative --ignore-platform-req=ext-redis
-
-# Set proper permissions for www-data (uid:gid = 33:33)
-RUN mkdir -p /var/www/backend/var/cache /var/www/backend/var/log /var/www/backend/var/uploads /var/www/backend/var/whisper /var/www/backend/public/up && \
-    chown -R www-data:www-data /var/www/backend/var /var/www/backend/vendor /var/www/backend/public/up && \
-    chmod -R 775 /var/www/backend/var /var/www/backend/public/up
+RUN composer install --prefer-dist --no-interaction --no-dev --no-scripts --optimize-autoloader --classmap-authoritative --ignore-platform-req=ext-redis && \
+    chown -R www-data:www-data /var/www/backend/vendor
 
 # Copy and setup entrypoint scripts
 COPY _docker/backend/docker-entrypoint.sh /usr/local/bin/


### PR DESCRIPTION
## Summary

Reduces image size of the built docker image by a few hundred mega bytes.

## Changes
- build whisper.cpp in a separate stage
- remove unneeded build deps after using them
- be smarter when using chmod

## Verification
- [ ] Not tested (explain)
- [ ] Manual
- [ ] Tests added/updated

## Notes
<!-- Related issues/links/threads. -->

## Screenshots/Logs
