### PR TITLE
fix: move highlight.js CSS import out of Promise.all destructure

### DIFF
--- a/frontend/src/composables/useHighlight.ts
+++ b/frontend/src/composables/useHighlight.ts
@@ -38,9 +38,9 @@ export function escapeHtml(text: string): string {
  */
 async function doLoad(): Promise<HLJSApi> {
   try {
+    // CSS side-effect import kept outside Promise.all to avoid
+    // Rolldown bundler issues with CSS modules in destructured arrays
     const [
-      ,
-      // CSS side-effect import (no export)
       { default: hljs },
       { default: javascript },
       { default: typescript },
@@ -61,7 +61,6 @@ async function doLoad(): Promise<HLJSApi> {
       { default: markdown },
       { default: plaintext },
     ] = await Promise.all([
-      import('highlight.js/styles/atom-one-dark.css'),
       import('highlight.js/lib/core'),
       import('highlight.js/lib/languages/javascript'),
       import('highlight.js/lib/languages/typescript'),
@@ -82,6 +81,7 @@ async function doLoad(): Promise<HLJSApi> {
       import('highlight.js/lib/languages/markdown'),
       import('highlight.js/lib/languages/plaintext'),
     ])
+    await import('highlight.js/styles/atom-one-dark.css')
 
     // Register primary language names
     hljs.registerLanguage('javascript', javascript)


### PR DESCRIPTION
## Summary

- Moves the `highlight.js/styles/atom-one-dark.css` side-effect import out of the destructured `Promise.all` array in `useHighlight.ts`
- Fixes `Uncaught (in promise) TypeError: Export 'atom_one_dark_exports' is not defined in module` on production (web.synaplan.com)
- Root cause: Vite 8's Rolldown bundler generates a broken export name from the CSS filename when it appears inside a destructured dynamic import array

## Details

CSS imports are side-effect-only (they inject a stylesheet, they don't export a value). When placed as the first element of a destructured `Promise.all`, Rolldown derives an export identifier (`atom_one_dark_exports`) from the filename and emits it — but the generated CSS module chunk doesn't actually define that export, causing a runtime `TypeError`.

The fix moves the CSS import to a separate `await` after the `Promise.all`, which is also more semantically correct since there's no value to destructure.

## Test plan

- [ ] `make -C frontend lint` passes
- [ ] `docker compose exec -T frontend npm run check:types` passes
- [ ] `make -C frontend test` passes
- [ ] Build succeeds (`make build`)
- [ ] Open a chat, send a message with a code block, verify syntax highlighting renders with dark theme
- [ ] No `atom_one_dark_exports` error in browser console