### PR TITLE
fix(ci): remove slow Azure apt mirror from Playwright deps install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -398,12 +398,16 @@ jobs:
       - name: Install Playwright browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         working-directory: frontend
-        run: npx playwright install --with-deps ${{ matrix.browser }}
+        run: |
+          sudo sed -i '/azure\.archive\.ubuntu\.com/d' /etc/apt/apt-mirrors.txt
+          npx playwright install --with-deps ${{ matrix.browser }}
 
       - name: Install Playwright system dependencies
         if: steps.playwright-cache.outputs.cache-hit == 'true'
         working-directory: frontend
-        run: npx playwright install-deps ${{ matrix.browser }}
+        run: |
+          sudo sed -i '/azure\.archive\.ubuntu\.com/d' /etc/apt/apt-mirrors.txt
+          npx playwright install-deps ${{ matrix.browser }}
 
       - name: Run E2E tests
         working-directory: frontend


### PR DESCRIPTION
## Summary

- Removes `azure.archive.ubuntu.com` from the runner's apt mirror priority list (`/etc/apt/apt-mirrors.txt`) before installing Playwright system dependencies
- Fixes sporadic 15–31 minute hangs in all 4 E2E matrix jobs (chromium, firefox, OIDC, OIDC Redirect)

## Context

GitHub Actions runners use `mirror+file:/etc/apt/apt-mirrors.txt` with Azure as priority 1 fallback. When this mirror is slow (not down, just throttled), apt hangs at ~29 kB/s instead of failing over. Analysis of 30 recent runs showed 3 outliers: 11 min, 28 min, and 31 min — all in the `Install Playwright system dependencies` step. Chromium is less affected (fewer apt packages), but Firefox and OIDC jobs were both hit.

After removal, apt uses `archive.ubuntu.com` (priority 2) and `security.ubuntu.com` (priority 3) directly.

## Test plan

- [ ] CI passes on this PR
- [ ] `Install Playwright system dependencies` completes in <30s for all E2E matrix legs
- [ ] Monitor next ~10 runs on main after merge for absence of 10+ min outliers