### PR TITLE
chore: replace deprecated Symfony APIs ahead of Symfony 8 upgrade

### DIFF
--- a/backend/phpstan.neon
+++ b/backend/phpstan.neon
@@ -16,7 +16,13 @@ parameters:
             identifiers:
                 - if.alwaysFalse
                 - varTag.misplaced
+                - unset.possiblyHookedProperty
             path: lib/grpc/*
+        -
+            identifiers:
+                - method.alreadyNarrowedType
+            path: tests/*
+            reportUnmatched: false
         -
             identifiers:
                 - property.unresolvableNativeType

--- a/backend/src/AI/Service/ProviderRegistry.php
+++ b/backend/src/AI/Service/ProviderRegistry.php
@@ -14,7 +14,7 @@ use App\AI\Interface\VisionProviderInterface;
 use App\Repository\ModelRepository;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\DependencyInjection\Attribute\TaggedIterator;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 
 /**
  * Provider Registry with DB-driven Capabilities.
@@ -28,21 +28,21 @@ class ProviderRegistry
     private ?array $dbCapabilities = null;
 
     public function __construct(
-        #[TaggedIterator('app.ai.chat')]
+        #[AutowireIterator('app.ai.chat')]
         iterable $chatProviders = [],
-        #[TaggedIterator('app.ai.embedding')]
+        #[AutowireIterator('app.ai.embedding')]
         iterable $embeddingProviders = [],
-        #[TaggedIterator('app.ai.vision')]
+        #[AutowireIterator('app.ai.vision')]
         iterable $visionProviders = [],
-        #[TaggedIterator('app.ai.image_generation')]
+        #[AutowireIterator('app.ai.image_generation')]
         iterable $imageGenerationProviders = [],
-        #[TaggedIterator('app.ai.video_generation')]
+        #[AutowireIterator('app.ai.video_generation')]
         iterable $videoGenerationProviders = [],
-        #[TaggedIterator('app.ai.speech_to_text')]
+        #[AutowireIterator('app.ai.speech_to_text')]
         iterable $speechToTextProviders = [],
-        #[TaggedIterator('app.ai.text_to_speech')]
+        #[AutowireIterator('app.ai.text_to_speech')]
         iterable $textToSpeechProviders = [],
-        #[TaggedIterator('app.ai.file_analysis')]
+        #[AutowireIterator('app.ai.file_analysis')]
         iterable $fileAnalysisProviders = [],
         private ModelRepository $modelRepository,
         private LoggerInterface $logger,

--- a/backend/src/Controller/AdminController.php
+++ b/backend/src/Controller/AdminController.php
@@ -16,7 +16,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\CurrentUser;
 
 #[Route('/api/v1/admin')]

--- a/backend/src/Controller/AuthProvidersController.php
+++ b/backend/src/Controller/AuthProvidersController.php
@@ -5,7 +5,7 @@ namespace App\Controller;
 use OpenApi\Attributes as OA;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 #[Route('/api/v1/auth')]
 class AuthProvidersController extends AbstractController

--- a/backend/src/Controller/FeedbackController.php
+++ b/backend/src/Controller/FeedbackController.php
@@ -13,7 +13,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\CurrentUser;
 
 #[Route('/api/v1/feedback')]

--- a/backend/src/Controller/GitHubAuthController.php
+++ b/backend/src/Controller/GitHubAuthController.php
@@ -13,7 +13,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 #[Route('/api/v1/auth/github')]

--- a/backend/src/Controller/GoogleAuthController.php
+++ b/backend/src/Controller/GoogleAuthController.php
@@ -13,7 +13,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 #[Route('/api/v1/auth/google')]

--- a/backend/src/Controller/KeycloakAuthController.php
+++ b/backend/src/Controller/KeycloakAuthController.php
@@ -12,7 +12,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**

--- a/backend/src/Controller/LegacyApiController.php
+++ b/backend/src/Controller/LegacyApiController.php
@@ -89,9 +89,9 @@ class LegacyApiController extends AbstractController
     {
         try {
             // Legacy Parameters
-            $userId = $request->get('user_id') ?? $request->getSession()->get('USERPROFILE')['BID'] ?? 1;
-            $messageText = $request->get('message') ?? $request->get('text') ?? '';
-            $widgetId = $request->get('widget_id') ?? $request->getSession()->get('widget_id');
+            $userId = $request->query->get('user_id') ?? $request->request->get('user_id') ?? $request->getSession()->get('USERPROFILE')['BID'] ?? 1;
+            $messageText = $request->query->get('message') ?? $request->request->get('message') ?? $request->query->get('text') ?? $request->request->get('text') ?? '';
+            $widgetId = $request->query->get('widget_id') ?? $request->request->get('widget_id') ?? $request->getSession()->get('widget_id');
 
             if (empty($messageText)) {
                 return $this->error('Message text cannot be empty', 400);
@@ -144,8 +144,8 @@ class LegacyApiController extends AbstractController
      */
     private function messageGet(Request $request): JsonResponse
     {
-        $messageId = $request->get('message_id') ?? $request->get('id');
-        $trackingId = $request->get('tracking_id');
+        $messageId = $request->query->get('message_id') ?? $request->request->get('message_id') ?? $request->query->get('id') ?? $request->request->get('id');
+        $trackingId = $request->query->get('tracking_id') ?? $request->request->get('tracking_id');
 
         try {
             if ($trackingId) {
@@ -186,7 +186,7 @@ class LegacyApiController extends AbstractController
      */
     private function againOptions(Request $request): JsonResponse
     {
-        $messageId = $request->get('in_id') ?? $request->get('message_id');
+        $messageId = $request->query->get('in_id') ?? $request->request->get('in_id') ?? $request->query->get('message_id') ?? $request->request->get('message_id');
 
         try {
             $message = $this->messageRepository->find($messageId);
@@ -215,7 +215,7 @@ class LegacyApiController extends AbstractController
      */
     private function getProfile(Request $request): JsonResponse
     {
-        $userId = $request->get('user_id') ?? $request->getSession()->get('USERPROFILE')['BID'] ?? null;
+        $userId = $request->query->get('user_id') ?? $request->request->get('user_id') ?? $request->getSession()->get('USERPROFILE')['BID'] ?? null;
 
         if (!$userId) {
             return $this->error('User not authenticated', 401);
@@ -249,7 +249,7 @@ class LegacyApiController extends AbstractController
      */
     private function chatStream(Request $request): Response
     {
-        $messageId = $request->get('message_id');
+        $messageId = $request->query->get('message_id') ?? $request->request->get('message_id');
 
         // Redirect to new streaming endpoint
         return $this->redirectToRoute('api_messages_stream', [
@@ -515,7 +515,7 @@ class LegacyApiController extends AbstractController
         }
 
         // Check request parameter
-        $userId = $request->get('user_id');
+        $userId = $request->query->get('user_id') ?? $request->request->get('user_id');
         if ($userId) {
             return (int) $userId;
         }

--- a/backend/src/Controller/OidcController.php
+++ b/backend/src/Controller/OidcController.php
@@ -7,7 +7,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 /**
  * OIDC Discovery Controller.

--- a/backend/src/Controller/TestMessageController.php
+++ b/backend/src/Controller/TestMessageController.php
@@ -6,7 +6,7 @@ use App\AI\Service\AiFacade;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 /**
  * Test Controller für Message Flow Testing mit TestProvider.

--- a/backend/src/Controller/UserMemoryController.php
+++ b/backend/src/Controller/UserMemoryController.php
@@ -16,7 +16,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\CurrentUser;
 
 #[Route('/api/v1/user/memories')]

--- a/backend/src/Service/Message/InferenceRouter.php
+++ b/backend/src/Service/Message/InferenceRouter.php
@@ -7,7 +7,7 @@ use App\Service\Message\Handler\ChatHandler;
 use App\Service\Message\Handler\CodeGenerationHandler;
 use App\Service\Message\Handler\MediaGenerationHandler;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\DependencyInjection\Attribute\TaggedIterator;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 
 /**
  * Router for Message Processing based on Intent/BTAG.
@@ -24,7 +24,7 @@ final class InferenceRouter
     private array $handlers = [];
 
     public function __construct(
-        #[TaggedIterator('app.message.handler')]
+        #[AutowireIterator('app.message.handler')]
         iterable $handlers,
         private LoggerInterface $logger,
     ) {

--- a/backend/tests/Command/InstallPluginForVerifiedUsersCommandTest.php
+++ b/backend/tests/Command/InstallPluginForVerifiedUsersCommandTest.php
@@ -36,7 +36,7 @@ final class InstallPluginForVerifiedUsersCommandTest extends TestCase
         );
 
         $application = new Application();
-        $application->add($command);
+        $application->addCommand($command);
 
         $this->commandTester = new CommandTester($application->find('app:plugin:install-verified-users'));
     }

--- a/backend/tests/Command/ModelDisableCommandTest.php
+++ b/backend/tests/Command/ModelDisableCommandTest.php
@@ -22,7 +22,7 @@ class ModelDisableCommandTest extends TestCase
         $command = new ModelDisableCommand($this->connection);
 
         $application = new Application();
-        $application->add($command);
+        $application->addCommand($command);
 
         $this->commandTester = new CommandTester($application->find('app:model:disable'));
     }

--- a/backend/tests/Command/ModelEnableCommandTest.php
+++ b/backend/tests/Command/ModelEnableCommandTest.php
@@ -22,7 +22,7 @@ class ModelEnableCommandTest extends TestCase
         $command = new ModelEnableCommand($this->connection);
 
         $application = new Application();
-        $application->add($command);
+        $application->addCommand($command);
 
         $this->commandTester = new CommandTester($application->find('app:model:enable'));
     }

--- a/backend/tests/Command/ModelListCommandTest.php
+++ b/backend/tests/Command/ModelListCommandTest.php
@@ -22,7 +22,7 @@ class ModelListCommandTest extends TestCase
         $command = new ModelListCommand($this->connection);
 
         $application = new Application();
-        $application->add($command);
+        $application->addCommand($command);
 
         $this->commandTester = new CommandTester($application->find('app:model:list'));
     }

--- a/backend/tests/Command/ModelSetDefaultCommandTest.php
+++ b/backend/tests/Command/ModelSetDefaultCommandTest.php
@@ -22,7 +22,7 @@ class ModelSetDefaultCommandTest extends TestCase
         $command = new ModelSetDefaultCommand($this->connection);
 
         $application = new Application();
-        $application->add($command);
+        $application->addCommand($command);
 
         $this->commandTester = new CommandTester($application->find('app:model:set-default'));
     }

--- a/backend/tests/Command/ProcessMailHandlersCommandTest.php
+++ b/backend/tests/Command/ProcessMailHandlersCommandTest.php
@@ -42,7 +42,7 @@ class ProcessMailHandlersCommandTest extends TestCase
         );
 
         $application = new Application();
-        $application->add($command);
+        $application->addCommand($command);
 
         $this->commandTester = new CommandTester($application->find('app:process-mail-handlers'));
     }

--- a/backend/tests/Command/PromptSeedCommandTest.php
+++ b/backend/tests/Command/PromptSeedCommandTest.php
@@ -23,7 +23,7 @@ class PromptSeedCommandTest extends TestCase
         $command = new PromptSeedCommand($this->connection);
 
         $application = new Application();
-        $application->add($command);
+        $application->addCommand($command);
 
         $this->commandTester = new CommandTester($application->find('app:prompt:seed'));
     }

--- a/backend/tests/Command/SyncModelPricesCommandTest.php
+++ b/backend/tests/Command/SyncModelPricesCommandTest.php
@@ -43,7 +43,7 @@ class SyncModelPricesCommandTest extends TestCase
         );
 
         $application = new Application();
-        $application->add($command);
+        $application->addCommand($command);
 
         $this->commandTester = new CommandTester($application->find('app:sync-model-prices'));
     }


### PR DESCRIPTION
## Summary

Backward-compatible replacements for Symfony APIs that are deprecated in 7.x and removed in 8.0. This prepares the codebase so the Renovate major-upgrade PRs (#783, #784, #803) can be merged cleanly.

- `TaggedIterator` → `AutowireIterator` (2 files — deprecated since 7.1, available since 6.4)
- `Routing\Annotation\Route` → `Routing\Attribute\Route` (9 controllers — deprecated since 6.0)
- `Request::get()` → `$request->query->get() ?? $request->request->get()` (`LegacyApiController` — removed in 8.0)
- `Application::add()` → `Application::addCommand()` (8 test files — deprecated since 7.4)
- PHPStan: ignore `unset.possiblyHookedProperty` in generated gRPC code (PHP 8.4 property hooks) and `method.alreadyNarrowedType` in tests

All replacements are backward-compatible with the current Symfony 7.4 on main. No version bumps — those come from the Renovate PRs.

## Test plan

- [ ] CI passes (lint, PHPStan, PHPUnit) — no new test failures expected since all replacements exist in Symfony 7.4
- [ ] Verified locally with PHP 8.4 + Symfony 8: all 1082 PHPUnit tests pass, PHPStan clean, CS Fixer clean