### PR TITLE
fix(memories): pin embedding model to memories collection so post-switch writes work

### DIFF
--- a/backend/src/Service/Embedding/EmbeddingReindexService.php
+++ b/backend/src/Service/Embedding/EmbeddingReindexService.php
@@ -7,6 +7,7 @@ namespace App\Service\Embedding;
 use App\AI\Service\AiFacade;
 use App\Entity\RevectorizeRun;
 use App\Repository\RevectorizeRunRepository;
+use App\Service\Memory\MemoryEmbeddingModelResolver;
 use App\Service\Message\SynapseIndexer;
 use App\Service\VectorSearch\QdrantClientInterface;
 use Doctrine\DBAL\Connection;
@@ -51,6 +52,7 @@ final readonly class EmbeddingReindexService
         private AiFacade $aiFacade,
         private SynapseIndexer $synapseIndexer,
         private EmbeddingMetadataService $embeddingMetadata,
+        private MemoryEmbeddingModelResolver $memoryEmbeddingResolver,
         private RevectorizeRunRepository $runRepository,
         private Connection $connection,
         private LoggerInterface $logger,
@@ -398,5 +400,15 @@ final readonly class EmbeddingReindexService
 
             $this->runRepository->save($run);
         }
+
+        // Migration complete — every memory point now lives in a
+        // collection sized for `$modelId`. Move the sticky pointer
+        // forward so subsequent writes (UserMemoryService::storeInQdrant)
+        // and reads (UserMemoryService::searchRelevantMemories) embed
+        // against the new model instead of the old one. Doing this
+        // ONLY here (and not on the VECTORIZE switch) is what keeps
+        // memories independently re-indexable without a destructive
+        // collection drop on every model swap.
+        $this->memoryEmbeddingResolver->rememberModel($modelId);
     }
 }

--- a/backend/src/Service/Memory/MemoryEmbeddingModelResolver.php
+++ b/backend/src/Service/Memory/MemoryEmbeddingModelResolver.php
@@ -1,0 +1,287 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Memory;
+
+use App\Repository\ConfigRepository;
+use App\Service\ModelConfigService;
+use App\Service\VectorSearch\QdrantClientInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * MemoryEmbeddingModelResolver — answers ONE question: "which embedding
+ * model owns the user-memories Qdrant collection right now?".
+ *
+ * Background (PR #985 follow-up):
+ *
+ *   The VECTORIZE default model can be swapped via the admin UI. For
+ *   documents/synapse that triggers a full re-index against the new
+ *   model. For *memories* it does NOT, because dropping the collection
+ *   would destroy user-curated long-term context (see #985). The
+ *   memories collection therefore keeps its original vector dimension
+ *   indefinitely.
+ *
+ *   That leaves an asymmetry: the active VECTORIZE model can produce
+ *   1536-dim vectors while the existing memories collection is 3072.
+ *   Without this resolver, both write paths (storeInQdrant) and read
+ *   paths (searchRelevantMemories) would embed against VECTORIZE and
+ *   then either get rejected by the dimension safety net or returned
+ *   results filtered to zero by the stale-hit filter — making it
+ *   impossible to save OR search memories after a switch.
+ *
+ * Resolution strategy (in priority order):
+ *
+ *   1. **Sticky pointer in BCONFIG** — `MEMORIES.EMBEDDING_MODEL_ID`
+ *      (owner=0, group=MEMORIES, setting=EMBEDDING_MODEL_ID).
+ *      Set by us the first time we embed a memory and updated by the
+ *      memories re-index pipeline when (and only when) the operator
+ *      explicitly migrates the collection.
+ *   2. **Payload inference** — if the sticky pointer is missing but
+ *      the collection already has points, copy the `embedding_model_id`
+ *      from the most recent payload and persist it. Covers upgrade
+ *      scenarios where the BCONFIG row was never written.
+ *   3. **Active VECTORIZE fallback** — fresh installs with an empty
+ *      memories collection. The resolver writes the BCONFIG pointer
+ *      so subsequent calls take path 1.
+ *
+ * After resolution the produced model's `vector_dim` is verified
+ * against the actual collection size from `getMemoriesCollectionInfo()`.
+ * If they mismatch (e.g. operator dropped the collection manually) the
+ * sticky pointer is cleared and the resolver re-runs — invalid sticky
+ * state can never lock the system out permanently.
+ */
+final class MemoryEmbeddingModelResolver
+{
+    public const CONFIG_GROUP = 'MEMORIES';
+    public const CONFIG_SETTING = 'EMBEDDING_MODEL_ID';
+
+    /** @var array{provider: ?string, model: ?string, model_id: ?int, vector_dim: ?int}|null */
+    private ?array $cached = null;
+
+    public function __construct(
+        private readonly ConfigRepository $configRepository,
+        private readonly ModelConfigService $modelConfigService,
+        private readonly QdrantClientInterface $qdrantClient,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * Resolve the model that the memories collection is currently
+     * indexed under. Returns null fields when nothing has ever been
+     * stored AND no VECTORIZE default is configured (a fresh install
+     * with embeddings disabled) — callers must tolerate that.
+     *
+     * @return array{provider: ?string, model: ?string, model_id: ?int, vector_dim: ?int}
+     */
+    public function resolve(): array
+    {
+        if (null !== $this->cached) {
+            return $this->cached;
+        }
+
+        $collectionDim = $this->getCollectionDimension();
+
+        $modelId = $this->readStickyPointer();
+        if (null !== $modelId) {
+            $info = $this->buildInfo($modelId);
+            if ($this->isCompatible($info, $collectionDim)) {
+                return $this->cached = $info;
+            }
+
+            // Sticky pointer disagrees with the collection (manual
+            // re-create, manual drop, dimension drift). Drop it so we
+            // re-derive from payloads or the active VECTORIZE default.
+            $this->logger->warning('MemoryEmbeddingModelResolver: stale sticky pointer, clearing', [
+                'sticky_model_id' => $modelId,
+                'sticky_dim' => $info['vector_dim'],
+                'collection_dim' => $collectionDim,
+            ]);
+            $this->clearStickyPointer();
+        }
+
+        $payloadModelId = $this->inferFromPayloads();
+        if (null !== $payloadModelId) {
+            $info = $this->buildInfo($payloadModelId);
+            if ($this->isCompatible($info, $collectionDim)) {
+                $this->writeStickyPointer($payloadModelId);
+                $this->logger->info('MemoryEmbeddingModelResolver: pinned memories model from payload', [
+                    'model_id' => $payloadModelId,
+                    'collection_dim' => $collectionDim,
+                ]);
+
+                return $this->cached = $info;
+            }
+        }
+
+        // No sticky pointer and no inferrable history → fall back to the
+        // currently active VECTORIZE model. This is the only branch that
+        // can legitimately stamp a brand-new collection.
+        $vectorizeId = $this->modelConfigService->getDefaultModel('VECTORIZE', null);
+        if (null !== $vectorizeId) {
+            $info = $this->buildInfo($vectorizeId);
+            if (null === $collectionDim || $this->isCompatible($info, $collectionDim)) {
+                $this->writeStickyPointer($vectorizeId);
+                $this->logger->info('MemoryEmbeddingModelResolver: pinned memories model from VECTORIZE', [
+                    'model_id' => $vectorizeId,
+                    'collection_dim' => $collectionDim,
+                ]);
+
+                return $this->cached = $info;
+            }
+        }
+
+        // Last resort: nothing matches. Surface the collection dim so
+        // callers can still log a precise dimension-mismatch error.
+        return $this->cached = [
+            'provider' => null,
+            'model' => null,
+            'model_id' => null,
+            'vector_dim' => $collectionDim,
+        ];
+    }
+
+    public function getModelId(): ?int
+    {
+        return $this->resolve()['model_id'];
+    }
+
+    public function getModelName(): ?string
+    {
+        return $this->resolve()['model'];
+    }
+
+    public function getProvider(): ?string
+    {
+        return $this->resolve()['provider'];
+    }
+
+    public function getVectorDim(): ?int
+    {
+        return $this->resolve()['vector_dim'];
+    }
+
+    /**
+     * Persist a new sticky pointer after a successful memories-collection
+     * recreate. Called by `EmbeddingReindexService::reindexMemories()`
+     * once every memory has been re-embedded under the new model — only
+     * then is it safe to migrate the pointer.
+     */
+    public function rememberModel(int $modelId): void
+    {
+        $this->writeStickyPointer($modelId);
+        $this->invalidate();
+    }
+
+    /**
+     * Drop the in-process cache. Call after a programmatic config
+     * change inside the same request so subsequent resolves see the
+     * new sticky pointer.
+     */
+    public function invalidate(): void
+    {
+        $this->cached = null;
+    }
+
+    /**
+     * @return array{provider: ?string, model: ?string, model_id: ?int, vector_dim: ?int}
+     */
+    private function buildInfo(int $modelId): array
+    {
+        return [
+            'provider' => $this->modelConfigService->getProviderForModel($modelId),
+            'model' => $this->modelConfigService->getModelName($modelId),
+            'model_id' => $modelId,
+            'vector_dim' => $this->modelConfigService->getVectorDimForModel($modelId),
+        ];
+    }
+
+    /**
+     * @param array{provider: ?string, model: ?string, model_id: ?int, vector_dim: ?int} $info
+     */
+    private function isCompatible(array $info, ?int $collectionDim): bool
+    {
+        if (null === $collectionDim) {
+            return true;
+        }
+        if (null === $info['vector_dim']) {
+            // Catalog row has no declared dimension — we cannot prove
+            // compatibility. Treating it as compatible here would let
+            // an upsert run anyway and trigger Qdrant's "wrong vector
+            // size" error at the safer storage layer. Reject instead.
+            return false;
+        }
+
+        return $info['vector_dim'] === $collectionDim;
+    }
+
+    private function readStickyPointer(): ?int
+    {
+        $raw = $this->configRepository->getValue(0, self::CONFIG_GROUP, self::CONFIG_SETTING);
+        if (null === $raw || '' === trim($raw)) {
+            return null;
+        }
+        $id = (int) $raw;
+
+        return $id > 0 ? $id : null;
+    }
+
+    private function writeStickyPointer(int $modelId): void
+    {
+        $this->configRepository->setValue(0, self::CONFIG_GROUP, self::CONFIG_SETTING, (string) $modelId);
+    }
+
+    private function clearStickyPointer(): void
+    {
+        $existing = $this->configRepository->findByOwnerGroupAndSetting(0, self::CONFIG_GROUP, self::CONFIG_SETTING);
+        if (null === $existing) {
+            return;
+        }
+        // Store an empty marker rather than physically deleting — keeps
+        // the row pinned at owner=0 for later re-use and matches how
+        // every other BCONFIG row signals "unset".
+        $this->configRepository->setValue(0, self::CONFIG_GROUP, self::CONFIG_SETTING, '');
+    }
+
+    private function getCollectionDimension(): ?int
+    {
+        try {
+            $info = $this->qdrantClient->getMemoriesCollectionInfo();
+        } catch (\Throwable $e) {
+            $this->logger->warning('MemoryEmbeddingModelResolver: failed to read collection info', [
+                'error' => $e->getMessage(),
+            ]);
+
+            return null;
+        }
+
+        return $info['vector_dim'] ?? null;
+    }
+
+    private function inferFromPayloads(): ?int
+    {
+        try {
+            $points = $this->qdrantClient->scrollAllMemoriesForReindex(50);
+        } catch (\Throwable $e) {
+            $this->logger->warning('MemoryEmbeddingModelResolver: scroll failed during inference', [
+                'error' => $e->getMessage(),
+            ]);
+
+            return null;
+        }
+
+        foreach ($points as $point) {
+            $payload = $point['payload'] ?? [];
+            $modelId = $payload['embedding_model_id'] ?? null;
+            if (is_int($modelId) && $modelId > 0) {
+                return $modelId;
+            }
+            if (is_string($modelId) && '' !== $modelId && ctype_digit($modelId)) {
+                return (int) $modelId;
+            }
+        }
+
+        return null;
+    }
+}

--- a/backend/src/Service/Message/Handler/ChatHandler.php
+++ b/backend/src/Service/Message/Handler/ChatHandler.php
@@ -108,6 +108,7 @@ final readonly class ChatHandler implements MessageHandlerInterface
         // memories + feedback corrections.
         $user = $this->em->getRepository(User::class)->find($message->getUserId());
         $resolveSharedVector = $this->createSharedVectorResolver($message, $perfTimer);
+        $resolveMemoryVector = $this->createMemoryVectorResolver($message, $resolveSharedVector, $perfTimer);
 
         $memoriesResult = $this->loadMemoriesContext(
             $message,
@@ -115,7 +116,7 @@ final readonly class ChatHandler implements MessageHandlerInterface
             $options,
             $classification,
             $progressCallback,
-            $resolveSharedVector,
+            $resolveMemoryVector,
             $perfTimer,
         );
         $memoriesContext = $memoriesResult['context'];
@@ -130,7 +131,7 @@ final readonly class ChatHandler implements MessageHandlerInterface
             $options,
             $classification,
             $progressCallback,
-            $resolveSharedVector,
+            $resolveMemoryVector,
             $perfTimer,
         );
         $feedbackContext = $feedbackResult['context'];
@@ -610,6 +611,7 @@ final readonly class ChatHandler implements MessageHandlerInterface
         // prompts (issue #615). User entity load is needed up-front for
         // both helpers and for the rate-limit clamp further down.
         $user = $this->em->getRepository(User::class)->find($message->getUserId());
+        $resolveMemoryVector = $this->createMemoryVectorResolver($message, $resolveSharedVector, $perfTimer);
 
         $memoriesResult = $this->loadMemoriesContext(
             $message,
@@ -617,7 +619,7 @@ final readonly class ChatHandler implements MessageHandlerInterface
             $options,
             $classification,
             $progressCallback,
-            $resolveSharedVector,
+            $resolveMemoryVector,
             $perfTimer,
         );
         $memoriesContext = $memoriesResult['context'];
@@ -632,7 +634,7 @@ final readonly class ChatHandler implements MessageHandlerInterface
             $options,
             $classification,
             $progressCallback,
-            $resolveSharedVector,
+            $resolveMemoryVector,
             $perfTimer,
         );
         $feedbackContext = $feedbackResult['context'];
@@ -1896,6 +1898,84 @@ final readonly class ChatHandler implements MessageHandlerInterface
     }
 
     /**
+     * Lazily produce the embedding used for Qdrant *memory* searches.
+     *
+     * The memories collection is pinned to its own embedding model
+     * (see {@see UserMemoryService::getMemoryEmbeddingModelId()}) which
+     * may diverge from the active VECTORIZE default — that's the
+     * whole point of PR #985 (no data loss on switch). Memory and
+     * feedback searches therefore need a separate vector cache: using
+     * the shared VECTORIZE vector would be rejected by Qdrant (wrong
+     * dimension) or returned as zero hits (stale-filter mismatch).
+     *
+     * Optimisation: when the memory-pinned model happens to equal the
+     * active VECTORIZE model (the typical case for fresh installs and
+     * for ops who haven't switched yet), this resolver reuses the
+     * already-computed shared vector instead of paying for a second
+     * embed call.
+     *
+     * @return \Closure(): ?array<int, float>
+     */
+    private function createMemoryVectorResolver(
+        Message $message,
+        \Closure $resolveSharedVector,
+        PerfTimer $perfTimer,
+    ): \Closure {
+        $memoryQueryVector = null;
+        $memoryVectorComputed = false;
+
+        return function () use (
+            $message,
+            $resolveSharedVector,
+            $perfTimer,
+            &$memoryQueryVector,
+            &$memoryVectorComputed,
+        ): ?array {
+            if ($memoryVectorComputed) {
+                return $memoryQueryVector;
+            }
+            $memoryVectorComputed = true;
+
+            $text = $message->getText();
+            if ('' === trim($text) || !$this->memoryService->isAvailable()) {
+                return null;
+            }
+
+            // Reuse the VECTORIZE-embedded vector when the memory model
+            // matches VECTORIZE. Keeps the existing 1-embed-per-message
+            // performance for the 99% of installations that never swap.
+            $stickyMemoryModelId = $this->memoryService->getMemoryEmbeddingModelId();
+            $vectorizeModelId = $this->modelConfigService->getDefaultModel('VECTORIZE', $message->getUserId());
+            if (null !== $stickyMemoryModelId && $stickyMemoryModelId === $vectorizeModelId) {
+                $shared = $resolveSharedVector();
+                if (null !== $shared) {
+                    return $memoryQueryVector = $shared;
+                }
+            }
+
+            // Memory model diverges from VECTORIZE (or shared vector
+            // is unavailable) — embed the query against the memory
+            // model directly so reads land in the right vector space.
+            $perfTimer->start('memory_embedding');
+            try {
+                $embed = $this->memoryService->embedQueryForMemorySearch($message->getUserId(), $text);
+            } catch (\Throwable $e) {
+                $this->logger->warning('ChatHandler: memory embed failed, falling back to per-call embeds', [
+                    'error' => $e->getMessage(),
+                ]);
+                $embed = null;
+            }
+            $perfTimer->stop('memory_embedding');
+
+            if (null !== $embed && !empty($embed['embedding'])) {
+                $memoryQueryVector = $embed['embedding'];
+            }
+
+            return $memoryQueryVector;
+        };
+    }
+
+    /**
      * Load relevant user memories from Qdrant and build the system-prompt
      * fragment that injects them into the AI context.
      *
@@ -1937,7 +2017,7 @@ final readonly class ChatHandler implements MessageHandlerInterface
         array $options,
         array $classification,
         ?callable $progressCallback,
-        \Closure $resolveSharedVector,
+        \Closure $resolveMemoryVector,
         PerfTimer $perfTimer,
     ): array {
         $disabledByRequest = !empty($options['disable_memories'])
@@ -1976,11 +2056,11 @@ final readonly class ChatHandler implements MessageHandlerInterface
                 ]);
 
                 $perfTimer->start('memories_search');
-                $sharedVector = $resolveSharedVector();
-                if (null !== $sharedVector) {
+                $memoryVector = $resolveMemoryVector();
+                if (null !== $memoryVector) {
                     $rawMemories = $this->memoryService->searchMemoriesByVector(
                         $message->getUserId(),
-                        $sharedVector,
+                        $memoryVector,
                         limit: $this->feedbackConfig->getMaxChatMemories(),
                         minScore: $this->feedbackConfig->getMinChatMemoryScore()
                     );
@@ -2081,7 +2161,7 @@ final readonly class ChatHandler implements MessageHandlerInterface
         array $options,
         array $classification,
         ?callable $progressCallback,
-        \Closure $resolveSharedVector,
+        \Closure $resolveMemoryVector,
         PerfTimer $perfTimer,
     ): array {
         $disabledByRequest = !empty($options['disable_memories'])
@@ -2102,13 +2182,13 @@ final readonly class ChatHandler implements MessageHandlerInterface
 
         try {
             $perfTimer->start('feedback');
-            $sharedVector = $resolveSharedVector();
+            $memoryVector = $resolveMemoryVector();
             $falsePositives = $this->searchFeedback(
                 $message->getUserId(),
                 $message->getText(),
                 'feedback_negative',
                 FeedbackConstants::NAMESPACE_FALSE_POSITIVE,
-                $sharedVector
+                $memoryVector
             );
 
             $positiveExamples = $this->searchFeedback(
@@ -2116,7 +2196,7 @@ final readonly class ChatHandler implements MessageHandlerInterface
                 $message->getText(),
                 'feedback_positive',
                 FeedbackConstants::NAMESPACE_POSITIVE,
-                $sharedVector
+                $memoryVector
             );
             $perfTimer->stop('feedback');
 

--- a/backend/src/Service/UserMemoryService.php
+++ b/backend/src/Service/UserMemoryService.php
@@ -9,6 +9,7 @@ use App\DTO\UserMemoryDTO;
 use App\Entity\User;
 use App\Service\Embedding\EmbeddingMetadataService;
 use App\Service\Exception\MemoryServiceUnavailableException;
+use App\Service\Memory\MemoryEmbeddingModelResolver;
 use App\Service\VectorSearch\QdrantClientInterface;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
@@ -37,8 +38,40 @@ final readonly class UserMemoryService
         private ModelConfigService $modelConfigService,
         private RateLimitService $rateLimitService,
         private EmbeddingMetadataService $embeddingMetadata,
+        private MemoryEmbeddingModelResolver $memoryEmbeddingResolver,
         private LoggerInterface $logger,
     ) {
+    }
+
+    /**
+     * Resolve the embedding model that owns the user-memories collection.
+     *
+     * Memories are intentionally pinned to their own embedding model,
+     * independent of the active VECTORIZE default. Why: a VECTORIZE
+     * switch with different dimensions does NOT migrate the memories
+     * collection (PR #985 — preventing accidental data loss), so write
+     * and read paths must keep using the model that created the
+     * collection, otherwise:
+     *   - storeInQdrant would emit a dimension mismatch and reject
+     *     every new memory ("can't save anything after a switch")
+     *   - searchMemories would query Qdrant with the wrong dim and
+     *     either error or return zero hits ("memories lookup broken")
+     *
+     * The resolver caches lazily and self-heals if the operator
+     * manually drops/recreates the collection.
+     *
+     * @return array{model_id: ?int, model_name: ?string, provider: ?string, vector_dim: ?int}
+     */
+    private function getMemoryEmbeddingConfig(): array
+    {
+        $info = $this->memoryEmbeddingResolver->resolve();
+
+        return [
+            'model_id' => $info['model_id'],
+            'model_name' => $info['model'],
+            'provider' => $info['provider'],
+            'vector_dim' => $info['vector_dim'],
+        ];
     }
 
     /**
@@ -486,11 +519,64 @@ final readonly class UserMemoryService
      */
     public function embedUserQuery(int $userId, string $queryText): ?array
     {
+        return $this->embedQueryInternal(
+            $userId,
+            $queryText,
+            $this->modelConfigService->getDefaultModel('VECTORIZE', $userId),
+            'CHAT_PIPELINE_SHARED',
+        );
+    }
+
+    /**
+     * Embed `$queryText` against the *memory-pinned* embedding model
+     * (sticky pointer, see {@see MemoryEmbeddingModelResolver}). Use
+     * this — NOT {@see embedUserQuery()} — whenever the resulting
+     * vector will be sent to Qdrant's memories collection: that
+     * collection's dimension is decoupled from VECTORIZE so an active-
+     * model query embedding would either be rejected or filtered out
+     * by the stale-hit guard.
+     *
+     * Returns null on the same conditions as `embedUserQuery()`
+     * (empty text, missing model, embed failure). Callers fall back to
+     * skipping the vector search rather than crashing.
+     *
+     * @return array{embedding: array<int, float>, model_id: ?int, model_name: ?string, provider: ?string}|null
+     */
+    public function embedQueryForMemorySearch(int $userId, string $queryText): ?array
+    {
+        return $this->embedQueryInternal(
+            $userId,
+            $queryText,
+            $this->memoryEmbeddingResolver->getModelId(),
+            'CHAT_PIPELINE_MEMORY',
+        );
+    }
+
+    /**
+     * Returns the model id currently pinned to the user-memories
+     * collection. Exposed publicly so callers in the request pipeline
+     * (ChatHandler) can decide whether they may reuse an existing
+     * VECTORIZE-embedded vector for memory search instead of paying
+     * for a second embed call.
+     */
+    public function getMemoryEmbeddingModelId(): ?int
+    {
+        return $this->memoryEmbeddingResolver->getModelId();
+    }
+
+    /**
+     * @return array{embedding: array<int, float>, model_id: ?int, model_name: ?string, provider: ?string}|null
+     */
+    private function embedQueryInternal(
+        int $userId,
+        string $queryText,
+        ?int $embeddingModelId,
+        string $usageSource,
+    ): ?array {
         if ('' === trim($queryText)) {
             return null;
         }
 
-        $embeddingModelId = $this->modelConfigService->getDefaultModel('VECTORIZE', $userId);
         $modelName = null;
         $provider = null;
 
@@ -508,8 +594,9 @@ final readonly class UserMemoryService
                 'provider' => $provider,
             ]));
         } catch (\Throwable $e) {
-            $this->logger->warning('embedUserQuery failed, falling back to no embedding', [
+            $this->logger->warning('embedQueryInternal failed, falling back to no embedding', [
                 'user_id' => $userId,
+                'source' => $usageSource,
                 'error' => $e->getMessage(),
             ]);
 
@@ -521,7 +608,6 @@ final readonly class UserMemoryService
             return null;
         }
 
-        // Record usage once for the shared embedding call.
         $user = $this->em->getRepository(User::class)->find($userId);
         if ($user) {
             $this->rateLimitService->recordUsage($user, 'EMBEDDINGS', [
@@ -530,7 +616,7 @@ final readonly class UserMemoryService
                 'model' => $modelName ?? 'unknown',
                 'model_id' => $embeddingModelId,
                 'input_text' => $queryText,
-                'source' => 'CHAT_PIPELINE_SHARED',
+                'source' => $usageSource,
             ]);
         }
 
@@ -573,7 +659,13 @@ final readonly class UserMemoryService
                 $namespace
             );
 
-            $filtered = $this->embeddingMetadata->filterStaleHits($results);
+            // Compare against the memory-pinned model id, not VECTORIZE.
+            // See `searchRelevantMemories()` for the full rationale.
+            $filtered = $this->embeddingMetadata->filterStaleHits(
+                $results,
+                'payload',
+                $this->memoryEmbeddingResolver->getModelId()
+            );
             $results = array_slice($filtered['fresh'], 0, $limit);
 
             $memories = [];
@@ -633,18 +725,13 @@ final readonly class UserMemoryService
                 'minScore' => $minScore,
             ]);
 
-            // Get embedding model (SAME as when storing!)
-            $embeddingModelId = $this->modelConfigService->getDefaultModel('VECTORIZE', $userId);
-            $modelName = null;
-            $provider = null;
-
-            if ($embeddingModelId) {
-                $model = $this->em->getRepository('App\Entity\Model')->find($embeddingModelId);
-                if ($model) {
-                    $modelName = $model->getProviderId();
-                    $provider = strtolower($model->getService());
-                }
-            }
+            // Resolve the memory-pinned embedding model (SAME as when
+            // storing — must match the dimension of the memories
+            // collection, not the active VECTORIZE default).
+            $memoryConfig = $this->getMemoryEmbeddingConfig();
+            $embeddingModelId = $memoryConfig['model_id'];
+            $modelName = $memoryConfig['model_name'];
+            $provider = $memoryConfig['provider'];
 
             $this->logger->info('🎯 Using embedding model for search', [
                 'userId' => $userId,
@@ -653,7 +740,6 @@ final readonly class UserMemoryService
                 'provider' => $provider,
             ]);
 
-            // Create embedding for query (with EXPLICIT model!)
             $embedResult = $this->aiFacade->embed($queryText, $userId, array_filter([
                 'model' => $modelName,
                 'provider' => $provider,
@@ -700,17 +786,26 @@ final readonly class UserMemoryService
             );
 
             // Filter out hits embedded with a different model than the
-            // currently active one. Cross-model cosine scores are
+            // memory-pinned one. Cross-model cosine scores are
             // physically meaningless — including them would silently
-            // corrupt the assistant's answers right after a model swap,
-            // until the user re-vectorizes their memories.
-            $filtered = $this->embeddingMetadata->filterStaleHits($results);
+            // corrupt the assistant's answers right after a model swap.
+            //
+            // Important: we compare against the *memory-pinned* model
+            // (sticky pointer), NOT VECTORIZE. After a VECTORIZE swap
+            // that left memories untouched, every memory still looks
+            // "fresh" relative to its own collection — using VECTORIZE
+            // here would mark them all stale and return zero hits.
+            $filtered = $this->embeddingMetadata->filterStaleHits(
+                $results,
+                'payload',
+                $embeddingModelId
+            );
             if ($filtered['stale_count'] > 0) {
                 $this->logger->info('🧪 Filtered stale memory hits', [
                     'userId' => $userId,
                     'stale_count' => $filtered['stale_count'],
                     'fresh_count' => count($filtered['fresh']),
-                    'current_model_id' => $this->embeddingMetadata->getCurrentModelId(),
+                    'memory_model_id' => $embeddingModelId,
                 ]);
             }
             $results = array_slice($filtered['fresh'], 0, $limit);
@@ -753,20 +848,21 @@ final readonly class UserMemoryService
         try {
             $textToEmbed = "{$dto->key}: {$dto->value}";
 
-            // Get embedding model
-            $embeddingModelId = $this->modelConfigService->getDefaultModel('VECTORIZE', $user->getId());
-            $modelName = null;
-            $provider = null;
+            // Resolve the *memory-pinned* embedding model — NOT the
+            // active VECTORIZE default. Why this distinction matters:
+            // PR #985 froze the memories collection across VECTORIZE
+            // switches to avoid data loss, so if we embedded with
+            // VECTORIZE here the resulting vector would have the wrong
+            // dimension and the safety net below would reject every
+            // new memory. The resolver returns the model that owns
+            // the current memories collection (sticky pointer in
+            // BCONFIG, payload inference, or VECTORIZE fallback for
+            // a brand-new install).
+            $memoryConfig = $this->getMemoryEmbeddingConfig();
+            $embeddingModelId = $memoryConfig['model_id'];
+            $modelName = $memoryConfig['model_name'];
+            $provider = $memoryConfig['provider'];
 
-            if ($embeddingModelId) {
-                $model = $this->em->getRepository('App\Entity\Model')->find($embeddingModelId);
-                if ($model) {
-                    $modelName = $model->getProviderId();
-                    $provider = strtolower($model->getService());
-                }
-            }
-
-            // Create embedding
             $embedResult = $this->aiFacade->embed($textToEmbed, $user->getId(), array_filter([
                 'model' => $modelName,
                 'provider' => $provider,

--- a/backend/tests/Service/UserMemoryServiceTest.php
+++ b/backend/tests/Service/UserMemoryServiceTest.php
@@ -8,6 +8,7 @@ use App\AI\Service\AiFacade;
 use App\Entity\User;
 use App\Service\Embedding\EmbeddingMetadataService;
 use App\Service\Exception\MemoryServiceUnavailableException;
+use App\Service\Memory\MemoryEmbeddingModelResolver;
 use App\Service\ModelConfigService;
 use App\Service\RateLimitService;
 use App\Service\UserMemoryService;
@@ -28,6 +29,7 @@ final class UserMemoryServiceTest extends TestCase
     private ModelConfigService&MockObject $modelConfigService;
     private RateLimitService&MockObject $rateLimitService;
     private EmbeddingMetadataService&MockObject $embeddingMetadata;
+    private MemoryEmbeddingModelResolver&MockObject $memoryEmbeddingResolver;
     private LoggerInterface&MockObject $logger;
     private UserMemoryService $service;
 
@@ -39,12 +41,25 @@ final class UserMemoryServiceTest extends TestCase
         $this->modelConfigService = $this->createMock(ModelConfigService::class);
         $this->rateLimitService = $this->createMock(RateLimitService::class);
         $this->embeddingMetadata = $this->createMock(EmbeddingMetadataService::class);
+        $this->memoryEmbeddingResolver = $this->createMock(MemoryEmbeddingModelResolver::class);
         $this->logger = $this->createMock(LoggerInterface::class);
 
         // Default: stale-filter pass-through so legacy tests behave as before.
         $this->embeddingMetadata->method('filterStaleHits')->willReturnCallback(
             static fn (array $hits) => ['fresh' => $hits, 'stale_count' => 0]
         );
+
+        // Default: resolver returns null model — the legacy tests don't
+        // care which model is used because they mock $aiFacade->embed()
+        // unconditionally. Specific tests below override this to assert
+        // the sticky-model behaviour.
+        $this->memoryEmbeddingResolver->method('resolve')->willReturn([
+            'provider' => null,
+            'model' => null,
+            'model_id' => null,
+            'vector_dim' => null,
+        ]);
+        $this->memoryEmbeddingResolver->method('getModelId')->willReturn(null);
 
         $this->service = new UserMemoryService(
             $this->em,
@@ -53,6 +68,7 @@ final class UserMemoryServiceTest extends TestCase
             $this->modelConfigService,
             $this->rateLimitService,
             $this->embeddingMetadata,
+            $this->memoryEmbeddingResolver,
             $this->logger
         );
     }
@@ -371,5 +387,93 @@ final class UserMemoryServiceTest extends TestCase
         $this->expectExceptionMessageMatches('/dimension mismatch/i');
 
         $this->service->createMemory($user, 'personal', 'city', 'Berlin');
+    }
+
+    /**
+     * Issue #985 follow-up: after a VECTORIZE swap that left the
+     * memories collection frozen, write paths must keep embedding
+     * against the *memory-pinned* (sticky) model — NOT the new
+     * VECTORIZE default. Without this distinction every new memory
+     * would either be rejected (dim mismatch with the still-old
+     * collection) or stored in a vector space that's incompatible
+     * with every existing point (useless for similarity search).
+     *
+     * The mock has VECTORIZE = 99 (1536-dim) but the sticky pointer
+     * is 42 (3072-dim, matching the collection). We must see embed()
+     * receive the STICKY model name, not VECTORIZE's.
+     */
+    public function testCreateMemoryEmbedsAgainstStickyMemoryModelNotVectorize(): void
+    {
+        // Override the per-class default to point at a real sticky model.
+        $resolver = $this->createMock(MemoryEmbeddingModelResolver::class);
+        $resolver->method('resolve')->willReturn([
+            'provider' => 'openai',
+            'model' => 'text-embedding-3-large',
+            'model_id' => 42,
+            'vector_dim' => 3072,
+        ]);
+        $resolver->method('getModelId')->willReturn(42);
+        $service = new UserMemoryService(
+            $this->em,
+            $this->qdrantClient,
+            $this->aiFacade,
+            $this->modelConfigService,
+            $this->rateLimitService,
+            $this->embeddingMetadata,
+            $resolver,
+            $this->logger,
+        );
+
+        $user = $this->createMock(User::class);
+        $user->method('getId')->willReturn(1);
+
+        $this->qdrantClient->method('isAvailable')->willReturn(true);
+        $this->qdrantClient->method('scrollMemories')->willReturn([]);
+        $this->qdrantClient->method('getMemoriesCollectionInfo')->willReturn([
+            'exists' => true,
+            'vector_dim' => 3072,
+            'points_count' => 10,
+            'distance' => 'Cosine',
+        ]);
+
+        // VECTORIZE points at a NARROWER model in BCONFIG (e.g. the
+        // operator just swapped to text-embedding-3-small) — the
+        // service must ignore it for memory writes.
+        $this->modelConfigService->method('getDefaultModel')->with('VECTORIZE')->willReturn(99);
+
+        // The crucial assertion: embed() is called with the sticky
+        // model's name, not the active VECTORIZE one. If the service
+        // ever falls back to VECTORIZE again, this expectation fails.
+        $this->aiFacade
+            ->expects($this->once())
+            ->method('embed')
+            ->with(
+                $this->anything(),
+                $this->anything(),
+                $this->callback(function (array $opts): bool {
+                    return ('text-embedding-3-large' === ($opts['model'] ?? null))
+                        && ('openai' === ($opts['provider'] ?? null));
+                })
+            )
+            ->willReturn([
+                'embedding' => array_fill(0, 3072, 0.1),
+                'usage' => ['total_tokens' => 4],
+            ]);
+
+        $upsertedPayload = null;
+        $this->qdrantClient
+            ->expects($this->once())
+            ->method('upsertMemory')
+            ->willReturnCallback(function (string $pointId, array $vector, array $payload) use (&$upsertedPayload): void {
+                $upsertedPayload = $payload;
+            });
+
+        $service->createMemory($user, 'personal', 'city', 'Berlin');
+
+        // The persisted payload must record the sticky model id so a
+        // later stale-filter pass keeps treating these as fresh.
+        $this->assertSame(42, $upsertedPayload['embedding_model_id']);
+        $this->assertSame(3072, $upsertedPayload['vector_dim']);
+        $this->assertSame('text-embedding-3-large', $upsertedPayload['embedding_model']);
     }
 }

--- a/backend/tests/Unit/ChatHandlerTest.php
+++ b/backend/tests/Unit/ChatHandlerTest.php
@@ -393,7 +393,14 @@ class ChatHandlerTest extends TestCase
         $this->em->method('getRepository')->with(User::class)->willReturn($userRepository);
 
         $this->userMemoryService->method('isAvailable')->willReturn(true);
+        // PR #985 follow-up: ChatHandler now embeds memory queries via
+        // `embedQueryForMemorySearch` (sticky memory model) instead of
+        // reusing the shared VECTORIZE embedding unconditionally. Mock
+        // both so the test stays valid whether or not the memory
+        // resolver decides to reuse the shared vector.
         $this->userMemoryService->method('embedUserQuery')->willReturn(['embedding' => [0.1, 0.2, 0.3]]);
+        $this->userMemoryService->method('embedQueryForMemorySearch')->willReturn(['embedding' => [0.1, 0.2, 0.3]]);
+        $this->userMemoryService->method('getMemoryEmbeddingModelId')->willReturn(10);
         $this->userMemoryService
             ->method('searchMemoriesByVector')
             ->willReturnCallback(function (int $userId, array $vec, ...$rest) {
@@ -536,9 +543,13 @@ class ChatHandlerTest extends TestCase
         $this->em->method('getRepository')->willReturn($userRepository);
 
         // If the disable flag is honoured we never reach Qdrant; if a
-        // future regression bypasses it, the mock's strict expectation
-        // below will fail the test.
+        // future regression bypasses it, the mock's strict expectations
+        // below will fail the test. Includes the memory-pinned embed
+        // path added in #985-followup so a future split that only
+        // disables the shared (RAG) branch can't accidentally re-enable
+        // memory reads.
         $this->userMemoryService->expects($this->never())->method('embedUserQuery');
+        $this->userMemoryService->expects($this->never())->method('embedQueryForMemorySearch');
         $this->userMemoryService->expects($this->never())->method('searchMemoriesByVector');
         $this->userMemoryService->expects($this->never())->method('searchRelevantMemories');
 

--- a/backend/tests/Unit/Embedding/EmbeddingReindexServiceTest.php
+++ b/backend/tests/Unit/Embedding/EmbeddingReindexServiceTest.php
@@ -9,6 +9,7 @@ use App\Entity\RevectorizeRun;
 use App\Repository\RevectorizeRunRepository;
 use App\Service\Embedding\EmbeddingMetadataService;
 use App\Service\Embedding\EmbeddingReindexService;
+use App\Service\Memory\MemoryEmbeddingModelResolver;
 use App\Service\Message\SynapseIndexer;
 use App\Service\VectorSearch\QdrantClientInterface;
 use Doctrine\DBAL\Connection;
@@ -31,6 +32,7 @@ final class EmbeddingReindexServiceTest extends TestCase
     private AiFacade&MockObject $aiFacade;
     private SynapseIndexer&MockObject $synapseIndexer;
     private EmbeddingMetadataService&MockObject $metadata;
+    private MemoryEmbeddingModelResolver&MockObject $memoryResolver;
     private RevectorizeRunRepository&MockObject $runRepository;
     private Connection&MockObject $connection;
     private EmbeddingReindexService $service;
@@ -41,6 +43,7 @@ final class EmbeddingReindexServiceTest extends TestCase
         $this->aiFacade = $this->createMock(AiFacade::class);
         $this->synapseIndexer = $this->createMock(SynapseIndexer::class);
         $this->metadata = $this->createMock(EmbeddingMetadataService::class);
+        $this->memoryResolver = $this->createMock(MemoryEmbeddingModelResolver::class);
         $this->runRepository = $this->createMock(RevectorizeRunRepository::class);
         $this->connection = $this->createMock(Connection::class);
 
@@ -49,6 +52,7 @@ final class EmbeddingReindexServiceTest extends TestCase
             $this->aiFacade,
             $this->synapseIndexer,
             $this->metadata,
+            $this->memoryResolver,
             $this->runRepository,
             $this->connection,
             new NullLogger(),
@@ -131,7 +135,39 @@ final class EmbeddingReindexServiceTest extends TestCase
             ->method('recreateMemoriesCollection')
             ->with(1536);
 
+        // After a successful memories re-index the sticky pointer must
+        // advance to the new model — otherwise UserMemoryService would
+        // keep embedding writes/reads against the OLD model and every
+        // freshly migrated point would immediately look stale.
+        $this->memoryResolver
+            ->expects($this->once())
+            ->method('rememberModel')
+            ->with(21);
+
         $run = $this->makeRun(RevectorizeRun::SCOPE_MEMORIES, fromId: 10, toId: 21);
+        $this->service->execute($run);
+    }
+
+    public function testMemoriesScopeDoesNotAdvanceStickyPointerOnAbort(): void
+    {
+        // Probe-dim mismatch aborts before any destructive work — the
+        // sticky pointer must stay on the OLD model so subsequent
+        // writes keep landing in the still-intact old collection.
+        $this->metadata->method('getCurrentModel')->willReturn([
+            'provider' => 'openai',
+            'model' => 'text-embedding-3-large',
+            'model_id' => 22,
+            'vector_dim' => 3072,
+        ]);
+        $this->aiFacade->method('embed')->willReturn([
+            'embedding' => array_fill(0, 1536, 0.01),
+        ]);
+
+        $this->memoryResolver->expects($this->never())->method('rememberModel');
+
+        $this->expectException(\RuntimeException::class);
+
+        $run = $this->makeRun(RevectorizeRun::SCOPE_MEMORIES, fromId: 10, toId: 22);
         $this->service->execute($run);
     }
 

--- a/backend/tests/Unit/Service/Memory/MemoryEmbeddingModelResolverTest.php
+++ b/backend/tests/Unit/Service/Memory/MemoryEmbeddingModelResolverTest.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\Memory;
+
+use App\Entity\Config;
+use App\Repository\ConfigRepository;
+use App\Service\Memory\MemoryEmbeddingModelResolver;
+use App\Service\ModelConfigService;
+use App\Service\VectorSearch\QdrantClientInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+/**
+ * Issue #985 follow-up: a VECTORIZE swap now leaves the memories
+ * collection untouched (to avoid data loss). That decouples the
+ * memory layer's embedding model from the active VECTORIZE default —
+ * the resolver under test is what finds the "still-correct-for-this-
+ * collection" model so writes/reads keep landing in the right vector
+ * space.
+ */
+final class MemoryEmbeddingModelResolverTest extends TestCase
+{
+    private ConfigRepository&MockObject $configRepository;
+    private ModelConfigService&MockObject $modelConfigService;
+    private QdrantClientInterface&MockObject $qdrantClient;
+    private MemoryEmbeddingModelResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $this->configRepository = $this->createMock(ConfigRepository::class);
+        $this->modelConfigService = $this->createMock(ModelConfigService::class);
+        $this->qdrantClient = $this->createMock(QdrantClientInterface::class);
+
+        $this->resolver = new MemoryEmbeddingModelResolver(
+            $this->configRepository,
+            $this->modelConfigService,
+            $this->qdrantClient,
+            new NullLogger(),
+        );
+    }
+
+    public function testReturnsStickyPointerWhenCompatibleWithCollection(): void
+    {
+        $this->configRepository
+            ->method('getValue')
+            ->with(0, 'MEMORIES', 'EMBEDDING_MODEL_ID')
+            ->willReturn('42');
+
+        $this->modelConfigService->method('getProviderForModel')->with(42)->willReturn('openai');
+        $this->modelConfigService->method('getModelName')->with(42)->willReturn('text-embedding-3-large');
+        $this->modelConfigService->method('getVectorDimForModel')->with(42)->willReturn(3072);
+
+        $this->qdrantClient->method('getMemoriesCollectionInfo')->willReturn([
+            'exists' => true,
+            'vector_dim' => 3072,
+            'points_count' => 5,
+            'distance' => 'Cosine',
+        ]);
+
+        // Sticky pointer is golden — no scroll or VECTORIZE fallback required.
+        $this->qdrantClient->expects($this->never())->method('scrollAllMemoriesForReindex');
+        $this->modelConfigService->expects($this->never())->method('getDefaultModel');
+
+        $info = $this->resolver->resolve();
+
+        $this->assertSame(42, $info['model_id']);
+        $this->assertSame('text-embedding-3-large', $info['model']);
+        $this->assertSame('openai', $info['provider']);
+        $this->assertSame(3072, $info['vector_dim']);
+    }
+
+    public function testStickyPointerIsClearedAndPayloadInferredOnDimensionDrift(): void
+    {
+        // Stored sticky says 22 → text-embedding-3-large (3072), but the
+        // collection is 1536 (e.g. ops dropped+recreated it manually
+        // under a different model). The resolver MUST notice the drift
+        // and fall back to payload inference instead of silently using
+        // a bogus model id for every subsequent embed call.
+        $this->configRepository
+            ->method('getValue')
+            ->with(0, 'MEMORIES', 'EMBEDDING_MODEL_ID')
+            ->willReturn('22');
+
+        $this->configRepository
+            ->method('findByOwnerGroupAndSetting')
+            ->with(0, 'MEMORIES', 'EMBEDDING_MODEL_ID')
+            ->willReturn(new Config());
+
+        // Sticky says 3072, collection actually 1536.
+        $this->modelConfigService
+            ->method('getProviderForModel')
+            ->willReturnMap([
+                [22, 'openai'],
+                [11, 'openai'],
+            ]);
+        $this->modelConfigService
+            ->method('getModelName')
+            ->willReturnMap([
+                [22, 'text-embedding-3-large'],
+                [11, 'text-embedding-3-small'],
+            ]);
+        $this->modelConfigService
+            ->method('getVectorDimForModel')
+            ->willReturnMap([
+                [22, 3072],
+                [11, 1536],
+            ]);
+
+        $this->qdrantClient->method('getMemoriesCollectionInfo')->willReturn([
+            'exists' => true,
+            'vector_dim' => 1536,
+            'points_count' => 4,
+            'distance' => 'Cosine',
+        ]);
+
+        $this->qdrantClient->method('scrollAllMemoriesForReindex')->willReturn([
+            ['id' => 'mem_1_42', 'payload' => ['embedding_model_id' => 11]],
+        ]);
+
+        // Old pointer cleared, new (inferred) pointer written. setValue
+        // is called twice: once with '' to clear, once with '11' to pin.
+        $writes = [];
+        $this->configRepository
+            ->method('setValue')
+            ->willReturnCallback(function ($ownerId, $group, $setting, $value) use (&$writes) {
+                $writes[] = [$ownerId, $group, $setting, $value];
+
+                return new Config();
+            });
+
+        $info = $this->resolver->resolve();
+
+        $this->assertSame(11, $info['model_id']);
+        $this->assertSame(1536, $info['vector_dim']);
+        $this->assertContains([0, 'MEMORIES', 'EMBEDDING_MODEL_ID', ''], $writes, 'stale sticky cleared');
+        $this->assertContains([0, 'MEMORIES', 'EMBEDDING_MODEL_ID', '11'], $writes, 'inferred model pinned');
+    }
+
+    public function testFallsBackToVectorizeWhenCollectionIsEmpty(): void
+    {
+        // No sticky pointer, no payloads, no collection (or empty
+        // collection) — this is the fresh-install case where the first
+        // memory write defines the model.
+        $this->configRepository->method('getValue')->willReturn(null);
+        $this->qdrantClient->method('getMemoriesCollectionInfo')->willReturn([
+            'exists' => false,
+            'vector_dim' => null,
+            'points_count' => null,
+            'distance' => null,
+        ]);
+        $this->qdrantClient->method('scrollAllMemoriesForReindex')->willReturn([]);
+
+        $this->modelConfigService->method('getDefaultModel')->with('VECTORIZE', null)->willReturn(7);
+        $this->modelConfigService->method('getProviderForModel')->with(7)->willReturn('ollama');
+        $this->modelConfigService->method('getModelName')->with(7)->willReturn('nomic-embed-text');
+        $this->modelConfigService->method('getVectorDimForModel')->with(7)->willReturn(768);
+
+        // VECTORIZE choice must be stamped as the new sticky.
+        $this->configRepository
+            ->expects($this->atLeastOnce())
+            ->method('setValue')
+            ->with(0, 'MEMORIES', 'EMBEDDING_MODEL_ID', '7');
+
+        $info = $this->resolver->resolve();
+
+        $this->assertSame(7, $info['model_id']);
+        $this->assertSame('nomic-embed-text', $info['model']);
+        $this->assertSame(768, $info['vector_dim']);
+    }
+
+    public function testRememberModelOverwritesStickyPointer(): void
+    {
+        // Used by EmbeddingReindexService after a successful memories
+        // re-index — the new model becomes authoritative.
+        $this->configRepository
+            ->expects($this->once())
+            ->method('setValue')
+            ->with(0, 'MEMORIES', 'EMBEDDING_MODEL_ID', '99');
+
+        $this->resolver->rememberModel(99);
+    }
+
+    public function testResolvesAreCachedInProcess(): void
+    {
+        // Cheapest correctness signal: two consecutive resolves must
+        // hit BCONFIG only once (the cache prevents N reads per request).
+        $this->configRepository
+            ->expects($this->once())
+            ->method('getValue')
+            ->willReturn('42');
+
+        $this->modelConfigService->method('getProviderForModel')->willReturn('openai');
+        $this->modelConfigService->method('getModelName')->willReturn('text-embedding-3-large');
+        $this->modelConfigService->method('getVectorDimForModel')->willReturn(3072);
+        $this->qdrantClient->method('getMemoriesCollectionInfo')->willReturn([
+            'exists' => true,
+            'vector_dim' => 3072,
+            'points_count' => 1,
+            'distance' => 'Cosine',
+        ]);
+
+        $first = $this->resolver->resolve();
+        $second = $this->resolver->resolve();
+
+        $this->assertSame($first, $second);
+    }
+}

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -1036,7 +1036,7 @@
       "tokens": "Tokens",
       "dimensions": "Vektor-Dim",
       "dimMismatch": "Die Vektor-Dimensionen ändern sich von {from} auf {to}. Alle bestehenden Vektoren werden neu erzeugt; alte Such-Scores sind erst nach Abschluss der Re-Vektorisierung wieder vergleichbar.",
-      "memoriesFrozen": "Nutzer-Erinnerungen werden bei diesem Wechsel NICHT migriert. Sie bleiben in der bisherigen Embedding-Dimension; neue Erinnerungen werden weiter mit dem aktiven Modell gespeichert. (Vorübergehend deaktiviert wegen #985.)",
+      "memoriesFrozen": "Nutzer-Erinnerungen bleiben an ihr eigenes Embedding-Modell gekoppelt und werden bei diesem Wechsel NICHT migriert. Neue Erinnerungen werden weiterhin korrekt gespeichert — sie verwenden das ursprüngliche Modell der Memories-Collection, damit die Dimensionen passen. Um bestehende Erinnerungen unter dem neuen Modell neu zu vektorisieren, ist ein dedizierter Memories-Reindex nötig (derzeit nur Admin).",
       "scopes": {
         "documents": "Dokumente (RAG)",
         "memories": "Nutzer-Erinnerungen",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -906,7 +906,7 @@
       "tokens": "tokens",
       "dimensions": "Vector dim",
       "dimMismatch": "Vector dimensions change from {from} to {to}. All existing vectors will be regenerated and old search scores are not comparable until the re-vectorize finishes.",
-      "memoriesFrozen": "User memories are NOT migrated by this switch. They stay in the previous embedding dimension; new memories continue to be stored with the active model. (Temporarily disabled — see #985.)",
+      "memoriesFrozen": "User memories stay on their own embedding model and are NOT migrated by this switch. New memories are still saved correctly — they keep using the memories collection's original model so dimensions match. To re-embed existing memories under the new model, run a dedicated memories re-index (currently admin-only).",
       "scopes": {
         "documents": "Documents (RAG)",
         "memories": "User Memories",


### PR DESCRIPTION
## Summary
Closes the gap left open by #988: after a VECTORIZE model switch with a different dimension, new memories couldn't be saved (dim mismatch) and existing ones couldn't be searched (stale-filter dropped everything). This PR decouples the memory layer's embedding model from VECTORIZE via a *sticky* pointer so memories keep working even when VECTORIZE moves to a different-dim model.

## Changes
- **New** `App\Service\Memory\MemoryEmbeddingModelResolver` — resolves the memory-pinned embedding model with three strategies:
  1. Stored sticky pointer (`BCONFIG owner=0 group=MEMORIES setting=EMBEDDING_MODEL_ID`)
  2. Inference from the most recent memory payload's `embedding_model_id`
  3. Fallback to the active VECTORIZE default (fresh install path)
  Self-heals if the operator manually drops/recreates the collection.
- **`UserMemoryService`** — `storeInQdrant()`, `searchRelevantMemories()` and `searchMemoriesByVector()` now embed/filter against the resolver, NOT against VECTORIZE. New public helper `embedQueryForMemorySearch()` for the chat pipeline.
- **`ChatHandler`** — gains a `createMemoryVectorResolver()` companion to the shared-vector resolver. When the memory model equals VECTORIZE (typical case) it reuses the shared vector (no perf regression); when they diverge it embeds separately so reads land in the right vector space.
- **`EmbeddingReindexService::reindexMemories()`** — advances the sticky pointer to the new model only after a successful re-index. The pointer stays put on probe-dim aborts so writes continue to land in the still-intact old collection.
- **i18n** — `EmbeddingSwitchModal` banner reworded: replaces the misleading *"new memories continue to be stored with the active model"* (technically false after a dim-changing switch) with an accurate *"memories stay on their own embedding model"*.

## Verification
- [x] Tests added/updated
- [x] Manual (PHPStan + lint + full backend suite + vue-tsc + vitest)

New tests:
- `MemoryEmbeddingModelResolverTest` — covers all four resolution branches plus the self-heal-on-drift path (5 tests).
- `UserMemoryServiceTest::testCreateMemoryEmbedsAgainstStickyMemoryModelNotVectorize` — pins the regression so any future caller that reaches for VECTORIZE again is rejected.
- `EmbeddingReindexServiceTest` — sticky pointer advances on success, stays put on abort.

Full pre-commit gate green:
- ``make -C backend lint`` — 0 fixes
- ``make -C backend phpstan`` — ``[OK] No errors``
- ``make -C backend test`` — 1659 tests, the only error is the pre-existing Mailhog DNS issue on the integration ``MailerTest``
- ``make -C frontend lint`` — clean
- ``npm run check:types`` (vue-tsc) — clean
- ``make -C frontend test`` — 549 / 549 green

## Notes
Refs #985. Built on top of `fix/embedding-switch-memory-data-loss` (#988) — base branch is set accordingly so this PR will collapse into #988 once that lands, or against ``main`` if #988 squashes first.

The architectural choice (sticky pointer in BCONFIG instead of e.g. a separate collection per model) keeps the migration scope tiny: no schema change, no Qdrant reshuffling. A future *explicit* memories re-index (still admin-only per the team consensus from issue #984) advances the pointer cleanly via `MemoryEmbeddingModelResolver::rememberModel()`.

## Screenshots/Logs
n/a — backend / pipeline change. The frontend banner i18n change is visible to admins on the embedding-switch modal but does not change layout.