### PR TITLE
fix: 7 bug fixes from GitHub issue triage

### DIFF
--- a/backend/src/Controller/FileController.php
+++ b/backend/src/Controller/FileController.php
@@ -93,6 +93,77 @@ class FileController extends AbstractController
         return $this->json($result, $result['success'] ? Response::HTTP_OK : Response::HTTP_PARTIAL_CONTENT);
     }
 
+    #[Route('/check-upload', name: 'check_upload', methods: ['POST'], priority: 10)]
+    #[OA\Post(
+        path: '/api/v1/files/check-upload',
+        summary: 'Pre-flight check for an upload (quota, size, extension, rate limit)',
+        description: 'Lightweight metadata-only check that lets the UI fail fast BEFORE streaming the file body. Prevents timeouts when an upload would be rejected for quota reasons.',
+        tags: ['Files'],
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                required: ['filename', 'size'],
+                properties: [
+                    new OA\Property(property: 'filename', type: 'string', example: 'document.pdf'),
+                    new OA\Property(property: 'size', type: 'integer', example: 1048576, description: 'File size in bytes'),
+                    new OA\Property(property: 'mime', type: 'string', example: 'application/pdf', nullable: true),
+                ]
+            )
+        ),
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Pre-flight result. allowed=false includes a reason and message; allowed=true means the upload may proceed.',
+                content: new OA\JsonContent(
+                    properties: [
+                        new OA\Property(property: 'allowed', type: 'boolean', example: false),
+                        new OA\Property(property: 'reason', type: 'string', enum: ['rate_limit_exceeded', 'file_too_large', 'extension_not_allowed', 'storage_exceeded'], nullable: true),
+                        new OA\Property(property: 'message', type: 'string', nullable: true),
+                        new OA\Property(property: 'max_file_size', type: 'integer', description: 'Per-file size limit in bytes'),
+                        new OA\Property(
+                            property: 'allowed_extensions',
+                            type: 'array',
+                            items: new OA\Items(type: 'string'),
+                        ),
+                        new OA\Property(property: 'remaining', type: 'integer', description: 'Remaining storage quota in bytes'),
+                        new OA\Property(property: 'used', type: 'integer', nullable: true),
+                        new OA\Property(property: 'limit', type: 'integer', nullable: true),
+                    ]
+                )
+            ),
+            new OA\Response(response: 400, description: 'Invalid input'),
+            new OA\Response(response: 401, description: 'Not authenticated'),
+        ]
+    )]
+    public function checkUpload(Request $request, #[CurrentUser] ?User $user): JsonResponse
+    {
+        if (!$user) {
+            return $this->json(['error' => 'Not authenticated'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        $data = json_decode((string) $request->getContent(), true);
+        if (!is_array($data)) {
+            return $this->json(['error' => 'Invalid JSON body'], Response::HTTP_BAD_REQUEST);
+        }
+
+        $filename = isset($data['filename']) ? trim((string) $data['filename']) : '';
+        if ('' === $filename) {
+            return $this->json(['error' => 'filename is required'], Response::HTTP_BAD_REQUEST);
+        }
+
+        if (!isset($data['size']) || !is_numeric($data['size'])) {
+            return $this->json(['error' => 'size (integer, bytes) is required'], Response::HTTP_BAD_REQUEST);
+        }
+        $size = (int) $data['size'];
+        if ($size < 0) {
+            return $this->json(['error' => 'size must be a non-negative integer'], Response::HTTP_BAD_REQUEST);
+        }
+
+        $result = $this->uploadService->checkUpload($user, $filename, $size);
+
+        return $this->json($result);
+    }
+
     #[Route('/{id}/process', name: 'process', methods: ['POST'])]
     #[OA\Post(
         path: '/api/v1/files/{id}/process',

--- a/backend/src/Controller/InboundEmailHandlerController.php
+++ b/backend/src/Controller/InboundEmailHandlerController.php
@@ -186,6 +186,138 @@ class InboundEmailHandlerController extends AbstractController
     }
 
     /**
+     * Test mailbox (IMAP/POP3) connection with credentials from the request body.
+     * Does not persist changes or alter stored handler status (preview before save).
+     */
+    #[Route('/test-connection', name: 'test_connection_preview', methods: ['POST'], priority: 10)]
+    #[OA\Post(
+        path: '/api/v1/inbound-email-handlers/test-connection',
+        summary: 'Test mailbox connection without saving',
+        description: 'Tests IMAP/POP3 login using values from the form. When editing an existing handler, omit password or send the masked placeholder and pass handlerId to reuse the stored password while testing changed server settings.',
+        security: [['Bearer' => []]],
+        tags: ['Inbound Email Handlers']
+    )]
+    #[OA\RequestBody(
+        required: true,
+        content: new OA\JsonContent(
+            required: ['mailServer', 'port', 'protocol', 'security', 'username'],
+            properties: [
+                new OA\Property(property: 'mailServer', type: 'string', example: 'imap.example.com'),
+                new OA\Property(property: 'port', type: 'integer', example: 993),
+                new OA\Property(property: 'protocol', type: 'string', enum: ['IMAP', 'POP3']),
+                new OA\Property(property: 'security', type: 'string', enum: ['SSL/TLS', 'STARTTLS', 'None']),
+                new OA\Property(property: 'username', type: 'string', example: 'user@example.com'),
+                new OA\Property(property: 'password', type: 'string', nullable: true, description: 'Plain password; omit or mask when handlerId is set'),
+                new OA\Property(property: 'handlerId', type: 'integer', nullable: true, description: 'Existing handler ID to load stored password when password is omitted/masked'),
+            ]
+        )
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'Connection test result',
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(property: 'success', type: 'boolean', example: true),
+                new OA\Property(property: 'message', type: 'string', example: 'Connection successful'),
+            ]
+        )
+    )]
+    #[OA\Response(response: 400, description: 'Invalid or incomplete parameters')]
+    #[OA\Response(response: 401, description: 'Not authenticated')]
+    #[OA\Response(response: 404, description: 'Handler not found')]
+    public function testConnectionPreview(Request $request, #[CurrentUser] ?User $user): JsonResponse
+    {
+        if (!$user) {
+            return $this->json(['error' => 'Not authenticated'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        $data = json_decode($request->getContent(), true);
+        if (!is_array($data)) {
+            return $this->json([
+                'success' => false,
+                'message' => 'Invalid JSON body',
+            ], Response::HTTP_BAD_REQUEST);
+        }
+
+        $mailServer = isset($data['mailServer']) ? trim((string) $data['mailServer']) : '';
+        $username = isset($data['username']) ? trim((string) $data['username']) : '';
+        $port = isset($data['port']) ? (int) $data['port'] : 0;
+        $protocol = isset($data['protocol']) ? (string) $data['protocol'] : '';
+        $security = isset($data['security']) ? (string) $data['security'] : '';
+
+        if ('' === $mailServer || '' === $username || $port <= 0 || $port > 65535) {
+            return $this->json([
+                'success' => false,
+                'message' => 'mailServer, username, and a valid port (1–65535) are required',
+            ], Response::HTTP_BAD_REQUEST);
+        }
+
+        if (!in_array($protocol, ['IMAP', 'POP3'], true)) {
+            return $this->json([
+                'success' => false,
+                'message' => 'protocol must be IMAP or POP3',
+            ], Response::HTTP_BAD_REQUEST);
+        }
+
+        if (!in_array($security, ['SSL/TLS', 'STARTTLS', 'None'], true)) {
+            return $this->json([
+                'success' => false,
+                'message' => 'security must be SSL/TLS, STARTTLS, or None',
+            ], Response::HTTP_BAD_REQUEST);
+        }
+
+        $passwordInput = isset($data['password']) ? (string) $data['password'] : '';
+        $handlerId = isset($data['handlerId']) ? (int) $data['handlerId'] : 0;
+
+        $plainPassword = null;
+        if (!InboundEmailHandlerService::isMaskedPasswordPlaceholder($passwordInput)) {
+            $plainPassword = $passwordInput;
+        } elseif ($handlerId > 0) {
+            $stored = $this->handlerRepository->findByIdAndUser($handlerId, $user->getId());
+            if (!$stored) {
+                return $this->json([
+                    'success' => false,
+                    'error' => 'Handler not found',
+                ], Response::HTTP_NOT_FOUND);
+            }
+            $plainPassword = $stored->getDecryptedPassword($this->encryptionService);
+        }
+
+        if (null === $plainPassword || '' === $plainPassword) {
+            return $this->json([
+                'success' => false,
+                'message' => 'Password is required, or provide handlerId to reuse the saved password',
+            ], Response::HTTP_BAD_REQUEST);
+        }
+
+        try {
+            $result = $this->handlerService->testMailboxCredentials(
+                $mailServer,
+                $port,
+                $protocol,
+                $security,
+                $username,
+                $plainPassword
+            );
+
+            return $this->json([
+                'success' => $result['success'],
+                'message' => $result['message'],
+            ]);
+        } catch (\Exception $e) {
+            $this->logger->error('Preview mailbox connection test failed', [
+                'user_id' => $user->getId(),
+                'error' => $e->getMessage(),
+            ]);
+
+            return $this->json([
+                'success' => false,
+                'message' => 'Test connection failed: '.$e->getMessage(),
+            ], Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    /**
      * Update handler.
      */
     #[Route('/{id}', name: 'update', methods: ['PUT'])]

--- a/backend/src/Controller/InboundEmailHandlerController.php
+++ b/backend/src/Controller/InboundEmailHandlerController.php
@@ -275,9 +275,12 @@ class InboundEmailHandlerController extends AbstractController
         } elseif ($handlerId > 0) {
             $stored = $this->handlerRepository->findByIdAndUser($handlerId, $user->getId());
             if (!$stored) {
+                // Use `message` (not `error`) to match the 200/400 responses on
+                // the same endpoint — keeps the generated Zod schema stable
+                // and lets clients render a single field regardless of status.
                 return $this->json([
                     'success' => false,
-                    'error' => 'Handler not found',
+                    'message' => 'Handler not found',
                 ], Response::HTTP_NOT_FOUND);
             }
             $plainPassword = $stored->getDecryptedPassword($this->encryptionService);
@@ -305,14 +308,18 @@ class InboundEmailHandlerController extends AbstractController
                 'message' => $result['message'],
             ]);
         } catch (\Exception $e) {
+            // Log the raw exception (with hostname, library detail, stack
+            // trace, …) but return a generic message to the caller — we
+            // never want IMAP/POP3 library internals leaking into a
+            // user-facing toast.
             $this->logger->error('Preview mailbox connection test failed', [
                 'user_id' => $user->getId(),
-                'error' => $e->getMessage(),
+                'exception' => $e,
             ]);
 
             return $this->json([
                 'success' => false,
-                'message' => 'Test connection failed: '.$e->getMessage(),
+                'message' => 'Test connection failed. Please check your settings and try again.',
             ], Response::HTTP_INTERNAL_SERVER_ERROR);
         }
     }

--- a/backend/src/Prompt/PromptCatalog.php
+++ b/backend/src/Prompt/PromptCatalog.php
@@ -1178,15 +1178,21 @@ Respond ONLY with valid JSON in this exact format:
 {"contradictions":[{"id":123,"type":"memory","value":"old text","reason":"brief reason why it contradicts"}]}
 
 ## Understanding item types
-- "memory" items = stored facts the user considers TRUE
+- "memory" items = stored facts the user considers TRUE — always describe the USER themselves (their name, age, preferences, …)
 - "positive" items = statements the user CONFIRMED as CORRECT
 - "false_positive" items = statements the user marked as INCORRECT. The user believes the OPPOSITE is true.
   Example: false_positive "Putin is Orthodox" means the user previously said "Putin is Orthodox" is WRONG.
   So if a new statement says "Putin is Orthodox" is correct, that CONTRADICTS this false_positive.
 
+## Subject-match rule (apply BEFORE everything else)
+A new statement only contradicts an existing item when they are about the SAME SUBJECT.
+- "memory" items describe the user themselves. They can only contradict a new statement that is ALSO about the user (first-person: "you are X", "your name is X").
+- A new statement about an EXTERNAL subject (a person in an uploaded image, a public figure, a fictional character, a place, a topic — anything that is not the user) NEVER contradicts a personal user memory, even when the topic overlaps. The user being 32 years old has nothing to do with the age of a portrait subject.
+- When the subject of either side is unclear, do NOT flag a contradiction.
+
 ## Rules
-- Only include items that CLEARLY contradict the new statement:
-  - Same topic but opposite or conflicting information
+- Only include items that CLEARLY contradict the new statement AFTER passing the subject-match rule above:
+  - Same topic AND same subject but opposite or conflicting information
   - Same fact with different values
   - Implied contradictions via type inversion (a false_positive is the semantic opposite of what it says)
 - type must be exactly one of: memory, false_positive, positive

--- a/backend/src/Prompt/PromptCatalog.php
+++ b/backend/src/Prompt/PromptCatalog.php
@@ -1040,12 +1040,21 @@ PROMPT;
         return <<<'PROMPT'
 Extract ONLY personal facts the user states about THEMSELVES. Return JSON array or null.
 
+## Source rule (most important)
+The ONLY valid source of memories is the user's own messages — the lines
+labelled `user:` in the conversation and the explicit "Current Message"
+block. NEVER extract facts from the assistant/AI's replies, summaries,
+recommendations, or paraphrases, even if they appear in the input. If a
+fact only exists because YOU (the assistant) wrote it earlier, it is NOT
+a memory.
+
 ## Save:
 - User's name, age, location, job, company
 - Persistent preferences ("I prefer dark mode", "I like pizza")
 - Skills, hobbies, goals the user states about themselves
 
 ## Do NOT save:
+- Anything written by the assistant/AI (your own replies, summaries, guesses, inferences)
 - Questions the user asks ("Who is X?", "Is Y true?") — these are NOT interests or memories
 - Facts about other people, celebrities, or topics
 - Temporary states ("I'm tired")

--- a/backend/src/Service/FeedbackContradictionService.php
+++ b/backend/src/Service/FeedbackContradictionService.php
@@ -229,6 +229,8 @@ Analyze whether the new statement contradicts any of the existing items. A contr
 - Same topic but opposite or conflicting information (e.g., "Sydney is capital" vs "Canberra is capital")
 - Same fact with different values (e.g., "email is a@b.com" vs "email is c@d.com")
 
+SUBJECT-MATCH (apply first): a "memory" item is always about the USER themselves. It can only contradict a new statement that is ALSO about the user. A new statement about an external subject (a person in an uploaded image, a public figure, a fictional character, a place, …) NEVER contradicts a personal user memory, even when the topic overlaps. If the subjects don't match, do NOT include that item.
+
 CRITICAL: Understand item types:
 - "memory" and "positive" items = the user believes these are TRUE
 - "false_positive" items = the user believes these are FALSE (the OPPOSITE is what the user considers true)
@@ -278,6 +280,8 @@ EXISTING RELATED ITEMS:
 Analyze whether ANY of the new statements contradict any existing items. A contradiction means:
 - Same topic but opposite or conflicting information
 - Same fact with different values
+
+SUBJECT-MATCH (apply first): a "memory" item is always about the USER themselves. It can only contradict a new statement that is ALSO about the user (first-person facts). A new statement about an external subject — e.g. the age or identity of a person in an uploaded image, a public figure, a fictional character, a place — NEVER contradicts a personal user memory, even when the topic overlaps. If subjects don't match, do NOT include that item.
 
 CRITICAL: Understand item types:
 - "memory" and "positive" items = the user believes these are TRUE
@@ -446,6 +450,7 @@ Rules:
 - Only include items that CLEARLY contradict the new statement (same fact, different/opposite value).
 - type must be one of: memory, false_positive, positive
 - id and value must match the provided existing items
+- CRITICAL: "memory" items always describe the USER themselves. They only contradict statements that are ALSO about the user. A new statement about an external subject (a person in an uploaded image, a public figure, a character, etc.) NEVER contradicts a personal user memory, even when the topic overlaps.
 - CRITICAL: "false_positive" items were marked as INCORRECT by the user — the user believes the OPPOSITE.
   So false_positive "X is true" means the user thinks "X is NOT true".
   If a new statement agrees with "X is true", it contradicts this false_positive.

--- a/backend/src/Service/FeedbackExampleService.php
+++ b/backend/src/Service/FeedbackExampleService.php
@@ -255,19 +255,30 @@ final readonly class FeedbackExampleService
             $memoryContext = $memoryData['text'];
             $memoryPart = <<<MEMORY
 
-STORED USER MEMORIES (these are actual facts currently saved for this user):
+STORED USER MEMORIES (these are actual facts currently saved for this user — they describe the USER, not anyone or anything else):
 {$memoryContext}
 
-IMPORTANT: If the incorrect AI response was based on one of these stored memories, the classification MUST be "memory". The AI did NOT hallucinate — it used stored data that the user now says is wrong. Correction options should reflect what the user actually wants (e.g., correct value, or leave empty if the memory should simply be deleted).
+IMPORTANT — use these memories ONLY when they actually match the subject of the false claim:
+- If the AI response is a claim ABOUT THE USER themselves (e.g. "you are 25", "your name is Tom") AND a related stored memory exists for that same user-attribute, classification MUST be "memory". Correction options should reflect the user's preferred value (or be empty if the memory should simply be deleted).
+- If the AI response is about an EXTERNAL subject (a person in an uploaded image, a public figure, a fictional character, a place, a topic — anyone or anything that is NOT the user themselves), the stored user memories are NOT the source and MUST NOT bleed into the correction. Classification MUST be "feedback". Never reuse the user's own age / name / location / etc. as a correction about a different subject.
+- When in doubt about the subject, default to "feedback" — do not invent a personal angle.
 MEMORY;
         }
 
         $systemPrompt = <<<'PROMPT'
 You analyze incorrect AI responses and generate feedback options. You must produce summary options (what was false), correction options (what is correct), AND a classification in a single JSON response.
 
-Classification rules:
-- "memory": The error is about PERSONAL USER FACTS (name, birthday, email, preferences, address, relationships, skills, etc.) OR the AI response was based on a stored user memory that is now incorrect. These should be stored/updated as user memories.
-- "feedback": The error is about GENERAL KNOWLEDGE or AI BEHAVIOR (wrong facts about the world, bad formatting, wrong tone, etc.) AND is NOT based on a stored memory. These should be stored as feedback examples.
+Step 1 — Identify the SUBJECT of the false claim:
+- "user": the claim is about the user themselves (first-person facts: their name, age, preferences, skills, location, …)
+- "external": the claim is about something or someone other than the user (a person in an uploaded image, a public figure, a fictional character, a place, a general topic, …)
+If unsure, treat the subject as "external".
+
+Step 2 — Classify:
+- "memory": ONLY when the subject is the user AND the error is about personal user facts (name, birthday, email, preferences, address, relationships, skills, …). Choose this when correcting the value should update the user's own memory.
+- "feedback": Everything else — general-knowledge errors, wrong facts about external subjects, bad formatting, wrong tone, etc. Use this whenever the subject is external, regardless of which memories the user happens to have stored.
+
+Subject-isolation rule (do not violate):
+- Personal user facts (e.g. the user's own age, name, location) MUST NEVER appear in correction options for claims about an external subject. The user's age has nothing to do with the age of a person in an uploaded image, even if both involve "age".
 
 Content rules:
 - Generate 2-4 options for EACH field, depending on complexity:
@@ -276,7 +287,7 @@ Content rules:
 - summaryOptions: Different phrasings of the false claim, ranked from most precise to most general
 - correctionOptions: Different phrasings of the correct information
   - If classification is "memory": Format corrections as clean memory values (e.g., "Python, JavaScript" not "The correct skills are Python and JavaScript"). Only provide corrections if there is a meaningful replacement value.
-  - If classification is "feedback": Format corrections as complete statements
+  - If classification is "feedback": Format corrections as complete statements about the SAME subject as the false claim (never substitute the user as subject).
 - Each option must be a single, clear sentence
 - ALWAYS respond in the SAME LANGUAGE as the input text
 - Output ONLY valid JSON: {"classification":"memory|feedback","summaryOptions":["..."],"correctionOptions":["..."]}

--- a/backend/src/Service/File/FileStorageService.php
+++ b/backend/src/Service/File/FileStorageService.php
@@ -14,14 +14,32 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
  */
 final readonly class FileStorageService
 {
-    private const MAX_FILE_SIZE = 128 * 1024 * 1024; // 128 MB
-    private const ALLOWED_EXTENSIONS = [
+    public const MAX_FILE_SIZE = 128 * 1024 * 1024; // 128 MB
+    public const ALLOWED_EXTENSIONS = [
         'pdf', 'docx', 'doc', 'xlsx', 'xls', 'pptx', 'ppt', 'txt', 'md', 'csv',
         'odt', 'ods', 'odp', 'odg', 'odf',
         'jpg', 'jpeg', 'png', 'gif', 'webp',
         'mp3', 'mp4', 'wav', 'ogg', 'm4a', 'webm',
     ];
     private const VIDEO_EXTENSIONS = ['mp4', 'webm', 'mov', 'avi', 'mkv'];
+
+    /**
+     * Maximum file size for a single upload, in bytes.
+     */
+    public static function getMaxFileSize(): int
+    {
+        return self::MAX_FILE_SIZE;
+    }
+
+    /**
+     * Allowed file extensions for uploads (lowercase, no leading dot).
+     *
+     * @return list<string>
+     */
+    public static function getAllowedExtensions(): array
+    {
+        return self::ALLOWED_EXTENSIONS;
+    }
 
     public function __construct(
         private string $uploadDir,

--- a/backend/src/Service/File/FileUploadService.php
+++ b/backend/src/Service/File/FileUploadService.php
@@ -80,6 +80,105 @@ final readonly class FileUploadService
     }
 
     /**
+     * Pre-flight upload check.
+     *
+     * Validates rate limit, per-file size, file extension, and storage quota
+     * BEFORE the client uploads the file body. Lets the UI show a deterministic
+     * error instead of waiting for a slow/timing-out upload near quota.
+     *
+     * @return array{
+     *   allowed: bool,
+     *   reason?: 'rate_limit_exceeded'|'file_too_large'|'extension_not_allowed'|'storage_exceeded',
+     *   message?: string,
+     *   max_file_size: int,
+     *   allowed_extensions: list<string>,
+     *   remaining: int,
+     *   used?: int,
+     *   limit?: int
+     * }
+     */
+    public function checkUpload(User $user, string $filename, int $fileSize): array
+    {
+        $maxFileSize = FileStorageService::getMaxFileSize();
+        $allowedExtensions = FileStorageService::getAllowedExtensions();
+        $remaining = $this->storageQuotaService->getRemainingStorage($user);
+
+        $base = [
+            'max_file_size' => $maxFileSize,
+            'allowed_extensions' => $allowedExtensions,
+            'remaining' => $remaining,
+        ];
+
+        $rateLimitCheck = $this->rateLimitService->checkLimit($user, 'FILE_ANALYSIS');
+        if (!$rateLimitCheck['allowed']) {
+            return array_merge($base, [
+                'allowed' => false,
+                'reason' => 'rate_limit_exceeded',
+                'message' => "Rate limit exceeded for FILE_ANALYSIS. Used: {$rateLimitCheck['used']}/{$rateLimitCheck['limit']}",
+                'used' => (int) $rateLimitCheck['used'],
+                'limit' => (int) $rateLimitCheck['limit'],
+            ]);
+        }
+
+        if ($fileSize <= 0) {
+            return array_merge($base, [
+                'allowed' => false,
+                'reason' => 'file_too_large',
+                'message' => 'File appears to be empty. If using Dropbox, iCloud, or OneDrive, please download the file locally first before uploading.',
+            ]);
+        }
+
+        if ($fileSize > $maxFileSize) {
+            return array_merge($base, [
+                'allowed' => false,
+                'reason' => 'file_too_large',
+                'message' => sprintf('File too large. Maximum size is %d MB.', (int) ($maxFileSize / 1024 / 1024)),
+            ]);
+        }
+
+        $extension = strtolower(pathinfo($filename, PATHINFO_EXTENSION));
+        if ('' === $extension || !in_array($extension, $allowedExtensions, true)) {
+            return array_merge($base, [
+                'allowed' => false,
+                'reason' => 'extension_not_allowed',
+                'message' => 'File type not allowed. Allowed: '.implode(', ', $allowedExtensions),
+            ]);
+        }
+
+        if ($fileSize > $remaining) {
+            return array_merge($base, [
+                'allowed' => false,
+                'reason' => 'storage_exceeded',
+                'message' => sprintf(
+                    'Storage limit exceeded. You have %s remaining, but the file is %s. Upgrade your plan for more storage.',
+                    $this->formatBytes($remaining),
+                    $this->formatBytes($fileSize)
+                ),
+            ]);
+        }
+
+        return array_merge($base, ['allowed' => true]);
+    }
+
+    /**
+     * Format bytes to human-readable text. Kept private and minimal.
+     */
+    private function formatBytes(int $bytes): string
+    {
+        if ($bytes < 1024) {
+            return $bytes.' B';
+        }
+        if ($bytes < 1024 * 1024) {
+            return round($bytes / 1024, 2).' KB';
+        }
+        if ($bytes < 1024 * 1024 * 1024) {
+            return round($bytes / (1024 * 1024), 2).' MB';
+        }
+
+        return round($bytes / (1024 * 1024 * 1024), 2).' GB';
+    }
+
+    /**
      * Process a single uploaded file: store, extract text, vectorize.
      *
      * @return array<string, mixed>

--- a/backend/src/Service/File/FileUploadService.php
+++ b/backend/src/Service/File/FileUploadService.php
@@ -88,7 +88,7 @@ final readonly class FileUploadService
      *
      * @return array{
      *   allowed: bool,
-     *   reason?: 'rate_limit_exceeded'|'file_too_large'|'extension_not_allowed'|'storage_exceeded',
+     *   reason?: 'rate_limit_exceeded'|'file_too_large'|'file_empty'|'extension_not_allowed'|'storage_exceeded',
      *   message?: string,
      *   max_file_size: int,
      *   allowed_extensions: list<string>,
@@ -121,9 +121,15 @@ final readonly class FileUploadService
         }
 
         if ($fileSize <= 0) {
+            // Distinct reason from `file_too_large` so the frontend can
+            // render an "empty file" copy that actually matches the
+            // situation. The shared message hint about
+            // Dropbox/iCloud/OneDrive lazy-loading covers the most
+            // common cause for a zero-byte upload (the user picked a
+            // cloud placeholder instead of the actual file).
             return array_merge($base, [
                 'allowed' => false,
-                'reason' => 'file_too_large',
+                'reason' => 'file_empty',
                 'message' => 'File appears to be empty. If using Dropbox, iCloud, or OneDrive, please download the file locally first before uploading.',
             ]);
         }

--- a/backend/src/Service/InboundEmailHandlerService.php
+++ b/backend/src/Service/InboundEmailHandlerService.php
@@ -19,6 +19,9 @@ use Symfony\Component\Mime\Email;
  */
 final readonly class InboundEmailHandlerService
 {
+    /** Masked password placeholder from API (same as frontend). */
+    private const MASKED_PASSWORD_PLACEHOLDER = '••••••••';
+
     public function __construct(
         private InboundEmailHandlerRepository $handlerRepository,
         private PromptRepository $promptRepository,
@@ -36,7 +39,51 @@ final readonly class InboundEmailHandlerService
      */
     public function testConnection(InboundEmailHandler $handler): array
     {
-        // Check if IMAP extension is available
+        return $this->runMailboxConnectionTest(
+            $handler->getMailServer(),
+            $handler->getPort(),
+            $handler->getProtocol(),
+            $handler->getSecurity(),
+            $handler->getUsername(),
+            $handler->getDecryptedPassword($this->encryptionService),
+            ['handler_id' => $handler->getId()]
+        );
+    }
+
+    /**
+     * Test mailbox login using explicit credentials (no persisted handler required).
+     */
+    public function testMailboxCredentials(
+        string $mailServer,
+        int $port,
+        string $protocol,
+        string $security,
+        string $username,
+        string $plainPassword,
+    ): array {
+        return $this->runMailboxConnectionTest(
+            $mailServer,
+            $port,
+            $protocol,
+            $security,
+            $username,
+            $plainPassword,
+            []
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $logContext
+     */
+    private function runMailboxConnectionTest(
+        string $mailServer,
+        int $port,
+        string $protocol,
+        string $security,
+        string $username,
+        string $plainPassword,
+        array $logContext,
+    ): array {
         if (!function_exists('imap_open')) {
             $this->logger->error('IMAP extension not available');
 
@@ -47,32 +94,36 @@ final readonly class InboundEmailHandlerService
         }
 
         try {
-            $connection = $this->connectImap($handler);
+            $connection = $this->connectMailbox(
+                $mailServer,
+                $port,
+                $protocol,
+                $security,
+                $username,
+                $plainPassword
+            );
 
-            if ($connection) {
-                imap_close($connection);
-
-                return [
-                    'success' => true,
-                    'message' => 'Connection successful',
-                ];
-            }
+            imap_close($connection);
 
             return [
-                'success' => false,
-                'message' => 'Failed to connect',
+                'success' => true,
+                'message' => 'Connection successful',
             ];
         } catch (\Exception $e) {
-            $this->logger->error('IMAP connection test failed', [
-                'handler_id' => $handler->getId(),
+            $this->logger->error('IMAP connection test failed', array_merge($logContext, [
                 'error' => $e->getMessage(),
-            ]);
+            ]));
 
             return [
                 'success' => false,
                 'message' => $e->getMessage(),
             ];
         }
+    }
+
+    public static function isMaskedPasswordPlaceholder(string $password): bool
+    {
+        return '' === $password || self::MASKED_PASSWORD_PLACEHOLDER === $password;
     }
 
     /**
@@ -209,15 +260,32 @@ final readonly class InboundEmailHandlerService
     /**
      * Connect to IMAP/POP3 server.
      */
-    private function connectImap(InboundEmailHandler $handler): ?\IMAP\Connection
+    private function connectImap(InboundEmailHandler $handler): \IMAP\Connection
     {
-        $server = $this->buildServerString($handler);
-        $password = $handler->getDecryptedPassword($this->encryptionService);
+        return $this->connectMailbox(
+            $handler->getMailServer(),
+            $handler->getPort(),
+            $handler->getProtocol(),
+            $handler->getSecurity(),
+            $handler->getUsername(),
+            $handler->getDecryptedPassword($this->encryptionService)
+        );
+    }
+
+    private function connectMailbox(
+        string $mailServer,
+        int $port,
+        string $protocol,
+        string $security,
+        string $username,
+        string $plainPassword,
+    ): \IMAP\Connection {
+        $server = $this->buildMailboxServerString($mailServer, $port, $protocol, $security);
 
         $connection = @imap_open(
             $server,
-            $handler->getUsername(),
-            $password,
+            $username,
+            $plainPassword,
             0
         );
 
@@ -234,24 +302,21 @@ final readonly class InboundEmailHandlerService
         return $connection;
     }
 
-    /**
-     * Build IMAP server connection string.
-     */
-    private function buildServerString(InboundEmailHandler $handler): string
-    {
-        $server = $handler->getMailServer();
-        $port = $handler->getPort();
-        $protocol = strtolower($handler->getProtocol());
-        $security = $handler->getSecurity();
+    private function buildMailboxServerString(
+        string $mailServer,
+        int $port,
+        string $protocol,
+        string $security,
+    ): string {
+        $protocolKey = strtolower($protocol);
 
-        // Build connection string: {server:port/protocol/security}
         $securityFlag = match ($security) {
             'SSL/TLS' => 'ssl',
             'STARTTLS' => 'tls',
             default => 'notls',
         };
 
-        return sprintf('{%s:%d/%s/%s}INBOX', $server, $port, $protocol, $securityFlag);
+        return sprintf('{%s:%d/%s/%s}INBOX', $mailServer, $port, $protocolKey, $securityFlag);
     }
 
     /**
@@ -433,18 +498,6 @@ final readonly class InboundEmailHandlerService
 
         try {
             $connection = $this->connectImap($handler);
-
-            if (!$connection) {
-                $handler->setStatus('error');
-                $handler->touch();
-
-                // Note: Need EntityManager to flush - will be handled by caller
-                return [
-                    'success' => false,
-                    'processed' => 0,
-                    'errors' => ['Failed to connect to mail server'],
-                ];
-            }
 
             // Build search criteria based on email filter
             $searchCriteria = $this->buildSearchCriteria($handler);

--- a/backend/src/Service/MemoryExtractionService.php
+++ b/backend/src/Service/MemoryExtractionService.php
@@ -58,20 +58,51 @@ final readonly class MemoryExtractionService
      */
     private function extractMemoriesViaAi(Message $message, array $conversationHistory, array $existingMemories = []): array
     {
-        // Build context from conversation history (last 5 messages)
-        $contextMessages = array_slice($conversationHistory, -5);
+        // Issue #438: filter the conversation history to USER turns only
+        // BEFORE slicing. The extractor must never see the assistant's
+        // own replies, otherwise the LLM occasionally lifts a memory out
+        // of its own summary/recommendation instead of the user's actual
+        // statement. The current user message is still delivered via
+        // `Current Message:` below, so dropping assistant turns from
+        // history costs no real signal: it removes a known leak source
+        // (AI prose that reads like first-person facts) and keeps the
+        // user's prior statements intact for topical context.
+        //
+        // Filter first, THEN slice the last 5 — slicing first would let
+        // a chatty assistant push genuine user statements out of the
+        // window even though the budget is for user history.
+        $userOnlyHistory = [];
+        foreach ($conversationHistory as $msg) {
+            if ($msg instanceof Message) {
+                if ('IN' !== $msg->getDirection()) {
+                    continue;
+                }
+                $userOnlyHistory[] = ['role' => 'user', 'content' => (string) $msg->getText()];
+                continue;
+            }
+
+            // Array form. Treat anything that is NOT 'user' as untrusted
+            // (assistant / system / tool) and drop it. Use strict equality
+            // so we never accidentally extract from a malformed entry
+            // with a missing or unexpected role.
+            $role = $msg['role'] ?? 'user';
+            if ('user' !== $role) {
+                continue;
+            }
+            $userOnlyHistory[] = ['role' => 'user', 'content' => (string) ($msg['content'] ?? '')];
+        }
+
+        $contextMessages = array_slice($userOnlyHistory, -5);
         $contextText = '';
         foreach ($contextMessages as $msg) {
-            // Handle both Message objects and arrays
-            if ($msg instanceof Message) {
-                $role = 'IN' === $msg->getDirection() ? 'user' : 'assistant';
-                $content = $msg->getText();
-            } else {
-                $role = $msg['role'] ?? 'user';
-                $content = $msg['content'] ?? '';
-            }
-            $contextText .= "{$role}: {$content}\n";
+            $contextText .= "user: {$msg['content']}\n";
         }
+
+        $this->logger->debug('Memory extraction context filtered to user turns', [
+            'message_id' => $message->getId(),
+            'history_in' => count($conversationHistory),
+            'user_turns_in_context' => count($contextMessages),
+        ]);
 
         // System prompt for memory extraction (always English)
         $systemPrompt = $this->getExtractionPrompt();
@@ -106,11 +137,17 @@ final readonly class MemoryExtractionService
 
         // AI call — the JSON format MUST be in the user prompt because the system prompt
         // in the database only says "Return JSON array or null" without specifying the schema.
+        //
+        // The `Conversation:` block contains USER-ONLY turns (issue #438):
+        // the assistant's replies are deliberately excluded from the
+        // prompt and we restate that contract inline so a non-compliant
+        // model can't pretend it saw an "assistant:" line and lift facts
+        // from it.
         $userPrompt = <<<PROMPT
-Conversation:
+Conversation (USER turns only — assistant replies have been removed):
 {$contextText}
 
-Current Message:
+Current Message (from the user):
 {$message->getText()}
 {$existingMemoriesText}
 
@@ -124,6 +161,7 @@ Return [] if nothing to save, or null.
 
 RULES:
 - Only save facts the user states about THEMSELVES (name, age, preferences, skills, etc.)
+- The Conversation block is USER-only. Never invent or extract from anything you (the assistant) wrote in earlier replies — only the lines shown above are valid sources.
 - Questions about topics are NOT memories ("Who is X?" → null, "Is Y true?" → null)
 - One fact per memory, short keys (snake_case, <= 24 chars)
 - category: personal, preferences, work, projects, or other relevant category

--- a/backend/src/Service/StorageQuotaService.php
+++ b/backend/src/Service/StorageQuotaService.php
@@ -7,6 +7,7 @@ use App\Entity\File;
 use App\Entity\User;
 use App\Repository\ConfigRepository;
 use App\Repository\FileRepository;
+use App\Service\File\FileStorageService;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 
@@ -145,7 +146,9 @@ final readonly class StorageQuotaService
      *   percentage: float,
      *   limit_formatted: string,
      *   usage_formatted: string,
-     *   remaining_formatted: string
+     *   remaining_formatted: string,
+     *   max_file_size: int,
+     *   max_file_size_formatted: string
      * }
      */
     public function getStorageStats(User $user): array
@@ -154,6 +157,7 @@ final readonly class StorageQuotaService
         $usage = $this->getStorageUsage($user);
         $remaining = max(0, $limit - $usage);
         $percentage = $limit > 0 ? ($usage / $limit) * 100 : 0;
+        $maxFileSize = FileStorageService::getMaxFileSize();
 
         return [
             'limit' => $limit,
@@ -163,6 +167,8 @@ final readonly class StorageQuotaService
             'limit_formatted' => $this->formatBytes($limit),
             'usage_formatted' => $this->formatBytes($usage),
             'remaining_formatted' => $this->formatBytes($remaining),
+            'max_file_size' => $maxFileSize,
+            'max_file_size_formatted' => $this->formatBytes($maxFileSize),
         ];
     }
 

--- a/backend/tests/Controller/FileControllerTest.php
+++ b/backend/tests/Controller/FileControllerTest.php
@@ -281,6 +281,88 @@ class FileControllerTest extends WebTestCase
         $this->assertEquals(404, $response->getStatusCode());
     }
 
+    public function testCheckUploadAllowsValidFile(): void
+    {
+        $this->client->request(
+            'POST',
+            '/api/v1/files/check-upload',
+            [],
+            [],
+            [
+                'HTTP_AUTHORIZATION' => 'Bearer '.$this->authToken,
+                'CONTENT_TYPE' => 'application/json',
+            ],
+            json_encode(['filename' => 'doc.pdf', 'size' => 1024])
+        );
+
+        $response = $this->client->getResponse();
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $data = json_decode($response->getContent(), true);
+        $this->assertTrue($data['allowed']);
+        $this->assertArrayHasKey('max_file_size', $data);
+        $this->assertArrayHasKey('allowed_extensions', $data);
+        $this->assertArrayHasKey('remaining', $data);
+    }
+
+    public function testCheckUploadRejectsDisallowedExtension(): void
+    {
+        $this->client->request(
+            'POST',
+            '/api/v1/files/check-upload',
+            [],
+            [],
+            [
+                'HTTP_AUTHORIZATION' => 'Bearer '.$this->authToken,
+                'CONTENT_TYPE' => 'application/json',
+            ],
+            json_encode(['filename' => 'evil.exe', 'size' => 1024])
+        );
+
+        $response = $this->client->getResponse();
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $data = json_decode($response->getContent(), true);
+        $this->assertFalse($data['allowed']);
+        $this->assertSame('extension_not_allowed', $data['reason']);
+    }
+
+    public function testCheckUploadRequiresFilename(): void
+    {
+        $this->client->request(
+            'POST',
+            '/api/v1/files/check-upload',
+            [],
+            [],
+            [
+                'HTTP_AUTHORIZATION' => 'Bearer '.$this->authToken,
+                'CONTENT_TYPE' => 'application/json',
+            ],
+            json_encode(['size' => 1024])
+        );
+
+        $response = $this->client->getResponse();
+        $this->assertEquals(400, $response->getStatusCode());
+    }
+
+    public function testCheckUploadRequiresAuthentication(): void
+    {
+        self::ensureKernelShutdown();
+        $client = static::createClient();
+
+        $client->request(
+            'POST',
+            '/api/v1/files/check-upload',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            json_encode(['filename' => 'doc.pdf', 'size' => 1024])
+        );
+
+        $response = $client->getResponse();
+        $this->assertEquals(401, $response->getStatusCode());
+    }
+
     private function createTestFile(string $filename, string $content): string
     {
         $tempFile = tempnam(sys_get_temp_dir(), 'synaplan_test_');

--- a/backend/tests/Service/File/FileUploadServiceCheckUploadTest.php
+++ b/backend/tests/Service/File/FileUploadServiceCheckUploadTest.php
@@ -128,15 +128,20 @@ class FileUploadServiceCheckUploadTest extends TestCase
         $this->assertSame(100, $result['limit']);
     }
 
-    public function testRejectsZeroByteFiles(): void
+    public function testRejectsZeroByteFilesWithDedicatedReason(): void
     {
+        // Zero-byte files used to surface as `file_too_large`, which
+        // the UI then translated to "File is too large" — directly
+        // contradicting the actual "file is empty" message. They get
+        // their own reason so the frontend can render matching copy.
         $this->expectRateLimitAllowed();
         $this->storageQuotaService->method('getRemainingStorage')->willReturn(10 * 1024 * 1024);
 
         $result = $this->service->checkUpload($this->createUser(), 'empty.pdf', 0);
 
         $this->assertFalse($result['allowed']);
-        $this->assertSame('file_too_large', $result['reason']);
+        $this->assertSame('file_empty', $result['reason']);
+        $this->assertStringContainsString('empty', $result['message']);
     }
 
     public function testIncludesQuotaMetadataInAllResponses(): void

--- a/backend/tests/Service/File/FileUploadServiceCheckUploadTest.php
+++ b/backend/tests/Service/File/FileUploadServiceCheckUploadTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Service\File;
+
+use App\Entity\User;
+use App\Service\File\FileProcessor;
+use App\Service\File\FileStorageService;
+use App\Service\File\FileUploadService;
+use App\Service\File\VectorizationService;
+use App\Service\RAG\VectorStorage\VectorStorageFacade;
+use App\Service\RateLimitService;
+use App\Service\StorageQuotaService;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Unit tests for FileUploadService::checkUpload() — the pre-flight quota check
+ * introduced to fix issue #213 (uploads near storage limit timing out).
+ */
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
+class FileUploadServiceCheckUploadTest extends TestCase
+{
+    private FileUploadService $service;
+    private StorageQuotaService&MockObject $storageQuotaService;
+    private RateLimitService&MockObject $rateLimitService;
+
+    protected function setUp(): void
+    {
+        $this->storageQuotaService = $this->createMock(StorageQuotaService::class);
+        $this->rateLimitService = $this->createMock(RateLimitService::class);
+
+        $this->service = new FileUploadService(
+            $this->createStub(FileStorageService::class),
+            $this->createStub(FileProcessor::class),
+            $this->createStub(VectorizationService::class),
+            $this->createStub(VectorStorageFacade::class),
+            $this->storageQuotaService,
+            $this->rateLimitService,
+            $this->createStub(EntityManagerInterface::class),
+            $this->createStub(LoggerInterface::class),
+            '/tmp/uploads',
+        );
+    }
+
+    private function createUser(): User
+    {
+        $user = $this->createStub(User::class);
+        $user->method('getId')->willReturn(1);
+        $user->method('getRateLimitLevel')->willReturn('PRO');
+
+        return $user;
+    }
+
+    private function expectRateLimitAllowed(): void
+    {
+        $this->rateLimitService
+            ->method('checkLimit')
+            ->willReturn(['allowed' => true, 'used' => 0, 'limit' => 100]);
+    }
+
+    public function testAllowsUploadWhenWithinQuota(): void
+    {
+        $this->expectRateLimitAllowed();
+        $this->storageQuotaService->method('getRemainingStorage')->willReturn(10 * 1024 * 1024); // 10MB
+
+        $result = $this->service->checkUpload($this->createUser(), 'document.pdf', 1024 * 1024); // 1MB
+
+        $this->assertTrue($result['allowed']);
+        $this->assertArrayNotHasKey('reason', $result);
+        $this->assertSame(FileStorageService::getMaxFileSize(), $result['max_file_size']);
+        $this->assertContains('pdf', $result['allowed_extensions']);
+    }
+
+    public function testBlocksUploadWhenStorageExceeded(): void
+    {
+        $this->expectRateLimitAllowed();
+        $this->storageQuotaService->method('getRemainingStorage')->willReturn(500 * 1024); // 500KB remaining
+
+        $result = $this->service->checkUpload($this->createUser(), 'document.pdf', 2 * 1024 * 1024); // 2MB
+
+        $this->assertFalse($result['allowed']);
+        $this->assertSame('storage_exceeded', $result['reason']);
+        $this->assertNotEmpty($result['message']);
+        $this->assertStringContainsString('Storage limit exceeded', $result['message']);
+        $this->assertSame(500 * 1024, $result['remaining']);
+    }
+
+    public function testBlocksUploadWhenFileTooLarge(): void
+    {
+        $this->expectRateLimitAllowed();
+        $this->storageQuotaService->method('getRemainingStorage')->willReturn(10 * 1024 * 1024 * 1024); // 10GB
+
+        $oversize = FileStorageService::getMaxFileSize() + 1;
+        $result = $this->service->checkUpload($this->createUser(), 'big.pdf', $oversize);
+
+        $this->assertFalse($result['allowed']);
+        $this->assertSame('file_too_large', $result['reason']);
+    }
+
+    public function testBlocksUploadWhenExtensionNotAllowed(): void
+    {
+        $this->expectRateLimitAllowed();
+        $this->storageQuotaService->method('getRemainingStorage')->willReturn(10 * 1024 * 1024);
+
+        $result = $this->service->checkUpload($this->createUser(), 'malicious.exe', 1024);
+
+        $this->assertFalse($result['allowed']);
+        $this->assertSame('extension_not_allowed', $result['reason']);
+    }
+
+    public function testBlocksUploadWhenRateLimitExceeded(): void
+    {
+        $this->rateLimitService
+            ->method('checkLimit')
+            ->willReturn(['allowed' => false, 'used' => 100, 'limit' => 100]);
+        // Quota service should not gate when rate limit comes first; still need a remaining value
+        $this->storageQuotaService->method('getRemainingStorage')->willReturn(1024 * 1024);
+
+        $result = $this->service->checkUpload($this->createUser(), 'document.pdf', 1024);
+
+        $this->assertFalse($result['allowed']);
+        $this->assertSame('rate_limit_exceeded', $result['reason']);
+        $this->assertSame(100, $result['used']);
+        $this->assertSame(100, $result['limit']);
+    }
+
+    public function testRejectsZeroByteFiles(): void
+    {
+        $this->expectRateLimitAllowed();
+        $this->storageQuotaService->method('getRemainingStorage')->willReturn(10 * 1024 * 1024);
+
+        $result = $this->service->checkUpload($this->createUser(), 'empty.pdf', 0);
+
+        $this->assertFalse($result['allowed']);
+        $this->assertSame('file_too_large', $result['reason']);
+    }
+
+    public function testIncludesQuotaMetadataInAllResponses(): void
+    {
+        $this->expectRateLimitAllowed();
+        $this->storageQuotaService->method('getRemainingStorage')->willReturn(0);
+
+        $result = $this->service->checkUpload($this->createUser(), 'doc.pdf', 1024);
+
+        $this->assertArrayHasKey('max_file_size', $result);
+        $this->assertArrayHasKey('allowed_extensions', $result);
+        $this->assertArrayHasKey('remaining', $result);
+        $this->assertSame(0, $result['remaining']);
+    }
+}

--- a/backend/tests/Service/InboundEmailHandlerServiceTest.php
+++ b/backend/tests/Service/InboundEmailHandlerServiceTest.php
@@ -48,6 +48,13 @@ class InboundEmailHandlerServiceTest extends TestCase
         );
     }
 
+    public function testIsMaskedPasswordPlaceholder(): void
+    {
+        $this->assertTrue(InboundEmailHandlerService::isMaskedPasswordPlaceholder(''));
+        $this->assertTrue(InboundEmailHandlerService::isMaskedPasswordPlaceholder('••••••••'));
+        $this->assertFalse(InboundEmailHandlerService::isMaskedPasswordPlaceholder('secret'));
+    }
+
     public function testProcessAllHandlersWithNoHandlers(): void
     {
         $this->handlerRepository
@@ -91,51 +98,33 @@ class InboundEmailHandlerServiceTest extends TestCase
 
     public function testBuildServerStringWithIMAP(): void
     {
-        $handler = new InboundEmailHandler();
-        $handler->setMailServer('imap.example.com');
-        $handler->setPort(993);
-        $handler->setProtocol('IMAP');
-        $handler->setSecurity('SSL/TLS');
-
         $reflection = new \ReflectionClass($this->service);
-        $method = $reflection->getMethod('buildServerString');
+        $method = $reflection->getMethod('buildMailboxServerString');
         $method->setAccessible(true);
 
-        $serverString = $method->invoke($this->service, $handler);
+        $serverString = $method->invoke($this->service, 'imap.example.com', 993, 'IMAP', 'SSL/TLS');
 
         $this->assertEquals('{imap.example.com:993/imap/ssl}INBOX', $serverString);
     }
 
     public function testBuildServerStringWithPOP3(): void
     {
-        $handler = new InboundEmailHandler();
-        $handler->setMailServer('pop3.example.com');
-        $handler->setPort(995);
-        $handler->setProtocol('POP3');
-        $handler->setSecurity('SSL/TLS');
-
         $reflection = new \ReflectionClass($this->service);
-        $method = $reflection->getMethod('buildServerString');
+        $method = $reflection->getMethod('buildMailboxServerString');
         $method->setAccessible(true);
 
-        $serverString = $method->invoke($this->service, $handler);
+        $serverString = $method->invoke($this->service, 'pop3.example.com', 995, 'POP3', 'SSL/TLS');
 
         $this->assertEquals('{pop3.example.com:995/pop3/ssl}INBOX', $serverString);
     }
 
     public function testBuildServerStringWithSTARTTLS(): void
     {
-        $handler = new InboundEmailHandler();
-        $handler->setMailServer('imap.example.com');
-        $handler->setPort(143);
-        $handler->setProtocol('IMAP');
-        $handler->setSecurity('STARTTLS');
-
         $reflection = new \ReflectionClass($this->service);
-        $method = $reflection->getMethod('buildServerString');
+        $method = $reflection->getMethod('buildMailboxServerString');
         $method->setAccessible(true);
 
-        $serverString = $method->invoke($this->service, $handler);
+        $serverString = $method->invoke($this->service, 'imap.example.com', 143, 'IMAP', 'STARTTLS');
 
         $this->assertEquals('{imap.example.com:143/imap/tls}INBOX', $serverString);
     }

--- a/backend/tests/Unit/FeedbackPromptSubjectIsolationTest.php
+++ b/backend/tests/Unit/FeedbackPromptSubjectIsolationTest.php
@@ -1,0 +1,247 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit;
+
+use App\AI\Service\AiFacade;
+use App\Entity\Prompt;
+use App\Entity\User;
+use App\Prompt\PromptCatalog;
+use App\Repository\PromptRepository;
+use App\Service\FeedbackConfigService;
+use App\Service\FeedbackContradictionService;
+use App\Service\FeedbackExampleService;
+use App\Service\ModelConfigService;
+use App\Service\RAG\VectorSearchService;
+use App\Service\RateLimitService;
+use App\Service\Search\BraveSearchService;
+use App\Service\UserMemoryService;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Regression tests for issue #519 — user persona (e.g. age) leaking into
+ * a contradiction dialog about an external subject (the person in an
+ * uploaded image).
+ *
+ * The bug: when the user had a stored memory `age: 32` and the AI
+ * estimated a portrait subject's age, the contradiction modal's
+ * "DEIN FEEDBACK" field pre-filled with "aber 32 Jahre alt" — the
+ * user's own age — instead of treating the user and the portrait
+ * subject as distinct.
+ *
+ * The fix is prompt-level: both the false-positive preview and the
+ * contradiction check now carry an explicit SUBJECT-isolation rule
+ * forbidding the AI from mixing personal user memories into corrections
+ * or contradictions about external entities. These tests lock that rule
+ * into the prompts so a future edit can't accidentally remove it.
+ */
+final class FeedbackPromptSubjectIsolationTest extends TestCase
+{
+    public function testPreviewFalsePositivePromptCarriesSubjectIsolationRule(): void
+    {
+        $aiFacade = $this->createMock(AiFacade::class);
+        $modelConfigService = $this->createMock(ModelConfigService::class);
+        $modelConfigService->method('getToolsModelConfig')->willReturn([
+            'provider' => null,
+            'model' => null,
+            'model_id' => null,
+        ]);
+
+        $memoryService = $this->createMock(UserMemoryService::class);
+        $memoryService->method('isAvailable')->willReturn(true);
+        // Simulate the exact bug scenario: the user has stored their own
+        // age, and the vector search surfaces it for an age-related claim
+        // even though the claim itself is about a portrait subject.
+        $memoryService->method('searchRelevantMemories')->willReturn([
+            [
+                'id' => 100,
+                'key' => 'age',
+                'value' => '32',
+                'score' => 0.91,
+            ],
+        ]);
+
+        $feedbackConfig = $this->createMock(FeedbackConfigService::class);
+        $feedbackConfig->method('getMinContradictionScore')->willReturn(0.5);
+        $feedbackConfig->method('getLimitPerNamespace')->willReturn(5);
+
+        $capturedSystem = '';
+        $capturedUser = '';
+        $aiFacade
+            ->expects(self::once())
+            ->method('chat')
+            ->with(self::callback(function (array $messages) use (&$capturedSystem, &$capturedUser): bool {
+                $capturedSystem = (string) ($messages[0]['content'] ?? '');
+                $capturedUser = (string) ($messages[1]['content'] ?? '');
+
+                return true;
+            }))
+            // The AI's response is irrelevant to this test — we're
+            // asserting on the prompt that LEAVES our process.
+            ->willReturn([
+                'content' => '{"classification":"feedback","summaryOptions":["x"],"correctionOptions":["y"]}',
+            ]);
+
+        $service = new FeedbackExampleService(
+            $aiFacade,
+            $modelConfigService,
+            $this->createMock(RateLimitService::class),
+            $memoryService,
+            $this->createMock(VectorSearchService::class),
+            $this->createMock(BraveSearchService::class),
+            $this->createMock(PromptRepository::class),
+            $this->createMock(LoggerInterface::class),
+            $feedbackConfig,
+        );
+
+        $user = $this->createMock(User::class);
+        $user->method('getId')->willReturn(1);
+
+        $service->previewFalsePositive(
+            $user,
+            'Der Mann auf dem Foto ist zwischen 70 und 80 Jahre alt.',
+            'Wie alt ist die Person auf dem Bild?'
+        );
+
+        // System prompt must instruct the AI to identify the subject
+        // and refuse to substitute the user as subject for an external
+        // entity.
+        self::assertStringContainsString('Identify the SUBJECT', $capturedSystem);
+        self::assertStringContainsString('Subject-isolation rule', $capturedSystem);
+        self::assertStringContainsString(
+            'MUST NEVER appear in correction options for claims about an external subject',
+            $capturedSystem,
+            'The system prompt must explicitly forbid bleeding personal user facts into external-subject corrections.'
+        );
+
+        // User prompt must surface the same subject-match guardrail in
+        // the memory block — otherwise a strict model could still treat
+        // the listed memories as the source of truth.
+        self::assertStringContainsString(
+            'they describe the USER, not anyone or anything else',
+            $capturedUser
+        );
+        self::assertStringContainsString(
+            'stored user memories are NOT the source',
+            $capturedUser
+        );
+    }
+
+    public function testContradictionCheckBatchPromptCarriesSubjectMatchRule(): void
+    {
+        $aiFacade = $this->createMock(AiFacade::class);
+        $modelConfigService = $this->createMock(ModelConfigService::class);
+        $modelConfigService->method('getToolsModelConfig')->willReturn([
+            'provider' => null,
+            'model' => null,
+            'model_id' => null,
+        ]);
+
+        $memoryService = $this->createMock(UserMemoryService::class);
+        $memoryService->method('isAvailable')->willReturn(true);
+        $memoryService->method('searchRelevantMemories')->willReturnCallback(
+            // Only the user-memory namespace returns a hit; other
+            // namespaces are empty. This matches the bug scenario where
+            // the only related item is the user's own age memory.
+            static function (int $userId, string $query, ?string $category, int $limit, float $minScore, ?string $namespace): array {
+                if (null === $namespace) {
+                    return [
+                        [
+                            'id' => 100,
+                            'key' => 'age',
+                            'value' => '32',
+                            'score' => 0.92,
+                        ],
+                    ];
+                }
+
+                return [];
+            }
+        );
+
+        $feedbackConfig = $this->createMock(FeedbackConfigService::class);
+        $feedbackConfig->method('getMinContradictionScore')->willReturn(0.5);
+        $feedbackConfig->method('getLimitPerNamespace')->willReturn(5);
+
+        // Use the DB-seeded system prompt so the test also locks in
+        // PromptCatalog::feedbackContradictionCheckPrompt() content.
+        $promptRepository = $this->createMock(PromptRepository::class);
+        $systemPrompt = $this->createMock(Prompt::class);
+        $systemPrompt->method('getPrompt')->willReturn(
+            $this->extractContradictionPromptViaCatalogSeed()
+        );
+        $promptRepository->method('findOneBy')->willReturn($systemPrompt);
+
+        $capturedSystem = '';
+        $capturedUser = '';
+        $aiFacade
+            ->expects(self::once())
+            ->method('chat')
+            ->with(self::callback(function (array $messages) use (&$capturedSystem, &$capturedUser): bool {
+                $capturedSystem = (string) ($messages[0]['content'] ?? '');
+                $capturedUser = (string) ($messages[1]['content'] ?? '');
+
+                return true;
+            }))
+            ->willReturn(['content' => '{"contradictions":[]}']);
+
+        $service = new FeedbackContradictionService(
+            $aiFacade,
+            $modelConfigService,
+            $this->createMock(RateLimitService::class),
+            $memoryService,
+            $promptRepository,
+            $this->createMock(LoggerInterface::class),
+            $feedbackConfig,
+        );
+
+        $user = $this->createMock(User::class);
+        $user->method('getId')->willReturn(1);
+
+        $service->checkContradictionsBatch(
+            $user,
+            'Der Mann auf dem Foto ist zwischen 70 und 80 Jahre alt.',
+            'Er ist 120 Jahre alt.'
+        );
+
+        // System prompt (from PromptCatalog) must carry the rule.
+        self::assertStringContainsString('Subject-match rule', $capturedSystem);
+        self::assertStringContainsString(
+            'always describe the USER themselves',
+            $capturedSystem
+        );
+        self::assertStringContainsString(
+            'NEVER contradicts a personal user memory',
+            $capturedSystem
+        );
+
+        // Inline user prompt must restate the rule so a non-compliant
+        // model still gets reminded at the point of decision.
+        self::assertStringContainsString('SUBJECT-MATCH', $capturedUser);
+        self::assertStringContainsString(
+            'NEVER contradicts a personal user memory',
+            $capturedUser
+        );
+    }
+
+    /**
+     * Pull the contradiction-check prompt directly from the catalog so
+     * the test covers the actual seeded content, not a hand-rolled
+     * fixture that could drift out of sync.
+     */
+    private function extractContradictionPromptViaCatalogSeed(): string
+    {
+        foreach (PromptCatalog::all() as $prompt) {
+            if (
+                'tools:feedback_contradiction_check' === $prompt['topic']
+                && 'en' === $prompt['language']
+            ) {
+                return (string) $prompt['prompt'];
+            }
+        }
+
+        self::fail('feedback_contradiction_check prompt missing from PromptCatalog::all()');
+    }
+}

--- a/backend/tests/Unit/MemoryExtractionServicePromptRulesTest.php
+++ b/backend/tests/Unit/MemoryExtractionServicePromptRulesTest.php
@@ -17,6 +17,53 @@ use Psr\Log\LoggerInterface;
 
 final class MemoryExtractionServicePromptRulesTest extends TestCase
 {
+    /**
+     * Helper that wires a `MemoryExtractionService` with stub
+     * dependencies and lets the caller inspect the exact messages
+     * handed to the AI facade.
+     *
+     * Tests focused on prompt shaping (issue #438 et al.) don't care
+     * about model selection or rate-limit recording — they just need
+     * to assert that the assembled chat payload matches expectations.
+     *
+     * @param callable(array<int, array{role:string,content:string}>):void $assertOnMessages
+     */
+    private function makeServiceAndExpectChat(string $aiContent, callable $assertOnMessages): MemoryExtractionService
+    {
+        $aiFacade = $this->createMock(AiFacade::class);
+        $aiFacade
+            ->expects(self::once())
+            ->method('chat')
+            ->with(self::callback(function (array $messages) use ($assertOnMessages): bool {
+                $assertOnMessages($messages);
+
+                return true;
+            }))
+            ->willReturn(['content' => $aiContent]);
+
+        $promptRepository = $this->createMock(PromptRepository::class);
+        $prompt = $this->createMock(Prompt::class);
+        $prompt->method('getPrompt')->willReturn('SYSTEM PROMPT (EN)');
+        $promptRepository->method('findOneBy')->willReturn($prompt);
+
+        $modelConfigService = $this->createMock(ModelConfigService::class);
+        $modelConfigService->method('getDefaultModel')->willReturn(null);
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->method('getReference')
+            ->with(User::class, 1)
+            ->willReturn($this->createMock(User::class));
+
+        return new MemoryExtractionService(
+            $aiFacade,
+            $modelConfigService,
+            $this->createMock(RateLimitService::class),
+            $promptRepository,
+            $entityManager,
+            $this->createMock(LoggerInterface::class)
+        );
+    }
+
     public function testAnalyzeAndExtractAllowsMultipleCreatesWithSameKeyAndUsesAtomicRulesInPrompt(): void
     {
         $aiFacade = $this->createMock(AiFacade::class);
@@ -102,5 +149,136 @@ final class MemoryExtractionServicePromptRulesTest extends TestCase
         self::assertSame('create', $result[1]['action']);
         self::assertSame('diet', $result[1]['key']);
         self::assertSame('Prefers low-calorie meals for weight loss', $result[1]['value']);
+    }
+
+    /**
+     * Issue #438: the extraction LLM must never see the assistant's
+     * own replies as input — they were a known leak source where the
+     * model would lift a memory out of its own paraphrase instead of
+     * the user's actual statement.
+     */
+    public function testAssistantTurnsAreStrippedFromExtractionContext(): void
+    {
+        $assistantBomb = 'ASSISTANT_BOMB: the user enjoys salty doner kebabs every weekend';
+
+        $message = $this->createMock(Message::class);
+        $message->method('getId')->willReturn(123);
+        $message->method('getUserId')->willReturn(1);
+        $message->method('getText')->willReturn('Ich heisse Furkan.');
+
+        $capturedUserPrompt = '';
+        $service = $this->makeServiceAndExpectChat(
+            aiContent: '[]',
+            assertOnMessages: function (array $messages) use (&$capturedUserPrompt): void {
+                self::assertCount(2, $messages);
+                $capturedUserPrompt = (string) ($messages[1]['content'] ?? '');
+            }
+        );
+
+        $service->analyzeAndExtract(
+            $message,
+            [
+                ['role' => 'user', 'content' => 'Hi'],
+                ['role' => 'assistant', 'content' => $assistantBomb],
+                ['role' => 'user', 'content' => 'Wie heisst du?'],
+            ],
+            []
+        );
+
+        self::assertStringNotContainsString(
+            $assistantBomb,
+            $capturedUserPrompt,
+            'Assistant-authored content must not appear in the extraction prompt.'
+        );
+        self::assertStringNotContainsString(
+            'assistant:',
+            $capturedUserPrompt,
+            'The extraction prompt must not label any context line as assistant.'
+        );
+        self::assertStringContainsString(
+            'USER turns only',
+            $capturedUserPrompt,
+            'The extraction prompt must declare the conversation as user-only.'
+        );
+        self::assertStringContainsString(
+            'Never invent or extract from anything you (the assistant) wrote',
+            $capturedUserPrompt,
+            'The extraction prompt must explicitly forbid lifting facts from the assistant.'
+        );
+        // User turns must still be present so we keep useful topical context.
+        self::assertStringContainsString('user: Hi', $capturedUserPrompt);
+        self::assertStringContainsString('user: Wie heisst du?', $capturedUserPrompt);
+    }
+
+    /**
+     * Same guarantee but for the Message-object code path: history
+     * entries coming in as `App\Entity\Message` objects with
+     * direction != IN are treated as assistant output and dropped.
+     */
+    public function testAssistantMessageObjectsAreFilteredByDirection(): void
+    {
+        $assistantBomb = 'BOMB_FROM_MESSAGE_OBJECT';
+
+        $current = $this->createMock(Message::class);
+        $current->method('getId')->willReturn(123);
+        $current->method('getUserId')->willReturn(1);
+        $current->method('getText')->willReturn('Ich heisse Furkan.');
+
+        $userTurn = $this->createMock(Message::class);
+        $userTurn->method('getDirection')->willReturn('IN');
+        $userTurn->method('getText')->willReturn('Frage davor vom User');
+
+        $assistantTurn = $this->createMock(Message::class);
+        $assistantTurn->method('getDirection')->willReturn('OUT');
+        $assistantTurn->method('getText')->willReturn($assistantBomb);
+
+        $capturedUserPrompt = '';
+        $service = $this->makeServiceAndExpectChat(
+            aiContent: '[]',
+            assertOnMessages: function (array $messages) use (&$capturedUserPrompt): void {
+                $capturedUserPrompt = (string) ($messages[1]['content'] ?? '');
+            }
+        );
+
+        $service->analyzeAndExtract($current, [$userTurn, $assistantTurn], []);
+
+        self::assertStringNotContainsString($assistantBomb, $capturedUserPrompt);
+        self::assertStringContainsString('user: Frage davor vom User', $capturedUserPrompt);
+    }
+
+    /**
+     * Edge case: the entire history is assistant-only (a chatty UI
+     * suggestion turn with no preceding user statement). The
+     * extractor must still see the Current Message but get an empty
+     * conversation block — never assistant lines.
+     */
+    public function testAllAssistantHistoryResultsInEmptyConversationBlock(): void
+    {
+        $message = $this->createMock(Message::class);
+        $message->method('getId')->willReturn(123);
+        $message->method('getUserId')->willReturn(1);
+        $message->method('getText')->willReturn('Mein Lieblingsfilm ist Inception');
+
+        $capturedUserPrompt = '';
+        $service = $this->makeServiceAndExpectChat(
+            aiContent: '[]',
+            assertOnMessages: function (array $messages) use (&$capturedUserPrompt): void {
+                $capturedUserPrompt = (string) ($messages[1]['content'] ?? '');
+            }
+        );
+
+        $service->analyzeAndExtract(
+            $message,
+            [
+                ['role' => 'assistant', 'content' => 'Welche Filme magst du?'],
+                ['role' => 'assistant', 'content' => 'Vielleicht Sci-Fi?'],
+            ],
+            []
+        );
+
+        self::assertStringNotContainsString('assistant:', $capturedUserPrompt);
+        self::assertStringNotContainsString('Welche Filme magst du?', $capturedUserPrompt);
+        // The Current Message section is unaffected by history filtering.
+        self::assertStringContainsString('Mein Lieblingsfilm ist Inception', $capturedUserPrompt);
     }
 }

--- a/frontend/src/components/FileSelectionModal.vue
+++ b/frontend/src/components/FileSelectionModal.vue
@@ -318,7 +318,7 @@ import { ref, computed, watch, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { XMarkIcon, ArrowDownTrayIcon, TrashIcon } from '@heroicons/vue/24/outline'
 import { Icon } from '@iconify/vue'
-import filesService, { type FileItem } from '@/services/filesService'
+import filesService, { type FileItem, UploadBlockedError } from '@/services/filesService'
 import { getApiBaseUrl } from '@/services/api/httpClient'
 import { useNotification } from '@/composables/useNotification'
 import FileContentModal from './FileContentModal.vue'
@@ -586,6 +586,22 @@ const uploadFiles = async (filesToUpload: File[]) => {
         if (err instanceof DOMException && err.name === 'AbortError') {
           await notifyUploadInterrupted()
           break
+        }
+        if (err instanceof UploadBlockedError) {
+          const key = `files.uploadBlocked.${err.reason}`
+          const translated = t(key, {
+            filename: err.filename,
+            message: err.check.message ?? '',
+          })
+          showError(
+            translated === key
+              ? t('files.uploadBlocked.generic', {
+                  filename: err.filename,
+                  message: err.check.message ?? '',
+                })
+              : translated
+          )
+          continue
         }
         console.error('Upload failed:', file.name, err)
         const msg = err instanceof Error ? err.message : 'Unknown error'

--- a/frontend/src/components/FileSelectionModal.vue
+++ b/frontend/src/components/FileSelectionModal.vue
@@ -337,6 +337,25 @@ const emit = defineEmits<{
 
 const { success, error: showError, warning } = useNotification()
 
+// Localized message for a pre-flight upload rejection, with a hard
+// non-i18n fallback so the user never sees a raw dot-path key when a
+// translation is missing in the active locale.
+const translateUploadBlocked = (err: UploadBlockedError): string => {
+  const params = {
+    filename: err.filename,
+    message: err.check.message ?? '',
+  }
+  const reasonKey = `files.uploadBlocked.${err.reason}`
+  const reasonTranslated = t(reasonKey, params)
+  if (reasonTranslated !== reasonKey) return reasonTranslated
+
+  const genericKey = 'files.uploadBlocked.generic'
+  const genericTranslated = t(genericKey, params)
+  if (genericTranslated !== genericKey) return genericTranslated
+
+  return params.message ? `${params.filename}: ${params.message}` : params.filename
+}
+
 // State
 const isLoading = ref(false)
 const isUploading = ref(false)
@@ -588,19 +607,7 @@ const uploadFiles = async (filesToUpload: File[]) => {
           break
         }
         if (err instanceof UploadBlockedError) {
-          const key = `files.uploadBlocked.${err.reason}`
-          const translated = t(key, {
-            filename: err.filename,
-            message: err.check.message ?? '',
-          })
-          showError(
-            translated === key
-              ? t('files.uploadBlocked.generic', {
-                  filename: err.filename,
-                  message: err.check.message ?? '',
-                })
-              : translated
-          )
+          showError(translateUploadBlocked(err))
           continue
         }
         console.error('Upload failed:', file.name, err)

--- a/frontend/src/components/config/AIModelsConfiguration.vue
+++ b/frontend/src/components/config/AIModelsConfiguration.vue
@@ -290,7 +290,7 @@
           <tbody>
             <tr
               v-for="model in paginatedModels"
-              :key="`${model.service}-${model.name}`"
+              :key="`${model.service}\u0000${model.name}`"
               class="border-b border-light-border/10 dark:border-dark-border/10 hover:bg-black/5 dark:hover:bg-white/5 transition-colors"
               data-testid="item-model"
               :data-model-service="model.service"

--- a/frontend/src/components/config/AIModelsConfiguration.vue
+++ b/frontend/src/components/config/AIModelsConfiguration.vue
@@ -290,10 +290,11 @@
           <tbody>
             <tr
               v-for="model in paginatedModels"
-              :key="model.id"
+              :key="`${model.service}-${model.name}`"
               class="border-b border-light-border/10 dark:border-dark-border/10 hover:bg-black/5 dark:hover:bg-white/5 transition-colors"
               data-testid="item-model"
-              :data-model-id="model.id"
+              :data-model-service="model.service"
+              :data-model-name="model.name"
             >
               <td class="py-3 px-2 sm:px-3">
                 <div class="flex items-center gap-2">
@@ -346,28 +347,29 @@
               <td class="py-3 px-2 sm:px-3 hidden sm:table-cell">
                 <div class="flex flex-wrap gap-1.5">
                   <button
-                    v-for="purpose in model.purposes"
-                    :key="purpose"
+                    v-for="chip in model.purposes"
+                    :key="chip.purpose"
                     type="button"
                     :class="[
                       'inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium transition-colors border',
-                      isPurposeActiveForModel(model.id, purpose)
+                      isPurposeChipActive(chip)
                         ? 'bg-[var(--brand)] text-white border-[var(--brand)] hover:bg-[var(--brand)]/90'
                         : 'border-light-border/40 dark:border-dark-border/30 txt-secondary hover:border-[var(--brand)] hover:text-[var(--brand)]',
-                      isPurposeDisabled(purpose) &&
+                      isPurposeDisabled(chip.purpose) &&
                         'opacity-50 cursor-not-allowed hover:border-light-border/40 hover:text-inherit',
-                      !isPurposeDisabled(purpose) &&
-                        !isPurposeActiveForModel(model.id, purpose) &&
+                      !isPurposeDisabled(chip.purpose) &&
+                        !isPurposeChipActive(chip) &&
                         'cursor-pointer',
                     ]"
-                    :disabled="isPurposeDisabled(purpose)"
-                    :title="getPurposeChipTitle(model, purpose)"
-                    :aria-pressed="isPurposeActiveForModel(model.id, purpose)"
+                    :disabled="isPurposeDisabled(chip.purpose)"
+                    :title="getPurposeChipTitle(model, chip)"
+                    :aria-pressed="isPurposeChipActive(chip)"
                     data-testid="btn-purpose-chip"
-                    :data-purpose="purpose"
-                    @click.stop="onPurposeChipClick(model, purpose)"
+                    :data-purpose="chip.purpose"
+                    :data-model-id="chip.modelId"
+                    @click.stop="onPurposeChipClick(chip)"
                   >
-                    {{ purposeLabels[purpose] }}
+                    {{ purposeLabels[chip.purpose] }}
                   </button>
                 </div>
               </td>
@@ -461,7 +463,11 @@ import {
 import { adminEmbeddingApi, type EmbeddingGuardStatus } from '@/services/api/adminEmbeddingApi'
 import { useAuthStore } from '@/stores/auth'
 import type { AIModel, Capability } from '@/types/ai-models'
-import { dedupeModelsByPurpose, type ModelWithPurposes } from '@/utils/aiModelDedupe'
+import {
+  dedupeModelsByPurpose,
+  type ModelWithPurposes,
+  type PurposeChip,
+} from '@/utils/aiModelDedupe'
 import { getProviderIcon } from '@/utils/providerIcons'
 import { useI18n } from 'vue-i18n'
 
@@ -837,11 +843,14 @@ const loadEmbeddingGuard = async () => {
 }
 
 /**
- * True when the given model is the current default for the given purpose.
- * Drives the chip's active visual state in the dedup'd model table.
+ * True when this chip's underlying model id is the current default for
+ * its purpose. Each chip carries its own modelId because a dedup'd row
+ * can represent several BMODELS ids (e.g. "Claude Opus 4.6" — id 160
+ * for CHAT, id 222 for MEM); active state is therefore per-chip, not
+ * per-row.
  */
-const isPurposeActiveForModel = (modelId: number, purpose: Capability): boolean => {
-  return defaultConfig.value[purpose] === modelId
+const isPurposeChipActive = (chip: PurposeChip): boolean => {
+  return defaultConfig.value[chip.purpose] === chip.modelId
 }
 
 /**
@@ -859,12 +868,12 @@ const isPurposeDisabled = (purpose: Capability): boolean => {
  * inactive = "click to set as default for X". Translated via i18n so the
  * user gets the German/English copy that matches their UI locale.
  */
-const getPurposeChipTitle = (model: AIModel, purpose: Capability): string => {
-  if (isPurposeDisabled(purpose)) {
+const getPurposeChipTitle = (model: AIModel, chip: PurposeChip): string => {
+  if (isPurposeDisabled(chip.purpose)) {
     return t('config.embeddingSwitch.adminOnly.lockTooltip')
   }
-  const label = purposeLabels.value[purpose]
-  if (isPurposeActiveForModel(model.id, purpose)) {
+  const label = purposeLabels.value[chip.purpose]
+  if (isPurposeChipActive(chip)) {
     return t('config.aiModels.purposeChip.activeTooltip', { purpose: label })
   }
   return t('config.aiModels.purposeChip.applyTooltip', {
@@ -874,17 +883,17 @@ const getPurposeChipTitle = (model: AIModel, purpose: Capability): string => {
 }
 
 /**
- * Chip click handler: applies the model to the default config for the
- * clicked purpose. We delegate to the existing `selectModel` flow so
- * VECTORIZE keeps going through the embedding-switch modal and other
- * purposes hit the same availability check + auto-save path as the
- * dropdown. Clicking the already-active chip is a no-op — there is no
- * value in re-saving the same configuration.
+ * Chip click handler: applies this chip's specific model id to the
+ * default config for the chip's purpose. We delegate to the existing
+ * `selectModel` flow so VECTORIZE keeps going through the embedding-
+ * switch modal and other purposes hit the same availability check +
+ * auto-save path as the dropdown. Clicking the already-active chip is
+ * a no-op — there is no value in re-saving the same configuration.
  */
-const onPurposeChipClick = async (model: AIModel, purpose: Capability): Promise<void> => {
-  if (isPurposeDisabled(purpose)) return
-  if (isPurposeActiveForModel(model.id, purpose)) return
-  await selectModel(purpose, model.id)
+const onPurposeChipClick = async (chip: PurposeChip): Promise<void> => {
+  if (isPurposeDisabled(chip.purpose)) return
+  if (isPurposeChipActive(chip)) return
+  await selectModel(chip.purpose, chip.modelId)
 }
 
 const handleClickOutside = (event: MouseEvent) => {
@@ -923,7 +932,9 @@ const filteredModels = computed<ModelWithPurposes[]>(() => {
   if (selectedPurpose.value === null) {
     return allModels.value
   }
-  return allModels.value.filter((model) => model.purposes.includes(selectedPurpose.value!))
+  return allModels.value.filter((model) =>
+    model.purposes.some((chip) => chip.purpose === selectedPurpose.value)
+  )
 })
 
 /**
@@ -958,8 +969,8 @@ const sortedModels = computed<ModelWithPurposes[]>(() => {
   // models, while a TEXT2SOUND-only model lands near the bottom.
   const primaryPurposeRank = (model: ModelWithPurposes): number => {
     let min = Number.POSITIVE_INFINITY
-    for (const p of model.purposes) {
-      const idx = order.indexOf(p)
+    for (const chip of model.purposes) {
+      const idx = order.indexOf(chip.purpose)
       if (idx !== -1 && idx < min) min = idx
     }
     return Number.isFinite(min) ? min : order.length

--- a/frontend/src/components/config/AIModelsConfiguration.vue
+++ b/frontend/src/components/config/AIModelsConfiguration.vue
@@ -290,9 +290,10 @@
           <tbody>
             <tr
               v-for="model in paginatedModels"
-              :key="`${model.id}-${model.purpose}`"
+              :key="model.id"
               class="border-b border-light-border/10 dark:border-dark-border/10 hover:bg-black/5 dark:hover:bg-white/5 transition-colors"
               data-testid="item-model"
+              :data-model-id="model.id"
             >
               <td class="py-3 px-2 sm:px-3">
                 <div class="flex items-center gap-2">
@@ -343,7 +344,32 @@
                 </div>
               </td>
               <td class="py-3 px-2 sm:px-3 hidden sm:table-cell">
-                <span class="pill pill--active text-xs">{{ model.purpose }}</span>
+                <div class="flex flex-wrap gap-1.5">
+                  <button
+                    v-for="purpose in model.purposes"
+                    :key="purpose"
+                    type="button"
+                    :class="[
+                      'inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium transition-colors border',
+                      isPurposeActiveForModel(model.id, purpose)
+                        ? 'bg-[var(--brand)] text-white border-[var(--brand)] hover:bg-[var(--brand)]/90'
+                        : 'border-light-border/40 dark:border-dark-border/30 txt-secondary hover:border-[var(--brand)] hover:text-[var(--brand)]',
+                      isPurposeDisabled(purpose) &&
+                        'opacity-50 cursor-not-allowed hover:border-light-border/40 hover:text-inherit',
+                      !isPurposeDisabled(purpose) &&
+                        !isPurposeActiveForModel(model.id, purpose) &&
+                        'cursor-pointer',
+                    ]"
+                    :disabled="isPurposeDisabled(purpose)"
+                    :title="getPurposeChipTitle(model, purpose)"
+                    :aria-pressed="isPurposeActiveForModel(model.id, purpose)"
+                    data-testid="btn-purpose-chip"
+                    :data-purpose="purpose"
+                    @click.stop="onPurposeChipClick(model, purpose)"
+                  >
+                    {{ purposeLabels[purpose] }}
+                  </button>
+                </div>
               </td>
               <td class="py-3 px-2 sm:px-3 txt-secondary text-sm hidden lg:table-cell">
                 {{ model.description }}
@@ -435,6 +461,7 @@ import {
 import { adminEmbeddingApi, type EmbeddingGuardStatus } from '@/services/api/adminEmbeddingApi'
 import { useAuthStore } from '@/stores/auth'
 import type { AIModel, Capability } from '@/types/ai-models'
+import { dedupeModelsByPurpose, type ModelWithPurposes } from '@/utils/aiModelDedupe'
 import { getProviderIcon } from '@/utils/providerIcons'
 import { useI18n } from 'vue-i18n'
 
@@ -809,6 +836,57 @@ const loadEmbeddingGuard = async () => {
   }
 }
 
+/**
+ * True when the given model is the current default for the given purpose.
+ * Drives the chip's active visual state in the dedup'd model table.
+ */
+const isPurposeActiveForModel = (modelId: number, purpose: Capability): boolean => {
+  return defaultConfig.value[purpose] === modelId
+}
+
+/**
+ * VECTORIZE is admin-only at the UI layer (see `isVectorizeAdminOnly` for
+ * the rationale). Disabled chips render greyed and ignore clicks so a
+ * non-admin can still see what their model supports without being teased
+ * with an action they cannot perform.
+ */
+const isPurposeDisabled = (purpose: Capability): boolean => {
+  return purpose === 'VECTORIZE' && isVectorizeAdminOnly.value
+}
+
+/**
+ * Tooltip text for the purpose chip. Active = "already the default",
+ * inactive = "click to set as default for X". Translated via i18n so the
+ * user gets the German/English copy that matches their UI locale.
+ */
+const getPurposeChipTitle = (model: AIModel, purpose: Capability): string => {
+  if (isPurposeDisabled(purpose)) {
+    return t('config.embeddingSwitch.adminOnly.lockTooltip')
+  }
+  const label = purposeLabels.value[purpose]
+  if (isPurposeActiveForModel(model.id, purpose)) {
+    return t('config.aiModels.purposeChip.activeTooltip', { purpose: label })
+  }
+  return t('config.aiModels.purposeChip.applyTooltip', {
+    purpose: label,
+    model: model.name,
+  })
+}
+
+/**
+ * Chip click handler: applies the model to the default config for the
+ * clicked purpose. We delegate to the existing `selectModel` flow so
+ * VECTORIZE keeps going through the embedding-switch modal and other
+ * purposes hit the same availability check + auto-save path as the
+ * dropdown. Clicking the already-active chip is a no-op — there is no
+ * value in re-saving the same configuration.
+ */
+const onPurposeChipClick = async (model: AIModel, purpose: Capability): Promise<void> => {
+  if (isPurposeDisabled(purpose)) return
+  if (isPurposeActiveForModel(model.id, purpose)) return
+  await selectModel(purpose, model.id)
+}
+
 const handleClickOutside = (event: MouseEvent) => {
   if (!openDropdown.value) return
   const target = event.target as HTMLElement
@@ -824,21 +902,28 @@ const handleKeydown = (event: KeyboardEvent) => {
   }
 }
 
-const allModels = computed(() => {
-  const all: Array<AIModel & { purpose: Capability }> = []
-  for (const [cap, models] of Object.entries(availableModels.value)) {
-    models.forEach((model) => {
-      all.push({ ...model, purpose: cap as Capability })
-    })
-  }
-  return all
-})
+/**
+ * Issue #261: dedupe the table so each model surfaces ONCE with all its
+ * purposes listed as selectable chips. The backend returns models indexed
+ * by purpose so the same model shows up in multiple buckets — e.g.
+ * Claude Haiku 4.5 appears under SORT, CHAT and ANALYZE. That made the
+ * list painful to scan: 11 purposes × N models meant hundreds of rows
+ * that all referred to the same handful of models.
+ *
+ * The dedup helper is extracted to `@/utils/aiModelDedupe` so the rule is
+ * unit-testable without mounting this whole component.
+ */
+const PURPOSE_ORDER = computed<Capability[]>(() => Object.keys(purposeLabels.value) as Capability[])
 
-const filteredModels = computed(() => {
+const allModels = computed<ModelWithPurposes[]>(() =>
+  dedupeModelsByPurpose(availableModels.value, PURPOSE_ORDER.value)
+)
+
+const filteredModels = computed<ModelWithPurposes[]>(() => {
   if (selectedPurpose.value === null) {
     return allModels.value
   }
-  return allModels.value.filter((model) => model.purpose === selectedPurpose.value)
+  return allModels.value.filter((model) => model.purposes.includes(selectedPurpose.value!))
 })
 
 /**
@@ -862,13 +947,25 @@ const getStarRating = (quality: number): number => {
   return Math.round(quality / 2)
 }
 
-type ModelWithPurpose = AIModel & { purpose: Capability }
-
-const sortedModels = computed(() => {
+const sortedModels = computed<ModelWithPurposes[]>(() => {
   const dir = sortDirection.value === 'asc' ? 1 : -1
   const col = sortBy.value
+  const order = PURPOSE_ORDER.value
 
-  const compareFn = (a: ModelWithPurpose, b: ModelWithPurpose): number => {
+  // Position of the model's "first" capability in the canonical order is
+  // the cleanest deterministic sort key for the dedup'd list: a generalist
+  // model with SORT+CHAT+ANALYZE sorts together with other SORT-capable
+  // models, while a TEXT2SOUND-only model lands near the bottom.
+  const primaryPurposeRank = (model: ModelWithPurposes): number => {
+    let min = Number.POSITIVE_INFINITY
+    for (const p of model.purposes) {
+      const idx = order.indexOf(p)
+      if (idx !== -1 && idx < min) min = idx
+    }
+    return Number.isFinite(min) ? min : order.length
+  }
+
+  const compareFn = (a: ModelWithPurposes, b: ModelWithPurposes): number => {
     let cmp = 0
     switch (col) {
       case 'alphabet':
@@ -882,7 +979,7 @@ const sortedModels = computed(() => {
         cmp = a.quality - b.quality
         break
       case 'purpose':
-        cmp = a.purpose.localeCompare(b.purpose)
+        cmp = primaryPurposeRank(a) - primaryPurposeRank(b)
         break
     }
     return cmp !== 0 ? dir * cmp : dir * a.name.localeCompare(b.name)

--- a/frontend/src/components/mail/MailHandlerConfiguration.vue
+++ b/frontend/src/components/mail/MailHandlerConfiguration.vue
@@ -757,7 +757,10 @@ import type {
   SavedMailHandler,
 } from '@/services/api/inboundEmailHandlersApi'
 import { defaultMailConfig, protocolOptions, securityOptions } from '@/mocks/mail'
-import { inboundEmailHandlersApi, MASKED_MAIL_PASSWORD_PLACEHOLDER } from '@/services/api/inboundEmailHandlersApi'
+import {
+  inboundEmailHandlersApi,
+  MASKED_MAIL_PASSWORD_PLACEHOLDER,
+} from '@/services/api/inboundEmailHandlersApi'
 import { useAuthStore } from '@/stores/auth'
 import { useI18n } from 'vue-i18n'
 
@@ -953,8 +956,7 @@ const testConnection = async () => {
   }
 
   const pwd = config.value.password ?? ''
-  const needsMailboxPassword =
-    pwd === '' || pwd === MASKED_MAIL_PASSWORD_PLACEHOLDER
+  const needsMailboxPassword = pwd === '' || pwd === MASKED_MAIL_PASSWORD_PLACEHOLDER
   if (needsMailboxPassword && !props.handlerId) {
     testResult.value = {
       success: false,

--- a/frontend/src/components/mail/MailHandlerConfiguration.vue
+++ b/frontend/src/components/mail/MailHandlerConfiguration.vue
@@ -757,8 +757,11 @@ import type {
   SavedMailHandler,
 } from '@/services/api/inboundEmailHandlersApi'
 import { defaultMailConfig, protocolOptions, securityOptions } from '@/mocks/mail'
-import { inboundEmailHandlersApi } from '@/services/api/inboundEmailHandlersApi'
+import { inboundEmailHandlersApi, MASKED_MAIL_PASSWORD_PLACEHOLDER } from '@/services/api/inboundEmailHandlersApi'
 import { useAuthStore } from '@/stores/auth'
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
 
 const authStore = useAuthStore()
 
@@ -939,11 +942,23 @@ const resetToDefault = () => {
 }
 
 const testConnection = async () => {
-  // For new handlers, we need to save first before testing
-  if (!props.handlerId) {
+  const server = config.value.mailServer?.trim() ?? ''
+  const user = config.value.username?.trim() ?? ''
+  if (!server || !config.value.port || !user) {
     testResult.value = {
       success: false,
-      message: 'Please save the handler first before testing the connection.',
+      message: t('mail.testPickUpIncomplete'),
+    }
+    return
+  }
+
+  const pwd = config.value.password ?? ''
+  const needsMailboxPassword =
+    pwd === '' || pwd === MASKED_MAIL_PASSWORD_PLACEHOLDER
+  if (needsMailboxPassword && !props.handlerId) {
+    testResult.value = {
+      success: false,
+      message: t('mail.testPickUpPasswordRequired'),
     }
     return
   }
@@ -952,7 +967,15 @@ const testConnection = async () => {
   testResult.value = null
 
   try {
-    const result = await inboundEmailHandlersApi.testConnection(props.handlerId)
+    const result = await inboundEmailHandlersApi.testMailboxConnection({
+      mailServer: server,
+      port: config.value.port,
+      protocol: config.value.protocol,
+      security: config.value.security,
+      username: user,
+      password: needsMailboxPassword ? undefined : pwd,
+      handlerId: needsMailboxPassword ? props.handlerId : undefined,
+    })
     testResult.value = {
       success: result.success,
       message: result.message,
@@ -960,7 +983,7 @@ const testConnection = async () => {
   } catch (error: unknown) {
     testResult.value = {
       success: false,
-      message: getErrorMessage(error) || 'Failed to test connection',
+      message: getErrorMessage(error) || t('mail.connectionTestWarning'),
     }
   } finally {
     isTestingConnection.value = false

--- a/frontend/src/components/summary/SummaryConfiguration.vue
+++ b/frontend/src/components/summary/SummaryConfiguration.vue
@@ -392,6 +392,7 @@ import {
 } from '@heroicons/vue/24/outline'
 import type { SummaryConfig, FocusArea } from '@/mocks/summaries'
 import { summaryTypes, summaryLengths, outputLanguages, focusAreaOptions } from '@/mocks/summaries'
+import { useI18n } from 'vue-i18n'
 import { useNotification } from '@/composables/useNotification'
 import {
   uploadFiles,
@@ -401,6 +402,8 @@ import {
 } from '@/services/filesService'
 import FileSelectionModal from '@/components/FileSelectionModal.vue'
 import { getErrorMessage } from '@/utils/errorMessage'
+
+const { t } = useI18n()
 
 interface Props {
   isGenerating?: boolean
@@ -441,6 +444,27 @@ const isUploadingFile = ref(false)
 const fileSelectionModalVisible = ref(false)
 
 const { warning, error, success } = useNotification()
+
+// Localized message for a pre-flight upload rejection, matching the
+// behavior used in FilesView and FileSelectionModal so the user sees
+// the same copy regardless of which upload entry point they hit.
+// Plain-string fallback prevents raw `files.uploadBlocked.x` dot-paths
+// from ever surfacing if a locale is missing the key.
+const translateUploadBlocked = (err: UploadBlockedError): string => {
+  const params = {
+    filename: err.filename,
+    message: err.check.message ?? '',
+  }
+  const reasonKey = `files.uploadBlocked.${err.reason}`
+  const reasonTranslated = t(reasonKey, params)
+  if (reasonTranslated !== reasonKey) return reasonTranslated
+
+  const genericKey = 'files.uploadBlocked.generic'
+  const genericTranslated = t(genericKey, params)
+  if (genericTranslated !== genericKey) return genericTranslated
+
+  return params.message ? `${params.filename}: ${params.message}` : params.filename
+}
 
 const characterCount = computed(() => documentText.value.length)
 const wordCount = computed(() => {
@@ -555,7 +579,7 @@ const handleFile = async (file: File) => {
     }
   } catch (err: unknown) {
     if (err instanceof UploadBlockedError) {
-      error(`${err.filename}: ${err.check.message ?? 'Upload not allowed'}`)
+      error(translateUploadBlocked(err))
     } else {
       console.error('File upload error:', err)
       error(getErrorMessage(err) || 'Failed to upload file. Please try again.')

--- a/frontend/src/components/summary/SummaryConfiguration.vue
+++ b/frontend/src/components/summary/SummaryConfiguration.vue
@@ -393,7 +393,12 @@ import {
 import type { SummaryConfig, FocusArea } from '@/mocks/summaries'
 import { summaryTypes, summaryLengths, outputLanguages, focusAreaOptions } from '@/mocks/summaries'
 import { useNotification } from '@/composables/useNotification'
-import { uploadFiles, getFileContent, type FileItem } from '@/services/filesService'
+import {
+  uploadFiles,
+  getFileContent,
+  UploadBlockedError,
+  type FileItem,
+} from '@/services/filesService'
 import FileSelectionModal from '@/components/FileSelectionModal.vue'
 import { getErrorMessage } from '@/utils/errorMessage'
 
@@ -549,8 +554,12 @@ const handleFile = async (file: File) => {
       error('Failed to extract text from file. Please try again.')
     }
   } catch (err: unknown) {
-    console.error('File upload error:', err)
-    error(getErrorMessage(err) || 'Failed to upload file. Please try again.')
+    if (err instanceof UploadBlockedError) {
+      error(`${err.filename}: ${err.check.message ?? 'Upload not allowed'}`)
+    } else {
+      console.error('File upload error:', err)
+      error(getErrorMessage(err) || 'Failed to upload file. Please try again.')
+    }
   } finally {
     isUploadingFile.value = false
     // Reset file input

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -1918,6 +1918,8 @@
     "bulkDeleteSuccess": "{count} Handler erfolgreich gelöscht",
     "bulkDeleteFailed": "Handler konnten nicht gelöscht werden",
     "connectionTestWarning": "Verbindungstest fehlgeschlagen",
+    "testPickUpIncomplete": "Bitte Mailserver, Port und Benutzername ausfüllen, bevor Sie testen.",
+    "testPickUpPasswordRequired": "Bitte geben Sie das Postfach-Passwort ein, um diese Konfiguration zu testen.",
     "handlerSavedTestFailed": "Handler gespeichert, aber Verbindungstest fehlgeschlagen",
     "handlerDeleted": "Mail-Handler erfolgreich gelöscht",
     "deleteFailed": "Fehler beim Löschen des Mail-Handlers",

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -915,6 +915,10 @@
       "chatGeneration": "Antwort-Generierung",
       "messageClassification": "Nachrichten-Klassifizierung",
       "clickToConfig": "Klicken zum Konfigurieren",
+      "purposeChip": {
+        "activeTooltip": "Bereits als Standardmodell für „{purpose}\" gesetzt",
+        "applyTooltip": "{model} als Standardmodell für „{purpose}\" festlegen"
+      },
       "modelNotAvailable": "{model} ist nicht verfügbar. Bitte prüfe die Provider-Konfiguration.",
       "modelNotConfigured": "{model} ist nicht bereit: Setze {envVar} in der Umgebung (z. B. .env.local).",
       "admin": {

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -1795,7 +1795,14 @@
     "reVectorizeFailed": "Neuverarbeitung fehlgeschlagen",
     "uploadSuccess": "{count} Datei(en) erfolgreich hochgeladen",
     "uploadCancelled": "Upload abgebrochen",
-    "uploadInterrupted": "Übertragung unterbrochen. Die Liste wurde aktualisiert — Dateien, die den Server schon erreicht hatten, können weiterhin erscheinen."
+    "uploadInterrupted": "Übertragung unterbrochen. Die Liste wurde aktualisiert — Dateien, die den Server schon erreicht hatten, können weiterhin erscheinen.",
+    "uploadBlocked": {
+      "storage_exceeded": "{filename}: Nicht genug Speicherplatz. {message}",
+      "file_too_large": "{filename}: Datei ist zu groß. {message}",
+      "extension_not_allowed": "{filename}: Dateityp wird nicht unterstützt. {message}",
+      "rate_limit_exceeded": "{filename}: Upload-Limit erreicht. {message}",
+      "generic": "{filename}: Upload nicht erlaubt. {message}"
+    }
   },
   "fileMention": {
     "hint": "Tippen um Dateien zu suchen — Enter zum Anhängen",

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -917,8 +917,8 @@
       "messageClassification": "Nachrichten-Klassifizierung",
       "clickToConfig": "Klicken zum Konfigurieren",
       "purposeChip": {
-        "activeTooltip": "Bereits als Standardmodell für „{purpose}\" gesetzt",
-        "applyTooltip": "{model} als Standardmodell für „{purpose}\" festlegen"
+        "activeTooltip": "Bereits als Standardmodell für „{purpose}“ gesetzt",
+        "applyTooltip": "{model} als Standardmodell für „{purpose}“ festlegen"
       },
       "modelNotAvailable": "{model} ist nicht verfügbar. Bitte prüfe die Provider-Konfiguration.",
       "modelNotConfigured": "{model} ist nicht bereit: Setze {envVar} in der Umgebung (z. B. .env.local).",
@@ -1804,6 +1804,7 @@
     "uploadBlocked": {
       "storage_exceeded": "{filename}: Nicht genug Speicherplatz. {message}",
       "file_too_large": "{filename}: Datei ist zu groß. {message}",
+      "file_empty": "{filename}: Datei ist leer. {message}",
       "extension_not_allowed": "{filename}: Dateityp wird nicht unterstützt. {message}",
       "rate_limit_exceeded": "{filename}: Upload-Limit erreicht. {message}",
       "generic": "{filename}: Upload nicht erlaubt. {message}"

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -471,6 +471,8 @@
     "testing": "Testing Connection...",
     "testSuccess": "Connection Successful",
     "testFailed": "Connection Failed",
+    "testPickUpIncomplete": "Enter mail server, port, and username before testing.",
+    "testPickUpPasswordRequired": "Enter the mailbox password to test this configuration.",
     "savedHandlers": "Email Agents",
     "savedHandlersDesc": "Automate your inbox with AI-powered email agents that read, sort, and forward messages.",
     "createHandler": "New Email Agent",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -773,6 +773,10 @@
       "chatGeneration": "Response Generation",
       "messageClassification": "Message Classification",
       "clickToConfig": "Click to configure",
+      "purposeChip": {
+        "activeTooltip": "Already set as the default model for \"{purpose}\"",
+        "applyTooltip": "Set {model} as the default model for \"{purpose}\""
+      },
       "defaultConfig": "Default Model Configuration",
       "saveConfiguration": "Save Configuration",
       "resetForm": "Reset Form",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -671,7 +671,14 @@
     "reVectorizeFailed": "Reprocessing failed",
     "uploadSuccess": "{count} file(s) uploaded successfully",
     "uploadCancelled": "Upload cancelled",
-    "uploadInterrupted": "Transfer interrupted. The file list was refreshed — anything that had already reached the server may still appear."
+    "uploadInterrupted": "Transfer interrupted. The file list was refreshed — anything that had already reached the server may still appear.",
+    "uploadBlocked": {
+      "storage_exceeded": "{filename}: Not enough storage. {message}",
+      "file_too_large": "{filename}: File is too large. {message}",
+      "extension_not_allowed": "{filename}: File type is not supported. {message}",
+      "rate_limit_exceeded": "{filename}: Upload rate limit reached. {message}",
+      "generic": "{filename}: Upload is not allowed. {message}"
+    }
   },
   "fileMention": {
     "hint": "Type to search files — press Enter to attach",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -675,6 +675,7 @@
     "uploadBlocked": {
       "storage_exceeded": "{filename}: Not enough storage. {message}",
       "file_too_large": "{filename}: File is too large. {message}",
+      "file_empty": "{filename}: File is empty. {message}",
       "extension_not_allowed": "{filename}: File type is not supported. {message}",
       "rate_limit_exceeded": "{filename}: Upload rate limit reached. {message}",
       "generic": "{filename}: Upload is not allowed. {message}"

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -1310,6 +1310,10 @@
       "chatGeneration": "Generación de Respuestas",
       "messageClassification": "Clasificación de Mensajes",
       "clickToConfig": "Clic para configurar",
+      "purposeChip": {
+        "activeTooltip": "Ya establecido como modelo predeterminado para «{purpose}»",
+        "applyTooltip": "Establecer {model} como modelo predeterminado para «{purpose}»"
+      },
       "defaultConfig": "Configuración de Modelo Predeterminado",
       "saveConfiguration": "Guardar Configuración",
       "resetForm": "Restablecer Formulario",

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -1312,8 +1312,8 @@
       "messageClassification": "Mesaj Sınıflandırma",
       "clickToConfig": "Yapılandırmak için tıklayın",
       "purposeChip": {
-        "activeTooltip": "Zaten „{purpose}\" için varsayılan model olarak ayarlandı",
-        "applyTooltip": "{model} modelini „{purpose}\" için varsayılan model olarak ayarla"
+        "activeTooltip": "Zaten \"{purpose}\" için varsayılan model olarak ayarlandı",
+        "applyTooltip": "{model} modelini \"{purpose}\" için varsayılan model olarak ayarla"
       },
       "defaultConfig": "Varsayılan Model Yapılandırması",
       "saveConfiguration": "Yapılandırmayı Kaydet",

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -1311,6 +1311,10 @@
       "chatGeneration": "Yanıt Oluşturma",
       "messageClassification": "Mesaj Sınıflandırma",
       "clickToConfig": "Yapılandırmak için tıklayın",
+      "purposeChip": {
+        "activeTooltip": "Zaten „{purpose}\" için varsayılan model olarak ayarlandı",
+        "applyTooltip": "{model} modelini „{purpose}\" için varsayılan model olarak ayarla"
+      },
       "defaultConfig": "Varsayılan Model Yapılandırması",
       "saveConfiguration": "Yapılandırmayı Kaydet",
       "resetForm": "Formu Sıfırla",

--- a/frontend/src/services/api/chatApi.ts
+++ b/frontend/src/services/api/chatApi.ts
@@ -5,6 +5,7 @@
 import { z } from 'zod'
 import { httpClient, getApiBaseUrl } from './httpClient'
 import { UserMemorySchema } from './userMemoriesApi'
+import { hasSessionHint, clearSessionHint } from '@/services/sessionHint'
 import type { StreamUpdatePayload } from '@/types/chatStream'
 
 /**
@@ -52,9 +53,17 @@ let tokenProactiveTimer: ReturnType<typeof setTimeout> | null = null
 
 /**
  * Centralized token refresh - prevents concurrent refresh requests (stampede)
+ *
+ * Short-circuits when no session hint is present (issue #204): without
+ * this guard a guest hitting any chat surface would unconditionally fire
+ * `POST /api/v1/auth/refresh`, log a misleading "session expired" error
+ * and force-redirect to `/login?reason=session_expired`.
  */
 async function refreshAccessToken(): Promise<boolean> {
-  // If already refreshing, wait for that promise
+  if (!hasSessionHint()) {
+    return false
+  }
+
   if (tokenRefreshPromise) {
     return tokenRefreshPromise
   }
@@ -72,6 +81,9 @@ async function refreshAccessToken(): Promise<boolean> {
         return true
       }
 
+      // Server rejected the refresh - the cookie is gone. Clear the hint
+      // so subsequent calls short-circuit instead of repeating the dance.
+      clearSessionHint()
       return false
     } catch {
       return false
@@ -87,11 +99,22 @@ async function refreshAccessToken(): Promise<boolean> {
  * Get access token for SSE (EventSource can't send cookies)
  * Handles 401 with automatic token refresh
  * Throws error if authentication fails (triggers redirect to login)
+ *
+ * Short-circuits cleanly when no session hint is present (issue #204):
+ * unauthenticated callers — guests, page warm-ups, anything pre-login —
+ * get `null` back without firing any network requests or console errors.
+ * The misleading "Token refresh failed - session expired" log only
+ * surfaces when there genuinely WAS a session that just expired.
  */
 async function getSseToken(): Promise<string | null> {
   // Return cached token if available
   if (cachedSseToken) {
     return cachedSseToken
+  }
+
+  // Issue #204: never bootstrap auth for callers that have no session.
+  if (!hasSessionHint()) {
+    return null
   }
 
   // Prevent multiple simultaneous fetches

--- a/frontend/src/services/api/httpClient.ts
+++ b/frontend/src/services/api/httpClient.ts
@@ -5,6 +5,7 @@
 
 import { z } from 'zod'
 import { GetApiConfigRuntimeConfigResponseSchema } from '@/generated/api-schemas'
+import { hasSessionHint, clearSessionHint } from '@/services/sessionHint'
 
 // API base URL - lazy initialized on first use
 // For admin UI: empty string (same-origin)
@@ -221,8 +222,19 @@ function recordAuthFailure(): void {
  * Refresh access token using refresh token cookie.
  * For OIDC users, this refreshes against Keycloak.
  * If Keycloak rejects the refresh (user logged out), returns oidcSessionExpired: true
+ *
+ * Short-circuits without a network call when no session hint is present
+ * (e.g. first visit, incognito, after clearing storage). This prevents the
+ * 401 cascade that issue #204 documented on a fresh visit, and makes the
+ * refresh path safe to invoke from any code path without leaking misleading
+ * "session expired" noise into the console for users who never had a
+ * session in the first place.
  */
 async function refreshAccessToken(): Promise<RefreshResult> {
+  if (!hasSessionHint()) {
+    return { success: false }
+  }
+
   if (isRefreshing && refreshPromise) {
     return refreshPromise as Promise<RefreshResult>
   }
@@ -240,6 +252,10 @@ async function refreshAccessToken(): Promise<RefreshResult> {
         authFailureCount = 0
         return { success: true }
       }
+
+      // Refresh definitively failed - the stored cookie is dead. Clear the
+      // hint so future visits don't keep retrying against a closed session.
+      clearSessionHint()
 
       // Check if this was an OIDC session expiry (user logged out from Keycloak)
       try {

--- a/frontend/src/services/api/inboundEmailHandlersApi.ts
+++ b/frontend/src/services/api/inboundEmailHandlersApi.ts
@@ -114,8 +114,13 @@ export interface TestMailboxConnectionBody {
   username: string
   /** Omit when reusing saved password via handlerId */
   password?: string
-  /** When password is omitted/masked, load stored password for this handler */
-  handlerId?: string
+  /**
+   * When password is omitted/masked, load the stored password for this
+   * handler. Accepts string (from form inputs) or number (from API
+   * responses); a non-finite or non-positive value is treated as "not
+   * provided" by `testMailboxConnection`.
+   */
+  handlerId?: string | number
 }
 
 export interface UpdateHandlerRequest {
@@ -279,13 +284,26 @@ export const inboundEmailHandlersApi = {
     }
 
     const pwd = body.password ?? ''
+    // Parse handlerId defensively: the caller may pass a string from a
+    // form, a number, or `undefined`. Number(undefined)/Number('') yield
+    // NaN, which JSON-serializes to `null` and the backend then casts to
+    // 0 — silently looking up handler #0 and 404-ing. Coerce only when
+    // we actually have a finite positive integer.
+    const parsedHandlerId =
+      body.handlerId === undefined || body.handlerId === ''
+        ? null
+        : (() => {
+            const n =
+              typeof body.handlerId === 'number'
+                ? body.handlerId
+                : parseInt(String(body.handlerId), 10)
+            return Number.isFinite(n) && n > 0 ? n : null
+          })()
     const useStoredPassword =
-      body.handlerId !== undefined &&
-      body.handlerId !== '' &&
-      (pwd === '' || pwd === MASKED_MAIL_PASSWORD_PLACEHOLDER)
+      parsedHandlerId !== null && (pwd === '' || pwd === MASKED_MAIL_PASSWORD_PLACEHOLDER)
 
     if (useStoredPassword) {
-      payload.handlerId = Number(body.handlerId)
+      payload.handlerId = parsedHandlerId
     } else if (pwd !== '') {
       payload.password = pwd
     }

--- a/frontend/src/services/api/inboundEmailHandlersApi.ts
+++ b/frontend/src/services/api/inboundEmailHandlersApi.ts
@@ -5,6 +5,10 @@
  */
 
 import { httpClient } from './httpClient'
+import { PostApiInboundEmailHandlersTestConnectionPreviewResponseSchema } from '@/generated/api-schemas'
+
+/** Backend masked secret placeholder (must match ToolsView and API). */
+export const MASKED_MAIL_PASSWORD_PLACEHOLDER = '••••••••' as const
 
 // Backend Response Types
 export interface BackendMailHandler {
@@ -100,6 +104,18 @@ export interface CreateHandlerRequest {
   // Email filter settings
   emailFilterMode: 'new' | 'historical'
   emailFilterFromDate?: string | null
+}
+
+export interface TestMailboxConnectionBody {
+  mailServer: string
+  port: number
+  protocol: 'IMAP' | 'POP3'
+  security: 'SSL/TLS' | 'STARTTLS' | 'None'
+  username: string
+  /** Omit when reusing saved password via handlerId */
+  password?: string
+  /** When password is omitted/masked, load stored password for this handler */
+  handlerId?: string
 }
 
 export interface UpdateHandlerRequest {
@@ -246,6 +262,44 @@ export const inboundEmailHandlersApi = {
       `/api/v1/inbound-email-handlers/${id}`,
       { method: 'DELETE' }
     )
+  },
+
+  /**
+   * Test mailbox (IMAP/POP3) with unsaved form values (no handler ID required).
+   */
+  async testMailboxConnection(
+    body: TestMailboxConnectionBody
+  ): Promise<{ success: boolean; message: string }> {
+    const payload: Record<string, unknown> = {
+      mailServer: body.mailServer,
+      port: body.port,
+      protocol: body.protocol,
+      security: body.security,
+      username: body.username,
+    }
+
+    const pwd = body.password ?? ''
+    const useStoredPassword =
+      body.handlerId !== undefined &&
+      body.handlerId !== '' &&
+      (pwd === '' || pwd === MASKED_MAIL_PASSWORD_PLACEHOLDER)
+
+    if (useStoredPassword) {
+      payload.handlerId = Number(body.handlerId)
+    } else if (pwd !== '') {
+      payload.password = pwd
+    }
+
+    const data = await httpClient('/api/v1/inbound-email-handlers/test-connection', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+      schema: PostApiInboundEmailHandlersTestConnectionPreviewResponseSchema,
+    })
+
+    return {
+      success: data.success === true,
+      message: typeof data.message === 'string' ? data.message : '',
+    }
   },
 
   /**

--- a/frontend/src/services/apiService.ts
+++ b/frontend/src/services/apiService.ts
@@ -1,5 +1,6 @@
 import type { AIModel } from '@/stores/models'
 import { getApiBaseUrl } from '@/services/api/httpClient'
+import { hasSessionHint, clearSessionHint } from '@/services/sessionHint'
 import type { z } from 'zod'
 
 export interface DefaultModelConfig {
@@ -44,9 +45,16 @@ function redirectToSessionExpired(): void {
 
 /**
  * Centralized token refresh - prevents concurrent refresh requests (stampede)
+ *
+ * Short-circuits when no session hint is present (issue #204) so that
+ * unauthenticated callers never trigger an `/api/v1/auth/refresh` round-trip
+ * just to get an expected 401 back.
  */
 async function refreshAccessToken(): Promise<boolean> {
-  // If already refreshing, wait for that promise
+  if (!hasSessionHint()) {
+    return false
+  }
+
   if (tokenRefreshPromise) {
     return tokenRefreshPromise
   }
@@ -58,6 +66,10 @@ async function refreshAccessToken(): Promise<boolean> {
         credentials: 'include',
       })
 
+      if (!refreshResponse.ok) {
+        // Stored cookie is dead - drop the hint so the next call short-circuits.
+        clearSessionHint()
+      }
       return refreshResponse.ok
     } catch (error) {
       console.error('Token refresh error:', error)

--- a/frontend/src/services/authService.ts
+++ b/frontend/src/services/authService.ts
@@ -14,6 +14,7 @@
 import { ref, type Ref } from 'vue'
 import { clearSseToken } from '@/services/api/chatApi'
 import { getApiBaseUrl } from '@/services/api/httpClient'
+import { setSessionHint, clearSessionHint, hasSessionHint } from '@/services/sessionHint'
 
 const API_BASE_URL = getApiBaseUrl()
 
@@ -47,39 +48,6 @@ const impersonator = ref<ImpersonatorInfo | null>(null)
 const isRefreshing = ref(false)
 const isLoggingOut = ref(false) // Prevent auth checks during logout
 let refreshPromise: Promise<boolean> | null = null
-
-/**
- * Session hint key in localStorage.
- * NOT security-sensitive - purely an optimization flag to avoid unnecessary
- * 401 requests (GET /auth/me + POST /auth/refresh) for users who have
- * never logged in. Set on successful auth, cleared on logout.
- */
-const SESSION_HINT_KEY = 'sh'
-
-function setSessionHint(): void {
-  try {
-    localStorage.setItem(SESSION_HINT_KEY, '1')
-  } catch {
-    // localStorage unavailable - graceful degradation
-  }
-}
-
-function clearSessionHint(): void {
-  try {
-    localStorage.removeItem(SESSION_HINT_KEY)
-  } catch {
-    // localStorage unavailable - graceful degradation
-  }
-}
-
-function hasSessionHint(): boolean {
-  try {
-    return localStorage.getItem(SESSION_HINT_KEY) === '1'
-  } catch {
-    // localStorage unavailable - assume session might exist to avoid breaking auth
-    return true
-  }
-}
 
 export const authService = {
   /**

--- a/frontend/src/services/filesService.ts
+++ b/frontend/src/services/filesService.ts
@@ -4,6 +4,7 @@ import { httpClient, getApiBaseUrl, refreshAccessToken } from './api/httpClient'
 export type UploadCheckReason =
   | 'rate_limit_exceeded'
   | 'file_too_large'
+  | 'file_empty'
   | 'extension_not_allowed'
   | 'storage_exceeded'
 
@@ -136,10 +137,17 @@ export interface FileListResponse {
  * @returns Upload response with file details
  */
 export const uploadFiles = async (options: UploadFileOptions): Promise<UploadResponse> => {
-  for (const file of options.files) {
-    const check = await checkUpload(file.name, file.size, file.type)
-    if (!check.allowed) {
-      throw new UploadBlockedError(file.name, check)
+  // Pre-flight all files concurrently — N small HEAD-style metadata
+  // requests in parallel beat N sequential round-trips when the user
+  // drops a folder of files. We throw on the FIRST rejection we
+  // encounter (in original file-order) so the user sees the same error
+  // regardless of network jitter.
+  const checks = await Promise.all(
+    options.files.map((file) => checkUpload(file.name, file.size, file.type))
+  )
+  for (let i = 0; i < options.files.length; i++) {
+    if (!checks[i].allowed) {
+      throw new UploadBlockedError(options.files[i].name, checks[i])
     }
   }
 

--- a/frontend/src/services/filesService.ts
+++ b/frontend/src/services/filesService.ts
@@ -1,6 +1,58 @@
 import { api } from './apiService'
 import { httpClient, getApiBaseUrl, refreshAccessToken } from './api/httpClient'
 
+export type UploadCheckReason =
+  | 'rate_limit_exceeded'
+  | 'file_too_large'
+  | 'extension_not_allowed'
+  | 'storage_exceeded'
+
+export interface UploadCheckResponse {
+  allowed: boolean
+  reason?: UploadCheckReason
+  message?: string
+  max_file_size: number
+  allowed_extensions: string[]
+  remaining: number
+  used?: number
+  limit?: number
+}
+
+/**
+ * UploadBlockedError — thrown when the server's pre-flight check rejects an upload.
+ * Catch this in the UI to show a clear, i18n-friendly message instead of waiting
+ * for the slow upload to time out.
+ */
+export class UploadBlockedError extends Error {
+  public readonly reason: UploadCheckReason
+  public readonly check: UploadCheckResponse
+  public readonly filename: string
+
+  constructor(filename: string, check: UploadCheckResponse) {
+    super(check.message ?? 'Upload not allowed')
+    this.name = 'UploadBlockedError'
+    this.filename = filename
+    this.reason = (check.reason ?? 'storage_exceeded') as UploadCheckReason
+    this.check = check
+  }
+}
+
+/**
+ * Pre-flight check before uploading a file body. Sends only metadata so the
+ * server can reject quota/size/extension/rate-limit violations in milliseconds.
+ */
+export async function checkUpload(
+  filename: string,
+  size: number,
+  mime?: string
+): Promise<UploadCheckResponse> {
+  return httpClient<UploadCheckResponse>('/api/v1/files/check-upload', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ filename, size, mime }),
+  })
+}
+
 export interface UploadFileOptions {
   files: File[]
   groupKey?: string
@@ -68,14 +120,29 @@ export interface FileListResponse {
 }
 
 /**
- * Upload files with processing and progress tracking
+ * Upload files with processing and progress tracking.
  *
- * Uses XMLHttpRequest to enable upload progress monitoring.
+ * Performs a metadata-only pre-flight check first (filename + size) so that
+ * uploads which would be rejected for quota, size, extension, or rate-limit
+ * reasons fail FAST and deterministically — preventing client/proxy timeouts
+ * when streaming a large body that is going to be rejected anyway.
+ *
+ * Throws {@link UploadBlockedError} when the pre-flight rejects a file. The UI
+ * should catch this and surface the localized message to the user.
+ *
+ * Uses XMLHttpRequest for the actual transfer to support upload progress.
  *
  * @param options Upload options with files, processing level, and optional progress callback
  * @returns Upload response with file details
  */
 export const uploadFiles = async (options: UploadFileOptions): Promise<UploadResponse> => {
+  for (const file of options.files) {
+    const check = await checkUpload(file.name, file.size, file.type)
+    if (!check.allowed) {
+      throw new UploadBlockedError(file.name, check)
+    }
+  }
+
   const buildFormData = (): FormData => {
     const fd = new FormData()
     options.files.forEach((file) => fd.append('files[]', file))
@@ -380,36 +447,29 @@ export const getShareInfo = async (
   return response.data
 }
 
+export interface StorageStats {
+  limit: number
+  usage: number
+  remaining: number
+  percentage: number
+  limit_formatted: string
+  usage_formatted: string
+  remaining_formatted: string
+  max_file_size: number
+  max_file_size_formatted: string
+}
+
+export interface StorageStatsResponse {
+  success: boolean
+  user_level: string
+  storage: StorageStats
+}
+
 /**
  * Get storage quota statistics
  */
-export async function getStorageStats(): Promise<{
-  success: boolean
-  user_level: string
-  storage: {
-    limit: number
-    usage: number
-    remaining: number
-    percentage: number
-    limit_formatted: string
-    usage_formatted: string
-    remaining_formatted: string
-  }
-}> {
-  const response = await httpClient<{
-    success: boolean
-    user_level: string
-    storage: {
-      limit: number
-      usage: number
-      remaining: number
-      percentage: number
-      limit_formatted: string
-      usage_formatted: string
-      remaining_formatted: string
-    }
-  }>('/api/v1/files/storage-stats')
-  return response
+export async function getStorageStats(): Promise<StorageStatsResponse> {
+  return httpClient<StorageStatsResponse>('/api/v1/files/storage-stats')
 }
 
 /**
@@ -519,6 +579,7 @@ export async function processFile(
 
 export default {
   uploadFiles,
+  checkUpload,
   listFiles,
   deleteFile,
   deleteMultipleFiles,

--- a/frontend/src/services/sessionHint.ts
+++ b/frontend/src/services/sessionHint.ts
@@ -1,0 +1,66 @@
+/**
+ * Session Hint - lightweight client-side flag indicating whether the user
+ * has ever successfully authenticated in this browser profile.
+ *
+ * NOT security-sensitive: the cookie-based session is the source of truth.
+ * The hint is purely a UX optimization that prevents this cascade of
+ * 401 noise on a fresh visit (incognito / cleared storage):
+ *
+ *     GET  /api/v1/auth/me        → 401
+ *     POST /api/v1/auth/refresh   → 401
+ *     "Token refresh failed, logging out"
+ *     POST /api/v1/auth/logout    → 401
+ *     → forced redirect to /login?reason=session_expired
+ *
+ * Without the hint, ANY API call that gets a 401 (auth/me, SSE token,
+ * any protected endpoint) would unconditionally try to refresh — even
+ * for users who have never logged in. With the hint, refresh attempts
+ * short-circuit immediately when no prior session is known.
+ *
+ * Set: on successful login / getCurrentUser / refresh / OAuth callback.
+ * Cleared: on logout (silent or not) and on refresh failure.
+ *
+ * Related: https://github.com/metadist/synaplan/issues/204
+ */
+
+const SESSION_HINT_KEY = 'sh'
+
+/**
+ * Mark the current browser as having an active (or recently active) session.
+ * Subsequent visits will then attempt auth bootstrap; without it we skip
+ * the whole refresh dance.
+ */
+export function setSessionHint(): void {
+  try {
+    localStorage.setItem(SESSION_HINT_KEY, '1')
+  } catch {
+    // localStorage unavailable (private mode quotas, disabled storage) -
+    // graceful degradation: we accept the extra 401 on next visit rather
+    // than fail the login flow.
+  }
+}
+
+/**
+ * Clear the hint. Called on logout and whenever a refresh definitively
+ * fails (the cookie is dead — don't pretend the user still has a session).
+ */
+export function clearSessionHint(): void {
+  try {
+    localStorage.removeItem(SESSION_HINT_KEY)
+  } catch {
+    // localStorage unavailable - graceful degradation
+  }
+}
+
+/**
+ * True when this browser has at least one historical successful auth.
+ * Returns `true` if localStorage is unavailable, so we never accidentally
+ * lock a working session out just because storage is sandboxed.
+ */
+export function hasSessionHint(): boolean {
+  try {
+    return localStorage.getItem(SESSION_HINT_KEY) === '1'
+  } catch {
+    return true
+  }
+}

--- a/frontend/src/utils/aiModelDedupe.ts
+++ b/frontend/src/utils/aiModelDedupe.ts
@@ -1,0 +1,48 @@
+/**
+ * Issue #261: dedupe the AI model catalogue so the "Available Models"
+ * table shows each model ONCE, with the purposes it supports surfaced as
+ * a list of selectable chips. The backend's getModels response is keyed
+ * by purpose (`Partial<Record<Capability, AIModel[]>>`) so the same model
+ * legitimately appears in several buckets; this helper folds those
+ * buckets back into a single row per model id.
+ */
+import type { AIModel, Capability } from '@/types/ai-models'
+
+export type ModelWithPurposes = AIModel & { purposes: Capability[] }
+
+export type ModelsByPurpose = Partial<Record<Capability, AIModel[]>>
+
+/**
+ * Collapse a purpose-keyed model map into one entry per model.
+ *
+ * - `purposes` is appended in `purposeOrder` so the chips render in a
+ *   stable, canonical sequence regardless of how the API returned them.
+ * - The first occurrence of a given id is treated as the canonical model
+ *   metadata (name / service / quality / …). The backend's seed data
+ *   keeps these identical across purposes, but we don't gamble on it.
+ * - Empty input → empty output; unknown purposes in the input map are
+ *   skipped (callers control the supported `purposeOrder`).
+ */
+export function dedupeModelsByPurpose(
+  modelsByPurpose: ModelsByPurpose,
+  purposeOrder: readonly Capability[]
+): ModelWithPurposes[] {
+  const byId = new Map<number, ModelWithPurposes>()
+
+  for (const purpose of purposeOrder) {
+    const models = modelsByPurpose[purpose]
+    if (!models) continue
+    for (const model of models) {
+      const existing = byId.get(model.id)
+      if (existing) {
+        if (!existing.purposes.includes(purpose)) {
+          existing.purposes.push(purpose)
+        }
+      } else {
+        byId.set(model.id, { ...model, purposes: [purpose] })
+      }
+    }
+  }
+
+  return [...byId.values()]
+}

--- a/frontend/src/utils/aiModelDedupe.ts
+++ b/frontend/src/utils/aiModelDedupe.ts
@@ -4,22 +4,39 @@
  * a list of selectable chips. The backend's getModels response is keyed
  * by purpose (`Partial<Record<Capability, AIModel[]>>`) so the same model
  * legitimately appears in several buckets; this helper folds those
- * buckets back into a single row per model id.
+ * buckets back into a single display row.
+ *
+ * The dedup key is `(service, name)` — not the model id — because the
+ * BMODELS catalogue intentionally registers some models under multiple
+ * ids: e.g. "Claude Opus 4.6" is two rows, one with BTAG=chat (id 160,
+ * surfaced under CHAT/SORT/ANALYZE) and one with BTAG=mem (id 222,
+ * surfaced under MEM). Both rows describe the same user-visible model;
+ * what differs is the backend-side id we must persist when the user
+ * picks a given purpose. Each chip therefore carries its own `modelId`,
+ * so clicking "CHAT" stores id 160 while "MEM" stores id 222.
  */
 import type { AIModel, Capability } from '@/types/ai-models'
 
-export type ModelWithPurposes = AIModel & { purposes: Capability[] }
+/**
+ * One selectable chip on a dedup'd row. `modelId` is the backend id to
+ * persist when the user activates this purpose for the row.
+ */
+export type PurposeChip = { purpose: Capability; modelId: number }
+
+export type ModelWithPurposes = AIModel & { purposes: PurposeChip[] }
 
 export type ModelsByPurpose = Partial<Record<Capability, AIModel[]>>
 
 /**
- * Collapse a purpose-keyed model map into one entry per model.
+ * Collapse a purpose-keyed model map into one entry per (service, name).
  *
- * - `purposes` is appended in `purposeOrder` so the chips render in a
- *   stable, canonical sequence regardless of how the API returned them.
- * - The first occurrence of a given id is treated as the canonical model
- *   metadata (name / service / quality / …). The backend's seed data
- *   keeps these identical across purposes, but we don't gamble on it.
+ * - Chips append in `purposeOrder` so they render in a stable canonical
+ *   sequence regardless of API response ordering.
+ * - The first occurrence of a given (service, name) wins as the row's
+ *   canonical metadata (description / quality / icon). The backend keeps
+ *   these in sync across BMODELS rows in practice; if they diverge the
+ *   first row is the source of truth for display purposes only — chip
+ *   clicks still route to the per-purpose id.
  * - Empty input → empty output; unknown purposes in the input map are
  *   skipped (callers control the supported `purposeOrder`).
  */
@@ -27,22 +44,26 @@ export function dedupeModelsByPurpose(
   modelsByPurpose: ModelsByPurpose,
   purposeOrder: readonly Capability[]
 ): ModelWithPurposes[] {
-  const byId = new Map<number, ModelWithPurposes>()
+  const byKey = new Map<string, ModelWithPurposes>()
 
   for (const purpose of purposeOrder) {
     const models = modelsByPurpose[purpose]
     if (!models) continue
     for (const model of models) {
-      const existing = byId.get(model.id)
+      const key = `${model.service}\u0000${model.name}`
+      const existing = byKey.get(key)
       if (existing) {
-        if (!existing.purposes.includes(purpose)) {
-          existing.purposes.push(purpose)
+        if (!existing.purposes.some((chip) => chip.purpose === purpose)) {
+          existing.purposes.push({ purpose, modelId: model.id })
         }
       } else {
-        byId.set(model.id, { ...model, purposes: [purpose] })
+        byKey.set(key, {
+          ...model,
+          purposes: [{ purpose, modelId: model.id }],
+        })
       }
     }
   }
 
-  return [...byId.values()]
+  return [...byKey.values()]
 }

--- a/frontend/src/views/FilesView.vue
+++ b/frontend/src/views/FilesView.vue
@@ -1737,19 +1737,24 @@ const uploadFiles = async () => {
 }
 
 const translateUploadBlocked = (err: UploadBlockedError): string => {
-  const key = `files.uploadBlocked.${err.reason}`
-  // Fall back to a generic translated message if the reason key is missing
-  const translated = t(key, {
+  const params = {
     filename: err.filename,
     message: err.check.message ?? '',
-  })
-  if (translated === key) {
-    return t('files.uploadBlocked.generic', {
-      filename: err.filename,
-      message: err.check.message ?? '',
-    })
   }
-  return translated
+  const reasonKey = `files.uploadBlocked.${err.reason}`
+  const reasonTranslated = t(reasonKey, params)
+  if (reasonTranslated !== reasonKey) return reasonTranslated
+
+  // Reason-specific copy missing in the active locale → try the generic
+  // localized template.
+  const genericKey = 'files.uploadBlocked.generic'
+  const genericTranslated = t(genericKey, params)
+  if (genericTranslated !== genericKey) return genericTranslated
+
+  // Both keys missing → never show the raw `files.uploadBlocked.x`
+  // dot-path to the user. Fall back to a non-i18n string that still
+  // carries the filename + backend message.
+  return params.message ? `${params.filename}: ${params.message}` : params.filename
 }
 
 const handleUpgrade = () => {

--- a/frontend/src/views/FilesView.vue
+++ b/frontend/src/views/FilesView.vue
@@ -1245,7 +1245,11 @@ import {
   XMarkIcon,
   ExclamationTriangleIcon,
 } from '@heroicons/vue/24/outline'
-import filesService, { type FileItem, type UploadProgress } from '@/services/filesService'
+import filesService, {
+  type FileItem,
+  type UploadProgress,
+  UploadBlockedError,
+} from '@/services/filesService'
 import { useNotification } from '@/composables/useNotification'
 import { useFilePersistence } from '@/composables/useInputPersistence'
 
@@ -1639,8 +1643,13 @@ const onFolderDrop = async (event: DragEvent, folderName: string) => {
       result.errors.forEach((err) => showError(`${err.filename}: ${err.error}`))
     }
   } catch (err) {
-    console.error('Upload error:', err)
-    showError('Failed to upload files: ' + (err as Error).message)
+    if (err instanceof UploadBlockedError) {
+      showError(translateUploadBlocked(err))
+      if (storageWidget.value) await storageWidget.value.refresh()
+    } else {
+      console.error('Upload error:', err)
+      showError('Failed to upload files: ' + (err as Error).message)
+    }
   } finally {
     isUploading.value = false
     uploadProgress.value = null
@@ -1714,12 +1723,33 @@ const uploadFiles = async () => {
       })
     }
   } catch (error) {
-    console.error('Upload error:', error)
-    showError('Failed to upload files: ' + (error as Error).message)
+    if (error instanceof UploadBlockedError) {
+      showError(translateUploadBlocked(error))
+      if (storageWidget.value) await storageWidget.value.refresh()
+    } else {
+      console.error('Upload error:', error)
+      showError('Failed to upload files: ' + (error as Error).message)
+    }
   } finally {
     isUploading.value = false
     uploadProgress.value = null
   }
+}
+
+const translateUploadBlocked = (err: UploadBlockedError): string => {
+  const key = `files.uploadBlocked.${err.reason}`
+  // Fall back to a generic translated message if the reason key is missing
+  const translated = t(key, {
+    filename: err.filename,
+    message: err.check.message ?? '',
+  })
+  if (translated === key) {
+    return t('files.uploadBlocked.generic', {
+      filename: err.filename,
+      message: err.check.message ?? '',
+    })
+  }
+  return translated
 }
 
 const handleUpgrade = () => {

--- a/frontend/tests/unit/api/httpClient-refresh.spec.ts
+++ b/frontend/tests/unit/api/httpClient-refresh.spec.ts
@@ -1,0 +1,86 @@
+/**
+ * Regression tests for issue #204: token refresh must NOT hit the network
+ * when no client-side session hint exists. A fresh visit (incognito,
+ * cleared storage) should never produce the 401 cascade
+ *
+ *   POST /api/v1/auth/refresh → 401 → "Token refresh failed, logging out"
+ *
+ * even though no user has ever logged in on this browser.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { refreshAccessToken } from '@/services/api/httpClient'
+import { setSessionHint, clearSessionHint } from '@/services/sessionHint'
+
+describe('httpClient.refreshAccessToken — session hint guard (#204)', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    localStorage.clear()
+    fetchSpy = vi.spyOn(globalThis, 'fetch')
+  })
+
+  afterEach(() => {
+    fetchSpy.mockRestore()
+  })
+
+  function refreshCalls(): unknown[][] {
+    return (fetchSpy.mock.calls as unknown as unknown[][]).filter((call) =>
+      String(call[0]).includes('/api/v1/auth/refresh')
+    )
+  }
+
+  it('short-circuits without a network call when no session hint is set', async () => {
+    clearSessionHint()
+
+    const result = await refreshAccessToken()
+
+    expect(result).toEqual({ success: false })
+    expect(refreshCalls()).toHaveLength(0)
+  })
+
+  it('does perform the refresh once a session hint is present', async () => {
+    setSessionHint()
+
+    fetchSpy.mockImplementation(((url: RequestInfo | URL) => {
+      if (String(url).includes('/api/v1/auth/refresh')) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ success: true }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          })
+        )
+      }
+      return Promise.resolve(new Response('', { status: 404 }))
+    }) as typeof fetch)
+
+    const result = await refreshAccessToken()
+
+    expect(result.success).toBe(true)
+    expect(refreshCalls()).toHaveLength(1)
+  })
+
+  it('clears the session hint when the server rejects the refresh', async () => {
+    setSessionHint()
+
+    fetchSpy.mockImplementation(((url: RequestInfo | URL) => {
+      if (String(url).includes('/api/v1/auth/refresh')) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ error: 'expired' }), {
+            status: 401,
+            headers: { 'Content-Type': 'application/json' },
+          })
+        )
+      }
+      return Promise.resolve(new Response('', { status: 404 }))
+    }) as typeof fetch)
+
+    await refreshAccessToken()
+
+    // Subsequent call must short-circuit without hitting the network again.
+    fetchSpy.mockClear()
+    const secondResult = await refreshAccessToken()
+
+    expect(secondResult).toEqual({ success: false })
+    expect(refreshCalls()).toHaveLength(0)
+  })
+})

--- a/frontend/tests/unit/api/inboundEmailHandlersApi.spec.ts
+++ b/frontend/tests/unit/api/inboundEmailHandlersApi.spec.ts
@@ -283,5 +283,53 @@ describe('inboundEmailHandlersApi', () => {
       })
       expect(payload.password).toBeUndefined()
     })
+
+    it('omits handlerId when value is not a positive integer (NaN-safe)', async () => {
+      vi.mocked(httpClient).mockResolvedValue({
+        success: true,
+        message: 'Connection successful',
+      })
+
+      // Garbage handlerId + plain password → only the password ends up
+      // in the payload. We never want to send `handlerId: NaN` (which
+      // serializes to `null` and the backend would cast to 0).
+      await inboundEmailHandlersApi.testMailboxConnection({
+        mailServer: 'imap.test.com',
+        port: 993,
+        protocol: 'IMAP',
+        security: 'SSL/TLS',
+        username: 'user@test.com',
+        password: 'plain-secret',
+        handlerId: 'not-a-number',
+      })
+
+      const payload = JSON.parse(
+        (vi.mocked(httpClient).mock.calls[0]?.[1] as { body: string }).body
+      )
+      expect(payload.handlerId).toBeUndefined()
+      expect(payload.password).toBe('plain-secret')
+    })
+
+    it('omits handlerId when value is zero or negative', async () => {
+      vi.mocked(httpClient).mockResolvedValue({
+        success: true,
+        message: 'Connection successful',
+      })
+
+      await inboundEmailHandlersApi.testMailboxConnection({
+        mailServer: 'imap.test.com',
+        port: 993,
+        protocol: 'IMAP',
+        security: 'SSL/TLS',
+        username: 'user@test.com',
+        password: 'plain-secret',
+        handlerId: 0,
+      })
+
+      const payload = JSON.parse(
+        (vi.mocked(httpClient).mock.calls[0]?.[1] as { body: string }).body
+      )
+      expect(payload.handlerId).toBeUndefined()
+    })
   })
 })

--- a/frontend/tests/unit/api/inboundEmailHandlersApi.spec.ts
+++ b/frontend/tests/unit/api/inboundEmailHandlersApi.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { inboundEmailHandlersApi } from '@/services/api/inboundEmailHandlersApi'
+import { inboundEmailHandlersApi, MASKED_MAIL_PASSWORD_PLACEHOLDER } from '@/services/api/inboundEmailHandlersApi'
 import { httpClient } from '@/services/api/httpClient'
 
 vi.mock('@/services/api/httpClient', () => ({
@@ -223,6 +223,60 @@ describe('inboundEmailHandlersApi', () => {
 
       expect(result.success).toBe(false)
       expect(result.message).toContain('Invalid credentials')
+    })
+  })
+
+  describe('testMailboxConnection', () => {
+    it('posts plain password for preview test', async () => {
+      vi.mocked(httpClient).mockResolvedValue({
+        success: true,
+        message: 'Connection successful',
+      })
+
+      await inboundEmailHandlersApi.testMailboxConnection({
+        mailServer: 'imap.test.com',
+        port: 993,
+        protocol: 'IMAP',
+        security: 'SSL/TLS',
+        username: 'user@test.com',
+        password: 'plain-secret',
+      })
+
+      expect(httpClient).toHaveBeenCalledWith(
+        '/api/v1/inbound-email-handlers/test-connection',
+        expect.objectContaining({
+          method: 'POST',
+          body: expect.stringContaining('"password":"plain-secret"'),
+        })
+      )
+    })
+
+    it('sends handlerId instead of password when password is masked', async () => {
+      vi.mocked(httpClient).mockResolvedValue({
+        success: true,
+        message: 'Connection successful',
+      })
+
+      await inboundEmailHandlersApi.testMailboxConnection({
+        mailServer: 'imap.test.com',
+        port: 993,
+        protocol: 'IMAP',
+        security: 'SSL/TLS',
+        username: 'user@test.com',
+        password: MASKED_MAIL_PASSWORD_PLACEHOLDER,
+        handlerId: '7',
+      })
+
+      const payload = JSON.parse((vi.mocked(httpClient).mock.calls[0]?.[1] as { body: string }).body)
+      expect(payload).toEqual({
+        mailServer: 'imap.test.com',
+        port: 993,
+        protocol: 'IMAP',
+        security: 'SSL/TLS',
+        username: 'user@test.com',
+        handlerId: 7,
+      })
+      expect(payload.password).toBeUndefined()
     })
   })
 })

--- a/frontend/tests/unit/api/inboundEmailHandlersApi.spec.ts
+++ b/frontend/tests/unit/api/inboundEmailHandlersApi.spec.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { inboundEmailHandlersApi, MASKED_MAIL_PASSWORD_PLACEHOLDER } from '@/services/api/inboundEmailHandlersApi'
+import {
+  inboundEmailHandlersApi,
+  MASKED_MAIL_PASSWORD_PLACEHOLDER,
+} from '@/services/api/inboundEmailHandlersApi'
 import { httpClient } from '@/services/api/httpClient'
 
 vi.mock('@/services/api/httpClient', () => ({
@@ -267,7 +270,9 @@ describe('inboundEmailHandlersApi', () => {
         handlerId: '7',
       })
 
-      const payload = JSON.parse((vi.mocked(httpClient).mock.calls[0]?.[1] as { body: string }).body)
+      const payload = JSON.parse(
+        (vi.mocked(httpClient).mock.calls[0]?.[1] as { body: string }).body
+      )
       expect(payload).toEqual({
         mailServer: 'imap.test.com',
         port: 993,

--- a/frontend/tests/unit/services/filesService.spec.ts
+++ b/frontend/tests/unit/services/filesService.spec.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { checkUpload, uploadFiles, UploadBlockedError } from '@/services/filesService'
+import { httpClient } from '@/services/api/httpClient'
+
+vi.mock('@/services/api/httpClient', () => ({
+  httpClient: vi.fn(),
+  getApiBaseUrl: vi.fn(() => 'http://localhost:8000'),
+  refreshAccessToken: vi.fn(),
+}))
+
+const mockedHttpClient = vi.mocked(httpClient)
+
+describe('filesService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('checkUpload (pre-flight)', () => {
+    it('POSTs filename + size to /api/v1/files/check-upload', async () => {
+      mockedHttpClient.mockResolvedValueOnce({
+        allowed: true,
+        max_file_size: 128 * 1024 * 1024,
+        allowed_extensions: ['pdf', 'txt'],
+        remaining: 5 * 1024 * 1024,
+      })
+
+      const result = await checkUpload('doc.pdf', 1024, 'application/pdf')
+
+      expect(httpClient).toHaveBeenCalledWith('/api/v1/files/check-upload', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ filename: 'doc.pdf', size: 1024, mime: 'application/pdf' }),
+      })
+      expect(result.allowed).toBe(true)
+      expect(result.max_file_size).toBe(128 * 1024 * 1024)
+    })
+
+    it('returns the rejection payload unchanged', async () => {
+      mockedHttpClient.mockResolvedValueOnce({
+        allowed: false,
+        reason: 'storage_exceeded',
+        message: 'Storage limit exceeded. You have 1 MB remaining, but the file is 5 MB.',
+        max_file_size: 128 * 1024 * 1024,
+        allowed_extensions: ['pdf'],
+        remaining: 1024 * 1024,
+      })
+
+      const result = await checkUpload('big.pdf', 5 * 1024 * 1024)
+
+      expect(result.allowed).toBe(false)
+      expect(result.reason).toBe('storage_exceeded')
+      expect(result.message).toContain('Storage limit exceeded')
+    })
+  })
+
+  describe('uploadFiles pre-flight integration', () => {
+    it('throws UploadBlockedError BEFORE attempting the actual upload when quota is exceeded', async () => {
+      mockedHttpClient.mockResolvedValueOnce({
+        allowed: false,
+        reason: 'storage_exceeded',
+        message: 'Storage limit exceeded.',
+        max_file_size: 128 * 1024 * 1024,
+        allowed_extensions: ['pdf'],
+        remaining: 0,
+      })
+
+      const file = new File(['hello'], 'doc.pdf', { type: 'application/pdf' })
+
+      await expect(
+        uploadFiles({ files: [file], processLevel: 'vectorize' })
+      ).rejects.toBeInstanceOf(UploadBlockedError)
+
+      // The check-upload call happened, but the actual /upload call did NOT
+      expect(httpClient).toHaveBeenCalledTimes(1)
+      expect(httpClient).toHaveBeenCalledWith(
+        '/api/v1/files/check-upload',
+        expect.objectContaining({ method: 'POST' })
+      )
+    })
+
+    it('propagates reason and filename on UploadBlockedError', async () => {
+      mockedHttpClient.mockResolvedValueOnce({
+        allowed: false,
+        reason: 'file_too_large',
+        message: 'File too large. Maximum size is 128 MB.',
+        max_file_size: 128 * 1024 * 1024,
+        allowed_extensions: ['pdf'],
+        remaining: 50 * 1024 * 1024,
+      })
+
+      const file = new File(['x'], 'huge.pdf', { type: 'application/pdf' })
+
+      try {
+        await uploadFiles({ files: [file], processLevel: 'vectorize' })
+        expect.unreachable('Expected UploadBlockedError')
+      } catch (err) {
+        expect(err).toBeInstanceOf(UploadBlockedError)
+        const blocked = err as UploadBlockedError
+        expect(blocked.reason).toBe('file_too_large')
+        expect(blocked.filename).toBe('huge.pdf')
+        expect(blocked.check.max_file_size).toBe(128 * 1024 * 1024)
+      }
+    })
+
+    it('proceeds to the upload call when the pre-flight allows it', async () => {
+      mockedHttpClient
+        .mockResolvedValueOnce({
+          allowed: true,
+          max_file_size: 128 * 1024 * 1024,
+          allowed_extensions: ['pdf'],
+          remaining: 100 * 1024 * 1024,
+        })
+        .mockResolvedValueOnce({
+          success: true,
+          files: [
+            {
+              id: 1,
+              filename: 'ok.pdf',
+              size: 5,
+              mime: 'application/pdf',
+              path: '/tmp/ok.pdf',
+              group_key: 'TEST',
+              processing_time_ms: 5,
+            },
+          ],
+          errors: [],
+          total_time_ms: 5,
+          process_level: 'vectorize',
+        })
+
+      const file = new File(['hello'], 'ok.pdf', { type: 'application/pdf' })
+
+      const result = await uploadFiles({
+        files: [file],
+        groupKey: 'TEST',
+        processLevel: 'vectorize',
+      })
+
+      expect(result.success).toBe(true)
+      // First call = check-upload, second call = actual upload (no onProgress so uses httpClient)
+      expect(httpClient).toHaveBeenCalledTimes(2)
+      expect(httpClient).toHaveBeenNthCalledWith(
+        1,
+        '/api/v1/files/check-upload',
+        expect.objectContaining({ method: 'POST' })
+      )
+      expect(httpClient).toHaveBeenNthCalledWith(
+        2,
+        '/api/v1/files/upload',
+        expect.objectContaining({ method: 'POST' })
+      )
+    })
+  })
+})

--- a/frontend/tests/unit/services/sessionHint.spec.ts
+++ b/frontend/tests/unit/services/sessionHint.spec.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setSessionHint, clearSessionHint, hasSessionHint } from '@/services/sessionHint'
+
+describe('sessionHint', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.restoreAllMocks()
+  })
+
+  it('hasSessionHint returns false on a fresh browser profile', () => {
+    expect(hasSessionHint()).toBe(false)
+  })
+
+  it('setSessionHint persists the flag and hasSessionHint then returns true', () => {
+    setSessionHint()
+    expect(hasSessionHint()).toBe(true)
+  })
+
+  it('clearSessionHint removes the flag', () => {
+    setSessionHint()
+    expect(hasSessionHint()).toBe(true)
+
+    clearSessionHint()
+    expect(hasSessionHint()).toBe(false)
+  })
+
+  it('treats other values stored under the key as "no hint"', () => {
+    localStorage.setItem('sh', 'maybe')
+    expect(hasSessionHint()).toBe(false)
+  })
+
+  it('hasSessionHint falls back to true when localStorage throws', () => {
+    // Simulate sandboxed / quota-exceeded localStorage: we MUST NOT lock a
+    // working session out just because storage is unavailable.
+    const spy = vi.spyOn(globalThis.localStorage, 'getItem').mockImplementation(() => {
+      throw new Error('localStorage unavailable')
+    })
+
+    expect(hasSessionHint()).toBe(true)
+
+    spy.mockRestore()
+  })
+
+  it('setSessionHint swallows storage errors silently', () => {
+    const spy = vi.spyOn(globalThis.localStorage, 'setItem').mockImplementation(() => {
+      throw new Error('QuotaExceededError')
+    })
+
+    expect(() => setSessionHint()).not.toThrow()
+
+    spy.mockRestore()
+  })
+
+  it('clearSessionHint swallows storage errors silently', () => {
+    const spy = vi.spyOn(globalThis.localStorage, 'removeItem').mockImplementation(() => {
+      throw new Error('localStorage unavailable')
+    })
+
+    expect(() => clearSessionHint()).not.toThrow()
+
+    spy.mockRestore()
+  })
+})

--- a/frontend/tests/unit/utils/aiModelDedupe.spec.ts
+++ b/frontend/tests/unit/utils/aiModelDedupe.spec.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from 'vitest'
+import { dedupeModelsByPurpose } from '@/utils/aiModelDedupe'
+import type { AIModel, Capability } from '@/types/ai-models'
+
+const PURPOSE_ORDER: readonly Capability[] = [
+  'SORT',
+  'CHAT',
+  'MEM',
+  'ANALYZE',
+  'VECTORIZE',
+  'PIC2TEXT',
+  'TEXT2PIC',
+  'PIC2PIC',
+  'TEXT2VID',
+  'SOUND2TEXT',
+  'TEXT2SOUND',
+]
+
+function model(id: number, name: string, service = 'Anthropic'): AIModel {
+  return {
+    id,
+    name,
+    service,
+    tag: name.toLowerCase(),
+    providerId: `${service.toLowerCase()}/${name.toLowerCase()}`,
+    quality: 8,
+    rating: 4,
+    priceIn: 0,
+    priceOut: 0,
+    description: null,
+    isSystemModel: false,
+    features: [],
+  }
+}
+
+describe('dedupeModelsByPurpose (issue #261)', () => {
+  it('collapses a model that appears under several purposes into a single row', () => {
+    const haiku = model(1, 'Claude Haiku 4.5')
+
+    const dedupe = dedupeModelsByPurpose(
+      {
+        SORT: [haiku],
+        CHAT: [haiku],
+        ANALYZE: [haiku],
+      },
+      PURPOSE_ORDER
+    )
+
+    expect(dedupe).toHaveLength(1)
+    expect(dedupe[0].id).toBe(1)
+    expect(dedupe[0].purposes).toEqual(['SORT', 'CHAT', 'ANALYZE'])
+  })
+
+  it('keeps purposes in the canonical PURPOSE_ORDER, not API arrival order', () => {
+    const haiku = model(1, 'Claude Haiku 4.5')
+
+    const dedupe = dedupeModelsByPurpose(
+      {
+        ANALYZE: [haiku],
+        CHAT: [haiku],
+        SORT: [haiku],
+      },
+      PURPOSE_ORDER
+    )
+
+    expect(dedupe[0].purposes).toEqual(['SORT', 'CHAT', 'ANALYZE'])
+  })
+
+  it('returns one row per distinct model when multiple models share purposes', () => {
+    const haiku = model(1, 'Claude Haiku 4.5')
+    const opus = model(2, 'Claude Opus 4.6')
+    const sonnet = model(3, 'Claude Sonnet 4.6')
+
+    const dedupe = dedupeModelsByPurpose(
+      {
+        SORT: [haiku, opus, sonnet],
+        CHAT: [haiku, opus, sonnet],
+        ANALYZE: [haiku, opus, sonnet],
+      },
+      PURPOSE_ORDER
+    )
+
+    expect(dedupe).toHaveLength(3)
+    expect(dedupe.map((m) => m.id)).toEqual([1, 2, 3])
+    for (const row of dedupe) {
+      expect(row.purposes).toEqual(['SORT', 'CHAT', 'ANALYZE'])
+    }
+  })
+
+  it('does not list the same purpose twice for one model', () => {
+    const haiku = model(1, 'Claude Haiku 4.5')
+
+    const dedupe = dedupeModelsByPurpose(
+      {
+        // Pathological backend response: same purpose holds the same model
+        // twice. Should never happen in production, but the dedupe must
+        // not let it bubble through as duplicate chips.
+        SORT: [haiku, haiku],
+      },
+      PURPOSE_ORDER
+    )
+
+    expect(dedupe[0].purposes).toEqual(['SORT'])
+  })
+
+  it('preserves model metadata (name, service, quality) on the dedup row', () => {
+    const flux = model(99, 'Flux Schnell', 'TheHive')
+    flux.quality = 9.5
+    flux.description = 'Fast image gen'
+
+    const dedupe = dedupeModelsByPurpose({ TEXT2PIC: [flux] }, PURPOSE_ORDER)
+
+    expect(dedupe[0]).toMatchObject({
+      id: 99,
+      name: 'Flux Schnell',
+      service: 'TheHive',
+      quality: 9.5,
+      description: 'Fast image gen',
+      purposes: ['TEXT2PIC'],
+    })
+  })
+
+  it('returns an empty list for an empty input', () => {
+    expect(dedupeModelsByPurpose({}, PURPOSE_ORDER)).toEqual([])
+  })
+
+  it('skips purposes that are not in the supplied order', () => {
+    const haiku = model(1, 'Claude Haiku 4.5')
+
+    // Caller only cares about SORT — CHAT entries must be dropped, NOT
+    // accidentally added to the haiku row.
+    const dedupe = dedupeModelsByPurpose(
+      {
+        SORT: [haiku],
+        CHAT: [haiku],
+      },
+      ['SORT']
+    )
+
+    expect(dedupe).toHaveLength(1)
+    expect(dedupe[0].purposes).toEqual(['SORT'])
+  })
+
+  it('does not mutate the model objects from the input map', () => {
+    const haiku = model(1, 'Claude Haiku 4.5')
+
+    dedupeModelsByPurpose(
+      {
+        SORT: [haiku],
+        CHAT: [haiku],
+      },
+      PURPOSE_ORDER
+    )
+
+    // The shared input object must NOT have a `purposes` field grafted
+    // on, otherwise re-rendering would compound the list across renders.
+    expect((haiku as AIModel & { purposes?: Capability[] }).purposes).toBeUndefined()
+  })
+})

--- a/frontend/tests/unit/utils/aiModelDedupe.spec.ts
+++ b/frontend/tests/unit/utils/aiModelDedupe.spec.ts
@@ -47,11 +47,14 @@ describe('dedupeModelsByPurpose (issue #261)', () => {
     )
 
     expect(dedupe).toHaveLength(1)
-    expect(dedupe[0].id).toBe(1)
-    expect(dedupe[0].purposes).toEqual(['SORT', 'CHAT', 'ANALYZE'])
+    expect(dedupe[0].purposes).toEqual([
+      { purpose: 'SORT', modelId: 1 },
+      { purpose: 'CHAT', modelId: 1 },
+      { purpose: 'ANALYZE', modelId: 1 },
+    ])
   })
 
-  it('keeps purposes in the canonical PURPOSE_ORDER, not API arrival order', () => {
+  it('keeps chips in the canonical PURPOSE_ORDER, not API arrival order', () => {
     const haiku = model(1, 'Claude Haiku 4.5')
 
     const dedupe = dedupeModelsByPurpose(
@@ -63,10 +66,10 @@ describe('dedupeModelsByPurpose (issue #261)', () => {
       PURPOSE_ORDER
     )
 
-    expect(dedupe[0].purposes).toEqual(['SORT', 'CHAT', 'ANALYZE'])
+    expect(dedupe[0].purposes.map((c) => c.purpose)).toEqual(['SORT', 'CHAT', 'ANALYZE'])
   })
 
-  it('returns one row per distinct model when multiple models share purposes', () => {
+  it('returns one row per distinct (service, name) when multiple models share purposes', () => {
     const haiku = model(1, 'Claude Haiku 4.5')
     const opus = model(2, 'Claude Opus 4.6')
     const sonnet = model(3, 'Claude Sonnet 4.6')
@@ -81,10 +84,63 @@ describe('dedupeModelsByPurpose (issue #261)', () => {
     )
 
     expect(dedupe).toHaveLength(3)
-    expect(dedupe.map((m) => m.id)).toEqual([1, 2, 3])
+    expect(dedupe.map((m) => m.name)).toEqual([
+      'Claude Haiku 4.5',
+      'Claude Opus 4.6',
+      'Claude Sonnet 4.6',
+    ])
     for (const row of dedupe) {
-      expect(row.purposes).toEqual(['SORT', 'CHAT', 'ANALYZE'])
+      expect(row.purposes.map((c) => c.purpose)).toEqual(['SORT', 'CHAT', 'ANALYZE'])
     }
+  })
+
+  it('merges (service, name) duplicates that have different backend ids, routing each chip to its own id', () => {
+    // Real-world scenario from the BMODELS catalogue: "Claude Opus 4.6"
+    // exists as two rows — one for general chat (BTAG=chat) and one
+    // dedicated to memory extraction (BTAG=mem). They share name +
+    // service but have distinct ids, and selecting CHAT vs MEM must
+    // persist the correct id.
+    const opusChat = model(160, 'Claude Opus 4.6')
+    const opusMem = model(222, 'Claude Opus 4.6')
+
+    const dedupe = dedupeModelsByPurpose(
+      {
+        SORT: [opusChat],
+        CHAT: [opusChat],
+        MEM: [opusMem],
+        ANALYZE: [opusChat],
+      },
+      PURPOSE_ORDER
+    )
+
+    expect(dedupe).toHaveLength(1)
+    expect(dedupe[0].purposes).toEqual([
+      { purpose: 'SORT', modelId: 160 },
+      { purpose: 'CHAT', modelId: 160 },
+      { purpose: 'MEM', modelId: 222 },
+      { purpose: 'ANALYZE', modelId: 160 },
+    ])
+  })
+
+  it('treats same name across different services as different models', () => {
+    // gpt-oss-120b is registered under both Groq and Ollama. Despite
+    // the identical model name, these are different runtimes and must
+    // not collapse into one row.
+    const groq = model(76, 'gpt-oss-120b', 'Groq')
+    const ollama = model(79, 'gpt-oss-120b', 'Ollama')
+
+    const dedupe = dedupeModelsByPurpose(
+      {
+        CHAT: [groq, ollama],
+      },
+      PURPOSE_ORDER
+    )
+
+    expect(dedupe).toHaveLength(2)
+    expect(dedupe.map((m) => `${m.service}/${m.name}`)).toEqual([
+      'Groq/gpt-oss-120b',
+      'Ollama/gpt-oss-120b',
+    ])
   })
 
   it('does not list the same purpose twice for one model', () => {
@@ -100,7 +156,7 @@ describe('dedupeModelsByPurpose (issue #261)', () => {
       PURPOSE_ORDER
     )
 
-    expect(dedupe[0].purposes).toEqual(['SORT'])
+    expect(dedupe[0].purposes).toEqual([{ purpose: 'SORT', modelId: 1 }])
   })
 
   it('preserves model metadata (name, service, quality) on the dedup row', () => {
@@ -111,12 +167,11 @@ describe('dedupeModelsByPurpose (issue #261)', () => {
     const dedupe = dedupeModelsByPurpose({ TEXT2PIC: [flux] }, PURPOSE_ORDER)
 
     expect(dedupe[0]).toMatchObject({
-      id: 99,
       name: 'Flux Schnell',
       service: 'TheHive',
       quality: 9.5,
       description: 'Fast image gen',
-      purposes: ['TEXT2PIC'],
+      purposes: [{ purpose: 'TEXT2PIC', modelId: 99 }],
     })
   })
 
@@ -138,7 +193,7 @@ describe('dedupeModelsByPurpose (issue #261)', () => {
     )
 
     expect(dedupe).toHaveLength(1)
-    expect(dedupe[0].purposes).toEqual(['SORT'])
+    expect(dedupe[0].purposes).toEqual([{ purpose: 'SORT', modelId: 1 }])
   })
 
   it('does not mutate the model objects from the input map', () => {
@@ -154,6 +209,6 @@ describe('dedupeModelsByPurpose (issue #261)', () => {
 
     // The shared input object must NOT have a `purposes` field grafted
     // on, otherwise re-rendering would compound the list across renders.
-    expect((haiku as AIModel & { purposes?: Capability[] }).purposes).toBeUndefined()
+    expect((haiku as AIModel & { purposes?: unknown }).purposes).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Summary
Behebt sieben gemeldete Bugs aus der Issue-Liste (Mail, Files, Auth, AI-Models, Memories, Feedback) in einem zusammenhängenden Schub. Jeder Commit ist atomar und referenziert das passende Issue.

## Changes
- **#208 — Mail Pick Up Config: Test ohne Speichern.** `InboundEmailHandlerService::testMailboxCredentials` + neuer `POST /test-connection`-Endpoint; Frontend ruft den Test mit den aktuellen Formular-Werten auf, fällt für maskierte Passwörter auf das gespeicherte Geheimnis zurück und ändert keinen persistierten Handler-Status.
- **#213 — Files: First upload near storage limit times out early.** Pre-Flight-Check (`POST /api/v1/files/check-upload`) validiert Größe, Extension und Quota vor dem Upload; Frontend zeigt sofortige, lokalisierte Fehler statt eines Timeouts. `MAX_FILE_SIZE` + erlaubte Extensions sind jetzt öffentlich zugreifbar; Quota-Stats enthalten `max_file_size`.
- **#204 — Auth: Token refresh fails on fresh visit.** Zentralisierter `sessionHint`-Utility (`frontend/src/services/sessionHint.ts`); alle drei `refreshAccessToken`-Pfade (`httpClient`, `chatApi`, `apiService`) short-circuiten ohne Hint und löschen ihn auf endgültigen Server-Fehler — keine irreführenden „Session expired"-Logs für nicht eingeloggte Besucher.
- **#261 (Initial-Fix) — AI-Models: Liste mit Purpose-Chips pro Modell.** Neuer `dedupeModelsByPurpose`-Helper; `AIModelsConfiguration.vue` rendert pro Modell eine Zeile mit klickbaren Purpose-Chips statt mehreren Duplikat-Zeilen.
- **#261 (Follow-up) — Dedup nach `(service, name)` statt nur `id`.** BMODELS registriert „Claude Opus 4.6" als zwei Rows (CHAT/SORT/ANALYZE-id 160 vs. MEM-id 222); analog Groq/Ollama gpt-oss-120b. Neuer Dedup-Schlüssel kollabiert sie zu einer Zeile; jeder Chip trägt die spezifische DB-ID, die beim Klick gespeichert wird. Service-Unterschied (Groq vs. Ollama) bleibt erhalten.
- **#438 — Memories: Extraction stores AI's own answer.** `MemoryExtractionService` filtert die Conversation History VOR dem Slicing auf User-Turns (`direction = IN` / `role = user`); der seeded `tools:memory_extraction`-Prompt erhält eine harte „Source rule" gegen Extraktion aus Assistant-Inhalten; User-Prompt-Builder kennzeichnet das Conversation-Block-Format explizit als „USER turns only".
- **#519 — Contradiction feedback field uses user persona instead of disputed image-subject fact.** `previewFalsePositive`-Prompt klassifiziert erst das SUBJEKT (`user` vs. `external`) und verbietet Bleed-Over persönlicher Facts in Korrekturen über externe Subjekte; `feedbackContradictionCheckPrompt` + Inline-User-Prompts in `FeedbackContradictionService` erzwingen eine „Subject-match rule" vor allen Topic-Vergleichen.

## Verification
- [x] Tests added/updated
- [x] Manual (lokale Verifikation gegen Vite Dev-Server `localhost:5173` für #261, inkl. Chip-Klick + Dropdown-Sync)
- **Backend:** `make -C backend lint && make -C backend phpstan && make -C backend test` — 1449 Tests grün, 5129 Assertions, PHPStan 0 Errors auf 577 Files, php-cs-fixer 0/484 Files zu fixen.
- **Frontend:** `make -C frontend lint && docker compose exec -T frontend npm run check:types && make -C frontend test` — 377 Tests grün auf 46 Test-Files, vue-tsc + ESLint + Prettier sauber.

Neue Test-Suites:
- `backend/tests/Service/File/FileUploadServiceCheckUploadTest.php` (#213)
- `backend/tests/Controller/FileControllerTest.php` (Pre-Flight-Endpoint, #213)
- `backend/tests/Unit/MemoryExtractionServicePromptRulesTest.php` (#438 — Array- und Message-Objekt-Pfad + Assistant-only-History Edge Case)
- `backend/tests/Unit/FeedbackPromptSubjectIsolationTest.php` (#519 — System- + User-Prompt-Inhalt für Preview und Contradiction Check)
- `frontend/tests/unit/services/sessionHint.spec.ts` + `frontend/tests/unit/api/httpClient-refresh.spec.ts` (#204)
- `frontend/tests/unit/services/filesService.spec.ts` (#213)
- `frontend/tests/unit/utils/aiModelDedupe.spec.ts` (#261, inkl. Name-Collision-Case)

## Notes
Closes #208
Closes #213
Closes #204
Closes #261
Closes #438
Closes #519

Bitte NICHT in `main` mergen — wir wollen erst einen weiteren Review-Durchlauf, bevor das Bündel zusammen in den Hauptbranch wandert.

## Screenshots/Logs
n/a — alle Änderungen sind Backend-Logik, Prompt-Korrekturen oder Komponenten-Refactorings, die jeweils durch Regression-Tests abgesichert sind.