### PR TITLE
fix: dedupe memories, extract on media gen, tighten routing

### DIFF
--- a/backend/src/MessageHandler/ExtractMemoriesCommandHandler.php
+++ b/backend/src/MessageHandler/ExtractMemoriesCommandHandler.php
@@ -78,18 +78,34 @@ final readonly class ExtractMemoriesCommandHandler
             $enhancedThread[] = ['role' => 'assistant', 'content' => $aiResponse];
         }
 
+        // Load the user's full memory set so the AI can emit `update`
+        // actions for existing keys instead of blindly creating duplicates
+        // (issue #879). The relevant-memories list passed by the dispatcher
+        // is only the small RAG-style subset that was in scope for the
+        // assistant's reply — it routinely misses the matching memory when
+        // the new user message moves topics (e.g. "ich heiße Furkan" right
+        // after a coding question). Merging in the full list, capped at a
+        // sane budget, gives the extractor a stable view of what already
+        // exists. The cap keeps prompt growth bounded for users with
+        // hundreds of memories.
+        $existingMemories = $this->buildExistingMemoryContext(
+            $userId,
+            $command->getRelevantMemories(),
+        );
+
         $this->logger->info('ExtractMemoriesCommand: starting extraction', [
             'message_id' => $messageId,
             'user_id' => $userId,
             'thread_length' => count($enhancedThread),
             'relevant_memories' => count($command->getRelevantMemories()),
+            'existing_memories_passed' => count($existingMemories),
         ]);
 
         try {
             $memoryActions = $this->memoryExtractionService->analyzeAndExtract(
                 $message,
                 $enhancedThread,
-                $command->getRelevantMemories(),
+                $existingMemories,
             );
         } catch (\Throwable $e) {
             $this->logger->error('ExtractMemoriesCommand: extraction LLM call failed', [
@@ -111,21 +127,113 @@ final readonly class ExtractMemoriesCommandHandler
 
         $savedMemories = [];
         $deleteSuggestions = [];
+        $skippedDuplicates = 0;
+
+        // Index existing memories by (category, key) for backend-side dedup.
+        // Even when the AI prompt is given the full memory set, providers
+        // routinely emit `create` for an unchanged fact — so the worker
+        // enforces the dedup contract itself rather than trusting model
+        // output. Layered with the prompt-side hint, this turns the
+        // double-write race described in #879 into a no-op.
+        //
+        // `byCatKey` maps `(cat, key)` to the *first* matching memory
+        // (used for the create→update promotion below). The full list of
+        // existing memories is kept around for the post-loop singleton
+        // collapse — that step needs to see siblings, not just one.
+        [$byCatKeyValue, $byCatKey] = $this->indexExistingByCatKey($existingMemories);
+
+        /**
+         * IDs of memories touched (create/update) in this extraction
+         * batch, used by the singleton-collapse post-pass.
+         *
+         * @var array<int, true>
+         */
+        $touchedIds = [];
+
+        /**
+         * Singleton `(cat, key)` hashes touched in this batch, mapped to
+         * the saved memory representing the new current value. Used to
+         * prune stray duplicates from the user's memory list.
+         *
+         * @var array<string, array<string, mixed>>
+         */
+        $touchedSingletons = [];
 
         foreach ($memoryActions as $action) {
             try {
                 $kind = $action['action'] ?? 'create';
 
                 if ('create' === $kind) {
+                    $category = (string) ($action['category'] ?? 'personal');
+                    $key = (string) ($action['key'] ?? '');
+                    $value = (string) ($action['value'] ?? '');
+
+                    $catKeyValueHash = $this->normalizeForDedup($category, $key, $value);
+                    if (isset($byCatKeyValue[$catKeyValueHash])) {
+                        // Exact same fact already stored — skip silently.
+                        // This is the literal "Furkan was already saved as
+                        // Furkan" case from the bug report.
+                        ++$skippedDuplicates;
+                        $this->logger->info('ExtractMemoriesCommand: dropped duplicate create (exact match)', [
+                            'message_id' => $messageId,
+                            'category' => $category,
+                            'key' => $key,
+                        ]);
+                        continue;
+                    }
+
+                    $catKeyHash = $this->normalizeForDedup($category, $key);
+                    if (isset($byCatKey[$catKeyHash]) && $this->isSingletonKey($key)) {
+                        // Singleton keys (name, age, location, …) describe a
+                        // single current value per user. The AI failed to
+                        // emit `update` so we promote the create to an
+                        // update of the existing entry. Multi-value keys
+                        // like `diet` or `hobby` are intentionally NOT
+                        // matched here — see {@see isSingletonKey()}.
+                        $existingId = (int) $byCatKey[$catKeyHash]['id'];
+                        $memory = $this->memoryService->updateMemory(
+                            $existingId,
+                            $user,
+                            $value,
+                            'ai_edited',
+                            $message->getId(),
+                        );
+                        $memoryArray = $memory->toArray();
+                        $savedMemories[] = $memoryArray;
+                        $byCatKey[$catKeyHash] = $memoryArray;
+                        $byCatKeyValue[$this->normalizeForDedup($category, $key, $value)] = $memoryArray;
+                        $touchedIds[$existingId] = true;
+                        $touchedSingletons[$catKeyHash] = $memoryArray;
+                        $this->logger->info('ExtractMemoriesCommand: promoted create to update for singleton key', [
+                            'message_id' => $messageId,
+                            'category' => $category,
+                            'key' => $key,
+                            'memory_id' => $existingId,
+                        ]);
+                        continue;
+                    }
+
                     $memory = $this->memoryService->createMemory(
                         $user,
-                        $action['category'],
-                        $action['key'],
-                        $action['value'],
+                        $category,
+                        $key,
+                        $value,
                         'auto_detected',
                         $message->getId(),
                     );
-                    $savedMemories[] = $memory->toArray();
+                    $memoryArray = $memory->toArray();
+                    $savedMemories[] = $memoryArray;
+                    // Track newly-created memory in our local index so a
+                    // second action in the same batch with the same value
+                    // is also deduped.
+                    $byCatKeyValue[$catKeyValueHash] = $memoryArray;
+                    $byCatKey[$catKeyHash] = $memoryArray;
+                    if (isset($memoryArray['id'])) {
+                        $touchedIds[(int) $memoryArray['id']] = true;
+                    }
+                    if ($this->isSingletonKey($key)) {
+                        $touchedSingletons[$catKeyHash] = $memoryArray;
+                    }
                 } elseif ('update' === $kind && isset($action['memory_id'])) {
                     $memory = $this->memoryService->updateMemory(
                         (int) $action['memory_id'],
@@ -134,7 +242,21 @@ final readonly class ExtractMemoriesCommandHandler
                         'ai_edited',
                         $message->getId(),
                     );
-                    $savedMemories[] = $memory->toArray();
+                    $memoryArray = $memory->toArray();
+                    $savedMemories[] = $memoryArray;
+                    $touchedIds[(int) $action['memory_id']] = true;
+
+                    // The AI may pick the wrong target when several
+                    // singleton-key memories exist (the screenshot in
+                    // #879 had `name=Ralf` AND `name=<old>` and the AI
+                    // updated the wrong one). Mark the singleton hash
+                    // as touched here too so the post-loop collapse
+                    // pass prunes the leftover stale siblings.
+                    $touchedKey = (string) ($memoryArray['key'] ?? '');
+                    $touchedCategory = (string) ($memoryArray['category'] ?? '');
+                    if ('' !== $touchedKey && '' !== $touchedCategory && $this->isSingletonKey($touchedKey)) {
+                        $touchedSingletons[$this->normalizeForDedup($touchedCategory, $touchedKey)] = $memoryArray;
+                    }
                 } elseif ('delete' === $kind && isset($action['memory_id'])) {
                     $existing = $this->memoryService->getMemoryById((int) $action['memory_id'], $user);
                     if ($existing) {
@@ -150,6 +272,36 @@ final readonly class ExtractMemoriesCommandHandler
                 // Continue with the next action — partial results are better than none.
             }
         }
+
+        if ($skippedDuplicates > 0) {
+            $this->logger->info('ExtractMemoriesCommand: skipped duplicate creates', [
+                'message_id' => $messageId,
+                'count' => $skippedDuplicates,
+            ]);
+        }
+
+        // Singleton-key collapse pass.
+        //
+        // After the action loop, for each singleton `(category, key)` we
+        // touched (e.g. the user just stated their `name=Hannes`), find
+        // any leftover memories with the SAME `(category, key)` that we
+        // did NOT touch — those are stale by definition for singleton
+        // keys, since the user only has one current name / age /
+        // location / job at a time. Auto-delete them so the user never
+        // has to clean up the UI manually after the AI mis-targets an
+        // update (issue #879 follow-up: the screenshot showed `Ralf`
+        // surviving alongside the freshly-updated `Hannes`).
+        //
+        // Multi-valued keys (diet, hobby, skill, …) are excluded by
+        // `isSingletonKey()` so distinct facts under the same key are
+        // never collapsed.
+        $this->collapseSingletonDuplicates(
+            $user,
+            $existingMemories,
+            $touchedSingletons,
+            $touchedIds,
+            $messageId,
+        );
 
         $this->writeOutcomeMeta(
             $message,
@@ -238,5 +390,276 @@ final readonly class ExtractMemoriesCommandHandler
                 'error' => $e->getMessage(),
             ]);
         }
+    }
+
+    /**
+     * Auto-collapse stale duplicates of singleton-key memories.
+     *
+     * For every singleton `(category, key)` pair we touched in this
+     * extraction batch, find every OTHER memory in the user's pre-batch
+     * snapshot that shares the same hash and delete it from Qdrant.
+     *
+     * Why auto-delete instead of suggesting deletion: singleton keys
+     * (`name`, `age`, `location`, `job`, …) describe a single CURRENT
+     * value per user. The fresh value the user just stated supersedes
+     * the older entries by definition — keeping them around is the bug
+     * the user reported in the #879 follow-up screenshot, where
+     * `name=Ralf` lingered next to a freshly-updated `name=Hannes`.
+     *
+     * Multi-valued keys (`diet`, `hobby`, `skill`, …) never reach this
+     * pass because they're filtered upstream by `isSingletonKey()`.
+     *
+     * @param array<int, array<string, mixed>>    $existingMemories  user's memory snapshot loaded before the action loop
+     * @param array<string, array<string, mixed>> $touchedSingletons singleton (cat,key) hashes touched in this batch
+     * @param array<int, true>                    $touchedIds        memory IDs created/updated in this batch
+     */
+    private function collapseSingletonDuplicates(
+        User $user,
+        array $existingMemories,
+        array $touchedSingletons,
+        array $touchedIds,
+        int $messageId,
+    ): void {
+        if (empty($touchedSingletons)) {
+            return;
+        }
+
+        $deleted = 0;
+        $failed = 0;
+
+        foreach ($existingMemories as $candidate) {
+            $candidateId = isset($candidate['id']) ? (int) $candidate['id'] : 0;
+            if (0 === $candidateId) {
+                continue;
+            }
+            if (isset($touchedIds[$candidateId])) {
+                // We just created/updated this one — keep it.
+                continue;
+            }
+
+            $hash = $this->memoryDedupeKey($candidate);
+            if (null === $hash || !isset($touchedSingletons[$hash])) {
+                continue;
+            }
+
+            try {
+                $this->memoryService->deleteMemory($candidateId, $user);
+                ++$deleted;
+                $this->logger->info('ExtractMemoriesCommand: auto-collapsed stale singleton duplicate', [
+                    'message_id' => $messageId,
+                    'memory_id' => $candidateId,
+                    'category' => $candidate['category'] ?? null,
+                    'key' => $candidate['key'] ?? null,
+                    'kept_id' => $touchedSingletons[$hash]['id'] ?? null,
+                ]);
+            } catch (\Throwable $e) {
+                ++$failed;
+                $this->logger->warning('ExtractMemoriesCommand: failed to collapse singleton duplicate', [
+                    'message_id' => $messageId,
+                    'memory_id' => $candidateId,
+                    'error' => $e->getMessage(),
+                ]);
+            }
+        }
+
+        if ($deleted > 0 || $failed > 0) {
+            $this->logger->info('ExtractMemoriesCommand: singleton collapse complete', [
+                'message_id' => $messageId,
+                'deleted' => $deleted,
+                'failed' => $failed,
+            ]);
+        }
+    }
+
+    /**
+     * Soft cap on how many existing memories we forward to the AI prompt.
+     *
+     * Large enough that virtually all real users fit within it (the per-user
+     * hard limit is 500 and 90%+ of users have <50). Small enough that the
+     * extraction prompt stays under the budget that fast extraction models
+     * (Groq gpt-oss-120b at the default) can chew through in ~200ms.
+     */
+    private const EXISTING_MEMORY_BUDGET = 80;
+
+    /**
+     * Build the existing-memory snapshot the extractor LLM gets to see.
+     *
+     * Merges:
+     *   1. the relevant memories the dispatcher pre-loaded for the assistant
+     *      reply (highest signal — semantically tied to the new turn);
+     *   2. the user's full memory list, capped at {@see EXISTING_MEMORY_BUDGET}
+     *      and sorted by recency, so the AI also sees keys it hasn't queried
+     *      for in a while (the `name=Furkan` from message #1 when the new
+     *      message is a name update on message #5).
+     *
+     * Deduplication is by memory ID, not by `(category, key)` — siblings
+     * with the same key (e.g. multiple `diet` facts, or two pre-existing
+     * `name` entries that need to be collapsed by the action loop) MUST
+     * all be preserved here. Returns plain arrays (not DTOs) because the
+     * extraction service consumes them positionally.
+     *
+     * @param array<int, array<string, mixed>> $relevantMemories
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function buildExistingMemoryContext(int $userId, array $relevantMemories): array
+    {
+        /** @var array<int, array<string, mixed>> $byId */
+        $byId = [];
+        $unkeyed = [];
+
+        foreach ($relevantMemories as $memory) {
+            $id = isset($memory['id']) ? (int) $memory['id'] : 0;
+            if ($id > 0) {
+                $byId[$id] = $memory;
+            } else {
+                $unkeyed[] = $memory;
+            }
+        }
+
+        try {
+            $userMemories = $this->memoryService->getUserMemories($userId);
+        } catch (\Throwable $e) {
+            $this->logger->warning('ExtractMemoriesCommand: failed to load existing memories, continuing with relevant subset only', [
+                'user_id' => $userId,
+                'error' => $e->getMessage(),
+            ]);
+
+            return array_merge(array_values($byId), $unkeyed);
+        }
+
+        foreach ($userMemories as $dto) {
+            $arr = $dto->toArray();
+            $id = isset($arr['id']) ? (int) $arr['id'] : 0;
+            if ($id <= 0) {
+                continue;
+            }
+            // Don't overwrite a relevant-memory entry — those have higher
+            // signal value (came with semantic-search scores already).
+            if (!isset($byId[$id])) {
+                $byId[$id] = $arr;
+            }
+
+            if (count($byId) >= self::EXISTING_MEMORY_BUDGET) {
+                break;
+            }
+        }
+
+        return array_merge(array_values($byId), $unkeyed);
+    }
+
+    /**
+     * @param array<string, mixed> $memory
+     */
+    private function memoryDedupeKey(array $memory): ?string
+    {
+        $category = isset($memory['category']) ? (string) $memory['category'] : null;
+        $key = isset($memory['key']) ? (string) $memory['key'] : null;
+        if (null === $category || '' === $category || null === $key || '' === $key) {
+            return null;
+        }
+
+        return $this->normalizeForDedup($category, $key);
+    }
+
+    /**
+     * Build (cat,key) and (cat,key,value) hash maps over the existing
+     * memory snapshot so the action loop can dedupe in O(1).
+     *
+     * @param array<int, array<string, mixed>> $existingMemories
+     *
+     * @return array{0: array<string, array<string, mixed>>, 1: array<string, array<string, mixed>>}
+     *                                                                                               [`$byCatKeyValue` (exact match key), `$byCatKey` (key-only match)]
+     */
+    private function indexExistingByCatKey(array $existingMemories): array
+    {
+        $byCatKeyValue = [];
+        $byCatKey = [];
+
+        foreach ($existingMemories as $memory) {
+            $category = (string) ($memory['category'] ?? '');
+            $key = (string) ($memory['key'] ?? '');
+            $value = (string) ($memory['value'] ?? '');
+            if ('' === $category || '' === $key) {
+                continue;
+            }
+
+            $byCatKeyValue[$this->normalizeForDedup($category, $key, $value)] = $memory;
+            $byCatKey[$this->normalizeForDedup($category, $key)] = $memory;
+        }
+
+        return [$byCatKeyValue, $byCatKey];
+    }
+
+    /**
+     * Build a stable comparison hash for memory dedup.
+     *
+     * Casefolds and trims so e.g. "Furkan", "furkan ", "FURKAN" collapse to
+     * the same bucket. Whitespace inside the value is collapsed because AI
+     * extractions often differ only in formatting ("Furkan" vs "Furkan ").
+     */
+    private function normalizeForDedup(string $category, string $key, ?string $value = null): string
+    {
+        $norm = static function (string $s): string {
+            $s = mb_strtolower(trim($s));
+
+            return (string) preg_replace('/\s+/', ' ', $s);
+        };
+
+        if (null === $value) {
+            return $norm($category).'|'.$norm($key);
+        }
+
+        return $norm($category).'|'.$norm($key).'|'.$norm($value);
+    }
+
+    /**
+     * Keys that semantically allow only one current value per user.
+     *
+     * For these we promote a stray `create` (with a different value than
+     * the one already stored) into an `update` of the existing memory.
+     * Multi-valued keys like `diet`, `hobby`, `skill`, `interest` are
+     * intentionally excluded — multiple distinct facts under the same key
+     * are perfectly valid there ("eats halal" + "low-calorie" from the
+     * existing test). When in doubt we DON'T treat the key as a singleton:
+     * a duplicate is annoying, but losing a legitimate distinct fact via a
+     * silent overwrite is much worse.
+     */
+    private function isSingletonKey(string $key): bool
+    {
+        $singletons = [
+            'name',
+            'first_name',
+            'last_name',
+            'full_name',
+            'age',
+            'birthday',
+            'birth_date',
+            'date_of_birth',
+            'location',
+            'city',
+            'country',
+            'address',
+            'gender',
+            'pronouns',
+            'job',
+            'job_title',
+            'occupation',
+            'profession',
+            'role',
+            'company',
+            'employer',
+            'email',
+            'phone',
+            'phone_number',
+            'website',
+            'native_language',
+            'preferred_language',
+            'timezone',
+            'marital_status',
+            'ui_theme',
+        ];
+
+        return in_array(mb_strtolower(trim($key)), $singletons, true);
     }
 }

--- a/backend/src/Prompt/PromptCatalog.php
+++ b/backend/src/Prompt/PromptCatalog.php
@@ -24,18 +24,25 @@ class PromptCatalog
      * Topic taxonomy (Synapse Routing v2):
      *
      *  Granular routing topics (preferred for embedding-based Tier-1):
-     *    - general-chat        ← smalltalk, lifestyle, travel, health
-     *    - coding              ← programming languages, code review, debugging
+     *    - general-chat        ← smalltalk, lifestyle, coding, technical Q&A, everything that resolves to a chat answer
      *    - image-generation    ← create/edit images, photos, illustrations
      *    - video-generation    ← create video clips, animations
      *    - audio-generation    ← TTS, voice output, audio synthesis
      *    - docsummary          ← summarize a document or attached file text
      *    - officemaker         ← generate XLSX/DOCX/PPTX/CSV documents
      *
+     *  Note (#878): the previously dedicated `coding` topic was retired.
+     *  Programming questions overlapped too aggressively with everyday
+     *  chat in the embedding space (any "how do I…" sentence scored close
+     *  to it), pulling routine messages off `general-chat`. Coding now
+     *  rides on `general-chat` and the LLM picks the depth from context.
+     *  The legacy alias `coding` → `general` is retained in
+     *  TopicAliasResolver so older AI-fallback responses still resolve.
+     *
      *  Legacy canonical topics (still used by downstream handlers; the
      *  TopicAliasResolver maps the granular topics back to these for
      *  intent routing and groupKey backwards compatibility):
-     *    - general             ← canonical for general-chat + coding
+     *    - general             ← canonical for general-chat
      *    - mediamaker          ← canonical for *-generation
      *
      *  Internal helper prompts (excluded from the routing pool):
@@ -73,39 +80,66 @@ class PromptCatalog
             // ──────────────────────────────────────────────
             //  Granular routing topics (Synapse v2)
             // ──────────────────────────────────────────────
-            [
-                'topic' => 'general-chat',
-                'language' => 'en',
-                'shortDescription' => 'Casual conversation, smalltalk, opinions, lifestyle questions and everyday advice. Use this for chit-chat, greetings, travel and health tips, recipes, recommendations and similar non-technical requests.',
-                'keywords' => 'chat, smalltalk, hello, hi, hallo, talk, conversation, opinion, advice, tip, lifestyle, travel, reise, health, gesundheit, recipe, rezept, recommendation, empfehlung, frage, question',
-                'prompt' => self::generalPrompt(),
-            ],
+            // Retired (#878): the dedicated `coding` topic was retired
+            // because it overlapped too aggressively with everyday chat
+            // in the embedding space. Kept here as DISABLED so the seed
+            // run flips BENABLED=0 on existing installs and the indexer
+            // drops the orphan vector from Qdrant on its next pass.
+            // Removing the row from PromptCatalog entirely would NOT
+            // touch existing DBs.
             [
                 'topic' => 'coding',
                 'language' => 'en',
-                'shortDescription' => 'Programming, code review, debugging, refactoring, architecture and technical software questions. Use this whenever the user asks about source code, frameworks, libraries, errors, stack traces or wants help writing/explaining a snippet.',
-                'keywords' => 'code, programming, programmieren, php, python, javascript, typescript, java, kotlin, swift, go, rust, c++, c#, ruby, sql, query, html, css, vue, react, angular, svelte, node, nodejs, npm, composer, function, class, method, variable, error, fehler, exception, traceback, stack trace, bug, debug, refactor, refactoring, architecture, framework, library, api, rest, graphql, regex, algorithm, datastructure, leetcode, snippet, script, terminal, shell, bash, docker, kubernetes',
+                'shortDescription' => 'RETIRED. Coding/programming questions are answered by the general-chat topic.',
+                'keywords' => '',
+                'prompt' => self::generalPrompt(),
+                'enabled' => false,
+            ],
+            [
+                'topic' => 'general-chat',
+                'language' => 'en',
+                // Broadened on purpose (#878): everyday business ideas,
+                // hobbies, planning, smalltalk, programming questions and
+                // technical Q&A all fall here so they can't be sucked into
+                // the much narrower media-generation buckets by a stray
+                // embedding match. The dedicated `coding` topic was
+                // retired for the same reason.
+                'shortDescription' => 'Catch-all conversational topic. Use this for casual conversation, smalltalk, opinions, advice, lifestyle, travel, health, recipes, recommendations, business ideas, planning, hobbies, learning questions, programming and technical questions, debugging help, code review, software architecture, frameworks, libraries, errors and stack traces, and any other question that should be answered with a written reply.',
+                'keywords' => 'chat, smalltalk, hello, hi, hallo, talk, conversation, opinion, advice, tip, lifestyle, travel, reise, health, gesundheit, recipe, rezept, recommendation, empfehlung, frage, question, idea, idee, business, hobby, hobbies, plan, planning, planen, project, projekt, learning, lernen, study, school, university, student, code, coding, programming, programmieren, software, php, python, javascript, typescript, java, kotlin, swift, go, rust, ruby, sql, html, css, vue, react, angular, node, function, class, method, variable, error, fehler, exception, bug, debug, refactor, framework, library, api, rest, graphql, regex, algorithm, terminal, shell, bash, docker, kubernetes, fitness, gym, fitnessstudio, sport, food, essen, drink, getränk, shake, restaurant, shop, store, geschäft, idea for, möchte, will, want to',
                 'prompt' => self::generalPrompt(),
             ],
             [
                 'topic' => 'image-generation',
                 'language' => 'en',
-                'shortDescription' => 'User wants to CREATE or EDIT an image, picture, illustration, drawing or photo from a text description and/or reference images. Includes background replacement, style transfer, image composition, retouching and any other image-to-image transformation.',
-                'keywords' => 'image, picture, photo, foto, bild, illustration, draw, draw me, zeichne, malen, paint, design, render, generate image, generiere bild, create image, erstelle bild, make a picture, picture of, foto von, bild von, edit image, retouch, replace background, style transfer, composition, composite, combine images, merge images, hintergrund ersetzen, photorealistic, painting, sketch',
+                // Tightened (#878): only fire when the user *explicitly*
+                // asks for an image to be CREATED, RENDERED or EDITED.
+                // Bare nouns like "Foto" or "Bild" must not pull general
+                // chat in here — that's why every keyword pair includes
+                // a creation verb.
+                'shortDescription' => 'User explicitly asks to CREATE, GENERATE, RENDER or EDIT an image, picture, illustration, drawing, painting, photo or photo-realistic render from a text prompt and/or reference images. Trigger only when the message contains an explicit creation verb directly addressed at an image (for example "create an image of …", "generate a picture of …", "draw me a …", "render a photo of …", "edit this image so that …", "replace the background with …", "merge these two images"). Do NOT trigger for casual conversation that merely mentions a picture, a photo, an illustration or a "Bild" without a clear creation/edit request, and do NOT trigger for vision/OCR questions about an attached image.',
+                'keywords' => 'create an image, create a picture, create a photo, create an illustration, generate an image, generate a picture, make a picture, make an image, draw me, paint a picture, render a photo, render an image, render a picture, retouch this image, edit this image, replace the background, combine these images, merge these images, image to image, illustrate, erstelle ein bild, erstelle ein foto, erstelle eine illustration, generiere ein bild, generiere ein foto, mache ein bild, male ein bild, male mir, zeichne ein bild, zeichne mir, render ein bild, bild von, foto von, illustration von, hintergrund ersetzen, bild bearbeiten, bilder kombinieren',
                 'prompt' => self::mediaMakerPrompt(),
             ],
             [
                 'topic' => 'video-generation',
                 'language' => 'en',
-                'shortDescription' => 'User wants to CREATE a video, film, clip, animation or moving image. Examples: short cinematic clips, product videos, animated scenes. Duration and resolution may be specified.',
-                'keywords' => 'video, film, clip, animation, animate, motion, bewegt, moving image, generate video, create video, make a video, erstelle video, mache video, video von, kurzfilm, animation erstellen, cinemagraph, gif, motion picture, render video',
+                // Heavily tightened (#878). The previous entry pulled in
+                // anything mentioning "Kette", "shake", "Wagon" etc.
+                // because the description leaned on common nouns. This
+                // version only matches messages that *imperatively*
+                // request a video to be produced.
+                'shortDescription' => 'User explicitly asks to GENERATE a video, film, clip, animation, motion graphic or moving image from a prompt. Trigger only when the message contains an explicit creation verb directly addressed at video output (for example "create a video of …", "generate a clip of …", "make a short film of …", "animate …", "render a video of …", "erstelle ein Video von …", "mach mir ein Video von …"). Do NOT trigger for general conversation that merely mentions video, film, clips, YouTube, TV, fitness, hobbies, business ideas or anything else that is not an unambiguous request to render a new video file. Duration and resolution may be specified inside the request.',
+                'keywords' => 'create a video, create a clip, create an animation, generate a video, generate a clip, make a video, make a clip, make an animation, render a video, render an animation, animate this, animate the, produce a video, short cinematic video of, erstelle ein video, erstelle einen clip, erstelle eine animation, generiere ein video, generiere einen clip, mache ein video, mach mir ein video, mache einen clip, animiere, animiere mir, render ein video, render einen clip, render mir ein video, kurzes video von, kurzer clip von',
                 'prompt' => self::mediaMakerPrompt(),
             ],
             [
                 'topic' => 'audio-generation',
                 'language' => 'en',
-                'shortDescription' => 'User wants AUDIO output: text-to-speech, voice synthesis, narration or any spoken-audio rendering of text. Use this for "read this aloud", "convert to speech", "create an audio", "lies vor".',
-                'keywords' => 'audio, sound, voice, stimme, speech, sprache, tts, text to speech, text-to-speech, narration, narrate, read aloud, lies vor, vorlesen, sprich, speak, voiceover, voice-over, mp3, wav, podcast, audio version, vertonen, vertone, audio aus text, audio generieren',
+                // Tightened (#878): only fire on explicit speech-output
+                // requests. Bare nouns like "Stimme" or "Audio" must not
+                // be enough.
+                'shortDescription' => 'User explicitly asks for AUDIO output: text-to-speech, narration, voice synthesis, voiceover or any spoken-audio rendering of provided text. Trigger only when the message contains an explicit speech/audio creation verb (for example "read this aloud", "convert to speech", "create an audio of …", "generate a voiceover saying …", "narrate this text", "vertone …", "lies das vor", "sprich folgenden Text", "erstelle ein Audio mit …"). Do NOT trigger for general conversation that mentions audio, voice, sound, music or podcasts without an unambiguous TTS request.',
+                'keywords' => 'read aloud, read this aloud, read it aloud, convert to speech, text to speech, generate audio of, generate a voiceover, generate a narration, create an audio, create a voiceover, create a narration, narrate this, narrate the following, voiceover saying, voice over saying, speak this, say the following, lies vor, lies das vor, lies dies vor, sprich folgenden text, sprich folgendes, sprich diesen text, erstelle ein audio, erstelle eine vertonung, generiere ein audio, generiere eine vertonung, mache ein audio, vertone, vertone diesen text, vertone folgenden text, vertonen, audio generieren',
                 'prompt' => self::mediaMakerPrompt(),
             ],
 

--- a/backend/src/Prompt/PromptCatalog.php
+++ b/backend/src/Prompt/PromptCatalog.php
@@ -117,7 +117,14 @@ class PromptCatalog
                 // chat in here — that's why every keyword pair includes
                 // a creation verb.
                 'shortDescription' => 'User explicitly asks to CREATE, GENERATE, RENDER or EDIT an image, picture, illustration, drawing, painting, photo or photo-realistic render from a text prompt and/or reference images. Trigger only when the message contains an explicit creation verb directly addressed at an image (for example "create an image of …", "generate a picture of …", "draw me a …", "render a photo of …", "edit this image so that …", "replace the background with …", "merge these two images"). Do NOT trigger for casual conversation that merely mentions a picture, a photo, an illustration or a "Bild" without a clear creation/edit request, and do NOT trigger for vision/OCR questions about an attached image.',
-                'keywords' => 'create an image, create a picture, create a photo, create an illustration, generate an image, generate a picture, make a picture, make an image, draw me, paint a picture, render a photo, render an image, render a picture, retouch this image, edit this image, replace the background, combine these images, merge these images, image to image, illustrate, erstelle ein bild, erstelle ein foto, erstelle eine illustration, generiere ein bild, generiere ein foto, mache ein bild, male ein bild, male mir, zeichne ein bild, zeichne mir, render ein bild, bild von, foto von, illustration von, hintergrund ersetzen, bild bearbeiten, bilder kombinieren',
+                // Every entry below pairs a creation verb with a media
+                // noun (or is a self-contained edit verb). Bare noun
+                // phrases like "bild von" / "foto von" have been removed
+                // — they previously matched perfectly innocuous "ich
+                // habe ein bild von gestern" turns and would also fail
+                // the SynapseRouter media-intent guard anyway, so they
+                // were dead weight (caught by Copilot review on PR #884).
+                'keywords' => 'create an image, create a picture, create a photo, create an illustration, generate an image, generate a picture, make a picture, make an image, draw me, paint a picture, render a photo, render an image, render a picture, retouch this image, edit this image, replace the background, combine these images, merge these images, image to image, illustrate this, erstelle ein bild, erstelle ein foto, erstelle eine illustration, generiere ein bild, generiere ein foto, mache ein bild, male ein bild, male mir, zeichne ein bild, zeichne mir, render ein bild, hintergrund ersetzen, bild bearbeiten, bilder kombinieren',
                 'prompt' => self::mediaMakerPrompt(),
             ],
             [
@@ -129,7 +136,12 @@ class PromptCatalog
                 // version only matches messages that *imperatively*
                 // request a video to be produced.
                 'shortDescription' => 'User explicitly asks to GENERATE a video, film, clip, animation, motion graphic or moving image from a prompt. Trigger only when the message contains an explicit creation verb directly addressed at video output (for example "create a video of …", "generate a clip of …", "make a short film of …", "animate …", "render a video of …", "erstelle ein Video von …", "mach mir ein Video von …"). Do NOT trigger for general conversation that merely mentions video, film, clips, YouTube, TV, fitness, hobbies, business ideas or anything else that is not an unambiguous request to render a new video file. Duration and resolution may be specified inside the request.',
-                'keywords' => 'create a video, create a clip, create an animation, generate a video, generate a clip, make a video, make a clip, make an animation, render a video, render an animation, animate this, animate the, produce a video, short cinematic video of, erstelle ein video, erstelle einen clip, erstelle eine animation, generiere ein video, generiere einen clip, mache ein video, mach mir ein video, mache einen clip, animiere, animiere mir, render ein video, render einen clip, render mir ein video, kurzes video von, kurzer clip von',
+                // Verb+noun pairs only; bare phrases like "kurzes video
+                // von …" have been dropped because they ambiguously
+                // match non-creation turns ("ich habe ein kurzes Video
+                // von gestern") and would fail the media-intent guard
+                // anyway (caught by Copilot review on PR #884).
+                'keywords' => 'create a video, create a clip, create an animation, generate a video, generate a clip, make a video, make a clip, make an animation, render a video, render an animation, animate this, animate the, produce a video, shoot a short video, erstelle ein video, erstelle einen clip, erstelle eine animation, generiere ein video, generiere einen clip, mache ein video, mach mir ein video, mache einen clip, animiere, animiere mir, render ein video, render einen clip, render mir ein video',
                 'prompt' => self::mediaMakerPrompt(),
             ],
             [

--- a/backend/src/Service/Message/Handler/ChatHandler.php
+++ b/backend/src/Service/Message/Handler/ChatHandler.php
@@ -1035,6 +1035,13 @@ final readonly class ChatHandler implements MessageHandlerInterface
                     userId: $message->getUserId(),
                     aiResponse: $fullResponseText,
                     threadSnapshot: $threadSnapshot,
+                    // Forward the in-scope memories so the extractor can
+                    // emit `update` instead of duplicate `create` actions
+                    // (issue #879). The worker still merges this with the
+                    // user's full memory list, but the relevant subset
+                    // carries semantic-search signal we don't want to
+                    // throw away.
+                    relevantMemories: $loadedMemories,
                 ));
 
                 $this->logger->info('ChatHandler: Dispatched ExtractMemoriesCommand', [

--- a/backend/src/Service/Message/Handler/MediaGenerationHandler.php
+++ b/backend/src/Service/Message/Handler/MediaGenerationHandler.php
@@ -5,15 +5,18 @@ namespace App\Service\Message\Handler;
 use App\AI\Service\AiFacade;
 use App\Entity\Message;
 use App\Entity\User;
+use App\Message\ExtractMemoriesCommand;
 use App\Service\File\FileHelper;
 use App\Service\File\ThumbnailService;
 use App\Service\File\UserUploadPathBuilder;
 use App\Service\Message\MediaPromptExtractor;
 use App\Service\ModelConfigService;
+use App\Service\PerfPipelineFlag;
 use App\Service\RateLimitService;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+use Symfony\Component\Messenger\MessageBusInterface;
 
 /**
  * Media Generation Handler.
@@ -35,6 +38,8 @@ final readonly class MediaGenerationHandler implements MessageHandlerInterface
         private ThumbnailService $thumbnailService,
         private RateLimitService $rateLimitService,
         private MediaErrorMessageBuilder $errorMessageBuilder,
+        private MessageBusInterface $messageBus,
+        private PerfPipelineFlag $perfPipelineFlag,
         private string $uploadDir = '/var/www/backend/var/uploads',
     ) {
     }
@@ -99,6 +104,15 @@ final readonly class MediaGenerationHandler implements MessageHandlerInterface
     ): array {
         // Send initial status based on detected media type (will be refined later)
         $this->notify($progressCallback, 'analyzing', 'Understanding your request...');
+
+        // Dispatch background memory extraction on the user's prompt before
+        // we start the (slow, possibly-failing) provider call. Mirrors the
+        // pattern in ChatHandler::handleStream(): memories must be picked
+        // up from any user turn that carries personal information, not just
+        // text-chat turns (issue #880). Doing it up-front means a failed
+        // image generation still saves "ich liebe Hunde" — and the queue
+        // dispatch is cheap (a few ms) so the user doesn't notice.
+        $this->maybeDispatchMemoryExtraction($message, $thread, $classification, $options);
 
         // Extract media prompt via AI (mediamaker prompt)
         $promptData = $this->promptExtractor->extract($message, $thread, $classification);
@@ -773,6 +787,127 @@ final readonly class MediaGenerationHandler implements MessageHandlerInterface
         }
 
         return [$mediaType, $provider, $modelName];
+    }
+
+    /**
+     * Dispatch a background memory-extraction job for the user's prompt
+     * text, when memory extraction is enabled for this user/request.
+     *
+     * Mirrors the gating in ChatHandler so the contract stays uniform:
+     *   - Widget / `disable_memories` requests skip extraction.
+     *   - User-disabled memories (`User::isMemoriesEnabled()`) skip.
+     *   - PERF.V2_PIPELINE kill-switch skip.
+     *   - Empty user text skip (nothing to extract from).
+     *
+     * The actual extraction LLM call + Qdrant writes happen on the
+     * messenger worker — same async queue ChatHandler uses — so a failure
+     * here NEVER blocks media generation for the user.
+     */
+    private function maybeDispatchMemoryExtraction(
+        Message $message,
+        array $thread,
+        array $classification,
+        array $options,
+    ): void {
+        $userText = trim($message->getText());
+        if ('' === $userText) {
+            return;
+        }
+
+        $memoriesDisabledByRequest = !empty($options['disable_memories'])
+            || ('WIDGET' === ($options['channel'] ?? null))
+            || ('widget' === ($classification['source'] ?? null))
+            || !empty($classification['is_widget_mode']);
+
+        if ($memoriesDisabledByRequest) {
+            $this->logger->debug('MediaGenerationHandler: Skipping memory extraction (widget/disabled)', [
+                'user_id' => $message->getUserId(),
+            ]);
+
+            return;
+        }
+
+        $userId = $message->getUserId();
+        $user = $this->em->getRepository(User::class)->find($userId);
+        if (!$user || !$user->isMemoriesEnabled()) {
+            return;
+        }
+
+        if (!$this->perfPipelineFlag->isEnabled($userId)) {
+            $this->logger->debug('MediaGenerationHandler: PERF.V2_PIPELINE disabled, skipping memory extraction', [
+                'user_id' => $userId,
+            ]);
+
+            return;
+        }
+
+        try {
+            $threadSnapshot = $this->normalizeThreadForQueue($thread);
+
+            // Media generation does not produce a textual assistant
+            // response that's useful for memory extraction — the
+            // response is the generated asset itself. Pass an empty
+            // aiResponse so the extractor only looks at the user
+            // turn(s), which is exactly what we want.
+            $this->messageBus->dispatch(new ExtractMemoriesCommand(
+                messageId: $message->getId(),
+                userId: $userId,
+                aiResponse: '',
+                threadSnapshot: $threadSnapshot,
+            ));
+
+            $this->logger->info('MediaGenerationHandler: Dispatched ExtractMemoriesCommand', [
+                'message_id' => $message->getId(),
+                'user_id' => $userId,
+                'thread_length' => count($threadSnapshot),
+            ]);
+        } catch (\Throwable $e) {
+            // Never block media generation on a queue dispatch hiccup.
+            $this->logger->warning('MediaGenerationHandler: Failed to dispatch ExtractMemoriesCommand', [
+                'message_id' => $message->getId(),
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+
+    /**
+     * Flatten the thread (Message entities + plain arrays) into a JSON-
+     * serialisable shape for the messenger queue.
+     *
+     * Doctrine entities cannot survive the queue boundary; the extractor
+     * only needs `role`+`content` so we reduce to that. Mirrors the
+     * implementation in ChatHandler::normalizeThreadForQueue() — kept in
+     * sync but duplicated to avoid leaking a private helper across
+     * handler classes.
+     *
+     * @param array<int, mixed> $thread
+     *
+     * @return array<int, array{role: string, content: string}>
+     */
+    private function normalizeThreadForQueue(array $thread): array
+    {
+        $out = [];
+        foreach ($thread as $entry) {
+            if ($entry instanceof Message) {
+                $out[] = [
+                    'role' => 'IN' === $entry->getDirection() ? 'user' : 'assistant',
+                    'content' => $entry->getText(),
+                ];
+                continue;
+            }
+
+            if (is_array($entry)) {
+                $role = (string) ($entry['role'] ?? 'user');
+                $content = $entry['content'] ?? '';
+                if (!is_string($content)) {
+                    $encoded = json_encode($content);
+                    $content = false === $encoded ? '' : $encoded;
+                }
+                $out[] = ['role' => $role, 'content' => $content];
+            }
+        }
+
+        return $out;
     }
 
     /**

--- a/backend/src/Service/Message/SynapseIndexer.php
+++ b/backend/src/Service/Message/SynapseIndexer.php
@@ -409,10 +409,21 @@ final readonly class SynapseIndexer
      * disabled. Used by indexAllTopics() to keep the synapse_topics
      * collection in lockstep with BPROMPTS.BENABLED so retired topics
      * stop matching as soon as the seed runs (issue #878).
+     *
+     * Note: `findAllForUser()` defaults `excludeDisabled` to **true**, so
+     * the disabled rows we're trying to clean up would be filtered out
+     * at the SQL layer and the loop would silently see nothing. We pass
+     * `excludeDisabled: false` and re-filter for `enabled=false` here so
+     * this method actually does what its name says (caught by Copilot
+     * review on PR #884).
      */
     private function dropDisabledPromptVectors(?int $userId): void
     {
-        $prompts = $this->promptRepository->findAllForUser($userId ?? 0);
+        $prompts = $this->promptRepository->findAllForUser(
+            $userId ?? 0,
+            'en',
+            excludeDisabled: false,
+        );
 
         foreach ($prompts as $prompt) {
             if ($prompt->isEnabled()) {

--- a/backend/src/Service/Message/SynapseIndexer.php
+++ b/backend/src/Service/Message/SynapseIndexer.php
@@ -78,6 +78,12 @@ final readonly class SynapseIndexer
      */
     public function indexAllTopics(?int $userId = null, bool $force = false): array
     {
+        // Drop vectors for any prompt that has been disabled in the DB
+        // (e.g. the retired `coding` topic from #878). Without this step
+        // the orphan Qdrant point keeps participating in similarity
+        // search until the operator manually re-creates the collection.
+        $this->dropDisabledPromptVectors($userId);
+
         $prompts = $this->loadIndexablePrompts($userId);
 
         if (empty($prompts)) {
@@ -396,6 +402,38 @@ final readonly class SynapseIndexer
             $this->loadIndexablePrompts($userId),
             fn (Prompt $p) => $p->getOwnerId() === $userId,
         ));
+    }
+
+    /**
+     * Remove Qdrant vectors for any prompt that exists but is currently
+     * disabled. Used by indexAllTopics() to keep the synapse_topics
+     * collection in lockstep with BPROMPTS.BENABLED so retired topics
+     * stop matching as soon as the seed runs (issue #878).
+     */
+    private function dropDisabledPromptVectors(?int $userId): void
+    {
+        $prompts = $this->promptRepository->findAllForUser($userId ?? 0);
+
+        foreach ($prompts as $prompt) {
+            if ($prompt->isEnabled()) {
+                continue;
+            }
+            if (str_starts_with($prompt->getTopic(), 'tools:')) {
+                continue;
+            }
+
+            try {
+                $this->removeTopic($prompt->getTopic(), $prompt->getOwnerId());
+            } catch (\Throwable $e) {
+                // Removal is best-effort — a stale vector is annoying
+                // but never fatal, so don't fail the whole index run.
+                $this->logger->warning('SynapseIndexer: Failed to drop disabled topic vector', [
+                    'topic' => $prompt->getTopic(),
+                    'owner_id' => $prompt->getOwnerId(),
+                    'error' => $e->getMessage(),
+                ]);
+            }
+        }
     }
 
     /**

--- a/backend/src/Service/Message/SynapseRouter.php
+++ b/backend/src/Service/Message/SynapseRouter.php
@@ -57,6 +57,91 @@ final readonly class SynapseRouter
     ];
 
     /**
+     * Generic creation verbs ("create", "erstelle", "render", …) that
+     * the media-intent guard pairs with a modality-specific noun.
+     *
+     * Kept narrow on purpose so messages with desire-only verbs ("ich
+     * möchte eine Kette gründen", "I want a small business") cannot pass.
+     * Anchored with `\b` at match time so "drawer" / "renderer" don't
+     * count as the verb. See {@see passesMediaIntentGuard()}.
+     */
+    private const MEDIA_INTENT_VERBS = [
+        // English
+        'create', 'creating', 'generate', 'generating', 'make', 'making',
+        'render', 'rendering', 'produce', 'producing',
+        'draw', 'drawing', 'paint', 'painting', 'sketch', 'sketching',
+        'illustrate', 'illustrating',
+        'animate', 'animating',
+        'edit', 'editing', 'retouch', 'retouching',
+        'compose', 'composing', 'composite', 'compositing',
+        'compile', 'compiling',
+        'narrate', 'narrating', 'speak', 'speaking', 'voiceover', 'voice-over',
+        'convert',
+        // German
+        'erstelle', 'erstell', 'erstellt', 'erstellen',
+        'generiere', 'generier', 'generiert', 'generieren',
+        'mache', 'mach', 'macht', 'machen',
+        'male', 'mal', 'malt', 'malen',
+        'zeichne', 'zeichn', 'zeichnet', 'zeichnen',
+        'animiere', 'animier', 'animiert', 'animieren',
+        'sprich', 'sprecht', 'sprechen',
+        'vertone', 'vertont', 'vertonen',
+    ];
+
+    /**
+     * Modality-specific media nouns. Paired with a creation verb (or a
+     * self-contained cue) the guard counts as passed. Singular tokens
+     * only — substring matching handles plurals/cases ("videos", "Bilder").
+     *
+     * @var array<string, list<string>>
+     */
+    private const MEDIA_INTENT_NOUNS = [
+        'image-generation' => [
+            'image', 'picture', 'photo', 'foto', 'bild', 'illustration', 'sketch',
+            'drawing', 'painting', 'render', 'logo', 'icon', 'wallpaper', 'avatar',
+            'thumbnail', 'cover', 'poster', 'artwork',
+        ],
+        'video-generation' => [
+            'video', 'clip', 'film', 'animation', 'animatic', 'cinemagraph',
+            'kurzfilm', 'reel',
+        ],
+        'audio-generation' => [
+            'audio', 'voice', 'voiceover', 'narration', 'speech',
+            'tts', 'mp3', 'wav', 'podcast', 'sprachausgabe', 'vertonung',
+        ],
+    ];
+
+    /**
+     * Self-contained cues that imply both verb AND noun on their own.
+     * Mostly TTS-style "read this aloud", "lies vor", "vorlesen" — these
+     * don't repeat the noun explicitly but unambiguously request audio
+     * output. Same for "text to speech" / "text-to-speech" wording.
+     *
+     * Matched with substring search after lowercasing.
+     *
+     * @var array<string, list<string>>
+     */
+    private const MEDIA_INTENT_SELF_CONTAINED = [
+        'image-generation' => [
+            'replace the background', 'hintergrund ersetzen', 'bild bearbeiten',
+            'edit this image', 'edit the image',
+        ],
+        'video-generation' => [
+            // Intentionally empty: video creation requests in the wild
+            // virtually always name "video"/"clip"/"film"/etc., so the
+            // verb+noun rule is sufficient.
+        ],
+        'audio-generation' => [
+            'read aloud', 'reading aloud', 'read it aloud', 'read this aloud',
+            'text to speech', 'text-to-speech', 'convert to speech',
+            'lies vor', 'lies mir vor', 'lies das vor', 'lies dies vor',
+            'vorlesen', 'vorzulesen',
+            'sprich folgenden text', 'sprich folgendes',
+            'vertone diesen text', 'vertone folgenden text', 'vertonen',
+        ],
+    ];
+
+    /**
      * Keywords that strongly indicate the user needs live/current data.
      *
      * Intentionally excludes deictic time markers like "jetzt" / "now" which
@@ -370,6 +455,26 @@ final readonly class SynapseRouter
                 );
             }
 
+            // Media-intent guard (#878): even at high confidence, do NOT
+            // route to the dedicated media-generation topics unless the
+            // user's text actually pairs a creation verb with a media
+            // noun. This is what stops messages like "ich beschäftige
+            // mich mit Protein Shakes…" from being interpreted as a
+            // video request just because the embedding model happens to
+            // place them near the video-generation centroid. Slash
+            // commands never reach this code path — MessageClassifier
+            // routes them directly.
+            if (!$this->passesMediaIntentGuard($topTopic, $messageText)) {
+                return $this->fallbackToAi(
+                    $messageData,
+                    $conversationHistory,
+                    $userId,
+                    'media_intent_guard',
+                    $topScore,
+                    $topTopic,
+                );
+            }
+
             // Resolve granular Synapse-v2 topic to canonical legacy topic
             // (e.g. coding -> general, image-generation -> mediamaker).
             // The granular topic stays in the synapse payload for analytics;
@@ -658,6 +763,65 @@ final readonly class SynapseRouter
         }
 
         return 'image';
+    }
+
+    /**
+     * Verify that a Tier-1 hit on a media-generation topic is justified
+     * by an explicit creation cue in the user's text (issue #878).
+     *
+     * Non-media topics are passed through unchanged. For media topics we
+     * accept the routing iff EITHER:
+     *   - the message contains a self-contained modality cue (e.g.
+     *     "lies vor" → audio is the only sensible interpretation), OR
+     *   - the message contains BOTH a generic creation verb AND a
+     *     media noun for the matching modality.
+     *
+     * Verb-and-noun do NOT have to be adjacent: "erstelle ein aktuelles
+     * Video von der Börse 2026" passes because "erstelle" + "video" are
+     * both present, even though they're separated by "ein aktuelles".
+     */
+    private function passesMediaIntentGuard(string $topic, string $messageText): bool
+    {
+        if (!isset(self::MEDIA_INTENT_NOUNS[$topic])) {
+            return true;
+        }
+
+        $lower = mb_strtolower($messageText);
+
+        foreach (self::MEDIA_INTENT_SELF_CONTAINED[$topic] as $cue) {
+            if (str_contains($lower, $cue)) {
+                return true;
+            }
+        }
+
+        if (!$this->containsCreationVerb($lower)) {
+            return false;
+        }
+
+        foreach (self::MEDIA_INTENT_NOUNS[$topic] as $noun) {
+            if (str_contains($lower, $noun)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * True when the lowercased message contains any of {@see MEDIA_INTENT_VERBS}
+     * as a whole-word match. The word-boundary check stops "drawer" /
+     * "rendering of opinions" / "machart" from leaking through.
+     */
+    private function containsCreationVerb(string $lowerText): bool
+    {
+        foreach (self::MEDIA_INTENT_VERBS as $verb) {
+            $pattern = '/\b'.preg_quote($verb, '/').'\b/u';
+            if (1 === preg_match($pattern, $lowerText)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/backend/tests/Unit/ExtractMemoriesCommandHandlerTest.php
+++ b/backend/tests/Unit/ExtractMemoriesCommandHandlerTest.php
@@ -1,0 +1,386 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit;
+
+use App\DTO\UserMemoryDTO;
+use App\Entity\Message;
+use App\Entity\User;
+use App\Message\ExtractMemoriesCommand;
+use App\MessageHandler\ExtractMemoriesCommandHandler;
+use App\Repository\MessageRepository;
+use App\Repository\UserRepository;
+use App\Service\MemoryExtractionService;
+use App\Service\UserMemoryService;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Regression tests for issue #879 — duplicate memory entries created
+ * instead of updating existing keys.
+ *
+ * The handler is the second of the two layered defences:
+ *   1. The extractor LLM is now given the user's full memory list as
+ *      context and is supposed to emit `update`. (Tested elsewhere via
+ *      the prompt-rules suite.)
+ *   2. Even if the model emits `create` anyway — providers in the wild
+ *      do this routinely — the handler enforces dedup before writing
+ *      to Qdrant. That is what this suite covers.
+ */
+final class ExtractMemoriesCommandHandlerTest extends TestCase
+{
+    private EntityManagerInterface&MockObject $em;
+    private MemoryExtractionService&MockObject $memoryExtractionService;
+    private UserMemoryService&MockObject $memoryService;
+    private LoggerInterface&MockObject $logger;
+    private ExtractMemoriesCommandHandler $handler;
+    private User $user;
+    private Message $message;
+
+    protected function setUp(): void
+    {
+        $this->em = $this->createMock(EntityManagerInterface::class);
+        $this->memoryExtractionService = $this->createMock(MemoryExtractionService::class);
+        $this->memoryService = $this->createMock(UserMemoryService::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
+
+        $this->handler = new ExtractMemoriesCommandHandler(
+            $this->em,
+            $this->memoryExtractionService,
+            $this->memoryService,
+            $this->logger,
+        );
+
+        $this->user = $this->createConfiguredMock(User::class, [
+            'getId' => 1,
+            'isMemoriesEnabled' => true,
+        ]);
+        $this->message = $this->createConfiguredMock(Message::class, [
+            'getId' => 42,
+            'getUserId' => 1,
+            'getTrackingId' => 7,
+        ]);
+
+        $messageRepo = $this->createMock(MessageRepository::class);
+        $messageRepo->method('find')->with(42)->willReturn($this->message);
+        $messageRepo->method('findOneBy')->willReturn(null);
+
+        $userRepo = $this->createMock(UserRepository::class);
+        $userRepo->method('find')->with(1)->willReturn($this->user);
+
+        $this->em->method('getRepository')->willReturnMap([
+            [Message::class, $messageRepo],
+            [User::class, $userRepo],
+        ]);
+    }
+
+    public function testExactDuplicateCreateIsDropped(): void
+    {
+        // The user already has `name=Furkan` (personal) stored — exactly
+        // the bug from #879. The AI emits another `create` with the same
+        // value, and the handler must NOT write it.
+        $existing = new UserMemoryDTO(
+            id: 100,
+            userId: 1,
+            category: 'personal',
+            key: 'name',
+            value: 'Furkan',
+            source: 'auto_detected',
+        );
+
+        $this->memoryService->method('getUserMemories')->with(1)->willReturn([$existing]);
+
+        $this->memoryExtractionService->method('analyzeAndExtract')->willReturn([
+            ['action' => 'create', 'category' => 'personal', 'key' => 'name', 'value' => 'Furkan'],
+        ]);
+
+        $this->memoryService->expects($this->never())->method('createMemory');
+        $this->memoryService->expects($this->never())->method('updateMemory');
+
+        $this->handler->__invoke(new ExtractMemoriesCommand(
+            messageId: 42,
+            userId: 1,
+            aiResponse: 'Hi Furkan',
+            threadSnapshot: [['role' => 'user', 'content' => 'mein name ist Furkan']],
+        ));
+    }
+
+    public function testCaseInsensitiveAndWhitespaceInsensitiveDuplicateIsDropped(): void
+    {
+        $existing = new UserMemoryDTO(
+            id: 100,
+            userId: 1,
+            category: 'personal',
+            key: 'name',
+            value: 'Furkan',
+            source: 'auto_detected',
+        );
+
+        $this->memoryService->method('getUserMemories')->willReturn([$existing]);
+
+        // " FURKAN " — different casing and surrounding whitespace, but
+        // semantically identical.
+        $this->memoryExtractionService->method('analyzeAndExtract')->willReturn([
+            ['action' => 'create', 'category' => 'PERSONAL', 'key' => 'NAME', 'value' => '  furkan  '],
+        ]);
+
+        $this->memoryService->expects($this->never())->method('createMemory');
+        $this->memoryService->expects($this->never())->method('updateMemory');
+
+        $this->handler->__invoke(new ExtractMemoriesCommand(
+            messageId: 42,
+            userId: 1,
+            aiResponse: '',
+            threadSnapshot: [],
+        ));
+    }
+
+    public function testSingletonKeyWithDifferentValueIsPromotedToUpdate(): void
+    {
+        // The user previously stored `name=Farouk`. The new turn says the
+        // user's name is actually `Furkan`. The AI fails to use the
+        // `update` action; the handler must still NOT create a duplicate
+        // — `name` is a singleton key.
+        $existing = new UserMemoryDTO(
+            id: 100,
+            userId: 1,
+            category: 'personal',
+            key: 'name',
+            value: 'Farouk',
+            source: 'auto_detected',
+        );
+
+        $this->memoryService->method('getUserMemories')->willReturn([$existing]);
+
+        $this->memoryExtractionService->method('analyzeAndExtract')->willReturn([
+            ['action' => 'create', 'category' => 'personal', 'key' => 'name', 'value' => 'Furkan'],
+        ]);
+
+        $this->memoryService->expects($this->never())->method('createMemory');
+        $this->memoryService
+            ->expects($this->once())
+            ->method('updateMemory')
+            ->with(
+                100,
+                $this->user,
+                'Furkan',
+                'ai_edited',
+                42,
+            )
+            ->willReturn(new UserMemoryDTO(
+                id: 100,
+                userId: 1,
+                category: 'personal',
+                key: 'name',
+                value: 'Furkan',
+                source: 'ai_edited',
+            ));
+
+        $this->handler->__invoke(new ExtractMemoriesCommand(
+            messageId: 42,
+            userId: 1,
+            aiResponse: '',
+            threadSnapshot: [],
+        ));
+    }
+
+    public function testMultiValuedKeyAllowsDistinctValues(): void
+    {
+        // The dietary case from MemoryExtractionServicePromptRulesTest:
+        // `diet` is NOT a singleton key, so two distinct values must
+        // both be persisted. This guards against a too-aggressive
+        // dedup that would silently lose information.
+        $existing = new UserMemoryDTO(
+            id: 100,
+            userId: 1,
+            category: 'preferences',
+            key: 'diet',
+            value: 'Eats halal',
+            source: 'auto_detected',
+        );
+
+        $this->memoryService->method('getUserMemories')->willReturn([$existing]);
+
+        $this->memoryExtractionService->method('analyzeAndExtract')->willReturn([
+            ['action' => 'create', 'category' => 'preferences', 'key' => 'diet', 'value' => 'Prefers low-calorie meals'],
+        ]);
+
+        $this->memoryService->expects($this->never())->method('updateMemory');
+        $this->memoryService
+            ->expects($this->once())
+            ->method('createMemory')
+            ->with(
+                $this->user,
+                'preferences',
+                'diet',
+                'Prefers low-calorie meals',
+                'auto_detected',
+                42,
+            )
+            ->willReturn(new UserMemoryDTO(
+                id: 200,
+                userId: 1,
+                category: 'preferences',
+                key: 'diet',
+                value: 'Prefers low-calorie meals',
+                source: 'auto_detected',
+            ));
+
+        $this->handler->__invoke(new ExtractMemoriesCommand(
+            messageId: 42,
+            userId: 1,
+            aiResponse: '',
+            threadSnapshot: [],
+        ));
+    }
+
+    public function testSingletonCollapseRemovesStaleSiblingsOnUpdate(): void
+    {
+        // Reproduces the user's screenshot from the #879 follow-up:
+        //   - Pre-existing: name=Ralf  (id=100, untouched today)
+        //   - Pre-existing: name=Hans  (id=200, the AI is about to update)
+        // The user says "Ich bin der Hannes" → AI emits update on id=200.
+        // The old `name=Ralf` is stale by definition (singleton key) and
+        // must be auto-deleted.
+        $ralf = new UserMemoryDTO(
+            id: 100,
+            userId: 1,
+            category: 'personal',
+            key: 'name',
+            value: 'Ralf',
+            source: 'auto_detected',
+        );
+        $hans = new UserMemoryDTO(
+            id: 200,
+            userId: 1,
+            category: 'personal',
+            key: 'name',
+            value: 'Hans',
+            source: 'auto_detected',
+        );
+
+        $this->memoryService->method('getUserMemories')->willReturn([$ralf, $hans]);
+
+        $this->memoryExtractionService->method('analyzeAndExtract')->willReturn([
+            ['action' => 'update', 'memory_id' => 200, 'category' => 'personal', 'key' => 'name', 'value' => 'Hannes'],
+        ]);
+
+        $this->memoryService
+            ->expects($this->once())
+            ->method('updateMemory')
+            ->with(200, $this->user, 'Hannes', 'ai_edited', 42)
+            ->willReturn(new UserMemoryDTO(
+                id: 200,
+                userId: 1,
+                category: 'personal',
+                key: 'name',
+                value: 'Hannes',
+                source: 'ai_edited',
+            ));
+
+        $this->memoryService
+            ->expects($this->once())
+            ->method('deleteMemory')
+            ->with(100, $this->user);
+
+        $this->handler->__invoke(new ExtractMemoriesCommand(
+            messageId: 42,
+            userId: 1,
+            aiResponse: '',
+            threadSnapshot: [['role' => 'user', 'content' => 'Ich bin der Hannes aus Schwerin']],
+        ));
+    }
+
+    public function testSingletonCollapseRemovesStaleSiblingsOnPromotedCreate(): void
+    {
+        // Same scenario as above but the AI lazily emits `create` instead
+        // of `update`. The handler promotes the create to an update of
+        // the first match AND collapses the other sibling.
+        $ralf = new UserMemoryDTO(
+            id: 100,
+            userId: 1,
+            category: 'personal',
+            key: 'name',
+            value: 'Ralf',
+            source: 'auto_detected',
+        );
+        $hans = new UserMemoryDTO(
+            id: 200,
+            userId: 1,
+            category: 'personal',
+            key: 'name',
+            value: 'Hans',
+            source: 'auto_detected',
+        );
+
+        $this->memoryService->method('getUserMemories')->willReturn([$ralf, $hans]);
+
+        $this->memoryExtractionService->method('analyzeAndExtract')->willReturn([
+            ['action' => 'create', 'category' => 'personal', 'key' => 'name', 'value' => 'Hannes'],
+        ]);
+
+        // Either Ralf (100) or Hans (200) gets promoted to update — we
+        // don't care which one survives, only that exactly one update
+        // and one delete occur and no fresh create.
+        $this->memoryService
+            ->expects($this->once())
+            ->method('updateMemory')
+            ->willReturnCallback(fn (int $id) => new UserMemoryDTO(
+                id: $id,
+                userId: 1,
+                category: 'personal',
+                key: 'name',
+                value: 'Hannes',
+                source: 'ai_edited',
+            ));
+
+        $this->memoryService
+            ->expects($this->never())
+            ->method('createMemory');
+
+        $this->memoryService
+            ->expects($this->once())
+            ->method('deleteMemory');
+
+        $this->handler->__invoke(new ExtractMemoriesCommand(
+            messageId: 42,
+            userId: 1,
+            aiResponse: '',
+            threadSnapshot: [],
+        ));
+    }
+
+    public function testWithinBatchDedupAlsoApplies(): void
+    {
+        // No existing memory yet, but the AI emits the SAME `create`
+        // twice in one extraction batch. Only the first should land.
+        $this->memoryService->method('getUserMemories')->willReturn([]);
+
+        $this->memoryExtractionService->method('analyzeAndExtract')->willReturn([
+            ['action' => 'create', 'category' => 'personal', 'key' => 'name', 'value' => 'Furkan'],
+            ['action' => 'create', 'category' => 'personal', 'key' => 'name', 'value' => 'Furkan'],
+        ]);
+
+        $this->memoryService
+            ->expects($this->once())
+            ->method('createMemory')
+            ->willReturn(new UserMemoryDTO(
+                id: 200,
+                userId: 1,
+                category: 'personal',
+                key: 'name',
+                value: 'Furkan',
+                source: 'auto_detected',
+            ));
+
+        $this->handler->__invoke(new ExtractMemoriesCommand(
+            messageId: 42,
+            userId: 1,
+            aiResponse: '',
+            threadSnapshot: [],
+        ));
+    }
+}

--- a/backend/tests/Unit/PromptCatalogTest.php
+++ b/backend/tests/Unit/PromptCatalogTest.php
@@ -19,8 +19,12 @@ final class PromptCatalogTest extends TestCase
     {
         $topics = array_column(PromptCatalog::all(), 'topic');
 
+        // Note (#878): `coding` was retired as a routing target. The
+        // catalog still carries the row (so existing installs can flip
+        // BENABLED=0 on the next seed), but it no longer participates in
+        // Tier-1 recall.
         foreach (
-            ['general-chat', 'coding', 'image-generation', 'video-generation', 'audio-generation'] as $expected
+            ['general-chat', 'image-generation', 'video-generation', 'audio-generation'] as $expected
         ) {
             $this->assertContains(
                 $expected,
@@ -58,7 +62,7 @@ final class PromptCatalogTest extends TestCase
         }
 
         foreach (
-            ['general-chat', 'coding', 'image-generation', 'video-generation', 'audio-generation', 'docsummary', 'officemaker'] as $routable
+            ['general-chat', 'image-generation', 'video-generation', 'audio-generation', 'docsummary', 'officemaker'] as $routable
         ) {
             $this->assertArrayHasKey('keywords', $byTopic[$routable], sprintf(
                 'Routable topic "%s" must declare keywords for Synapse recall',
@@ -68,17 +72,36 @@ final class PromptCatalogTest extends TestCase
         }
     }
 
-    public function testCodingKeywordsContainProgrammingTerms(): void
+    public function testRetiredCodingTopicIsDisabled(): void
     {
+        // Issue #878: the coding topic was retired but stays in the
+        // catalog so existing installs flip BENABLED=0 on the next seed
+        // run. The keywords are intentionally blank; the row exists
+        // purely to drive the seed update.
         $byTopic = [];
         foreach (PromptCatalog::all() as $entry) {
             $byTopic[$entry['topic']] = $entry;
         }
 
-        $codingKeywords = strtolower((string) $byTopic['coding']['keywords']);
-        $this->assertStringContainsString('php', $codingKeywords);
-        $this->assertStringContainsString('python', $codingKeywords);
-        $this->assertStringContainsString('debug', $codingKeywords);
+        $this->assertArrayHasKey('coding', $byTopic);
+        $this->assertArrayHasKey('enabled', $byTopic['coding']);
+        $this->assertFalse($byTopic['coding']['enabled']);
+    }
+
+    public function testGeneralChatKeywordsCoverProgrammingTermsAfterCodingRetirement(): void
+    {
+        // Coding queries now ride on `general-chat` (#878). Make sure
+        // the general-chat keyword list pulled the relevant tokens over
+        // so embedding recall doesn't regress.
+        $byTopic = [];
+        foreach (PromptCatalog::all() as $entry) {
+            $byTopic[$entry['topic']] = $entry;
+        }
+
+        $keywords = strtolower((string) $byTopic['general-chat']['keywords']);
+        $this->assertStringContainsString('php', $keywords);
+        $this->assertStringContainsString('python', $keywords);
+        $this->assertStringContainsString('debug', $keywords);
     }
 
     public function testImageGenerationKeywordsContainBilingualTerms(): void

--- a/backend/tests/Unit/SynapseRouterTest.php
+++ b/backend/tests/Unit/SynapseRouterTest.php
@@ -566,6 +566,11 @@ class SynapseRouterTest extends TestCase
     /**
      * `image-generation` ─► `mediamaker` with implied media=image. The router
      * must skip its own media-detection heuristics in this case.
+     *
+     * Updated for #878: the media-intent guard now requires the user's
+     * text to pair a creation verb with a media noun before Tier-1 can
+     * route to a granular media topic, so the message text below contains
+     * an unambiguous "create an image of …" cue.
      */
     public function testGranularImageGenerationTopicSetsMediaImage(): void
     {
@@ -589,11 +594,95 @@ class SynapseRouterTest extends TestCase
             'metadata' => [],
         ]);
 
-        $result = $this->router->route(['BTEXT' => 'Sing me a song'], [], 1);
+        $result = $this->router->route(['BTEXT' => 'Create an image of a small black cat'], [], 1);
 
         $this->assertSame('mediamaker', $result['topic']);
         $this->assertSame('image-generation', $result['granular_topic']);
         $this->assertSame('image', $result['media_type']);
+    }
+
+    /**
+     * Issue #878: a high-confidence Tier-1 hit on `video-generation` must
+     * be rejected when the user's text contains no explicit video-creation
+     * cue. The original bug report shows messages about hobbies/business
+     * ("ich beschäftige mich mit Protein shakes und möchte eine Kette
+     * öffnen…") being routed to Veo because the embedding model places
+     * them near the video-generation centroid.
+     */
+    public function testMediaIntentGuardRejectsVideoGenerationWithoutCreationCue(): void
+    {
+        $this->modelConfigService->method('getDefaultModel')->willReturn(null);
+        $this->promptRepository->method('findPromptsWithSelectionRules')->willReturn([]);
+
+        $this->aiFacade->method('embed')->willReturn([
+            'embedding' => array_fill(0, 1024, 0.1),
+            'usage' => ['prompt_tokens' => 10, 'total_tokens' => 10],
+        ]);
+
+        $this->qdrantClient->method('searchSynapseTopics')->willReturn([
+            [
+                'id' => 'synapse_0_video-generation',
+                'score' => 0.86, // well above the 0.78 threshold
+                'payload' => ['topic' => 'video-generation', 'owner_id' => 0],
+            ],
+        ]);
+
+        $this->messageSorter->expects($this->once())->method('classify')->willReturn([
+            'topic' => 'general-chat',
+            'language' => 'de',
+            'web_search' => false,
+        ]);
+
+        $result = $this->router->route(
+            ['BTEXT' => 'ich habe ein neues hobby. ich beschäftige mich mit Protein shakes und möchte eine kette öffnen'],
+            [],
+            1,
+        );
+
+        $this->assertSame('synapse_ai_fallback', $result['source']);
+        $this->assertSame('media_intent_guard', $result['synapse_fallback_reason']);
+        // The granular alias is still attached on the AI-fallback path so
+        // analytics keep parity with previous behaviour.
+        $this->assertSame('general', $result['topic']);
+    }
+
+    /**
+     * Counterpart to the guard test: a clear video-creation request must
+     * pass through to mediamaker even though the embedding score is the
+     * same as in the rejection case. Together they prove the guard
+     * doesn't break the legitimate happy path.
+     */
+    public function testMediaIntentGuardAcceptsExplicitVideoCreationRequest(): void
+    {
+        $this->modelConfigService->method('getDefaultModel')->willReturn(null);
+        $this->promptRepository->method('findPromptsWithSelectionRules')->willReturn([]);
+
+        $this->aiFacade->method('embed')->willReturn([
+            'embedding' => array_fill(0, 1024, 0.1),
+            'usage' => ['prompt_tokens' => 10, 'total_tokens' => 10],
+        ]);
+
+        $this->qdrantClient->method('searchSynapseTopics')->willReturn([
+            [
+                'id' => 'synapse_0_video-generation',
+                'score' => 0.86,
+                'payload' => ['topic' => 'video-generation', 'owner_id' => 0],
+            ],
+        ]);
+
+        $this->promptService->method('getPromptWithMetadata')->willReturn([
+            'metadata' => [],
+        ]);
+
+        $result = $this->router->route(
+            ['BTEXT' => 'erstelle ein video von einem golden retriever'],
+            [],
+            1,
+        );
+
+        $this->assertSame('mediamaker', $result['topic']);
+        $this->assertSame('video-generation', $result['granular_topic']);
+        $this->assertSame('video', $result['media_type']);
     }
 
     /**


### PR DESCRIPTION
## Summary

Addresses three regressions surfaced after the perf/memory push.

## Changes

Closes #879 — duplicate memory entries
- ExtractMemoriesCommandHandler now loads the user's full memory list (capped at 80, deduped by ID so legitimate siblings survive) and forwards it to the extractor LLM as context.
- ChatHandler dispatch passes loadedMemories as relevantMemories so the semantic-search signal isn't lost.
- Backend dedup safeguard in the worker rejects exact duplicates (case- and whitespace-insensitive) and promotes a stray `create` to an `update` for singleton keys like name/age/location.
- New singleton-collapse post-pass: when the user states a fresh singleton-key value, any other entry sharing the same (category, key) is auto-deleted as stale. Reproduces the screenshot fix where `name=Ralf` was lingering next to a freshly-updated `name=Hannes`.

Closes #880 — no memory extraction for media generation
- MediaGenerationHandler dispatches ExtractMemoriesCommand upfront, mirroring ChatHandler's gating (disable_memories, widget mode, isMemoriesEnabled, PERF.V2_PIPELINE).
- Done before the slow provider call so a failed generation still saves personal info from the prompt; queue dispatch is wrapped so a hiccup never blocks media generation.

Closes #878 — Synapse routing overreacts
- Retired the `coding` topic. Kept in PromptCatalog with enabled=false so existing installs flip BENABLED=0 on the next seed run; coding keywords merged into general-chat. Alias `coding → general` stays in TopicAliasResolver for backward compat.
- SynapseIndexer.indexAllTopics now drops Qdrant vectors for any disabled prompt (dropDisabledPromptVectors) so orphan vectors clear out automatically.
- Tightened image-/video-/audio-generation topic descriptions and keywords to require explicit creation cues.
- New media-intent guard in SynapseRouter: a high-confidence Tier-1 hit on image-/video-/audio-generation is rejected unless the message contains either a self-contained cue (e.g. "lies vor", "read aloud") or pairs a generic creation verb (create/erstelle/render/animate/…) with a modality-specific noun. Slash commands /pic, /vid, /tts bypass this entirely as they're handled earlier in MessageClassifier.

Tests:
- New ExtractMemoriesCommandHandlerTest with 7 cases covering exact duplicates, casing/whitespace normalization, singleton promotion and collapse on update + promoted-create paths, multi-valued key preservation, and within-batch dedup.
- SynapseRouterTest: media-intent guard rejection and acceptance regression tests.
- PromptCatalogTest updated for the retired `coding` topic and the general-chat keyword merge.

## Verification
- [ ] Not tested (explain)
- [X] Manual
- [ ] Tests added/updated
