### PR TITLE
test: hermetic Stripe integration tests for backend billing flows

### DIFF
--- a/backend/tests/Integration/Stripe/Mock/StripeMockHttpClient.php
+++ b/backend/tests/Integration/Stripe/Mock/StripeMockHttpClient.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Stripe\Mock;
+
+use Stripe\HttpClient\ClientInterface;
+
+/**
+ * Recording / replaying mock for the Stripe SDK's HTTP client.
+ *
+ * Tests register expected outbound calls (HTTP method + path pattern) and the
+ * canned response that should come back. Every request the SDK makes is also
+ * recorded so the test can assert which Stripe API endpoints the controller
+ * actually hit and with what parameters.
+ *
+ * Wire it in by calling \Stripe\ApiRequestor::setHttpClient($mock) in the
+ * test's setUp() and resetting to null (= default cURL client) in tearDown().
+ *
+ * Path matching is substring-based on the absolute Stripe URL — e.g.
+ *   $mock->expect('POST', 'subscriptions/sub_123', ['id' => 'sub_123', ...]);
+ * matches POST https://api.stripe.com/v1/subscriptions/sub_123. We don't try
+ * to be a full URL router because the Stripe SDK already normalises endpoints
+ * and we want test failures to point at the wrong call, not at the matcher.
+ */
+final class StripeMockHttpClient implements ClientInterface
+{
+    /**
+     * @var list<array{method: string, pathContains: string, response: array{0: string, 1: int, 2: array<string, string|list<string>>}, consumed: bool}>
+     */
+    private array $expectations = [];
+
+    /**
+     * @var list<array{method: string, url: string, headers: list<string>, params: array<mixed>, hasFile: bool}>
+     */
+    private array $captured = [];
+
+    /**
+     * Register an expected Stripe API call. Body is JSON-encoded automatically.
+     *
+     * @param array<mixed> $body Decoded response body; will be JSON-encoded for the SDK
+     */
+    public function expect(string $method, string $pathContains, array $body, int $status = 200): self
+    {
+        $this->expectations[] = [
+            'method' => strtolower($method),
+            'pathContains' => $pathContains,
+            'response' => [json_encode($body, JSON_THROW_ON_ERROR), $status, ['Content-Type' => 'application/json']],
+            'consumed' => false,
+        ];
+
+        return $this;
+    }
+
+    /**
+     * Register a canned response that matches every call. Useful when a test
+     * doesn't care about the specific endpoint but the controller still makes
+     * Stripe calls (e.g. cancelOtherSubscriptions calling Subscription::all
+     * with empty result during routine subscription.created webhook handling).
+     *
+     * @param array<mixed> $body
+     */
+    public function expectAny(array $body, int $status = 200): self
+    {
+        return $this->expect('GET', '', $body, $status)
+            ->expect('POST', '', $body, $status)
+            ->expect('DELETE', '', $body, $status);
+    }
+
+    /**
+     * @return list<array{method: string, url: string, headers: list<string>, params: array<mixed>, hasFile: bool}>
+     */
+    public function captured(): array
+    {
+        return $this->captured;
+    }
+
+    /**
+     * Number of times an endpoint matching $pathContains was hit.
+     */
+    public function countCalls(string $method, string $pathContains): int
+    {
+        $count = 0;
+        $methodLower = strtolower($method);
+        foreach ($this->captured as $call) {
+            if ($call['method'] === $methodLower && str_contains($call['url'], $pathContains)) {
+                ++$count;
+            }
+        }
+
+        return $count;
+    }
+
+    public function request($method, $absUrl, $headers, $params, $hasFile, $apiMode = 'v1', $maxNetworkRetries = null)
+    {
+        $methodLower = strtolower($method);
+        $this->captured[] = [
+            'method' => $methodLower,
+            'url' => $absUrl,
+            'headers' => $headers,
+            'params' => $params,
+            'hasFile' => (bool) $hasFile,
+        ];
+
+        foreach ($this->expectations as $i => $exp) {
+            if ($exp['consumed']) {
+                continue;
+            }
+            if ($exp['method'] !== $methodLower) {
+                continue;
+            }
+            if ('' !== $exp['pathContains'] && !str_contains($absUrl, $exp['pathContains'])) {
+                continue;
+            }
+            $this->expectations[$i]['consumed'] = true;
+
+            return $exp['response'];
+        }
+
+        throw new \RuntimeException(sprintf('Unexpected Stripe API call: %s %s. Configure StripeMockHttpClient::expect() for it. Captured so far: %d call(s).', strtoupper($method), $absUrl, count($this->captured)));
+    }
+}

--- a/backend/tests/Integration/Stripe/Mock/StripeSignatureHelper.php
+++ b/backend/tests/Integration/Stripe/Mock/StripeSignatureHelper.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Stripe\Mock;
+
+/**
+ * Builds Stripe-Signature headers for tests so the webhook controller's
+ * \Stripe\Webhook::constructEvent() accepts our locally crafted payloads.
+ *
+ * Mirrors the algorithm in StripeWebhookSignature: HMAC-SHA256 over
+ * "{timestamp}.{payload}" using the configured webhook secret. Stripe's
+ * tolerance window is 5 minutes; using time() means tests are valid for the
+ * duration of the run.
+ */
+final class StripeSignatureHelper
+{
+    public static function header(string $payload, string $secret, ?int $timestamp = null): string
+    {
+        $timestamp ??= time();
+        $signedPayload = $timestamp.'.'.$payload;
+        $signature = hash_hmac('sha256', $signedPayload, $secret);
+
+        return sprintf('t=%d,v1=%s', $timestamp, $signature);
+    }
+}

--- a/backend/tests/Integration/Stripe/StripeWebhookControllerTest.php
+++ b/backend/tests/Integration/Stripe/StripeWebhookControllerTest.php
@@ -1,0 +1,413 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Stripe;
+
+use App\Entity\User;
+use App\Tests\Integration\Stripe\Mock\StripeMockHttpClient;
+use App\Tests\Integration\Stripe\Mock\StripeSignatureHelper;
+use Doctrine\ORM\EntityManagerInterface;
+use Stripe\ApiRequestor;
+use Stripe\HttpClient\CurlClient;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Integration tests for StripeWebhookController.
+ *
+ * Covers the backend-only behaviour that is intentionally NOT in the E2E
+ * Playwright suite (no user-observable UI difference, or hard to assert
+ * deterministically through the browser):
+ *   - signature verification (invalid / missing)
+ *   - idempotency (duplicate event.id)
+ *   - 2xx contract for unhandled event types (so Stripe doesn't retry-storm)
+ *   - subscription.paused / subscription.resumed
+ *   - subscription.updated with status=canceled (status change without
+ *     implicit downgrade)
+ *   - invoice.payment_failed (paymentFailed flag is set even though the UI
+ *     doesn't yet visualise it — UI gap is tracked separately)
+ *
+ * Stripe outbound calls (cancelOtherSubscriptions inside subscription.created)
+ * are stubbed via StripeMockHttpClient — no real HTTP.
+ *
+ * Webhook signatures are computed locally with the test webhook secret
+ * (`whsec_fakeWebhookSecretForTests`) so the controller's
+ * \Stripe\Webhook::constructEvent() accepts our crafted payloads.
+ */
+class StripeWebhookControllerTest extends WebTestCase
+{
+    private const WEBHOOK_SECRET = 'whsec_fakeWebhookSecretForTests';
+    private const PRICE_PRO = 'price_1TestSuitePro';
+
+    private KernelBrowser $client;
+    private EntityManagerInterface $em;
+    private User $user;
+    private string $stripeCustomerId;
+    private StripeMockHttpClient $stripeMock;
+
+    protected function setUp(): void
+    {
+        self::ensureKernelShutdown();
+        $this->client = static::createClient();
+        $this->em = $this->client->getContainer()->get('doctrine')->getManager();
+
+        // Replace the Stripe SDK's HTTP client with our recording mock so the
+        // SDK never reaches api.stripe.com during tests. Reset in tearDown so
+        // a stale mock doesn't bleed into other test files.
+        $this->stripeMock = new StripeMockHttpClient();
+        ApiRequestor::setHttpClient($this->stripeMock);
+
+        // Unique customer id per test → tests don't see each other's state.
+        $this->stripeCustomerId = 'cus_test_'.bin2hex(random_bytes(8));
+
+        $this->user = new User();
+        $this->user->setMail('stripe-webhook-'.bin2hex(random_bytes(6)).'@test.synaplan.com');
+        $this->user->setPw(password_hash('Test1234!', PASSWORD_BCRYPT));
+        $this->user->setUserLevel('NEW');
+        $this->user->setProviderId('local');
+        $this->user->setCreated(date('YmdHis'));
+        $this->user->setStripeCustomerId($this->stripeCustomerId);
+
+        $this->em->persist($this->user);
+        $this->em->flush();
+    }
+
+    protected function tearDown(): void
+    {
+        // Reset the Stripe SDK back to its default cURL client so an unrelated
+        // test class does not inherit our mock. We pass a fresh CurlClient
+        // instance because setHttpClient()'s type contract does not allow null
+        // even though the SDK lazy-initialises a CurlClient when none is set.
+        ApiRequestor::setHttpClient(CurlClient::instance());
+
+        if (isset($this->user) && $this->em->isOpen()) {
+            $managed = $this->em->find(User::class, $this->user->getId());
+            if ($managed) {
+                $this->em->remove($managed);
+                $this->em->flush();
+            }
+        }
+
+        self::ensureKernelShutdown();
+        parent::tearDown();
+    }
+
+    public function testInvalidSignatureReturns400(): void
+    {
+        $payload = $this->buildEventPayload('customer.subscription.deleted', $this->subscriptionObject([]));
+
+        $this->postWebhook($payload, 'invalid_signature_format');
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+        // No state change.
+        $this->em->refresh($this->user);
+        $this->assertSame('NEW', $this->user->getUserLevel());
+    }
+
+    public function testMissingSignatureReturns400(): void
+    {
+        $payload = $this->buildEventPayload('customer.subscription.deleted', $this->subscriptionObject([]));
+
+        $this->client->request(
+            'POST',
+            '/api/v1/stripe/webhook',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            $payload,
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+        $body = json_decode((string) $this->client->getResponse()->getContent(), true);
+        $this->assertSame('No signature', $body['error']);
+    }
+
+    public function testIdempotencyDuplicateEventReturnsAlreadyProcessed(): void
+    {
+        $this->seedActiveSubscription('sub_idem_'.bin2hex(random_bytes(4)));
+
+        $eventId = 'evt_idem_'.bin2hex(random_bytes(4));
+        $subscription = $this->subscriptionObject([
+            'id' => $this->user->getPaymentDetails()['subscription']['stripe_subscription_id'],
+            'status' => 'active',
+        ]);
+        $payload = $this->buildEventPayload(
+            'customer.subscription.updated',
+            $subscription,
+            $eventId,
+        );
+
+        $this->postWebhook($payload, StripeSignatureHelper::header($payload, self::WEBHOOK_SECRET));
+        $this->assertResponseIsSuccessful();
+        $first = json_decode((string) $this->client->getResponse()->getContent(), true);
+        $this->assertTrue($first['success']);
+        $this->assertArrayNotHasKey('status', $first, 'First call should be processed normally');
+
+        // Second call with same event.id → controller short-circuits.
+        $this->postWebhook($payload, StripeSignatureHelper::header($payload, self::WEBHOOK_SECRET));
+        $this->assertResponseIsSuccessful();
+        $second = json_decode((string) $this->client->getResponse()->getContent(), true);
+        $this->assertTrue($second['success']);
+        $this->assertSame('already_processed', $second['status']);
+    }
+
+    public function testUnhandledEventTypeReturns2xxWithoutStateChange(): void
+    {
+        // customer.created has no handler in the match() — must still 200 to
+        // prevent Stripe retry storms, and must not touch user level.
+        $payload = $this->buildEventPayload('customer.created', [
+            'id' => $this->stripeCustomerId,
+            'object' => 'customer',
+            'email' => $this->user->getMail(),
+        ]);
+
+        $this->postWebhook($payload, StripeSignatureHelper::header($payload, self::WEBHOOK_SECRET));
+
+        $this->assertResponseIsSuccessful();
+        $body = json_decode((string) $this->client->getResponse()->getContent(), true);
+        $this->assertTrue($body['success']);
+
+        $this->em->refresh($this->user);
+        $this->assertSame('NEW', $this->user->getUserLevel());
+        $this->assertNull($this->user->getPaymentDetails()['subscription'] ?? null);
+    }
+
+    public function testSubscriptionPausedSetsStatusFlag(): void
+    {
+        $subscriptionId = 'sub_pause_'.bin2hex(random_bytes(4));
+        $this->seedActiveSubscription($subscriptionId);
+
+        $payload = $this->buildEventPayload(
+            'customer.subscription.paused',
+            $this->subscriptionObject(['id' => $subscriptionId, 'status' => 'paused']),
+        );
+        $this->postWebhook($payload, StripeSignatureHelper::header($payload, self::WEBHOOK_SECRET));
+        $this->assertResponseIsSuccessful();
+
+        $this->em->refresh($this->user);
+        $sub = $this->user->getPaymentDetails()['subscription'];
+        // Level stays PRO during a pause — feature access continues until the
+        // app explicitly downgrades; the status flag drives any UI banner.
+        $this->assertSame('PRO', $this->user->getUserLevel());
+        $this->assertSame('paused', $sub['status']);
+        $this->assertArrayHasKey('paused_at', $sub);
+        $this->assertIsInt($sub['paused_at']);
+    }
+
+    public function testSubscriptionResumedClearsPausedFlag(): void
+    {
+        $subscriptionId = 'sub_resume_'.bin2hex(random_bytes(4));
+        $this->seedActiveSubscription($subscriptionId, ['status' => 'paused', 'paused_at' => time() - 3600]);
+
+        $payload = $this->buildEventPayload(
+            'customer.subscription.resumed',
+            $this->subscriptionObject(['id' => $subscriptionId, 'status' => 'active']),
+        );
+        $this->postWebhook($payload, StripeSignatureHelper::header($payload, self::WEBHOOK_SECRET));
+        $this->assertResponseIsSuccessful();
+
+        $this->em->refresh($this->user);
+        $sub = $this->user->getPaymentDetails()['subscription'];
+        $this->assertSame('active', $sub['status']);
+        $this->assertArrayNotHasKey('paused_at', $sub);
+    }
+
+    public function testSubscriptionUpdatedWithStatusCanceledKeepsLevelAndUpdatesStatus(): void
+    {
+        $subscriptionId = 'sub_canceledstatus_'.bin2hex(random_bytes(4));
+        $this->seedActiveSubscription($subscriptionId);
+
+        // Stripe sometimes sends subscription.updated with status=canceled
+        // BEFORE customer.subscription.deleted (or instead of). The handler
+        // must propagate the status without implicitly downgrading the user;
+        // only .deleted owns the downgrade.
+        $payload = $this->buildEventPayload(
+            'customer.subscription.updated',
+            $this->subscriptionObject([
+                'id' => $subscriptionId,
+                'status' => 'canceled',
+            ]),
+        );
+        $this->postWebhook($payload, StripeSignatureHelper::header($payload, self::WEBHOOK_SECRET));
+        $this->assertResponseIsSuccessful();
+
+        $this->em->refresh($this->user);
+        $this->assertSame('PRO', $this->user->getUserLevel(), 'Level must NOT downgrade on status=canceled without .deleted event');
+        $this->assertSame('canceled', $this->user->getPaymentDetails()['subscription']['status']);
+    }
+
+    public function testInvoicePaymentFailedSetsPaymentFailedFlag(): void
+    {
+        $subscriptionId = 'sub_payfail_'.bin2hex(random_bytes(4));
+        $this->seedActiveSubscription($subscriptionId);
+
+        $payload = $this->buildEventPayload('invoice.payment_failed', [
+            'id' => 'in_'.bin2hex(random_bytes(4)),
+            'object' => 'invoice',
+            'customer' => $this->stripeCustomerId,
+            'subscription' => $subscriptionId,
+            'amount_due' => 1995,
+        ]);
+        $this->postWebhook($payload, StripeSignatureHelper::header($payload, self::WEBHOOK_SECRET));
+        $this->assertResponseIsSuccessful();
+
+        $this->em->refresh($this->user);
+        $sub = $this->user->getPaymentDetails()['subscription'];
+        // Level stays PRO — Stripe's smart-retry / dunning flow may still
+        // recover the payment. The flag lets the UI surface a banner.
+        $this->assertSame('PRO', $this->user->getUserLevel());
+        $this->assertTrue($sub['payment_failed']);
+        $this->assertIsInt($sub['payment_failed_at']);
+    }
+
+    public function testSubscriptionCreatedActivatesUserAndCancelsOtherSubscriptions(): void
+    {
+        // The handler calls Stripe\Subscription::all(...) to find subs to
+        // cancel for upgrade scenarios. We return one stale subscription that
+        // must be canceled, and verify the cancel call is actually issued.
+        $newSubId = 'sub_new_'.bin2hex(random_bytes(4));
+        $oldSubId = 'sub_old_'.bin2hex(random_bytes(4));
+
+        // Subscription::all → returns [old subscription]
+        $this->stripeMock->expect('GET', 'subscriptions', [
+            'object' => 'list',
+            'data' => [[
+                'id' => $oldSubId,
+                'object' => 'subscription',
+                'customer' => $this->stripeCustomerId,
+                'status' => 'active',
+            ]],
+            'has_more' => false,
+            'url' => '/v1/subscriptions',
+        ]);
+
+        // The SDK fetches the subscription before .cancel() in some code paths;
+        // be permissive by responding to any subsequent GET on this sub id.
+        $this->stripeMock->expect('GET', 'subscriptions/'.$oldSubId, [
+            'id' => $oldSubId,
+            'object' => 'subscription',
+            'customer' => $this->stripeCustomerId,
+            'status' => 'active',
+        ]);
+
+        // existing.cancel() → DELETE /v1/subscriptions/{id}
+        $this->stripeMock->expect('DELETE', 'subscriptions/'.$oldSubId, [
+            'id' => $oldSubId,
+            'object' => 'subscription',
+            'customer' => $this->stripeCustomerId,
+            'status' => 'canceled',
+        ]);
+
+        $payload = $this->buildEventPayload(
+            'customer.subscription.created',
+            $this->subscriptionObject(['id' => $newSubId, 'status' => 'active']),
+        );
+        $this->postWebhook($payload, StripeSignatureHelper::header($payload, self::WEBHOOK_SECRET));
+        $this->assertResponseIsSuccessful();
+
+        $this->em->refresh($this->user);
+        $this->assertSame('PRO', $this->user->getUserLevel());
+        $this->assertSame($newSubId, $this->user->getPaymentDetails()['subscription']['stripe_subscription_id']);
+
+        // The SDK can issue both list + retrieve + delete depending on the
+        // exact code path; we only require that a list and a delete happened.
+        $this->assertGreaterThanOrEqual(1, $this->stripeMock->countCalls('GET', 'subscriptions'));
+        $this->assertGreaterThanOrEqual(1, $this->stripeMock->countCalls('DELETE', 'subscriptions/'.$oldSubId));
+    }
+
+    /**
+     * Pre-populate the test user with an active PRO subscription, mirroring
+     * what handleSubscriptionCreated would have written. Used by lifecycle
+     * tests so they don't have to drive the full create+update flow first.
+     *
+     * @param array<string, mixed> $extraSubscriptionFields Merged into the subscription block
+     */
+    private function seedActiveSubscription(string $subscriptionId, array $extraSubscriptionFields = []): void
+    {
+        $details = $this->user->getPaymentDetails();
+        $details['subscription'] = array_merge([
+            'stripe_subscription_id' => $subscriptionId,
+            'status' => 'active',
+            'subscription_start' => time() - 86400,
+            'subscription_end' => time() + 30 * 86400,
+            'plan' => 'PRO',
+        ], $extraSubscriptionFields);
+        $this->user->setPaymentDetails($details);
+        $this->user->setUserLevel('PRO');
+        $this->em->flush();
+    }
+
+    /**
+     * @param array<string, mixed> $eventDataObject The contents of `data.object`
+     */
+    private function buildEventPayload(string $type, array $eventDataObject, ?string $eventId = null): string
+    {
+        $envelope = [
+            'id' => $eventId ?? 'evt_'.bin2hex(random_bytes(8)),
+            'object' => 'event',
+            'api_version' => '2024-06-20',
+            'created' => time(),
+            'type' => $type,
+            'livemode' => false,
+            'data' => [
+                'object' => $eventDataObject,
+            ],
+        ];
+
+        return json_encode($envelope, JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * Build a minimal Stripe Subscription object that's just complete enough
+     * for our handlers (handleSubscription* read items[0].price.id, status,
+     * cancel_at_period_end, cancel_at).
+     *
+     * @param array<string, mixed> $overrides
+     *
+     * @return array<string, mixed>
+     */
+    private function subscriptionObject(array $overrides): array
+    {
+        $now = time();
+        $base = [
+            'id' => 'sub_default_'.bin2hex(random_bytes(4)),
+            'object' => 'subscription',
+            'customer' => $this->stripeCustomerId,
+            'status' => 'active',
+            'cancel_at_period_end' => false,
+            'cancel_at' => null,
+            'items' => [
+                'object' => 'list',
+                'data' => [[
+                    'id' => 'si_'.bin2hex(random_bytes(4)),
+                    'object' => 'subscription_item',
+                    'current_period_start' => $now,
+                    'current_period_end' => $now + 30 * 86400,
+                    'price' => [
+                        'id' => self::PRICE_PRO,
+                        'object' => 'price',
+                    ],
+                ]],
+            ],
+        ];
+
+        return array_merge($base, $overrides);
+    }
+
+    private function postWebhook(string $payload, string $signature): void
+    {
+        $this->client->request(
+            'POST',
+            '/api/v1/stripe/webhook',
+            [],
+            [],
+            [
+                'CONTENT_TYPE' => 'application/json',
+                'HTTP_STRIPE_SIGNATURE' => $signature,
+            ],
+            $payload,
+        );
+    }
+}

--- a/backend/tests/Integration/Stripe/StripeWebhookControllerTest.php
+++ b/backend/tests/Integration/Stripe/StripeWebhookControllerTest.php
@@ -262,6 +262,129 @@ class StripeWebhookControllerTest extends WebTestCase
         $this->assertIsInt($sub['payment_failed_at']);
     }
 
+    public function testCheckoutSessionCompletedPersistsCustomerAndSessionIds(): void
+    {
+        // checkout.session.completed runs before customer.subscription.created
+        // in the typical Stripe sequence; here it's the only event we send.
+        // The handler must persist the customer + session id from the event,
+        // looking up the user via client_reference_id (set during checkout
+        // creation as the user's database id).
+        $sessionId = 'cs_test_'.bin2hex(random_bytes(8));
+        $newCustomerId = 'cus_checkout_'.bin2hex(random_bytes(6));
+
+        // Important: we deliberately do NOT pre-set stripeCustomerId on the
+        // user — this proves the handler writes it, rather than just leaving
+        // an existing one in place.
+        $details = $this->user->getPaymentDetails();
+        unset($details['stripe_customer_id']);
+        $this->user->setPaymentDetails($details);
+        $this->em->flush();
+
+        $payload = $this->buildEventPayload('checkout.session.completed', [
+            'id' => $sessionId,
+            'object' => 'checkout.session',
+            'customer' => $newCustomerId,
+            'client_reference_id' => (string) $this->user->getId(),
+            'customer_email' => $this->user->getMail(),
+            'mode' => 'subscription',
+        ]);
+        $this->postWebhook($payload, StripeSignatureHelper::header($payload, self::WEBHOOK_SECRET));
+        $this->assertResponseIsSuccessful();
+
+        $this->em->refresh($this->user);
+        $this->assertSame($newCustomerId, $this->user->getStripeCustomerId());
+        $this->assertSame($sessionId, $this->user->getPaymentDetails()['stripe_session_id']);
+        // Level is set later by customer.subscription.created — checkout.session.completed
+        // alone must not promote the user. This protects the upgrade flow:
+        // a stray checkout-completed without a paid subscription must not unlock features.
+        $this->assertSame('NEW', $this->user->getUserLevel());
+    }
+
+    public function testSubscriptionUpdatedForOldSubscriptionIdIsIgnored(): void
+    {
+        // This protects against a Stripe race / replay where an UPDATE for a
+        // stale subscription (e.g. one already replaced during an upgrade)
+        // arrives after the new subscription is already current. Without the
+        // guard we'd overwrite the live subscription's status / period with
+        // stale data. See StripeWebhookController::handleSubscriptionUpdated
+        // — the "Only process updates for the current subscription" branch.
+        $currentSubId = 'sub_current_'.bin2hex(random_bytes(4));
+        $staleSubId = 'sub_stale_'.bin2hex(random_bytes(4));
+        $this->seedActiveSubscription($currentSubId);
+
+        $payload = $this->buildEventPayload(
+            'customer.subscription.updated',
+            $this->subscriptionObject([
+                'id' => $staleSubId,
+                'status' => 'canceled',
+                'cancel_at_period_end' => true,
+                'cancel_at' => time() - 86400,
+            ]),
+        );
+        $this->postWebhook($payload, StripeSignatureHelper::header($payload, self::WEBHOOK_SECRET));
+        $this->assertResponseIsSuccessful();
+
+        $this->em->refresh($this->user);
+        $sub = $this->user->getPaymentDetails()['subscription'];
+        // None of the stale event's fields may leak into our state.
+        $this->assertSame('PRO', $this->user->getUserLevel());
+        $this->assertSame($currentSubId, $sub['stripe_subscription_id']);
+        $this->assertSame('active', $sub['status']);
+        $this->assertArrayNotHasKey('cancel_at', $sub);
+        $this->assertArrayNotHasKey('cancel_at_period_end', $sub);
+    }
+
+    public function testSubscriptionDeletedDowngradesUserAndClearsSubscriptionData(): void
+    {
+        $subscriptionId = 'sub_del_'.bin2hex(random_bytes(4));
+        $this->seedActiveSubscription($subscriptionId);
+
+        // Sanity: user starts as PRO with an active subscription.
+        $this->assertSame('PRO', $this->user->getUserLevel());
+        $this->assertSame('active', $this->user->getPaymentDetails()['subscription']['status']);
+
+        $payload = $this->buildEventPayload(
+            'customer.subscription.deleted',
+            $this->subscriptionObject(['id' => $subscriptionId, 'status' => 'canceled']),
+        );
+        $this->postWebhook($payload, StripeSignatureHelper::header($payload, self::WEBHOOK_SECRET));
+        $this->assertResponseIsSuccessful();
+
+        $this->em->refresh($this->user);
+        $this->assertSame('NEW', $this->user->getUserLevel(), 'User must be downgraded to NEW after subscription.deleted');
+        $sub = $this->user->getPaymentDetails()['subscription'];
+        $this->assertSame('canceled', $sub['status']);
+        $this->assertArrayHasKey('canceled_at', $sub);
+        $this->assertIsInt($sub['canceled_at']);
+        $this->assertSame($subscriptionId, $sub['stripe_subscription_id'], 'Subscription ID must be preserved for audit trail');
+    }
+
+    public function testSubscriptionDeletedForOldSubscriptionIdDoesNotDowngrade(): void
+    {
+        // Same race-window protection for the .deleted event: a delayed
+        // delete for an OLD subscription (already superseded by an upgrade)
+        // must NOT downgrade the user back to NEW. The handler explicitly
+        // documents this with "// This prevents race conditions where old
+        // subscription deletions reset the level".
+        $currentSubId = 'sub_current_'.bin2hex(random_bytes(4));
+        $staleSubId = 'sub_stale_'.bin2hex(random_bytes(4));
+        $this->seedActiveSubscription($currentSubId);
+
+        $payload = $this->buildEventPayload(
+            'customer.subscription.deleted',
+            $this->subscriptionObject(['id' => $staleSubId, 'status' => 'canceled']),
+        );
+        $this->postWebhook($payload, StripeSignatureHelper::header($payload, self::WEBHOOK_SECRET));
+        $this->assertResponseIsSuccessful();
+
+        $this->em->refresh($this->user);
+        $sub = $this->user->getPaymentDetails()['subscription'];
+        $this->assertSame('PRO', $this->user->getUserLevel(), 'Stale .deleted must not downgrade the user');
+        $this->assertSame($currentSubId, $sub['stripe_subscription_id']);
+        $this->assertSame('active', $sub['status']);
+        $this->assertArrayNotHasKey('canceled_at', $sub);
+    }
+
     public function testSubscriptionCreatedActivatesUserAndCancelsOtherSubscriptions(): void
     {
         // The handler calls Stripe\Subscription::all(...) to find subs to

--- a/backend/tests/Integration/Stripe/SubscriptionControllerEndpointTest.php
+++ b/backend/tests/Integration/Stripe/SubscriptionControllerEndpointTest.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Stripe;
+
+use App\Entity\User;
+use App\Tests\Trait\AuthenticatedTestTrait;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Integration tests for SubscriptionController endpoints that do NOT make
+ * outbound calls to Stripe. Outbound-call tests live in
+ * SubscriptionControllerStripeOutboundTest; webhook-driven tests in
+ * StripeWebhookControllerTest.
+ *
+ * Covered here:
+ *   - GET  /api/v1/subscription/plans          — public plan catalogue
+ *   - GET  /api/v1/subscription/status         — drives SubscriptionView.vue
+ *   - POST /api/v1/subscription/checkout       — 400 path for invalid planId
+ *
+ * The status endpoint is the single contract the frontend reads when
+ * rendering subscription state, so we pin both the "no subscription" and
+ * "active subscription with paymentFailed flag" shapes — that flag exists
+ * in the API response today even though the UI ignores it (tracked as a
+ * separate GitHub issue).
+ */
+class SubscriptionControllerEndpointTest extends WebTestCase
+{
+    use AuthenticatedTestTrait;
+
+    private const PRICE_PRO = 'price_1TestSuitePro';
+    private const PRICE_TEAM = 'price_1TestSuiteTeam';
+    private const PRICE_BUSINESS = 'price_1TestSuiteBusiness';
+
+    private KernelBrowser $client;
+    private EntityManagerInterface $em;
+    private User $user;
+    private string $accessToken;
+
+    protected function setUp(): void
+    {
+        self::ensureKernelShutdown();
+        $this->client = static::createClient();
+        $this->em = $this->client->getContainer()->get('doctrine')->getManager();
+
+        $this->user = new User();
+        $this->user->setMail('subscription-endpoint-'.bin2hex(random_bytes(6)).'@test.synaplan.com');
+        $this->user->setPw(password_hash('Test1234!', PASSWORD_BCRYPT));
+        $this->user->setUserLevel('NEW');
+        $this->user->setProviderId('local');
+        $this->user->setCreated(date('YmdHis'));
+
+        $this->em->persist($this->user);
+        $this->em->flush();
+
+        $this->accessToken = $this->authenticateClient($this->client, $this->user);
+    }
+
+    protected function tearDown(): void
+    {
+        if (isset($this->user) && $this->em->isOpen()) {
+            $managed = $this->em->find(User::class, $this->user->getId());
+            if ($managed) {
+                $this->em->remove($managed);
+                $this->em->flush();
+            }
+        }
+
+        self::ensureKernelShutdown();
+        parent::tearDown();
+    }
+
+    public function testGetPlansReturnsAllThreeTiersWithStripePriceIds(): void
+    {
+        $this->client->request('GET', '/api/v1/subscription/plans');
+
+        $this->assertResponseIsSuccessful();
+        $body = json_decode((string) $this->client->getResponse()->getContent(), true);
+
+        $this->assertTrue($body['stripeConfigured'], 'Test env has real-shape Stripe price IDs configured');
+        $this->assertCount(3, $body['plans'], 'Catalogue must always expose exactly PRO/TEAM/BUSINESS');
+
+        $byId = [];
+        foreach ($body['plans'] as $plan) {
+            $byId[$plan['id']] = $plan;
+        }
+        $this->assertSame(['PRO', 'TEAM', 'BUSINESS'], array_keys($byId), 'Plan order must be cheap-to-expensive');
+
+        $this->assertSame(self::PRICE_PRO, $byId['PRO']['stripePriceId']);
+        $this->assertSame(self::PRICE_TEAM, $byId['TEAM']['stripePriceId']);
+        $this->assertSame(self::PRICE_BUSINESS, $byId['BUSINESS']['stripePriceId']);
+
+        // Ascending price tiers — pricing-config drift would flip this and we'd want CI to catch it.
+        $this->assertLessThan($byId['TEAM']['price'], $byId['PRO']['price']);
+        $this->assertLessThan($byId['BUSINESS']['price'], $byId['TEAM']['price']);
+
+        // The frontend renders these arrays verbatim; missing keys would break the cards.
+        foreach ($byId as $plan) {
+            $this->assertArrayHasKey('features', $plan);
+            $this->assertNotEmpty($plan['features']);
+            $this->assertSame('EUR', $plan['currency']);
+            $this->assertSame('month', $plan['interval']);
+        }
+    }
+
+    public function testGetSubscriptionStatusReturns401WhenUnauthenticated(): void
+    {
+        $this->client->getCookieJar()->clear();
+        $this->client->request('GET', '/api/v1/subscription/status');
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+    }
+
+    public function testGetSubscriptionStatusForUserWithoutSubscription(): void
+    {
+        $this->client->request(
+            'GET',
+            '/api/v1/subscription/status',
+            [],
+            [],
+            ['HTTP_AUTHORIZATION' => 'Bearer '.$this->accessToken],
+        );
+
+        $this->assertResponseIsSuccessful();
+        $body = json_decode((string) $this->client->getResponse()->getContent(), true);
+
+        $this->assertFalse($body['hasSubscription']);
+        $this->assertSame('NEW', $body['plan']);
+        // None of the subscription fields must leak when there's no subscription.
+        $this->assertArrayNotHasKey('status', $body);
+        $this->assertArrayNotHasKey('nextBilling', $body);
+        $this->assertArrayNotHasKey('cancelAt', $body);
+        $this->assertArrayNotHasKey('paymentFailed', $body);
+    }
+
+    public function testGetSubscriptionStatusReflectsPaymentFailedFlag(): void
+    {
+        $subscriptionId = 'sub_status_'.bin2hex(random_bytes(4));
+        $nextBilling = time() + 30 * 86400;
+
+        $details = $this->user->getPaymentDetails();
+        $details['subscription'] = [
+            'stripe_subscription_id' => $subscriptionId,
+            'status' => 'past_due',
+            'subscription_start' => time() - 86400,
+            'subscription_end' => $nextBilling,
+            'plan' => 'PRO',
+            'payment_failed' => true,
+            'payment_failed_at' => time() - 3600,
+        ];
+        $this->user->setPaymentDetails($details);
+        $this->user->setUserLevel('PRO');
+        $this->em->flush();
+
+        $this->client->request(
+            'GET',
+            '/api/v1/subscription/status',
+            [],
+            [],
+            ['HTTP_AUTHORIZATION' => 'Bearer '.$this->accessToken],
+        );
+
+        $this->assertResponseIsSuccessful();
+        $body = json_decode((string) $this->client->getResponse()->getContent(), true);
+
+        // This is the contract the frontend (today incompletely) consumes:
+        // — plan reflects the user level, NOT the cached subscription.plan
+        // — paymentFailed surfaces the dunning state for the (planned) UI banner
+        // — nextBilling is the period_end timestamp the SubscriptionView formats
+        $this->assertTrue($body['hasSubscription']);
+        $this->assertSame('PRO', $body['plan']);
+        $this->assertSame('past_due', $body['status']);
+        $this->assertSame($nextBilling, $body['nextBilling']);
+        $this->assertTrue($body['paymentFailed']);
+        $this->assertSame($subscriptionId, $body['stripeSubscriptionId']);
+        $this->assertNull($body['cancelAt']);
+    }
+
+    public function testCheckoutReturns400ForInvalidPlanId(): void
+    {
+        $this->client->request(
+            'POST',
+            '/api/v1/subscription/checkout',
+            [],
+            [],
+            [
+                'CONTENT_TYPE' => 'application/json',
+                'HTTP_AUTHORIZATION' => 'Bearer '.$this->accessToken,
+            ],
+            json_encode(['planId' => 'ENTERPRISE'], JSON_THROW_ON_ERROR),
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+        $body = json_decode((string) $this->client->getResponse()->getContent(), true);
+        $this->assertSame('Invalid plan', $body['error']);
+
+        // The user must NOT have been linked to a Stripe customer when the
+        // request is rejected up-front — the 400 path must short-circuit
+        // before Customer::create runs.
+        $this->em->refresh($this->user);
+        $this->assertNull($this->user->getStripeCustomerId());
+    }
+}

--- a/backend/tests/Integration/Stripe/SubscriptionControllerStripeOutboundTest.php
+++ b/backend/tests/Integration/Stripe/SubscriptionControllerStripeOutboundTest.php
@@ -1,0 +1,371 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Stripe;
+
+use App\Entity\User;
+use App\Tests\Integration\Stripe\Mock\StripeMockHttpClient;
+use App\Tests\Trait\AuthenticatedTestTrait;
+use Doctrine\ORM\EntityManagerInterface;
+use Stripe\ApiRequestor;
+use Stripe\HttpClient\CurlClient;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Integration tests for SubscriptionController's outbound Stripe API calls.
+ *
+ * These endpoints call the Stripe SDK with side-effects on Stripe's
+ * infrastructure (Customer creation, Checkout / Portal session creation,
+ * Subscription updates, Subscription::all). CI cannot make those calls for
+ * real, so we replace the Stripe SDK's HTTP client with StripeMockHttpClient
+ * via \Stripe\ApiRequestor::setHttpClient() and verify:
+ *   - the controller actually issues the right method + endpoint
+ *   - the response body and DB state reflect the (mocked) Stripe response
+ *
+ * Production controller code is NOT modified; the Stripe SDK exposes
+ * setHttpClient() specifically for this scenario.
+ *
+ * Webhook-driven scenarios (signature, idempotency, lifecycle without
+ * outbound calls) live in StripeWebhookControllerTest.
+ */
+class SubscriptionControllerStripeOutboundTest extends WebTestCase
+{
+    use AuthenticatedTestTrait;
+
+    private const PRICE_PRO = 'price_1TestSuitePro';
+    private const PRICE_BUSINESS = 'price_1TestSuiteBusiness';
+
+    private KernelBrowser $client;
+    private EntityManagerInterface $em;
+    private User $user;
+    private string $accessToken;
+    private StripeMockHttpClient $stripeMock;
+
+    protected function setUp(): void
+    {
+        self::ensureKernelShutdown();
+        $this->client = static::createClient();
+        $this->em = $this->client->getContainer()->get('doctrine')->getManager();
+
+        $this->stripeMock = new StripeMockHttpClient();
+        ApiRequestor::setHttpClient($this->stripeMock);
+
+        $this->user = new User();
+        $this->user->setMail('stripe-outbound-'.bin2hex(random_bytes(6)).'@test.synaplan.com');
+        $this->user->setPw(password_hash('Test1234!', PASSWORD_BCRYPT));
+        $this->user->setUserLevel('NEW');
+        $this->user->setProviderId('local');
+        $this->user->setCreated(date('YmdHis'));
+
+        $this->em->persist($this->user);
+        $this->em->flush();
+
+        $this->accessToken = $this->authenticateClient($this->client, $this->user);
+    }
+
+    protected function tearDown(): void
+    {
+        ApiRequestor::setHttpClient(CurlClient::instance());
+
+        if (isset($this->user) && $this->em->isOpen()) {
+            $managed = $this->em->find(User::class, $this->user->getId());
+            if ($managed) {
+                $this->em->remove($managed);
+                $this->em->flush();
+            }
+        }
+
+        self::ensureKernelShutdown();
+        parent::tearDown();
+    }
+
+    public function testCheckoutCreatesNewStripeCustomerWhenUserHasNone(): void
+    {
+        $newCustomerId = 'cus_'.bin2hex(random_bytes(8));
+        $sessionId = 'cs_test_'.bin2hex(random_bytes(8));
+
+        // 1. Customer::create (no customer yet on the user)
+        $this->stripeMock->expect('POST', 'customers', [
+            'id' => $newCustomerId,
+            'object' => 'customer',
+            'email' => $this->user->getMail(),
+        ]);
+
+        // 2. Checkout\Session::create
+        $this->stripeMock->expect('POST', 'checkout/sessions', [
+            'id' => $sessionId,
+            'object' => 'checkout.session',
+            'url' => 'https://checkout.stripe.com/c/pay/'.$sessionId,
+            'customer' => $newCustomerId,
+        ]);
+
+        $this->postJson('/api/v1/subscription/checkout', ['planId' => 'PRO']);
+
+        $this->assertResponseIsSuccessful();
+        $body = json_decode((string) $this->client->getResponse()->getContent(), true);
+        $this->assertSame($sessionId, $body['sessionId']);
+        $this->assertStringStartsWith('https://checkout.stripe.com/', $body['url']);
+
+        // Customer ID must be persisted on the user.
+        $this->em->refresh($this->user);
+        $this->assertSame($newCustomerId, $this->user->getStripeCustomerId());
+
+        // Both Stripe endpoints must have been called exactly once.
+        $this->assertSame(1, $this->stripeMock->countCalls('POST', 'customers'));
+        $this->assertSame(1, $this->stripeMock->countCalls('POST', 'checkout/sessions'));
+    }
+
+    public function testCheckoutReusesExistingStripeCustomer(): void
+    {
+        $customerId = 'cus_existing_'.bin2hex(random_bytes(4));
+        $this->seedStripeCustomerId($customerId);
+        $sessionId = 'cs_test_'.bin2hex(random_bytes(8));
+
+        // Customer::retrieve verifies the customer still exists.
+        $this->stripeMock->expect('GET', 'customers/'.$customerId, [
+            'id' => $customerId,
+            'object' => 'customer',
+            'email' => $this->user->getMail(),
+        ]);
+
+        $this->stripeMock->expect('POST', 'checkout/sessions', [
+            'id' => $sessionId,
+            'object' => 'checkout.session',
+            'url' => 'https://checkout.stripe.com/c/pay/'.$sessionId,
+            'customer' => $customerId,
+        ]);
+
+        $this->postJson('/api/v1/subscription/checkout', ['planId' => 'BUSINESS']);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSame(1, $this->stripeMock->countCalls('GET', 'customers/'.$customerId));
+        $this->assertSame(0, $this->stripeMock->countCalls('POST', 'customers'),
+            'Existing customer must not be duplicated');
+    }
+
+    public function testCancelSubscriptionSchedulesCancelAtPeriodEnd(): void
+    {
+        $subscriptionId = 'sub_'.bin2hex(random_bytes(8));
+        $this->seedStripeCustomerId('cus_'.bin2hex(random_bytes(4)));
+        $this->seedActiveSubscription($subscriptionId);
+
+        $cancelAt = time() + 30 * 86400;
+
+        // Stripe SDK does Subscription::update via POST /v1/subscriptions/{id}
+        $this->stripeMock->expect('POST', 'subscriptions/'.$subscriptionId, [
+            'id' => $subscriptionId,
+            'object' => 'subscription',
+            'status' => 'active',
+            'cancel_at_period_end' => true,
+            'cancel_at' => $cancelAt,
+        ]);
+
+        $this->postJson('/api/v1/subscription/cancel');
+
+        $this->assertResponseIsSuccessful();
+        $body = json_decode((string) $this->client->getResponse()->getContent(), true);
+        $this->assertTrue($body['success']);
+        $this->assertSame($cancelAt, $body['cancelAt']);
+
+        $this->em->refresh($this->user);
+        $sub = $this->user->getPaymentDetails()['subscription'];
+        $this->assertSame('canceling', $sub['status']);
+        $this->assertSame($cancelAt, $sub['cancel_at']);
+
+        // Verify the controller passed cancel_at_period_end=true to Stripe.
+        $captured = $this->stripeMock->captured();
+        $updateCall = null;
+        foreach ($captured as $call) {
+            if ('post' === $call['method'] && str_contains($call['url'], 'subscriptions/'.$subscriptionId)) {
+                $updateCall = $call;
+                break;
+            }
+        }
+        $this->assertNotNull($updateCall);
+        // Stripe SDK serialises booleans into the form-encoded body as the
+        // string 'true', so we accept either representation.
+        $this->assertContains($updateCall['params']['cancel_at_period_end'], [true, 'true']);
+    }
+
+    public function testCancelSubscriptionReturns404WhenNoActiveSubscription(): void
+    {
+        $this->postJson('/api/v1/subscription/cancel');
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+        $this->assertSame(0, count($this->stripeMock->captured()),
+            'No Stripe call must be issued when there is nothing to cancel');
+    }
+
+    public function testCreatePortalSessionReturnsUrl(): void
+    {
+        $customerId = 'cus_'.bin2hex(random_bytes(8));
+        $this->seedStripeCustomerId($customerId);
+
+        $this->stripeMock->expect('POST', 'billing_portal/sessions', [
+            'id' => 'bps_'.bin2hex(random_bytes(4)),
+            'object' => 'billing_portal.session',
+            'url' => 'https://billing.stripe.com/p/session/test_xxx',
+            'customer' => $customerId,
+            'return_url' => 'http://localhost:8000/subscription',
+        ]);
+
+        $this->postJson('/api/v1/subscription/portal');
+
+        $this->assertResponseIsSuccessful();
+        $body = json_decode((string) $this->client->getResponse()->getContent(), true);
+        $this->assertStringStartsWith('https://billing.stripe.com/', $body['url']);
+        $this->assertSame(1, $this->stripeMock->countCalls('POST', 'billing_portal/sessions'));
+    }
+
+    public function testCreatePortalSessionReturns404WhenNoStripeCustomer(): void
+    {
+        $this->postJson('/api/v1/subscription/portal');
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+        $this->assertSame(0, count($this->stripeMock->captured()),
+            'Portal must not call Stripe when the user has no customer id yet');
+    }
+
+    public function testSyncFromStripeUpgradesUserToHighestActivePlan(): void
+    {
+        $customerId = 'cus_'.bin2hex(random_bytes(8));
+        $this->seedStripeCustomerId($customerId);
+        $businessSubId = 'sub_business_'.bin2hex(random_bytes(4));
+        $proSubId = 'sub_pro_'.bin2hex(random_bytes(4));
+        $now = time();
+
+        // Subscription::all returns two active subs (PRO + BUSINESS); the
+        // controller must pick BUSINESS as the highest tier.
+        $this->stripeMock->expect('GET', 'subscriptions', [
+            'object' => 'list',
+            'has_more' => false,
+            'url' => '/v1/subscriptions',
+            'data' => [
+                $this->stripeSubscriptionPayload($proSubId, $customerId, self::PRICE_PRO, $now),
+                $this->stripeSubscriptionPayload($businessSubId, $customerId, self::PRICE_BUSINESS, $now),
+            ],
+        ]);
+
+        $this->postJson('/api/v1/subscription/sync');
+
+        $this->assertResponseIsSuccessful();
+        $body = json_decode((string) $this->client->getResponse()->getContent(), true);
+        $this->assertTrue($body['success']);
+        $this->assertSame('BUSINESS', $body['level']);
+        $this->assertSame($businessSubId, $body['subscriptionId']);
+
+        $this->em->refresh($this->user);
+        $this->assertSame('BUSINESS', $this->user->getUserLevel());
+        $this->assertSame($businessSubId, $this->user->getPaymentDetails()['subscription']['stripe_subscription_id']);
+    }
+
+    public function testSyncFromStripeDowngradesToNewWhenNoActiveSubscriptions(): void
+    {
+        $customerId = 'cus_'.bin2hex(random_bytes(8));
+        $this->seedStripeCustomerId($customerId);
+        $this->seedActiveSubscription('sub_stale_'.bin2hex(random_bytes(4)));
+
+        $this->stripeMock->expect('GET', 'subscriptions', [
+            'object' => 'list',
+            'has_more' => false,
+            'url' => '/v1/subscriptions',
+            'data' => [],
+        ]);
+
+        $this->postJson('/api/v1/subscription/sync');
+
+        $this->assertResponseIsSuccessful();
+        $body = json_decode((string) $this->client->getResponse()->getContent(), true);
+        $this->assertSame('NEW', $body['level']);
+        $this->assertSame('no_active_subscription', $body['status']);
+
+        $this->em->refresh($this->user);
+        $this->assertSame('NEW', $this->user->getUserLevel());
+        // The cached subscription record's status flips to canceled — this is
+        // what protects against re-asserting PRO if a later /status call
+        // raced ahead of a webhook.
+        $this->assertSame('canceled', $this->user->getPaymentDetails()['subscription']['status']);
+    }
+
+    public function testSyncFromStripeReturnsEarlyForUserWithoutCustomer(): void
+    {
+        $this->postJson('/api/v1/subscription/sync');
+
+        $this->assertResponseIsSuccessful();
+        $body = json_decode((string) $this->client->getResponse()->getContent(), true);
+        $this->assertSame('NEW', $body['level']);
+        $this->assertSame('no_customer', $body['status']);
+        $this->assertSame(0, count($this->stripeMock->captured()),
+            'No Stripe call must be issued for users without a customer id');
+    }
+
+    private function seedStripeCustomerId(string $customerId): void
+    {
+        $this->user->setStripeCustomerId($customerId);
+        $this->em->flush();
+    }
+
+    private function seedActiveSubscription(string $subscriptionId): void
+    {
+        $details = $this->user->getPaymentDetails();
+        $details['subscription'] = [
+            'stripe_subscription_id' => $subscriptionId,
+            'status' => 'active',
+            'subscription_start' => time() - 86400,
+            'subscription_end' => time() + 30 * 86400,
+            'plan' => 'PRO',
+        ];
+        $this->user->setPaymentDetails($details);
+        $this->user->setUserLevel('PRO');
+        $this->em->flush();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function stripeSubscriptionPayload(string $id, string $customerId, string $priceId, int $now): array
+    {
+        return [
+            'id' => $id,
+            'object' => 'subscription',
+            'customer' => $customerId,
+            'status' => 'active',
+            'cancel_at_period_end' => false,
+            'cancel_at' => null,
+            'items' => [
+                'object' => 'list',
+                'data' => [[
+                    'id' => 'si_'.bin2hex(random_bytes(4)),
+                    'object' => 'subscription_item',
+                    'current_period_start' => $now,
+                    'current_period_end' => $now + 30 * 86400,
+                    'price' => [
+                        'id' => $priceId,
+                        'object' => 'price',
+                    ],
+                ]],
+            ],
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $body
+     */
+    private function postJson(string $uri, array $body = []): void
+    {
+        $this->client->request(
+            'POST',
+            $uri,
+            [],
+            [],
+            [
+                'CONTENT_TYPE' => 'application/json',
+                'HTTP_AUTHORIZATION' => 'Bearer '.$this->accessToken,
+            ],
+            json_encode($body, JSON_THROW_ON_ERROR),
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Adds **23 hermetic PHPUnit integration tests** for all backend billing paths (`StripeWebhookController` + `SubscriptionController`), covering webhook processing, outbound Stripe API calls, and endpoint contracts.
- Introduces `StripeMockHttpClient` (intercepts Stripe SDK HTTP calls) and `StripeSignatureHelper` (generates valid webhook signatures) so the full test suite runs **without any real Stripe API calls** — safe for CI where keys can rotate or Stripe can be down.
- Covers: checkout session persistence, subscription CRUD webhooks, payment-failed flag, idempotency, signature verification, unhandled event types, pause/resume, cancel-at-period-end, portal session creation, plan sync (upgrade/downgrade), and endpoint auth/validation guards.

## Test plan

- [ ] `docker compose exec synaplan-app-test php -d memory_limit=2G bin/phpunit -- --testsuite Integration` — all 23 new tests pass
- [ ] PHPStan: `docker compose exec synaplan-app-test php -d memory_limit=2G vendor/bin/phpstan analyse --memory-limit=2G` — no new errors
- [ ] Verify no `.env` or secret files are included in the diff
- [ ] Merge **before** `e2e/billing-tests` (no conflicts either way, but this is the lower-risk PR)