### PR TITLE
Fix #697: Return clarification instead of silently defaulting to image

### DIFF
--- a/backend/src/Service/Message/Handler/MediaGenerationHandler.php
+++ b/backend/src/Service/Message/Handler/MediaGenerationHandler.php
@@ -195,13 +195,24 @@ final readonly class MediaGenerationHandler implements MessageHandlerInterface
                 $mediaType = 'image';
                 $this->logger->info('MediaGenerationHandler: Using media type hint from extractor (image)');
             } else {
-                $modelId = $this->modelConfigService->getDefaultModel('TEXT2PIC', $effectiveUserId);
-                $mediaType = 'image';
-
-                $this->logger->warning('MediaGenerationHandler: Media type not determined from extractor, defaulting to image', [
-                    'model_id' => $modelId,
+                $this->logger->warning('MediaGenerationHandler: Media type not determined from extractor, asking user to clarify', [
                     'prompt_preview' => substr($prompt, 0, 100),
                 ]);
+
+                $lang = $classification['language'] ?? 'en';
+                $clarification = 'de' === $lang
+                    ? 'Ich konnte nicht erkennen, welche Art von Medium du erstellen möchtest. '
+                        .'Bitte verwende einen der folgenden Befehle: `/pic` für Bilder, `/vid` für Videos.'
+                    : 'I couldn\'t determine what type of media you want to generate. '
+                        .'Please use one of the following commands: `/pic` for images, `/vid` for videos.';
+
+                $streamCallback($clarification);
+
+                return [
+                    'metadata' => [
+                        'error' => 'media_type_not_determined',
+                    ],
+                ];
             }
         }
 


### PR DESCRIPTION
## Summary
- When `MediaGenerationHandler` cannot determine the media type from any of the
  three detection layers (sorter → JSON → regex), it now returns a user-facing
  clarification message instead of silently generating an image
- Bilingual (EN/DE), consistent with existing error messages in `MediaErrorMessageBuilder`
- Returns early with `error: media_type_not_determined` metadata

## Context
Fixes #697. Previously, asking for media in ambiguous phrasing (e.g.
"Erstelle mir eine Aufnahme von einem kurzen Gedicht") would silently produce
a PNG image. Now the user sees:

> I couldn't determine what type of media you want to generate.
> Please use one of the following commands: `/pic` for images, `/vid` for videos.

## Test plan
- [ ] Send a media request with ambiguous phrasing (no clear image/video/audio keywords)
- [ ] Verify clarification message is returned instead of a generated image
- [ ] Verify `/pic` and `/vid` slash commands still work as before
- [ ] Verify explicit image/video/audio requests still route correctly
- [ ] Test with German language setting for localized message