### PR TITLE
fix: add LOCK_DSN default to docker-compose files

### DIFF
--- a/_docker/backend/docker-entrypoint.sh
+++ b/_docker/backend/docker-entrypoint.sh
@@ -3,16 +3,11 @@ set -euo pipefail
 
 echo "🚀 Starting Synaplan Backend..."
 
-# Create .env from .env.example if missing or empty
-# Docker Compose env_file with required:false may create an empty file before the entrypoint runs
-if [ ! -f /var/www/backend/.env ] || [ ! -s /var/www/backend/.env ]; then
-    if [ -f /var/www/backend/.env.example ]; then
-        echo "📝 Creating .env from .env.example..."
-        cp /var/www/backend/.env.example /var/www/backend/.env
-    else
-        echo "📝 Creating empty .env file..."
-        touch /var/www/backend/.env
-    fi
+# Create empty .env file if it doesn't exist
+# This is needed for Symfony's Dotenv component to work properly
+if [ ! -f /var/www/backend/.env ]; then
+    echo "📝 Creating empty .env file..."
+    touch /var/www/backend/.env
 fi
 
 # Fix .env ownership to match the parent directory (host user's UID/GID on bind-mounts).

--- a/docker-compose-minimal.yml
+++ b/docker-compose-minimal.yml
@@ -97,6 +97,7 @@ services:
       AI_DEFAULT_PROVIDER: groq
       # Token Configuration
       TOKEN_SECRET: 'change_me_in_production_use_openssl_rand_hex_32'
+      LOCK_DSN: ${LOCK_DSN:-flock}
       # Mailer (Mailhog for development)
       MAILER_DSN: smtp://mailhog:1025
       # External API Keys loaded from backend/.env via env_file

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,6 +98,7 @@ services:
       AI_DEFAULT_PROVIDER: ollama
       # Token Configuration
       TOKEN_SECRET: 'change_me_in_production_use_openssl_rand_hex_32'
+      LOCK_DSN: ${LOCK_DSN:-flock}
       # Mailer (Mailhog for development)
       MAILER_DSN: smtp://mailhog:1025
       # External API Keys loaded from backend/.env via env_file


### PR DESCRIPTION
## Summary
Added missing LOCK_DSN variable to docker-compose files

## Changes
Set LOCK_DSN: ${LOCK_DSN:-flock} as environment default in docker-compose.yml and docker-compose-minimal.yml. Reverts the .env.example copy approach from the previous commit — entrypoint stays unchanged.

## Verification
- [ ] Not tested (explain)
- [x] Manual
- [ ] Tests added/updated

## Notes
<!-- Related issues/links/threads. -->

## Screenshots/Logs
