### PR TITLE
ci: cache Playwright browsers in E2E jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -386,9 +386,23 @@ jobs:
         working-directory: frontend
         run: npm ci
 
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ matrix.browser }}-${{ hashFiles('frontend/package-lock.json') }}
+          restore-keys: ${{ runner.os }}-playwright-${{ matrix.browser }}-
+
       - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         working-directory: frontend
         run: npx playwright install --with-deps ${{ matrix.browser }}
+
+      - name: Install Playwright system dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        working-directory: frontend
+        run: npx playwright install-deps ${{ matrix.browser }}
 
       - name: Run E2E tests
         working-directory: frontend


### PR DESCRIPTION
## Summary
Enabled playwright caching

## Changes
Browser downloads (especially Firefox) took 20-390s per E2E job. Cache browsers by browser type + package-lock hash, only install system dependencies on cache hit.

## Verification
- [x] Not tested 
will be tested in ci
- [ ] Manual
- [ ] Tests added/updated

## Notes
<!-- Related issues/links/threads. -->

## Screenshots/Logs
