### PR TITLE
fix: use static CSS import for highlight.js to avoid Rolldown bundling bug

### DIFF
--- a/frontend/src/composables/useHighlight.ts
+++ b/frontend/src/composables/useHighlight.ts
@@ -20,6 +20,12 @@
  */
 
 import type { HLJSApi } from 'highlight.js'
+// Static import so Rolldown (Vite 8) emits it as a plain CSS asset.
+// A dynamic import() causes Rolldown to generate an undeclared
+// `atom_one_dark_exports` binding that crashes at runtime.
+// This file is only imported by lazy-loaded components, so the CSS
+// still stays out of the initial bundle.
+import 'highlight.js/styles/atom-one-dark.css'
 
 let hljsInstance: HLJSApi | null = null
 let loadPromise: Promise<HLJSApi> | null = null
@@ -39,8 +45,6 @@ export function escapeHtml(text: string): string {
 async function doLoad(): Promise<HLJSApi> {
   try {
     const [
-      ,
-      // CSS side-effect import (no export)
       { default: hljs },
       { default: javascript },
       { default: typescript },
@@ -61,7 +65,6 @@ async function doLoad(): Promise<HLJSApi> {
       { default: markdown },
       { default: plaintext },
     ] = await Promise.all([
-      import('highlight.js/styles/atom-one-dark.css'),
       import('highlight.js/lib/core'),
       import('highlight.js/lib/languages/javascript'),
       import('highlight.js/lib/languages/typescript'),


### PR DESCRIPTION
## Summary

- Vite 8's Rolldown bundler generates an undeclared `atom_one_dark_exports` binding when `highlight.js/styles/atom-one-dark.css` is dynamically imported via `import()`, causing a `SyntaxError` at runtime in production builds
- Moves the CSS import from a dynamic `import()` inside `Promise.all` to a static top-level `import` in `useHighlight.ts`, so Rolldown emits it as a plain CSS asset
- This file is only imported by lazy-loaded components, so the CSS still stays out of the initial bundle

## How to verify

```bash
# Before fix (on main): bug is present in prod bundle
docker compose exec -T frontend npx vite build
grep "atom_one_dark_exports" frontend/dist/assets/vendor-highlight-*.js
# ^ returns a match → bug

# After fix (this branch): bug is gone
docker compose exec -T frontend npx vite build
grep "atom_one_dark_exports" frontend/dist/assets/vendor-highlight-*.js
# ^ no match → fixed
```

## Test plan

- [x] `grep` confirms `atom_one_dark_exports` is absent from production bundle
- [ ] CI passes (lint, phpstan, tests, type-check)
- [ ] Syntax highlighting still works in chat responses on production build