### PR TITLE
handling anonymous chats better, ignoring memories

### DIFF
--- a/backend/phpstan-baseline.neon
+++ b/backend/phpstan-baseline.neon
@@ -627,7 +627,7 @@ parameters:
 		-
 			message: '#^Call to an undefined method App\\AI\\Service\\AiFacade\:\:method\(\)\.$#'
 			identifier: method.notFound
-			count: 3
+			count: 4
 			path: tests/Unit/ChatHandlerTest.php
 
 		-
@@ -639,19 +639,37 @@ parameters:
 		-
 			message: '#^Call to an undefined method App\\Repository\\PromptRepository\:\:method\(\)\.$#'
 			identifier: method.notFound
-			count: 6
+			count: 7
+			path: tests/Unit/ChatHandlerTest.php
+
+		-
+			message: '#^Call to an undefined method App\\Service\\MemoryExtractionService\:\:expects\(\)\.$#'
+			identifier: method.notFound
+			count: 1
 			path: tests/Unit/ChatHandlerTest.php
 
 		-
 			message: '#^Call to an undefined method App\\Service\\ModelConfigService\:\:method\(\)\.$#'
 			identifier: method.notFound
-			count: 13
+			count: 14
 			path: tests/Unit/ChatHandlerTest.php
 
 		-
 			message: '#^Call to an undefined method App\\Service\\PromptService\:\:expects\(\)\.$#'
 			identifier: method.notFound
 			count: 1
+			path: tests/Unit/ChatHandlerTest.php
+
+		-
+			message: '#^Call to an undefined method App\\Service\\PromptService\:\:method\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: tests/Unit/ChatHandlerTest.php
+
+		-
+			message: '#^Call to an undefined method App\\Service\\UserMemoryService\:\:expects\(\)\.$#'
+			identifier: method.notFound
+			count: 3
 			path: tests/Unit/ChatHandlerTest.php
 
 		-

--- a/backend/src/Controller/StreamController.php
+++ b/backend/src/Controller/StreamController.php
@@ -474,6 +474,15 @@ class StreamController extends AbstractController
                 $incomingMessage->setDirection('IN');
                 $incomingMessage->setStatus($continueMessageId ? 'hidden' : 'processing');
 
+                // Tag channel so memory/feedback services can refuse to
+                // read/write owner-scoped data for anonymous traffic paths
+                // (widget-test from the owner UI, guest trial on synaplan.com).
+                if ($isWidgetMode) {
+                    $incomingMessage->setMeta('channel', 'WIDGET');
+                } elseif ($isGuestMode) {
+                    $incomingMessage->setMeta('channel', 'GUEST');
+                }
+
                 $this->em->persist($incomingMessage);
                 $this->em->flush(); // Flush first so message has an ID
 

--- a/backend/src/Controller/StreamController.php
+++ b/backend/src/Controller/StreamController.php
@@ -474,17 +474,20 @@ class StreamController extends AbstractController
                 $incomingMessage->setDirection('IN');
                 $incomingMessage->setStatus($continueMessageId ? 'hidden' : 'processing');
 
+                $this->em->persist($incomingMessage);
+                $this->em->flush(); // Flush first so message has an ID
+
                 // Tag channel so memory/feedback services can refuse to
                 // read/write owner-scoped data for anonymous traffic paths
                 // (widget-test from the owner UI, guest trial on synaplan.com).
+                // MUST be after the first flush so MessageMeta has a valid message ID.
                 if ($isWidgetMode) {
                     $incomingMessage->setMeta('channel', 'WIDGET');
+                    $this->em->flush();
                 } elseif ($isGuestMode) {
                     $incomingMessage->setMeta('channel', 'GUEST');
+                    $this->em->flush();
                 }
-
-                $this->em->persist($incomingMessage);
-                $this->em->flush(); // Flush first so message has an ID
 
                 // Attach multiple files if uploaded (NEW: File entities with ManyToMany)
                 if (!empty($fileIdArray)) {

--- a/backend/src/Controller/WidgetPublicController.php
+++ b/backend/src/Controller/WidgetPublicController.php
@@ -334,12 +334,13 @@ class WidgetPublicController extends AbstractController
             $incomingMessage->setDateTime(date('YmdHis'));
             $incomingMessage->setProviderIndex('widget'); // Special provider index for widgets
 
+            $this->em->persist($incomingMessage);
+            $this->em->flush(); // MUST flush before setMeta() so the message has an ID
+
             // Tag channel so downstream services (memory, feedback) can refuse
             // to read/write owner-scoped data for anonymous widget visitors.
             $incomingMessage->setMeta('channel', 'WIDGET');
             $incomingMessage->setMeta('widget_id', $widget->getWidgetId());
-
-            $this->em->persist($incomingMessage);
             $this->em->flush();
 
             // Publish event for user message (so admin panel receives it in real-time)
@@ -662,10 +663,12 @@ class WidgetPublicController extends AbstractController
                     $outgoingMessage->setText($responseText);
                     $outgoingMessage->setDirection('OUT');
                     $outgoingMessage->setStatus('complete');
-                    $outgoingMessage->setMeta('channel', 'WIDGET');
-                    $outgoingMessage->setMeta('widget_id', $widgetId);
 
                     $this->em->persist($outgoingMessage);
+                    $this->em->flush(); // MUST flush before setMeta() so the message has an ID
+
+                    $outgoingMessage->setMeta('channel', 'WIDGET');
+                    $outgoingMessage->setMeta('widget_id', $widgetId);
                     $this->em->flush();
 
                     // Update session's last message time and preview with AI response

--- a/backend/src/Controller/WidgetPublicController.php
+++ b/backend/src/Controller/WidgetPublicController.php
@@ -334,6 +334,11 @@ class WidgetPublicController extends AbstractController
             $incomingMessage->setDateTime(date('YmdHis'));
             $incomingMessage->setProviderIndex('widget'); // Special provider index for widgets
 
+            // Tag channel so downstream services (memory, feedback) can refuse
+            // to read/write owner-scoped data for anonymous widget visitors.
+            $incomingMessage->setMeta('channel', 'WIDGET');
+            $incomingMessage->setMeta('widget_id', $widget->getWidgetId());
+
             $this->em->persist($incomingMessage);
             $this->em->flush();
 
@@ -657,6 +662,8 @@ class WidgetPublicController extends AbstractController
                     $outgoingMessage->setText($responseText);
                     $outgoingMessage->setDirection('OUT');
                     $outgoingMessage->setStatus('complete');
+                    $outgoingMessage->setMeta('channel', 'WIDGET');
+                    $outgoingMessage->setMeta('widget_id', $widgetId);
 
                     $this->em->persist($outgoingMessage);
                     $this->em->flush();

--- a/backend/src/Service/MemoryExtractionService.php
+++ b/backend/src/Service/MemoryExtractionService.php
@@ -41,6 +41,21 @@ final readonly class MemoryExtractionService
      */
     public function analyzeAndExtract(Message $message, array $conversationHistory, array $existingMemories = []): array
     {
+        // Defense-in-depth: never extract memories for anonymous traffic.
+        // Widget visitors and guest-trial sessions are stored under the owner's
+        // user id, so an unguarded call here would pollute the owner's Qdrant
+        // collection. The incoming message is tagged at the entry points
+        // (WidgetPublicController, StreamController).
+        $channel = $message->getMeta('channel');
+        if (null !== $channel && self::isPublicChannel($channel)) {
+            $this->logger->info('MemoryExtractionService: skipping extraction for public channel', [
+                'message_id' => $message->getId(),
+                'channel' => $channel,
+            ]);
+
+            return [];
+        }
+
         $this->logger->info('Memory extraction triggered (AI-based with update capability)', [
             'message_id' => $message->getId(),
             'user_id' => $message->getUserId(),
@@ -49,6 +64,16 @@ final readonly class MemoryExtractionService
 
         // Extract via AI (AI decides: create, update, or skip)
         return $this->extractMemoriesViaAi($message, $conversationHistory, $existingMemories);
+    }
+
+    /**
+     * Channels whose traffic must never read or write owner-scoped memories.
+     *
+     * Kept in sync with the tags set in WidgetPublicController / StreamController.
+     */
+    public static function isPublicChannel(string $channel): bool
+    {
+        return in_array(strtoupper($channel), ['WIDGET', 'GUEST'], true);
     }
 
     /**

--- a/backend/src/Service/Message/Handler/ChatHandler.php
+++ b/backend/src/Service/Message/Handler/ChatHandler.php
@@ -461,13 +461,22 @@ final readonly class ChatHandler implements MessageHandlerInterface
         // Load user memories from Qdrant/Microservice
         $memoriesContext = '';
         $loadedMemories = [];
-        $memoriesDisabledByRequest = !empty($options['disable_memories'])
-            || ('WIDGET' === ($options['channel'] ?? null))
-            || ('widget' === ($classification['source'] ?? null));
 
-        // Load user entity (Message only has userId, not User object)
+        // Three-layer guard: explicit option, options channel, persisted message
+        // channel meta (tagged at WidgetPublicController / StreamController). The
+        // last one is the durable source of truth — it survives even if a future
+        // code path forgets to set options['disable_memories'].
+        $channelOption = strtoupper((string) ($options['channel'] ?? ''));
+        $channelMeta = strtoupper((string) $message->getMeta('channel'));
+        $memoriesDisabledByRequest = !empty($options['disable_memories'])
+            || in_array($channelOption, ['WIDGET', 'GUEST'], true)
+            || in_array($channelMeta, ['WIDGET', 'GUEST'], true);
+
+        // Load user entity (Message only has userId, not User object).
+        // Fail closed: if the user lookup fails for any reason, treat memories
+        // as disabled rather than risk writing to the wrong account.
         $user = $this->em->getRepository(User::class)->find($message->getUserId());
-        $memoriesEnabledForUser = $user?->isMemoriesEnabled() ?? true;
+        $memoriesEnabledForUser = $user?->isMemoriesEnabled() ?? false;
 
         if ($memoriesDisabledByRequest) {
             $this->logger->debug('ChatHandler: Memories disabled for widget request, skipping memories', [

--- a/backend/src/Service/UserMemoryService.php
+++ b/backend/src/Service/UserMemoryService.php
@@ -93,6 +93,20 @@ final readonly class UserMemoryService
         ?int $messageId = null,
         ?string $namespace = null,
     ): UserMemoryDTO {
+        // Belt-and-suspenders: refuse if the owner has memories turned off.
+        // Auto-extracted memories in widget/guest flows are already blocked
+        // upstream (MemoryExtractionService returns [] and ChatHandler never
+        // calls us), but this closes the door for any future caller too.
+        if ('auto_detected' === $source && !$user->isMemoriesEnabled()) {
+            $this->logger->info('UserMemoryService: refusing auto_detected memory, user has memories disabled', [
+                'user_id' => $user->getId(),
+                'category' => $category,
+                'key' => $key,
+            ]);
+
+            throw new \InvalidArgumentException('Memories are disabled for this user.');
+        }
+
         $this->assertAvailable('create memory', [
             'user_id' => $user->getId(),
             'category' => $category,

--- a/backend/tests/Service/UserMemoryServiceTest.php
+++ b/backend/tests/Service/UserMemoryServiceTest.php
@@ -123,6 +123,7 @@ final class UserMemoryServiceTest extends TestCase
     {
         $user = $this->createMock(User::class);
         $user->method('getId')->willReturn(123);
+        $user->method('isMemoriesEnabled')->willReturn(true);
 
         $this->qdrantClient
             ->expects($this->once())
@@ -136,6 +137,69 @@ final class UserMemoryServiceTest extends TestCase
         $this->expectException(MemoryServiceUnavailableException::class);
 
         $this->service->createMemory($user, 'personal', 'favourite_colour', 'green');
+    }
+
+    /**
+     * Auto-extracted memories must be refused when the owner has memories
+     * disabled. This is a belt-and-suspenders guard: widget/guest flows are
+     * already blocked upstream (MemoryExtractionService returns [] for public
+     * channels, ChatHandler gates both read and write), but any future caller
+     * that bypasses those layers still cannot write into a disabled user's
+     * Qdrant namespace.
+     */
+    public function testCreateMemoryRefusesAutoDetectedWhenUserHasMemoriesDisabled(): void
+    {
+        $user = $this->createMock(User::class);
+        $user->method('getId')->willReturn(42);
+        $user->method('isMemoriesEnabled')->willReturn(false);
+
+        // Must NOT reach Qdrant availability check or upsert.
+        $this->qdrantClient
+            ->expects($this->never())
+            ->method('isAvailable');
+        $this->qdrantClient
+            ->expects($this->never())
+            ->method('upsertMemory');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Memories are disabled');
+
+        $this->service->createMemory(
+            $user,
+            'preferences',
+            'diet',
+            'Eats halal',
+            'auto_detected',
+            99
+        );
+    }
+
+    /**
+     * User-initiated memory creation (from the Synaplan UI "Add memory" button)
+     * must still work even if the auto-extraction setting is off — the guard
+     * only targets 'auto_detected' source.
+     */
+    public function testCreateMemoryAllowsUserCreatedWhenAutoExtractionDisabled(): void
+    {
+        $user = $this->createMock(User::class);
+        $user->method('getId')->willReturn(42);
+        $user->method('isMemoriesEnabled')->willReturn(false);
+
+        $this->qdrantClient
+            ->expects($this->once())
+            ->method('isAvailable')
+            ->willReturn(false);
+
+        // Fails because Qdrant unavailable, NOT because of the memories-disabled guard.
+        $this->expectException(MemoryServiceUnavailableException::class);
+
+        $this->service->createMemory(
+            $user,
+            'preferences',
+            'diet',
+            'Eats halal',
+            'user_created'
+        );
     }
 
     public function testUpdateMemoryThrowsWhenQdrantUnavailable(): void

--- a/backend/tests/Unit/ChatHandlerTest.php
+++ b/backend/tests/Unit/ChatHandlerTest.php
@@ -403,4 +403,74 @@ class ChatHandlerTest extends TestCase
             $streamCallback
         );
     }
+
+    /**
+     * Widget-tagged messages (anonymous visitors on a customer's website) must
+     * never read from or write to the owner's Qdrant memory collection. The
+     * incoming message is tagged with channel=WIDGET in WidgetPublicController;
+     * ChatHandler must honour that tag even if the caller forgets to also pass
+     * `disable_memories` in $options.
+     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('publicChannelProvider')]
+    public function testHandleStreamNeverTouchesMemoriesForPublicChannelMessage(string $channel): void
+    {
+        $message = $this->createMock(Message::class);
+        $message->method('getUserId')->willReturn(1);
+        $message->method('getText')->willReturn('Hi, how much does your product cost?');
+        $message->method('getFileText')->willReturn('');
+        $message->method('getFiles')->willReturn(new \Doctrine\Common\Collections\ArrayCollection());
+        // Channel tag is the durable source of truth that the guard reads.
+        $message->method('getMeta')->willReturnMap([
+            ['channel', null, $channel],
+        ]);
+
+        $this->promptService->method('getPromptWithMetadata')->willReturn([
+            'prompt' => null,
+            'metadata' => [],
+        ]);
+        $this->promptRepository->method('findOneBy')->willReturn(null);
+        $this->modelConfigService->method('getDefaultModel')->willReturn(null);
+
+        // Memory service must never be consulted for read or write.
+        $this->userMemoryService
+            ->expects($this->never())
+            ->method('searchRelevantMemories');
+        $this->userMemoryService
+            ->expects($this->never())
+            ->method('createMemory');
+        $this->userMemoryService
+            ->expects($this->never())
+            ->method('updateMemory');
+
+        // Extraction must be skipped outright.
+        $this->memoryExtractionService
+            ->expects($this->never())
+            ->method('analyzeAndExtract');
+
+        $this->aiFacade
+            ->method('chatStream')
+            ->willReturn(['provider' => 'test', 'model' => 'test']);
+
+        $this->handler->handleStream(
+            $message,
+            [],
+            ['topic' => 'CHAT', 'language' => 'en'],
+            static function ($chunk) {}
+            // NOTE: deliberately NOT passing disable_memories in $options — the
+            // meta tag on the Message must be enough on its own.
+        );
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function publicChannelProvider(): array
+    {
+        return [
+            'widget (uppercase)' => ['WIDGET'],
+            'guest (uppercase)' => ['GUEST'],
+            'widget (lowercase)' => ['widget'],
+            'guest (mixed case)' => ['Guest'],
+        ];
+    }
 }

--- a/backend/tests/Unit/MemoryExtractionServicePromptRulesTest.php
+++ b/backend/tests/Unit/MemoryExtractionServicePromptRulesTest.php
@@ -103,4 +103,49 @@ final class MemoryExtractionServicePromptRulesTest extends TestCase
         self::assertSame('diet', $result[1]['key']);
         self::assertSame('Prefers low-calorie meals for weight loss', $result[1]['value']);
     }
+
+    /**
+     * Widget visitors are stored under the owner's user id, so an unguarded
+     * memory extraction would pollute the owner's Qdrant memories with
+     * anonymous-visitor content. The service must refuse extraction when the
+     * message is tagged with a public channel (WIDGET / GUEST).
+     */
+    public function testAnalyzeAndExtractSkipsWidgetTaggedMessages(): void
+    {
+        foreach (['WIDGET', 'GUEST', 'widget', 'guest'] as $channel) {
+            $aiFacade = $this->createMock(AiFacade::class);
+            // Must never call the AI for a public-channel message.
+            $aiFacade->expects(self::never())->method('chat');
+
+            $message = $this->createMock(Message::class);
+            $message->method('getId')->willReturn(99);
+            $message->method('getUserId')->willReturn(1);
+            $message->method('getMeta')->with('channel')->willReturn($channel);
+
+            $service = new MemoryExtractionService(
+                $aiFacade,
+                $this->createMock(ModelConfigService::class),
+                $this->createMock(RateLimitService::class),
+                $this->createMock(PromptRepository::class),
+                $this->createMock(EntityManagerInterface::class),
+                $this->createMock(LoggerInterface::class)
+            );
+
+            $result = $service->analyzeAndExtract($message, [], []);
+
+            self::assertSame([], $result, sprintf('Expected empty result for channel %s', $channel));
+        }
+    }
+
+    public function testIsPublicChannelHelper(): void
+    {
+        self::assertTrue(MemoryExtractionService::isPublicChannel('WIDGET'));
+        self::assertTrue(MemoryExtractionService::isPublicChannel('GUEST'));
+        self::assertTrue(MemoryExtractionService::isPublicChannel('widget'));
+        self::assertTrue(MemoryExtractionService::isPublicChannel('Guest'));
+        self::assertFalse(MemoryExtractionService::isPublicChannel('WEB'));
+        self::assertFalse(MemoryExtractionService::isPublicChannel('whatsapp'));
+        self::assertFalse(MemoryExtractionService::isPublicChannel('email'));
+        self::assertFalse(MemoryExtractionService::isPublicChannel(''));
+    }
 }


### PR DESCRIPTION
## Summary
Avoiding anonymous chats to build memories on the platform

## Changes
Memory handling files:

backend/src/Controller/StreamController.php                    |  9 +++
backend/src/Controller/WidgetPublicController.php              |  7 +++
backend/src/Service/MemoryExtractionService.php                | 25 ++++++++
backend/src/Service/Message/Handler/ChatHandler.php            | 17 ++++--
backend/src/Service/UserMemoryService.php            ...

and the test files for it

## Verification
- [ ] Not tested (explain)
- [x] Manual
- [ ] Tests added/updated
