### PR TITLE
chore(docker): keep ollama_test out of CI integration profile

### DIFF
--- a/docker-compose.test.ci.yml
+++ b/docker-compose.test.ci.yml
@@ -2,6 +2,9 @@
 # This file configures the setup for CI by:
 #   1. Using a pre-built Docker image (via APP_IMAGE env var)
 #   2. Removing volume mounts: no backend/plugins mounts (baked into image)
+#   3. Keeping ollama_test out of CI: in docker-compose.test.yml it shares the
+#      `integration` profile with Tika. app_test uses ollama-stub; the service
+#      below overrides profiles so the ollama/ollama image is not pulled here.
 #
 # app_test reaches whatsapp-stub at http://whatsapp-stub:3999 via backend/.env.test (WHATSAPP_GRAPH_API_BASE_URL).
 # app_test reaches ollama-stub at http://ollama-stub:11434 via OLLAMA_BASE_URL in compose environment.
@@ -15,3 +18,7 @@ services:
     image: ${APP_IMAGE:-}
  
     volumes: !reset []
+
+  ollama_test:
+    profiles: !override
+      - disabled


### PR DESCRIPTION
## Summary
Extends `docker-compose.test.ci.yml` so `ollama_test` is not started when `--profile integration` is used (same profile as Tika in `docker-compose.test.yml`).

`app_test` uses `ollama-stub`; CI should not pull the full `ollama/ollama` image. The overlay moves `ollama_test` to a non-selected profile via `profiles: !override`.

## Notes
Consumers that clone Synaplan for CI (e.g. synaplan-opencloud) should bump their pinned `SYNAPLAN_REF` / image digest after this lands so the checkout includes this overlay.