### PR TITLE
refactor: remove unused template refs

### DIFF
--- a/frontend/src/components/ChatInput.vue
+++ b/frontend/src/components/ChatInput.vue
@@ -116,7 +116,6 @@
           </button>
 
           <input
-            ref="fileInputRef"
             type="file"
             multiple
             class="hidden"
@@ -329,7 +328,7 @@ const mentionPaletteVisible = ref(false)
 const mentionPaletteRef = ref<InstanceType<typeof FileMentionPalette> | null>(null)
 const mentionQuery = ref('')
 const textareaRef = ref<InstanceType<typeof Textarea> | null>(null)
-const fileInputRef = ref<HTMLInputElement | null>(null)
+
 const activeCommand = ref<string | null>(null)
 const isDragging = ref(false)
 const isFocused = ref(false)

--- a/frontend/src/components/MessageCode.vue
+++ b/frontend/src/components/MessageCode.vue
@@ -45,7 +45,7 @@
     </div>
     <pre class="p-4 overflow-x-auto text-sm scroll-thin">
       <!-- eslint-disable-next-line vue/no-v-html -- trusted HTML from syntax highlighter -->
-      <code ref="codeRef" class="hljs font-mono" v-html="highlightedCode"></code>
+      <code class="hljs font-mono" v-html="highlightedCode"></code>
     </pre>
   </div>
 </template>
@@ -63,7 +63,6 @@ interface Props {
 const props = defineProps<Props>()
 
 const copied = ref(false)
-const codeRef = ref<HTMLElement | null>(null)
 const hljsReady = ref(false)
 
 // Load highlight.js and trigger re-render when ready

--- a/frontend/src/components/widgets/AdvancedWidgetConfig.vue
+++ b/frontend/src/components/widgets/AdvancedWidgetConfig.vue
@@ -1289,7 +1289,6 @@ SynaplanWidget.init({
                         }}</span>
                       </span>
                       <input
-                        ref="fileUploadInput"
                         type="file"
                         class="hidden"
                         accept=".pdf,.doc,.docx,.txt,.md,.csv,.json"
@@ -1828,7 +1827,7 @@ const existingMetadata = ref<Record<string, unknown>>({})
 const isSystemPrompt = computed(() => promptData.isDefault && promptData.id > 0)
 
 // File upload for Knowledge Base
-const fileUploadInput = ref<HTMLInputElement | null>(null)
+
 const promptFiles = ref<{ id: number; fileName: string; chunks: number }[]>([])
 const uploadingFile = ref(false)
 const deletingFileId = ref<number | null>(null)

--- a/frontend/src/views/FilesView.vue
+++ b/frontend/src/views/FilesView.vue
@@ -236,7 +236,6 @@
                       class="w-4 h-4 text-[var(--brand)] shrink-0"
                     />
                     <input
-                      ref="newFolderInput"
                       v-model="groupKeyword"
                       type="text"
                       class="flex-1 px-3 py-2 text-sm rounded-lg bg-black/[0.03] dark:bg-white/[0.03] txt-primary placeholder:txt-secondary/50 focus:outline-none focus:ring-2 focus:ring-[var(--brand)]"
@@ -1167,7 +1166,7 @@ const storageWidget = ref<InstanceType<typeof StorageQuotaWidget> | null>(null)
 const groupKeyword = ref('')
 const selectedGroup = ref('')
 const isCreatingNewFolder = ref(false)
-const newFolderInput = ref<HTMLInputElement | null>(null)
+
 const fileInputRef = ref<HTMLInputElement | null>(null)
 // File upload state (removed processLevel - always vectorize)
 const selectedFiles = ref<File[]>([])

--- a/frontend/src/views/WidgetsView.vue
+++ b/frontend/src/views/WidgetsView.vue
@@ -373,7 +373,6 @@
             >
               <ChatWidget
                 :key="chatWidgetKey"
-                ref="chatWidgetRef"
                 :widget-id="testWidget.widgetId"
                 :api-url="apiUrl"
                 :primary-color="testWidget.config?.primaryColor || '#007bff'"
@@ -447,7 +446,6 @@ const testWidget = ref<widgetsApi.Widget | null>(null)
 const overlayMode = ref<'test' | 'internal'>('internal')
 const internalSessionId = ref('')
 const chatWidgetKey = ref(0)
-const chatWidgetRef = ref<InstanceType<typeof ChatWidget> | null>(null)
 
 const testWidgetCustomFields = computed(() => testWidget.value?.config?.customFields ?? [])
 


### PR DESCRIPTION
## Summary

- Remove 5 template refs that were declared but never read in script (dead code)
- Prepares for vue-tsc v3 (#752) which flags these as TS6133

After this lands on `main`, rebase #752 — it should pass CI.

## Test plan

- [x] `make -C frontend lint`
- [x] `docker compose exec -T frontend npm run check:types`
- [x] `make -C frontend test` — 295 tests passed