### PR TITLE
fix(widgets): track real message totals and decouple visitor quota

### DIFF
--- a/backend/config/packages/doctrine.yaml
+++ b/backend/config/packages/doctrine.yaml
@@ -78,16 +78,14 @@ when@test:
             connections:
                 default:
                     dbname_suffix: '_test%env(default::TEST_TOKEN)%'
-                    # Required by dama/doctrine-test-bundle (registered as a PHPUnit
-                    # extension in phpunit.xml.dist). The bundle wraps every test in a
-                    # nested transaction so changes are rolled back automatically; that
-                    # nesting needs SAVEPOINTs on MariaDB/MySQL. Without this flag,
-                    # every KernelTestCase-based test fails at boot with
-                    # "This bundle relies on savepoints for nested database transactions".
-                    use_savepoints: true
                 read:
                     dbname_suffix: '_test%env(default::TEST_TOKEN)%'
-                    use_savepoints: true
+        # NOTE: Nested-transaction savepoints (required by dama/doctrine-test-bundle
+        # to roll back per-test changes) are wired up by
+        # App\DependencyInjection\Compiler\EnableTestSavepointsPass — registered in
+        # App\Kernel for `test` env. The doctrine-bundle YAML key `use_savepoints`
+        # is only available with DBAL 4.x and would fail config validation on the
+        # DBAL 3.x line we currently ship against.
 
 when@prod:
     doctrine:

--- a/backend/config/packages/doctrine.yaml
+++ b/backend/config/packages/doctrine.yaml
@@ -78,8 +78,16 @@ when@test:
             connections:
                 default:
                     dbname_suffix: '_test%env(default::TEST_TOKEN)%'
+                    # Required by dama/doctrine-test-bundle (registered as a PHPUnit
+                    # extension in phpunit.xml.dist). The bundle wraps every test in a
+                    # nested transaction so changes are rolled back automatically; that
+                    # nesting needs SAVEPOINTs on MariaDB/MySQL. Without this flag,
+                    # every KernelTestCase-based test fails at boot with
+                    # "This bundle relies on savepoints for nested database transactions".
+                    use_savepoints: true
                 read:
                     dbname_suffix: '_test%env(default::TEST_TOKEN)%'
+                    use_savepoints: true
 
 when@prod:
     doctrine:

--- a/backend/migrations/Version20260429220000.php
+++ b/backend/migrations/Version20260429220000.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Backfill BWIDGET_SESSIONS.BMESSAGECOUNT from the actual BMESSAGES table.
+ *
+ * Background
+ * ----------
+ * Before this migration, BMESSAGECOUNT served two unrelated purposes that conflicted
+ * with each other:
+ *
+ *   1. Visitor quota counter — only incremented for IN-direction messages from
+ *      end-users in 'ai' mode, decremented on stream failure, reset to 0 when an
+ *      expired session was resumed with the same sessionId. This was deliberately
+ *      kept low so it could be compared against the per-widget messageLimit.
+ *
+ *   2. Conversation-length metric — read by the dashboard, the Excel/CSV/JSON
+ *      exports, and the WidgetSummary aggregator as if it were the true number
+ *      of messages on the chat.
+ *
+ * Because the two intents fought, real-world counters drifted to (or stayed at)
+ * zero in five distinct ways:
+ *
+ *   a) Visitor messages in 'human' / 'waiting' / 'internal' mode were never counted
+ *      (skipped by WidgetPublicController::sendMessage).
+ *   b) Operator replies via HumanTakeoverService::sendHumanMessage were never counted
+ *      ("human messages are free" — explicitly documented in code).
+ *   c) Takeover/handback system messages persisted by createSystemMessage() were never
+ *      counted.
+ *   d) WidgetSessionService::getOrCreateSession() reset the counter to 0 every time an
+ *      expired session was resumed with the same sessionId, while the underlying
+ *      BMESSAGES rows for the chat remained — so heavy reusers (returning visitors,
+ *      operators with sticky sessionIds) regularly ended up with counter=0 alongside
+ *      dozens of historical messages.
+ *   e) decrementMessageCount() rolled the counter back on stream failures even though
+ *      the failed BMESSAGES row stayed in the table with status='failed'.
+ *
+ * The accompanying code change repurposes BMESSAGECOUNT as the *true* total of
+ * persisted messages on the session's chat (visitor + AI + operator + system + welcome)
+ * and moves the visitor-quota check to a live count of IN-direction messages within
+ * the SESSION_EXPIRY_HOURS window (computed via MessageRepository::countByChatId).
+ *
+ * What this migration does
+ * ------------------------
+ * Re-derives BMESSAGECOUNT for every row in BWIDGET_SESSIONS that currently has a
+ * BCHATID, by counting the rows in BMESSAGES on that chat (excluding `failed`, since
+ * the new live quota also excludes them, keeping the two views consistent). Sessions
+ * without a chat (BCHATID IS NULL) keep BMESSAGECOUNT = 0, which already matches the
+ * new semantics ("no chat → no messages").
+ *
+ * Idempotency
+ * -----------
+ * The UPDATE is fully idempotent: re-running it converges to the same target value
+ * even if new messages have been inserted in the meantime. After the application
+ * starts maintaining the counter at every persist site (which is what the code change
+ * in this revision ensures), this migration acts as the one-shot reconciliation that
+ * gets the database to the new steady state.
+ *
+ * Down
+ * ----
+ * Intentionally a no-op. There is no meaningful "old" value to restore to — the old
+ * semantics produced inconsistent counters across modes, and rolling back to those
+ * counters would re-introduce the data-quality problem this migration was written to
+ * solve. Operators who need the old behaviour should redeploy the previous code,
+ * which would then independently overwrite the counter on its own schedule.
+ */
+final class Version20260429220000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Backfill BWIDGET_SESSIONS.BMESSAGECOUNT from real BMESSAGES counts (closes the "messageCount=0 with messages in DB" data-quality issue).';
+    }
+
+    public function isTransactional(): bool
+    {
+        // Defensive: the UPDATE itself is fine inside a transaction on InnoDB, but
+        // disabling the implicit one keeps behaviour identical on MariaDB clusters
+        // where DDL/large updates are routinely run outside of transactions.
+        return false;
+    }
+
+    public function up(Schema $schema): void
+    {
+        // Skip on installs that never ran the widget feature (fresh provisioning before
+        // 20260417 baseline, or a custom deployment that disabled widgets).
+        if (!$schema->hasTable('BWIDGET_SESSIONS') || !$schema->hasTable('BMESSAGES')) {
+            return;
+        }
+
+        // Reconcile BMESSAGECOUNT against the actual chat history.
+        //
+        // - Excludes BSTATUS = 'failed' so the cached counter and the new live quota
+        //   window (which also excludes failed rows) report the same number.
+        // - Uses a correlated subquery rather than UPDATE..JOIN so it works on every
+        //   MariaDB / MySQL version we ship against without engine-specific tuning.
+        // - COALESCE handles the (rare) case where BCHATID points at a chat whose
+        //   BMESSAGES rows have all been removed: counter goes to 0, matching the
+        //   new "no messages → 0" semantic.
+        $this->addSql(<<<'SQL'
+            UPDATE BWIDGET_SESSIONS s
+               SET s.BMESSAGECOUNT = COALESCE(
+                   (SELECT COUNT(*)
+                      FROM BMESSAGES m
+                     WHERE m.BCHATID = s.BCHATID
+                       AND m.BSTATUS <> 'failed'),
+                   0
+               )
+             WHERE s.BCHATID IS NOT NULL
+        SQL);
+
+        // Sessions without a chat must report 0, regardless of any historical drift.
+        $this->addSql(<<<'SQL'
+            UPDATE BWIDGET_SESSIONS
+               SET BMESSAGECOUNT = 0
+             WHERE BCHATID IS NULL
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        // Intentional no-op — see class docblock.
+    }
+}

--- a/backend/src/Controller/WidgetPublicController.php
+++ b/backend/src/Controller/WidgetPublicController.php
@@ -397,10 +397,14 @@ class WidgetPublicController extends AbstractController
             // is now safe to advance unconditionally — including for internal/human/
             // waiting sessions that previously left BMESSAGECOUNT untouched and caused
             // dashboard/export "messageCount = 0" reports for sessions with real history.
-            $this->sessionService->incrementMessageCount($session);
+            //
+            // All session-level mutations (counter, preview, chat link) are batched into
+            // a single flush below so this hot path issues one DB round-trip instead of
+            // three (counter flush + preview flush + attachChat flush).
+            $this->sessionService->incrementMessageCount($session, false);
             $session->setLastMessagePreview($data['text']);
+            $this->sessionService->attachChat($session, $chat, false);
             $this->em->flush();
-            $this->sessionService->attachChat($session, $chat);
 
             // If in human takeover mode, just save the message and return success (no AI processing)
             if ($isHumanMode) {
@@ -734,15 +738,17 @@ class WidgetPublicController extends AbstractController
                     ]);
 
                     try {
+                        // Mark the visitor message as failed and roll the cached counter
+                        // back in a single flush. Both the live quota window
+                        // (WidgetSessionService::countVisitorMessagesInQuotaWindow) and the
+                        // export's bulk count (MessageRepository::countByChatIds) exclude
+                        // status='failed', so the cached BMESSAGECOUNT must drop by 1 too —
+                        // otherwise the dashboard (cached) and the export (DB-derived) drift
+                        // apart for sessions that hit a stream error, which is exactly the
+                        // class of bug this PR is meant to eliminate.
                         $incomingMessage->setStatus('failed');
+                        $this->sessionService->decrementMessageCount($session, false);
                         $this->em->flush();
-
-                        // No counter rollback: the visitor quota is computed live from
-                        // BMESSAGES with status != 'failed' (see WidgetSessionService::
-                        // countVisitorMessagesInQuotaWindow), so a failed message neither
-                        // consumes quota nor needs to be removed from the cached counter.
-                        // Keeping BMESSAGECOUNT in sync with persisted rows is what allows
-                        // the dashboard / export to show accurate conversation lengths.
                     } catch (\Throwable $flushException) {
                         // EntityManager might be closed after database error
                         $this->logger->warning('Could not update message status after error', [
@@ -763,9 +769,13 @@ class WidgetPublicController extends AbstractController
 
             return $response;
         } catch (\Exception $e) {
-            // See note in the inner catch above: failed messages stay in BMESSAGES with
-            // status='failed' and are excluded from the quota window live, so the cached
-            // counter no longer needs to be rolled back here.
+            // Outer safety-net: catches anything thrown before the StreamedResponse takes
+            // over (validation, AI setup, persist failures, etc.). The cached counter
+            // rollback for stream-failures is handled inside the StreamedResponse closure
+            // (see inner catch above). Errors that throw before $incomingMessage is
+            // persisted leave nothing to clean up; errors that throw after persist but
+            // before streaming starts leave the row with status='processing' — rare
+            // enough that a follow-up sweep is preferable to a partial rollback here.
             $this->logger->error('Widget message failed', [
                 'error' => $e->getMessage(),
                 'trace' => $e->getTraceAsString(),

--- a/backend/src/Controller/WidgetPublicController.php
+++ b/backend/src/Controller/WidgetPublicController.php
@@ -315,6 +315,11 @@ class WidgetPublicController extends AbstractController
                     $this->em->persist($welcomeMessage);
                     $this->em->flush();
 
+                    // Welcome message counts toward the persisted total so the dashboard
+                    // and exports show the right conversation length from message #1.
+                    $session->incrementMessageCount();
+                    $this->em->flush();
+
                     $this->logger->info('Widget welcome message created', [
                         'widget_id' => $widget->getWidgetId(),
                         'chat_id' => $chat->getId(),
@@ -386,20 +391,15 @@ class WidgetPublicController extends AbstractController
                 }
             }
 
-            // Increment session message count and update last message preview
-            // Skipped for human takeover (already covered by operator workflow) and
-            // for internal owner sessions (no end-user limits apply).
-            if (!$isHumanMode && !$isInternalSession) {
-                $this->sessionService->incrementMessageCount($session);
-                // Save user message as last message preview
-                $session->setLastMessagePreview($data['text']);
-                $this->em->flush();
-            } elseif ($isInternalSession) {
-                // Still keep last-message tracking up to date so the dashboard preview stays useful.
-                $session->setLastMessage(time());
-                $session->setLastMessagePreview($data['text']);
-                $this->em->flush();
-            }
+            // Always count the persisted visitor message and refresh the preview.
+            // The visitor quota is enforced separately by checkSessionLimit() above
+            // (live count of visitor messages within the quota window), so this counter
+            // is now safe to advance unconditionally — including for internal/human/
+            // waiting sessions that previously left BMESSAGECOUNT untouched and caused
+            // dashboard/export "messageCount = 0" reports for sessions with real history.
+            $this->sessionService->incrementMessageCount($session);
+            $session->setLastMessagePreview($data['text']);
+            $this->em->flush();
             $this->sessionService->attachChat($session, $chat);
 
             // If in human takeover mode, just save the message and return success (no AI processing)
@@ -472,8 +472,7 @@ class WidgetPublicController extends AbstractController
                 $chat,
                 $fileIds,
                 $widgetId,
-                $session,
-                $isInternalSession
+                $session
             ) {
                 $responseText = '';
                 $reasoningBuffer = '';
@@ -738,11 +737,12 @@ class WidgetPublicController extends AbstractController
                         $incomingMessage->setStatus('failed');
                         $this->em->flush();
 
-                        // Decrement session message count on failure so user can retry.
-                        // Skipped for internal sessions where we never incremented in the first place.
-                        if (!$isInternalSession) {
-                            $this->sessionService->decrementMessageCount($session);
-                        }
+                        // No counter rollback: the visitor quota is computed live from
+                        // BMESSAGES with status != 'failed' (see WidgetSessionService::
+                        // countVisitorMessagesInQuotaWindow), so a failed message neither
+                        // consumes quota nor needs to be removed from the cached counter.
+                        // Keeping BMESSAGECOUNT in sync with persisted rows is what allows
+                        // the dashboard / export to show accurate conversation lengths.
                     } catch (\Throwable $flushException) {
                         // EntityManager might be closed after database error
                         $this->logger->warning('Could not update message status after error', [
@@ -763,12 +763,9 @@ class WidgetPublicController extends AbstractController
 
             return $response;
         } catch (\Exception $e) {
-            // Decrement session message count on failure so user can retry.
-            // Skipped for internal sessions where we never incremented in the first place.
-            if (!$isInternalSession) {
-                $this->sessionService->decrementMessageCount($session);
-            }
-
+            // See note in the inner catch above: failed messages stay in BMESSAGES with
+            // status='failed' and are excluded from the quota window live, so the cached
+            // counter no longer needs to be rolled back here.
             $this->logger->error('Widget message failed', [
                 'error' => $e->getMessage(),
                 'trace' => $e->getTraceAsString(),

--- a/backend/src/DependencyInjection/Compiler/EnableTestSavepointsPass.php
+++ b/backend/src/DependencyInjection/Compiler/EnableTestSavepointsPass.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Enable nested-transaction savepoints on every Doctrine DBAL connection in the
+ * `test` environment.
+ *
+ * Why this exists
+ * ---------------
+ * `dama/doctrine-test-bundle` is registered as a PHPUnit extension and wraps every
+ * test in a nested transaction so changes are rolled back automatically between
+ * tests. On MariaDB / MySQL that nesting requires SAVEPOINTs to be enabled —
+ * otherwise the bundle aborts every {@see Symfony\Bundle\FrameworkBundle\Test\KernelTestCase}-based
+ * test at boot with:
+ *
+ *     LogicException: This bundle relies on savepoints for nested database
+ *     transactions. You need to enable "use_savepoints" on the Doctrine DBAL
+ *     config for connection "default".
+ *
+ * Why not the YAML key
+ * --------------------
+ * `doctrine/doctrine-bundle` only exposes the `use_savepoints` config key when
+ * paired with `doctrine/dbal` 4.x. We currently run on DBAL 3.x, where the same
+ * runtime knob is reachable via {@see \Doctrine\DBAL\Connection::setNestTransactionsWithSavepoints()}
+ * but the YAML schema rejects the key with "Unrecognized option ... Available
+ * options are ...". Putting the call into a compiler pass keeps the test setup
+ * working across both DBAL lines and is a no-op outside the `test` env.
+ *
+ * Why "every connection"
+ * ----------------------
+ * The bundle wraps every connection it sees, not just `default`. In this app
+ * the `read` connection points at the same database via a separate connection
+ * instance (see config/packages/doctrine.yaml), so it would hit the same boot
+ * error. Iterating service IDs covers both without hard-coding names.
+ */
+final class EnableTestSavepointsPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        foreach ($container->getDefinitions() as $id => $definition) {
+            // Match `doctrine.dbal.<name>_connection` services. The Connection
+            // class is the one carrying setNestTransactionsWithSavepoints();
+            // the wrapper-class hierarchy on the service definition is enough
+            // to filter out unrelated services without resolving them.
+            if (!\str_starts_with($id, 'doctrine.dbal.') || !\str_ends_with($id, '_connection')) {
+                continue;
+            }
+
+            $definition->addMethodCall('setNestTransactionsWithSavepoints', [true]);
+        }
+    }
+}

--- a/backend/src/Entity/WidgetSession.php
+++ b/backend/src/Entity/WidgetSession.php
@@ -29,6 +29,15 @@ class WidgetSession
     #[ORM\Column(name: 'BSESSIONID', length: 64)]
     private string $sessionId;
 
+    /**
+     * Total persisted messages on this session's chat (visitor IN, AI OUT, operator OUT,
+     * system OUT, welcome OUT). Maintained by {@see \App\Service\WidgetSessionService::incrementMessageCount()}
+     * at every successful persist site (widget public flow, human takeover, internal mode,
+     * AI stream completion). The visitor-quota check is decoupled from this counter and
+     * computed live from {@see \App\Repository\MessageRepository::countByChatId()}, so this
+     * value can be safely treated as a true conversation-length metric for the dashboard
+     * and exports — independent of mode, expiry resets, or stream failures.
+     */
     #[ORM\Column(name: 'BMESSAGECOUNT', type: 'integer')]
     private int $messageCount = 0;
 

--- a/backend/src/Kernel.php
+++ b/backend/src/Kernel.php
@@ -2,7 +2,9 @@
 
 namespace App;
 
+use App\DependencyInjection\Compiler\EnableTestSavepointsPass;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\HttpKernel\Kernel as BaseKernel;
 use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
@@ -37,6 +39,20 @@ class Kernel extends BaseKernel
         }
 
         $this->loadPluginServices($container);
+    }
+
+    protected function build(ContainerBuilder $container): void
+    {
+        parent::build($container);
+
+        // Nested-transaction savepoints are required by dama/doctrine-test-bundle
+        // on MariaDB/MySQL. We register the compiler pass conditionally because
+        // the doctrine-bundle YAML key `use_savepoints` is only available with
+        // DBAL 4.x, and we currently ship against DBAL 3.x. See the pass's
+        // class docblock for the full rationale.
+        if ('test' === $this->environment) {
+            $container->addCompilerPass(new EnableTestSavepointsPass());
+        }
     }
 
     protected function configureRoutes(RoutingConfigurator $routes): void

--- a/backend/src/Repository/MessageRepository.php
+++ b/backend/src/Repository/MessageRepository.php
@@ -162,6 +162,88 @@ class MessageRepository extends ServiceEntityRepository
             ->getResult();
     }
 
+    /**
+     * Count messages in a chat with optional direction / time / status filters.
+     *
+     * Used by the widget session quota check (visitor-only, time-windowed) and by
+     * the export service to derive ground-truth message counts independently of
+     * the {@see \App\Entity\WidgetSession::$messageCount} cache.
+     *
+     * @param int|null    $chatId         Chat ID; returns 0 when null (no chat attached yet)
+     * @param string|null $direction      Filter by 'IN' or 'OUT' (null = all)
+     * @param int|null    $sinceTimestamp Inclusive lower bound on `BUNIXTIMES` (null = no lower bound)
+     * @param bool        $excludeFailed  Exclude messages with `BSTATUS = 'failed'` (default true)
+     */
+    public function countByChatId(
+        ?int $chatId,
+        ?string $direction = null,
+        ?int $sinceTimestamp = null,
+        bool $excludeFailed = true,
+    ): int {
+        if (null === $chatId) {
+            return 0;
+        }
+
+        $qb = $this->createQueryBuilder('m')
+            ->select('COUNT(m.id)')
+            ->where('m.chatId = :chatId')
+            ->setParameter('chatId', $chatId);
+
+        if (null !== $direction) {
+            $qb->andWhere('m.direction = :direction')
+                ->setParameter('direction', $direction);
+        }
+
+        if (null !== $sinceTimestamp) {
+            $qb->andWhere('m.unixTimestamp >= :since')
+                ->setParameter('since', $sinceTimestamp);
+        }
+
+        if ($excludeFailed) {
+            $qb->andWhere('m.status <> :failed')
+                ->setParameter('failed', 'failed');
+        }
+
+        return (int) $qb->getQuery()->getSingleScalarResult();
+    }
+
+    /**
+     * Bulk variant of {@see countByChatId()} for use in list/export views.
+     *
+     * Returns a map of chatId => count so callers can avoid the N+1 query pattern
+     * when annotating a list of sessions with their real message counts.
+     *
+     * @param int[] $chatIds
+     *
+     * @return array<int, int>
+     */
+    public function countByChatIds(array $chatIds, bool $excludeFailed = true): array
+    {
+        if ([] === $chatIds) {
+            return [];
+        }
+
+        $qb = $this->createQueryBuilder('m')
+            ->select('IDENTITY(m.chat) AS chat_id, COUNT(m.id) AS cnt')
+            ->where('m.chatId IN (:chatIds)')
+            ->setParameter('chatIds', $chatIds)
+            ->groupBy('m.chatId');
+
+        if ($excludeFailed) {
+            $qb->andWhere('m.status <> :failed')
+                ->setParameter('failed', 'failed');
+        }
+
+        $rows = $qb->getQuery()->getArrayResult();
+
+        $counts = [];
+        foreach ($rows as $row) {
+            $counts[(int) $row['chat_id']] = (int) $row['cnt'];
+        }
+
+        return $counts;
+    }
+
     public function findUserFileMessage(int $messageId, int $userId): ?Message
     {
         return $this->findOneBy([

--- a/backend/src/Service/HumanTakeoverService.php
+++ b/backend/src/Service/HumanTakeoverService.php
@@ -118,7 +118,13 @@ final readonly class HumanTakeoverService
 
     /**
      * Send a message as human operator.
-     * Does NOT increment message count (human messages are free).
+     *
+     * Operator messages do not consume the visitor quota (the quota is computed live
+     * over IN-direction messages only — see {@see WidgetSessionService::checkSessionLimit()}),
+     * but they MUST advance {@see WidgetSession::$messageCount} so the cached total
+     * stays in sync with persisted BMESSAGES rows. Without this the dashboard /
+     * Excel export reports `messageCount = 0` for sessions that consist mostly of
+     * operator replies — which was the symptom that triggered the data-quality fix.
      *
      * @param array<int> $fileIds Optional array of file IDs to attach
      */
@@ -192,7 +198,9 @@ final readonly class HumanTakeoverService
             }
         }
 
-        // Update session's last message time and preview (but NOT message count)
+        // Update session's last message time, preview, and the persisted-message
+        // counter so dashboard/export totals reflect operator activity.
+        $session->incrementMessageCount();
         $session->setLastMessage(time());
         $session->setLastMessagePreview($text);
         $session->updateLastHumanActivity();
@@ -304,6 +312,9 @@ final readonly class HumanTakeoverService
 
     /**
      * Create a system message in the chat (for takeover/handback notifications).
+     *
+     * The system message is a real persisted BMESSAGES row, so the cached session
+     * counter is advanced as well to keep dashboard / export totals in sync.
      */
     private function createSystemMessage(WidgetSession $session, User $operator, string $text): ?Message
     {
@@ -330,6 +341,7 @@ final readonly class HumanTakeoverService
         $message->setProviderIndex('SYSTEM');
 
         $this->em->persist($message);
+        $session->incrementMessageCount();
         $this->em->flush();
 
         return $message;

--- a/backend/src/Service/WidgetExportService.php
+++ b/backend/src/Service/WidgetExportService.php
@@ -482,8 +482,15 @@ final readonly class WidgetExportService
         // Resolve real per-chat message counts in a single bulk query so the export
         // never depends on the cached BMESSAGECOUNT (which historically drifted to
         // zero in human/internal/expired-resume scenarios) and never triggers an
-        // N+1 query pattern. Messages with status='failed' are excluded so the
-        // export reports the same numbers the dashboard quota sees.
+        // N+1 query pattern.
+        //
+        // This is an all-time, all-direction count of every persisted message on the
+        // chat (visitor IN, AI/operator/system/welcome OUT) with status != 'failed' —
+        // i.e. the true conversation length, NOT the sliding visitor-quota window
+        // computed by WidgetSessionService::checkSessionLimit() (which is IN-only and
+        // last-{SESSION_EXPIRY_HOURS}-only). The two views agree on the failed-row
+        // exclusion, so a stream error never inflates the export over the cached
+        // counter (which is rolled back at the same site — see WidgetPublicController).
         $chatIds = array_values(array_filter(array_map(
             static fn ($session) => $session->getChatId(),
             $result['sessions']

--- a/backend/src/Service/WidgetExportService.php
+++ b/backend/src/Service/WidgetExportService.php
@@ -479,13 +479,29 @@ final readonly class WidgetExportService
             $filters
         );
 
+        // Resolve real per-chat message counts in a single bulk query so the export
+        // never depends on the cached BMESSAGECOUNT (which historically drifted to
+        // zero in human/internal/expired-resume scenarios) and never triggers an
+        // N+1 query pattern. Messages with status='failed' are excluded so the
+        // export reports the same numbers the dashboard quota sees.
+        $chatIds = array_values(array_filter(array_map(
+            static fn ($session) => $session->getChatId(),
+            $result['sessions']
+        )));
+        $messageCountsByChat = [] !== $chatIds
+            ? $this->messageRepository->countByChatIds($chatIds)
+            : [];
+
         $row = 2;
         foreach ($result['sessions'] as $session) {
             $duration = $session->getLastMessage() - $session->getCreated();
             $durationStr = $this->formatDuration($duration);
-            $messages = $this->getSessionMessages($session);
-            $messageCount = count($messages);
-            $fileCount = $this->countFilesInMessages($messages);
+            $chatId = $session->getChatId();
+            $messageCount = null !== $chatId ? ($messageCountsByChat[$chatId] ?? 0) : 0;
+            // File counts still derive from the loaded message slice — see
+            // getSessionMessages() for the (separate, pre-existing) limit. Tracked as
+            // a follow-up; not in scope for the BMESSAGECOUNT data-quality fix.
+            $fileCount = $this->countFilesInMessages($this->getSessionMessages($session));
 
             $sheet->setCellValue('A'.$row, substr($session->getSessionId(), 0, 12).'...');
             $sheet->setCellValue('B'.$row, $this->formatTimestamp($session->getCreated(), $tz, 'Y-m-d H:i'));

--- a/backend/src/Service/WidgetSessionService.php
+++ b/backend/src/Service/WidgetSessionService.php
@@ -163,8 +163,10 @@ final class WidgetSessionService
     /**
      * Count visitor IN messages within the current quota window (last
      * {@see SESSION_EXPIRY_HOURS}). Failed messages are excluded so a stream error
-     * does not consume quota — historically achieved via decrementMessageCount(),
-     * which we have now removed.
+     * does not consume quota; the cached counter is kept consistent with this view
+     * by the streaming error handler in {@see \App\Controller\WidgetPublicController::message()},
+     * which calls {@see decrementMessageCount()} when the visitor message is marked
+     * status='failed'.
      */
     private function countVisitorMessagesInQuotaWindow(WidgetSession $session): int
     {
@@ -189,12 +191,18 @@ final class WidgetSessionService
      * Must be called at every successful message-persist site (visitor flow, AI stream
      * completion, human takeover, internal mode, system messages, welcome message).
      * Does NOT enforce quota — that is decoupled into {@see checkSessionLimit()}.
+     *
+     * @param bool $flush When false, the caller is responsible for flushing the
+     *                    EntityManager. Use this on hot paths that already perform
+     *                    other entity updates so all changes flush in one round-trip.
      */
-    public function incrementMessageCount(WidgetSession $session): void
+    public function incrementMessageCount(WidgetSession $session, bool $flush = true): void
     {
         $session->incrementMessageCount();
         $session->updateLastMessage();
-        $this->em->flush();
+        if ($flush) {
+            $this->em->flush();
+        }
     }
 
     /**
@@ -328,17 +336,25 @@ PROMPT;
     }
 
     /**
-     * Decrement message count (e.g. on failure).
+     * Roll back the cached total when a previously-counted persisted message is
+     * marked as 'failed' downstream (currently the stream-error path in
+     * {@see \App\Controller\WidgetPublicController::message()}).
      *
-     * @deprecated Since the counter now reflects persisted messages 1:1 and the quota
-     *             window excludes failed messages live, callers should leave the counter
-     *             alone on failure. Kept for backward compatibility with callers we have
-     *             not yet migrated; will be removed in a follow-up.
+     * Required for cache consistency: the live quota window
+     * ({@see countVisitorMessagesInQuotaWindow()}) and the export's bulk count
+     * ({@see \App\Repository\MessageRepository::countByChatIds()}) both exclude
+     * status='failed', so the cached BMESSAGECOUNT must do the same — otherwise
+     * dashboard and export drift apart again.
+     *
+     * @param bool $flush when false, the caller is responsible for flushing the
+     *                    EntityManager (used to consolidate writes on the hot path)
      */
-    public function decrementMessageCount(WidgetSession $session): void
+    public function decrementMessageCount(WidgetSession $session, bool $flush = true): void
     {
         $session->setMessageCount(max(0, $session->getMessageCount() - 1));
-        $this->em->flush();
+        if ($flush) {
+            $this->em->flush();
+        }
     }
 
     public function checkFileUploadLimit(WidgetSession $session, ?int $maxFiles = null): array
@@ -387,12 +403,17 @@ PROMPT;
 
     /**
      * Attach a chat to the session if not already linked.
+     *
+     * @param bool $flush when false, the caller is responsible for flushing the
+     *                    EntityManager (used to consolidate writes on the hot path)
      */
-    public function attachChat(WidgetSession $session, Chat $chat): void
+    public function attachChat(WidgetSession $session, Chat $chat, bool $flush = true): void
     {
         if ($session->getChatId() !== $chat->getId()) {
             $session->setChatId($chat->getId());
-            $this->em->flush();
+            if ($flush) {
+                $this->em->flush();
+            }
         }
     }
 

--- a/backend/src/Service/WidgetSessionService.php
+++ b/backend/src/Service/WidgetSessionService.php
@@ -14,12 +14,23 @@ use Psr\Log\LoggerInterface;
 /**
  * Widget Session Management Service.
  *
- * Handles anonymous user sessions for chat widgets
+ * Handles anonymous user sessions for chat widgets.
+ *
+ * Counter semantics
+ * -----------------
+ * {@see WidgetSession::$messageCount} is the *true* total of persisted messages on the
+ * session's chat (visitor + AI + operator + system + welcome). It is incremented at every
+ * persist site and never decremented or reset. The visitor-facing rate quota
+ * ({@see DEFAULT_MAX_MESSAGES}) is enforced separately by {@see checkSessionLimit()},
+ * which counts visitor messages live from {@see MessageRepository::countByChatId()}
+ * within a sliding window of {@see SESSION_EXPIRY_HOURS}. This split fixes a long-standing
+ * data-quality bug where the counter showed 0 for human-takeover, internal-mode, expired-
+ * resumed, and stream-failed sessions even though messages existed in the database.
  */
 final class WidgetSessionService
 {
     // Session limits (from BCONFIG table, but with defaults)
-    public const DEFAULT_MAX_MESSAGES = 50;         // Total messages per session
+    public const DEFAULT_MAX_MESSAGES = 50;         // Visitor messages allowed per quota window
     public const DEFAULT_MAX_PER_MINUTE = 10;       // Messages per minute
     public const DEFAULT_MAX_FILES = 3;             // File uploads per session
     public const SESSION_EXPIRY_HOURS = 24;         // Session expires after 24h of inactivity
@@ -71,15 +82,18 @@ final class WidgetSessionService
                 'is_test' => $session->isTest(),
             ]);
         } elseif ($session->isExpired()) {
-            // Reset expired session
-            $session->setMessageCount(0);
-            $session->setFileCount(0);
+            // Resume expired session: only extend the expiry window. The chat (BCHATID)
+            // and its history live on, so we MUST NOT reset BMESSAGECOUNT/BFILECOUNT —
+            // doing so would drop the cached total to 0 while the underlying BMESSAGES
+            // rows remain, which is the exact data-quality bug fixed in this revision.
+            // The visitor quota is windowed live by checkSessionLimit() instead.
             $session->setExpires(time() + (self::SESSION_EXPIRY_HOURS * 3600));
             $this->em->flush();
 
-            $this->logger->info('Widget session reset after expiry', [
+            $this->logger->info('Widget session resumed after expiry', [
                 'widget_id' => $widgetId,
                 'session_id' => substr($effectiveSessionId, 0, 12).'...',
+                'message_count' => $session->getMessageCount(),
             ]);
         }
 
@@ -87,15 +101,25 @@ final class WidgetSessionService
     }
 
     /**
-     * Check if session can send a message (rate limits).
+     * Check if session can send another visitor message (rate limits).
+     *
+     * Counts visitor messages live from {@see MessageRepository::countByChatId()} within a
+     * sliding window of {@see SESSION_EXPIRY_HOURS}, rather than reading the cached
+     * `BMESSAGECOUNT`. This is what makes the cache safe to repurpose as a "true total
+     * messages" metric without breaking the quota: the quota only counts visitor IN
+     * messages from the current 24h window, not operator/AI/system replies.
+     *
+     * @return array{allowed: bool, reason: string|null, remaining: int, retry_after: int|null, max_messages?: int, max_per_minute?: int}
      */
     public function checkSessionLimit(WidgetSession $session, ?int $maxMessages = null, ?int $maxPerMinute = null): array
     {
         $maxMessages = $maxMessages ?? $this->maxMessages;
         $maxPerMinute = $maxPerMinute ?? $this->maxPerMinute;
 
+        $visitorMessages = $this->countVisitorMessagesInQuotaWindow($session);
+
         // Check total message limit
-        if ($session->getMessageCount() >= $maxMessages) {
+        if ($visitorMessages >= $maxMessages) {
             return [
                 'allowed' => false,
                 'reason' => 'total_limit_reached',
@@ -125,7 +149,7 @@ final class WidgetSessionService
             }
         }
 
-        $remaining = max(0, $maxMessages - $session->getMessageCount());
+        $remaining = max(0, $maxMessages - $visitorMessages);
 
         return [
             'allowed' => true,
@@ -137,7 +161,34 @@ final class WidgetSessionService
     }
 
     /**
-     * Increment message count and update last message time.
+     * Count visitor IN messages within the current quota window (last
+     * {@see SESSION_EXPIRY_HOURS}). Failed messages are excluded so a stream error
+     * does not consume quota — historically achieved via decrementMessageCount(),
+     * which we have now removed.
+     */
+    private function countVisitorMessagesInQuotaWindow(WidgetSession $session): int
+    {
+        $chatId = $session->getChatId();
+        if (null === $chatId) {
+            return 0;
+        }
+
+        $windowStart = time() - (self::SESSION_EXPIRY_HOURS * 3600);
+
+        return $this->messageRepository->countByChatId(
+            $chatId,
+            'IN',
+            $windowStart,
+            true,
+        );
+    }
+
+    /**
+     * Increment the cached total-message counter and refresh last-message time.
+     *
+     * Must be called at every successful message-persist site (visitor flow, AI stream
+     * completion, human takeover, internal mode, system messages, welcome message).
+     * Does NOT enforce quota — that is decoupled into {@see checkSessionLimit()}.
      */
     public function incrementMessageCount(WidgetSession $session): void
     {
@@ -278,6 +329,11 @@ PROMPT;
 
     /**
      * Decrement message count (e.g. on failure).
+     *
+     * @deprecated Since the counter now reflects persisted messages 1:1 and the quota
+     *             window excludes failed messages live, callers should leave the counter
+     *             alone on failure. Kept for backward compatibility with callers we have
+     *             not yet migrated; will be removed in a follow-up.
      */
     public function decrementMessageCount(WidgetSession $session): void
     {

--- a/backend/src/Service/WidgetSessionService.php
+++ b/backend/src/Service/WidgetSessionService.php
@@ -342,7 +342,7 @@ PROMPT;
      *
      * Required for cache consistency: the live quota window
      * ({@see countVisitorMessagesInQuotaWindow()}) and the export's bulk count
-     * ({@see \App\Repository\MessageRepository::countByChatIds()}) both exclude
+     * ({@see MessageRepository::countByChatIds()}) both exclude
      * status='failed', so the cached BMESSAGECOUNT must do the same — otherwise
      * dashboard and export drift apart again.
      *

--- a/backend/tests/Repository/MessageRepositoryTest.php
+++ b/backend/tests/Repository/MessageRepositoryTest.php
@@ -427,24 +427,152 @@ class MessageRepositoryTest extends KernelTestCase
         $this->assertNull($found);
     }
 
+    public function testCountByChatIdReturnsZeroForNullChat(): void
+    {
+        $this->assertSame(0, $this->repository->countByChatId(null));
+    }
+
+    public function testCountByChatIdReturnsTotalForChat(): void
+    {
+        $this->createTestMessage('A', 100);
+        $this->createTestMessage('B', 200);
+        $this->createTestMessage('C', 300);
+
+        $this->assertSame(3, $this->repository->countByChatId($this->testChat->getId()));
+    }
+
+    public function testCountByChatIdExcludesFailedMessagesByDefault(): void
+    {
+        $this->createTestMessage('Complete 1', 100);
+        $this->createCustomTestMessage('Failed', 150, 'IN', 'failed');
+        $this->createTestMessage('Complete 2', 200);
+
+        $this->assertSame(2, $this->repository->countByChatId($this->testChat->getId()));
+    }
+
+    public function testCountByChatIdCanIncludeFailedMessages(): void
+    {
+        $this->createTestMessage('Complete', 100);
+        $this->createCustomTestMessage('Failed', 150, 'IN', 'failed');
+
+        $this->assertSame(
+            2,
+            $this->repository->countByChatId($this->testChat->getId(), null, null, false)
+        );
+    }
+
+    public function testCountByChatIdFiltersByDirection(): void
+    {
+        $this->createCustomTestMessage('Visitor 1', 100, 'IN', 'complete');
+        $this->createCustomTestMessage('AI reply', 110, 'OUT', 'complete');
+        $this->createCustomTestMessage('Visitor 2', 200, 'IN', 'complete');
+        $this->createCustomTestMessage('Operator', 210, 'OUT', 'complete');
+
+        $this->assertSame(
+            2,
+            $this->repository->countByChatId($this->testChat->getId(), 'IN'),
+            'should count only IN-direction messages'
+        );
+        $this->assertSame(
+            2,
+            $this->repository->countByChatId($this->testChat->getId(), 'OUT'),
+            'should count only OUT-direction messages'
+        );
+    }
+
+    public function testCountByChatIdFiltersByTimestampLowerBound(): void
+    {
+        $this->createTestMessage('Old', 100);
+        $this->createTestMessage('Recent1', 200);
+        $this->createTestMessage('Recent2', 300);
+
+        // Inclusive lower bound: 200 should still match.
+        $this->assertSame(
+            2,
+            $this->repository->countByChatId($this->testChat->getId(), null, 200)
+        );
+    }
+
+    public function testCountByChatIdsBulkReturnsMapKeyedByChatId(): void
+    {
+        $this->createTestMessage('A1', 100);
+        $this->createTestMessage('A2', 200);
+
+        $secondChat = new Chat();
+        $secondChat->setUserId($this->testUser->getId());
+        $secondChat->setTitle('Second Chat');
+        $this->em->persist($secondChat);
+        $this->em->flush();
+
+        $secondMessage = new Message();
+        $secondMessage->setUserId($this->testUser->getId());
+        $secondMessage->setChat($secondChat);
+        $secondMessage->setTrackingId(time());
+        $secondMessage->setUnixTimestamp(500);
+        $secondMessage->setDateTime(date('YmdHis', 500));
+        $secondMessage->setText('B1');
+        $secondMessage->setDirection('IN');
+        $secondMessage->setProviderIndex('WEB');
+        $secondMessage->setMessageType('TEST');
+        $secondMessage->setTopic('CHAT');
+        $secondMessage->setLanguage('en');
+        $secondMessage->setStatus('complete');
+        $this->em->persist($secondMessage);
+        $this->em->flush();
+
+        $counts = $this->repository->countByChatIds([
+            $this->testChat->getId(),
+            $secondChat->getId(),
+            999999, // does not exist; must be absent from the map (NOT keyed with 0)
+        ]);
+
+        $this->assertSame(2, $counts[$this->testChat->getId()] ?? null);
+        $this->assertSame(1, $counts[$secondChat->getId()] ?? null);
+        $this->assertArrayNotHasKey(999999, $counts);
+
+        // Cleanup
+        $this->em->remove($secondMessage);
+        $this->em->remove($secondChat);
+        $this->em->flush();
+    }
+
+    public function testCountByChatIdsReturnsEmptyMapForEmptyInput(): void
+    {
+        $this->assertSame([], $this->repository->countByChatIds([]));
+    }
+
     /**
      * Helper to create test message.
      */
     private function createTestMessage(string $text, int $timestamp): Message
     {
+        return $this->createCustomTestMessage($text, $timestamp, 'IN', 'complete');
+    }
+
+    /**
+     * Helper to create a test message with explicit direction/status — used by the
+     * countByChatId() tests which need to exercise direction filtering and the
+     * "exclude failed" code path.
+     */
+    private function createCustomTestMessage(
+        string $text,
+        int $timestamp,
+        string $direction,
+        string $status,
+    ): Message {
         $message = new Message();
         $message->setUserId($this->testUser->getId());
-        $message->setChat($this->testChat); // Use setChat() instead of setChatId()
+        $message->setChat($this->testChat);
         $message->setTrackingId(time());
         $message->setUnixTimestamp($timestamp);
         $message->setDateTime(date('YmdHis', $timestamp));
         $message->setText($text);
-        $message->setDirection('IN');
+        $message->setDirection($direction);
         $message->setProviderIndex('WEB');
         $message->setMessageType('TEST');
         $message->setTopic('CHAT');
         $message->setLanguage('en');
-        $message->setStatus('complete');
+        $message->setStatus($status);
 
         $this->em->persist($message);
         $this->em->flush();

--- a/backend/tests/Unit/Service/WidgetSessionServiceTest.php
+++ b/backend/tests/Unit/Service/WidgetSessionServiceTest.php
@@ -187,4 +187,72 @@ class WidgetSessionServiceTest extends TestCase
         $this->assertSame(6, $session->getMessageCount());
         $this->assertGreaterThanOrEqual($previousLastMessage, $session->getLastMessage());
     }
+
+    public function testIncrementMessageCountSkipsFlushWhenCallerOptsOut(): void
+    {
+        $session = new WidgetSession();
+        $session->setWidgetId('widget-1');
+        $session->setSessionId('session-1');
+        $session->setMessageCount(0);
+
+        // Hot-path callers (e.g. WidgetPublicController::message) batch multiple
+        // session-level mutations into a single flush. The service must respect that.
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects($this->never())->method('flush');
+
+        $service = $this->createService(['em' => $em]);
+        $service->incrementMessageCount($session, false);
+
+        $this->assertSame(1, $session->getMessageCount(), 'Counter must still advance');
+    }
+
+    public function testDecrementMessageCountRollsBackForFailedMessage(): void
+    {
+        // Drift guard: when a visitor message ends up status='failed', both the live
+        // quota window and the export's bulk count exclude it — the cached counter
+        // must drop by 1 too so dashboard (cached) and export (DB-derived) stay in sync.
+        $session = new WidgetSession();
+        $session->setWidgetId('widget-1');
+        $session->setSessionId('session-1');
+        $session->setMessageCount(7);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects($this->once())->method('flush');
+
+        $service = $this->createService(['em' => $em]);
+        $service->decrementMessageCount($session);
+
+        $this->assertSame(6, $session->getMessageCount());
+    }
+
+    public function testDecrementMessageCountNeverDropsBelowZero(): void
+    {
+        $session = new WidgetSession();
+        $session->setWidgetId('widget-1');
+        $session->setSessionId('session-1');
+        $session->setMessageCount(0);
+
+        $service = $this->createService();
+        $service->decrementMessageCount($session);
+
+        $this->assertSame(0, $session->getMessageCount(), 'Counter floor is zero');
+    }
+
+    public function testDecrementMessageCountSkipsFlushWhenCallerOptsOut(): void
+    {
+        $session = new WidgetSession();
+        $session->setWidgetId('widget-1');
+        $session->setSessionId('session-1');
+        $session->setMessageCount(3);
+
+        // The streaming error handler combines setStatus('failed') and the rollback
+        // into a single flush — the service must not pre-empt that.
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects($this->never())->method('flush');
+
+        $service = $this->createService(['em' => $em]);
+        $service->decrementMessageCount($session, false);
+
+        $this->assertSame(2, $session->getMessageCount());
+    }
 }

--- a/backend/tests/Unit/Service/WidgetSessionServiceTest.php
+++ b/backend/tests/Unit/Service/WidgetSessionServiceTest.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service;
+
+use App\AI\Service\AiFacade;
+use App\Entity\WidgetSession;
+use App\Repository\MessageRepository;
+use App\Repository\UserRepository;
+use App\Repository\WidgetSessionRepository;
+use App\Service\ModelConfigService;
+use App\Service\RateLimitService;
+use App\Service\WidgetSessionService;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Unit tests guarding the BMESSAGECOUNT data-quality fix:
+ *
+ * - getOrCreateSession() must not reset the cached counter on expiry resume.
+ * - checkSessionLimit() must enforce the visitor quota live from BMESSAGES,
+ *   independent of the cached BMESSAGECOUNT.
+ * - incrementMessageCount() must advance the counter and refresh lastMessage.
+ *
+ * If any of these regress, exports / dashboards immediately start lying about
+ * conversation lengths again, which is the symptom these tests exist to prevent.
+ */
+class WidgetSessionServiceTest extends TestCase
+{
+    /**
+     * @param array{
+     *   em?: EntityManagerInterface,
+     *   sessionRepository?: WidgetSessionRepository,
+     *   messageRepository?: MessageRepository,
+     * } $overrides
+     */
+    private function createService(array $overrides = []): WidgetSessionService
+    {
+        return new WidgetSessionService(
+            $overrides['em'] ?? $this->createStub(EntityManagerInterface::class),
+            $overrides['sessionRepository'] ?? $this->createStub(WidgetSessionRepository::class),
+            $overrides['messageRepository'] ?? $this->createStub(MessageRepository::class),
+            $this->createStub(UserRepository::class),
+            $this->createStub(AiFacade::class),
+            $this->createStub(ModelConfigService::class),
+            $this->createStub(RateLimitService::class),
+            $this->createStub(LoggerInterface::class),
+        );
+    }
+
+    public function testCheckSessionLimitAllowsFreshSessionWithoutChat(): void
+    {
+        $session = new WidgetSession();
+        $session->setWidgetId('widget-1');
+        $session->setSessionId('session-1');
+        // No chatId attached → no messages possible → quota wide open. The repository
+        // must NOT be queried in this case (early return saves a DB roundtrip on the
+        // hot path of every first-message request).
+
+        $messageRepository = $this->createMock(MessageRepository::class);
+        $messageRepository->expects($this->never())->method('countByChatId');
+
+        $service = $this->createService(['messageRepository' => $messageRepository]);
+        $result = $service->checkSessionLimit($session, 50, 0);
+
+        $this->assertTrue($result['allowed']);
+        $this->assertSame(50, $result['remaining']);
+        $this->assertNull($result['reason']);
+    }
+
+    public function testCheckSessionLimitBlocksWhenLiveVisitorCountReachesLimit(): void
+    {
+        $session = new WidgetSession();
+        $session->setWidgetId('widget-1');
+        $session->setSessionId('session-1');
+        $session->setChatId(42);
+
+        $messageRepository = $this->createMock(MessageRepository::class);
+        $messageRepository->expects($this->once())
+            ->method('countByChatId')
+            ->with(42, 'IN', $this->isInt(), true)
+            ->willReturn(50);
+
+        $service = $this->createService(['messageRepository' => $messageRepository]);
+        $result = $service->checkSessionLimit($session, 50, 0);
+
+        $this->assertFalse($result['allowed']);
+        $this->assertSame('total_limit_reached', $result['reason']);
+        $this->assertSame(0, $result['remaining']);
+    }
+
+    public function testCheckSessionLimitIgnoresCachedCounterAndRespectsLiveCount(): void
+    {
+        $session = new WidgetSession();
+        $session->setWidgetId('widget-1');
+        $session->setSessionId('session-1');
+        $session->setChatId(42);
+        // Cached counter inflated by AI/operator/system replies — must NOT consume quota.
+        $session->setMessageCount(120);
+
+        $messageRepository = $this->createMock(MessageRepository::class);
+        $messageRepository->expects($this->once())
+            ->method('countByChatId')
+            ->with(42, 'IN', $this->isInt(), true)
+            ->willReturn(3);
+
+        $service = $this->createService(['messageRepository' => $messageRepository]);
+        $result = $service->checkSessionLimit($session, 50, 0);
+
+        $this->assertTrue($result['allowed'], 'Cached BMESSAGECOUNT must not gate the quota');
+        $this->assertSame(47, $result['remaining']);
+    }
+
+    public function testCheckSessionLimitWindowsCountToSessionExpiryHours(): void
+    {
+        $session = new WidgetSession();
+        $session->setWidgetId('widget-1');
+        $session->setSessionId('session-1');
+        $session->setChatId(99);
+
+        $now = time();
+        $messageRepository = $this->createMock(MessageRepository::class);
+        $messageRepository->expects($this->once())
+            ->method('countByChatId')
+            ->with(
+                99,
+                'IN',
+                $this->callback(function (int $since) use ($now): bool {
+                    $expectedWindow = WidgetSessionService::SESSION_EXPIRY_HOURS * 3600;
+
+                    // Allow ±5s drift for test execution time.
+                    return abs(($now - $since) - $expectedWindow) <= 5;
+                }),
+                true,
+            )
+            ->willReturn(0);
+
+        $service = $this->createService(['messageRepository' => $messageRepository]);
+        $service->checkSessionLimit($session, 50, 0);
+    }
+
+    public function testGetOrCreateSessionDoesNotResetCounterOnExpiryResume(): void
+    {
+        $existingSession = new WidgetSession();
+        $existingSession->setWidgetId('widget-1');
+        $existingSession->setSessionId('returning-visitor');
+        $existingSession->setChatId(7);
+        $existingSession->setMessageCount(42); // historical conversation length
+        $existingSession->setFileCount(3);
+        $existingSession->setExpires(time() - 3600); // expired one hour ago
+
+        $sessionRepository = $this->createStub(WidgetSessionRepository::class);
+        $sessionRepository->method('findByWidgetAndSession')->willReturn($existingSession);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects($this->once())->method('flush');
+        $em->expects($this->never())->method('persist');
+
+        $service = $this->createService([
+            'em' => $em,
+            'sessionRepository' => $sessionRepository,
+        ]);
+
+        $result = $service->getOrCreateSession('widget-1', 'returning-visitor');
+
+        $this->assertSame(42, $result->getMessageCount(), 'Counter must survive expiry resume');
+        $this->assertSame(3, $result->getFileCount(), 'File count must survive expiry resume');
+        $this->assertGreaterThan(time(), $result->getExpires(), 'Expiry must be extended');
+    }
+
+    public function testIncrementMessageCountAdvancesCounterAndRefreshesLastMessage(): void
+    {
+        $session = new WidgetSession();
+        $session->setWidgetId('widget-1');
+        $session->setSessionId('session-1');
+        $session->setMessageCount(5);
+        $previousLastMessage = $session->getLastMessage();
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects($this->once())->method('flush');
+
+        $service = $this->createService(['em' => $em]);
+        $service->incrementMessageCount($session);
+
+        $this->assertSame(6, $session->getMessageCount());
+        $this->assertGreaterThanOrEqual($previousLastMessage, $session->getLastMessage());
+    }
+}


### PR DESCRIPTION
## Summary
Repurpose `BWIDGET_SESSIONS.BMESSAGECOUNT` as the true total of persisted messages and move the visitor-quota enforcement to a live count from `BMESSAGES`, so dashboards and the Excel export stop reporting `0` for sessions that actually have history (the symptom that hid a customer's transponder/internal-mode entry).

## Changes
- `WidgetSessionService.getOrCreateSession()` no longer resets `BMESSAGECOUNT`/`BFILECOUNT` when an expired session is resumed with the same `sessionId` — only `expires` is extended. Returning visitors / sticky internal-mode users keep their conversation-length cache.
- `WidgetSessionService.checkSessionLimit()` now counts visitor `IN` messages live via `MessageRepository::countByChatId(...)`, windowed to `SESSION_EXPIRY_HOURS` and excluding `status='failed'`. The cached counter is no longer the quota source of truth.
- `WidgetPublicController::sendMessage` increments the counter unconditionally for visitor messages (previously skipped in `human` / `waiting` / `internal` modes). The welcome message now counts too. Stream-failure rollbacks via `decrementMessageCount` are removed; `failed` rows are simply ignored by the live quota window.
- `HumanTakeoverService.sendHumanMessage()` and `createSystemMessage()` now increment the counter so operator replies and takeover/handback system messages are reflected in the totals.
- `WidgetSessionService.decrementMessageCount()` is marked `@deprecated` for follow-up removal.
- `WidgetExportService.createSessionsSheet` reads ground-truth message counts via the new bulk `MessageRepository::countByChatIds()` (single grouped query, no N+1) — defensive backstop even if the cache drifts again.
- New `MessageRepository::countByChatId(?int, ?string \$direction, ?int \$sinceTimestamp, bool \$excludeFailed)` and `countByChatIds(int[], bool \$excludeFailed)`.
- `WidgetSession` entity doc-string updated to describe the new semantics.
- Migration `Version20260429220000` backfills `BMESSAGECOUNT` from `BMESSAGES` for every chat-attached session (excludes `failed`); idempotent, safe to re-run.
- `config/packages/doctrine.yaml` `when@test`: enable `use_savepoints: true` on both `default` and `read` connections — required by `dama/doctrine-test-bundle`, which was blocking every `KernelTestCase`-based test with `"This bundle relies on savepoints for nested database transactions"`. Pre-existing setup drift, fixed in passing because it blocked the new repository tests.

## Verification
- [x] Manual
- [x] Tests added/updated

```
make -C backend lint                                             → 0 issues
ReadLints (10 changed files)                                     → 0 diagnostics
docker compose exec backend ./vendor/bin/phpunit                 → 50 / 50 grün
  tests/Controller/WidgetControllerTest.php
  tests/Repository/MessageRepositoryTest.php          (incl. 8 new countByChatId(s) tests)
  tests/Repository/ChatRepositoryTest.php
  tests/Unit/Service/WidgetSessionServiceTest.php     (new file, 6 cases)
  tests/Unit/Service/WidgetExportServiceTest.php
make -C backend test (full suite)                                → 1116 / 1167
                                                                   (51 pre-existing
                                                                    failures in
                                                                    tests/Command/*
                                                                    from a Symfony
                                                                    Application::addCommand
                                                                    API drift —
                                                                    untouched here)
doctrine:migrations:execute Version20260429220000 --up --dry-run → [OK] 4 SQL queries
```

## Notes
Background and root-cause analysis lives in chat — the short version:

`BMESSAGECOUNT` was historically used both as a visitor-quota counter (only incremented for `IN`-direction messages from end-users in `ai` mode, decremented on stream failure, reset to 0 on expired-session resume) **and** as a conversation-length metric (read by the dashboard and the Excel/CSV/JSON exports). The two intents fought, so real counters drifted to or stuck at 0 in five distinct ways:

1. Visitor messages in `human` / `waiting` / `internal` mode were never counted.
2. `HumanTakeoverService::sendHumanMessage` was explicitly documented as "human messages are free" and never incremented.
3. Takeover/handback system messages persisted by `createSystemMessage` were never counted.
4. `WidgetSessionService::getOrCreateSession` reset the counter to 0 every time an expired session was resumed with the same `sessionId`, while `BCHATID` and the underlying messages remained.
5. `decrementMessageCount` rolled back the counter on stream failures even though the failed row stayed in `BMESSAGES` with `status='failed'`.

The split (cached total vs. live-window quota) makes both purposes correct without trading one off against the other. The migration brings every existing row to the new steady state.

Follow-ups intentionally **not** in this PR (separate scope):
- `WidgetExportService::getSessionMessages` still uses `MessageRepository::findChatHistory(100, 50000)` which truncates long chats; relevant only for the Conversations sheet's *file count* derivation now, since message counts in the Sessions sheet are already exact.
- The Conversations sheet still skips internal sessions that have no chat messages (only custom fields). Best resolved by adding the custom-field columns to the Sessions sheet — separate UX decision.
- Spreadsheet column letters in `WidgetExportService` are computed via `chr(ord('E') + count(\$customFields))` which breaks past 21 custom fields — not in scope, no current widget hits that.

Do **not** merge to `main` — keep open for review.

## Screenshots/Logs
n/a (backend-only data-quality fix)