### PR TITLE
fix: FrankenPhpRuntime double escaping and migration drop index

### DIFF
--- a/_docker/backend/synaplan-worker-mode.Caddyfile
+++ b/_docker/backend/synaplan-worker-mode.Caddyfile
@@ -21,6 +21,6 @@ frankenphp {
 		# worker.php needed.
 		file "/var/www/backend/public/index.php"
 		num  {$FRANKENPHP_WORKER_NUM:16}
-		env  APP_RUNTIME "App\\Runtime\\FrankenPhpRuntime"
+		env  APP_RUNTIME App\Runtime\FrankenPhpRuntime
 	}
 }

--- a/backend/migrations/Version20260420000000.php
+++ b/backend/migrations/Version20260420000000.php
@@ -58,7 +58,7 @@ final class Version20260420000000 extends AbstractMigration
                 AND c1.BID      < c2.keep_bid
         SQL);
 
-        $this->addSql('DROP INDEX idx_config_lookup ON BCONFIG');
+        $this->addSql('DROP INDEX IF EXISTS idx_config_lookup ON BCONFIG');
         $this->addSql('CREATE UNIQUE INDEX uniq_config_owner_group_setting ON BCONFIG (BOWNERID, BGROUP, BSETTING)');
     }
 


### PR DESCRIPTION
## Summary
- Fixes a double-escaping issue in the worker Caddyfile where `APP_RUNTIME` was enclosed in quotes, causing PHP to fail to find the `App\\Runtime\\FrankenPhpRuntime` class.
- Adds `IF EXISTS` to the `DROP INDEX` statement in a recent migration to prevent errors on re-runs.

Made with [Cursor](https://cursor.com)