### PR TITLE
fix(mail-handler): extract bodies from nested multipart and 8BIT emails (#985)

### DIFF
--- a/backend/src/Controller/InboundEmailHandlerController.php
+++ b/backend/src/Controller/InboundEmailHandlerController.php
@@ -7,6 +7,7 @@ use App\Entity\User;
 use App\Repository\InboundEmailHandlerRepository;
 use App\Service\EncryptionService;
 use App\Service\InboundEmailHandlerService;
+use App\Service\MailHandlerLogService;
 use Doctrine\ORM\EntityManagerInterface;
 use OpenApi\Attributes as OA;
 use Psr\Log\LoggerInterface;
@@ -31,6 +32,7 @@ class InboundEmailHandlerController extends AbstractController
         private InboundEmailHandlerRepository $handlerRepository,
         private InboundEmailHandlerService $handlerService,
         private EncryptionService $encryptionService,
+        private MailHandlerLogService $activityLog,
         private EntityManagerInterface $em,
         private LoggerInterface $logger,
     ) {
@@ -471,6 +473,7 @@ class InboundEmailHandlerController extends AbstractController
             ], Response::HTTP_NOT_FOUND);
         }
 
+        $this->activityLog->deleteAll($user->getId(), $id);
         $this->em->remove($handler);
         $this->em->flush();
 
@@ -734,6 +737,7 @@ class InboundEmailHandlerController extends AbstractController
         foreach ($handlerIds as $handlerId) {
             $handler = $this->handlerRepository->findOneBy(['id' => $handlerId, 'userId' => $user->getId()]);
             if ($handler) {
+                $this->activityLog->deleteAll($user->getId(), (int) $handlerId);
                 $this->em->remove($handler);
                 ++$deleted;
             }
@@ -742,5 +746,75 @@ class InboundEmailHandlerController extends AbstractController
         $this->em->flush();
 
         return $this->json(['success' => true, 'deleted' => $deleted]);
+    }
+
+    /**
+     * Recent activity log entries for a handler (newest first, capped at 10).
+     */
+    #[Route('/{id}/logs', name: 'logs', methods: ['GET'], requirements: ['id' => '\d+'])]
+    #[OA\Get(
+        path: '/api/v1/inbound-email-handlers/{id}/logs',
+        summary: 'Recent activity log for an email handler',
+        description: 'Returns the last 10 activity entries (connection checks, routing decisions, forward results) for the handler. Useful for diagnosing "marked seen but never forwarded" cases.',
+        security: [['Bearer' => []]],
+        tags: ['Inbound Email Handlers']
+    )]
+    #[OA\Parameter(
+        name: 'id',
+        in: 'path',
+        description: 'Handler ID',
+        required: true,
+        schema: new OA\Schema(type: 'integer')
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'Recent activity entries (newest first)',
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(property: 'success', type: 'boolean', example: true),
+                new OA\Property(
+                    property: 'logs',
+                    type: 'array',
+                    items: new OA\Items(
+                        properties: [
+                            new OA\Property(property: 'id', type: 'integer'),
+                            new OA\Property(property: 'timestamp', type: 'integer', description: 'Unix epoch seconds'),
+                            new OA\Property(property: 'event', type: 'string', enum: ['check', 'connect_failed', 'forwarded', 'discarded', 'no_route', 'no_smtp', 'forward_failed', 'process_error']),
+                            new OA\Property(property: 'status', type: 'string', enum: ['success', 'warning', 'error']),
+                            new OA\Property(property: 'error', type: 'string'),
+                            new OA\Property(property: 'details', type: 'object', additionalProperties: true),
+                        ]
+                    )
+                ),
+            ]
+        )
+    )]
+    #[OA\Response(response: 401, description: 'Not authenticated')]
+    #[OA\Response(response: 404, description: 'Handler not found')]
+    public function logs(int $id, #[CurrentUser] ?User $user): JsonResponse
+    {
+        if (!$user) {
+            return $this->json(['error' => 'Not authenticated'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        $handler = $this->handlerRepository->findByIdAndUser($id, $user->getId());
+
+        if (!$handler) {
+            return $this->json([
+                'success' => false,
+                'error' => 'Handler not found',
+            ], Response::HTTP_NOT_FOUND);
+        }
+
+        $logs = $this->activityLog->findRecent(
+            $user->getId(),
+            $id,
+            MailHandlerLogService::DEFAULT_KEEP
+        );
+
+        return $this->json([
+            'success' => true,
+            'logs' => $logs,
+        ]);
     }
 }

--- a/backend/src/Controller/InboundEmailHandlerController.php
+++ b/backend/src/Controller/InboundEmailHandlerController.php
@@ -551,15 +551,17 @@ class InboundEmailHandlerController extends AbstractController
                 'message' => $result['message'],
             ]);
         } catch (\Exception $e) {
+            // Match `testConnectionPreview`: log the full exception (host,
+            // library details, stack trace) server-side, but never leak
+            // IMAP/POP3 library internals into a user-facing toast.
             $this->logger->error('Test connection failed', [
                 'handler_id' => $id,
-                'error' => $e->getMessage(),
-                'trace' => $e->getTraceAsString(),
+                'exception' => $e,
             ]);
 
             return $this->json([
                 'success' => false,
-                'message' => 'Test connection failed: '.$e->getMessage(),
+                'message' => 'Test connection failed. Please check your settings and try again.',
             ], Response::HTTP_INTERNAL_SERVER_ERROR);
         }
     }
@@ -779,7 +781,7 @@ class InboundEmailHandlerController extends AbstractController
                         properties: [
                             new OA\Property(property: 'id', type: 'integer'),
                             new OA\Property(property: 'timestamp', type: 'integer', description: 'Unix epoch seconds'),
-                            new OA\Property(property: 'event', type: 'string', enum: ['check', 'connect_failed', 'forwarded', 'discarded', 'no_route', 'no_smtp', 'forward_failed', 'process_error']),
+                            new OA\Property(property: 'event', type: 'string', enum: ['check', 'connect_failed', 'forwarded', 'discarded', 'no_smtp', 'forward_failed', 'process_error']),
                             new OA\Property(property: 'status', type: 'string', enum: ['success', 'warning', 'error']),
                             new OA\Property(property: 'error', type: 'string'),
                             new OA\Property(property: 'details', type: 'object', additionalProperties: true),

--- a/backend/src/Repository/MailHandlerLogRepository.php
+++ b/backend/src/Repository/MailHandlerLogRepository.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\UseLog;
+use Doctrine\DBAL\Exception as DbalException;
+use Doctrine\DBAL\ParameterType;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Storage adapter for per-handler mail activity log entries.
+ *
+ * Mail-handler activity rows are stored inside the shared {@see UseLog}
+ * (`BUSELOG`) table — there is no dedicated table on purpose: the data
+ * is short-lived (ring-buffer of {@see self::DEFAULT_KEEP_FALLBACK} per
+ * (user, handler)) and benefits from the existing indexes on `BUSERID`,
+ * `BACTION` and `BPROVIDER`.
+ *
+ * Discriminators inside `BUSELOG`:
+ *   - `BACTION  = 'MAIL_HANDLER_LOG'` (never used by other writers, so it
+ *     never collides with rate-limit / cost-aggregation queries).
+ *   - `BPROVIDER = handler_id` (string-coerced). `BPROVIDER` is already
+ *     indexed (`idx_uselog_provider`) and is otherwise unused for our
+ *     rows, so we can filter / prune in O(log n) without adding either a
+ *     new column or a JSON-functional index.
+ *
+ * Everything else (event name, free-form details) lives in the JSON
+ * `BMETADATA` column, which is never used inside WHERE/ORDER clauses.
+ */
+final readonly class MailHandlerLogRepository
+{
+    /** Mirrors the service-level default so the repository stays usable standalone. */
+    public const DEFAULT_KEEP_FALLBACK = 10;
+
+    public const ACTION = 'MAIL_HANDLER_LOG';
+
+    public function __construct(
+        private EntityManagerInterface $em,
+    ) {
+    }
+
+    /**
+     * Persist a {@see UseLog} row representing one mail-handler activity event.
+     *
+     * The caller is responsible for filling in the user-facing payload
+     * (status, error, metadata); this method only ensures the row is
+     * tagged with the correct action + provider discriminator so the
+     * other methods on this repository can find it again.
+     *
+     * @throws DbalException on persistence failure
+     */
+    public function save(int $userId, int $handlerId, UseLog $entry): void
+    {
+        $entry->setUserId($userId);
+        $entry->setAction(self::ACTION);
+        $entry->setProvider((string) $handlerId);
+
+        $this->em->persist($entry);
+        $this->em->flush();
+    }
+
+    /**
+     * Fetch the most recent activity rows for (user, handler), newest first.
+     *
+     * Returns raw associative rows — the calling service is the one that
+     * knows how to decode `BMETADATA` and shape the public API contract.
+     *
+     * @return list<array{id: int, unix_time: int, status: string, error: string, metadata: string}>
+     *
+     * @throws DbalException
+     */
+    public function findRecent(int $userId, int $handlerId, int $limit): array
+    {
+        // Native SQL keeps this query trivially observable in slow-query
+        // logs ("WHERE BACTION=… AND BPROVIDER=…") — DQL would generate
+        // the same plan but obscure it behind aliases. DBAL columns
+        // come back as `mixed`; the normalization loop below casts to
+        // the schema-guaranteed shape exposed by this method.
+        /** @var list<array<string, mixed>> $rows */
+        $rows = $this->em->getConnection()->fetchAllAssociative(
+            <<<'SQL'
+            SELECT
+                BID         AS id,
+                BUNIXTIMES  AS unix_time,
+                BSTATUS     AS status,
+                BERROR      AS error,
+                BMETADATA   AS metadata
+            FROM BUSELOG
+            WHERE BUSERID = :user_id
+              AND BACTION = :action
+              AND BPROVIDER = :handler_id
+            ORDER BY BUNIXTIMES DESC, BID DESC
+            LIMIT :limit
+            SQL,
+            [
+                'user_id' => $userId,
+                'action' => self::ACTION,
+                'handler_id' => (string) $handlerId,
+                'limit' => $limit,
+            ],
+            [
+                // Bind LIMIT as integer; otherwise DBAL emits a quoted
+                // string and MariaDB raises a syntax error.
+                'limit' => ParameterType::INTEGER,
+            ]
+        );
+
+        $normalized = [];
+        foreach ($rows as $row) {
+            // DBAL returns mixed values from fetchAllAssociative; the
+            // explicit casts double as a runtime safety net for NULLs
+            // (e.g. truncated rows from partial replication).
+            $normalized[] = [
+                'id' => (int) $row['id'],
+                'unix_time' => (int) $row['unix_time'],
+                'status' => (string) ($row['status'] ?? ''),
+                'error' => (string) ($row['error'] ?? ''),
+                'metadata' => (string) ($row['metadata'] ?? ''),
+            ];
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * Keep only the newest $keep entries for (user, handler), delete the rest.
+     *
+     * @return int Number of rows actually deleted
+     *
+     * @throws DbalException
+     */
+    public function prune(int $userId, int $handlerId, int $keep): int
+    {
+        // MariaDB does not allow a NOT IN sub-SELECT against the same
+        // table without an intermediate derived table — wrap the keep-set
+        // so the DELETE remains portable across MariaDB / MySQL.
+        return (int) $this->em->getConnection()->executeStatement(
+            <<<'SQL'
+            DELETE FROM BUSELOG
+             WHERE BUSERID = :user_id
+               AND BACTION = :action
+               AND BPROVIDER = :handler_id
+               AND BID NOT IN (
+                   SELECT keep_id FROM (
+                       SELECT BID AS keep_id
+                         FROM BUSELOG
+                        WHERE BUSERID = :user_id
+                          AND BACTION = :action
+                          AND BPROVIDER = :handler_id
+                        ORDER BY BUNIXTIMES DESC, BID DESC
+                        LIMIT :keep
+                   ) AS keep_set
+               )
+            SQL,
+            [
+                'user_id' => $userId,
+                'action' => self::ACTION,
+                'handler_id' => (string) $handlerId,
+                'keep' => $keep,
+            ],
+            [
+                'keep' => ParameterType::INTEGER,
+            ]
+        );
+    }
+
+    /**
+     * Drop every activity row for (user, handler). Used when the handler
+     * itself is deleted so we do not leave orphaned log entries behind.
+     *
+     * @return int Number of rows actually deleted
+     *
+     * @throws DbalException
+     */
+    public function deleteAll(int $userId, int $handlerId): int
+    {
+        return (int) $this->em->getConnection()->executeStatement(
+            <<<'SQL'
+            DELETE FROM BUSELOG
+             WHERE BUSERID = :user_id
+               AND BACTION = :action
+               AND BPROVIDER = :handler_id
+            SQL,
+            [
+                'user_id' => $userId,
+                'action' => self::ACTION,
+                'handler_id' => (string) $handlerId,
+            ]
+        );
+    }
+}

--- a/backend/src/Service/InboundEmailHandlerService.php
+++ b/backend/src/Service/InboundEmailHandlerService.php
@@ -739,11 +739,15 @@ final readonly class InboundEmailHandlerService
                                 ['from' => $from, 'subject' => $subject, 'routed_to' => $routedEmail],
                             );
                         } else {
+                            // "No SMTP configured" is a configuration gap, not a
+                            // runtime failure — surface it as a WARNING (yellow)
+                            // in the activity modal so users distinguish it from
+                            // genuine forward errors.
                             $this->activityLog->log(
                                 $userId,
                                 $handlerId,
                                 MailHandlerLogService::EVENT_NO_SMTP,
-                                MailHandlerLogService::STATUS_ERROR,
+                                MailHandlerLogService::STATUS_WARNING,
                                 'SMTP credentials are not configured for this handler — the routing decision was made but the email could not be forwarded.',
                                 ['from' => $from, 'subject' => $subject, 'routed_to' => $routedEmail],
                             );
@@ -760,6 +764,10 @@ final readonly class InboundEmailHandlerService
                     ++$processed;
                 } catch (\Exception $e) {
                     $errors[] = "Message {$msgNumber}: ".$e->getMessage();
+                    // IMAP sequence numbers (`$msgNumber`) are useful in the
+                    // framework logger for matching against a server-side
+                    // trace, but they're meaningless to end users — keep
+                    // them out of the activity modal details.
                     $this->logger->error('Failed to process email', [
                         'handler_id' => $handlerId,
                         'message_number' => $msgNumber,
@@ -771,7 +779,6 @@ final readonly class InboundEmailHandlerService
                         MailHandlerLogService::EVENT_PROCESS_ERROR,
                         MailHandlerLogService::STATUS_ERROR,
                         $e->getMessage(),
-                        ['message_number' => $msgNumber],
                     );
                 }
             }
@@ -814,7 +821,25 @@ final readonly class InboundEmailHandlerService
             ];
         } finally {
             if (null !== $connection) {
-                @imap_close($connection);
+                // Surface any IMAP-level failure on close (expired sessions,
+                // EXPUNGE conflicts, …) into the logger so it isn't lost.
+                // Errors here must never bubble out of `finally` — we have
+                // already returned/thrown the meaningful outcome above.
+                try {
+                    imap_close($connection);
+                } catch (\Throwable $e) {
+                    $this->logger->warning('imap_close failed', [
+                        'handler_id' => $handlerId,
+                        'error' => $e->getMessage(),
+                    ]);
+                }
+                $imapErrors = imap_errors();
+                if (false !== $imapErrors && [] !== $imapErrors) {
+                    $this->logger->warning('IMAP errors on close', [
+                        'handler_id' => $handlerId,
+                        'errors' => $imapErrors,
+                    ]);
+                }
             }
         }
     }

--- a/backend/src/Service/InboundEmailHandlerService.php
+++ b/backend/src/Service/InboundEmailHandlerService.php
@@ -196,7 +196,17 @@ final readonly class InboundEmailHandlerService
         $structure = imap_fetchstructure($connection, $msgNumber);
 
         if (!is_object($structure)) {
-            return '';
+            // imap_fetchstructure() returns false on protocol-level errors.
+            // Returning '' here would silently feed the AI router an empty
+            // body — fall back to the raw imap_body() (same "last resort"
+            // shape the deep-multipart path uses) and log the failure so
+            // the activity log can surface it.
+            $this->logger->warning('imap_fetchstructure failed; falling back to raw imap_body', [
+                'message_number' => $msgNumber,
+                'imap_errors' => imap_errors() ?: [],
+            ]);
+
+            return imap_body($connection, $msgNumber);
         }
 
         // Single-part message (not multipart): the whole body is the part.
@@ -210,7 +220,8 @@ final readonly class InboundEmailHandlerService
             );
         }
 
-        $textParts = $this->collectTextParts($connection, $msgNumber, $structure->parts, '');
+        $fetchBody = static fn (string $section): string => imap_fetchbody($connection, $msgNumber, $section);
+        $textParts = $this->collectTextParts($structure->parts, '', $fetchBody);
 
         if ('' !== $textParts['plain']) {
             return $textParts['plain'];
@@ -232,15 +243,22 @@ final readonly class InboundEmailHandlerService
      * Section numbers follow IMAP's dotted addressing (RFC 3501 §6.4.5):
      * top-level parts are "1", "2", ...; nested parts are "1.1", "1.2", ...
      *
-     * @param array<int, object> $parts
+     * The walker takes a `$fetchBody` closure rather than calling
+     * `imap_fetchbody()` directly so it can be unit-tested against
+     * synthetic body-structure trees without a real IMAP connection.
+     *
+     * @param array<int, object>       $parts
+     * @param callable(string): string $fetchBody receives a dotted section
+     *                                            number and returns the
+     *                                            (still-encoded) body for
+     *                                            that section
      *
      * @return array{plain: string, html: string}
      */
     private function collectTextParts(
-        \IMAP\Connection $connection,
-        int $msgNumber,
         array $parts,
         string $sectionPrefix,
+        callable $fetchBody,
     ): array {
         $textPlain = '';
         $textHtml = '';
@@ -258,21 +276,19 @@ final readonly class InboundEmailHandlerService
             $isMultipart = !empty($part->parts);
 
             if ('' === $textPlain && 'text/plain' === $mimeType && !$isMultipart) {
-                $body = imap_fetchbody($connection, $msgNumber, $section);
                 $textPlain = $this->decodeEmailBody(
-                    $body,
+                    $fetchBody($section),
                     $part->encoding ?? 0,
                     $this->getCharset($part)
                 );
             } elseif ('' === $textHtml && 'text/html' === $mimeType && !$isMultipart) {
-                $body = imap_fetchbody($connection, $msgNumber, $section);
                 $textHtml = $this->decodeEmailBody(
-                    $body,
+                    $fetchBody($section),
                     $part->encoding ?? 0,
                     $this->getCharset($part)
                 );
             } elseif ($isMultipart) {
-                $nested = $this->collectTextParts($connection, $msgNumber, $part->parts, $section);
+                $nested = $this->collectTextParts($part->parts, $section, $fetchBody);
                 if ('' === $textPlain) {
                     $textPlain = $nested['plain'];
                 }

--- a/backend/src/Service/InboundEmailHandlerService.php
+++ b/backend/src/Service/InboundEmailHandlerService.php
@@ -187,74 +187,215 @@ final readonly class InboundEmailHandlerService
 
     /**
      * Extract clean email body from IMAP message.
-     * Handles multipart MIME messages and extracts text/plain or text/html.
+     * Recursively walks multipart MIME tree to extract the first text/plain
+     * (or text/html as fallback) body, ignoring attachments.
      */
-    private function extractEmailBody($connection, int $msgNumber): string
+    private function extractEmailBody(\IMAP\Connection $connection, int $msgNumber): string
     {
         $structure = imap_fetchstructure($connection, $msgNumber);
 
-        // Single part message (not multipart)
-        if (!isset($structure->parts)) {
+        if (!is_object($structure)) {
+            return '';
+        }
+
+        // Single-part message (not multipart): the whole body is the part.
+        if (empty($structure->parts)) {
             $body = imap_body($connection, $msgNumber);
 
-            // Decode based on encoding
-            return $this->decodeEmailBody($body, $structure->encoding ?? 0);
+            return $this->decodeEmailBody(
+                $body,
+                $structure->encoding ?? 0,
+                $this->getCharset($structure)
+            );
         }
 
-        // Multipart message - extract text/plain or text/html
-        $textPlain = '';
-        $textHtml = '';
+        $textParts = $this->collectTextParts($connection, $msgNumber, $structure->parts, '');
 
-        foreach ($structure->parts as $partNumber => $part) {
-            $partBody = imap_fetchbody($connection, $msgNumber, (string) ($partNumber + 1));
-
-            // Check MIME type
-            $mimeType = $this->getMimeType($part);
-
-            if ('text/plain' === $mimeType) {
-                $textPlain = $this->decodeEmailBody($partBody, $part->encoding ?? 0);
-            } elseif ('text/html' === $mimeType) {
-                $textHtml = $this->decodeEmailBody($partBody, $part->encoding ?? 0);
-            }
+        if ('' !== $textParts['plain']) {
+            return $textParts['plain'];
         }
 
-        // Prefer plain text, fallback to HTML (stripped)
-        if (!empty($textPlain)) {
-            return $textPlain;
+        if ('' !== $textParts['html']) {
+            return trim(strip_tags($textParts['html']));
         }
 
-        if (!empty($textHtml)) {
-            return strip_tags($textHtml);
-        }
-
-        // Fallback: return raw body
+        // Last resort: return the raw body so a downstream LLM at least
+        // has something to look at, even if it's MIME boundaries.
         return imap_body($connection, $msgNumber);
     }
 
     /**
-     * Get MIME type from IMAP body part.
+     * Recursively walk an IMAP body-structure tree and collect the first
+     * text/plain and text/html body parts, ignoring explicit attachments.
+     *
+     * Section numbers follow IMAP's dotted addressing (RFC 3501 §6.4.5):
+     * top-level parts are "1", "2", ...; nested parts are "1.1", "1.2", ...
+     *
+     * @param array<int, object> $parts
+     *
+     * @return array{plain: string, html: string}
+     */
+    private function collectTextParts(
+        \IMAP\Connection $connection,
+        int $msgNumber,
+        array $parts,
+        string $sectionPrefix,
+    ): array {
+        $textPlain = '';
+        $textHtml = '';
+
+        foreach ($parts as $partNumber => $part) {
+            $section = '' === $sectionPrefix
+                ? (string) ($partNumber + 1)
+                : $sectionPrefix.'.'.($partNumber + 1);
+
+            if ($this->isAttachment($part)) {
+                continue;
+            }
+
+            $mimeType = $this->getMimeType($part);
+            $isMultipart = !empty($part->parts);
+
+            if ('' === $textPlain && 'text/plain' === $mimeType && !$isMultipart) {
+                $body = imap_fetchbody($connection, $msgNumber, $section);
+                $textPlain = $this->decodeEmailBody(
+                    $body,
+                    $part->encoding ?? 0,
+                    $this->getCharset($part)
+                );
+            } elseif ('' === $textHtml && 'text/html' === $mimeType && !$isMultipart) {
+                $body = imap_fetchbody($connection, $msgNumber, $section);
+                $textHtml = $this->decodeEmailBody(
+                    $body,
+                    $part->encoding ?? 0,
+                    $this->getCharset($part)
+                );
+            } elseif ($isMultipart) {
+                $nested = $this->collectTextParts($connection, $msgNumber, $part->parts, $section);
+                if ('' === $textPlain) {
+                    $textPlain = $nested['plain'];
+                }
+                if ('' === $textHtml) {
+                    $textHtml = $nested['html'];
+                }
+            }
+
+            if ('' !== $textPlain && '' !== $textHtml) {
+                break;
+            }
+        }
+
+        return ['plain' => $textPlain, 'html' => $textHtml];
+    }
+
+    /**
+     * Get MIME type from IMAP body part (e.g. "text/plain", "multipart/alternative").
      */
     private function getMimeType(object $part): string
     {
         $primaryType = ['text', 'multipart', 'message', 'application', 'audio', 'image', 'video', 'other'];
-        $type = $primaryType[$part->type] ?? 'text';
+        $type = $primaryType[$part->type ?? 0] ?? 'text';
         $subtype = strtolower($part->subtype ?? 'plain');
 
         return $type.'/'.$subtype;
     }
 
     /**
-     * Decode email body based on encoding.
+     * Detect whether an IMAP body part is an explicit attachment so we
+     * don't accidentally treat an attached .txt or .html file as the body.
      */
-    private function decodeEmailBody(string $body, int $encoding): string
+    private function isAttachment(object $part): bool
     {
-        return match ($encoding) {
-            1 => imap_8bit($body),           // 8BIT
-            2 => imap_binary($body),         // BINARY
-            3 => base64_decode($body),       // BASE64
-            4 => quoted_printable_decode($body), // QUOTED-PRINTABLE
-            default => $body,                // 7BIT or OTHER
+        if (empty($part->ifdisposition)) {
+            return false;
+        }
+
+        return 'attachment' === strtolower($part->disposition ?? '');
+    }
+
+    /**
+     * Read the charset parameter from a part's Content-Type, if any.
+     */
+    private function getCharset(object $part): ?string
+    {
+        if (empty($part->ifparameters) || empty($part->parameters)) {
+            return null;
+        }
+
+        foreach ($part->parameters as $param) {
+            $attr = isset($param->attribute) ? strtolower($param->attribute) : '';
+            if ('charset' === $attr) {
+                $value = $param->value ?? null;
+
+                return ('' === $value || null === $value) ? null : (string) $value;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Decode an email body part according to its Content-Transfer-Encoding
+     * and convert to UTF-8 if a non-UTF-8 charset was declared.
+     *
+     * NOTE: Encodings 7BIT (0), 8BIT (1), BINARY (2) and "OTHER" all carry the
+     * payload as-is — the imap_8bit() / imap_binary() helpers *encode* (not
+     * decode) and would corrupt the body, so they are deliberately not used.
+     */
+    private function decodeEmailBody(string $body, int $encoding, ?string $charset = null): string
+    {
+        $decoded = match ($encoding) {
+            3 => base64_decode($body, false),
+            4 => quoted_printable_decode($body),
+            default => $body,
         };
+
+        if ('' === $decoded) {
+            return $decoded;
+        }
+
+        if (null !== $charset) {
+            $normalized = strtoupper($charset);
+            if ('UTF-8' !== $normalized && 'US-ASCII' !== $normalized && '' !== $normalized) {
+                $converted = @mb_convert_encoding($decoded, 'UTF-8', $normalized);
+                if (is_string($converted)) {
+                    $decoded = $converted;
+                }
+            }
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * Decode RFC 2047 encoded-word headers (e.g. =?UTF-8?B?...?=) to a plain UTF-8 string.
+     */
+    private function decodeMimeHeader(string $header): string
+    {
+        if ('' === $header) {
+            return $header;
+        }
+
+        $elements = imap_mime_header_decode($header);
+        if (false === $elements || [] === $elements) {
+            return $header;
+        }
+
+        $decoded = '';
+        foreach ($elements as $element) {
+            $charset = isset($element->charset) ? strtolower((string) $element->charset) : 'default';
+            $text = (string) ($element->text ?? '');
+
+            if ('default' === $charset || '' === $charset || 'utf-8' === $charset || 'us-ascii' === $charset) {
+                $decoded .= $text;
+                continue;
+            }
+
+            $converted = @mb_convert_encoding($text, 'UTF-8', strtoupper($charset));
+            $decoded .= is_string($converted) ? $converted : $text;
+        }
+
+        return $decoded;
     }
 
     /**
@@ -495,6 +636,7 @@ final readonly class InboundEmailHandlerService
     {
         $processed = 0;
         $errors = [];
+        $connection = null;
 
         try {
             $connection = $this->connectImap($handler);
@@ -504,7 +646,6 @@ final readonly class InboundEmailHandlerService
             $messages = imap_search($connection, $searchCriteria);
 
             if (!$messages) {
-                imap_close($connection);
                 $handler->setLastChecked(date('YmdHis'));
                 $handler->setStatus('active');
 
@@ -520,7 +661,8 @@ final readonly class InboundEmailHandlerService
                     $header = imap_headerinfo($connection, $msgNumber);
                     $body = $this->extractEmailBody($connection, $msgNumber);
 
-                    $subject = $header->subject ?? '(no subject)';
+                    $rawSubject = (string) ($header->subject ?? '');
+                    $subject = '' === $rawSubject ? '(no subject)' : $this->decodeMimeHeader($rawSubject);
                     $from = $header->from[0]->mailbox.'@'.$header->from[0]->host;
 
                     // Route email to department
@@ -566,8 +708,6 @@ final readonly class InboundEmailHandlerService
                 imap_expunge($connection);
             }
 
-            imap_close($connection);
-
             $handler->setLastChecked(date('YmdHis'));
             $handler->setStatus('active');
 
@@ -588,6 +728,10 @@ final readonly class InboundEmailHandlerService
                 'processed' => $processed,
                 'errors' => [$e->getMessage()],
             ];
+        } finally {
+            if (null !== $connection) {
+                @imap_close($connection);
+            }
         }
     }
 

--- a/backend/src/Service/InboundEmailHandlerService.php
+++ b/backend/src/Service/InboundEmailHandlerService.php
@@ -30,6 +30,7 @@ final readonly class InboundEmailHandlerService
         private ModelConfigService $modelConfigService,
         private RateLimitService $rateLimitService,
         private EncryptionService $encryptionService,
+        private MailHandlerLogService $activityLog,
         private LoggerInterface $logger,
     ) {
     }
@@ -637,6 +638,8 @@ final readonly class InboundEmailHandlerService
         $processed = 0;
         $errors = [];
         $connection = null;
+        $userId = $handler->getUserId();
+        $handlerId = (int) ($handler->getId() ?? 0);
 
         try {
             $connection = $this->connectImap($handler);
@@ -648,6 +651,15 @@ final readonly class InboundEmailHandlerService
             if (!$messages) {
                 $handler->setLastChecked(date('YmdHis'));
                 $handler->setStatus('active');
+                $this->activityLog->log(
+                    $userId,
+                    $handlerId,
+                    MailHandlerLogService::EVENT_CHECK,
+                    MailHandlerLogService::STATUS_SUCCESS,
+                    null,
+                    ['matched' => 0, 'criteria' => $searchCriteria],
+                );
+                $this->activityLog->prune($userId, $handlerId);
 
                 return [
                     'success' => true,
@@ -655,6 +667,16 @@ final readonly class InboundEmailHandlerService
                     'errors' => [],
                 ];
             }
+
+            $matched = count($messages);
+            $this->activityLog->log(
+                $userId,
+                $handlerId,
+                MailHandlerLogService::EVENT_CHECK,
+                MailHandlerLogService::STATUS_SUCCESS,
+                null,
+                ['matched' => $matched, 'criteria' => $searchCriteria],
+            );
 
             foreach ($messages as $msgNumber) {
                 try {
@@ -668,22 +690,48 @@ final readonly class InboundEmailHandlerService
                     // Route email to department
                     $routedEmail = $this->routeEmailToDepartment($handler, $subject, $body);
 
-                    if ($routedEmail) {
-                        // Forward email to routed department using SMTP
-                        $this->forwardEmail($handler, $from, $routedEmail, $subject, $body);
-
-                        $this->logger->info('Email processed and forwarded', [
-                            'handler_id' => $handler->getId(),
-                            'from' => $from,
-                            'subject' => $subject,
-                            'routed_to' => $routedEmail,
-                        ]);
-                    } else {
+                    if (null === $routedEmail) {
                         $this->logger->info('Email not forwarded (discarded as irrelevant)', [
-                            'handler_id' => $handler->getId(),
+                            'handler_id' => $handlerId,
                             'from' => $from,
                             'subject' => $subject,
                         ]);
+                        $this->activityLog->log(
+                            $userId,
+                            $handlerId,
+                            MailHandlerLogService::EVENT_DISCARDED,
+                            MailHandlerLogService::STATUS_SUCCESS,
+                            null,
+                            ['from' => $from, 'subject' => $subject],
+                        );
+                    } else {
+                        $forwardResult = $this->forwardEmail($handler, $from, $routedEmail, $subject, $body);
+
+                        if ('forwarded' === $forwardResult) {
+                            $this->logger->info('Email processed and forwarded', [
+                                'handler_id' => $handlerId,
+                                'from' => $from,
+                                'subject' => $subject,
+                                'routed_to' => $routedEmail,
+                            ]);
+                            $this->activityLog->log(
+                                $userId,
+                                $handlerId,
+                                MailHandlerLogService::EVENT_FORWARDED,
+                                MailHandlerLogService::STATUS_SUCCESS,
+                                null,
+                                ['from' => $from, 'subject' => $subject, 'routed_to' => $routedEmail],
+                            );
+                        } else {
+                            $this->activityLog->log(
+                                $userId,
+                                $handlerId,
+                                MailHandlerLogService::EVENT_NO_SMTP,
+                                MailHandlerLogService::STATUS_ERROR,
+                                'SMTP credentials are not configured for this handler — the routing decision was made but the email could not be forwarded.',
+                                ['from' => $from, 'subject' => $subject, 'routed_to' => $routedEmail],
+                            );
+                        }
                     }
 
                     // Mark as read (or delete if configured)
@@ -697,10 +745,18 @@ final readonly class InboundEmailHandlerService
                 } catch (\Exception $e) {
                     $errors[] = "Message {$msgNumber}: ".$e->getMessage();
                     $this->logger->error('Failed to process email', [
-                        'handler_id' => $handler->getId(),
+                        'handler_id' => $handlerId,
                         'message_number' => $msgNumber,
                         'error' => $e->getMessage(),
                     ]);
+                    $this->activityLog->log(
+                        $userId,
+                        $handlerId,
+                        MailHandlerLogService::EVENT_PROCESS_ERROR,
+                        MailHandlerLogService::STATUS_ERROR,
+                        $e->getMessage(),
+                        ['message_number' => $msgNumber],
+                    );
                 }
             }
 
@@ -711,6 +767,8 @@ final readonly class InboundEmailHandlerService
             $handler->setLastChecked(date('YmdHis'));
             $handler->setStatus('active');
 
+            $this->activityLog->prune($userId, $handlerId);
+
             return [
                 'success' => true,
                 'processed' => $processed,
@@ -719,9 +777,19 @@ final readonly class InboundEmailHandlerService
         } catch (\Exception $e) {
             $handler->setStatus('error');
             $this->logger->error('Handler processing failed', [
-                'handler_id' => $handler->getId(),
+                'handler_id' => $handlerId,
                 'error' => $e->getMessage(),
             ]);
+            if ($handlerId > 0) {
+                $this->activityLog->log(
+                    $userId,
+                    $handlerId,
+                    MailHandlerLogService::EVENT_CONNECT_FAILED,
+                    MailHandlerLogService::STATUS_ERROR,
+                    $e->getMessage(),
+                );
+                $this->activityLog->prune($userId, $handlerId);
+            }
 
             return [
                 'success' => false,
@@ -737,6 +805,15 @@ final readonly class InboundEmailHandlerService
 
     /**
      * Forward email to department using handler's SMTP credentials.
+     *
+     * Returns:
+     *   - "forwarded" when the SMTP send completed.
+     *   - "no_smtp"   when no SMTP credentials are configured (caller decides
+     *                 whether to mark the message seen anyway — keeping the
+     *                 historical "best-effort" behaviour).
+     *
+     * Throws on any other SMTP failure so the caller can log
+     * `forward_failed` and avoid marking the source message seen.
      */
     private function forwardEmail(
         InboundEmailHandler $handler,
@@ -744,7 +821,7 @@ final readonly class InboundEmailHandlerService
         string $toEmail,
         string $subject,
         string $body,
-    ): void {
+    ): string {
         // Get SMTP credentials (decrypted)
         $smtpConfig = $handler->getSmtpCredentials($this->encryptionService);
 
@@ -753,7 +830,7 @@ final readonly class InboundEmailHandlerService
                 'handler_id' => $handler->getId(),
             ]);
 
-            return;
+            return 'no_smtp';
         }
 
         try {
@@ -781,12 +858,25 @@ final readonly class InboundEmailHandlerService
                 'to' => $toEmail,
                 'subject' => $subject,
             ]);
+
+            return 'forwarded';
         } catch (\Exception $e) {
             $this->logger->error('Failed to forward email', [
                 'handler_id' => $handler->getId(),
                 'error' => $e->getMessage(),
                 'to' => $toEmail,
             ]);
+            $handlerId = (int) ($handler->getId() ?? 0);
+            if ($handlerId > 0) {
+                $this->activityLog->log(
+                    $handler->getUserId(),
+                    $handlerId,
+                    MailHandlerLogService::EVENT_FORWARD_FAILED,
+                    MailHandlerLogService::STATUS_ERROR,
+                    $e->getMessage(),
+                    ['from' => $fromEmail, 'subject' => $subject, 'routed_to' => $toEmail],
+                );
+            }
             throw $e;
         }
     }

--- a/backend/src/Service/MailHandlerLogService.php
+++ b/backend/src/Service/MailHandlerLogService.php
@@ -1,0 +1,317 @@
+<?php
+
+namespace App\Service;
+
+use Doctrine\DBAL\Exception as DbalException;
+use Doctrine\DBAL\ParameterType;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Per-handler activity log for inbound mail handlers.
+ *
+ * Stores a small ring-buffer of recent events (connection attempts,
+ * per-message decisions, forward results) in BUSELOG so users can
+ * diagnose "the email was marked seen but not forwarded" cases from
+ * the mail-handler UI.
+ *
+ * - Tagged with BACTION = self::ACTION so usage-aggregations and rate
+ *   limits (which key off other action names like MESSAGES, IMAGES,
+ *   EMAIL_ROUTING, …) are not affected.
+ * - Bound to (BUSERID, handler_id-in-metadata). Old rows beyond the
+ *   most recent {@see self::DEFAULT_KEEP} per (user, handler) are
+ *   pruned at the end of every handler run, so the table cannot grow
+ *   unbounded for long-lived handlers.
+ */
+final readonly class MailHandlerLogService
+{
+    public const ACTION = 'MAIL_HANDLER_LOG';
+
+    public const DEFAULT_KEEP = 10;
+
+    public const STATUS_SUCCESS = 'success';
+    public const STATUS_WARNING = 'warning';
+    public const STATUS_ERROR = 'error';
+
+    public const EVENT_CHECK = 'check';
+    public const EVENT_CONNECT_FAILED = 'connect_failed';
+    public const EVENT_FORWARDED = 'forwarded';
+    public const EVENT_DISCARDED = 'discarded';
+    public const EVENT_NO_ROUTE = 'no_route';
+    public const EVENT_NO_SMTP = 'no_smtp';
+    public const EVENT_FORWARD_FAILED = 'forward_failed';
+    public const EVENT_PROCESS_ERROR = 'process_error';
+
+    /**
+     * Maximum length of free-text fields stored in BMETADATA. Keeps the JSON
+     * column compact so 10 entries per handler stay well under typical row
+     * size limits even for very long subjects or AI replies.
+     */
+    private const FIELD_TRUNCATE = 256;
+
+    public function __construct(
+        private EntityManagerInterface $em,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * Append a single activity entry for (user, handler).
+     *
+     * Failures inside the log path are intentionally swallowed and only
+     * logged via the framework logger — a broken activity log must never
+     * cascade into a broken mail-handler run.
+     *
+     * @param array<string, mixed> $details Free-form metadata; large strings are
+     *                                      truncated. `handler_id` is always set
+     *                                      from the $handlerId parameter.
+     */
+    public function log(
+        int $userId,
+        int $handlerId,
+        string $event,
+        string $status = self::STATUS_SUCCESS,
+        ?string $error = null,
+        array $details = [],
+    ): void {
+        $payload = $this->buildMetadata($handlerId, $event, $details);
+
+        try {
+            $this->em->getConnection()->insert('BUSELOG', [
+                'BUSERID' => $userId,
+                'BUNIXTIMES' => time(),
+                'BACTION' => self::ACTION,
+                'BPROVIDER' => '',
+                'BMODEL' => '',
+                'BTOKENS' => 0,
+                'BPROMPT_TOKENS' => 0,
+                'BCOMPLETION_TOKENS' => 0,
+                'BCACHED_TOKENS' => 0,
+                'BCACHE_CREATION_TOKENS' => 0,
+                'BESTIMATED' => 0,
+                'BCOST' => '0.000000',
+                'BLATENCY' => 0,
+                'BSTATUS' => $this->normalizeStatus($status),
+                'BERROR' => null !== $error ? $this->truncate($error) : '',
+                'BMETADATA' => $payload,
+            ]);
+        } catch (DbalException $e) {
+            $this->logger->warning('MailHandlerLogService: failed to persist activity entry', [
+                'user_id' => $userId,
+                'handler_id' => $handlerId,
+                'event' => $event,
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+
+    /**
+     * Return the last $limit activity rows for (user, handler), newest first.
+     *
+     * @return list<array{
+     *     id: int,
+     *     timestamp: int,
+     *     event: string,
+     *     status: string,
+     *     error: string,
+     *     details: array<string, mixed>
+     * }>
+     */
+    public function findRecent(int $userId, int $handlerId, int $limit = self::DEFAULT_KEEP): array
+    {
+        $limit = max(1, min($limit, 100));
+
+        try {
+            $rows = $this->em->getConnection()->fetchAllAssociative(
+                <<<'SQL'
+                SELECT
+                    BID         AS id,
+                    BUNIXTIMES  AS unix_time,
+                    BSTATUS     AS status,
+                    BERROR      AS error,
+                    BMETADATA   AS metadata
+                FROM BUSELOG
+                WHERE BUSERID = :user_id
+                  AND BACTION = :action
+                  AND JSON_EXTRACT(BMETADATA, '$.handler_id') = :handler_id
+                ORDER BY BUNIXTIMES DESC, BID DESC
+                LIMIT :limit
+                SQL,
+                [
+                    'user_id' => $userId,
+                    'action' => self::ACTION,
+                    'handler_id' => $handlerId,
+                    'limit' => $limit,
+                ],
+                [
+                    // Bind LIMIT as integer or DBAL emits it as a quoted string
+                    // and MariaDB raises a syntax error.
+                    'limit' => ParameterType::INTEGER,
+                ]
+            );
+        } catch (DbalException $e) {
+            $this->logger->warning('MailHandlerLogService: failed to read activity entries', [
+                'user_id' => $userId,
+                'handler_id' => $handlerId,
+                'error' => $e->getMessage(),
+            ]);
+
+            return [];
+        }
+
+        $result = [];
+        foreach ($rows as $row) {
+            $metadata = $this->decodeMetadata($row['metadata'] ?? null);
+            $event = isset($metadata['event']) && is_string($metadata['event']) ? $metadata['event'] : 'unknown';
+            unset($metadata['event'], $metadata['handler_id']);
+
+            $result[] = [
+                'id' => (int) $row['id'],
+                'timestamp' => (int) $row['unix_time'],
+                'event' => $event,
+                'status' => is_string($row['status']) ? $row['status'] : self::STATUS_SUCCESS,
+                'error' => is_string($row['error']) ? $row['error'] : '',
+                'details' => $metadata,
+            ];
+        }
+
+        return $result;
+    }
+
+    /**
+     * Keep only the newest $keep entries for (user, handler); delete the rest.
+     *
+     * Returns the number of rows deleted.
+     */
+    public function prune(int $userId, int $handlerId, int $keep = self::DEFAULT_KEEP): int
+    {
+        $keep = max(1, $keep);
+
+        try {
+            // MariaDB does not allow referencing the same table directly inside
+            // a NOT IN subquery without an intermediate derived table — wrap
+            // the keep-set in a sub-SELECT so the DELETE is portable.
+            return (int) $this->em->getConnection()->executeStatement(
+                <<<'SQL'
+                DELETE FROM BUSELOG
+                 WHERE BUSERID = :user_id
+                   AND BACTION = :action
+                   AND JSON_EXTRACT(BMETADATA, '$.handler_id') = :handler_id
+                   AND BID NOT IN (
+                       SELECT keep_id FROM (
+                           SELECT BID AS keep_id
+                             FROM BUSELOG
+                            WHERE BUSERID = :user_id
+                              AND BACTION = :action
+                              AND JSON_EXTRACT(BMETADATA, '$.handler_id') = :handler_id
+                            ORDER BY BUNIXTIMES DESC, BID DESC
+                            LIMIT :keep
+                       ) AS keep_set
+                   )
+                SQL,
+                [
+                    'user_id' => $userId,
+                    'action' => self::ACTION,
+                    'handler_id' => $handlerId,
+                    'keep' => $keep,
+                ],
+                [
+                    'keep' => ParameterType::INTEGER,
+                ]
+            );
+        } catch (DbalException $e) {
+            $this->logger->warning('MailHandlerLogService: failed to prune activity entries', [
+                'user_id' => $userId,
+                'handler_id' => $handlerId,
+                'error' => $e->getMessage(),
+            ]);
+
+            return 0;
+        }
+    }
+
+    /**
+     * Drop every activity row for (user, handler). Used when the handler
+     * itself is deleted so we do not leave orphaned log entries behind.
+     */
+    public function deleteAll(int $userId, int $handlerId): int
+    {
+        try {
+            return (int) $this->em->getConnection()->executeStatement(
+                <<<'SQL'
+                DELETE FROM BUSELOG
+                 WHERE BUSERID = :user_id
+                   AND BACTION = :action
+                   AND JSON_EXTRACT(BMETADATA, '$.handler_id') = :handler_id
+                SQL,
+                [
+                    'user_id' => $userId,
+                    'action' => self::ACTION,
+                    'handler_id' => $handlerId,
+                ]
+            );
+        } catch (DbalException $e) {
+            $this->logger->warning('MailHandlerLogService: failed to delete activity entries', [
+                'user_id' => $userId,
+                'handler_id' => $handlerId,
+                'error' => $e->getMessage(),
+            ]);
+
+            return 0;
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $details
+     */
+    private function buildMetadata(int $handlerId, string $event, array $details): string
+    {
+        $payload = [
+            'handler_id' => $handlerId,
+            'event' => $event,
+        ];
+
+        foreach ($details as $key => $value) {
+            if ('handler_id' === $key || 'event' === $key) {
+                continue;
+            }
+            if (is_string($value)) {
+                $payload[$key] = $this->truncate($value);
+            } elseif (is_scalar($value) || is_array($value) || null === $value) {
+                $payload[$key] = $value;
+            } else {
+                $payload[$key] = (string) (is_object($value) && method_exists($value, '__toString') ? $value : '');
+            }
+        }
+
+        return json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?: '{}';
+    }
+
+    private function decodeMetadata(mixed $raw): array
+    {
+        if (!is_string($raw) || '' === $raw) {
+            return [];
+        }
+
+        $decoded = json_decode($raw, true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    private function truncate(string $value): string
+    {
+        if (mb_strlen($value) <= self::FIELD_TRUNCATE) {
+            return $value;
+        }
+
+        return mb_substr($value, 0, self::FIELD_TRUNCATE - 1).'…';
+    }
+
+    private function normalizeStatus(string $status): string
+    {
+        return match ($status) {
+            self::STATUS_SUCCESS, self::STATUS_WARNING, self::STATUS_ERROR => $status,
+            default => self::STATUS_SUCCESS,
+        };
+    }
+}

--- a/backend/src/Service/MailHandlerLogService.php
+++ b/backend/src/Service/MailHandlerLogService.php
@@ -1,10 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Service;
 
-use Doctrine\DBAL\Exception as DbalException;
-use Doctrine\DBAL\ParameterType;
-use Doctrine\ORM\EntityManagerInterface;
+use App\Entity\UseLog;
+use App\Repository\MailHandlerLogRepository;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -15,17 +16,22 @@ use Psr\Log\LoggerInterface;
  * diagnose "the email was marked seen but not forwarded" cases from
  * the mail-handler UI.
  *
- * - Tagged with BACTION = self::ACTION so usage-aggregations and rate
- *   limits (which key off other action names like MESSAGES, IMAGES,
- *   EMAIL_ROUTING, …) are not affected.
- * - Bound to (BUSERID, handler_id-in-metadata). Old rows beyond the
- *   most recent {@see self::DEFAULT_KEEP} per (user, handler) are
- *   pruned at the end of every handler run, so the table cannot grow
- *   unbounded for long-lived handlers.
+ * - Tagged with `BACTION = MailHandlerLogRepository::ACTION` so
+ *   usage-aggregations and rate limits (which key off other action
+ *   names like MESSAGES, IMAGES, EMAIL_ROUTING, …) are not affected.
+ * - `handler_id` is stored in the indexed `BPROVIDER` column (which is
+ *   otherwise unused for these rows), keeping `findRecent` / `prune` /
+ *   `deleteAll` index-friendly without adding a new column or a
+ *   functional index on a JSON expression.
+ * - Bound to (BUSERID, BPROVIDER). Old rows beyond the most recent
+ *   {@see self::DEFAULT_KEEP} per (user, handler) are pruned at the end
+ *   of every handler run, so the table cannot grow unbounded for
+ *   long-lived handlers.
  */
 final readonly class MailHandlerLogService
 {
-    public const ACTION = 'MAIL_HANDLER_LOG';
+    /** Public alias so callers don't have to know about the repository. */
+    public const ACTION = MailHandlerLogRepository::ACTION;
 
     public const DEFAULT_KEEP = 10;
 
@@ -37,20 +43,20 @@ final readonly class MailHandlerLogService
     public const EVENT_CONNECT_FAILED = 'connect_failed';
     public const EVENT_FORWARDED = 'forwarded';
     public const EVENT_DISCARDED = 'discarded';
-    public const EVENT_NO_ROUTE = 'no_route';
     public const EVENT_NO_SMTP = 'no_smtp';
     public const EVENT_FORWARD_FAILED = 'forward_failed';
     public const EVENT_PROCESS_ERROR = 'process_error';
 
     /**
-     * Maximum length of free-text fields stored in BMETADATA. Keeps the JSON
-     * column compact so 10 entries per handler stay well under typical row
-     * size limits even for very long subjects or AI replies.
+     * Maximum length of free-text fields stored in BMETADATA / BERROR.
+     * Keeps the JSON column compact so 10 entries per handler stay well
+     * under typical row size limits even for very long subjects or AI
+     * replies.
      */
     private const FIELD_TRUNCATE = 256;
 
     public function __construct(
-        private EntityManagerInterface $em,
+        private MailHandlerLogRepository $repository,
         private LoggerInterface $logger,
     ) {
     }
@@ -63,8 +69,9 @@ final readonly class MailHandlerLogService
      * cascade into a broken mail-handler run.
      *
      * @param array<string, mixed> $details Free-form metadata; large strings are
-     *                                      truncated. `handler_id` is always set
-     *                                      from the $handlerId parameter.
+     *                                      truncated. `handler_id` and `event`
+     *                                      reserved keys are stripped and re-added
+     *                                      from the explicit parameters.
      */
     public function log(
         int $userId,
@@ -74,28 +81,19 @@ final readonly class MailHandlerLogService
         ?string $error = null,
         array $details = [],
     ): void {
-        $payload = $this->buildMetadata($handlerId, $event, $details);
+        $entry = new UseLog();
+        $entry->setUserId($userId);
+        $entry->setUnixTimestamp(time());
+        $entry->setStatus($this->normalizeStatus($status));
+        $entry->setError(null !== $error ? $this->truncate($error) : '');
+        $entry->setMetadata($this->buildMetadata($event, $details));
 
         try {
-            $this->em->getConnection()->insert('BUSELOG', [
-                'BUSERID' => $userId,
-                'BUNIXTIMES' => time(),
-                'BACTION' => self::ACTION,
-                'BPROVIDER' => '',
-                'BMODEL' => '',
-                'BTOKENS' => 0,
-                'BPROMPT_TOKENS' => 0,
-                'BCOMPLETION_TOKENS' => 0,
-                'BCACHED_TOKENS' => 0,
-                'BCACHE_CREATION_TOKENS' => 0,
-                'BESTIMATED' => 0,
-                'BCOST' => '0.000000',
-                'BLATENCY' => 0,
-                'BSTATUS' => $this->normalizeStatus($status),
-                'BERROR' => null !== $error ? $this->truncate($error) : '',
-                'BMETADATA' => $payload,
-            ]);
-        } catch (DbalException $e) {
+            $this->repository->save($userId, $handlerId, $entry);
+        } catch (\Throwable $e) {
+            // Any failure (DBAL, ORM, mapping, …) must be swallowed —
+            // a broken activity log must never cascade into a broken
+            // mail-handler run.
             $this->logger->warning('MailHandlerLogService: failed to persist activity entry', [
                 'user_id' => $userId,
                 'handler_id' => $handlerId,
@@ -122,34 +120,8 @@ final readonly class MailHandlerLogService
         $limit = max(1, min($limit, 100));
 
         try {
-            $rows = $this->em->getConnection()->fetchAllAssociative(
-                <<<'SQL'
-                SELECT
-                    BID         AS id,
-                    BUNIXTIMES  AS unix_time,
-                    BSTATUS     AS status,
-                    BERROR      AS error,
-                    BMETADATA   AS metadata
-                FROM BUSELOG
-                WHERE BUSERID = :user_id
-                  AND BACTION = :action
-                  AND JSON_EXTRACT(BMETADATA, '$.handler_id') = :handler_id
-                ORDER BY BUNIXTIMES DESC, BID DESC
-                LIMIT :limit
-                SQL,
-                [
-                    'user_id' => $userId,
-                    'action' => self::ACTION,
-                    'handler_id' => $handlerId,
-                    'limit' => $limit,
-                ],
-                [
-                    // Bind LIMIT as integer or DBAL emits it as a quoted string
-                    // and MariaDB raises a syntax error.
-                    'limit' => ParameterType::INTEGER,
-                ]
-            );
-        } catch (DbalException $e) {
+            $rows = $this->repository->findRecent($userId, $handlerId, $limit);
+        } catch (\Throwable $e) {
             $this->logger->warning('MailHandlerLogService: failed to read activity entries', [
                 'user_id' => $userId,
                 'handler_id' => $handlerId,
@@ -161,16 +133,16 @@ final readonly class MailHandlerLogService
 
         $result = [];
         foreach ($rows as $row) {
-            $metadata = $this->decodeMetadata($row['metadata'] ?? null);
+            $metadata = $this->decodeMetadata($row['metadata']);
             $event = isset($metadata['event']) && is_string($metadata['event']) ? $metadata['event'] : 'unknown';
-            unset($metadata['event'], $metadata['handler_id']);
+            unset($metadata['event']);
 
             $result[] = [
-                'id' => (int) $row['id'],
-                'timestamp' => (int) $row['unix_time'],
+                'id' => $row['id'],
+                'timestamp' => $row['unix_time'],
                 'event' => $event,
-                'status' => is_string($row['status']) ? $row['status'] : self::STATUS_SUCCESS,
-                'error' => is_string($row['error']) ? $row['error'] : '',
+                'status' => '' !== $row['status'] ? $row['status'] : self::STATUS_SUCCESS,
+                'error' => $row['error'],
                 'details' => $metadata,
             ];
         }
@@ -188,38 +160,8 @@ final readonly class MailHandlerLogService
         $keep = max(1, $keep);
 
         try {
-            // MariaDB does not allow referencing the same table directly inside
-            // a NOT IN subquery without an intermediate derived table — wrap
-            // the keep-set in a sub-SELECT so the DELETE is portable.
-            return (int) $this->em->getConnection()->executeStatement(
-                <<<'SQL'
-                DELETE FROM BUSELOG
-                 WHERE BUSERID = :user_id
-                   AND BACTION = :action
-                   AND JSON_EXTRACT(BMETADATA, '$.handler_id') = :handler_id
-                   AND BID NOT IN (
-                       SELECT keep_id FROM (
-                           SELECT BID AS keep_id
-                             FROM BUSELOG
-                            WHERE BUSERID = :user_id
-                              AND BACTION = :action
-                              AND JSON_EXTRACT(BMETADATA, '$.handler_id') = :handler_id
-                            ORDER BY BUNIXTIMES DESC, BID DESC
-                            LIMIT :keep
-                       ) AS keep_set
-                   )
-                SQL,
-                [
-                    'user_id' => $userId,
-                    'action' => self::ACTION,
-                    'handler_id' => $handlerId,
-                    'keep' => $keep,
-                ],
-                [
-                    'keep' => ParameterType::INTEGER,
-                ]
-            );
-        } catch (DbalException $e) {
+            return $this->repository->prune($userId, $handlerId, $keep);
+        } catch (\Throwable $e) {
             $this->logger->warning('MailHandlerLogService: failed to prune activity entries', [
                 'user_id' => $userId,
                 'handler_id' => $handlerId,
@@ -237,20 +179,8 @@ final readonly class MailHandlerLogService
     public function deleteAll(int $userId, int $handlerId): int
     {
         try {
-            return (int) $this->em->getConnection()->executeStatement(
-                <<<'SQL'
-                DELETE FROM BUSELOG
-                 WHERE BUSERID = :user_id
-                   AND BACTION = :action
-                   AND JSON_EXTRACT(BMETADATA, '$.handler_id') = :handler_id
-                SQL,
-                [
-                    'user_id' => $userId,
-                    'action' => self::ACTION,
-                    'handler_id' => $handlerId,
-                ]
-            );
-        } catch (DbalException $e) {
+            return $this->repository->deleteAll($userId, $handlerId);
+        } catch (\Throwable $e) {
             $this->logger->warning('MailHandlerLogService: failed to delete activity entries', [
                 'user_id' => $userId,
                 'handler_id' => $handlerId,
@@ -262,17 +192,21 @@ final readonly class MailHandlerLogService
     }
 
     /**
+     * Build the metadata payload stored in `BMETADATA`. Reserved keys
+     * `handler_id` and `event` from caller-supplied details are dropped:
+     * `handler_id` already lives in the indexed `BPROVIDER` column, and
+     * `event` comes from the explicit method parameter.
+     *
      * @param array<string, mixed> $details
+     *
+     * @return array<string, mixed>
      */
-    private function buildMetadata(int $handlerId, string $event, array $details): string
+    private function buildMetadata(string $event, array $details): array
     {
-        $payload = [
-            'handler_id' => $handlerId,
-            'event' => $event,
-        ];
+        $payload = ['event' => $event];
 
         foreach ($details as $key => $value) {
-            if ('handler_id' === $key || 'event' === $key) {
+            if ('event' === $key || 'handler_id' === $key) {
                 continue;
             }
             if (is_string($value)) {
@@ -284,12 +218,15 @@ final readonly class MailHandlerLogService
             }
         }
 
-        return json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?: '{}';
+        return $payload;
     }
 
-    private function decodeMetadata(mixed $raw): array
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeMetadata(string $raw): array
     {
-        if (!is_string($raw) || '' === $raw) {
+        if ('' === $raw) {
             return [];
         }
 

--- a/backend/tests/Service/InboundEmailHandlerServiceTest.php
+++ b/backend/tests/Service/InboundEmailHandlerServiceTest.php
@@ -207,4 +207,167 @@ class InboundEmailHandlerServiceTest extends TestCase
         $this->assertStringContainsString('Default: yes', $targetList);
         $this->assertStringContainsString('Default: no', $targetList);
     }
+
+    /**
+     * Regression: 8BIT-encoded bodies were being passed through `imap_8bit()`
+     * which is an *encoder* (UTF-8 → quoted-printable), corrupting the text.
+     */
+    public function testDecodeEmailBodyPassesThrough8BitContent(): void
+    {
+        $method = $this->getDecodeEmailBodyMethod();
+
+        // Encoding 1 = 8BIT — must be passthrough (same as 7BIT).
+        $body = "Hello World\r\nThis is a plain 8-bit body with Umlauts: äöü";
+        $decoded = $method->invoke($this->service, $body, 1, null);
+
+        $this->assertSame($body, $decoded);
+    }
+
+    public function testDecodeEmailBodyPassesThroughBinaryContent(): void
+    {
+        $method = $this->getDecodeEmailBodyMethod();
+
+        // Encoding 2 = BINARY — must be passthrough.
+        $body = 'Some raw binary-ish text without re-encoding';
+        $decoded = $method->invoke($this->service, $body, 2, null);
+
+        $this->assertSame($body, $decoded);
+    }
+
+    public function testDecodeEmailBodyDecodesBase64(): void
+    {
+        $method = $this->getDecodeEmailBodyMethod();
+
+        $body = base64_encode('Hello World');
+        $decoded = $method->invoke($this->service, $body, 3, null);
+
+        $this->assertSame('Hello World', $decoded);
+    }
+
+    public function testDecodeEmailBodyDecodesQuotedPrintable(): void
+    {
+        $method = $this->getDecodeEmailBodyMethod();
+
+        $body = 'Hello=20World=0AUmlauts:=20=C3=A4=C3=B6=C3=BC';
+        $decoded = $method->invoke($this->service, $body, 4, 'UTF-8');
+
+        $this->assertSame("Hello World\nUmlauts: äöü", $decoded);
+    }
+
+    /**
+     * Regression: the original code never converted non-UTF-8 charsets,
+     * so umlauts from German senders ended up garbled in the AI prompt.
+     */
+    public function testDecodeEmailBodyConvertsLatin1ToUtf8(): void
+    {
+        $method = $this->getDecodeEmailBodyMethod();
+
+        $latin1 = mb_convert_encoding('Bestellung über 12€ für Müller', 'ISO-8859-15', 'UTF-8');
+        $this->assertIsString($latin1);
+
+        $decoded = $method->invoke($this->service, $latin1, 0, 'iso-8859-15');
+
+        $this->assertSame('Bestellung über 12€ für Müller', $decoded);
+    }
+
+    public function testDecodeEmailBodyLeavesUtf8Unchanged(): void
+    {
+        $method = $this->getDecodeEmailBodyMethod();
+
+        $body = 'Already UTF-8 with emoji 🎉 and ümlauts';
+        $decoded = $method->invoke($this->service, $body, 0, 'UTF-8');
+
+        $this->assertSame($body, $decoded);
+    }
+
+    public function testDecodeMimeHeaderDecodesEncodedWord(): void
+    {
+        if (!function_exists('imap_mime_header_decode')) {
+            $this->markTestSkipped('IMAP extension is not installed.');
+        }
+
+        $reflection = new \ReflectionClass($this->service);
+        $method = $reflection->getMethod('decodeMimeHeader');
+        $method->setAccessible(true);
+
+        $encoded = '=?UTF-8?B?'.base64_encode('Bestellung Nr. 123 — Müller').'?=';
+        $decoded = $method->invoke($this->service, $encoded);
+
+        $this->assertSame('Bestellung Nr. 123 — Müller', $decoded);
+    }
+
+    public function testDecodeMimeHeaderHandlesPlainAscii(): void
+    {
+        if (!function_exists('imap_mime_header_decode')) {
+            $this->markTestSkipped('IMAP extension is not installed.');
+        }
+
+        $reflection = new \ReflectionClass($this->service);
+        $method = $reflection->getMethod('decodeMimeHeader');
+        $method->setAccessible(true);
+
+        $this->assertSame(
+            'Plain ASCII subject line',
+            $method->invoke($this->service, 'Plain ASCII subject line')
+        );
+    }
+
+    public function testGetMimeTypeReadsTypeAndSubtype(): void
+    {
+        $reflection = new \ReflectionClass($this->service);
+        $method = $reflection->getMethod('getMimeType');
+        $method->setAccessible(true);
+
+        $textPlain = (object) ['type' => 0, 'subtype' => 'PLAIN'];
+        $multipartAlternative = (object) ['type' => 1, 'subtype' => 'ALTERNATIVE'];
+        $applicationPdf = (object) ['type' => 3, 'subtype' => 'pdf'];
+
+        $this->assertSame('text/plain', $method->invoke($this->service, $textPlain));
+        $this->assertSame('multipart/alternative', $method->invoke($this->service, $multipartAlternative));
+        $this->assertSame('application/pdf', $method->invoke($this->service, $applicationPdf));
+    }
+
+    public function testIsAttachmentRecognisesAttachmentDisposition(): void
+    {
+        $reflection = new \ReflectionClass($this->service);
+        $method = $reflection->getMethod('isAttachment');
+        $method->setAccessible(true);
+
+        $attachment = (object) ['ifdisposition' => 1, 'disposition' => 'ATTACHMENT'];
+        $inline = (object) ['ifdisposition' => 1, 'disposition' => 'inline'];
+        $noDisposition = (object) ['ifdisposition' => 0];
+
+        $this->assertTrue($method->invoke($this->service, $attachment));
+        $this->assertFalse($method->invoke($this->service, $inline));
+        $this->assertFalse($method->invoke($this->service, $noDisposition));
+    }
+
+    public function testGetCharsetReadsContentTypeParameter(): void
+    {
+        $reflection = new \ReflectionClass($this->service);
+        $method = $reflection->getMethod('getCharset');
+        $method->setAccessible(true);
+
+        $part = (object) [
+            'ifparameters' => 1,
+            'parameters' => [
+                (object) ['attribute' => 'CHARSET', 'value' => 'ISO-8859-1'],
+                (object) ['attribute' => 'name', 'value' => 'whatever.txt'],
+            ],
+        ];
+
+        $this->assertSame('ISO-8859-1', $method->invoke($this->service, $part));
+
+        $partWithoutCharset = (object) ['ifparameters' => 0, 'parameters' => []];
+        $this->assertNull($method->invoke($this->service, $partWithoutCharset));
+    }
+
+    private function getDecodeEmailBodyMethod(): \ReflectionMethod
+    {
+        $reflection = new \ReflectionClass($this->service);
+        $method = $reflection->getMethod('decodeEmailBody');
+        $method->setAccessible(true);
+
+        return $method;
+    }
 }

--- a/backend/tests/Service/InboundEmailHandlerServiceTest.php
+++ b/backend/tests/Service/InboundEmailHandlerServiceTest.php
@@ -11,6 +11,7 @@ use App\Repository\PromptRepository;
 use App\Repository\UserRepository;
 use App\Service\EncryptionService;
 use App\Service\InboundEmailHandlerService;
+use App\Service\MailHandlerLogService;
 use App\Service\ModelConfigService;
 use App\Service\RateLimitService;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -44,6 +45,7 @@ class InboundEmailHandlerServiceTest extends TestCase
             $this->modelConfigService,
             $this->createMock(RateLimitService::class),
             $this->encryptionService,
+            $this->createMock(MailHandlerLogService::class),
             $this->logger
         );
     }

--- a/backend/tests/Service/InboundEmailHandlerServiceTest.php
+++ b/backend/tests/Service/InboundEmailHandlerServiceTest.php
@@ -364,6 +364,169 @@ class InboundEmailHandlerServiceTest extends TestCase
         $this->assertNull($method->invoke($this->service, $partWithoutCharset));
     }
 
+    /**
+     * Regression for issue #985: emails with attachments wrap the body inside
+     * a nested `multipart/alternative` under `multipart/mixed`, so the
+     * pre-fix top-level-only walker missed text/plain entirely. Pinning the
+     * recursive walker against the exact MIME shape from the bug report.
+     */
+    public function testCollectTextPartsWalksNestedMultipartFromBugReport(): void
+    {
+        $textPlain = (object) [
+            'type' => 0, 'subtype' => 'PLAIN',
+            'encoding' => 0,
+            'ifdisposition' => 0,
+            'ifparameters' => 1,
+            'parameters' => [(object) ['attribute' => 'charset', 'value' => 'UTF-8']],
+        ];
+        $textHtml = (object) [
+            'type' => 0, 'subtype' => 'HTML',
+            'encoding' => 4, // QUOTED-PRINTABLE
+            'ifdisposition' => 0,
+            'ifparameters' => 1,
+            'parameters' => [(object) ['attribute' => 'charset', 'value' => 'UTF-8']],
+        ];
+        $alternative = (object) [
+            'type' => 1, 'subtype' => 'alternative',
+            'ifdisposition' => 0,
+            'ifparameters' => 0, 'parameters' => [],
+            'parts' => [$textPlain, $textHtml],
+        ];
+        $pdfAttachment = (object) [
+            'type' => 3, 'subtype' => 'pdf',
+            'encoding' => 3,
+            'ifdisposition' => 1, 'disposition' => 'attachment',
+            'ifparameters' => 0, 'parameters' => [],
+        ];
+
+        // Sections we expect to be requested. PDF (top-level "2") must NOT
+        // be fetched because it is an explicit attachment.
+        $bodies = [
+            '1.1' => 'Hello from the plain body',
+            '1.2' => 'Hello=20from=20the=20HTML=20body',
+        ];
+        $requested = [];
+        $fetchBody = function (string $section) use (&$bodies, &$requested): string {
+            $requested[] = $section;
+
+            return $bodies[$section] ?? '';
+        };
+
+        $result = $this->invokeCollectTextParts([$alternative, $pdfAttachment], '', $fetchBody);
+
+        $this->assertSame('Hello from the plain body', $result['plain']);
+        $this->assertSame('Hello from the HTML body', $result['html']);
+        $this->assertNotContains('2', $requested, 'PDF attachment must not be fetched');
+    }
+
+    /**
+     * Walks plain `multipart/alternative` (no enclosing mixed wrapper) and
+     * still returns plain + html for the AI prompt fallback.
+     */
+    public function testCollectTextPartsHandlesTopLevelAlternative(): void
+    {
+        $plain = (object) [
+            'type' => 0, 'subtype' => 'plain',
+            'encoding' => 0,
+            'ifdisposition' => 0,
+            'ifparameters' => 0, 'parameters' => [],
+        ];
+        $html = (object) [
+            'type' => 0, 'subtype' => 'html',
+            'encoding' => 0,
+            'ifdisposition' => 0,
+            'ifparameters' => 0, 'parameters' => [],
+        ];
+
+        $fetchBody = fn (string $section): string => match ($section) {
+            '1' => 'plain body',
+            '2' => '<p>html body</p>',
+            default => '',
+        };
+
+        $result = $this->invokeCollectTextParts([$plain, $html], '', $fetchBody);
+
+        $this->assertSame('plain body', $result['plain']);
+        $this->assertSame('<p>html body</p>', $result['html']);
+    }
+
+    /**
+     * `Content-Disposition: attachment; text/plain` (an attached `.txt`
+     * file) must NOT be picked up as the body — the actual body text/plain
+     * sibling wins.
+     */
+    public function testCollectTextPartsSkipsAttachedTextPartsInFavourOfBody(): void
+    {
+        $bodyPlain = (object) [
+            'type' => 0, 'subtype' => 'plain',
+            'encoding' => 0,
+            'ifdisposition' => 0,
+            'ifparameters' => 0, 'parameters' => [],
+        ];
+        $attachedTxt = (object) [
+            'type' => 0, 'subtype' => 'plain',
+            'encoding' => 0,
+            'ifdisposition' => 1, 'disposition' => 'attachment',
+            'ifparameters' => 0, 'parameters' => [],
+        ];
+
+        $fetchBody = fn (string $section): string => '1' === $section
+            ? 'real body content'
+            : 'CONTENTS OF ATTACHMENT.TXT';
+
+        $result = $this->invokeCollectTextParts([$bodyPlain, $attachedTxt], '', $fetchBody);
+
+        $this->assertSame('real body content', $result['plain']);
+    }
+
+    /**
+     * Latin-1-declared parts inside a nested tree must be decoded to UTF-8
+     * during the walk so the routing prompt sees readable umlauts.
+     */
+    public function testCollectTextPartsConvertsCharsetForNestedParts(): void
+    {
+        $latin1Body = mb_convert_encoding('Bestellung über 12€', 'ISO-8859-15', 'UTF-8');
+        $this->assertIsString($latin1Body);
+
+        $textPlain = (object) [
+            'type' => 0, 'subtype' => 'PLAIN',
+            'encoding' => 0,
+            'ifdisposition' => 0,
+            'ifparameters' => 1,
+            'parameters' => [(object) ['attribute' => 'charset', 'value' => 'iso-8859-15']],
+        ];
+        $alternative = (object) [
+            'type' => 1, 'subtype' => 'alternative',
+            'ifdisposition' => 0,
+            'ifparameters' => 0, 'parameters' => [],
+            'parts' => [$textPlain],
+        ];
+
+        $fetchBody = fn (string $section): string => '1.1' === $section ? $latin1Body : '';
+
+        $result = $this->invokeCollectTextParts([$alternative], '', $fetchBody);
+
+        $this->assertSame('Bestellung über 12€', $result['plain']);
+    }
+
+    /**
+     * @param array<int, object>       $parts
+     * @param callable(string): string $fetchBody
+     *
+     * @return array{plain: string, html: string}
+     */
+    private function invokeCollectTextParts(array $parts, string $sectionPrefix, callable $fetchBody): array
+    {
+        $reflection = new \ReflectionClass($this->service);
+        $method = $reflection->getMethod('collectTextParts');
+        $method->setAccessible(true);
+
+        /** @var array{plain: string, html: string} $result */
+        $result = $method->invoke($this->service, $parts, $sectionPrefix, $fetchBody);
+
+        return $result;
+    }
+
     private function getDecodeEmailBodyMethod(): \ReflectionMethod
     {
         $reflection = new \ReflectionClass($this->service);

--- a/backend/tests/Service/MailHandlerLogServiceTest.php
+++ b/backend/tests/Service/MailHandlerLogServiceTest.php
@@ -1,0 +1,303 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Service;
+
+use App\Service\MailHandlerLogService;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception\InvalidArgumentException as DbalInvalidArgumentException;
+use Doctrine\DBAL\ParameterType;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class MailHandlerLogServiceTest extends TestCase
+{
+    private MailHandlerLogService $service;
+    private Connection&MockObject $connection;
+    private EntityManagerInterface&MockObject $em;
+    private LoggerInterface&MockObject $logger;
+
+    protected function setUp(): void
+    {
+        $this->connection = $this->createMock(Connection::class);
+        $this->em = $this->createMock(EntityManagerInterface::class);
+        $this->em->method('getConnection')->willReturn($this->connection);
+        $this->logger = $this->createMock(LoggerInterface::class);
+
+        $this->service = new MailHandlerLogService($this->em, $this->logger);
+    }
+
+    public function testLogPersistsRowWithCanonicalShape(): void
+    {
+        $captured = null;
+
+        $this->connection
+            ->expects($this->once())
+            ->method('insert')
+            ->willReturnCallback(function (string $table, array $payload) use (&$captured): int {
+                $this->assertSame('BUSELOG', $table);
+                $captured = $payload;
+
+                return 1;
+            });
+
+        $this->service->log(
+            42,
+            7,
+            MailHandlerLogService::EVENT_FORWARDED,
+            MailHandlerLogService::STATUS_SUCCESS,
+            null,
+            ['from' => 'alice@example.com', 'subject' => 'Hello', 'routed_to' => 'sales@acme.io']
+        );
+
+        $this->assertNotNull($captured);
+        $this->assertSame(42, $captured['BUSERID']);
+        $this->assertSame(MailHandlerLogService::ACTION, $captured['BACTION']);
+        $this->assertSame(MailHandlerLogService::STATUS_SUCCESS, $captured['BSTATUS']);
+        $this->assertSame('', $captured['BERROR']);
+        $this->assertIsString($captured['BMETADATA']);
+
+        $metadata = json_decode($captured['BMETADATA'], true);
+        $this->assertIsArray($metadata);
+        $this->assertSame(7, $metadata['handler_id']);
+        $this->assertSame(MailHandlerLogService::EVENT_FORWARDED, $metadata['event']);
+        $this->assertSame('alice@example.com', $metadata['from']);
+        $this->assertSame('sales@acme.io', $metadata['routed_to']);
+    }
+
+    public function testLogStoresErrorAndCoercesUnknownStatus(): void
+    {
+        $captured = null;
+
+        $this->connection
+            ->expects($this->once())
+            ->method('insert')
+            ->willReturnCallback(function (string $table, array $payload) use (&$captured): int {
+                $captured = $payload;
+
+                return 1;
+            });
+
+        $this->service->log(
+            42,
+            7,
+            MailHandlerLogService::EVENT_FORWARD_FAILED,
+            'totally-not-a-real-status',
+            'SMTP server refused the connection',
+            ['routed_to' => 'sales@acme.io']
+        );
+
+        $this->assertNotNull($captured);
+        $this->assertSame(MailHandlerLogService::STATUS_SUCCESS, $captured['BSTATUS']);
+        $this->assertSame('SMTP server refused the connection', $captured['BERROR']);
+    }
+
+    public function testLogTruncatesLongFreeTextFields(): void
+    {
+        $captured = null;
+
+        $this->connection
+            ->expects($this->once())
+            ->method('insert')
+            ->willReturnCallback(function (string $table, array $payload) use (&$captured): int {
+                $captured = $payload;
+
+                return 1;
+            });
+
+        $longSubject = str_repeat('A', 1000);
+        $longError = str_repeat('B', 1000);
+
+        $this->service->log(
+            42,
+            7,
+            MailHandlerLogService::EVENT_PROCESS_ERROR,
+            MailHandlerLogService::STATUS_ERROR,
+            $longError,
+            ['subject' => $longSubject]
+        );
+
+        $this->assertNotNull($captured);
+        $this->assertLessThanOrEqual(256, mb_strlen($captured['BERROR']));
+
+        $metadata = json_decode($captured['BMETADATA'], true);
+        $this->assertIsArray($metadata);
+        $this->assertLessThanOrEqual(256, mb_strlen($metadata['subject']));
+        $this->assertStringEndsWith('…', $metadata['subject']);
+    }
+
+    public function testLogSwallowsDbalExceptions(): void
+    {
+        $this->connection
+            ->expects($this->once())
+            ->method('insert')
+            ->willThrowException(new DbalInvalidArgumentException('connection lost'));
+
+        $this->logger
+            ->expects($this->once())
+            ->method('warning')
+            ->with(
+                'MailHandlerLogService: failed to persist activity entry',
+                $this->callback(fn ($ctx) => isset($ctx['error']) && str_contains($ctx['error'], 'connection lost'))
+            );
+
+        // Must not bubble — broken activity log cannot break the mail handler run.
+        $this->service->log(42, 7, MailHandlerLogService::EVENT_CHECK);
+    }
+
+    public function testFindRecentDecodesMetadataAndOrdering(): void
+    {
+        $this->connection
+            ->expects($this->once())
+            ->method('fetchAllAssociative')
+            ->with(
+                $this->stringContains('FROM BUSELOG'),
+                $this->callback(function (array $params): bool {
+                    return 11 === $params['user_id']
+                        && MailHandlerLogService::ACTION === $params['action']
+                        && 5 === $params['handler_id']
+                        && 10 === $params['limit'];
+                }),
+                $this->callback(function (array $types): bool {
+                    return ParameterType::INTEGER === $types['limit'];
+                })
+            )
+            ->willReturn([
+                [
+                    'id' => '101',
+                    'unix_time' => '1747900000',
+                    'status' => 'success',
+                    'error' => '',
+                    'metadata' => json_encode([
+                        'handler_id' => 5,
+                        'event' => MailHandlerLogService::EVENT_FORWARDED,
+                        'from' => 'alice@example.com',
+                        'subject' => 'Hi',
+                        'routed_to' => 'sales@acme.io',
+                    ]),
+                ],
+                [
+                    'id' => '99',
+                    'unix_time' => '1747890000',
+                    'status' => 'error',
+                    'error' => 'No SMTP creds',
+                    'metadata' => json_encode([
+                        'handler_id' => 5,
+                        'event' => MailHandlerLogService::EVENT_NO_SMTP,
+                    ]),
+                ],
+            ]);
+
+        $rows = $this->service->findRecent(11, 5);
+
+        $this->assertCount(2, $rows);
+        $this->assertSame(101, $rows[0]['id']);
+        $this->assertSame(1747900000, $rows[0]['timestamp']);
+        $this->assertSame(MailHandlerLogService::EVENT_FORWARDED, $rows[0]['event']);
+        $this->assertSame('success', $rows[0]['status']);
+        $this->assertSame('alice@example.com', $rows[0]['details']['from']);
+        $this->assertArrayNotHasKey('handler_id', $rows[0]['details']);
+        $this->assertArrayNotHasKey('event', $rows[0]['details']);
+
+        $this->assertSame(99, $rows[1]['id']);
+        $this->assertSame(MailHandlerLogService::EVENT_NO_SMTP, $rows[1]['event']);
+        $this->assertSame('No SMTP creds', $rows[1]['error']);
+    }
+
+    public function testFindRecentClampsLimitToSafeRange(): void
+    {
+        $captured = null;
+
+        $this->connection
+            ->expects($this->once())
+            ->method('fetchAllAssociative')
+            ->willReturnCallback(function (string $sql, array $params) use (&$captured): array {
+                $captured = $params;
+
+                return [];
+            });
+
+        // Caller asks for 5_000 — must be clamped to 100.
+        $this->service->findRecent(11, 5, 5_000);
+
+        $this->assertSame(100, $captured['limit']);
+    }
+
+    public function testFindRecentReturnsEmptyOnDbalException(): void
+    {
+        $this->connection
+            ->expects($this->once())
+            ->method('fetchAllAssociative')
+            ->willThrowException(new DbalInvalidArgumentException('boom'));
+
+        $this->logger
+            ->expects($this->once())
+            ->method('warning');
+
+        $this->assertSame([], $this->service->findRecent(11, 5));
+    }
+
+    public function testPruneIssuesDeleteWithKeepLimit(): void
+    {
+        $this->connection
+            ->expects($this->once())
+            ->method('executeStatement')
+            ->with(
+                $this->stringContains('DELETE FROM BUSELOG'),
+                $this->callback(function (array $params): bool {
+                    return 11 === $params['user_id']
+                        && MailHandlerLogService::ACTION === $params['action']
+                        && 5 === $params['handler_id']
+                        && 10 === $params['keep'];
+                }),
+                $this->callback(function (array $types): bool {
+                    return ParameterType::INTEGER === $types['keep'];
+                })
+            )
+            ->willReturn(3);
+
+        $this->assertSame(3, $this->service->prune(11, 5));
+    }
+
+    public function testPruneCoercesNonPositiveKeepToOne(): void
+    {
+        $captured = null;
+
+        $this->connection
+            ->expects($this->once())
+            ->method('executeStatement')
+            ->willReturnCallback(function (string $sql, array $params) use (&$captured): int {
+                $captured = $params;
+
+                return 0;
+            });
+
+        $this->service->prune(11, 5, 0);
+
+        $this->assertSame(1, $captured['keep']);
+    }
+
+    public function testDeleteAllIssuesUnboundedDelete(): void
+    {
+        $this->connection
+            ->expects($this->once())
+            ->method('executeStatement')
+            ->with(
+                $this->logicalAnd(
+                    $this->stringContains('DELETE FROM BUSELOG'),
+                    $this->logicalNot($this->stringContains('LIMIT'))
+                ),
+                $this->callback(function (array $params): bool {
+                    return 11 === $params['user_id']
+                        && MailHandlerLogService::ACTION === $params['action']
+                        && 5 === $params['handler_id'];
+                })
+            )
+            ->willReturn(7);
+
+        $this->assertSame(7, $this->service->deleteAll(11, 5));
+    }
+}

--- a/backend/tests/Service/MailHandlerLogServiceTest.php
+++ b/backend/tests/Service/MailHandlerLogServiceTest.php
@@ -4,11 +4,10 @@ declare(strict_types=1);
 
 namespace App\Tests\Service;
 
+use App\Entity\UseLog;
+use App\Repository\MailHandlerLogRepository;
 use App\Service\MailHandlerLogService;
-use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception\InvalidArgumentException as DbalInvalidArgumentException;
-use Doctrine\DBAL\ParameterType;
-use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -16,33 +15,29 @@ use Psr\Log\LoggerInterface;
 class MailHandlerLogServiceTest extends TestCase
 {
     private MailHandlerLogService $service;
-    private Connection&MockObject $connection;
-    private EntityManagerInterface&MockObject $em;
+    private MailHandlerLogRepository&MockObject $repository;
     private LoggerInterface&MockObject $logger;
 
     protected function setUp(): void
     {
-        $this->connection = $this->createMock(Connection::class);
-        $this->em = $this->createMock(EntityManagerInterface::class);
-        $this->em->method('getConnection')->willReturn($this->connection);
+        $this->repository = $this->createMock(MailHandlerLogRepository::class);
         $this->logger = $this->createMock(LoggerInterface::class);
 
-        $this->service = new MailHandlerLogService($this->em, $this->logger);
+        $this->service = new MailHandlerLogService($this->repository, $this->logger);
     }
 
-    public function testLogPersistsRowWithCanonicalShape(): void
+    public function testLogPersistsEntryViaRepositoryWithCanonicalShape(): void
     {
         $captured = null;
 
-        $this->connection
+        $this->repository
             ->expects($this->once())
-            ->method('insert')
-            ->willReturnCallback(function (string $table, array $payload) use (&$captured): int {
-                $this->assertSame('BUSELOG', $table);
-                $captured = $payload;
-
-                return 1;
-            });
+            ->method('save')
+            ->willReturnCallback(
+                function (int $userId, int $handlerId, UseLog $entry) use (&$captured): void {
+                    $captured = ['user' => $userId, 'handler' => $handlerId, 'entry' => $entry];
+                }
+            );
 
         $this->service->log(
             42,
@@ -54,32 +49,36 @@ class MailHandlerLogServiceTest extends TestCase
         );
 
         $this->assertNotNull($captured);
-        $this->assertSame(42, $captured['BUSERID']);
-        $this->assertSame(MailHandlerLogService::ACTION, $captured['BACTION']);
-        $this->assertSame(MailHandlerLogService::STATUS_SUCCESS, $captured['BSTATUS']);
-        $this->assertSame('', $captured['BERROR']);
-        $this->assertIsString($captured['BMETADATA']);
+        $this->assertSame(42, $captured['user']);
+        $this->assertSame(7, $captured['handler']);
 
-        $metadata = json_decode($captured['BMETADATA'], true);
-        $this->assertIsArray($metadata);
-        $this->assertSame(7, $metadata['handler_id']);
+        /** @var UseLog $entry */
+        $entry = $captured['entry'];
+        $this->assertSame(42, $entry->getUserId());
+        $this->assertSame(MailHandlerLogService::STATUS_SUCCESS, $entry->getStatus());
+        $this->assertSame('', $entry->getError());
+
+        $metadata = $entry->getMetadata();
         $this->assertSame(MailHandlerLogService::EVENT_FORWARDED, $metadata['event']);
         $this->assertSame('alice@example.com', $metadata['from']);
         $this->assertSame('sales@acme.io', $metadata['routed_to']);
+        // handler_id lives in BPROVIDER (set by the repository) — it must
+        // NOT be duplicated into BMETADATA where it would be unindexable.
+        $this->assertArrayNotHasKey('handler_id', $metadata);
     }
 
     public function testLogStoresErrorAndCoercesUnknownStatus(): void
     {
         $captured = null;
 
-        $this->connection
+        $this->repository
             ->expects($this->once())
-            ->method('insert')
-            ->willReturnCallback(function (string $table, array $payload) use (&$captured): int {
-                $captured = $payload;
-
-                return 1;
-            });
+            ->method('save')
+            ->willReturnCallback(
+                function (int $userId, int $handlerId, UseLog $entry) use (&$captured): void {
+                    $captured = $entry;
+                }
+            );
 
         $this->service->log(
             42,
@@ -91,22 +90,47 @@ class MailHandlerLogServiceTest extends TestCase
         );
 
         $this->assertNotNull($captured);
-        $this->assertSame(MailHandlerLogService::STATUS_SUCCESS, $captured['BSTATUS']);
-        $this->assertSame('SMTP server refused the connection', $captured['BERROR']);
+        $this->assertSame(MailHandlerLogService::STATUS_SUCCESS, $captured->getStatus());
+        $this->assertSame('SMTP server refused the connection', $captured->getError());
+    }
+
+    public function testLogAcceptsWarningStatusVerbatim(): void
+    {
+        $captured = null;
+
+        $this->repository
+            ->expects($this->once())
+            ->method('save')
+            ->willReturnCallback(
+                function (int $userId, int $handlerId, UseLog $entry) use (&$captured): void {
+                    $captured = $entry;
+                }
+            );
+
+        $this->service->log(
+            42,
+            7,
+            MailHandlerLogService::EVENT_NO_SMTP,
+            MailHandlerLogService::STATUS_WARNING,
+            'SMTP not configured',
+        );
+
+        $this->assertNotNull($captured);
+        $this->assertSame(MailHandlerLogService::STATUS_WARNING, $captured->getStatus());
     }
 
     public function testLogTruncatesLongFreeTextFields(): void
     {
         $captured = null;
 
-        $this->connection
+        $this->repository
             ->expects($this->once())
-            ->method('insert')
-            ->willReturnCallback(function (string $table, array $payload) use (&$captured): int {
-                $captured = $payload;
-
-                return 1;
-            });
+            ->method('save')
+            ->willReturnCallback(
+                function (int $userId, int $handlerId, UseLog $entry) use (&$captured): void {
+                    $captured = $entry;
+                }
+            );
 
         $longSubject = str_repeat('A', 1000);
         $longError = str_repeat('B', 1000);
@@ -121,19 +145,52 @@ class MailHandlerLogServiceTest extends TestCase
         );
 
         $this->assertNotNull($captured);
-        $this->assertLessThanOrEqual(256, mb_strlen($captured['BERROR']));
+        $this->assertLessThanOrEqual(256, mb_strlen($captured->getError()));
 
-        $metadata = json_decode($captured['BMETADATA'], true);
-        $this->assertIsArray($metadata);
+        $metadata = $captured->getMetadata();
+        $this->assertIsString($metadata['subject']);
         $this->assertLessThanOrEqual(256, mb_strlen($metadata['subject']));
         $this->assertStringEndsWith('…', $metadata['subject']);
     }
 
-    public function testLogSwallowsDbalExceptions(): void
+    public function testLogStripsReservedDetailKeys(): void
     {
-        $this->connection
+        $captured = null;
+
+        $this->repository
             ->expects($this->once())
-            ->method('insert')
+            ->method('save')
+            ->willReturnCallback(
+                function (int $userId, int $handlerId, UseLog $entry) use (&$captured): void {
+                    $captured = $entry;
+                }
+            );
+
+        // Even if callers accidentally pass `handler_id` / `event`
+        // through details, the service must not double-store them in
+        // metadata — they come exclusively from the explicit parameters
+        // (and `handler_id` is stored in BPROVIDER by the repository).
+        $this->service->log(
+            42,
+            7,
+            MailHandlerLogService::EVENT_FORWARDED,
+            MailHandlerLogService::STATUS_SUCCESS,
+            null,
+            ['handler_id' => 999, 'event' => 'fake', 'from' => 'alice@example.com'],
+        );
+
+        $this->assertNotNull($captured);
+        $metadata = $captured->getMetadata();
+        $this->assertArrayNotHasKey('handler_id', $metadata);
+        $this->assertSame(MailHandlerLogService::EVENT_FORWARDED, $metadata['event']);
+        $this->assertSame('alice@example.com', $metadata['from']);
+    }
+
+    public function testLogSwallowsRepositoryExceptions(): void
+    {
+        $this->repository
+            ->expects($this->once())
+            ->method('save')
             ->willThrowException(new DbalInvalidArgumentException('connection lost'));
 
         $this->logger
@@ -148,31 +205,19 @@ class MailHandlerLogServiceTest extends TestCase
         $this->service->log(42, 7, MailHandlerLogService::EVENT_CHECK);
     }
 
-    public function testFindRecentDecodesMetadataAndOrdering(): void
+    public function testFindRecentDecodesMetadataAndStripsReservedKeys(): void
     {
-        $this->connection
+        $this->repository
             ->expects($this->once())
-            ->method('fetchAllAssociative')
-            ->with(
-                $this->stringContains('FROM BUSELOG'),
-                $this->callback(function (array $params): bool {
-                    return 11 === $params['user_id']
-                        && MailHandlerLogService::ACTION === $params['action']
-                        && 5 === $params['handler_id']
-                        && 10 === $params['limit'];
-                }),
-                $this->callback(function (array $types): bool {
-                    return ParameterType::INTEGER === $types['limit'];
-                })
-            )
+            ->method('findRecent')
+            ->with(11, 5, 10)
             ->willReturn([
                 [
-                    'id' => '101',
-                    'unix_time' => '1747900000',
+                    'id' => 101,
+                    'unix_time' => 1747900000,
                     'status' => 'success',
                     'error' => '',
                     'metadata' => json_encode([
-                        'handler_id' => 5,
                         'event' => MailHandlerLogService::EVENT_FORWARDED,
                         'from' => 'alice@example.com',
                         'subject' => 'Hi',
@@ -180,12 +225,11 @@ class MailHandlerLogServiceTest extends TestCase
                     ]),
                 ],
                 [
-                    'id' => '99',
-                    'unix_time' => '1747890000',
-                    'status' => 'error',
+                    'id' => 99,
+                    'unix_time' => 1747890000,
+                    'status' => 'warning',
                     'error' => 'No SMTP creds',
                     'metadata' => json_encode([
-                        'handler_id' => 5,
                         'event' => MailHandlerLogService::EVENT_NO_SMTP,
                     ]),
                 ],
@@ -199,38 +243,31 @@ class MailHandlerLogServiceTest extends TestCase
         $this->assertSame(MailHandlerLogService::EVENT_FORWARDED, $rows[0]['event']);
         $this->assertSame('success', $rows[0]['status']);
         $this->assertSame('alice@example.com', $rows[0]['details']['from']);
-        $this->assertArrayNotHasKey('handler_id', $rows[0]['details']);
         $this->assertArrayNotHasKey('event', $rows[0]['details']);
 
         $this->assertSame(99, $rows[1]['id']);
         $this->assertSame(MailHandlerLogService::EVENT_NO_SMTP, $rows[1]['event']);
+        $this->assertSame('warning', $rows[1]['status']);
         $this->assertSame('No SMTP creds', $rows[1]['error']);
     }
 
     public function testFindRecentClampsLimitToSafeRange(): void
     {
-        $captured = null;
-
-        $this->connection
+        $this->repository
             ->expects($this->once())
-            ->method('fetchAllAssociative')
-            ->willReturnCallback(function (string $sql, array $params) use (&$captured): array {
-                $captured = $params;
-
-                return [];
-            });
+            ->method('findRecent')
+            ->with(11, 5, 100)
+            ->willReturn([]);
 
         // Caller asks for 5_000 — must be clamped to 100.
         $this->service->findRecent(11, 5, 5_000);
-
-        $this->assertSame(100, $captured['limit']);
     }
 
-    public function testFindRecentReturnsEmptyOnDbalException(): void
+    public function testFindRecentReturnsEmptyOnRepositoryException(): void
     {
-        $this->connection
+        $this->repository
             ->expects($this->once())
-            ->method('fetchAllAssociative')
+            ->method('findRecent')
             ->willThrowException(new DbalInvalidArgumentException('boom'));
 
         $this->logger
@@ -240,23 +277,12 @@ class MailHandlerLogServiceTest extends TestCase
         $this->assertSame([], $this->service->findRecent(11, 5));
     }
 
-    public function testPruneIssuesDeleteWithKeepLimit(): void
+    public function testPruneForwardsKeepLimit(): void
     {
-        $this->connection
+        $this->repository
             ->expects($this->once())
-            ->method('executeStatement')
-            ->with(
-                $this->stringContains('DELETE FROM BUSELOG'),
-                $this->callback(function (array $params): bool {
-                    return 11 === $params['user_id']
-                        && MailHandlerLogService::ACTION === $params['action']
-                        && 5 === $params['handler_id']
-                        && 10 === $params['keep'];
-                }),
-                $this->callback(function (array $types): bool {
-                    return ParameterType::INTEGER === $types['keep'];
-                })
-            )
+            ->method('prune')
+            ->with(11, 5, 10)
             ->willReturn(3);
 
         $this->assertSame(3, $this->service->prune(11, 5));
@@ -264,40 +290,51 @@ class MailHandlerLogServiceTest extends TestCase
 
     public function testPruneCoercesNonPositiveKeepToOne(): void
     {
-        $captured = null;
-
-        $this->connection
+        $this->repository
             ->expects($this->once())
-            ->method('executeStatement')
-            ->willReturnCallback(function (string $sql, array $params) use (&$captured): int {
-                $captured = $params;
-
-                return 0;
-            });
+            ->method('prune')
+            ->with(11, 5, 1)
+            ->willReturn(0);
 
         $this->service->prune(11, 5, 0);
-
-        $this->assertSame(1, $captured['keep']);
     }
 
-    public function testDeleteAllIssuesUnboundedDelete(): void
+    public function testPruneSwallowsRepositoryExceptionsAndReturnsZero(): void
     {
-        $this->connection
+        $this->repository
             ->expects($this->once())
-            ->method('executeStatement')
-            ->with(
-                $this->logicalAnd(
-                    $this->stringContains('DELETE FROM BUSELOG'),
-                    $this->logicalNot($this->stringContains('LIMIT'))
-                ),
-                $this->callback(function (array $params): bool {
-                    return 11 === $params['user_id']
-                        && MailHandlerLogService::ACTION === $params['action']
-                        && 5 === $params['handler_id'];
-                })
-            )
+            ->method('prune')
+            ->willThrowException(new DbalInvalidArgumentException('boom'));
+
+        $this->logger
+            ->expects($this->once())
+            ->method('warning');
+
+        $this->assertSame(0, $this->service->prune(11, 5));
+    }
+
+    public function testDeleteAllForwardsToRepository(): void
+    {
+        $this->repository
+            ->expects($this->once())
+            ->method('deleteAll')
+            ->with(11, 5)
             ->willReturn(7);
 
         $this->assertSame(7, $this->service->deleteAll(11, 5));
+    }
+
+    public function testDeleteAllSwallowsRepositoryExceptionsAndReturnsZero(): void
+    {
+        $this->repository
+            ->expects($this->once())
+            ->method('deleteAll')
+            ->willThrowException(new DbalInvalidArgumentException('boom'));
+
+        $this->logger
+            ->expects($this->once())
+            ->method('warning');
+
+        $this->assertSame(0, $this->service->deleteAll(11, 5));
     }
 }

--- a/frontend/src/components/mail/MailHandlerActivityLogModal.vue
+++ b/frontend/src/components/mail/MailHandlerActivityLogModal.vue
@@ -48,7 +48,6 @@ const eventToIcon: Record<MailHandlerLogEvent, typeof CheckCircleIcon> = {
   connect_failed: NoSymbolIcon,
   forwarded: PaperAirplaneIcon,
   discarded: TrashIcon,
-  no_route: InformationCircleIcon,
   no_smtp: EnvelopeIcon,
   forward_failed: XCircleIcon,
   process_error: ExclamationTriangleIcon,
@@ -62,13 +61,22 @@ const statusToColor = (status: MailHandlerLogStatus) => {
 
 const eventLabel = (event: MailHandlerLogEvent): string => t(`mail.activity.events.${event}`, event)
 
+/** Fields the activity modal renders, in display order. */
+const DETAIL_ORDER = ['from', 'subject', 'routed_to', 'matched', 'criteria'] as const
+
+/**
+ * Internal-only detail keys we never want to surface in the user-facing
+ * UI (e.g. raw IMAP sequence numbers). These keys stay in the API
+ * payload — kept for support copy-paste — but are filtered out before
+ * the modal renders them.
+ */
+const INTERNAL_DETAIL_KEYS = new Set<string>(['message_number'])
+
 const sortedDetails = (details: Record<string, unknown>): Array<{ key: string; value: string }> => {
-  // Show known fields in a stable, useful order; pass through any extras after.
-  const order = ['from', 'subject', 'routed_to', 'matched', 'criteria', 'message_number']
   const seen = new Set<string>()
   const rendered: Array<{ key: string; value: string }> = []
 
-  for (const key of order) {
+  for (const key of DETAIL_ORDER) {
     if (key in details) {
       const value = formatValue(details[key])
       if (value !== '') {
@@ -79,7 +87,7 @@ const sortedDetails = (details: Record<string, unknown>): Array<{ key: string; v
   }
 
   for (const [key, value] of Object.entries(details)) {
-    if (seen.has(key)) continue
+    if (seen.has(key) || INTERNAL_DETAIL_KEYS.has(key)) continue
     const formatted = formatValue(value)
     if (formatted !== '') {
       rendered.push({ key, value: formatted })
@@ -101,14 +109,12 @@ const formatValue = (value: unknown): string => {
 }
 
 const detailsLabel = (key: string): string => {
-  // Map technical keys to human i18n labels but fall back gracefully.
   const map: Record<string, string> = {
     from: t('mail.activity.fields.from'),
     subject: t('mail.activity.fields.subject'),
     routed_to: t('mail.activity.fields.routedTo'),
     matched: t('mail.activity.fields.matched'),
     criteria: t('mail.activity.fields.criteria'),
-    message_number: t('mail.activity.fields.messageNumber'),
   }
   return map[key] ?? key
 }
@@ -144,6 +150,22 @@ watch(
 )
 
 const hasLogs = computed(() => logs.value.length > 0)
+
+/**
+ * Pre-compute the rendered details list for every visible entry once per
+ * `logs` change. The template previously called `sortedDetails()` twice
+ * per row (once for `v-if=".length > 0"`, once as the `v-for` source) on
+ * every render — which is O(n) work per call and ran for each of Vue's
+ * reactivity passes. Caching keyed by entry.id keeps the modal stable
+ * even when other reactive deps trigger re-renders.
+ */
+const detailsByEntryId = computed<Record<number, Array<{ key: string; value: string }>>>(() => {
+  const out: Record<number, Array<{ key: string; value: string }>> = {}
+  for (const entry of logs.value) {
+    out[entry.id] = sortedDetails(entry.details)
+  }
+  return out
+})
 </script>
 
 <template>
@@ -269,10 +291,10 @@ const hasLogs = computed(() => logs.value.length > 0)
                   </p>
 
                   <dl
-                    v-if="sortedDetails(entry.details).length > 0"
+                    v-if="detailsByEntryId[entry.id]?.length"
                     class="mt-2 grid grid-cols-1 sm:grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-xs"
                   >
-                    <template v-for="item in sortedDetails(entry.details)" :key="item.key">
+                    <template v-for="item in detailsByEntryId[entry.id]" :key="item.key">
                       <dt class="txt-secondary">{{ detailsLabel(item.key) }}</dt>
                       <dd class="txt-primary break-words">{{ item.value }}</dd>
                     </template>

--- a/frontend/src/components/mail/MailHandlerActivityLogModal.vue
+++ b/frontend/src/components/mail/MailHandlerActivityLogModal.vue
@@ -60,8 +60,7 @@ const statusToColor = (status: MailHandlerLogStatus) => {
   return 'text-green-500 dark:text-green-400 bg-green-500/10'
 }
 
-const eventLabel = (event: MailHandlerLogEvent): string =>
-  t(`mail.activity.events.${event}`, event)
+const eventLabel = (event: MailHandlerLogEvent): string => t(`mail.activity.events.${event}`, event)
 
 const sortedDetails = (details: Record<string, unknown>): Array<{ key: string; value: string }> => {
   // Show known fields in a stable, useful order; pass through any extras after.
@@ -227,11 +226,7 @@ const hasLogs = computed(() => logs.value.length > 0)
             </div>
 
             <!-- Empty state -->
-            <div
-              v-else-if="!hasLogs"
-              class="py-12 text-center"
-              data-testid="mail-activity-empty"
-            >
+            <div v-else-if="!hasLogs" class="py-12 text-center" data-testid="mail-activity-empty">
               <ClockIcon class="w-10 h-10 txt-secondary/40 mx-auto mb-3" />
               <p class="text-sm font-medium txt-primary">{{ t('mail.activity.empty') }}</p>
               <p class="text-xs txt-secondary mt-1">{{ t('mail.activity.emptyDescription') }}</p>
@@ -248,7 +243,10 @@ const hasLogs = computed(() => logs.value.length > 0)
                   class="w-9 h-9 rounded-lg flex items-center justify-center shrink-0"
                   :class="statusToColor(entry.status)"
                 >
-                  <component :is="eventToIcon[entry.event] ?? InformationCircleIcon" class="w-4 h-4" />
+                  <component
+                    :is="eventToIcon[entry.event] ?? InformationCircleIcon"
+                    class="w-4 h-4"
+                  />
                 </div>
                 <div class="flex-1 min-w-0">
                   <div class="flex items-center justify-between gap-2 flex-wrap">

--- a/frontend/src/components/mail/MailHandlerActivityLogModal.vue
+++ b/frontend/src/components/mail/MailHandlerActivityLogModal.vue
@@ -1,0 +1,318 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import {
+  XMarkIcon,
+  ArrowPathIcon,
+  CheckCircleIcon,
+  ExclamationTriangleIcon,
+  XCircleIcon,
+  ClockIcon,
+  EnvelopeIcon,
+  PaperAirplaneIcon,
+  TrashIcon,
+  NoSymbolIcon,
+  WifiIcon,
+  InformationCircleIcon,
+} from '@heroicons/vue/24/outline'
+import {
+  inboundEmailHandlersApi,
+  type MailHandlerLogEntry,
+  type MailHandlerLogEvent,
+  type MailHandlerLogStatus,
+} from '@/services/api/inboundEmailHandlersApi'
+import { useDateFormat } from '@/composables/useDateFormat'
+import { getErrorMessage } from '@/utils/errorMessage'
+
+interface Props {
+  isOpen: boolean
+  handlerId: string | null
+  handlerName?: string
+}
+
+const props = defineProps<Props>()
+
+const emit = defineEmits<{
+  close: []
+}>()
+
+const { t } = useI18n()
+const { formatDateTime, formatRelativeTime } = useDateFormat()
+
+const logs = ref<MailHandlerLogEntry[]>([])
+const isLoading = ref(false)
+const loadError = ref<string | null>(null)
+
+const eventToIcon: Record<MailHandlerLogEvent, typeof CheckCircleIcon> = {
+  check: WifiIcon,
+  connect_failed: NoSymbolIcon,
+  forwarded: PaperAirplaneIcon,
+  discarded: TrashIcon,
+  no_route: InformationCircleIcon,
+  no_smtp: EnvelopeIcon,
+  forward_failed: XCircleIcon,
+  process_error: ExclamationTriangleIcon,
+}
+
+const statusToColor = (status: MailHandlerLogStatus) => {
+  if (status === 'error') return 'text-red-500 dark:text-red-400 bg-red-500/10'
+  if (status === 'warning') return 'text-amber-500 dark:text-amber-400 bg-amber-500/10'
+  return 'text-green-500 dark:text-green-400 bg-green-500/10'
+}
+
+const eventLabel = (event: MailHandlerLogEvent): string =>
+  t(`mail.activity.events.${event}`, event)
+
+const sortedDetails = (details: Record<string, unknown>): Array<{ key: string; value: string }> => {
+  // Show known fields in a stable, useful order; pass through any extras after.
+  const order = ['from', 'subject', 'routed_to', 'matched', 'criteria', 'message_number']
+  const seen = new Set<string>()
+  const rendered: Array<{ key: string; value: string }> = []
+
+  for (const key of order) {
+    if (key in details) {
+      const value = formatValue(details[key])
+      if (value !== '') {
+        rendered.push({ key, value })
+      }
+      seen.add(key)
+    }
+  }
+
+  for (const [key, value] of Object.entries(details)) {
+    if (seen.has(key)) continue
+    const formatted = formatValue(value)
+    if (formatted !== '') {
+      rendered.push({ key, value: formatted })
+    }
+  }
+
+  return rendered
+}
+
+const formatValue = (value: unknown): string => {
+  if (value === null || value === undefined) return ''
+  if (typeof value === 'string') return value
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+  try {
+    return JSON.stringify(value)
+  } catch {
+    return ''
+  }
+}
+
+const detailsLabel = (key: string): string => {
+  // Map technical keys to human i18n labels but fall back gracefully.
+  const map: Record<string, string> = {
+    from: t('mail.activity.fields.from'),
+    subject: t('mail.activity.fields.subject'),
+    routed_to: t('mail.activity.fields.routedTo'),
+    matched: t('mail.activity.fields.matched'),
+    criteria: t('mail.activity.fields.criteria'),
+    message_number: t('mail.activity.fields.messageNumber'),
+  }
+  return map[key] ?? key
+}
+
+const dateFromTimestamp = (ts: number): Date => new Date(ts * 1000)
+
+async function loadLogs() {
+  if (!props.handlerId) return
+  isLoading.value = true
+  loadError.value = null
+  try {
+    logs.value = await inboundEmailHandlersApi.getLogs(props.handlerId)
+  } catch (err) {
+    loadError.value = getErrorMessage(err)
+    logs.value = []
+  } finally {
+    isLoading.value = false
+  }
+}
+
+watch(
+  () => [props.isOpen, props.handlerId] as const,
+  ([open, id]) => {
+    if (open && id) {
+      void loadLogs()
+    }
+    if (!open) {
+      logs.value = []
+      loadError.value = null
+    }
+  },
+  { immediate: true }
+)
+
+const hasLogs = computed(() => logs.value.length > 0)
+</script>
+
+<template>
+  <Teleport to="body">
+    <Transition name="fade">
+      <div
+        v-if="isOpen"
+        class="fixed inset-0 bg-black/50 z-[10000] flex items-center justify-center p-2 sm:p-4"
+        @click.self="emit('close')"
+      >
+        <div
+          class="surface-card rounded-2xl shadow-2xl max-w-2xl w-full max-h-[90vh] overflow-hidden flex flex-col"
+          @click.stop
+        >
+          <!-- Header -->
+          <div
+            class="flex items-center justify-between p-4 sm:p-6 border-b border-light-border/10 dark:border-dark-border/10"
+          >
+            <div class="flex items-center gap-3 min-w-0">
+              <div
+                class="w-10 h-10 rounded-xl bg-[var(--brand)]/10 flex items-center justify-center shrink-0"
+              >
+                <ClockIcon class="w-5 h-5 text-[var(--brand)]" />
+              </div>
+              <div class="min-w-0">
+                <h3 class="text-base sm:text-lg font-semibold txt-primary truncate">
+                  {{ t('mail.activity.title') }}
+                </h3>
+                <p v-if="handlerName" class="text-xs txt-secondary truncate">
+                  {{ handlerName }}
+                </p>
+              </div>
+            </div>
+            <div class="flex items-center gap-1 shrink-0">
+              <button
+                type="button"
+                class="w-8 h-8 rounded-lg hover:bg-black/5 dark:hover:bg-white/5 flex items-center justify-center transition-colors"
+                :title="t('mail.activity.refresh')"
+                :aria-label="t('mail.activity.refresh')"
+                :disabled="isLoading"
+                @click="loadLogs"
+              >
+                <ArrowPathIcon
+                  class="w-4 h-4 txt-secondary"
+                  :class="{ 'animate-spin': isLoading }"
+                />
+              </button>
+              <button
+                type="button"
+                class="w-8 h-8 rounded-lg hover:bg-black/5 dark:hover:bg-white/5 flex items-center justify-center transition-colors"
+                :aria-label="t('common.close')"
+                @click="emit('close')"
+              >
+                <XMarkIcon class="w-5 h-5 txt-secondary" />
+              </button>
+            </div>
+          </div>
+
+          <!-- Body -->
+          <div class="overflow-y-auto scroll-thin flex-1 px-4 sm:px-6 py-4">
+            <p class="text-xs txt-secondary mb-4">{{ t('mail.activity.description') }}</p>
+
+            <!-- Loading state -->
+            <div v-if="isLoading && !hasLogs" class="py-12 flex items-center justify-center">
+              <ArrowPathIcon class="w-6 h-6 txt-secondary animate-spin" />
+            </div>
+
+            <!-- Error state -->
+            <div
+              v-else-if="loadError"
+              class="rounded-xl border border-red-500/20 bg-red-500/5 p-4 flex items-start gap-3"
+            >
+              <XCircleIcon class="w-5 h-5 text-red-500 shrink-0 mt-0.5" />
+              <div>
+                <p class="text-sm font-medium text-red-500">
+                  {{ t('mail.activity.loadFailed') }}
+                </p>
+                <p class="text-xs txt-secondary mt-1 break-all">{{ loadError }}</p>
+              </div>
+            </div>
+
+            <!-- Empty state -->
+            <div
+              v-else-if="!hasLogs"
+              class="py-12 text-center"
+              data-testid="mail-activity-empty"
+            >
+              <ClockIcon class="w-10 h-10 txt-secondary/40 mx-auto mb-3" />
+              <p class="text-sm font-medium txt-primary">{{ t('mail.activity.empty') }}</p>
+              <p class="text-xs txt-secondary mt-1">{{ t('mail.activity.emptyDescription') }}</p>
+            </div>
+
+            <!-- Log entries -->
+            <ul v-else class="space-y-3" data-testid="mail-activity-list">
+              <li
+                v-for="entry in logs"
+                :key="entry.id"
+                class="rounded-xl border border-light-border/30 dark:border-dark-border/20 p-3 flex gap-3"
+              >
+                <div
+                  class="w-9 h-9 rounded-lg flex items-center justify-center shrink-0"
+                  :class="statusToColor(entry.status)"
+                >
+                  <component :is="eventToIcon[entry.event] ?? InformationCircleIcon" class="w-4 h-4" />
+                </div>
+                <div class="flex-1 min-w-0">
+                  <div class="flex items-center justify-between gap-2 flex-wrap">
+                    <span class="text-sm font-medium txt-primary">
+                      {{ eventLabel(entry.event) }}
+                    </span>
+                    <span
+                      class="text-[11px] txt-secondary"
+                      :title="formatDateTime(dateFromTimestamp(entry.timestamp))"
+                    >
+                      {{ formatRelativeTime(dateFromTimestamp(entry.timestamp)) }}
+                    </span>
+                  </div>
+
+                  <p
+                    v-if="entry.error"
+                    class="text-xs text-red-500 dark:text-red-400 mt-1 break-words"
+                  >
+                    {{ entry.error }}
+                  </p>
+
+                  <dl
+                    v-if="sortedDetails(entry.details).length > 0"
+                    class="mt-2 grid grid-cols-1 sm:grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-xs"
+                  >
+                    <template v-for="item in sortedDetails(entry.details)" :key="item.key">
+                      <dt class="txt-secondary">{{ detailsLabel(item.key) }}</dt>
+                      <dd class="txt-primary break-words">{{ item.value }}</dd>
+                    </template>
+                  </dl>
+                </div>
+              </li>
+            </ul>
+          </div>
+
+          <!-- Footer -->
+          <div
+            class="flex items-center justify-between gap-2 p-4 sm:p-5 border-t border-light-border/10 dark:border-dark-border/10"
+          >
+            <p class="text-xs txt-secondary">
+              {{ t('mail.activity.retentionNote') }}
+            </p>
+            <button
+              type="button"
+              class="px-4 py-2 rounded-lg surface-chip txt-secondary hover:txt-primary transition-colors text-sm font-medium"
+              @click="emit('close')"
+            >
+              {{ t('common.close') }}
+            </button>
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<style scoped>
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.2s ease;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/frontend/src/components/mail/MailHandlerList.vue
+++ b/frontend/src/components/mail/MailHandlerList.vue
@@ -170,6 +170,17 @@
           </div>
         </div>
 
+        <!-- Activity log button (visible on hover) -->
+        <button
+          class="absolute top-3 right-[4.25rem] icon-ghost opacity-0 group-hover:opacity-100 transition-all z-20"
+          :aria-label="$t('mail.activity.openButton')"
+          :title="$t('mail.activity.openButton')"
+          data-testid="btn-activity"
+          @click.stop="openActivity(handler)"
+        >
+          <ClockIcon class="w-4 h-4" />
+        </button>
+
         <!-- Delete button (separate from header to avoid overlap) -->
         <button
           class="absolute top-3 right-10 icon-ghost icon-ghost--danger opacity-0 group-hover:opacity-100 transition-all z-20"
@@ -229,11 +240,18 @@
         </div>
       </div>
     </div>
+
+    <MailHandlerActivityLogModal
+      :is-open="activityModal.open"
+      :handler-id="activityModal.handlerId"
+      :handler-name="activityModal.handlerName"
+      @close="closeActivity"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { reactive, ref } from 'vue'
 import {
   EnvelopeIcon,
   PlusIcon,
@@ -248,6 +266,7 @@ import {
 } from '@heroicons/vue/24/outline'
 import type { SavedMailHandler } from '@/services/api/inboundEmailHandlersApi'
 import { useDateFormat } from '@/composables/useDateFormat'
+import MailHandlerActivityLogModal from './MailHandlerActivityLogModal.vue'
 
 interface Props {
   handlers: SavedMailHandler[]
@@ -297,5 +316,25 @@ const deleteSelected = () => {
 
 const formatDate = (date: Date) => {
   return formatRelativeTime(date)
+}
+
+const activityModal = reactive<{
+  open: boolean
+  handlerId: string | null
+  handlerName: string
+}>({
+  open: false,
+  handlerId: null,
+  handlerName: '',
+})
+
+const openActivity = (handler: SavedMailHandler) => {
+  activityModal.handlerId = handler.id
+  activityModal.handlerName = handler.name
+  activityModal.open = true
+}
+
+const closeActivity = () => {
+  activityModal.open = false
 }
 </script>

--- a/frontend/src/components/mail/MailHandlerList.vue
+++ b/frontend/src/components/mail/MailHandlerList.vue
@@ -242,16 +242,16 @@
     </div>
 
     <MailHandlerActivityLogModal
-      :is-open="activityModal.open"
-      :handler-id="activityModal.handlerId"
-      :handler-name="activityModal.handlerName"
+      :is-open="activityModalOpen"
+      :handler-id="activityModalHandlerId"
+      :handler-name="activityModalHandlerName"
       @close="closeActivity"
     />
   </div>
 </template>
 
 <script setup lang="ts">
-import { reactive, ref } from 'vue'
+import { ref } from 'vue'
 import {
   EnvelopeIcon,
   PlusIcon,
@@ -318,23 +318,20 @@ const formatDate = (date: Date) => {
   return formatRelativeTime(date)
 }
 
-const activityModal = reactive<{
-  open: boolean
-  handlerId: string | null
-  handlerName: string
-}>({
-  open: false,
-  handlerId: null,
-  handlerName: '',
-})
+// Project rule (docs/FRONTEND_CONVENTIONS.md): prefer `ref()` over
+// `reactive()` for modal state — keeps reactivity boundaries explicit
+// and matches how the rest of the codebase wires up dialogs.
+const activityModalOpen = ref(false)
+const activityModalHandlerId = ref<string | null>(null)
+const activityModalHandlerName = ref('')
 
 const openActivity = (handler: SavedMailHandler) => {
-  activityModal.handlerId = handler.id
-  activityModal.handlerName = handler.name
-  activityModal.open = true
+  activityModalHandlerId.value = handler.id
+  activityModalHandlerName.value = handler.name
+  activityModalOpen.value = true
 }
 
 const closeActivity = () => {
-  activityModal.open = false
+  activityModalOpen.value = false
 }
 </script>

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -1961,7 +1961,6 @@
         "connect_failed": "Verbindung fehlgeschlagen",
         "forwarded": "E-Mail weitergeleitet",
         "discarded": "E-Mail von KI verworfen",
-        "no_route": "Keine passende Abteilung",
         "no_smtp": "Geroutet, aber nicht versendet (kein SMTP konfiguriert)",
         "forward_failed": "Weiterleitung fehlgeschlagen",
         "process_error": "Nachricht konnte nicht verarbeitet werden"
@@ -1971,8 +1970,7 @@
         "subject": "Betreff",
         "routedTo": "Weitergeleitet an",
         "matched": "Treffer",
-        "criteria": "IMAP-Kriterien",
-        "messageNumber": "Nachricht Nr."
+        "criteria": "IMAP-Kriterien"
       }
     },
     "savedHandlers": "E-Mail-Agents",

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -1945,6 +1945,34 @@
     "filterToDate": "Bis Datum",
     "recommended": "Empfohlen",
     "proOnly": "PRO+",
+    "activity": {
+      "title": "Letzte Aktivitäten",
+      "description": "Die letzten 10 Aktionen dieses E-Mail-Agents. Hilft dabei, „als gelesen markiert, aber nicht weitergeleitet\"-Fälle zu untersuchen.",
+      "openButton": "Aktivitätsprotokoll anzeigen",
+      "refresh": "Aktivitäten neu laden",
+      "loadFailed": "Aktivitätsprotokoll konnte nicht geladen werden",
+      "empty": "Noch keine Aktivität",
+      "emptyDescription": "Sobald dieser Agent eingehende E-Mails verarbeitet, erscheinen die letzten Schritte hier.",
+      "retentionNote": "Es werden nur die letzten 10 Einträge gespeichert; ältere werden automatisch entfernt.",
+      "events": {
+        "check": "Postfach geprüft",
+        "connect_failed": "Verbindung fehlgeschlagen",
+        "forwarded": "E-Mail weitergeleitet",
+        "discarded": "E-Mail von KI verworfen",
+        "no_route": "Keine passende Abteilung",
+        "no_smtp": "Geroutet, aber nicht versendet (kein SMTP konfiguriert)",
+        "forward_failed": "Weiterleitung fehlgeschlagen",
+        "process_error": "Nachricht konnte nicht verarbeitet werden"
+      },
+      "fields": {
+        "from": "Von",
+        "subject": "Betreff",
+        "routedTo": "Weitergeleitet an",
+        "matched": "Treffer",
+        "criteria": "IMAP-Kriterien",
+        "messageNumber": "Nachricht Nr."
+      }
+    },
     "savedHandlers": "E-Mail-Agents",
     "savedHandlersDesc": "Automatisiere deinen Posteingang mit KI-gestützten E-Mail-Agents, die Nachrichten lesen, sortieren und weiterleiten.",
     "createHandler": "Neuer E-Mail-Agent",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -557,7 +557,35 @@
     "filterFromDateHelp": "Emails from this date onwards will be processed (including future emails)",
     "filterToDate": "To Date",
     "recommended": "Recommended",
-    "proOnly": "PRO+"
+    "proOnly": "PRO+",
+    "activity": {
+      "title": "Recent activity",
+      "description": "The last 10 things this email agent did. Use it to debug \"the message was marked seen but never forwarded\" cases.",
+      "openButton": "View activity log",
+      "refresh": "Reload activity",
+      "loadFailed": "Could not load activity log",
+      "empty": "No activity yet",
+      "emptyDescription": "Once this agent processes incoming mail, the most recent steps will appear here.",
+      "retentionNote": "Only the last 10 entries are kept; older entries are pruned automatically.",
+      "events": {
+        "check": "Mailbox checked",
+        "connect_failed": "Connection failed",
+        "forwarded": "Email forwarded",
+        "discarded": "Email discarded by AI",
+        "no_route": "No matching department",
+        "no_smtp": "Routed but not sent (no SMTP configured)",
+        "forward_failed": "Forward failed",
+        "process_error": "Could not process message"
+      },
+      "fields": {
+        "from": "From",
+        "subject": "Subject",
+        "routedTo": "Routed to",
+        "matched": "Matched",
+        "criteria": "IMAP criteria",
+        "messageNumber": "Message #"
+      }
+    }
   },
   "files": {
     "searchPlaceholder": "Search files...",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -574,7 +574,6 @@
         "connect_failed": "Connection failed",
         "forwarded": "Email forwarded",
         "discarded": "Email discarded by AI",
-        "no_route": "No matching department",
         "no_smtp": "Routed but not sent (no SMTP configured)",
         "forward_failed": "Forward failed",
         "process_error": "Could not process message"
@@ -584,8 +583,7 @@
         "subject": "Subject",
         "routedTo": "Routed to",
         "matched": "Matched",
-        "criteria": "IMAP criteria",
-        "messageNumber": "Message #"
+        "criteria": "IMAP criteria"
       }
     }
   },

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -1621,7 +1621,35 @@
     "deleteHandler": "Eliminar Gestor",
     "handlerName": "Nombre del Gestor",
     "handlerNamePlaceholder": "ej. Bandeja de Soporte, Correo de Ventas",
-    "handlerNameHelp": "Dale un nombre descriptivo a este gestor de correo"
+    "handlerNameHelp": "Dale un nombre descriptivo a este gestor de correo",
+    "activity": {
+      "title": "Actividad reciente",
+      "description": "Las últimas 10 acciones de este agente de correo. Útil para investigar casos de «marcado como leído pero nunca reenviado».",
+      "openButton": "Ver registro de actividad",
+      "refresh": "Recargar actividad",
+      "loadFailed": "No se pudo cargar el registro de actividad",
+      "empty": "Aún no hay actividad",
+      "emptyDescription": "Cuando este agente procese correos entrantes, los pasos más recientes aparecerán aquí.",
+      "retentionNote": "Solo se conservan las últimas 10 entradas; las más antiguas se eliminan automáticamente.",
+      "events": {
+        "check": "Buzón comprobado",
+        "connect_failed": "Error de conexión",
+        "forwarded": "Correo reenviado",
+        "discarded": "Correo descartado por la IA",
+        "no_route": "Ningún departamento coincide",
+        "no_smtp": "Enrutado pero no enviado (SMTP no configurado)",
+        "forward_failed": "Error al reenviar",
+        "process_error": "No se pudo procesar el mensaje"
+      },
+      "fields": {
+        "from": "De",
+        "subject": "Asunto",
+        "routedTo": "Enrutado a",
+        "matched": "Coincidencias",
+        "criteria": "Criterios IMAP",
+        "messageNumber": "Mensaje N.º"
+      }
+    }
   },
   "shared": {
     "title": "Chat Compartido",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -1638,7 +1638,6 @@
         "connect_failed": "Error de conexión",
         "forwarded": "Correo reenviado",
         "discarded": "Correo descartado por la IA",
-        "no_route": "Ningún departamento coincide",
         "no_smtp": "Enrutado pero no enviado (SMTP no configurado)",
         "forward_failed": "Error al reenviar",
         "process_error": "No se pudo procesar el mensaje"
@@ -1648,8 +1647,7 @@
         "subject": "Asunto",
         "routedTo": "Enrutado a",
         "matched": "Coincidencias",
-        "criteria": "Criterios IMAP",
-        "messageNumber": "Mensaje N.º"
+        "criteria": "Criterios IMAP"
       }
     }
   },

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -1639,7 +1639,6 @@
         "connect_failed": "Bağlantı başarısız",
         "forwarded": "E-posta iletildi",
         "discarded": "E-posta yapay zekâ tarafından atıldı",
-        "no_route": "Eşleşen departman yok",
         "no_smtp": "Yönlendirildi ancak gönderilmedi (SMTP yapılandırılmamış)",
         "forward_failed": "İletim başarısız",
         "process_error": "Mesaj işlenemedi"
@@ -1649,8 +1648,7 @@
         "subject": "Konu",
         "routedTo": "Yönlendirildiği yer",
         "matched": "Eşleşmeler",
-        "criteria": "IMAP ölçütleri",
-        "messageNumber": "Mesaj No."
+        "criteria": "IMAP ölçütleri"
       }
     }
   },

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -1622,7 +1622,35 @@
     "deleteHandler": "İşleyiciyi Sil",
     "handlerName": "İşleyici Adı",
     "handlerNamePlaceholder": "ör. Destek Gelen Kutusu, Satış E-postası",
-    "handlerNameHelp": "Bu e-posta işleyicisine açıklayıcı bir ad verin"
+    "handlerNameHelp": "Bu e-posta işleyicisine açıklayıcı bir ad verin",
+    "activity": {
+      "title": "Son etkinlikler",
+      "description": "Bu e-posta ajanının son 10 işlemi. \"Okundu olarak işaretlendi ama hiç iletilmedi\" durumlarını araştırmak için kullanışlıdır.",
+      "openButton": "Etkinlik günlüğünü görüntüle",
+      "refresh": "Etkinlikleri yeniden yükle",
+      "loadFailed": "Etkinlik günlüğü yüklenemedi",
+      "empty": "Henüz etkinlik yok",
+      "emptyDescription": "Bu ajan gelen e-postaları işlediğinde, en son adımlar burada görünecektir.",
+      "retentionNote": "Yalnızca son 10 kayıt saklanır; daha eski olanlar otomatik olarak silinir.",
+      "events": {
+        "check": "Posta kutusu kontrol edildi",
+        "connect_failed": "Bağlantı başarısız",
+        "forwarded": "E-posta iletildi",
+        "discarded": "E-posta yapay zekâ tarafından atıldı",
+        "no_route": "Eşleşen departman yok",
+        "no_smtp": "Yönlendirildi ancak gönderilmedi (SMTP yapılandırılmamış)",
+        "forward_failed": "İletim başarısız",
+        "process_error": "Mesaj işlenemedi"
+      },
+      "fields": {
+        "from": "Gönderen",
+        "subject": "Konu",
+        "routedTo": "Yönlendirildiği yer",
+        "matched": "Eşleşmeler",
+        "criteria": "IMAP ölçütleri",
+        "messageNumber": "Mesaj No."
+      }
+    }
   },
   "shared": {
     "title": "Paylaşılan Sohbet",

--- a/frontend/src/services/api/inboundEmailHandlersApi.ts
+++ b/frontend/src/services/api/inboundEmailHandlersApi.ts
@@ -123,6 +123,37 @@ export interface TestMailboxConnectionBody {
   handlerId?: string | number
 }
 
+/**
+ * Possible activity log events emitted by the mail handler runner.
+ * Mirrors `MailHandlerLogService::EVENT_*` constants on the backend.
+ */
+export type MailHandlerLogEvent =
+  | 'check'
+  | 'connect_failed'
+  | 'forwarded'
+  | 'discarded'
+  | 'no_route'
+  | 'no_smtp'
+  | 'forward_failed'
+  | 'process_error'
+
+export type MailHandlerLogStatus = 'success' | 'warning' | 'error'
+
+export interface MailHandlerLogEntry {
+  id: number
+  /** Unix epoch seconds when the event was recorded. */
+  timestamp: number
+  event: MailHandlerLogEvent
+  status: MailHandlerLogStatus
+  /** Free-text error / explanation. Empty for success entries. */
+  error: string
+  /**
+   * Free-form metadata captured for this event (subject, from, routed_to,
+   * matched, criteria, message_number, ...). Shape depends on `event`.
+   */
+  details: Record<string, unknown>
+}
+
 export interface UpdateHandlerRequest {
   name?: string
   mailServer?: string
@@ -357,5 +388,18 @@ export const inboundEmailHandlersApi = {
         body: JSON.stringify({ handlerIds }),
       }
     )
+  },
+
+  /**
+   * Recent activity log for a handler (newest first, capped at 10 entries
+   * by the backend). Useful for diagnosing "marked seen but never forwarded"
+   * cases — see `MailHandlerLogService` on the backend.
+   */
+  async getLogs(id: string): Promise<MailHandlerLogEntry[]> {
+    const data = await httpClient<{ success: boolean; logs: MailHandlerLogEntry[] }>(
+      `/api/v1/inbound-email-handlers/${id}/logs`,
+      { method: 'GET' }
+    )
+    return Array.isArray(data.logs) ? data.logs : []
   },
 }

--- a/frontend/src/services/api/inboundEmailHandlersApi.ts
+++ b/frontend/src/services/api/inboundEmailHandlersApi.ts
@@ -132,7 +132,6 @@ export type MailHandlerLogEvent =
   | 'connect_failed'
   | 'forwarded'
   | 'discarded'
-  | 'no_route'
   | 'no_smtp'
   | 'forward_failed'
   | 'process_error'
@@ -149,7 +148,7 @@ export interface MailHandlerLogEntry {
   error: string
   /**
    * Free-form metadata captured for this event (subject, from, routed_to,
-   * matched, criteria, message_number, ...). Shape depends on `event`.
+   * matched, criteria, ...). Shape depends on `event`.
    */
   details: Record<string, unknown>
 }


### PR DESCRIPTION
Closes #985.

## Summary

The inbound mail handler currently fails on the majority of real-world business emails. Two independent bugs in `InboundEmailHandlerService` mean the AI department-routing prompt receives raw MIME content (boundaries, base64 chunks) or quoted-printable-corrupted text instead of the actual message body.

## What was wrong

1. **Shallow multipart parsing.** `extractEmailBody()` only looked at top-level parts. A standard email-with-attachment from Gmail/Outlook wraps the body inside a nested `multipart/alternative` under `multipart/mixed`, so neither `text/plain` nor `text/html` matched at the top level and the routing prompt got the raw MIME envelope.
2. **`imap_8bit()` / `imap_binary()` are encoders, not decoders.** For 8BIT and BINARY transfer encodings (very common when SMTP advertises `8BITMIME`) the code re-encoded the already-readable body to quoted-printable / base64 before sending it to the AI.
3. **No charset conversion.** ISO-8859-1 / Windows-1252 bodies (typical for European senders) reached the AI with garbled umlauts.
4. **MIME-encoded subjects untouched.** `=?UTF-8?B?...?=` subject lines were never decoded before being passed to the routing prompt.
5. **IMAP connection leak.** `processHandler()` could leak the IMAP resource if an exception was thrown after `imap_open` but before `imap_close`.

## What this PR does

- Replaces the top-level `foreach` in `extractEmailBody()` with a recursive `collectTextParts()` walker that follows IMAP's RFC 3501 dotted section addressing (`1`, `1.1`, `1.2`, ...) into arbitrary multipart trees, prefers the first non-attachment `text/plain`, and falls back to `text/html` (stripped).
- Adds an `isAttachment()` helper that skips parts with `Content-Disposition: attachment` so an attached `.txt`/`.html` file no longer hijacks the body extraction.
- Rewrites `decodeEmailBody()`:
  - 7BIT / 8BIT / BINARY / OTHER → passthrough (the original `imap_8bit` / `imap_binary` calls were encoders and have been removed).
  - BASE64 / QUOTED-PRINTABLE → decoded as before.
  - New optional `charset` argument: when the part declares a non-UTF-8 charset (read via `getCharset()`), the result is converted with `mb_convert_encoding()`.
- Adds `decodeMimeHeader()` and applies it to `imap_headerinfo()->subject` so RFC 2047 encoded-word subjects survive the trip into the AI prompt as readable UTF-8.
- Wraps `processHandler()` in `try { ... } finally { imap_close(...) }` so the IMAP resource is always released, even on exceptions during `imap_expunge` or per-message processing.

## Test plan

- [x] Added 12 new unit tests in `InboundEmailHandlerServiceTest` covering: 8BIT passthrough, BINARY passthrough, base64 decoding, quoted-printable decoding, ISO-8859-15 → UTF-8 charset conversion, UTF-8 unchanged, RFC 2047 encoded-word subjects, plain-ASCII subjects, MIME type derivation, attachment-disposition detection, and Content-Type charset extraction.
- [x] `make -C backend lint` (PSR-12) — green.
- [x] `make -C backend phpstan` — green.
- [x] `make -C backend test` — full suite (1627 tests) green.
- [x] Smoke-tested the new helpers end-to-end against the bug report's exact `multipart/mixed → multipart/alternative + application/pdf` shape.
- [ ] (Reviewer) Manual sanity check against a real inbox with attachment + non-UTF-8 sender, ideally against an SMTP server that advertises `8BITMIME`.