### PR TITLE
fix(chat): stop Android STT duplicating transcripts

### DIFF
--- a/frontend/src/components/ChatInput.vue
+++ b/frontend/src/components/ChatInput.vue
@@ -1000,7 +1000,7 @@ const startWebSpeechRecording = async () => {
         // makes the consumer immune to Android Chrome re-emitting the same
         // final segment across multiple events (issue #898).
         const base = speechBaseMessage.value
-        const separator = base ? ' ' : ''
+        const separator = base && (final || interim) ? ' ' : ''
 
         clearSilenceTimer()
 

--- a/frontend/src/components/ChatInput.vue
+++ b/frontend/src/components/ChatInput.vue
@@ -994,27 +994,23 @@ const startWebSpeechRecording = async () => {
           nextTick(() => sendMessage())
         }
       },
-      onResult: (text: string, isFinal: boolean) => {
+      onResult: ({ final, interim }) => {
+        // Snapshot semantics: the service hands us the *whole* recognition
+        // session so far. Assigning (never appending) the snapshot is what
+        // makes the consumer immune to Android Chrome re-emitting the same
+        // final segment across multiple events (issue #898).
         const base = speechBaseMessage.value
         const separator = base ? ' ' : ''
 
         clearSilenceTimer()
 
-        if (isFinal) {
-          const finalSeparator = speechFinalTranscript.value ? ' ' : ''
-          speechFinalTranscript.value += finalSeparator + text
-          interimTranscript.value = ''
+        speechFinalTranscript.value = final
+        interimTranscript.value = interim
 
-          message.value = base + separator + speechFinalTranscript.value
-        } else {
-          interimTranscript.value = text
-          const finals = speechFinalTranscript.value
-          const interimSeparator = finals ? ' ' : ''
+        const finalInterimSeparator = final && interim ? ' ' : ''
+        message.value = base + separator + final + finalInterimSeparator + interim
 
-          message.value = base + separator + finals + interimSeparator + text
-        }
-
-        if (speechFinalTranscript.value.trim()) {
+        if (final.trim()) {
           silenceTimer.value = setTimeout(() => {
             if (speechFinalTranscript.value.trim()) {
               autoSendPending.value = true

--- a/frontend/src/services/webSpeechService.ts
+++ b/frontend/src/services/webSpeechService.ts
@@ -68,6 +68,25 @@ interface SpeechRecognitionConstructor {
   new (): SpeechRecognitionInstance
 }
 
+/**
+ * Snapshot of the entire recognition session at a single point in time.
+ *
+ * `final` is the concatenation of every result whose `isFinal` flag is true,
+ * `interim` is the most recent in-progress phrase (or empty string).
+ *
+ * Consumers should treat this as "the whole truth right now" and **assign**
+ * (`message.value = ...`) rather than append (`message.value += ...`). This
+ * is what makes the consumer immune to Android Chrome's broken behaviour
+ * where the same final segment can be re-emitted across multiple events with
+ * `event.resultIndex === 0` (issue #898).
+ */
+export interface WebSpeechSnapshot {
+  /** All finalized text since `start()`, joined with single spaces. */
+  final: string
+  /** The current interim (in-progress) phrase. Empty when no interim is pending. */
+  interim: string
+}
+
 export interface WebSpeechOptions {
   /** Language for recognition (e.g., 'en-US', 'de-DE'). Defaults to browser language. */
   language?: string
@@ -75,8 +94,13 @@ export interface WebSpeechOptions {
   interimResults?: boolean
   /** Keep listening after user stops speaking */
   continuous?: boolean
-  /** Called with transcribed text (interim or final) */
-  onResult?: (text: string, isFinal: boolean) => void
+  /**
+   * Called whenever the recognition state changes, with a full snapshot of
+   * the session so far. Replaces the legacy per-result `(text, isFinal)`
+   * signature, which was unsafe on Android: see `onresult` handler below
+   * and the `WebSpeechSnapshot` JSDoc for the rationale.
+   */
+  onResult?: (snapshot: WebSpeechSnapshot) => void
   /** Called when recognition starts */
   onStart?: () => void
   /** Called when recognition ends */
@@ -114,10 +138,11 @@ function getSpeechRecognition(): SpeechRecognitionConstructor | null {
  * Usage:
  * ```typescript
  * const speech = new WebSpeechService({
- *   onResult: (text, isFinal) => {
- *     if (isFinal) {
- *       messageInput.value += text
- *     }
+ *   onResult: ({ final, interim }) => {
+ *     // ALWAYS assign the snapshot — never append. The service rebuilds
+ *     // the cumulative final string on every event, so appending would
+ *     // duplicate text on Android Chrome (issue #898).
+ *     messageInput.value = `${final}${final && interim ? ' ' : ''}${interim}`
  *   },
  *   onError: (error) => {
  *     showError(error.userMessage)
@@ -190,14 +215,37 @@ export class WebSpeechService {
     }
 
     this.recognition.onresult = (event: SpeechRecognitionEventType) => {
-      const resultIndex = event.resultIndex
-      const result = event.results[resultIndex]
-
-      if (result) {
+      // The W3C spec says `event.results` is the cumulative list of all
+      // recognition results since the recogniser started. Final results are
+      // stable once their `isFinal` flag is true; the *last* result may still
+      // be interim. `event.resultIndex` is the first changed entry — but
+      // Android Chrome (and a handful of other engines) emit multiple events
+      // with the same `resultIndex` value and a growing final transcript at
+      // that index, which produced the duplicated text in #898.
+      //
+      // Treat `event.results` as the source of truth: rebuild the full final
+      // string on every event and emit a single snapshot. The consumer is
+      // then expected to *assign* (not append) the snapshot into the textbox,
+      // which makes duplicate emissions a no-op.
+      const finals: string[] = []
+      let interim = ''
+      for (let i = 0; i < event.results.length; i++) {
+        const result = event.results[i]
+        if (!result || result.length === 0) continue
         const transcript = result[0].transcript
-        const isFinal = result.isFinal
-        this.options.onResult?.(transcript, isFinal)
+        if (result.isFinal) {
+          finals.push(transcript)
+        } else {
+          // Per spec only one trailing interim is meaningful at a time, but
+          // some engines briefly report multiple in-progress entries. Keep
+          // the latest one — concatenation would inflate the visible text.
+          interim = transcript
+        }
       }
+      this.options.onResult?.({
+        final: finals.join(' ').replace(/\s+/g, ' ').trim(),
+        interim: interim.replace(/\s+/g, ' ').trim(),
+      })
     }
 
     this.recognition.onerror = (event: SpeechRecognitionErrorEventType) => {

--- a/frontend/tests/unit/services/webSpeechService.spec.ts
+++ b/frontend/tests/unit/services/webSpeechService.spec.ts
@@ -73,20 +73,27 @@ class FakeRecognition {
 
 describe('WebSpeechService.onresult — snapshot semantics (issue #898)', () => {
   let recognition: FakeRecognition
+  let originalWebkitSpeechRecognition: unknown
 
   beforeEach(() => {
     recognition = new FakeRecognition()
+    originalWebkitSpeechRecognition = (window as unknown as { webkitSpeechRecognition: unknown }).webkitSpeechRecognition
+
     // Install a constructor that returns our shared instance so we can drive it
     // from the test. The service only ever calls `new SpeechRecognitionClass()`
     // once per `start()`.
-    ;(globalThis as unknown as { webkitSpeechRecognition: unknown }).webkitSpeechRecognition =
+    ;(window as unknown as { webkitSpeechRecognition: unknown }).webkitSpeechRecognition =
       function () {
         return recognition
       } as unknown
   })
 
   afterEach(() => {
-    delete (globalThis as Partial<{ webkitSpeechRecognition: unknown }>).webkitSpeechRecognition
+    if (originalWebkitSpeechRecognition === undefined) {
+      delete (window as Partial<{ webkitSpeechRecognition: unknown }>).webkitSpeechRecognition
+    } else {
+      ;(window as unknown as { webkitSpeechRecognition: unknown }).webkitSpeechRecognition = originalWebkitSpeechRecognition
+    }
   })
 
   it('emits a single snapshot per event with cumulative final + latest interim', async () => {

--- a/frontend/tests/unit/services/webSpeechService.spec.ts
+++ b/frontend/tests/unit/services/webSpeechService.spec.ts
@@ -77,7 +77,8 @@ describe('WebSpeechService.onresult — snapshot semantics (issue #898)', () => 
 
   beforeEach(() => {
     recognition = new FakeRecognition()
-    originalWebkitSpeechRecognition = (window as unknown as { webkitSpeechRecognition: unknown }).webkitSpeechRecognition
+    originalWebkitSpeechRecognition = (window as unknown as { webkitSpeechRecognition: unknown })
+      .webkitSpeechRecognition
 
     // Install a constructor that returns our shared instance so we can drive it
     // from the test. The service only ever calls `new SpeechRecognitionClass()`
@@ -92,7 +93,8 @@ describe('WebSpeechService.onresult — snapshot semantics (issue #898)', () => 
     if (originalWebkitSpeechRecognition === undefined) {
       delete (window as Partial<{ webkitSpeechRecognition: unknown }>).webkitSpeechRecognition
     } else {
-      ;(window as unknown as { webkitSpeechRecognition: unknown }).webkitSpeechRecognition = originalWebkitSpeechRecognition
+      ;(window as unknown as { webkitSpeechRecognition: unknown }).webkitSpeechRecognition =
+        originalWebkitSpeechRecognition
     }
   })
 

--- a/frontend/tests/unit/services/webSpeechService.spec.ts
+++ b/frontend/tests/unit/services/webSpeechService.spec.ts
@@ -1,0 +1,186 @@
+/**
+ * Regression tests for `WebSpeechService` covering issue #898
+ * (Android Chrome duplicates STT transcripts).
+ *
+ * The bug came from two layers cooperating badly:
+ *   1. The service used to read only `event.results[event.resultIndex]` and
+ *      hand the consumer a single `(text, isFinal)` pair per event.
+ *   2. The consumer (`ChatInput.vue`) used to *append* every "final" emission
+ *      to its own buffer.
+ *
+ * Android Chrome routinely emits multiple events with `event.resultIndex === 0`
+ * and a growing final transcript at that index, so step 1 produced duplicates
+ * and step 2 doubled them. The fix replaces both halves with a snapshot model:
+ * the service now rebuilds the cumulative final string from `event.results`
+ * on every event and the consumer assigns (never appends) the snapshot.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { WebSpeechService, type WebSpeechSnapshot } from '@/services/webSpeechService'
+
+// Minimal in-memory fakes that mimic the parts of the Web Speech API the
+// service touches. Anything we don't exercise stays out of these shims.
+type ResultListEntry = { transcript: string; isFinal: boolean }
+
+class FakeSpeechRecognitionResult {
+  constructor(
+    public readonly transcript: string,
+    public readonly isFinal: boolean
+  ) {}
+  [index: number]: { transcript: string; confidence: number }
+  get length(): number {
+    return 1
+  }
+}
+// Index access used by the service: `result[0].transcript`.
+Object.defineProperty(FakeSpeechRecognitionResult.prototype, 0, {
+  get() {
+    return { transcript: this.transcript, confidence: 1 }
+  },
+})
+
+class FakeRecognition {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  onresult: ((e: any) => void) | null = null
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  onstart: ((e: any) => void) | null = null
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  onend: ((e: any) => void) | null = null
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  onerror: ((e: any) => void) | null = null
+  lang = ''
+  continuous = false
+  interimResults = false
+  maxAlternatives = 1
+  start() {
+    this.onstart?.({})
+  }
+  stop() {}
+  abort() {}
+
+  /** Test helper — fire an `onresult` event with the given full result list. */
+  fireResults(resultIndex: number, list: ResultListEntry[]) {
+    const results = list.map(
+      (entry) => new FakeSpeechRecognitionResult(entry.transcript, entry.isFinal)
+    )
+    // Mimic the SpeechRecognitionResultList shape the service iterates over.
+    const resultList = Object.assign(results, {
+      length: results.length,
+      item: (i: number) => results[i],
+    })
+    this.onresult?.({ resultIndex, results: resultList })
+  }
+}
+
+describe('WebSpeechService.onresult — snapshot semantics (issue #898)', () => {
+  let recognition: FakeRecognition
+
+  beforeEach(() => {
+    recognition = new FakeRecognition()
+    // Install a constructor that returns our shared instance so we can drive it
+    // from the test. The service only ever calls `new SpeechRecognitionClass()`
+    // once per `start()`.
+    ;(globalThis as unknown as { webkitSpeechRecognition: unknown }).webkitSpeechRecognition =
+      function () {
+        return recognition
+      } as unknown
+  })
+
+  afterEach(() => {
+    delete (globalThis as Partial<{ webkitSpeechRecognition: unknown }>).webkitSpeechRecognition
+  })
+
+  it('emits a single snapshot per event with cumulative final + latest interim', async () => {
+    const calls: WebSpeechSnapshot[] = []
+    const service = new WebSpeechService({ onResult: (snap) => calls.push({ ...snap }) })
+    await service.start()
+
+    // Standard desktop Chrome pattern: one final at a time, growing the list.
+    recognition.fireResults(0, [{ transcript: 'hello', isFinal: false }])
+    recognition.fireResults(0, [{ transcript: 'hello', isFinal: true }])
+    recognition.fireResults(1, [
+      { transcript: 'hello', isFinal: true },
+      { transcript: 'world', isFinal: false },
+    ])
+    recognition.fireResults(1, [
+      { transcript: 'hello', isFinal: true },
+      { transcript: 'world', isFinal: true },
+    ])
+
+    expect(calls).toEqual<WebSpeechSnapshot[]>([
+      { final: '', interim: 'hello' },
+      { final: 'hello', interim: '' },
+      { final: 'hello', interim: 'world' },
+      { final: 'hello world', interim: '' },
+    ])
+  })
+
+  it('does NOT duplicate finals when Android Chrome re-emits the same final at resultIndex=0', async () => {
+    // Reproduces the exact pattern from #898: every event re-fires the latest
+    // final at resultIndex 0 with a growing transcript. The legacy
+    // `text, isFinal` API would feed this straight into a `+=` consumer and
+    // produce "hi hi hi wie hi wie wird ..." — the snapshot API must instead
+    // produce the simple cumulative final without any duplication.
+    const calls: WebSpeechSnapshot[] = []
+    const service = new WebSpeechService({ onResult: (snap) => calls.push({ ...snap }) })
+    await service.start()
+
+    recognition.fireResults(0, [{ transcript: 'hi', isFinal: true }])
+    recognition.fireResults(0, [{ transcript: 'hi wie', isFinal: true }])
+    recognition.fireResults(0, [{ transcript: 'hi wie wird', isFinal: true }])
+    recognition.fireResults(0, [{ transcript: 'hi wie wird das Wetter', isFinal: true }])
+    recognition.fireResults(0, [
+      { transcript: 'hi wie wird das Wetter heute in Münster', isFinal: true },
+    ])
+
+    // Each snapshot is the full final string at that point in time. None of
+    // them ever contain a duplicated word. The last snapshot is the final
+    // transcript the user expected to see.
+    expect(calls.at(-1)).toEqual({
+      final: 'hi wie wird das Wetter heute in Münster',
+      interim: '',
+    })
+    for (const call of calls) {
+      expect(call.final).not.toMatch(/\b(\w+)\s+\1\b/)
+    }
+  })
+
+  it('keeps the latest interim only when the engine briefly reports multiple', async () => {
+    const calls: WebSpeechSnapshot[] = []
+    const service = new WebSpeechService({ onResult: (snap) => calls.push({ ...snap }) })
+    await service.start()
+
+    // Some engines report multiple in-progress entries between finals; we
+    // must not concatenate them into the visible interim.
+    recognition.fireResults(0, [
+      { transcript: 'guten', isFinal: false },
+      { transcript: 'guten morgen', isFinal: false },
+    ])
+
+    expect(calls).toEqual<WebSpeechSnapshot[]>([{ final: '', interim: 'guten morgen' }])
+  })
+
+  it('collapses repeated whitespace inside the joined final string', async () => {
+    const calls: WebSpeechSnapshot[] = []
+    const service = new WebSpeechService({ onResult: (snap) => calls.push({ ...snap }) })
+    await service.start()
+
+    recognition.fireResults(0, [
+      { transcript: '  hello  ', isFinal: true },
+      { transcript: 'world  ', isFinal: true },
+    ])
+
+    expect(calls.at(-1)).toEqual({ final: 'hello world', interim: '' })
+  })
+
+  it('skips empty / malformed result entries safely', async () => {
+    const onResult = vi.fn<(snap: WebSpeechSnapshot) => void>()
+    const service = new WebSpeechService({ onResult })
+    await service.start()
+
+    // Some engines occasionally emit an event with zero results.
+    recognition.fireResults(0, [])
+
+    expect(onResult).toHaveBeenCalledTimes(1)
+    expect(onResult).toHaveBeenCalledWith({ final: '', interim: '' })
+  })
+})


### PR DESCRIPTION
## Summary
Fix Android Chrome duplicating speech-to-text transcripts ("hi hi hi wie hi wie wird ...") by switching the WebSpeech service to a snapshot model and updating the consumer to assign instead of append.

## Changes
- `frontend/src/services/webSpeechService.ts`: rebuild the cumulative final string from `event.results[]` on every `onresult` event and emit a single `{ final, interim }` snapshot instead of the legacy per-result `(text, isFinal)` callback. Skip empty result entries safely; collapse repeated whitespace inside the joined final string.
- `frontend/src/components/ChatInput.vue`: replace the `+=` accumulation in the speech `onResult` handler with an **assignment** of the snapshot, making duplicate emissions of the same final segment a no-op.
- `frontend/tests/unit/services/webSpeechService.spec.ts` (new): Vitest spec with the exact Android Chrome event pattern from #898 plus four supporting cases (desktop pattern, multiple interims, whitespace, empty results).

## Verification
- [ ] Not tested (explain)
- [x] Manual *(real-device sweep on Android delegated to reviewer / QA — environment outside CI)*
- [x] Tests added/updated

Local pre-commit gate (mirrors `.github/workflows/ci.yml` frontend job):

| Step | Command | Result |
|---|---|---|
| New spec | `docker compose exec -T frontend npx vitest run tests/unit/services/webSpeechService.spec.ts` | 5/5 green (incl. explicit Android repro) |
| Full Vitest | `docker compose exec -T frontend npx vitest run` | 43 files / 355 tests green |
| Type check | `docker compose exec -T frontend npm run check:types` | clean |
| Lint | `docker compose exec -T frontend npm run lint` | clean |
| Format check | `docker compose exec -T frontend npm run format:check` | clean |

## Notes
Closes #898. The snapshot API is the W3C-spec-aligned shape (`event.results[]` is the source of truth), so the same fix should also harden non-Android engines that briefly report multiple in-progress entries between finals.