### PR TITLE
refactor(e2e): replace numeric IDs with descriptive names and group t…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,7 +345,7 @@ jobs:
           PROFILE="${{ matrix.compose_profiles }}"
 
           # app_test entrypoint loads fixtures on first run (APP_ENV=test, empty DB)
-          # so TestProvider model (id 900) and admin user exist for E2E (e.g. id=003).
+          # so TestProvider model (-1 > -7) and admin user exist for E2E.
           echo "Starting services..."
           $COMPOSE $PROFILE up -d
 

--- a/frontend/tests/e2e/README.md
+++ b/frontend/tests/e2e/README.md
@@ -9,7 +9,7 @@ cd frontend
 npm install
 npx playwright install --with-deps
 npm run test:e2e                        # E2E tests
-npm run test:e2e -- -g "id=013"         # Single test
+npm run test:e2e -- -g "standard model"  # Single test (grep by name)
 npm run test:e2e:ui                     # Playwright UI
 ```
 
@@ -86,11 +86,11 @@ From the **frontend** directory:
 | What                               | Command                                                                    |
 | ---------------------------------- | -------------------------------------------------------------------------- |
 | **Dev stack**: E2E tests           | `npm run test:e2e`                                                         |
-| **Dev stack**: single test         | `npm run test:e2e -- -g "id=013"`                                          |
+| **Dev stack**: single test         | `npm run test:e2e -- -g "standard model"`                                  |
 | **Test stack**: E2E tests          | `BASE_URL=http://localhost:8001 npm run test:e2e`                          |
 | **Test stack**: full CI-like       | `make test-e2e-full` (builds test stack + runs all E2E)                    |
 | **Test stack**: CI-like (no @noci) | `BASE_URL=http://localhost:8001 npm run test:e2e -- --grep-invert "@noci"` |
-| **Test stack**: single test        | `BASE_URL=http://localhost:8001 npm run test:e2e -- -g "id=020"`           |
+| **Test stack**: single test        | `BASE_URL=http://localhost:8001 npm run test:e2e -- -g "embedded chat"`    |
 | **WhatsApp only**                  | `BASE_URL=http://localhost:8001 npm run test:e2e:whatsapp`                 |
 | **Playwright UI**                  | `npm run test:e2e:ui`                                                      |
 

--- a/frontend/tests/e2e/tests/auth-api.spec.ts
+++ b/frontend/tests/e2e/tests/auth-api.spec.ts
@@ -5,31 +5,29 @@ import { CREDENTIALS } from '../config/credentials'
 
 const apiBase = () => getApiUrl()
 
-test('@noci @api @smoke health endpoint returns 200 id=api-001', async ({ request }) => {
-  const res = await request.get(`${apiBase()}/api/health`)
-  expect(res.status()).toBe(200)
-})
-
-test('@noci @api @smoke login returns 200 and sets auth cookies id=api-002', async ({
-  request,
-}) => {
-  const res = await request.post(`${apiBase()}/api/v1/auth/login`, {
-    data: {
-      email: CREDENTIALS.DEFAULT_USER,
-      password: CREDENTIALS.DEFAULT_PASSWORD,
-    },
+test.describe('@noci @api @smoke Auth API', () => {
+  test('health endpoint returns 200', async ({ request }) => {
+    const res = await request.get(`${apiBase()}/api/health`)
+    expect(res.status()).toBe(200)
   })
-  expect(res.status()).toBe(200)
-  const setCookie = res.headers()['set-cookie']
-  expect(setCookie).toBeDefined()
-  const cookieStr = Array.isArray(setCookie) ? setCookie.join(' ') : setCookie
-  expect(cookieStr).toMatch(/access_token|refresh_token|SESSION/)
-})
 
-test('@noci @api authenticated request with getAuthHeaders succeeds id=api-003', async ({
-  request,
-}) => {
-  const headers = await getAuthHeaders(request)
-  const res = await request.get(`${apiBase()}/api/v1/chats`, { headers })
-  expect(res.status()).toBe(200)
+  test('login returns 200 and sets auth cookies', async ({ request }) => {
+    const res = await request.post(`${apiBase()}/api/v1/auth/login`, {
+      data: {
+        email: CREDENTIALS.DEFAULT_USER,
+        password: CREDENTIALS.DEFAULT_PASSWORD,
+      },
+    })
+    expect(res.status()).toBe(200)
+    const setCookie = res.headers()['set-cookie']
+    expect(setCookie).toBeDefined()
+    const cookieStr = Array.isArray(setCookie) ? setCookie.join(' ') : setCookie
+    expect(cookieStr).toMatch(/access_token|refresh_token|SESSION/)
+  })
+
+  test('authenticated request with getAuthHeaders succeeds', async ({ request }) => {
+    const headers = await getAuthHeaders(request)
+    const res = await request.get(`${apiBase()}/api/v1/chats`, { headers })
+    expect(res.status()).toBe(200)
+  })
 })

--- a/frontend/tests/e2e/tests/auth.spec.ts
+++ b/frontend/tests/e2e/tests/auth.spec.ts
@@ -4,76 +4,102 @@ import { selectors } from '../helpers/selectors'
 import { clearMailHog, waitForVerificationHref, normalizeVerificationUrl } from '../helpers/email'
 import { URLS, TIMEOUTS, INTERVALS } from '../config/config'
 
-test('@002 @ci @smoke @auth should successfully login', async ({ page, credentials }) => {
-  await login(page, credentials)
-  await expect(page.locator(selectors.chat.textInput)).toBeVisible({ timeout: 10_000 })
-})
+test.describe('@ci @auth Authentication', () => {
+  test('@smoke should successfully login', async ({ page, credentials }) => {
+    await test.step('Act: login with credentials', async () => {
+      await login(page, credentials)
+    })
 
-test('@005 @ci @smoke @auth logout should clear session', async ({ page, credentials }) => {
-  await login(page, credentials)
-
-  await page.locator(selectors.userMenu.button).waitFor({ state: 'visible' })
-  await page.locator(selectors.userMenu.button).click()
-  await page.locator(selectors.userMenu.logoutBtn).click()
-
-  // After logout the user lands on /logged-out (OIDC) or /login (standard).
-  // Accept either destination as proof that the session was cleared.
-  await expect(
-    page.locator(`${selectors.login.email}, ${selectors.loggedOut.page}`).first()
-  ).toBeVisible({ timeout: 15_000 })
-  await expect(page).toHaveURL(/login|logged-out/)
-
-  // Navigating to a protected route must not restore the session
-  await page.goto('/profile')
-  await expect(
-    page.locator(`${selectors.login.email}, ${selectors.loggedOut.page}`).first()
-  ).toBeVisible({ timeout: 15_000 })
-  await expect(page).toHaveURL(/login|logged-out/)
-})
-
-// TODO: Use a pre-verified DB fixture + delete before test, then assert login fails (avoids MailHog/verify flow).
-test('@011 @ci @auth @smoke deleted user cannot login', async ({ page, request }) => {
-  const email = `deleted-user-${Date.now()}@example.test`
-  const password = 'DeleteMe123!'
-
-  await clearMailHog(request)
-
-  const register = await request.post(`${URLS.BASE_URL}/api/v1/auth/register`, {
-    data: { email, password, recaptchaToken: '' },
+    await test.step('Assert: chat input is visible after login', async () => {
+      await expect(page.locator(selectors.chat.textInput)).toBeVisible({ timeout: 10_000 })
+    })
   })
-  expect(register.ok()).toBeTruthy()
 
-  const href = await waitForVerificationHref(request, email, {
-    timeout: TIMEOUTS.LONG,
-    intervals: INTERVALS.FAST(),
+  test('@smoke logout should clear session', async ({ page, credentials }) => {
+    await test.step('Arrange: login', async () => {
+      await login(page, credentials)
+    })
+
+    await test.step('Act: logout via user menu', async () => {
+      await page.locator(selectors.userMenu.button).waitFor({ state: 'visible' })
+      await page.locator(selectors.userMenu.button).click()
+      await page.locator(selectors.userMenu.logoutBtn).click()
+    })
+
+    await test.step('Assert: redirected to login or logged-out page', async () => {
+      // After logout the user lands on /logged-out (OIDC) or /login (standard).
+      // Accept either destination as proof that the session was cleared.
+      await expect(
+        page.locator(`${selectors.login.email}, ${selectors.loggedOut.page}`).first()
+      ).toBeVisible({ timeout: 15_000 })
+      await expect(page).toHaveURL(/login|logged-out/)
+    })
+
+    await test.step('Assert: navigating to protected route does not restore session', async () => {
+      await page.goto('/profile')
+      await expect(
+        page.locator(`${selectors.login.email}, ${selectors.loggedOut.page}`).first()
+      ).toBeVisible({ timeout: 15_000 })
+      await expect(page).toHaveURL(/login|logged-out/)
+    })
   })
-  await page.goto(normalizeVerificationUrl(href))
-  await page
-    .locator(selectors.verifyEmail.successState)
-    .waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
 
-  await page.locator(selectors.verifyEmail.goToLoginLink).click()
-  await expect(page).toHaveURL(/\/login/)
+  // TODO: Use a pre-verified DB fixture + delete before test, then assert login fails (avoids MailHog/verify flow).
+  test('@smoke deleted user cannot login', async ({ page, request }) => {
+    const email = `deleted-user-${Date.now()}@example.test`
+    const password = 'DeleteMe123!'
 
-  await login(page, { user: email, pass: password })
-  await expect(page.locator(selectors.chat.textInput)).toBeVisible({ timeout: TIMEOUTS.STANDARD })
+    await test.step('Arrange: register and verify a new user', async () => {
+      await clearMailHog(request)
 
-  await page.locator(selectors.userMenu.button).click()
-  await page.locator(selectors.userMenu.logoutBtn).click()
-  await expect(page.locator(selectors.login.email)).toBeVisible({ timeout: TIMEOUTS.STANDARD })
+      const register = await request.post(`${URLS.BASE_URL}/api/v1/auth/register`, {
+        data: { email, password, recaptchaToken: '' },
+      })
+      expect(register.ok()).toBeTruthy()
 
-  const deleted = await deleteUser(request, email)
-  expect(deleted, 'Admin API must delete the user so login can be asserted').toBe(true)
+      const href = await waitForVerificationHref(request, email, {
+        timeout: TIMEOUTS.LONG,
+        intervals: INTERVALS.FAST(),
+      })
+      await page.goto(normalizeVerificationUrl(href))
+      await page
+        .locator(selectors.verifyEmail.successState)
+        .waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
 
-  await page.goto('/login')
-  await page.fill(selectors.login.email, email)
-  await page.fill(selectors.login.password, password)
-  await page.locator(selectors.login.submit).click()
+      await page.locator(selectors.verifyEmail.goToLoginLink).click()
+      await expect(page).toHaveURL(/\/login/)
+    })
 
-  const errorEl = page.locator('.alert-error-text')
-  await errorEl.waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
-  const text = (await errorEl.innerText()).trim().toLowerCase()
-  expect(text).toContain('invalid')
-  expect(text).toContain('credentials')
-  await expect(page).toHaveURL(/login/)
+    await test.step('Arrange: verify the new user can login', async () => {
+      await login(page, { user: email, pass: password })
+      await expect(page.locator(selectors.chat.textInput)).toBeVisible({
+        timeout: TIMEOUTS.STANDARD,
+      })
+
+      await page.locator(selectors.userMenu.button).click()
+      await page.locator(selectors.userMenu.logoutBtn).click()
+      await expect(page.locator(selectors.login.email)).toBeVisible({
+        timeout: TIMEOUTS.STANDARD,
+      })
+    })
+
+    await test.step('Act: delete the user via admin API', async () => {
+      const deleted = await deleteUser(request, email)
+      expect(deleted, 'Admin API must delete the user so login can be asserted').toBe(true)
+    })
+
+    await test.step('Assert: login attempt shows invalid credentials error', async () => {
+      await page.goto('/login')
+      await page.fill(selectors.login.email, email)
+      await page.fill(selectors.login.password, password)
+      await page.locator(selectors.login.submit).click()
+
+      const errorEl = page.locator('.alert-error-text')
+      await errorEl.waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
+      const text = (await errorEl.innerText()).trim().toLowerCase()
+      expect(text).toContain('invalid')
+      expect(text).toContain('credentials')
+      await expect(page).toHaveURL(/login/)
+    })
+  })
 })

--- a/frontend/tests/e2e/tests/chat-share.spec.ts
+++ b/frontend/tests/e2e/tests/chat-share.spec.ts
@@ -4,11 +4,8 @@ import { login } from '../helpers/auth'
 import { ChatHelper } from '../helpers/chat'
 import { TIMEOUTS } from '../config/config'
 
-test.describe('Chat Share', () => {
-  test('@001 @ci @smoke User can share chat and open shared link in incognito', async ({
-    page,
-    credentials,
-  }) => {
+test.describe('@ci @smoke Chat Share', () => {
+  test('user can share chat and open shared link in incognito', async ({ page, credentials }) => {
     const uniqueMessage = `Chat share E2E ${Date.now()} – please reply briefly.`
 
     await test.step('Arrange: login via UI', async () => {
@@ -46,7 +43,6 @@ test.describe('Chat Share', () => {
         await modal
           .locator(selectors.nav.chatManagerListRows)
           .waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
-        // Last chat = first row (newest first); prefer data-testid per E2E rules
         const lastChatRow = modal.locator(selectors.nav.chatV2Row).first()
         await lastChatRow.scrollIntoViewIfNeeded()
         await lastChatRow.hover()

--- a/frontend/tests/e2e/tests/chat.spec.ts
+++ b/frontend/tests/e2e/tests/chat.spec.ts
@@ -13,139 +13,143 @@ const e2eDir = path.join(__dirname, '..')
 
 const VISION_FIXTURE = readFileSync(path.join(e2eDir, FIXTURE_PATHS.VISION_PATTERN_64))
 
-test('@003 @ci @smoke Standard model generates answer', async ({ page, credentials }) => {
-  await login(page, credentials)
-  const chat = new ChatHelper(page)
+test.describe('@ci @smoke Chat', () => {
+  test('standard model generates answer', async ({ page, credentials }) => {
+    await login(page, credentials)
+    const chat = new ChatHelper(page)
 
-  await test.step('Arrange: start new chat', async () => {
-    await chat.startNewChat()
-  })
+    await test.step('Arrange: start new chat', async () => {
+      await chat.startNewChat()
+    })
 
-  const previousCount = await chat.conversationBubbles().count()
+    const previousCount = await chat.conversationBubbles().count()
 
-  await test.step('Act: send smoke test message', async () => {
-    await page.locator(selectors.chat.textInput).fill(PROMPTS.CHAT_SMOKE)
-    await page.locator(selectors.chat.sendBtn).click()
-  })
+    await test.step('Act: send smoke test message', async () => {
+      await page.locator(selectors.chat.textInput).fill(PROMPTS.CHAT_SMOKE)
+      await page.locator(selectors.chat.sendBtn).click()
+    })
 
-  const aiText = await chat.waitForAnswer(previousCount)
+    const aiText = await chat.waitForAnswer(previousCount)
 
-  await test.step('Assert: stream ended and assistant reply non-empty', async () => {
-    expect(aiText.length).toBeGreaterThan(0)
+    await test.step('Assert: stream ended and assistant reply non-empty', async () => {
+      expect(aiText.length).toBeGreaterThan(0)
+    })
   })
 })
 
-test('@004 @noci @nightly User can chat with all models and get a "success" answer', async ({
-  page,
-  credentials,
-}) => {
-  test.setTimeout(120_000)
-  const failures: string[] = []
-  const chat = new ChatHelper(page)
+test.describe('@noci @nightly Chat — all models', () => {
+  test('user can chat with all models and get a "success" answer', async ({
+    page,
+    credentials,
+  }) => {
+    test.setTimeout(120_000)
+    const failures: string[] = []
+    const chat = new ChatHelper(page)
 
-  await login(page, credentials)
-  await chat.startNewChat()
+    await login(page, credentials)
+    await chat.startNewChat()
 
-  try {
+    try {
+      const previousCount = await chat.conversationBubbles().count()
+      await page.locator(selectors.chat.textInput).fill(PROMPTS.CHAT_SMOKE)
+      await page.locator(selectors.chat.sendBtn).click()
+
+      const aiText = await chat.waitForAnswer(previousCount)
+      await expect(aiText, 'Initial model should answer').toContain('success')
+    } catch (error) {
+      failures.push(
+        `Initial message failed: ${error instanceof Error ? error.message : String(error)}`
+      )
+    }
+
+    await chat.runAgainOptions('success', failures, 'chat')
+
+    if (failures.length > 0) {
+      console.warn('Model run issues:', failures)
+      await expect.soft(failures, 'All models should respond without errors').toEqual([])
+    }
+  })
+})
+
+test.describe('@noci @regression Chat — vision', () => {
+  test('user can upload an image and gets a description from all models', async ({
+    page,
+    credentials,
+  }) => {
+    const failures: string[] = []
+    const chat = new ChatHelper(page)
+
+    await login(page, credentials)
+    await chat.ensureAdvancedMode()
+    await chat.startNewChat()
+
+    await chat.attachFile({
+      name: 'vision-1x1.png',
+      mimeType: 'image/png',
+      buffer: VISION_FIXTURE,
+    })
+
     const previousCount = await chat.conversationBubbles().count()
-    await page.locator(selectors.chat.textInput).fill(PROMPTS.CHAT_SMOKE)
+    await page.locator(selectors.chat.textInput).fill('What do you see in this image?')
     await page.locator(selectors.chat.sendBtn).click()
 
     const aiText = await chat.waitForAnswer(previousCount)
-    await expect(aiText, 'Initial model should answer').toContain('success')
-  } catch (error) {
-    failures.push(
-      `Initial message failed: ${error instanceof Error ? error.message : String(error)}`
-    )
-  }
+    await expect.soft(aiText.includes('error') || aiText.includes('failed')).toBeFalsy()
 
-  await chat.runAgainOptions('success', failures, 'chat')
+    await chat.runAgainOptions(undefined, failures, 'vision')
 
-  if (failures.length > 0) {
-    console.warn('Model run issues:', failures)
-    await expect.soft(failures, 'All models should respond without errors').toEqual([])
-  }
-})
-
-test('@008 @noci @regression User can upload an image and gets a discription from all models', async ({
-  page,
-  credentials,
-}) => {
-  const failures: string[] = []
-  const chat = new ChatHelper(page)
-
-  await login(page, credentials)
-  await chat.ensureAdvancedMode()
-  await chat.startNewChat()
-
-  await chat.attachFile({
-    name: 'vision-1x1.png',
-    mimeType: 'image/png',
-    buffer: VISION_FIXTURE,
+    if (failures.length > 0) {
+      console.warn('Vision purpose issues:', failures)
+      await expect.soft(failures).toEqual([])
+    }
   })
-
-  const previousCount = await chat.conversationBubbles().count()
-  await page.locator(selectors.chat.textInput).fill('What do you see in this image?')
-  await page.locator(selectors.chat.sendBtn).click()
-
-  const aiText = await chat.waitForAnswer(previousCount)
-  await expect.soft(aiText.includes('error') || aiText.includes('failed')).toBeFalsy()
-
-  await chat.runAgainOptions(undefined, failures, 'vision')
-
-  if (failures.length > 0) {
-    console.warn('Vision purpose issues:', failures)
-    await expect.soft(failures).toEqual([])
-  }
 })
 
-test('@009 @noci @regression User can generate an image and test all models', async ({
-  page,
-  credentials,
-}) => {
-  const failures: string[] = []
-  const chat = new ChatHelper(page)
+test.describe('@noci @regression Chat — image generation', () => {
+  test('user can generate an image and test all models', async ({ page, credentials }) => {
+    const failures: string[] = []
+    const chat = new ChatHelper(page)
 
-  await login(page, credentials)
-  await chat.ensureAdvancedMode()
-  await chat.startNewChat()
+    await login(page, credentials)
+    await chat.ensureAdvancedMode()
+    await chat.startNewChat()
 
-  const previousCount = await chat.conversationBubbles().count()
-  await page.locator(selectors.chat.textInput).fill('draw a tiny blue square')
-  await page.locator(selectors.chat.sendBtn).click()
+    const previousCount = await chat.conversationBubbles().count()
+    await page.locator(selectors.chat.textInput).fill('draw a tiny blue square')
+    await page.locator(selectors.chat.sendBtn).click()
 
-  const aiText = await chat.waitForAnswer(previousCount)
-  await expect.soft(aiText.includes('error') || aiText.includes('failed')).toBeFalsy()
+    const aiText = await chat.waitForAnswer(previousCount)
+    await expect.soft(aiText.includes('error') || aiText.includes('failed')).toBeFalsy()
 
-  await chat.runAgainOptions(undefined, failures, 'image generation')
+    await chat.runAgainOptions(undefined, failures, 'image generation')
 
-  if (failures.length > 0) {
-    console.warn('Image generation issues:', failures)
-    await expect.soft(failures).toEqual([])
-  }
+    if (failures.length > 0) {
+      console.warn('Image generation issues:', failures)
+      await expect.soft(failures).toEqual([])
+    }
+  })
 })
 
-test('@010 @noci @regression User can generate a video and test all models', async ({
-  page,
-  credentials,
-}) => {
-  const failures: string[] = []
-  const chat = new ChatHelper(page)
+test.describe('@noci @regression Chat — video generation', () => {
+  test('user can generate a video and test all models', async ({ page, credentials }) => {
+    const failures: string[] = []
+    const chat = new ChatHelper(page)
 
-  await login(page, credentials)
-  await chat.ensureAdvancedMode()
-  await chat.startNewChat()
+    await login(page, credentials)
+    await chat.ensureAdvancedMode()
+    await chat.startNewChat()
 
-  const previousCount = await chat.conversationBubbles().count()
-  await page.locator(selectors.chat.textInput).fill('/vid short demo clip of a robot waving')
-  await page.locator(selectors.chat.sendBtn).click()
+    const previousCount = await chat.conversationBubbles().count()
+    await page.locator(selectors.chat.textInput).fill('/vid short demo clip of a robot waving')
+    await page.locator(selectors.chat.sendBtn).click()
 
-  const aiText = await chat.waitForAnswer(previousCount, true)
-  await expect.soft(aiText.includes('error') || aiText.includes('failed')).toBeFalsy()
-  await chat.runAgainOptions(undefined, failures, 'video generation', true)
+    const aiText = await chat.waitForAnswer(previousCount, true)
+    await expect.soft(aiText.includes('error') || aiText.includes('failed')).toBeFalsy()
+    await chat.runAgainOptions(undefined, failures, 'video generation', true)
 
-  if (failures.length > 0) {
-    console.warn('Video generation issues:', failures)
-    await expect.soft(failures).toEqual([])
-  }
+    if (failures.length > 0) {
+      console.warn('Video generation issues:', failures)
+      await expect.soft(failures).toEqual([])
+    }
+  })
 })

--- a/frontend/tests/e2e/tests/email.spec.ts
+++ b/frontend/tests/e2e/tests/email.spec.ts
@@ -18,14 +18,14 @@ function webhookUrl(): string {
   return `${getApiUrl()}${WEBHOOK_PATH}`
 }
 
-test.describe('@ci Smart-Email smoke @smoke', () => {
+test.describe('@ci @smoke Smart-Email', () => {
   test.describe.configure({ mode: 'serial' })
 
   test.beforeEach(async ({ request }) => {
     await clearMailHog(request)
   })
 
-  test('Inbound → Reply sent: webhook 2xx, exactly one reply in MailHog', async ({ request }) => {
+  test('inbound webhook triggers exactly one reply in MailHog', async ({ request }) => {
     await test.step('Arrange: verify 0 messages', async () => {
       const messages = await fetchMessages(request)
       expect(messages.length, 'MailHog should be empty before trigger').toBe(0)
@@ -77,7 +77,7 @@ test.describe('@ci Smart-Email smoke @smoke', () => {
     })
   })
 
-  test('Invalid payload → 400, error body, no reply in MailHog', async ({ request }) => {
+  test('invalid payload returns 400 and sends no reply', async ({ request }) => {
     await test.step('Arrange: empty MailHog', async () => {
       const messages = await fetchMessages(request)
       expect(messages.length).toBe(0)
@@ -89,7 +89,6 @@ test.describe('@ci Smart-Email smoke @smoke', () => {
           from: TEST_FROM,
           to: TEST_TO,
           subject: 'No body',
-          // body missing
         },
       })
       expect(res.status()).toBe(400)

--- a/frontend/tests/e2e/tests/oidc-admin.spec.ts
+++ b/frontend/tests/e2e/tests/oidc-admin.spec.ts
@@ -2,23 +2,26 @@ import { test, expect } from '@playwright/test'
 import { loginViaOidcButton } from '../helpers/auth'
 import { selectors } from '../helpers/selectors'
 
-test.describe('@oidc @oidc-button OIDC admin role promotion', () => {
-  test('@ci @oidc @oidc-button @auth OIDC user with administrator role should access admin page', async ({
-    page,
-  }) => {
-    // The Keycloak testuser should have the "administrator" realm role
-    // (assigned in _docker/keycloak/setup.sh), which matches the
-    // OIDC_ADMIN_ROLES config and should promote the user to ADMIN on login.
-    await loginViaOidcButton(page)
-    await expect(page.locator(selectors.chat.textInput)).toBeVisible({ timeout: 10_000 })
+test.describe('@ci @oidc @oidc-button OIDC Admin Role Promotion', () => {
+  test('@auth user with administrator role should access admin page', async ({ page }) => {
+    await test.step('Arrange: login via OIDC button', async () => {
+      // The Keycloak testuser should have the "administrator" realm role
+      // (assigned in _docker/keycloak/setup.sh), which matches the
+      // OIDC_ADMIN_ROLES config and should promote the user to ADMIN on login.
+      await loginViaOidcButton(page)
+      await expect(page.locator(selectors.chat.textInput)).toBeVisible({ timeout: 10_000 })
+    })
 
-    // Navigate to the admin page — should be accessible if OIDC admin promotion worked
-    await page.goto('/admin')
+    await test.step('Act: navigate to admin page', async () => {
+      await page.goto('/admin')
+    })
 
-    // If the user was promoted to ADMIN, the admin view renders.
-    // If not (bug: role never assigned in Keycloak), the router guard
-    // redirects to /chat and this assertion fails.
-    await expect(page.locator('[data-testid="view-admin"]')).toBeVisible({ timeout: 10_000 })
-    await expect(page).toHaveURL(/\/admin/)
+    await test.step('Assert: admin view is accessible', async () => {
+      // If the user was promoted to ADMIN, the admin view renders.
+      // If not (bug: role never assigned in Keycloak), the router guard
+      // redirects to /chat and this assertion fails.
+      await expect(page.locator('[data-testid="view-admin"]')).toBeVisible({ timeout: 10_000 })
+      await expect(page).toHaveURL(/\/admin/)
+    })
   })
 })

--- a/frontend/tests/e2e/tests/oidc-auth.spec.ts
+++ b/frontend/tests/e2e/tests/oidc-auth.spec.ts
@@ -2,21 +2,32 @@ import { test, expect } from '@playwright/test'
 import { loginViaOidcButton } from '../helpers/auth'
 import { selectors } from '../helpers/selectors'
 
-test.describe('@oidc @oidc-button button login', () => {
-  test('@ci @oidc @oidc-button @auth should login via OIDC button click', async ({ page }) => {
-    await loginViaOidcButton(page)
-    await expect(page.locator(selectors.chat.textInput)).toBeVisible({ timeout: 10_000 })
+test.describe('@ci @oidc @oidc-button OIDC Button Login', () => {
+  test('@auth should login via OIDC button click', async ({ page }) => {
+    await test.step('Act: login via OIDC button', async () => {
+      await loginViaOidcButton(page)
+    })
+
+    await test.step('Assert: chat input is visible', async () => {
+      await expect(page.locator(selectors.chat.textInput)).toBeVisible({ timeout: 10_000 })
+    })
   })
 
-  test('@ci @oidc @oidc-button @auth should logout from OIDC session', async ({ page }) => {
-    await loginViaOidcButton(page)
+  test('@auth should logout from OIDC session', async ({ page }) => {
+    await test.step('Arrange: login via OIDC button', async () => {
+      await loginViaOidcButton(page)
+    })
 
-    await page.locator(selectors.userMenu.button).waitFor({ state: 'visible' })
-    await page.locator(selectors.userMenu.button).click()
-    await page.locator(selectors.userMenu.logoutBtn).click()
+    await test.step('Act: logout via user menu', async () => {
+      await page.locator(selectors.userMenu.button).waitFor({ state: 'visible' })
+      await page.locator(selectors.userMenu.button).click()
+      await page.locator(selectors.userMenu.logoutBtn).click()
+    })
 
-    // OIDC logout redirects through Keycloak and lands on /logged-out
-    await expect(page.locator(selectors.loggedOut.page)).toBeVisible({ timeout: 15_000 })
-    await expect(page).toHaveURL(/logged-out/)
+    await test.step('Assert: redirected to logged-out page', async () => {
+      // OIDC logout redirects through Keycloak and lands on /logged-out
+      await expect(page.locator(selectors.loggedOut.page)).toBeVisible({ timeout: 15_000 })
+      await expect(page).toHaveURL(/logged-out/)
+    })
   })
 })

--- a/frontend/tests/e2e/tests/oidc-redirect.spec.ts
+++ b/frontend/tests/e2e/tests/oidc-redirect.spec.ts
@@ -2,27 +2,28 @@ import { test, expect } from '@playwright/test'
 import { loginViaOidcRedirect } from '../helpers/auth'
 import { selectors } from '../helpers/selectors'
 
-test.describe('@oidc @oidc-redirect auto-redirect', () => {
-  test('@ci @oidc @oidc-redirect @auth should auto-redirect to Keycloak on login page', async ({
-    page,
-  }) => {
-    await loginViaOidcRedirect(page)
-    await expect(page.locator(selectors.chat.textInput)).toBeVisible({ timeout: 10_000 })
+test.describe('@ci @oidc @oidc-redirect OIDC Auto-Redirect', () => {
+  test('@auth should auto-redirect to Keycloak on login page', async ({ page }) => {
+    await test.step('Act: trigger OIDC auto-redirect login', async () => {
+      await loginViaOidcRedirect(page)
+    })
+
+    await test.step('Assert: chat input is visible after redirect', async () => {
+      await expect(page.locator(selectors.chat.textInput)).toBeVisible({ timeout: 10_000 })
+    })
   })
 
-  test('@ci @oidc @oidc-redirect @auth should not redirect on session_expired', async ({
-    page,
-  }) => {
-    await page.goto('/login?reason=session_expired')
+  test('@auth should not redirect on session_expired', async ({ page }) => {
+    await test.step('Act: navigate to login with session_expired reason', async () => {
+      await page.goto('/login?reason=session_expired')
+    })
 
-    // Should show session expired section with manual SSO button, not auto-redirect
-    const sessionExpiredSection = page.locator(selectors.oidc.sessionExpiredSection)
-    await expect(sessionExpiredSection).toBeVisible({ timeout: 10_000 })
+    await test.step('Assert: session expired section shown with manual SSO button', async () => {
+      const sessionExpiredSection = page.locator(selectors.oidc.sessionExpiredSection)
+      await expect(sessionExpiredSection).toBeVisible({ timeout: 10_000 })
 
-    // Password form should still be hidden
-    await expect(page.locator(selectors.login.email)).not.toBeVisible()
-
-    // Manual SSO button should be available
-    await expect(page.locator(selectors.oidc.keycloakButton)).toBeVisible()
+      await expect(page.locator(selectors.login.email)).not.toBeVisible()
+      await expect(page.locator(selectors.oidc.keycloakButton)).toBeVisible()
+    })
   })
 })

--- a/frontend/tests/e2e/tests/rag-search.spec.ts
+++ b/frontend/tests/e2e/tests/rag-search.spec.ts
@@ -17,62 +17,65 @@ const RAG_SEARCH_PHRASE = readFileSync(ragFixturePath, 'utf-8').trim()
  * Full semantic search E2E: upload fixture file, search for same phrase, assert at least one result.
  * Requires real AI (embeddings); excluded from CI via @noci.
  */
-test('@007 @noci @smoke semantic search finds uploaded content (real AI)', async ({
-  page,
-  credentials,
-}) => {
-  await login(page, credentials)
+test.describe('@noci @smoke RAG Semantic Search', () => {
+  test('semantic search finds uploaded content (real AI)', async ({ page, credentials }) => {
+    await login(page, credentials)
 
-  await test.step('Arrange: navigate to Files page', async () => {
-    const filesBtn = page.locator('[data-testid="btn-sidebar-v2--files"]')
-    await filesBtn.waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
-    await filesBtn.click()
-    await page
-      .locator(selectors.files.page)
-      .waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
-  })
-
-  const fileName = path.basename(ragFixturePath)
-  await test.step('Act: upload fixture file (most_important_thing.txt)', async () => {
-    await page.locator(selectors.files.fileInput).setInputFiles(ragFixturePath)
-    await page.locator(selectors.files.uploadButton).click()
-  })
-
-  await test.step('Assert: file appears in file list', async () => {
-    await page
-      .locator(selectors.files.table)
-      .waitFor({ state: 'visible', timeout: TIMEOUTS.VERY_LONG })
-    await expect(page.getByRole('row', { name: fileName })).toBeVisible({
-      timeout: TIMEOUTS.VERY_LONG,
+    await test.step('Arrange: navigate to Files page', async () => {
+      const filesBtn = page.locator('[data-testid="btn-sidebar-v2--files"]')
+      await filesBtn.waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
+      await filesBtn.click()
+      await page
+        .locator(selectors.files.page)
+        .waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
     })
-  })
 
-  await test.step('Act: navigate to Semantic Search and run query', async () => {
-    await page.goto('/rag')
-    await page.locator(selectors.rag.page).waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
-    await page.locator(selectors.rag.queryInput).fill(RAG_SEARCH_PHRASE)
-    await page.locator(selectors.rag.searchButton).click()
-  })
+    const fileName = path.basename(ragFixturePath)
+    await test.step('Act: upload fixture file (most_important_thing.txt)', async () => {
+      await page.locator(selectors.files.fileInput).setInputFiles(ragFixturePath)
+      await page.locator(selectors.files.uploadButton).click()
+    })
 
-  await test.step('Assert: search completes with at least one result, no error', async () => {
-    const summary = page.locator(selectors.rag.searchSummary)
-    const errorBanner = page.getByText(/error|failed|not found|model.*not found/i)
-    const result = await Promise.race([
-      summary.waitFor({ state: 'visible', timeout: TIMEOUTS.EXTREME }).then(() => 'done' as const),
-      errorBanner
-        .waitFor({ state: 'visible', timeout: TIMEOUTS.EXTREME })
-        .then(() => 'error' as const),
-    ])
-    if (result === 'error') {
-      const text = await errorBanner.textContent()
-      throw new Error(`RAG search ended in error: ${text?.trim() ?? 'error banner visible'}`)
-    }
-    await expect(summary).toBeVisible()
-    const results = page.locator(selectors.rag.resultItem)
-    const count = await results.count()
-    expect(
-      count,
-      'Semantic search should find at least one chunk for the uploaded phrase'
-    ).toBeGreaterThan(0)
+    await test.step('Assert: file appears in file list', async () => {
+      await page
+        .locator(selectors.files.table)
+        .waitFor({ state: 'visible', timeout: TIMEOUTS.VERY_LONG })
+      await expect(page.getByRole('row', { name: fileName })).toBeVisible({
+        timeout: TIMEOUTS.VERY_LONG,
+      })
+    })
+
+    await test.step('Act: navigate to Semantic Search and run query', async () => {
+      await page.goto('/rag')
+      await page
+        .locator(selectors.rag.page)
+        .waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
+      await page.locator(selectors.rag.queryInput).fill(RAG_SEARCH_PHRASE)
+      await page.locator(selectors.rag.searchButton).click()
+    })
+
+    await test.step('Assert: search completes with at least one result, no error', async () => {
+      const summary = page.locator(selectors.rag.searchSummary)
+      const errorBanner = page.getByText(/error|failed|not found|model.*not found/i)
+      const result = await Promise.race([
+        summary
+          .waitFor({ state: 'visible', timeout: TIMEOUTS.EXTREME })
+          .then(() => 'done' as const),
+        errorBanner
+          .waitFor({ state: 'visible', timeout: TIMEOUTS.EXTREME })
+          .then(() => 'error' as const),
+      ])
+      if (result === 'error') {
+        const text = await errorBanner.textContent()
+        throw new Error(`RAG search ended in error: ${text?.trim() ?? 'error banner visible'}`)
+      }
+      await expect(summary).toBeVisible()
+      const results = page.locator(selectors.rag.resultItem)
+      const count = await results.count()
+      expect(
+        count,
+        'Semantic search should find at least one chunk for the uploaded phrase'
+      ).toBeGreaterThan(0)
+    })
   })
 })

--- a/frontend/tests/e2e/tests/registration.spec.ts
+++ b/frontend/tests/e2e/tests/registration.spec.ts
@@ -4,98 +4,97 @@ import { deleteUser } from '../helpers/auth'
 import { clearMailHog, waitForVerificationHref, normalizeVerificationUrl } from '../helpers/email'
 import { TIMEOUTS, INTERVALS } from '../config/config'
 
-test.beforeEach(async ({ request }) => {
-  await clearMailHog(request)
-})
+test.describe('@ci @password @auth Registration', () => {
+  test.beforeEach(async ({ request }) => {
+    await clearMailHog(request)
+  })
 
-test('@ci @password @auth @smoke registration flow with email verification id=006', async ({
-  page,
-  request,
-}) => {
-  test.skip(process.env.AUTH_METHOD === 'oidc', 'Registration tests only run with password auth')
-  const uniqueSuffix = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
-  const testEmail = `test+${uniqueSuffix}@test.com`
-  const testPassword = 'Test1234'
+  test('@smoke registration flow with email verification', async ({ page, request }) => {
+    test.skip(process.env.AUTH_METHOD === 'oidc', 'Registration tests only run with password auth')
+    const uniqueSuffix = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+    const testEmail = `test+${uniqueSuffix}@test.com`
+    const testPassword = 'Test1234'
 
-  try {
-    await test.step('Open registration page', async () => {
-      await page.goto('/login')
-      await page
-        .locator(selectors.login.email)
-        .waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
-
-      await page.locator(selectors.login.signUpLink).click()
-      await expect(page).toHaveURL(/\/register/)
-      await page
-        .locator(selectors.register.fullName)
-        .waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
-    })
-
-    await test.step('Submit registration form', async () => {
-      await page.locator(selectors.register.fullName).fill('test')
-      await page.locator(selectors.register.email).fill(testEmail)
-      await page.locator(selectors.register.password).fill(testPassword)
-      await page.locator(selectors.register.confirmPassword).fill(testPassword)
-      await page.locator(selectors.register.submit).click()
-    })
-
-    await test.step('See registration success or error (fail-fast)', async () => {
-      const successLocator = page.locator(selectors.register.successSection)
-      const errorLocator = page.locator(selectors.register.errorAlert)
-      const result = await Promise.race([
-        successLocator
-          .waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
-          .then(() => 'success' as const),
-        errorLocator
-          .waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
-          .then(() => 'error' as const),
-      ])
-      if (result === 'error') {
-        const text = await errorLocator.textContent()
-        throw new Error(`Registration failed: ${text?.trim() ?? 'error alert visible'}`)
-      }
-    })
-
-    await test.step('Return to login screen', async () => {
-      await page.locator(selectors.register.backToLoginBtn).click()
-      await expect(page).toHaveURL(/\/login/)
-    })
-
-    const href = await test.step('Wait for verification email', async () => {
-      return waitForVerificationHref(request, testEmail, {
-        timeout: TIMEOUTS.STANDARD,
-        intervals: INTERVALS.FAST(),
-      })
-    })
-
-    await test.step('Open verification link', async () => {
-      await page.goto(normalizeVerificationUrl(href))
-      await page
-        .locator(selectors.verifyEmail.successState)
-        .waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
-    })
-
-    await test.step('Login with verified user', async () => {
-      await page.locator(selectors.verifyEmail.goToLoginLink).click()
-      await expect(page).toHaveURL(/\/login/)
-
-      await page.locator(selectors.login.email).fill(testEmail)
-      await page.locator(selectors.login.password).fill(testPassword)
-      await page.locator(selectors.login.submit).click()
-
-      await page
-        .locator(selectors.nav.sidebar)
-        .waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
-      await page
-        .locator(selectors.chat.textInput)
-        .waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
-      await expect(page.locator(selectors.chat.textInput)).toBeEnabled()
-    })
-  } finally {
     try {
-      await deleteUser(request, testEmail)
-    } catch {
-      // Cleanup failure must not mask the real test failure
+      await test.step('Arrange: open registration page', async () => {
+        await page.goto('/login')
+        await page
+          .locator(selectors.login.email)
+          .waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
+
+        await page.locator(selectors.login.signUpLink).click()
+        await expect(page).toHaveURL(/\/register/)
+        await page
+          .locator(selectors.register.fullName)
+          .waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
+      })
+
+      await test.step('Act: submit registration form', async () => {
+        await page.locator(selectors.register.fullName).fill('test')
+        await page.locator(selectors.register.email).fill(testEmail)
+        await page.locator(selectors.register.password).fill(testPassword)
+        await page.locator(selectors.register.confirmPassword).fill(testPassword)
+        await page.locator(selectors.register.submit).click()
+      })
+
+      await test.step('Assert: registration success or error (fail-fast)', async () => {
+        const successLocator = page.locator(selectors.register.successSection)
+        const errorLocator = page.locator(selectors.register.errorAlert)
+        const result = await Promise.race([
+          successLocator
+            .waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
+            .then(() => 'success' as const),
+          errorLocator
+            .waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
+            .then(() => 'error' as const),
+        ])
+        if (result === 'error') {
+          const text = await errorLocator.textContent()
+          throw new Error(`Registration failed: ${text?.trim() ?? 'error alert visible'}`)
+        }
+      })
+
+      await test.step('Act: return to login screen', async () => {
+        await page.locator(selectors.register.backToLoginBtn).click()
+        await expect(page).toHaveURL(/\/login/)
+      })
+
+      const href = await test.step('Act: wait for verification email', async () => {
+        return waitForVerificationHref(request, testEmail, {
+          timeout: TIMEOUTS.STANDARD,
+          intervals: INTERVALS.FAST(),
+        })
+      })
+
+      await test.step('Act: open verification link', async () => {
+        await page.goto(normalizeVerificationUrl(href))
+        await page
+          .locator(selectors.verifyEmail.successState)
+          .waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
+      })
+
+      await test.step('Assert: login with verified user succeeds', async () => {
+        await page.locator(selectors.verifyEmail.goToLoginLink).click()
+        await expect(page).toHaveURL(/\/login/)
+
+        await page.locator(selectors.login.email).fill(testEmail)
+        await page.locator(selectors.login.password).fill(testPassword)
+        await page.locator(selectors.login.submit).click()
+
+        await page
+          .locator(selectors.nav.sidebar)
+          .waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
+        await page
+          .locator(selectors.chat.textInput)
+          .waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
+        await expect(page.locator(selectors.chat.textInput)).toBeEnabled()
+      })
+    } finally {
+      try {
+        await deleteUser(request, testEmail)
+      } catch {
+        // Cleanup failure must not mask the real test failure
+      }
     }
-  }
+  })
 })

--- a/frontend/tests/e2e/tests/subscription.spec.ts
+++ b/frontend/tests/e2e/tests/subscription.spec.ts
@@ -53,167 +53,167 @@ async function pollSubscriptionStatus(
   return lastStatus
 }
 
-test('@ci @subscription Happy path: checkout PRO via mock webhook', async ({
-  page,
-  request,
-  credentials,
-}) => {
-  const customerId = `cus_${randomUUID()}`
-  const subscriptionId = `sub_${randomUUID()}`
-  let userId: string
-  let headers: { Cookie: string }
+test.describe('@ci @subscription Subscription', () => {
+  test('happy path: checkout PRO via mock webhook', async ({ page, request, credentials }) => {
+    const customerId = `cus_${randomUUID()}`
+    const subscriptionId = `sub_${randomUUID()}`
+    let userId: string
+    let headers: { Cookie: string }
 
-  await test.step('Arrange: login and get user ID', async () => {
-    await login(page, credentials)
-    headers = await getAuthHeaders(request, credentials)
-    const meRes = await request.get(`${API_URL}/api/v1/auth/me`, { headers })
-    const meData = await meRes.json()
-    userId = String(meData.user.id)
-  })
+    await test.step('Arrange: login and get user ID', async () => {
+      await login(page, credentials)
+      headers = await getAuthHeaders(request, credentials)
+      const meRes = await request.get(`${API_URL}/api/v1/auth/me`, { headers })
+      const meData = await meRes.json()
+      userId = String(meData.user.id)
+    })
 
-  await test.step('Arrange: navigate to subscription and verify no active plan', async () => {
-    await navigateToSubscriptionViaUI(page)
-    await page.waitForSelector(selectors.subscription.cardPlan, { timeout: TIMEOUTS.STANDARD })
-
-    await expect(page.locator(selectors.subscription.sectionCurrentPlan)).not.toBeVisible()
-    await expect(page.locator(selectors.subscription.btnSelectPro)).toBeVisible()
-  })
-
-  let checkoutIntercepted = false
-  await test.step('Act: intercept checkout and click PRO plan', async () => {
-    try {
-      await page.route('**/api/v1/subscription/checkout', (route) => {
-        checkoutIntercepted = true
-        return route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify({
-            sessionId: 'cs_test_mock',
-            url: '/subscription?checkout_intercepted=true',
-          }),
-        })
-      })
-
-      await page.locator(selectors.subscription.btnSelectPro).click()
-
+    await test.step('Arrange: navigate to subscription and verify no active plan', async () => {
+      await navigateToSubscriptionViaUI(page)
       await page.waitForSelector(selectors.subscription.cardPlan, { timeout: TIMEOUTS.STANDARD })
-      expect(checkoutIntercepted).toBe(true)
-    } finally {
-      await page.unroute('**/api/v1/subscription/checkout')
-    }
-  })
 
-  await test.step('Act: send mock webhooks (checkout completed + subscription created)', async () => {
-    const checkoutResult = await sendCheckoutCompletedWebhook(request, {
-      customerId,
-      subscriptionId,
-      userId: userId!,
+      await expect(page.locator(selectors.subscription.sectionCurrentPlan)).not.toBeVisible()
+      await expect(page.locator(selectors.subscription.btnSelectPro)).toBeVisible()
     })
-    expectWebhookSuccess(checkoutResult, 'checkout.session.completed')
 
-    const subResult = await sendSubscriptionCreatedWebhook(request, {
-      customerId,
-      subscriptionId,
-      userId: userId!,
+    let checkoutIntercepted = false
+    await test.step('Act: intercept checkout and click PRO plan', async () => {
+      try {
+        await page.route('**/api/v1/subscription/checkout', (route) => {
+          checkoutIntercepted = true
+          return route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+              sessionId: 'cs_test_mock',
+              url: '/subscription?checkout_intercepted=true',
+            }),
+          })
+        })
+
+        await page.locator(selectors.subscription.btnSelectPro).click()
+
+        await page.waitForSelector(selectors.subscription.cardPlan, {
+          timeout: TIMEOUTS.STANDARD,
+        })
+        expect(checkoutIntercepted).toBe(true)
+      } finally {
+        await page.unroute('**/api/v1/subscription/checkout')
+      }
     })
-    expectWebhookSuccess(subResult, 'customer.subscription.created')
-  })
 
-  await test.step('Wait: poll until backend has processed webhooks', async () => {
-    await pollSubscriptionStatus(
-      request,
-      headers,
-      (s) => s.hasSubscription === true && s.plan === 'PRO' && s.status === 'active',
-      'hasSubscription=true, plan=PRO, status=active'
-    )
-  })
+    await test.step('Act: send mock webhooks (checkout completed + subscription created)', async () => {
+      const checkoutResult = await sendCheckoutCompletedWebhook(request, {
+        customerId,
+        subscriptionId,
+        userId: userId!,
+      })
+      expectWebhookSuccess(checkoutResult, 'checkout.session.completed')
 
-  await test.step('Assert: subscription page shows PRO active', async () => {
-    await page.reload({ waitUntil: 'domcontentloaded' })
-    await navigateToSubscriptionViaUI(page)
-
-    const currentPlanSection = page.locator(selectors.subscription.sectionCurrentPlan)
-    await expect(currentPlanSection).toBeVisible({ timeout: TIMEOUTS.STANDARD })
-
-    const levelBadge = page.locator(selectors.subscription.badgeCurrentLevel)
-    await expect(levelBadge).toHaveText('PRO')
-
-    const statusBadge = page.locator(selectors.subscription.badgeStatus)
-    await expect(statusBadge).toBeVisible()
-  })
-})
-
-test('@ci @subscription Negative path: payment failed after active subscription', async ({
-  page,
-  request,
-  credentials,
-}) => {
-  const customerId = `cus_${randomUUID()}`
-  const subscriptionId = `sub_${randomUUID()}`
-  let userId: string
-  let headers: { Cookie: string }
-
-  await test.step('Arrange: login and get user ID', async () => {
-    await login(page, credentials)
-    headers = await getAuthHeaders(request, credentials)
-    const meRes = await request.get(`${API_URL}/api/v1/auth/me`, { headers })
-    const meData = await meRes.json()
-    userId = String(meData.user.id)
-  })
-
-  await test.step('Arrange: activate PRO subscription via webhooks', async () => {
-    const checkoutResult = await sendCheckoutCompletedWebhook(request, {
-      customerId,
-      subscriptionId,
-      userId: userId!,
+      const subResult = await sendSubscriptionCreatedWebhook(request, {
+        customerId,
+        subscriptionId,
+        userId: userId!,
+      })
+      expectWebhookSuccess(subResult, 'customer.subscription.created')
     })
-    expectWebhookSuccess(checkoutResult, 'checkout.session.completed')
 
-    const subResult = await sendSubscriptionCreatedWebhook(request, {
-      customerId,
-      subscriptionId,
-      userId: userId!,
+    await test.step('Wait: poll until backend has processed webhooks', async () => {
+      await pollSubscriptionStatus(
+        request,
+        headers,
+        (s) => s.hasSubscription === true && s.plan === 'PRO' && s.status === 'active',
+        'hasSubscription=true, plan=PRO, status=active'
+      )
     })
-    expectWebhookSuccess(subResult, 'customer.subscription.created')
 
-    await pollSubscriptionStatus(
-      request,
-      headers,
-      (s) => s.hasSubscription === true && s.plan === 'PRO',
-      'hasSubscription=true, plan=PRO'
-    )
+    await test.step('Assert: subscription page shows PRO active', async () => {
+      await page.reload({ waitUntil: 'domcontentloaded' })
+      await navigateToSubscriptionViaUI(page)
+
+      const currentPlanSection = page.locator(selectors.subscription.sectionCurrentPlan)
+      await expect(currentPlanSection).toBeVisible({ timeout: TIMEOUTS.STANDARD })
+
+      const levelBadge = page.locator(selectors.subscription.badgeCurrentLevel)
+      await expect(levelBadge).toHaveText('PRO')
+
+      const statusBadge = page.locator(selectors.subscription.badgeStatus)
+      await expect(statusBadge).toBeVisible()
+    })
   })
 
-  await test.step('Arrange: verify PRO is shown in UI', async () => {
-    await page.reload({ waitUntil: 'domcontentloaded' })
-    await navigateToSubscriptionViaUI(page)
+  test('negative path: payment failed after active subscription', async ({
+    page,
+    request,
+    credentials,
+  }) => {
+    const customerId = `cus_${randomUUID()}`
+    const subscriptionId = `sub_${randomUUID()}`
+    let userId: string
+    let headers: { Cookie: string }
 
-    const levelBadge = page.locator(selectors.subscription.badgeCurrentLevel)
-    await expect(levelBadge).toHaveText('PRO', { timeout: TIMEOUTS.STANDARD })
-  })
+    await test.step('Arrange: login and get user ID', async () => {
+      await login(page, credentials)
+      headers = await getAuthHeaders(request, credentials)
+      const meRes = await request.get(`${API_URL}/api/v1/auth/me`, { headers })
+      const meData = await meRes.json()
+      userId = String(meData.user.id)
+    })
 
-  await test.step('Act: send payment failed webhook', async () => {
-    const result = await sendPaymentFailedWebhook(request, { customerId })
-    expectWebhookSuccess(result, 'invoice.payment_failed')
-  })
+    await test.step('Arrange: activate PRO subscription via webhooks', async () => {
+      const checkoutResult = await sendCheckoutCompletedWebhook(request, {
+        customerId,
+        subscriptionId,
+        userId: userId!,
+      })
+      expectWebhookSuccess(checkoutResult, 'checkout.session.completed')
 
-  await test.step('Wait: poll until backend has processed payment_failed', async () => {
-    await pollSubscriptionStatus(
-      request,
-      headers,
-      (s) => s.paymentFailed === true,
-      'paymentFailed=true'
-    )
-  })
+      const subResult = await sendSubscriptionCreatedWebhook(request, {
+        customerId,
+        subscriptionId,
+        userId: userId!,
+      })
+      expectWebhookSuccess(subResult, 'customer.subscription.created')
 
-  await test.step('Assert: subscription page still shows PRO (paymentFailed not yet visible in UI)', async () => {
-    await page.reload({ waitUntil: 'domcontentloaded' })
-    await navigateToSubscriptionViaUI(page)
+      await pollSubscriptionStatus(
+        request,
+        headers,
+        (s) => s.hasSubscription === true && s.plan === 'PRO',
+        'hasSubscription=true, plan=PRO'
+      )
+    })
 
-    const currentPlanSection = page.locator(selectors.subscription.sectionCurrentPlan)
-    await expect(currentPlanSection).toBeVisible({ timeout: TIMEOUTS.STANDARD })
+    await test.step('Arrange: verify PRO is shown in UI', async () => {
+      await page.reload({ waitUntil: 'domcontentloaded' })
+      await navigateToSubscriptionViaUI(page)
 
-    const levelBadge = page.locator(selectors.subscription.badgeCurrentLevel)
-    await expect(levelBadge).toHaveText('PRO')
+      const levelBadge = page.locator(selectors.subscription.badgeCurrentLevel)
+      await expect(levelBadge).toHaveText('PRO', { timeout: TIMEOUTS.STANDARD })
+    })
+
+    await test.step('Act: send payment failed webhook', async () => {
+      const result = await sendPaymentFailedWebhook(request, { customerId })
+      expectWebhookSuccess(result, 'invoice.payment_failed')
+    })
+
+    await test.step('Wait: poll until backend has processed payment_failed', async () => {
+      await pollSubscriptionStatus(
+        request,
+        headers,
+        (s) => s.paymentFailed === true,
+        'paymentFailed=true'
+      )
+    })
+
+    await test.step('Assert: subscription page still shows PRO (paymentFailed not yet visible in UI)', async () => {
+      await page.reload({ waitUntil: 'domcontentloaded' })
+      await navigateToSubscriptionViaUI(page)
+
+      const currentPlanSection = page.locator(selectors.subscription.sectionCurrentPlan)
+      await expect(currentPlanSection).toBeVisible({ timeout: TIMEOUTS.STANDARD })
+
+      const levelBadge = page.locator(selectors.subscription.badgeCurrentLevel)
+      await expect(levelBadge).toHaveText('PRO')
+    })
   })
 })

--- a/frontend/tests/e2e/tests/task-prompts.spec.ts
+++ b/frontend/tests/e2e/tests/task-prompts.spec.ts
@@ -7,14 +7,14 @@ import { TIMEOUTS } from '../config/config'
 const PAGE = '/config/task-prompts'
 const SEL = selectors.taskPrompts
 
-test.describe('Task Prompts: model editing on system prompts', () => {
-  test('@021 @ci Admin can edit AI model, rules and content on system prompt', async ({
+test.describe('@ci Task Prompts', () => {
+  test('admin can edit AI model, rules and content on system prompt', async ({
     page,
     credentials,
   }) => {
     void credentials
 
-    await test.step('Arrange: login and select a prompt', async () => {
+    await test.step('Arrange: login as admin and select a prompt', async () => {
       await login(page, CREDENTIALS.getAdminCredentials())
       await page.goto(PAGE)
       const select = page.locator(SEL.promptSelect)
@@ -30,7 +30,7 @@ test.describe('Task Prompts: model editing on system prompts', () => {
     })
   })
 
-  test('@022 @ci Non-admin can edit AI model, rules and content on system prompt', async ({
+  test('non-admin can edit AI model, rules and content on system prompt', async ({
     page,
     credentials,
   }) => {

--- a/frontend/tests/e2e/tests/whatsapp.spec.ts
+++ b/frontend/tests/e2e/tests/whatsapp.spec.ts
@@ -42,14 +42,14 @@ async function postWebhookAndAssert2xx(request: APIRequestContext, payload: obje
   expect(json.success).toBe(true)
 }
 
-test.describe('@ci @whatsapp WhatsApp smoke @smoke', () => {
+test.describe('@ci @whatsapp @smoke WhatsApp', () => {
   test.describe.configure({ mode: 'serial' })
 
   test.beforeEach(async ({ request }, testInfo) => {
     await resetStub(request, getStubBaseUrl(), makeRunId(testInfo.testId))
   })
 
-  test('Text: webhook 2xx, exactly one outbound text, contract, idempotency', async ({
+  test('text: webhook 2xx, exactly one outbound, contract, idempotency', async ({
     request,
   }, testInfo) => {
     const baseUrl = getStubBaseUrl()
@@ -83,7 +83,7 @@ test.describe('@ci @whatsapp WhatsApp smoke @smoke', () => {
     })
   })
 
-  test('Negative: stub 500 → backend reports failed, exactly one attempt', async ({
+  test('negative: stub 500 → backend reports failed, exactly one attempt', async ({
     request,
   }, testInfo) => {
     const baseUrl = getStubBaseUrl()
@@ -116,7 +116,7 @@ test.describe('@ci @whatsapp WhatsApp smoke @smoke', () => {
     })
   })
 
-  test('Image: webhook 2xx, exactly one outbound message (text or image)', async ({
+  test('image: webhook 2xx, exactly one outbound message (text or image)', async ({
     request,
   }, testInfo) => {
     const baseUrl = getStubBaseUrl()
@@ -151,9 +151,7 @@ test.describe('@ci @whatsapp WhatsApp smoke @smoke', () => {
     })
   })
 
-  test('Audio: webhook 2xx, exactly one outbound message (text; stub audio is invalid so no TTS)', async ({
-    request,
-  }, testInfo) => {
+  test('audio: webhook 2xx, exactly one outbound text message', async ({ request }, testInfo) => {
     const baseUrl = getStubBaseUrl()
     const runId = makeRunId(testInfo.testId)
     const messageId = `smoke-audio-${Date.now()}-${Math.random().toString(36).slice(2)}`

--- a/frontend/tests/e2e/tests/widget.spec.ts
+++ b/frontend/tests/e2e/tests/widget.spec.ts
@@ -26,420 +26,406 @@ import { fileURLToPath } from 'url'
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 
-// In-app Test Widget overlay (no cross-origin). Test stack: expect "success"; dev: any non-empty reply.
-test('@013 @noci @smoke @widget @security Widget: overlay receives response', async ({
-  page,
-  credentials,
-}) => {
-  await login(page, credentials)
+test.describe('@ci @smoke Widget', () => {
+  test('applies settings and auto-open', async ({ page, credentials }) => {
+    await login(page, credentials)
 
-  const widgetName = WIDGET_NAMES.unique(WIDGET_NAMES.FULL_FLOW)
-  await createTestWidget(page, widgetName, URLS.TEST_PAGE_URL)
-  await updateWidgetSettings(page, widgetName, {})
+    const widgetName = WIDGET_NAMES.unique('Test Widget Settings')
+    const widgetInfo = await createTestWidget(page, widgetName, URLS.TEST_PAGE_URL)
+    const apiUrl = getApiUrl()
 
-  await page.goto('/tools/chat-widget')
-  await page.waitForSelector(selectors.widgets.page, { timeout: TIMEOUTS.LONG })
-
-  const testButton = page.locator(selectors.widgets.widgetCard.testButton).first()
-  await testButton.waitFor({ state: 'visible', timeout: TIMEOUTS.LONG })
-  await testButton.click()
-
-  const overlay = page.locator(selectors.widgets.testChatOverlay)
-  await overlay.waitFor({ state: 'visible', timeout: TIMEOUTS.LONG })
-
-  const chatWindow = overlay.locator(selectors.widget.chatWindow)
-  await chatWindow.waitFor({ state: 'visible', timeout: TIMEOUTS.LONG })
-
-  const input = overlay.locator(selectors.widget.input)
-  await expect(input).toBeVisible({ timeout: TIMEOUTS.SHORT })
-
-  const messagesContainer = overlay.locator(selectors.widget.messagesContainer)
-  await messagesContainer.waitFor({ state: 'attached', timeout: TIMEOUTS.SHORT }).catch(() => {})
-  const previousCount = await messagesContainer.locator(selectors.widget.messageContainers).count()
-
-  await input.fill(PROMPTS.SMOKE_TEST)
-  await overlay.locator(selectors.widget.sendButton).click()
-
-  const userBubble = overlay.locator(selectors.widget.messageUserText).last()
-  await expect(userBubble).toBeVisible({ timeout: TIMEOUTS.SHORT })
-  await expect(userBubble).toContainText('smoke test')
-
-  await expect
-    .poll(
-      async () => {
-        const count = await messagesContainer.locator(selectors.widget.messageContainers).count()
-        return count > previousCount ? count : null
-      },
-      { timeout: TIMEOUTS.VERY_LONG, intervals: INTERVALS.FAST() }
-    )
-    .not.toBeNull()
-
-  const aiTextElement = overlay.locator(selectors.widget.messageAiText).last()
-  await aiTextElement.waitFor({ state: 'visible', timeout: TIMEOUTS.VERY_LONG })
-
-  let lastText = ''
-  let stableCount = 0
-  await expect
-    .poll(
-      async () => {
-        const el = overlay.locator(selectors.widget.messageAiText).last()
-        if ((await el.count()) === 0) return null
-        const text = (await el.innerText()).trim().toLowerCase()
-        if (text.length === 0) return null
-        if (text === lastText) {
-          stableCount++
-          if (stableCount >= 2) return text
-          return null
-        }
-        lastText = text
-        stableCount = 1
-        return null
-      },
-      { timeout: TIMEOUTS.VERY_LONG, intervals: INTERVALS.FAST() }
-    )
-    .not.toBeNull()
-
-  const aiText = (await overlay.locator(selectors.widget.messageAiText).last().innerText()).trim()
-  expect(aiText.length).toBeGreaterThan(0)
-})
-
-test('@014 @ci @smoke @widget Widget: applies settings and auto-open', async ({
-  page,
-  credentials,
-}) => {
-  await login(page, credentials)
-
-  const widgetName = WIDGET_NAMES.unique('Test Widget Settings')
-  const widgetInfo = await createTestWidget(page, widgetName, URLS.TEST_PAGE_URL)
-  const apiUrl = getApiUrl()
-
-  await updateWidgetSettings(page, widgetName, {
-    autoMessage: WIDGET_MESSAGES.AUTO_MESSAGE,
-    autoOpen: true,
-  })
-
-  await gotoWidgetTestPage(page, widgetInfo.widgetId, apiUrl)
-
-  // autoOpen: true → widget opens itself, no button click needed
-  const widgetHost = page.locator(selectors.widget.host)
-  const chatWindow = widgetHost.locator(selectors.widget.chatWindow)
-  await chatWindow.waitFor({ state: 'visible', timeout: TIMEOUTS.LONG })
-
-  const autoMessage = widgetHost.locator(selectors.widget.messageAutoText)
-  await expect(autoMessage).toHaveText(WIDGET_MESSAGES.AUTO_MESSAGE, { timeout: TIMEOUTS.STANDARD })
-
-  await page.goto('/tools/chat-widget')
-  await page.waitForSelector(selectors.widgets.page, { timeout: TIMEOUTS.SHORT })
-  await updateWidgetSettings(page, widgetName, {
-    isActive: false,
-  })
-
-  const configResponse = page.waitForResponse(
-    (response) =>
-      response.url().includes(`/api/v1/widget/${widgetInfo.widgetId}/config`) &&
-      response.status() === 503,
-    { timeout: TIMEOUTS.STANDARD }
-  )
-  await gotoWidgetTestPage(page, widgetInfo.widgetId, apiUrl)
-  await configResponse
-
-  const inactiveWidgetButton = page.locator(selectors.widget.button)
-  await expect(inactiveWidgetButton).not.toBeVisible({ timeout: TIMEOUTS.SHORT })
-  const inactiveWidgetHost = page.locator(selectors.widget.host)
-  await expect(inactiveWidgetHost).toHaveCount(0)
-})
-
-// Widget allows only example.com; page is localhost → backend returns 403 domain_not_whitelisted.
-test('@015 @ci @smoke @widget @security Widget: blocked on non-whitelisted domain', async ({
-  page,
-  credentials,
-}) => {
-  await login(page, credentials)
-
-  const widgetName = WIDGET_NAMES.unique(WIDGET_NAMES.NOT_WHITELISTED)
-  const widgetInfo = await createTestWidget(page, widgetName, WIDGET_TEST_URLS.EXAMPLE_DOMAIN)
-  await updateWidgetSettings(page, widgetName, {})
-
-  const apiUrl = getApiUrl()
-
-  await test.step('Act: open test page → Assert: 403 or console 403, widget not shown', async () => {
-    const consoleDomainForbidden = new Promise<void>((resolve) => {
-      page.on('console', (msg) => {
-        const text = msg.text()
-        if (text.includes('Domain not allowed') && text.includes('403')) resolve()
-      })
+    await updateWidgetSettings(page, widgetName, {
+      autoMessage: WIDGET_MESSAGES.AUTO_MESSAGE,
+      autoOpen: true,
     })
-
-    const configResponse = page.waitForResponse(
-      (res) =>
-        res.url().includes(`/api/v1/widget/${widgetInfo.widgetId}/config`) && res.status() === 403,
-      { timeout: TIMEOUTS.STANDARD }
-    )
 
     await gotoWidgetTestPage(page, widgetInfo.widgetId, apiUrl)
 
-    const result = await Promise.race([
-      configResponse.then((r) => ({ type: 'response' as const, response: r })),
-      consoleDomainForbidden.then(() => ({ type: 'console' as const })),
-    ])
+    // autoOpen: true → widget opens itself, no button click needed
+    const widgetHost = page.locator(selectors.widget.host)
+    const chatWindow = widgetHost.locator(selectors.widget.chatWindow)
+    await chatWindow.waitFor({ state: 'visible', timeout: TIMEOUTS.LONG })
 
-    if (result.type === 'response') {
-      const body = await result.response.json()
-      expect(body.reason).toBe('domain_not_whitelisted')
-    }
-
-    await expect(page.locator(selectors.widget.button)).not.toBeVisible({
-      timeout: TIMEOUTS.SHORT,
+    const autoMessage = widgetHost.locator(selectors.widget.messageAutoText)
+    await expect(autoMessage).toHaveText(WIDGET_MESSAGES.AUTO_MESSAGE, {
+      timeout: TIMEOUTS.STANDARD,
     })
-    await expect(page.locator(selectors.widget.host)).toHaveCount(0)
-  })
 
-  await test.step('Arrange: add localhost to whitelist', async () => {
     await page.goto('/tools/chat-widget')
     await page.waitForSelector(selectors.widgets.page, { timeout: TIMEOUTS.SHORT })
-
-    const widgetCard = page
-      .locator(selectors.widgets.widgetCard.item)
-      .filter({ hasText: widgetName })
-      .first()
-    await widgetCard.locator(selectors.widgets.widgetCard.advancedButton).click()
-    await page.waitForSelector(selectors.widgets.advancedConfig.modal, {
-      timeout: TIMEOUTS.STANDARD,
+    await updateWidgetSettings(page, widgetName, {
+      isActive: false,
     })
 
-    const securityTab = page.locator(selectors.widgets.advancedConfig.securityTab)
-    if (!(await securityTab.isVisible())) {
-      await page.locator(selectors.widgets.advancedConfig.tabButtonSecurity).click()
-      await securityTab.waitFor({ state: 'visible', timeout: TIMEOUTS.SHORT })
-    }
-    await page.locator(selectors.widgets.advancedConfig.domainInput).fill('localhost')
-    await page.locator(selectors.widgets.advancedConfig.addDomainButton).click()
+    const configResponse = page.waitForResponse(
+      (response) =>
+        response.url().includes(`/api/v1/widget/${widgetInfo.widgetId}/config`) &&
+        response.status() === 503,
+      { timeout: TIMEOUTS.STANDARD }
+    )
+    await gotoWidgetTestPage(page, widgetInfo.widgetId, apiUrl)
+    await configResponse
 
-    const modal = page.locator(selectors.widgets.advancedConfig.modal)
-    const saveButton = modal.locator(selectors.widgets.advancedConfig.saveButton)
-    await saveButton.scrollIntoViewIfNeeded()
-    await saveButton.click()
-    await page.waitForSelector(selectors.widgets.advancedConfig.modal, {
-      state: 'hidden',
-      timeout: TIMEOUTS.STANDARD,
+    const inactiveWidgetButton = page.locator(selectors.widget.button)
+    await expect(inactiveWidgetButton).not.toBeVisible({ timeout: TIMEOUTS.SHORT })
+    const inactiveWidgetHost = page.locator(selectors.widget.host)
+    await expect(inactiveWidgetHost).toHaveCount(0)
+  })
+
+  test('@security blocked on non-whitelisted domain', async ({ page, credentials }) => {
+    await login(page, credentials)
+
+    const widgetName = WIDGET_NAMES.unique(WIDGET_NAMES.NOT_WHITELISTED)
+    const widgetInfo = await createTestWidget(page, widgetName, WIDGET_TEST_URLS.EXAMPLE_DOMAIN)
+    await updateWidgetSettings(page, widgetName, {})
+
+    const apiUrl = getApiUrl()
+
+    await test.step('Act: open test page → Assert: 403 or console 403, widget not shown', async () => {
+      const consoleDomainForbidden = new Promise<void>((resolve) => {
+        page.on('console', (msg) => {
+          const text = msg.text()
+          if (text.includes('Domain not allowed') && text.includes('403')) resolve()
+        })
+      })
+
+      const configResponse = page.waitForResponse(
+        (res) =>
+          res.url().includes(`/api/v1/widget/${widgetInfo.widgetId}/config`) &&
+          res.status() === 403,
+        { timeout: TIMEOUTS.STANDARD }
+      )
+
+      await gotoWidgetTestPage(page, widgetInfo.widgetId, apiUrl)
+
+      const result = await Promise.race([
+        configResponse.then((r) => ({ type: 'response' as const, response: r })),
+        consoleDomainForbidden.then(() => ({ type: 'console' as const })),
+      ])
+
+      if (result.type === 'response') {
+        const body = await result.response.json()
+        expect(body.reason).toBe('domain_not_whitelisted')
+      }
+
+      await expect(page.locator(selectors.widget.button)).not.toBeVisible({
+        timeout: TIMEOUTS.SHORT,
+      })
+      await expect(page.locator(selectors.widget.host)).toHaveCount(0)
+    })
+
+    await test.step('Arrange: add localhost to whitelist', async () => {
+      await page.goto('/tools/chat-widget')
+      await page.waitForSelector(selectors.widgets.page, { timeout: TIMEOUTS.SHORT })
+
+      const widgetCard = page
+        .locator(selectors.widgets.widgetCard.item)
+        .filter({ hasText: widgetName })
+        .first()
+      await widgetCard.locator(selectors.widgets.widgetCard.advancedButton).click()
+      await page.waitForSelector(selectors.widgets.advancedConfig.modal, {
+        timeout: TIMEOUTS.STANDARD,
+      })
+
+      const securityTab = page.locator(selectors.widgets.advancedConfig.securityTab)
+      if (!(await securityTab.isVisible())) {
+        await page.locator(selectors.widgets.advancedConfig.tabButtonSecurity).click()
+        await securityTab.waitFor({ state: 'visible', timeout: TIMEOUTS.SHORT })
+      }
+      await page.locator(selectors.widgets.advancedConfig.domainInput).fill('localhost')
+      await page.locator(selectors.widgets.advancedConfig.addDomainButton).click()
+
+      const modal = page.locator(selectors.widgets.advancedConfig.modal)
+      const saveButton = modal.locator(selectors.widgets.advancedConfig.saveButton)
+      await saveButton.scrollIntoViewIfNeeded()
+      await saveButton.click()
+      await page.waitForSelector(selectors.widgets.advancedConfig.modal, {
+        state: 'hidden',
+        timeout: TIMEOUTS.STANDARD,
+      })
+    })
+
+    await test.step('Act: open widget → Assert: chat window visible', async () => {
+      await openWidgetOnTestPage(page, widgetInfo.widgetId, apiUrl)
+      const chatWindow = page.locator(selectors.widget.host).locator(selectors.widget.chatWindow)
+      await expect(chatWindow).toBeVisible()
     })
   })
 
-  await test.step('Act: open widget → Assert: chat window visible', async () => {
-    await openWidgetOnTestPage(page, widgetInfo.widgetId, apiUrl)
-    const chatWindow = page.locator(selectors.widget.host).locator(selectors.widget.chatWindow)
-    await expect(chatWindow).toBeVisible()
+  test('embedded chat receives response', async ({ page, credentials }) => {
+    await login(page, credentials)
+
+    const widgetName = WIDGET_NAMES.unique('Embedded Widget Flow')
+    const widgetInfo = await createTestWidget(page, widgetName, URLS.TEST_PAGE_URL)
+    await updateWidgetSettings(page, widgetName, {})
+
+    const apiUrl = getApiUrl()
+    await test.step('Arrange: open widget on test page', async () => {
+      await openWidgetOnTestPage(page, widgetInfo.widgetId, apiUrl)
+    })
+
+    const widgetHost = page.locator(selectors.widget.host)
+    const messagesContainer = widgetHost.locator(selectors.widget.messagesContainer)
+    const messageContainers = messagesContainer.locator(selectors.widget.messageContainers)
+    const input = widgetHost.locator(selectors.widget.input)
+    await expect(input).toBeVisible({ timeout: TIMEOUTS.SHORT })
+
+    const previousCount = await countWidgetMessages(page)
+
+    await test.step('Act: send smoke test message', async () => {
+      await input.fill(PROMPTS.SMOKE_TEST)
+      await widgetHost.locator(selectors.widget.sendButton).click()
+    })
+
+    const userContainer = messageContainers.nth(previousCount)
+    await expect(userContainer.locator(selectors.widget.messageUserText)).toBeVisible({
+      timeout: TIMEOUTS.SHORT,
+    })
+    await expect(userContainer).toContainText('smoke test')
+
+    const assistantIndex = previousCount + 1
+    const newBubble = messageContainers.nth(assistantIndex)
+    await newBubble.waitFor({ state: 'attached', timeout: TIMEOUTS.STANDARD })
+    await newBubble.scrollIntoViewIfNeeded()
+    await newBubble.waitFor({ state: 'visible', timeout: TIMEOUTS.SHORT })
+
+    await newBubble
+      .locator(selectors.widget.messageDone)
+      .waitFor({ state: 'visible', timeout: TIMEOUTS.VERY_LONG })
+
+    const aiText = (await newBubble.locator(selectors.widget.messageAiText).innerText())
+      .trim()
+      .toLowerCase()
+
+    await test.step('Assert: stream ended (message-done) and assistant reply non-empty', async () => {
+      expect(aiText.length).toBeGreaterThan(0)
+    })
   })
 })
 
-test('@016 @noci @smoke @widget Widget: file upload returns answer', async ({
-  page,
-  credentials,
-}) => {
-  await login(page, credentials)
+test.describe('@noci @smoke Widget — full flow', () => {
+  test('@security overlay receives response', async ({ page, credentials }) => {
+    await login(page, credentials)
 
-  const widgetName = WIDGET_NAMES.unique('Test Widget File Upload')
-  const widgetInfo = await createTestWidget(page, widgetName, URLS.TEST_PAGE_URL)
-  await updateWidgetSettings(page, widgetName, {
-    allowFileUpload: true,
-  })
+    const widgetName = WIDGET_NAMES.unique(WIDGET_NAMES.FULL_FLOW)
+    await createTestWidget(page, widgetName, URLS.TEST_PAGE_URL)
+    await updateWidgetSettings(page, widgetName, {})
 
-  const apiUrl = getApiUrl()
-  await openWidgetOnTestPage(page, widgetInfo.widgetId, apiUrl)
+    await page.goto('/tools/chat-widget')
+    await page.waitForSelector(selectors.widgets.page, { timeout: TIMEOUTS.LONG })
 
-  const widgetHost = page.locator(selectors.widget.host)
+    const testButton = page.locator(selectors.widgets.widgetCard.testButton).first()
+    await testButton.waitFor({ state: 'visible', timeout: TIMEOUTS.LONG })
+    await testButton.click()
 
-  const attachButton = widgetHost.locator(selectors.widget.attachButton)
-  await expect(attachButton).toBeVisible({ timeout: TIMEOUTS.SHORT })
+    const overlay = page.locator(selectors.widgets.testChatOverlay)
+    await overlay.waitFor({ state: 'visible', timeout: TIMEOUTS.LONG })
 
-  const fileInput = widgetHost.locator(selectors.widget.fileInput)
-  const filePath = path.join(__dirname, '../test_data/most_important_thing.txt')
-  await fileInput.setInputFiles(filePath)
+    const chatWindow = overlay.locator(selectors.widget.chatWindow)
+    await chatWindow.waitFor({ state: 'visible', timeout: TIMEOUTS.LONG })
 
-  const fileName = widgetHost.locator('text=most_important_thing.txt')
-  await expect(fileName).toBeVisible({ timeout: TIMEOUTS.STANDARD })
+    const input = overlay.locator(selectors.widget.input)
+    await expect(input).toBeVisible({ timeout: TIMEOUTS.SHORT })
 
-  await expect(widgetHost.locator(selectors.widget.errorFileUpload)).toHaveCount(0)
-  await expect(widgetHost.locator(selectors.widget.errorFileSize)).toHaveCount(0)
-  await expect(widgetHost.locator(selectors.widget.errorFileUploadLimit)).toHaveCount(0)
+    const messagesContainer = overlay.locator(selectors.widget.messagesContainer)
+    await messagesContainer.waitFor({ state: 'attached', timeout: TIMEOUTS.SHORT }).catch(() => {})
+    const previousCount = await messagesContainer
+      .locator(selectors.widget.messageContainers)
+      .count()
 
-  const input = widgetHost.locator(selectors.widget.input)
-  await input.fill('Please read this file')
-  await widgetHost.locator(selectors.widget.sendButton).click()
-
-  const previousCount = await countWidgetMessages(page)
-  const aiText = await waitForWidgetAnswer(page, previousCount)
-  await expect(widgetHost.locator(selectors.widget.messageDone).last()).toBeVisible()
-  expect(aiText.length).toBeGreaterThan(0)
-
-  await expect(widgetHost.locator(selectors.widget.errorFileUpload)).toHaveCount(0)
-  await expect(widgetHost.locator(selectors.widget.errorFileSize)).toHaveCount(0)
-  await expect(widgetHost.locator(selectors.widget.errorFileUploadLimit)).toHaveCount(0)
-})
-
-test('@018 @noci @smoke @widget Widget: enforces file upload limit', async ({
-  page,
-  credentials,
-}) => {
-  await login(page, credentials)
-
-  const widgetName = WIDGET_NAMES.unique('Test Widget File Upload Limit')
-  const widgetInfo = await createTestWidget(page, widgetName, URLS.TEST_PAGE_URL)
-  await updateWidgetSettings(page, widgetName, {
-    allowFileUpload: true,
-    fileUploadLimit: 1,
-  })
-
-  const apiUrl = getApiUrl()
-  await openWidgetOnTestPage(page, widgetInfo.widgetId, apiUrl)
-
-  const widgetHost = page.locator(selectors.widget.host)
-
-  const fileInput = widgetHost.locator(selectors.widget.fileInput)
-  const firstFilePath = path.join(__dirname, '../test_data/most_important_thing.txt')
-  const secondFilePath = path.join(__dirname, '../test_data/second_most_important_thing.txt')
-
-  await fileInput.setInputFiles([firstFilePath, secondFilePath])
-
-  const errorMessageUpload = widgetHost.locator(selectors.widget.errorFileUpload)
-  await expect(errorMessageUpload).toBeVisible({ timeout: TIMEOUTS.STANDARD })
-  const errorTextUpload = await errorMessageUpload.textContent()
-  expect(errorTextUpload?.toLowerCase()).toMatch(/file.*upload.*limit|limit.*reached/i)
-
-  await fileInput.setInputFiles([])
-
-  await fileInput.setInputFiles(firstFilePath)
-  const firstFileName = widgetHost.locator('text=most_important_thing.txt')
-  await expect(firstFileName).toBeVisible({ timeout: TIMEOUTS.STANDARD })
-
-  const input = widgetHost.locator(selectors.widget.input)
-  await input.fill('Test message with file')
-  await widgetHost.locator(selectors.widget.sendButton).click()
-
-  const previousCount = await countWidgetMessages(page)
-  await waitForWidgetAnswer(page, previousCount)
-  await expect(widgetHost.locator(selectors.widget.messageDone).last()).toBeVisible()
-
-  await fileInput.setInputFiles(secondFilePath)
-
-  const errorMessageLimit = widgetHost.locator(selectors.widget.errorFileUploadLimit)
-  await expect(errorMessageLimit).toBeVisible({ timeout: TIMEOUTS.STANDARD })
-  const errorTextLimit = await errorMessageLimit.textContent()
-  expect(errorTextLimit?.toLowerCase()).toMatch(/file.*upload.*limit|limit.*reached/i)
-
-  const fileCount = await widgetHost.locator('text=most_important_thing.txt').count()
-  expect(fileCount).toBe(1)
-})
-
-test('@019 @noci @smoke @widget Widget: enforces max file size', async ({ page, credentials }) => {
-  await login(page, credentials)
-
-  const widgetName = WIDGET_NAMES.unique('Test Widget Max File Size')
-  const widgetInfo = await createTestWidget(page, widgetName, URLS.TEST_PAGE_URL)
-  await updateWidgetSettings(page, widgetName, {
-    allowFileUpload: true,
-    maxFileSize: 1,
-  })
-
-  const apiUrl = getApiUrl()
-  await openWidgetOnTestPage(page, widgetInfo.widgetId, apiUrl)
-
-  const widgetHost = page.locator(selectors.widget.host)
-
-  const fileInput = widgetHost.locator(selectors.widget.fileInput)
-  const largeFilePath = path.join(__dirname, '../test_data/sky_scrapers.jpg')
-  await fileInput.setInputFiles(largeFilePath)
-
-  const fileSizeError = widgetHost.locator(selectors.widget.errorFileSize)
-  await expect(fileSizeError).toBeVisible({ timeout: TIMEOUTS.STANDARD })
-  const errorText = await fileSizeError.textContent()
-  expect(errorText?.toLowerCase()).toMatch(/exceeds|too.*large|file.*size.*limit|limit/i)
-
-  const fileName = widgetHost.locator('text=sky_scrapers.jpg')
-  await expect(fileName).not.toBeVisible({ timeout: TIMEOUTS.SHORT })
-})
-
-test('@017 @noci @smoke @widget Widget: task prompt returns answer', async ({
-  page,
-  credentials,
-}) => {
-  await login(page, credentials)
-
-  const widgetName = WIDGET_NAMES.unique('Test Widget Task Prompt')
-  const widgetInfo = await createTestWidget(page, widgetName, URLS.TEST_PAGE_URL)
-
-  const filePath = path.join(__dirname, '../test_data/most_important_thing.txt')
-  await setWidgetTaskPrompt(
-    page,
-    widgetName,
-    WIDGET_TASK_PROMPT_KNOWLEDGE_BASE,
-    undefined,
-    filePath
-  )
-
-  const apiUrl = getApiUrl()
-  await openWidgetOnTestPage(page, widgetInfo.widgetId, apiUrl)
-
-  const widgetHost = page.locator(selectors.widget.host)
-  const input = widgetHost.locator(selectors.widget.input)
-  const previousCount = await countWidgetMessages(page)
-  await input.fill(WIDGET_TASK_PROMPT_QUESTION)
-  await widgetHost.locator(selectors.widget.sendButton).click()
-
-  const aiText = await waitForWidgetAnswer(page, previousCount)
-  await expect(widgetHost.locator(selectors.widget.messageDone).last()).toBeVisible()
-  expect(aiText.length).toBeGreaterThan(0)
-})
-
-test('@020 @ci @smoke @widget Widget: embedded chat receives response', async ({
-  page,
-  credentials,
-}) => {
-  await login(page, credentials)
-
-  const widgetName = WIDGET_NAMES.unique('Embedded Widget Flow')
-  const widgetInfo = await createTestWidget(page, widgetName, URLS.TEST_PAGE_URL)
-  await updateWidgetSettings(page, widgetName, {})
-
-  const apiUrl = getApiUrl()
-  await test.step('Arrange: open widget on test page', async () => {
-    await openWidgetOnTestPage(page, widgetInfo.widgetId, apiUrl)
-  })
-
-  const widgetHost = page.locator(selectors.widget.host)
-  const messagesContainer = widgetHost.locator(selectors.widget.messagesContainer)
-  const messageContainers = messagesContainer.locator(selectors.widget.messageContainers)
-  const input = widgetHost.locator(selectors.widget.input)
-  await expect(input).toBeVisible({ timeout: TIMEOUTS.SHORT })
-
-  const previousCount = await countWidgetMessages(page)
-
-  await test.step('Act: send smoke test message', async () => {
     await input.fill(PROMPTS.SMOKE_TEST)
+    await overlay.locator(selectors.widget.sendButton).click()
+
+    const userBubble = overlay.locator(selectors.widget.messageUserText).last()
+    await expect(userBubble).toBeVisible({ timeout: TIMEOUTS.SHORT })
+    await expect(userBubble).toContainText('smoke test')
+
+    await expect
+      .poll(
+        async () => {
+          const count = await messagesContainer.locator(selectors.widget.messageContainers).count()
+          return count > previousCount ? count : null
+        },
+        { timeout: TIMEOUTS.VERY_LONG, intervals: INTERVALS.FAST() }
+      )
+      .not.toBeNull()
+
+    const aiTextElement = overlay.locator(selectors.widget.messageAiText).last()
+    await aiTextElement.waitFor({ state: 'visible', timeout: TIMEOUTS.VERY_LONG })
+
+    let lastText = ''
+    let stableCount = 0
+    await expect
+      .poll(
+        async () => {
+          const el = overlay.locator(selectors.widget.messageAiText).last()
+          if ((await el.count()) === 0) return null
+          const text = (await el.innerText()).trim().toLowerCase()
+          if (text.length === 0) return null
+          if (text === lastText) {
+            stableCount++
+            if (stableCount >= 2) return text
+            return null
+          }
+          lastText = text
+          stableCount = 1
+          return null
+        },
+        { timeout: TIMEOUTS.VERY_LONG, intervals: INTERVALS.FAST() }
+      )
+      .not.toBeNull()
+
+    const aiText = (await overlay.locator(selectors.widget.messageAiText).last().innerText()).trim()
+    expect(aiText.length).toBeGreaterThan(0)
+  })
+
+  test('file upload returns answer', async ({ page, credentials }) => {
+    await login(page, credentials)
+
+    const widgetName = WIDGET_NAMES.unique('Test Widget File Upload')
+    const widgetInfo = await createTestWidget(page, widgetName, URLS.TEST_PAGE_URL)
+    await updateWidgetSettings(page, widgetName, {
+      allowFileUpload: true,
+    })
+
+    const apiUrl = getApiUrl()
+    await openWidgetOnTestPage(page, widgetInfo.widgetId, apiUrl)
+
+    const widgetHost = page.locator(selectors.widget.host)
+
+    const attachButton = widgetHost.locator(selectors.widget.attachButton)
+    await expect(attachButton).toBeVisible({ timeout: TIMEOUTS.SHORT })
+
+    const fileInput = widgetHost.locator(selectors.widget.fileInput)
+    const filePath = path.join(__dirname, '../test_data/most_important_thing.txt')
+    await fileInput.setInputFiles(filePath)
+
+    const fileName = widgetHost.locator('text=most_important_thing.txt')
+    await expect(fileName).toBeVisible({ timeout: TIMEOUTS.STANDARD })
+
+    await expect(widgetHost.locator(selectors.widget.errorFileUpload)).toHaveCount(0)
+    await expect(widgetHost.locator(selectors.widget.errorFileSize)).toHaveCount(0)
+    await expect(widgetHost.locator(selectors.widget.errorFileUploadLimit)).toHaveCount(0)
+
+    const inputEl = widgetHost.locator(selectors.widget.input)
+    await inputEl.fill('Please read this file')
     await widgetHost.locator(selectors.widget.sendButton).click()
+
+    const previousCount = await countWidgetMessages(page)
+    const aiText = await waitForWidgetAnswer(page, previousCount)
+    await expect(widgetHost.locator(selectors.widget.messageDone).last()).toBeVisible()
+    expect(aiText.length).toBeGreaterThan(0)
+
+    await expect(widgetHost.locator(selectors.widget.errorFileUpload)).toHaveCount(0)
+    await expect(widgetHost.locator(selectors.widget.errorFileSize)).toHaveCount(0)
+    await expect(widgetHost.locator(selectors.widget.errorFileUploadLimit)).toHaveCount(0)
   })
 
-  const userContainer = messageContainers.nth(previousCount)
-  await expect(userContainer.locator(selectors.widget.messageUserText)).toBeVisible({
-    timeout: TIMEOUTS.SHORT,
+  test('enforces file upload limit', async ({ page, credentials }) => {
+    await login(page, credentials)
+
+    const widgetName = WIDGET_NAMES.unique('Test Widget File Upload Limit')
+    const widgetInfo = await createTestWidget(page, widgetName, URLS.TEST_PAGE_URL)
+    await updateWidgetSettings(page, widgetName, {
+      allowFileUpload: true,
+      fileUploadLimit: 1,
+    })
+
+    const apiUrl = getApiUrl()
+    await openWidgetOnTestPage(page, widgetInfo.widgetId, apiUrl)
+
+    const widgetHost = page.locator(selectors.widget.host)
+
+    const fileInput = widgetHost.locator(selectors.widget.fileInput)
+    const firstFilePath = path.join(__dirname, '../test_data/most_important_thing.txt')
+    const secondFilePath = path.join(__dirname, '../test_data/second_most_important_thing.txt')
+
+    await fileInput.setInputFiles([firstFilePath, secondFilePath])
+
+    const errorMessageUpload = widgetHost.locator(selectors.widget.errorFileUpload)
+    await expect(errorMessageUpload).toBeVisible({ timeout: TIMEOUTS.STANDARD })
+    const errorTextUpload = await errorMessageUpload.textContent()
+    expect(errorTextUpload?.toLowerCase()).toMatch(/file.*upload.*limit|limit.*reached/i)
+
+    await fileInput.setInputFiles([])
+
+    await fileInput.setInputFiles(firstFilePath)
+    const firstFileName = widgetHost.locator('text=most_important_thing.txt')
+    await expect(firstFileName).toBeVisible({ timeout: TIMEOUTS.STANDARD })
+
+    const inputEl = widgetHost.locator(selectors.widget.input)
+    await inputEl.fill('Test message with file')
+    await widgetHost.locator(selectors.widget.sendButton).click()
+
+    const previousCount = await countWidgetMessages(page)
+    await waitForWidgetAnswer(page, previousCount)
+    await expect(widgetHost.locator(selectors.widget.messageDone).last()).toBeVisible()
+
+    await fileInput.setInputFiles(secondFilePath)
+
+    const errorMessageLimit = widgetHost.locator(selectors.widget.errorFileUploadLimit)
+    await expect(errorMessageLimit).toBeVisible({ timeout: TIMEOUTS.STANDARD })
+    const errorTextLimit = await errorMessageLimit.textContent()
+    expect(errorTextLimit?.toLowerCase()).toMatch(/file.*upload.*limit|limit.*reached/i)
+
+    const fileCount = await widgetHost.locator('text=most_important_thing.txt').count()
+    expect(fileCount).toBe(1)
   })
-  await expect(userContainer).toContainText('smoke test')
 
-  const assistantIndex = previousCount + 1
-  const newBubble = messageContainers.nth(assistantIndex)
-  await newBubble.waitFor({ state: 'attached', timeout: TIMEOUTS.STANDARD })
-  await newBubble.scrollIntoViewIfNeeded()
-  await newBubble.waitFor({ state: 'visible', timeout: TIMEOUTS.SHORT })
+  test('enforces max file size', async ({ page, credentials }) => {
+    await login(page, credentials)
 
-  await newBubble
-    .locator(selectors.widget.messageDone)
-    .waitFor({ state: 'visible', timeout: TIMEOUTS.VERY_LONG })
+    const widgetName = WIDGET_NAMES.unique('Test Widget Max File Size')
+    const widgetInfo = await createTestWidget(page, widgetName, URLS.TEST_PAGE_URL)
+    await updateWidgetSettings(page, widgetName, {
+      allowFileUpload: true,
+      maxFileSize: 1,
+    })
 
-  const aiText = (await newBubble.locator(selectors.widget.messageAiText).innerText())
-    .trim()
-    .toLowerCase()
+    const apiUrl = getApiUrl()
+    await openWidgetOnTestPage(page, widgetInfo.widgetId, apiUrl)
 
-  await test.step('Assert: stream ended (message-done) and assistant reply non-empty', async () => {
+    const widgetHost = page.locator(selectors.widget.host)
+
+    const fileInput = widgetHost.locator(selectors.widget.fileInput)
+    const largeFilePath = path.join(__dirname, '../test_data/sky_scrapers.jpg')
+    await fileInput.setInputFiles(largeFilePath)
+
+    const fileSizeError = widgetHost.locator(selectors.widget.errorFileSize)
+    await expect(fileSizeError).toBeVisible({ timeout: TIMEOUTS.STANDARD })
+    const errorText = await fileSizeError.textContent()
+    expect(errorText?.toLowerCase()).toMatch(/exceeds|too.*large|file.*size.*limit|limit/i)
+
+    const fileNameEl = widgetHost.locator('text=sky_scrapers.jpg')
+    await expect(fileNameEl).not.toBeVisible({ timeout: TIMEOUTS.SHORT })
+  })
+
+  test('task prompt returns answer', async ({ page, credentials }) => {
+    await login(page, credentials)
+
+    const widgetName = WIDGET_NAMES.unique('Test Widget Task Prompt')
+    const widgetInfo = await createTestWidget(page, widgetName, URLS.TEST_PAGE_URL)
+
+    const filePath = path.join(__dirname, '../test_data/most_important_thing.txt')
+    await setWidgetTaskPrompt(
+      page,
+      widgetName,
+      WIDGET_TASK_PROMPT_KNOWLEDGE_BASE,
+      undefined,
+      filePath
+    )
+
+    const apiUrl = getApiUrl()
+    await openWidgetOnTestPage(page, widgetInfo.widgetId, apiUrl)
+
+    const widgetHost = page.locator(selectors.widget.host)
+    const input = widgetHost.locator(selectors.widget.input)
+    const previousCount = await countWidgetMessages(page)
+    await input.fill(WIDGET_TASK_PROMPT_QUESTION)
+    await widgetHost.locator(selectors.widget.sendButton).click()
+
+    const aiText = await waitForWidgetAnswer(page, previousCount)
+    await expect(widgetHost.locator(selectors.widget.messageDone).last()).toBeVisible()
     expect(aiText.length).toBeGreaterThan(0)
   })
 })


### PR DESCRIPTION
## Summary

Replaces opaque numeric test IDs (`@003`, `@013`, `@020`, …) with human-readable names across **all 15 E2E spec files** and groups related tests into `test.describe` blocks. This makes test output, grep filtering, and Playwright UI immediately understandable without a lookup table.

### What changed

- **Numeric IDs removed** — `@003 @ci @smoke Standard model generates answer` becomes `test.describe('@ci @smoke Chat', () => { test('standard model generates answer', …) })`
- **`test.describe` grouping** — every spec file now wraps its tests in a describe block; shared tags (`@ci`, `@smoke`, `@noci`, `@oidc`, …) live on the describe level, per-test tags only where needed
- **`test.step` Arrange/Act/Assert** — added structured steps to tests that were missing them (auth, OIDC, registration, widget)
- **Lowercase titles** — normalized `"User can share chat…"` → `"user can share chat…"` for consistency
- **New spec: `task-prompts.spec.ts`** — tests that admin and non-admin users can edit AI model, rules, and content on system prompts
- **CI & README** — updated `ci.yml` comment and `README.md` examples to use name-based grep instead of ID-based (`-g "standard model"` instead of `-g "id=013"`)
- **Minor cleanups** — removed redundant inline comments, fixed typo "discription" → "description"