### PR TITLE
fix: WhatsApp message handling improvements and Discord classification logging

### DIFF
--- a/backend/src/Service/Message/MessageClassifier.php
+++ b/backend/src/Service/Message/MessageClassifier.php
@@ -142,6 +142,8 @@ class MessageClassifier
             'topic' => $result['topic'],
             'language' => $result['language'],
             'web_search' => $result['web_search'] ?? false,
+            'media_type' => $result['media_type'] ?? null,
+            'duration' => $result['duration'] ?? null,
             'raw_ai_response' => $result['raw_response'] ?? 'N/A',
         ]);
 

--- a/backend/src/Service/Message/MessageSorter.php
+++ b/backend/src/Service/Message/MessageSorter.php
@@ -4,6 +4,7 @@ namespace App\Service\Message;
 
 use App\AI\Service\AiFacade;
 use App\Repository\PromptRepository;
+use App\Service\DiscordNotificationService;
 use App\Service\ModelConfigService;
 use App\Service\PromptService;
 use Psr\Log\LoggerInterface;
@@ -34,6 +35,7 @@ class MessageSorter
         private ModelConfigService $modelConfigService,
         private PromptService $promptService,
         private LoggerInterface $logger,
+        private DiscordNotificationService $discord,
     ) {
     }
 
@@ -194,8 +196,23 @@ class MessageSorter
                 'topic' => $parsed['topic'],
                 'language' => $parsed['language'],
                 'web_search' => $parsed['web_search'] ?? false,
+                'media_type' => $parsed['media_type'] ?? null,
+                'duration' => $parsed['duration'] ?? null,
                 'raw_ai_response' => $aiResponse,
             ]);
+
+            // Send Discord notification for debugging classification issues
+            $this->discord->notifyClassification(
+                $messageData['BTEXT'] ?? '',
+                [
+                    'topic' => $parsed['topic'],
+                    'language' => $parsed['language'],
+                    'media_type' => $parsed['media_type'] ?? null,
+                    'duration' => $parsed['duration'] ?? null,
+                    'raw_response' => $aiResponse,
+                ],
+                $userId
+            );
 
             $promptMetadata = [];
             if (!empty($parsed['topic'])) {

--- a/backend/tests/Unit/MessageSorterTest.php
+++ b/backend/tests/Unit/MessageSorterTest.php
@@ -4,6 +4,7 @@ namespace App\Tests\Unit;
 
 use App\AI\Service\AiFacade;
 use App\Repository\PromptRepository;
+use App\Service\DiscordNotificationService;
 use App\Service\Message\MessageSorter;
 use App\Service\ModelConfigService;
 use App\Service\PromptService;
@@ -24,13 +25,15 @@ class MessageSorterTest extends TestCase
         $modelConfigService = $this->createMock(ModelConfigService::class);
         $promptService = $this->createMock(PromptService::class);
         $logger = $this->createMock(LoggerInterface::class);
+        $discord = $this->createMock(DiscordNotificationService::class);
 
         $this->sorter = new MessageSorter(
             $aiFacade,
             $promptRepository,
             $modelConfigService,
             $promptService,
-            $logger
+            $logger,
+            $discord
         );
 
         // Make private methods accessible for testing


### PR DESCRIPTION
## Summary
Improve WhatsApp message handling by adding support for location, contacts, and sticker messages, fixing Markdown formatting for WhatsApp responses, and adding Discord logging for AI classification debugging.

## Changes
- **Location messages**: Parse and format WhatsApp location sharing (coordinates, name, address, Maps link)
- **Contact messages**: Parse and format WhatsApp contact sharing (name, phone numbers, emails)
- **Sticker messages**: Treat stickers as images for Vision AI analysis
- **WhatsApp Markdown**: Convert standard Markdown (`**bold**`, `~~strike~~`, headers) to WhatsApp syntax (`*bold*`, `~strike~`)
- **Discord classification logging**: Add `notifyClassification()` to send AI sorter results (topic, media_type, duration, raw response) to Discord for debugging
- **Enhanced logging**: Add `media_type` and `duration` to MessageSorter and MessageClassifier logs
- **Test fixes**: Update MessageSorterTest for new constructor, fix WhatsAppServiceTest for sticker support

## Verification
- [ ] Not tested (explain)
- [x] Manual
- [x] Tests added/updated

## Notes
- This PR helps debug the issue where video generation requests via WhatsApp result in image generation instead
- Discord will now show the full AI classification result including `media_type` detection
- If `media_type: ❌ NOT DETECTED` appears in Discord, the issue is in the AI sorter/prompt