### PR TITLE
fix(e2e): wait for empty-state before counting bubbles in startNewChat

### DIFF
--- a/frontend/tests/e2e/helpers/chat.ts
+++ b/frontend/tests/e2e/helpers/chat.ts
@@ -49,7 +49,15 @@ export class ChatHelper {
 
   /**
    * Start a new chat. Supports V2 (sidebar plus button) and V1 (chat toggle + dropdown).
-   * Waits for the new chat input to be visible, empty, and enabled.
+   *
+   * Waits for the new chat to be fully committed by asserting the empty-state
+   * marker (`state-empty`) is visible. This is required to avoid a race with
+   * `historyStore.loadMessages()` which is triggered asynchronously by the
+   * `activeChatId` watcher in ChatView: if we sample `conversationBubbles().count()`
+   * before that async call replaces `messages.value = []`, the count picks up
+   * DOM residue from the previously active chat, and any later bubbles added
+   * optimistically by `sendMessage` get wiped by the delayed replacement —
+   * leaving `waitForAnswer(previousCount)` stuck on a non-existent `nth(N)` bubble.
    */
   async startNewChat(): Promise<void> {
     const v2NewChatBtn = this.page.locator(selectors.nav.sidebarV2NewChat)
@@ -67,6 +75,10 @@ export class ChatHelper {
     await textInput.waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
     await expect(textInput).toHaveValue('', { timeout: TIMEOUTS.SHORT })
     await expect(textInput).toBeEnabled()
+
+    await this.page
+      .locator(selectors.chat.stateEmpty)
+      .waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
   }
 
   async attachFile(file: { name: string; mimeType: string; buffer: Buffer }): Promise<void> {

--- a/frontend/tests/e2e/helpers/selectors.ts
+++ b/frontend/tests/e2e/helpers/selectors.ts
@@ -89,6 +89,8 @@ export const selectors = {
     fileInput: '[data-testid="input-chat-file"]',
     messageContainer: '[data-testid="message-container"]',
     aiAnswerBubble: '[data-testid="assistant-message-bubble"]',
+    /** Empty-state for a new/empty chat (shown while messages.length === 0 && !isLoadingMessages). Use to assert that a fresh chat is fully committed before counting bubbles. */
+    stateEmpty: '[data-testid="state-empty"]',
     /** Terminal: present when streaming finished */
     chatDone: '[data-testid="message-done"]',
     /** Terminal: present when message ended in error */


### PR DESCRIPTION
## Summary

- Fixes flaky Ollama integration E2E tests (`chat via Ollama provider produces response` and `thinking/reasoning tokens are forwarded`) that intermittently timed out waiting for `nth(N)` assistant bubble
- Root cause: `ChatHelper.startNewChat()` returned as soon as the text input was visible, but `historyStore.loadMessages()` — triggered asynchronously by the `activeChatId` watcher in `ChatView.vue` — had not necessarily replaced `messages.value` yet. This caused `conversationBubbles().count()` to pick up DOM residue from the previous chat (`previousCount = 1`), and the subsequent `messages.value = loadedMessages` clobbered the optimistically added streaming message, leaving `waitForAnswer` stuck on a non-existent bubble
- Fix: `startNewChat()` now waits for the `[data-testid="state-empty"]` marker (visible only when `messages.length === 0 && !isLoadingMessages`), ensuring the new chat is fully committed before any bubble count is taken

## Test plan

- [x] `frontend/tests/e2e/helpers/chat.ts` — `startNewChat()` waits for `state-empty`
- [x] `frontend/tests/e2e/helpers/selectors.ts` — new `stateEmpty` selector added
- [ ] CI: Ollama integration tests pass without retries on chromium
- [ ] No regression in other E2E tests that use `startNewChat()`