### PR TITLE
fix: only show cookie consent banner when analytics is configured

### DIFF
--- a/frontend/src/components/CookieConsent.vue
+++ b/frontend/src/components/CookieConsent.vue
@@ -56,7 +56,9 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
 import { getStoredConsent, storeConsent, type CookieConsent } from '@/composables/useCookieConsent'
+import { useConfigStore } from '@/stores/config'
 
+const config = useConfigStore()
 const showBanner = ref(false)
 
 const emit = defineEmits<{
@@ -76,6 +78,9 @@ function rejectAll() {
 }
 
 onMounted(() => {
+  // Only show banner when analytics is configured (Google Tag enabled)
+  if (!config.googleTag.enabled) return
+
   // Show banner if no consent stored or consent version outdated
   const consent = getStoredConsent()
   if (!consent) {

--- a/frontend/tests/unit/components/CookieConsent.spec.ts
+++ b/frontend/tests/unit/components/CookieConsent.spec.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import CookieConsent from '@/components/CookieConsent.vue'
+
+const mockConfig = vi.hoisted(() => ({ googleTagEnabled: false }))
+
+vi.mock('@/stores/config', () => ({
+  useConfigStore: () => ({
+    googleTag: {
+      get enabled() {
+        return mockConfig.googleTagEnabled
+      },
+    },
+  }),
+}))
+
+const mountOptions = { global: { stubs: { Teleport: true } } }
+
+describe('CookieConsent', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('should not show banner when googleTag is disabled', async () => {
+    mockConfig.googleTagEnabled = false
+    const wrapper = mount(CookieConsent, mountOptions)
+    await wrapper.vm.$nextTick()
+    expect(wrapper.find('[data-testid="cookie-consent-banner"]').exists()).toBe(false)
+  })
+
+  it('should show banner when googleTag is enabled and no consent stored', async () => {
+    mockConfig.googleTagEnabled = true
+    const wrapper = mount(CookieConsent, mountOptions)
+    await wrapper.vm.$nextTick()
+    expect(wrapper.find('[data-testid="cookie-consent-banner"]').exists()).toBe(true)
+  })
+
+  it('should not show banner when googleTag is enabled but consent already stored', async () => {
+    mockConfig.googleTagEnabled = true
+    localStorage.setItem(
+      'cookie_consent',
+      JSON.stringify({ version: '1', analytics: true, timestamp: Date.now() })
+    )
+    const wrapper = mount(CookieConsent, mountOptions)
+    await wrapper.vm.$nextTick()
+    expect(wrapper.find('[data-testid="cookie-consent-banner"]').exists()).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

- Cookie consent banner was rendering unconditionally on login, register, and shared chat pages even when Google Tag Manager was not configured
- Added `config.googleTag.enabled` guard inside `CookieConsent.vue` so the component itself decides whether to show — parent views remain unchanged
- Added unit test verifying the banner is hidden when analytics is disabled, shown when enabled

## Test plan

- [x] Unit test: banner hidden when googleTag disabled, shown when enabled, hidden when consent already stored (3 cases)
- [x] Full unit test suite passes (203/203)
- [x] Frontend lint + prettier passes