### PR TITLE
fix: exclude TestProvider models by ID instead of selectable flag

### DIFF
--- a/backend/src/Controller/ConfigController.php
+++ b/backend/src/Controller/ConfigController.php
@@ -378,9 +378,9 @@ class ConfigController extends AbstractController
             return $this->json(['error' => 'Not authenticated'], Response::HTTP_UNAUTHORIZED);
         }
 
-        $models = $this->modelRepository->findBy(
-            ['active' => 1, 'selectable' => 1],
-            ['quality' => 'DESC', 'rating' => 'DESC']
+        $models = array_filter(
+            $this->modelRepository->findBy(['active' => 1], ['quality' => 'DESC', 'rating' => 'DESC']),
+            static fn ($m) => $m->getId() > 0,
         );
 
         // Build model list with tag information


### PR DESCRIPTION


## Summary
The selectable=1 filter (added in 759fa88) was meant to hide TestProvider models but also excluded bge-m3 (selectable=0, active=1). Filter on id>0 instead, since TestProvider models use negative IDs.


## Changes
-

## Verification
- [ ] Not tested (explain)
- [x] Manual
- [ ] Tests added/updated
