### PR TITLE
ci: validate Doctrine mapping metadata in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,13 +119,15 @@ jobs:
         # a migration, CI MUST fail so we surface the gap before deploy.
         run: php bin/console doctrine:migrations:migrate --no-interaction --allow-no-migration
 
-      - name: Verify schema matches entities (no migration drift)
+      - name: Validate Doctrine mapping metadata
         working-directory: backend
-        # Fails when an entity has been changed without a matching migration,
-        # OR when a migration drifts from the ORM mapping (column length, default,
-        # nullable, index shape, …). `--skip-sync` ignores Doctrine's own
-        # `doctrine_migration_versions` table, which the MariaDB DBAL comparator
-        # mis-reports as out-of-sync (see docs/MIGRATIONS.md "DBAL bug bypass").
+        # Validates that ORM mapping metadata is internally consistent — catches
+        # broken `targetEntity`, mismatched `mappedBy`/`inversedBy`, missing
+        # join columns, etc. `--skip-sync` skips the database synchronization
+        # check entirely, so this step does NOT detect missing migrations or
+        # entity↔database drift; the full sync check is a known follow-up
+        # because the legacy baseline schema and current entity defaults still
+        # differ in many places (see docs/MIGRATIONS.md).
         run: php bin/console doctrine:schema:validate --skip-sync
 
       - name: Load demo fixtures

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,15 @@ jobs:
         # a migration, CI MUST fail so we surface the gap before deploy.
         run: php bin/console doctrine:migrations:migrate --no-interaction --allow-no-migration
 
+      - name: Verify schema matches entities (no migration drift)
+        working-directory: backend
+        # Fails when an entity has been changed without a matching migration,
+        # OR when a migration drifts from the ORM mapping (column length, default,
+        # nullable, index shape, …). `--skip-sync` ignores Doctrine's own
+        # `doctrine_migration_versions` table, which the MariaDB DBAL comparator
+        # mis-reports as out-of-sync (see docs/MIGRATIONS.md "DBAL bug bypass").
+        run: php bin/console doctrine:schema:validate --skip-sync
+
       - name: Load demo fixtures
         working-directory: backend
         # Loads only dev/test demo data (admin/demo/test users). Production-essential

--- a/backend/src/Entity/MessageMeta.php
+++ b/backend/src/Entity/MessageMeta.php
@@ -19,7 +19,7 @@ class MessageMeta
     #[ORM\Column(name: 'BMESSAGEID', type: 'bigint')]
     private int $messageId;
 
-    #[ORM\ManyToOne(targetEntity: Message::class)]
+    #[ORM\ManyToOne(targetEntity: Message::class, inversedBy: 'metadata')]
     #[ORM\JoinColumn(name: 'BMESSAGEID', referencedColumnName: 'BID')]
     private ?Message $message = null;
 


### PR DESCRIPTION
## Summary
Adds `doctrine:schema:validate --skip-sync` to CI right after `doctrine:migrations:migrate`, so broken ORM mapping metadata fails the build before merge. The new check immediately surfaced one real bi-directional-relation bug in `MessageMeta` that's fixed in the same commit.

## Changes
- `.github/workflows/ci.yml`: add `Validate Doctrine mapping metadata` step. `--skip-sync` skips the database synchronization check entirely — the step validates ORM mapping metadata only (mismatched `mappedBy`/`inversedBy`, broken `targetEntity`, missing join columns, …), it does NOT detect missing migrations or entity↔database drift.
- `backend/src/Entity/MessageMeta.php`: add missing `inversedBy: 'metadata'` on the `Message` ManyToOne. `Message#metadata` already declared `mappedBy: 'message'` on the inverse side, so the relation was bi-directional in intent but only uni-directional in metadata, which the new validator caught.

## Verification
- [x] Tests added/updated
- [x] Manual

Locally inside the dev stack:

```
composer phpstan                        → 506 files, 0 errors
composer lint:fix                       → 0 of 402 files changed
php bin/phpunit                         → 1004 tests, all green
doctrine:schema:validate --skip-sync    → [OK] mapping files are correct
```

CI on this branch is the final cross-check.

## Notes
**What this PR catches:** future ORM-mapping mistakes — typos in `mappedBy`, missing `inversedBy` on inverse sides of bi-directional relations, broken `targetEntity` references, dangling join columns, etc. Plus the existing `MessageMeta` bug surfaced and fixed.

**What this PR does NOT catch (deliberately):** entity↔database drift. The full `doctrine:schema:validate` (without `--skip-sync`) currently reports substantial DB-side drift between the baseline migration (`Version20260417000000`, generated via `dump-schema` from the legacy prod database) and current entity defaults — column lengths, default values, JSON nullability, and similar. Reconciling that drift is ≈20 `ALTER TABLE` statements across most tables and changes runtime behaviour in subtle ways. It deserves its own dedicated PR with careful per-table review and is **explicitly out of scope here**.

Follow-up issue to track: full schema reconciliation (entities ↔ migrations) — to be opened after this lands.

## Screenshots/Logs
Local run before the mapping fix (= the bug the new check would have caught in CI):

```
 [FAIL] The entity-class App\Entity\Message mapping is invalid:
 * The field App\Entity\Message#metadata is on the inverse side of a bi-directional
   relationship, but the specified mappedBy association on the target-entity
   App\Entity\MessageMeta#message does not contain the required 'inversedBy: "metadata"' attribute.
```

Local run after the fix:

```
 [OK] The mapping files are correct.
 [SKIPPED] The database was not checked for synchronicity.
```