### PR TITLE
fix(ollama): use correct camelCase property names for token usage counts

### DIFF
--- a/backend/src/AI/Provider/OllamaProvider.php
+++ b/backend/src/AI/Provider/OllamaProvider.php
@@ -110,8 +110,8 @@ class OllamaProvider implements ChatProviderInterface, EmbeddingProviderInterfac
                 'messages' => $ollamaMessages,
             ]);
 
-            $promptTokens = $response->prompt_eval_count ?? 0;
-            $completionTokens = $response->eval_count ?? 0;
+            $promptTokens = $response->promptEvalCount ?? 0;
+            $completionTokens = $response->evalCount ?? 0;
 
             $usage = [
                 'prompt_tokens' => $promptTokens,
@@ -225,9 +225,12 @@ class OllamaProvider implements ChatProviderInterface, EmbeddingProviderInterfac
 
                 // Final chunk contains usage data
                 if (isset($chunk->done) && $chunk->done) {
-                    $promptTokens = $chunk->prompt_eval_count ?? 0;
-                    $completionTokens = $chunk->eval_count ?? 0;
-                    $this->logger->info('🔵 Ollama: Stream done signal received');
+                    $promptTokens = $chunk->promptEvalCount ?? 0;
+                    $completionTokens = $chunk->evalCount ?? 0;
+                    $this->logger->info('🔵 Ollama: Stream done signal received', [
+                        'prompt_tokens' => $promptTokens,
+                        'completion_tokens' => $completionTokens,
+                    ]);
                     break;
                 }
             }


### PR DESCRIPTION
## Summary
Fix token statistics always showing 0 for all Ollama models (incl. gpt-oss) by correcting snake_case → camelCase property access on the SDK's ChatResponse object.

## Changes
- Fixed `OllamaProvider::chat()` and `chatStream()` to use `promptEvalCount`/`evalCount` (camelCase) instead of `prompt_eval_count`/`eval_count` (snake_case), matching the `ardagnsrn/ollama-php` SDK's ChatResponse properties.
- Added token count logging on stream completion for easier debugging.

## Verification
- [ ] Not tested (explain)
- [x] Manual
- [ ] Tests added/updated

Verified by reviewing the SDK source (`ChatResponse::from()` maps to camelCase readonly properties). Can be confirmed on live by checking token stats after a gpt-oss:120b chat request.

## Notes
The bug affected **all** Ollama models, not just gpt-oss:120b. PHP's `??` operator silently coalesced the undefined snake_case properties to `0`, so no errors were thrown — tokens were just never recorded.