### PR TITLE
fix(ci): retry docker compose pull and avoid build-time pulls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,6 +343,7 @@ jobs:
         run: |
           COMPOSE="docker compose -f docker-compose.test.yml -f docker-compose.test.ci.yml"
           PROFILE="${{ matrix.compose_profiles }}"
+          n=0; until $COMPOSE $PROFILE pull; do n=$((n+1)); [ "$n" -ge 4 ] && exit 1; sleep $((n*15)); done
 
           # app_test entrypoint loads fixtures on first run (APP_ENV=test, empty DB)
           # so TestProvider model (-1 > -7) and admin user exist for E2E.

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -125,11 +125,18 @@ services:
       - synaplan-test-network
 
   # WhatsApp Graph API stub (starts by default for all E2E jobs).
+  # Uses node:22-alpine directly instead of a Dockerfile build so that
+  # `docker compose pull` (with retry) covers this image too.
   whatsapp-stub:
-    build:
-      context: frontend/tests/e2e/stub-servers/whatsapp
-      dockerfile: Dockerfile
+    image: node:22-alpine@sha256:4d64b49e6c891c8fc821007cb1cdc6c0db7773110ac2c34bf2e6960adef62ed3
     container_name: synaplan-whatsapp-stub
+    working_dir: /app
+    volumes:
+      - ./frontend/tests/e2e/stub-servers/whatsapp/whatsapp-stub-server.ts:/app/whatsapp-stub-server.ts:ro
+    environment:
+      PORT: "3999"
+      STUB_HOST: whatsapp-stub
+    command: ["node", "whatsapp-stub-server.ts"]
     ports:
       - "3999:3999"
     init: true

--- a/frontend/tests/e2e/stub-servers/whatsapp/Dockerfile
+++ b/frontend/tests/e2e/stub-servers/whatsapp/Dockerfile
@@ -1,6 +1,0 @@
-FROM node:22-alpine
-WORKDIR /app
-COPY whatsapp-stub-server.ts .
-ENV PORT=3999 STUB_HOST=whatsapp-stub
-EXPOSE 3999
-CMD ["node", "whatsapp-stub-server.ts"]


### PR DESCRIPTION
## Summary

- Add `docker compose pull` with exponential backoff retry (up to 4 attempts) before starting E2E test services, to handle transient Docker Hub / registry outages
- Convert `whatsapp-stub` from `build:` (Dockerfile) to `image: node:22-alpine` + volume-mount so that the pull retry covers this service too
- Delete the now-unused `frontend/tests/e2e/stub-servers/whatsapp/Dockerfile`

## Context

OIDC E2E tests failed during a merge to main due to a Docker Hub 504 Gateway Timeout when pulling `node:22-alpine` inside the whatsapp-stub Dockerfile build. The `docker compose pull` retry didn't help because `build:` services pull their base image inside BuildKit, not via `docker compose pull`. After a manual re-run, CI passed.

By switching to `image:` + volume-mount, all image pulls are now covered by the retry logic. The stub is a single TypeScript file with zero npm dependencies (uses only Node builtins), so no build step is needed.

## Test plan

- [x] `docker compose -f docker-compose.test.yml config` parses correctly
- [x] `docker compose -f docker-compose.test.yml -f docker-compose.test.ci.yml config` parses correctly
- [x] Stub starts locally, responds to `GET /__requests` with `[]`
- [ ] CI E2E tests pass (all 4 matrix jobs)