### PR TITLE
fix: increase widget builder memory limit to prevent OOM crash

### DIFF
--- a/docker-compose-minimal.yml
+++ b/docker-compose-minimal.yml
@@ -47,9 +47,9 @@ services:
     command: sh -c "npm ci && npm run build:widget -- --watch"
     environment:
       NODE_ENV: development
-      NODE_OPTIONS: '--max-old-space-size=768'
-    mem_limit: 1g
-    memswap_limit: 1g
+      NODE_OPTIONS: '--max-old-space-size=3072'
+    mem_limit: 4g
+    memswap_limit: 4g
     volumes:
       - ./frontend:/app
       # Anonymous volume to prevent host node_modules from being mounted

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,9 +47,9 @@ services:
     command: sh -c "npm ci && npm run build:widget -- --watch"
     environment:
       NODE_ENV: development
-      NODE_OPTIONS: '--max-old-space-size=768'
-    mem_limit: 1g
-    memswap_limit: 1g
+      NODE_OPTIONS: '--max-old-space-size=3072'
+    mem_limit: 4g
+    memswap_limit: 4g
     volumes:
       - ./frontend:/app
       # Anonymous volume to prevent host node_modules from being mounted


### PR DESCRIPTION
Vite + Terser build for 4500+ modules peaks at ~3.6 GB RSS. The previous 768 MB heap / 1 GB container limit caused a crash loop that wiped dist-widget/ on every restart (emptyOutDir), leaving widget.js permanently missing.