### PR TITLE
fix: unblock Renovate bot by removing schedule and enabling immediate  PRs

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -5,11 +5,11 @@
     "docker:enableMajor",
     ":separateMultipleMajorReleases"
   ],
+  "enabled": true,
   "timezone": "Europe/Berlin",
-  "schedule": ["before 9am on monday"],
   "prConcurrentLimit": 6,
   "prHourlyLimit": 2,
-  "prCreation": "not-pending",
+  "prCreation": "immediate",
   "dependencyDashboard": true,
   "labels": ["dependencies"],
   "packageRules": [


### PR DESCRIPTION
## Summary
Renovate bot has not created any PRs or a Dependency Dashboard issue. The `schedule` + `prCreation: not-pending` combination likely prevented PRs from appearing.

## Changes
- Remove `schedule` restriction (`"before 9am on monday"`) so Renovate can run immediately
- Change `prCreation` from `"not-pending"` to `"immediate"` (Renovate default)
- Add explicit `"enabled": true`

## Verification
- [ ] Not tested — verify after merge by checking for Renovate Dependency Dashboard issue and PRs
- If PRs still don't appear, the Renovate GitHub App may not be installed: https://github.com/apps/renovate → Configure → ensure `metadist/synaplan` has access

## Notes
Once Renovate is working, we can re-add a weekly schedule if desired.