### PR TITLE
fix(whatsapp): persist incoming media as File entity so the web chat can play it (#976)

### DIFF
--- a/backend/src/Controller/StaticUploadController.php
+++ b/backend/src/Controller/StaticUploadController.php
@@ -245,9 +245,20 @@ class StaticUploadController extends AbstractController
             ->getQuery()
             ->getOneOrNullResult();
 
+        // Prefer the owning Message's user_id when an attachment exists.
+        // The legacy `Message::filePath` branch above derives ownership
+        // from the Message; mirroring that here keeps access decisions
+        // consistent if the File row and its owning Message ever drift
+        // (e.g. impersonation paths or future schema migrations) — we
+        // never want a File-fallback to grant access the Message branch
+        // would have refused.
+        $ownerUserId = $linkedMessage instanceof Message
+            ? $linkedMessage->getUserId()
+            : $file->getUserId();
+
         return [
             'message' => $linkedMessage instanceof Message ? $linkedMessage : null,
-            'owner_user_id' => $file->getUserId(),
+            'owner_user_id' => $ownerUserId,
             'source' => $linkedMessage ? 'file_attached_to_message' : 'file_orphan',
             'file_id' => $file->getId(),
         ];

--- a/backend/src/Controller/StaticUploadController.php
+++ b/backend/src/Controller/StaticUploadController.php
@@ -2,7 +2,9 @@
 
 namespace App\Controller;
 
+use App\Entity\Message;
 use App\Entity\User;
+use App\Repository\FileRepository;
 use App\Repository\MessageRepository;
 use App\Service\File\FileHelper;
 use Psr\Log\LoggerInterface;
@@ -24,6 +26,7 @@ class StaticUploadController extends AbstractController
 {
     public function __construct(
         private MessageRepository $messageRepository,
+        private FileRepository $fileRepository,
         private string $uploadDir,
         private LoggerInterface $logger,
     ) {
@@ -98,41 +101,44 @@ class StaticUploadController extends AbstractController
             return $this->serveFile($path, $request);
         }
 
-        // 1. For regular files: Find message by filePath (format: "/api/v1/files/uploads/{path}")
-        $filePath = "/api/v1/files/uploads/{$path}";
-
-        $message = $this->messageRepository->createQueryBuilder('m')
-            ->leftJoin('m.chat', 'c')
-            ->addSelect('c')
-            ->where('m.filePath = :path')
-            ->setParameter('path', $filePath)
-            ->getQuery()
-            ->getOneOrNullResult();
-
-        if (!$message) {
-            $this->logger->warning('StaticUploadController: Message not found for file', [
+        // 1. Resolve the asset to either a Message (legacy + AI-generated)
+        //    or a File entity (user uploads, WhatsApp media — issue #976).
+        //    The Message lookup tolerates both the prefixed
+        //    `/api/v1/files/uploads/...` form (AI-generated content,
+        //    `MediaGenerationHandler`) AND the raw relative path that
+        //    older WhatsApp messages persisted before File entities were
+        //    introduced. The File entity fallback covers regular web
+        //    uploads (issue #955) and new WhatsApp media stored via
+        //    `WhatsAppService::handleMediaDownload`.
+        $context = $this->resolveFileContext($path);
+        if (!$context) {
+            $this->logger->warning('StaticUploadController: File not found in database', [
                 'path' => $path,
-                'file_path' => $filePath,
             ]);
             throw $this->createNotFoundException('File not found in database');
         }
 
+        $message = $context['message'];
+        $ownerUserId = $context['owner_user_id'];
+
         // 2. Check if file is public (chat is shared) AND not expired
-        $chat = $message->getChat();
+        $chat = $message?->getChat();
         $isPublicCheck = $chat ? $chat->isPublic() : false;
-        $isExpiredCheck = $message->isShareExpired();
+        $isExpiredCheck = $message ? $message->isShareExpired() : false;
         $isPublicAndValid = $isPublicCheck && !$isExpiredCheck;
 
         $this->logger->info('StaticUploadController: Access check', [
             'path' => $path,
-            'message_id' => $message->getId(),
+            'source' => $context['source'],
+            'message_id' => $message?->getId(),
+            'file_id' => $context['file_id'],
             'chat_id' => $chat ? $chat->getId() : null,
             'is_public' => $isPublicCheck,
             'is_expired' => $isExpiredCheck,
             'is_public_and_valid' => $isPublicAndValid,
             'has_user' => null !== $user,
             'user_id' => $user?->getId(),
-            'owner_id' => $message->getUserId(),
+            'owner_id' => $ownerUserId,
         ]);
 
         // 3. Permission check: Public files OR authenticated owner
@@ -141,7 +147,7 @@ class StaticUploadController extends AbstractController
             if (!$user) {
                 $this->logger->warning('StaticUploadController: Unauthorized access attempt', [
                     'path' => $path,
-                    'is_chat_public' => $chat ? $chat->isPublic() : false,
+                    'is_chat_public' => $isPublicCheck,
                     'ip' => $_SERVER['REMOTE_ADDR'] ?? 'unknown',
                 ]);
 
@@ -151,12 +157,12 @@ class StaticUploadController extends AbstractController
             }
 
             // Check ownership (only owner can access private files)
-            if ($message->getUserId() !== $user->getId()) {
+            if ($ownerUserId !== $user->getId()) {
                 $this->logger->warning('StaticUploadController: Forbidden access attempt', [
                     'path' => $path,
                     'user_id' => $user->getId(),
-                    'owner_id' => $message->getUserId(),
-                    'is_chat_public' => $chat ? $chat->isPublic() : false,
+                    'owner_id' => $ownerUserId,
+                    'is_chat_public' => $isPublicCheck,
                 ]);
 
                 return $this->json([
@@ -165,7 +171,11 @@ class StaticUploadController extends AbstractController
             }
         }
 
-        // 4. Additional check for expired public shares
+        // 4. Additional check for expired public shares.
+        // `$chat` is only non-null when `$message` is set (we resolved
+        // `$chat = $message?->getChat()` above), so the existing chat
+        // checks already imply a non-null message — no extra null guard
+        // needed.
         if ($chat && $chat->isPublic() && $message->isShareExpired()) {
             $this->logger->info('StaticUploadController: Expired share link accessed', [
                 'path' => $path,
@@ -178,6 +188,69 @@ class StaticUploadController extends AbstractController
 
         // 5. Serve the file
         return $this->serveFile($path, $request);
+    }
+
+    /**
+     * Resolve a relative upload path to its owning Message (preferred) or
+     * orphan File entity, returning the metadata needed for the access
+     * check.
+     *
+     * Priority:
+     *  1. `Message::filePath` matching either the prefixed serve URL or
+     *     the raw relative path. This covers AI-generated media (which
+     *     stores the prefixed form) and legacy inbound WhatsApp messages
+     *     (which persisted the raw relative path before issue #976).
+     *  2. `File::filePath` matching the raw relative path. This covers
+     *     regular web uploads (issue #955 surfaced inline `<audio>`
+     *     playback for them) and new WhatsApp media that travels through
+     *     the same `File` pipeline.
+     *
+     * @return array{message: ?Message, owner_user_id: int, source: string, file_id: ?int}|null
+     */
+    private function resolveFileContext(string $path): ?array
+    {
+        $apiPath = '/api/v1/files/uploads/'.$path;
+
+        $message = $this->messageRepository->createQueryBuilder('m')
+            ->leftJoin('m.chat', 'c')
+            ->addSelect('c')
+            ->where('m.filePath = :apiPath OR m.filePath = :rawPath')
+            ->setParameter('apiPath', $apiPath)
+            ->setParameter('rawPath', $path)
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        if ($message instanceof Message) {
+            return [
+                'message' => $message,
+                'owner_user_id' => $message->getUserId(),
+                'source' => 'message_filepath',
+                'file_id' => null,
+            ];
+        }
+
+        $file = $this->fileRepository->findOneBy(['filePath' => $path]);
+        if (null === $file) {
+            return null;
+        }
+
+        $linkedMessage = $this->messageRepository->createQueryBuilder('m')
+            ->leftJoin('m.chat', 'c')
+            ->addSelect('c')
+            ->innerJoin('m.files', 'f')
+            ->where('f.id = :fileId')
+            ->setParameter('fileId', $file->getId())
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        return [
+            'message' => $linkedMessage instanceof Message ? $linkedMessage : null,
+            'owner_user_id' => $file->getUserId(),
+            'source' => $linkedMessage ? 'file_attached_to_message' : 'file_orphan',
+            'file_id' => $file->getId(),
+        ];
     }
 
     /**

--- a/backend/src/Service/WhatsAppService.php
+++ b/backend/src/Service/WhatsAppService.php
@@ -1440,9 +1440,14 @@ final class WhatsAppService
             $file->setFileMime((string) ($downloadResult['mime_type'] ?? 'application/octet-stream'));
             $file->setStatus('uploaded');
 
+            // Persist + attach without an inner flush — `handleIncomingMessage`
+            // performs a single flush right after we return, which now
+            // covers BOTH the File row AND the Message↔File association
+            // in one transaction. An earlier version flushed twice and
+            // wrote the M2M row in a separate INSERT, which was wasteful
+            // and could leave a half-attached File if the second flush
+            // failed.
             $this->em->persist($file);
-            $this->em->flush();
-
             $message->addFile($file);
             $message->setFile(1);
 
@@ -1451,7 +1456,6 @@ final class WhatsAppService
                 'type' => $dto->type,
                 'file_path' => $relativePath,
                 'file_type' => $downloadResult['file_type'],
-                'file_id' => $file->getId(),
                 'size' => $downloadResult['size'] ?? 0,
             ]);
 

--- a/backend/src/Service/WhatsAppService.php
+++ b/backend/src/Service/WhatsAppService.php
@@ -5,6 +5,7 @@ namespace App\Service;
 use App\AI\Service\AiFacade;
 use App\DTO\WhatsApp\IncomingMessageDto;
 use App\Entity\Chat;
+use App\Entity\File;
 use App\Entity\Message;
 use App\Entity\User;
 use App\Service\File\FileProcessor;
@@ -1419,15 +1420,38 @@ final class WhatsAppService
                 return 'Failed to download media file';
             }
 
+            // Issue #976: persist the downloaded asset as a `File` entity
+            // attached to the message, mirroring how regular web uploads
+            // travel through `MessageController::uploadFileForChat` and
+            // `StreamController`. Without this, WhatsApp media bypassed the
+            // standard storage pipeline: `Message::filePath` carried a raw
+            // relative path while the static-serve controller only matched
+            // the `/api/v1/files/uploads/...` prefix, so the audio 404'd in
+            // the web chat. Storing it as a File entity also lets the
+            // recording show up in the user's Files page and travel through
+            // the same access-control path as any other upload.
+            $relativePath = $downloadResult['file_path'];
+            $file = new File();
+            $file->setUserId($effectiveUserId);
+            $file->setFilePath($relativePath);
+            $file->setFileType($downloadResult['file_type'] ?? 'unknown');
+            $file->setFileName(basename($relativePath));
+            $file->setFileSize((int) ($downloadResult['size'] ?? 0));
+            $file->setFileMime((string) ($downloadResult['mime_type'] ?? 'application/octet-stream'));
+            $file->setStatus('uploaded');
+
+            $this->em->persist($file);
+            $this->em->flush();
+
+            $message->addFile($file);
             $message->setFile(1);
-            $message->setFilePath($downloadResult['file_path']);
-            $message->setFileType($downloadResult['file_type'] ?? 'unknown');
 
             $this->logger->info('WhatsApp: Media downloaded successfully', [
                 'media_id' => $mediaId,
                 'type' => $dto->type,
-                'file_path' => $downloadResult['file_path'],
+                'file_path' => $relativePath,
                 'file_type' => $downloadResult['file_type'],
+                'file_id' => $file->getId(),
                 'size' => $downloadResult['size'] ?? 0,
             ]);
 
@@ -1444,13 +1468,14 @@ final class WhatsAppService
                     ]);
 
                     [$extractedText, $extractionDetails] = $this->fileProcessor->extractText(
-                        $downloadResult['file_path'],
+                        $relativePath,
                         $downloadResult['file_type'],
                         $effectiveUserId
                     );
 
                     if (!empty($extractedText)) {
-                        $message->setFileText($extractedText);
+                        $file->setFileText($extractedText);
+                        $file->setStatus('extracted');
 
                         // CRITICAL: For audio/video messages, replace placeholder text with transcription
                         // This ensures the AI receives the actual spoken content
@@ -1467,6 +1492,7 @@ final class WhatsAppService
                         }
                     } else {
                         // Extraction failed - return error to user instead of proceeding with placeholder
+                        $file->setStatus('error');
                         $this->logger->warning('WhatsApp: No text extracted from audio/video', [
                             'type' => $dto->type,
                             'details' => $extractionDetails ?? [],
@@ -1490,7 +1516,7 @@ final class WhatsAppService
                         $this->logger->info('WhatsApp: Image/sticker with caption, delegating to ChatHandler vision', [
                             'type' => $dto->type,
                             'caption' => $caption,
-                            'file_path' => $downloadResult['file_path'],
+                            'file_path' => $relativePath,
                         ]);
                     } else {
                         // No caption: ask for a description
@@ -1500,25 +1526,29 @@ final class WhatsAppService
                         $message->setText($prompt);
                         $this->logger->info('WhatsApp: Image/sticker without caption, requesting description', [
                             'type' => $dto->type,
-                            'file_path' => $downloadResult['file_path'],
+                            'file_path' => $relativePath,
                         ]);
                     }
-                // Note: fileText is intentionally NOT set - ChatHandler will include
-                // the image directly in the Vision API request for proper analysis
+                // Note: fileText is intentionally NOT set on the File entity
+                // here — ChatHandler reads the image straight off disk for
+                // the Vision API request, and storing a placeholder text
+                // would only confuse downstream classifiers.
                 } else {
                     // For documents and other types, use standard extraction
                     [$extractedText] = $this->fileProcessor->extractText(
-                        $downloadResult['file_path'],
+                        $relativePath,
                         $downloadResult['file_type'],
                         $effectiveUserId
                     );
 
                     if (!empty($extractedText)) {
-                        $message->setFileText($extractedText);
+                        $file->setFileText($extractedText);
+                        $file->setStatus('extracted');
                     }
                 }
             } catch (\Throwable $e) {
                 $extractionError = $e->getMessage();
+                $file->setStatus('error');
                 $this->logger->error('WhatsApp: Text extraction failed', [
                     'type' => $dto->type,
                     'file_type' => $downloadResult['file_type'],

--- a/backend/tests/Controller/StaticUploadControllerTest.php
+++ b/backend/tests/Controller/StaticUploadControllerTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Controller;
 use App\Entity\File;
 use App\Entity\Message;
 use App\Entity\User;
+use App\Service\File\UserUploadPathBuilder;
 use App\Tests\Trait\AuthenticatedTestTrait;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
@@ -199,15 +200,13 @@ class StaticUploadControllerTest extends WebTestCase
             $this->fail('app.upload_dir must be a string.');
         }
 
-        // Mirror the user-scoped folder layout used by both regular
-        // uploads and the WhatsApp pipeline so realpath() inside the
-        // controller still keeps us under $uploadDir.
-        $userBase = sprintf(
-            '%02d/%03d/%05d',
-            $this->user->getId() % 100,
-            ($this->user->getId() / 100) % 1000,
-            $this->user->getId(),
-        );
+        // Use the production sharding helper instead of duplicating its
+        // modulo math — drift between the test fixture and the real
+        // pipeline would silently make the regression test miss real
+        // bugs (e.g. if the layout ever changes for large user IDs).
+        $pathBuilder = $this->client->getContainer()->get(UserUploadPathBuilder::class);
+        $userBase = $pathBuilder->buildUserBaseRelativePath($this->user->getId());
+
         $relativePath = $userBase.'/'.date('Y').'/'.date('m').'/'.$filename;
         $absolute = $uploadDir.'/'.$relativePath;
 
@@ -222,12 +221,20 @@ class StaticUploadControllerTest extends WebTestCase
 
     private function persistFile(string $relativePath, string $type, string $mime): File
     {
+        // Read the actual byte size from disk so the persisted File row
+        // matches what real uploads look like — using strlen($relativePath)
+        // would store the path length in BFILESIZE and trip up any UI or
+        // logic that reads it as the body size.
+        $uploadDir = $this->client->getContainer()->getParameter('app.upload_dir');
+        $absolute = $uploadDir.'/'.$relativePath;
+        $bytes = is_file($absolute) ? (int) filesize($absolute) : 0;
+
         $file = new File();
         $file->setUserId($this->user->getId());
         $file->setFilePath($relativePath);
         $file->setFileType($type);
         $file->setFileName(basename($relativePath));
-        $file->setFileSize(strlen($relativePath));
+        $file->setFileSize($bytes);
         $file->setFileMime($mime);
         $file->setStatus('uploaded');
         $this->em->persist($file);

--- a/backend/tests/Controller/StaticUploadControllerTest.php
+++ b/backend/tests/Controller/StaticUploadControllerTest.php
@@ -1,0 +1,258 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Controller;
+
+use App\Entity\File;
+use App\Entity\Message;
+use App\Entity\User;
+use App\Tests\Trait\AuthenticatedTestTrait;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Regression tests for issue #976: WhatsApp voice messages must be
+ * playable in the web chat the same way regular uploads are.
+ *
+ * Before the fix `WhatsAppService::handleMediaDownload` only set
+ * `Message::filePath` to the raw relative path, while
+ * `StaticUploadController` only matched the prefixed
+ * `/api/v1/files/uploads/...` form or AI filename patterns. The fix
+ * persists WhatsApp media as a `File` entity (mirroring web uploads)
+ * and teaches `StaticUploadController` how to resolve both shapes for
+ * legacy and new messages.
+ *
+ * These tests boot the kernel and exercise the controller through the
+ * HTTP stack so the Doctrine query, security, and serving paths all
+ * run end-to-end.
+ */
+class StaticUploadControllerTest extends WebTestCase
+{
+    use AuthenticatedTestTrait;
+
+    private KernelBrowser $client;
+    private \Doctrine\ORM\EntityManagerInterface $em;
+    private User $user;
+    private string $authToken;
+
+    /**
+     * Files we created on disk during the test, removed in tearDown.
+     *
+     * @var list<string>
+     */
+    private array $diskPaths = [];
+
+    /**
+     * Database rows we created during the test, removed in tearDown.
+     *
+     * @var list<File>
+     */
+    private array $createdFiles = [];
+
+    /**
+     * @var list<Message>
+     */
+    private array $createdMessages = [];
+
+    protected function setUp(): void
+    {
+        self::ensureKernelShutdown();
+        $this->client = static::createClient();
+        $this->em = $this->client->getContainer()->get('doctrine')->getManager();
+
+        $user = $this->em->getRepository(User::class)->findOneBy(['mail' => 'demo@synaplan.com']);
+        if (!$user instanceof User) {
+            $this->markTestSkipped('Test user demo@synaplan.com not found. Run fixtures first.');
+        }
+        $this->user = $user;
+        $this->authToken = $this->authenticateClient($this->client, $this->user);
+    }
+
+    protected function tearDown(): void
+    {
+        if (!isset($this->em) || !$this->em->isOpen()) {
+            self::bootKernel();
+            $this->em = self::getContainer()->get('doctrine')->getManager();
+        }
+
+        foreach ($this->createdMessages as $message) {
+            $managed = $this->em->find(Message::class, $message->getId());
+            if ($managed) {
+                $this->em->remove($managed);
+            }
+        }
+        foreach ($this->createdFiles as $file) {
+            $managed = $this->em->find(File::class, $file->getId());
+            if ($managed) {
+                $this->em->remove($managed);
+            }
+        }
+        $this->em->flush();
+
+        foreach ($this->diskPaths as $path) {
+            if (is_file($path)) {
+                @unlink($path);
+            }
+        }
+
+        static::ensureKernelShutdown();
+        parent::tearDown();
+    }
+
+    /**
+     * Issue #976: A WhatsApp voice file persisted via the new pipeline
+     * (File entity attached to a Message, no `Message::filePath` set)
+     * must be servable via `/api/v1/files/uploads/{path}` to its owner.
+     */
+    public function testServesFileEntityAttachedToMessage(): void
+    {
+        $relativePath = $this->createUploadOnDisk('whatsapp_'.bin2hex(random_bytes(4)).'.ogg', 'voice-bytes');
+        $file = $this->persistFile($relativePath, 'audio', 'audio/ogg');
+        $message = $this->persistMessage();
+        $message->addFile($file);
+        $this->em->flush();
+
+        $this->client->request(
+            'GET',
+            '/api/v1/files/uploads/'.$relativePath,
+            [],
+            [],
+            ['HTTP_AUTHORIZATION' => 'Bearer '.$this->authToken],
+        );
+
+        $response = $this->client->getResponse();
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertStringContainsString('audio/ogg', (string) $response->headers->get('Content-Type'));
+    }
+
+    /**
+     * Backward compatibility: messages created BEFORE the fix stored the
+     * raw relative path in `Message::filePath` (no prefix, no File
+     * entity). Those legacy rows must keep working — otherwise upgrading
+     * production would break every existing WhatsApp voice message in
+     * the chat history.
+     */
+    public function testServesLegacyMessageWithRawRelativeFilePath(): void
+    {
+        $relativePath = $this->createUploadOnDisk('whatsapp_'.bin2hex(random_bytes(4)).'.ogg', 'legacy-voice');
+        $message = $this->persistMessage();
+        $message->setFile(1);
+        $message->setFilePath($relativePath); // raw, NOT prefixed — pre-#976 shape
+        $message->setFileType('audio');
+        $this->em->flush();
+
+        $this->client->request(
+            'GET',
+            '/api/v1/files/uploads/'.$relativePath,
+            [],
+            [],
+            ['HTTP_AUTHORIZATION' => 'Bearer '.$this->authToken],
+        );
+
+        $this->assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+    }
+
+    /**
+     * Anonymous requests for a privately-owned File entity must be
+     * rejected. Without this guard the File-entity fallback would
+     * silently bypass the auth check that the legacy `Message::filePath`
+     * branch performs.
+     */
+    public function testRejectsAnonymousRequestForPrivateFileEntity(): void
+    {
+        $relativePath = $this->createUploadOnDisk('whatsapp_'.bin2hex(random_bytes(4)).'.ogg', 'private-bytes');
+        $file = $this->persistFile($relativePath, 'audio', 'audio/ogg');
+        $message = $this->persistMessage();
+        $message->addFile($file);
+        $this->em->flush();
+
+        $this->client->getCookieJar()->clear();
+
+        $this->client->request('GET', '/api/v1/files/uploads/'.$relativePath);
+
+        $this->assertSame(Response::HTTP_UNAUTHORIZED, $this->client->getResponse()->getStatusCode());
+    }
+
+    /**
+     * Unknown paths must still return 404 — the new fallback must not
+     * accidentally widen the surface to anything on disk.
+     */
+    public function testReturns404ForUnknownPath(): void
+    {
+        $this->client->request(
+            'GET',
+            '/api/v1/files/uploads/does/not/exist/'.bin2hex(random_bytes(4)).'.ogg',
+            [],
+            [],
+            ['HTTP_AUTHORIZATION' => 'Bearer '.$this->authToken],
+        );
+
+        $this->assertSame(Response::HTTP_NOT_FOUND, $this->client->getResponse()->getStatusCode());
+    }
+
+    private function createUploadOnDisk(string $filename, string $contents): string
+    {
+        $uploadDir = $this->client->getContainer()->getParameter('app.upload_dir');
+        if (!is_string($uploadDir)) {
+            $this->fail('app.upload_dir must be a string.');
+        }
+
+        // Mirror the user-scoped folder layout used by both regular
+        // uploads and the WhatsApp pipeline so realpath() inside the
+        // controller still keeps us under $uploadDir.
+        $userBase = sprintf(
+            '%02d/%03d/%05d',
+            $this->user->getId() % 100,
+            ($this->user->getId() / 100) % 1000,
+            $this->user->getId(),
+        );
+        $relativePath = $userBase.'/'.date('Y').'/'.date('m').'/'.$filename;
+        $absolute = $uploadDir.'/'.$relativePath;
+
+        if (!is_dir(dirname($absolute))) {
+            mkdir(dirname($absolute), 0o775, true);
+        }
+        file_put_contents($absolute, $contents);
+        $this->diskPaths[] = $absolute;
+
+        return $relativePath;
+    }
+
+    private function persistFile(string $relativePath, string $type, string $mime): File
+    {
+        $file = new File();
+        $file->setUserId($this->user->getId());
+        $file->setFilePath($relativePath);
+        $file->setFileType($type);
+        $file->setFileName(basename($relativePath));
+        $file->setFileSize(strlen($relativePath));
+        $file->setFileMime($mime);
+        $file->setStatus('uploaded');
+        $this->em->persist($file);
+        $this->em->flush();
+        $this->createdFiles[] = $file;
+
+        return $file;
+    }
+
+    private function persistMessage(): Message
+    {
+        $message = new Message();
+        $message->setUserId($this->user->getId());
+        $message->setTrackingId(0);
+        $message->setProviderIndex('test_'.bin2hex(random_bytes(4)));
+        $message->setUnixTimestamp(time());
+        $message->setDateTime(date('Y-m-d H:i:s'));
+        $message->setMessageType('WA');
+        $message->setText('test message for #976');
+        $message->setDirection('IN');
+        $message->setStatus('NEW');
+        $this->em->persist($message);
+        $this->em->flush();
+        $this->createdMessages[] = $message;
+
+        return $message;
+    }
+}

--- a/backend/tests/Service/WhatsAppServiceTest.php
+++ b/backend/tests/Service/WhatsAppServiceTest.php
@@ -6,7 +6,6 @@ namespace App\Tests\Service;
 
 use App\AI\Service\AiFacade;
 use App\DTO\WhatsApp\IncomingMessageDto;
-use App\Entity\File;
 use App\Entity\Message;
 use App\Entity\User;
 use App\Service\DiscordNotificationService;

--- a/backend/tests/Service/WhatsAppServiceTest.php
+++ b/backend/tests/Service/WhatsAppServiceTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Service;
 
 use App\AI\Service\AiFacade;
 use App\DTO\WhatsApp\IncomingMessageDto;
+use App\Entity\File;
 use App\Entity\Message;
 use App\Entity\User;
 use App\Service\DiscordNotificationService;


### PR DESCRIPTION
## Summary
WhatsApp voice/audio messages 404'd in the web chat because incoming media was stored on a path shape `StaticUploadController` couldn't resolve — this aligns the WhatsApp pipeline with the regular web upload pipeline so the existing `<audio>` player just works.

## Changes
- `WhatsAppService::handleMediaDownload`: persist downloaded WhatsApp media as a `File` entity attached to the `Message` (mirrors `MessageController::uploadFileForChat` / `StreamController`); transcripts now land on `File::fileText` instead of `Message::fileText`; `Message::file=1` kept for backward compatibility.
- `StaticUploadController`: new `resolveFileContext()` helper looks up assets by `Message::filePath` (both `/api/v1/files/uploads/...` prefixed AND raw relative — the latter keeps pre-fix WhatsApp messages working) and falls back to `File::filePath` (the standard web-upload path, also covers new WhatsApp media). Owner / public-share / expired-share gating preserved.
- New regression test `tests/Controller/StaticUploadControllerTest.php` (4 cases): File-entity-attached-to-message, legacy raw `Message::filePath`, anonymous private access (401), unknown path (404).
- Existing 88 `WhatsAppServiceTest` cases still green.

## Verification
- [ ] Not tested (explain)
- [ ] Manual
- [x] Tests added/updated

Quality gates run locally:
- `make -C backend lint` — 0 fixable
- `make -C backend phpstan` (level 5) — `No errors`
- `tests/Service/WhatsAppServiceTest.php` + `tests/Controller/StaticUploadControllerTest.php` — 92/92 OK
- Full backend suite green except the pre-existing `MailerTest` (needs `mailhog:1025` container — verified unrelated by re-running it on a clean `origin/main`).

Frontend untouched: PR #986 already shipped the `MessageAudio.vue` fallback. With this backend fix the audio request returns a real 200 instead of 404, so the fallback no longer fires.

## Notes
- Closes #976
- Builds on / supersedes the partial fix from #986 (which only handled the frontend crash, not the 404 root cause).
- Backward compatible: legacy WhatsApp messages already in production keep playing via the `Message::filePath`-raw branch in `resolveFileContext()`. No migration needed.

## Screenshots/Logs
_n/a — same `<audio>` UI, just no longer 404. Server-side log line `StaticUploadController: Access check` now reports `source: file_attached_to_message` for new WhatsApp uploads instead of bailing with `File not found in database`._