### PR TITLE
chore: restore renovate config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ]
+}


### PR DESCRIPTION
## Summary
- Restore `renovate.json5` with `config:recommended` preset — accidentally deleted during the Symfony migration (`dd06a0b2`)
- Without it, Renovate closed the Dependency Dashboard (#30) and runs with bare defaults (no dashboard, no grouping)
- This will re-enable the Dependency Dashboard and recommended presets

## Test plan
- [ ] Verify Renovate reopens/creates a new Dependency Dashboard issue after merge
- [ ] Confirm existing open PRs (#548, #549) are unaffected