### PR TITLE
fix(email): persist chat association and outgoing message in email webhook

### DIFF
--- a/backend/src/Controller/WebhookController.php
+++ b/backend/src/Controller/WebhookController.php
@@ -285,10 +285,11 @@ class WebhookController extends AbstractController
                 $inReplyTo
             );
 
-            // Create incoming message
+            // Create incoming message (use setChat(): BCHATID is mapped on both chatId and chat;
+            // setChatId() alone can leave the association unset so Doctrine persists NULL.)
             $message = new Message();
             $message->setUserId($user->getId());
-            $message->setChatId($chat->getId());
+            $message->setChat($chat);
             $message->setTrackingId(time());
             $message->setProviderIndex('EMAIL');
             $message->setUnixTimestamp(time());
@@ -418,6 +419,41 @@ class WebhookController extends AbstractController
                     }
                 }
             }
+
+            $classification = $result['classification'];
+            $message->setTopic($classification['topic'] ?? 'CHAT');
+            $message->setLanguage($classification['language'] ?? 'en');
+            $message->setStatus('complete');
+
+            $outgoingMessage = new Message();
+            $outgoingMessage->setUserId($user->getId());
+            $outgoingMessage->setChat($chat);
+            $outgoingMessage->setTrackingId($message->getTrackingId());
+            $outgoingMessage->setProviderIndex('EMAIL');
+            $outgoingMessage->setUnixTimestamp(time());
+            $outgoingMessage->setDateTime(date('YmdHis'));
+            $outgoingMessage->setMessageType('MAIL');
+            $outgoingMessage->setFile(0);
+            $outgoingMessage->setTopic($classification['topic'] ?? 'CHAT');
+            $outgoingMessage->setLanguage($classification['language'] ?? 'en');
+            $outgoingMessage->setText($responseText);
+            $outgoingMessage->setDirection('OUT');
+            $outgoingMessage->setStatus('complete');
+
+            $this->em->persist($outgoingMessage);
+            $this->em->flush();
+
+            $outgoingMessage->setMeta('ai_chat_provider', $provider ?? 'unknown');
+            $outgoingMessage->setMeta('ai_chat_model', $model ?? 'unknown');
+            if (!empty($metadata['usage'])) {
+                $outgoingMessage->setMeta('ai_chat_usage', json_encode($metadata['usage']));
+            }
+            if (!empty($metadata['model_id'])) {
+                $outgoingMessage->setMeta('ai_chat_model_id', (string) $metadata['model_id']);
+            }
+
+            $chat->updateTimestamp();
+            $this->em->flush();
 
             // Send email response back to user
             try {


### PR DESCRIPTION
## Summary
Fix for non-shown email conversation in the dashboard

## Changes
The email webhook uses setChatId() instead of setChat(). Because BCHATID is mapped twice on the Message entity (scalar field + ManyToOne association), Doctrine writes NULL — messages are not associated with any chat.

Additionally, no outgoing message (OUT) is persisted after AI processing. The response is only sent via email but never stored as a DB record, so the chat appears empty in the UI.

- Use setChat($chat) instead of setChatId() for correct Doctrine mapping
- Create and persist OUT message with AI response text and metadata
- Update incoming message status to 'complete' with classification data
- Call chat->updateTimestamp() so the chat sorts correctly in the sidebar

## Verification
- [ ] Not tested (explain)
- [x] Manual
- [ ] Tests added/updated

## Notes
<!-- Related issues/links/threads. -->

## Screenshots/Logs
