### PR TITLE
fix(test): return realistic sorting JSON from TestProvider

### DIFF
--- a/backend/src/AI/Provider/TestProvider.php
+++ b/backend/src/AI/Provider/TestProvider.php
@@ -85,8 +85,14 @@ class TestProvider implements ChatProviderInterface, EmbeddingProviderInterface,
         $userContent = $lastMessage['content'] ?? 'hello';
         $userMessage = strtolower($userContent);
 
-        // Search-query-style request (e.g. SearchQueryGenerator with tools:search prompt): return cleaned query like fallbackExtraction
         $systemContent = 'system' === $messages[0]['role'] ? ($messages[0]['content'] ?? '') : '';
+
+        // Sort/classification prompt (tools:sort): return realistic JSON
+        if (str_contains($systemContent, 'BTOPIC') && str_contains($systemContent, 'BWEBSEARCH')) {
+            return $this->mockSortClassification($userContent, $systemContent);
+        }
+
+        // Search-query-style request (e.g. SearchQueryGenerator with tools:search prompt): return cleaned query like fallbackExtraction
         if (str_contains($systemContent, 'search') && str_contains($systemContent, 'query')) {
             return $this->mockSearchQueryExtraction($userContent);
         }
@@ -122,6 +128,200 @@ class TestProvider implements ChatProviderInterface, EmbeddingProviderInterface,
         $contextInfo = count($messages) > 1 ? ' (Message #'.count($messages).' in conversation)' : '';
 
         return "TestProvider response: I received your message '{$userMessage}'{$contextInfo}. This is a mock response to test the system. Try asking me to create an image or video!";
+    }
+
+    /**
+     * Mock sort/classification: parse the user message JSON and return a
+     * realistic classification response that MessageSorter::parseResponse()
+     * can decode. Mirrors what a real LLM would return for the tools:sort
+     * prompt: the same JSON object with BTOPIC, BLANG, BWEBSEARCH (and
+     * optionally BMEDIA, BDURATION, BRESOLUTION, BINPUTMODE) updated.
+     */
+    private function mockSortClassification(string $userContent, string $systemContent): string
+    {
+        $data = json_decode($userContent, true);
+        if (!is_array($data)) {
+            return json_encode(['BTOPIC' => 'general', 'BLANG' => 'en', 'BWEBSEARCH' => 0], JSON_THROW_ON_ERROR);
+        }
+
+        $text = strtolower($data['BTEXT'] ?? '');
+        $fileText = strtolower($data['BFILETEXT'] ?? '');
+
+        $data['BLANG'] = $this->detectLanguage($text ?: $fileText);
+        $data['BWEBSEARCH'] = $this->needsWebSearch($text) ? 1 : 0;
+
+        $availableTopics = $this->extractAvailableTopics($systemContent);
+        $classification = $this->classifyTopic($text ?: $fileText, $data, $availableTopics);
+
+        $data['BTOPIC'] = $classification['topic'];
+
+        if (isset($classification['media_type'])) {
+            $data['BMEDIA'] = $classification['media_type'];
+        }
+        if (isset($classification['duration'])) {
+            $data['BDURATION'] = $classification['duration'];
+        }
+        if (isset($classification['resolution'])) {
+            $data['BRESOLUTION'] = $classification['resolution'];
+        }
+        if (isset($classification['input_mode'])) {
+            $data['BINPUTMODE'] = $classification['input_mode'];
+        }
+
+        return json_encode($data, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
+    }
+
+    private function detectLanguage(string $text): string
+    {
+        if ('' === $text) {
+            return 'en';
+        }
+
+        $patterns = [
+            'de' => '/\b(ich|und|der|die|das|ein|eine|ist|bitte|danke|erstelle|mache|kannst|hallo|wie|was|wer|wo|warum|nicht|auch|aber|oder|für|mit|von)\b/u',
+            'fr' => '/\b(je|tu|il|elle|nous|vous|les|une|est|sont|avec|pour|dans|pas|merci|bonjour|oui|non|comment|pourquoi)\b/u',
+            'es' => '/\b(yo|tú|él|ella|los|las|una|estoy|somos|para|con|por|hola|gracias|sí|cómo|qué|dónde|pero|también)\b/u',
+            'it' => '/\b(io|tu|lui|lei|noi|gli|una|sono|siamo|per|con|ciao|grazie|come|cosa|dove|perché|anche|questo|quello)\b/u',
+            'nl' => '/\b(ik|je|hij|zij|wij|het|een|zijn|hebben|voor|met|van|hallo|dank|hoe|wat|waar|waarom|niet|ook)\b/u',
+            'pt' => '/\b(eu|tu|ele|ela|nós|uma|são|para|com|olá|obrigado|como|onde|porquê|também|este|esse)\b/u',
+            'ru' => '/[а-яА-ЯёЁ]{3,}/u',
+            'tr' => '/\b(ben|sen|bir|için|ile|merhaba|teşekkür|nasıl|neden|nerede|ama|veya|değil|var|yok|çok|bu|şu)\b/u',
+            'sv' => '/\b(jag|du|han|hon|vi|det|ett|för|med|hej|tack|hur|vad|var|varför|inte|också|men|eller)\b/u',
+        ];
+
+        $scores = [];
+        foreach ($patterns as $lang => $pattern) {
+            if (preg_match_all($pattern, $text, $matches)) {
+                $scores[$lang] = count($matches[0]);
+            }
+        }
+
+        if (empty($scores)) {
+            return 'en';
+        }
+
+        arsort($scores);
+
+        return array_key_first($scores);
+    }
+
+    private function needsWebSearch(string $text): bool
+    {
+        return (bool) preg_match(
+            '/\b(aktuell|current|news|wetter|weather|preis|price|heute|today|gestern|yesterday|2024|2025|2026|börse|stock|restaurant|öffnungszeiten|opening hours)\b/u',
+            $text
+        );
+    }
+
+    /**
+     * Extract the list of valid topic slugs from the system prompt's
+     * KEYLIST section (e.g. "general" | "mediamaker" | "coding").
+     *
+     * @return string[]
+     */
+    private function extractAvailableTopics(string $systemContent): array
+    {
+        if (preg_match_all('/"([^"]+)"/', $systemContent, $matches)) {
+            $candidates = array_unique($matches[1]);
+
+            return array_values(array_filter(
+                $candidates,
+                fn (string $t) => !in_array($t, ['de', 'en', 'it', 'es', 'fr', 'nl', 'pt', 'ru', 'sv', 'tr', 'image', 'video', 'audio', 'text_only', 'reference_images', '720p', '1080p', '4K'], true)
+                    && !str_starts_with($t, 'tools:')
+            ));
+        }
+
+        return ['general'];
+    }
+
+    /**
+     * Classify the user text into a topic. Uses keyword matching against the
+     * available topics and media-generation heuristics.
+     *
+     * @param string[] $availableTopics
+     *
+     * @return array{topic: string, media_type?: string, duration?: int, resolution?: string, input_mode?: string}
+     */
+    private function classifyTopic(string $text, array $data, array $availableTopics): array
+    {
+        $hasMediamaker = in_array('mediamaker', $availableTopics, true);
+
+        if ($hasMediamaker) {
+            $mediaResult = $this->detectMediaIntent($text, $data);
+            if (null !== $mediaResult) {
+                return $mediaResult;
+            }
+        }
+
+        return ['topic' => $data['BTOPIC'] ?: 'general'];
+    }
+
+    /**
+     * Detect media generation intent and return structured classification,
+     * or null when the message is not a media request.
+     *
+     * @return array{topic: string, media_type: string, duration?: int, resolution?: string, input_mode?: string}|null
+     */
+    private function detectMediaIntent(string $text, array $data): ?array
+    {
+        $isVideoRequest = (bool) preg_match('/\b(video|film|clip|animation|movie)\b/u', $text);
+        $isAudioRequest = (bool) preg_match('/\b(sprich|vorlesen|lies vor|speak|tts|text.to.speech|vertone|audio|aloud)\b/u', $text)
+            || (bool) preg_match('/\bread\b.*\b(aloud|vor)\b/u', $text);
+        $isImageGenRequest = (bool) preg_match('/\b(erstelle.*bild|generate.*image|create.*image|create.*picture|mache.*foto|draw|zeichne|illustr|render|design.*logo|bild.*erstellen|image.*generat)\b/u', $text);
+
+        $hasImageAttachments = false;
+        if (!empty($data['BATTACHED_FILES'])) {
+            $hasImageAttachments = (bool) preg_match('/\b(jpg|jpeg|png|gif|webp)\b/i', $data['BATTACHED_FILES']);
+        }
+        if (!$hasImageAttachments && !empty($data['BFILETYPE'])) {
+            $hasImageAttachments = (bool) preg_match('/^image\//i', $data['BFILETYPE']);
+        }
+
+        $isImageEditRequest = $hasImageAttachments && (bool) preg_match(
+            '/\b(edit|bearbeit|combine|kombin|merge|blend|replace|ersetze|style|transform|mach.*daraus|put.*into|füge.*ein)\b/u',
+            $text
+        );
+
+        if ($isVideoRequest) {
+            $result = ['topic' => 'mediamaker', 'media_type' => 'video'];
+
+            if (preg_match('/(\d+)\s*(?:sekund|second|sec|s\b)/u', $text, $m)) {
+                $duration = (int) $m[1];
+                $result['duration'] = max(4, min(8, $duration));
+            }
+
+            if (preg_match('/\b(720p?|1080p?|4k|uhd|hd|fullhd|full.hd)\b/ui', $text, $m)) {
+                $result['resolution'] = $this->mapResolution($m[1]);
+            }
+
+            return $result;
+        }
+
+        if ($isAudioRequest) {
+            return ['topic' => 'mediamaker', 'media_type' => 'audio'];
+        }
+
+        if ($isImageEditRequest) {
+            return ['topic' => 'mediamaker', 'media_type' => 'image', 'input_mode' => 'reference_images'];
+        }
+
+        if ($isImageGenRequest) {
+            return ['topic' => 'mediamaker', 'media_type' => 'image', 'input_mode' => 'text_only'];
+        }
+
+        return null;
+    }
+
+    private function mapResolution(string $raw): string
+    {
+        $key = strtolower(preg_replace('/[\s\-_]+/', '', $raw));
+
+        return match ($key) {
+            '720', '720p', 'hd' => '720p',
+            '1080', '1080p', 'fhd', 'fullhd' => '1080p',
+            '4k', 'uhd' => '4K',
+            default => '1080p',
+        };
     }
 
     /**

--- a/backend/tests/Integration/Stripe/StripeWebhookControllerTest.php
+++ b/backend/tests/Integration/Stripe/StripeWebhookControllerTest.php
@@ -35,6 +35,9 @@ use Symfony\Component\HttpFoundation\Response;
  * Webhook signatures are computed locally with the test webhook secret
  * (`whsec_fakeWebhookSecretForTests`) so the controller's
  * \Stripe\Webhook::constructEvent() accepts our crafted payloads.
+ *
+ * Fails in dev when Docker exports a real STRIPE_WEBHOOK_SECRET (overrides
+ * .env.test). In CI no real Stripe vars exist, so these pass.
  */
 class StripeWebhookControllerTest extends WebTestCase
 {

--- a/backend/tests/Unit/TestProviderSortingTest.php
+++ b/backend/tests/Unit/TestProviderSortingTest.php
@@ -1,0 +1,288 @@
+<?php
+
+namespace App\Tests\Unit;
+
+use App\AI\Provider\TestProvider;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests that TestProvider returns realistic sorting/classification JSON
+ * when invoked with a tools:sort-style system prompt, so that
+ * MessageSorter::parseResponse() can decode the response instead of
+ * falling back to defaults.
+ */
+class TestProviderSortingTest extends TestCase
+{
+    private TestProvider $provider;
+    private string $sortSystemPrompt;
+
+    protected function setUp(): void
+    {
+        $this->provider = new TestProvider();
+
+        $this->sortSystemPrompt = <<<'PROMPT'
+You are an assistant of assistants. You sort user requests by setting JSON values only.
+Classify the user's message into one of these BTOPIC categories:
+- "general": General questions and conversation
+- "mediamaker": Image, video, or audio generation
+- "coding": Programming and development questions
+Set BWEBSEARCH to 1 if the user needs current information, otherwise 0.
+Answer format: "BTOPIC": "general" | "mediamaker" | "coding"
+"BLANG": "de" | "en" | "it" | "es" | "fr" | "nl" | "pt" | "ru" | "sv" | "tr"
+"BWEBSEARCH": 0 | 1
+PROMPT;
+    }
+
+    private function classifyMessage(string $text, string $lang = 'en', string $topic = '', array $extra = []): array
+    {
+        $messageData = array_merge([
+            'BTEXT' => $text,
+            'BLANG' => $lang,
+            'BTOPIC' => $topic,
+            'BFILETEXT' => '',
+            'BWEBSEARCH' => 0,
+        ], $extra);
+
+        $messages = [
+            ['role' => 'system', 'content' => $this->sortSystemPrompt],
+            ['role' => 'user', 'content' => json_encode($messageData, JSON_UNESCAPED_UNICODE)],
+        ];
+
+        $result = $this->provider->chat($messages);
+
+        $decoded = json_decode($result['content'], true);
+        $this->assertIsArray($decoded, 'Sort response must be valid JSON, got: '.$result['content']);
+
+        return $decoded;
+    }
+
+    // ================================================
+    // Response format
+    // ================================================
+
+    public function testSortResponseIsValidJson(): void
+    {
+        $result = $this->classifyMessage('Hello, how are you?');
+
+        $this->assertArrayHasKey('BTOPIC', $result);
+        $this->assertArrayHasKey('BLANG', $result);
+        $this->assertArrayHasKey('BWEBSEARCH', $result);
+    }
+
+    public function testSortResponsePreservesOriginalFields(): void
+    {
+        $result = $this->classifyMessage('Hello', 'en', 'general', [
+            'BDATETIME' => '2026-05-07 10:00:00',
+            'BFILEPATH' => '/some/path',
+        ]);
+
+        $this->assertSame('2026-05-07 10:00:00', $result['BDATETIME']);
+        $this->assertSame('/some/path', $result['BFILEPATH']);
+    }
+
+    // ================================================
+    // Language detection
+    // ================================================
+
+    #[DataProvider('languageDetectionProvider')]
+    public function testDetectsLanguageCorrectly(string $text, string $expectedLang): void
+    {
+        $result = $this->classifyMessage($text);
+
+        $this->assertSame($expectedLang, $result['BLANG']);
+    }
+
+    public static function languageDetectionProvider(): array
+    {
+        return [
+            'German' => ['Kannst du mir bitte helfen? Ich habe eine Frage.', 'de'],
+            'English' => ['Can you help me with this question?', 'en'],
+            'French' => ['Bonjour, comment allez-vous aujourd\'hui?', 'fr'],
+            'Spanish' => ['Hola, cómo estoy para hacer esto?', 'es'],
+            'Turkish' => ['Merhaba, ben bir soru sormak istiyorum', 'tr'],
+            'Italian' => ['Ciao, come siamo noi oggi?', 'it'],
+            'unknown fallback' => ['xyzzy 12345 foo', 'en'],
+        ];
+    }
+
+    // ================================================
+    // Topic classification — general
+    // ================================================
+
+    public function testClassifiesGenericQuestionAsGeneral(): void
+    {
+        $result = $this->classifyMessage('What is the meaning of life?');
+
+        $this->assertSame('general', $result['BTOPIC']);
+    }
+
+    public function testPreservesExistingTopicForGenericMessage(): void
+    {
+        $result = $this->classifyMessage('Tell me more about that', topic: 'coding');
+
+        $this->assertSame('coding', $result['BTOPIC']);
+    }
+
+    // ================================================
+    // Topic classification — mediamaker (video)
+    // ================================================
+
+    #[DataProvider('videoRequestProvider')]
+    public function testClassifiesVideoRequestAsMediamaker(string $text): void
+    {
+        $result = $this->classifyMessage($text);
+
+        $this->assertSame('mediamaker', $result['BTOPIC']);
+        $this->assertSame('video', $result['BMEDIA']);
+    }
+
+    public static function videoRequestProvider(): array
+    {
+        return [
+            'English' => ['Create a video of a sunset over the ocean'],
+            'German' => ['Erstelle ein Video von einem Hund im Park'],
+        ];
+    }
+
+    public function testExtractsVideoDuration(): void
+    {
+        $result = $this->classifyMessage('Make a 6 second video of a running dog');
+
+        $this->assertSame('mediamaker', $result['BTOPIC']);
+        $this->assertSame('video', $result['BMEDIA']);
+        $this->assertSame(6, $result['BDURATION']);
+    }
+
+    public function testClampsDurationToMaximum(): void
+    {
+        $result = $this->classifyMessage('Create a 30 second video of fireworks');
+
+        $this->assertSame(8, $result['BDURATION']);
+    }
+
+    public function testExtractsVideoResolution(): void
+    {
+        $result = $this->classifyMessage('Generate a 4k video of a car race');
+
+        $this->assertSame('4K', $result['BRESOLUTION']);
+    }
+
+    // ================================================
+    // Topic classification — mediamaker (image)
+    // ================================================
+
+    #[DataProvider('imageGenerationProvider')]
+    public function testClassifiesImageGenerationAsMediamaker(string $text): void
+    {
+        $result = $this->classifyMessage($text);
+
+        $this->assertSame('mediamaker', $result['BTOPIC']);
+        $this->assertSame('image', $result['BMEDIA']);
+        $this->assertSame('text_only', $result['BINPUTMODE']);
+    }
+
+    public static function imageGenerationProvider(): array
+    {
+        return [
+            'English' => ['Create an image of a mountain landscape'],
+            'German' => ['Erstelle ein Bild von einem Sonnenuntergang'],
+        ];
+    }
+
+    public function testClassifiesImageEditWithAttachmentAsMediamaker(): void
+    {
+        $result = $this->classifyMessage(
+            'Edit this photo and replace the background',
+            extra: ['BATTACHED_FILES' => 'photo.jpg', 'BATTACHED_COUNT' => 1]
+        );
+
+        $this->assertSame('mediamaker', $result['BTOPIC']);
+        $this->assertSame('image', $result['BMEDIA']);
+        $this->assertSame('reference_images', $result['BINPUTMODE']);
+    }
+
+    public function testImageDescriptionWithAttachmentStaysGeneral(): void
+    {
+        $result = $this->classifyMessage(
+            'What is shown in this image?',
+            extra: ['BATTACHED_FILES' => 'photo.jpg', 'BATTACHED_COUNT' => 1]
+        );
+
+        $this->assertSame('general', $result['BTOPIC']);
+        $this->assertArrayNotHasKey('BMEDIA', $result);
+    }
+
+    // ================================================
+    // Topic classification — mediamaker (audio)
+    // ================================================
+
+    public function testClassifiesAudioRequestAsMediamaker(): void
+    {
+        $result = $this->classifyMessage('Read this text aloud please');
+
+        $this->assertSame('mediamaker', $result['BTOPIC']);
+        $this->assertSame('audio', $result['BMEDIA']);
+    }
+
+    // ================================================
+    // Web search detection
+    // ================================================
+
+    #[DataProvider('webSearchProvider')]
+    public function testWebSearchDetection(string $text, int $expected): void
+    {
+        $result = $this->classifyMessage($text);
+
+        $this->assertSame($expected, $result['BWEBSEARCH']);
+    }
+
+    public static function webSearchProvider(): array
+    {
+        return [
+            'current events EN' => ['What is the current weather in Berlin?', 1],
+            'current events DE' => ['Wie ist das aktuelle Wetter in München?', 1],
+            'general question' => ['Explain quantum physics', 0],
+        ];
+    }
+
+    // ================================================
+    // Edge cases
+    // ================================================
+
+    public function testHandlesEmptyText(): void
+    {
+        $result = $this->classifyMessage('');
+
+        $this->assertSame('general', $result['BTOPIC']);
+        $this->assertSame('en', $result['BLANG']);
+    }
+
+    public function testHandlesNonJsonUserMessage(): void
+    {
+        $messages = [
+            ['role' => 'system', 'content' => $this->sortSystemPrompt],
+            ['role' => 'user', 'content' => 'This is not JSON at all'],
+        ];
+
+        $result = $this->provider->chat($messages);
+        $decoded = json_decode($result['content'], true);
+
+        $this->assertIsArray($decoded);
+        $this->assertSame('general', $decoded['BTOPIC']);
+        $this->assertSame('en', $decoded['BLANG']);
+    }
+
+    public function testDoesNotTriggerSortForNormalChat(): void
+    {
+        $messages = [
+            ['role' => 'system', 'content' => 'You are a helpful assistant.'],
+            ['role' => 'user', 'content' => 'Hello!'],
+        ];
+
+        $result = $this->provider->chat($messages);
+
+        $this->assertNull(json_decode($result['content'], true),
+            'Normal chat should NOT return JSON sort response');
+    }
+}


### PR DESCRIPTION
## Summary

- **TestProvider** detects `tools:sort` system prompts and returns valid classification JSON instead of plaintext that `MessageSorter::parseResponse()` could not decode
- Deterministic heuristics for language detection (10 languages), topic classification (general/mediamaker), web search, media type/duration/resolution
- 27 unit tests covering all classification paths, edge cases, and DE/EN keywords
- Documents why Stripe integration tests fail in dev (real `STRIPE_WEBHOOK_SECRET` from Docker overrides `.env.test`)

## What this changes in CI

Previously, every SORT call in CI hit the JSON fallback (`general`/`en`), so routing code paths (topic resolution, prompt selection, media-type forwarding) were dead code. Now the real paths are exercised with realistic mock data.

## Test plan

- [x] `TestProviderSortingTest` — 27/27 green
- [x] All 840 Unit/AI tests green (0 failures)
- [x] PHPStan clean
- [x] PSR-12 lint clean
- [x] Existing E2E smoke test unaffected (verified: same routing result for `CHAT_SMOKE` prompt)