### PR TITLE
fix(frontend): add ESC key and backdrop click handlers to widget modals

### DIFF
--- a/frontend/src/components/widgets/EmbedCodeDialog.vue
+++ b/frontend/src/components/widgets/EmbedCodeDialog.vue
@@ -3,6 +3,7 @@
   <div
     class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm"
     data-testid="modal-embed-code"
+    @click.self="$emit('close')"
   >
     <div
       class="surface-card rounded-2xl max-w-4xl w-full max-h-[90vh] flex flex-col shadow-2xl"
@@ -97,7 +98,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, onMounted, onUnmounted } from 'vue'
 import { Icon } from '@iconify/vue'
 import type { Widget } from '@/services/api/widgetsApi'
 import { useNotification } from '@/composables/useNotification'
@@ -110,7 +111,7 @@ interface Props {
 }
 
 defineProps<Props>()
-defineEmits<{
+const emit = defineEmits<{
   close: []
 }>()
 
@@ -135,4 +136,23 @@ const copyToClipboard = async (text: string, type: string) => {
     console.error('Failed to copy:', error)
   }
 }
+
+/**
+ * Handle ESC key press
+ */
+const handleEscape = (event: KeyboardEvent) => {
+  if (event.key === 'Escape') {
+    emit('close')
+  }
+}
+
+onMounted(() => {
+  // Add ESC key listener
+  window.addEventListener('keydown', handleEscape)
+})
+
+onUnmounted(() => {
+  // Remove ESC key listener
+  window.removeEventListener('keydown', handleEscape)
+})
 </script>

--- a/frontend/src/components/widgets/WidgetEditorModal.vue
+++ b/frontend/src/components/widgets/WidgetEditorModal.vue
@@ -3,6 +3,7 @@
   <div
     class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm"
     data-testid="modal-widget-editor"
+    @click.self="$emit('close')"
   >
     <div
       class="surface-card rounded-2xl max-w-4xl w-full max-h-[90vh] overflow-y-auto shadow-2xl"
@@ -466,7 +467,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, watch } from 'vue'
+import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
 import { Icon } from '@iconify/vue'
 import type { Widget, WidgetConfig } from '@/services/api/widgetsApi'
 import { promptsApi } from '@/services/api/promptsApi'
@@ -894,6 +895,15 @@ const handleSave = () => {
   emit('save', data)
 }
 
+/**
+ * Handle ESC key press
+ */
+const handleEscape = (event: KeyboardEvent) => {
+  if (event.key === 'Escape') {
+    emit('close')
+  }
+}
+
 onMounted(() => {
   if (isEdit.value) {
     if (props.widget) {
@@ -912,5 +922,13 @@ onMounted(() => {
       pushAllowedDomain(window.location.host)
     }
   }
+
+  // Add ESC key listener
+  window.addEventListener('keydown', handleEscape)
+})
+
+onUnmounted(() => {
+  // Remove ESC key listener
+  window.removeEventListener('keydown', handleEscape)
 })
 </script>


### PR DESCRIPTION
## Summary
Widget modals (Edit and Embed Code) can now be closed by pressing ESC or clicking outside the modal.

## Changes
- Added `@click.self` handler to modal overlays in `WidgetEditorModal` and `EmbedCodeDialog` to close on backdrop click
- Added ESC key event listeners using `onMounted`/`onUnmounted` lifecycle hooks
- Properly clean up event listeners on component unmount

## Verification
- [x] Manual
- [ ] Tests added/updated
- [ ] Not tested (explain)

Tested manually in browser at http://localhost:5173/tools/chat-widget:
1. Opened "Get Code" modal → ESC key closes it ✓
2. Opened "Get Code" modal → clicking backdrop closes it ✓
3. Opened "Edit" modal → ESC key closes it ✓
4. Opened "Edit" modal → clicking backdrop closes it ✓

## Notes
Fixes user-reported issue where widget modals could only be closed using the X button, making the UX frustrating for users expecting standard modal behavior.