### PR TITLE
fix: batch of chat, memories and web-search issue fixes

### DIFF
--- a/backend/phpstan-baseline.neon
+++ b/backend/phpstan-baseline.neon
@@ -567,25 +567,25 @@ parameters:
 		-
 			message: '#^Call to an undefined method App\\Repository\\ConfigRepository\:\:expects\(\)\.$#'
 			identifier: method.notFound
-			count: 8
+			count: 10
 			path: tests/Unit/ModelConfigServiceTest.php
 
 		-
 			message: '#^Call to an undefined method App\\Repository\\ConfigRepository\:\:method\(\)\.$#'
 			identifier: method.notFound
-			count: 6
+			count: 7
 			path: tests/Unit/ModelConfigServiceTest.php
 
 		-
 			message: '#^Call to an undefined method App\\Repository\\ModelRepository\:\:expects\(\)\.$#'
 			identifier: method.notFound
-			count: 2
+			count: 3
 			path: tests/Unit/ModelConfigServiceTest.php
 
 		-
 			message: '#^Call to an undefined method App\\Repository\\ModelRepository\:\:method\(\)\.$#'
 			identifier: method.notFound
-			count: 5
+			count: 7
 			path: tests/Unit/ModelConfigServiceTest.php
 
 		-

--- a/backend/src/Controller/UserMemoryController.php
+++ b/backend/src/Controller/UserMemoryController.php
@@ -598,19 +598,24 @@ class UserMemoryController extends AbstractController
             ], Response::HTTP_BAD_REQUEST);
         }
 
-        // Resolve chat model up front so we can fail fast with a clear, actionable
+        // Resolve memory model up front so we can fail fast with a clear, actionable
         // error code when no model is configured. Without this pre-check the request
         // would either reach the provider with an empty model (provider-dependent
         // behaviour) or fail later inside the AI stack with a confusing message.
-        $chatModelConfig = $this->getUserChatModelConfig($user->getId());
+        //
+        // IMPORTANT: this MUST use the same MEM → CHAT fallback chain as the async
+        // MemoryExtractionService — otherwise the "New Memory" UI silently runs on
+        // the expensive CHAT model (e.g. Claude Opus) instead of the dedicated MEM
+        // model (e.g. Groq gpt-oss-120b). See issue #973.
+        $memoryModelConfig = $this->modelConfigService->getMemoryModelConfig($user->getId());
 
-        if (null === $chatModelConfig['model'] || null === $chatModelConfig['provider']) {
+        if (null === $memoryModelConfig['model'] || null === $memoryModelConfig['provider']) {
             $response = [
-                'error' => 'No chat model configured for AI structuring',
+                'error' => 'No memory model configured for AI structuring',
                 'code' => self::ERROR_CODE_AI_NO_CHAT_MODEL,
             ];
             if ($user->isAdmin()) {
-                $response['debug'] = 'No default CHAT model configured for this user. Set one under Profile → AI Models, or as global default.';
+                $response['debug'] = 'No default MEM or CHAT model configured for this user. Set one under Profile → AI Models, or as global default.';
             }
 
             return $this->json($response, Response::HTTP_SERVICE_UNAVAILABLE);
@@ -667,8 +672,8 @@ class UserMemoryController extends AbstractController
                 userId: $user->getId(),
                 options: array_filter([
                     'json_mode' => true,
-                    'model' => $chatModelConfig['model'],
-                    'provider' => $chatModelConfig['provider'],
+                    'model' => $memoryModelConfig['model'],
+                    'provider' => $memoryModelConfig['provider'],
                     'temperature' => 0.3, // Low temperature for consistent JSON output
                 ])
             );
@@ -678,7 +683,7 @@ class UserMemoryController extends AbstractController
             $this->rateLimitService->recordUsage($user, 'MEMORY_PARSE', [
                 'provider' => $response['provider'] ?? 'unknown',
                 'model' => $response['model'] ?? 'unknown',
-                'model_id' => $chatModelConfig['model_id'] ?? null,
+                'model_id' => $memoryModelConfig['model_id'] ?? null,
                 'usage' => $response['usage'] ?? [],
                 'response_text' => $content,
                 'input_text' => $userMessage,
@@ -1003,28 +1008,5 @@ class UserMemoryController extends AbstractController
         }
 
         return $this->json($payload, Response::HTTP_SERVICE_UNAVAILABLE);
-    }
-
-    /**
-     * Get both model name AND provider for the user's default chat model.
-     *
-     * Resolves both from the same model ID to prevent provider/model mismatch
-     * (e.g., sending an OpenAI model name to Groq provider).
-     *
-     * @return array{model: string|null, provider: string|null, model_id: int|null}
-     */
-    private function getUserChatModelConfig(int $userId): array
-    {
-        $modelId = $this->modelConfigService->getDefaultModel('CHAT', $userId);
-
-        if ($modelId) {
-            return [
-                'model' => $this->modelConfigService->getModelName($modelId),
-                'provider' => $this->modelConfigService->getProviderForModel($modelId),
-                'model_id' => $modelId,
-            ];
-        }
-
-        return ['model' => null, 'provider' => null, 'model_id' => null];
     }
 }

--- a/backend/src/Service/Embedding/EmbeddingReindexService.php
+++ b/backend/src/Service/Embedding/EmbeddingReindexService.php
@@ -259,10 +259,10 @@ final readonly class EmbeddingReindexService
         $modelId = $modelInfo['model_id'];
         $modelName = $modelInfo['model'];
         $provider = $modelInfo['provider'];
+        $vectorDim = $modelInfo['vector_dim'];
 
         if (null === $modelId || null === $modelName || null === $provider) {
             $this->logger->warning('EmbeddingReindex: memories skipped — no model configured');
-            // See reindexDocuments() — same rationale (#948).
             $run->incrementChunksFailed();
             $this->runRepository->save($run);
 
@@ -270,22 +270,16 @@ final readonly class EmbeddingReindexService
         }
 
         try {
-            // Walk EVERY user's memories (#948). The previous
-            // `scrollMemories(0, ...)` call filtered on `user_id === 0`
-            // and therefore never returned a single real memory — the
-            // reindex was a silent no-op even when the UI reported
-            // "completed".
             $points = $this->qdrantClient->scrollAllMemoriesForReindex(50000);
         } catch (\Throwable $e) {
             $this->logger->error('EmbeddingReindex: memories scroll failed', ['error' => $e->getMessage()]);
-            // Failure to even *discover* the memory points must be
-            // surfaced as a run-level failure — otherwise the run shows
-            // 0/0 and looks like "nothing to do" instead of "broken".
             $run->incrementChunksFailed();
             $this->runRepository->save($run);
 
             return;
         }
+
+        $this->qdrantClient->recreateMemoriesCollection($vectorDim);
 
         foreach (array_chunk($points, self::MEMORIES_BATCH) as $batchPoints) {
             $texts = [];
@@ -331,12 +325,7 @@ final readonly class EmbeddingReindexService
                     continue;
                 }
 
-                // Same dimension-coercion as the documents path —
-                // synapse_memories also has a fixed collection dim.
-                $vector = $this->normalizeVectorDimension(
-                    array_map('floatval', $vector),
-                    self::DOC_VECTOR_DIMENSION,
-                );
+                $vector = array_map('floatval', $vector);
 
                 $pointId = (string) ($payload['_id'] ?? '');
                 if ('' === $pointId) {
@@ -349,7 +338,7 @@ final readonly class EmbeddingReindexService
                 $payload['embedding_model_id'] = $modelId;
                 $payload['embedding_provider'] = $provider;
                 $payload['embedding_model'] = $modelName;
-                $payload['vector_dim'] = self::DOC_VECTOR_DIMENSION;
+                $payload['vector_dim'] = $vectorDim;
                 $payload['indexed_at'] = date(\DATE_ATOM);
 
                 $this->qdrantClient->upsertMemory($pointId, $vector, $payload);

--- a/backend/src/Service/MemoryExtractionService.php
+++ b/backend/src/Service/MemoryExtractionService.php
@@ -397,44 +397,23 @@ PROMPT;
     /**
      * Resolve which model runs the memory-extraction LLM call.
      *
-     * Phase 2d priority:
-     *   1. User-scoped DEFAULTMODEL.MEM   (per-user override, set via the admin UI)
-     *   2. Global DEFAULTMODEL.MEM        (the new "Memory extraction model"
-     *                                       BMODELS row, BTAG=mem, default
-     *                                       points at Groq gpt-oss-120b for
-     *                                       ~200 ms TTFT)
-     *   3. User-scoped DEFAULTMODEL.CHAT  (legacy fallback — preserved for
-     *                                       installations that haven't seeded
-     *                                       the MEM tag yet)
-     *   4. Global DEFAULTMODEL.CHAT       (last resort)
-     *
-     * The MEM tag exists so picking a slow/expensive chat model (e.g. Gemini
-     * 3.x Pro) for the user-facing answer no longer cascades into the
-     * background memory extraction.
+     * Delegates to {@see ModelConfigService::getMemoryModelConfig()} so the
+     * same MEM → CHAT fallback chain is shared with the synchronous
+     * "New Memory" UI endpoint (UserMemoryController::parseMemory). See #973.
      *
      * @return array{model: string|null, provider: string|null, model_id: int|null}
      */
     private function getExtractionModelConfig(int $userId): array
     {
-        $modelId = $this->modelConfigService->getDefaultModel('MEM', $userId)
-            ?? $this->modelConfigService->getDefaultModel('MEM', 0)
-            ?? $this->modelConfigService->getDefaultModel('CHAT', $userId)
-            ?? $this->modelConfigService->getDefaultModel('CHAT', 0);
-
-        if (!$modelId) {
-            return ['model' => null, 'provider' => null, 'model_id' => null];
-        }
-
-        $model = $this->modelConfigService->getModelName($modelId);
-        $provider = $this->modelConfigService->getProviderForModel($modelId);
+        $config = $this->modelConfigService->getMemoryModelConfig($userId);
 
         $this->logger->debug('Memory extraction model resolved', [
             'user_id' => $userId,
-            'model_id' => $modelId,
-            'model' => $model,
-            'provider' => $provider,
+            'model_id' => $config['model_id'],
+            'model' => $config['model'],
+            'provider' => $config['provider'],
         ]);
 
-        return ['model' => $model, 'provider' => $provider, 'model_id' => $modelId];
+        return $config;
     }
 }

--- a/backend/src/Service/Message/Handler/FileAnalysisHandler.php
+++ b/backend/src/Service/Message/Handler/FileAnalysisHandler.php
@@ -18,6 +18,13 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
  * - For images without extracted text: Uses Vision AI
  * - For audio files: Requires pre-transcribed text from PreProcessor
  *
+ * Issue #978: when the user attaches multiple files to a single message,
+ * combine the extracted text of ALL document/audio attachments into one
+ * chat-model prompt instead of silently dropping every file after the
+ * first. Images are still analysed one-at-a-time because the provider
+ * Vision APIs accept a single image per call, but their results are
+ * aggregated into a single response when multiple images are uploaded.
+ *
  * Note: File type extensions are defined in MessagePreProcessor to avoid duplication.
  */
 #[AutoconfigureTag('app.message.handler')]
@@ -56,10 +63,9 @@ final readonly class FileAnalysisHandler implements MessageHandlerInterface
 
         $userPrompt = $message->getText();
 
-        // Get file info
-        $fileInfo = $this->getFileInfo($message);
+        $filesInfo = $this->getFilesInfo($message);
 
-        if (!$fileInfo) {
+        if ([] === $filesInfo) {
             $this->logger->error('FileAnalysisHandler: No file found', [
                 'message_id' => $message->getId(),
             ]);
@@ -70,88 +76,62 @@ final readonly class FileAnalysisHandler implements MessageHandlerInterface
             ];
         }
 
-        $this->logger->info('FileAnalysisHandler: Processing file', [
-            'file_id' => $fileInfo['id'],
-            'file_name' => $fileInfo['name'],
-            'file_type' => $fileInfo['type'],
-            'has_extracted_text' => !empty($fileInfo['text']),
-            'extracted_text_length' => strlen($fileInfo['text'] ?? ''),
-            'is_image' => $fileInfo['is_image'],
-            'is_audio' => $fileInfo['is_audio'],
-            'is_document' => $fileInfo['is_document'],
-        ]);
+        $this->logFilesInfo($message, $filesInfo, streaming: false);
 
-        // Decision logic (explicit and ordered by priority):
-        // 1. Audio files: Must have transcribed text from PreProcessor
-        if ($fileInfo['is_audio']) {
-            if (!empty($fileInfo['text'])) {
-                // Issue #955: respond conversationally to the voice
-                // message instead of treating the audio file as a
-                // document to summarise.
-                return $this->handleAudioWithChatModel($message, $fileInfo, $userPrompt, $classification, $progressCallback);
-            }
-            // Audio without transcription → Error
-            $this->logger->error('FileAnalysisHandler: Audio file without transcription', [
-                'file_id' => $fileInfo['id'],
-                'file_name' => $fileInfo['name'],
-            ]);
+        $route = $this->routeFiles($filesInfo);
 
-            return [
-                'content' => 'Audio transcription failed or is not yet available. Please try again in a moment.',
-                'metadata' => ['error' => 'audio_not_transcribed'],
-            ];
+        switch ($route['kind']) {
+            case 'documents':
+                // Documents (optionally bundled with transcribed audio as extra
+                // context) — analyse all of them in a single chat-model call.
+                return $this->handleDocumentsWithChatModel(
+                    $message,
+                    $route['documents'],
+                    $userPrompt,
+                    $classification,
+                    $progressCallback,
+                );
+
+            case 'audio':
+                // Issue #955: respond conversationally to voice messages.
+                // Multiple recordings get their transcripts joined so the LLM
+                // sees the full spoken content (#978).
+                return $this->handleAudioWithChatModel(
+                    $message,
+                    $route['audio'],
+                    $userPrompt,
+                    $classification,
+                    $progressCallback,
+                );
+
+            case 'images':
+                return $this->handleImagesWithVisionModel(
+                    $message,
+                    $route['images'],
+                    $userPrompt,
+                    $classification,
+                    $progressCallback,
+                );
+
+            case 'document_extraction_pending':
+            case 'document_extraction_failed':
+                return $this->buildDocumentExtractionError($route);
+
+            case 'audio_not_transcribed':
+                return $this->buildAudioNotTranscribedError($route['audio_files']);
+
+            case 'unsupported':
+            default:
+                $this->logger->warning('FileAnalysisHandler: Unsupported file types only', [
+                    'message_id' => $message->getId(),
+                    'file_types' => array_map(static fn (array $f): ?string => $f['type'], $filesInfo),
+                ]);
+
+                return [
+                    'content' => 'This file type cannot be analyzed. Supported types include documents (such as PDF, Word, Excel), images (such as JPG, PNG, GIF), and audio files (such as MP3, OGG, WAV).',
+                    'metadata' => ['error' => 'unsupported_file_type'],
+                ];
         }
-
-        // 2. Documents (PDF, DOCX, etc.): Must have extracted text from PreProcessor
-        if ($fileInfo['is_document']) {
-            if (!empty($fileInfo['text'])) {
-                // Document with extracted text → Use Chat Model
-                return $this->handleWithChatModel($message, $fileInfo, $userPrompt, $classification, $progressCallback);
-            }
-
-            // Document without extracted text → distinguish between
-            // "still extracting" (issue #729 race) and "extraction failed"
-            $isStillExtracting = in_array(
-                $fileInfo['status'] ?? '',
-                ['uploaded', 'extracting'],
-                true
-            );
-            $this->logger->error('FileAnalysisHandler: Document without extracted text', [
-                'file_id' => $fileInfo['id'],
-                'file_name' => $fileInfo['name'],
-                'file_type' => $fileInfo['type'],
-                'file_status' => $fileInfo['status'] ?? null,
-                'still_extracting' => $isStillExtracting,
-            ]);
-
-            return [
-                'content' => $isStillExtracting
-                    ? 'The document is still being prepared. Please wait a moment and send your question again — extraction is usually fast, but very large documents can take a few extra seconds.'
-                    : "I couldn't read any text from this document. It may be empty, scanned without OCR, password-protected, or in an unsupported format. Try a different file or paste the text directly.",
-                'metadata' => [
-                    'error' => $isStillExtracting
-                        ? 'document_extraction_in_progress'
-                        : 'document_extraction_failed',
-                    'file_status' => $fileInfo['status'] ?? null,
-                ],
-            ];
-        }
-
-        // 3. Images → Use Vision Model
-        if ($fileInfo['is_image']) {
-            return $this->handleWithVisionModel($message, $fileInfo, $userPrompt, $classification, $progressCallback);
-        }
-
-        // 4. Other files → Error
-        $this->logger->warning('FileAnalysisHandler: Unsupported file type', [
-            'file_type' => $fileInfo['type'],
-            'file_name' => $fileInfo['name'],
-        ]);
-
-        return [
-            'content' => 'This file type cannot be analyzed. Supported types include documents (such as PDF, Word, Excel), images (such as JPG, PNG, GIF), and audio files (such as MP3, OGG, WAV).',
-            'metadata' => ['error' => 'unsupported_file_type'],
-        ];
     }
 
     /**
@@ -169,10 +149,9 @@ final readonly class FileAnalysisHandler implements MessageHandlerInterface
 
         $userPrompt = $message->getText();
 
-        // Get file info
-        $fileInfo = $this->getFileInfo($message);
+        $filesInfo = $this->getFilesInfo($message);
 
-        if (!$fileInfo) {
+        if ([] === $filesInfo) {
             $this->logger->error('FileAnalysisHandler: No file found (streaming)', [
                 'message_id' => $message->getId(),
             ]);
@@ -184,91 +163,69 @@ final readonly class FileAnalysisHandler implements MessageHandlerInterface
             ];
         }
 
-        $this->logger->info('FileAnalysisHandler: Processing file (streaming)', [
-            'file_id' => $fileInfo['id'],
-            'file_name' => $fileInfo['name'],
-            'file_type' => $fileInfo['type'],
-            'has_extracted_text' => !empty($fileInfo['text']),
-            'extracted_text_length' => strlen($fileInfo['text'] ?? ''),
-            'is_image' => $fileInfo['is_image'],
-            'is_audio' => $fileInfo['is_audio'],
-            'is_document' => $fileInfo['is_document'],
-        ]);
+        $this->logFilesInfo($message, $filesInfo, streaming: true);
 
-        // Decision logic (explicit and ordered by priority):
-        // 1. Audio files: Must have transcribed text from PreProcessor
-        if ($fileInfo['is_audio']) {
-            if (!empty($fileInfo['text'])) {
-                // Issue #955: respond conversationally to the voice
-                // message instead of treating the audio file as a
-                // document to summarise.
-                return $this->handleStreamAudioWithChatModel($message, $fileInfo, $userPrompt, $classification, $streamCallback, $progressCallback, $options);
-            }
-            // Audio without transcription → Error
-            $this->logger->error('FileAnalysisHandler: Audio file without transcription (streaming)', [
-                'file_id' => $fileInfo['id'],
-                'file_name' => $fileInfo['name'],
-            ]);
+        $route = $this->routeFiles($filesInfo);
 
-            $streamCallback('Audio transcription failed or is not yet available. Please try again in a moment.');
+        switch ($route['kind']) {
+            case 'documents':
+                return $this->handleStreamDocumentsWithChatModel(
+                    $message,
+                    $route['documents'],
+                    $userPrompt,
+                    $classification,
+                    $streamCallback,
+                    $progressCallback,
+                    $options,
+                );
 
-            return [
-                'metadata' => ['error' => 'audio_not_transcribed'],
-            ];
+            case 'audio':
+                return $this->handleStreamAudioWithChatModel(
+                    $message,
+                    $route['audio'],
+                    $userPrompt,
+                    $classification,
+                    $streamCallback,
+                    $progressCallback,
+                    $options,
+                );
+
+            case 'images':
+                return $this->handleStreamImagesWithVisionModel(
+                    $message,
+                    $route['images'],
+                    $userPrompt,
+                    $classification,
+                    $streamCallback,
+                    $progressCallback,
+                );
+
+            case 'document_extraction_pending':
+            case 'document_extraction_failed':
+                $error = $this->buildDocumentExtractionError($route);
+                $streamCallback($error['content']);
+
+                return ['metadata' => $error['metadata']];
+
+            case 'audio_not_transcribed':
+                $error = $this->buildAudioNotTranscribedError($route['audio_files']);
+                $streamCallback($error['content']);
+
+                return ['metadata' => $error['metadata']];
+
+            case 'unsupported':
+            default:
+                $this->logger->warning('FileAnalysisHandler: Unsupported file types only (streaming)', [
+                    'message_id' => $message->getId(),
+                    'file_types' => array_map(static fn (array $f): ?string => $f['type'], $filesInfo),
+                ]);
+
+                $streamCallback('This file type cannot be analyzed. Supported types include documents (such as PDF, Word, Excel), images (such as JPG, PNG, GIF), and audio files (such as MP3, OGG, WAV).');
+
+                return [
+                    'metadata' => ['error' => 'unsupported_file_type'],
+                ];
         }
-
-        // 2. Documents (PDF, DOCX, etc.): Must have extracted text from PreProcessor
-        if ($fileInfo['is_document']) {
-            if (!empty($fileInfo['text'])) {
-                // Document with extracted text → Use Chat Model with streaming
-                return $this->handleStreamWithChatModel($message, $fileInfo, $userPrompt, $classification, $streamCallback, $progressCallback, $options);
-            }
-
-            // Document without extracted text → distinguish between
-            // "still extracting" (issue #729 race) and "extraction failed"
-            $isStillExtracting = in_array(
-                $fileInfo['status'] ?? '',
-                ['uploaded', 'extracting'],
-                true
-            );
-            $this->logger->error('FileAnalysisHandler: Document without extracted text (streaming)', [
-                'file_id' => $fileInfo['id'],
-                'file_name' => $fileInfo['name'],
-                'file_type' => $fileInfo['type'],
-                'file_status' => $fileInfo['status'] ?? null,
-                'still_extracting' => $isStillExtracting,
-            ]);
-
-            $streamCallback($isStillExtracting
-                ? 'The document is still being prepared. Please wait a moment and send your question again — extraction is usually fast, but very large documents can take a few extra seconds.'
-                : "I couldn't read any text from this document. It may be empty, scanned without OCR, password-protected, or in an unsupported format. Try a different file or paste the text directly.");
-
-            return [
-                'metadata' => [
-                    'error' => $isStillExtracting
-                        ? 'document_extraction_in_progress'
-                        : 'document_extraction_failed',
-                    'file_status' => $fileInfo['status'] ?? null,
-                ],
-            ];
-        }
-
-        // 3. Images → Use Vision Model (non-streaming, then output)
-        if ($fileInfo['is_image']) {
-            return $this->handleStreamWithVisionModel($message, $fileInfo, $userPrompt, $classification, $streamCallback, $progressCallback);
-        }
-
-        // 4. Other files → Error
-        $this->logger->warning('FileAnalysisHandler: Unsupported file type (streaming)', [
-            'file_type' => $fileInfo['type'],
-            'file_name' => $fileInfo['name'],
-        ]);
-
-        $streamCallback('This file type cannot be analyzed. Supported types include documents (such as PDF, Word, Excel), images (such as JPG, PNG, GIF), and audio files (such as MP3, OGG, WAV).');
-
-        return [
-            'metadata' => ['error' => 'unsupported_file_type'],
-        ];
     }
 
     /**
@@ -280,17 +237,27 @@ final readonly class FileAnalysisHandler implements MessageHandlerInterface
      * meta-commentary like
      * "The OGG audio file contains a very short recording that says…".
      *
+     * Issue #978: when several voice notes are attached to the same
+     * message, every transcript is included so the LLM can reply to
+     * the full spoken content instead of just the first recording.
+     *
+     * @param list<array<string, mixed>> $audioFiles
+     *
      * @return array{system: string, prompt: string}
      */
-    private function buildAudioConversationalPrompt(array $fileInfo, string $userPrompt): array
+    private function buildAudioConversationalPrompt(array $audioFiles, string $userPrompt): array
     {
-        $transcript = trim((string) ($fileInfo['text'] ?? ''));
+        $transcript = $this->joinAudioTranscripts($audioFiles);
         $cleanedUserPrompt = trim($userPrompt);
 
         $isGeneric = $this->isGenericAudioPlaceholder($cleanedUserPrompt, $transcript);
 
+        $intro = count($audioFiles) > 1
+            ? 'The user sent you '.count($audioFiles).' voice messages. The transcripts of what they actually said are provided below in order.'
+            : 'The user sent you a voice message. The transcript of what they actually said is provided below.';
+
         $systemPrompt =
-            "The user sent you a voice message. The transcript of what they actually said is provided below.\n\n"
+            $intro."\n\n"
             ."Respond directly and conversationally to the transcript, exactly as you would to a normal text chat message.\n\n"
             ."IMPORTANT — do NOT:\n"
             ."- describe, summarize, or analyze the audio file itself\n"
@@ -314,6 +281,37 @@ final readonly class FileAnalysisHandler implements MessageHandlerInterface
             'system' => $systemPrompt,
             'prompt' => '' !== $finalPrompt ? $finalPrompt : $transcript,
         ];
+    }
+
+    /**
+     * Concatenate the transcripts of every uploaded voice note. When
+     * more than one recording is attached we label them so the LLM can
+     * tell them apart; for the single-file case we preserve the old
+     * (label-free) shape so existing tests/prompt expectations don't
+     * regress.
+     *
+     * @param list<array<string, mixed>> $audioFiles
+     */
+    private function joinAudioTranscripts(array $audioFiles): string
+    {
+        if (1 === count($audioFiles)) {
+            return trim((string) ($audioFiles[0]['text'] ?? ''));
+        }
+
+        $parts = [];
+        foreach ($audioFiles as $index => $audio) {
+            $transcript = trim((string) ($audio['text'] ?? ''));
+            if ('' === $transcript) {
+                continue;
+            }
+            $label = 'Voice message '.($index + 1);
+            if (!empty($audio['name'])) {
+                $label .= ' ('.$audio['name'].')';
+            }
+            $parts[] = "--- {$label} ---\n".$transcript;
+        }
+
+        return implode("\n\n", $parts);
     }
 
     /**
@@ -360,19 +358,23 @@ final readonly class FileAnalysisHandler implements MessageHandlerInterface
     }
 
     /**
-     * Handle voice message (audio with transcript) using Chat Model —
-     * conversational reply path (issue #955).
+     * Handle voice message(s) (audio with transcript) using Chat Model —
+     * conversational reply path (issue #955). Multiple voice notes
+     * attached to the same message are merged so every transcript
+     * reaches the LLM (issue #978).
+     *
+     * @param list<array<string, mixed>> $audioFiles
      */
     private function handleAudioWithChatModel(
         Message $message,
-        array $fileInfo,
+        array $audioFiles,
         string $userPrompt,
         array $classification,
         ?callable $progressCallback,
     ): array {
         $this->notify($progressCallback, 'generating', 'Replying to voice message...');
 
-        $prompts = $this->buildAudioConversationalPrompt($fileInfo, $userPrompt);
+        $prompts = $this->buildAudioConversationalPrompt($audioFiles, $userPrompt);
 
         $effectiveUserId = $this->modelConfigService->getEffectiveUserIdForMessage($message);
         $modelId = $classification['model_id']
@@ -392,7 +394,8 @@ final readonly class FileAnalysisHandler implements MessageHandlerInterface
             'model' => $modelName,
             'user_id' => $message->getUserId(),
             'effective_user_id' => $effectiveUserId,
-            'transcript_length' => strlen($fileInfo['text'] ?? ''),
+            'transcript_length' => strlen($prompts['system']),
+            'voice_message_count' => count($audioFiles),
         ]);
 
         try {
@@ -419,14 +422,15 @@ final readonly class FileAnalysisHandler implements MessageHandlerInterface
                     'provider' => $result['provider'] ?? $provider ?? 'unknown',
                     'model' => $result['model'] ?? $modelName ?? 'unknown',
                     'model_id' => $modelId,
-                    'analyzed_file' => $fileInfo['name'],
+                    'analyzed_file' => $this->describeFileList($audioFiles),
+                    'analyzed_file_count' => count($audioFiles),
                     'analysis_type' => 'voice_message_reply',
                 ],
             ];
         } catch (\Exception $e) {
             $this->logger->error('FileAnalysisHandler: Voice message reply failed', [
                 'error' => $e->getMessage(),
-                'file' => $fileInfo['name'],
+                'files' => $this->describeFileList($audioFiles),
             ]);
 
             return [
@@ -441,11 +445,13 @@ final readonly class FileAnalysisHandler implements MessageHandlerInterface
     }
 
     /**
-     * Handle voice message with streaming Chat Model (issue #955).
+     * Handle voice message(s) with streaming Chat Model (issues #955, #978).
+     *
+     * @param list<array<string, mixed>> $audioFiles
      */
     private function handleStreamAudioWithChatModel(
         Message $message,
-        array $fileInfo,
+        array $audioFiles,
         string $userPrompt,
         array $classification,
         callable $streamCallback,
@@ -454,7 +460,7 @@ final readonly class FileAnalysisHandler implements MessageHandlerInterface
     ): array {
         $this->notify($progressCallback, 'generating', 'Replying to voice message...');
 
-        $prompts = $this->buildAudioConversationalPrompt($fileInfo, $userPrompt);
+        $prompts = $this->buildAudioConversationalPrompt($audioFiles, $userPrompt);
 
         $effectiveUserId = $this->modelConfigService->getEffectiveUserIdForMessage($message);
         $modelId = $classification['model_id']
@@ -474,7 +480,8 @@ final readonly class FileAnalysisHandler implements MessageHandlerInterface
             'model' => $modelName,
             'user_id' => $message->getUserId(),
             'effective_user_id' => $effectiveUserId,
-            'transcript_length' => strlen($fileInfo['text'] ?? ''),
+            'transcript_length' => strlen($prompts['system']),
+            'voice_message_count' => count($audioFiles),
         ]);
 
         try {
@@ -501,14 +508,15 @@ final readonly class FileAnalysisHandler implements MessageHandlerInterface
                     'provider' => $result['provider'] ?? $provider ?? 'unknown',
                     'model' => $result['model'] ?? $modelName ?? 'unknown',
                     'model_id' => $modelId,
-                    'analyzed_file' => $fileInfo['name'],
+                    'analyzed_file' => $this->describeFileList($audioFiles),
+                    'analyzed_file_count' => count($audioFiles),
                     'analysis_type' => 'voice_message_reply',
                 ],
             ];
         } catch (\Exception $e) {
             $this->logger->error('FileAnalysisHandler: Streaming voice message reply failed', [
                 'error' => $e->getMessage(),
-                'file' => $fileInfo['name'],
+                'files' => $this->describeFileList($audioFiles),
             ]);
 
             $streamCallback('Voice message reply failed: '.$e->getMessage());
@@ -524,28 +532,28 @@ final readonly class FileAnalysisHandler implements MessageHandlerInterface
     }
 
     /**
-     * Handle document with pre-extracted text using Chat Model.
+     * Handle one-or-more documents with pre-extracted text using the
+     * Chat Model. Issue #978: every attached document's content is
+     * concatenated into the system prompt so the LLM can reason about
+     * all uploaded files, not just the first one.
+     *
+     * @param list<array<string, mixed>> $documents
      */
-    private function handleWithChatModel(
+    private function handleDocumentsWithChatModel(
         Message $message,
-        array $fileInfo,
+        array $documents,
         string $userPrompt,
         array $classification,
         ?callable $progressCallback,
     ): array {
-        $this->notify($progressCallback, 'generating', 'Analyzing document content...');
+        $this->notify(
+            $progressCallback,
+            'generating',
+            count($documents) > 1 ? 'Analyzing document contents...' : 'Analyzing document content...',
+        );
 
-        // Build context with extracted file content
-        $systemPrompt = "You are analyzing a document. The user has uploaded a file and wants to know about its contents.\n\n";
-        $systemPrompt .= "=== FILE INFORMATION ===\n";
-        $systemPrompt .= "Filename: {$fileInfo['name']}\n";
-        $systemPrompt .= "Type: {$fileInfo['type']}\n\n";
-        $systemPrompt .= "=== EXTRACTED CONTENT ===\n";
-        $systemPrompt .= $fileInfo['text']."\n";
-        $systemPrompt .= "=== END OF CONTENT ===\n\n";
-        $systemPrompt .= 'Answer the user\'s question about this document. If they ask what\'s in the file, summarize the key points.';
-
-        $finalPrompt = !empty($userPrompt) ? $userPrompt : 'What is in this document? Please summarize the content.';
+        $systemPrompt = $this->buildDocumentsSystemPrompt($documents);
+        $finalPrompt = $this->buildDocumentsUserPrompt($userPrompt, $documents);
 
         // Model priority: Again model_id > Task-prompt aiModel > DB default (ANALYZE → CHAT)
         $effectiveUserId = $this->modelConfigService->getEffectiveUserIdForMessage($message);
@@ -567,6 +575,7 @@ final readonly class FileAnalysisHandler implements MessageHandlerInterface
             'model' => $modelName,
             'user_id' => $message->getUserId(),
             'effective_user_id' => $effectiveUserId,
+            'document_count' => count($documents),
         ]);
 
         try {
@@ -593,14 +602,15 @@ final readonly class FileAnalysisHandler implements MessageHandlerInterface
                     'provider' => $result['provider'] ?? $provider ?? 'unknown',
                     'model' => $result['model'] ?? $modelName ?? 'unknown',
                     'model_id' => $modelId,
-                    'analyzed_file' => $fileInfo['name'],
+                    'analyzed_file' => $this->describeFileList($documents),
+                    'analyzed_file_count' => count($documents),
                     'analysis_type' => 'chat_with_extracted_text',
                 ],
             ];
         } catch (\Exception $e) {
             $this->logger->error('FileAnalysisHandler: Chat analysis failed', [
                 'error' => $e->getMessage(),
-                'file' => $fileInfo['name'],
+                'files' => $this->describeFileList($documents),
             ]);
 
             return [
@@ -615,30 +625,27 @@ final readonly class FileAnalysisHandler implements MessageHandlerInterface
     }
 
     /**
-     * Handle document with streaming using Chat Model.
+     * Streaming variant of {@see handleDocumentsWithChatModel}.
+     *
+     * @param list<array<string, mixed>> $documents
      */
-    private function handleStreamWithChatModel(
+    private function handleStreamDocumentsWithChatModel(
         Message $message,
-        array $fileInfo,
+        array $documents,
         string $userPrompt,
         array $classification,
         callable $streamCallback,
         ?callable $progressCallback,
         array $options,
     ): array {
-        $this->notify($progressCallback, 'generating', 'Analyzing document content...');
+        $this->notify(
+            $progressCallback,
+            'generating',
+            count($documents) > 1 ? 'Analyzing document contents...' : 'Analyzing document content...',
+        );
 
-        // Build context with extracted file content
-        $systemPrompt = "You are analyzing a document. The user has uploaded a file and wants to know about its contents.\n\n";
-        $systemPrompt .= "=== FILE INFORMATION ===\n";
-        $systemPrompt .= "Filename: {$fileInfo['name']}\n";
-        $systemPrompt .= "Type: {$fileInfo['type']}\n\n";
-        $systemPrompt .= "=== EXTRACTED CONTENT ===\n";
-        $systemPrompt .= $fileInfo['text']."\n";
-        $systemPrompt .= "=== END OF CONTENT ===\n\n";
-        $systemPrompt .= 'Answer the user\'s question about this document. If they ask what\'s in the file, summarize the key points.';
-
-        $finalPrompt = !empty($userPrompt) ? $userPrompt : 'What is in this document? Please summarize the content.';
+        $systemPrompt = $this->buildDocumentsSystemPrompt($documents);
+        $finalPrompt = $this->buildDocumentsUserPrompt($userPrompt, $documents);
 
         // Model priority: Again model_id > Task-prompt aiModel > DB default (ANALYZE → CHAT)
         $effectiveUserId = $this->modelConfigService->getEffectiveUserIdForMessage($message);
@@ -660,6 +667,7 @@ final readonly class FileAnalysisHandler implements MessageHandlerInterface
             'model' => $modelName,
             'user_id' => $message->getUserId(),
             'effective_user_id' => $effectiveUserId,
+            'document_count' => count($documents),
         ]);
 
         try {
@@ -668,7 +676,6 @@ final readonly class FileAnalysisHandler implements MessageHandlerInterface
                 ['role' => 'user', 'content' => $finalPrompt],
             ];
 
-            // Use streaming chat
             $result = $this->aiFacade->chatStream(
                 $messages,
                 $streamCallback,
@@ -687,14 +694,15 @@ final readonly class FileAnalysisHandler implements MessageHandlerInterface
                     'provider' => $result['provider'] ?? $provider ?? 'unknown',
                     'model' => $result['model'] ?? $modelName ?? 'unknown',
                     'model_id' => $modelId,
-                    'analyzed_file' => $fileInfo['name'],
+                    'analyzed_file' => $this->describeFileList($documents),
+                    'analyzed_file_count' => count($documents),
                     'analysis_type' => 'chat_with_extracted_text',
                 ],
             ];
         } catch (\Exception $e) {
             $this->logger->error('FileAnalysisHandler: Chat streaming analysis failed', [
                 'error' => $e->getMessage(),
-                'file' => $fileInfo['name'],
+                'files' => $this->describeFileList($documents),
             ]);
 
             $streamCallback('Document analysis failed: '.$e->getMessage());
@@ -710,34 +718,80 @@ final readonly class FileAnalysisHandler implements MessageHandlerInterface
     }
 
     /**
-     * Handle image using Vision Model.
+     * Build the system prompt that bundles the extracted text of every
+     * uploaded document. Single-file uploads keep the original layout
+     * so the prompt the LLM sees is unchanged for the common case.
+     *
+     * @param list<array<string, mixed>> $documents
      */
-    private function handleWithVisionModel(
+    private function buildDocumentsSystemPrompt(array $documents): string
+    {
+        if (1 === count($documents)) {
+            $doc = $documents[0];
+            $prompt = "You are analyzing a document. The user has uploaded a file and wants to know about its contents.\n\n";
+            $prompt .= "=== FILE INFORMATION ===\n";
+            $prompt .= "Filename: {$doc['name']}\n";
+            $prompt .= "Type: {$doc['type']}\n\n";
+            $prompt .= "=== EXTRACTED CONTENT ===\n";
+            $prompt .= $doc['text']."\n";
+            $prompt .= "=== END OF CONTENT ===\n\n";
+            $prompt .= 'Answer the user\'s question about this document. If they ask what\'s in the file, summarize the key points.';
+
+            return $prompt;
+        }
+
+        $count = count($documents);
+        $prompt = "You are analyzing {$count} documents. The user has uploaded multiple files and wants to know about their contents. Treat the documents as a related set — cross-reference them when the user's question spans more than one file, and clearly attribute any quotes or facts to the originating filename.\n\n";
+
+        foreach ($documents as $index => $doc) {
+            $position = $index + 1;
+            $prompt .= "=== FILE {$position} OF {$count} INFORMATION ===\n";
+            $prompt .= "Filename: {$doc['name']}\n";
+            $prompt .= "Type: {$doc['type']}\n\n";
+            $prompt .= "=== FILE {$position} EXTRACTED CONTENT ===\n";
+            $prompt .= $doc['text']."\n";
+            $prompt .= "=== END OF FILE {$position} CONTENT ===\n\n";
+        }
+
+        $prompt .= 'Answer the user\'s question using information from any of the files above. When summarizing, list the key points per file so the user can tell which document each statement came from.';
+
+        return $prompt;
+    }
+
+    /**
+     * Pick a sensible default user prompt when the user did not type
+     * anything alongside their uploads.
+     *
+     * @param list<array<string, mixed>> $documents
+     */
+    private function buildDocumentsUserPrompt(string $userPrompt, array $documents): string
+    {
+        $userPrompt = trim($userPrompt);
+        if ('' !== $userPrompt) {
+            return $userPrompt;
+        }
+
+        return count($documents) > 1
+            ? 'What is in these documents? Please summarize the content of each file.'
+            : 'What is in this document? Please summarize the content.';
+    }
+
+    /**
+     * Handle one-or-more images using the Vision Model. Issue #978:
+     * vision providers only accept a single image per request, so
+     * multi-image uploads are dispatched one-at-a-time and the
+     * per-image descriptions are aggregated into a single reply that
+     * the rest of the system handles like a normal handler result.
+     *
+     * @param list<array<string, mixed>> $images
+     */
+    private function handleImagesWithVisionModel(
         Message $message,
-        array $fileInfo,
+        array $images,
         string $userPrompt,
         array $classification,
         ?callable $progressCallback,
     ): array {
-        $this->notify($progressCallback, 'analyzing', 'Analyzing image...');
-
-        $analysisPrompt = !empty($userPrompt) ? $userPrompt : 'Please describe this image in detail.';
-
-        // Check if file exists
-        $fullPath = $this->uploadDir.'/'.$fileInfo['path'];
-        if (!file_exists($fullPath)) {
-            $this->logger->error('FileAnalysisHandler: File not found on disk', [
-                'path' => $fileInfo['path'],
-                'full_path' => $fullPath,
-            ]);
-
-            return [
-                'content' => "File not found: {$fileInfo['name']}",
-                'metadata' => ['error' => 'file_not_found'],
-            ];
-        }
-
-        // Model priority: Again model_id > Task-prompt aiModel > DB default (PIC2TEXT)
         $effectiveUserId = $this->modelConfigService->getEffectiveUserIdForMessage($message);
         $modelId = $classification['model_id']
             ?? $this->resolvePromptAiModel($classification)
@@ -750,68 +804,63 @@ final readonly class FileAnalysisHandler implements MessageHandlerInterface
             $modelName = $this->modelConfigService->getModelName($modelId);
         }
 
-        $this->logger->info('FileAnalysisHandler: Using Vision model for image', [
+        $this->logger->info('FileAnalysisHandler: Using Vision model for image(s)', [
             'model_id' => $modelId,
             'provider' => $provider,
             'model' => $modelName,
             'user_id' => $message->getUserId(),
             'effective_user_id' => $effectiveUserId,
+            'image_count' => count($images),
         ]);
 
-        try {
-            $result = $this->aiFacade->analyzeImage(
-                $fileInfo['path'],
-                $analysisPrompt,
-                $message->getUserId(),
-                [
-                    'provider' => $provider,
-                    'model' => $modelName,
-                    'max_tokens' => 4000,
-                ]
-            );
+        $perImage = $this->analyzeImageBatch($message, $images, $userPrompt, $provider, $modelName, $progressCallback);
+        $content = $this->combineImageAnalyses($perImage, $images);
 
-            $this->notify($progressCallback, 'complete', 'Analysis complete.');
+        $this->notify($progressCallback, 'complete', 'Analysis complete.');
 
-            return [
-                'content' => $result['content'],
-                'metadata' => [
-                    'provider' => $result['provider'] ?? 'unknown',
-                    'model' => $result['model'] ?? 'unknown',
-                    'model_id' => $modelId,
-                    'analyzed_file' => $fileInfo['name'],
-                    'analysis_type' => 'vision',
-                ],
-            ];
-        } catch (\Exception $e) {
-            $this->logger->error('FileAnalysisHandler: Vision analysis failed', [
-                'error' => $e->getMessage(),
-                'file' => $fileInfo['name'],
-            ]);
-
-            return [
-                'content' => 'Image analysis failed: '.$e->getMessage(),
-                'metadata' => [
-                    'error' => $e->getMessage(),
-                    'provider' => $provider,
-                    'model' => $modelName,
-                ],
-            ];
+        $firstSuccess = null;
+        foreach ($perImage as $entry) {
+            if (isset($entry['content'])) {
+                $firstSuccess = $entry;
+                break;
+            }
         }
+
+        return [
+            'content' => $content,
+            'metadata' => [
+                'provider' => $firstSuccess['provider'] ?? $provider ?? 'unknown',
+                'model' => $firstSuccess['model'] ?? $modelName ?? 'unknown',
+                'model_id' => $modelId,
+                'analyzed_file' => $this->describeFileList($images),
+                'analyzed_file_count' => count($images),
+                'analysis_type' => 'vision',
+            ],
+        ];
     }
 
     /**
-     * Handle image with streaming using Vision Model.
+     * Streaming variant — vision providers do not stream, so the
+     * aggregated result is emitted in one chunk after every image has
+     * been analyzed.
+     *
+     * @param list<array<string, mixed>> $images
      */
-    private function handleStreamWithVisionModel(
+    private function handleStreamImagesWithVisionModel(
         Message $message,
-        array $fileInfo,
+        array $images,
         string $userPrompt,
         array $classification,
         callable $streamCallback,
         ?callable $progressCallback,
     ): array {
-        // Vision AI doesn't support streaming, so get full result and output it
-        $result = $this->handleWithVisionModel($message, $fileInfo, $userPrompt, $classification, $progressCallback);
+        $result = $this->handleImagesWithVisionModel(
+            $message,
+            $images,
+            $userPrompt,
+            $classification,
+            $progressCallback,
+        );
 
         if (isset($result['content'])) {
             $streamCallback($result['content']);
@@ -823,62 +872,459 @@ final readonly class FileAnalysisHandler implements MessageHandlerInterface
     }
 
     /**
-     * Get file information from message.
+     * Dispatch one vision call per image and capture either a
+     * `content` field on success or an `error` field on failure so the
+     * aggregator can render a partial response without throwing.
+     *
+     * @param list<array<string, mixed>> $images
+     *
+     * @return list<array<string, mixed>>
      */
-    private function getFileInfo(Message $message): ?array
-    {
-        // Check for files in the MessageFiles relation
-        $files = $message->getFiles();
-        if ($files->count() > 0) {
-            /** @var File $file */
-            $file = $files->first();
+    private function analyzeImageBatch(
+        Message $message,
+        array $images,
+        string $userPrompt,
+        ?string $provider,
+        ?string $modelName,
+        ?callable $progressCallback,
+    ): array {
+        $perImagePrompt = !empty($userPrompt)
+            ? $userPrompt
+            : (count($images) > 1
+                ? 'Please describe this image in detail. The user uploaded several images in the same message — describe each one independently.'
+                : 'Please describe this image in detail.');
 
-            $fileType = strtolower($file->getFileType());
-            $isImage = in_array($fileType, MessagePreProcessor::IMAGE_EXTENSIONS, true);
-            $isAudio = in_array($fileType, MessagePreProcessor::AUDIO_EXTENSIONS, true);
-            $isDocument = in_array($fileType, MessagePreProcessor::DOCUMENT_EXTENSIONS, true);
+        $results = [];
 
-            // Normalize path to be relative to the upload directory (var/uploads).
-            // DB values should be stored relative; older/legacy values may contain "/uploads/" or full URLs.
-            $filePath = $this->normalizeRelativeUploadPath($file->getFilePath());
+        foreach ($images as $index => $image) {
+            $progressMessage = count($images) > 1
+                ? sprintf('Analyzing image %d of %d...', $index + 1, count($images))
+                : 'Analyzing image...';
+            $this->notify($progressCallback, 'analyzing', $progressMessage);
 
-            return [
-                'id' => $file->getId(),
-                'name' => $file->getFileName(),
-                'type' => $file->getFileType(),
-                'path' => $filePath,
-                'text' => $file->getFileText(), // Pre-extracted text!
-                'status' => $file->getStatus(),
-                'is_image' => $isImage,
-                'is_audio' => $isAudio,
-                'is_document' => $isDocument,
-            ];
+            $fullPath = $this->uploadDir.'/'.$image['path'];
+            if (!file_exists($fullPath)) {
+                $this->logger->error('FileAnalysisHandler: File not found on disk', [
+                    'path' => $image['path'],
+                    'full_path' => $fullPath,
+                    'image_index' => $index,
+                ]);
+                $results[] = [
+                    'name' => $image['name'],
+                    'error' => 'file_not_found',
+                    'message' => "File not found: {$image['name']}",
+                ];
+
+                continue;
+            }
+
+            try {
+                $analysis = $this->aiFacade->analyzeImage(
+                    $image['path'],
+                    $perImagePrompt,
+                    $message->getUserId(),
+                    [
+                        'provider' => $provider,
+                        'model' => $modelName,
+                        'max_tokens' => 4000,
+                    ]
+                );
+
+                $results[] = [
+                    'name' => $image['name'],
+                    'content' => $analysis['content'] ?? '',
+                    'provider' => $analysis['provider'] ?? null,
+                    'model' => $analysis['model'] ?? null,
+                ];
+            } catch (\Exception $e) {
+                $this->logger->error('FileAnalysisHandler: Vision analysis failed', [
+                    'error' => $e->getMessage(),
+                    'file' => $image['name'],
+                    'image_index' => $index,
+                ]);
+
+                $results[] = [
+                    'name' => $image['name'],
+                    'error' => 'analysis_failed',
+                    'message' => 'Image analysis failed: '.$e->getMessage(),
+                ];
+            }
         }
 
-        // Legacy: Check for file path in message
+        return $results;
+    }
+
+    /**
+     * Merge per-image vision results into a single reply string. Keeps
+     * the single-image output identical to the legacy format so that
+     * existing UX (and any test snapshots) are not affected.
+     *
+     * @param list<array<string, mixed>> $results
+     * @param list<array<string, mixed>> $images
+     */
+    private function combineImageAnalyses(array $results, array $images): string
+    {
+        if (1 === count($results)) {
+            $only = $results[0];
+
+            return $only['content'] ?? $only['message'] ?? 'Image analysis failed.';
+        }
+
+        $parts = [];
+        foreach ($results as $index => $entry) {
+            $position = $index + 1;
+            $name = $entry['name'] ?? ($images[$index]['name'] ?? 'image '.$position);
+            $body = $entry['content'] ?? $entry['message'] ?? 'Image analysis failed.';
+            $parts[] = "### Image {$position}: {$name}\n\n{$body}";
+        }
+
+        return implode("\n\n---\n\n", $parts);
+    }
+
+    /**
+     * Get file information for every attachment on the message. Issue
+     * #978: returning the full collection (instead of only the first
+     * row) is the foundation for the multi-document routing in
+     * {@see routeFiles()}.
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function getFilesInfo(Message $message): array
+    {
+        $infos = [];
+
+        $files = $message->getFiles();
+        if ($files->count() > 0) {
+            foreach ($files as $file) {
+                /* @var File $file */
+                $infos[] = $this->buildFileInfoFromEntity($file);
+            }
+
+            return $infos;
+        }
+
+        // Legacy single-file fallback (BMESSAGES.BFILEPATH / BFILETEXT).
         $filePath = $message->getFilePath();
         if ($filePath) {
             $extension = strtolower(pathinfo($filePath, PATHINFO_EXTENSION));
-            $isImage = in_array($extension, MessagePreProcessor::IMAGE_EXTENSIONS, true);
-            $isAudio = in_array($extension, MessagePreProcessor::AUDIO_EXTENSIONS, true);
-            $isDocument = in_array($extension, MessagePreProcessor::DOCUMENT_EXTENSIONS, true);
+            $infos[] = $this->buildFileInfo(
+                id: null,
+                name: basename($filePath),
+                type: $extension,
+                rawPath: $filePath,
+                text: $message->getFileText() ?: '',
+                status: null,
+            );
+        }
 
-            $filePath = $this->normalizeRelativeUploadPath($filePath);
+        return $infos;
+    }
 
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildFileInfoFromEntity(File $file): array
+    {
+        return $this->buildFileInfo(
+            id: $file->getId(),
+            name: $file->getFileName(),
+            type: $file->getFileType(),
+            rawPath: $file->getFilePath(),
+            text: $file->getFileText(),
+            status: $file->getStatus(),
+        );
+    }
+
+    /**
+     * Build a normalized file-info row from raw values. Keeping a
+     * single factory keeps the legacy single-file path and the modern
+     * `File` entity path in sync, so the routing layer never has to
+     * special-case where a row originated.
+     *
+     * @return array<string, mixed>
+     */
+    private function buildFileInfo(
+        ?int $id,
+        ?string $name,
+        ?string $type,
+        ?string $rawPath,
+        ?string $text,
+        ?string $status,
+    ): array {
+        $normalizedType = strtolower((string) $type);
+        $isImage = in_array($normalizedType, MessagePreProcessor::IMAGE_EXTENSIONS, true);
+        $isAudio = in_array($normalizedType, MessagePreProcessor::AUDIO_EXTENSIONS, true);
+        $isDocument = in_array($normalizedType, MessagePreProcessor::DOCUMENT_EXTENSIONS, true);
+
+        // Normalize path to be relative to the upload directory (var/uploads).
+        // DB values should be stored relative; older/legacy values may contain "/uploads/" or full URLs.
+        $path = $this->normalizeRelativeUploadPath((string) $rawPath);
+
+        return [
+            'id' => $id,
+            'name' => (string) ($name ?? basename($path)),
+            'type' => (string) $type,
+            'path' => $path,
+            'text' => (string) ($text ?? ''),
+            'status' => $status,
+            'is_image' => $isImage,
+            'is_audio' => $isAudio,
+            'is_document' => $isDocument,
+        ];
+    }
+
+    /**
+     * Decide which handler path the uploaded files should travel down.
+     * Returns a `kind` discriminator plus the buckets that path
+     * consumes so the caller can switch on it without re-doing the
+     * categorization.
+     *
+     * Priority rules:
+     *  1. Documents with extracted text → chat-model "document" path.
+     *     Any transcribed audio is appended as virtual "transcript"
+     *     documents so its content reaches the model too.
+     *  2. Otherwise audio-only (one or many) with transcripts → the
+     *     conversational voice-reply path.
+     *  3. Otherwise images → the vision path.
+     *  4. Otherwise we surface the first applicable error
+     *     (missing transcript / document still extracting / unsupported).
+     *
+     * @param list<array<string, mixed>> $filesInfo
+     *
+     * @return array{
+     *     kind: string,
+     *     documents?: list<array<string, mixed>>,
+     *     audio?: list<array<string, mixed>>,
+     *     images?: list<array<string, mixed>>,
+     *     audio_files?: list<array<string, mixed>>,
+     *     pending_documents?: list<array<string, mixed>>,
+     *     failed_documents?: list<array<string, mixed>>
+     * }
+     */
+    private function routeFiles(array $filesInfo): array
+    {
+        $documentsWithText = [];
+        $documentsPending = [];
+        $documentsFailed = [];
+        $audioWithText = [];
+        $audioMissingText = [];
+        $images = [];
+
+        foreach ($filesInfo as $info) {
+            if ($info['is_audio']) {
+                if ('' !== trim((string) ($info['text'] ?? ''))) {
+                    $audioWithText[] = $info;
+                } else {
+                    $audioMissingText[] = $info;
+                }
+                continue;
+            }
+
+            if ($info['is_document']) {
+                if ('' !== trim((string) ($info['text'] ?? ''))) {
+                    $documentsWithText[] = $info;
+                } else {
+                    $isStillExtracting = in_array(
+                        (string) ($info['status'] ?? ''),
+                        ['uploaded', 'extracting'],
+                        true
+                    );
+                    if ($isStillExtracting) {
+                        $documentsPending[] = $info;
+                    } else {
+                        $documentsFailed[] = $info;
+                    }
+                }
+                continue;
+            }
+
+            if ($info['is_image']) {
+                $images[] = $info;
+            }
+        }
+
+        // 1. Documents (with text) take priority. Merge any transcribed
+        //    audio into the document set as a virtual transcript file so
+        //    the chat model still sees the spoken content alongside the
+        //    PDFs/MDs the user attached.
+        if ([] !== $documentsWithText) {
+            $documents = $documentsWithText;
+            foreach ($audioWithText as $audio) {
+                $documents[] = $this->wrapAudioAsTranscriptDocument($audio);
+            }
+
+            return ['kind' => 'documents', 'documents' => $documents];
+        }
+
+        // 2. Audio-only message(s) with usable transcripts → reply
+        //    conversationally to the spoken content.
+        if ([] !== $audioWithText && [] === $images) {
+            return ['kind' => 'audio', 'audio' => $audioWithText];
+        }
+
+        // 3. Images only → vision path. We tolerate transcribed audio
+        //    being present alongside images by passing the spoken
+        //    content as the per-image prompt below isn't ideal, so we
+        //    fall through to vision and rely on its prompt for now.
+        if ([] !== $images && [] === $audioWithText) {
+            return ['kind' => 'images', 'images' => $images];
+        }
+
+        // 3b. Mixed images + audio (no documents): describe the images
+        //     and still attempt to route audio sensibly. The simplest
+        //     pragmatic behaviour is to favour images so the user sees
+        //     something useful; audio without a document is rare in
+        //     this combination.
+        if ([] !== $images) {
+            return ['kind' => 'images', 'images' => $images];
+        }
+
+        // 4. No usable documents / audio / images — surface the most
+        //    specific error that explains why.
+        if ([] !== $audioMissingText) {
             return [
-                'id' => null,
-                'name' => basename($filePath),
-                'type' => $extension,
-                'path' => $filePath,
-                'text' => $message->getFileText() ?: '', // Get text from message for legacy
-                'status' => null,
-                'is_image' => $isImage,
-                'is_audio' => $isAudio,
-                'is_document' => $isDocument,
+                'kind' => 'audio_not_transcribed',
+                'audio_files' => $audioMissingText,
             ];
         }
 
-        return null;
+        if ([] !== $documentsPending) {
+            return [
+                'kind' => 'document_extraction_pending',
+                'pending_documents' => $documentsPending,
+                'failed_documents' => $documentsFailed,
+            ];
+        }
+
+        if ([] !== $documentsFailed) {
+            return [
+                'kind' => 'document_extraction_failed',
+                'pending_documents' => $documentsPending,
+                'failed_documents' => $documentsFailed,
+            ];
+        }
+
+        return ['kind' => 'unsupported'];
+    }
+
+    /**
+     * Treat a transcribed audio attachment as a virtual "transcript"
+     * document so the multi-document prompt builder can include its
+     * spoken content alongside real PDFs/MDs without growing a special
+     * branch.
+     *
+     * @param array<string, mixed> $audio
+     *
+     * @return array<string, mixed>
+     */
+    private function wrapAudioAsTranscriptDocument(array $audio): array
+    {
+        $name = (string) ($audio['name'] ?? 'voice-message');
+        $type = (string) ($audio['type'] ?? 'audio');
+
+        return [
+            'id' => $audio['id'] ?? null,
+            'name' => $name.' (voice transcript)',
+            'type' => $type.' transcript',
+            'path' => $audio['path'] ?? '',
+            'text' => "Voice message transcript:\n".trim((string) ($audio['text'] ?? '')),
+            'status' => $audio['status'] ?? null,
+            'is_image' => false,
+            'is_audio' => false,
+            'is_document' => true,
+        ];
+    }
+
+    /**
+     * @param array{
+     *     kind: string,
+     *     pending_documents?: list<array<string, mixed>>,
+     *     failed_documents?: list<array<string, mixed>>
+     * } $route
+     *
+     * @return array{content: string, metadata: array<string, mixed>}
+     */
+    private function buildDocumentExtractionError(array $route): array
+    {
+        $pending = $route['pending_documents'] ?? [];
+        $failed = $route['failed_documents'] ?? [];
+        $isStillExtracting = 'document_extraction_pending' === $route['kind'];
+
+        $this->logger->error('FileAnalysisHandler: Document(s) without extracted text', [
+            'pending_files' => $this->describeFileList($pending),
+            'failed_files' => $this->describeFileList($failed),
+            'still_extracting' => $isStillExtracting,
+        ]);
+
+        $firstStatus = ($pending[0]['status'] ?? $failed[0]['status'] ?? null);
+
+        return [
+            'content' => $isStillExtracting
+                ? 'The document is still being prepared. Please wait a moment and send your question again — extraction is usually fast, but very large documents can take a few extra seconds.'
+                : "I couldn't read any text from this document. It may be empty, scanned without OCR, password-protected, or in an unsupported format. Try a different file or paste the text directly.",
+            'metadata' => [
+                'error' => $isStillExtracting
+                    ? 'document_extraction_in_progress'
+                    : 'document_extraction_failed',
+                'file_status' => $firstStatus,
+            ],
+        ];
+    }
+
+    /**
+     * @param list<array<string, mixed>> $audioFiles
+     *
+     * @return array{content: string, metadata: array<string, mixed>}
+     */
+    private function buildAudioNotTranscribedError(array $audioFiles): array
+    {
+        $this->logger->error('FileAnalysisHandler: Audio file(s) without transcription', [
+            'files' => $this->describeFileList($audioFiles),
+        ]);
+
+        return [
+            'content' => 'Audio transcription failed or is not yet available. Please try again in a moment.',
+            'metadata' => ['error' => 'audio_not_transcribed'],
+        ];
+    }
+
+    /**
+     * Log a compact summary that covers every attached file. The old
+     * single-file logging missed everything past the first row, which
+     * made it hard to spot multi-file dropping in production logs.
+     *
+     * @param list<array<string, mixed>> $filesInfo
+     */
+    private function logFilesInfo(Message $message, array $filesInfo, bool $streaming): void
+    {
+        $suffix = $streaming ? ' (streaming)' : '';
+        $this->logger->info('FileAnalysisHandler: Processing file(s)'.$suffix, [
+            'message_id' => $message->getId(),
+            'file_count' => count($filesInfo),
+            'files' => array_map(static fn (array $info): array => [
+                'id' => $info['id'] ?? null,
+                'name' => $info['name'] ?? null,
+                'type' => $info['type'] ?? null,
+                'is_image' => $info['is_image'] ?? false,
+                'is_audio' => $info['is_audio'] ?? false,
+                'is_document' => $info['is_document'] ?? false,
+                'has_extracted_text' => '' !== trim((string) ($info['text'] ?? '')),
+                'extracted_text_length' => strlen((string) ($info['text'] ?? '')),
+                'status' => $info['status'] ?? null,
+            ], $filesInfo),
+        ]);
+    }
+
+    /**
+     * Short, log/metadata-friendly summary of a file collection.
+     *
+     * @param list<array<string, mixed>> $files
+     */
+    private function describeFileList(array $files): string
+    {
+        $names = array_map(static fn (array $f): string => (string) ($f['name'] ?? 'unnamed'), $files);
+
+        return implode(', ', $names);
     }
 
     /**

--- a/backend/src/Service/Message/MessageClassifier.php
+++ b/backend/src/Service/Message/MessageClassifier.php
@@ -566,11 +566,19 @@ final readonly class MessageClassifier
 
         // Web-search hint phrases that the AI sorter would flip `web_search`
         // for. Better to take the slow path so we surface results.
+        //
+        // German cost/price queries (#974): the bare infinitive `kosten` is
+        // far less common than the conjugated `kostet`, so we use the stem
+        // `kost` which catches `kostet`/`kosten`/`gekostet` while only
+        // accidentally matching rare false-positives like `kostüm`/`kostbar`
+        // — both of which still benefit from the slow path more than they
+        // suffer from it.
         static $searchTriggers = [
             'search the web', 'google ', 'latest news', 'current price',
             'today\'s', "today's", 'right now', 'this week',
             'aktuelle nachrichten', 'durchsuche das internet',
             'busca en', 'recherche dans',
+            'kost', 'preis', 'wie teuer', 'flug nach', 'flüge',
         ];
         foreach ($searchTriggers as $trigger) {
             if (str_contains($lower, $trigger)) {

--- a/backend/src/Service/Message/SynapseRouter.php
+++ b/backend/src/Service/Message/SynapseRouter.php
@@ -147,10 +147,16 @@ final readonly class SynapseRouter
      * Intentionally excludes deictic time markers like "jetzt" / "now" which
      * are extremely common in follow-up requests ("jetzt das in blau", "jetzt
      * ein video davon", "now make it 4K") and almost never imply a web search.
+     *
+     * The German cost stem is `kost` (not `kosten`): the bare infinitive
+     * `kosten` does not appear in the most common phrasing "Was kostet …?"
+     * and `str_contains('kostet', 'kosten') === false`. The shorter stem
+     * also catches `kostet`/`gekostet`/`kostete` while leaving compounds
+     * like `unkosten` matched too. See issue #974.
      */
     private const WEB_SEARCH_KEYWORDS = [
         'aktuell', 'current', 'heute', 'today', 'news', 'nachrichten',
-        'wetter', 'weather', 'preis', 'price', 'kosten', 'cost',
+        'wetter', 'weather', 'preis', 'price', 'kost', 'cost', 'wie teuer',
         'neueste', 'latest', 'kürzlich', 'recently',
         'live', 'echtzeit', 'realtime', 'real-time',
         'öffnungszeiten', 'opening hours', 'restaurant', 'geschäft', 'store',

--- a/backend/src/Service/ModelConfigService.php
+++ b/backend/src/Service/ModelConfigService.php
@@ -408,6 +408,47 @@ final readonly class ModelConfigService
     }
 
     /**
+     * Resolve the model that should run memory-related AI calls (auto-extraction
+     * from chat messages AND the "New Memory" parse endpoint in the UI).
+     *
+     * Priority:
+     *   1. User-scoped DEFAULTMODEL.MEM   (per-user override, set via the admin UI)
+     *   2. Global DEFAULTMODEL.MEM        (the dedicated "Memory extraction model"
+     *                                       BMODELS row, BTAG=mem, default points at
+     *                                       Groq gpt-oss-120b for ~200 ms TTFT)
+     *   3. User-scoped DEFAULTMODEL.CHAT  (legacy fallback — preserved for
+     *                                       installations that haven't seeded
+     *                                       the MEM tag yet)
+     *   4. Global DEFAULTMODEL.CHAT       (last resort)
+     *
+     * The MEM tag exists so picking a slow/expensive chat model (e.g. Claude
+     * Opus 4) for the user-facing answer no longer cascades into the cheaper
+     * memory extraction path. Centralising the resolution here keeps the
+     * background MemoryExtractionService and the synchronous UserMemoryController
+     * parse endpoint in lockstep — see issue #973.
+     *
+     * @return array{model: ?string, provider: ?string, model_id: ?int}
+     */
+    public function getMemoryModelConfig(?int $userId = null): array
+    {
+        // getDefaultModel() already walks user-scope → global, so we only need
+        // two outer calls (MEM then CHAT) — not four. Hitting MEM/0 explicitly
+        // after MEM/$userId would just repeat the same global lookup.
+        $modelId = $this->getDefaultModel('MEM', $userId)
+            ?? $this->getDefaultModel('CHAT', $userId);
+
+        if (!$modelId) {
+            return ['model' => null, 'provider' => null, 'model_id' => null];
+        }
+
+        return [
+            'model' => $this->getModelName($modelId),
+            'provider' => $this->getProviderForModel($modelId),
+            'model_id' => $modelId,
+        ];
+    }
+
+    /**
      * Get provider name for a specific model ID
      * Returns provider name from BMODELS.BSERVICE (e.g., 'Ollama', 'OpenAI').
      */

--- a/backend/src/Service/UserMemoryService.php
+++ b/backend/src/Service/UserMemoryService.php
@@ -777,29 +777,27 @@ final readonly class UserMemoryService
                 throw new \RuntimeException('Failed to create embedding');
             }
 
-            // Dimension safety net (#948).
+            // Dimension safety net (#948, #959).
             //
-            // Qdrant collections are created with a FIXED dimension at install
-            // time. If the admin switches VECTORIZE to a model with a different
-            // native output dimension (e.g. 1024 → 1536), Qdrant rejects every
-            // upsert with HTTP 400 and the memory is silently lost. The user
-            // gets a friendly "memory saved" UI confirmation but nothing
-            // actually stored. Fail loud HERE so the worker logs surface the
-            // real cause and HTTP callers see a 503 instead of phantom-success.
-            $expectedDim = $this->embeddingMetadata->getCurrentVectorDim();
+            // Compare the embedding's actual dimension against the Qdrant
+            // collection's configured vector size — NOT the model's
+            // self-reported dim, which always matches its own output and
+            // therefore never detects the real mismatch (model vs collection).
+            $collectionInfo = $this->qdrantClient->getMemoriesCollectionInfo();
+            $collectionDim = $collectionInfo['vector_dim'];
             $actualDim = count($embedding);
-            if ($actualDim !== $expectedDim) {
+            if (null !== $collectionDim && $actualDim !== $collectionDim) {
                 $this->logger->error('Memory storage rejected — embedding dimension mismatches collection', [
                     'user_id' => $user->getId(),
                     'memory_id' => $memoryId,
-                    'expected_dim' => $expectedDim,
+                    'collection_dim' => $collectionDim,
                     'actual_dim' => $actualDim,
                     'model_id' => $embeddingModelId,
                     'provider' => $provider,
                     'model' => $modelName,
                 ]);
 
-                throw new \RuntimeException(sprintf('Embedding dimension mismatch: model produced %d-dim vectors but the collection expects %d. The administrator must re-run the vector re-index for the active model.', $actualDim, $expectedDim));
+                throw new \RuntimeException(sprintf('Embedding dimension mismatch: model produced %d-dim vectors but the collection expects %d. The administrator must re-run the vector re-index for the active model.', $actualDim, $collectionDim));
             }
 
             $this->rateLimitService->recordUsage($user, 'EMBEDDINGS', [

--- a/backend/src/Service/VectorSearch/QdrantClientDirect.php
+++ b/backend/src/Service/VectorSearch/QdrantClientDirect.php
@@ -1159,6 +1159,83 @@ final class QdrantClientDirect implements QdrantClientInterface
         }
     }
 
+    public function getMemoriesCollectionInfo(): array
+    {
+        $defaults = [
+            'exists' => false,
+            'vector_dim' => null,
+            'points_count' => null,
+            'distance' => null,
+        ];
+
+        try {
+            $response = $this->qdrantRequest('GET', "/collections/{$this->memoriesCollection}");
+            $result = $response['result'] ?? [];
+
+            $vectorsConfig = $result['config']['params']['vectors'] ?? [];
+
+            return [
+                'exists' => true,
+                'vector_dim' => isset($vectorsConfig['size']) ? (int) $vectorsConfig['size'] : null,
+                'points_count' => isset($result['points_count']) ? (int) $result['points_count'] : null,
+                'distance' => $vectorsConfig['distance'] ?? null,
+            ];
+        } catch (\Throwable $e) {
+            $this->logger->debug('getMemoriesCollectionInfo: collection missing or unreachable', [
+                'error' => $e->getMessage(),
+            ]);
+
+            return $defaults;
+        }
+    }
+
+    public function recreateMemoriesCollection(int $vectorDimension): void
+    {
+        $collection = $this->memoriesCollection;
+
+        try {
+            $this->qdrantRequest('DELETE', "/collections/{$collection}");
+            unset($this->ensuredCollections[$collection]);
+            $this->logger->info('Dropped existing memories collection', [
+                'collection' => $collection,
+            ]);
+        } catch (\Throwable $e) {
+            $this->logger->debug('recreateMemoriesCollection: drop skipped', [
+                'collection' => $collection,
+                'error' => $e->getMessage(),
+            ]);
+        }
+
+        try {
+            $this->qdrantRequest('PUT', "/collections/{$collection}", [
+                'vectors' => [
+                    'size' => $vectorDimension,
+                    'distance' => 'Cosine',
+                ],
+            ]);
+
+            $this->createPayloadIndex($collection, 'user_id', 'integer');
+            $this->createPayloadIndex($collection, 'category', 'keyword');
+            $this->createPayloadIndex($collection, 'active', 'bool');
+            $this->createPayloadIndex($collection, '_point_id', 'keyword');
+
+            $this->ensuredCollections[$collection] = true;
+
+            $this->logger->info('Recreated Qdrant memories collection', [
+                'collection' => $collection,
+                'vector_dim' => $vectorDimension,
+            ]);
+        } catch (\Throwable $e) {
+            $this->logger->error('Failed to recreate memories collection', [
+                'collection' => $collection,
+                'vector_dim' => $vectorDimension,
+                'error' => $e->getMessage(),
+            ]);
+
+            throw $e;
+        }
+    }
+
     private function ensureSynapseCollection(): void
     {
         $collection = $this->synapseCollection;

--- a/backend/src/Service/VectorSearch/QdrantClientInterface.php
+++ b/backend/src/Service/VectorSearch/QdrantClientInterface.php
@@ -287,6 +287,24 @@ interface QdrantClientInterface
      */
     public function recreateSynapseCollection(int $vectorDimension): void;
 
+    // --- Memory Collection Management ---
+
+    /**
+     * Get information about the memories collection (vector size, point count, status).
+     *
+     * @return array{exists: bool, vector_dim: ?int, points_count: ?int, distance: ?string}
+     */
+    public function getMemoriesCollectionInfo(): array;
+
+    /**
+     * Drop the memories collection (if present) and recreate it with the given
+     * vector dimension. Used when the embedding model is swapped to one with
+     * a different output dimension (e.g. 1024 ─► 1536).
+     *
+     * Idempotent — safe to call when the collection does not yet exist.
+     */
+    public function recreateMemoriesCollection(int $vectorDimension): void;
+
     /**
      * Get the synapse collection name.
      */

--- a/backend/src/Service/VectorSearch/QdrantClientMock.php
+++ b/backend/src/Service/VectorSearch/QdrantClientMock.php
@@ -257,6 +257,21 @@ final class QdrantClientMock implements QdrantClientInterface
         $this->synapsePoints = [];
     }
 
+    public function getMemoriesCollectionInfo(): array
+    {
+        return [
+            'exists' => true,
+            'vector_dim' => 1024,
+            'points_count' => 0,
+            'distance' => 'Cosine',
+        ];
+    }
+
+    public function recreateMemoriesCollection(int $vectorDimension): void
+    {
+        $this->logger->info('QdrantClientMock: recreateMemoriesCollection', ['vector_dim' => $vectorDimension]);
+    }
+
     public function getSynapseCollection(): string
     {
         return 'synapse_topics';

--- a/backend/tests/Service/UserMemoryServiceTest.php
+++ b/backend/tests/Service/UserMemoryServiceTest.php
@@ -346,11 +346,16 @@ final class UserMemoryServiceTest extends TestCase
         $this->qdrantClient->method('isAvailable')->willReturn(true);
         $this->qdrantClient->method('scrollMemories')->willReturn([]);
 
+        // Collection was created with 1024-dim but the new model produces 1536-dim vectors.
+        $this->qdrantClient->method('getMemoriesCollectionInfo')->willReturn([
+            'exists' => true,
+            'vector_dim' => 1024,
+            'points_count' => 15,
+            'distance' => 'Cosine',
+        ]);
+
         $this->modelConfigService->method('getDefaultModel')->willReturn(42);
         $this->em->method('getRepository')->willReturn($this->createMock(\Doctrine\ORM\EntityRepository::class));
-
-        // Active collection dim is 1024 but the new model produces 1536-dim vectors.
-        $this->embeddingMetadata->method('getCurrentVectorDim')->willReturn(1024);
 
         $this->aiFacade
             ->method('embed')

--- a/backend/tests/Unit/MessageClassifierTest.php
+++ b/backend/tests/Unit/MessageClassifierTest.php
@@ -579,6 +579,74 @@ class MessageClassifierTest extends TestCase
         yield 'generier (colloquial imperative)' => ['generier mir bitte ein logo'];
     }
 
+    /**
+     * Regression for #974.
+     *
+     * German cost/price queries like "Was kostet ein Flug nach Bergen?" used
+     * to slip through the fast-path because the trigger list only had a few
+     * English phrases plus the very specific `aktuelle nachrichten`. With
+     * the fast-path enabled (default-on) the AI sorter was never reached,
+     * `web_search` stayed `false`, and the model hallucinated "Ich starte
+     * eine Suche" without ever actually triggering Brave Search. Verify
+     * these messages now defer to the full sorter where web_search can be
+     * activated.
+     *
+     * @return iterable<string, array{0: string}>
+     */
+    public static function germanCostQueryFastPathProvider(): iterable
+    {
+        yield 'kostet + travel' => ['Was kostet ein Flug nach Bergen?'];
+        yield 'kostet + restaurant' => ['Was kostet ein Kebap-Gericht in Münster?'];
+        yield 'wie teuer' => ['Wie teuer ist ein iPhone 17?'];
+        yield 'preis (noun)' => ['Was ist der Preis für ein Bitcoin?'];
+        yield 'flüge (plural)' => ['Gibt es günstige Flüge im Dezember?'];
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('germanCostQueryFastPathProvider')]
+    public function testFastPathYieldsToAiSorterOnGermanCostQueries(string $text): void
+    {
+        $configRepo = $this->createMock(ConfigRepository::class);
+        // Synapse off, fast-path on (default).
+        $configRepo->method('getValue')->willReturnCallback(static function (int $owner, string $group, string $setting): ?string {
+            return 'QDRANT_SEARCH' === $group ? '0' : null;
+        });
+
+        $sorter = $this->createMock(MessageSorter::class);
+        // The AI sorter MUST be reached — that's the entire point: without
+        // it, web_search never flips to true for these queries.
+        $sorter->expects($this->once())
+            ->method('classify')
+            ->willReturn(['topic' => 'general', 'language' => 'de', 'web_search' => true]);
+
+        $classifier = new MessageClassifier(
+            $sorter,
+            $this->createMock(SynapseRouter::class),
+            new TopicAliasResolver(),
+            $this->createMock(MessageMetaRepository::class),
+            $this->createMock(ModelConfigService::class),
+            $configRepo,
+            $this->createMock(EntityManagerInterface::class),
+            $this->createMock(LoggerInterface::class),
+        );
+
+        $message = $this->createMock(Message::class);
+        $message->method('getId')->willReturn(974);
+        $message->method('getUserId')->willReturn(10);
+        $message->method('getText')->willReturn($text);
+        $message->method('getLanguage')->willReturn('de');
+        $message->method('getFile')->willReturn(0);
+        $message->method('getFiles')->willReturn(new \Doctrine\Common\Collections\ArrayCollection());
+        $message->method('getDateTime')->willReturn('20260518120000');
+        $message->method('getFilePath')->willReturn('');
+        $message->method('getTopic')->willReturn('');
+        $message->method('getFileText')->willReturn('');
+
+        $result = $classifier->classify($message);
+
+        $this->assertSame('ai_sorting', $result['source'], sprintf('Fast-path must yield to the AI sorter for "%s" (#974)', $text));
+        $this->assertFalse($result['skip_sorting']);
+    }
+
     #[\PHPUnit\Framework\Attributes\DataProvider('germanMediaImperativeProvider')]
     public function testFastPathYieldsToAiSorterOnGermanGenerateImperatives(string $text): void
     {

--- a/backend/tests/Unit/ModelConfigServiceTest.php
+++ b/backend/tests/Unit/ModelConfigServiceTest.php
@@ -599,6 +599,120 @@ class ModelConfigServiceTest extends TestCase
         $this->assertNull($result, 'User not found in database should return null');
     }
 
+    /**
+     * Regression test for issue #973.
+     *
+     * The "New Memory" UI parse endpoint (UserMemoryController::parseMemory)
+     * and the async MemoryExtractionService MUST share the same MEM → CHAT
+     * fallback chain. Otherwise admins who configure a cheap MEM model see
+     * the UI silently fall back to the (expensive) CHAT default.
+     */
+    public function testGetMemoryModelConfigPrefersUserMemOverGlobalMemAndChat(): void
+    {
+        $userId = 42;
+        $userMemModelId = 220;
+
+        $userMemConfig = $this->createMock(Config::class);
+        $userMemConfig->method('getValue')->willReturn((string) $userMemModelId);
+
+        // findOneBy should be hit exactly once — the very first MEM lookup wins.
+        $this->configRepository
+            ->expects($this->once())
+            ->method('findOneBy')
+            ->with([
+                'ownerId' => $userId,
+                'group' => 'DEFAULTMODEL',
+                'setting' => 'MEM',
+            ])
+            ->willReturn($userMemConfig);
+
+        $model = $this->createMock(Model::class);
+        $model->method('getService')->willReturn('Groq');
+        $model->method('getProviderId')->willReturn('gpt-oss-120b');
+
+        $this->modelRepository
+            ->method('find')
+            ->with($userMemModelId)
+            ->willReturn($model);
+
+        $result = $this->service->getMemoryModelConfig($userId);
+
+        $this->assertSame([
+            'model' => 'gpt-oss-120b',
+            'provider' => 'groq',
+            'model_id' => $userMemModelId,
+        ], $result);
+    }
+
+    public function testGetMemoryModelConfigFallsThroughGlobalMemUserChatToGlobalChat(): void
+    {
+        $userId = 7;
+        $globalChatModelId = 160;
+
+        $globalChatConfig = $this->createMock(Config::class);
+        $globalChatConfig->method('getValue')->willReturn((string) $globalChatModelId);
+
+        // Walk the full chain: user MEM → global MEM → user CHAT → global CHAT.
+        // Only the very last lookup returns a config.
+        $this->configRepository
+            ->expects($this->exactly(4))
+            ->method('findOneBy')
+            ->willReturnCallback(
+                function (array $criteria) use ($userId, $globalChatConfig) {
+                    static $calls = 0;
+                    ++$calls;
+
+                    $expectedSequence = [
+                        ['ownerId' => $userId, 'group' => 'DEFAULTMODEL', 'setting' => 'MEM'],
+                        ['ownerId' => 0, 'group' => 'DEFAULTMODEL', 'setting' => 'MEM'],
+                        ['ownerId' => $userId, 'group' => 'DEFAULTMODEL', 'setting' => 'CHAT'],
+                        ['ownerId' => 0, 'group' => 'DEFAULTMODEL', 'setting' => 'CHAT'],
+                    ];
+
+                    self::assertSame(
+                        $expectedSequence[$calls - 1],
+                        $criteria,
+                        "Fallback chain step {$calls} called with unexpected criteria"
+                    );
+
+                    return 4 === $calls ? $globalChatConfig : null;
+                }
+            );
+
+        $model = $this->createMock(Model::class);
+        $model->method('getService')->willReturn('Anthropic');
+        $model->method('getProviderId')->willReturn('claude-opus-4-6');
+
+        $this->modelRepository
+            ->method('find')
+            ->with($globalChatModelId)
+            ->willReturn($model);
+
+        $result = $this->service->getMemoryModelConfig($userId);
+
+        $this->assertSame([
+            'model' => 'claude-opus-4-6',
+            'provider' => 'anthropic',
+            'model_id' => $globalChatModelId,
+        ], $result);
+    }
+
+    public function testGetMemoryModelConfigReturnsNullsWhenNothingConfigured(): void
+    {
+        $this->configRepository
+            ->method('findOneBy')
+            ->willReturn(null);
+
+        $this->modelRepository
+            ->expects($this->never())
+            ->method('find');
+
+        $this->assertSame(
+            ['model' => null, 'provider' => null, 'model_id' => null],
+            $this->service->getMemoryModelConfig(99)
+        );
+    }
+
     public function testGetEffectiveUserIdForMessageWithWebChannelUnverifiedUser(): void
     {
         $userId = 25;

--- a/backend/tests/Unit/Service/Message/Handler/FileAnalysisHandlerMultiFileTest.php
+++ b/backend/tests/Unit/Service/Message/Handler/FileAnalysisHandlerMultiFileTest.php
@@ -26,6 +26,7 @@ class FileAnalysisHandlerMultiFileTest extends TestCase
     private ModelConfigService&MockObject $modelConfigService;
     private LoggerInterface&MockObject $logger;
     private FileAnalysisHandler $handler;
+    private string $uploadDir;
 
     protected function setUp(): void
     {
@@ -33,17 +34,31 @@ class FileAnalysisHandlerMultiFileTest extends TestCase
         $this->modelConfigService = $this->createMock(ModelConfigService::class);
         $this->logger = $this->createMock(LoggerInterface::class);
 
+        // Use a hermetic per-test upload directory so the vision-path
+        // tests work in any environment (Docker container, GitHub
+        // Actions runner, dev laptop) without depending on a hardcoded
+        // `/var/www/backend/var/uploads` location.
+        $this->uploadDir = sys_get_temp_dir().'/synaplan-file-analysis-'.bin2hex(random_bytes(8));
+        mkdir($this->uploadDir, 0o775, true);
+
         $this->handler = new FileAnalysisHandler(
             $this->aiFacade,
             $this->modelConfigService,
             $this->logger,
-            '/var/www/backend/var/uploads',
+            $this->uploadDir,
         );
 
         $this->modelConfigService->method('getEffectiveUserIdForMessage')->willReturn(7);
         $this->modelConfigService->method('getDefaultModel')->willReturn(123);
         $this->modelConfigService->method('getProviderForModel')->willReturn('openai');
         $this->modelConfigService->method('getModelName')->willReturn('gpt-4');
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_dir($this->uploadDir)) {
+            $this->removeDirectoryRecursive($this->uploadDir);
+        }
     }
 
     /**
@@ -364,13 +379,33 @@ class FileAnalysisHandlerMultiFileTest extends TestCase
     private function stubImagePathsExist(array $relativePaths): void
     {
         foreach ($relativePaths as $relative) {
-            $full = '/var/www/backend/var/uploads/'.$relative;
-            if (!is_dir(dirname($full))) {
-                @mkdir(dirname($full), 0o775, true);
+            $full = $this->uploadDir.'/'.$relative;
+            $dir = dirname($full);
+            if (!is_dir($dir) && !mkdir($dir, 0o775, true) && !is_dir($dir)) {
+                throw new \RuntimeException(sprintf('Failed to create test upload directory "%s"', $dir));
             }
-            if (!file_exists($full)) {
-                file_put_contents($full, 'fake-image-bytes');
+            if (false === file_put_contents($full, 'fake-image-bytes')) {
+                throw new \RuntimeException(sprintf('Failed to write test upload file "%s"', $full));
             }
         }
+    }
+
+    private function removeDirectoryRecursive(string $path): void
+    {
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+
+        foreach ($iterator as $item) {
+            /** @var \SplFileInfo $item */
+            if ($item->isDir()) {
+                rmdir($item->getPathname());
+            } else {
+                unlink($item->getPathname());
+            }
+        }
+
+        rmdir($path);
     }
 }

--- a/backend/tests/Unit/Service/Message/Handler/FileAnalysisHandlerMultiFileTest.php
+++ b/backend/tests/Unit/Service/Message/Handler/FileAnalysisHandlerMultiFileTest.php
@@ -1,0 +1,376 @@
+<?php
+
+namespace App\Tests\Unit\Service\Message\Handler;
+
+use App\AI\Service\AiFacade;
+use App\Entity\File;
+use App\Entity\Message;
+use App\Service\Message\Handler\FileAnalysisHandler;
+use App\Service\ModelConfigService;
+use Doctrine\Common\Collections\ArrayCollection;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Issue #978 — when the user attaches multiple documents (or voice
+ * messages) to a single chat message, the previous implementation
+ * silently dropped every file after the first because
+ * `FileAnalysisHandler` called `$files->first()` once. These tests
+ * pin the multi-file behaviour so the regression cannot reappear.
+ */
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
+class FileAnalysisHandlerMultiFileTest extends TestCase
+{
+    private AiFacade&MockObject $aiFacade;
+    private ModelConfigService&MockObject $modelConfigService;
+    private LoggerInterface&MockObject $logger;
+    private FileAnalysisHandler $handler;
+
+    protected function setUp(): void
+    {
+        $this->aiFacade = $this->createMock(AiFacade::class);
+        $this->modelConfigService = $this->createMock(ModelConfigService::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
+
+        $this->handler = new FileAnalysisHandler(
+            $this->aiFacade,
+            $this->modelConfigService,
+            $this->logger,
+            '/var/www/backend/var/uploads',
+        );
+
+        $this->modelConfigService->method('getEffectiveUserIdForMessage')->willReturn(7);
+        $this->modelConfigService->method('getDefaultModel')->willReturn(123);
+        $this->modelConfigService->method('getProviderForModel')->willReturn('openai');
+        $this->modelConfigService->method('getModelName')->willReturn('gpt-4');
+    }
+
+    /**
+     * Primary regression for #978: two .md documents attached to one
+     * message used to feed only the first file's text to the LLM,
+     * which made the assistant ignore the second document entirely.
+     * After the fix, both files' extracted text must reach the model
+     * in one labelled prompt.
+     */
+    public function testTwoDocumentsBothReachTheModelInOnePrompt(): void
+    {
+        $message = $this->buildMessageWithFiles([
+            $this->buildFile(id: 1, name: 'rules.md', type: 'md', path: '13/000/rules.md', text: 'Rule 1: ship small PRs.'),
+            $this->buildFile(id: 2, name: 'plan.md', type: 'md', path: '13/000/plan.md', text: 'Step A: write tests.'),
+        ], text: 'Evaluate my plan based on the rules.');
+
+        $captured = null;
+        $this->aiFacade
+            ->expects($this->once())
+            ->method('chat')
+            ->willReturnCallback(function (array $messages) use (&$captured) {
+                $captured = $messages;
+
+                return [
+                    'content' => 'Your plan aligns with the rules.',
+                    'provider' => 'openai',
+                    'model' => 'gpt-4',
+                ];
+            });
+
+        $result = $this->handler->handle($message, [], []);
+
+        $this->assertNotNull($captured);
+        $system = $captured[0]['content'];
+
+        $this->assertStringContainsString('analyzing 2 documents', $system);
+        $this->assertStringContainsString('rules.md', $system);
+        $this->assertStringContainsString('plan.md', $system);
+        $this->assertStringContainsString('Rule 1: ship small PRs.', $system);
+        $this->assertStringContainsString('Step A: write tests.', $system);
+        $this->assertStringContainsString('=== FILE 1 OF 2 INFORMATION ===', $system);
+        $this->assertStringContainsString('=== FILE 2 OF 2 INFORMATION ===', $system);
+
+        $this->assertSame('Evaluate my plan based on the rules.', $captured[1]['content']);
+        $this->assertSame('Your plan aligns with the rules.', $result['content']);
+        $this->assertSame('chat_with_extracted_text', $result['metadata']['analysis_type']);
+        $this->assertSame(2, $result['metadata']['analyzed_file_count']);
+        $this->assertSame('rules.md, plan.md', $result['metadata']['analyzed_file']);
+    }
+
+    /**
+     * The single-document case must keep producing the original
+     * prompt layout so existing UX and prompt-quality tuning are
+     * preserved. This guards against accidentally regressing the
+     * common case while fixing the multi-file one.
+     */
+    public function testSingleDocumentUsesLegacyPromptShape(): void
+    {
+        $message = $this->buildMessageWithFiles([
+            $this->buildFile(id: 1, name: 'report.pdf', type: 'pdf', path: '13/000/report.pdf', text: 'Quarterly revenue rose.'),
+        ], text: 'Summarize.');
+
+        $captured = null;
+        $this->aiFacade
+            ->expects($this->once())
+            ->method('chat')
+            ->willReturnCallback(function (array $messages) use (&$captured) {
+                $captured = $messages;
+
+                return ['content' => 'Revenue is up.', 'provider' => 'openai', 'model' => 'gpt-4'];
+            });
+
+        $this->handler->handle($message, [], []);
+
+        $this->assertNotNull($captured);
+        $system = $captured[0]['content'];
+
+        $this->assertStringContainsString('You are analyzing a document.', $system);
+        $this->assertStringContainsString('=== FILE INFORMATION ===', $system);
+        $this->assertStringContainsString('Filename: report.pdf', $system);
+        $this->assertStringContainsString('Quarterly revenue rose.', $system);
+        $this->assertStringNotContainsString('=== FILE 1 OF', $system);
+    }
+
+    /**
+     * Streaming path must also receive every document's text — the
+     * SSE chat route is what the production UI calls.
+     */
+    public function testStreamingMultipleDocumentsForwardsAllContent(): void
+    {
+        $message = $this->buildMessageWithFiles([
+            $this->buildFile(id: 1, name: 'a.pdf', type: 'pdf', path: '13/000/a.pdf', text: 'Alpha content.'),
+            $this->buildFile(id: 2, name: 'b.pdf', type: 'pdf', path: '13/000/b.pdf', text: 'Beta content.'),
+        ], text: '');
+
+        $captured = null;
+        $streamed = '';
+        $this->aiFacade
+            ->expects($this->once())
+            ->method('chatStream')
+            ->willReturnCallback(function (array $messages, callable $cb) use (&$captured) {
+                $captured = $messages;
+                $cb('Comparison...');
+
+                return ['provider' => 'openai', 'model' => 'gpt-4'];
+            });
+
+        $sink = function (string $chunk) use (&$streamed): void {
+            $streamed .= $chunk;
+        };
+
+        $result = $this->handler->handleStream($message, [], [], $sink);
+
+        $this->assertNotNull($captured);
+        $this->assertStringContainsString('Alpha content.', $captured[0]['content']);
+        $this->assertStringContainsString('Beta content.', $captured[0]['content']);
+        $this->assertSame('What is in these documents? Please summarize the content of each file.', $captured[1]['content']);
+        $this->assertSame('Comparison...', $streamed);
+        $this->assertSame(2, $result['metadata']['analyzed_file_count']);
+    }
+
+    /**
+     * If the user combines documents with a voice note, the spoken
+     * transcript must reach the model alongside the document text.
+     * Previously only the alphabetically-first file (or whichever
+     * landed at index 0) made it through.
+     */
+    public function testMixedDocumentAndAudioMergesTranscriptIntoPrompt(): void
+    {
+        $message = $this->buildMessageWithFiles([
+            $this->buildFile(id: 1, name: 'spec.md', type: 'md', path: '13/000/spec.md', text: 'Spec body.'),
+            $this->buildFile(id: 2, name: 'note.ogg', type: 'ogg', path: '13/000/note.ogg', text: 'Please double-check section three.'),
+        ], text: 'Apply my comments.');
+
+        $captured = null;
+        $this->aiFacade
+            ->expects($this->once())
+            ->method('chat')
+            ->willReturnCallback(function (array $messages) use (&$captured) {
+                $captured = $messages;
+
+                return ['content' => 'Section three reviewed.', 'provider' => 'openai', 'model' => 'gpt-4'];
+            });
+
+        $this->handler->handle($message, [], []);
+
+        $this->assertNotNull($captured);
+        $system = $captured[0]['content'];
+
+        $this->assertStringContainsString('Spec body.', $system);
+        $this->assertStringContainsString('Voice message transcript:', $system);
+        $this->assertStringContainsString('Please double-check section three.', $system);
+        $this->assertSame('Apply my comments.', $captured[1]['content']);
+    }
+
+    /**
+     * Two voice notes in one bubble used to drop the second
+     * transcript on the floor. Both must now reach the LLM, labelled
+     * so the model can tell them apart, while the conversational
+     * audio system prompt is still used (no "you are analyzing a
+     * document" regression).
+     */
+    public function testMultipleVoiceMessagesAreAllTranscribedIntoPrompt(): void
+    {
+        $message = $this->buildMessageWithFiles([
+            $this->buildFile(id: 1, name: 'first.ogg', type: 'ogg', path: '13/000/first.ogg', text: 'Hi, how are you?'),
+            $this->buildFile(id: 2, name: 'second.ogg', type: 'ogg', path: '13/000/second.ogg', text: 'Also can you remind me tomorrow?'),
+        ], text: '');
+
+        $captured = null;
+        $this->aiFacade
+            ->expects($this->once())
+            ->method('chat')
+            ->willReturnCallback(function (array $messages) use (&$captured) {
+                $captured = $messages;
+
+                return ['content' => "I'm well, sure!", 'provider' => 'openai', 'model' => 'gpt-4'];
+            });
+
+        $result = $this->handler->handle($message, [], []);
+
+        $this->assertNotNull($captured);
+        $system = $captured[0]['content'];
+
+        $this->assertStringContainsString('2 voice messages', $system);
+        $this->assertStringContainsString('Voice message 1 (first.ogg)', $system);
+        $this->assertStringContainsString('Voice message 2 (second.ogg)', $system);
+        $this->assertStringContainsString('Hi, how are you?', $system);
+        $this->assertStringContainsString('Also can you remind me tomorrow?', $system);
+        $this->assertStringNotContainsString('You are analyzing a document', $system);
+
+        $this->assertSame('voice_message_reply', $result['metadata']['analysis_type']);
+        $this->assertSame(2, $result['metadata']['analyzed_file_count']);
+    }
+
+    /**
+     * Multi-image uploads previously stopped after the first vision
+     * call. The handler must dispatch one vision call per image and
+     * combine the per-image descriptions into a single labelled
+     * response so the user sees every analysis.
+     */
+    public function testMultipleImagesAreAnalyzedAndAggregated(): void
+    {
+        $message = $this->buildMessageWithFiles([
+            $this->buildFile(id: 1, name: 'left.png', type: 'png', path: 'present/left.png'),
+            $this->buildFile(id: 2, name: 'right.png', type: 'png', path: 'present/right.png'),
+        ], text: 'What do you see?');
+
+        $this->stubImagePathsExist(['present/left.png', 'present/right.png']);
+
+        $calls = [];
+        $this->aiFacade
+            ->expects($this->exactly(2))
+            ->method('analyzeImage')
+            ->willReturnCallback(function (string $path) use (&$calls) {
+                $calls[] = $path;
+
+                return [
+                    'content' => 'description for '.basename($path),
+                    'provider' => 'openai',
+                    'model' => 'gpt-4o',
+                ];
+            });
+
+        $result = $this->handler->handle($message, [], []);
+
+        $this->assertSame(['present/left.png', 'present/right.png'], $calls);
+        $this->assertStringContainsString('### Image 1: left.png', $result['content']);
+        $this->assertStringContainsString('description for left.png', $result['content']);
+        $this->assertStringContainsString('### Image 2: right.png', $result['content']);
+        $this->assertStringContainsString('description for right.png', $result['content']);
+        $this->assertSame('vision', $result['metadata']['analysis_type']);
+        $this->assertSame(2, $result['metadata']['analyzed_file_count']);
+    }
+
+    /**
+     * If one image vision call fails, the other should still be
+     * delivered so the user gets a useful partial response instead
+     * of a hard error covering both files.
+     */
+    public function testMultipleImagesRenderPartialResultsWhenOneFails(): void
+    {
+        $message = $this->buildMessageWithFiles([
+            $this->buildFile(id: 1, name: 'ok.png', type: 'png', path: 'present/ok.png'),
+            $this->buildFile(id: 2, name: 'bad.png', type: 'png', path: 'present/bad.png'),
+        ], text: '');
+
+        $this->stubImagePathsExist(['present/ok.png', 'present/bad.png']);
+
+        $this->aiFacade
+            ->expects($this->exactly(2))
+            ->method('analyzeImage')
+            ->willReturnCallback(function (string $path) {
+                if (str_contains($path, 'bad')) {
+                    throw new \RuntimeException('boom');
+                }
+
+                return [
+                    'content' => 'ok description',
+                    'provider' => 'openai',
+                    'model' => 'gpt-4o',
+                ];
+            });
+
+        $result = $this->handler->handle($message, [], []);
+
+        $this->assertStringContainsString('### Image 1: ok.png', $result['content']);
+        $this->assertStringContainsString('ok description', $result['content']);
+        $this->assertStringContainsString('### Image 2: bad.png', $result['content']);
+        $this->assertStringContainsString('Image analysis failed: boom', $result['content']);
+    }
+
+    /**
+     * Build a Message mock that exposes the given files via getFiles().
+     *
+     * @param list<File> $files
+     */
+    private function buildMessageWithFiles(array $files, string $text): Message&MockObject
+    {
+        $collection = new ArrayCollection($files);
+
+        $message = $this->createMock(Message::class);
+        $message->method('getId')->willReturn(42);
+        $message->method('getUserId')->willReturn(7);
+        $message->method('getFiles')->willReturn($collection);
+        $message->method('getText')->willReturn($text);
+
+        return $message;
+    }
+
+    private function buildFile(
+        int $id,
+        string $name,
+        string $type,
+        string $path,
+        string $text = '',
+        string $status = 'processed',
+    ): File&MockObject {
+        $file = $this->createMock(File::class);
+        $file->method('getId')->willReturn($id);
+        $file->method('getFileName')->willReturn($name);
+        $file->method('getFileType')->willReturn($type);
+        $file->method('getFilePath')->willReturn($path);
+        $file->method('getFileText')->willReturn($text);
+        $file->method('getStatus')->willReturn($status);
+
+        return $file;
+    }
+
+    /**
+     * Make sure the upload paths used in the vision-path tests
+     * actually exist on disk so `handleImagesWithVisionModel` does
+     * not short-circuit with "file_not_found" before reaching the
+     * provider call we want to assert on.
+     *
+     * @param list<string> $relativePaths
+     */
+    private function stubImagePathsExist(array $relativePaths): void
+    {
+        foreach ($relativePaths as $relative) {
+            $full = '/var/www/backend/var/uploads/'.$relative;
+            if (!is_dir(dirname($full))) {
+                @mkdir(dirname($full), 0o775, true);
+            }
+            if (!file_exists($full)) {
+                file_put_contents($full, 'fake-image-bytes');
+            }
+        }
+    }
+}

--- a/backend/tests/Unit/SynapseRouterTest.php
+++ b/backend/tests/Unit/SynapseRouterTest.php
@@ -204,6 +204,56 @@ class SynapseRouterTest extends TestCase
         $this->assertTrue($result['web_search']);
     }
 
+    /**
+     * Regression test for issue #974.
+     *
+     * The most common German phrasing for asking about prices is "Was kostet
+     * X?" — conjugated, not the bare infinitive. The previous keyword list
+     * used the literal `kosten`, but `str_contains('kostet', 'kosten')` is
+     * `false`, so neither WhatsApp nor the web chat ever triggered the Brave
+     * Search pipeline for these queries. Use the shorter stem `kost` instead.
+     *
+     * @return iterable<string, array{0: string}>
+     */
+    public static function germanCostQueryProvider(): iterable
+    {
+        yield 'kostet (singular)' => ['Was kostet ein Flug nach Bergen?'];
+        yield 'kostet + restaurant' => ['Was kostet ein Kebap-Gericht in Münster?'];
+        yield 'wie teuer' => ['Wie teuer ist ein iPhone 17?'];
+        yield 'gekostet (past)' => ['Was hat das Konzert gestern gekostet?'];
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('germanCostQueryProvider')]
+    public function testGermanCostQueriesTriggerWebSearch(string $text): void
+    {
+        $this->modelConfigService->method('getDefaultModel')->willReturn(null);
+        $this->promptRepository->method('findPromptsWithSelectionRules')->willReturn([]);
+
+        $this->aiFacade->method('embed')->willReturn([
+            'embedding' => array_fill(0, 1024, 0.1),
+            'usage' => ['prompt_tokens' => 10, 'total_tokens' => 10],
+        ]);
+
+        $this->qdrantClient->method('searchSynapseTopics')->willReturn([
+            [
+                'id' => 'synapse_0_general',
+                'score' => 0.90,
+                'payload' => ['topic' => 'general', 'owner_id' => 0],
+            ],
+        ]);
+
+        $this->promptService->method('getPromptWithMetadata')->willReturn([
+            'metadata' => ['tool_internet' => false],
+        ]);
+
+        $result = $this->router->route(['BTEXT' => $text], [], 1);
+
+        $this->assertTrue(
+            $result['web_search'],
+            sprintf('German cost/price query "%s" must trigger web search (#974)', $text),
+        );
+    }
+
     public function testDetectsYearPatternAsWebSearch(): void
     {
         $this->modelConfigService->method('getDefaultModel')->willReturn(null);

--- a/frontend/src/components/MessageAudio.vue
+++ b/frontend/src/components/MessageAudio.vue
@@ -1,17 +1,81 @@
 <template>
-  <div class="my-3">
+  <div class="my-3" data-testid="section-message-audio">
     <div
       class="relative w-full surface-card overflow-hidden rounded-lg border border-light-border/30 dark:border-dark-border/20 p-4"
     >
-      <div class="flex items-center gap-2 sm:gap-4">
+      <!-- Error state: file could not be loaded (404, NotSupportedError, etc.) -->
+      <div v-if="hasFailed" class="flex items-center gap-3" data-testid="audio-load-error">
+        <div
+          class="flex-shrink-0 w-10 h-10 sm:w-12 sm:h-12 rounded-full bg-red-500/15 text-red-500 flex items-center justify-center"
+          aria-hidden="true"
+        >
+          <svg class="w-5 h-5 sm:w-6 sm:h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M12 9v2m0 4h.01M4.93 19h14.14a2 2 0 001.74-3l-7.07-12.25a2 2 0 00-3.48 0L3.19 16a2 2 0 001.74 3z"
+            />
+          </svg>
+        </div>
+        <div class="flex-1 min-w-0">
+          <p class="text-sm font-medium txt-primary">
+            {{ $t('chat.audioUnavailable') }}
+          </p>
+          <p class="text-xs txt-secondary mt-0.5">
+            {{ $t('chat.audioUnavailableDescription') }}
+          </p>
+        </div>
+        <a
+          v-if="canDownload"
+          :href="props.url"
+          :download="fileName"
+          class="flex-shrink-0 txt-primary hover:text-[var(--brand)] transition-colors"
+          :aria-label="$t('commands.download')"
+          data-testid="btn-audio-download-fallback"
+        >
+          <svg class="w-5 h-5 sm:w-6 sm:h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
+            />
+          </svg>
+        </a>
+      </div>
+
+      <div v-else class="flex items-center gap-2 sm:gap-4">
         <!-- Play/Pause Button -->
         <button
-          class="flex-shrink-0 w-10 h-10 sm:w-12 sm:h-12 rounded-full bg-[var(--brand)] text-white flex items-center justify-center hover:bg-[var(--brand)]/90 transition-all shadow-lg"
+          class="flex-shrink-0 w-10 h-10 sm:w-12 sm:h-12 rounded-full bg-[var(--brand)] text-white flex items-center justify-center hover:bg-[var(--brand)]/90 transition-all shadow-lg disabled:opacity-50 disabled:cursor-not-allowed"
           :aria-label="isPlaying ? 'Pause' : 'Play'"
+          :disabled="isRetrying"
+          data-testid="btn-audio-play"
           @click="togglePlay"
         >
           <svg
-            v-if="!isPlaying"
+            v-if="isRetrying"
+            class="w-5 h-5 sm:w-6 sm:h-6 animate-spin"
+            fill="none"
+            viewBox="0 0 24 24"
+          >
+            <circle
+              class="opacity-25"
+              cx="12"
+              cy="12"
+              r="10"
+              stroke="currentColor"
+              stroke-width="4"
+            />
+            <path
+              class="opacity-75"
+              fill="currentColor"
+              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+            />
+          </svg>
+          <svg
+            v-else-if="!isPlaying"
             class="w-5 h-5 sm:w-6 sm:h-6 ml-0.5 sm:ml-1"
             fill="currentColor"
             viewBox="0 0 24 24"
@@ -48,6 +112,7 @@
         <button
           class="flex-shrink-0 txt-primary hover:text-[var(--brand)] transition-colors"
           :aria-label="isMuted ? 'Unmute' : 'Mute'"
+          data-testid="btn-audio-mute"
           @click="toggleMute"
         >
           <svg
@@ -82,7 +147,7 @@
 
         <!-- Download Button -->
         <a
-          :href="url"
+          :href="props.url"
           :download="fileName"
           class="flex-shrink-0 txt-primary hover:text-[var(--brand)] transition-colors"
           :aria-label="$t('commands.download')"
@@ -100,12 +165,16 @@
 
       <!-- Hidden Audio Element -->
       <audio
+        v-if="!hasFailed"
         ref="audioRef"
-        :src="url"
+        :src="audioSrc"
         class="hidden"
+        preload="metadata"
+        data-testid="media-audio-player"
         @timeupdate="updateProgress"
-        @loadedmetadata="updateDuration"
+        @loadedmetadata="handleLoadSuccess"
         @ended="onEnded"
+        @error="handleAudioError"
       ></audio>
     </div>
   </div>
@@ -129,10 +198,41 @@ const progress = ref(0)
 const currentTimeSeconds = ref(0)
 const durationSeconds = ref(0)
 const isDragging = ref(false)
+const hasAutoPlayed = ref(false)
+
+// Issue #976: WhatsApp voice notes sometimes 404 on first load because the
+// uploaded file has not yet propagated across the NFS-shared upload volume
+// to the web tier. Retry with cache-busted URLs (same pattern as
+// `MessageVideo.vue`) so a transient miss self-recovers instead of crashing
+// the entire chat view via an unhandled `NotSupportedError` rejection from
+// `<audio>.play()`.
+const retryCount = ref(0)
+const maxRetries = 3
+const retryDelays = [1000, 2000, 3000]
+const isRetrying = ref(false)
+const hasFailed = ref(false)
+const cacheBuster = ref(0)
+
+const audioSrc = computed(() => {
+  if (cacheBuster.value === 0) {
+    return props.url
+  }
+  const separator = props.url.includes('?') ? '&' : '?'
+  return `${props.url}${separator}_retry=${cacheBuster.value}`
+})
 
 const fileName = computed(() => {
-  const parts = props.url.split('/')
+  const parts = props.url.split('?')[0].split('/')
   return parts[parts.length - 1] || 'audio.mp3'
+})
+
+// Only offer the download fallback link when the source is fetchable as a
+// file (avoids surfacing a broken `download` anchor on `data:` URLs or empty
+// inputs, which are placeholders rather than real audio attachments).
+const canDownload = computed(() => {
+  const url = props.url?.trim() ?? ''
+  if (!url) return false
+  return !url.startsWith('data:')
 })
 
 const formatTime = (seconds: number): string => {
@@ -145,15 +245,82 @@ const formatTime = (seconds: number): string => {
 const currentTime = computed(() => formatTime(currentTimeSeconds.value))
 const duration = computed(() => formatTime(durationSeconds.value))
 
-const togglePlay = () => {
+const handleAudioError = () => {
+  if (retryCount.value < maxRetries) {
+    isRetrying.value = true
+    const delay = retryDelays[retryCount.value]
+    console.warn(
+      `Audio load failed, retrying in ${delay}ms (attempt ${retryCount.value + 1}/${maxRetries})`
+    )
+
+    setTimeout(() => {
+      retryCount.value++
+      cacheBuster.value = Date.now()
+      // Force the <audio> element to re-fetch the (cache-busted) URL.
+      if (audioRef.value) {
+        audioRef.value.load()
+      }
+    }, delay)
+  } else {
+    // All retries exhausted — degrade to a non-crashing error state with a
+    // download fallback so the user can still grab the file directly.
+    isRetrying.value = false
+    isPlaying.value = false
+    hasFailed.value = true
+    console.error('Audio failed to load after all retries:', props.url)
+  }
+}
+
+const handleLoadSuccess = () => {
+  isRetrying.value = false
+  hasFailed.value = false
   if (!audioRef.value) return
+  durationSeconds.value = audioRef.value.duration || 0
+
+  // Autoplay for voice reply audio (only on first successful load).
+  // Browser autoplay policies may block this; the catch keeps the rejection
+  // from bubbling up to the global error handler and crashing the page.
+  if (props.autoplay && !hasAutoPlayed.value) {
+    hasAutoPlayed.value = true
+    audioRef.value
+      .play()
+      .then(() => {
+        isPlaying.value = true
+      })
+      .catch(() => {
+        // Autoplay was blocked — the user can still click play manually.
+      })
+  }
+}
+
+const togglePlay = async () => {
+  if (!audioRef.value || hasFailed.value || isRetrying.value) return
 
   if (isPlaying.value) {
     audioRef.value.pause()
-  } else {
-    audioRef.value.play()
+    isPlaying.value = false
+    return
   }
-  isPlaying.value = !isPlaying.value
+
+  try {
+    // `play()` returns a Promise that rejects on `NotSupportedError`
+    // (404 / unsupported codec) or `NotAllowedError` (autoplay block).
+    // Without an await + try/catch this becomes an unhandled rejection that
+    // tears down the chat view through the global error handler — see #976.
+    await audioRef.value.play()
+    isPlaying.value = true
+  } catch (err) {
+    isPlaying.value = false
+    // `NotSupportedError` indicates the source could not be loaded — escalate
+    // to the load-error retry/fallback flow so the UI doesn't sit silently
+    // in a broken state.
+    const name = (err as DOMException)?.name
+    if (name === 'NotSupportedError') {
+      handleAudioError()
+      return
+    }
+    console.warn('Audio playback failed:', err)
+  }
 }
 
 const toggleMute = () => {
@@ -170,36 +337,19 @@ const updateProgress = () => {
   }
 }
 
-const updateDuration = () => {
-  if (!audioRef.value) return
-  durationSeconds.value = audioRef.value.duration || 0
-
-  // Autoplay for voice reply audio (only on first load)
-  if (props.autoplay && !hasAutoPlayed.value) {
-    hasAutoPlayed.value = true
-    audioRef.value
-      .play()
-      .then(() => {
-        isPlaying.value = true
-      })
-      .catch(() => {
-        // Browser may block autoplay — user can click play manually
-      })
-  }
-}
-
-const hasAutoPlayed = ref(false)
-
 const seek = (event: MouseEvent) => {
-  if (!audioRef.value) return
+  if (!audioRef.value || hasFailed.value) return
   const rect = (event.currentTarget as HTMLElement).getBoundingClientRect()
   const percent = (event.clientX - rect.left) / rect.width
-  audioRef.value.currentTime = percent * audioRef.value.duration
+  const total = audioRef.value.duration
+  if (!isFinite(total) || total <= 0) return
+  audioRef.value.currentTime = percent * total
   progress.value = percent * 100
   currentTimeSeconds.value = audioRef.value.currentTime
 }
 
 const startDragging = (event: MouseEvent) => {
+  if (hasFailed.value) return
   isDragging.value = true
   seek(event)
 
@@ -225,7 +375,6 @@ const onEnded = () => {
   currentTimeSeconds.value = 0
 }
 
-// Cleanup on unmount
 onUnmounted(() => {
   if (audioRef.value && isPlaying.value) {
     audioRef.value.pause()

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -72,6 +72,8 @@
     "showAll": "Alle anzeigen",
     "recent": "Letzte Unterhaltungen",
     "ttsGenerating": "Sprachantwort wird erstellt…",
+    "audioUnavailable": "Audio konnte nicht geladen werden",
+    "audioUnavailableDescription": "Die Datei ist auf dem Server nicht verfügbar. Versuche es später erneut oder lade sie herunter.",
     "rename": "Chat umbenennen",
     "enterNewName": "Gib einen neuen Titel für diesen Chat ein:",
     "renameNote": "Diese Änderung gilt nur für deine Ansicht. Der Widget-Nutzer sieht diesen Titel nicht.",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -77,6 +77,8 @@
     "showAll": "Show All",
     "recent": "Recent Conversations",
     "ttsGenerating": "Adding spoken answer…",
+    "audioUnavailable": "Audio could not be loaded",
+    "audioUnavailableDescription": "The file is currently unavailable on the server. Please try again later or download it.",
     "rename": "Rename Chat",
     "enterNewName": "Enter a new title for this chat:",
     "renameNote": "This change only affects your view. The widget user won't see this title.",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -72,6 +72,8 @@
     "showAll": "Mostrar Todo",
     "recent": "Conversaciones Recientes",
     "ttsGenerating": "Añadiendo respuesta hablada…",
+    "audioUnavailable": "El audio no se pudo cargar",
+    "audioUnavailableDescription": "El archivo no está disponible en el servidor por el momento. Inténtalo de nuevo más tarde o descárgalo.",
     "rename": "Renombrar Chat",
     "enterNewName": "Ingresa un nuevo título para este chat:",
     "namePlaceholder": "Título del chat...",

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -72,6 +72,8 @@
     "showAll": "Tümünü Göster",
     "recent": "Son Konuşmalar",
     "ttsGenerating": "Sesli yanıt ekleniyor…",
+    "audioUnavailable": "Ses yüklenemedi",
+    "audioUnavailableDescription": "Dosya şu anda sunucuda mevcut değil. Lütfen daha sonra tekrar deneyin veya indirin.",
     "rename": "Sohbeti Yeniden Adlandır",
     "enterNewName": "Bu sohbet için yeni bir başlık girin:",
     "namePlaceholder": "Sohbet başlığı...",

--- a/frontend/tests/unit/MessageAudio.spec.ts
+++ b/frontend/tests/unit/MessageAudio.spec.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { nextTick } from 'vue'
+import MessageAudio from '@/components/MessageAudio.vue'
+
+/**
+ * Stub out the parts of HTMLMediaElement that JSDOM omits. The `<audio>`
+ * element in tests needs `load()`, `play()`, and `pause()` to exist as
+ * spy-friendly functions so we can drive the load/error/playback lifecycle
+ * by hand without needing a real audio decoder.
+ */
+function stubAudioElement(overrides: Partial<HTMLAudioElement> = {}) {
+  const proto = HTMLMediaElement.prototype
+  Object.defineProperty(proto, 'play', {
+    configurable: true,
+    writable: true,
+    value: overrides.play ?? vi.fn().mockResolvedValue(undefined),
+  })
+  Object.defineProperty(proto, 'pause', {
+    configurable: true,
+    writable: true,
+    value: overrides.pause ?? vi.fn(),
+  })
+  Object.defineProperty(proto, 'load', {
+    configurable: true,
+    writable: true,
+    value: overrides.load ?? vi.fn(),
+  })
+}
+
+describe('MessageAudio', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    stubAudioElement()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('renders the audio element with the provided URL', () => {
+    const wrapper = mount(MessageAudio, {
+      props: {
+        url: 'https://example.com/voice.ogg',
+      },
+    })
+
+    const audio = wrapper.find('[data-testid="media-audio-player"]')
+    expect(audio.exists()).toBe(true)
+    expect(audio.attributes('src')).toBe('https://example.com/voice.ogg')
+  })
+
+  it('retries with a cache-busted URL when the audio element fires an error', async () => {
+    const wrapper = mount(MessageAudio, {
+      props: {
+        url: '/api/v1/files/uploads/13/voice.ogg',
+      },
+    })
+
+    const audio = wrapper.find('[data-testid="media-audio-player"]')
+    await audio.trigger('error')
+
+    // First retry waits 1s before reloading.
+    vi.advanceTimersByTime(1000)
+    await nextTick()
+
+    const retried = wrapper.find('[data-testid="media-audio-player"]')
+    expect(retried.attributes('src')).toMatch(/_retry=\d+/)
+  })
+
+  it('shows the unavailable error UI after all retries are exhausted', async () => {
+    const wrapper = mount(MessageAudio, {
+      props: {
+        url: '/api/v1/files/uploads/13/voice.ogg',
+      },
+    })
+
+    // Three failed loads → still retrying, no error state yet.
+    for (let i = 0; i < 3; i++) {
+      await wrapper.find('[data-testid="media-audio-player"]').trigger('error')
+      vi.advanceTimersByTime(5000)
+      await nextTick()
+    }
+
+    // Fourth failure exhausts the retry budget and surfaces the error state.
+    await wrapper.find('[data-testid="media-audio-player"]').trigger('error')
+    await nextTick()
+
+    expect(wrapper.find('[data-testid="audio-load-error"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="media-audio-player"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="btn-audio-download-fallback"]').exists()).toBe(true)
+  })
+
+  it('does not let a play() rejection escape as an unhandled promise rejection', async () => {
+    // Simulate the exact failure path from issue #976: the audio file 404s,
+    // so calling play() rejects with NotSupportedError. The component must
+    // catch this so the global error handler does NOT show the full-screen
+    // crash view.
+    const rejection = Object.assign(new Error('The element has no supported sources.'), {
+      name: 'NotSupportedError',
+    })
+    stubAudioElement({
+      play: vi.fn().mockRejectedValue(rejection),
+    })
+
+    const unhandledHandler = vi.fn()
+    window.addEventListener('unhandledrejection', unhandledHandler)
+
+    const wrapper = mount(MessageAudio, {
+      props: {
+        url: '/api/v1/files/uploads/13/voice.ogg',
+      },
+    })
+
+    await wrapper.find('[data-testid="btn-audio-play"]').trigger('click')
+    await flushPromises()
+
+    expect(unhandledHandler).not.toHaveBeenCalled()
+    window.removeEventListener('unhandledrejection', unhandledHandler)
+  })
+
+  it('escalates a play() NotSupportedError to the load-error retry flow', async () => {
+    const rejection = Object.assign(new Error('The element has no supported sources.'), {
+      name: 'NotSupportedError',
+    })
+    stubAudioElement({
+      play: vi.fn().mockRejectedValue(rejection),
+    })
+
+    const wrapper = mount(MessageAudio, {
+      props: {
+        url: '/api/v1/files/uploads/13/voice.ogg',
+      },
+    })
+
+    await wrapper.find('[data-testid="btn-audio-play"]').trigger('click')
+    await flushPromises()
+
+    // Disabled spinner button confirms the retry flow was entered.
+    const playBtn = wrapper.find<HTMLButtonElement>('[data-testid="btn-audio-play"]')
+    expect(playBtn.attributes('disabled')).toBeDefined()
+  })
+})


### PR DESCRIPTION
## Summary
Sammelt fünf Bugfixes aus den GitHub-Issues — Multi-File-Chat-Analyse, Audio-Player-Crash, fehlende deutsche Websuche-Trigger sowie zwei Memory-/Qdrant-Themen — in einem PR gegen `main`.

## Changes
- **fix(chat): process every attached file in `FileAnalysisHandler`** — Handler operiert jetzt auf `getFilesInfo()` + `routeFiles()` statt nur `$files->first()`. Dokumente werden mit `=== FILE x OF N ===` gebündelt, Voice-Notes-Transcripte ins Conversational-Prompt gemerged, Mixed Audio/Doc als virtuelles Transcript-Dokument zugestellt, Bilder sequenziell dispatcht und aggregiert (mit Per-Image-Error-Block statt Total-Fail). Neuer `FileAnalysisHandlerMultiFileTest` plus erweitertes Logging (`analyzed_file_count`).
- **fix(chat): prevent audio player crash on missing files** — `MessageAudio` übernimmt das `MessageVideo`-Resilience-Pattern (3× Retry mit cache-busted Delay, `play()` in try/catch, Download-Fallback statt globalem "Etwas ist schiefgelaufen"-Crash).
- **fix(chat): trigger web search for German cost/price queries** — `MessageClassifier::canFastPathClassify()` ergänzt um deutsche Kosten-/Reise-Stems (`kost`, `preis`, `wie teuer`, `flug nach`, `flüge`); `SynapseRouter::WEB_SEARCH_KEYWORDS` ersetzt `kosten` durch Stem `kost` (matcht `kostet`/`gekostet`/`kostete`) plus `wie teuer`. Regression-Tests in `MessageClassifierTest` und `SynapseRouterTest`.
- **fix(memories): use MEM model in `parseMemory` UI endpoint** — `POST /api/v1/user/memories/parse` nutzt jetzt `DEFAULTMODEL.MEM` (mit CHAT-Fallback) statt direkt CHAT. Logik in neuen `ModelConfigService::getMemoryModelConfig()` zentralisiert, sodass UI- und async-Pfad (`MemoryExtractionService`) eine Quelle teilen. Unit-Tests für Priority-Chain + Empty-Config.
- **fix(memories): recreate collection on VECTORIZE model switch** — `QdrantClientInterface`/`Direct`/`Mock` erhalten `recreateMemoriesCollection()` + `getMemoriesCollectionInfo()`. `reindexMemories()` legt die Memory-Collection mit der nativen Dimension des neuen Modells neu an; `normalizeVectorDimension()` im Reindex-Pfad entfernt. Dimensions-Safety-Check in `UserMemoryService::storeInQdrant()` vergleicht jetzt gegen die echte Qdrant-Collection-Dimension.
- **chore: merge `main`** in den Branch (OWA-Handshake- und OWA-Redirect-Fixes aus #977/#982).

## Verification
- [x] Manual — Issue-spezifische Repros gegen lokales Docker-Setup, plus neue PHPUnit/Vitest-Tests in den jeweiligen Commits.
- [x] Tests added/updated — `FileAnalysisHandlerMultiFileTest`, `MessageClassifierTest`, `SynapseRouterTest`, `ModelConfigService` Unit-Tests, `pendingAuthRedirect.spec.ts` (aus dem main-merge).

## Notes
Closes #978
Closes #976
Closes #974
Closes #973
Closes #959

Nicht in `main` mergen — bitte vorher Review.

## Screenshots/Logs