### PR TITLE
fix(ci): retry docker compose pull; stubs without Dockerfile builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,7 +343,7 @@ jobs:
         run: |
           COMPOSE="docker compose -f docker-compose.test.yml -f docker-compose.test.ci.yml"
           PROFILE="${{ matrix.compose_profiles }}"
-          n=0; until $COMPOSE $PROFILE pull; do n=$((n+1)); [ "$n" -ge 4 ] && exit 1; sleep $((n*15)); done
+          n=0; until $COMPOSE $PROFILE pull --ignore-buildable; do n=$((n+1)); [ "$n" -ge 4 ] && exit 1; sleep $((n*15)); done
 
           # app_test entrypoint loads fixtures on first run (APP_ENV=test, empty DB)
           # so TestProvider model (-1 > -7) and admin user exist for E2E.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,6 +343,7 @@ jobs:
         run: |
           COMPOSE="docker compose -f docker-compose.test.yml -f docker-compose.test.ci.yml"
           PROFILE="${{ matrix.compose_profiles }}"
+          n=0; until $COMPOSE $PROFILE pull --ignore-buildable; do n=$((n+1)); [ "$n" -ge 4 ] && exit 1; sleep $((n*15)); done
 
           # app_test entrypoint loads fixtures on first run (APP_ENV=test, empty DB)
           # so TestProvider model (-1 > -7) and admin user exist for E2E.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,7 +343,7 @@ jobs:
         run: |
           COMPOSE="docker compose -f docker-compose.test.yml -f docker-compose.test.ci.yml"
           PROFILE="${{ matrix.compose_profiles }}"
-          n=0; until $COMPOSE $PROFILE pull --ignore-buildable; do n=$((n+1)); [ "$n" -ge 4 ] && exit 1; sleep $((n*15)); done
+          n=0; until $COMPOSE $PROFILE pull; do n=$((n+1)); [ "$n" -ge 4 ] && exit 1; sleep $((n*15)); done
 
           # app_test entrypoint loads fixtures on first run (APP_ENV=test, empty DB)
           # so TestProvider model (-1 > -7) and admin user exist for E2E.

--- a/docker-compose.test.ci.yml
+++ b/docker-compose.test.ci.yml
@@ -11,7 +11,8 @@
 
 services:
   app_test:
-    # Use pre-built image from CI (e.g., synaplan-test:ci)
+    # Use pre-built image from CI (loaded via `docker load` from build artifact)
     image: ${APP_IMAGE:-}
- 
+    pull_policy: never
+
     volumes: !reset []

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -125,11 +125,18 @@ services:
       - synaplan-test-network
 
   # WhatsApp Graph API stub (starts by default for all E2E jobs).
+  # Uses node:22-alpine directly instead of a Dockerfile build so that
+  # `docker compose pull` (with retry) covers this image too.
   whatsapp-stub:
-    build:
-      context: frontend/tests/e2e/stub-servers/whatsapp
-      dockerfile: Dockerfile
+    image: node:22-alpine@sha256:4d64b49e6c891c8fc821007cb1cdc6c0db7773110ac2c34bf2e6960adef62ed3
     container_name: synaplan-whatsapp-stub
+    working_dir: /app
+    volumes:
+      - ./frontend/tests/e2e/stub-servers/whatsapp/whatsapp-stub-server.ts:/app/whatsapp-stub-server.ts:ro
+    environment:
+      PORT: "3999"
+      STUB_HOST: whatsapp-stub
+    command: ["node", "whatsapp-stub-server.ts"]
     ports:
       - "3999:3999"
     init: true

--- a/frontend/tests/e2e/stub-servers/whatsapp/Dockerfile
+++ b/frontend/tests/e2e/stub-servers/whatsapp/Dockerfile
@@ -1,6 +1,0 @@
-FROM node:22-alpine
-WORKDIR /app
-COPY whatsapp-stub-server.ts .
-ENV PORT=3999 STUB_HOST=whatsapp-stub
-EXPOSE 3999
-CMD ["node", "whatsapp-stub-server.ts"]


### PR DESCRIPTION
## Summary

- **`docker compose pull` with retry** before E2E services start, to survive transient Docker Hub / registry outages.
- **WhatsApp + Ollama stubs** use the same pattern: pinned `node:22-alpine` digest + bind-mount of the `.ts` server file + `user: node`, instead of `build:` Dockerfiles. That way the pull retry covers both stubs (no BuildKit base-image pull during `up`).
- **Removed** `frontend/tests/e2e/stub-servers/whatsapp/Dockerfile` and `ollama/Dockerfile` as redundant.
- **Dropped `--ignore-buildable`** on the pull step (plain `docker compose pull`) for broader compatibility with Compose versions on runners.

## Context

## Test plan

- [ ] CI green (all E2E matrix jobs including OIDC)