### PR TITLE
fix: add missing ANALYZE and TOOLS default model entries

### DIFF
--- a/_devextras/db-loadfiles/BCONFIG.sql
+++ b/_devextras/db-loadfiles/BCONFIG.sql
@@ -97,7 +97,9 @@ INSERT INTO `BCONFIG` VALUES
 (51,2,'widget_1','color','#007bff'),
 (52,2,'widget_1','position','bottom-right'),
 (53,2,'widget_1','autoMessage','Hello! How can I help you today?'),
-(54,2,'widget_1','prompt','general');
+(54,2,'widget_1','prompt','general'),
+(55,0,'DEFAULTMODEL','ANALYZE','76'),
+(56,0,'DEFAULTMODEL','TOOLS','76');
 /*!40000 ALTER TABLE `BCONFIG` ENABLE KEYS */;
 UNLOCK TABLES;
 commit;

--- a/backend/src/DataFixtures/ConfigFixtures.php
+++ b/backend/src/DataFixtures/ConfigFixtures.php
@@ -24,6 +24,7 @@ class ConfigFixtures extends Fixture implements DependentFixtureInterface
             ['ownerId' => 0, 'group' => 'DEFAULTMODEL', 'setting' => 'TEXT2SOUND', 'value' => '140'],  // Piper (free)
             ['ownerId' => 0, 'group' => 'DEFAULTMODEL', 'setting' => 'PIC2TEXT',   'value' => '17'],   // Groq Llama 4 Scout
             ['ownerId' => 0, 'group' => 'DEFAULTMODEL', 'setting' => 'SOUND2TEXT', 'value' => '21'],   // Groq whisper-large-v3
+            ['ownerId' => 0, 'group' => 'DEFAULTMODEL', 'setting' => 'ANALYZE',    'value' => '76'],   // Groq gpt-oss-120b (chat models can analyze)
             ['ownerId' => 0, 'group' => 'DEFAULTMODEL', 'setting' => 'VECTORIZE',  'value' => '13'],   // Ollama bge-m3
 
             ['ownerId' => 0, 'group' => 'ai', 'setting' => 'default_chat_provider', 'value' => 'groq'],


### PR DESCRIPTION
## Summary
Without a global default for ANALYZE (ownerId=0, group=DEFAULTMODEL, setting=ANALYZE), the UI shows "-- Select Model --" for file analysis because no fallback exists. TOOLS was also missing from BCONFIG.sql.


## Verification
- [ ] Not tested (explain)
- [x] Manual
- [ ] Tests added/updated

