### PR TITLE
feat(impersonation): allow admins to impersonate other admin accounts

### DIFF
--- a/backend/src/Controller/AdminImpersonationController.php
+++ b/backend/src/Controller/AdminImpersonationController.php
@@ -38,7 +38,7 @@ final class AdminImpersonationController extends AbstractController
     #[OA\Post(
         path: '/api/v1/admin/impersonate/{userId}',
         summary: 'Start impersonating a user',
-        description: 'Admin-only. Mints a fresh access token scoped to the target user with an `impersonator_id` claim, moves the admin\'s refresh token aside into a single HttpOnly stash cookie, and clears the regular refresh cookie. No additional refresh token is persisted for the target. The original admin session is restored via `/exit`. Refused for self-impersonation, other admins, OIDC sessions, and nested impersonations.',
+        description: 'Admin-only. Mints a fresh access token scoped to the target user with an `impersonator_id` claim, moves the admin\'s refresh token aside into a single HttpOnly stash cookie, and clears the regular refresh cookie. No additional refresh token is persisted for the target. The original admin session is restored via `/exit`. Admins may impersonate any other user, including other admins. Refused for self-impersonation, OIDC sessions, and nested impersonations.',
         security: [['Bearer' => []]],
         tags: ['Admin']
     )]
@@ -81,7 +81,7 @@ final class AdminImpersonationController extends AbstractController
             ]
         )
     )]
-    #[OA\Response(response: 403, description: 'Caller is not an admin, or rule violated (self/admin/nested/OIDC)')]
+    #[OA\Response(response: 403, description: 'Caller is not an admin, or rule violated (self/nested/OIDC)')]
     #[OA\Response(response: 404, description: 'Target user not found')]
     public function start(
         int $userId,

--- a/backend/src/Service/ImpersonationService.php
+++ b/backend/src/Service/ImpersonationService.php
@@ -39,12 +39,17 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
  *
  * Constraints (enforced server-side; the UI only mirrors them):
  *   - Only ROLE_ADMIN users may impersonate.
- *   - You cannot impersonate yourself.
- *   - You cannot impersonate another admin (privilege-escalation guard).
+ *   - You cannot impersonate yourself (the resulting session would be a
+ *     no-op and only confuse the audit trail).
  *   - You cannot nest impersonations — exit first.
  *   - OIDC/Keycloak sessions are not supported, since we have no app-token
  *     refresh to stash. The caller gets a clean error and the impersonation
  *     is refused without mutating cookies.
+ *
+ * Note: Impersonating another admin IS allowed. Admins legitimately need to
+ * walk into a peer's account (handover, debugging an admin-only flow, etc.).
+ * Every start/stop is logged at warning level with both ids so the audit
+ * trail stays attributable to the original admin.
  */
 final readonly class ImpersonationService
 {
@@ -225,12 +230,6 @@ final readonly class ImpersonationService
         if (!$target instanceof User) {
             return null;
         }
-        // Targets that have since been promoted to admin must not continue to
-        // be impersonated — the privilege-escalation guard at start-time only
-        // checks the initial state.
-        if ($target->isAdmin()) {
-            return null;
-        }
 
         $freshAccess = $this->tokenService->generateAccessToken(
             $target,
@@ -312,10 +311,6 @@ final readonly class ImpersonationService
 
         if ($admin->getId() === $target->getId()) {
             throw new AccessDeniedException('You cannot impersonate yourself.');
-        }
-
-        if ($target->isAdmin()) {
-            throw new AccessDeniedException('You cannot impersonate another administrator.');
         }
 
         if ($this->isImpersonating($request)) {

--- a/backend/tests/Unit/Service/ImpersonationServiceTest.php
+++ b/backend/tests/Unit/Service/ImpersonationServiceTest.php
@@ -76,15 +76,47 @@ final class ImpersonationServiceTest extends TestCase
         $this->service->startImpersonation($admin, $admin, $this->requestWithAppTokens(), new Response());
     }
 
-    public function testStartImpersonationRefusesAnotherAdmin(): void
+    public function testStartImpersonationAllowsAnotherAdminTarget(): void
     {
+        // Admin-on-admin impersonation is intentionally permitted: handover,
+        // peer debugging, etc. The audit log captures both ids so the action
+        // remains attributable. The only guard against cross-admin abuse is
+        // the start/stop warning log + the hard self-impersonation refusal.
         $admin = $this->makeUser(id: 1, level: 'ADMIN');
         $otherAdmin = $this->makeUser(id: 2, level: 'ADMIN');
 
-        $this->expectException(AccessDeniedException::class);
-        $this->expectExceptionMessage('another administrator');
+        $request = $this->requestWithAppTokens([
+            TokenService::REFRESH_COOKIE => 'admin-refresh',
+        ]);
+        $response = new Response();
 
-        $this->service->startImpersonation($admin, $otherAdmin, $this->requestWithAppTokens(), new Response());
+        $this->tokenService
+            ->expects(self::once())
+            ->method('generateAccessToken')
+            ->with($otherAdmin, 1)
+            ->willReturn('other-admin-impersonation-access');
+
+        $this->tokenService
+            ->method('createAccessCookie')
+            ->willReturn(Cookie::create(TokenService::ACCESS_COOKIE)->withValue('other-admin-impersonation-access'));
+
+        $this->tokenService
+            ->expects(self::once())
+            ->method('createClearRefreshCookie')
+            ->willReturn(Cookie::create(TokenService::REFRESH_COOKIE)->withValue(''));
+
+        $this->service->startImpersonation($admin, $otherAdmin, $request, $response);
+
+        $cookies = $this->indexCookies($response);
+        self::assertSame(
+            'admin-refresh',
+            $cookies[ImpersonationService::ADMIN_REFRESH_STASH_COOKIE]->getValue(),
+            'admin refresh token must still be stashed when impersonating another admin'
+        );
+        self::assertSame(
+            'other-admin-impersonation-access',
+            $cookies[TokenService::ACCESS_COOKIE]->getValue()
+        );
     }
 
     public function testStartImpersonationRefusesNestedImpersonation(): void
@@ -430,13 +462,15 @@ final class ImpersonationServiceTest extends TestCase
         );
     }
 
-    public function testRefreshReturnsNullWhenTargetWasPromotedToAdmin(): void
+    public function testRefreshSucceedsWhenTargetIsAdmin(): void
     {
-        // Mid-impersonation the target was promoted to admin. We must stop
-        // refreshing impersonation access tokens for them — otherwise a
-        // legitimate admin's session would be silently downgraded.
+        // Admin-on-admin impersonation is allowed at start time, so the
+        // refresh path must keep the session alive for an admin target —
+        // including one that was promoted mid-session. The impersonator
+        // claim plus stash refresh token still uniquely identify the
+        // operating admin, so attribution is not lost.
         $admin = $this->makeUser(id: 1, level: 'ADMIN');
-        $promotedTarget = $this->makeUser(id: 7, level: 'ADMIN');
+        $adminTarget = $this->makeUser(id: 7, level: 'ADMIN');
 
         $request = $this->requestWithAppTokens([
             ImpersonationService::ADMIN_REFRESH_STASH_COOKIE => 'stashed-refresh',
@@ -460,15 +494,19 @@ final class ImpersonationServiceTest extends TestCase
 
         $this->userRepository
             ->method('find')
-            ->willReturn($promotedTarget);
+            ->willReturn($adminTarget);
 
         $this->tokenService
-            ->expects(self::never())
-            ->method('generateAccessToken');
+            ->expects(self::once())
+            ->method('generateAccessToken')
+            ->with($adminTarget, 1)
+            ->willReturn('refreshed-admin-target-access');
 
-        self::assertNull(
-            $this->service->issueRefreshedImpersonationAccessToken($request)
-        );
+        $result = $this->service->issueRefreshedImpersonationAccessToken($request);
+
+        self::assertNotNull($result);
+        self::assertSame('refreshed-admin-target-access', $result['access_token']);
+        self::assertSame($adminTarget, $result['user']);
     }
 
     // ---------------------------------------------------------------------

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -163,7 +163,6 @@
       "confirmAction": "Sitzung starten",
       "started": "Du siehst die Anwendung jetzt als {email}.",
       "startFailed": "Impersonation konnte nicht gestartet werden",
-      "cannotImpersonateAdmin": "Andere Administratoren können nicht impersoniert werden.",
       "cannotImpersonateSelf": "Du kannst dich nicht selbst impersonieren.",
       "banner": {
         "viewing": "Angemeldet als {email}",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -168,7 +168,6 @@
       "confirmAction": "Start session",
       "started": "You are now viewing the application as {email}.",
       "startFailed": "Could not start impersonation",
-      "cannotImpersonateAdmin": "Other administrators cannot be impersonated.",
       "cannotImpersonateSelf": "You cannot impersonate yourself.",
       "banner": {
         "viewing": "Viewing as {email}",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -160,7 +160,6 @@
       "confirmAction": "Iniciar sesión",
       "started": "Ahora ves la aplicación como {email}.",
       "startFailed": "No se pudo iniciar la suplantación",
-      "cannotImpersonateAdmin": "No puedes suplantar a otros administradores.",
       "cannotImpersonateSelf": "No puedes suplantarte a ti mismo.",
       "banner": {
         "viewing": "Viendo como {email}",

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -160,7 +160,6 @@
       "confirmAction": "Oturumu başlat",
       "started": "Uygulamayı şimdi {email} olarak görüntülüyorsun.",
       "startFailed": "Kimliğe bürünme başlatılamadı",
-      "cannotImpersonateAdmin": "Diğer yöneticilerin kimliğine bürünülemez.",
       "cannotImpersonateSelf": "Kendi kimliğine bürünemezsin.",
       "banner": {
         "viewing": "{email} olarak görüntüleniyor",

--- a/frontend/src/views/AdminView.vue
+++ b/frontend/src/views/AdminView.vue
@@ -262,7 +262,6 @@
                           class="flex items-center justify-end gap-1"
                         >
                           <button
-                            v-if="user.level !== 'ADMIN'"
                             class="p-2 rounded-lg text-amber-600 hover:text-amber-700 dark:text-amber-400 dark:hover:text-amber-300 hover:bg-amber-50 dark:hover:bg-amber-900/20"
                             :title="$t('admin.impersonate.buttonTitle')"
                             :data-testid="`btn-impersonate-user-${user.id}`"
@@ -964,8 +963,11 @@ async function deleteUser() {
 
 /**
  * Start an impersonation session for the given user.
+ *
  * UX flow:
- *   1. Inline guard rails (mirror what the backend enforces): no self, no admin.
+ *   1. Inline self-check (mirrors the backend's only hard refusal that the UI
+ *      can see ahead of time — admin-on-admin is intentionally allowed, and
+ *      nesting/OIDC are session-scoped checks that only the server can make).
  *   2. Confirmation dialog so this never happens by accident — the admin is
  *      effectively logging in as someone else.
  *   3. On success: success notification + navigate to / (the impersonated
@@ -977,10 +979,6 @@ async function confirmImpersonate(targetUser: AdminUser) {
 
   if (targetUser.id === currentUserId.value) {
     showError(t('admin.impersonate.cannotImpersonateSelf'))
-    return
-  }
-  if (targetUser.level === 'ADMIN') {
-    showError(t('admin.impersonate.cannotImpersonateAdmin'))
     return
   }
 

--- a/frontend/tests/unit/stores/auth-impersonation.spec.ts
+++ b/frontend/tests/unit/stores/auth-impersonation.spec.ts
@@ -105,16 +105,20 @@ describe('useAuthStore — impersonation', () => {
   })
 
   it('startImpersonation surfaces a server error verbatim and leaves state untouched', async () => {
+    // Use a refusal that is still actually thrown by the backend — self
+    // impersonation is the one inline guard the UI also enforces. The point
+    // here is that the server message is propagated verbatim and the store
+    // is not mutated on failure, regardless of which rule fired.
     startApiMock.mockResolvedValueOnce({
       success: false,
-      error: 'You cannot impersonate another administrator.',
+      error: 'You cannot impersonate yourself.',
     })
 
     const store = useAuthStore()
     const result = await store.startImpersonation(2)
 
     expect(result.success).toBe(false)
-    expect(result.error).toBe('You cannot impersonate another administrator.')
+    expect(result.error).toBe('You cannot impersonate yourself.')
     expect(store.isImpersonating).toBe(false)
     expect(refreshUserMock).not.toHaveBeenCalled()
   })


### PR DESCRIPTION
## Summary
Lets ROLE_ADMIN users impersonate any other user — including peers that also hold the ADMIN role. Self-impersonation, OIDC, and nesting refusals stay in place, and the audit log still carries both ids.

## Changes
- `ImpersonationService::assertCanImpersonate`: dropped the `target->isAdmin()` refusal; only self-impersonation, nesting, and OIDC sessions are still rejected.
- `ImpersonationService::issueRefreshedImpersonationAccessToken`: removed the "target was promoted to admin" short-circuit so the session survives a refresh for any target user.
- PHPDoc on `ImpersonationService` + OpenAPI description / 403 response on `AdminImpersonationController` updated to reflect the new contract.
- `ImpersonationServiceTest`: rewrote `testStartImpersonationRefusesAnotherAdmin` → `testStartImpersonationAllowsAnotherAdminTarget` (verifies the cookie stash still works for admin targets) and `testRefreshReturnsNullWhenTargetWasPromotedToAdmin` → `testRefreshSucceedsWhenTargetIsAdmin`.
- `AdminView.vue`: removed the `v-if="user.level !== 'ADMIN'"` filter on the impersonate button and the inline `cannotImpersonateAdmin` guard; the self-check stays.
- i18n: dropped the now-unused `admin.impersonate.cannotImpersonateAdmin` key in `de`, `en`, `es`, `tr`.
- `auth-impersonation.spec.ts`: replaced the stale "another administrator" mock error text with the still-valid self-impersonation refusal.

## Verification
- [ ] Not tested (explain)
- [x] Manual
- [x] Tests added/updated

Checks run locally (Docker):
- `make -C backend lint` — green
- Impersonation + profile-update + Keycloak suites (`tests/Unit/Service/ImpersonationServiceTest`, `tests/Controller/AdminImpersonationControllerTest`, `tests/Controller/ProfileUpdateImpersonationFullFlowTest`, `tests/Controller/ProfileUpdateImpersonationTest`, `tests/Controller/ProfileUpdateMemoriesEnabledRegressionTest`, `tests/Unit/KeycloakAuthControllerTest`): 32/32 green
- `make -C frontend lint` — green
- `docker compose exec -T frontend npm run check:types` (vue-tsc) — green
- `make -C frontend test` — 42 files, 350 tests green

Known preexisting failures NOT touched by this PR (same `Symfony\Component\Console\Application::addCommand()` API mismatch, all inside `backend/tests/Command/*Test.php`): 8 PHPStan errors and 51 PHPUnit errors. Happy to file a separate PR for that.

## Notes
- Security invariants preserved: self-impersonation still refused; nesting refused; OIDC sessions still refused (no app-token refresh to stash). Start and stop are logged at warning level with both admin id and target id, so admin-on-admin sessions stay fully attributable in the audit trail.
- No DB schema, migrations, or seed data changes.
- OpenAPI description-only change; Zod schemas regeneration is a no-op.

## Screenshots/Logs
_N/A — server-side rule change + UI filter removal only._
