### PR TITLE
fix(config): surface premium-required reason in models save toast

### DIFF
--- a/frontend/src/components/config/AIModelsConfiguration.vue
+++ b/frontend/src/components/config/AIModelsConfiguration.vue
@@ -433,6 +433,7 @@ import {
   checkModelAvailability,
 } from '@/services/api/configApi'
 import { adminEmbeddingApi, type EmbeddingGuardStatus } from '@/services/api/adminEmbeddingApi'
+import { ApiError } from '@/services/api/httpClient'
 import { useAuthStore } from '@/stores/auth'
 import type { AIModel, Capability } from '@/types/ai-models'
 import { getProviderIcon } from '@/utils/providerIcons'
@@ -923,7 +924,23 @@ const saveConfiguration = async () => {
     }
   } catch (err: unknown) {
     console.error('Failed to save configuration:', err)
-    showError(t('config.aiModels.saveError'))
+    // Issue #883: surface the actual reason the backend gave us instead of
+    // a generic "Failed to save model configuration" toast. The premium
+    // gate on `ConfigController::saveDefaultModels` returns a structured
+    // 403 `{ error: 'requires_premium', message: 'Switching the embedding
+    // model requires an active paid subscription. Current level: NEW.', ... }`
+    // and `httpClient.ApiError` now exposes both the message and the code.
+    if (err instanceof ApiError && 403 === err.status) {
+      const reason =
+        'requires_premium' === err.code
+          ? t('config.aiModels.saveErrorPremiumRequired', { reason: err.message })
+          : err.message
+      showError(reason)
+    } else if (err instanceof Error && err.message) {
+      showError(err.message)
+    } else {
+      showError(t('config.aiModels.saveError'))
+    }
   } finally {
     saving.value = false
   }

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -891,6 +891,7 @@
       "noModelsAvailable": "Keine Modelle für diesen Verwendungszweck verfügbar",
       "saveSuccess": "Modellkonfiguration gespeichert",
       "saveError": "Modellkonfiguration konnte nicht gespeichert werden",
+      "saveErrorPremiumRequired": "{reason} Bitte aktualisiere deinen Tarif oder wähle ein anderes Modell.",
       "tableName": "Name",
       "tableService": "Anbieter",
       "tableRating": "Bewertung",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -740,6 +740,7 @@
       "noModelsAvailable": "No models available for this purpose",
       "saveSuccess": "Model configuration saved",
       "saveError": "Failed to save model configuration",
+      "saveErrorPremiumRequired": "{reason} Please upgrade your plan, or pick a different model.",
       "tableName": "Name",
       "tableService": "Service",
       "tableRating": "Rating",

--- a/frontend/src/services/api/httpClient.ts
+++ b/frontend/src/services/api/httpClient.ts
@@ -6,6 +6,32 @@
 import { z } from 'zod'
 import { GetApiConfigRuntimeConfigResponseSchema } from '@/generated/api-schemas'
 
+/**
+ * Structured error thrown by httpClient on a non-OK response.
+ *
+ * Extends `Error` so every existing `catch (err) { if (err instanceof Error)
+ * ... }` consumer keeps working unchanged: `.message` is set to the
+ * human-readable text the backend chose (preferring `message`, falling back
+ * to the legacy `error` code, falling back to the bare HTTP status line).
+ *
+ * Consumers that want to differentiate between failure modes (e.g. show a
+ * specific upgrade CTA for `requires_premium` 403s — issue #883) can narrow
+ * with `instanceof ApiError` and inspect `.status`, `.code` and `.details`.
+ */
+export class ApiError extends Error {
+  public readonly name = 'ApiError'
+
+  public constructor(
+    public readonly status: number,
+    message: string,
+    public readonly code?: string,
+    public readonly details?: Record<string, unknown>,
+    public readonly debug?: string
+  ) {
+    super(message)
+  }
+}
+
 // API base URL - lazy initialized on first use
 // For admin UI: empty string (same-origin)
 // For cross-origin scenarios: full URL could be set
@@ -398,10 +424,24 @@ async function httpClient<T = unknown, S extends z.Schema | undefined = undefine
     }
 
     let errorMessage = `HTTP ${response.status}: ${response.statusText}`
+    let errorCode: string | undefined
+    let errorDetails: Record<string, unknown> | undefined
     let debugInfo: string | undefined
     try {
       const errorData = await response.json()
-      errorMessage = errorData.error || errorData.message || errorMessage
+      // Prefer the human-readable `message` field when the backend sends a
+      // structured `{ error: 'code', message: 'human text', ... }` shape (used
+      // by ConfigController premium gate, memory-service unavailable, etc.).
+      // Fall back to bare `error` so legacy single-field responses keep their
+      // current text. Issue #883: surface "Switching the embedding model
+      // requires an active paid subscription..." instead of "requires_premium".
+      errorMessage = errorData.message || errorData.error || errorMessage
+      if (typeof errorData.error === 'string') {
+        errorCode = errorData.error
+      }
+      if (errorData && typeof errorData === 'object') {
+        errorDetails = errorData as Record<string, unknown>
+      }
       // Capture debug info if present (only sent to admins by backend)
       debugInfo = errorData.debug
     } catch {
@@ -409,7 +449,7 @@ async function httpClient<T = unknown, S extends z.Schema | undefined = undefine
     }
     // Include debug info in error message if present
     const fullMessage = debugInfo ? `${errorMessage}\n[Debug] ${debugInfo}` : errorMessage
-    throw new Error(fullMessage)
+    throw new ApiError(response.status, fullMessage, errorCode, errorDetails, debugInfo)
   }
 
   // Parse response based on requested type

--- a/frontend/tests/unit/api/httpClient.spec.ts
+++ b/frontend/tests/unit/api/httpClient.spec.ts
@@ -1,0 +1,157 @@
+/**
+ * Tests for `httpClient`'s structured error path.
+ *
+ * Issue #883: a non-premium user picking a premium embedding model on
+ * `/config/ai-models` got a generic "Failed to save model configuration"
+ * toast even though the backend already returned the correct human-readable
+ * reason in `{ message: 'Switching the embedding model requires an active
+ * paid subscription. Current level: NEW.', error: 'requires_premium', ... }`.
+ *
+ * The fix is two-piece:
+ *   1. `httpClient` throws an `ApiError` that carries `status`, `code`
+ *      (the backend's machine-readable `error` field) and `details`
+ *      (the full body).
+ *   2. `ApiError.message` prefers the backend's `message` field over the
+ *      legacy `error` code so generic consumers immediately get a useful
+ *      string with no extra plumbing.
+ *
+ * The frontend view is then free to inspect `code === 'requires_premium'`
+ * and wrap the message in a richer i18n string with an upgrade CTA.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { ApiError, httpClient } from '@/services/api/httpClient'
+
+type MockResponseInit = {
+  ok: boolean
+  status: number
+  statusText?: string
+  body: unknown
+}
+
+const mockResponse = ({ ok, status, statusText, body }: MockResponseInit): Response => {
+  return {
+    ok,
+    status,
+    statusText: statusText ?? '',
+    json: async () => body,
+    text: async () => (typeof body === 'string' ? body : JSON.stringify(body)),
+    blob: async () => new Blob([JSON.stringify(body)]),
+  } as unknown as Response
+}
+
+describe('httpClient ApiError shape (issue #883)', () => {
+  let originalFetch: typeof fetch
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    vi.restoreAllMocks()
+  })
+
+  it('throws ApiError with the backend message preferred over the error code', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      mockResponse({
+        ok: false,
+        status: 403,
+        body: {
+          error: 'requires_premium',
+          message:
+            'Switching the embedding model requires an active paid subscription. Current level: NEW.',
+          capability: 'VECTORIZE',
+          currentLevel: 'NEW',
+        },
+      })
+    )
+
+    await expect(
+      httpClient('/api/v1/config/models/defaults', { method: 'POST' })
+    ).rejects.toSatisfy((err: unknown) => {
+      expect(err).toBeInstanceOf(ApiError)
+      const apiError = err as ApiError
+      // Generic consumers get the human-readable text via .message — they
+      // don't have to know about the code/details split.
+      expect(apiError.message).toBe(
+        'Switching the embedding model requires an active paid subscription. Current level: NEW.'
+      )
+      // Premium-aware consumers can branch on .code without parsing strings.
+      expect(apiError.status).toBe(403)
+      expect(apiError.code).toBe('requires_premium')
+      expect(apiError.details).toMatchObject({
+        capability: 'VECTORIZE',
+        currentLevel: 'NEW',
+      })
+      return true
+    })
+  })
+
+  it('falls back to the bare `error` field when no `message` is present', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      mockResponse({
+        ok: false,
+        status: 400,
+        body: { error: 'Invalid data' },
+      })
+    )
+
+    await expect(
+      httpClient('/api/v1/config/models/defaults', { method: 'POST' })
+    ).rejects.toSatisfy((err: unknown) => {
+      expect(err).toBeInstanceOf(ApiError)
+      const apiError = err as ApiError
+      expect(apiError.message).toBe('Invalid data')
+      expect(apiError.status).toBe(400)
+      expect(apiError.code).toBe('Invalid data')
+      return true
+    })
+  })
+
+  it('includes admin debug info in the message when present', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      mockResponse({
+        ok: false,
+        status: 503,
+        body: {
+          error: 'Memory service temporarily unavailable',
+          debug: 'Qdrant connection refused at qdrant:6333',
+        },
+      })
+    )
+
+    await expect(httpClient('/api/v1/user/memories', {})).rejects.toSatisfy((err: unknown) => {
+      expect(err).toBeInstanceOf(ApiError)
+      const apiError = err as ApiError
+      expect(apiError.status).toBe(503)
+      expect(apiError.debug).toBe('Qdrant connection refused at qdrant:6333')
+      // The legacy "[Debug] " annotation is preserved in .message so existing
+      // toasts in admin views keep showing the operator-only diagnostic.
+      expect(apiError.message).toContain('Memory service temporarily unavailable')
+      expect(apiError.message).toContain('[Debug] Qdrant connection refused at qdrant:6333')
+      return true
+    })
+  })
+
+  it('falls back to a synthetic HTTP message when the body is not JSON', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 502,
+      statusText: 'Bad Gateway',
+      json: async () => {
+        throw new SyntaxError('Unexpected token <')
+      },
+    } as unknown as Response)
+
+    await expect(
+      httpClient('/api/v1/config/models/defaults', { method: 'POST' })
+    ).rejects.toSatisfy((err: unknown) => {
+      expect(err).toBeInstanceOf(ApiError)
+      const apiError = err as ApiError
+      expect(apiError.status).toBe(502)
+      expect(apiError.message).toBe('HTTP 502: Bad Gateway')
+      expect(apiError.code).toBeUndefined()
+      return true
+    })
+  })
+})


### PR DESCRIPTION
## Summary
Replace the generic "Failed to save model configuration" toast on `/config/ai-models` with the actual reason the backend returned (e.g. "Switching the embedding model requires an active paid subscription. Current level: NEW. Please upgrade your plan, or pick a different model.").

## Changes
- `frontend/src/services/api/httpClient.ts`:
  - New `class ApiError extends Error` exposing `status`, `code`, `details`, `debug` so consumers can branch on machine-readable codes without parsing strings.
  - Error path now throws `ApiError`. Prefers the backend's human-readable `message` over the legacy `error` code for the displayed text, so existing generic catch blocks immediately show useful text with no extra plumbing.
- `frontend/src/components/config/AIModelsConfiguration.vue`:
  - Catch block detects `ApiError` with status 403 + code `requires_premium`, wraps the backend message in the new `saveErrorPremiumRequired` i18n string with an upgrade-CTA hint.
  - Generic non-200 errors fall back to `err.message`; truly opaque errors keep the original generic toast.
- `frontend/src/i18n/{en,de}.json`: new `config.aiModels.saveErrorPremiumRequired` key in both languages.
- `frontend/tests/unit/api/httpClient.spec.ts` (new): four Vitest cases — message-preferred over code, bare-error fallback, admin debug suffix preservation, non-JSON-body synthetic-status fallback.

## Verification
- [ ] Not tested (explain)
- [x] Manual *(behavior reproduced from the issue's STR; final UX confirmation by reviewer or QA against a non-premium user account)*
- [x] Tests added/updated

Local pre-commit gate (mirrors `.github/workflows/ci.yml` frontend job):

| Step | Command | Result |
|---|---|---|
| New spec | `docker compose exec -T frontend npx vitest run tests/unit/api/httpClient.spec.ts` | 4/4 green |
| Full Vitest | `docker compose exec -T frontend npx vitest run` | 43 files / 354 tests green |
| Type check | `docker compose exec -T frontend npm run check:types` | clean |
| Lint | `docker compose exec -T frontend npm run lint` | clean |
| Format check | `docker compose exec -T frontend npm run format:check` | clean |

## Notes
Closes #883.

Sister issue #891 ("per-prompt AI model bypass") was originally planned to ship in the same PR, but on closer reading there is no per-model premium attribute in the current data model — the only model gate is the embedding-switch guard (`EmbeddingModelChangeGuard`), which is VECTORIZE-specific and operates on the *act of changing the active embedding model*, not on individual model identities. The prompt's `aiModel` metadata is consumed only by the chat path (`StreamController:1530`) and is not subject to that gate. A follow-up architectural discussion on whether to introduce per-model premium tagging is more appropriate than a reactive validation in `PromptController`. Linking back to #891 with that finding so the project can decide.

The new `ApiError` class is general — a follow-up could update other catch sites (memory parse 503, widget upload errors, etc.) to display the backend's chosen message instead of generic copy. Out of scope here to keep the diff focused.

## Screenshots/Logs
N/A — pure UX wiring fix; the visible output is the toast text, identical to what the backend already logs.

Made with [Cursor](https://cursor.com)