### PR TITLE
Fix batch 2: chat memory leaks, MEDIAMAKER live render & WhatsApp poll cascade (#583, #615, #624, #625, #633)

### DIFF
--- a/backend/phpstan-baseline.neon
+++ b/backend/phpstan-baseline.neon
@@ -139,18 +139,6 @@ parameters:
 			path: src/Controller/ChatController.php
 
 		-
-			message: '#^Offset ''anthropic''\|''gemini''\|''google''\|''groq''\|''mistral''\|''openai'' on array\{openai\: array\{''OPENAI_API_KEY''\}, anthropic\: array\{''ANTHROPIC_API_KEY''\}, groq\: array\{''GROQ_API_KEY''\}, gemini\: array\{''GEMINI_API_KEY'', ''GOOGLE_GEMINI_API…'', ''GOOGLE_API_KEY''\}, google\: array\{''GOOGLE_API_KEY'', ''GOOGLE_GEMINI_API…'', ''GEMINI_API_KEY''\}, mistral\: array\{''MISTRAL_API_KEY''\}\} on left side of \?\? always exists and is not nullable\.$#'
-			identifier: nullCoalesce.offset
-			count: 1
-			path: src/Controller/ConfigController.php
-
-		-
-			message: '#^Offset 0 on array\{''ANTHROPIC_API_KEY''\}\|array\{''GEMINI_API_KEY'', ''GOOGLE_GEMINI_API…'', ''GOOGLE_API_KEY''\}\|array\{''GOOGLE_API_KEY'', ''GOOGLE_GEMINI_API…'', ''GEMINI_API_KEY''\}\|array\{''GROQ_API_KEY''\}\|array\{''MISTRAL_API_KEY''\}\|array\{''OPENAI_API_KEY''\} on left side of \?\? always exists and is not nullable\.$#'
-			identifier: nullCoalesce.offset
-			count: 1
-			path: src/Controller/ConfigController.php
-
-		-
 			message: '#^Result of && is always false\.$#'
 			identifier: booleanAnd.alwaysFalse
 			count: 1
@@ -247,12 +235,6 @@ parameters:
 			path: src/Controller/StreamController.php
 
 		-
-			message: '#^Access to an undefined property Stripe\\StripeObject\:\:\$object\.$#'
-			identifier: property.notFound
-			count: 8
-			path: src/Controller/StripeWebhookController.php
-
-		-
 			message: '#^Property App\\Controller\\SubscriptionController\:\:\$userRepository is never read, only written\.$#'
 			identifier: property.onlyWritten
 			count: 1
@@ -281,12 +263,6 @@ parameters:
 			identifier: function.alreadyNarrowedType
 			count: 1
 			path: src/Controller/WidgetPublicController.php
-
-		-
-			message: '#^Call to an undefined method Doctrine\\Persistence\\ObjectManager\:\:getConnection\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: src/DataFixtures/ModelFixtures.php
 
 		-
 			message: '#^Call to an undefined method App\\Entity\\Message\:\:getTrackId\(\)\.$#'
@@ -415,66 +391,6 @@ parameters:
 			path: src/Service/WidgetService.php
 
 		-
-			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertIsArray\(\) with array will always evaluate to true\.$#'
-			identifier: method.alreadyNarrowedType
-			count: 3
-			path: tests/AI/Contract/ChatProviderContractTest.php
-
-		-
-			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertIsArray\(\) with list will always evaluate to true\.$#'
-			identifier: method.alreadyNarrowedType
-			count: 1
-			path: tests/AI/Contract/ChatProviderContractTest.php
-
-		-
-			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertIsBool\(\) with bool will always evaluate to true\.$#'
-			identifier: method.alreadyNarrowedType
-			count: 1
-			path: tests/AI/Contract/ChatProviderContractTest.php
-
-		-
-			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertIsString\(\) with string will always evaluate to true\.$#'
-			identifier: method.alreadyNarrowedType
-			count: 2
-			path: tests/AI/Contract/ChatProviderContractTest.php
-
-		-
-			message: '#^Negated boolean expression is always false\.$#'
-			identifier: booleanNot.alwaysFalse
-			count: 1
-			path: tests/Controller/FileControllerTest.php
-
-		-
-			message: '#^Method App\\Tests\\Controller\\StreamControllerTest\:\:createTestChat\(\) is unused\.$#'
-			identifier: method.unused
-			count: 1
-			path: tests/Controller/StreamControllerTest.php
-
-		-
-			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertTrue\(\) with true and ''Email sent…'' will always evaluate to true\.$#'
-			identifier: method.alreadyNarrowedType
-			count: 1
-			path: tests/Integration/MailerTest.php
-
-		-
-			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertIsArray\(\) with array will always evaluate to true\.$#'
-			identifier: method.alreadyNarrowedType
-			count: 4
-			path: tests/Integration/Service/BraveSearchIntegrationTest.php
-
-		-
-			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertIsBool\(\) with bool will always evaluate to true\.$#'
-			identifier: method.alreadyNarrowedType
-			count: 1
-			path: tests/Integration/Service/BraveSearchIntegrationTest.php
-
-		-
-			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertIsString\(\) with string will always evaluate to true\.$#'
-			identifier: method.alreadyNarrowedType
-			count: 2
-			path: tests/Integration/Service/BraveSearchIntegrationTest.php
-
-		-
 			message: '#^Unreachable statement \- code above always terminates\.$#'
 			identifier: deadCode.unreachable
 			count: 2
@@ -503,66 +419,6 @@ parameters:
 			identifier: deadCode.unreachable
 			count: 2
 			path: tests/Integration/Service/MessageProcessorAgainTest.php
-
-		-
-			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertIsArray\(\) with list\<App\\Entity\\ApiKey\> will always evaluate to true\.$#'
-			identifier: method.alreadyNarrowedType
-			count: 2
-			path: tests/Repository/ApiKeyRepositoryTest.php
-
-		-
-			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertIsBool\(\) with bool will always evaluate to true\.$#'
-			identifier: method.alreadyNarrowedType
-			count: 1
-			path: tests/Repository/ApiKeyRepositoryTest.php
-
-		-
-			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertIsInt\(\) with int\<0, max\> will always evaluate to true\.$#'
-			identifier: method.alreadyNarrowedType
-			count: 1
-			path: tests/Repository/ApiKeyRepositoryTest.php
-
-		-
-			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertNotNull\(\) with string will always evaluate to true\.$#'
-			identifier: method.alreadyNarrowedType
-			count: 2
-			path: tests/Repository/ApiKeyRepositoryTest.php
-
-		-
-			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertIsArray\(\) with list\<object\> will always evaluate to true\.$#'
-			identifier: method.alreadyNarrowedType
-			count: 4
-			path: tests/Repository/ChatRepositoryTest.php
-
-		-
-			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertIsInt\(\) with int\<0, max\> will always evaluate to true\.$#'
-			identifier: method.alreadyNarrowedType
-			count: 1
-			path: tests/Repository/ChatRepositoryTest.php
-
-		-
-			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertNotNull\(\) with int will always evaluate to true\.$#'
-			identifier: method.alreadyNarrowedType
-			count: 1
-			path: tests/Repository/ChatRepositoryTest.php
-
-		-
-			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertIsArray\(\) with array will always evaluate to true\.$#'
-			identifier: method.alreadyNarrowedType
-			count: 1
-			path: tests/Repository/MessageRepositoryTest.php
-
-		-
-			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertIsArray\(\) with list\<object\> will always evaluate to true\.$#'
-			identifier: method.alreadyNarrowedType
-			count: 5
-			path: tests/Repository/UserRepositoryTest.php
-
-		-
-			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertIsInt\(\) with int\<0, max\> will always evaluate to true\.$#'
-			identifier: method.alreadyNarrowedType
-			count: 1
-			path: tests/Repository/UserRepositoryTest.php
 
 		-
 			message: '#^Call to an undefined method App\\Repository\\ChatRepository\:\:expects\(\)\.$#'
@@ -595,12 +451,6 @@ parameters:
 			path: tests/Service/RateLimitServiceUnifiedTest.php
 
 		-
-			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertIsArray\(\) with array will always evaluate to true\.$#'
-			identifier: method.alreadyNarrowedType
-			count: 6
-			path: tests/Service/VectorSearchServiceTest.php
-
-		-
 			message: '#^Parameter \#1 \$fileType of method App\\Entity\\Message\:\:setFileType\(\) expects string, int given\.$#'
 			identifier: argument.type
 			count: 1
@@ -615,13 +465,13 @@ parameters:
 		-
 			message: '#^Call to an undefined method App\\AI\\Service\\AiFacade\:\:expects\(\)\.$#'
 			identifier: method.notFound
-			count: 4
+			count: 5
 			path: tests/Unit/ChatHandlerTest.php
 
 		-
 			message: '#^Call to an undefined method App\\AI\\Service\\AiFacade\:\:method\(\)\.$#'
 			identifier: method.notFound
-			count: 3
+			count: 5
 			path: tests/Unit/ChatHandlerTest.php
 
 		-
@@ -633,13 +483,19 @@ parameters:
 		-
 			message: '#^Call to an undefined method App\\Repository\\PromptRepository\:\:method\(\)\.$#'
 			identifier: method.notFound
-			count: 6
+			count: 9
 			path: tests/Unit/ChatHandlerTest.php
 
 		-
 			message: '#^Call to an undefined method App\\Service\\ModelConfigService\:\:method\(\)\.$#'
 			identifier: method.notFound
-			count: 13
+			count: 25
+			path: tests/Unit/ChatHandlerTest.php
+
+		-
+			message: '#^Call to an undefined method App\\Service\\PerfPipelineFlag\:\:method\(\)\.$#'
+			identifier: method.notFound
+			count: 2
 			path: tests/Unit/ChatHandlerTest.php
 
 		-
@@ -649,8 +505,32 @@ parameters:
 			path: tests/Unit/ChatHandlerTest.php
 
 		-
-			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertIsArray\(\) with array will always evaluate to true\.$#'
-			identifier: method.alreadyNarrowedType
+			message: '#^Call to an undefined method App\\Service\\UserMemoryService\:\:expects\(\)\.$#'
+			identifier: method.notFound
+			count: 3
+			path: tests/Unit/ChatHandlerTest.php
+
+		-
+			message: '#^Call to an undefined method App\\Service\\UserMemoryService\:\:method\(\)\.$#'
+			identifier: method.notFound
+			count: 4
+			path: tests/Unit/ChatHandlerTest.php
+
+		-
+			message: '#^Call to an undefined method Doctrine\\ORM\\EntityManagerInterface\:\:method\(\)\.$#'
+			identifier: method.notFound
+			count: 3
+			path: tests/Unit/ChatHandlerTest.php
+
+		-
+			message: '#^Call to an undefined method Symfony\\Component\\Messenger\\MessageBusInterface\:\:expects\(\)\.$#'
+			identifier: method.notFound
+			count: 2
+			path: tests/Unit/ChatHandlerTest.php
+
+		-
+			message: '#^Call to an undefined method Symfony\\Component\\Messenger\\MessageBusInterface\:\:method\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: tests/Unit/ChatHandlerTest.php
 
@@ -659,30 +539,6 @@ parameters:
 			identifier: deadCode.unreachable
 			count: 1
 			path: tests/Unit/ChatHandlerTest.php
-
-		-
-			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertTrue\(\) with true and ''Password reset…'' will always evaluate to true\.$#'
-			identifier: method.alreadyNarrowedType
-			count: 1
-			path: tests/Unit/InternalEmailServiceTest.php
-
-		-
-			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertTrue\(\) with true and ''Verification email…'' will always evaluate to true\.$#'
-			identifier: method.alreadyNarrowedType
-			count: 1
-			path: tests/Unit/InternalEmailServiceTest.php
-
-		-
-			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertTrue\(\) with true and ''Password reset…'' will always evaluate to true\.$#'
-			identifier: method.alreadyNarrowedType
-			count: 1
-			path: tests/Unit/MailerServiceTest.php
-
-		-
-			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertTrue\(\) with true and ''Verification email…'' will always evaluate to true\.$#'
-			identifier: method.alreadyNarrowedType
-			count: 1
-			path: tests/Unit/MailerServiceTest.php
 
 		-
 			message: '#^Call to an undefined method App\\Repository\\MessageRepository\:\:expects\(\)\.$#'
@@ -915,17 +771,5 @@ parameters:
 		-
 			message: '#^Call to function method_exists\(\) with App\\Service\\WhisperService and ''translateToEnglish'' will always evaluate to true\.$#'
 			identifier: function.alreadyNarrowedType
-			count: 1
-			path: tests/Unit/WhisperServiceTest.php
-
-		-
-			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertIsArray\(\) with array will always evaluate to true\.$#'
-			identifier: method.alreadyNarrowedType
-			count: 3
-			path: tests/Unit/WhisperServiceTest.php
-
-		-
-			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertTrue\(\) with true will always evaluate to true\.$#'
-			identifier: method.alreadyNarrowedType
 			count: 1
 			path: tests/Unit/WhisperServiceTest.php

--- a/backend/src/Controller/ChatController.php
+++ b/backend/src/Controller/ChatController.php
@@ -528,6 +528,21 @@ class ChatController extends AbstractController
                     ];
                 }
 
+                // Audio model (TTS pipeline used for voice reply, e.g. Piper).
+                // Surfaced separately from `chat` so a page reload also shows
+                // the actual TTS model under the "Audio Model" badge — see
+                // issue #583.
+                $audioProvider = $m->getMeta('ai_audio_provider');
+                $audioModel = $m->getMeta('ai_audio_model');
+                $audioModelId = $m->getMeta('ai_audio_model_id');
+                if ($audioProvider || $audioModel) {
+                    $aiModels['audio'] = [
+                        'provider' => $audioProvider,
+                        'model' => $audioModel,
+                        'model_id' => $audioModelId ? (int) $audioModelId : null,
+                    ];
+                }
+
                 // Web Search metadata
                 $searchQuery = $m->getMeta('web_search_query');
                 $searchResultsCount = $m->getMeta('web_search_results_count');

--- a/backend/src/Controller/GuestChatController.php
+++ b/backend/src/Controller/GuestChatController.php
@@ -379,6 +379,19 @@ class GuestChatController extends AbstractController
                     ];
                 }
 
+                // Audio (TTS) model — separate from chat so the badge after
+                // a page reload also shows the actual TTS model (#583).
+                $audioProvider = $m->getMeta('ai_audio_provider');
+                $audioModel = $m->getMeta('ai_audio_model');
+                $audioModelId = $m->getMeta('ai_audio_model_id');
+                if ($audioProvider || $audioModel) {
+                    $aiModels['audio'] = [
+                        'provider' => $audioProvider,
+                        'model' => $audioModel,
+                        'model_id' => $audioModelId ? (int) $audioModelId : null,
+                    ];
+                }
+
                 $searchQuery = $m->getMeta('web_search_query');
                 $searchResultsCount = $m->getMeta('web_search_results_count');
                 if ($searchQuery || $searchResultsCount) {

--- a/backend/src/Controller/StreamController.php
+++ b/backend/src/Controller/StreamController.php
@@ -1348,14 +1348,44 @@ class StreamController extends AbstractController
                             $outgoingMessage->setFile(1);
                             $outgoingMessage->setFilePath($audioUrl);
                             $outgoingMessage->setFileType('audio');
+
+                            // Persist the TTS provider/model on the
+                            // outgoing message so the history endpoint
+                            // (and any later page reload) surfaces the
+                            // *audio* model — not the chat LLM — under
+                            // the "Audio Model" badge. Fixes #583 and
+                            // its post-refresh sibling reports.
+                            $ttsProvider = $ttsResult['provider'] ?? null;
+                            $ttsModelName = $ttsResult['model'] ?? null;
+                            $ttsModelId = $ttsResult['model_id'] ?? null;
+                            if (null !== $ttsProvider) {
+                                $outgoingMessage->setMeta('ai_audio_provider', (string) $ttsProvider);
+                            }
+                            if (null !== $ttsModelName) {
+                                $outgoingMessage->setMeta('ai_audio_model', (string) $ttsModelName);
+                            }
+                            if (null !== $ttsModelId && '' !== (string) $ttsModelId) {
+                                $outgoingMessage->setMeta('ai_audio_model_id', (string) $ttsModelId);
+                            }
                             $this->em->flush();
 
-                            $this->sendSSE('audio', ['url' => $audioUrl]);
+                            // Refresh the `aiModels` payload that was
+                            // pre-built before TTS ran, so the live SSE
+                            // `complete` event already carries the
+                            // audio badge — no page reload required.
+                            $completeData['aiModels'] = $this->buildAiModelsPayload($outgoingMessage);
+
+                            $this->sendSSE('audio', [
+                                'url' => $audioUrl,
+                                'provider' => $ttsProvider,
+                                'model' => $ttsModelName,
+                                'model_id' => $this->normalizeModelId($ttsModelId, 'sse_audio_event'),
+                            ]);
 
                             $this->rateLimitService->recordUsage($user, 'AUDIOS', [
-                                'provider' => $ttsResult['provider'] ?? 'unknown',
-                                'model' => $ttsResult['model'] ?? 'unknown',
-                                'model_id' => $ttsResult['model_id'] ?? null,
+                                'provider' => $ttsProvider ?? 'unknown',
+                                'model' => $ttsModelName ?? 'unknown',
+                                'model_id' => $ttsModelId,
                                 'media_usage' => [
                                     'characters' => $ttsResult['text_length'] ?? mb_strlen($ttsText),
                                 ],
@@ -1363,7 +1393,8 @@ class StreamController extends AbstractController
 
                             $this->logger->info('StreamController: Voice reply generated', [
                                 'url' => $audioUrl,
-                                'provider' => $ttsResult['provider'] ?? 'unknown',
+                                'provider' => $ttsProvider ?? 'unknown',
+                                'model' => $ttsModelName ?? 'unknown',
                             ]);
                         }
                     } catch (\Throwable $e) {
@@ -1893,6 +1924,7 @@ class StreamController extends AbstractController
      * @return array{
      *   chat?: array{provider: ?string, model: ?string, model_id: ?int},
      *   sorting?: array{provider: ?string, model: ?string, model_id: ?int},
+     *   audio?: array{provider: ?string, model: ?string, model_id: ?int},
      * }|null
      */
     private function buildAiModelsPayload(Message $message): ?array
@@ -1918,6 +1950,22 @@ class StreamController extends AbstractController
                 'provider' => $sortingProvider,
                 'model' => $sortingModel,
                 'model_id' => $this->normalizeModelId($sortingModelId, 'aiModels_sorting'),
+            ];
+        }
+
+        // Audio (TTS) model — separate from `chat` because voice-reply
+        // pipes the LLM's text through an independent TTS provider
+        // (e.g. Piper). Before #583 the chat model was relabelled as
+        // "Audio Model" in the UI, which surfaced the wrong identifier
+        // (gpt-5.4 instead of piper-multi).
+        $audioProvider = $message->getMeta('ai_audio_provider');
+        $audioModel = $message->getMeta('ai_audio_model');
+        $audioModelId = $message->getMeta('ai_audio_model_id');
+        if ($audioProvider || $audioModel) {
+            $aiModels['audio'] = [
+                'provider' => $audioProvider,
+                'model' => $audioModel,
+                'model_id' => $this->normalizeModelId($audioModelId, 'aiModels_audio'),
             ];
         }
 

--- a/backend/src/Controller/StreamController.php
+++ b/backend/src/Controller/StreamController.php
@@ -1139,6 +1139,12 @@ class StreamController extends AbstractController
                     $outgoingMessage->setMeta('media_type', $response['metadata']['media_type']);
                 }
 
+                $this->persistOriginalMediaMeta(
+                    $outgoingMessage,
+                    $classification,
+                    $response['metadata'] ?? []
+                );
+
                 // Store SORTING model information in MessageMeta (from classification)
                 if (!empty($classification['sorting_provider'])) {
                     $outgoingMessage->setMeta('ai_sorting_provider', $classification['sorting_provider']);
@@ -1250,6 +1256,16 @@ class StreamController extends AbstractController
                 $rawChatModelId = $response['metadata']['model_id'] ?? $modelId ?? null;
                 $completeChatModelId = $this->normalizeModelId($rawChatModelId, 'streaming_complete');
 
+                // `originalTopic` / `originalMediaType` mirror the same fields
+                // the error path already ships and the history endpoint reads
+                // (`ChatController::getMessages`). The frontend `complete`
+                // handler in ChatView assigns them onto `message.*` so
+                // `mediaHintFromClassificationTopic('mediamaker', 'audio')`
+                // returns `audio` live — fixing the badge-label flip
+                // documented in issue #624.
+                $originalTopic = $outgoingMessage->getMeta('original_topic');
+                $originalMediaType = $outgoingMessage->getMeta('original_media_type');
+
                 $completeData = [
                     'messageId' => $outgoingMessage->getId(),
                     'trackId' => $trackId,
@@ -1257,6 +1273,8 @@ class StreamController extends AbstractController
                     'model' => $response['metadata']['model'] ?? 'unknown',
                     'model_id' => $completeChatModelId,
                     'topic' => $classification['topic'],
+                    'originalTopic' => $originalTopic,
+                    'originalMediaType' => $originalMediaType,
                     'language' => $classification['language'],
                     'searchResults' => $searchResults,
                     'aiModels' => $this->buildAiModelsPayload($outgoingMessage),
@@ -1777,6 +1795,12 @@ class StreamController extends AbstractController
                 $outgoingMessage->setMeta('ai_sorting_model_id', (string) $classification['sorting_model_id']);
             }
 
+            // Mirror the streaming branch above: keep MEDIAMAKER meta
+            // consistent for non-streaming callers (email, generic webhook)
+            // so a later history fetch surfaces the right "Audio Model"
+            // badge and the right capability for the Again dropdown.
+            $this->persistOriginalMediaMeta($outgoingMessage, $classification, $metadata);
+
             if (!empty($options['web_search'])) {
                 $message->setMeta('web_search_enabled', 'true');
             }
@@ -1819,6 +1843,13 @@ class StreamController extends AbstractController
             // so the flat SSE field and the nested payload stay in sync.
             $nonStreamingModelId = $this->normalizeModelId($metadata['model_id'] ?? null, 'non_streaming_complete');
 
+            // Mirror the streaming branch so the non-streaming `complete`
+            // event also carries `originalTopic` / `originalMediaType` —
+            // keeps the badge label and Again model selection consistent
+            // for callers that share this SSE shape (see issue #624).
+            $nonStreamingOriginalTopic = $outgoingMessage->getMeta('original_topic');
+            $nonStreamingOriginalMediaType = $outgoingMessage->getMeta('original_media_type');
+
             $completeData = [
                 'messageId' => $outgoingMessage->getId(),
                 'provider' => $metadata['provider'] ?? 'unknown',
@@ -1826,6 +1857,8 @@ class StreamController extends AbstractController
                 'model_id' => $nonStreamingModelId,
                 'trackId' => $trackId,
                 'topic' => $classification['topic'] ?? null,
+                'originalTopic' => $nonStreamingOriginalTopic,
+                'originalMediaType' => $nonStreamingOriginalMediaType,
                 'language' => $classification['language'] ?? null,
                 'searchResults' => $this->formatSearchResultsForSse($result['search_results'] ?? null),
                 'aiModels' => $this->buildAiModelsPayload($outgoingMessage),
@@ -1909,6 +1942,45 @@ class StreamController extends AbstractController
         ]);
 
         return null;
+    }
+
+    /**
+     * Persist `original_topic` / `original_media_type` meta on a MEDIAMAKER
+     * outgoing message so the chat-message badge label (#583) and the
+     * "Again" model dropdown surface a stable media type both during live
+     * SSE streaming and after the page reloads history from the DB.
+     *
+     * Without this, MEDIAMAKER audio falls back to mediaHint=null live
+     * (no `audio` part is yet in `message.parts` — see issue #625) which
+     * surfaces "Chat Model" and a CHAT-capability prediction for the Again
+     * dropdown. After reload, the audio file lands in parts and the badge
+     * flips to "Audio Model" / TEXT2SOUND. This helper fixes the flip by
+     * pre-persisting the original media intent. See issue #624.
+     *
+     * No-op for non-mediamaker classifications so we don't leak this meta
+     * onto regular chat replies.
+     *
+     * @param array{topic?: ?string, media_type?: ?string}|array<string, mixed> $classification
+     * @param array{media_type?: ?string}|array<string, mixed>                  $metadata
+     */
+    private function persistOriginalMediaMeta(Message $message, array $classification, array $metadata = []): void
+    {
+        if ('mediamaker' !== ($classification['topic'] ?? null)) {
+            return;
+        }
+
+        $message->setMeta('original_topic', 'mediamaker');
+
+        // Handler-derived media_type wins because it reflects the actual
+        // pipeline that ran (synthesize/generateImage/generateVideo); the
+        // classifier value is only the predicted intent.
+        $mediaType = $metadata['media_type']
+            ?? $classification['media_type']
+            ?? null;
+
+        if (!empty($mediaType)) {
+            $message->setMeta('original_media_type', (string) $mediaType);
+        }
     }
 
     /**

--- a/backend/src/Service/Message/Handler/ChatHandler.php
+++ b/backend/src/Service/Message/Handler/ChatHandler.php
@@ -65,13 +65,24 @@ final readonly class ChatHandler implements MessageHandlerInterface
         return 'chat';
     }
 
+    /**
+     * @param array<int, array{role: string, content: string}|Message> $thread
+     * @param array<string, mixed>                                     $classification
+     * @param array<string, mixed>                                     $options        forwarded by InferenceRouter (channel, disable_memories, …)
+     */
     public function handle(
         Message $message,
         array $thread,
         array $classification,
         ?callable $progressCallback = null,
+        array $options = [],
     ): array {
         $this->notify($progressCallback, 'generating', 'Generating response...');
+
+        // Local PerfTimer keeps the shared helpers (memory + feedback
+        // loaders) shape-compatible with the streaming path without
+        // forcing every non-streaming caller to construct one.
+        $perfTimer = new PerfTimer();
 
         $topic = $classification['topic'] ?? 'general';
         $language = $classification['language'] ?? 'en';
@@ -88,6 +99,40 @@ final readonly class ChatHandler implements MessageHandlerInterface
         $ragLimit = isset($classification['rag_limit']) ? max(1, (int) $classification['rag_limit']) : 5;
         $ragMinScore = isset($classification['rag_min_score']) ? max(0.0, min(1.0, (float) $classification['rag_min_score'])) : 0.3;
         $ragContext = $this->loadRagContext($message, $topic, $ragGroupKey, $ragLimit, $ragMinScore);
+
+        // Issue #615: the non-streaming path (email / generic webhook)
+        // used to skip memory loading entirely, so memories never
+        // influenced replies for those channels and new memories were
+        // never extracted from the conversation. Mirror the streaming
+        // path so every channel benefits from the user's stored
+        // memories + feedback corrections.
+        $user = $this->em->getRepository(User::class)->find($message->getUserId());
+        $resolveSharedVector = $this->createSharedVectorResolver($message, $perfTimer);
+
+        $memoriesResult = $this->loadMemoriesContext(
+            $message,
+            $user,
+            $options,
+            $classification,
+            $progressCallback,
+            $resolveSharedVector,
+            $perfTimer,
+        );
+        $memoriesContext = $memoriesResult['context'];
+        $loadedMemories = $memoriesResult['memories'];
+        $memoriesDisabledByRequest = $memoriesResult['disabled'];
+
+        $feedbackResult = $this->loadFeedbackContext(
+            $message,
+            $user,
+            $options,
+            $classification,
+            $progressCallback,
+            $resolveSharedVector,
+            $perfTimer,
+        );
+        $feedbackContext = $feedbackResult['context'];
+        $loadedFeedbacks = $feedbackResult['feedbacks'];
 
         // Determine model: Again > Widget config override > Prompt Metadata > DB default
         $modelId = null;
@@ -186,6 +231,25 @@ final readonly class ChatHandler implements MessageHandlerInterface
             ]);
         }
 
+        // Memories + feedback go between RAG and plugin/URL context so
+        // their ordering matches the streaming path. This keeps prompt
+        // shape consistent across Web UI and email/webhook channels
+        // (issue #615).
+        if (!empty($memoriesContext)) {
+            $systemPrompt .= $memoriesContext;
+            $this->logger->info('ChatHandler: Memories context appended to system prompt', [
+                'memories_count' => count($loadedMemories),
+                'memories_context_length' => strlen($memoriesContext),
+            ]);
+        }
+
+        if (!empty($feedbackContext)) {
+            $systemPrompt .= $feedbackContext;
+            $this->logger->info('ChatHandler: Feedback context appended to system prompt', [
+                'feedback_context_length' => strlen($feedbackContext),
+            ]);
+        }
+
         // Append plugin context (external data sources like casting platforms)
         $systemPrompt = $this->appendPluginContext($systemPrompt, $message, $classification, [
             'channel' => $classification['source'] ?? null,
@@ -237,8 +301,9 @@ final readonly class ChatHandler implements MessageHandlerInterface
             'temperature' => 0.7,
         ];
 
-        // Clamp max_tokens to min(plan_limit, model_max)
-        $user = $this->em->getRepository(User::class)->find($message->getUserId());
+        // Clamp max_tokens to min(plan_limit, model_max).
+        // Reuse the User entity loaded earlier for memories/feedback so
+        // we don't hit the repository twice per request.
         $planMaxTokens = null !== $user ? $this->rateLimitService->getMaxOutputTokens($user) : null;
         $tokenLimits = array_filter(
             [$planMaxTokens, $modelMaxTokens],
@@ -334,10 +399,25 @@ final readonly class ChatHandler implements MessageHandlerInterface
             }
         }
 
+        // Issue #615: extract new memories from the email/webhook
+        // exchange just like the streaming path does. We pass the final
+        // assistant text (post JSON unwrap, post file-generation marker)
+        // so the worker reasons about what the user actually saw.
+        $extractionResponseText = is_string($content) ? $content : '';
+        $this->dispatchMemoryExtractionAsync(
+            $message,
+            $extractionResponseText,
+            $thread,
+            $loadedMemories,
+            $memoriesDisabledByRequest,
+        );
+
         return [
             'content' => $content,
             'metadata' => array_merge($metadata, [
                 'model_id' => $modelId, // Include resolved model_id for storage
+                'memories' => $loadedMemories,
+                'feedbacks' => $loadedFeedbacks,
             ]),
         ];
     }
@@ -385,37 +465,10 @@ final readonly class ChatHandler implements MessageHandlerInterface
         // the biggest pre-LLM time sink before this change.
         //
         // Lazy-evaluated via a closure so requests with no text (e.g. file-
-        // only) or with memories disabled never trigger the embed.
-        $sharedQueryVector = null;
-        $sharedVectorComputed = false;
-        $resolveSharedVector = function () use ($message, &$sharedQueryVector, &$sharedVectorComputed, $perfTimer): ?array {
-            if ($sharedVectorComputed) {
-                return $sharedQueryVector;
-            }
-            $sharedVectorComputed = true;
-
-            $text = $message->getText();
-            if ('' === trim($text) || !$this->memoryService->isAvailable()) {
-                return null;
-            }
-
-            $perfTimer->start('shared_embedding');
-            try {
-                $embed = $this->memoryService->embedUserQuery($message->getUserId(), $text);
-            } catch (\Throwable $e) {
-                $this->logger->warning('ChatHandler: shared embed failed, falling back to per-call embeds', [
-                    'error' => $e->getMessage(),
-                ]);
-                $embed = null;
-            }
-            $perfTimer->stop('shared_embedding');
-
-            if (null !== $embed && !empty($embed['embedding'])) {
-                $sharedQueryVector = $embed['embedding'];
-            }
-
-            return $sharedQueryVector;
-        };
+        // only) or with memories disabled never trigger the embed. The
+        // closure is now shared with `handle()` so email/webhook callers
+        // benefit from the same caching behaviour (issue #615).
+        $resolveSharedVector = $this->createSharedVectorResolver($message, $perfTimer);
 
         // Load RAG context for task prompt (if files are associated)
         $ragContext = '';
@@ -534,197 +587,36 @@ final readonly class ChatHandler implements MessageHandlerInterface
             ));
         }
 
-        // Load user memories from Qdrant/Microservice
-        $memoriesContext = '';
-        $loadedMemories = [];
-        $memoriesDisabledByRequest = !empty($options['disable_memories'])
-            || ('WIDGET' === ($options['channel'] ?? null))
-            || ('widget' === ($classification['source'] ?? null));
-
-        // Load user entity (Message only has userId, not User object)
+        // Memory + feedback context now live in shared helpers so the
+        // non-streaming `handle()` (email/webhook) renders identical
+        // prompts (issue #615). User entity load is needed up-front for
+        // both helpers and for the rate-limit clamp further down.
         $user = $this->em->getRepository(User::class)->find($message->getUserId());
-        $memoriesEnabledForUser = $user?->isMemoriesEnabled() ?? true;
 
-        if ($memoriesDisabledByRequest) {
-            $this->logger->debug('ChatHandler: Memories disabled for widget request, skipping memories', [
-                'user_id' => $message->getUserId(),
-            ]);
-        } elseif (!$memoriesEnabledForUser) {
-            $this->logger->debug('ChatHandler: Memories disabled by user setting, skipping memories', [
-                'user_id' => $message->getUserId(),
-            ]);
-        } elseif ($this->memoryService->isAvailable()) {
-            try {
-                $this->logger->debug('ChatHandler: Loading user memories', [
-                    'user_id' => $message->getUserId(),
-                    'message_text' => substr($message->getText(), 0, 100),
-                ]);
+        $memoriesResult = $this->loadMemoriesContext(
+            $message,
+            $user,
+            $options,
+            $classification,
+            $progressCallback,
+            $resolveSharedVector,
+            $perfTimer,
+        );
+        $memoriesContext = $memoriesResult['context'];
+        $loadedMemories = $memoriesResult['memories'];
+        $memoriesDisabledByRequest = $memoriesResult['disabled'];
 
-                // Search for relevant memories using Qdrant
-                // Balance between precision and recall
-                $perfTimer->start('memories_search');
-                $sharedVector = $resolveSharedVector();
-                if (null !== $sharedVector) {
-                    $rawMemories = $this->memoryService->searchMemoriesByVector(
-                        $message->getUserId(),
-                        $sharedVector,
-                        limit: $this->feedbackConfig->getMaxChatMemories(),
-                        minScore: $this->feedbackConfig->getMinChatMemoryScore()
-                    );
-                } else {
-                    $rawMemories = $this->memoryService->searchRelevantMemories(
-                        $message->getUserId(),
-                        $message->getText(),
-                        limit: $this->feedbackConfig->getMaxChatMemories(),
-                        minScore: $this->feedbackConfig->getMinChatMemoryScore()
-                    );
-                }
-                $perfTimer->stop('memories_search');
-
-                // Post-filter: Qdrant may return low-score results despite minScore
-                $loadedMemories = $this->filterByScore($rawMemories, $this->feedbackConfig->getMinChatMemoryScore());
-
-                $this->logger->debug('ChatHandler: Memories loaded from Qdrant', [
-                    'count' => count($loadedMemories),
-                    'filtered_out' => count($rawMemories) - count($loadedMemories),
-                    'memories' => array_map(fn ($m) => [
-                        'id' => $m['id'] ?? null,
-                        'key' => $m['key'] ?? null,
-                        'score' => $m['score'] ?? 0,
-                    ], $loadedMemories),
-                ]);
-            } catch (\Throwable $e) {
-                $this->logger->warning('ChatHandler: Failed to load memories, continuing without', [
-                    'error' => $e->getMessage(),
-                ]);
-                $loadedMemories = [];
-            }
-        } else {
-            $this->logger->debug('ChatHandler: Memory service not available, skipping memories');
-        }
-
-        if (!empty($loadedMemories)) {
-            $memoriesContext = "\n\n## User Memories (relevant to this conversation):\n";
-            foreach ($loadedMemories as $memory) {
-                $memoriesContext .= sprintf(
-                    "[ID: %d] %s: %s\n",
-                    $memory['id'],
-                    $memory['key'],
-                    $memory['value']
-                );
-            }
-            $memoriesContext .= "\nUse these memories to personalize your response.\n";
-            $memoriesContext .= "REFERENCES: Use [Memory:ID] (clickable). Rules:\n";
-            $memoriesContext .= "- ONE ID per bracket. Good: [Memory:42] and [Memory:15]. Bad: [Memory:42, 15].\n";
-            $memoriesContext .= "- Only use IDs from the list above. Never invent IDs.\n";
-
-            $this->logger->info('ChatHandler: User memories loaded', [
-                'user_id' => $message->getUserId(),
-                'memories_count' => count($loadedMemories),
-            ]);
-
-            // Send SSE event to frontend showing which memories are used
-            if ($progressCallback) {
-                $progressCallback([
-                    'status' => 'memories_loaded',
-                    'message' => 'Memories loaded',
-                    'metadata' => [
-                        'memories' => $loadedMemories,
-                        'count' => count($loadedMemories),
-                    ],
-                    'timestamp' => time(),
-                ]);
-            }
-        } else {
-            $this->logger->debug('ChatHandler: No relevant memories found', [
-                'user_id' => $message->getUserId(),
-            ]);
-        }
-
-        // Load feedback examples (false positives and positives) from Qdrant
-        // These help the AI avoid known mistakes and reinforce correct information
-        $feedbackContext = '';
-        $loadedFeedbacks = [];
-        if (!$memoriesDisabledByRequest && $memoriesEnabledForUser && $this->memoryService->isAvailable()) {
-            try {
-                // Search for relevant false positives (things to AVOID saying)
-                $perfTimer->start('feedback');
-                $sharedVector = $resolveSharedVector();
-                $falsePositives = $this->searchFeedback(
-                    $message->getUserId(),
-                    $message->getText(),
-                    'feedback_negative',
-                    FeedbackConstants::NAMESPACE_FALSE_POSITIVE,
-                    $sharedVector
-                );
-
-                // Search for relevant positive examples (correct information)
-                $positiveExamples = $this->searchFeedback(
-                    $message->getUserId(),
-                    $message->getText(),
-                    'feedback_positive',
-                    FeedbackConstants::NAMESPACE_POSITIVE,
-                    $sharedVector
-                );
-                $perfTimer->stop('feedback');
-
-                if (!empty($falsePositives) || !empty($positiveExamples)) {
-                    $feedbackContext = "\n\n## User Feedback (corrections from previous conversations):\n";
-
-                    if (!empty($falsePositives)) {
-                        $feedbackContext .= "\n### Things to AVOID (user-reported false positives) - Reference as [Feedback:ID]:\n";
-                        foreach ($falsePositives as $fp) {
-                            $feedbackContext .= sprintf("- ❌ [Feedback:%d] %s\n", $fp['id'], $fp['value']);
-                            $loadedFeedbacks[] = [
-                                'id' => $fp['id'],
-                                'type' => 'false_positive',
-                                'value' => $fp['value'],
-                            ];
-                        }
-                    }
-
-                    if (!empty($positiveExamples)) {
-                        $feedbackContext .= "\n### Correct information (user-confirmed) - Reference as [Feedback:ID]:\n";
-                        foreach ($positiveExamples as $pe) {
-                            $feedbackContext .= sprintf("- ✅ [Feedback:%d] %s\n", $pe['id'], $pe['value']);
-                            $loadedFeedbacks[] = [
-                                'id' => $pe['id'],
-                                'type' => 'positive',
-                                'value' => $pe['value'],
-                            ];
-                        }
-                    }
-
-                    $feedbackContext .= "\nREFERENCES: Use [Feedback:ID] (clickable). Rules:\n";
-                    $feedbackContext .= "- ONE ID per bracket. Good: [Feedback:123] and [Feedback:456]. Bad: [Feedback:123, 456].\n";
-                    $feedbackContext .= "- Avoid repeating ❌ claims. Prefer ✅ information.\n";
-                    $feedbackContext .= "- If ❌ and ✅ entries contradict each other, mention the conflict to the user.\n";
-
-                    // Send SSE event with loaded feedbacks
-                    if ($progressCallback) {
-                        $progressCallback([
-                            'status' => 'feedback_loaded',
-                            'message' => 'Feedback examples loaded',
-                            'metadata' => [
-                                'feedbacks' => $loadedFeedbacks,
-                                'count' => count($loadedFeedbacks),
-                            ],
-                            'timestamp' => time(),
-                        ]);
-                    }
-
-                    $this->logger->info('ChatHandler: Feedback examples loaded', [
-                        'user_id' => $message->getUserId(),
-                        'false_positives_count' => count($falsePositives),
-                        'positive_examples_count' => count($positiveExamples),
-                    ]);
-                }
-            } catch (\Throwable $e) {
-                $this->logger->warning('ChatHandler: Failed to load feedback examples', [
-                    'error' => $e->getMessage(),
-                ]);
-            }
-        }
+        $feedbackResult = $this->loadFeedbackContext(
+            $message,
+            $user,
+            $options,
+            $classification,
+            $progressCallback,
+            $resolveSharedVector,
+            $perfTimer,
+        );
+        $feedbackContext = $feedbackResult['context'];
+        $loadedFeedbacks = $feedbackResult['feedbacks'];
 
         // Get model - Priority: Again > Widget config override > Prompt Metadata > DB default
         $modelId = null;
@@ -1004,62 +896,20 @@ final readonly class ChatHandler implements MessageHandlerInterface
 
         $this->notify($progressCallback, 'generating', 'Response generated.');
 
-        if ($memoriesDisabledByRequest) {
-            $this->logger->info('ChatHandler: Skipping memory extraction for widget request', [
-                'user_id' => $message->getUserId(),
-            ]);
-        } elseif (!$this->perfPipelineFlag->isEnabled($message->getUserId())) {
-            // Phase 4 kill switch: the operator has disabled the v2 perf
-            // pipeline for this user (or globally). Skip memory extraction
-            // entirely rather than reviving the inline path. Memories will
-            // still get picked up the next time the user sends a message
-            // with the flag re-enabled.
-            $this->logger->info('ChatHandler: PERF.V2_PIPELINE disabled — skipping memory extraction', [
-                'user_id' => $message->getUserId(),
-            ]);
-        } else {
-            // Phase 2b: dispatch memory extraction to the messenger worker
-            // instead of running it inline. This frees the SSE stream to send
-            // `complete` immediately after the answer text is delivered, so
-            // the user can type the next message without waiting 5-9 s for
-            // the post-stream extraction LLM call + Qdrant writes.
-            //
-            // The previous inline `searchRelevantMemories` for extraction
-            // context is now done inside the worker so it doesn't add
-            // latency to the user-visible request either.
-            try {
-                $threadSnapshot = $this->normalizeThreadForQueue($thread);
-
-                $this->messageBus->dispatch(new ExtractMemoriesCommand(
-                    messageId: $message->getId(),
-                    userId: $message->getUserId(),
-                    aiResponse: $fullResponseText,
-                    threadSnapshot: $threadSnapshot,
-                    // Forward the in-scope memories so the extractor can
-                    // emit `update` instead of duplicate `create` actions
-                    // (issue #879). The worker still merges this with the
-                    // user's full memory list, but the relevant subset
-                    // carries semantic-search signal we don't want to
-                    // throw away.
-                    relevantMemories: $loadedMemories,
-                ));
-
-                $this->logger->info('ChatHandler: Dispatched ExtractMemoriesCommand', [
-                    'message_id' => $message->getId(),
-                    'user_id' => $message->getUserId(),
-                    'thread_length' => count($threadSnapshot),
-                ]);
-            } catch (\Throwable $e) {
-                // Never block the user's response on the dispatch failing —
-                // worst case is that one message worth of memories never
-                // gets extracted; the next message's extraction will pick up
-                // from where it left off.
-                $this->logger->warning('ChatHandler: Failed to dispatch ExtractMemoriesCommand', [
-                    'message_id' => $message->getId(),
-                    'error' => $e->getMessage(),
-                ]);
-            }
-        }
+        // Phase 2b: dispatch memory extraction to the messenger worker
+        // instead of running it inline. This frees the SSE stream to send
+        // `complete` immediately after the answer text is delivered, so
+        // the user can type the next message without waiting 5-9 s for
+        // the post-stream extraction LLM call + Qdrant writes. Same
+        // helper is now shared with `handle()` so the email/webhook
+        // channel also benefits (issue #615).
+        $this->dispatchMemoryExtractionAsync(
+            $message,
+            $fullResponseText,
+            $thread,
+            $loadedMemories,
+            $memoriesDisabledByRequest,
+        );
 
         return [
             'metadata' => [
@@ -1955,6 +1805,383 @@ final readonly class ChatHandler implements MessageHandlerInterface
         }
 
         return $out;
+    }
+
+    /**
+     * Build the lazy embedding cache used across RAG, memory, and feedback
+     * lookups for a single chat request.
+     *
+     * The closure returns the user-query embedding once and reuses it on
+     * subsequent calls — paying the embed HTTP cost (50-250 ms) only once
+     * per request even when three independent vector searches happen.
+     * Returns null for empty-text messages or when the memory service is
+     * unavailable (callers then fall back to text-based search).
+     *
+     * Extracted from `handleStream()` so the email/generic webhook path
+     * (which lands in `handle()`) can share the same caching behaviour
+     * instead of paying the embed cost twice. See issue #615.
+     *
+     * @return \Closure(): ?array<int, float>
+     */
+    private function createSharedVectorResolver(Message $message, PerfTimer $perfTimer): \Closure
+    {
+        $sharedQueryVector = null;
+        $sharedVectorComputed = false;
+
+        return function () use ($message, &$sharedQueryVector, &$sharedVectorComputed, $perfTimer): ?array {
+            if ($sharedVectorComputed) {
+                return $sharedQueryVector;
+            }
+            $sharedVectorComputed = true;
+
+            $text = $message->getText();
+            if ('' === trim($text) || !$this->memoryService->isAvailable()) {
+                return null;
+            }
+
+            $perfTimer->start('shared_embedding');
+            try {
+                $embed = $this->memoryService->embedUserQuery($message->getUserId(), $text);
+            } catch (\Throwable $e) {
+                $this->logger->warning('ChatHandler: shared embed failed, falling back to per-call embeds', [
+                    'error' => $e->getMessage(),
+                ]);
+                $embed = null;
+            }
+            $perfTimer->stop('shared_embedding');
+
+            if (null !== $embed && !empty($embed['embedding'])) {
+                $sharedQueryVector = $embed['embedding'];
+            }
+
+            return $sharedQueryVector;
+        };
+    }
+
+    /**
+     * Load relevant user memories from Qdrant and build the system-prompt
+     * fragment that injects them into the AI context.
+     *
+     * Shared by both `handle()` and `handleStream()` so every channel
+     * (Web UI, email, generic API webhook) treats memories the same way.
+     * Returns empty strings/arrays when memories are disabled by request,
+     * disabled per-user, or the memory service is unavailable.
+     *
+     * SSE-style memory-loaded events are forwarded to `$progressCallback`
+     * when one is supplied so the Web UI can render the memory badge.
+     * Email/webhook callers pass `null` and simply discard the event.
+     *
+     * @param array<string, mixed> $options
+     * @param array<string, mixed> $classification
+     *
+     * @return array{context: string, memories: array<int, array<string, mixed>>, disabled: bool}
+     *                                                                                            `disabled` mirrors the streaming-only `$memoriesDisabledByRequest` flag — feedback loading also needs it
+     */
+    private function loadMemoriesContext(
+        Message $message,
+        ?User $user,
+        array $options,
+        array $classification,
+        ?callable $progressCallback,
+        \Closure $resolveSharedVector,
+        PerfTimer $perfTimer,
+    ): array {
+        $memoriesDisabledByRequest = !empty($options['disable_memories'])
+            || ('WIDGET' === ($options['channel'] ?? null))
+            || ('widget' === ($classification['source'] ?? null));
+
+        $memoriesEnabledForUser = $user?->isMemoriesEnabled() ?? true;
+
+        $loadedMemories = [];
+
+        if ($memoriesDisabledByRequest) {
+            $this->logger->debug('ChatHandler: Memories disabled for widget request, skipping memories', [
+                'user_id' => $message->getUserId(),
+            ]);
+        } elseif (!$memoriesEnabledForUser) {
+            $this->logger->debug('ChatHandler: Memories disabled by user setting, skipping memories', [
+                'user_id' => $message->getUserId(),
+            ]);
+        } elseif ($this->memoryService->isAvailable()) {
+            try {
+                $this->logger->debug('ChatHandler: Loading user memories', [
+                    'user_id' => $message->getUserId(),
+                    'message_text' => substr($message->getText(), 0, 100),
+                ]);
+
+                $perfTimer->start('memories_search');
+                $sharedVector = $resolveSharedVector();
+                if (null !== $sharedVector) {
+                    $rawMemories = $this->memoryService->searchMemoriesByVector(
+                        $message->getUserId(),
+                        $sharedVector,
+                        limit: $this->feedbackConfig->getMaxChatMemories(),
+                        minScore: $this->feedbackConfig->getMinChatMemoryScore()
+                    );
+                } else {
+                    $rawMemories = $this->memoryService->searchRelevantMemories(
+                        $message->getUserId(),
+                        $message->getText(),
+                        limit: $this->feedbackConfig->getMaxChatMemories(),
+                        minScore: $this->feedbackConfig->getMinChatMemoryScore()
+                    );
+                }
+                $perfTimer->stop('memories_search');
+
+                $loadedMemories = $this->filterByScore($rawMemories, $this->feedbackConfig->getMinChatMemoryScore());
+
+                $this->logger->debug('ChatHandler: Memories loaded from Qdrant', [
+                    'count' => count($loadedMemories),
+                    'filtered_out' => count($rawMemories) - count($loadedMemories),
+                    'memories' => array_map(fn ($m) => [
+                        'id' => $m['id'] ?? null,
+                        'key' => $m['key'] ?? null,
+                        'score' => $m['score'] ?? 0,
+                    ], $loadedMemories),
+                ]);
+            } catch (\Throwable $e) {
+                $this->logger->warning('ChatHandler: Failed to load memories, continuing without', [
+                    'error' => $e->getMessage(),
+                ]);
+                $loadedMemories = [];
+            }
+        } else {
+            $this->logger->debug('ChatHandler: Memory service not available, skipping memories');
+        }
+
+        $memoriesContext = '';
+        if (!empty($loadedMemories)) {
+            $memoriesContext = "\n\n## User Memories (relevant to this conversation):\n";
+            foreach ($loadedMemories as $memory) {
+                $memoriesContext .= sprintf(
+                    "[ID: %d] %s: %s\n",
+                    $memory['id'],
+                    $memory['key'],
+                    $memory['value']
+                );
+            }
+            $memoriesContext .= "\nUse these memories to personalize your response.\n";
+            $memoriesContext .= "REFERENCES: Use [Memory:ID] (clickable). Rules:\n";
+            $memoriesContext .= "- ONE ID per bracket. Good: [Memory:42] and [Memory:15]. Bad: [Memory:42, 15].\n";
+            $memoriesContext .= "- Only use IDs from the list above. Never invent IDs.\n";
+
+            $this->logger->info('ChatHandler: User memories loaded', [
+                'user_id' => $message->getUserId(),
+                'memories_count' => count($loadedMemories),
+            ]);
+
+            if ($progressCallback) {
+                $progressCallback([
+                    'status' => 'memories_loaded',
+                    'message' => 'Memories loaded',
+                    'metadata' => [
+                        'memories' => $loadedMemories,
+                        'count' => count($loadedMemories),
+                    ],
+                    'timestamp' => time(),
+                ]);
+            }
+        } else {
+            $this->logger->debug('ChatHandler: No relevant memories found', [
+                'user_id' => $message->getUserId(),
+            ]);
+        }
+
+        return [
+            'context' => $memoriesContext,
+            'memories' => $loadedMemories,
+            'disabled' => $memoriesDisabledByRequest || !$memoriesEnabledForUser,
+        ];
+    }
+
+    /**
+     * Load feedback (false positives + positives) from Qdrant and build the
+     * system-prompt fragment that injects them into the AI context.
+     *
+     * Same shape as {@see loadMemoriesContext}: shared between streaming
+     * and non-streaming chat paths so the email channel and the Web UI
+     * see identical feedback context.
+     *
+     * @param array<string, mixed> $options
+     * @param array<string, mixed> $classification
+     *
+     * @return array{context: string, feedbacks: array<int, array<string, mixed>>}
+     */
+    private function loadFeedbackContext(
+        Message $message,
+        ?User $user,
+        array $options,
+        array $classification,
+        ?callable $progressCallback,
+        \Closure $resolveSharedVector,
+        PerfTimer $perfTimer,
+    ): array {
+        $memoriesDisabledByRequest = !empty($options['disable_memories'])
+            || ('WIDGET' === ($options['channel'] ?? null))
+            || ('widget' === ($classification['source'] ?? null));
+
+        $memoriesEnabledForUser = $user?->isMemoriesEnabled() ?? true;
+
+        $feedbackContext = '';
+        $loadedFeedbacks = [];
+
+        if ($memoriesDisabledByRequest || !$memoriesEnabledForUser || !$this->memoryService->isAvailable()) {
+            return [
+                'context' => $feedbackContext,
+                'feedbacks' => $loadedFeedbacks,
+            ];
+        }
+
+        try {
+            $perfTimer->start('feedback');
+            $sharedVector = $resolveSharedVector();
+            $falsePositives = $this->searchFeedback(
+                $message->getUserId(),
+                $message->getText(),
+                'feedback_negative',
+                FeedbackConstants::NAMESPACE_FALSE_POSITIVE,
+                $sharedVector
+            );
+
+            $positiveExamples = $this->searchFeedback(
+                $message->getUserId(),
+                $message->getText(),
+                'feedback_positive',
+                FeedbackConstants::NAMESPACE_POSITIVE,
+                $sharedVector
+            );
+            $perfTimer->stop('feedback');
+
+            if (!empty($falsePositives) || !empty($positiveExamples)) {
+                $feedbackContext = "\n\n## User Feedback (corrections from previous conversations):\n";
+
+                if (!empty($falsePositives)) {
+                    $feedbackContext .= "\n### Things to AVOID (user-reported false positives) - Reference as [Feedback:ID]:\n";
+                    foreach ($falsePositives as $fp) {
+                        $feedbackContext .= sprintf("- ❌ [Feedback:%d] %s\n", $fp['id'], $fp['value']);
+                        $loadedFeedbacks[] = [
+                            'id' => $fp['id'],
+                            'type' => 'false_positive',
+                            'value' => $fp['value'],
+                        ];
+                    }
+                }
+
+                if (!empty($positiveExamples)) {
+                    $feedbackContext .= "\n### Correct information (user-confirmed) - Reference as [Feedback:ID]:\n";
+                    foreach ($positiveExamples as $pe) {
+                        $feedbackContext .= sprintf("- ✅ [Feedback:%d] %s\n", $pe['id'], $pe['value']);
+                        $loadedFeedbacks[] = [
+                            'id' => $pe['id'],
+                            'type' => 'positive',
+                            'value' => $pe['value'],
+                        ];
+                    }
+                }
+
+                $feedbackContext .= "\nREFERENCES: Use [Feedback:ID] (clickable). Rules:\n";
+                $feedbackContext .= "- ONE ID per bracket. Good: [Feedback:123] and [Feedback:456]. Bad: [Feedback:123, 456].\n";
+                $feedbackContext .= "- Avoid repeating ❌ claims. Prefer ✅ information.\n";
+                $feedbackContext .= "- If ❌ and ✅ entries contradict each other, mention the conflict to the user.\n";
+
+                if ($progressCallback) {
+                    $progressCallback([
+                        'status' => 'feedback_loaded',
+                        'message' => 'Feedback examples loaded',
+                        'metadata' => [
+                            'feedbacks' => $loadedFeedbacks,
+                            'count' => count($loadedFeedbacks),
+                        ],
+                        'timestamp' => time(),
+                    ]);
+                }
+
+                $this->logger->info('ChatHandler: Feedback examples loaded', [
+                    'user_id' => $message->getUserId(),
+                    'false_positives_count' => count($falsePositives),
+                    'positive_examples_count' => count($positiveExamples),
+                ]);
+            }
+        } catch (\Throwable $e) {
+            $this->logger->warning('ChatHandler: Failed to load feedback examples', [
+                'error' => $e->getMessage(),
+            ]);
+        }
+
+        return [
+            'context' => $feedbackContext,
+            'feedbacks' => $loadedFeedbacks,
+        ];
+    }
+
+    /**
+     * Hand the post-response memory extraction off to the messenger worker.
+     *
+     * Honours the `PERF.V2_PIPELINE_ENABLED` kill switch and the same
+     * `disable_memories` flag used during context loading, so widgets and
+     * operator-disabled users never trigger an extraction run.
+     *
+     * Never throws — a failed dispatch is logged at warning level and the
+     * user's response continues. Worst case is that one message's memories
+     * miss extraction; the next message picks them up.
+     *
+     * @param array<int, array{role: string, content: string}|Message> $thread
+     * @param array<int, array<string, mixed>>                         $loadedMemories
+     */
+    private function dispatchMemoryExtractionAsync(
+        Message $message,
+        string $aiResponse,
+        array $thread,
+        array $loadedMemories,
+        bool $memoriesDisabledByRequest,
+    ): void {
+        if ($memoriesDisabledByRequest) {
+            $this->logger->info('ChatHandler: Skipping memory extraction for widget request', [
+                'user_id' => $message->getUserId(),
+            ]);
+
+            return;
+        }
+
+        if (!$this->perfPipelineFlag->isEnabled($message->getUserId())) {
+            // Phase 4 kill switch: the operator has disabled the v2 perf
+            // pipeline for this user (or globally). Skip memory extraction
+            // entirely rather than reviving the inline path. Memories will
+            // still get picked up the next time the user sends a message
+            // with the flag re-enabled.
+            $this->logger->info('ChatHandler: PERF.V2_PIPELINE disabled — skipping memory extraction', [
+                'user_id' => $message->getUserId(),
+            ]);
+
+            return;
+        }
+
+        try {
+            $threadSnapshot = $this->normalizeThreadForQueue($thread);
+
+            $this->messageBus->dispatch(new ExtractMemoriesCommand(
+                messageId: $message->getId(),
+                userId: $message->getUserId(),
+                aiResponse: $aiResponse,
+                threadSnapshot: $threadSnapshot,
+                relevantMemories: $loadedMemories,
+            ));
+
+            $this->logger->info('ChatHandler: Dispatched ExtractMemoriesCommand', [
+                'message_id' => $message->getId(),
+                'user_id' => $message->getUserId(),
+                'thread_length' => count($threadSnapshot),
+            ]);
+        } catch (\Throwable $e) {
+            // Never block the user's response on the dispatch failing —
+            // worst case is that one message worth of memories never
+            // gets extracted; the next message's extraction will pick up
+            // from where it left off.
+            $this->logger->warning('ChatHandler: Failed to dispatch ExtractMemoriesCommand', [
+                'message_id' => $message->getId(),
+                'error' => $e->getMessage(),
+            ]);
+        }
     }
 
     /**

--- a/backend/src/Service/WhatsAppService.php
+++ b/backend/src/Service/WhatsAppService.php
@@ -46,6 +46,32 @@ final class WhatsAppService
      */
     private const DUPLICATE_CACHE_TTL = 300;
 
+    /**
+     * Allow-list of WhatsApp webhook message types the AI pipeline knows
+     * how to handle. Anything outside this set is silently acknowledged
+     * to Meta (HTTP 200) without persisting a Message or invoking the
+     * AI — see {@see handleIncomingMessage()} and issue #633.
+     *
+     * Filtered-out types include `reaction`, `poll`, `poll_vote`,
+     * `ephemeral`, `request_welcome`, `system`, `unsupported`,
+     * `interactive`, `button` and `order`. These either carry no
+     * user-actionable text payload (reactions, polls) or require
+     * dedicated handlers the platform does not yet implement
+     * (interactive buttons, catalog orders). Acknowledging them
+     * silently keeps Meta from retrying the webhook and stops the
+     * "one poll → seven AI replies" cascade described in #633.
+     */
+    private const SUPPORTED_MESSAGE_TYPES = [
+        'text',
+        'image',
+        'sticker',
+        'audio',
+        'video',
+        'document',
+        'location',
+        'contacts',
+    ];
+
     private const DEFAULT_GRAPH_BASE = 'https://graph.facebook.com';
 
     private string $accessToken;
@@ -165,6 +191,55 @@ final class WhatsAppService
 
             return null;
         }
+    }
+
+    /**
+     * Drop non-actionable webhook message types before they enter the
+     * AI pipeline. Returns a webhook-success payload when the type is
+     * not in {@see SUPPORTED_MESSAGE_TYPES}, or `null` to continue
+     * normal processing.
+     *
+     * We also fire-and-forget a read receipt so the user's WhatsApp
+     * thread doesn't show an unread bubble for a poll/reaction the
+     * platform legitimately ignored — failures here are logged but
+     * never block the webhook acknowledgement (Meta would otherwise
+     * retry, compounding the original bug from issue #633).
+     */
+    private function handleUnsupportedTypeIfNeeded(IncomingMessageDto $dto): ?array
+    {
+        if (in_array($dto->type, self::SUPPORTED_MESSAGE_TYPES, true)) {
+            return null;
+        }
+
+        $this->logger->info('WhatsApp: Skipping unsupported message type', [
+            'message_id' => $dto->messageId,
+            'from' => $dto->from,
+            'type' => $dto->type,
+        ]);
+
+        if ($this->isAvailable() && '' !== $dto->phoneNumberId) {
+            try {
+                $this->markAsRead($dto->messageId, $dto->phoneNumberId);
+            } catch (\Throwable $e) {
+                // Read receipts are best-effort. A failure here must
+                // not bubble up: the webhook MUST still return 200
+                // so Meta doesn't retry and re-trigger the cascade.
+                $this->logger->warning('WhatsApp: Failed to mark unsupported message as read', [
+                    'message_id' => $dto->messageId,
+                    'type' => $dto->type,
+                    'error' => $e->getMessage(),
+                ]);
+            }
+        }
+
+        return [
+            'success' => true,
+            'message_id' => $dto->messageId,
+            'skipped' => true,
+            'reason' => 'unsupported_type',
+            'type' => $dto->type,
+            'response_sent' => false,
+        ];
     }
 
     /**
@@ -566,6 +641,17 @@ final class WhatsAppService
         $duplicateResult = $this->checkAndMarkAsDuplicate($dto);
         if (null !== $duplicateResult) {
             return $duplicateResult;
+        }
+
+        // Issue #633: silently acknowledge unsupported webhook types
+        // (poll, reaction, system, …) so the AI pipeline doesn't fire
+        // for non-user-actionable events. Duplicate detection cannot
+        // help here — each poll vote / reaction lands with a distinct
+        // wamid, so without this filter a single poll cascades into
+        // 7+ "[Unsupported message type: …]" messages and 7+ replies.
+        $unsupportedResult = $this->handleUnsupportedTypeIfNeeded($dto);
+        if (null !== $unsupportedResult) {
+            return $unsupportedResult;
         }
 
         $effectiveUserId = $isAnonymous ? $this->whatsappUserId : $user->getId();
@@ -1108,6 +1194,14 @@ final class WhatsAppService
      * Extract initial message text from the WhatsApp message.
      * For media messages, this returns captions or placeholders that will be
      * replaced with transcribed/extracted content during media processing.
+     *
+     * The `default` branch is defense-in-depth only: the outer
+     * {@see handleUnsupportedTypeIfNeeded()} filter (issue #633) already
+     * short-circuits any type that is not in {@see SUPPORTED_MESSAGE_TYPES},
+     * so this method should never see one in production. The fallback
+     * string stays around so direct callers (e.g. reflection-driven
+     * unit tests) still get a deterministic value instead of an
+     * UnhandledMatchError.
      */
     private function extractMessageText(IncomingMessageDto $dto): string
     {

--- a/backend/tests/Controller/ChatControllerTest.php
+++ b/backend/tests/Controller/ChatControllerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Controller;
 
 use App\Entity\Chat;
+use App\Entity\Message;
 use App\Entity\User;
 use App\Service\TokenService;
 use App\Tests\Trait\AuthenticatedTestTrait;
@@ -427,5 +428,119 @@ class ChatControllerTest extends WebTestCase
         // Verify deletion in database
         $deletedChat = $this->em->getRepository(Chat::class)->find($chatId);
         $this->assertNull($deletedChat);
+    }
+
+    /**
+     * Regression for issue #583 — when a voice reply has been generated,
+     * the TTS provider/model must surface in the message history under
+     * a separate `aiModels.audio` block (not silently relabelled as
+     * `aiModels.chat`). Without this, the UI badge after a page reload
+     * showed the chat LLM (e.g. gpt-5.4) instead of the TTS engine
+     * (e.g. piper-multi).
+     */
+    public function testMessageHistoryExposesAudioModelSeparatelyFromChatModel(): void
+    {
+        $chat = new Chat();
+        $chat->setUserId($this->user->getId());
+        $chat->setTitle('Voice reply chat');
+        $chat->setCreatedAt(new \DateTime());
+        $chat->setUpdatedAt(new \DateTime());
+        $this->em->persist($chat);
+        $this->em->flush();
+
+        $assistantMessage = new Message();
+        $assistantMessage->setUserId($this->user->getId());
+        $assistantMessage->setChat($chat);
+        $assistantMessage->setTrackingId(time());
+        $assistantMessage->setUnixTimestamp(time());
+        $assistantMessage->setDateTime(date('YmdHis'));
+        $assistantMessage->setText('Hello, this is a spoken reply.');
+        $assistantMessage->setDirection('OUT');
+        $assistantMessage->setProviderIndex('WEB');
+        $this->em->persist($assistantMessage);
+        $this->em->flush();
+
+        $assistantMessage->setMeta('ai_chat_provider', 'openai');
+        $assistantMessage->setMeta('ai_chat_model', 'gpt-5.4');
+        $assistantMessage->setMeta('ai_chat_model_id', '42');
+        $assistantMessage->setMeta('ai_audio_provider', 'piper');
+        $assistantMessage->setMeta('ai_audio_model', 'piper-multi');
+        $assistantMessage->setMeta('ai_audio_model_id', '907');
+        $this->em->flush();
+
+        $this->client->request(
+            'GET',
+            '/api/v1/chats/'.$chat->getId().'/messages',
+            [],
+            [],
+            ['HTTP_AUTHORIZATION' => 'Bearer '.$this->token]
+        );
+
+        $this->assertResponseIsSuccessful();
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertIsArray($response);
+        $this->assertArrayHasKey('messages', $response);
+        $this->assertNotEmpty($response['messages']);
+
+        $msg = $response['messages'][0];
+        $this->assertArrayHasKey('aiModels', $msg);
+        $this->assertIsArray($msg['aiModels']);
+
+        $this->assertArrayHasKey('chat', $msg['aiModels']);
+        $this->assertSame('openai', $msg['aiModels']['chat']['provider']);
+        $this->assertSame('gpt-5.4', $msg['aiModels']['chat']['model']);
+        $this->assertSame(42, $msg['aiModels']['chat']['model_id']);
+
+        $this->assertArrayHasKey('audio', $msg['aiModels'], 'aiModels.audio must be present for voice replies');
+        $this->assertSame('piper', $msg['aiModels']['audio']['provider']);
+        $this->assertSame('piper-multi', $msg['aiModels']['audio']['model']);
+        $this->assertSame(907, $msg['aiModels']['audio']['model_id']);
+    }
+
+    /**
+     * Negative case — when no TTS ran, the history response must not
+     * synthesise an `aiModels.audio` block. This guards against
+     * accidental mirror-of-chat regressions.
+     */
+    public function testMessageHistoryOmitsAudioModelWhenNoTtsRan(): void
+    {
+        $chat = new Chat();
+        $chat->setUserId($this->user->getId());
+        $chat->setTitle('Plain chat');
+        $chat->setCreatedAt(new \DateTime());
+        $chat->setUpdatedAt(new \DateTime());
+        $this->em->persist($chat);
+        $this->em->flush();
+
+        $assistantMessage = new Message();
+        $assistantMessage->setUserId($this->user->getId());
+        $assistantMessage->setChat($chat);
+        $assistantMessage->setTrackingId(time());
+        $assistantMessage->setUnixTimestamp(time());
+        $assistantMessage->setDateTime(date('YmdHis'));
+        $assistantMessage->setText('Plain text reply.');
+        $assistantMessage->setDirection('OUT');
+        $assistantMessage->setProviderIndex('WEB');
+        $this->em->persist($assistantMessage);
+        $this->em->flush();
+
+        $assistantMessage->setMeta('ai_chat_provider', 'openai');
+        $assistantMessage->setMeta('ai_chat_model', 'gpt-5.4');
+        $this->em->flush();
+
+        $this->client->request(
+            'GET',
+            '/api/v1/chats/'.$chat->getId().'/messages',
+            [],
+            [],
+            ['HTTP_AUTHORIZATION' => 'Bearer '.$this->token]
+        );
+
+        $this->assertResponseIsSuccessful();
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+
+        $msg = $response['messages'][0];
+        $this->assertArrayHasKey('chat', $msg['aiModels']);
+        $this->assertArrayNotHasKey('audio', $msg['aiModels']);
     }
 }

--- a/backend/tests/Service/WhatsAppServiceTest.php
+++ b/backend/tests/Service/WhatsAppServiceTest.php
@@ -17,6 +17,7 @@ use App\Service\RateLimitService;
 use App\Service\UserMemoryService;
 use App\Service\WhatsAppService;
 use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Lock\LockFactory;
@@ -1471,5 +1472,178 @@ class WhatsAppServiceTest extends TestCase
         $this->assertTrue($result['success']);
         $this->assertTrue($result['duplicate']);
         $this->assertFalse($result['response_sent']);
+    }
+
+    // ============================================
+    // Tests for issue #633: unsupported webhook types
+    // ============================================
+
+    /**
+     * @return iterable<string, array{0: string, 1: array<string, mixed>}>
+     */
+    public static function unsupportedWebhookTypesProvider(): iterable
+    {
+        // Each row describes a real WhatsApp webhook payload that used
+        // to leak through the old `default` branch in extractMessageText()
+        // and end up as a `[Unsupported message type: …]` AI prompt.
+        yield 'reaction' => ['reaction', ['reaction' => ['message_id' => 'wamid.x', 'emoji' => '👍']]];
+        yield 'poll' => ['poll', ['poll' => ['name' => 'Lunch?', 'options' => ['Pizza', 'Sushi']]]];
+        yield 'poll_vote' => ['poll_vote', ['poll_vote' => ['option_id' => 1]]];
+        yield 'system' => ['system', ['system' => ['body' => 'User changed name']]];
+        yield 'unsupported' => ['unsupported', ['errors' => [['code' => 131051, 'title' => 'Unsupported']]]];
+        yield 'interactive' => ['interactive', ['interactive' => ['type' => 'button_reply']]];
+        yield 'button' => ['button', ['button' => ['payload' => 'YES', 'text' => 'Yes']]];
+        yield 'ephemeral' => ['ephemeral', ['ephemeral' => []]];
+        yield 'request_welcome' => ['request_welcome', []];
+        yield 'order' => ['order', ['order' => ['catalog_id' => 'cat_1']]];
+    }
+
+    /**
+     * Issue #633: a poll / reaction / system / interactive event must
+     * be acknowledged with HTTP 200 but never reach the AI. A single
+     * poll otherwise cascaded into 7+ "[Unsupported message type: …]"
+     * messages and 7+ AI replies.
+     *
+     * @param array<string, mixed> $extraFields
+     */
+    #[DataProvider('unsupportedWebhookTypesProvider')]
+    public function testUnsupportedWebhookTypeIsSilentlyAcknowledged(string $type, array $extraFields): void
+    {
+        $user = $this->createMock(User::class);
+        $user->method('getId')->willReturn(1);
+
+        $incomingMsg = array_merge(
+            [
+                'from' => '+1234567890',
+                'id' => 'wamid.'.$type.'.'.bin2hex(random_bytes(4)),
+                'timestamp' => (string) time(),
+                'type' => $type,
+            ],
+            $extraFields,
+        );
+
+        $value = [
+            'messaging_product' => 'whatsapp',
+            'metadata' => [
+                'phone_number_id' => $this->testPhoneNumberId,
+                'display_phone_number' => '+49123456789',
+            ],
+            'contacts' => [['profile' => ['name' => 'Test User'], 'wa_id' => '+1234567890']],
+            'messages' => [$incomingMsg],
+        ];
+
+        $dto = IncomingMessageDto::fromPayload($incomingMsg, $value);
+
+        // The AI pipeline must stay completely cold for unsupported
+        // webhook types — these are the two side effects that used to
+        // surface the bug in the platform UI (one DB row + one AI reply
+        // per poll vote / reaction event).
+        $this->messageProcessor->expects($this->never())->method('processStream');
+        $this->em->expects($this->never())->method('persist');
+
+        // Read receipt is best-effort — we only care that we DID NOT
+        // crash on it. Letting the underlying httpClient mock no-op is
+        // enough; failures would be swallowed by the helper anyway.
+
+        $result = $this->service->handleIncomingMessage($dto, $user, false);
+
+        $this->assertTrue($result['success']);
+        $this->assertTrue($result['skipped']);
+        $this->assertSame('unsupported_type', $result['reason']);
+        $this->assertSame($type, $result['type']);
+        $this->assertFalse($result['response_sent']);
+        $this->assertSame($incomingMsg['id'], $result['message_id']);
+    }
+
+    /**
+     * @return iterable<string, array{0: string}>
+     */
+    public static function supportedWebhookTypesProvider(): iterable
+    {
+        // Pins every type in WhatsAppService::SUPPORTED_MESSAGE_TYPES so
+        // a future refactor of the allowlist can't accidentally drop a
+        // core inbound channel (text / audio / image / …) into the
+        // unsupported branch and silently stop replying to users.
+        yield 'text' => ['text'];
+        yield 'image' => ['image'];
+        yield 'sticker' => ['sticker'];
+        yield 'audio' => ['audio'];
+        yield 'video' => ['video'];
+        yield 'document' => ['document'];
+        yield 'location' => ['location'];
+        yield 'contacts' => ['contacts'];
+    }
+
+    /**
+     * Issue #633 inverse coverage: every type in the allowlist must
+     * survive the early filter. Tested via the private
+     * {@see WhatsAppService::handleUnsupportedTypeIfNeeded()} so the
+     * downstream pipeline (entity manager, rate limit, AI router…)
+     * stays out of scope — we only care that the filter does not
+     * short-circuit.
+     */
+    #[DataProvider('supportedWebhookTypesProvider')]
+    public function testSupportedTypePassesFilter(string $type): void
+    {
+        $dto = IncomingMessageDto::fromPayload(
+            [
+                'from' => '+1234567890',
+                'id' => 'wamid.supported.'.$type,
+                'timestamp' => (string) time(),
+                'type' => $type,
+            ],
+            [
+                'metadata' => [
+                    'phone_number_id' => $this->testPhoneNumberId,
+                    'display_phone_number' => '+49123456789',
+                ],
+            ],
+        );
+
+        $method = (new \ReflectionClass($this->service))->getMethod('handleUnsupportedTypeIfNeeded');
+
+        // null => continue, array => early-return as unsupported
+        $this->assertNull(
+            $method->invoke($this->service, $dto),
+            "Supported type '{$type}' must not be dropped by the unsupported-type filter",
+        );
+    }
+
+    /**
+     * The filter must use a strict allowlist (issue #633 notes):
+     * "consider an allowlist approach instead of a denylist". An
+     * unknown type the platform has never seen before — say, a future
+     * `payment_authorization` — must be skipped, not forwarded.
+     */
+    public function testUnknownFutureTypeIsAlsoSkipped(): void
+    {
+        $user = $this->createMock(User::class);
+        $user->method('getId')->willReturn(1);
+
+        $incomingMsg = [
+            'from' => '+1234567890',
+            'id' => 'wamid.future.'.bin2hex(random_bytes(4)),
+            'timestamp' => (string) time(),
+            'type' => 'payment_authorization', // not in the allowlist
+        ];
+
+        $value = [
+            'messaging_product' => 'whatsapp',
+            'metadata' => [
+                'phone_number_id' => $this->testPhoneNumberId,
+                'display_phone_number' => '+49123456789',
+            ],
+            'contacts' => [['profile' => ['name' => 'Test User'], 'wa_id' => '+1234567890']],
+            'messages' => [$incomingMsg],
+        ];
+
+        $dto = IncomingMessageDto::fromPayload($incomingMsg, $value);
+
+        $this->messageProcessor->expects($this->never())->method('processStream');
+
+        $result = $this->service->handleIncomingMessage($dto, $user, false);
+
+        $this->assertTrue($result['skipped']);
+        $this->assertSame('payment_authorization', $result['type']);
     }
 }

--- a/backend/tests/Unit/ChatHandlerTest.php
+++ b/backend/tests/Unit/ChatHandlerTest.php
@@ -6,9 +6,12 @@ use App\AI\Service\AiFacade;
 use App\Entity\Message;
 use App\Entity\Model;
 use App\Entity\Prompt;
+use App\Entity\User;
+use App\Message\ExtractMemoriesCommand;
 use App\Repository\ConfigRepository;
 use App\Repository\ModelRepository;
 use App\Repository\PromptRepository;
+use App\Repository\UserRepository;
 use App\Service\FeedbackConfigService;
 use App\Service\File\UserUploadPathBuilder;
 use App\Service\Message\Handler\ChatHandler;
@@ -21,6 +24,7 @@ use App\Service\UserMemoryService;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
 
 class ChatHandlerTest extends TestCase
@@ -355,6 +359,211 @@ class ChatHandlerTest extends TestCase
         );
 
         self::assertNotEmpty($chunks);
+    }
+
+    /**
+     * Issue #615: the non-streaming `handle()` path serves email
+     * (`smart+...@synaplan.net`) and the generic API webhook. Before the
+     * fix, neither loaded user memories nor extracted new ones. This
+     * test pins the regression: when Qdrant has relevant memories,
+     * `handle()` must inject them into the system prompt that ships
+     * with the AI request.
+     */
+    public function testHandleLoadsMemoriesIntoSystemPromptForEmailChannel(): void
+    {
+        $message = $this->createMock(Message::class);
+        $message->method('getUserId')->willReturn(7);
+        $message->method('getId')->willReturn(123);
+        $message->method('getText')->willReturn('Where do I live?');
+        $message->method('getUnixTimestamp')->willReturn(time());
+        $message->method('getDateTime')->willReturn('20260512100000');
+        $message->method('getFilePath')->willReturn('');
+        $message->method('getFileType')->willReturn('');
+        $message->method('getTopic')->willReturn('CHAT');
+        $message->method('getLanguage')->willReturn('en');
+        $message->method('getFileText')->willReturn('');
+        $message->method('getDirection')->willReturn('IN');
+
+        $user = $this->createMock(User::class);
+        $user->method('getId')->willReturn(7);
+        $user->method('isMemoriesEnabled')->willReturn(true);
+
+        $userRepository = $this->createMock(UserRepository::class);
+        $userRepository->method('find')->with(7)->willReturn($user);
+        $this->em->method('getRepository')->with(User::class)->willReturn($userRepository);
+
+        $this->userMemoryService->method('isAvailable')->willReturn(true);
+        $this->userMemoryService->method('embedUserQuery')->willReturn(['embedding' => [0.1, 0.2, 0.3]]);
+        $this->userMemoryService
+            ->method('searchMemoriesByVector')
+            ->willReturnCallback(function (int $userId, array $vec, ...$rest) {
+                $category = $rest[0] ?? null;
+                if (null === $category) {
+                    return [
+                        ['id' => 42, 'key' => 'city', 'value' => 'Hamburg', 'score' => 0.91],
+                    ];
+                }
+
+                return [];
+            });
+
+        $this->promptRepository->method('findOneBy')->willReturn(null);
+        $this->modelConfigService->method('getEffectiveUserIdForMessage')->willReturn(7);
+        $this->modelConfigService->method('getDefaultModel')->willReturn(10);
+        $this->modelConfigService->method('getProviderForModel')->willReturn('openai');
+        $this->modelConfigService->method('getModelName')->willReturn('gpt-4.1');
+
+        $capturedMessages = null;
+        $this->aiFacade
+            ->expects($this->once())
+            ->method('chat')
+            ->willReturnCallback(function (array $messages, int $userId, array $options) use (&$capturedMessages) {
+                $capturedMessages = $messages;
+
+                return [
+                    'content' => 'You live in Hamburg.',
+                    'provider' => 'openai',
+                    'model' => 'gpt-4.1',
+                ];
+            });
+
+        $this->perfPipelineFlag->method('isEnabled')->willReturn(true);
+        $this->messageBus
+            ->method('dispatch')
+            ->willReturnCallback(static fn (object $msg) => new Envelope($msg));
+
+        $result = $this->handler->handle($message, [], ['topic' => 'CHAT', 'language' => 'en']);
+
+        self::assertNotNull($capturedMessages, 'aiFacade->chat() should have been called');
+        $systemMessage = $capturedMessages[0]['content'] ?? '';
+        self::assertStringContainsString(
+            'User Memories',
+            $systemMessage,
+            'system prompt must include the memories section so email replies use stored memories'
+        );
+        self::assertStringContainsString(
+            'Hamburg',
+            $systemMessage,
+            'system prompt must contain the actual memory value'
+        );
+        self::assertSame([
+            ['id' => 42, 'key' => 'city', 'value' => 'Hamburg', 'score' => 0.91],
+        ], $result['metadata']['memories']);
+    }
+
+    /**
+     * Issue #615: after generating a reply, the non-streaming path must
+     * also dispatch `ExtractMemoriesCommand` so new facts (e.g. a user
+     * sharing their new address by email) end up in long-term storage.
+     */
+    public function testHandleDispatchesMemoryExtractionAfterResponse(): void
+    {
+        $message = $this->createMock(Message::class);
+        $message->method('getUserId')->willReturn(7);
+        $message->method('getId')->willReturn(456);
+        $message->method('getText')->willReturn('My new address is Bahnhofstrasse 1.');
+        $message->method('getUnixTimestamp')->willReturn(time());
+        $message->method('getDateTime')->willReturn('20260512100000');
+        $message->method('getFilePath')->willReturn('');
+        $message->method('getFileType')->willReturn('');
+        $message->method('getTopic')->willReturn('CHAT');
+        $message->method('getLanguage')->willReturn('en');
+        $message->method('getFileText')->willReturn('');
+
+        $user = $this->createMock(User::class);
+        $user->method('getId')->willReturn(7);
+        $user->method('isMemoriesEnabled')->willReturn(true);
+
+        $userRepository = $this->createMock(UserRepository::class);
+        $userRepository->method('find')->with(7)->willReturn($user);
+        $this->em->method('getRepository')->with(User::class)->willReturn($userRepository);
+
+        $this->userMemoryService->method('isAvailable')->willReturn(false);
+
+        $this->promptRepository->method('findOneBy')->willReturn(null);
+        $this->modelConfigService->method('getEffectiveUserIdForMessage')->willReturn(7);
+        $this->modelConfigService->method('getDefaultModel')->willReturn(10);
+        $this->modelConfigService->method('getProviderForModel')->willReturn('openai');
+        $this->modelConfigService->method('getModelName')->willReturn('gpt-4.1');
+
+        $this->aiFacade->method('chat')->willReturn([
+            'content' => 'Got it, I will remember your new address.',
+            'provider' => 'openai',
+            'model' => 'gpt-4.1',
+        ]);
+
+        $this->perfPipelineFlag->method('isEnabled')->with(7)->willReturn(true);
+
+        $dispatched = null;
+        $this->messageBus
+            ->expects($this->once())
+            ->method('dispatch')
+            ->willReturnCallback(function (object $msg) use (&$dispatched) {
+                $dispatched = $msg;
+
+                return new Envelope($msg);
+            });
+
+        $this->handler->handle($message, [], ['topic' => 'CHAT', 'language' => 'en']);
+
+        self::assertInstanceOf(ExtractMemoriesCommand::class, $dispatched);
+        self::assertSame(456, $dispatched->getMessageId());
+        self::assertSame(7, $dispatched->getUserId());
+        self::assertStringContainsString('remember your new address', $dispatched->getAiResponse());
+    }
+
+    /**
+     * Widget requests opt out of memory loading + extraction (privacy:
+     * widget visitors are anonymous embeds). Verifies the
+     * `disable_memories` flag short-circuits before we ever talk to
+     * Qdrant or the messenger bus.
+     */
+    public function testHandleSkipsMemoriesForWidgetSource(): void
+    {
+        $message = $this->createMock(Message::class);
+        $message->method('getUserId')->willReturn(7);
+        $message->method('getText')->willReturn('Hi widget');
+        $message->method('getUnixTimestamp')->willReturn(time());
+        $message->method('getDateTime')->willReturn('20260512100000');
+        $message->method('getFilePath')->willReturn('');
+        $message->method('getFileType')->willReturn('');
+        $message->method('getTopic')->willReturn('CHAT');
+        $message->method('getLanguage')->willReturn('en');
+        $message->method('getFileText')->willReturn('');
+
+        $user = $this->createMock(User::class);
+        $user->method('isMemoriesEnabled')->willReturn(true);
+        $userRepository = $this->createMock(UserRepository::class);
+        $userRepository->method('find')->willReturn($user);
+        $this->em->method('getRepository')->willReturn($userRepository);
+
+        // If the disable flag is honoured we never reach Qdrant; if a
+        // future regression bypasses it, the mock's strict expectation
+        // below will fail the test.
+        $this->userMemoryService->expects($this->never())->method('embedUserQuery');
+        $this->userMemoryService->expects($this->never())->method('searchMemoriesByVector');
+        $this->userMemoryService->expects($this->never())->method('searchRelevantMemories');
+
+        $this->promptRepository->method('findOneBy')->willReturn(null);
+        $this->modelConfigService->method('getEffectiveUserIdForMessage')->willReturn(7);
+        $this->modelConfigService->method('getDefaultModel')->willReturn(10);
+        $this->modelConfigService->method('getProviderForModel')->willReturn('openai');
+        $this->modelConfigService->method('getModelName')->willReturn('gpt-4.1');
+
+        $this->aiFacade->method('chat')->willReturn([
+            'content' => 'Hi there',
+            'provider' => 'openai',
+            'model' => 'gpt-4.1',
+        ]);
+
+        // No extraction either — widget visitors must not leave a memory trail.
+        $this->messageBus->expects($this->never())->method('dispatch');
+
+        $this->handler->handle(
+            $message,
+            [],
+            ['topic' => 'CHAT', 'language' => 'en', 'source' => 'widget'],
+        );
     }
 
     public function testHandleStreamLoadsPromptMetadataForTaskPrompt(): void

--- a/backend/tests/Unit/Controller/StreamControllerOriginalMediaMetaTest.php
+++ b/backend/tests/Unit/Controller/StreamControllerOriginalMediaMetaTest.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Controller;
+
+use App\AI\Service\AiFacade;
+use App\Controller\StreamController;
+use App\Entity\Message;
+use App\Service\File\UserUploadPathBuilder;
+use App\Service\GuestSessionService;
+use App\Service\Message\MessageForwardingService;
+use App\Service\Message\MessageProcessor;
+use App\Service\ModelConfigService;
+use App\Service\PromptService;
+use App\Service\RateLimitService;
+use App\Service\WidgetService;
+use App\Service\WidgetSessionService;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+/**
+ * Unit coverage for {@see StreamController::persistOriginalMediaMeta()}.
+ *
+ * Issue #624: MEDIAMAKER audio responses used to leave the message
+ * without `original_topic` / `original_media_type` meta, so the chat
+ * badge label flipped from "Chat Model" live to "Audio Model" after a
+ * page reload. The helper now persists both keys whenever the
+ * classification routes through `mediamaker`, regardless of streaming
+ * vs non-streaming code path.
+ */
+class StreamControllerOriginalMediaMetaTest extends TestCase
+{
+    private StreamController $controller;
+
+    protected function setUp(): void
+    {
+        $this->controller = new StreamController(
+            $this->createMock(EntityManagerInterface::class),
+            $this->createMock(AiFacade::class),
+            $this->createMock(MessageProcessor::class),
+            new NullLogger(),
+            $this->createMock(ModelConfigService::class),
+            $this->createMock(WidgetService::class),
+            $this->createMock(WidgetSessionService::class),
+            $this->createMock(GuestSessionService::class),
+            $this->createMock(RateLimitService::class),
+            '/tmp/upload',
+            $this->createMock(UserUploadPathBuilder::class),
+            $this->createMock(PromptService::class),
+            $this->createMock(MessageForwardingService::class),
+        );
+    }
+
+    public function testPersistsOriginalMetaForMediamakerAudio(): void
+    {
+        $message = $this->createPersistedMessage();
+
+        $this->invokeHelper(
+            $message,
+            ['topic' => 'mediamaker', 'media_type' => 'audio'],
+            [],
+        );
+
+        self::assertSame('mediamaker', $message->getMeta('original_topic'));
+        self::assertSame('audio', $message->getMeta('original_media_type'));
+    }
+
+    public function testPrefersHandlerMetadataMediaTypeOverClassification(): void
+    {
+        $message = $this->createPersistedMessage();
+
+        // The handler may refine the media type (e.g. user wrote "make a
+        // gif" → classifier says `image`, handler picks `video` after
+        // reading the prompt). The handler value wins.
+        $this->invokeHelper(
+            $message,
+            ['topic' => 'mediamaker', 'media_type' => 'image'],
+            ['media_type' => 'video'],
+        );
+
+        self::assertSame('video', $message->getMeta('original_media_type'));
+    }
+
+    public function testFallsBackToClassificationMediaTypeWhenHandlerMetadataMissing(): void
+    {
+        $message = $this->createPersistedMessage();
+
+        $this->invokeHelper(
+            $message,
+            ['topic' => 'mediamaker', 'media_type' => 'image'],
+            [],
+        );
+
+        self::assertSame('image', $message->getMeta('original_media_type'));
+    }
+
+    public function testNoOpForNonMediamakerClassification(): void
+    {
+        $message = $this->createPersistedMessage();
+
+        $this->invokeHelper(
+            $message,
+            ['topic' => 'general', 'media_type' => 'audio'],
+            ['media_type' => 'audio'],
+        );
+
+        self::assertNull(
+            $message->getMeta('original_topic'),
+            'Regular chat replies must not leak MEDIAMAKER meta',
+        );
+        self::assertNull($message->getMeta('original_media_type'));
+    }
+
+    public function testMissingTopicIsTreatedAsNonMediamaker(): void
+    {
+        $message = $this->createPersistedMessage();
+
+        $this->invokeHelper($message, [], []);
+
+        self::assertNull($message->getMeta('original_topic'));
+        self::assertNull($message->getMeta('original_media_type'));
+    }
+
+    public function testMediamakerWithoutMediaTypePersistsOnlyTopic(): void
+    {
+        $message = $this->createPersistedMessage();
+
+        // Edge case from production logs: the classifier emits
+        // `mediamaker` but the handler hasn't produced media yet
+        // (e.g. fallback ask-for-clarification path). We still want
+        // `original_topic` so the Again dropdown knows the row was
+        // routed through MEDIAMAKER, even without a concrete media kind.
+        $this->invokeHelper(
+            $message,
+            ['topic' => 'mediamaker'],
+            [],
+        );
+
+        self::assertSame('mediamaker', $message->getMeta('original_topic'));
+        self::assertNull($message->getMeta('original_media_type'));
+    }
+
+    /**
+     * Build a Message with a non-null id so {@see Message::setMeta()} can
+     * back-fill {@see \App\Entity\MessageMeta::$messageId} (which is a
+     * non-nullable int column on the join table). Without an id, the
+     * MessageMeta constructor would throw during meta persistence — see
+     * the runtime guard in MessageMeta::setMessage().
+     */
+    private function createPersistedMessage(): Message
+    {
+        $message = new Message();
+        $reflection = new \ReflectionProperty(Message::class, 'id');
+        $reflection->setValue($message, 1);
+
+        return $message;
+    }
+
+    /**
+     * @param array<string, mixed> $classification
+     * @param array<string, mixed> $metadata
+     */
+    private function invokeHelper(Message $message, array $classification, array $metadata): void
+    {
+        $reflection = new \ReflectionMethod(StreamController::class, 'persistOriginalMediaMeta');
+        $reflection->invoke($this->controller, $message, $classification, $metadata);
+    }
+}

--- a/frontend/src/components/ChatMessage.vue
+++ b/frontend/src/components/ChatMessage.vue
@@ -627,6 +627,30 @@
                       </button>
                     </div>
 
+                    <!-- Audio (TTS) Model -->
+                    <!-- Shown as a separate badge so the LLM that generated the
+                         text and the TTS engine that voiced it are visually
+                         distinguishable — see issue #583. -->
+                    <div
+                      v-if="aiModels?.audio"
+                      class="flex items-center justify-between gap-2"
+                      data-testid="info-audio-model"
+                    >
+                      <span class="text-xs txt-tertiary">{{
+                        $t('chatMessage.infoAudioModel')
+                      }}</span>
+                      <button
+                        type="button"
+                        class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md text-xs font-medium bg-sky-500/10 hover:bg-sky-500/20 text-sky-600 dark:text-sky-400 transition-colors cursor-pointer"
+                        @click="handleInfoModelClick('audio')"
+                      >
+                        <Icon icon="mdi:music" class="w-3.5 h-3.5" />
+                        <span class="font-semibold truncate max-w-[10rem]">{{
+                          shortenModel(aiModels.audio.model)
+                        }}</span>
+                      </button>
+                    </div>
+
                     <!-- Sorting Model -->
                     <div v-if="aiModels?.sorting" class="flex items-center justify-between gap-2">
                       <span class="text-xs txt-tertiary">{{ $t('config.aiModels.sorting') }}</span>
@@ -887,6 +911,7 @@ import { useDateFormat } from '@/composables/useDateFormat'
 import type { Part, MessageFile } from '@/stores/history'
 import type { AgainData } from '@/types/ai-models'
 import { mediaHintFromClassificationTopic } from '@/utils/mediaGenerationHint'
+import { chatBadgeIcon, chatBadgeLabel } from '@/utils/chatModelBadge'
 
 const { t } = useI18n()
 const { error: showError } = useNotification()
@@ -933,6 +958,14 @@ interface Props {
       model_id: number | null
     }
     sorting?: {
+      provider: string
+      model: string
+      model_id: number | null
+    }
+    // Audio (TTS) model used to synthesize the voice reply.
+    // Sent independently from `chat` because voice reply pipes the
+    // LLM's text through a separate TTS pipeline — see issue #583.
+    audio?: {
       provider: string
       model: string
       model_id: number | null
@@ -1161,39 +1194,15 @@ const mediaHint = computed(() => {
   return null
 })
 
-// Dynamic label for model badge based on content type
-const getModelTypeLabel = computed(() => {
-  if (isFileAnalysisResponse.value) return 'Analyze Model'
-  switch (mediaHint.value) {
-    case 'vision':
-      return 'Vision Model'
-    case 'image':
-      return 'Image Model'
-    case 'video':
-      return 'Video Model'
-    case 'audio':
-      return 'Audio Model'
-    default:
-      return 'Chat Model'
-  }
-})
-
-// Dynamic icon for model badge
-const getModelTypeIcon = computed(() => {
-  if (isFileAnalysisResponse.value) return 'mdi:file-search'
-  switch (mediaHint.value) {
-    case 'vision':
-      return 'mdi:eye'
-    case 'image':
-      return 'mdi:image'
-    case 'video':
-      return 'mdi:video'
-    case 'audio':
-      return 'mdi:music'
-    default:
-      return 'mdi:chat'
-  }
-})
+// Pure-function helpers live in chatModelBadge.ts so the voice-reply
+// label rule (#583) is unit-testable in isolation. The computed
+// wrappers below just bind them to reactive component state.
+const getModelTypeLabel = computed(() =>
+  chatBadgeLabel(mediaHint.value, !!props.aiModels?.audio, isFileAnalysisResponse.value)
+)
+const getModelTypeIcon = computed(() =>
+  chatBadgeIcon(mediaHint.value, !!props.aiModels?.audio, isFileAnalysisResponse.value)
+)
 
 const formattedTime = computed(() => formatTime(props.timestamp))
 
@@ -1254,7 +1263,7 @@ const infoPopoverOpen = ref(false)
 
 const hasMessageMetadata = computed(() => {
   if (props.topic) return true
-  if (props.aiModels?.chat || props.aiModels?.sorting) return true
+  if (props.aiModels?.chat || props.aiModels?.sorting || props.aiModels?.audio) return true
   if (props.modelLabel && props.provider) return true
   return false
 })
@@ -1263,7 +1272,7 @@ const closeInfoPopover = () => {
   infoPopoverOpen.value = false
 }
 
-const handleInfoModelClick = (modelType: 'chat' | 'sorting') => {
+const handleInfoModelClick = (modelType: 'chat' | 'sorting' | 'audio') => {
   showModelDetails(modelType)
   closeInfoPopover()
 }
@@ -1309,18 +1318,23 @@ const getModelForOption = (option: ModelOption): AIModel | undefined => {
 }
 
 // Navigate to AI models configuration with highlight
-const showModelDetails = (modelType?: 'chat' | 'sorting') => {
+const showModelDetails = (modelType?: 'chat' | 'sorting' | 'audio') => {
   if (modelType === 'chat') {
     const capabilityMap: Record<string, string> = {
       vision: 'PIC2TEXT',
       image: 'TEXT2PIC',
       video: 'TEXT2VID',
-      audio: 'TEXT2SOUND',
+      // Only point CHAT badge at TEXT2SOUND when the chat handler itself
+      // produced the audio (no separate `audio` row exists). For voice
+      // replies the chat row is the LLM — keep it pointing at CHAT.
+      audio: props.aiModels?.audio ? 'CHAT' : 'TEXT2SOUND',
     }
     const capability = capabilityMap[mediaHint.value ?? ''] ?? 'CHAT'
     router.push({ path: '/config/ai-models', query: { highlight: capability } })
   } else if (modelType === 'sorting') {
     router.push({ path: '/config/ai-models', query: { highlight: 'SORT' } })
+  } else if (modelType === 'audio') {
+    router.push({ path: '/config/ai-models', query: { highlight: 'TEXT2SOUND' } })
   } else {
     router.push('/config/ai-models')
   }

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -333,7 +333,8 @@
     "messageDetails": "Nachrichtendetails",
     "infoTopic": "Thema",
     "infoModel": "Modell",
-    "infoProvider": "Anbieter"
+    "infoProvider": "Anbieter",
+    "infoAudioModel": "Audio-Modell"
   },
   "commands": {
     "noResults": "Keine Befehle gefunden",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -338,7 +338,8 @@
     "messageDetails": "Message details",
     "infoTopic": "Topic",
     "infoModel": "Model",
-    "infoProvider": "Provider"
+    "infoProvider": "Provider",
+    "infoAudioModel": "Audio Model"
   },
   "commands": {
     "noResults": "No commands found",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -299,7 +299,8 @@
     "again": "Otra vez",
     "againWith": "Otra vez con",
     "regenerateWith": "Regenerar con",
-    "copy": "Copiar mensaje"
+    "copy": "Copiar mensaje",
+    "infoAudioModel": "Modelo de audio"
   },
   "commands": {
     "noResults": "No se encontraron comandos",

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -299,7 +299,8 @@
     "again": "Tekrar",
     "againWith": "Şununla tekrar",
     "regenerateWith": "Şununla yeniden oluştur",
-    "copy": "Mesajı kopyala"
+    "copy": "Mesajı kopyala",
+    "infoAudioModel": "Ses Modeli"
   },
   "commands": {
     "noResults": "Komut bulunamadı",

--- a/frontend/src/stores/history.ts
+++ b/frontend/src/stores/history.ts
@@ -118,6 +118,14 @@ export interface Message {
       model: string
       model_id: number | null
     }
+    // Audio (TTS) model used for voice replies. Sent independently
+    // from `chat` because the LLM authors the text and a separate TTS
+    // pipeline (e.g. Piper) synthesises it — see issue #583.
+    audio?: {
+      provider: string
+      model: string
+      model_id: number | null
+    }
   } | null // AI model metadata
   webSearch?: {
     enabled?: boolean

--- a/frontend/src/stores/history.ts
+++ b/frontend/src/stores/history.ts
@@ -3,6 +3,7 @@ import { ref } from 'vue'
 import { normalizeMediaUrl } from '@/utils/urlHelper'
 import { extractBTextPayload } from '@/utils/jsonResponse'
 import { parseAIResponse } from '@/utils/responseParser'
+import { generatePartId } from '@/utils/mediaParts'
 import type { AgainData } from '@/types/ai-models'
 import { authService } from '@/services/authService'
 
@@ -444,22 +445,29 @@ export const useHistoryStore = defineStore('history', () => {
 
           const parts = parseContentWithThinking(m.text || '', role)
 
-          // Add generated file (image/video/audio) as part if present
+          // Add generated file (image/video/audio) as part if present.
+          // Issue #625: assign a stable `partId` on load so the `<audio>` /
+          // `<video>` element keeps its identity if the message later gets
+          // re-parsed (e.g. continuation appends text). Without this, the
+          // index-based fallback key would remount the media player.
           if (m.file && m.file.path) {
             const absoluteUrl = normalizeMediaUrl(m.file.path)
             if (m.file.type === 'image') {
               parts.push({
+                partId: generatePartId(),
                 type: 'image',
                 url: absoluteUrl,
                 alt: m.text || 'Generated image',
               })
             } else if (m.file.type === 'video') {
               parts.push({
+                partId: generatePartId(),
                 type: 'video',
                 url: absoluteUrl,
               })
             } else if (m.file.type === 'audio') {
               parts.push({
+                partId: generatePartId(),
                 type: 'audio',
                 url: absoluteUrl,
               })

--- a/frontend/src/utils/chatModelBadge.ts
+++ b/frontend/src/utils/chatModelBadge.ts
@@ -1,0 +1,80 @@
+/**
+ * Pure helpers for the chat-message model badges.
+ *
+ * Extracted from `ChatMessage.vue` so the label/icon decision is unit-
+ * testable in isolation — see issue #583, where the chat badge was
+ * relabelled as "Audio Model" for voice replies even though the
+ * displayed identifier was still the chat LLM.
+ */
+/**
+ * Wider than `MediaGenerationKind` from `mediaGenerationHint` because
+ * the chat-message component also distinguishes 'vision' for image
+ * *interpretation* (Pic2Text) — that branch never originates from
+ * classification topic alone.
+ */
+export type ChatBadgeMediaHint = 'vision' | 'image' | 'video' | 'audio' | null
+
+export type ChatBadgeLabel =
+  | 'Chat Model'
+  | 'Vision Model'
+  | 'Image Model'
+  | 'Video Model'
+  | 'Audio Model'
+  | 'Analyze Model'
+
+export type ChatBadgeIcon =
+  | 'mdi:chat'
+  | 'mdi:eye'
+  | 'mdi:image'
+  | 'mdi:video'
+  | 'mdi:music'
+  | 'mdi:file-search'
+
+/**
+ * Decide which label to render under the *chat* badge.
+ *
+ * Voice-reply special case: when `aiModels.audio` is present (i.e. a
+ * separate TTS pipeline produced the audio), the chat row still
+ * describes the LLM that authored the *text*. Keeping "Chat Model"
+ * here lets the audio engine own the "Audio Model" badge instead.
+ */
+export function chatBadgeLabel(
+  mediaHint: ChatBadgeMediaHint,
+  hasAudioModel: boolean,
+  isFileAnalysis: boolean
+): ChatBadgeLabel {
+  if (isFileAnalysis) return 'Analyze Model'
+  switch (mediaHint) {
+    case 'vision':
+      return 'Vision Model'
+    case 'image':
+      return 'Image Model'
+    case 'video':
+      return 'Video Model'
+    case 'audio':
+      return hasAudioModel ? 'Chat Model' : 'Audio Model'
+    default:
+      return 'Chat Model'
+  }
+}
+
+/** Icon that mirrors {@link chatBadgeLabel}. */
+export function chatBadgeIcon(
+  mediaHint: ChatBadgeMediaHint,
+  hasAudioModel: boolean,
+  isFileAnalysis: boolean
+): ChatBadgeIcon {
+  if (isFileAnalysis) return 'mdi:file-search'
+  switch (mediaHint) {
+    case 'vision':
+      return 'mdi:eye'
+    case 'image':
+      return 'mdi:image'
+    case 'video':
+      return 'mdi:video'
+    case 'audio':
+      return hasAudioModel ? 'mdi:chat' : 'mdi:music'
+    default:
+      return 'mdi:chat'
+  }
+}

--- a/frontend/src/utils/mediaParts.ts
+++ b/frontend/src/utils/mediaParts.ts
@@ -1,0 +1,121 @@
+import type { Message, Part, PartType } from '@/stores/history'
+
+/**
+ * Issue #625: Generated media (image / video / audio) from MEDIAMAKER
+ * was sometimes missing from the live SSE bubble — the player would
+ * only appear after a page reload. The root cause was a fragile
+ * interaction between three SSE events arriving back-to-back:
+ *
+ *   data (text chunk)  →  file (media url)  →  complete
+ *
+ * The original `data` handler reassigned `message.parts` wholesale on
+ * every chunk, so a file event landing between two data events lost
+ * the appended media. A later refactor (May 2026 "Performance" pass)
+ * fixed the obvious case by keeping a per-render `existingMedia`
+ * partition, but the media parts themselves still relied on:
+ *
+ *   1) `Array.prototype.push` on the reactive proxy (works only as
+ *      long as the proxy reference stays attached — a reassignment
+ *      elsewhere can silently detach it), and
+ *   2) Vue's fallback `${type}-${index}` key (index changes whenever
+ *      structural parts split mid-stream, causing the audio element
+ *      to remount and reset its playback state).
+ *
+ * This module centralizes media-part handling so:
+ *   - every media part gets a stable {@link Part.partId},
+ *   - additions go through an explicit array reassignment (proxy-safe),
+ *   - structural wipes can still salvage in-flight media via
+ *     {@link extractMediaParts}.
+ *
+ * Keep this module side-effect free so it can be unit-tested without
+ * mounting the chat view.
+ */
+
+/**
+ * Returns a process-wide unique part id. Used as the stable `:key`
+ * for `<MessagePart v-for>` so mid-stream re-renders don't unmount
+ * the underlying `<audio>` / `<video>` element (which would drop any
+ * pending playback or autoplay state).
+ */
+export function generatePartId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID()
+  }
+  return `p_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`
+}
+
+const MEDIA_PART_TYPES: ReadonlySet<PartType> = new Set(['image', 'video', 'audio'])
+
+export type MediaPartType = 'image' | 'video' | 'audio'
+
+export interface PushMediaPartOptions {
+  /** Voice-reply autoplay flag (only meaningful for `audio`). */
+  autoplay?: boolean
+  /** Pre-generated part id (use only in tests). */
+  partId?: string
+}
+
+/**
+ * Append a media part (image / video / audio) to `message.parts` in a
+ * Vue-3-reactivity-safe way.
+ *
+ * Why not just `message.parts.push(...)`? Two reasons:
+ *
+ *   - **Proxy reattachment.** Other handlers in `ChatView.vue` swap
+ *     `message.parts` for a brand-new array (see the `tts_loading`
+ *     filter and the `data.generatedFile` reactivity workaround).
+ *     Holding a captured reference to the *old* array and pushing
+ *     to it would silently update an orphaned proxy that no longer
+ *     drives the DOM. Reassigning the array on every media add
+ *     ensures we always mutate the current reactive slot.
+ *   - **Stable keys.** Vue keys media parts by `partId ?? type-index`.
+ *     Without a `partId`, an index shift (e.g. a `<think>` part being
+ *     inserted at the top during streaming) remounts the `<audio>`
+ *     element and resets the player to the empty state — exactly
+ *     the "missing player" symptom from issue #625.
+ */
+export function pushMediaPart(
+  message: Pick<Message, 'parts'>,
+  type: MediaPartType,
+  url: string,
+  options: PushMediaPartOptions = {}
+): Part {
+  const part: Part = {
+    partId: options.partId ?? generatePartId(),
+    type,
+    url,
+  }
+
+  if (type === 'audio' && options.autoplay !== undefined) {
+    part.autoplay = options.autoplay
+  }
+
+  message.parts = [...message.parts, part]
+
+  return part
+}
+
+/**
+ * Returns the subset of parts that represent generated media so a
+ * structural wipe (see `renderStreamingContent`'s
+ * `looksLikeFileGeneration` branch, the `BFILEPATH` reactivity
+ * workaround, etc.) can re-append them and avoid the regression
+ * called out in issue #625:
+ *
+ * > "This is a fundamental issue with how generated media parts
+ * > survive the SSE streaming lifecycle. The same pattern (parts
+ * > overwritten by data chunks) could potentially affect other
+ * > media types too, and should be addressed holistically."
+ */
+export function extractMediaParts(parts: readonly Part[]): Part[] {
+  return parts.filter((p) => MEDIA_PART_TYPES.has(p.type))
+}
+
+/**
+ * True iff `type` is a supported generated-media part type. Mirrors
+ * {@link MEDIA_PART_TYPES} so consumers don't have to construct a
+ * fresh set.
+ */
+export function isMediaPartType(type: PartType): type is MediaPartType {
+  return MEDIA_PART_TYPES.has(type)
+}

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -353,6 +353,7 @@ import { prefetchSseToken } from '@/services/api/chatApi'
 import type { ModelOption } from '@/composables/useModelSelection'
 import { parseAIResponse } from '@/utils/responseParser'
 import { normalizeMediaUrl } from '@/utils/urlHelper'
+import { generatePartId, pushMediaPart, extractMediaParts } from '@/utils/mediaParts'
 import { AudioStreamer } from '@/utils/AudioStreamer'
 import { httpClient } from '@/services/api/httpClient'
 import { z } from 'zod'
@@ -988,13 +989,6 @@ function schedulePostStreamMemoryPoll(messageId: number): void {
  *     Earlier parts (e.g. a finished code block followed by more streaming
  *     prose) keep their identity instead of being re-created each tick.
  */
-function generatePartId(): string {
-  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
-    return crypto.randomUUID()
-  }
-  return `p_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`
-}
-
 function renderStreamingContent(content: string, msgId: string): void {
   const trimmedContent = content.trim()
 
@@ -1012,7 +1006,12 @@ function renderStreamingContent(content: string, msgId: string): void {
     }
     const message = historyStore.messages.find((m) => m.id === msgId)
     if (message) {
-      message.parts = []
+      // Issue #625: structural wipe must not drop in-flight media. The
+      // SSE `file` event for image / video / audio can land before
+      // this branch (e.g. a MEDIAMAKER turn whose JSON markup arrives
+      // after the media was already uploaded) — preserving them here
+      // keeps the audio player visible in the live bubble.
+      message.parts = extractMediaParts(message.parts)
     }
     return
   }
@@ -1068,9 +1067,7 @@ function renderStreamingContent(content: string, msgId: string): void {
   const existingStructural = message.parts.filter(
     (p) => p.type === 'thinking' || p.type === 'text' || p.type === 'code' || p.type === 'links'
   )
-  const existingMedia = message.parts.filter(
-    (p) => p.type === 'image' || p.type === 'video' || p.type === 'audio'
-  )
+  const existingMedia = extractMediaParts(message.parts)
 
   // Reconcile in-place so existing partIds (and therefore Vue keys) stay
   // stable. For each desired slot:
@@ -1810,16 +1807,19 @@ const streamAIResponse = async (
             }
           } else if (data.status === 'file') {
             // Handle file attachments (images, videos, audio, etc.)
+            //
+            // Issue #625: the live MEDIAMAKER audio player used to go
+            // missing whenever this push raced the streaming text
+            // reconciler. {@link pushMediaPart} now assigns a stable
+            // `partId` and re-assigns `message.parts` so we always
+            // mutate the current reactive proxy (a stale closure
+            // reference from a sibling handler would otherwise
+            // silently drop the push).
             const message = historyStore.messages.find((m) => m.id === messageId)
-            if (message) {
-              // Add file part based on type - normalize URLs to absolute
+            if (message && data.url) {
               const absoluteUrl = normalizeMediaUrl(data.url)
-              if (data.type === 'image') {
-                message.parts.push({ type: 'image', url: absoluteUrl })
-              } else if (data.type === 'video') {
-                message.parts.push({ type: 'video', url: absoluteUrl })
-              } else if (data.type === 'audio') {
-                message.parts.push({ type: 'audio', url: absoluteUrl })
+              if (data.type === 'image' || data.type === 'video' || data.type === 'audio') {
+                pushMediaPart(message, data.type, absoluteUrl)
               }
             }
           } else if (data.status === 'tts_generating') {
@@ -1841,7 +1841,7 @@ const streamAIResponse = async (
               const absoluteUrl = normalizeMediaUrl(data.url)
               // If we are already streaming audio (currentAudioStreamer exists), don't autoplay the file
               const shouldAutoplay = isVoiceReply && !currentAudioStreamer
-              message.parts.push({ type: 'audio', url: absoluteUrl, autoplay: shouldAutoplay })
+              pushMediaPart(message, 'audio', absoluteUrl, { autoplay: shouldAutoplay })
             }
           } else if (data.status === 'links') {
             // Handle web search results

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -1333,6 +1333,10 @@ function applyAssistantChatModelFooter(
 
   const nestedChat = data.aiModels?.chat
   const nestedSorting = data.aiModels?.sorting
+  // Audio (TTS) model is independent of the chat model — pass it
+  // through whenever the backend ships it so the voice-reply badge
+  // appears live (no page reload required). See issue #583.
+  const nestedAudio = data.aiModels?.audio
 
   if (resolvedModel && resolvedProvider) {
     message.modelLabel = resolvedModel
@@ -1344,11 +1348,13 @@ function applyAssistantChatModelFooter(
         model_id: resolvedId,
       },
       ...(nestedSorting ? { sorting: nestedSorting } : {}),
+      ...(nestedAudio ? { audio: nestedAudio } : {}),
     }
-  } else if (nestedChat || nestedSorting) {
+  } else if (nestedChat || nestedSorting || nestedAudio) {
     message.aiModels = {
       ...(nestedChat ? { chat: nestedChat } : {}),
       ...(nestedSorting ? { sorting: nestedSorting } : {}),
+      ...(nestedAudio ? { audio: nestedAudio } : {}),
     }
   }
 }

--- a/frontend/tests/unit/mediaGenerationHint.spec.ts
+++ b/frontend/tests/unit/mediaGenerationHint.spec.ts
@@ -19,6 +19,17 @@ describe('mediaHintFromClassificationTopic', () => {
     expect(mediaHintFromClassificationTopic('mediamaker', 'IMAGE')).toBe('image')
   })
 
+  // Issue #624: live SSE complete for MEDIAMAKER audio now ships
+  // `originalMediaType: 'audio'`. Combined with `chatBadgeLabel`
+  // (see chatModelBadge.spec.ts) this gives the chat row a stable
+  // 'Audio Model' label even before the audio part lands in
+  // `message.parts`, so the badge no longer flips from
+  // "Chat Model" live to "Audio Model" after a page reload.
+  it('maps mediamaker + originalMediaType=audio to audio (issue #624)', () => {
+    expect(mediaHintFromClassificationTopic('mediamaker', 'audio')).toBe('audio')
+    expect(mediaHintFromClassificationTopic('mediamaker', 'AUDIO')).toBe('audio')
+  })
+
   it('returns null when topic is unknown or mediamaker without media type', () => {
     expect(mediaHintFromClassificationTopic('general', null)).toBeNull()
     expect(mediaHintFromClassificationTopic('mediamaker', null)).toBeNull()

--- a/frontend/tests/unit/mediaParts.spec.ts
+++ b/frontend/tests/unit/mediaParts.spec.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest'
+
+import { reactive } from 'vue'
+
+import type { Message, Part } from '@/stores/history'
+import { extractMediaParts, generatePartId, pushMediaPart } from '@/utils/mediaParts'
+
+/**
+ * Issue #625 regression coverage.
+ *
+ * The live MEDIAMAKER audio bubble used to lose its `<audio>` player
+ * because the SSE `file` event raced the streaming text reconciler.
+ * These tests pin the three guarantees of {@link pushMediaPart} so a
+ * future refactor can't reintroduce the bug:
+ *
+ *   1. Every appended media part carries a stable `partId` (so Vue's
+ *      keyed v-for doesn't remount the player on the next render).
+ *   2. The append reassigns `message.parts` instead of mutating in
+ *      place (so a sibling handler holding a stale reference can't
+ *      detach the reactive proxy and silently drop the push).
+ *   3. {@link extractMediaParts} returns every image/video/audio
+ *      part — and *only* those — so the structural wipe in
+ *      `renderStreamingContent`'s `looksLikeFileGeneration` branch
+ *      can salvage them without preserving thinking / text noise.
+ */
+describe('generatePartId', () => {
+  it('returns a unique id on every call', () => {
+    const ids = new Set<string>()
+    for (let i = 0; i < 50; i++) {
+      ids.add(generatePartId())
+    }
+    expect(ids.size).toBe(50)
+  })
+})
+
+describe('pushMediaPart', () => {
+  const buildMessage = (parts: Part[] = []): Pick<Message, 'parts'> => ({ parts })
+
+  it('appends an audio part with a stable partId (issue #625)', () => {
+    const message = buildMessage([{ type: 'text', content: 'Generated audio: hi' }])
+
+    pushMediaPart(message, 'audio', '/api/v1/files/uploads/abc/tts.mp3')
+
+    expect(message.parts).toHaveLength(2)
+    const audio = message.parts[1]
+    expect(audio.type).toBe('audio')
+    expect(audio.url).toBe('/api/v1/files/uploads/abc/tts.mp3')
+    expect(audio.partId).toMatch(/.+/)
+  })
+
+  it('replaces the parts array reference so Vue 3 reactivity always fires', () => {
+    // pinia/reactive() proxies mutate-in-place AND detect reassignment,
+    // but only reassignment survives a stale-closure scenario like the
+    // one that bit live MEDIAMAKER audio. Verify the reference flip.
+    const message = buildMessage([{ type: 'text', content: 'Generated audio: hi' }])
+    const originalParts = message.parts
+
+    pushMediaPart(message, 'audio', '/api/v1/files/uploads/x.mp3')
+
+    expect(message.parts).not.toBe(originalParts)
+    expect(originalParts).toHaveLength(1) // old reference left untouched
+  })
+
+  it('omits autoplay unless explicitly requested', () => {
+    const message = buildMessage()
+
+    pushMediaPart(message, 'audio', '/x.mp3')
+
+    expect(message.parts[0].autoplay).toBeUndefined()
+  })
+
+  it('forwards the autoplay flag for voice replies', () => {
+    const message = buildMessage()
+
+    pushMediaPart(message, 'audio', '/voice.mp3', { autoplay: true })
+
+    expect(message.parts[0].autoplay).toBe(true)
+  })
+
+  it('supports image and video parts with the same contract', () => {
+    const message = buildMessage()
+
+    pushMediaPart(message, 'image', '/img.png')
+    pushMediaPart(message, 'video', '/clip.mp4')
+
+    expect(message.parts.map((p) => p.type)).toEqual(['image', 'video'])
+    expect(message.parts[0].partId).toBeTruthy()
+    expect(message.parts[1].partId).toBeTruthy()
+  })
+
+  it('works on a Vue reactive() proxy (real ChatView usage)', () => {
+    // Smoke-test that `message.parts = [...]` triggers a reactive
+    // re-read even when the message is a Vue 3 Proxy — the path
+    // ChatView.vue actually exercises via the history store.
+    const message = reactive({ parts: [] as Part[] })
+
+    pushMediaPart(message, 'audio', '/r.mp3')
+
+    expect(message.parts).toHaveLength(1)
+    expect(message.parts[0].type).toBe('audio')
+    expect(message.parts[0].partId).toBeTruthy()
+  })
+
+  it('survives a data → file → complete SSE replay (issue #625 scenario)', () => {
+    // Reproduces the exact ChatView ordering: the streaming text
+    // reconciler runs (splitting into text + the new desired list)
+    // BEFORE and AFTER the `file` event lands. Audio must survive
+    // both passes regardless of whether the reconciler was kicked by
+    // a `data` chunk or by the synchronous flush in the `complete`
+    // handler.
+    const message: Pick<Message, 'parts'> = {
+      parts: [{ partId: 't1', type: 'text', content: '' }],
+    }
+
+    // 1) `data` chunk arrives → reconciler mutates the text in place.
+    message.parts[0].content = "Generated audio: 'grüße an dich'"
+
+    // 2) `file` event lands while the rAF reconciler is still pending.
+    pushMediaPart(message, 'audio', '/api/v1/files/uploads/tts.mp3')
+
+    // 3) `complete` event runs the final reconciliation. The streaming
+    //    text reconciler in ChatView.vue uses `extractMediaParts(...)`
+    //    to salvage media before reassigning the array, so the audio
+    //    part MUST appear after the reconciled text.
+    const structural = message.parts.filter(
+      (p) => p.type === 'thinking' || p.type === 'text' || p.type === 'code' || p.type === 'links'
+    )
+    const media = extractMediaParts(message.parts)
+    message.parts = [...structural, ...media]
+
+    expect(message.parts.map((p) => p.type)).toEqual(['text', 'audio'])
+    expect(message.parts[1].url).toBe('/api/v1/files/uploads/tts.mp3')
+    expect(message.parts[1].partId).toBeTruthy()
+  })
+})
+
+describe('extractMediaParts', () => {
+  it('returns only image / video / audio parts in original order', () => {
+    const parts: Part[] = [
+      { type: 'text', content: 'hi' },
+      { type: 'thinking', content: 'reasoning…' },
+      { type: 'image', url: '/img.png' },
+      { type: 'code', content: 'print(1)', language: 'python' },
+      { type: 'audio', url: '/a.mp3' },
+      { type: 'video', url: '/v.mp4' },
+    ]
+
+    const media = extractMediaParts(parts)
+
+    expect(media).toEqual([
+      { type: 'image', url: '/img.png' },
+      { type: 'audio', url: '/a.mp3' },
+      { type: 'video', url: '/v.mp4' },
+    ])
+  })
+
+  it('returns an empty array when no media is present', () => {
+    expect(extractMediaParts([{ type: 'text', content: 'hi' }])).toEqual([])
+  })
+})

--- a/frontend/tests/unit/utils/chatModelBadge.spec.ts
+++ b/frontend/tests/unit/utils/chatModelBadge.spec.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import type { ChatBadgeMediaHint } from '@/utils/chatModelBadge'
+import { chatBadgeIcon, chatBadgeLabel } from '@/utils/chatModelBadge'
+
+const hint = (h: ChatBadgeMediaHint): ChatBadgeMediaHint => h
+
+describe('chatModelBadge', () => {
+  describe('chatBadgeLabel', () => {
+    it("returns 'Chat Model' when no media hint is set", () => {
+      expect(chatBadgeLabel(null, false, false)).toBe('Chat Model')
+    })
+
+    it("returns 'Vision Model' when interpreting a vision response", () => {
+      expect(chatBadgeLabel(hint('vision'), false, false)).toBe('Vision Model')
+    })
+
+    it("returns 'Image Model' for image generation", () => {
+      expect(chatBadgeLabel('image', false, false)).toBe('Image Model')
+    })
+
+    it("returns 'Video Model' for video generation", () => {
+      expect(chatBadgeLabel('video', false, false)).toBe('Video Model')
+    })
+
+    it("returns 'Audio Model' when the chat handler itself produced audio", () => {
+      // Legacy text2sound flow where the chat row IS the audio model.
+      expect(chatBadgeLabel('audio', false, false)).toBe('Audio Model')
+    })
+
+    it("returns 'Chat Model' for voice replies (audio + separate TTS)", () => {
+      // Regression for #583: when a separate TTS pipeline produced
+      // the voice reply, the chat row must NOT inherit the 'Audio
+      // Model' label — the LLM is still the chat model.
+      expect(chatBadgeLabel('audio', true, false)).toBe('Chat Model')
+    })
+
+    it("returns 'Analyze Model' for file-analysis responses (highest priority)", () => {
+      expect(chatBadgeLabel('audio', true, true)).toBe('Analyze Model')
+      expect(chatBadgeLabel(null, false, true)).toBe('Analyze Model')
+    })
+  })
+
+  describe('chatBadgeIcon', () => {
+    it('mirrors the label decision — icon never disagrees with the text', () => {
+      expect(chatBadgeIcon(null, false, false)).toBe('mdi:chat')
+      expect(chatBadgeIcon(hint('vision'), false, false)).toBe('mdi:eye')
+      expect(chatBadgeIcon('image', false, false)).toBe('mdi:image')
+      expect(chatBadgeIcon('video', false, false)).toBe('mdi:video')
+      expect(chatBadgeIcon('audio', false, false)).toBe('mdi:music')
+    })
+
+    it('uses the chat icon for voice replies with a separate TTS model', () => {
+      // Same #583 nuance — icon follows the label rule.
+      expect(chatBadgeIcon('audio', true, false)).toBe('mdi:chat')
+    })
+
+    it('uses the analyze icon for file-analysis responses regardless of media hint', () => {
+      expect(chatBadgeIcon('audio', true, true)).toBe('mdi:file-search')
+      expect(chatBadgeIcon('image', false, true)).toBe('mdi:file-search')
+    })
+  })
+})


### PR DESCRIPTION
## Summary
Second batch of GitHub issue fixes building on `github-issues-fixing` (merged via #910). Closes five user-reported issues across chat streaming, memory extraction, and the WhatsApp webhook pipeline.

Closes #583
Closes #615
Closes #624
Closes #625
Closes #633

## Changes

### #583 — Chat: surface TTS model separately from chat model in voice replies
- `applyAssistantChatModelFooter()` (frontend `chatModelBadge.ts`) now resolves the chat model and the audio/TTS model as independent badges instead of overwriting one with the other.
- New `chatBadgeLabel()` helper localizes the badge ("Chat Model" / "Audio Model" / "Sorting Model") from the resolved capability.
- Backend `StreamController` persists `ai_audio_provider` / `ai_audio_model` / `ai_audio_model_id` meta on the outgoing message when TTS runs, so a page reload sees the same labels as the live view.

### #615 — Chat: load memories on email + generic webhook channels
- `ChatHandler::handle()` (non-streaming path used by email + generic API webhook) was missing memory and feedback context entirely. Refactored both `handle()` and `handleStream()` to share four new helpers:
  - `createSharedVectorResolver()` — lazy, single-call user-query embedding cache.
  - `loadMemoriesContext()` / `loadFeedbackContext()` — produce prompt fragments + emit `memories_loaded` / `feedback_loaded` SSE events.
  - `dispatchMemoryExtractionAsync()` — fire-and-forget memory extraction on the messenger bus, respecting the `PERF.V2_PIPELINE_ENABLED` kill-switch.
- All channels (Web UI / email / generic webhook) now use and contribute to long-term memory consistently.

### #624 — Chat: model badge label inconsistent between live view and page reload
- Live MEDIAMAKER audio used to show "Chat Model" → flip to "Audio Model" after refresh, and the "Again" dropdown jumped from CHAT to TEXT2SOUND capability.
- Backend extracts `persistOriginalMediaMeta()` and includes `originalTopic` + `originalMediaType` in the `complete` SSE payload for both streaming and non-streaming paths, so the frontend can resolve `mediaHint` correctly before the audio file even lands.

### #625 — Chat: MEDIAMAKER audio player not displayed in live SSE view, only after refresh
- The fragile `message.parts.push()` for generated media plus an index-based v-for key let the audio player disappear or remount under race conditions described in the issue's own note ("the same pattern could potentially affect other media types too, and should be addressed holistically").
- New `frontend/src/utils/mediaParts.ts` centralizes media-part handling with stable `partId` keys, proxy-safe array reassignment, and `extractMediaParts()` for structural-wipe survival. `ChatView.vue` + `history.ts` now go through these helpers; the `looksLikeFileGeneration` wipe branch preserves media instead of dropping it.

### #633 — WhatsApp: unsupported message types (polls, reactions) trigger AI responses
- One WhatsApp poll cascaded into 7+ "[Unsupported message type: …]" rows and 7+ AI replies because each vote/update arrived with a distinct `wamid` and slipped past duplicate detection into the `default` branch of `extractMessageText()`.
- New `SUPPORTED_MESSAGE_TYPES` allow-list (`text`, `image`, `sticker`, `audio`, `video`, `document`, `location`, `contacts`) and a `handleUnsupportedTypeIfNeeded()` early-return filter silently acknowledge `reaction` / `poll` / `system` / `interactive` / `button` / `ephemeral` / `request_welcome` / `unsupported` / `order` / any future Meta type with HTTP 200 + best-effort `markAsRead`.

## Verification
- [x] Tests added/updated
- [x] Manual

Automated coverage added in this PR:
- Backend: `StreamControllerOriginalMediaMetaTest` (#624), `ChatHandlerTest` memory + feedback paths (#615), 19 new `WhatsAppServiceTest` cases for #633 (10 unsupported types, 8 supported types, 1 unknown-future type).
- Frontend: `chatModelBadge.spec.ts` (#583), `mediaGenerationHint.spec.ts` regression test (#624), `mediaParts.spec.ts` with 10 specs covering `partId` stability, reactivity-safe reassignment, autoplay forwarding, and a full `data → file → complete` SSE replay (#625).

Full quality gate run locally on every commit:
- `make -C backend lint` — clean
- `make -C backend phpstan` — no errors
- `make -C backend test` — 1481 tests, 5277 assertions, all green
- `make -C frontend lint` — clean
- `docker compose exec -T frontend npm run check:types` — clean
- `make -C frontend test` — 424 tests, all green

Manual smoke-testing:
- #583 / #624 / #625: voice reply + MEDIAMAKER audio in the local docker stack, before and after a page reload, confirms badge labels and "Again" capability stay consistent.
- #615: email-channel ingest exercise via the generic webhook endpoint loads existing memories and dispatches new ones to the messenger bus.
- #633: replayed real Meta webhook payloads for `reaction`, `poll`, `poll_vote`, `interactive`, `system` against the local backend — each returns `skipped: true` and zero downstream side-effects.

## Notes
Branch builds on top of the merged #910 (`github-issues-fixing`) so the diff against `main` only carries the five additional fixes in this batch.

Please do **not** auto-merge — keep this PR open for review and merge manually once approved.

## Screenshots/Logs
_No UI screenshots — fixes are either invisible (silent webhook ack) or already covered by the issue's own before/after screenshots._