### PR TITLE
fix(ui): improve dark mode borders, file selection and mobile UX on files page

### DIFF
--- a/frontend/src/assets/markdown.css
+++ b/frontend/src/assets/markdown.css
@@ -371,7 +371,7 @@
 .dark .markdown-content td,
 .dark .markdown-content .markdown-table th,
 .dark .markdown-content .markdown-table td {
-  border-color: rgba(255, 255, 255, 0.15);
+  border-color: rgba(255, 255, 255, 0.08);
 }
 
 .dark .markdown-content th,
@@ -393,15 +393,15 @@
 }
 
 .dark .markdown-content details {
-  border-color: rgba(255, 255, 255, 0.15);
+  border-color: rgba(255, 255, 255, 0.08);
   background-color: rgba(255, 255, 255, 0.03);
 }
 
 .dark .markdown-content details[open] > summary {
-  border-bottom-color: rgba(255, 255, 255, 0.15);
+  border-bottom-color: rgba(255, 255, 255, 0.08);
 }
 
 .dark .markdown-content .footnotes,
 .dark .markdown-content section.footnotes {
-  border-top-color: rgba(255, 255, 255, 0.15);
+  border-top-color: rgba(255, 255, 255, 0.08);
 }

--- a/frontend/src/assets/widget-markdown.css
+++ b/frontend/src/assets/widget-markdown.css
@@ -277,7 +277,7 @@
 .dark .markdown-content table td,
 .dark .markdown-content .markdown-table th,
 .dark .markdown-content .markdown-table td {
-  border-color: rgba(255, 255, 255, 0.2);
+  border-color: rgba(255, 255, 255, 0.08);
 }
 
 .dark .markdown-content table th,

--- a/frontend/src/components/admin/ConfigField.vue
+++ b/frontend/src/components/admin/ConfigField.vue
@@ -225,6 +225,6 @@ const statusColor = computed(() => {
 }
 
 :root.dark .config-field {
-  border-color: var(--dark-border-20, rgba(255, 255, 255, 0.1));
+  border-color: var(--dark-border-20, rgba(255, 255, 255, 0.06));
 }
 </style>

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -1276,6 +1276,8 @@
     "standalone": "Eigenständig",
     "attachedToMessage": "Diese Datei ist an eine Nachricht angehängt",
     "standaloneFile": "Diese Datei ist eigenständig (nicht an eine Nachricht angehängt)",
+    "selectAll": "Alle auswählen ({count})",
+    "deselectAll": "Auswahl aufheben",
     "deleteSelected": "Ausgewählte löschen",
     "deleteSelectedConfirmTitle": "Ausgewählte Dateien löschen?",
     "deleteSelectedConfirmMessage": "Möchten Sie wirklich {count} ausgewählte Datei(en) löschen? Diese Aktion kann nicht rückgängig gemacht werden und die Dateien werden dauerhaft gelöscht.",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -524,6 +524,8 @@
     "standalone": "Standalone",
     "attachedToMessage": "This file is attached to a message",
     "standaloneFile": "This file is standalone (not attached to any message)",
+    "selectAll": "Select all ({count})",
+    "deselectAll": "Deselect all",
     "deleteSelected": "Delete Selected",
     "deleteSelectedConfirmTitle": "Delete Selected Files?",
     "deleteSelectedConfirmMessage": "Are you sure you want to delete {count} selected file(s)? This action cannot be undone and the files will be permanently deleted.",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -1052,6 +1052,8 @@
     "standalone": "Independiente",
     "attachedToMessage": "Este archivo está adjunto a un mensaje",
     "standaloneFile": "Este archivo es independiente (no adjunto a ningún mensaje)",
+    "selectAll": "Seleccionar todo ({count})",
+    "deselectAll": "Deseleccionar todo",
     "deleteSelected": "Eliminar Seleccionados",
     "deleteSelectedConfirmTitle": "¿Eliminar Archivos Seleccionados?",
     "deleteSelectedConfirmMessage": "¿Estás seguro de que deseas eliminar {count} archivo(s) seleccionado(s)? Esta acción no se puede deshacer y los archivos se eliminarán permanentemente.",

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -1052,6 +1052,8 @@
     "standalone": "Bağımsız",
     "attachedToMessage": "Bu dosya bir mesaja ekli",
     "standaloneFile": "Bu dosya bağımsız (herhangi bir mesaja ekli değil)",
+    "selectAll": "Tümünü seç ({count})",
+    "deselectAll": "Seçimi kaldır",
     "deleteSelected": "Seçilenleri Sil",
     "deleteSelectedConfirmTitle": "Seçili Dosyalar Silinsin mi?",
     "deleteSelectedConfirmMessage": "{count} seçili dosyayı silmek istediğinizden emin misiniz? Bu işlem geri alınamaz ve dosyalar kalıcı olarak silinecektir.",

--- a/frontend/src/style-v2.css
+++ b/frontend/src/style-v2.css
@@ -719,7 +719,7 @@
 }
 .design-v2.dark .checkbox-brand {
   background: rgba(255, 255, 255, 0.04);
-  border-color: rgba(255, 255, 255, 0.15);
+  border-color: rgba(255, 255, 255, 0.1);
 }
 .design-v2.dark .checkbox-brand:hover {
   border-color: var(--brand-light);

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1,5 +1,10 @@
 @import 'tailwindcss';
 
+@theme {
+  --color-light-border: rgb(0 0 0);
+  --color-dark-border: rgb(255 255 255);
+}
+
 /* Base */
 @layer base {
   body {
@@ -222,16 +227,16 @@
   }
 
   .border-light-border {
-    border-color: rgba(0, 0, 0, 0.1);
+    border-color: rgba(0, 0, 0, 0.08);
   }
   .dark .border-light-border {
-    border-color: rgba(255, 255, 255, 0.1);
+    border-color: rgba(255, 255, 255, 0.05);
   }
   .border-dark-border {
-    border-color: rgba(0, 0, 0, 0.2);
+    border-color: rgba(0, 0, 0, 0.15);
   }
   .dark .border-dark-border {
-    border-color: rgba(255, 255, 255, 0.15);
+    border-color: rgba(255, 255, 255, 0.07);
   }
 
   /* Primärbutton */
@@ -287,11 +292,11 @@
     pointer-events: none;
   }
   .dark .btn-secondary {
-    border-color: rgba(255, 255, 255, 0.1);
+    border-color: rgba(255, 255, 255, 0.06);
   }
   .dark .btn-secondary:hover {
     background: rgba(255, 255, 255, 0.05);
-    border-color: rgba(255, 255, 255, 0.15);
+    border-color: rgba(255, 255, 255, 0.1);
   }
 
   /* Dropdowns */

--- a/frontend/src/views/FilesView.vue
+++ b/frontend/src/views/FilesView.vue
@@ -52,7 +52,7 @@
             <div
               v-for="(file, index) in selectedFiles"
               :key="index"
-              class="flex items-center gap-3 p-3 rounded-lg border border-light-border/30 dark:border-dark-border/20 bg-black/[0.02] dark:bg-white/[0.02]"
+              class="flex items-center gap-3 p-3 rounded-lg border border-light-border/30 dark:border-dark-border/8 bg-black/[0.02] dark:bg-white/[0.02]"
             >
               <Icon :icon="getFileIcon(file.name)" class="w-5 h-5 txt-secondary" />
               <div class="flex-1 min-w-0">
@@ -106,7 +106,7 @@
 
             <button
               v-if="selectedFiles.length > 0 && !isUploading"
-              class="px-4 py-2.5 rounded-lg border border-light-border/30 dark:border-dark-border/20 txt-secondary hover:txt-primary hover:border-[var(--brand)]/50 hover:bg-[var(--brand)]/5 transition-all text-sm flex items-center gap-1.5"
+              class="px-4 py-2.5 rounded-lg border border-light-border/30 dark:border-dark-border/8 txt-secondary hover:txt-primary hover:border-[var(--brand)]/50 hover:bg-[var(--brand)]/5 transition-all text-sm flex items-center gap-1.5"
               data-testid="btn-add-more"
               @click="fileInputRef?.click()"
             >
@@ -196,7 +196,7 @@
                   :class="
                     !selectedGroup && !groupKeyword
                       ? 'border-[var(--brand)] bg-[var(--brand)]/10 text-[var(--brand)]'
-                      : 'border-light-border/30 dark:border-dark-border/20 txt-secondary hover:border-[var(--brand)]/50 hover:bg-[var(--brand)]/5'
+                      : 'border-light-border/30 dark:border-dark-border/8 txt-secondary hover:border-[var(--brand)]/50 hover:bg-[var(--brand)]/5'
                   "
                   @click="(clearFolderSelection(), (folderPickerOpen = false))"
                 >
@@ -213,7 +213,7 @@
                     :class="
                       selectedGroup === folder.name && !groupKeyword
                         ? 'border-[var(--brand)] bg-[var(--brand)]/10 text-[var(--brand)]'
-                        : 'border-light-border/30 dark:border-dark-border/20 txt-secondary hover:border-[var(--brand)]/50 hover:bg-[var(--brand)]/5'
+                        : 'border-light-border/30 dark:border-dark-border/8 txt-secondary hover:border-[var(--brand)]/50 hover:bg-[var(--brand)]/5'
                     "
                     @click="(selectExistingFolder(folder.name), (folderPickerOpen = false))"
                   >
@@ -229,7 +229,7 @@
                 </div>
 
                 <!-- New folder input -->
-                <div class="mt-3 pt-3 border-t border-light-border/20 dark:border-dark-border/10">
+                <div class="mt-3 pt-3 border-t border-light-border/20 dark:border-dark-border/5">
                   <div class="flex items-center gap-2">
                     <Icon
                       icon="heroicons:folder-plus"
@@ -325,7 +325,7 @@
                     :class="
                       folderDropTarget === folder.name
                         ? 'border-[var(--brand)] bg-[var(--brand)]/10 shadow-lg shadow-[var(--brand)]/20 scale-[1.03]'
-                        : 'border-light-border/20 dark:border-dark-border/15 hover:border-[var(--brand)]/30 hover:shadow-lg hover:shadow-[var(--brand)]/5 hover:bg-[var(--brand)]/[0.03]'
+                        : 'border-light-border/20 dark:border-dark-border/7 hover:border-[var(--brand)]/30 hover:shadow-lg hover:shadow-[var(--brand)]/5 hover:bg-[var(--brand)]/[0.03]'
                     "
                     :data-testid="`folder-card-${folder.name}`"
                     @click="enterFolder(folder.name)"
@@ -389,7 +389,7 @@
               <div v-if="paginatedFiles.length > 0" data-testid="section-table">
                 <div
                   v-if="fileGroups.length > 0"
-                  class="flex items-center gap-2 mb-3 pt-2 border-t border-light-border/10 dark:border-dark-border/10"
+                  class="flex items-center gap-2 mb-3 pt-2 border-t border-light-border/10 dark:border-dark-border/5"
                 >
                   <Icon icon="heroicons:document-text" class="w-4 h-4 txt-secondary" />
                   <span class="text-xs font-medium txt-secondary uppercase tracking-wider">{{
@@ -400,10 +400,27 @@
 
                 <!-- Mobile card list -->
                 <div class="sm:hidden space-y-2">
+                  <button
+                    class="flex items-center gap-2 px-3 py-2 text-xs txt-secondary"
+                    @click="toggleSelectAll"
+                  >
+                    <input
+                      type="checkbox"
+                      :checked="allSelected"
+                      class="checkbox-brand shrink-0"
+                      @click.stop
+                      @change="toggleSelectAll"
+                    />
+                    {{
+                      allSelected
+                        ? $t('files.deselectAll')
+                        : $t('files.selectAll', { count: totalCount })
+                    }}
+                  </button>
                   <div
                     v-for="file in paginatedFiles"
                     :key="file.id"
-                    class="flex items-center gap-3 p-3 rounded-xl border border-light-border/15 dark:border-dark-border/10 hover:bg-black/[0.02] dark:hover:bg-white/[0.02] transition-colors"
+                    class="flex items-center gap-3 p-3 rounded-xl border border-light-border/15 dark:border-dark-border/5 hover:bg-black/[0.02] dark:hover:bg-white/[0.02] transition-colors"
                     data-testid="item-file"
                   >
                     <input
@@ -420,17 +437,17 @@
                     </div>
                     <div class="flex-1 min-w-0">
                       <p class="text-sm txt-primary truncate">{{ file.filename }}</p>
-                      <div class="flex items-center gap-2 mt-0.5">
-                        <span class="text-[11px] txt-secondary">{{
+                      <div class="flex items-center gap-2 mt-0.5 min-w-0">
+                        <span class="text-[11px] txt-secondary shrink-0">{{
                           formatFileSize(file.file_size)
                         }}</span>
                         <button
                           v-if="file.group_key"
-                          class="inline-flex items-center gap-0.5 text-[10px] text-[var(--brand)]/70"
+                          class="inline-flex items-center gap-0.5 text-[10px] text-[var(--brand)]/70 min-w-0"
                           @click="enterFolder(file.group_key!)"
                         >
-                          <Icon icon="heroicons:folder-solid" class="w-3 h-3" />
-                          {{ file.group_key }}
+                          <Icon icon="heroicons:folder-solid" class="w-3 h-3 shrink-0" />
+                          <span class="truncate">{{ file.group_key }}</span>
                         </button>
                       </div>
                     </div>
@@ -456,7 +473,7 @@
                 <!-- Desktop table -->
                 <table class="w-full hidden sm:table">
                   <thead>
-                    <tr class="border-b border-light-border/30 dark:border-dark-border/20">
+                    <tr class="border-b border-light-border/30 dark:border-dark-border/8">
                       <th class="text-left py-2.5 px-2 w-8">
                         <input
                           type="checkbox"
@@ -485,7 +502,7 @@
                     <tr
                       v-for="file in paginatedFiles"
                       :key="file.id"
-                      class="group border-b border-light-border/10 dark:border-dark-border/10 hover:bg-black/[0.03] dark:hover:bg-white/[0.03] transition-colors"
+                      class="group border-b border-light-border/10 dark:border-dark-border/5 hover:bg-black/[0.03] dark:hover:bg-white/[0.03] transition-colors"
                       data-testid="item-file"
                     >
                       <td class="py-2.5 px-2">
@@ -567,7 +584,7 @@
                 <!-- Pagination -->
                 <div
                   v-if="totalPages > 1"
-                  class="flex items-center justify-between mt-4 pt-4 border-t border-light-border/10 dark:border-dark-border/10"
+                  class="flex items-center justify-between mt-4 pt-4 border-t border-light-border/10 dark:border-dark-border/5"
                 >
                   <span class="text-xs txt-secondary"
                     >{{ $t('files.page') }} {{ currentPage }} / {{ totalPages }}</span
@@ -575,14 +592,14 @@
                   <div class="flex gap-2">
                     <button
                       :disabled="currentPage === 1"
-                      class="px-3 py-1.5 rounded-lg border border-light-border/30 dark:border-dark-border/20 txt-primary text-sm hover:bg-black/5 dark:hover:bg-white/5 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                      class="px-3 py-1.5 rounded-lg border border-light-border/30 dark:border-dark-border/8 txt-primary text-sm hover:bg-black/5 dark:hover:bg-white/5 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
                       @click="previousPage"
                     >
                       {{ $t('files.previous') }}
                     </button>
                     <button
                       :disabled="currentPage >= totalPages"
-                      class="px-3 py-1.5 rounded-lg border border-light-border/30 dark:border-dark-border/20 txt-primary text-sm hover:bg-black/5 dark:hover:bg-white/5 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                      class="px-3 py-1.5 rounded-lg border border-light-border/30 dark:border-dark-border/8 txt-primary text-sm hover:bg-black/5 dark:hover:bg-white/5 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
                       @click="nextPage"
                     >
                       {{ $t('files.next') }}
@@ -690,10 +707,27 @@
             <div v-else data-testid="section-table">
               <!-- Mobile card list -->
               <div class="sm:hidden space-y-2">
+                <button
+                  class="flex items-center gap-2 px-3 py-2 text-xs txt-secondary"
+                  @click="toggleSelectAll"
+                >
+                  <input
+                    type="checkbox"
+                    :checked="allSelected"
+                    class="checkbox-brand shrink-0"
+                    @click.stop
+                    @change="toggleSelectAll"
+                  />
+                  {{
+                    allSelected
+                      ? $t('files.deselectAll')
+                      : $t('files.selectAll', { count: totalCount })
+                  }}
+                </button>
                 <div
                   v-for="file in paginatedFiles"
                   :key="file.id"
-                  class="flex items-center gap-3 p-3 rounded-xl border border-light-border/15 dark:border-dark-border/10 hover:bg-black/[0.02] dark:hover:bg-white/[0.02] transition-colors"
+                  class="flex items-center gap-3 p-3 rounded-xl border border-light-border/15 dark:border-dark-border/5 hover:bg-black/[0.02] dark:hover:bg-white/[0.02] transition-colors"
                   data-testid="item-file"
                 >
                   <input
@@ -738,7 +772,7 @@
               <!-- Desktop table -->
               <table class="w-full hidden sm:table">
                 <thead>
-                  <tr class="border-b border-light-border/30 dark:border-dark-border/20">
+                  <tr class="border-b border-light-border/30 dark:border-dark-border/8">
                     <th class="text-left py-2.5 px-2 w-8">
                       <input
                         type="checkbox"
@@ -767,7 +801,7 @@
                   <tr
                     v-for="file in paginatedFiles"
                     :key="file.id"
-                    class="group border-b border-light-border/10 dark:border-dark-border/10 hover:bg-black/[0.03] dark:hover:bg-white/[0.03] transition-colors"
+                    class="group border-b border-light-border/10 dark:border-dark-border/5 hover:bg-black/[0.03] dark:hover:bg-white/[0.03] transition-colors"
                     data-testid="item-file"
                   >
                     <td class="py-2.5 px-2">
@@ -843,7 +877,7 @@
               <!-- Pagination -->
               <div
                 v-if="totalPages > 1"
-                class="flex items-center justify-between mt-4 pt-4 border-t border-light-border/10 dark:border-dark-border/10"
+                class="flex items-center justify-between mt-4 pt-4 border-t border-light-border/10 dark:border-dark-border/5"
                 data-testid="section-pagination"
               >
                 <span class="text-xs txt-secondary">
@@ -852,14 +886,14 @@
                 <div class="flex gap-2">
                   <button
                     :disabled="currentPage === 1"
-                    class="px-3 py-1.5 rounded-lg border border-light-border/30 dark:border-dark-border/20 txt-primary text-sm hover:bg-black/5 dark:hover:bg-white/5 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                    class="px-3 py-1.5 rounded-lg border border-light-border/30 dark:border-dark-border/8 txt-primary text-sm hover:bg-black/5 dark:hover:bg-white/5 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
                     @click="previousPage"
                   >
                     {{ $t('files.previous') }}
                   </button>
                   <button
                     :disabled="currentPage >= totalPages"
-                    class="px-3 py-1.5 rounded-lg border border-light-border/30 dark:border-dark-border/20 txt-primary text-sm hover:bg-black/5 dark:hover:bg-white/5 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                    class="px-3 py-1.5 rounded-lg border border-light-border/30 dark:border-dark-border/8 txt-primary text-sm hover:bg-black/5 dark:hover:bg-white/5 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
                     @click="nextPage"
                   >
                     {{ $t('files.next') }}
@@ -937,7 +971,7 @@
             <!-- Actions -->
             <div class="flex gap-3 justify-end pt-2">
               <button
-                class="px-4 py-2 rounded-lg border border-light-border/30 dark:border-dark-border/20 txt-secondary hover:bg-black/5 dark:hover:bg-white/5 transition-all text-sm font-medium"
+                class="px-4 py-2 rounded-lg border border-light-border/30 dark:border-dark-border/8 txt-secondary hover:bg-black/5 dark:hover:bg-white/5 transition-all text-sm font-medium"
                 data-testid="btn-delete-selected-cancel"
                 @click="cancelDeleteSelected"
               >
@@ -1036,10 +1070,7 @@ const totalPages = computed(() => {
 const paginatedFiles = computed(() => files.value)
 
 const allSelected = computed(() => {
-  return (
-    paginatedFiles.value.length > 0 &&
-    paginatedFiles.value.every((file) => selectedFileIds.value.includes(file.id))
-  )
+  return totalCount.value > 0 && selectedFileIds.value.length === totalCount.value
 })
 
 const handleFileSelect = (event: Event) => {
@@ -1388,20 +1419,24 @@ const toggleFileSelection = (fileId: number) => {
   }
 }
 
-const toggleSelectAll = () => {
+const toggleSelectAll = async () => {
   if (allSelected.value) {
-    paginatedFiles.value.forEach((file) => {
-      const index = selectedFileIds.value.indexOf(file.id)
-      if (index > -1) {
-        selectedFileIds.value.splice(index, 1)
-      }
-    })
+    selectedFileIds.value = []
   } else {
-    paginatedFiles.value.forEach((file) => {
-      if (!selectedFileIds.value.includes(file.id)) {
-        selectedFileIds.value.push(file.id)
-      }
-    })
+    try {
+      const response = await filesService.listFiles(
+        filterGroup.value || undefined,
+        1,
+        totalCount.value || 1000
+      )
+      selectedFileIds.value = response.files.map((f) => f.id)
+    } catch {
+      paginatedFiles.value.forEach((file) => {
+        if (!selectedFileIds.value.includes(file.id)) {
+          selectedFileIds.value.push(file.id)
+        }
+      })
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
<!-- One sentence on what changed and why. -->
Fixes harsh dark mode border colors across the app by registering Tailwind v4 theme colors, improves "Select all" to work across all pages (not just the current one), and adds the missing select-all checkbox on mobile.

## Changes
- Register `light-border` and `dark-border` as Tailwind v4 `@theme` colors so `/XX` opacity modifiers actually work (previously fell back to `currentColor` = 100% white in dark mode)
- Reduce dark mode border opacities across global CSS (`style.css`, `style-v2.css`, `markdown.css`, `widget-markdown.css`, `ConfigField.vue`) for softer, less harsh borders
- Fix "Select all" checkbox to select **all files across all pages** by fetching all file IDs from the API, instead of only selecting the current page
- Add "Select all / Deselect all" button to mobile card list views (root and folder view) — previously only visible in the desktop table header
- Truncate long folder names in mobile file cards with ellipsis to prevent file size text from being squeezed onto two lines
- Add i18n keys for `files.selectAll` and `files.deselectAll` in all 4 languages (EN, DE, TR, ES)

## Verification
- [x] Manual
  - Dark mode: check borders on `/files`, markdown tables, buttons, checkboxes — should be subtle, not glaring
  - Files page: click "Select all" with multiple pages of files — all files should be selected, not just the current page
  - Mobile view: verify "Select all" checkbox appears above file list, long folder names truncate with `...`

## Notes
<!-- Related issues/links/threads. -->
- Root cause for border issue: Tailwind v4 uses `@import 'tailwindcss'` without `@config`, so `tailwind.config.js` colors were never loaded. The custom CSS utilities (`.border-light-border`, `.border-dark-border`) only matched the base class, not the `/XX` opacity variants, causing `currentColor` fallback.
- The `@theme` block in `style.css` is the Tailwind v4 equivalent of defining colors in `tailwind.config.js`.

## Screenshots/Logs