### PR TITLE
chore(renovate): fix packageRules order for grouped PRs

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -13,6 +13,12 @@
   "labels": ["dependencies"],
   "packageRules": [
     {
+      "description": "Catch-all composer patch/minor FIRST — later rules override groupName for Framework/QA",
+      "groupName": "Backend Dependencies",
+      "matchManagers": ["composer"],
+      "matchUpdateTypes": ["minor", "patch"]
+    },
+    {
       "description": "Framework updates isolated — historically broke CI (#669)",
       "groupName": "PHP Framework",
       "matchManagers": ["composer"],
@@ -30,6 +36,12 @@
       "matchUpdateTypes": ["minor", "patch"]
     },
     {
+      "description": "Catch-all npm patch/minor FIRST — Frontend Core rule below overrides",
+      "groupName": "Frontend Dependencies",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch"]
+    },
+    {
       "description": "Frontend core frameworks grouped separately",
       "groupName": "Frontend Core",
       "matchManagers": ["npm"],
@@ -39,18 +51,6 @@
         "typescript", "@typescript-eslint/**", "vue-tsc",
         "tailwindcss", "@tailwindcss/**"
       ],
-      "matchUpdateTypes": ["minor", "patch"]
-    },
-    {
-      "description": "All remaining backend packages — never broke CI",
-      "groupName": "Backend Dependencies",
-      "matchManagers": ["composer"],
-      "matchUpdateTypes": ["minor", "patch"]
-    },
-    {
-      "description": "All remaining frontend packages — never broke CI",
-      "groupName": "Frontend Dependencies",
-      "matchManagers": ["npm"],
       "matchUpdateTypes": ["minor", "patch"]
     },
     {


### PR DESCRIPTION
## Summary

Reorders `packageRules` in `renovate.json5` so **catch-all** Composer/npm minor+patch grouping runs **first**, and **specific** rules (PHP Framework, QA & Dev Tools, Frontend Core) come **after**.

## Why

Renovate applies `packageRules` in order; **later matching rules override earlier ones** for the same field (e.g. `groupName`). With the catch-all **last**, it could override the intended `groupName` for Symfony/Doctrine, QA tools, and Vue/Vite — effectively collapsing those updates into generic "Backend Dependencies" / "Frontend Dependencies" PRs.

## What changes

- Move **Backend Dependencies** (all `composer` minor/patch) and **Frontend Dependencies** (all `npm` minor/patch) rules to the **top** of `packageRules`.
- Keep Framework, QA, and Frontend Core rules **below** so they still win for matching packages.

## Risk

Config-only; no runtime change. After merge, spot-check the next Renovate PRs (titles/grouping) on the dependency dashboard.


Made with [Cursor](https://cursor.com)