### PR TITLE
fix(widget): prevent loading when widget status is inactive

### DIFF
--- a/frontend/src/widget.ts
+++ b/frontend/src/widget.ts
@@ -97,7 +97,12 @@ class SynaplanWidget {
    * Lazy mode: Show button, load chat on click
    */
   private async startLazy() {
-    await this.loadRemoteConfig()
+    const configLoaded = await this.loadRemoteConfig()
+    if (!configLoaded) {
+      console.warn('Synaplan Widget: Widget is not active or unavailable')
+      return
+    }
+
     this.createButton()
 
     if (this.config?.autoOpen) {
@@ -109,12 +114,17 @@ class SynaplanWidget {
    * Eager mode: Load chat immediately
    */
   private async startEager() {
-    await this.loadRemoteConfig()
+    const configLoaded = await this.loadRemoteConfig()
+    if (!configLoaded) {
+      console.warn('Synaplan Widget: Widget is not active or unavailable')
+      return
+    }
+
     await this.loadChat()
   }
 
-  private async loadRemoteConfig(): Promise<void> {
-    if (!this.config || this.config.isPreview) return
+  private async loadRemoteConfig(): Promise<boolean> {
+    if (!this.config || this.config.isPreview) return true
 
     try {
       const apiUrl = this.config.apiUrl || ''
@@ -124,7 +134,16 @@ class SynaplanWidget {
         },
       })
 
-      if (!response.ok) return
+      if (!response.ok) {
+        if (response.status === 503) {
+          console.warn('Synaplan Widget: Widget is not active (503 Service Unavailable)')
+        } else if (response.status === 404) {
+          console.error('Synaplan Widget: Widget not found (404)')
+        } else {
+          console.error(`Synaplan Widget: Failed to load config (${response.status})`)
+        }
+        return false
+      }
 
       const data = await response.json()
 
@@ -134,9 +153,13 @@ class SynaplanWidget {
           ...data.config,
           widgetTitle: data.name || this.config.widgetTitle,
         }
+        return true
       }
+
+      return false
     } catch (error) {
-      console.warn('Synaplan Widget: Failed to load remote config', error)
+      console.error('Synaplan Widget: Failed to load remote config', error)
+      return false
     }
   }
 


### PR DESCRIPTION
## Summary
Inactive widgets no longer load or display on client websites, preventing resource usage and avoiding confusion when widgets are intentionally disabled.

## Changes
- Modified `widget.ts` `loadRemoteConfig()` to return boolean indicating success/failure
- Added early return in `startLazy()` and `startEager()` when config loading fails
- Enhanced error handling with specific status code logging (503 for inactive, 404 for not found)
- Widget now respects backend's `isActive()` check from `/api/v1/widget/{widgetId}/config` endpoint
- Console warnings inform developers when widget fails to load due to inactive status

## Verification
- [x] Manual
- [ ] Tests added/updated
- [ ] Not tested (explain)

**Testing Steps:**
1. Set widget status to "inactive" in admin panel
2. Load page with widget embed code
3. Verify widget button does not appear
4. Check console for warning: "Synaplan Widget: Widget is not active or unavailable"
5. Set widget back to "active"
6. Verify widget loads normally

## Notes
Closes #332

Backend already returns 503 Service Unavailable when `WidgetService::isWidgetActive()` returns false (checks both widget status and owner rate limits). Frontend now properly handles this response and prevents widget initialization.