### PR TITLE
fix(qdrant): address PR #811 review - atomic writes, de-dup

### DIFF
--- a/backend/config/services.yaml
+++ b/backend/config/services.yaml
@@ -487,6 +487,12 @@ services:
         alias: App\Service\VectorSearch\QdrantClientDirect
     # For Development without Qdrant: alias: App\Service\VectorSearch\QdrantClientMock
 
+    # Maintenance helper used by app:qdrant:migrate-legacy-point-ids
+    App\Service\VectorSearch\LegacyPointIdMigrator:
+        arguments:
+            $httpClient: '@Symfony\Contracts\HttpClient\HttpClientInterface'
+            $qdrantUrl: '%env(QDRANT_URL)%'
+
     # Monolog Formatter Factory (for env-based log format switching)
     App\Service\MonologFormatterFactory:
         arguments:

--- a/backend/src/Command/MigrateLegacyPointIdsCommand.php
+++ b/backend/src/Command/MigrateLegacyPointIdsCommand.php
@@ -85,8 +85,21 @@ final class MigrateLegacyPointIdsCommand extends Command
 
         $which = strtolower((string) $input->getOption('collection'));
         $apply = (bool) $input->getOption('apply');
-        $limitRaw = (string) $input->getOption('limit');
-        $limit = ('all' === strtolower($limitRaw) || '' === $limitRaw) ? 0 : max(0, (int) $limitRaw);
+
+        // Strict --limit parsing. A typo like `--limit=al` must NOT silently
+        // degrade to 0 (= no cap) and risk migrating every point, especially
+        // combined with --apply. Accept only "all" (case-insensitive) or a
+        // positive integer; reject everything else with a clear message.
+        $limitRaw = trim((string) $input->getOption('limit'));
+        if ('' === $limitRaw || 'all' === strtolower($limitRaw)) {
+            $limit = 0;
+        } elseif (ctype_digit($limitRaw) && (int) $limitRaw > 0) {
+            $limit = (int) $limitRaw;
+        } else {
+            $io->error(sprintf('Invalid --limit value "%s". Use "all" or a positive integer.', $limitRaw));
+
+            return Command::INVALID;
+        }
 
         $collections = match ($which) {
             'memories' => [$this->qdrantClient->getMemoriesCollection()],

--- a/backend/src/Command/MigrateLegacyPointIdsCommand.php
+++ b/backend/src/Command/MigrateLegacyPointIdsCommand.php
@@ -4,15 +4,14 @@ declare(strict_types=1);
 
 namespace App\Command;
 
+use App\Service\VectorSearch\LegacyPointIdMigrator;
+use App\Service\VectorSearch\QdrantClientDirect;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\Uid\Uuid;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
  * One-shot migration for Qdrant collections that still contain points whose
@@ -30,6 +29,10 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  * UUIDv5 and the primary ID matches `_point_id`.
  *
  * Safe to run repeatedly. Default is dry-run.
+ *
+ * The actual scrolling, UUID derivation and rekey loop lives in
+ * {@see LegacyPointIdMigrator} so it can be unit-tested with MockHttpClient;
+ * this command is just CLI wiring.
  */
 #[AsCommand(
     name: 'app:qdrant:migrate-legacy-point-ids',
@@ -37,19 +40,9 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 )]
 final class MigrateLegacyPointIdsCommand extends Command
 {
-    private const BATCH_LIMIT = 100;
-
-    /** UUIDv5 namespace for point-ID derivation — must match QdrantClientDirect::generatePointUuid(). */
-    private const POINT_ID_NAMESPACE = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
-
     public function __construct(
-        private readonly HttpClientInterface $httpClient,
-        #[Autowire('%env(QDRANT_URL)%')]
-        private readonly string $qdrantUrl,
-        #[Autowire('%env(default::QDRANT_MEMORIES_COLLECTION)%')]
-        private readonly ?string $memoriesCollectionOverride = null,
-        #[Autowire('%env(default::QDRANT_DOCUMENTS_COLLECTION)%')]
-        private readonly ?string $documentsCollectionOverride = null,
+        private readonly QdrantClientDirect $qdrantClient,
+        private readonly LegacyPointIdMigrator $migrator,
     ) {
         parent::__construct();
     }
@@ -74,8 +67,8 @@ final class MigrateLegacyPointIdsCommand extends Command
                 'limit',
                 null,
                 InputOption::VALUE_REQUIRED,
-                'Maximum points to migrate in this run (0 = all). Useful for canarying.',
-                '0'
+                'Global cap on migrated points across all selected collections. Omit or pass "all" for no cap.',
+                'all'
             );
     }
 
@@ -83,7 +76,8 @@ final class MigrateLegacyPointIdsCommand extends Command
     {
         $io = new SymfonyStyle($input, $output);
 
-        if ('' === $this->qdrantUrl || 'http://' === $this->qdrantUrl || 'https://' === $this->qdrantUrl) {
+        $qdrantUrl = $this->qdrantClient->getQdrantUrl();
+        if ('' === $qdrantUrl || 'http://' === $qdrantUrl || 'https://' === $qdrantUrl) {
             $io->error('QDRANT_URL is not configured.');
 
             return Command::FAILURE;
@@ -91,12 +85,16 @@ final class MigrateLegacyPointIdsCommand extends Command
 
         $which = strtolower((string) $input->getOption('collection'));
         $apply = (bool) $input->getOption('apply');
-        $limit = max(0, (int) $input->getOption('limit'));
+        $limitRaw = (string) $input->getOption('limit');
+        $limit = ('all' === strtolower($limitRaw) || '' === $limitRaw) ? 0 : max(0, (int) $limitRaw);
 
         $collections = match ($which) {
-            'memories' => [$this->memoriesCollection()],
-            'documents' => [$this->documentsCollection()],
-            'all' => [$this->memoriesCollection(), $this->documentsCollection()],
+            'memories' => [$this->qdrantClient->getMemoriesCollection()],
+            'documents' => [$this->qdrantClient->getDocumentsCollection()],
+            'all' => [
+                $this->qdrantClient->getMemoriesCollection(),
+                $this->qdrantClient->getDocumentsCollection(),
+            ],
             default => null,
         };
 
@@ -108,10 +106,10 @@ final class MigrateLegacyPointIdsCommand extends Command
 
         $io->title('Qdrant legacy point-ID migration');
         $io->definitionList(
-            ['Qdrant URL' => $this->qdrantUrl],
+            ['Qdrant URL' => $qdrantUrl],
             ['Collections' => implode(', ', $collections)],
             ['Mode' => $apply ? 'APPLY (writes)' : 'DRY RUN (read-only)'],
-            ['Limit' => 0 === $limit ? 'all points' : (string) $limit],
+            ['Limit' => 0 === $limit ? 'no cap' : (string) $limit],
         );
 
         $totalScanned = 0;
@@ -120,21 +118,41 @@ final class MigrateLegacyPointIdsCommand extends Command
         $totalErrors = 0;
 
         foreach ($collections as $collection) {
-            [$scanned, $legacy, $migrated, $errors] = $this->migrateCollection($collection, $apply, $limit, $io);
-            $totalScanned += $scanned;
-            $totalLegacy += $legacy;
-            $totalMigrated += $migrated;
-            $totalErrors += $errors;
-
-            if ($limit > 0 && $totalMigrated >= $limit) {
+            if (0 !== $limit && $totalMigrated >= $limit) {
                 break;
             }
+
+            $remaining = 0 === $limit ? 0 : max(0, $limit - $totalMigrated);
+
+            $io->section(sprintf('Collection: %s', $collection));
+
+            $report = $this->migrator->migrateCollection(
+                collection: $collection,
+                apply: $apply,
+                limit: $remaining,
+                onPoint: function (string $phase, string $logicalId, int|string $fromId, string $toUuid) use ($io): void {
+                    $prefix = match ($phase) {
+                        'would-migrate' => '<comment>would migrate</comment>',
+                        'migrate' => '<info>migrate</info>',
+                        'skip-missing-payload' => '<comment>skip</comment>',
+                        'skip-missing-vector' => '<error>skip</error>',
+                        'failed' => '<error>failed</error>',
+                        default => $phase,
+                    };
+                    $io->writeln(sprintf('  %s %s  %s → %s', $prefix, $logicalId, (string) $fromId, $toUuid));
+                },
+            );
+
+            $totalScanned += $report->scanned;
+            $totalLegacy += $report->legacy;
+            $totalMigrated += $report->migrated;
+            $totalErrors += $report->errors;
         }
 
         $io->section('Summary');
         $io->definitionList(
             ['Points scanned' => (string) $totalScanned],
-            ['Legacy (non-UUID) points' => (string) $totalLegacy],
+            ['Legacy (non-canonical-UUID) points' => (string) $totalLegacy],
             [$apply ? 'Points migrated' : 'Points that WOULD migrate' => (string) $totalMigrated],
             ['Errors' => (string) $totalErrors],
         );
@@ -144,173 +162,5 @@ final class MigrateLegacyPointIdsCommand extends Command
         }
 
         return $totalErrors > 0 ? Command::FAILURE : Command::SUCCESS;
-    }
-
-    /**
-     * @return array{int, int, int, int} [scanned, legacy, migrated, errors]
-     */
-    private function migrateCollection(string $collection, bool $apply, int $limit, SymfonyStyle $io): array
-    {
-        $io->section(sprintf('Collection: %s', $collection));
-
-        $scanned = 0;
-        $legacy = 0;
-        $migrated = 0;
-        $errors = 0;
-        $offset = null;
-
-        do {
-            $body = [
-                'limit' => self::BATCH_LIMIT,
-                'with_payload' => true,
-                'with_vector' => true,
-            ];
-            if (null !== $offset) {
-                $body['offset'] = $offset;
-            }
-
-            try {
-                $response = $this->qdrantRequest('POST', "/collections/{$collection}/points/scroll", $body);
-            } catch (\Throwable $e) {
-                $io->error(sprintf('Failed to scroll %s: %s', $collection, $e->getMessage()));
-
-                return [$scanned, $legacy, $migrated, ++$errors];
-            }
-
-            /** @var list<array{id: int|string, payload?: array<string, mixed>, vector?: list<float>}> $points */
-            $points = $response['result']['points'] ?? [];
-
-            foreach ($points as $point) {
-                ++$scanned;
-
-                $primaryId = $point['id'];
-                $logicalId = $point['payload']['_point_id'] ?? null;
-
-                // Skip points that are already correctly keyed, or that lack
-                // the `_point_id` payload entirely (we have nothing to derive
-                // a new UUID from).
-                if (is_string($primaryId) && $this->isUuid($primaryId)) {
-                    continue;
-                }
-                if (!is_string($logicalId) || '' === $logicalId) {
-                    $io->writeln(sprintf('  <comment>skip</comment> id=%s — missing `_point_id` payload', var_export($primaryId, true)));
-                    continue;
-                }
-
-                ++$legacy;
-
-                $newUuid = $this->deriveUuid($logicalId);
-                $vector = $point['vector'] ?? null;
-
-                if (!is_array($vector) || [] === $vector) {
-                    $io->writeln(sprintf('  <error>skip</error> %s — no vector available to re-upsert', $logicalId));
-                    ++$errors;
-                    continue;
-                }
-
-                $io->writeln(sprintf(
-                    '  %s %s  %s → %s',
-                    $apply ? '<info>migrate</info>' : '<comment>would migrate</comment>',
-                    $logicalId,
-                    (string) $primaryId,
-                    $newUuid,
-                ));
-
-                if (!$apply) {
-                    ++$migrated;
-                    if ($limit > 0 && $migrated >= $limit) {
-                        return [$scanned, $legacy, $migrated, $errors];
-                    }
-                    continue;
-                }
-
-                try {
-                    // 1) Upsert under the new UUID primary (carries the full
-                    //    payload, including `_point_id`).
-                    $this->qdrantRequest('PUT', "/collections/{$collection}/points?wait=true", [
-                        'points' => [
-                            [
-                                'id' => $newUuid,
-                                'vector' => $vector,
-                                'payload' => $point['payload'] ?? [],
-                            ],
-                        ],
-                    ]);
-
-                    // 2) Delete the old primary-ID point. Using the primary
-                    //    ID directly here is correct — we are explicitly
-                    //    targeting the legacy row by its raw integer ID.
-                    $this->qdrantRequest('POST', "/collections/{$collection}/points/delete?wait=true", [
-                        'points' => [$primaryId],
-                    ]);
-
-                    ++$migrated;
-                } catch (\Throwable $e) {
-                    $io->writeln(sprintf('    <error>failed</error>: %s', $e->getMessage()));
-                    ++$errors;
-                }
-
-                if ($limit > 0 && $migrated >= $limit) {
-                    return [$scanned, $legacy, $migrated, $errors];
-                }
-            }
-
-            $offset = $response['result']['next_page_offset'] ?? null;
-        } while (null !== $offset && !empty($points));
-
-        return [$scanned, $legacy, $migrated, $errors];
-    }
-
-    private function memoriesCollection(): string
-    {
-        $override = $this->memoriesCollectionOverride ?? '';
-
-        return '' !== $override ? $override : 'user_memories';
-    }
-
-    private function documentsCollection(): string
-    {
-        $override = $this->documentsCollectionOverride ?? '';
-
-        return '' !== $override ? $override : 'user_documents';
-    }
-
-    private function deriveUuid(string $logicalId): string
-    {
-        return Uuid::v5(Uuid::fromString(self::POINT_ID_NAMESPACE), $logicalId)->toRfc4122();
-    }
-
-    private function isUuid(string $value): bool
-    {
-        return 1 === preg_match('/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i', $value);
-    }
-
-    /**
-     * @param array<string, mixed>|null $body
-     *
-     * @return array<string, mixed>
-     */
-    private function qdrantRequest(string $method, string $path, ?array $body = null): array
-    {
-        $options = ['headers' => ['Content-Type' => 'application/json']];
-        if (null !== $body) {
-            $options['json'] = $body;
-        }
-
-        $response = $this->httpClient->request($method, "{$this->qdrantUrl}{$path}", $options);
-        $status = $response->getStatusCode();
-        if ($status < 200 || $status >= 300) {
-            throw new \RuntimeException(sprintf('Qdrant %s %s failed with HTTP %d: %s', $method, $path, $status, $response->getContent(false)));
-        }
-
-        $content = $response->getContent();
-        if ('' === $content) {
-            return [];
-        }
-
-        /** @var array<string, mixed> $decoded */
-        $decoded = json_decode($content, true, 512, \JSON_THROW_ON_ERROR);
-
-        return $decoded;
     }
 }

--- a/backend/src/Service/VectorSearch/LegacyPointIdMigrationReport.php
+++ b/backend/src/Service/VectorSearch/LegacyPointIdMigrationReport.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\VectorSearch;
+
+/**
+ * Outcome of a single call to {@see LegacyPointIdMigrator::migrateCollection()}.
+ */
+final readonly class LegacyPointIdMigrationReport
+{
+    public function __construct(
+        public int $scanned,
+        public int $legacy,
+        public int $migrated,
+        public int $errors,
+    ) {
+    }
+}

--- a/backend/src/Service/VectorSearch/LegacyPointIdMigrator.php
+++ b/backend/src/Service/VectorSearch/LegacyPointIdMigrator.php
@@ -46,7 +46,6 @@ final class LegacyPointIdMigrator
         $errors = 0;
 
         $offset = null;
-        $lastOffset = null; // guards against Qdrant returning the same offset twice
 
         do {
             $body = [
@@ -154,11 +153,14 @@ final class LegacyPointIdMigrator
 
             $nextOffset = $response['result']['next_page_offset'] ?? null;
 
-            // Progress guard: abort the loop if Qdrant returns the same
-            // `next_page_offset` it returned last iteration. This can only
-            // happen under a bug or a pathological race, and without the
-            // guard the loop would spin forever on the same page.
-            if (null !== $nextOffset && $nextOffset === $lastOffset) {
+            // Progress guard: abort the loop if Qdrant tells us to scroll
+            // back to the very offset we just requested, i.e. the cursor
+            // did not advance. This can only happen under a Qdrant bug
+            // or a race with a concurrent delete; without the guard the
+            // loop would spin forever on the same page. Comparing against
+            // the REQUEST offset (not against the previously returned
+            // next-offset) catches this on the first stuck iteration.
+            if (null !== $nextOffset && $nextOffset === $offset) {
                 $this->logger->warning('Scroll offset did not advance during legacy-point migration; aborting loop', [
                     'collection' => $collection,
                     'offset' => is_scalar($nextOffset) ? (string) $nextOffset : '(complex)',
@@ -166,7 +168,6 @@ final class LegacyPointIdMigrator
                 break;
             }
 
-            $lastOffset = $offset;
             $offset = $nextOffset;
         } while (null !== $offset && !empty($points));
 

--- a/backend/src/Service/VectorSearch/LegacyPointIdMigrator.php
+++ b/backend/src/Service/VectorSearch/LegacyPointIdMigrator.php
@@ -1,0 +1,205 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\VectorSearch;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * Rekeys Qdrant points whose primary ID is still in the legacy
+ * Rust-microservice integer scheme to the canonical UUIDv5 derived from
+ * their `_point_id` payload.
+ *
+ * Works on any collection that stores points with a `_point_id` payload.
+ * Split out of {@see \App\Command\MigrateLegacyPointIdsCommand} so the
+ * scroll + rekey loop can be unit-tested with {@see \Symfony\Component\HttpClient\MockHttpClient}.
+ */
+final class LegacyPointIdMigrator
+{
+    private const SCROLL_BATCH_LIMIT = 100;
+
+    public function __construct(
+        private readonly HttpClientInterface $httpClient,
+        private readonly string $qdrantUrl,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * Scroll `$collection` and rekey every point whose primary ID is not
+     * already the canonical UUIDv5 for its `_point_id` payload.
+     *
+     * @param int                                                                                 $limit   0 = no cap; otherwise migrate at most this many points before returning
+     * @param \Closure(string $phase, string $logicalId, int|string $fromId, string $toUuid):void $onPoint Callback for progress reporting; see {@see LegacyPointIdMigrationReport} for phases
+     */
+    public function migrateCollection(
+        string $collection,
+        bool $apply,
+        int $limit,
+        ?\Closure $onPoint = null,
+    ): LegacyPointIdMigrationReport {
+        $scanned = 0;
+        $legacy = 0;
+        $migrated = 0;
+        $errors = 0;
+
+        $offset = null;
+        $lastOffset = null; // guards against Qdrant returning the same offset twice
+
+        do {
+            $body = [
+                'limit' => self::SCROLL_BATCH_LIMIT,
+                'with_payload' => true,
+                'with_vector' => true,
+            ];
+            if (null !== $offset) {
+                $body['offset'] = $offset;
+            }
+
+            try {
+                $response = $this->qdrantRequest('POST', "/collections/{$collection}/points/scroll", $body);
+            } catch (\Throwable $e) {
+                $this->logger->error('Failed to scroll collection during legacy-point migration', [
+                    'collection' => $collection,
+                    'error' => $e->getMessage(),
+                ]);
+
+                return new LegacyPointIdMigrationReport($scanned, $legacy, $migrated, $errors + 1);
+            }
+
+            /** @var list<array{id: int|string, payload?: array<string, mixed>, vector?: list<float>}> $points */
+            $points = $response['result']['points'] ?? [];
+
+            foreach ($points as $point) {
+                ++$scanned;
+
+                $primaryId = $point['id'];
+                $logicalId = $point['payload']['_point_id'] ?? null;
+
+                if (!is_string($logicalId) || '' === $logicalId) {
+                    if (null !== $onPoint) {
+                        $onPoint('skip-missing-payload', '(none)', $primaryId, '(none)');
+                    }
+                    continue;
+                }
+
+                if (QdrantPointId::isCanonicalUuid($primaryId, $logicalId)) {
+                    continue;
+                }
+
+                ++$legacy;
+
+                $newUuid = QdrantPointId::uuidFor($logicalId);
+                $vector = $point['vector'] ?? null;
+
+                if (!is_array($vector) || [] === $vector) {
+                    if (null !== $onPoint) {
+                        $onPoint('skip-missing-vector', $logicalId, $primaryId, $newUuid);
+                    }
+                    ++$errors;
+                    continue;
+                }
+
+                if (null !== $onPoint) {
+                    $onPoint($apply ? 'migrate' : 'would-migrate', $logicalId, $primaryId, $newUuid);
+                }
+
+                if (!$apply) {
+                    ++$migrated;
+                    if (0 !== $limit && $migrated >= $limit) {
+                        return new LegacyPointIdMigrationReport($scanned, $legacy, $migrated, $errors);
+                    }
+                    continue;
+                }
+
+                try {
+                    // Atomic rekey: batch-delete the legacy primary ID and
+                    // upsert the canonical UUID-keyed copy in one request.
+                    // If the batch fails mid-way, Qdrant returns an error
+                    // BEFORE either op is committed (validated upfront).
+                    $this->qdrantRequest('POST', "/collections/{$collection}/points/batch?wait=true", [
+                        'operations' => [
+                            ['upsert' => ['points' => [
+                                [
+                                    'id' => $newUuid,
+                                    'vector' => $vector,
+                                    'payload' => $point['payload'] ?? [],
+                                ],
+                            ]]],
+                            ['delete' => ['points' => [$primaryId]]],
+                        ],
+                    ]);
+
+                    ++$migrated;
+                } catch (\Throwable $e) {
+                    if (null !== $onPoint) {
+                        $onPoint('failed', $logicalId, $primaryId, $newUuid);
+                    }
+                    $this->logger->error('Failed to rekey legacy point', [
+                        'collection' => $collection,
+                        'logical_id' => $logicalId,
+                        'from_id' => (string) $primaryId,
+                        'to_uuid' => $newUuid,
+                        'error' => $e->getMessage(),
+                    ]);
+                    ++$errors;
+                }
+
+                if (0 !== $limit && $migrated >= $limit) {
+                    return new LegacyPointIdMigrationReport($scanned, $legacy, $migrated, $errors);
+                }
+            }
+
+            $nextOffset = $response['result']['next_page_offset'] ?? null;
+
+            // Progress guard: abort the loop if Qdrant returns the same
+            // `next_page_offset` it returned last iteration. This can only
+            // happen under a bug or a pathological race, and without the
+            // guard the loop would spin forever on the same page.
+            if (null !== $nextOffset && $nextOffset === $lastOffset) {
+                $this->logger->warning('Scroll offset did not advance during legacy-point migration; aborting loop', [
+                    'collection' => $collection,
+                    'offset' => is_scalar($nextOffset) ? (string) $nextOffset : '(complex)',
+                ]);
+                break;
+            }
+
+            $lastOffset = $offset;
+            $offset = $nextOffset;
+        } while (null !== $offset && !empty($points));
+
+        return new LegacyPointIdMigrationReport($scanned, $legacy, $migrated, $errors);
+    }
+
+    /**
+     * @param array<string, mixed>|null $body
+     *
+     * @return array<string, mixed>
+     */
+    private function qdrantRequest(string $method, string $path, ?array $body = null): array
+    {
+        $options = [];
+        if (null !== $body) {
+            $options['headers'] = ['Content-Type' => 'application/json'];
+            $options['json'] = $body;
+        }
+
+        $response = $this->httpClient->request($method, "{$this->qdrantUrl}{$path}", $options);
+        $status = $response->getStatusCode();
+        if ($status < 200 || $status >= 300) {
+            throw new \RuntimeException(sprintf('Qdrant %s %s failed with HTTP %d: %s', $method, $path, $status, $response->getContent(false)));
+        }
+
+        $content = $response->getContent();
+        if ('' === $content) {
+            return [];
+        }
+
+        /** @var array<string, mixed> $decoded */
+        $decoded = json_decode($content, true, 512, \JSON_THROW_ON_ERROR);
+
+        return $decoded;
+    }
+}

--- a/backend/src/Service/VectorSearch/QdrantClientDirect.php
+++ b/backend/src/Service/VectorSearch/QdrantClientDirect.php
@@ -120,8 +120,11 @@ final class QdrantClientDirect implements QdrantClientInterface
      *
      * `with_vector: false` is deliberate — memory callers only need the
      * payload (key/value/category/…) and skipping 1024 floats per request
-     * keeps this on the hot path of chat responses. Use getDocument() if
-     * you do need the vector.
+     * keeps this on the hot path of chat responses. Returns the payload
+     * only; memories do not expose a vector-returning read path because no
+     * current caller needs it. If one ever does, add a dedicated method
+     * rather than toggling `with_vector` here (the default empty-payload
+     * savings matter for latency).
      */
     public function getMemory(string $pointId, ?string $namespace = null): ?array
     {

--- a/backend/src/Service/VectorSearch/QdrantClientDirect.php
+++ b/backend/src/Service/VectorSearch/QdrantClientDirect.php
@@ -6,7 +6,6 @@ namespace App\Service\VectorSearch;
 
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\Uid\Uuid;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\ItemInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -50,6 +49,26 @@ final class QdrantClientDirect implements QdrantClientInterface
             : self::DEFAULT_DOCUMENTS_COLLECTION;
     }
 
+    public function getMemoriesCollection(): string
+    {
+        return $this->memoriesCollection;
+    }
+
+    public function getDocumentsCollection(): string
+    {
+        return $this->documentsCollection;
+    }
+
+    public function getQdrantUrl(): string
+    {
+        return $this->qdrantUrl;
+    }
+
+    public function getHttpClient(): HttpClientInterface
+    {
+        return $this->httpClient;
+    }
+
     // ──────────────────────────────────────────────
     //  Memory Operations
     // ──────────────────────────────────────────────
@@ -62,22 +81,27 @@ final class QdrantClientDirect implements QdrantClientInterface
         $payload['_point_id'] = $pointId;
 
         try {
-            // Remove any prior point carrying the same `_point_id` payload
-            // before writing the new UUID-keyed one. Without this step, a
-            // legacy integer-keyed point and the new UUID-keyed point would
-            // coexist (same `_point_id` payload, different primary IDs) and
-            // scrolls would surface duplicates. Deleting by payload filter is
-            // cheap and a no-op when nothing matches.
-            $this->qdrantRequest('POST', "/collections/{$collection}/points/delete?wait=true", [
-                'filter' => $this->pointIdFilter($pointId),
-            ]);
-
-            $this->upsertPoints($collection, [
-                [
-                    'id' => $this->generatePointUuid($pointId),
-                    'vector' => $vector,
-                    'payload' => $payload,
-                ],
+            // Atomic delete-by-payload + upsert in a single request. The pre-
+            // delete is needed because production clusters still contain
+            // legacy integer-keyed points from the pre-v2.4.0 Rust
+            // microservice that share `_point_id` with the new UUID-keyed
+            // points. Without this step, the legacy ghost and the new point
+            // would coexist and scrolls would surface duplicates.
+            //
+            // Using /points/batch rather than two sequential calls: keeps
+            // latency the same as a plain upsert, orders the ops server-side
+            // (delete is validated and applied before upsert), and avoids
+            // the "crash between delete and upsert leaves no point" window
+            // that two separate wait=true requests would open.
+            $this->pointsBatch($collection, [
+                ['delete' => ['filter' => QdrantPointId::payloadFilterFor($pointId)]],
+                ['upsert' => ['points' => [
+                    [
+                        'id' => QdrantPointId::uuidFor($pointId),
+                        'vector' => $vector,
+                        'payload' => $payload,
+                    ],
+                ]]],
             ]);
 
             $this->logger->debug('Memory upserted to Qdrant', ['point_id' => $pointId]);
@@ -91,6 +115,14 @@ final class QdrantClientDirect implements QdrantClientInterface
         }
     }
 
+    /**
+     * Fetch a single memory point's payload, if present.
+     *
+     * `with_vector: false` is deliberate — memory callers only need the
+     * payload (key/value/category/…) and skipping 1024 floats per request
+     * keeps this on the hot path of chat responses. Use getDocument() if
+     * you do need the vector.
+     */
     public function getMemory(string $pointId, ?string $namespace = null): ?array
     {
         $collection = $this->resolveMemoriesCollection($namespace);
@@ -104,7 +136,7 @@ final class QdrantClientDirect implements QdrantClientInterface
             // infrastructure problem rather than a missing memory, so we let
             // the underlying \RuntimeException propagate for 503 mapping.
             $response = $this->qdrantRequest('POST', "/collections/{$collection}/points/scroll", [
-                'filter' => $this->pointIdFilter($pointId),
+                'filter' => QdrantPointId::payloadFilterFor($pointId),
                 'limit' => 1,
                 'with_payload' => true,
                 'with_vector' => false,
@@ -146,24 +178,38 @@ final class QdrantClientDirect implements QdrantClientInterface
                 $must[] = ['key' => 'category', 'match' => ['value' => $category]];
             }
 
+            // Ask for up to 2x the requested limit so dedup below doesn't
+            // short-change the caller when legacy+UUID pairs sit above the
+            // score threshold for the same logical point.
             $response = $this->qdrantRequest('POST', "/collections/{$collection}/points/search", [
                 'vector' => $queryVector,
                 'filter' => ['must' => $must],
-                'limit' => $limit,
+                'limit' => $limit * 2,
                 'score_threshold' => $minScore,
                 'with_payload' => true,
             ]);
 
-            $results = [];
+            // Dedup by `_point_id` — keep the best-scoring copy of each
+            // logical point. Until `app:qdrant:migrate-legacy-point-ids`
+            // runs, production collections may still have two rows per
+            // logical point (one integer-keyed, one UUID-keyed), so the
+            // same `_point_id` can appear twice in one response.
+            $bestByLogical = [];
             foreach ($response['result'] ?? [] as $hit) {
-                $results[] = [
-                    'id' => $hit['payload']['_point_id'] ?? (string) $hit['id'],
-                    'score' => $hit['score'],
-                    'payload' => $hit['payload'] ?? [],
-                ];
+                $logical = $hit['payload']['_point_id'] ?? (string) $hit['id'];
+                if (!isset($bestByLogical[$logical]) || $hit['score'] > $bestByLogical[$logical]['score']) {
+                    $bestByLogical[$logical] = [
+                        'id' => $logical,
+                        'score' => $hit['score'],
+                        'payload' => $hit['payload'] ?? [],
+                    ];
+                }
             }
 
-            return $results;
+            $results = array_values($bestByLogical);
+            usort($results, static fn (array $a, array $b): int => $b['score'] <=> $a['score']);
+
+            return array_slice($results, 0, $limit);
         } catch (\Throwable $e) {
             $this->logger->error('Failed to search memories in Qdrant', [
                 'user_id' => $userId,
@@ -199,15 +245,21 @@ final class QdrantClientDirect implements QdrantClientInterface
                 'with_vector' => false,
             ]);
 
-            $memories = [];
+            // Dedup by `_point_id` — see searchMemories() for why this is
+            // needed until the legacy-point migration has run. First-seen
+            // wins; scrolls don't return a score to discriminate on.
+            $memoriesByLogical = [];
             foreach ($response['result']['points'] ?? [] as $point) {
-                $memories[] = [
-                    'id' => $point['payload']['_point_id'] ?? (string) $point['id'],
-                    'payload' => $point['payload'] ?? [],
-                ];
+                $logical = $point['payload']['_point_id'] ?? (string) $point['id'];
+                if (!isset($memoriesByLogical[$logical])) {
+                    $memoriesByLogical[$logical] = [
+                        'id' => $logical,
+                        'payload' => $point['payload'] ?? [],
+                    ];
+                }
             }
 
-            return $memories;
+            return array_values($memoriesByLogical);
         } catch (\Throwable $e) {
             $this->logger->error('Failed to scroll memories in Qdrant', [
                 'user_id' => $userId,
@@ -230,7 +282,7 @@ final class QdrantClientDirect implements QdrantClientInterface
             // by a mismatched primary ID returns HTTP 200 with no effect — the
             // bug this fix addresses.
             $this->qdrantRequest('POST', "/collections/{$collection}/points/delete?wait=true", [
-                'filter' => $this->pointIdFilter($pointId),
+                'filter' => QdrantPointId::payloadFilterFor($pointId),
             ]);
 
             $this->logger->debug('Memory deleted from Qdrant', ['point_id' => $pointId]);
@@ -293,19 +345,18 @@ final class QdrantClientDirect implements QdrantClientInterface
         $payload['_point_id'] = $pointId;
 
         try {
-            // See upsertMemory() for the rationale — prevents a primary-ID
-            // mismatch between a legacy point and the new UUID-keyed one from
-            // producing duplicate rows that share the same `_point_id`.
-            $this->qdrantRequest('POST', "/collections/{$this->documentsCollection}/points/delete?wait=true", [
-                'filter' => $this->pointIdFilter($pointId),
-            ]);
-
-            $this->upsertPoints($this->documentsCollection, [
-                [
-                    'id' => $this->generatePointUuid($pointId),
-                    'vector' => $vector,
-                    'payload' => $payload,
-                ],
+            // See upsertMemory() — atomic delete-by-payload + upsert via
+            // /points/batch removes any legacy integer-keyed ghost and
+            // writes the new UUID-keyed point in a single request.
+            $this->pointsBatch($this->documentsCollection, [
+                ['delete' => ['filter' => QdrantPointId::payloadFilterFor($pointId)]],
+                ['upsert' => ['points' => [
+                    [
+                        'id' => QdrantPointId::uuidFor($pointId),
+                        'vector' => $vector,
+                        'payload' => $payload,
+                    ],
+                ]]],
             ]);
         } catch (\Throwable $e) {
             $this->logger->error('Failed to upsert document to Qdrant', [
@@ -330,7 +381,7 @@ final class QdrantClientDirect implements QdrantClientInterface
                 $payload = $doc['payload'] ?? [];
                 $payload['_point_id'] = $doc['point_id'];
                 $points[] = [
-                    'id' => $this->generatePointUuid($doc['point_id']),
+                    'id' => QdrantPointId::uuidFor($doc['point_id']),
                     'vector' => $doc['vector'],
                     'payload' => $payload,
                 ];
@@ -400,13 +451,21 @@ final class QdrantClientDirect implements QdrantClientInterface
         }
     }
 
+    /**
+     * Fetch a single document chunk, including its vector.
+     *
+     * `with_vector: true` (unlike getMemory()) because callers of this
+     * endpoint are generally about to reuse the vector — e.g. re-indexing
+     * or rebuilding a RAG group. It is NOT on any hot request path, so
+     * paying the 1024-float payload cost is fine.
+     */
     public function getDocument(string $pointId): ?array
     {
         try {
             // See getMemory() — scroll by `_point_id` payload so legacy
             // integer-keyed points are still findable.
             $response = $this->qdrantRequest('POST', "/collections/{$this->documentsCollection}/points/scroll", [
-                'filter' => $this->pointIdFilter($pointId),
+                'filter' => QdrantPointId::payloadFilterFor($pointId),
                 'limit' => 1,
                 'with_payload' => true,
                 'with_vector' => true,
@@ -441,7 +500,7 @@ final class QdrantClientDirect implements QdrantClientInterface
             // correct scheme for a collection that may still contain legacy
             // integer-keyed points alongside current UUID-keyed ones.
             $this->qdrantRequest('POST', "/collections/{$this->documentsCollection}/points/delete?wait=true", [
-                'filter' => $this->pointIdFilter($pointId),
+                'filter' => QdrantPointId::payloadFilterFor($pointId),
             ]);
         } catch (\Throwable $e) {
             $this->logger->error('Failed to delete document', [
@@ -763,33 +822,10 @@ final class QdrantClientDirect implements QdrantClientInterface
     //  Internal helpers
     // ──────────────────────────────────────────────
 
-    /**
-     * Deterministic UUID v5 from a string point ID for stable mapping.
-     *
-     * Only used when writing NEW points. Read/delete paths route through the
-     * `_point_id` payload filter (see pointIdFilter()) to remain compatible
-     * with legacy integer-keyed points from the pre-v2.4.0 Rust microservice.
-     */
-    private function generatePointUuid(string $pointId): string
-    {
-        return Uuid::v5(Uuid::fromString('6ba7b810-9dad-11d1-80b4-00c04fd430c8'), $pointId)->toRfc4122();
-    }
-
-    /**
-     * Build a Qdrant filter that matches the point whose `_point_id` payload
-     * equals `$pointId` — the canonical logical identifier for both legacy
-     * (integer-keyed) and current (UUID-keyed) points.
-     *
-     * @return array{must: list<array{key: string, match: array{value: string}}>}
-     */
-    private function pointIdFilter(string $pointId): array
-    {
-        return [
-            'must' => [
-                ['key' => '_point_id', 'match' => ['value' => $pointId]],
-            ],
-        ];
-    }
+    // Canonical point-ID helpers (UUID derivation, `_point_id` payload filter)
+    // live in {@see QdrantPointId} so the maintenance CLI and any other
+    // consumer derive identical UUIDs without duplicating the namespace
+    // constant.
 
     private function resolveMemoriesCollection(?string $namespace): string
     {
@@ -947,12 +983,29 @@ final class QdrantClientDirect implements QdrantClientInterface
     }
 
     /**
-     * @param array<array{id: string, vector: float[], payload: array}> $points
+     * @param list<array{id: string, vector: list<float>, payload: array<string, mixed>}> $points
      */
     private function upsertPoints(string $collection, array $points): void
     {
         $this->qdrantRequest('PUT', "/collections/{$collection}/points?wait=true", [
             'points' => $points,
+        ]);
+    }
+
+    /**
+     * Execute a list of operations in a single batch request.
+     *
+     * Used by upsertMemory/upsertDocument to sequence
+     * `delete-by-payload-filter` and `upsert` inside one HTTP round-trip,
+     * which closes the "crash between two wait=true calls leaves no point"
+     * window that two separate calls would open.
+     *
+     * @param list<array<string, mixed>> $operations Qdrant batch operation descriptors
+     */
+    private function pointsBatch(string $collection, array $operations): void
+    {
+        $this->qdrantRequest('POST', "/collections/{$collection}/points/batch?wait=true", [
+            'operations' => $operations,
         ]);
     }
 

--- a/backend/src/Service/VectorSearch/QdrantPointId.php
+++ b/backend/src/Service/VectorSearch/QdrantPointId.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\VectorSearch;
+
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Helper for translating synaplan-logical point IDs (`mem_{userId}_{memoryId}`,
+ * `doc_{userId}_{fileId}_{chunk}`) into the canonical Qdrant primary ID
+ * (UUIDv5 under the fixed namespace) and into the payload filter we use for
+ * "find this logical point regardless of how it was originally keyed".
+ *
+ * Shared between QdrantClientDirect (runtime read/write) and
+ * {@see \App\Command\MigrateLegacyPointIdsCommand} (one-shot cleanup) so
+ * neither can drift and produce mismatched UUIDs.
+ */
+final class QdrantPointId
+{
+    /**
+     * UUIDv5 namespace for point-ID derivation.
+     *
+     * This is the canonical DNS namespace from RFC 4122 §Appendix C —
+     * {@see https://www.rfc-editor.org/rfc/rfc4122#appendix-C}. Changing
+     * this value breaks mapping of every existing stored point; DO NOT
+     * change it without a full data migration.
+     */
+    public const NAMESPACE_UUID = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
+
+    /** Cached parsed namespace to avoid re-parsing on every call. */
+    private static ?Uuid $namespaceUuid = null;
+
+    /**
+     * Deterministic UUIDv5 primary key for a logical point ID.
+     *
+     * Same input always produces the same UUID, so callers can safely
+     * recompute it instead of storing it alongside the logical ID.
+     */
+    public static function uuidFor(string $logicalPointId): string
+    {
+        if (null === self::$namespaceUuid) {
+            self::$namespaceUuid = Uuid::fromString(self::NAMESPACE_UUID);
+        }
+
+        return Uuid::v5(self::$namespaceUuid, $logicalPointId)->toRfc4122();
+    }
+
+    /**
+     * Qdrant filter that matches the point whose `_point_id` payload
+     * equals `$logicalPointId` — the canonical logical identifier that
+     * works for both legacy (integer-keyed) and current (UUID-keyed) points.
+     *
+     * @return array{must: list<array{key: string, match: array{value: string}}>}
+     */
+    public static function payloadFilterFor(string $logicalPointId): array
+    {
+        return [
+            'must' => [
+                ['key' => '_point_id', 'match' => ['value' => $logicalPointId]],
+            ],
+        ];
+    }
+
+    /**
+     * Check whether a Qdrant primary ID is already in canonical UUIDv5
+     * form AND matches the UUID we would derive from `_point_id`.
+     *
+     * Used by the migration command to identify points that still need
+     * to be rekeyed. Unlike a generic UUID-format check, this also
+     * rejects UUIDv4 or any other derivation, so only points that
+     * exactly match the current scheme are considered "canonical".
+     */
+    public static function isCanonicalUuid(int|string $primaryId, string $logicalPointId): bool
+    {
+        if (!is_string($primaryId)) {
+            return false;
+        }
+
+        return 0 === strcasecmp($primaryId, self::uuidFor($logicalPointId));
+    }
+}

--- a/backend/tests/Service/VectorSearch/LegacyPointIdMigratorTest.php
+++ b/backend/tests/Service/VectorSearch/LegacyPointIdMigratorTest.php
@@ -198,8 +198,9 @@ final class LegacyPointIdMigratorTest extends TestCase
     }
 
     /**
-     * Progress guard: if Qdrant returns the same `next_page_offset` twice
-     * in a row (would otherwise be an infinite loop), we abort and exit.
+     * Progress guard: if Qdrant returns a `next_page_offset` equal to the
+     * one we just sent, the cursor is stuck on the same page and the
+     * guard must abort on the very next iteration.
      */
     public function testAbortsWhenScrollOffsetDoesNotAdvance(): void
     {
@@ -207,7 +208,8 @@ final class LegacyPointIdMigratorTest extends TestCase
         $factory = function (string $method, string $url, array $options) use (&$callCount): MockResponse {
             ++$callCount;
 
-            // Always return the same next_page_offset → loop must break.
+            // Always return the same next_page_offset → loop must break
+            // the moment we ask for that offset and get it back unchanged.
             return new MockResponse(
                 json_encode([
                     'result' => [
@@ -232,10 +234,11 @@ final class LegacyPointIdMigratorTest extends TestCase
             limit: 0,
         );
 
-        // 2 scroll calls: first one (offset=null), second one (offset='stuck-offset-xyz');
-        // third iteration is blocked by the progress guard.
-        $this->assertLessThanOrEqual(3, $callCount, 'progress guard must stop the loop within 2-3 iterations');
-        $this->assertGreaterThanOrEqual(1, $callCount);
+        // Exactly 2 scroll calls expected:
+        //   Iter 1: offset=null              → returns next=stuck        (no stuckness yet)
+        //   Iter 2: offset=stuck             → returns next=stuck        (guard fires, break)
+        // A third call would indicate the guard is broken.
+        $this->assertSame(2, $callCount, 'progress guard must abort on the first iteration where next_page_offset equals the requested offset');
         $this->assertGreaterThan(0, $report->scanned);
     }
 

--- a/backend/tests/Service/VectorSearch/LegacyPointIdMigratorTest.php
+++ b/backend/tests/Service/VectorSearch/LegacyPointIdMigratorTest.php
@@ -1,0 +1,340 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Service\VectorSearch;
+
+use App\Service\VectorSearch\LegacyPointIdMigrator;
+use App\Service\VectorSearch\QdrantPointId;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+/**
+ * @see LegacyPointIdMigrator
+ */
+final class LegacyPointIdMigratorTest extends TestCase
+{
+    private const COLLECTION = 'user_memories';
+
+    public function testDryRunReportsLegacyPointsWithoutWriting(): void
+    {
+        $requests = $this->recordingHttpClient([
+            '/collections/user_memories/points/scroll' => [
+                'method' => 'POST',
+                'response' => $this->scrollResponseWith([
+                    $this->legacyPoint(82402287705672322, 'mem_152_leg1'),
+                    $this->legacyPoint(105733502448967875, 'mem_499_leg2'),
+                    $this->canonicalPoint('mem_2_canon1'),
+                ]),
+            ],
+        ]);
+
+        $migrator = new LegacyPointIdMigrator(
+            httpClient: $requests['client'],
+            qdrantUrl: 'http://localhost:6333',
+            logger: new NullLogger(),
+        );
+
+        $phases = [];
+        $report = $migrator->migrateCollection(
+            collection: self::COLLECTION,
+            apply: false,
+            limit: 0,
+            onPoint: static function (string $phase, string $logicalId) use (&$phases): void {
+                $phases[] = [$phase, $logicalId];
+            },
+        );
+
+        $this->assertSame(3, $report->scanned);
+        $this->assertSame(2, $report->legacy, 'one point is already canonically keyed and should not count as legacy');
+        $this->assertSame(2, $report->migrated, 'dry-run counts planned migrations');
+        $this->assertSame(0, $report->errors);
+
+        $this->assertSame([
+            ['would-migrate', 'mem_152_leg1'],
+            ['would-migrate', 'mem_499_leg2'],
+        ], $phases);
+
+        // Dry run must NOT issue any batch/delete/upsert writes.
+        $this->assertSame(
+            ['/collections/user_memories/points/scroll'],
+            array_column($requests['calls'], 'path'),
+        );
+    }
+
+    public function testApplyRekeysLegacyPointsViaBatchUpsertThenDelete(): void
+    {
+        $requests = $this->recordingHttpClient([
+            '/collections/user_memories/points/scroll' => [
+                'method' => 'POST',
+                'response' => $this->scrollResponseWith([
+                    $this->legacyPoint(82402287705672322, 'mem_152_leg1'),
+                ]),
+            ],
+            '/collections/user_memories/points/batch' => [
+                'method' => 'POST',
+                'response' => new MockResponse(
+                    json_encode(['result' => [['status' => 'completed'], ['status' => 'completed']], 'status' => 'ok']),
+                    ['http_code' => 200]
+                ),
+            ],
+        ]);
+
+        $migrator = new LegacyPointIdMigrator(
+            httpClient: $requests['client'],
+            qdrantUrl: 'http://localhost:6333',
+            logger: new NullLogger(),
+        );
+
+        $report = $migrator->migrateCollection(
+            collection: self::COLLECTION,
+            apply: true,
+            limit: 0,
+        );
+
+        $this->assertSame(1, $report->migrated);
+        $this->assertSame(0, $report->errors);
+
+        $batchCalls = array_values(array_filter(
+            $requests['calls'],
+            static fn (array $c): bool => str_ends_with((string) $c['path'], '/points/batch'),
+        ));
+        $this->assertCount(1, $batchCalls, 'each legacy point produces exactly one batch request');
+
+        $body = json_decode((string) $batchCalls[0]['body'], true);
+        $this->assertIsArray($body);
+        $this->assertArrayHasKey('operations', $body);
+        $ops = $body['operations'];
+
+        // Upsert first (so the canonical copy exists before we drop the legacy ID),
+        // then delete the legacy primary ID.
+        $this->assertSame(
+            ['upsert', 'delete'],
+            [array_key_first($ops[0]), array_key_first($ops[1])],
+            'batch must upsert before deleting so a batch-level abort never leaves zero points'
+        );
+
+        $upsertedPoint = $ops[0]['upsert']['points'][0];
+        $this->assertSame(QdrantPointId::uuidFor('mem_152_leg1'), $upsertedPoint['id']);
+        $this->assertSame('mem_152_leg1', $upsertedPoint['payload']['_point_id']);
+
+        $this->assertSame([82402287705672322], $ops[1]['delete']['points']);
+    }
+
+    public function testLimitCapsMigrationCountExactly(): void
+    {
+        $requests = $this->recordingHttpClient([
+            '/collections/user_memories/points/scroll' => [
+                'method' => 'POST',
+                'response' => $this->scrollResponseWith([
+                    $this->legacyPoint(1, 'mem_1_a'),
+                    $this->legacyPoint(2, 'mem_1_b'),
+                    $this->legacyPoint(3, 'mem_1_c'),
+                    $this->legacyPoint(4, 'mem_1_d'),
+                    $this->legacyPoint(5, 'mem_1_e'),
+                ]),
+            ],
+            '/collections/user_memories/points/batch' => [
+                'method' => 'POST',
+                'response' => new MockResponse(
+                    json_encode(['result' => [['status' => 'completed'], ['status' => 'completed']], 'status' => 'ok']),
+                    ['http_code' => 200]
+                ),
+            ],
+        ]);
+
+        $migrator = new LegacyPointIdMigrator(
+            httpClient: $requests['client'],
+            qdrantUrl: 'http://localhost:6333',
+            logger: new NullLogger(),
+        );
+
+        $report = $migrator->migrateCollection(
+            collection: self::COLLECTION,
+            apply: true,
+            limit: 2,
+        );
+
+        $this->assertSame(2, $report->migrated);
+        $batchCalls = array_values(array_filter(
+            $requests['calls'],
+            static fn (array $c): bool => str_ends_with((string) $c['path'], '/points/batch'),
+        ));
+        $this->assertCount(2, $batchCalls, 'limit must stop the rekey loop exactly at the cap');
+    }
+
+    public function testSkipsPointsWithoutPointIdPayload(): void
+    {
+        $requests = $this->recordingHttpClient([
+            '/collections/user_memories/points/scroll' => [
+                'method' => 'POST',
+                'response' => $this->scrollResponseWith([
+                    ['id' => 999, 'payload' => ['user_id' => 1], 'vector' => [0.1, 0.2]],
+                ]),
+            ],
+        ]);
+
+        $migrator = new LegacyPointIdMigrator(
+            httpClient: $requests['client'],
+            qdrantUrl: 'http://localhost:6333',
+            logger: new NullLogger(),
+        );
+
+        $phases = [];
+        $report = $migrator->migrateCollection(
+            collection: self::COLLECTION,
+            apply: true,
+            limit: 0,
+            onPoint: static function (string $phase) use (&$phases): void {
+                $phases[] = $phase;
+            },
+        );
+
+        $this->assertSame(0, $report->legacy);
+        $this->assertSame(0, $report->migrated);
+        $this->assertSame(['skip-missing-payload'], $phases);
+    }
+
+    /**
+     * Progress guard: if Qdrant returns the same `next_page_offset` twice
+     * in a row (would otherwise be an infinite loop), we abort and exit.
+     */
+    public function testAbortsWhenScrollOffsetDoesNotAdvance(): void
+    {
+        $callCount = 0;
+        $factory = function (string $method, string $url, array $options) use (&$callCount): MockResponse {
+            ++$callCount;
+
+            // Always return the same next_page_offset → loop must break.
+            return new MockResponse(
+                json_encode([
+                    'result' => [
+                        'points' => [$this->legacyPoint(1, 'mem_loop_bug')],
+                        'next_page_offset' => 'stuck-offset-xyz',
+                    ],
+                    'status' => 'ok',
+                ]),
+                ['http_code' => 200]
+            );
+        };
+
+        $migrator = new LegacyPointIdMigrator(
+            httpClient: new MockHttpClient($factory),
+            qdrantUrl: 'http://localhost:6333',
+            logger: new NullLogger(),
+        );
+
+        $report = $migrator->migrateCollection(
+            collection: self::COLLECTION,
+            apply: false,
+            limit: 0,
+        );
+
+        // 2 scroll calls: first one (offset=null), second one (offset='stuck-offset-xyz');
+        // third iteration is blocked by the progress guard.
+        $this->assertLessThanOrEqual(3, $callCount, 'progress guard must stop the loop within 2-3 iterations');
+        $this->assertGreaterThanOrEqual(1, $callCount);
+        $this->assertGreaterThan(0, $report->scanned);
+    }
+
+    /**
+     * @return array{id: int, payload: array<string, mixed>, vector: list<float>}
+     */
+    private function legacyPoint(int $id, string $logicalId): array
+    {
+        return [
+            'id' => $id,
+            'payload' => [
+                '_point_id' => $logicalId,
+                'user_id' => 1,
+                'key' => 'test',
+                'value' => 'test',
+                'category' => 'personal',
+                'source' => 'user_created',
+                'active' => true,
+                'created' => 0,
+                'updated' => 0,
+            ],
+            'vector' => array_fill(0, 4, 0.1), // small vector, we don't care about dim here
+        ];
+    }
+
+    /**
+     * A point already keyed under its canonical UUIDv5 — migration must leave it alone.
+     *
+     * @return array{id: string, payload: array<string, mixed>, vector: list<float>}
+     */
+    private function canonicalPoint(string $logicalId): array
+    {
+        return [
+            'id' => QdrantPointId::uuidFor($logicalId),
+            'payload' => [
+                '_point_id' => $logicalId,
+                'user_id' => 1,
+                'key' => 'x',
+                'value' => 'y',
+                'category' => 'personal',
+                'source' => 'user_created',
+                'active' => true,
+                'created' => 0,
+                'updated' => 0,
+            ],
+            'vector' => array_fill(0, 4, 0.1),
+        ];
+    }
+
+    /**
+     * @param list<array<string, mixed>> $points
+     */
+    private function scrollResponseWith(array $points): MockResponse
+    {
+        return new MockResponse(
+            json_encode([
+                'result' => [
+                    'points' => $points,
+                    'next_page_offset' => null,
+                ],
+                'status' => 'ok',
+            ]),
+            ['http_code' => 200]
+        );
+    }
+
+    /**
+     * Build a MockHttpClient whose response is picked by URL suffix, and
+     * capture every call for post-hoc assertions. Returns both the client
+     * and a `&$calls` array by reference via the returned tuple.
+     *
+     * @param array<string, array{method: string, response: MockResponse}> $routes Map of URL-path-suffix => response spec
+     *
+     * @return array{client: MockHttpClient, calls: list<array{method: string, path: string, body: ?string}>}
+     */
+    private function recordingHttpClient(array $routes): array
+    {
+        $calls = [];
+
+        $factory = function (string $method, string $url, array $options) use ($routes, &$calls): MockResponse {
+            $path = (string) parse_url($url, \PHP_URL_PATH);
+            $calls[] = [
+                'method' => $method,
+                'path' => $path,
+                'body' => isset($options['body']) && is_string($options['body']) ? $options['body'] : null,
+            ];
+
+            foreach ($routes as $suffix => $spec) {
+                if (str_ends_with($path, $suffix)) {
+                    return clone $spec['response'];
+                }
+            }
+
+            return new MockResponse('Unexpected URL in test: '.$url, ['http_code' => 500]);
+        };
+
+        return [
+            'client' => new MockHttpClient($factory),
+            'calls' => &$calls,
+        ];
+    }
+}

--- a/backend/tests/Service/VectorSearch/QdrantClientDirectTest.php
+++ b/backend/tests/Service/VectorSearch/QdrantClientDirectTest.php
@@ -27,12 +27,13 @@ final class QdrantClientDirectTest extends TestCase
     /**
      * Build a QdrantClientDirect backed by a route-based MockHttpClient.
      *
-     * Callers that want to inspect the raw HTTP calls made by the client
-     * can pass an empty array in by reference as `$calls`; it will be
-     * populated with one entry per request.
+     * Each responder is called with no arguments; tests that need to
+     * inspect what was sent pass an array in by reference as `$calls`
+     * and assert against it after the fact. The one-call-per-responder
+     * zero-arg contract matches the `fn () => ...` form used below.
      *
-     * @param array<string, callable(array{method: string, path: string, query: string, body: ?string}):MockResponse> $routes Map of path-suffix => responder callback
-     * @param list<array{method: string, path: string, query: string, body: ?string}>                                 $calls
+     * @param array<string, callable():MockResponse>                                  $routes Map of path-suffix => responder callback
+     * @param list<array{method: string, path: string, query: string, body: ?string}> $calls
      */
     private function buildClient(array $routes, array &$calls = []): QdrantClientDirect
     {
@@ -40,12 +41,11 @@ final class QdrantClientDirectTest extends TestCase
             $path = (string) (parse_url($url, \PHP_URL_PATH) ?? '');
             $query = (string) (parse_url($url, \PHP_URL_QUERY) ?? '');
             $body = isset($options['body']) && is_string($options['body']) ? $options['body'] : null;
-            $call = ['method' => $method, 'path' => $path, 'query' => $query, 'body' => $body];
-            $calls[] = $call;
+            $calls[] = ['method' => $method, 'path' => $path, 'query' => $query, 'body' => $body];
 
             foreach ($routes as $suffix => $responder) {
                 if (str_ends_with($path, $suffix)) {
-                    return $responder($call);
+                    return $responder();
                 }
             }
 

--- a/backend/tests/Service/VectorSearch/QdrantClientDirectTest.php
+++ b/backend/tests/Service/VectorSearch/QdrantClientDirectTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Service\VectorSearch;
 
 use App\Service\VectorSearch\QdrantClientDirect;
+use App\Service\VectorSearch\QdrantPointId;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Symfony\Component\HttpClient\MockHttpClient;
@@ -13,264 +14,357 @@ use Symfony\Component\HttpClient\Response\MockResponse;
 /**
  * Tests for QdrantClientDirect — talks to Qdrant REST API directly.
  *
- * Uses mock HTTP responses matching Qdrant's native API format.
+ * These tests use a callback-style MockHttpClient that routes by URL path,
+ * not a fixed response list. That keeps tests robust against future internal
+ * optimisations (parallel index creation, extra health probes, caching, …)
+ * that change the exact sequence of HTTP calls but not the observable
+ * contract for any given endpoint.
  */
 final class QdrantClientDirectTest extends TestCase
 {
+    private const QDRANT_URL = 'http://localhost:6333';
+
     /**
-     * @param array<MockResponse> $responses
+     * Build a QdrantClientDirect backed by a route-based MockHttpClient.
+     *
+     * Callers that want to inspect the raw HTTP calls made by the client
+     * can pass an empty array in by reference as `$calls`; it will be
+     * populated with one entry per request.
+     *
+     * @param array<string, callable(array{method: string, path: string, query: string, body: ?string}):MockResponse> $routes Map of path-suffix => responder callback
+     * @param list<array{method: string, path: string, query: string, body: ?string}>                                 $calls
      */
-    private function createClient(array $responses): QdrantClientDirect
+    private function buildClient(array $routes, array &$calls = []): QdrantClientDirect
     {
-        $mockClient = new MockHttpClient($responses);
+        $factory = function (string $method, string $url, array $options) use ($routes, &$calls): MockResponse {
+            $path = (string) (parse_url($url, \PHP_URL_PATH) ?? '');
+            $query = (string) (parse_url($url, \PHP_URL_QUERY) ?? '');
+            $body = isset($options['body']) && is_string($options['body']) ? $options['body'] : null;
+            $call = ['method' => $method, 'path' => $path, 'query' => $query, 'body' => $body];
+            $calls[] = $call;
+
+            foreach ($routes as $suffix => $responder) {
+                if (str_ends_with($path, $suffix)) {
+                    return $responder($call);
+                }
+            }
+
+            return new MockResponse('No route matched '.$method.' '.$path, ['http_code' => 599]);
+        };
 
         return new QdrantClientDirect(
-            httpClient: $mockClient,
-            qdrantUrl: 'http://localhost:6333',
+            httpClient: new MockHttpClient($factory),
+            qdrantUrl: self::QDRANT_URL,
             logger: new NullLogger(),
         );
     }
 
-    public function testUpsertMemorySuccess(): void
+    private function okEmpty(): MockResponse
     {
-        $this->expectNotToPerformAssertions();
+        return new MockResponse(
+            json_encode(['result' => ['status' => 'completed'], 'status' => 'ok']),
+            ['http_code' => 200],
+        );
+    }
 
-        $responses = [
-            // ensureMemoriesCollection -> GET /collections/user_memories
-            new MockResponse(json_encode(['result' => ['status' => 'green']]), ['http_code' => 200]),
-            // ensurePayloadIndexes -> PUT /collections/user_memories/index  x4
-            new MockResponse(json_encode(['result' => ['status' => 'acknowledged']]), ['http_code' => 200]),
-            new MockResponse(json_encode(['result' => ['status' => 'acknowledged']]), ['http_code' => 200]),
-            new MockResponse(json_encode(['result' => ['status' => 'acknowledged']]), ['http_code' => 200]),
-            new MockResponse(json_encode(['result' => ['status' => 'acknowledged']]), ['http_code' => 200]),
-            // upsertMemory -> pre-upsert POST /collections/user_memories/points/delete?wait=true
-            new MockResponse(json_encode(['result' => ['status' => 'completed']]), ['http_code' => 200]),
-            // upsertMemory -> PUT /collections/user_memories/points?wait=true
-            new MockResponse(json_encode(['result' => ['status' => 'completed']]), ['http_code' => 200]),
-        ];
-
-        $client = $this->createClient($responses);
+    public function testUpsertMemoryIssuesAtomicBatchDeleteThenUpsert(): void
+    {
+        $calls = [];
+        $client = $this->buildClient([
+            // ensureMemoriesCollection: GET collection exists
+            '/collections/user_memories' => fn () => new MockResponse(
+                json_encode(['result' => ['status' => 'green']]),
+                ['http_code' => 200]
+            ),
+            // idempotent payload-index creation (any number of calls)
+            '/collections/user_memories/index' => fn () => $this->okEmpty(),
+            // the batch endpoint — the heart of upsertMemory
+            '/collections/user_memories/points/batch' => fn () => new MockResponse(
+                json_encode(['result' => [['status' => 'completed'], ['status' => 'completed']], 'status' => 'ok']),
+                ['http_code' => 200]
+            ),
+        ], $calls);
 
         $client->upsertMemory(
             pointId: 'mem_1_123',
             vector: array_fill(0, 1024, 0.5),
-            payload: [
-                'user_id' => 1,
-                'category' => 'test',
-                'key' => 'test_key',
-                'value' => 'test_value',
-                'source' => 'test',
-                'created' => time(),
-                'updated' => time(),
-                'active' => true,
-            ]
+            payload: ['user_id' => 1, 'category' => 'test', 'key' => 'k', 'value' => 'v', 'source' => 'user_created', 'active' => true],
         );
+
+        $batchCalls = array_values(array_filter(
+            $calls,
+            static fn (array $c): bool => str_ends_with($c['path'], '/points/batch'),
+        ));
+        $this->assertCount(1, $batchCalls, 'upsertMemory must make exactly one batch request, not a sequence of delete+put');
+        $this->assertStringContainsString('wait=true', $batchCalls[0]['query']);
+
+        $body = json_decode((string) $batchCalls[0]['body'], true);
+        $this->assertIsArray($body);
+        $this->assertArrayHasKey('operations', $body);
+        $this->assertCount(2, $body['operations']);
+        $this->assertArrayHasKey('delete', $body['operations'][0]);
+        $this->assertArrayHasKey('upsert', $body['operations'][1]);
+        $this->assertSame(
+            ['must' => [['key' => '_point_id', 'match' => ['value' => 'mem_1_123']]]],
+            $body['operations'][0]['delete']['filter'],
+            'delete must be scoped by `_point_id` payload filter, not by primary ID',
+        );
+
+        $upsertedPoint = $body['operations'][1]['upsert']['points'][0];
+        $this->assertSame(QdrantPointId::uuidFor('mem_1_123'), $upsertedPoint['id']);
+        $this->assertSame('mem_1_123', $upsertedPoint['payload']['_point_id']);
     }
 
-    public function testGetMemorySuccess(): void
+    public function testGetMemoryUsesPointIdPayloadFilterNotPrimaryKey(): void
     {
-        $responses = [
-            // getMemory -> POST /collections/user_memories/points/scroll
-            // (filter on `_point_id` payload, matches both legacy int + UUID keys)
-            new MockResponse(json_encode([
-                'result' => [
-                    'points' => [
-                        [
-                            'id' => 'some-uuid',
+        $calls = [];
+        $client = $this->buildClient([
+            '/collections/user_memories/points/scroll' => fn () => new MockResponse(
+                json_encode(['result' => ['points' => [], 'next_page_offset' => null]]),
+                ['http_code' => 200],
+            ),
+        ], $calls);
+
+        $client->getMemory('mem_1_123');
+
+        $scrollCalls = array_values(array_filter(
+            $calls,
+            static fn (array $c): bool => str_ends_with($c['path'], '/points/scroll'),
+        ));
+        $this->assertCount(1, $scrollCalls);
+
+        $body = json_decode((string) $scrollCalls[0]['body'], true);
+        $this->assertArrayNotHasKey('ids', $body, 'getMemory must not lookup by primary ID');
+        $this->assertArrayHasKey('filter', $body);
+        $this->assertSame('_point_id', $body['filter']['must'][0]['key']);
+        $this->assertSame('mem_1_123', $body['filter']['must'][0]['match']['value']);
+    }
+
+    public function testGetMemoryReturnsPayloadWhenFound(): void
+    {
+        $client = $this->buildClient([
+            '/collections/user_memories/points/scroll' => fn () => new MockResponse(
+                json_encode([
+                    'result' => [
+                        'points' => [[
+                            'id' => 'anything',
                             'payload' => [
                                 '_point_id' => 'mem_1_123',
                                 'user_id' => 1,
                                 'category' => 'test',
-                                'key' => 'test_key',
-                                'value' => 'test_value',
+                                'key' => 'k',
+                                'value' => 'v',
                             ],
-                        ],
+                        ]],
+                        'next_page_offset' => null,
                     ],
-                    'next_page_offset' => null,
-                ],
-            ]), ['http_code' => 200]),
-        ];
+                ]),
+                ['http_code' => 200],
+            ),
+        ]);
 
-        $client = $this->createClient($responses);
         $result = $client->getMemory('mem_1_123');
 
         $this->assertIsArray($result);
-        $this->assertEquals(1, $result['user_id']);
-        $this->assertEquals('test', $result['category']);
+        $this->assertSame(1, $result['user_id']);
+        $this->assertSame('test', $result['category']);
     }
 
-    public function testGetMemoryNotFound(): void
+    public function testGetMemoryReturnsNullWhenNotFound(): void
     {
-        $responses = [
-            new MockResponse(json_encode([
-                'result' => ['points' => [], 'next_page_offset' => null],
-            ]), ['http_code' => 200]),
-        ];
+        $client = $this->buildClient([
+            '/collections/user_memories/points/scroll' => fn () => new MockResponse(
+                json_encode(['result' => ['points' => [], 'next_page_offset' => null]]),
+                ['http_code' => 200],
+            ),
+        ]);
 
-        $client = $this->createClient($responses);
-        $result = $client->getMemory('mem_1_nonexistent');
-
-        $this->assertNull($result);
+        $this->assertNull($client->getMemory('mem_1_missing'));
     }
 
-    /**
-     * Regression lock for issue where deleteMemory was sending the derived
-     * UUIDv5 as the primary ID, which silently no-ops on legacy points stored
-     * by the pre-v2.4.0 Rust microservice under integer IDs. The delete MUST
-     * target the point by `_point_id` payload filter so both schemes resolve.
-     */
     public function testDeleteMemoryUsesPointIdPayloadFilterNotPrimaryKey(): void
     {
-        $capturedUrl = null;
-        $capturedBody = null;
-
-        $factory = function (string $method, string $url, array $options) use (&$capturedUrl, &$capturedBody): MockResponse {
-            $capturedUrl = $url;
-            $capturedBody = $options['body'] ?? null;
-
-            return new MockResponse(json_encode(['result' => ['status' => 'completed']]), ['http_code' => 200]);
-        };
-
-        $mockClient = new MockHttpClient($factory);
-        $client = new QdrantClientDirect(
-            httpClient: $mockClient,
-            qdrantUrl: 'http://localhost:6333',
-            logger: new NullLogger(),
-        );
+        $calls = [];
+        $client = $this->buildClient([
+            '/collections/user_memories/points/delete' => fn () => $this->okEmpty(),
+        ], $calls);
 
         $client->deleteMemory('mem_1_123');
 
-        $this->assertIsString($capturedUrl);
-        $this->assertStringContainsString('/collections/user_memories/points/delete', $capturedUrl);
-        $this->assertStringContainsString('wait=true', $capturedUrl);
+        $deleteCalls = array_values(array_filter(
+            $calls,
+            static fn (array $c): bool => str_ends_with($c['path'], '/points/delete'),
+        ));
+        $this->assertCount(1, $deleteCalls);
+        $this->assertStringContainsString('wait=true', $deleteCalls[0]['query']);
 
-        $this->assertIsString($capturedBody);
-        /** @var array{filter?: array{must?: array<array{key?: string, match?: array{value?: string}}>}, points?: mixed} $decoded */
-        $decoded = json_decode($capturedBody, true);
-
-        // Must delete by payload filter, not by primary `points` ID list.
-        $this->assertArrayNotHasKey('points', $decoded, 'deleteMemory must not send primary-ID list; that breaks legacy int-keyed points');
-        $this->assertArrayHasKey('filter', $decoded);
-        $this->assertSame('_point_id', $decoded['filter']['must'][0]['key'] ?? null);
-        $this->assertSame('mem_1_123', $decoded['filter']['must'][0]['match']['value'] ?? null);
-    }
-
-    public function testDeleteMemorySuccess(): void
-    {
-        $this->expectNotToPerformAssertions();
-
-        $responses = [
-            new MockResponse(json_encode(['result' => ['status' => 'completed']]), ['http_code' => 200]),
-        ];
-
-        $client = $this->createClient($responses);
-        $client->deleteMemory('mem_1_123');
+        $body = json_decode((string) $deleteCalls[0]['body'], true);
+        $this->assertArrayNotHasKey('points', $body, 'deleteMemory must not send primary-ID list; that breaks legacy int-keyed points');
+        $this->assertArrayHasKey('filter', $body);
+        $this->assertSame('_point_id', $body['filter']['must'][0]['key']);
+        $this->assertSame('mem_1_123', $body['filter']['must'][0]['match']['value']);
     }
 
     /**
-     * Regression lock for the getMemory read path — must scroll by `_point_id`
-     * payload filter (not lookup by primary UUID).
+     * Regression test for the scroll-dedup safety net. Until the one-shot
+     * legacy migration runs, the same logical memory can exist under BOTH
+     * an integer primary and a UUID primary. Scroll must not show both.
      */
-    public function testGetMemoryUsesPointIdPayloadFilterNotPrimaryKey(): void
+    public function testScrollMemoriesDedupesDuplicateLogicalPoints(): void
     {
-        $capturedUrl = null;
-        $capturedBody = null;
+        $client = $this->buildClient([
+            '/collections/user_memories/points/scroll' => fn () => new MockResponse(
+                json_encode([
+                    'result' => [
+                        'points' => [
+                            [
+                                'id' => 82402287705672322, // legacy int
+                                'payload' => [
+                                    '_point_id' => 'mem_1_dup',
+                                    'user_id' => 1,
+                                    'category' => 'a',
+                                    'key' => 'k',
+                                    'value' => 'legacy-copy',
+                                    'active' => true,
+                                ],
+                            ],
+                            [
+                                'id' => QdrantPointId::uuidFor('mem_1_dup'), // UUID copy
+                                'payload' => [
+                                    '_point_id' => 'mem_1_dup',
+                                    'user_id' => 1,
+                                    'category' => 'a',
+                                    'key' => 'k',
+                                    'value' => 'uuid-copy',
+                                    'active' => true,
+                                ],
+                            ],
+                            [
+                                'id' => 'different-uuid',
+                                'payload' => [
+                                    '_point_id' => 'mem_1_other',
+                                    'user_id' => 1,
+                                    'category' => 'a',
+                                    'key' => 'k2',
+                                    'value' => 'other',
+                                    'active' => true,
+                                ],
+                            ],
+                        ],
+                        'next_page_offset' => null,
+                    ],
+                ]),
+                ['http_code' => 200],
+            ),
+        ]);
 
-        $factory = function (string $method, string $url, array $options) use (&$capturedUrl, &$capturedBody): MockResponse {
-            $capturedUrl = $url;
-            $capturedBody = $options['body'] ?? null;
+        $memories = $client->scrollMemories(userId: 1);
+        $logicalIds = array_map(static fn (array $m): string => $m['id'], $memories);
 
-            return new MockResponse(json_encode([
-                'result' => ['points' => [], 'next_page_offset' => null],
-            ]), ['http_code' => 200]);
-        };
-
-        $mockClient = new MockHttpClient($factory);
-        $client = new QdrantClientDirect(
-            httpClient: $mockClient,
-            qdrantUrl: 'http://localhost:6333',
-            logger: new NullLogger(),
-        );
-
-        $client->getMemory('mem_1_123');
-
-        $this->assertIsString($capturedUrl);
-        $this->assertStringContainsString('/collections/user_memories/points/scroll', $capturedUrl);
-
-        $this->assertIsString($capturedBody);
-        /** @var array{filter?: array{must?: array<array{key?: string, match?: array{value?: string}}>}, ids?: mixed} $decoded */
-        $decoded = json_decode($capturedBody, true);
-
-        $this->assertArrayNotHasKey('ids', $decoded, 'getMemory must not lookup by primary ID; that misses legacy int-keyed points');
-        $this->assertArrayHasKey('filter', $decoded);
-        $this->assertSame('_point_id', $decoded['filter']['must'][0]['key'] ?? null);
-        $this->assertSame('mem_1_123', $decoded['filter']['must'][0]['match']['value'] ?? null);
+        $this->assertCount(2, $memories, 'duplicate logical points must collapse into one entry');
+        $this->assertSame(['mem_1_dup', 'mem_1_other'], $logicalIds);
     }
 
-    public function testSearchMemoriesSuccess(): void
+    public function testSearchMemoriesDedupesAndKeepsHigherScoringCopy(): void
     {
-        $responses = [
-            new MockResponse(json_encode([
-                'result' => [
-                    [
-                        'id' => 'some-uuid',
-                        'score' => 0.95,
-                        'payload' => [
-                            '_point_id' => 'mem_1_123',
-                            'user_id' => 1,
-                            'category' => 'test',
-                            'key' => 'test_key',
-                            'value' => 'test_value',
-                            'active' => true,
+        $client = $this->buildClient([
+            '/collections/user_memories/points/search' => fn () => new MockResponse(
+                json_encode([
+                    'result' => [
+                        [
+                            'id' => 11111,
+                            'score' => 0.72,
+                            'payload' => [
+                                '_point_id' => 'mem_1_dup',
+                                'user_id' => 1, 'category' => 'a', 'key' => 'k', 'value' => 'legacy', 'active' => true,
+                            ],
+                        ],
+                        [
+                            'id' => QdrantPointId::uuidFor('mem_1_dup'),
+                            'score' => 0.91,
+                            'payload' => [
+                                '_point_id' => 'mem_1_dup',
+                                'user_id' => 1, 'category' => 'a', 'key' => 'k', 'value' => 'fresh-uuid', 'active' => true,
+                            ],
                         ],
                     ],
-                ],
-            ]), ['http_code' => 200]),
-        ];
+                ]),
+                ['http_code' => 200],
+            ),
+        ]);
 
-        $client = $this->createClient($responses);
         $results = $client->searchMemories(
             queryVector: array_fill(0, 1024, 0.5),
             userId: 1,
             category: null,
             limit: 5,
-            minScore: 0.7
+            minScore: 0.7,
         );
 
         $this->assertCount(1, $results);
-        $this->assertEquals('mem_1_123', $results[0]['id']);
-        $this->assertEquals(0.95, $results[0]['score']);
+        $this->assertSame('mem_1_dup', $results[0]['id']);
+        $this->assertSame(0.91, $results[0]['score'], 'dedup must keep the higher-scoring copy');
+        $this->assertSame('fresh-uuid', $results[0]['payload']['value']);
     }
 
-    public function testHealthCheckSuccess(): void
+    public function testUpsertDocumentIssuesAtomicBatchDeleteThenUpsert(): void
     {
-        $responses = [
-            new MockResponse('', ['http_code' => 200]),
-        ];
+        $calls = [];
+        $client = $this->buildClient([
+            '/collections/user_documents' => fn () => new MockResponse(
+                json_encode(['result' => ['status' => 'green']]),
+                ['http_code' => 200]
+            ),
+            '/collections/user_documents/index' => fn () => $this->okEmpty(),
+            '/collections/user_documents/points/batch' => fn () => new MockResponse(
+                json_encode(['result' => [['status' => 'completed'], ['status' => 'completed']], 'status' => 'ok']),
+                ['http_code' => 200]
+            ),
+        ], $calls);
 
-        $client = $this->createClient($responses);
-        $healthy = $client->healthCheck();
+        $client->upsertDocument(
+            pointId: 'doc_1_42_0',
+            vector: array_fill(0, 1024, 0.1),
+            payload: ['user_id' => 1, 'file_id' => 42, 'group_key' => 'g', 'text' => 't'],
+        );
 
-        $this->assertTrue($healthy);
+        $batchCalls = array_values(array_filter(
+            $calls,
+            static fn (array $c): bool => str_ends_with($c['path'], '/points/batch'),
+        ));
+        $this->assertCount(1, $batchCalls);
+
+        $body = json_decode((string) $batchCalls[0]['body'], true);
+        $this->assertArrayHasKey('delete', $body['operations'][0]);
+        $this->assertArrayHasKey('upsert', $body['operations'][1]);
+        $this->assertSame(
+            'doc_1_42_0',
+            $body['operations'][0]['delete']['filter']['must'][0]['match']['value'],
+        );
     }
 
-    public function testHealthCheckFailure(): void
+    public function testHealthCheckReturnsTrueOn200(): void
     {
-        $responses = [
-            new MockResponse('Service Unavailable', ['http_code' => 503]),
-        ];
+        $client = $this->buildClient([
+            '/healthz' => fn () => new MockResponse('', ['http_code' => 200]),
+        ]);
 
-        $client = $this->createClient($responses);
-        $healthy = $client->healthCheck();
-
-        $this->assertFalse($healthy);
+        $this->assertTrue($client->healthCheck());
     }
 
-    public function testHealthCheckNotConfigured(): void
+    public function testHealthCheckReturnsFalseOn503(): void
     {
-        $mockClient = new MockHttpClient([]);
+        $client = $this->buildClient([
+            '/healthz' => fn () => new MockResponse('Service Unavailable', ['http_code' => 503]),
+        ]);
+
+        $this->assertFalse($client->healthCheck());
+    }
+
+    public function testHealthCheckReturnsFalseWhenNotConfigured(): void
+    {
         $client = new QdrantClientDirect(
-            httpClient: $mockClient,
+            httpClient: new MockHttpClient([]),
             qdrantUrl: '',
             logger: new NullLogger(),
         );
@@ -279,109 +373,18 @@ final class QdrantClientDirectTest extends TestCase
         $this->assertFalse($client->isAvailable());
     }
 
-    public function testUpsertDocumentSuccess(): void
+    public function testCollectionNameGettersExposeConfiguredNames(): void
     {
-        $this->expectNotToPerformAssertions();
-
-        $responses = [
-            // ensureDocumentsCollection -> GET /collections/user_documents
-            new MockResponse(json_encode(['result' => ['status' => 'green']]), ['http_code' => 200]),
-            // ensurePayloadIndexes -> PUT /collections/user_documents/index  x4
-            new MockResponse(json_encode(['result' => ['status' => 'acknowledged']]), ['http_code' => 200]),
-            new MockResponse(json_encode(['result' => ['status' => 'acknowledged']]), ['http_code' => 200]),
-            new MockResponse(json_encode(['result' => ['status' => 'acknowledged']]), ['http_code' => 200]),
-            new MockResponse(json_encode(['result' => ['status' => 'acknowledged']]), ['http_code' => 200]),
-            // upsertDocument -> pre-upsert POST /points/delete?wait=true
-            new MockResponse(json_encode(['result' => ['status' => 'completed']]), ['http_code' => 200]),
-            // upsertDocument -> PUT /points?wait=true
-            new MockResponse(json_encode(['result' => ['status' => 'completed']]), ['http_code' => 200]),
-        ];
-
-        $client = $this->createClient($responses);
-        $client->upsertDocument(
-            pointId: 'doc_1_42_0',
-            vector: array_fill(0, 1024, 0.1),
-            payload: [
-                'user_id' => 1,
-                'file_id' => 42,
-                'group_key' => 'default',
-                'text' => 'test chunk',
-            ]
-        );
-    }
-
-    public function testSearchDocumentsSuccess(): void
-    {
-        $responses = [
-            new MockResponse(json_encode([
-                'result' => [
-                    [
-                        'id' => 'some-uuid',
-                        'score' => 0.85,
-                        'payload' => [
-                            '_point_id' => 'doc_1_42_0',
-                            'user_id' => 1,
-                            'file_id' => 42,
-                            'text' => 'matching chunk',
-                            'group_key' => 'default',
-                            'start_line' => 0,
-                            'end_line' => 10,
-                        ],
-                    ],
-                ],
-            ]), ['http_code' => 200]),
-        ];
-
-        $client = $this->createClient($responses);
-        $results = $client->searchDocuments(
-            vector: array_fill(0, 1024, 0.1),
-            userId: 1,
+        $client = new QdrantClientDirect(
+            httpClient: new MockHttpClient([]),
+            qdrantUrl: 'http://x',
+            logger: new NullLogger(),
+            memoriesCollection: 'custom_mem',
+            documentsCollection: 'custom_doc',
         );
 
-        $this->assertCount(1, $results);
-        $this->assertEquals(0.85, $results[0]['score']);
-        $this->assertEquals('matching chunk', $results[0]['payload']['text']);
-    }
-
-    public function testScrollMemoriesSuccess(): void
-    {
-        $responses = [
-            new MockResponse(json_encode([
-                'result' => [
-                    'points' => [
-                        [
-                            'id' => 'uuid-1',
-                            'payload' => [
-                                '_point_id' => 'mem_1_1',
-                                'user_id' => 1,
-                                'category' => 'general',
-                                'key' => 'name',
-                                'value' => 'Test User',
-                                'active' => true,
-                            ],
-                        ],
-                        [
-                            'id' => 'uuid-2',
-                            'payload' => [
-                                '_point_id' => 'mem_1_2',
-                                'user_id' => 1,
-                                'category' => 'preference',
-                                'key' => 'language',
-                                'value' => 'German',
-                                'active' => true,
-                            ],
-                        ],
-                    ],
-                    'next_page_offset' => null,
-                ],
-            ]), ['http_code' => 200]),
-        ];
-
-        $client = $this->createClient($responses);
-        $memories = $client->scrollMemories(userId: 1);
-
-        $this->assertCount(2, $memories);
-        $this->assertEquals('mem_1_1', $memories[0]['id']);
-        $this->assertEquals('mem_1_2', $memories[1]['id']);
+        $this->assertSame('custom_mem', $client->getMemoriesCollection());
+        $this->assertSame('custom_doc', $client->getDocumentsCollection());
+        $this->assertSame('http://x', $client->getQdrantUrl());
     }
 }

--- a/backend/tests/Service/VectorSearch/QdrantPointIdTest.php
+++ b/backend/tests/Service/VectorSearch/QdrantPointIdTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Service\VectorSearch;
+
+use App\Service\VectorSearch\QdrantPointId;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @see QdrantPointId
+ */
+final class QdrantPointIdTest extends TestCase
+{
+    /**
+     * Cross-check against a UUID computed outside the codebase to detect
+     * any future accidental namespace change.
+     */
+    public function testUuidForIsDeterministicAndMatchesKnownValue(): void
+    {
+        // Hand-computed against the canonical DNS namespace
+        // 6ba7b810-9dad-11d1-80b4-00c04fd430c8 with name "mem_152_1769723312080348".
+        $this->assertSame(
+            'dd188347-154f-55e4-9c69-699010e7828a',
+            QdrantPointId::uuidFor('mem_152_1769723312080348')
+        );
+
+        // Stable across calls
+        $this->assertSame(
+            QdrantPointId::uuidFor('mem_1_42'),
+            QdrantPointId::uuidFor('mem_1_42'),
+        );
+    }
+
+    public function testPayloadFilterForMatchesOnPointIdKey(): void
+    {
+        $filter = QdrantPointId::payloadFilterFor('mem_1_42');
+
+        $this->assertSame([
+            'must' => [
+                ['key' => '_point_id', 'match' => ['value' => 'mem_1_42']],
+            ],
+        ], $filter);
+    }
+
+    public function testIsCanonicalUuidRejectsLegacyIntegerPrimary(): void
+    {
+        $this->assertFalse(
+            QdrantPointId::isCanonicalUuid(82402287705672322, 'mem_152_1769723312080348'),
+        );
+    }
+
+    public function testIsCanonicalUuidAcceptsCorrectlyDerivedUuid(): void
+    {
+        $logical = 'mem_1_42';
+        $this->assertTrue(
+            QdrantPointId::isCanonicalUuid(QdrantPointId::uuidFor($logical), $logical),
+        );
+    }
+
+    /**
+     * A UUID that is syntactically valid but NOT the one we would derive
+     * for this logical ID must NOT be treated as canonical — otherwise a
+     * hand-written UUIDv4 could mask a migration-needed state.
+     */
+    public function testIsCanonicalUuidRejectsUnrelatedUuid(): void
+    {
+        // Random UUIDv4, not derived from the namespace
+        $this->assertFalse(
+            QdrantPointId::isCanonicalUuid('550e8400-e29b-41d4-a716-446655440000', 'mem_1_42'),
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Addresses https://github.com/metadist/synaplan/pull/811#issuecomment review from orgaralf. The previous commit on this branch (783d8b4c5) solved the original delete bug but introduced a data-loss window on upsert, missed scroll-level dedup, duplicated UUID derivation in the migration command, and shipped the command without tests. This commit closes those gaps.

Atomicity (review item 1, data-loss window)
-------------------------------------------

Both upsertMemory() and upsertDocument() used to issue two separate wait=true requests (delete-by-payload + upsert). A crash between them left the point gone until the caller retried. They now use Qdrant's /points/batch endpoint so delete+upsert ride a single HTTP round-trip, ordered server-side. Side benefits: lower tail latency on the chat hot path and no Raft split-brain surprises from interleaved acks.

LegacyPointIdMigrator uses the same endpoint the other way (upsert new UUID first, delete legacy primary ID second) so a mid-batch abort leaves the canonical copy intact.

Global --limit (review item 2)
------------------------------

The command passed the raw --limit value to each collection, so --limit=10 against two collections could migrate up to 20 points. Now the remaining quota is decremented across collections, and the sentinel is the explicit string "all" rather than "0".

Canonical-UUID check (review item 3)
-----------------------------------

QdrantPointId::isCanonicalUuid() now recomputes the expected UUIDv5 and compares, instead of permissively accepting any UUID-shaped string. A hand-written UUIDv4 on a point would previously have been skipped as "already canonical"; it now correctly drives a migration.

Scroll progress guard (review item 4)
-------------------------------------

LegacyPointIdMigrator::migrateCollection() remembers the previous next_page_offset and aborts the loop if Qdrant returns the same offset twice in a row. Prevents an infinite loop under a Qdrant bug or a race with a concurrent delete.

Scroll / search dedup (review item 5)
-------------------------------------

Until the migration runs, prod still has int-keyed + UUID-keyed copies of the same logical memory. QdrantClientDirect::scrollMemories() and searchMemories() now collapse duplicates by `_point_id`. Search asks Qdrant for 2x the requested limit first so the dedup doesn't short- change the caller, then keeps the higher-scoring copy per logical ID.

Code-dedup (review items 8, 9)
------------------------------

UUID derivation and payload-filter construction moved to a single QdrantPointId helper used by both QdrantClientDirect and the migration command. The command is now thin CLI wiring; scrolling + rekey loop lives in LegacyPointIdMigrator (new), with a LegacyPointIdMigrationReport value object for the summary. This removes three copies of the namespace constant and the qdrantRequest() wrapper and unblocks unit testing of the migration logic.

Tests (review items 10, 11)
---------------------------

- New LegacyPointIdMigratorTest: 5 tests covering dry-run reporting, apply path (asserting the batch upsert→delete order), global --limit cap, missing-payload skip, and the progress guard.
- New QdrantPointIdTest: 5 tests pinning the UUID derivation against a hand-computed expected value so any future namespace drift fails CI.
- QdrantClientDirectTest refactored to a route-based MockHttpClient (path → responder callback) so future internal optimisations can change the number and order of HTTP calls without breaking the suite. Added regression locks for scroll/search dedup behaviour.

Misc review follow-ups
----------------------

- Cached the parsed namespace Uuid so large migrations don't re-parse it per point (item 13).
- Documented the intentional getMemory with_vector=false vs getDocument with_vector=true asymmetry instead of harmonising (item 14) — memory fetches are on the chat hot path, documents are not.
- Added collection-name + URL getters to QdrantClientDirect so the migration command can read them without duplicating env parsing.

Verification
------------
- make -C backend lint: clean (395 files checked).
- make -C backend phpstan: clean (0 errors, 546 files).
- Targeted PHPUnit (VectorSearch + memory + feedback + mock): 62 tests, all passing, including 10 new tests from this commit.
- End-to-end against the live 3-node cluster via SSH tunnel: seeded an int-keyed test point under user_id=99999888, ran `app:qdrant:migrate-legacy-point-ids --limit=1 --apply`, verified the old int primary ID is gone and the canonical UUID-keyed copy carries the original payload. Disposable point cleaned up.

