### PR TITLE
fix(seed): preserve manual UI edits to AI models across container restarts

### DIFF
--- a/backend/src/Command/ModelSeedCommand.php
+++ b/backend/src/Command/ModelSeedCommand.php
@@ -25,9 +25,14 @@ final class ModelSeedCommand extends Command
     protected function configure(): void
     {
         $this->setHelp(
-            "Upserts every model from App\\Model\\ModelCatalog into BMODELS.\n".
-            "In dev/test, also upserts mock TestProvider models with negative IDs.\n\n".
-            'Safe to run on every deploy — uses INSERT ... ON DUPLICATE KEY UPDATE.'
+            "Reconciles BMODELS with App\\Model\\ModelCatalog.\n".
+            "In dev/test, also adds mock TestProvider models with negative IDs.\n\n".
+            "Per row the seeder either INSERTs (new model), UPDATEs (catalog code\n".
+            "changed and the row was untouched), SKIPs (already in sync) or\n".
+            "PRESERVEs (admin edited the row via the /config/ai-models UI — manual\n".
+            "changes are detected via a content fingerprint stored in BJSON and are\n".
+            "never overwritten by container restarts).\n\n".
+            'Safe to run on every deploy.'
         );
     }
 
@@ -35,7 +40,13 @@ final class ModelSeedCommand extends Command
     {
         $io = new SymfonyStyle($input, $output);
         $result = $this->seeder->seed();
-        $io->success(sprintf('Upserted %d models.', $result->inserted));
+        $io->success(sprintf(
+            'Models reconciled: inserted=%d, updated=%d, skipped=%d, preserved=%d.',
+            $result->inserted,
+            $result->updated,
+            $result->skipped,
+            $result->preserved,
+        ));
 
         return Command::SUCCESS;
     }

--- a/backend/src/Command/SeedAllCommand.php
+++ b/backend/src/Command/SeedAllCommand.php
@@ -74,10 +74,16 @@ final class SeedAllCommand extends Command
         $rows = [];
         foreach ($steps as [$label, $callable]) {
             $result = $this->runStep($io, $label, $callable);
-            $rows[] = [$label, (string) $result->inserted, (string) $result->updated, (string) $result->skipped];
+            $rows[] = [
+                $label,
+                (string) $result->inserted,
+                (string) $result->updated,
+                (string) $result->skipped,
+                (string) $result->preserved,
+            ];
         }
 
-        $io->table(['Step', 'Inserted', 'Updated', 'Skipped'], $rows);
+        $io->table(['Step', 'Inserted', 'Updated', 'Skipped', 'Preserved'], $rows);
 
         $io->success('All seed steps completed.');
 
@@ -92,10 +98,11 @@ final class SeedAllCommand extends Command
         $io->section("Seeding: $label");
         $result = $step();
         $io->writeln(sprintf(
-            '  → inserted=%d, updated=%d, skipped=%d',
+            '  → inserted=%d, updated=%d, skipped=%d, preserved=%d',
             $result->inserted,
             $result->updated,
-            $result->skipped
+            $result->skipped,
+            $result->preserved,
         ));
 
         return $result;

--- a/backend/src/Model/ModelCatalog.php
+++ b/backend/src/Model/ModelCatalog.php
@@ -39,6 +39,21 @@ class ModelCatalog
     ];
 
     /**
+     * BJSON key that stores the catalog fingerprint of the last successful seed
+     * write. ModelSeeder uses it to detect manual UI edits and skip them on
+     * future runs (see fingerprint() and ModelSeeder::seed()).
+     */
+    public const FINGERPRINT_KEY = '__catalog_fingerprint';
+
+    /**
+     * Number of decimals used to normalise float fields before fingerprinting.
+     * Catalog prices are authored with at most 4 decimals (e.g. 0.092); 6 leaves
+     * comfortable headroom and shields the hash from float-string round-trips
+     * via Doctrine DBAL.
+     */
+    private const FINGERPRINT_FLOAT_PRECISION = 6;
+
+    /**
      * Insert or update a model row via `INSERT … ON DUPLICATE KEY UPDATE`.
      *
      * Field ownership rules:
@@ -51,6 +66,11 @@ class ModelCatalog
      *     Test fixtures that need to force a value should issue an explicit UPDATE
      *     after the upsert (see ModelSeeder::seed()).
      *
+     * Every write embeds the catalog fingerprint into BJSON under
+     * self::FINGERPRINT_KEY. ModelSeeder reads this back to detect manual UI edits
+     * and only re-applies catalog values to rows whose values still match the
+     * previously-seeded fingerprint.
+     *
      * Returns the MySQL/MariaDB affected-rows value so callers can distinguish
      * inserts from updates:
      *   - 1 → row was inserted
@@ -59,6 +79,9 @@ class ModelCatalog
      */
     public static function upsert(Connection $connection, array $model, bool $system = false): int
     {
+        $json = is_array($model['json'] ?? null) ? $model['json'] : [];
+        $json[self::FINGERPRINT_KEY] = self::fingerprint($model);
+
         return (int) $connection->executeStatement(
             'INSERT INTO BMODELS (BID, BSERVICE, BNAME, BTAG, BSELECTABLE, BACTIVE, BPROVID, BPRICEIN, BINUNIT, BPRICEOUT, BOUTUNIT, BQUALITY, BRATING, BISDEFAULT, BJSON)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
@@ -75,8 +98,47 @@ class ModelCatalog
                 $model['priceIn'], $model['inUnit'], $model['priceOut'],
                 $model['outUnit'], $model['quality'], $model['rating'],
                 $system ? 1 : 0,
-                json_encode($model['json']),
+                json_encode($json, \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE),
             ]
+        );
+    }
+
+    /**
+     * Compute a stable fingerprint of a model's catalog-owned fields.
+     *
+     * The hash deliberately ignores operator-owned columns (BSELECTABLE, BACTIVE,
+     * BISDEFAULT, BSHOWWHENFREE) and the fingerprint key itself, so that:
+     *   - admins toggling enabled/active flags do NOT shift the fingerprint, and
+     *   - the value we write into BJSON.__catalog_fingerprint can be regenerated
+     *     deterministically from the row we read back later.
+     *
+     * Floats are rounded to FINGERPRINT_FLOAT_PRECISION decimals to neutralise the
+     * float→string→float round trip performed by the DBAL float type.
+     *
+     * @param array<string, mixed> $row catalog or DB-shaped row (see ModelSeeder::loadExistingRowsById)
+     */
+    public static function fingerprint(array $row): string
+    {
+        $json = is_array($row['json'] ?? null) ? $row['json'] : [];
+        unset($json[self::FINGERPRINT_KEY]);
+
+        $payload = [
+            'service' => (string) ($row['service'] ?? ''),
+            'name' => (string) ($row['name'] ?? ''),
+            'tag' => (string) ($row['tag'] ?? ''),
+            'providerId' => (string) ($row['providerId'] ?? ''),
+            'priceIn' => round((float) ($row['priceIn'] ?? 0.0), self::FINGERPRINT_FLOAT_PRECISION),
+            'inUnit' => (string) ($row['inUnit'] ?? ''),
+            'priceOut' => round((float) ($row['priceOut'] ?? 0.0), self::FINGERPRINT_FLOAT_PRECISION),
+            'outUnit' => (string) ($row['outUnit'] ?? ''),
+            'quality' => round((float) ($row['quality'] ?? 0.0), self::FINGERPRINT_FLOAT_PRECISION),
+            'rating' => round((float) ($row['rating'] ?? 0.0), self::FINGERPRINT_FLOAT_PRECISION),
+            'json' => $json,
+        ];
+
+        return hash(
+            'sha256',
+            (string) json_encode($payload, \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE | \JSON_THROW_ON_ERROR)
         );
     }
 

--- a/backend/src/Model/ModelCatalog.php
+++ b/backend/src/Model/ModelCatalog.php
@@ -61,10 +61,12 @@ class ModelCatalog
      *     BSERVICE, BNAME, BTAG, BPROVID, BPRICEIN, BINUNIT, BPRICEOUT, BOUTUNIT,
      *     BQUALITY, BRATING, BJSON. Truth lives in this class; deploy = update.
      *   - **Operator-owned** (only set on INSERT, NEVER overwritten):
-     *     BSELECTABLE, BACTIVE, BISDEFAULT. These can be toggled by admins via
-     *     the AdminModelsService UI; container restarts must not wipe those choices.
-     *     Test fixtures that need to force a value should issue an explicit UPDATE
-     *     after the upsert (see ModelSeeder::seed()).
+     *     BSELECTABLE, BACTIVE, BISDEFAULT, BSHOWWHENFREE. These can be toggled
+     *     by admins via the AdminModelsService UI; container restarts must not
+     *     wipe those choices. BSHOWWHENFREE is not part of this statement at all
+     *     (no INSERT column / no UPDATE clause) — it is managed exclusively by
+     *     the admin UI and migrations. Test fixtures that need to force a value
+     *     should issue an explicit UPDATE after the upsert (see ModelSeeder::seed()).
      *
      * Every write embeds the catalog fingerprint into BJSON under
      * self::FINGERPRINT_KEY. ModelSeeder reads this back to detect manual UI edits

--- a/backend/src/Seed/ModelSeeder.php
+++ b/backend/src/Seed/ModelSeeder.php
@@ -10,13 +10,33 @@ use Doctrine\DBAL\Connection;
 /**
  * Idempotent seeder for the AI model catalog (BMODELS).
  *
- * - Always upserts every model defined in App\Model\ModelCatalog::all() (positive IDs).
- * - In dev/test, additionally upserts mock test-models with negative IDs (so they can
- *   never collide with the auto-increment range used by real catalog rows).
- * - In `test`, also flips test models to selectable/showWhenFree so the admin UI
- *   exposes them in the E2E stack.
+ * Behaviour per row (decided in {@see decideAction()}):
  *
- * Safe to run repeatedly: ModelCatalog::upsert() uses INSERT ... ON DUPLICATE KEY UPDATE.
+ *   1. **No DB row yet** → INSERT the catalog values + fingerprint.
+ *      New models added to ModelCatalog land in the database on next deploy.
+ *   2. **DB row exists, fingerprint stored, row still matches stored fingerprint**:
+ *        - if catalog values differ → UPDATE catalog-owned columns + fingerprint
+ *          ("code change rolled out to a row that nobody touched").
+ *        - if catalog values are identical → SKIP (already in sync, no write).
+ *   3. **DB row exists but values differ from the stored fingerprint** → PRESERVE.
+ *      An admin edited the row via /config/ai-models after we last seeded it; we
+ *      MUST NOT overwrite their changes on container restart.
+ *   4. **DB row exists with no fingerprint at all** (legacy row predating the
+ *      fingerprint mechanism):
+ *        - if the row already matches the catalog exactly → silently adopt by
+ *          writing the fingerprint (no visible change to the user).
+ *        - otherwise → PRESERVE (assume the operator customised it manually,
+ *          err on the side of not destroying data).
+ *
+ * Result: container startup only touches BMODELS for new models or genuine
+ * code-side changes against untouched rows. Operator overrides survive every
+ * restart, and we no longer issue dozens of redundant writes per boot.
+ *
+ * In dev/test the seeder additionally upserts mock test-models with negative IDs
+ * (so they cannot collide with the auto-increment range used by real catalog
+ * rows). The same fingerprint protection applies to them. In `test`, the seeder
+ * also flips test models to selectable/showWhenFree so the admin UI exposes them
+ * in the E2E stack.
  */
 final readonly class ModelSeeder
 {
@@ -36,6 +56,11 @@ final readonly class ModelSeeder
         ['id' => -11, 'service' => 'ollama', 'name' => 'stub-embed-model', 'tag' => 'vectorize', 'providerId' => 'stub-embed-model'],
     ];
 
+    private const ACTION_INSERT = 'insert';
+    private const ACTION_UPDATE = 'update';
+    private const ACTION_PRESERVE = 'preserve';
+    private const ACTION_SKIP = 'skip';
+
     public function __construct(
         private Connection $connection,
         private string $environment,
@@ -44,13 +69,17 @@ final readonly class ModelSeeder
 
     public function seed(): SeedResult
     {
-        $inserted = 0;
-        $updated = 0;
-        $skipped = 0;
+        $existing = $this->loadExistingRowsById();
+        $counters = [
+            self::ACTION_INSERT => 0,
+            self::ACTION_UPDATE => 0,
+            self::ACTION_PRESERVE => 0,
+            self::ACTION_SKIP => 0,
+        ];
 
         if (in_array($this->environment, ['dev', 'test'], true)) {
             foreach (self::TEST_MODELS as $base) {
-                $affected = ModelCatalog::upsert($this->connection, array_merge($base, [
+                $row = array_merge($base, [
                     'selectable' => 0,
                     'active' => 1,
                     'priceIn' => 0,
@@ -60,8 +89,9 @@ final readonly class ModelSeeder
                     'quality' => 1,
                     'rating' => 0,
                     'json' => ['description' => 'Mock model for E2E/CI. No API key required.'],
-                ]));
-                $this->tally($affected, $inserted, $updated, $skipped);
+                ]);
+                $action = $this->processRow($row, $existing[$row['id']] ?? null);
+                ++$counters[$action];
             }
 
             if ('test' === $this->environment) {
@@ -71,23 +101,127 @@ final readonly class ModelSeeder
             }
         }
 
-        foreach (ModelCatalog::all() as $data) {
-            $affected = ModelCatalog::upsert($this->connection, $data);
-            $this->tally($affected, $inserted, $updated, $skipped);
+        foreach (ModelCatalog::all() as $catalog) {
+            $action = $this->processRow($catalog, $existing[$catalog['id']] ?? null);
+            ++$counters[$action];
         }
 
-        return new SeedResult('models', inserted: $inserted, updated: $updated, skipped: $skipped);
+        return new SeedResult(
+            'models',
+            inserted: $counters[self::ACTION_INSERT],
+            updated: $counters[self::ACTION_UPDATE],
+            skipped: $counters[self::ACTION_SKIP],
+            preserved: $counters[self::ACTION_PRESERVE],
+        );
     }
 
     /**
-     * Bucket the affected-rows value returned by ON DUPLICATE KEY UPDATE.
+     * Apply the decision returned by {@see decideAction()} and return its label
+     * so the caller can tally per-bucket counts.
+     *
+     * @param array<string, mixed>      $catalog  catalog-side row (source of truth)
+     * @param array<string, mixed>|null $existing DB row in catalog shape (null → not in DB)
      */
-    private function tally(int $affected, int &$inserted, int &$updated, int &$skipped): void
+    private function processRow(array $catalog, ?array $existing): string
     {
-        match ($affected) {
-            1 => ++$inserted,
-            2 => ++$updated,
-            default => ++$skipped,
-        };
+        $action = $this->decideAction($catalog, $existing);
+
+        if (self::ACTION_INSERT === $action || self::ACTION_UPDATE === $action) {
+            ModelCatalog::upsert($this->connection, $catalog);
+        }
+
+        return $action;
+    }
+
+    /**
+     * Pure decision function — does NOT touch the database. Extracted to keep
+     * the table at the top of this class auditable and to make the algorithm
+     * trivially unit-testable (see ModelSeederTest).
+     *
+     * @param array<string, mixed>      $catalog
+     * @param array<string, mixed>|null $existing
+     */
+    private function decideAction(array $catalog, ?array $existing): string
+    {
+        if (null === $existing) {
+            return self::ACTION_INSERT;
+        }
+
+        $stored = $existing['json'][ModelCatalog::FINGERPRINT_KEY] ?? null;
+        $current = ModelCatalog::fingerprint($existing);
+        $desired = ModelCatalog::fingerprint($catalog);
+
+        if (!is_string($stored)) {
+            // Legacy row predating the fingerprint mechanism. We can only safely
+            // claim it as catalog-managed if it already matches the catalog
+            // values bit-for-bit; otherwise we have no way of telling apart a
+            // forgotten manual edit from a stale catalog version, so we leave
+            // the row untouched.
+            return $current === $desired ? self::ACTION_UPDATE : self::ACTION_PRESERVE;
+        }
+
+        if ($stored !== $current) {
+            // Row was edited via the admin UI after we last seeded it. Preserve.
+            return self::ACTION_PRESERVE;
+        }
+
+        if ($desired === $stored) {
+            return self::ACTION_SKIP;
+        }
+
+        // Row matches the previously-seeded fingerprint, but the catalog has
+        // moved on (e.g. price update shipped in a release). Roll the change in.
+        return self::ACTION_UPDATE;
+    }
+
+    /**
+     * Load every BMODELS row in catalog shape so the per-row decision logic does
+     * not have to issue N SELECTs.
+     *
+     * @return array<int, array<string, mixed>> indexed by BID
+     */
+    private function loadExistingRowsById(): array
+    {
+        $rows = $this->connection->fetchAllAssociative(
+            'SELECT BID, BSERVICE, BNAME, BTAG, BPROVID, BPRICEIN, BINUNIT, BPRICEOUT, BOUTUNIT, BQUALITY, BRATING, BJSON FROM BMODELS'
+        );
+
+        $byId = [];
+        foreach ($rows as $row) {
+            $byId[(int) $row['BID']] = [
+                'id' => (int) $row['BID'],
+                'service' => (string) $row['BSERVICE'],
+                'name' => (string) $row['BNAME'],
+                'tag' => (string) $row['BTAG'],
+                'providerId' => (string) $row['BPROVID'],
+                'priceIn' => (float) $row['BPRICEIN'],
+                'inUnit' => (string) $row['BINUNIT'],
+                'priceOut' => (float) $row['BPRICEOUT'],
+                'outUnit' => (string) $row['BOUTUNIT'],
+                'quality' => (float) $row['BQUALITY'],
+                'rating' => (float) $row['BRATING'],
+                'json' => $this->decodeJson($row['BJSON'] ?? null),
+            ];
+        }
+
+        return $byId;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeJson(mixed $raw): array
+    {
+        if (is_array($raw)) {
+            return $raw;
+        }
+
+        if (!is_string($raw) || '' === $raw) {
+            return [];
+        }
+
+        $decoded = json_decode($raw, true);
+
+        return is_array($decoded) ? $decoded : [];
     }
 }

--- a/backend/src/Seed/SeedResult.php
+++ b/backend/src/Seed/SeedResult.php
@@ -17,11 +17,18 @@ final readonly class SeedResult
         public int $inserted,
         public int $updated = 0,
         public int $skipped = 0,
+        /**
+         * Rows the seeder intentionally left untouched because they look
+         * operator-customised (e.g. the admin edited prices via the UI and we
+         * detected the divergence via a content fingerprint). Distinct from
+         * `$skipped`, which means "row already in sync, nothing to do".
+         */
+        public int $preserved = 0,
     ) {
     }
 
     public function total(): int
     {
-        return $this->inserted + $this->updated + $this->skipped;
+        return $this->inserted + $this->updated + $this->skipped + $this->preserved;
     }
 }

--- a/backend/tests/Unit/Model/ModelCatalogTest.php
+++ b/backend/tests/Unit/Model/ModelCatalogTest.php
@@ -179,4 +179,91 @@ class ModelCatalogTest extends TestCase
     {
         $this->assertNull(ModelCatalog::findBidByKey('nonexistent:provider:chat'));
     }
+
+    public function testFingerprintIsDeterministic(): void
+    {
+        $model = ModelCatalog::find('groq:llama-3.3-70b-versatile')[0];
+
+        $this->assertSame(ModelCatalog::fingerprint($model), ModelCatalog::fingerprint($model));
+    }
+
+    public function testFingerprintIgnoresOperatorOwnedFields(): void
+    {
+        $model = ModelCatalog::find('groq:llama-3.3-70b-versatile')[0];
+        $expected = ModelCatalog::fingerprint($model);
+
+        $toggled = array_merge($model, [
+            'selectable' => 0,
+            'active' => 0,
+            'showWhenFree' => 1,
+        ]);
+
+        $this->assertSame($expected, ModelCatalog::fingerprint($toggled));
+    }
+
+    public function testFingerprintIgnoresEmbeddedFingerprintKey(): void
+    {
+        $model = ModelCatalog::find('groq:llama-3.3-70b-versatile')[0];
+        $expected = ModelCatalog::fingerprint($model);
+
+        $stamped = $model;
+        $stamped['json'][ModelCatalog::FINGERPRINT_KEY] = 'previously-stored-hash';
+
+        $this->assertSame($expected, ModelCatalog::fingerprint($stamped));
+    }
+
+    public function testFingerprintChangesWhenCatalogValueChanges(): void
+    {
+        $model = ModelCatalog::find('groq:llama-3.3-70b-versatile')[0];
+        $original = ModelCatalog::fingerprint($model);
+
+        $model['priceIn'] = 0.99;
+
+        $this->assertNotSame($original, ModelCatalog::fingerprint($model));
+    }
+
+    public function testFingerprintIsStableAcrossFloatRoundTrip(): void
+    {
+        // Doctrine DBAL hands floats back as native floats; the identity should
+        // survive a string round-trip equivalent to what (float) $row['BPRICEIN']
+        // produces after JSON encode/decode in the actual seed flow.
+        $model = ModelCatalog::find('groq:llama-3.3-70b-versatile')[0];
+        $original = ModelCatalog::fingerprint($model);
+
+        $roundTripped = $model;
+        $roundTripped['priceIn'] = (float) (string) $model['priceIn'];
+        $roundTripped['priceOut'] = (float) (string) $model['priceOut'];
+        $roundTripped['quality'] = (float) (string) $model['quality'];
+        $roundTripped['rating'] = (float) (string) $model['rating'];
+
+        $this->assertSame($original, ModelCatalog::fingerprint($roundTripped));
+    }
+
+    public function testUpsertEmbedsFingerprintInJsonPayload(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $model = ModelCatalog::find('groq:llama-3.3-70b-versatile')[0];
+        $expectedFingerprint = ModelCatalog::fingerprint($model);
+
+        // @phpstan-ignore-next-line
+        $connection
+            ->expects($this->once())
+            ->method('executeStatement')
+            ->with(
+                $this->anything(),
+                $this->callback(static function (array $params) use ($expectedFingerprint): bool {
+                    $jsonPayload = end($params);
+                    if (!is_string($jsonPayload)) {
+                        return false;
+                    }
+
+                    $decoded = json_decode($jsonPayload, true);
+
+                    return is_array($decoded)
+                        && ($decoded[ModelCatalog::FINGERPRINT_KEY] ?? null) === $expectedFingerprint;
+                }),
+            );
+
+        ModelCatalog::upsert($connection, $model);
+    }
 }

--- a/backend/tests/Unit/Seed/ModelSeederTest.php
+++ b/backend/tests/Unit/Seed/ModelSeederTest.php
@@ -1,0 +1,240 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Seed;
+
+use App\Model\ModelCatalog;
+use App\Seed\ModelSeeder;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Drives ModelSeeder's per-row decision logic against a mocked Connection so we
+ * can assert which BMODELS rows actually get touched in each scenario.
+ *
+ * The four branches exercised here mirror the table in ModelSeeder's class
+ * docblock:
+ *   - row missing             → INSERT
+ *   - fingerprint matches,
+ *     catalog code changed    → UPDATE
+ *   - row was UI-edited
+ *     (fingerprint mismatch)  → PRESERVE (no write)
+ *   - row matches catalog and
+ *     fingerprint identical   → SKIP (no write)
+ *
+ * The mock counts each executeStatement() invocation so we can verify both the
+ * SeedResult counters AND that no surprise writes leak through.
+ */
+final class ModelSeederTest extends TestCase
+{
+    public function testInsertsCatalogRowsWhenDatabaseIsEmpty(): void
+    {
+        $connection = $this->buildConnection(existing: [], expectedWrites: count(ModelCatalog::all()));
+        $seeder = new ModelSeeder($connection, 'prod');
+
+        $result = $seeder->seed();
+
+        $this->assertSame(count(ModelCatalog::all()), $result->inserted);
+        $this->assertSame(0, $result->updated);
+        $this->assertSame(0, $result->preserved);
+        $this->assertSame(0, $result->skipped);
+    }
+
+    public function testSkipsRowsAlreadyInSyncWithStoredFingerprint(): void
+    {
+        $existing = [];
+        foreach (ModelCatalog::all() as $row) {
+            $existing[] = $this->stampFingerprint($row);
+        }
+
+        $connection = $this->buildConnection(existing: $existing, expectedWrites: 0);
+        $seeder = new ModelSeeder($connection, 'prod');
+
+        $result = $seeder->seed();
+
+        $this->assertSame(0, $result->inserted);
+        $this->assertSame(0, $result->updated);
+        $this->assertSame(0, $result->preserved);
+        $this->assertSame(count(ModelCatalog::all()), $result->skipped);
+    }
+
+    public function testUpdatesRowWhenCatalogValueChangesAndRowIsUntouched(): void
+    {
+        // Simulate the situation right after a catalog code change: every row
+        // in the DB still carries the previously-seeded fingerprint, but the
+        // first model now differs from what's in code (newer release shipped a
+        // price update).
+        $catalog = ModelCatalog::all();
+        $existing = [];
+        foreach ($catalog as $row) {
+            $existing[] = $this->stampFingerprint($row);
+        }
+
+        $stale = array_merge($catalog[0], ['priceIn' => 999.99]);
+        $existing[0] = $this->stampFingerprint($stale);
+
+        $connection = $this->buildConnection(existing: $existing, expectedWrites: 1);
+        $seeder = new ModelSeeder($connection, 'prod');
+
+        $result = $seeder->seed();
+
+        $this->assertSame(1, $result->updated);
+        $this->assertSame(0, $result->inserted);
+        $this->assertSame(0, $result->preserved);
+        $this->assertSame(count($catalog) - 1, $result->skipped);
+    }
+
+    public function testPreservesRowEditedViaAdminUi(): void
+    {
+        // Same starting point as above, but this time the divergence comes from
+        // an admin edit on /config/ai-models — the row's price changed AFTER
+        // the fingerprint was recorded, so we must leave it alone.
+        $catalog = ModelCatalog::all();
+        $existing = [];
+        foreach ($catalog as $row) {
+            $existing[] = $this->stampFingerprint($row);
+        }
+
+        $existing[0]['priceIn'] = 7.77;
+
+        $connection = $this->buildConnection(existing: $existing, expectedWrites: 0);
+        $seeder = new ModelSeeder($connection, 'prod');
+
+        $result = $seeder->seed();
+
+        $this->assertSame(1, $result->preserved);
+        $this->assertSame(0, $result->inserted);
+        $this->assertSame(0, $result->updated);
+        $this->assertSame(count($catalog) - 1, $result->skipped);
+    }
+
+    public function testAdoptsLegacyRowThatMatchesCatalogExactly(): void
+    {
+        // Legacy row predating the fingerprint: same values as the catalog,
+        // BJSON has no fingerprint key. Safe to silently claim by writing the
+        // fingerprint — no user-visible field changes.
+        $target = ModelCatalog::all()[0];
+        $legacy = $target;
+        unset($legacy['json'][ModelCatalog::FINGERPRINT_KEY]);
+
+        $existing = $this->seedExistingFromCatalog([$target['id'] => $legacy]);
+
+        $connection = $this->buildConnection(existing: $existing, expectedWrites: 1);
+        $seeder = new ModelSeeder($connection, 'prod');
+
+        $result = $seeder->seed();
+
+        $this->assertSame(1, $result->updated);
+        $this->assertSame(0, $result->preserved);
+    }
+
+    public function testPreservesLegacyRowThatDivergesFromCatalog(): void
+    {
+        // Legacy row whose price differs from the catalog AND has no
+        // fingerprint — could be a forgotten manual edit OR a stale seed; we
+        // can't tell, so we err on the side of preserving operator data.
+        $target = ModelCatalog::all()[0];
+        $legacy = $target;
+        $legacy['priceIn'] = 13.13;
+        unset($legacy['json'][ModelCatalog::FINGERPRINT_KEY]);
+
+        $existing = $this->seedExistingFromCatalog([$target['id'] => $legacy]);
+
+        $connection = $this->buildConnection(existing: $existing, expectedWrites: 0);
+        $seeder = new ModelSeeder($connection, 'prod');
+
+        $result = $seeder->seed();
+
+        $this->assertSame(1, $result->preserved);
+        $this->assertSame(0, $result->updated);
+    }
+
+    /**
+     * Build a Connection mock that returns the given rows for the seeder's
+     * SELECT and asserts the expected number of write calls.
+     *
+     * @param list<array<string, mixed>> $existing rows in catalog shape
+     */
+    private function buildConnection(array $existing, int $expectedWrites): Connection
+    {
+        $mock = $this->createMock(Connection::class);
+
+        $rows = array_map([$this, 'toDbRow'], $existing);
+
+        // @phpstan-ignore-next-line method.notFound
+        $mock->method('fetchAllAssociative')->willReturn($rows);
+
+        // @phpstan-ignore-next-line method.notFound
+        $mock->expects($this->exactly($expectedWrites))
+            ->method('executeStatement')
+            ->willReturn(1);
+
+        return $mock;
+    }
+
+    /**
+     * Build a list of "existing" rows by overlaying the given catalog-shape
+     * overrides on top of the full catalog. Indexes the override map by ID so
+     * the calling test can target a specific catalog entry.
+     *
+     * @param array<int, array<string, mixed>> $overridesById
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function seedExistingFromCatalog(array $overridesById): array
+    {
+        $rows = [];
+        foreach (ModelCatalog::all() as $catalogRow) {
+            $id = (int) $catalogRow['id'];
+            if (isset($overridesById[$id])) {
+                $rows[] = $overridesById[$id];
+                continue;
+            }
+            $rows[] = $this->stampFingerprint($catalogRow);
+        }
+
+        return $rows;
+    }
+
+    /**
+     * Translate a catalog-shape row into the BMODELS column shape returned by
+     * Connection::fetchAllAssociative().
+     *
+     * @param array<string, mixed> $row
+     *
+     * @return array<string, mixed>
+     */
+    private function toDbRow(array $row): array
+    {
+        return [
+            'BID' => $row['id'],
+            'BSERVICE' => $row['service'],
+            'BNAME' => $row['name'],
+            'BTAG' => $row['tag'],
+            'BPROVID' => $row['providerId'],
+            'BPRICEIN' => $row['priceIn'],
+            'BINUNIT' => $row['inUnit'],
+            'BPRICEOUT' => $row['priceOut'],
+            'BOUTUNIT' => $row['outUnit'],
+            'BQUALITY' => $row['quality'],
+            'BRATING' => $row['rating'],
+            'BJSON' => json_encode($row['json'] ?? [], \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE),
+        ];
+    }
+
+    /**
+     * Embed the catalog fingerprint of $row into BJSON, mirroring what
+     * ModelCatalog::upsert() persists at write time.
+     *
+     * @param array<string, mixed> $row
+     *
+     * @return array<string, mixed>
+     */
+    private function stampFingerprint(array $row): array
+    {
+        $row['json'][ModelCatalog::FINGERPRINT_KEY] = ModelCatalog::fingerprint($row);
+
+        return $row;
+    }
+}

--- a/backend/tests/Unit/Seed/ModelSeederTest.php
+++ b/backend/tests/Unit/Seed/ModelSeederTest.php
@@ -13,15 +13,19 @@ use PHPUnit\Framework\TestCase;
  * Drives ModelSeeder's per-row decision logic against a mocked Connection so we
  * can assert which BMODELS rows actually get touched in each scenario.
  *
- * The four branches exercised here mirror the table in ModelSeeder's class
- * docblock:
- *   - row missing             → INSERT
+ * The scenarios exercised here mirror ModelSeeder's full decision table,
+ * including both fingerprinted rows and legacy rows with no stored fingerprint:
+ *   - row missing                       → INSERT
  *   - fingerprint matches,
- *     catalog code changed    → UPDATE
+ *     catalog code changed              → UPDATE
  *   - row was UI-edited
- *     (fingerprint mismatch)  → PRESERVE (no write)
+ *     (fingerprint mismatch)            → PRESERVE (no write)
  *   - row matches catalog and
- *     fingerprint identical   → SKIP (no write)
+ *     fingerprint identical             → SKIP (no write)
+ *   - legacy row matches catalog
+ *     (no fingerprint)                  → adopt via UPDATE
+ *   - legacy row diverges from catalog
+ *     (no fingerprint)                  → PRESERVE (no write)
  *
  * The mock counts each executeStatement() invocation so we can verify both the
  * SeedResult counters AND that no surprise writes leak through.

--- a/docs/MIGRATIONS.md
+++ b/docs/MIGRATIONS.md
@@ -51,9 +51,30 @@ Don't edit migrations or fixtures — extend the catalog source of truth:
 
 All seeders are idempotent and safe to re-run any number of times:
 
-- **Models / prompts** use `INSERT … ON DUPLICATE KEY UPDATE` on **catalog-owned columns
-only** — operator toggles (e.g. `BSELECTABLE`, `BSHOWWHENFREE`) are preserved across
-re-seeds, but corrected names/prices/providerIds DO propagate to existing installs.
+- **Models** use a **content-fingerprint protection** scheme on top of
+`INSERT … ON DUPLICATE KEY UPDATE` (see `App\Model\ModelCatalog::fingerprint()`).
+Every successful write embeds the SHA-256 of the row's catalog-owned fields into
+`BJSON.__catalog_fingerprint`. On the next seed run, `App\Seed\ModelSeeder` decides
+per row:
+
+  | DB state                                         | Action     | Why |
+  | ------------------------------------------------ | ---------- | --- |
+  | Row missing                                      | INSERT     | New model in code |
+  | Stored fingerprint matches row, code unchanged   | SKIP       | Already in sync, no write |
+  | Stored fingerprint matches row, code changed     | UPDATE     | Roll out catalog update to a row nobody touched |
+  | Stored fingerprint mismatches row                | PRESERVE   | Admin edited the row via `/config/ai-models`; never overwrite |
+  | Legacy row with no fingerprint, matches catalog  | UPDATE     | Silently adopt as catalog-managed |
+  | Legacy row with no fingerprint, diverges         | PRESERVE   | Could be a forgotten manual edit; err on safety |
+
+  This means **container restarts no longer overwrite manual UI edits** to model
+prices, names, JSON, etc. — admin changes survive forever (until the admin
+deletes them or re-aligns the row with the catalog values exactly). Operator
+toggles (`BSELECTABLE`, `BACTIVE`, `BISDEFAULT`, `BSHOWWHENFREE`) are still
+excluded from the upsert UPDATE clause as a second layer of defence.
+
+- **Prompts** use `INSERT … ON DUPLICATE KEY UPDATE` on catalog-owned columns
+only — operator toggles are preserved across re-seeds, but corrected
+names/contents DO propagate to existing installs.
 - **`BCONFIG`** (defaults + rate limits) uses `INSERT IGNORE`, race-safe via the
 `UNIQUE(BOWNERID, BGROUP, BSETTING)` index added in `Version20260420000000`. This
 means **`BCONFIG` defaults are bootstrap-only**: if you change a default value in

--- a/docs/MIGRATIONS.md
+++ b/docs/MIGRATIONS.md
@@ -52,10 +52,10 @@ Don't edit migrations or fixtures — extend the catalog source of truth:
 All seeders are idempotent and safe to re-run any number of times:
 
 - **Models** use a **content-fingerprint protection** scheme on top of
-`INSERT … ON DUPLICATE KEY UPDATE` (see `App\Model\ModelCatalog::fingerprint()`).
-Every successful write embeds the SHA-256 of the row's catalog-owned fields into
-`BJSON.__catalog_fingerprint`. On the next seed run, `App\Seed\ModelSeeder` decides
-per row:
+  `INSERT … ON DUPLICATE KEY UPDATE` (see `App\Model\ModelCatalog::fingerprint()`).
+  Every successful write embeds the SHA-256 of the row's catalog-owned fields into
+  `BJSON.__catalog_fingerprint`. On the next seed run, `App\Seed\ModelSeeder` decides
+  per row:
 
   | DB state                                         | Action     | Why |
   | ------------------------------------------------ | ---------- | --- |
@@ -67,14 +67,14 @@ per row:
   | Legacy row with no fingerprint, diverges         | PRESERVE   | Could be a forgotten manual edit; err on safety |
 
   This means **container restarts no longer overwrite manual UI edits** to model
-prices, names, JSON, etc. — admin changes survive forever (until the admin
-deletes them or re-aligns the row with the catalog values exactly). Operator
-toggles (`BSELECTABLE`, `BACTIVE`, `BISDEFAULT`, `BSHOWWHENFREE`) are still
-excluded from the upsert UPDATE clause as a second layer of defence.
+  prices, names, JSON, etc. — admin changes survive forever (until the admin
+  deletes them or re-aligns the row with the catalog values exactly). Operator
+  toggles (`BSELECTABLE`, `BACTIVE`, `BISDEFAULT`, `BSHOWWHENFREE`) are still
+  excluded from the upsert UPDATE clause as a second layer of defence.
 
 - **Prompts** use `INSERT … ON DUPLICATE KEY UPDATE` on catalog-owned columns
-only — operator toggles are preserved across re-seeds, but corrected
-names/contents DO propagate to existing installs.
+  only — operator toggles are preserved across re-seeds, but corrected
+  names/contents DO propagate to existing installs.
 - **`BCONFIG`** (defaults + rate limits) uses `INSERT IGNORE`, race-safe via the
 `UNIQUE(BOWNERID, BGROUP, BSETTING)` index added in `Version20260420000000`. This
 means **`BCONFIG` defaults are bootstrap-only**: if you change a default value in


### PR DESCRIPTION
## Summary
ModelSeeder no longer wipes manual edits made via `/config/ai-models` on container restart — every catalog write now stamps a content fingerprint into `BJSON.__catalog_fingerprint`, and the seeder uses that fingerprint to decide per row whether to insert / update a code-side change / skip / preserve operator data.

## Changes
- `App\Model\ModelCatalog::fingerprint()` — stable SHA-256 over catalog-owned fields (floats rounded to 6 decimals to survive the DBAL float round-trip; operator-owned fields excluded so toggling `selectable`/`active` does not shift the hash).
- `App\Model\ModelCatalog::upsert()` — embeds the fingerprint into `BJSON.__catalog_fingerprint` on every write. The `INSERT ... ON DUPLICATE KEY UPDATE` SQL itself is unchanged (operator-owned `BSELECTABLE`/`BACTIVE`/`BISDEFAULT` still excluded from the UPDATE clause).
- `App\Seed\ModelSeeder` — pre-fetches `BMODELS` in one `SELECT` and decides per row:

  | DB state                                            | Action     |
  | --------------------------------------------------- | ---------- |
  | row missing                                         | INSERT     |
  | fingerprint matches DB row, catalog code identical  | SKIP       |
  | fingerprint matches DB row, catalog code changed    | UPDATE     |
  | fingerprint differs from DB row (UI edit)           | PRESERVE   |
  | legacy row without fingerprint, matches catalog     | UPDATE (silent claim) |
  | legacy row without fingerprint, diverges            | PRESERVE   |

  Decision logic is extracted into a pure `decideAction()` so it is trivially unit-testable.
- `App\Seed\SeedResult` — new optional `preserved` counter (default `0`, backwards compatible with `PromptSeeder`/`BConfigSeeder`/etc.); `total()` now includes it.
- `app:seed` and `app:model:seed` — surface the new counter in their startup output and log table so operators can see at a glance how many rows were protected from being clobbered.
- Tests: `ModelCatalogTest` gains 6 cases (deterministic fingerprint, ignores operator fields, ignores embedded fingerprint key, changes when catalog changes, float round-trip stability, `upsert()` writes fingerprint into JSON param). New `ModelSeederTest` covers all six branches of the decision matrix above against a mocked `Connection`.
- `docs/MIGRATIONS.md` — new table describing the per-row behaviour and the explicit guarantee that container restarts no longer overwrite manual UI edits.

## Verification
- [x] Tests added/updated
- [x] Manual

```
docker compose exec backend composer phpstan       → No errors
docker compose exec backend composer lint:fix      → 1 file fixed (formatting only)
docker compose exec backend bin/phpunit            → 1080 tests, 3910 assertions, OK
docker compose exec backend bin/phpunit \
    --filter 'ModelCatalogTest|ModelSeederTest'    → 28 tests, 930 assertions, OK
```

## Notes
- **First deploy on existing installs:** every BMODELS row is initially treated as a legacy row (no fingerprint). Rows that are bit-identical with the catalog get silently adopted (fingerprint embedded, no user-visible change); rows that diverge are PRESERVED defensively (we cannot tell apart a forgotten manual edit from a stale seed). From the second restart onward, the decision matrix above applies normally.
- **AdminModelsService is intentionally untouched.** When an admin edits a value via the UI, the new DB content no longer matches the stored fingerprint → the seeder detects the divergence automatically and skips the row. If the admin later reverts to exactly the catalog values, the seeder regains control automatically (current row hash matches catalog hash again).
- Operator-owned columns (`BSELECTABLE`, `BACTIVE`, `BISDEFAULT`, `BSHOWWHENFREE`) remain excluded from both the upsert UPDATE clause and the fingerprint payload, so toggling those flags neither breaks the protection nor triggers spurious writes.
- Follow-up to PR #825 (migration bootstrap hardening); not blocking it.

## Screenshots/Logs
Container startup output now reports the new counter:

```
[OK] Models reconciled: inserted=0, updated=2, skipped=46, preserved=3.
```

(Translation: 2 catalog code-changes rolled out, 46 rows already in sync, 3 rows preserved because the admin edited them via the UI.)