### PR TITLE
chore(frontend): remove deprecated baseUrl from tsconfig

### DIFF
--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -15,7 +15,6 @@
     "jsx": "preserve",
 
     /* Path mapping */
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     },


### PR DESCRIPTION
## Summary

- Removes `"baseUrl": "."` from `frontend/tsconfig.app.json`
- Since TypeScript 4.1, `paths` resolves relative to the tsconfig file without needing `baseUrl`
- This unblocks Renovate PR #876 (TypeScript 6), which treats `baseUrl` without non-relative imports as a deprecation error

## Verified locally on TS 5.9.3 (current main)

- `vue-tsc -b --noEmit` — 0 errors
- `npm run build` — success
- `npm test` — 45 test files, 374 tests passed

## Context

TypeScript 6 (PR #876) fails CI because `baseUrl: "."` triggers a deprecation error when no non-relative imports use it. Vite already handles `@/` alias resolution via its own `resolve.alias` config, so `baseUrl` in tsconfig was only used by the type-checker and is no longer needed.