### PR TITLE
feat(frontend): add password visibility toggle to login and registration pages

### DIFF
--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -1267,7 +1267,9 @@
     "sessionExpired": "Sitzung abgelaufen",
     "sessionExpiredDesc": "Deine Sitzung ist abgelaufen. Bitte melde dich erneut an, um fortzufahren.",
     "authenticationRequired": "Anmeldung erforderlich. Bitte melde dich an, um fortzufahren.",
-    "tokenRefreshFailed": "Sitzung konnte nicht erneuert werden. Bitte melde dich erneut an."
+    "tokenRefreshFailed": "Sitzung konnte nicht erneuert werden. Bitte melde dich erneut an.",
+    "showPassword": "Passwort anzeigen",
+    "hidePassword": "Passwort ausblenden"
   },
   "cookies": {
     "title": "Cookie-Einstellungen",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -1078,7 +1078,9 @@
     "sessionExpired": "Session Expired",
     "sessionExpiredDesc": "Your session has expired. Please log in again to continue.",
     "authenticationRequired": "Authentication required. Please log in to continue.",
-    "tokenRefreshFailed": "Failed to refresh your session. Please log in again."
+    "tokenRefreshFailed": "Failed to refresh your session. Please log in again.",
+    "showPassword": "Show password",
+    "hidePassword": "Hide password"
   },
   "unsavedChanges": {
     "title": "You have unsaved changes",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -334,7 +334,9 @@
     "passwordResetSuccessDesc": "Si existe una cuenta con esta dirección de correo, te hemos enviado un enlace para restablecer tu contraseña. Por favor revisa tu bandeja de entrada.",
     "recaptchaError": "Error de verificación reCAPTCHA. Por favor intenta de nuevo.",
     "backToHomepage": "← Volver a www.synaplan.com",
-    "hostingTermsNote": "Aplican los términos y condiciones de la plataforma de hosting."
+    "hostingTermsNote": "Aplican los términos y condiciones de la plataforma de hosting.",
+    "showPassword": "Mostrar contraseña",
+    "hidePassword": "Ocultar contraseña"
   },
   "unsavedChanges": {
     "title": "Tienes cambios sin guardar",

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -334,7 +334,9 @@
     "passwordResetSuccessDesc": "Bu e-posta adresiyle bir hesap varsa, şifre sıfırlama bağlantısı gönderdik. Lütfen gelen kutunuzu kontrol edin.",
     "recaptchaError": "reCAPTCHA doğrulaması başarısız. Lütfen tekrar deneyin.",
     "backToHomepage": "← www.synaplan.com'a geri dön",
-    "hostingTermsNote": "Barındırma platformunun kullanım koşulları geçerlidir."
+    "hostingTermsNote": "Barındırma platformunun kullanım koşulları geçerlidir.",
+    "showPassword": "Şifreyi göster",
+    "hidePassword": "Şifreyi gizle"
   },
   "unsavedChanges": {
     "title": "Kaydedilmemiş değişiklikleriniz var",

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -60,15 +60,27 @@
             <label for="password" class="block text-sm font-medium txt-primary mb-2">
               {{ $t('auth.password') }}
             </label>
-            <input
-              id="password"
-              v-model="password"
-              type="password"
-              required
-              class="w-full px-4 py-3 rounded-lg surface-chip txt-primary placeholder:txt-secondary focus:outline-none focus:ring-2 focus:ring-[var(--brand)] transition-colors border-0"
-              :placeholder="$t('auth.password')"
-              data-testid="input-password"
-            />
+            <div class="relative">
+              <input
+                id="password"
+                v-model="password"
+                :type="showPassword ? 'text' : 'password'"
+                required
+                class="w-full px-4 py-3 pr-12 rounded-lg surface-chip txt-primary placeholder:txt-secondary focus:outline-none focus:ring-2 focus:ring-[var(--brand)] transition-colors border-0"
+                :placeholder="$t('auth.password')"
+                data-testid="input-password"
+              />
+              <button
+                type="button"
+                class="absolute right-3 top-1/2 -translate-y-1/2 p-1 rounded txt-secondary hover:txt-primary transition-colors focus:outline-none focus:ring-2 focus:ring-[var(--brand)]"
+                :aria-label="showPassword ? $t('auth.hidePassword') : $t('auth.showPassword')"
+                data-testid="btn-toggle-password"
+                @click="showPassword = !showPassword"
+              >
+                <EyeSlashIcon v-if="showPassword" class="w-5 h-5" />
+                <EyeIcon v-else class="w-5 h-5" />
+              </button>
+            </div>
           </div>
 
           <div class="flex items-center justify-end">
@@ -210,7 +222,7 @@
 import { ref, computed, onMounted } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import { useI18n } from 'vue-i18n'
-import { SunIcon, MoonIcon } from '@heroicons/vue/24/outline'
+import { SunIcon, MoonIcon, EyeIcon, EyeSlashIcon } from '@heroicons/vue/24/outline'
 import { useTheme } from '../composables/useTheme'
 import { useAuth } from '../composables/useAuth'
 import { useRecaptcha } from '../composables/useRecaptcha'
@@ -240,6 +252,7 @@ const logoSrc = computed(
 
 const email = ref('')
 const password = ref('')
+const showPassword = ref(false)
 
 const currentLanguage = computed(() => locale.value)
 

--- a/frontend/src/views/RegisterView.vue
+++ b/frontend/src/views/RegisterView.vue
@@ -119,16 +119,28 @@
             <label for="password" class="block text-sm font-medium txt-primary mb-2">
               {{ $t('auth.password') }}
             </label>
-            <input
-              id="password"
-              v-model="password"
-              type="password"
-              required
-              class="w-full px-4 py-3 rounded-lg surface-chip txt-primary placeholder:txt-secondary focus:outline-none focus:ring-2 focus:ring-[var(--brand)] transition-colors border-0"
-              :class="{ 'ring-2 ring-red-500': passwordErrors.length > 0 }"
-              :placeholder="$t('auth.password')"
-              data-testid="input-password"
-            />
+            <div class="relative">
+              <input
+                id="password"
+                v-model="password"
+                :type="showPassword ? 'text' : 'password'"
+                required
+                class="w-full px-4 py-3 pr-12 rounded-lg surface-chip txt-primary placeholder:txt-secondary focus:outline-none focus:ring-2 focus:ring-[var(--brand)] transition-colors border-0"
+                :class="{ 'ring-2 ring-red-500': passwordErrors.length > 0 }"
+                :placeholder="$t('auth.password')"
+                data-testid="input-password"
+              />
+              <button
+                type="button"
+                class="absolute right-3 top-1/2 -translate-y-1/2 p-1 rounded txt-secondary hover:txt-primary transition-colors focus:outline-none focus:ring-2 focus:ring-[var(--brand)]"
+                :aria-label="showPassword ? $t('auth.hidePassword') : $t('auth.showPassword')"
+                data-testid="btn-toggle-password"
+                @click="showPassword = !showPassword"
+              >
+                <EyeSlashIcon v-if="showPassword" class="w-5 h-5" />
+                <EyeIcon v-else class="w-5 h-5" />
+              </button>
+            </div>
             <div v-if="passwordErrors.length > 0" class="mt-2 space-y-1">
               <p
                 v-for="err in passwordErrors"
@@ -144,15 +156,29 @@
             <label for="confirmPassword" class="block text-sm font-medium txt-primary mb-2">
               {{ $t('auth.confirmPassword') }}
             </label>
-            <input
-              id="confirmPassword"
-              v-model="confirmPassword"
-              type="password"
-              required
-              class="w-full px-4 py-3 rounded-lg surface-chip txt-primary placeholder:txt-secondary focus:outline-none focus:ring-2 focus:ring-[var(--brand)] transition-colors border-0"
-              :placeholder="$t('auth.confirmPassword')"
-              data-testid="input-confirm-password"
-            />
+            <div class="relative">
+              <input
+                id="confirmPassword"
+                v-model="confirmPassword"
+                :type="showConfirmPassword ? 'text' : 'password'"
+                required
+                class="w-full px-4 py-3 pr-12 rounded-lg surface-chip txt-primary placeholder:txt-secondary focus:outline-none focus:ring-2 focus:ring-[var(--brand)] transition-colors border-0"
+                :placeholder="$t('auth.confirmPassword')"
+                data-testid="input-confirm-password"
+              />
+              <button
+                type="button"
+                class="absolute right-3 top-1/2 -translate-y-1/2 p-1 rounded txt-secondary hover:txt-primary transition-colors focus:outline-none focus:ring-2 focus:ring-[var(--brand)]"
+                :aria-label="
+                  showConfirmPassword ? $t('auth.hidePassword') : $t('auth.showPassword')
+                "
+                data-testid="btn-toggle-confirm-password"
+                @click="showConfirmPassword = !showConfirmPassword"
+              >
+                <EyeSlashIcon v-if="showConfirmPassword" class="w-5 h-5" />
+                <EyeIcon v-else class="w-5 h-5" />
+              </button>
+            </div>
           </div>
 
           <!-- Error Message -->
@@ -353,7 +379,7 @@
 import { ref, computed, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
-import { SunIcon, MoonIcon } from '@heroicons/vue/24/outline'
+import { SunIcon, MoonIcon, EyeIcon, EyeSlashIcon } from '@heroicons/vue/24/outline'
 import { useTheme } from '../composables/useTheme'
 import { useAuth } from '../composables/useAuth'
 import { useRecaptcha } from '../composables/useRecaptcha'
@@ -384,6 +410,8 @@ const fullName = ref('')
 const email = ref('')
 const password = ref('')
 const confirmPassword = ref('')
+const showPassword = ref(false)
+const showConfirmPassword = ref(false)
 
 const currentLanguage = computed(() => locale.value)
 


### PR DESCRIPTION
## Summary
Add eye icon buttons next to password fields on login and registration pages to allow users to show/hide their password input.

## Changes
- Added password visibility toggle button to `LoginView.vue` (1 password field)
- Added password visibility toggle buttons to `RegisterView.vue` (2 password fields: password + confirm password)
- Added translations for `showPassword` and `hidePassword` in all 4 languages (EN, DE, ES, TR)
- Used `EyeIcon` and `EyeSlashIcon` from Heroicons for consistent iconography

## Verification
- [ ] Not tested (explain)
- [x] Manual
- [ ] Tests added/updated

## Notes
- Follows existing design patterns with `txt-secondary hover:txt-primary` styling
- Button includes proper `aria-label` for accessibility
- Toggle state is independent per field (password and confirm password can be toggled separately)

## Screenshots/Logs
N/A