### PR TITLE
feat: centralize date formatting with user timezone support

### DIFF
--- a/backend/src/Controller/WidgetExportController.php
+++ b/backend/src/Controller/WidgetExportController.php
@@ -75,6 +75,13 @@ class WidgetExportController extends AbstractController
         description: 'Filter by session mode',
         schema: new OA\Schema(type: 'string', enum: ['ai', 'human', 'waiting', 'internal'])
     )]
+    #[OA\Parameter(
+        name: 'timezone',
+        in: 'query',
+        required: false,
+        description: 'IANA timezone for date formatting (e.g. Europe/Berlin)',
+        schema: new OA\Schema(type: 'string', default: 'UTC')
+    )]
     #[OA\Response(
         response: 200,
         description: 'Export file',
@@ -106,6 +113,8 @@ class WidgetExportController extends AbstractController
             return $this->json(['error' => 'Invalid format. Use: xlsx, csv, json'], Response::HTTP_BAD_REQUEST);
         }
 
+        $tz = WidgetExportService::resolveTimezone($request->query->getString('timezone', 'UTC'));
+
         $filters = [];
         if ($request->query->has('from')) {
             $filters['from'] = (int) $request->query->get('from');
@@ -124,9 +133,9 @@ class WidgetExportController extends AbstractController
         try {
             $baseUrl = $request->getSchemeAndHttpHost();
             $filePath = match ($format) {
-                'xlsx' => $this->exportService->exportToExcel($widget, $filters),
-                'csv' => $this->exportService->exportToCsv($widget, $filters),
-                'json' => $this->exportService->exportToJson($widget, $filters, $baseUrl),
+                'xlsx' => $this->exportService->exportToExcel($widget, $filters, $tz),
+                'csv' => $this->exportService->exportToCsv($widget, $filters, $tz),
+                'json' => $this->exportService->exportToJson($widget, $filters, $baseUrl, $tz),
             };
 
             $contentType = match ($format) {

--- a/backend/src/Service/WidgetExportService.php
+++ b/backend/src/Service/WidgetExportService.php
@@ -52,29 +52,53 @@ final readonly class WidgetExportService
     ) {
     }
 
+    public static function resolveTimezone(string $timezone): \DateTimeZone
+    {
+        try {
+            return new \DateTimeZone($timezone);
+        } catch (\Exception) {
+            return new \DateTimeZone('UTC');
+        }
+    }
+
+    private function formatTimestamp(int $timestamp, \DateTimeZone $tz, string $format = 'Y-m-d H:i:s'): string
+    {
+        $dt = new \DateTime('@'.$timestamp);
+        $dt->setTimezone($tz);
+
+        return $dt->format($format);
+    }
+
+    private function formatNow(\DateTimeZone $tz, string $format = 'Y-m-d H:i:s'): string
+    {
+        $dt = new \DateTime('now', $tz);
+
+        return $dt->format($format);
+    }
+
     /**
      * Export widget sessions to Excel format.
      *
      * @param WidgetSessionExportFilters $filters
      */
-    public function exportToExcel(Widget $widget, array $filters = []): string
+    public function exportToExcel(Widget $widget, array $filters = [], \DateTimeZone $tz = new \DateTimeZone('UTC')): string
     {
         $spreadsheet = new Spreadsheet();
 
         // Sheet 1: Overview
         $overviewSheet = $spreadsheet->getActiveSheet();
         $overviewSheet->setTitle('Overview');
-        $this->createOverviewSheet($overviewSheet, $widget, $filters);
+        $this->createOverviewSheet($overviewSheet, $widget, $filters, $tz);
 
         // Sheet 2: Conversations
         $conversationsSheet = $spreadsheet->createSheet();
         $conversationsSheet->setTitle('Conversations');
-        $this->createConversationsSheet($conversationsSheet, $widget, $filters);
+        $this->createConversationsSheet($conversationsSheet, $widget, $filters, $tz);
 
         // Sheet 3: Sessions Summary
         $sessionsSheet = $spreadsheet->createSheet();
         $sessionsSheet->setTitle('Sessions');
-        $this->createSessionsSheet($sessionsSheet, $widget, $filters);
+        $this->createSessionsSheet($sessionsSheet, $widget, $filters, $tz);
 
         // Generate file
         $tempFile = tempnam(sys_get_temp_dir(), 'widget_export_').'.xlsx';
@@ -89,7 +113,7 @@ final readonly class WidgetExportService
      *
      * @param WidgetSessionExportFilters $filters
      */
-    public function exportToCsv(Widget $widget, array $filters = []): string
+    public function exportToCsv(Widget $widget, array $filters = [], \DateTimeZone $tz = new \DateTimeZone('UTC')): string
     {
         $tempFile = tempnam(sys_get_temp_dir(), 'widget_export_').'.csv';
         $handle = fopen($tempFile, 'w');
@@ -131,11 +155,11 @@ final readonly class WidgetExportService
             foreach ($messages as $message) {
                 $row = [
                     $session->getSessionId(),
-                    date('Y-m-d H:i:s', $session->getCreated()),
-                    date('Y-m-d H:i:s', $session->getLastMessage()),
+                    $this->formatTimestamp($session->getCreated(), $tz),
+                    $this->formatTimestamp($session->getLastMessage(), $tz),
                     $messageCount,
                     $session->getMode(),
-                    date('Y-m-d H:i:s', $message['timestamp']),
+                    $this->formatTimestamp($message['timestamp'], $tz),
                     $message['sender'],
                     $message['text'],
                 ];
@@ -157,7 +181,7 @@ final readonly class WidgetExportService
      *
      * @param WidgetSessionExportFilters $filters
      */
-    public function exportToJson(Widget $widget, array $filters = [], string $baseUrl = ''): string
+    public function exportToJson(Widget $widget, array $filters = [], string $baseUrl = '', \DateTimeZone $tz = new \DateTimeZone('UTC')): string
     {
         $result = $this->sessionRepository->findSessionsByWidget(
             $widget->getWidgetId(),
@@ -171,7 +195,7 @@ final readonly class WidgetExportService
         $widgetData = [
             'id' => $widget->getWidgetId(),
             'name' => $widget->getName(),
-            'exported_at' => date('c'),
+            'exported_at' => $this->formatNow($tz, 'c'),
         ];
         if (!empty($customFields)) {
             $widgetData['custom_fields'] = $customFields;
@@ -224,15 +248,15 @@ final readonly class WidgetExportService
 
             $sessionData = [
                 'session_id' => $session->getSessionId(),
-                'created' => date('c', $session->getCreated()),
-                'last_activity' => date('c', $session->getLastMessage()),
+                'created' => $this->formatTimestamp($session->getCreated(), $tz, 'c'),
+                'last_activity' => $this->formatTimestamp($session->getLastMessage(), $tz, 'c'),
                 'message_count' => $messageCount,
                 'file_count' => $fileCount,
                 'mode' => $session->getMode(),
                 'messages' => array_map(fn ($m) => [
                     'direction' => $m['direction'],
                     'text' => $m['text'],
-                    'timestamp' => date('c', $m['timestamp']),
+                    'timestamp' => $this->formatTimestamp($m['timestamp'], $tz, 'c'),
                     'sender' => $m['sender'],
                     'files' => array_map(fn ($f) => [
                         ...$f,
@@ -250,8 +274,8 @@ final readonly class WidgetExportService
         }
 
         // Set actual date range from exported sessions
-        $exportData['export_range']['from'] = $earliestCreated ? date('c', $earliestCreated) : null;
-        $exportData['export_range']['to'] = $latestActivity ? date('c', $latestActivity) : null;
+        $exportData['export_range']['from'] = $earliestCreated ? $this->formatTimestamp($earliestCreated, $tz, 'c') : null;
+        $exportData['export_range']['to'] = $latestActivity ? $this->formatTimestamp($latestActivity, $tz, 'c') : null;
 
         $exportData['statistics']['total_messages'] = $totalMessages;
         $exportData['statistics']['total_files'] = $totalFiles;
@@ -271,7 +295,7 @@ final readonly class WidgetExportService
         return $tempFile;
     }
 
-    private function createOverviewSheet(Worksheet $sheet, Widget $widget, array $filters): void
+    private function createOverviewSheet(Worksheet $sheet, Widget $widget, array $filters, \DateTimeZone $tz): void
     {
         // Title styling
         $sheet->setCellValue('A1', 'Widget Export Report');
@@ -285,12 +309,12 @@ final readonly class WidgetExportService
         $sheet->setCellValue('A4', 'Widget ID:');
         $sheet->setCellValue('B4', $widget->getWidgetId());
         $sheet->setCellValue('A5', 'Export Date:');
-        $sheet->setCellValue('B5', date('Y-m-d H:i:s'));
+        $sheet->setCellValue('B5', $this->formatNow($tz));
 
         // Filter info
         $sheet->setCellValue('A7', 'Export Range:');
-        $fromDate = isset($filters['from']) ? date('Y-m-d', $filters['from']) : 'All time';
-        $toDate = isset($filters['to']) ? date('Y-m-d', $filters['to']) : 'Present';
+        $fromDate = isset($filters['from']) ? $this->formatTimestamp($filters['from'], $tz, 'Y-m-d') : 'All time';
+        $toDate = isset($filters['to']) ? $this->formatTimestamp($filters['to'], $tz, 'Y-m-d') : 'Present';
         $sheet->setCellValue('B7', $fromDate.' to '.$toDate);
 
         $totalSessions = $this->sessionRepository->countSessionsWithFilters($widget->getWidgetId(), $filters);
@@ -339,7 +363,7 @@ final readonly class WidgetExportService
         $sheet->getColumnDimension('B')->setWidth(40);
     }
 
-    private function createConversationsSheet(Worksheet $sheet, Widget $widget, array $filters): void
+    private function createConversationsSheet(Worksheet $sheet, Widget $widget, array $filters, \DateTimeZone $tz): void
     {
         $customFields = $widget->getConfig()['customFields'] ?? [];
 
@@ -389,8 +413,8 @@ final readonly class WidgetExportService
                 }
 
                 $sheet->setCellValue('A'.$row, '#'.$sessionNum);
-                $sheet->setCellValue('B'.$row, date('Y-m-d', $message['timestamp']));
-                $sheet->setCellValue('C'.$row, date('H:i:s', $message['timestamp']));
+                $sheet->setCellValue('B'.$row, $this->formatTimestamp($message['timestamp'], $tz, 'Y-m-d'));
+                $sheet->setCellValue('C'.$row, $this->formatTimestamp($message['timestamp'], $tz, 'H:i:s'));
                 $sheet->setCellValue('D'.$row, $message['sender']);
                 $sheet->setCellValue('E'.$row, $message['text']);
 
@@ -432,7 +456,7 @@ final readonly class WidgetExportService
         $sheet->getStyle('E:E')->getAlignment()->setWrapText(true);
     }
 
-    private function createSessionsSheet(Worksheet $sheet, Widget $widget, array $filters): void
+    private function createSessionsSheet(Worksheet $sheet, Widget $widget, array $filters, \DateTimeZone $tz): void
     {
         // Header
         $headers = ['Session ID', 'Created', 'Last Activity', 'Messages', 'Files', 'Mode', 'Duration'];
@@ -464,8 +488,8 @@ final readonly class WidgetExportService
             $fileCount = $this->countFilesInMessages($messages);
 
             $sheet->setCellValue('A'.$row, substr($session->getSessionId(), 0, 12).'...');
-            $sheet->setCellValue('B'.$row, date('Y-m-d H:i', $session->getCreated()));
-            $sheet->setCellValue('C'.$row, date('Y-m-d H:i', $session->getLastMessage()));
+            $sheet->setCellValue('B'.$row, $this->formatTimestamp($session->getCreated(), $tz, 'Y-m-d H:i'));
+            $sheet->setCellValue('C'.$row, $this->formatTimestamp($session->getLastMessage(), $tz, 'Y-m-d H:i'));
             $sheet->setCellValue('D'.$row, $messageCount);
             $sheet->setCellValue('E'.$row, $fileCount);
             $sheet->setCellValue('F'.$row, ucfirst($session->getMode()));

--- a/backend/tests/Unit/Service/WidgetExportServiceTest.php
+++ b/backend/tests/Unit/Service/WidgetExportServiceTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service;
+
+use App\Service\WidgetExportService;
+use PHPUnit\Framework\TestCase;
+
+class WidgetExportServiceTest extends TestCase
+{
+    public function testResolveTimezoneWithValidTimezone(): void
+    {
+        $tz = WidgetExportService::resolveTimezone('Europe/Berlin');
+
+        $this->assertSame('Europe/Berlin', $tz->getName());
+    }
+
+    public function testResolveTimezoneWithUtc(): void
+    {
+        $tz = WidgetExportService::resolveTimezone('UTC');
+
+        $this->assertSame('UTC', $tz->getName());
+    }
+
+    public function testResolveTimezoneFallsBackToUtcOnInvalidInput(): void
+    {
+        $tz = WidgetExportService::resolveTimezone('Invalid/Timezone');
+
+        $this->assertSame('UTC', $tz->getName());
+    }
+
+    public function testResolveTimezoneFallsBackToUtcOnEmptyString(): void
+    {
+        $tz = WidgetExportService::resolveTimezone('');
+
+        $this->assertSame('UTC', $tz->getName());
+    }
+
+    public function testResolveTimezoneWithAmericaNewYork(): void
+    {
+        $tz = WidgetExportService::resolveTimezone('America/New_York');
+
+        $this->assertSame('America/New_York', $tz->getName());
+    }
+
+    public function testResolveTimezoneWithAsiaTokyo(): void
+    {
+        $tz = WidgetExportService::resolveTimezone('Asia/Tokyo');
+
+        $this->assertSame('Asia/Tokyo', $tz->getName());
+    }
+}

--- a/frontend/src/components/ChatBrowser.vue
+++ b/frontend/src/components/ChatBrowser.vue
@@ -477,12 +477,14 @@ import { useChatsStore } from '@/stores/chats'
 import { useDialog } from '@/composables/useDialog'
 import { useNotification } from '@/composables/useNotification'
 import { useI18n } from 'vue-i18n'
+import { useDateFormat } from '@/composables/useDateFormat'
 
 const chatsStore = useChatsStore()
 const router = useRouter()
 const dialog = useDialog()
 const { success: showSuccess } = useNotification()
 const { t } = useI18n()
+const { formatRelativeTime } = useDateFormat()
 
 // Filter states
 const searchQuery = ref('')
@@ -596,28 +598,10 @@ const handleBulkDelete = async () => {
   }
 }
 
-// Format date helper
 const formatDate = (timestamp: number | string | undefined): string => {
   if (!timestamp) return t('common.unknown')
-
   const date = typeof timestamp === 'number' ? new Date(timestamp * 1000) : new Date(timestamp)
-  const now = new Date()
-  const diffInSeconds = Math.floor((now.getTime() - date.getTime()) / 1000)
-
-  if (diffInSeconds < 60) return t('common.justNow')
-  if (diffInSeconds < 3600) {
-    const minutes = Math.floor(diffInSeconds / 60)
-    return t('common.minutesAgo', { count: minutes })
-  }
-  if (diffInSeconds < 86400) {
-    const hours = Math.floor(diffInSeconds / 3600)
-    return t('common.hoursAgo', { count: hours })
-  }
-  if (diffInSeconds < 604800) {
-    const days = Math.floor(diffInSeconds / 86400)
-    return t('common.daysAgo', { count: days })
-  }
-  return date.toLocaleDateString()
+  return formatRelativeTime(date)
 }
 
 // Get date range filter

--- a/frontend/src/components/ChatDropdown.vue
+++ b/frontend/src/components/ChatDropdown.vue
@@ -150,6 +150,7 @@
 import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
 import { useRoute } from 'vue-router'
 import { useI18n } from 'vue-i18n'
+import { useDateFormat } from '@/composables/useDateFormat'
 import {
   ChatBubbleLeftRightIcon,
   ChevronDownIcon,
@@ -174,6 +175,7 @@ const router = useRouter()
 const chatsStore = useChatsStore()
 const dialog = useDialog()
 const { t } = useI18n()
+const { formatRelativeTime } = useDateFormat()
 
 const isOpen = ref(false)
 const openMenuChatId = ref<number | null>(null)
@@ -224,24 +226,8 @@ const isActive = computed(() => route.path === '/')
 // Active chat ID
 const activeChat = computed(() => chatsStore.activeChatId)
 
-// Format a date as relative or compact timestamp
 const formatTimestamp = (dateStr: string): string => {
-  const date = new Date(dateStr)
-  const now = new Date()
-  const diffMs = now.getTime() - date.getTime()
-  const diffMins = Math.floor(diffMs / 60000)
-  const diffHours = Math.floor(diffMs / 3600000)
-  const diffDays = Math.floor(diffMs / 86400000)
-
-  if (diffMins < 1) return 'just now'
-  if (diffMins < 60) return `${diffMins}m ago`
-  if (diffHours < 24) return `${diffHours}h ago`
-  if (diffDays < 7) return `${diffDays}d ago`
-
-  // Fallback to compact date
-  const month = String(date.getMonth() + 1).padStart(2, '0')
-  const day = String(date.getDate()).padStart(2, '0')
-  return `${month}/${day}`
+  return formatRelativeTime(new Date(dateStr))
 }
 
 const getDisplayTitle = (chat: {

--- a/frontend/src/components/ChatMessage.vue
+++ b/frontend/src/components/ChatMessage.vue
@@ -824,6 +824,7 @@ import MessageFeedbacks from './MessageFeedbacks.vue'
 import GroqIcon from '@/components/icons/GroqIcon.vue'
 import ExternalLinkWarning from '@/components/common/ExternalLinkWarning.vue'
 import { useExternalLink } from '@/composables/useExternalLink'
+import { useDateFormat } from '@/composables/useDateFormat'
 import type { Part, MessageFile } from '@/stores/history'
 import type { AgainData } from '@/types/ai-models'
 import { mediaHintFromClassificationTopic } from '@/utils/mediaGenerationHint'
@@ -831,6 +832,7 @@ import { mediaHintFromClassificationTopic } from '@/utils/mediaGenerationHint'
 const { t } = useI18n()
 const { error: showError } = useNotification()
 const { pendingUrl, warningOpen, openExternalLink, closeWarning } = useExternalLink()
+const { formatTime } = useDateFormat()
 
 interface Props {
   role: 'user' | 'assistant'
@@ -1151,12 +1153,7 @@ const getModelTypeTitle = computed(() => {
   }
 })
 
-const formattedTime = computed(() => {
-  const date = props.timestamp
-  const hours = date.getHours().toString().padStart(2, '0')
-  const minutes = date.getMinutes().toString().padStart(2, '0')
-  return `${hours}:${minutes}`
-})
+const formattedTime = computed(() => formatTime(props.timestamp))
 
 // Check if we're in a processing state (hide model info during these states)
 const isProcessing = computed(() => {

--- a/frontend/src/components/MemoriesDialog.vue
+++ b/frontend/src/components/MemoriesDialog.vue
@@ -205,6 +205,7 @@
 <script setup lang="ts">
 import { ref, computed, watch, nextTick } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useDateFormat } from '@/composables/useDateFormat'
 import { useRouter } from 'vue-router'
 import { Icon } from '@iconify/vue'
 import { useMemoriesStore } from '@/stores/userMemories'
@@ -235,7 +236,8 @@ const props = withDefaults(defineProps<Props>(), {
 })
 const emit = defineEmits<Emits>()
 
-const { t, locale } = useI18n()
+const { t } = useI18n()
+const { formatDateTime } = useDateFormat()
 const router = useRouter()
 const memoriesStore = useMemoriesStore()
 const { confirm } = useDialog()
@@ -437,23 +439,13 @@ async function handleSaveMultiple(actions: ParsedAction[]) {
 }
 
 function formatDate(date: Date | number | string): string {
-  // Backend returns unix timestamps in SECONDS (e.g. 1705234567)
-  // JS Date expects milliseconds, so convert when needed.
   const d =
     typeof date === 'number'
       ? new Date(date < 10_000_000_000 ? date * 1000 : date)
       : typeof date === 'string'
         ? new Date(date)
         : date
-  const browserLocale = typeof navigator !== 'undefined' ? navigator.language : 'en'
-  const activeLocale = (locale?.value || browserLocale) as string
-  return new Intl.DateTimeFormat(activeLocale, {
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-    hour: '2-digit',
-    minute: '2-digit',
-  }).format(d)
+  return formatDateTime(d)
 }
 
 function viewAllMemories() {

--- a/frontend/src/components/MemoryListView.vue
+++ b/frontend/src/components/MemoryListView.vue
@@ -259,6 +259,7 @@
 import { ref, computed } from 'vue'
 import { Icon } from '@iconify/vue'
 import type { UserMemory } from '@/services/api/userMemoriesApi'
+import { useDateFormat } from '@/composables/useDateFormat'
 
 interface Props {
   memories: UserMemory[]
@@ -274,6 +275,8 @@ interface Emits {
 
 const props = defineProps<Props>()
 const emit = defineEmits<Emits>()
+
+const { formatDateTime } = useDateFormat()
 
 const searchQuery = ref('')
 const filterValue = ref('') // Format: 'category:xyz' or 'key:xyz'
@@ -374,12 +377,7 @@ function bulkDelete() {
 }
 
 function formatTimestamp(timestamp: number) {
-  const date = new Date(timestamp * 1000)
-  return (
-    date.toLocaleDateString() +
-    ' ' +
-    date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
-  )
+  return formatDateTime(new Date(timestamp * 1000))
 }
 
 const categoryColors: Record<string, string> = {

--- a/frontend/src/components/MessageLink.vue
+++ b/frontend/src/components/MessageLink.vue
@@ -22,6 +22,7 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
+import { useDateFormat } from '@/composables/useDateFormat'
 
 interface Props {
   url: string
@@ -29,9 +30,9 @@ interface Props {
 }
 
 const props = defineProps<Props>()
+const { formatDateTime } = useDateFormat()
 
 const formattedExpiry = computed(() => {
-  const date = new Date(props.expiresAt)
-  return date.toLocaleString()
+  return formatDateTime(new Date(props.expiresAt))
 })
 </script>

--- a/frontend/src/components/ShareModal.vue
+++ b/frontend/src/components/ShareModal.vue
@@ -188,10 +188,12 @@
 import { ref, computed, watch } from 'vue'
 import * as filesService from '@/services/filesService'
 import { useNotification } from '@/composables/useNotification'
+import { useDateFormat } from '@/composables/useDateFormat'
 import { useConfigStore } from '@/stores/config'
 import { getErrorMessage } from '@/utils/errorMessage'
 
 const { success: showSuccess, error: showError } = useNotification()
+const { formatDateTime } = useDateFormat()
 const config = useConfigStore()
 
 interface Props {
@@ -324,7 +326,7 @@ const copyLink = async () => {
 }
 
 const formatDate = (timestamp: number): string => {
-  return new Date(timestamp * 1000).toLocaleString()
+  return formatDateTime(new Date(timestamp * 1000))
 }
 
 const close = () => {

--- a/frontend/src/components/SidebarChatList.vue
+++ b/frontend/src/components/SidebarChatList.vue
@@ -84,6 +84,7 @@
 import { ref, computed, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
+import { useDateFormat } from '@/composables/useDateFormat'
 import { ChevronRightIcon, PuzzlePieceIcon } from '@heroicons/vue/24/outline'
 import SidebarChatListItem from './SidebarChatListItem.vue'
 import ChatShareModal from './ChatShareModal.vue'
@@ -93,6 +94,7 @@ import { useNotification } from '@/composables/useNotification'
 import type { Chat } from '@/mocks/chats'
 
 const { t } = useI18n()
+const { formatRelativeTime } = useDateFormat()
 const chatsStore = useChatsStore()
 const router = useRouter()
 const dialog = useDialog()
@@ -103,17 +105,9 @@ const sections = ref({
   widgetArchived: false,
 })
 
-// Helper to format dates
 const formatDate = (value: string | number): string => {
   const date = typeof value === 'number' ? new Date(value * 1000) : new Date(value)
-  const now = new Date()
-  const diffInSeconds = Math.floor((now.getTime() - date.getTime()) / 1000)
-
-  if (diffInSeconds < 60) return 'Just now'
-  if (diffInSeconds < 3600) return `${Math.floor(diffInSeconds / 60)}m ago`
-  if (diffInSeconds < 86400) return `${Math.floor(diffInSeconds / 3600)}h ago`
-  if (diffInSeconds < 604800) return `${Math.floor(diffInSeconds / 86400)}d ago`
-  return date.toLocaleDateString()
+  return formatRelativeTime(date)
 }
 
 // Generate default widget title from session info

--- a/frontend/src/components/SidebarV2.vue
+++ b/frontend/src/components/SidebarV2.vue
@@ -612,11 +612,13 @@ import { useChatsStore, isDefaultChatTitle, type Chat as StoreChat } from '../st
 import { useDialog } from '../composables/useDialog'
 import { getFeaturesStatus } from '../services/featuresService'
 import { useI18n } from 'vue-i18n'
+import { useDateFormat } from '@/composables/useDateFormat'
 import MemoriesDialog from './MemoriesDialog.vue'
 import ChatShareModal from './ChatShareModal.vue'
 import GuestFeatureGateModal from './guest/GuestFeatureGateModal.vue'
 
 const { t } = useI18n()
+const { formatRelativeTime } = useDateFormat()
 const sidebarStore = useSidebarStore()
 const authStore = useAuthStore()
 const appModeStore = useAppModeStore()
@@ -997,17 +999,7 @@ const getDisplayTitle = (chat: StoreChat): string => {
 }
 
 const formatTimestamp = (dateStr: string): string => {
-  const date = new Date(dateStr)
-  const now = new Date()
-  const diffMs = now.getTime() - date.getTime()
-  const diffMins = Math.floor(diffMs / 60000)
-  const diffHours = Math.floor(diffMs / 3600000)
-  const diffDays = Math.floor(diffMs / 86400000)
-  if (diffMins < 1) return t('chat.timeNow')
-  if (diffMins < 60) return t('chat.timeMinutes', { n: diffMins })
-  if (diffHours < 24) return t('chat.timeHours', { n: diffHours })
-  if (diffDays < 7) return t('chat.timeDays', { n: diffDays })
-  return `${String(date.getMonth() + 1).padStart(2, '0')}/${String(date.getDate()).padStart(2, '0')}`
+  return formatRelativeTime(new Date(dateStr))
 }
 
 const getChannelIcon = (chat: StoreChat): string | null => {

--- a/frontend/src/components/config/APIKeysConfiguration.vue
+++ b/frontend/src/components/config/APIKeysConfiguration.vue
@@ -388,10 +388,12 @@ import {
 import { useDialog } from '@/composables/useDialog'
 import { useNotification } from '@/composables/useNotification'
 import { useI18n } from 'vue-i18n'
+import { useDateFormat } from '@/composables/useDateFormat'
 
 const dialog = useDialog()
 const { success, error: showError } = useNotification()
 const { t } = useI18n()
+const { formatDateTime } = useDateFormat()
 
 interface UIApiKey {
   id: number
@@ -588,14 +590,7 @@ const deleteAPIKey = async (keyId: number) => {
 }
 
 const formatDate = (timestamp: number): string => {
-  const date = new Date(timestamp * 1000) // Convert Unix timestamp to milliseconds
-  return new Intl.DateTimeFormat('en-US', {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-  }).format(date)
+  return formatDateTime(new Date(timestamp * 1000))
 }
 
 onMounted(() => {

--- a/frontend/src/components/config/PhoneVerification.vue
+++ b/frontend/src/components/config/PhoneVerification.vue
@@ -299,6 +299,7 @@ import { ref, onMounted, computed, onUnmounted } from 'vue'
 import { useNotification } from '@/composables/useNotification'
 import { useDialog } from '@/composables/useDialog'
 import { useI18n } from 'vue-i18n'
+import { useDateFormat } from '@/composables/useDateFormat'
 import { DevicePhoneMobileIcon } from '@heroicons/vue/24/outline'
 import { useConfigStore } from '@/stores/config'
 import { refreshAccessToken } from '@/services/api/httpClient'
@@ -307,6 +308,7 @@ import { getErrorMessage as getUnknownErrorMessage } from '@/utils/errorMessage'
 const { success, error: showError } = useNotification()
 const dialog = useDialog()
 const { t } = useI18n()
+const { formatDate: formatDateStr } = useDateFormat()
 
 interface PhoneVerificationStatus {
   verification_code?: string | null
@@ -634,7 +636,7 @@ const removePhone = async () => {
 
 const formatDate = (timestamp?: number) => {
   if (!timestamp) return '—'
-  return new Date(timestamp * 1000).toLocaleDateString()
+  return formatDateStr(new Date(timestamp * 1000))
 }
 
 const formatDisplayPhone = (phone?: string) => {

--- a/frontend/src/components/config/TaskPromptsConfiguration.vue
+++ b/frontend/src/components/config/TaskPromptsConfiguration.vue
@@ -754,6 +754,7 @@
 import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
 import { useEscapeKey } from '@/composables/useEscapeKey'
 import { useI18n } from 'vue-i18n'
+import { useDateFormat } from '@/composables/useDateFormat'
 import { Icon } from '@iconify/vue'
 import {
   promptsApi,
@@ -810,6 +811,7 @@ interface ToolOption {
 const { success, error: showError } = useNotification()
 const dialog = useDialog()
 const { t, locale } = useI18n()
+const { formatRelativeTime } = useDateFormat()
 const authStore = useAuthStore()
 const isAdmin = computed(() => authStore.isAdmin)
 
@@ -1484,19 +1486,8 @@ const handleDeleteFile = async (messageId: number) => {
   }
 }
 
-/**
- * Format date for display
- */
 const formatDate = (dateString: string): string => {
-  const date = new Date(dateString)
-  const now = new Date()
-  const diffInSeconds = Math.floor((now.getTime() - date.getTime()) / 1000)
-
-  if (diffInSeconds < 60) return 'Just now'
-  if (diffInSeconds < 3600) return `${Math.floor(diffInSeconds / 60)}m ago`
-  if (diffInSeconds < 86400) return `${Math.floor(diffInSeconds / 3600)}h ago`
-  if (diffInSeconds < 604800) return `${Math.floor(diffInSeconds / 86400)}d ago`
-  return date.toLocaleDateString()
+  return formatRelativeTime(new Date(dateString))
 }
 
 /**

--- a/frontend/src/components/config/UsageStatistics.vue
+++ b/frontend/src/components/config/UsageStatistics.vue
@@ -357,7 +357,7 @@
                 data-testid="item-activity"
               >
                 <td class="px-3 py-3 txt-secondary whitespace-nowrap">
-                  {{ formatDateTime(entry.timestamp) }}
+                  {{ getTimeAgo(entry.timestamp) }}
                 </td>
                 <td class="px-3 py-3">
                   <span class="px-2 py-1 rounded-full text-xs font-medium surface-chip">
@@ -496,10 +496,12 @@ import {
 } from '@/api/usageApi'
 import { useNotification } from '@/composables/useNotification'
 import { useI18n } from 'vue-i18n'
+import { useDateFormat } from '@/composables/useDateFormat'
 import { authService } from '@/services/authService'
 
 const { success, error: showError } = useNotification()
 const { t } = useI18n()
+const { formatDate: formatDateStr, formatRelativeTime } = useDateFormat()
 
 const loading = ref(false)
 const exporting = ref(false)
@@ -679,33 +681,11 @@ const getBudgetBarClass = (percent: number) => {
 }
 
 const formatDate = (timestamp: number) => {
-  return new Date(timestamp * 1000).toLocaleDateString()
+  return formatDateStr(new Date(timestamp * 1000))
 }
 
-const formatDateTime = (timestamp: number) => {
-  const date = new Date(timestamp * 1000)
-  const now = new Date()
-  const diff = now.getTime() - date.getTime()
-
-  // Less than 1 minute
-  if (diff < 60000) {
-    return t('common.justNow')
-  }
-
-  // Less than 1 hour
-  if (diff < 3600000) {
-    const minutes = Math.floor(diff / 60000)
-    return t('common.minutesAgo', { count: minutes })
-  }
-
-  // Less than 24 hours
-  if (diff < 86400000) {
-    const hours = Math.floor(diff / 3600000)
-    return t('common.hoursAgo', { count: hours })
-  }
-
-  // More than 24 hours - show full date
-  return date.toLocaleString()
+const getTimeAgo = (timestamp: number) => {
+  return formatRelativeTime(new Date(timestamp * 1000))
 }
 
 onMounted(() => {

--- a/frontend/src/components/mail/MailHandlerList.vue
+++ b/frontend/src/components/mail/MailHandlerList.vue
@@ -247,6 +247,7 @@ import {
   XMarkIcon,
 } from '@heroicons/vue/24/outline'
 import type { SavedMailHandler } from '@/services/api/inboundEmailHandlersApi'
+import { useDateFormat } from '@/composables/useDateFormat'
 
 interface Props {
   handlers: SavedMailHandler[]
@@ -261,6 +262,8 @@ const emit = defineEmits<{
   bulkUpdateStatus: [handlerIds: string[], status: 'active' | 'inactive']
   bulkDelete: [handlerIds: string[]]
 }>()
+
+const { formatRelativeTime } = useDateFormat()
 
 const selectedHandlers = ref<string[]>([])
 
@@ -293,14 +296,6 @@ const deleteSelected = () => {
 }
 
 const formatDate = (date: Date) => {
-  const now = new Date()
-  const diff = now.getTime() - date.getTime()
-  const days = Math.floor(diff / (1000 * 60 * 60 * 24))
-
-  if (days === 0) return 'Today'
-  if (days === 1) return 'Yesterday'
-  if (days < 7) return `${days}d ago`
-
-  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+  return formatRelativeTime(date)
 }
 </script>

--- a/frontend/src/components/memories/MemoryCard.vue
+++ b/frontend/src/components/memories/MemoryCard.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useDateFormat } from '@/composables/useDateFormat'
 import type { UserMemory } from '@/services/api/userMemoriesApi'
 import { Pencil, Trash2 } from 'lucide-vue-next'
 
@@ -15,7 +16,8 @@ const emit = defineEmits<{
   delete: [memory: UserMemory]
 }>()
 
-const { t, locale } = useI18n()
+const { t } = useI18n()
+const { formatDateTime } = useDateFormat()
 
 const sourceLabel = computed(() => {
   return t(`memories.source.${props.memory.source}`)
@@ -26,16 +28,7 @@ const categoryLabel = computed(() => {
 })
 
 const formattedDate = computed(() => {
-  const date = new Date(props.memory.updated * 1000)
-  const browserLocale = typeof navigator !== 'undefined' ? navigator.language : 'en'
-  const activeLocale = (locale?.value || browserLocale) as string
-  return new Intl.DateTimeFormat(activeLocale, {
-    day: '2-digit',
-    month: '2-digit',
-    year: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-  }).format(date)
+  return formatDateTime(new Date(props.memory.updated * 1000))
 })
 </script>
 

--- a/frontend/src/components/memories/MemorySelectionCard.vue
+++ b/frontend/src/components/memories/MemorySelectionCard.vue
@@ -2,6 +2,7 @@
 import { Icon } from '@iconify/vue'
 import { useI18n } from 'vue-i18n'
 import type { UserMemory } from '@/services/api/userMemoriesApi'
+import { useDateFormat } from '@/composables/useDateFormat'
 
 const props = defineProps<{
   memory: UserMemory
@@ -15,6 +16,7 @@ const emit = defineEmits<{
 }>()
 
 const { t } = useI18n()
+const { formatDateTime } = useDateFormat()
 </script>
 
 <template>
@@ -50,9 +52,7 @@ const { t } = useI18n()
 
     <div class="flex items-center justify-between text-xs txt-tertiary mb-3 md:mb-4">
       <span>{{ $t(`memories.source.${props.memory.source}`) }}</span>
-      <span class="truncate ml-2">{{
-        new Date(props.memory.updated * 1000).toLocaleString()
-      }}</span>
+      <span class="truncate ml-2">{{ formatDateTime(new Date(props.memory.updated * 1000)) }}</span>
     </div>
 
     <div class="flex gap-2">

--- a/frontend/src/components/widgets/ChatWidget.vue
+++ b/frontend/src/components/widgets/ChatWidget.vue
@@ -641,6 +641,7 @@ import {
   WidgetUnavailableError,
 } from '@/services/api/widgetsApi'
 import { useI18n } from 'vue-i18n'
+import { useDateFormat } from '@/composables/useDateFormat'
 import { parseAIResponse } from '@/utils/responseParser'
 import { getMarkdownRenderer } from '@/composables/useMarkdown'
 import { subscribeToSession, type EventSubscription, type WidgetEvent } from '@/services/sseClient'
@@ -805,6 +806,7 @@ let operatorTypingTimer: ReturnType<typeof setTimeout> | null = null
 
 const isMobile = ref(false)
 const { t } = useI18n()
+const { formatTime, formatDateTime } = useDateFormat()
 
 const allowFileUploads = computed(
   () => !!props.allowFileUpload && (!props.isPreview || props.testMode || props.internalMode)
@@ -980,15 +982,8 @@ const toggleFullscreen = () => {
   isFullscreen.value = !isFullscreen.value
 }
 
-// Format a date for the export
 const formatExportDate = (date: Date): string => {
-  return date.toLocaleString(undefined, {
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-    hour: '2-digit',
-    minute: '2-digit',
-  })
+  return formatDateTime(date)
 }
 
 // Escape HTML special characters
@@ -1643,10 +1638,6 @@ const scrollToBottom = async () => {
   if (messagesContainer.value) {
     messagesContainer.value.scrollTop = messagesContainer.value.scrollHeight
   }
-}
-
-const formatTime = (date: Date): string => {
-  return date.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' })
 }
 
 const getSenderLabel = (message: Message): string => {

--- a/frontend/src/components/widgets/WidgetSessionCard.vue
+++ b/frontend/src/components/widgets/WidgetSessionCard.vue
@@ -51,7 +51,7 @@
 
     <!-- Footer -->
     <div class="flex items-center justify-between text-xs txt-secondary">
-      <span>{{ $t('widgetSessions.created') }}: {{ formatDate(session.created) }}</span>
+      <span>{{ $t('widgetSessions.created') }}: {{ formatSessionDate(session.created) }}</span>
       <div class="flex items-center gap-2" @click.stop>
         <button
           v-if="session.mode === 'ai' && !session.isExpired"
@@ -78,6 +78,7 @@
 import { computed } from 'vue'
 import { Icon } from '@iconify/vue'
 import { useI18n } from 'vue-i18n'
+import { useDateFormat } from '@/composables/useDateFormat'
 import type { WidgetSession } from '@/services/api/widgetSessionsApi'
 
 const props = defineProps<{
@@ -91,6 +92,7 @@ defineEmits<{
 }>()
 
 const { t } = useI18n()
+const { formatRelativeTime, formatDate } = useDateFormat()
 
 const modeIcon = computed(() => {
   switch (props.session.mode) {
@@ -154,17 +156,10 @@ const modeLabel = computed(() => {
 
 const timeAgo = computed(() => {
   if (!props.session.lastMessage) return '-'
-
-  const now = Math.floor(Date.now() / 1000)
-  const diff = now - props.session.lastMessage
-
-  if (diff < 60) return t('common.justNow')
-  if (diff < 3600) return t('common.minutesAgo', { count: Math.floor(diff / 60) })
-  if (diff < 86400) return t('common.hoursAgo', { count: Math.floor(diff / 3600) })
-  return t('common.daysAgo', { count: Math.floor(diff / 86400) })
+  return formatRelativeTime(new Date(props.session.lastMessage * 1000))
 })
 
-const formatDate = (timestamp: number) => {
-  return new Date(timestamp * 1000).toLocaleDateString()
+const formatSessionDate = (timestamp: number) => {
+  return formatDate(new Date(timestamp * 1000))
 }
 </script>

--- a/frontend/src/components/widgets/WidgetSummaryPanel.vue
+++ b/frontend/src/components/widgets/WidgetSummaryPanel.vue
@@ -587,6 +587,7 @@ import { ref, computed, watch, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { Icon } from '@iconify/vue'
 import { useI18n } from 'vue-i18n'
+import { useDateFormat } from '@/composables/useDateFormat'
 import * as widgetSessionsApi from '@/services/api/widgetSessionsApi'
 import { useNotification } from '@/composables/useNotification'
 import { useAuth } from '@/composables/useAuth'
@@ -609,6 +610,7 @@ const emit = defineEmits<{
 
 const router = useRouter()
 const { t } = useI18n()
+const { formatDate, formatDateTime } = useDateFormat()
 const { error, success } = useNotification()
 const { isTeam, isAdmin } = useAuth()
 
@@ -657,18 +659,16 @@ const dateToNumber = (dateStr: string): number | undefined => {
   return parseInt(dateStr.replace(/-/g, ''), 10)
 }
 
-// Format date from YYYYMMDD to readable string
 const formatDateNumber = (date: number): string => {
   const str = String(date)
-  const year = str.substring(0, 4)
-  const month = str.substring(4, 6)
-  const day = str.substring(6, 8)
-  return `${day}.${month}.${year}`
+  const y = parseInt(str.substring(0, 4))
+  const m = parseInt(str.substring(4, 6)) - 1
+  const d = parseInt(str.substring(6, 8))
+  return formatDate(new Date(y, m, d))
 }
 
-// Format timestamp to readable date
 const formatTimestamp = (timestamp: number): string => {
-  return new Date(timestamp * 1000).toLocaleString()
+  return formatDateTime(new Date(timestamp * 1000))
 }
 
 // Load saved summaries

--- a/frontend/src/composables/useDateFormat.ts
+++ b/frontend/src/composables/useDateFormat.ts
@@ -1,0 +1,72 @@
+import { useI18n } from 'vue-i18n'
+
+const MINUTE_MS = 60_000
+const HOUR_MS = 3_600_000
+const DAY_MS = 86_400_000
+const DAYS_RELATIVE_THRESHOLD = 7
+
+export const useDateFormat = () => {
+  const { t, locale } = useI18n()
+
+  const formatTime = (date: Date): string => {
+    return new Intl.DateTimeFormat(locale.value, {
+      hour: '2-digit',
+      minute: '2-digit',
+    }).format(date)
+  }
+
+  const formatDate = (date: Date): string => {
+    return new Intl.DateTimeFormat(locale.value, {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+    }).format(date)
+  }
+
+  const formatDateTime = (date: Date): string => {
+    return new Intl.DateTimeFormat(locale.value, {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    }).format(date)
+  }
+
+  const formatRelativeTime = (date: Date): string => {
+    const now = Date.now()
+    const diffMs = now - date.getTime()
+
+    if (diffMs < MINUTE_MS) return t('common.justNow')
+
+    const diffMins = Math.floor(diffMs / MINUTE_MS)
+    if (diffMins < 60) return t('common.minutesAgo', { count: diffMins }, diffMins)
+
+    const diffHours = Math.floor(diffMs / HOUR_MS)
+    if (diffHours < 24) return t('common.hoursAgo', { count: diffHours }, diffHours)
+
+    const diffDays = Math.floor(diffMs / DAY_MS)
+    if (diffDays < DAYS_RELATIVE_THRESHOLD)
+      return t('common.daysAgo', { count: diffDays }, diffDays)
+
+    return formatDate(date)
+  }
+
+  const getDateLabel = (date: Date): string => {
+    const today = new Date()
+    today.setHours(0, 0, 0, 0)
+
+    const target = new Date(date)
+    target.setHours(0, 0, 0, 0)
+
+    const diffMs = today.getTime() - target.getTime()
+    const diffDays = Math.round(diffMs / DAY_MS)
+
+    if (diffDays === 0) return t('common.today')
+    if (diffDays === 1) return t('common.yesterday')
+
+    return formatDate(date)
+  }
+
+  return { formatTime, formatDate, formatDateTime, formatRelativeTime, getDateLabel }
+}

--- a/frontend/src/composables/useDateFormat.ts
+++ b/frontend/src/composables/useDateFormat.ts
@@ -1,37 +1,52 @@
+import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 const MINUTE_MS = 60_000
 const HOUR_MS = 3_600_000
-const DAY_MS = 86_400_000
 const DAYS_RELATIVE_THRESHOLD = 7
+
+function calendarDayDiff(a: Date, b: Date): number {
+  const utcA = Date.UTC(a.getFullYear(), a.getMonth(), a.getDate())
+  const utcB = Date.UTC(b.getFullYear(), b.getMonth(), b.getDate())
+  return Math.floor((utcA - utcB) / 86_400_000)
+}
 
 export const useDateFormat = () => {
   const { t, locale } = useI18n()
 
-  const formatTime = (date: Date): string => {
-    return new Intl.DateTimeFormat(locale.value, {
-      hour: '2-digit',
-      minute: '2-digit',
-    }).format(date)
-  }
+  const timeFormatter = computed(
+    () =>
+      new Intl.DateTimeFormat(locale.value, {
+        hour: '2-digit',
+        minute: '2-digit',
+      })
+  )
 
-  const formatDate = (date: Date): string => {
-    return new Intl.DateTimeFormat(locale.value, {
-      day: '2-digit',
-      month: '2-digit',
-      year: 'numeric',
-    }).format(date)
-  }
+  const dateFormatter = computed(
+    () =>
+      new Intl.DateTimeFormat(locale.value, {
+        day: '2-digit',
+        month: '2-digit',
+        year: 'numeric',
+      })
+  )
 
-  const formatDateTime = (date: Date): string => {
-    return new Intl.DateTimeFormat(locale.value, {
-      day: '2-digit',
-      month: '2-digit',
-      year: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit',
-    }).format(date)
-  }
+  const dateTimeFormatter = computed(
+    () =>
+      new Intl.DateTimeFormat(locale.value, {
+        day: '2-digit',
+        month: '2-digit',
+        year: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+      })
+  )
+
+  const formatTime = (date: Date): string => timeFormatter.value.format(date)
+
+  const formatDate = (date: Date): string => dateFormatter.value.format(date)
+
+  const formatDateTime = (date: Date): string => dateTimeFormatter.value.format(date)
 
   const formatRelativeTime = (date: Date): string => {
     const now = Date.now()
@@ -45,22 +60,15 @@ export const useDateFormat = () => {
     const diffHours = Math.floor(diffMs / HOUR_MS)
     if (diffHours < 24) return t('common.hoursAgo', { count: diffHours }, diffHours)
 
-    const diffDays = Math.floor(diffMs / DAY_MS)
-    if (diffDays < DAYS_RELATIVE_THRESHOLD)
+    const diffDays = calendarDayDiff(new Date(now), date)
+    if (diffDays > 0 && diffDays < DAYS_RELATIVE_THRESHOLD)
       return t('common.daysAgo', { count: diffDays }, diffDays)
 
     return formatDate(date)
   }
 
   const getDateLabel = (date: Date): string => {
-    const today = new Date()
-    today.setHours(0, 0, 0, 0)
-
-    const target = new Date(date)
-    target.setHours(0, 0, 0, 0)
-
-    const diffMs = today.getTime() - target.getTime()
-    const diffDays = Math.round(diffMs / DAY_MS)
+    const diffDays = calendarDayDiff(new Date(), date)
 
     if (diffDays === 0) return t('common.today')
     if (diffDays === 1) return t('common.yesterday')

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -1287,6 +1287,8 @@
     "minutesAgo": "vor {count} Minute | vor {count} Minuten",
     "hoursAgo": "vor {count} Stunde | vor {count} Stunden",
     "daysAgo": "vor {count} Tag | vor {count} Tagen",
+    "today": "Heute",
+    "yesterday": "Gestern",
     "back": "Zurück",
     "next": "Weiter",
     "continue": "Weiter",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -1182,6 +1182,8 @@
     "minutesAgo": "{count} minute ago | {count} minutes ago",
     "hoursAgo": "{count} hour ago | {count} hours ago",
     "daysAgo": "{count} day ago | {count} days ago",
+    "today": "Today",
+    "yesterday": "Yesterday",
     "previous": "Previous",
     "loadMore": "Load more",
     "error": "Error",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -504,6 +504,8 @@
     "minutesAgo": "hace {count} minuto | hace {count} minutos",
     "hoursAgo": "hace {count} hora | hace {count} horas",
     "daysAgo": "hace {count} día | hace {count} días",
+    "today": "Hoy",
+    "yesterday": "Ayer",
     "previous": "Anterior",
     "error": "Error",
     "success": "Éxito",

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -504,6 +504,8 @@
     "minutesAgo": "{count} dakika önce",
     "hoursAgo": "{count} saat önce",
     "daysAgo": "{count} gün önce",
+    "today": "Bugün",
+    "yesterday": "Dün",
     "previous": "Önceki",
     "error": "Hata",
     "success": "Başarılı",

--- a/frontend/src/services/api/widgetSessionsApi.ts
+++ b/frontend/src/services/api/widgetSessionsApi.ts
@@ -269,6 +269,7 @@ export interface ExportParams {
   to?: number
   mode?: 'ai' | 'human' | 'waiting' | 'internal'
   sessionIds?: string[]
+  timezone?: string
 }
 
 /**
@@ -299,6 +300,9 @@ export function getExportUrl(widgetId: string, params: ExportParams = {}): strin
   if (params.sessionIds && params.sessionIds.length > 0) {
     queryParams.set('sessionIds', params.sessionIds.join(','))
   }
+
+  const timezone = params.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone
+  queryParams.set('timezone', timezone)
 
   const queryString = queryParams.toString()
   return `/api/v1/widgets/${widgetId}/export${queryString ? `?${queryString}` : ''}`

--- a/frontend/src/views/AdminView.vue
+++ b/frontend/src/views/AdminView.vue
@@ -704,9 +704,11 @@ const AdminSubscriptionsPanel = defineAsyncComponent(
 import { useAuthStore } from '@/stores/auth'
 import { useConfigStore } from '@/stores/config'
 import { useI18n } from 'vue-i18n'
+import { useDateFormat } from '@/composables/useDateFormat'
 import { useNotification } from '@/composables/useNotification'
 
 const { t } = useI18n()
+const { formatDateTime } = useDateFormat()
 const authStore = useAuthStore()
 const config = useConfigStore()
 const { success, error: showError } = useNotification()
@@ -1010,11 +1012,7 @@ function formatDate(dateStr: string): string {
   try {
     const date = new Date(dateStr)
     if (isNaN(date.getTime())) return '—'
-    return (
-      date.toLocaleDateString() +
-      ' ' +
-      date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
-    )
+    return formatDateTime(date)
   } catch {
     return '—'
   }

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -346,6 +346,7 @@ import GuestBanner from '@/components/guest/GuestBanner.vue'
 import GuestSignupModal from '@/components/guest/GuestSignupModal.vue'
 import GuestFeatureGateModal from '@/components/guest/GuestFeatureGateModal.vue'
 import { usePromoTips } from '@/composables/usePromoTips'
+import { useDateFormat } from '@/composables/useDateFormat'
 
 const SaveCancelledMessageResponseSchema = z
   .object({
@@ -376,6 +377,7 @@ const guestStore = useGuestStore()
 const memoriesStore = useMemoriesStore()
 const feedbackStore = useFeedbackStore()
 const promoTips = usePromoTips()
+const { getDateLabel } = useDateFormat()
 
 const isGuestMode = computed(() => !authStore.isAuthenticated && guestStore.isGuestMode)
 const showGuestSignupModal = ref(false)
@@ -664,26 +666,6 @@ async function generateChatTitleFromFirstMessage(firstMessage: string) {
 
   // Update chat title
   await chatsStore.updateChatTitle(chat.id, title)
-}
-
-const getDateLabel = (date: Date): string => {
-  const today = new Date()
-  today.setHours(0, 0, 0, 0)
-
-  const messageDate = new Date(date)
-  messageDate.setHours(0, 0, 0, 0)
-
-  const diffTime = today.getTime() - messageDate.getTime()
-  const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24))
-
-  if (diffDays === 0) return 'Today'
-  if (diffDays === 1) return 'Yesterday'
-
-  return messageDate.toLocaleDateString('de-DE', {
-    day: '2-digit',
-    month: '2-digit',
-    year: 'numeric',
-  })
 }
 
 const groupedMessages = computed(() => {

--- a/frontend/src/views/FeedbackView.vue
+++ b/frontend/src/views/FeedbackView.vue
@@ -397,12 +397,14 @@
 import { ref, computed, onMounted, watch, nextTick } from 'vue'
 import { useRoute } from 'vue-router'
 import { useI18n } from 'vue-i18n'
+import { useDateFormat } from '@/composables/useDateFormat'
 import { Icon } from '@iconify/vue'
 import MainLayout from '@/components/MainLayout.vue'
 import { useFeedbackStore } from '@/stores/userFeedback'
 import type { Feedback } from '@/services/api/userFeedbackApi'
 
 const { t } = useI18n()
+const { formatDateTime } = useDateFormat()
 const route = useRoute()
 const feedbackStore = useFeedbackStore()
 
@@ -532,17 +534,9 @@ watch(
   { immediate: true }
 )
 
-// ── Helpers ────────────────────────────────────────────
 function formatDate(timestamp: number): string {
   if (!timestamp) return ''
-  const date = new Date(timestamp * 1000)
-  return date.toLocaleDateString(undefined, {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-  })
+  return formatDateTime(new Date(timestamp * 1000))
 }
 
 function highlightSearch(text: string): string {

--- a/frontend/src/views/LiveSupportView.vue
+++ b/frontend/src/views/LiveSupportView.vue
@@ -214,6 +214,7 @@ import { getErrorMessage } from '@/utils/errorMessage'
 import { ref, computed, onMounted, onBeforeUnmount, nextTick } from 'vue'
 import { Icon } from '@iconify/vue'
 import { useI18n } from 'vue-i18n'
+import { useDateFormat } from '@/composables/useDateFormat'
 import MainLayout from '@/components/MainLayout.vue'
 import * as widgetsApi from '@/services/api/widgetsApi'
 import * as widgetSessionsApi from '@/services/api/widgetSessionsApi'
@@ -221,6 +222,7 @@ import { useNotification } from '@/composables/useNotification'
 import { subscribeToNotifications, type EventSubscription } from '@/services/sseClient'
 
 const { t } = useI18n()
+const { formatRelativeTime, formatTime: formatTimeStr } = useDateFormat()
 const { success, error } = useNotification()
 
 const widgets = ref<widgetsApi.Widget[]>([])
@@ -380,18 +382,11 @@ const scrollToBottom = () => {
 
 const formatTime = (timestamp: number) => {
   if (!timestamp) return '-'
-  const date = new Date(timestamp * 1000)
-  const now = new Date()
-  const diff = now.getTime() - date.getTime()
-
-  if (diff < 60000) return t('common.justNow')
-  if (diff < 3600000) return t('common.minutesAgo', { count: Math.floor(diff / 60000) })
-  if (diff < 86400000) return t('common.hoursAgo', { count: Math.floor(diff / 3600000) })
-  return date.toLocaleDateString()
+  return formatRelativeTime(new Date(timestamp * 1000))
 }
 
 const formatMessageTime = (timestamp: number) => {
-  return new Date(timestamp * 1000).toLocaleTimeString()
+  return formatTimeStr(new Date(timestamp * 1000))
 }
 
 onMounted(async () => {

--- a/frontend/src/views/SharedChatView.vue
+++ b/frontend/src/views/SharedChatView.vue
@@ -313,6 +313,7 @@
 import { ref, computed, onMounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
+import { useDateFormat } from '@/composables/useDateFormat'
 import MessageImage from '../components/MessageImage.vue'
 import MessageVideo from '../components/MessageVideo.vue'
 import MessageCode from '../components/MessageCode.vue'
@@ -352,6 +353,7 @@ const config = useConfigStore()
 const route = useRoute()
 const router = useRouter()
 const { locale, t } = useI18n()
+const { formatDateTime } = useDateFormat()
 
 const loading = ref(true)
 const error = ref(false)
@@ -571,7 +573,7 @@ onMounted(async () => {
 })
 
 const formatDate = (timestamp: number): string => {
-  return new Date(timestamp * 1000).toLocaleString(currentLang.value)
+  return formatDateTime(new Date(timestamp * 1000))
 }
 
 interface MessagePart {

--- a/frontend/src/views/SubscriptionView.vue
+++ b/frontend/src/views/SubscriptionView.vue
@@ -203,6 +203,7 @@ import { ref, computed, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { Icon } from '@iconify/vue'
 import { useI18n } from 'vue-i18n'
+import { useDateFormat } from '@/composables/useDateFormat'
 import {
   subscriptionApi,
   type SubscriptionPlan,
@@ -214,6 +215,7 @@ import { useDialog } from '@/composables/useDialog'
 import MainLayout from '@/components/MainLayout.vue'
 
 const { t } = useI18n()
+const { formatDateTime } = useDateFormat()
 const router = useRouter()
 const authStore = useAuthStore()
 const config = useConfigStore()
@@ -361,11 +363,7 @@ function capitalize(str: string): string {
 function formatDate(timestamp: string | number): string {
   try {
     const date = typeof timestamp === 'number' ? new Date(timestamp * 1000) : new Date(timestamp)
-    return (
-      date.toLocaleDateString() +
-      ' ' +
-      date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
-    )
+    return formatDateTime(date)
   } catch {
     return String(timestamp)
   }

--- a/frontend/src/views/WidgetSessionsView.vue
+++ b/frontend/src/views/WidgetSessionsView.vue
@@ -957,6 +957,7 @@ import { ref, computed, onMounted, onUnmounted, onBeforeUnmount, nextTick, watch
 import { useRoute, useRouter } from 'vue-router'
 import { Icon } from '@iconify/vue'
 import { useI18n } from 'vue-i18n'
+import { useDateFormat } from '@/composables/useDateFormat'
 import MainLayout from '@/components/MainLayout.vue'
 import MessageText from '@/components/MessageText.vue'
 import WidgetExportDialog from '@/components/widgets/WidgetExportDialog.vue'
@@ -972,6 +973,7 @@ import { subscribeToSession, type EventSubscription, type WidgetEvent } from '@/
 const route = useRoute()
 const router = useRouter()
 const { t } = useI18n()
+const { formatRelativeTime, formatTime: formatTimeStr } = useDateFormat()
 const { success, error } = useNotification()
 const { confirm } = useDialog()
 
@@ -2083,16 +2085,11 @@ const getCountryName = (countryCode: string | null): string => {
 
 const getTimeAgo = (timestamp: number | null) => {
   if (!timestamp) return '-'
-  const now = Math.floor(Date.now() / 1000)
-  const diff = now - timestamp
-  if (diff < 60) return t('common.justNow')
-  if (diff < 3600) return t('common.minutesAgo', { count: Math.floor(diff / 60) })
-  if (diff < 86400) return t('common.hoursAgo', { count: Math.floor(diff / 3600) })
-  return t('common.daysAgo', { count: Math.floor(diff / 86400) })
+  return formatRelativeTime(new Date(timestamp * 1000))
 }
 
 const formatTime = (timestamp: number) => {
-  return new Date(timestamp * 1000).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+  return formatTimeStr(new Date(timestamp * 1000))
 }
 
 const getSenderLabel = (message: widgetSessionsApi.SessionMessage) => {

--- a/frontend/tests/unit/composables/useDateFormat.spec.ts
+++ b/frontend/tests/unit/composables/useDateFormat.spec.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { ref } from 'vue'
+
+const mockLocale = ref('en')
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string, _params?: Record<string, unknown>, plural?: number) => {
+      const translations: Record<string, string | ((n: number) => string)> = {
+        'common.justNow': 'Just now',
+        'common.minutesAgo': (n: number) => `${n} minute${n === 1 ? '' : 's'} ago`,
+        'common.hoursAgo': (n: number) => `${n} hour${n === 1 ? '' : 's'} ago`,
+        'common.daysAgo': (n: number) => `${n} day${n === 1 ? '' : 's'} ago`,
+        'common.today': 'Today',
+        'common.yesterday': 'Yesterday',
+      }
+      const entry = translations[key]
+      if (typeof entry === 'function') return entry(plural ?? 0)
+      return entry ?? key
+    },
+    locale: mockLocale,
+  }),
+}))
+
+import { useDateFormat } from '@/composables/useDateFormat'
+
+describe('useDateFormat', () => {
+  let fmt: ReturnType<typeof useDateFormat>
+
+  beforeEach(() => {
+    mockLocale.value = 'en'
+    fmt = useDateFormat()
+  })
+
+  describe('formatTime', () => {
+    it('should return a formatted time string', () => {
+      const date = new Date(2025, 5, 15, 14, 30, 0)
+      const result = fmt.formatTime(date)
+      expect(result).toContain('30')
+    })
+  })
+
+  describe('formatDate', () => {
+    it('should return a formatted date string with year', () => {
+      const date = new Date(2025, 0, 5)
+      const result = fmt.formatDate(date)
+      expect(result).toContain('2025')
+    })
+  })
+
+  describe('formatDateTime', () => {
+    it('should contain both date and time parts', () => {
+      const date = new Date(2025, 11, 24, 18, 45)
+      const result = fmt.formatDateTime(date)
+      expect(result).toContain('2025')
+      expect(result).toContain('45')
+    })
+  })
+
+  describe('formatter caching', () => {
+    it('should return same formatter instance when locale does not change', () => {
+      const date = new Date(2025, 5, 15, 10, 0, 0)
+      const first = fmt.formatTime(date)
+      const second = fmt.formatTime(date)
+      expect(first).toBe(second)
+    })
+
+    it('should update formatter when locale changes', () => {
+      const date = new Date(2025, 0, 15, 14, 30, 0)
+      const enResult = fmt.formatDate(date)
+
+      mockLocale.value = 'de'
+      const deResult = fmt.formatDate(date)
+
+      expect(enResult).not.toBe(deResult)
+    })
+  })
+
+  describe('formatRelativeTime', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date(2025, 5, 15, 12, 0, 0))
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('should return "Just now" for timestamps less than 1 minute ago', () => {
+      const date = new Date(2025, 5, 15, 11, 59, 30)
+      expect(fmt.formatRelativeTime(date)).toBe('Just now')
+    })
+
+    it('should return "Just now" for future timestamps (clock skew)', () => {
+      const future = new Date(2025, 5, 15, 12, 0, 30)
+      expect(fmt.formatRelativeTime(future)).toBe('Just now')
+    })
+
+    it('should return minutes ago for timestamps 1-59 minutes in the past', () => {
+      const date = new Date(2025, 5, 15, 11, 30, 0)
+      expect(fmt.formatRelativeTime(date)).toBe('30 minutes ago')
+    })
+
+    it('should return hours ago for timestamps 1-23 hours in the past', () => {
+      const date = new Date(2025, 5, 15, 9, 0, 0)
+      expect(fmt.formatRelativeTime(date)).toBe('3 hours ago')
+    })
+
+    it('should return days ago for timestamps 1-6 days in the past', () => {
+      const date = new Date(2025, 5, 13, 12, 0, 0)
+      expect(fmt.formatRelativeTime(date)).toBe('2 days ago')
+    })
+
+    it('should fall back to formatted date for timestamps >= 7 days', () => {
+      const date = new Date(2025, 5, 1, 12, 0, 0)
+      const result = fmt.formatRelativeTime(date)
+      expect(result).toContain('2025')
+    })
+  })
+
+  describe('getDateLabel', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date(2025, 5, 15, 12, 0, 0))
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('should return "Today" for today', () => {
+      const today = new Date(2025, 5, 15, 8, 0, 0)
+      expect(fmt.getDateLabel(today)).toBe('Today')
+    })
+
+    it('should return "Yesterday" for yesterday', () => {
+      const yesterday = new Date(2025, 5, 14, 23, 59, 0)
+      expect(fmt.getDateLabel(yesterday)).toBe('Yesterday')
+    })
+
+    it('should return formatted date for older dates', () => {
+      const older = new Date(2025, 5, 10, 12, 0, 0)
+      const result = fmt.getDateLabel(older)
+      expect(result).toContain('2025')
+    })
+
+    it('should handle DST boundary correctly using calendar days', () => {
+      vi.setSystemTime(new Date(2025, 2, 31, 0, 30, 0))
+      const yesterday = new Date(2025, 2, 30, 23, 30, 0)
+      expect(fmt.getDateLabel(yesterday)).toBe('Yesterday')
+    })
+
+    it('should return "Today" for future timestamp on the same day', () => {
+      const laterToday = new Date(2025, 5, 15, 23, 59, 0)
+      expect(fmt.getDateLabel(laterToday)).toBe('Today')
+    })
+  })
+})


### PR DESCRIPTION
## Summary
Centralize all date/time formatting into a single `useDateFormat` composable and ensure all timestamps from the database (stored in UTC) are displayed in the user's local timezone across the entire application, including widget exports.

## Changes
- Add `frontend/src/composables/useDateFormat.ts` with `formatTime`, `formatDate`, `formatDateTime`, `formatRelativeTime`, and `getDateLabel` — all using `Intl.DateTimeFormat` with the current `vue-i18n` locale
- Add i18n keys `common.today` / `common.yesterday` in all 4 languages (DE, EN, ES, TR)
- Replace duplicated local date formatting logic in 28 frontend components/views with calls to `useDateFormat`
- Update `WidgetExportService.php` to accept a `DateTimeZone` parameter and format all exported timestamps in the user's timezone
- Update `WidgetExportController.php` to read the `timezone` query parameter from the request
- Update `widgetSessionsApi.ts` to automatically send the browser's timezone with export requests

## Verification
- [ ] Manual
- [x] Tests added/updated

## Notes
Covers all user-facing timestamps: chat messages, sidebar, memories, widget sessions, admin views, exports (XLSX, CSV, JSON).

## Screenshots/Logs