### PR TITLE
fix(ui): teleport overlays to #app instead of body

### DIFF
--- a/frontend/src/components/ChatShareModal.vue
+++ b/frontend/src/components/ChatShareModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <Teleport to="body">
+  <Teleport to="#app">
     <Transition name="modal">
       <div
         v-if="isOpen"

--- a/frontend/src/components/ConfirmDialog.vue
+++ b/frontend/src/components/ConfirmDialog.vue
@@ -1,5 +1,5 @@
 <template>
-  <Teleport to="body">
+  <Teleport to="#app">
     <Transition name="modal">
       <div
         v-if="isOpen"

--- a/frontend/src/components/CookieConsent.vue
+++ b/frontend/src/components/CookieConsent.vue
@@ -1,5 +1,5 @@
 <template>
-  <Teleport to="body">
+  <Teleport to="#app">
     <Transition
       enter-active-class="transition-all duration-300 ease-out"
       enter-from-class="translate-y-full opacity-0"

--- a/frontend/src/components/FileContentModal.vue
+++ b/frontend/src/components/FileContentModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <Teleport to="body">
+  <Teleport to="#app">
     <Transition name="modal">
       <div
         v-if="isOpen"

--- a/frontend/src/components/FileSelectionModal.vue
+++ b/frontend/src/components/FileSelectionModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <Teleport to="body">
+  <Teleport to="#app">
     <Transition name="modal">
       <div
         v-if="visible"

--- a/frontend/src/components/MemoriesDialog.vue
+++ b/frontend/src/components/MemoriesDialog.vue
@@ -1,5 +1,5 @@
 <template>
-  <Teleport to="body">
+  <Teleport to="#app">
     <Transition name="fade">
       <div
         v-if="isOpen"

--- a/frontend/src/components/MemoryToast.vue
+++ b/frontend/src/components/MemoryToast.vue
@@ -1,5 +1,5 @@
 <template>
-  <Teleport to="body">
+  <Teleport to="#app">
     <TransitionGroup name="toast-slide" tag="div" class="fixed bottom-4 right-4 z-50 space-y-2">
       <div
         v-for="memory in memories"

--- a/frontend/src/components/MessageImage.vue
+++ b/frontend/src/components/MessageImage.vue
@@ -35,8 +35,8 @@
     <p v-if="alt" class="mt-2 text-sm txt-secondary">{{ alt }}</p>
   </div>
 
-  <!-- Fullscreen Modal - Teleported to body to ensure highest z-index -->
-  <Teleport to="body">
+  <!-- Fullscreen Modal - Teleported to #app to overlay other app content -->
+  <Teleport to="#app">
     <Transition
       enter-active-class="transition-opacity duration-300"
       enter-from-class="opacity-0"

--- a/frontend/src/components/NotificationContainer.vue
+++ b/frontend/src/components/NotificationContainer.vue
@@ -1,7 +1,7 @@
 <template>
-  <Teleport to="body">
+  <Teleport to="#app">
     <div
-      class="fixed top-4 right-4 z-[9999] flex flex-col gap-3 pointer-events-none"
+      class="absolute top-4 right-4 z-[9999] flex flex-col gap-3 pointer-events-none"
       data-testid="comp-notification-container"
     >
       <TransitionGroup

--- a/frontend/src/components/PromoTipBanner.vue
+++ b/frontend/src/components/PromoTipBanner.vue
@@ -59,7 +59,7 @@
   </Transition>
 
   <!-- Expanded: Full-screen centered modal with blurred backdrop -->
-  <Teleport to="body">
+  <Teleport to="#app">
     <Transition
       enter-active-class="transition-all duration-300 ease-out"
       enter-from-class="opacity-0"

--- a/frontend/src/components/ShareModal.vue
+++ b/frontend/src/components/ShareModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <Teleport to="body">
+  <Teleport to="#app">
     <Transition name="modal">
       <div
         v-if="isOpen"

--- a/frontend/src/components/SidebarV2.vue
+++ b/frontend/src/components/SidebarV2.vue
@@ -85,8 +85,8 @@
     </div>
   </aside>
 
-  <!-- User Dropdown (teleported to body to escape stacking context) -->
-  <Teleport to="body">
+  <!-- User Dropdown (teleported to #app to escape local stacking context) -->
+  <Teleport to="#app">
     <Transition
       enter-active-class="transition ease-out duration-150"
       enter-from-class="opacity-0 scale-95"
@@ -176,8 +176,8 @@
     </Transition>
   </Teleport>
 
-  <!-- Nav Children Dropdown (teleported to body to escape stacking context) -->
-  <Teleport to="body">
+  <!-- Nav Children Dropdown (teleported to #app to escape local stacking context) -->
+  <Teleport to="#app">
     <Transition
       enter-active-class="transition ease-out duration-150"
       enter-from-class="opacity-0 scale-95"
@@ -253,7 +253,7 @@
   </Teleport>
 
   <!-- Chat Management Modal -->
-  <Teleport to="body">
+  <Teleport to="#app">
     <Transition name="modal">
       <div
         v-if="chatModalOpen"

--- a/frontend/src/components/common/ExternalLinkWarning.vue
+++ b/frontend/src/components/common/ExternalLinkWarning.vue
@@ -51,7 +51,7 @@ defineExpose({ shouldShowWarning })
 </script>
 
 <template>
-  <Teleport to="body">
+  <Teleport to="#app">
     <Transition name="fade">
       <div
         v-if="isOpen"

--- a/frontend/src/components/common/LimitReachedModal.vue
+++ b/frontend/src/components/common/LimitReachedModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <Teleport to="body">
+  <Teleport to="#app">
     <Transition name="modal">
       <div
         v-if="isOpen"

--- a/frontend/src/components/config/APIKeysConfiguration.vue
+++ b/frontend/src/components/config/APIKeysConfiguration.vue
@@ -274,7 +274,7 @@
     </div>
 
     <!-- API Key Created Modal -->
-    <Teleport to="body">
+    <Teleport to="#app">
       <Transition
         enter-active-class="transition-opacity duration-200"
         leave-active-class="transition-opacity duration-150"

--- a/frontend/src/components/feedback/ContradictionModal.vue
+++ b/frontend/src/components/feedback/ContradictionModal.vue
@@ -96,7 +96,7 @@ function handleCancel() {
 </script>
 
 <template>
-  <Teleport to="body">
+  <Teleport to="#app">
     <Transition name="modal">
       <div
         v-if="isOpen"

--- a/frontend/src/components/feedback/FalsePositiveModal.vue
+++ b/frontend/src/components/feedback/FalsePositiveModal.vue
@@ -359,7 +359,7 @@ const isMemory = computed(() => props.classification === 'memory')
 </script>
 
 <template>
-  <Teleport to="body">
+  <Teleport to="#app">
     <Transition name="fade">
       <div
         v-if="isOpen"

--- a/frontend/src/components/help/HelpDialog.vue
+++ b/frontend/src/components/help/HelpDialog.vue
@@ -1,5 +1,5 @@
 <template>
-  <Teleport to="body">
+  <Teleport to="#app">
     <Transition
       enter-active-class="transition-opacity duration-200"
       enter-from-class="opacity-0"

--- a/frontend/src/components/help/HelpTour.vue
+++ b/frontend/src/components/help/HelpTour.vue
@@ -1,5 +1,5 @@
 <template>
-  <Teleport to="body">
+  <Teleport to="#app">
     <Transition
       enter-active-class="transition-opacity duration-200"
       enter-from-class="opacity-0"

--- a/frontend/src/components/memories/MemoryDeleteDialog.vue
+++ b/frontend/src/components/memories/MemoryDeleteDialog.vue
@@ -1,5 +1,5 @@
 <template>
-  <Teleport to="body">
+  <Teleport to="#app">
     <Transition name="fade">
       <div
         v-if="isOpen"

--- a/frontend/src/components/memories/MemoryEditDialog.vue
+++ b/frontend/src/components/memories/MemoryEditDialog.vue
@@ -98,7 +98,7 @@ function handleBackdropClick(event: MouseEvent) {
 </script>
 
 <template>
-  <Teleport to="body">
+  <Teleport to="#app">
     <div
       class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50"
       @click="handleBackdropClick"

--- a/frontend/src/components/memories/MemorySuggestionToast.vue
+++ b/frontend/src/components/memories/MemorySuggestionToast.vue
@@ -62,7 +62,7 @@ function handleClose() {
 </script>
 
 <template>
-  <Teleport to="body">
+  <Teleport to="#app">
     <Transition
       enter-active-class="transition-all duration-300"
       enter-from-class="opacity-0 translate-y-4"

--- a/frontend/src/components/summary/SummaryResultModal.vue
+++ b/frontend/src/components/summary/SummaryResultModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <Teleport to="body">
+  <Teleport to="#app">
     <Transition name="modal">
       <div
         v-if="isOpen"

--- a/frontend/src/components/widgets/AdvancedWidgetConfig.vue
+++ b/frontend/src/components/widgets/AdvancedWidgetConfig.vue
@@ -1,5 +1,5 @@
 <template>
-  <Teleport to="body">
+  <Teleport to="#app">
     <div
       class="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm flex items-center justify-center p-2 sm:p-4"
       data-testid="modal-advanced-config"

--- a/frontend/src/components/widgets/FilePicker.vue
+++ b/frontend/src/components/widgets/FilePicker.vue
@@ -1,5 +1,5 @@
 <template>
-  <Teleport to="body">
+  <Teleport to="#app">
     <Transition name="modal">
       <div
         v-if="isOpen"

--- a/frontend/src/components/widgets/SetupChatModal.vue
+++ b/frontend/src/components/widgets/SetupChatModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <Teleport to="body">
+  <Teleport to="#app">
     <div
       class="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm flex items-center justify-center p-4"
       data-testid="modal-setup-chat"

--- a/frontend/src/components/widgets/SimpleWidgetForm.vue
+++ b/frontend/src/components/widgets/SimpleWidgetForm.vue
@@ -1,5 +1,5 @@
 <template>
-  <Teleport to="body">
+  <Teleport to="#app">
     <div
       class="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm flex items-center justify-center p-4"
       data-testid="modal-simple-widget-form"

--- a/frontend/src/components/widgets/WidgetExportDialog.vue
+++ b/frontend/src/components/widgets/WidgetExportDialog.vue
@@ -1,5 +1,5 @@
 <template>
-  <Teleport to="body">
+  <Teleport to="#app">
     <div
       class="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4"
       @click.self="$emit('close')"

--- a/frontend/src/components/widgets/WidgetSuccessModal.vue
+++ b/frontend/src/components/widgets/WidgetSuccessModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <Teleport to="body">
+  <Teleport to="#app">
     <div
       class="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm flex items-center justify-center p-4"
       data-testid="modal-widget-success"

--- a/frontend/src/composables/useFullscreenTeleportTarget.ts
+++ b/frontend/src/composables/useFullscreenTeleportTarget.ts
@@ -6,10 +6,10 @@ import { onBeforeUnmount, onMounted, ref } from 'vue'
  * target that switches to document.fullscreenElement when present.
  */
 export function useFullscreenTeleportTarget() {
-  const teleportTarget = ref<HTMLElement | string>('body')
+  const teleportTarget = ref<HTMLElement | string>('#app')
 
   const update = () => {
-    teleportTarget.value = (document.fullscreenElement as HTMLElement | null) ?? 'body'
+    teleportTarget.value = (document.fullscreenElement as HTMLElement | null) ?? '#app'
   }
 
   onMounted(() => {

--- a/frontend/src/views/AdminView.vue
+++ b/frontend/src/views/AdminView.vue
@@ -574,7 +574,7 @@
     </div>
 
     <!-- Delete Confirmation Modal -->
-    <Teleport to="body">
+    <Teleport to="#app">
       <Transition name="modal">
         <div
           v-if="showDeleteModal"

--- a/frontend/src/views/FeedbackView.vue
+++ b/frontend/src/views/FeedbackView.vue
@@ -336,7 +336,7 @@
     </div>
 
     <!-- Delete Confirmation Dialog (single + bulk) -->
-    <Teleport to="body">
+    <Teleport to="#app">
       <Transition name="fade">
         <div
           v-if="deleteConfirmOpen"

--- a/frontend/src/views/FilesView.vue
+++ b/frontend/src/views/FilesView.vue
@@ -167,7 +167,7 @@
         </div>
 
         <!-- Folder Picker Modal -->
-        <Teleport to="body">
+        <Teleport to="#app">
           <Transition name="dialog-fade">
             <div
               v-if="folderPickerOpen"
@@ -772,7 +772,7 @@
     />
 
     <!-- Confirm Delete Selected Dialog (Multiple Files) -->
-    <Teleport to="body">
+    <Teleport to="#app">
       <Transition name="dialog-fade">
         <div
           v-if="isDeleteSelectedOpen"

--- a/frontend/src/views/MemoriesView.vue
+++ b/frontend/src/views/MemoriesView.vue
@@ -140,7 +140,7 @@
       </div>
 
       <!-- Fullscreen Overlay wenn Memories für User deaktiviert sind -->
-      <Teleport to="body">
+      <Teleport to="#app">
         <div
           v-if="!memoriesEnabledForUser"
           class="fixed inset-0 z-[9999] flex items-center justify-center p-4 bg-black/70 backdrop-blur-md"

--- a/frontend/src/views/ProfileView.vue
+++ b/frontend/src/views/ProfileView.vue
@@ -408,7 +408,7 @@
     <UnsavedChangesBar :show="hasUnsavedChanges" @save="handleSave" @discard="handleDiscard" />
 
     <!-- Delete Account Modal -->
-    <Teleport to="body">
+    <Teleport to="#app">
       <div
         v-if="showDeleteModal"
         class="fixed inset-0 bg-black/50 dark:bg-black/70 flex items-center justify-center z-50 px-4"

--- a/frontend/src/views/WidgetSessionsView.vue
+++ b/frontend/src/views/WidgetSessionsView.vue
@@ -624,7 +624,7 @@
       </div>
 
       <!-- Mobile/Tablet Summary Panel Overlay (< xl) -->
-      <Teleport to="body">
+      <Teleport to="#app">
         <Transition
           enter-active-class="transition-all duration-300 ease-out"
           enter-from-class="opacity-0"

--- a/frontend/src/views/WidgetsView.vue
+++ b/frontend/src/views/WidgetsView.vue
@@ -272,7 +272,7 @@
     />
 
     <!-- Test Chat Overlay -->
-    <Teleport to="body">
+    <Teleport to="#app">
       <div
         v-if="testWidget"
         class="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4"

--- a/frontend/tests/unit/MessageImage.spec.ts
+++ b/frontend/tests/unit/MessageImage.spec.ts
@@ -6,6 +6,12 @@ import MessageImage from '@/components/MessageImage.vue'
 describe('MessageImage', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
+    // Provide #app teleport target
+    if (!document.getElementById('app')) {
+      const app = document.createElement('div')
+      app.id = 'app'
+      document.body.appendChild(app)
+    }
   })
 
   it('should render image with correct src', async () => {

--- a/frontend/tests/unit/composables/useFullscreenTeleportTarget.spec.ts
+++ b/frontend/tests/unit/composables/useFullscreenTeleportTarget.spec.ts
@@ -22,8 +22,8 @@ describe('useFullscreenTeleportTarget', () => {
       setup() {
         const { teleportTarget } = useFullscreenTeleportTarget()
         const label = computed(() => {
-          if (teleportTarget.value === 'body') {
-            return 'body'
+          if (teleportTarget.value === '#app') {
+            return '#app'
           }
           return (teleportTarget.value as HTMLElement).tagName
         })
@@ -32,7 +32,7 @@ describe('useFullscreenTeleportTarget', () => {
     }
 
     const wrapper = mount(TestComponent)
-    expect(wrapper.text()).toContain('body')
+    expect(wrapper.text()).toContain('#app')
 
     const fsEl = document.createElement('div')
     ;(document.fullscreenElement as any) = fsEl
@@ -44,6 +44,6 @@ describe('useFullscreenTeleportTarget', () => {
     document.dispatchEvent(new Event('fullscreenchange'))
     await nextTick()
 
-    expect(wrapper.text()).toContain('body')
+    expect(wrapper.text()).toContain('#app')
   })
 })


### PR DESCRIPTION
## Summary
- Change all `<Teleport to="body">` to `<Teleport to="#app">` across 36 files
- Update `useFullscreenTeleportTarget` composable default from `body` to `#app`
- Switch notification container from `fixed` to `absolute` positioning

This ensures overlays render within the `#app` container instead of the viewport, so they position correctly when an external topbar occupies the top of the viewport.

## Test plan
- [x] Notifications appear below the VSAP topbar (not behind it)
- [ ] Modals/dialogs open correctly and are not clipped
- [ ] Fullscreen mode still shows overlays
- [ ] Standalone mode (no VSAP topbar) still works