### PR TITLE
chore(renovate): preserve semver ranges instead of pinning

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:best-practices",
+    ":preserveSemverRanges",
     "docker:enableMajor",
     ":separateMultipleMajorReleases"
   ],


### PR DESCRIPTION
## Summary

- Adds `:preserveSemverRanges` preset to Renovate config to keep `^` ranges in `package.json` and `composer.json`
- `config:best-practices` includes `:pinAllExceptPeerDependencies` which replaces ranges with exact versions — this creates unnecessary pin PRs without security benefit since lockfiles already guarantee reproducible installs
- Docker image digest pinning and GitHub Actions SHA pinning remain active (those provide real supply-chain security)

## Effect

After merge, Renovate should auto-close or update PR #663 (pin dependencies) since pinning is no longer requested.

## Test plan

- [ ] Verify Renovate Dashboard updates after merge
- [ ] Verify PR #663 is closed or updated by Renovate
- [ ] Confirm future Renovate PRs preserve `^` ranges in package.json

