### PR TITLE
fix(auth): preserve deep-link redirect across OAuth and query cleanup

### DIFF
--- a/frontend/src/components/auth/OAuthCallback.vue
+++ b/frontend/src/components/auth/OAuthCallback.vue
@@ -79,7 +79,7 @@ import { ref, computed, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
 import { useI18n } from 'vue-i18n'
-import { consumePendingRedirect } from '@/utils/pendingAuthRedirect'
+import { clearPendingRedirect, consumePendingRedirect } from '@/utils/pendingAuthRedirect'
 import Button from '../Button.vue'
 
 const router = useRouter()
@@ -118,6 +118,9 @@ onMounted(async () => {
 
     // Check for error in URL params
     if (errorParam) {
+      // Cancelled / failed OAuth must not leave a pending deep-link in
+      // sessionStorage, or the next plain login could be hijacked.
+      clearPendingRedirect()
       error.value = decodeURIComponent(errorParam)
       return
     }
@@ -132,32 +135,34 @@ onMounted(async () => {
         const result = await authStore.handleOAuthCallback()
 
         if (result) {
-          // Resume any pending deep-link that started this round-trip
-          // (e.g. the Outlook add-in `/addin/connect` bridge). Falls back
-          // to home if nothing was persisted. See `pendingAuthRedirect.ts`.
           const target = consumePendingRedirect() ?? '/'
-          console.log('✅ Session verified, redirecting to', target)
           // Clear URL params for clean history
           window.history.replaceState({}, document.title, '/auth/callback')
 
+          // Short delay so the success spinner is perceivable before
+          // the route change unmounts this view.
           setTimeout(() => {
             router.push(target)
           }, 500)
         } else {
           console.error('❌ Session verification failed')
+          clearPendingRedirect()
           error.value = t('auth.socialLoginError')
         }
       } catch (e: unknown) {
         console.error('❌ Failed to verify session after OAuth:', e)
+        clearPendingRedirect()
         error.value = t('auth.socialLoginError')
       }
     } else {
       // No success param and no error - something went wrong
       console.error('❌ OAuth callback without success or error')
+      clearPendingRedirect()
       error.value = t('auth.socialLoginError')
     }
   } catch (e: unknown) {
     console.error('❌ OAuth callback error:', e)
+    clearPendingRedirect()
     error.value = getErrorMessage(e) || t('auth.socialLoginError')
   }
 })

--- a/frontend/src/components/auth/OAuthCallback.vue
+++ b/frontend/src/components/auth/OAuthCallback.vue
@@ -79,6 +79,7 @@ import { ref, computed, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
 import { useI18n } from 'vue-i18n'
+import { consumePendingRedirect } from '@/utils/pendingAuthRedirect'
 import Button from '../Button.vue'
 
 const router = useRouter()
@@ -131,13 +132,16 @@ onMounted(async () => {
         const result = await authStore.handleOAuthCallback()
 
         if (result) {
-          console.log('✅ Session verified, redirecting to home')
+          // Resume any pending deep-link that started this round-trip
+          // (e.g. the Outlook add-in `/addin/connect` bridge). Falls back
+          // to home if nothing was persisted. See `pendingAuthRedirect.ts`.
+          const target = consumePendingRedirect() ?? '/'
+          console.log('✅ Session verified, redirecting to', target)
           // Clear URL params for clean history
           window.history.replaceState({}, document.title, '/auth/callback')
 
-          // Redirect to home
           setTimeout(() => {
-            router.push('/')
+            router.push(target)
           }, 500)
         } else {
           console.error('❌ Session verification failed')

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -4,6 +4,7 @@ import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
 import { authService, type AuthUser, type ImpersonatorInfo } from '@/services/authService'
 import { useConfigStore } from '@/stores/config'
+import { clearPendingRedirect } from '@/utils/pendingAuthRedirect'
 
 export type User = AuthUser
 export type { ImpersonatorInfo } from '@/services/authService'
@@ -118,6 +119,9 @@ export const useAuthStore = defineStore('auth', () => {
     user.value = null
     impersonator.value = null
     loading.value = true
+    // Drop any in-flight deep-link intent so the next login isn't hijacked
+    // by a stale entry from this session.
+    clearPendingRedirect()
 
     try {
       await authService.logout()

--- a/frontend/src/utils/pendingAuthRedirect.ts
+++ b/frontend/src/utils/pendingAuthRedirect.ts
@@ -28,21 +28,41 @@ interface PendingRedirect {
   expiresAt: number
 }
 
+function safeRemove(key: string): void {
+  try {
+    sessionStorage.removeItem(key)
+  } catch {
+    // ignore — sessionStorage may be unavailable (private mode, SSR).
+  }
+}
+
 function safeGet(key: string): PendingRedirect | null {
   try {
     const raw = sessionStorage.getItem(key)
     if (!raw) return null
     const parsed = JSON.parse(raw) as Partial<PendingRedirect>
     if (typeof parsed.path !== 'string' || typeof parsed.expiresAt !== 'number') {
-      sessionStorage.removeItem(key)
+      // Wrong shape — drop it so we don't keep re-parsing the same garbage.
+      safeRemove(key)
       return null
     }
     if (parsed.expiresAt < Date.now()) {
-      sessionStorage.removeItem(key)
+      safeRemove(key)
+      return null
+    }
+    // Defence in depth: re-validate the path on read. A tampered or stale
+    // entry with the right shape but an unsafe path (protocol-relative,
+    // schemed, oversized, etc.) must not be returned to callers, who use
+    // the result for `router.push` without further checks.
+    if (!isSafeRedirectPath(parsed.path)) {
+      safeRemove(key)
       return null
     }
     return { path: parsed.path, expiresAt: parsed.expiresAt }
   } catch {
+    // Malformed JSON or sessionStorage throwing on read — self-heal by
+    // dropping the entry so subsequent calls don't keep failing.
+    safeRemove(key)
     return null
   }
 }
@@ -52,14 +72,6 @@ function safeSet(key: string, value: PendingRedirect): void {
     sessionStorage.setItem(key, JSON.stringify(value))
   } catch {
     // sessionStorage may be unavailable (private mode, SSR, quota).
-  }
-}
-
-function safeRemove(key: string): void {
-  try {
-    sessionStorage.removeItem(key)
-  } catch {
-    // ignore
   }
 }
 

--- a/frontend/src/utils/pendingAuthRedirect.ts
+++ b/frontend/src/utils/pendingAuthRedirect.ts
@@ -81,6 +81,8 @@ function safeSet(key: string, value: PendingRedirect): void {
  *   - empty / non-string inputs
  *   - protocol-relative URLs (`//evil.example`)
  *   - schemed URLs (`https://…`, `javascript:…`, `data:…`)
+ *   - paths containing a backslash (some browsers normalise `\` → `/`,
+ *     which can be used to smuggle a host through path-only validation)
  *   - over-long payloads
  */
 export function isSafeRedirectPath(path: unknown): path is string {
@@ -88,6 +90,7 @@ export function isSafeRedirectPath(path: unknown): path is string {
   if (path.length === 0 || path.length > MAX_PATH_LENGTH) return false
   if (!path.startsWith('/')) return false
   if (path.startsWith('//')) return false
+  if (path.includes('\\')) return false
   return true
 }
 

--- a/frontend/src/utils/pendingAuthRedirect.ts
+++ b/frontend/src/utils/pendingAuthRedirect.ts
@@ -1,0 +1,117 @@
+/**
+ * Session-scoped helpers that survive a login round-trip — in particular
+ * an OAuth provider redirect that destroys all SPA state (and therefore the
+ * `?redirect=…` query param on `/login`).
+ *
+ * Set by `LoginView.handleSocialLogin` and `AddinConnectView.bootstrap` just
+ * before they trigger a navigation that may bounce through a third-party
+ * provider. Consumed by `OAuthCallback` (and as a fallback by
+ * `LoginView.handleLogin`) once the user lands back on Synaplan.
+ *
+ * Security:
+ *   - Only same-origin relative paths (starting with `/`) are accepted,
+ *     to prevent an open-redirect from a tampered `?redirect=`.
+ *   - Capped at 2 KiB to make abuse uninteresting.
+ *   - 10-minute TTL so a stale entry from a previous session can't hijack
+ *     the next login.
+ *   - One-shot: consume clears the entry.
+ *   - sessionStorage failures (private mode, SSR, quota) silently no-op
+ *     rather than throw, because login must keep working regardless.
+ */
+
+const PENDING_REDIRECT_KEY = 'synaplan.pendingAuthRedirect'
+const TTL_MS = 10 * 60 * 1000
+const MAX_PATH_LENGTH = 2048
+
+interface PendingRedirect {
+  path: string
+  expiresAt: number
+}
+
+function safeGet(key: string): PendingRedirect | null {
+  try {
+    const raw = sessionStorage.getItem(key)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as Partial<PendingRedirect>
+    if (typeof parsed.path !== 'string' || typeof parsed.expiresAt !== 'number') {
+      sessionStorage.removeItem(key)
+      return null
+    }
+    if (parsed.expiresAt < Date.now()) {
+      sessionStorage.removeItem(key)
+      return null
+    }
+    return { path: parsed.path, expiresAt: parsed.expiresAt }
+  } catch {
+    return null
+  }
+}
+
+function safeSet(key: string, value: PendingRedirect): void {
+  try {
+    sessionStorage.setItem(key, JSON.stringify(value))
+  } catch {
+    // sessionStorage may be unavailable (private mode, SSR, quota).
+  }
+}
+
+function safeRemove(key: string): void {
+  try {
+    sessionStorage.removeItem(key)
+  } catch {
+    // ignore
+  }
+}
+
+/**
+ * Reject anything that isn't a single-leading-slash same-origin path.
+ * Specifically rejects:
+ *   - empty / non-string inputs
+ *   - protocol-relative URLs (`//evil.example`)
+ *   - schemed URLs (`https://…`, `javascript:…`, `data:…`)
+ *   - over-long payloads
+ */
+export function isSafeRedirectPath(path: unknown): path is string {
+  if (typeof path !== 'string') return false
+  if (path.length === 0 || path.length > MAX_PATH_LENGTH) return false
+  if (!path.startsWith('/')) return false
+  if (path.startsWith('//')) return false
+  return true
+}
+
+/**
+ * Persist the post-login redirect target. Silently ignores unsafe inputs;
+ * the caller doesn't need to validate first.
+ */
+export function setPendingRedirect(path: string): void {
+  if (!isSafeRedirectPath(path)) return
+  safeSet(PENDING_REDIRECT_KEY, { path, expiresAt: Date.now() + TTL_MS })
+}
+
+/**
+ * Read the pending redirect WITHOUT clearing it. Useful for previewing
+ * (e.g. unit tests, debug logs); production code should prefer
+ * {@link consumePendingRedirect} to avoid double-application.
+ */
+export function peekPendingRedirect(): string | null {
+  return safeGet(PENDING_REDIRECT_KEY)?.path ?? null
+}
+
+/**
+ * Read and clear the pending redirect in one shot. Returns `null` if there
+ * isn't one (or it expired, or sessionStorage is unavailable).
+ */
+export function consumePendingRedirect(): string | null {
+  const v = safeGet(PENDING_REDIRECT_KEY)
+  if (!v) return null
+  safeRemove(PENDING_REDIRECT_KEY)
+  return v.path
+}
+
+/**
+ * Drop any pending redirect (e.g. on explicit sign-out or on a navigation
+ * that supersedes the pending intent).
+ */
+export function clearPendingRedirect(): void {
+  safeRemove(PENDING_REDIRECT_KEY)
+}

--- a/frontend/src/views/AddinConnectView.vue
+++ b/frontend/src/views/AddinConnectView.vue
@@ -143,6 +143,7 @@ import { useAuthStore } from '@/stores/auth'
 import { authReady } from '@/stores/auth'
 import { useTheme } from '@/composables/useTheme'
 import { createApiKey } from '@/services/api/apiKeysApi'
+import { setPendingRedirect } from '@/utils/pendingAuthRedirect'
 
 /**
  * /addin/connect — Synamail Outlook add-in bridge page.
@@ -333,10 +334,16 @@ async function bootstrap(): Promise<void> {
 
     if (!authStore.isAuthenticated) {
       // Round-trip through /login so the user authenticates, then comes
-      // back here with the same state nonce intact.
+      // back here with the same state nonce intact. Belt-and-suspenders:
+      // we put the destination on the URL (the SPA-native channel) AND in
+      // sessionStorage (the OAuth-survives-roundtrip channel), so the
+      // bridge can resume the connect flow whether the user picked the
+      // email-password form or a social provider that bounces through a
+      // third-party origin. See utils/pendingAuthRedirect.ts.
       const redirect =
         `/addin/connect?state=${encodeURIComponent(stateNonce.value)}` +
         `&baseUrl=${encodeURIComponent(targetBaseUrl.value)}`
+      setPendingRedirect(redirect)
       void router.push({ path: '/login', query: { redirect } })
       return
     }

--- a/frontend/src/views/AddinConnectView.vue
+++ b/frontend/src/views/AddinConnectView.vue
@@ -333,13 +333,8 @@ async function bootstrap(): Promise<void> {
     await authReady
 
     if (!authStore.isAuthenticated) {
-      // Round-trip through /login so the user authenticates, then comes
-      // back here with the same state nonce intact. Belt-and-suspenders:
-      // we put the destination on the URL (the SPA-native channel) AND in
-      // sessionStorage (the OAuth-survives-roundtrip channel), so the
-      // bridge can resume the connect flow whether the user picked the
-      // email-password form or a social provider that bounces through a
-      // third-party origin. See utils/pendingAuthRedirect.ts.
+      // Stash in sessionStorage too: a social-provider OAuth round-trip
+      // would otherwise drop the `redirect` query and strand the user.
       const redirect =
         `/addin/connect?state=${encodeURIComponent(stateNonce.value)}` +
         `&baseUrl=${encodeURIComponent(targetBaseUrl.value)}`

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -367,6 +367,11 @@ import { useAuth } from '../composables/useAuth'
 import { useRecaptcha } from '../composables/useRecaptcha'
 import { validateEmail } from '../composables/usePasswordValidation'
 import { useConfigStore } from '@/stores/config'
+import {
+  consumePendingRedirect,
+  isSafeRedirectPath,
+  setPendingRedirect,
+} from '@/utils/pendingAuthRedirect'
 
 const router = useRouter()
 const route = useRoute()
@@ -446,7 +451,17 @@ onMounted(async () => {
   const reason = route.query.reason as string
   if (reason === 'session_expired') sessionExpired.value = true
   if (route.query.registered === 'true') justRegistered.value = true
-  if (reason || route.query.registered) router.replace({ query: {} })
+  if (reason || route.query.registered) {
+    // Strip the inbound `reason` / `registered` query keys, but preserve any
+    // other query params (notably `redirect`, which deep-links such as the
+    // Outlook add-in `/addin/connect` bridge depend on). Previously this
+    // line did `router.replace({ query: {} })`, which clobbered `redirect`
+    // and left users on `/` after login instead of back at the deep-link.
+    const cleaned = { ...route.query }
+    delete cleaned.reason
+    delete cleaned.registered
+    router.replace({ query: cleaned })
+  }
 
   await loadSocialProviders()
 
@@ -471,12 +486,25 @@ const handleLogin = async () => {
   if (success) {
     loginSuccess.value = true
     setTimeout(() => {
-      router.push((router.currentRoute.value.query.redirect as string) || '/')
+      // Prefer the query param (the primary, SPA-native channel), but fall
+      // back to sessionStorage so a deep-link survives a bounce that wiped
+      // the URL (e.g. an OAuth provider round-trip or a router replace).
+      const fromQuery = router.currentRoute.value.query.redirect as string | undefined
+      const queryPath = isSafeRedirectPath(fromQuery) ? fromQuery : null
+      const target = queryPath ?? consumePendingRedirect() ?? '/'
+      router.push(target)
     }, 400)
   }
 }
 
 const handleSocialLogin = (provider: string) => {
+  // OAuth providers redirect through their own origin, which destroys the
+  // SPA's URL state (including `?redirect=…`). Persist the intent to
+  // sessionStorage so OAuthCallback can resume it after the round-trip.
+  const fromQuery = route.query.redirect as string | undefined
+  if (isSafeRedirectPath(fromQuery)) {
+    setPendingRedirect(fromQuery)
+  }
   window.location.href = `${config.appBaseUrl}/api/v1/auth/${provider}/login`
 }
 </script>

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -452,11 +452,7 @@ onMounted(async () => {
   if (reason === 'session_expired') sessionExpired.value = true
   if (route.query.registered === 'true') justRegistered.value = true
   if (reason || route.query.registered) {
-    // Strip the inbound `reason` / `registered` query keys, but preserve any
-    // other query params (notably `redirect`, which deep-links such as the
-    // Outlook add-in `/addin/connect` bridge depend on). Previously this
-    // line did `router.replace({ query: {} })`, which clobbered `redirect`
-    // and left users on `/` after login instead of back at the deep-link.
+    // Strip only `reason`/`registered`; keep `redirect` so deep-links survive.
     const cleaned = { ...route.query }
     delete cleaned.reason
     delete cleaned.registered
@@ -485,10 +481,8 @@ const handleLogin = async () => {
   const success = await login(email.value, password.value, recaptchaToken)
   if (success) {
     loginSuccess.value = true
+    // Short delay so the success checkmark animation can play before nav.
     setTimeout(() => {
-      // Prefer the query param (the primary, SPA-native channel), but fall
-      // back to sessionStorage so a deep-link survives a bounce that wiped
-      // the URL (e.g. an OAuth provider round-trip or a router replace).
       const fromQuery = router.currentRoute.value.query.redirect as string | undefined
       const queryPath = isSafeRedirectPath(fromQuery) ? fromQuery : null
       const target = queryPath ?? consumePendingRedirect() ?? '/'
@@ -498,13 +492,10 @@ const handleLogin = async () => {
 }
 
 const handleSocialLogin = (provider: string) => {
-  // OAuth providers redirect through their own origin, which destroys the
-  // SPA's URL state (including `?redirect=…`). Persist the intent to
-  // sessionStorage so OAuthCallback can resume it after the round-trip.
-  const fromQuery = route.query.redirect as string | undefined
-  if (isSafeRedirectPath(fromQuery)) {
-    setPendingRedirect(fromQuery)
-  }
+  // OAuth round-trip strips the SPA's URL state, so stash the intent
+  // for OAuthCallback to pick up. setPendingRedirect validates internally.
+  const redirect = route.query.redirect as string | undefined
+  if (redirect) setPendingRedirect(redirect)
   window.location.href = `${config.appBaseUrl}/api/v1/auth/${provider}/login`
 }
 </script>

--- a/frontend/tests/unit/utils/pendingAuthRedirect.spec.ts
+++ b/frontend/tests/unit/utils/pendingAuthRedirect.spec.ts
@@ -132,15 +132,39 @@ describe('clearPendingRedirect', () => {
 })
 
 describe('robustness against corrupted storage', () => {
-  it('ignores and clears entries with malformed JSON', () => {
+  it('self-heals entries with malformed JSON', () => {
     sessionStorage.setItem(KEY, '{not json')
     expect(peekPendingRedirect()).toBeNull()
-    expect(consumePendingRedirect()).toBeNull()
+    // The malformed entry must be removed so subsequent reads don't keep
+    // re-parsing the same garbage.
+    expect(sessionStorage.getItem(KEY)).toBeNull()
   })
 
-  it('ignores and clears entries with the wrong shape', () => {
+  it('self-heals entries with the wrong shape', () => {
     sessionStorage.setItem(KEY, JSON.stringify({ path: 123, expiresAt: 'soon' }))
     expect(peekPendingRedirect()).toBeNull()
+    expect(sessionStorage.getItem(KEY)).toBeNull()
+  })
+
+  it('self-heals entries whose stored path fails re-validation on read', () => {
+    // Mimic a tampered or stale entry: correct JSON shape and future
+    // expiry, but the path itself is unsafe (protocol-relative). Even
+    // though setPendingRedirect would have rejected this at write time,
+    // the helper must defend against the value already being present.
+    sessionStorage.setItem(
+      KEY,
+      JSON.stringify({ path: '//evil.example/path', expiresAt: Date.now() + 60_000 })
+    )
+    expect(peekPendingRedirect()).toBeNull()
+    expect(sessionStorage.getItem(KEY)).toBeNull()
+  })
+
+  it('also self-heals entries with a schemed path', () => {
+    sessionStorage.setItem(
+      KEY,
+      JSON.stringify({ path: 'javascript:alert(1)', expiresAt: Date.now() + 60_000 })
+    )
+    expect(consumePendingRedirect()).toBeNull()
     expect(sessionStorage.getItem(KEY)).toBeNull()
   })
 

--- a/frontend/tests/unit/utils/pendingAuthRedirect.spec.ts
+++ b/frontend/tests/unit/utils/pendingAuthRedirect.spec.ts
@@ -1,0 +1,163 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  clearPendingRedirect,
+  consumePendingRedirect,
+  isSafeRedirectPath,
+  peekPendingRedirect,
+  setPendingRedirect,
+} from '@/utils/pendingAuthRedirect'
+
+const KEY = 'synaplan.pendingAuthRedirect'
+
+beforeEach(() => {
+  sessionStorage.clear()
+  vi.useRealTimers()
+})
+
+afterEach(() => {
+  sessionStorage.clear()
+})
+
+describe('isSafeRedirectPath', () => {
+  it('accepts a single-leading-slash same-origin path', () => {
+    expect(isSafeRedirectPath('/addin/connect?state=abc')).toBe(true)
+    expect(isSafeRedirectPath('/chat')).toBe(true)
+    expect(isSafeRedirectPath('/')).toBe(true)
+  })
+
+  it('rejects non-strings and empty strings', () => {
+    expect(isSafeRedirectPath(undefined)).toBe(false)
+    expect(isSafeRedirectPath(null)).toBe(false)
+    expect(isSafeRedirectPath(123)).toBe(false)
+    expect(isSafeRedirectPath({})).toBe(false)
+    expect(isSafeRedirectPath('')).toBe(false)
+  })
+
+  it('rejects protocol-relative URLs (open-redirect vector)', () => {
+    expect(isSafeRedirectPath('//evil.example/path')).toBe(false)
+    expect(isSafeRedirectPath('//evil.example')).toBe(false)
+  })
+
+  it('rejects schemed URLs', () => {
+    expect(isSafeRedirectPath('https://evil.example/path')).toBe(false)
+    expect(isSafeRedirectPath('http://localhost/path')).toBe(false)
+    expect(isSafeRedirectPath('javascript:alert(1)')).toBe(false)
+    expect(isSafeRedirectPath('data:text/html,<script>')).toBe(false)
+  })
+
+  it('rejects paths that do not start with /', () => {
+    expect(isSafeRedirectPath('addin/connect')).toBe(false)
+    expect(isSafeRedirectPath('?state=abc')).toBe(false)
+  })
+
+  it('rejects payloads over 2 KiB', () => {
+    expect(isSafeRedirectPath('/' + 'a'.repeat(2047))).toBe(true)
+    expect(isSafeRedirectPath('/' + 'a'.repeat(2048))).toBe(false)
+  })
+})
+
+describe('setPendingRedirect + peekPendingRedirect', () => {
+  it('persists a safe path and reads it back without clearing', () => {
+    setPendingRedirect('/addin/connect?state=NONCE&baseUrl=https%3A%2F%2Fweb.synaplan.com')
+    expect(peekPendingRedirect()).toBe(
+      '/addin/connect?state=NONCE&baseUrl=https%3A%2F%2Fweb.synaplan.com'
+    )
+    // Peek must not clear.
+    expect(peekPendingRedirect()).toBe(
+      '/addin/connect?state=NONCE&baseUrl=https%3A%2F%2Fweb.synaplan.com'
+    )
+  })
+
+  it('silently ignores unsafe inputs without throwing', () => {
+    setPendingRedirect('https://evil.example/path')
+    setPendingRedirect('//evil.example')
+    setPendingRedirect('not-a-path')
+    setPendingRedirect('')
+    expect(peekPendingRedirect()).toBeNull()
+    expect(sessionStorage.getItem(KEY)).toBeNull()
+  })
+
+  it('overwrites an earlier value', () => {
+    setPendingRedirect('/first')
+    setPendingRedirect('/second')
+    expect(peekPendingRedirect()).toBe('/second')
+  })
+})
+
+describe('consumePendingRedirect', () => {
+  it('returns the stored path and clears the entry', () => {
+    setPendingRedirect('/addin/connect?state=NONCE')
+    expect(consumePendingRedirect()).toBe('/addin/connect?state=NONCE')
+    expect(peekPendingRedirect()).toBeNull()
+    expect(sessionStorage.getItem(KEY)).toBeNull()
+  })
+
+  it('returns null when nothing is stored', () => {
+    expect(consumePendingRedirect()).toBeNull()
+  })
+
+  it('is one-shot — a second consume yields null', () => {
+    setPendingRedirect('/chat')
+    expect(consumePendingRedirect()).toBe('/chat')
+    expect(consumePendingRedirect()).toBeNull()
+  })
+})
+
+describe('TTL behaviour', () => {
+  it('expires an entry older than 10 minutes and clears it on access', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-21T10:00:00Z'))
+    setPendingRedirect('/addin/connect?state=NONCE')
+
+    vi.setSystemTime(new Date('2026-05-21T10:09:59Z'))
+    expect(peekPendingRedirect()).toBe('/addin/connect?state=NONCE')
+
+    vi.setSystemTime(new Date('2026-05-21T10:10:01Z'))
+    expect(peekPendingRedirect()).toBeNull()
+    expect(sessionStorage.getItem(KEY)).toBeNull()
+  })
+})
+
+describe('clearPendingRedirect', () => {
+  it('removes any stored entry', () => {
+    setPendingRedirect('/chat')
+    clearPendingRedirect()
+    expect(peekPendingRedirect()).toBeNull()
+    expect(sessionStorage.getItem(KEY)).toBeNull()
+  })
+
+  it('is a no-op when nothing is stored', () => {
+    expect(() => clearPendingRedirect()).not.toThrow()
+  })
+})
+
+describe('robustness against corrupted storage', () => {
+  it('ignores and clears entries with malformed JSON', () => {
+    sessionStorage.setItem(KEY, '{not json')
+    expect(peekPendingRedirect()).toBeNull()
+    expect(consumePendingRedirect()).toBeNull()
+  })
+
+  it('ignores and clears entries with the wrong shape', () => {
+    sessionStorage.setItem(KEY, JSON.stringify({ path: 123, expiresAt: 'soon' }))
+    expect(peekPendingRedirect()).toBeNull()
+    expect(sessionStorage.getItem(KEY)).toBeNull()
+  })
+
+  it('tolerates sessionStorage throwing on get', () => {
+    const spy = vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('quota')
+    })
+    expect(peekPendingRedirect()).toBeNull()
+    expect(consumePendingRedirect()).toBeNull()
+    spy.mockRestore()
+  })
+
+  it('tolerates sessionStorage throwing on set', () => {
+    const spy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('quota')
+    })
+    expect(() => setPendingRedirect('/chat')).not.toThrow()
+    spy.mockRestore()
+  })
+})

--- a/frontend/tests/unit/utils/pendingAuthRedirect.spec.ts
+++ b/frontend/tests/unit/utils/pendingAuthRedirect.spec.ts
@@ -45,6 +45,12 @@ describe('isSafeRedirectPath', () => {
     expect(isSafeRedirectPath('data:text/html,<script>')).toBe(false)
   })
 
+  it('rejects paths containing a backslash (browsers may normalise to /)', () => {
+    expect(isSafeRedirectPath('/\\evil.example/path')).toBe(false)
+    expect(isSafeRedirectPath('/path\\with\\backslash')).toBe(false)
+    expect(isSafeRedirectPath('/path/\\\\evil.example')).toBe(false)
+  })
+
   it('rejects paths that do not start with /', () => {
     expect(isSafeRedirectPath('addin/connect')).toBe(false)
     expect(isSafeRedirectPath('?state=abc')).toBe(false)


### PR DESCRIPTION
## Summary

Fixes two bugs that stranded users on `/chat` after sign-in instead of returning them to the deep-link they came from. The trigger we hit in production was the Synamail Outlook add-in: the `/addin/connect` bridge page sent users through `/login`, they signed in with a social provider, OAuth round-trip dropped them on `/chat`, and the taskpane sign-in spinner hung forever because `Office.context.ui.messageParent` was never reached.

### Root causes

1. **`LoginView.onMounted` (line 449)** unconditionally wiped the entire query when `reason` or `registered` was set, dropping `redirect` along with it. Any deep-link bounced through `/login?reason=auth_required` lost its intent.
2. **`handleSocialLogin`** does `window.location.href` to the OAuth provider, which destroys SPA URL state. `OAuthCallback` then pushed the hardcoded `/`, ignoring any pending redirect intent.

### Fix

New `frontend/src/utils/pendingAuthRedirect.ts` — minimal sessionStorage-backed helper that survives the OAuth round-trip. Used from:

- `LoginView.handleSocialLogin` — `setPendingRedirect(route.query.redirect)` before `window.location.href`.
- `LoginView.handleLogin` — fallback `consumePendingRedirect()` if the `?redirect=` query was lost.
- `OAuthCallback` — `consumePendingRedirect()` on successful session, push to it instead of `/`.
- `AddinConnectView.bootstrap` — belt-and-suspenders: also call `setPendingRedirect` before pushing `/login`, so the bridge survives even if `LoginView` somehow loses the query.

Also: `LoginView.onMounted` now strips only `reason`/`registered` from the query instead of clobbering the whole thing.

### Helper hardening

- Only same-origin relative paths (`/…`) accepted; rejects protocol-relative (`//evil`), schemed (`https:`, `javascript:`, `data:`), non-strings, empty.
- 2 KiB cap, 10-minute TTL, one-shot on consume.
- All sessionStorage ops in try/catch — degrades gracefully in private mode / quota / SSR.

### Non-goals / unchanged

- No new dependencies.
- No public API changes; existing component props/events untouched.
- Zero behaviour change for non-deep-link logins (helper returns `null` → existing `'/'` fallback fires).
- Plays nicely with all existing login paths: email/password, OAuth (Google/GitHub/Keycloak/Microsoft), OIDC auto-redirect.

## Test plan

- [x] `make -C frontend lint` (Prettier + ESLint) — green
- [x] `docker compose exec -T frontend npm run check:types` (`vue-tsc -b`) — green
- [x] `make -C frontend test` (Vitest) — **541 tests across 57 files passing**, including 19 new tests for the helper covering safety, TTL, one-shot, storage-failure paths
- [ ] CI: full pipeline on this PR
- [ ] Post-merge: rebuild + deploy `ghcr.io/metadist/synaplan:latest` to web1/web2/web3 (`docker compose pull && bash re-startwebN.sh`)
- [ ] Manual smoke from Synamail (Outlook add-in): click "Sign in to Synaplan" → dialog → sign in with social provider → dialog should land back on `/addin/connect`, show **Connect** button, issue API key, post to parent taskpane, dialog closes

## Notes for reviewers

- Backend gates (`make -C backend lint/phpstan/test`) skipped per `AGENTS.md` — no PHP touched.
- The new helper is generic; once shipped, any other deep-link surface that bounces through `/login` (e.g. shared-chat invites, password-reset flows, future plugin entry points) inherits the fix for free.

Made with [Cursor](https://cursor.com)