### PR TITLE
feat: add /tts slash command for audio generation

### DIFF
--- a/backend/src/Service/Message/Handler/MediaGenerationHandler.php
+++ b/backend/src/Service/Message/Handler/MediaGenerationHandler.php
@@ -142,6 +142,10 @@ final readonly class MediaGenerationHandler implements MessageHandlerInterface
             $mediaType = 'video';
             $isSlashCommand = true;
             $this->logger->info('MediaGenerationHandler: Detected /vid command, forcing video generation');
+        } elseif ('tools:tts' === $topic) {
+            $mediaType = 'audio';
+            $isSlashCommand = true;
+            $this->logger->info('MediaGenerationHandler: Detected /tts command, forcing audio generation');
         }
 
         // Priority: Again model_id > Task-prompt aiModel > DB default
@@ -168,6 +172,8 @@ final readonly class MediaGenerationHandler implements MessageHandlerInterface
             if ($isSlashCommand) {
                 if ('video' === $mediaType) {
                     $modelId = $this->modelConfigService->getDefaultModel('TEXT2VID', $effectiveUserId);
+                } elseif ('audio' === $mediaType) {
+                    $modelId = $this->modelConfigService->getDefaultModel('TEXT2SOUND', $effectiveUserId);
                 } else {
                     $modelId = $this->modelConfigService->getDefaultModel('TEXT2PIC', $effectiveUserId);
                 }
@@ -202,9 +208,9 @@ final readonly class MediaGenerationHandler implements MessageHandlerInterface
                 $lang = $classification['language'] ?? 'en';
                 $clarification = 'de' === $lang
                     ? 'Ich konnte nicht erkennen, welche Art von Medium du erstellen möchtest. '
-                        .'Bitte verwende einen der folgenden Befehle: `/pic` für Bilder, `/vid` für Videos.'
+                        .'Bitte verwende einen der folgenden Befehle: `/pic` für Bilder, `/vid` für Videos, `/tts` für Audio.'
                     : 'I couldn\'t determine what type of media you want to generate. '
-                        .'Please use one of the following commands: `/pic` for images, `/vid` for videos.';
+                        .'Please use one of the following commands: `/pic` for images, `/vid` for videos, `/tts` for audio.';
 
                 $streamCallback($clarification);
 

--- a/backend/src/Service/Message/MessageClassifier.php
+++ b/backend/src/Service/Message/MessageClassifier.php
@@ -29,6 +29,7 @@ final readonly class MessageClassifier
     private const TOOL_COMMANDS = [
         '/pic' => 'tools:pic',
         '/vid' => 'tools:vid',
+        '/tts' => 'tools:tts',
         '/search' => 'tools:search',
         '/lang' => 'tools:lang',
         '/web' => 'tools:web',
@@ -295,6 +296,7 @@ final readonly class MessageClassifier
             'text2sound' => 'image_generation',
             'tools:pic' => 'image_generation', // /pic command
             'tools:vid' => 'image_generation', // /vid command
+            'tools:tts' => 'image_generation', // /tts command (audio via MediaGenerationHandler)
 
             // Document/Office generation
             'officemaker' => 'document_generation',

--- a/frontend/src/stores/commands.ts
+++ b/frontend/src/stores/commands.ts
@@ -26,6 +26,13 @@ export const commandsData: Command[] = [
     icon: 'mdi:video',
   },
   {
+    name: 'tts',
+    description: 'Generate audio from text',
+    usage: '/tts [text to speech]',
+    requiresArgs: true,
+    icon: 'mdi:microphone',
+  },
+  {
     name: 'search',
     description: 'Search the web',
     usage: '/search [query]',


### PR DESCRIPTION
## Summary

- Adds `/tts` as explicit slash command for audio/TTS generation, completing the media command trio (`/pic`, `/vid`, `/tts`)
- Routes `/tts` through `MediaGenerationHandler` using the `TEXT2SOUND` default model
- Updates the clarification message (shown when media type can't be determined) to mention `/tts`
- Adds `/tts` to the frontend command autocomplete

Closes #697 (remaining `/tts` escape hatch part).

## Test plan

- [ ] Send `/tts Hello world` — should generate audio via TEXT2SOUND model
- [ ] Send ambiguous media request (e.g. "Erstelle mir eine Aufnahme") — clarification message should list `/pic`, `/vid`, `/tts`
- [ ] `/pic` and `/vid` still work as before
- [ ] Frontend autocomplete shows `/tts` with microphone icon