### PR TITLE
fix: discard stale loadMessages responses on chat switch

### DIFF
--- a/frontend/src/stores/history.ts
+++ b/frontend/src/stores/history.ts
@@ -281,6 +281,12 @@ export const useHistoryStore = defineStore('history', () => {
   const hasMoreMessages = ref(false)
   const currentOffset = ref(0)
 
+  // Monotonic generation counter: incremented each time loadMessages is called
+  // for a fresh chat (offset === 0). Responses from older generations are
+  // discarded so a slow response for a previous chat never overwrites the
+  // messages of the current one.
+  let loadGeneration = 0
+
   const addMessage = (
     role: 'user' | 'assistant',
     parts: Part[],
@@ -402,6 +408,10 @@ export const useHistoryStore = defineStore('history', () => {
   const loadMessages = async (chatId: number, offset = 0, limit = 50) => {
     if (!checkAuthOrRedirect()) return
 
+    // Fresh load (offset 0) bumps the generation so any in-flight response
+    // for a *previous* chat is silently discarded when it lands.
+    const myGeneration = offset === 0 ? ++loadGeneration : loadGeneration
+
     isLoadingMessages.value = true
 
     // Reset pagination state when loading from start (prevents stale state on error)
@@ -417,6 +427,8 @@ export const useHistoryStore = defineStore('history', () => {
         messages?: ApiLoadedMessageRow[]
         pagination?: { hasMore?: boolean }
       }
+
+      if (myGeneration !== loadGeneration) return
 
       if (response.success && response.messages) {
         const loadedMessages: Message[] = response.messages.map((m) => {
@@ -498,10 +510,10 @@ export const useHistoryStore = defineStore('history', () => {
             originalMediaType: m.originalMediaType ?? m.original_media_type ?? null,
             backendMessageId: m.id,
             files: files.length > 0 ? files : undefined,
-            aiModels: m.aiModels || null, // Parse AI model metadata from backend
-            webSearch: m.webSearch || null, // Parse web search metadata from backend
-            searchResults: m.searchResults || null, // Parse actual search results from backend
-            tool: toolData, // Reconstruct tool metadata from topic
+            aiModels: m.aiModels || null,
+            webSearch: m.webSearch || null,
+            searchResults: m.searchResults || null,
+            tool: toolData,
           }
         })
 
@@ -516,9 +528,12 @@ export const useHistoryStore = defineStore('history', () => {
         hasMoreMessages.value = response.pagination?.hasMore || false
       }
     } catch (error) {
+      if (myGeneration !== loadGeneration) return
       console.error('Failed to load messages:', error)
     } finally {
-      isLoadingMessages.value = false
+      if (myGeneration === loadGeneration) {
+        isLoadingMessages.value = false
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- Fixes race condition in `historyStore.loadMessages` where concurrent calls for different chats could overwrite each other's results
- Root cause of the flaky E2E test `thinking/reasoning tokens are forwarded` (CI #1993 on main after merging #877)
- Adds a monotonic generation counter — responses from older loads are silently discarded

## Root cause

When switching chats, `ChatView.onMounted` can still be running `loadMessages(oldChatId)` while `startNewChat()` triggers `loadMessages(newChatId)` via the `activeChatId` watcher. Whichever response lands **last** wins — if the old chat's response is slower, it overwrites the new (empty) chat's messages, permanently hiding `[data-testid="state-empty"]`.

## What changed

| File | Change |
|------|--------|
| `frontend/src/stores/history.ts` | Add `loadGeneration` counter; discard stale responses in try/catch/finally |

## Test plan

- [x] `make -C frontend lint` — passed
- [x] `docker compose exec -T frontend npm run check:types` — passed
- [x] `make -C frontend test` — 350 tests passed
- [ ] CI E2E tests pass (the previously flaky `ollama-integration` test should now be stable)