### PR TITLE
chore: rename templatex plugin entry to synaform in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,7 +71,7 @@ _devextras/screenvideo/.narration-tmp/
 
 # Plugins (developed externally, copied to server manually)
 plugins/brogent/
-plugins/templatex/
+plugins/synaform/
 plugins/sortx/
 plugins/marketeer/
 


### PR DESCRIPTION
## Summary
The TemplateX plugin has been renamed to Synaform in its own repo (metadist/Synaform). Update the externally-developed plugin entry so the freshly installed plugins/synaform/ directory stays untracked.

## Changes
gitignore and nameing!

## Verification
- [ ] Not tested (explain)
- [x] Manual
- [ ] Tests added/updated

## Notes

https://github.com/metadist/Synaform
