### PR TITLE
Fix/photo upload

### DIFF
--- a/backend/src/AI/Provider/OpenAIProvider.php
+++ b/backend/src/AI/Provider/OpenAIProvider.php
@@ -440,7 +440,7 @@ class OpenAIProvider implements ChatProviderInterface, EmbeddingProviderInterfac
      * Convert Chat Completions message format to Responses API format.
      *
      * Chat Completions uses: {type: "text", text: "..."} and {type: "image_url", image_url: {url: "..."}}
-     * Responses API uses:    {type: "input_text", text: "..."} and {type: "input_image", image_url: "..."}
+     * Responses API uses:    {type: "input_text"/"output_text", text: "..."} and {type: "input_image", image_url: "..."}
      */
     private function convertToResponsesFormat(array $messages): array
     {

--- a/backend/src/Service/File/FileStorageService.php
+++ b/backend/src/Service/File/FileStorageService.php
@@ -18,7 +18,7 @@ final readonly class FileStorageService
     private const ALLOWED_EXTENSIONS = [
         'pdf', 'docx', 'doc', 'xlsx', 'xls', 'pptx', 'ppt', 'txt', 'md', 'csv',
         'odt', 'ods', 'odp', 'odg', 'odf',
-        'jpg', 'jpeg', 'png', 'gif', 'webp', 'heic', 'heif',
+        'jpg', 'jpeg', 'png', 'gif', 'webp',
         'mp3', 'mp4', 'wav', 'ogg', 'm4a', 'webm',
     ];
     private const VIDEO_EXTENSIONS = ['mp4', 'webm', 'mov', 'avi', 'mkv'];


### PR DESCRIPTION
## Summary
Allow photo uploads for GPT5.4 Responses from mobile

## Changes
Formats and handling of photo uploads from mobile. Every time you selected GPT5.4 with photo and text, it broke

## Verification
- [ ] Not tested (explain)
- [X] Manual
- [ ] Tests added/updated

