### PR TITLE
feat(routing): retire granular alias topics by default + admin toggle

### DIFF
--- a/backend/src/Command/PromptSeedCommand.php
+++ b/backend/src/Command/PromptSeedCommand.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace App\Command;
 
-use App\Prompt\PromptCatalog;
-use Doctrine\DBAL\Connection;
+use App\Seed\PromptSeeder;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -19,7 +18,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 final class PromptSeedCommand extends Command
 {
     public function __construct(
-        private readonly Connection $connection,
+        private readonly PromptSeeder $promptSeeder,
     ) {
         parent::__construct();
     }
@@ -29,8 +28,10 @@ final class PromptSeedCommand extends Command
         $this->setHelp(
             "Upserts all built-in system prompts (ownerId=0) into the database.\n\n".
             "New prompts are inserted, existing ones are updated with the latest text.\n".
-            "User-created prompts (ownerId>0) are never touched.\n\n".
-            'This command is idempotent and safe to run on every container start.'
+            "User-created prompts (ownerId>0) are never touched. After the catalog\n".
+            "write, the granular-topics admin toggle is re-applied so BPROMPTS.BENABLED\n".
+            "stays in lock-step with the operator's choice across re-seeds.\n\n".
+            'Idempotent and safe to run on every container start.'
         );
     }
 
@@ -38,20 +39,13 @@ final class PromptSeedCommand extends Command
     {
         $io = new SymfonyStyle($input, $output);
 
-        $result = PromptCatalog::seed($this->connection);
-
-        foreach ($result['inserted'] as $topic) {
-            $io->writeln("  <info>Inserted</info> $topic");
-        }
-        foreach ($result['updated'] as $topic) {
-            $io->writeln("  <comment>Updated</comment> $topic");
-        }
+        $result = $this->promptSeeder->seed();
 
         $io->success(sprintf(
             'Seeded %d system prompts (%d inserted, %d updated).',
-            count($result['inserted']) + count($result['updated']),
-            count($result['inserted']),
-            count($result['updated']),
+            $result->inserted + $result->updated,
+            $result->inserted,
+            $result->updated,
         ));
 
         return Command::SUCCESS;

--- a/backend/src/Prompt/PromptCatalog.php
+++ b/backend/src/Prompt/PromptCatalog.php
@@ -66,12 +66,12 @@ class PromptCatalog
                 'topic' => 'general',
                 'language' => 'en',
                 'shortDescription' => 'Catch-all topic for everyday questions, smalltalk, advice, opinions and any request that does not fit a more specific topic. Used as a routing fallback when no granular topic matches.',
-                // Folded the granular `general-chat` keyword list in here
-                // when the granular topic was shipped DISABLED by default
-                // (this commit). When Synapse v2 is OFF (the default) the
-                // legacy AI sorter only sees `general` — these keywords
-                // keep Synapse v2 embedding recall strong if it ever gets
-                // enabled without flipping the granular topics back on.
+                // Keyword list intentionally broad: when the granular
+                // routing aliases are disabled (the default state), Synapse
+                // v2 embedding recall for chat / lifestyle / programming
+                // queries has to land here, so the canonical row carries
+                // the union of vocabulary that would otherwise be spread
+                // across `general-chat` and friends.
                 'keywords' => 'fallback, default, catch-all, allgemein, frage, question, chat, smalltalk, hello, hi, hallo, talk, conversation, opinion, advice, tip, lifestyle, travel, reise, health, gesundheit, recipe, rezept, recommendation, empfehlung, idea, idee, business, hobby, hobbies, plan, planning, planen, project, projekt, learning, lernen, study, school, university, student, code, coding, programming, programmieren, software, php, python, javascript, typescript, java, kotlin, swift, go, rust, ruby, sql, html, css, vue, react, angular, node, function, class, method, variable, error, fehler, exception, bug, debug, refactor, framework, library, api, rest, graphql, regex, algorithm, terminal, shell, bash, docker, kubernetes, fitness, gym, fitnessstudio, sport, food, essen, drink, getränk, shake, restaurant, shop, store, geschäft, idea for, möchte, will, want to',
                 'prompt' => self::generalPrompt(),
             ],
@@ -87,25 +87,20 @@ class PromptCatalog
             //  Granular routing topics (Synapse v2)
             // ──────────────────────────────────────────────
             //
-            // All five entries below are aliases of canonical legacy topics
+            // The five entries below are aliases of canonical legacy topics
             // (`general` for chat/coding, `mediamaker` for the *-generation
-            // family — see TopicAliasResolver::TOPIC_ALIASES). They exist so
-            // Synapse Routing v2's embedding tier can discriminate at a
-            // finer granularity; downstream handlers only ever see the
-            // canonical topic after TopicAliasResolver runs.
+            // family — see TopicAliasResolver::TOPIC_ALIASES). They give
+            // Synapse Routing v2's embedding tier a finer-grained taxonomy;
+            // downstream handlers only ever see the canonical topic after
+            // TopicAliasResolver runs.
             //
-            // They are SHIPPED DISABLED (BENABLED=0). The legacy AI sorter
-            // otherwise sees both the canonical and the granular row in its
-            // choice list and produces brittle near-duplicate picks (e.g.
-            // `general` vs `general-chat`). Admins who enable Synapse v2
-            // can flip them all back on via the
-            // `QDRANT_SEARCH.GRANULAR_TOPICS_ENABLED` BCONFIG toggle, which
-            // also flips BENABLED on these rows via GranularTopicsManager.
-            //
-            // The catalog entry is kept (not removed) so:
-            //   - existing installs flip BENABLED=0 on the next seed
-            //   - the SynapseIndexer drops orphan vectors from Qdrant
-            //   - re-enabling restores keywords/description, no manual SQL
+            // Shipped DISABLED (BENABLED=0) so the legacy AI sorter sees
+            // only canonical topics and is not asked to disambiguate
+            // alias-vs-canonical near-duplicates. Admins enable them as a
+            // group via the `QDRANT_SEARCH.GRANULAR_TOPICS_ENABLED` BCONFIG
+            // toggle; GranularTopicsManager keeps BENABLED in lock-step,
+            // and PromptSeeder re-applies the toggle after every seed so a
+            // re-run cannot clobber an admin-enabled state.
             [
                 'topic' => 'coding',
                 'language' => 'en',

--- a/backend/src/Prompt/PromptCatalog.php
+++ b/backend/src/Prompt/PromptCatalog.php
@@ -66,7 +66,13 @@ class PromptCatalog
                 'topic' => 'general',
                 'language' => 'en',
                 'shortDescription' => 'Catch-all topic for everyday questions, smalltalk, advice, opinions and any request that does not fit a more specific topic. Used as a routing fallback when no granular topic matches.',
-                'keywords' => 'fallback, default, catch-all, allgemein, frage, question',
+                // Folded the granular `general-chat` keyword list in here
+                // when the granular topic was shipped DISABLED by default
+                // (this commit). When Synapse v2 is OFF (the default) the
+                // legacy AI sorter only sees `general` — these keywords
+                // keep Synapse v2 embedding recall strong if it ever gets
+                // enabled without flipping the granular topics back on.
+                'keywords' => 'fallback, default, catch-all, allgemein, frage, question, chat, smalltalk, hello, hi, hallo, talk, conversation, opinion, advice, tip, lifestyle, travel, reise, health, gesundheit, recipe, rezept, recommendation, empfehlung, idea, idee, business, hobby, hobbies, plan, planning, planen, project, projekt, learning, lernen, study, school, university, student, code, coding, programming, programmieren, software, php, python, javascript, typescript, java, kotlin, swift, go, rust, ruby, sql, html, css, vue, react, angular, node, function, class, method, variable, error, fehler, exception, bug, debug, refactor, framework, library, api, rest, graphql, regex, algorithm, terminal, shell, bash, docker, kubernetes, fitness, gym, fitnessstudio, sport, food, essen, drink, getränk, shake, restaurant, shop, store, geschäft, idea for, möchte, will, want to',
                 'prompt' => self::generalPrompt(),
             ],
             [
@@ -80,13 +86,26 @@ class PromptCatalog
             // ──────────────────────────────────────────────
             //  Granular routing topics (Synapse v2)
             // ──────────────────────────────────────────────
-            // Retired (#878): the dedicated `coding` topic was retired
-            // because it overlapped too aggressively with everyday chat
-            // in the embedding space. Kept here as DISABLED so the seed
-            // run flips BENABLED=0 on existing installs and the indexer
-            // drops the orphan vector from Qdrant on its next pass.
-            // Removing the row from PromptCatalog entirely would NOT
-            // touch existing DBs.
+            //
+            // All five entries below are aliases of canonical legacy topics
+            // (`general` for chat/coding, `mediamaker` for the *-generation
+            // family — see TopicAliasResolver::TOPIC_ALIASES). They exist so
+            // Synapse Routing v2's embedding tier can discriminate at a
+            // finer granularity; downstream handlers only ever see the
+            // canonical topic after TopicAliasResolver runs.
+            //
+            // They are SHIPPED DISABLED (BENABLED=0). The legacy AI sorter
+            // otherwise sees both the canonical and the granular row in its
+            // choice list and produces brittle near-duplicate picks (e.g.
+            // `general` vs `general-chat`). Admins who enable Synapse v2
+            // can flip them all back on via the
+            // `QDRANT_SEARCH.GRANULAR_TOPICS_ENABLED` BCONFIG toggle, which
+            // also flips BENABLED on these rows via GranularTopicsManager.
+            //
+            // The catalog entry is kept (not removed) so:
+            //   - existing installs flip BENABLED=0 on the next seed
+            //   - the SynapseIndexer drops orphan vectors from Qdrant
+            //   - re-enabling restores keywords/description, no manual SQL
             [
                 'topic' => 'coding',
                 'language' => 'en',
@@ -107,6 +126,7 @@ class PromptCatalog
                 'shortDescription' => 'Catch-all conversational topic. Use this for casual conversation, smalltalk, opinions, advice, lifestyle, travel, health, recipes, recommendations, business ideas, planning, hobbies, learning questions, programming and technical questions, debugging help, code review, software architecture, frameworks, libraries, errors and stack traces, and any other question that should be answered with a written reply.',
                 'keywords' => 'chat, smalltalk, hello, hi, hallo, talk, conversation, opinion, advice, tip, lifestyle, travel, reise, health, gesundheit, recipe, rezept, recommendation, empfehlung, frage, question, idea, idee, business, hobby, hobbies, plan, planning, planen, project, projekt, learning, lernen, study, school, university, student, code, coding, programming, programmieren, software, php, python, javascript, typescript, java, kotlin, swift, go, rust, ruby, sql, html, css, vue, react, angular, node, function, class, method, variable, error, fehler, exception, bug, debug, refactor, framework, library, api, rest, graphql, regex, algorithm, terminal, shell, bash, docker, kubernetes, fitness, gym, fitnessstudio, sport, food, essen, drink, getränk, shake, restaurant, shop, store, geschäft, idea for, möchte, will, want to',
                 'prompt' => self::generalPrompt(),
+                'enabled' => false,
             ],
             [
                 'topic' => 'image-generation',
@@ -126,6 +146,7 @@ class PromptCatalog
                 // were dead weight (caught by Copilot review on PR #884).
                 'keywords' => 'create an image, create a picture, create a photo, create an illustration, generate an image, generate a picture, make a picture, make an image, draw me, paint a picture, render a photo, render an image, render a picture, retouch this image, edit this image, replace the background, combine these images, merge these images, image to image, illustrate this, erstelle ein bild, erstelle ein foto, erstelle eine illustration, generiere ein bild, generiere ein foto, mache ein bild, male ein bild, male mir, zeichne ein bild, zeichne mir, render ein bild, hintergrund ersetzen, bild bearbeiten, bilder kombinieren',
                 'prompt' => self::mediaMakerPrompt(),
+                'enabled' => false,
             ],
             [
                 'topic' => 'video-generation',
@@ -143,6 +164,7 @@ class PromptCatalog
                 // anyway (caught by Copilot review on PR #884).
                 'keywords' => 'create a video, create a clip, create an animation, generate a video, generate a clip, make a video, make a clip, make an animation, render a video, render an animation, animate this, animate the, produce a video, shoot a short video, erstelle ein video, erstelle einen clip, erstelle eine animation, generiere ein video, generiere einen clip, mache ein video, mach mir ein video, mache einen clip, animiere, animiere mir, render ein video, render einen clip, render mir ein video',
                 'prompt' => self::mediaMakerPrompt(),
+                'enabled' => false,
             ],
             [
                 'topic' => 'audio-generation',
@@ -153,6 +175,7 @@ class PromptCatalog
                 'shortDescription' => 'User explicitly asks for AUDIO output: text-to-speech, narration, voice synthesis, voiceover or any spoken-audio rendering of provided text. Trigger only when the message contains an explicit speech/audio creation verb (for example "read this aloud", "convert to speech", "create an audio of …", "generate a voiceover saying …", "narrate this text", "vertone …", "lies das vor", "sprich folgenden Text", "erstelle ein Audio mit …"). Do NOT trigger for general conversation that mentions audio, voice, sound, music or podcasts without an unambiguous TTS request.',
                 'keywords' => 'read aloud, read this aloud, read it aloud, convert to speech, text to speech, generate audio of, generate a voiceover, generate a narration, create an audio, create a voiceover, create a narration, narrate this, narrate the following, voiceover saying, voice over saying, speak this, say the following, lies vor, lies das vor, lies dies vor, sprich folgenden text, sprich folgendes, sprich diesen text, erstelle ein audio, erstelle eine vertonung, generiere ein audio, generiere eine vertonung, mache ein audio, vertone, vertone diesen text, vertone folgenden text, vertonen, audio generieren',
                 'prompt' => self::mediaMakerPrompt(),
+                'enabled' => false,
             ],
 
             // ──────────────────────────────────────────────

--- a/backend/src/Repository/PromptRepository.php
+++ b/backend/src/Repository/PromptRepository.php
@@ -36,6 +36,33 @@ class PromptRepository extends ServiceEntityRepository
     }
 
     /**
+     * Return EVERY prompt row matching a topic for a given owner, across
+     * all languages. Used by GranularTopicsManager to flip BENABLED on
+     * every variant of a topic in lock-step with the
+     * `QDRANT_SEARCH.GRANULAR_TOPICS_ENABLED` toggle.
+     *
+     * Differs from `findByTopic` (which returns the most recent single
+     * row): callers that need to mutate state must touch every row, not
+     * just the freshest, so per-language variants stay consistent.
+     *
+     * @return list<Prompt>
+     */
+    public function findAllByTopicAndOwner(string $topic, int $ownerId): array
+    {
+        /** @var list<Prompt> $rows */
+        $rows = $this->createQueryBuilder('p')
+            ->where('p.topic = :topic')
+            ->andWhere('p.ownerId = :ownerId')
+            ->setParameter('topic', $topic)
+            ->setParameter('ownerId', $ownerId)
+            ->orderBy('p.id', 'ASC')
+            ->getQuery()
+            ->getResult();
+
+        return $rows;
+    }
+
+    /**
      * Get all available topics for sorting
      * Includes both system (ownerId=0) AND user-specific prompts.
      *

--- a/backend/src/Seed/PromptSeeder.php
+++ b/backend/src/Seed/PromptSeeder.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Seed;
 
 use App\Prompt\PromptCatalog;
+use App\Repository\ConfigRepository;
+use App\Service\Message\GranularTopicsManager;
 use Doctrine\DBAL\Connection;
 
 /**
@@ -12,21 +14,46 @@ use Doctrine\DBAL\Connection;
  *
  * Wraps PromptCatalog::seed(), which itself uses INSERT/UPDATE on
  * (ownerId, topic, language). User-created prompts (ownerId>0) are never touched.
+ *
+ * After the catalog write, re-converges the BENABLED flag on the granular
+ * routing aliases to whatever the admin chose via the
+ * `GRANULAR_TOPICS_ENABLED` BCONFIG toggle. Without this step, every
+ * `app:seed` run (deploy, container restart, manual re-seed) would
+ * silently overwrite an admin-enabled toggle's effect on BPROMPTS while
+ * leaving the BCONFIG row alone, producing a split-brain state where the
+ * admin UI shows ON but the prompt rows are disabled.
  */
 final readonly class PromptSeeder
 {
-    public function __construct(private Connection $connection)
-    {
+    public function __construct(
+        private Connection $connection,
+        private ConfigRepository $configRepository,
+        private GranularTopicsManager $granularTopicsManager,
+    ) {
     }
 
     public function seed(): SeedResult
     {
         $result = PromptCatalog::seed($this->connection);
 
+        $this->convergeGranularToggleState();
+
         return new SeedResult(
             'prompts',
             inserted: count($result['inserted']),
             updated: count($result['updated']),
         );
+    }
+
+    /**
+     * Re-apply the admin toggle state so BPROMPTS.BENABLED matches BCONFIG
+     * after the catalog seed. The manager is idempotent — when the rows
+     * already match (the common case on a fresh install with the toggle
+     * absent), this is a no-op.
+     */
+    private function convergeGranularToggleState(): void
+    {
+        $enabled = GranularTopicsManager::resolveToggleState($this->configRepository);
+        $this->granularTopicsManager->applyState($enabled);
     }
 }

--- a/backend/src/Service/Admin/SystemConfigService.php
+++ b/backend/src/Service/Admin/SystemConfigService.php
@@ -7,7 +7,6 @@ namespace App\Service\Admin;
 use App\Repository\ConfigRepository;
 use App\Service\FeedbackConstants;
 use App\Service\Message\GranularTopicsManager;
-use App\Service\Message\MessageSorter;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -30,8 +29,8 @@ final readonly class SystemConfigService
         private readonly string $projectDir,
         private readonly LoggerInterface $logger,
         private readonly ConfigRepository $configRepository,
+        private readonly string $defaultTtsUrl,
         private readonly GranularTopicsManager $granularTopicsManager,
-        private readonly string $defaultTtsUrl = 'http://localhost:10200',
     ) {
         $this->schema = $this->buildSchema();
     }
@@ -249,42 +248,50 @@ final readonly class SystemConfigService
             $this->configRepository->setValue(self::DB_OWNER_ID, self::DB_GROUP, $key, $value);
             $this->logChange($key, $value);
 
-            // Side-effect: when the granular-topics master switch is toggled,
-            // also flip BENABLED on the matching catalog rows so the AI sort
-            // pool and the Synapse indexer agree with the new state from the
-            // very next request. The manager is idempotent and only writes
-            // rows whose state actually changes.
-            if (MessageSorter::GRANULAR_TOPICS_CONFIG_KEY === $key) {
-                $enabled = (bool) (filter_var($value, FILTER_VALIDATE_BOOL, FILTER_NULL_ON_FAILURE) ?? false);
-                try {
-                    $report = $this->granularTopicsManager->applyState($enabled);
-                    $this->logger->info('SystemConfigService: granular routing topics toggled', [
-                        'enabled' => $enabled,
-                        'flipped' => $report['flipped'],
-                        'unchanged' => $report['unchanged'],
-                        'missing' => $report['missing'],
-                    ]);
-                } catch (\Throwable $sideEffect) {
-                    // The BCONFIG write itself succeeded — the prompt-state
-                    // sync failing is a soft error we surface in the log so
-                    // the operator can re-run `app:seed` to converge. We do
-                    // NOT roll back the config write, because the next read
-                    // of MessageSorter::granularTopicsEnabled() will already
-                    // reflect the new flag and the AI-sort filter is the
-                    // primary gate; BENABLED is belt-and-suspenders.
-                    $this->logger->error('SystemConfigService: granular topics state sync failed', [
-                        'key' => $key,
-                        'value' => $value,
-                        'error' => $sideEffect->getMessage(),
-                    ]);
-                }
-            }
+            $this->applyConfigSideEffects(self::DB_GROUP, $key, $value);
 
             return ['success' => true, 'requiresRestart' => false];
         } catch (\Throwable $e) {
             $this->logger->error('Failed to save DB config', ['key' => $key, 'error' => $e->getMessage()]);
 
             return ['success' => false, 'requiresRestart' => false, 'message' => 'Database write failed'];
+        }
+    }
+
+    /**
+     * Side-effects triggered by specific BCONFIG writes.
+     *
+     * Kept as an explicit, narrow dispatch table rather than an event
+     * subscriber: there is exactly one cross-module hook today
+     * (`GRANULAR_TOPICS_ENABLED` → flip BPROMPTS.BENABLED), and a full
+     * event/listener layer would add framework surface area without
+     * earning its keep. Add new entries here only when a config write
+     * has to mutate state outside BCONFIG.
+     *
+     * Failures are logged and swallowed: the primary BCONFIG write has
+     * already succeeded, and downstream readers will pick up the new
+     * value on their next request. Re-running `app:seed` converges any
+     * BPROMPTS state that the manager failed to flip.
+     */
+    private function applyConfigSideEffects(string $group, string $key, string $value): void
+    {
+        if (GranularTopicsManager::CONFIG_GROUP === $group && GranularTopicsManager::CONFIG_KEY === $key) {
+            $enabled = filter_var($value, FILTER_VALIDATE_BOOL, FILTER_NULL_ON_FAILURE) ?? false;
+            try {
+                $report = $this->granularTopicsManager->applyState($enabled);
+                $this->logger->info('SystemConfigService: granular routing topics toggled', [
+                    'enabled' => $enabled,
+                    'flipped' => $report['flipped'],
+                    'unchanged' => $report['unchanged'],
+                    'missing' => $report['missing'],
+                ]);
+            } catch (\Throwable $sideEffect) {
+                $this->logger->error('SystemConfigService: granular topics state sync failed', [
+                    'key' => $key,
+                    'value' => $value,
+                    'error' => $sideEffect->getMessage(),
+                ]);
+            }
         }
     }
 

--- a/backend/src/Service/Admin/SystemConfigService.php
+++ b/backend/src/Service/Admin/SystemConfigService.php
@@ -6,6 +6,8 @@ namespace App\Service\Admin;
 
 use App\Repository\ConfigRepository;
 use App\Service\FeedbackConstants;
+use App\Service\Message\GranularTopicsManager;
+use App\Service\Message\MessageSorter;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -28,6 +30,7 @@ final readonly class SystemConfigService
         private readonly string $projectDir,
         private readonly LoggerInterface $logger,
         private readonly ConfigRepository $configRepository,
+        private readonly GranularTopicsManager $granularTopicsManager,
         private readonly string $defaultTtsUrl = 'http://localhost:10200',
     ) {
         $this->schema = $this->buildSchema();
@@ -87,6 +90,7 @@ final readonly class SystemConfigService
                     'qdrant' => ['label' => 'Qdrant', 'fields' => ['QDRANT_URL']],
                     'synapse' => ['label' => 'Synapse Routing', 'fields' => [
                         'SYNAPSE_ROUTING_ENABLED', 'SYNAPSE_CONFIDENCE_THRESHOLD',
+                        'GRANULAR_TOPICS_ENABLED',
                     ]],
                     'qdrant_search' => ['label' => 'Search Thresholds', 'fields' => [
                         'MIN_CHAT_FEEDBACK_SCORE', 'MIN_CHAT_MEMORY_SCORE', 'MIN_CONTRADICTION_SCORE',
@@ -244,6 +248,37 @@ final readonly class SystemConfigService
         try {
             $this->configRepository->setValue(self::DB_OWNER_ID, self::DB_GROUP, $key, $value);
             $this->logChange($key, $value);
+
+            // Side-effect: when the granular-topics master switch is toggled,
+            // also flip BENABLED on the matching catalog rows so the AI sort
+            // pool and the Synapse indexer agree with the new state from the
+            // very next request. The manager is idempotent and only writes
+            // rows whose state actually changes.
+            if (MessageSorter::GRANULAR_TOPICS_CONFIG_KEY === $key) {
+                $enabled = (bool) (filter_var($value, FILTER_VALIDATE_BOOL, FILTER_NULL_ON_FAILURE) ?? false);
+                try {
+                    $report = $this->granularTopicsManager->applyState($enabled);
+                    $this->logger->info('SystemConfigService: granular routing topics toggled', [
+                        'enabled' => $enabled,
+                        'flipped' => $report['flipped'],
+                        'unchanged' => $report['unchanged'],
+                        'missing' => $report['missing'],
+                    ]);
+                } catch (\Throwable $sideEffect) {
+                    // The BCONFIG write itself succeeded — the prompt-state
+                    // sync failing is a soft error we surface in the log so
+                    // the operator can re-run `app:seed` to converge. We do
+                    // NOT roll back the config write, because the next read
+                    // of MessageSorter::granularTopicsEnabled() will already
+                    // reflect the new flag and the AI-sort filter is the
+                    // primary gate; BENABLED is belt-and-suspenders.
+                    $this->logger->error('SystemConfigService: granular topics state sync failed', [
+                        'key' => $key,
+                        'value' => $value,
+                        'error' => $sideEffect->getMessage(),
+                    ]);
+                }
+            }
 
             return ['success' => true, 'requiresRestart' => false];
         } catch (\Throwable $e) {
@@ -820,6 +855,20 @@ final readonly class SystemConfigService
                 'tab' => 'vectordb', 'section' => 'synapse', 'type' => 'number',
                 'sensitive' => false, 'description' => 'Min cosine similarity score for Synapse to route directly (0.0–1.0). Below this threshold, the system falls back to AI-based sorting. Default: 0.78',
                 'default' => '0.78',
+                'source' => 'database',
+            ],
+            // Granular routing aliases (general-chat, coding, image-generation,
+            // video-generation, audio-generation) are aliases of the canonical
+            // legacy topics (`general`, `mediamaker`) — see TopicAliasResolver.
+            // They exist so Synapse Routing v2's embedding tier can discriminate
+            // more finely; the legacy AI sorter sees them as near-duplicate
+            // routing targets and produces brittle picks. Ships OFF; flipping
+            // this toggle also flips BENABLED on the matching BPROMPTS rows
+            // (see GranularTopicsManager + SystemConfigService::setDatabaseValue).
+            'GRANULAR_TOPICS_ENABLED' => [
+                'tab' => 'vectordb', 'section' => 'synapse', 'type' => 'boolean',
+                'sensitive' => false, 'description' => 'Include granular routing topics (general-chat, coding, image-generation, video-generation, audio-generation) in the routing pool. OFF (default) keeps only canonical topics (general, mediamaker) — cleaner choice list for the legacy AI sorter. Turn ON when Synapse Routing v2 is enabled so its embedding tier can discriminate finer-grained intents. Toggling automatically flips BENABLED on the corresponding BPROMPTS rows.',
+                'default' => 'false',
                 'source' => 'database',
             ],
             // === Search Thresholds (database-backed, no restart required) ===

--- a/backend/src/Service/Message/GranularTopicsManager.php
+++ b/backend/src/Service/Message/GranularTopicsManager.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Service\Message;
 
+use App\Repository\ConfigRepository;
 use App\Repository\PromptRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
@@ -32,12 +33,37 @@ use Psr\Log\LoggerInterface;
  */
 final readonly class GranularTopicsManager
 {
+    /**
+     * BCONFIG coordinates of the admin toggle that controls the granular
+     * routing aliases. Owned here (not on MessageSorter or
+     * SystemConfigService) because the manager is the conceptual home of
+     * the granular-topic state — every reader and writer in the codebase
+     * should refer to these constants instead of inlining the strings.
+     */
+    public const CONFIG_GROUP = 'QDRANT_SEARCH';
+    public const CONFIG_KEY = 'GRANULAR_TOPICS_ENABLED';
+
     public function __construct(
         private TopicAliasResolver $topicAliasResolver,
         private PromptRepository $promptRepository,
         private EntityManagerInterface $entityManager,
         private LoggerInterface $logger,
     ) {
+    }
+
+    /**
+     * Resolve the current admin intent from BCONFIG using the same truthy
+     * parser as `MessageClassifier::isSynapseEnabled()`. Absent row → false.
+     */
+    public static function resolveToggleState(ConfigRepository $configRepository): bool
+    {
+        $raw = $configRepository->getValue(0, self::CONFIG_GROUP, self::CONFIG_KEY);
+
+        if (null === $raw) {
+            return false;
+        }
+
+        return filter_var($raw, \FILTER_VALIDATE_BOOL, \FILTER_NULL_ON_FAILURE) ?? false;
     }
 
     /**

--- a/backend/src/Service/Message/GranularTopicsManager.php
+++ b/backend/src/Service/Message/GranularTopicsManager.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Message;
+
+use App\Repository\PromptRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Manages the BENABLED flag on the granular routing topics that are
+ * aliases of canonical legacy topics (see TopicAliasResolver::TOPIC_ALIASES,
+ * e.g. `general-chat` → `general`, `image-generation` → `mediamaker`).
+ *
+ * Why this exists:
+ *   - The granular topics only make sense when Synapse Routing v2 (embedding
+ *     tier) is in use; the legacy AI sorter sees them as near-duplicates of
+ *     the canonical topics and produces brittle picks (e.g. "general" vs
+ *     "general-chat"). The system therefore ships with granular topics
+ *     DISABLED in PromptCatalog so the AI sorter only sees canonical names.
+ *   - When an admin enables Synapse v2 (or wants the granular taxonomy
+ *     for any other reason) they flip the `QDRANT_SEARCH.GRANULAR_TOPICS_ENABLED`
+ *     BCONFIG row via the admin UI; `SystemConfigService::setValue()` then
+ *     calls into here to flip the matching BPROMPTS rows in lock-step.
+ *
+ * The operation is idempotent: rows already in the target state are skipped,
+ * so calling `applyState(false)` twice in a row only writes on the first
+ * call. Owner-scoped to BOWNERID=0 because the catalog only seeds system
+ * defaults; user-created prompts that happen to share a granular topic name
+ * are left untouched.
+ */
+final readonly class GranularTopicsManager
+{
+    public function __construct(
+        private TopicAliasResolver $topicAliasResolver,
+        private PromptRepository $promptRepository,
+        private EntityManagerInterface $entityManager,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * Set BENABLED to the requested state on every system-owned
+     * (BOWNERID = 0) prompt whose topic is a known granular alias.
+     *
+     * Returns the list of topics that were actually flipped and the
+     * list that were already in the target state — useful for admin
+     * UI confirmation messages and for tests.
+     *
+     * @return array{flipped: list<string>, unchanged: list<string>, missing: list<string>}
+     */
+    public function applyState(bool $enabled): array
+    {
+        $aliasTopics = array_keys($this->topicAliasResolver->getAliasMap());
+
+        $flipped = [];
+        $unchanged = [];
+        $missing = [];
+
+        foreach ($aliasTopics as $topic) {
+            $prompts = $this->promptRepository->findAllByTopicAndOwner($topic, 0);
+
+            if ([] === $prompts) {
+                // Catalog row not seeded yet (fresh install before app:seed)
+                // — nothing to flip. Not an error; the next seed will create
+                // the row with the catalog's own enabled flag.
+                $missing[] = $topic;
+                continue;
+            }
+
+            $anyChanged = false;
+            foreach ($prompts as $prompt) {
+                if ($prompt->isEnabled() === $enabled) {
+                    continue;
+                }
+                $prompt->setEnabled($enabled);
+                $this->entityManager->persist($prompt);
+                $anyChanged = true;
+            }
+
+            if ($anyChanged) {
+                $flipped[] = $topic;
+            } else {
+                $unchanged[] = $topic;
+            }
+        }
+
+        if ([] !== $flipped) {
+            $this->entityManager->flush();
+        }
+
+        $this->logger->info('GranularTopicsManager: applied state', [
+            'enabled' => $enabled,
+            'flipped' => $flipped,
+            'unchanged' => $unchanged,
+            'missing' => $missing,
+        ]);
+
+        return [
+            'flipped' => $flipped,
+            'unchanged' => $unchanged,
+            'missing' => $missing,
+        ];
+    }
+}

--- a/backend/src/Service/Message/MessageSorter.php
+++ b/backend/src/Service/Message/MessageSorter.php
@@ -4,6 +4,7 @@ namespace App\Service\Message;
 
 use App\AI\Service\AiFacade;
 use App\Entity\User;
+use App\Repository\ConfigRepository;
 use App\Repository\PromptRepository;
 use App\Service\DiscordNotificationService;
 use App\Service\ModelConfigService;
@@ -68,6 +69,19 @@ final readonly class MessageSorter
         '2k' => '1080p',
     ];
 
+    /**
+     * BCONFIG key that controls whether the granular routing aliases
+     * (`general-chat`, `coding`, `image-generation`, `video-generation`,
+     * `audio-generation`) participate in the AI sorter's choice list.
+     *
+     * Stored at (BOWNERID=0, BGROUP=QDRANT_SEARCH). Mirrors the existing
+     * SYNAPSE_ROUTING_ENABLED toggle so admins can find both flags in the
+     * same Routing Configuration screen. Default OFF, matching the
+     * canonical-only experience the AI sort prompt is designed for.
+     */
+    public const GRANULAR_TOPICS_CONFIG_GROUP = 'QDRANT_SEARCH';
+    public const GRANULAR_TOPICS_CONFIG_KEY = 'GRANULAR_TOPICS_ENABLED';
+
     public function __construct(
         private AiFacade $aiFacade,
         private PromptRepository $promptRepository,
@@ -77,6 +91,8 @@ final readonly class MessageSorter
         private EntityManagerInterface $em,
         private LoggerInterface $logger,
         private DiscordNotificationService $discord,
+        private TopicAliasResolver $topicAliasResolver,
+        private ConfigRepository $configRepository,
     ) {
     }
 
@@ -144,11 +160,7 @@ final readonly class MessageSorter
         // Get all available topics (exclude tools:* internal topics)
         // Include user-specific prompts if userId is provided
         // Load prompts for ALL supported languages to ensure user prompts are included
-        $topics = $this->promptRepository->getAllTopics(0, $userId, excludeTools: true);
-
-        // Get topics with descriptions - all prompts included regardless of language
-        // so the sorter knows every available routing target
-        $topicsWithDesc = $this->promptRepository->getTopicsWithDescriptions(0, '', $userId, excludeTools: true);
+        [$topics, $topicsWithDesc] = $this->buildTopicPool($userId);
 
         // Build dynamic list and key list for prompt
         $dynamicList = $this->buildDynamicList($topicsWithDesc);
@@ -350,6 +362,67 @@ final readonly class MessageSorter
         }
 
         return null;
+    }
+
+    /**
+     * Build the AI sorter's choice list: the list of routable topic keys
+     * and the parallel list of `{ topic, description }` rows that get
+     * injected into the [KEYLIST] / [DYNAMICLIST] placeholders.
+     *
+     * Granular routing aliases (e.g. `general-chat`, `image-generation`)
+     * are filtered out when `QDRANT_SEARCH.GRANULAR_TOPICS_ENABLED` is
+     * false. They are aliases of canonical legacy topics (see
+     * TopicAliasResolver::TOPIC_ALIASES) and only exist to give Synapse
+     * Routing v2's embedding tier a finer-grained taxonomy; showing them
+     * to the LLM sorter creates near-duplicate routing targets ("general"
+     * vs "general-chat") and produces brittle, model-dependent picks.
+     *
+     * This filter is belt-and-suspenders next to the PromptCatalog ship-
+     * disabled defaults — even if an operator (or a stale seed) enabled
+     * a granular row in BPROMPTS while the toggle stays OFF, the AI sort
+     * pool stays clean.
+     *
+     * @return array{0: list<string>, 1: list<array{topic: string, description: string, ownerId: int}>}
+     */
+    private function buildTopicPool(?int $userId): array
+    {
+        $topics = $this->promptRepository->getAllTopics(0, $userId, excludeTools: true);
+        $topicsWithDesc = $this->promptRepository->getTopicsWithDescriptions(0, '', $userId, excludeTools: true);
+
+        if ($this->granularTopicsEnabled()) {
+            return [array_values($topics), array_values($topicsWithDesc)];
+        }
+
+        $resolver = $this->topicAliasResolver;
+        $topics = array_values(array_filter(
+            $topics,
+            static fn (string $topic): bool => !$resolver->isAlias($topic),
+        ));
+        $topicsWithDesc = array_values(array_filter(
+            $topicsWithDesc,
+            static fn (array $row): bool => !$resolver->isAlias((string) $row['topic']),
+        ));
+
+        return [$topics, $topicsWithDesc];
+    }
+
+    /**
+     * Whether granular routing aliases should be visible to the AI sorter.
+     *
+     * Default OFF — matches the catalog ship state and the post-hot-fix
+     * production behaviour. Admins flip this via the Routing Configuration
+     * UI; the SystemConfigService write hook also flips BENABLED on the
+     * matching BPROMPTS rows via GranularTopicsManager.
+     */
+    private function granularTopicsEnabled(): bool
+    {
+        $value = $this->configRepository->getValue(0, self::GRANULAR_TOPICS_CONFIG_GROUP, self::GRANULAR_TOPICS_CONFIG_KEY);
+
+        if (null === $value) {
+            return false;
+        }
+
+        return filter_var($value, \FILTER_VALIDATE_BOOL, \FILTER_NULL_ON_FAILURE) ?? false;
     }
 
     /**

--- a/backend/src/Service/Message/MessageSorter.php
+++ b/backend/src/Service/Message/MessageSorter.php
@@ -4,7 +4,6 @@ namespace App\Service\Message;
 
 use App\AI\Service\AiFacade;
 use App\Entity\User;
-use App\Repository\ConfigRepository;
 use App\Repository\PromptRepository;
 use App\Service\DiscordNotificationService;
 use App\Service\ModelConfigService;
@@ -69,19 +68,6 @@ final readonly class MessageSorter
         '2k' => '1080p',
     ];
 
-    /**
-     * BCONFIG key that controls whether the granular routing aliases
-     * (`general-chat`, `coding`, `image-generation`, `video-generation`,
-     * `audio-generation`) participate in the AI sorter's choice list.
-     *
-     * Stored at (BOWNERID=0, BGROUP=QDRANT_SEARCH). Mirrors the existing
-     * SYNAPSE_ROUTING_ENABLED toggle so admins can find both flags in the
-     * same Routing Configuration screen. Default OFF, matching the
-     * canonical-only experience the AI sort prompt is designed for.
-     */
-    public const GRANULAR_TOPICS_CONFIG_GROUP = 'QDRANT_SEARCH';
-    public const GRANULAR_TOPICS_CONFIG_KEY = 'GRANULAR_TOPICS_ENABLED';
-
     public function __construct(
         private AiFacade $aiFacade,
         private PromptRepository $promptRepository,
@@ -91,8 +77,6 @@ final readonly class MessageSorter
         private EntityManagerInterface $em,
         private LoggerInterface $logger,
         private DiscordNotificationService $discord,
-        private TopicAliasResolver $topicAliasResolver,
-        private ConfigRepository $configRepository,
     ) {
     }
 
@@ -157,10 +141,16 @@ final readonly class MessageSorter
             ];
         }
 
-        // Get all available topics (exclude tools:* internal topics)
-        // Include user-specific prompts if userId is provided
-        // Load prompts for ALL supported languages to ensure user prompts are included
-        [$topics, $topicsWithDesc] = $this->buildTopicPool($userId);
+        // Get all available topics (exclude tools:* internal topics).
+        // Granular routing aliases (`general-chat`, `coding`,
+        // `image-generation`, `video-generation`, `audio-generation`) are
+        // gated by their `BENABLED` flag in BPROMPTS, which the admin
+        // controls via the `GRANULAR_TOPICS_ENABLED` toggle through
+        // GranularTopicsManager. When OFF (default) the disabled rows
+        // are filtered out at the SQL level by `excludeDisabled: true`,
+        // so the sorter sees only canonical topics with no extra plumbing.
+        $topics = $this->promptRepository->getAllTopics(0, $userId, excludeTools: true);
+        $topicsWithDesc = $this->promptRepository->getTopicsWithDescriptions(0, '', $userId, excludeTools: true);
 
         // Build dynamic list and key list for prompt
         $dynamicList = $this->buildDynamicList($topicsWithDesc);
@@ -362,67 +352,6 @@ final readonly class MessageSorter
         }
 
         return null;
-    }
-
-    /**
-     * Build the AI sorter's choice list: the list of routable topic keys
-     * and the parallel list of `{ topic, description }` rows that get
-     * injected into the [KEYLIST] / [DYNAMICLIST] placeholders.
-     *
-     * Granular routing aliases (e.g. `general-chat`, `image-generation`)
-     * are filtered out when `QDRANT_SEARCH.GRANULAR_TOPICS_ENABLED` is
-     * false. They are aliases of canonical legacy topics (see
-     * TopicAliasResolver::TOPIC_ALIASES) and only exist to give Synapse
-     * Routing v2's embedding tier a finer-grained taxonomy; showing them
-     * to the LLM sorter creates near-duplicate routing targets ("general"
-     * vs "general-chat") and produces brittle, model-dependent picks.
-     *
-     * This filter is belt-and-suspenders next to the PromptCatalog ship-
-     * disabled defaults — even if an operator (or a stale seed) enabled
-     * a granular row in BPROMPTS while the toggle stays OFF, the AI sort
-     * pool stays clean.
-     *
-     * @return array{0: list<string>, 1: list<array{topic: string, description: string, ownerId: int}>}
-     */
-    private function buildTopicPool(?int $userId): array
-    {
-        $topics = $this->promptRepository->getAllTopics(0, $userId, excludeTools: true);
-        $topicsWithDesc = $this->promptRepository->getTopicsWithDescriptions(0, '', $userId, excludeTools: true);
-
-        if ($this->granularTopicsEnabled()) {
-            return [array_values($topics), array_values($topicsWithDesc)];
-        }
-
-        $resolver = $this->topicAliasResolver;
-        $topics = array_values(array_filter(
-            $topics,
-            static fn (string $topic): bool => !$resolver->isAlias($topic),
-        ));
-        $topicsWithDesc = array_values(array_filter(
-            $topicsWithDesc,
-            static fn (array $row): bool => !$resolver->isAlias((string) $row['topic']),
-        ));
-
-        return [$topics, $topicsWithDesc];
-    }
-
-    /**
-     * Whether granular routing aliases should be visible to the AI sorter.
-     *
-     * Default OFF — matches the catalog ship state and the post-hot-fix
-     * production behaviour. Admins flip this via the Routing Configuration
-     * UI; the SystemConfigService write hook also flips BENABLED on the
-     * matching BPROMPTS rows via GranularTopicsManager.
-     */
-    private function granularTopicsEnabled(): bool
-    {
-        $value = $this->configRepository->getValue(0, self::GRANULAR_TOPICS_CONFIG_GROUP, self::GRANULAR_TOPICS_CONFIG_KEY);
-
-        if (null === $value) {
-            return false;
-        }
-
-        return filter_var($value, \FILTER_VALIDATE_BOOL, \FILTER_NULL_ON_FAILURE) ?? false;
     }
 
     /**

--- a/backend/tests/Command/PromptSeedCommandTest.php
+++ b/backend/tests/Command/PromptSeedCommandTest.php
@@ -5,22 +5,27 @@ declare(strict_types=1);
 namespace App\Tests\Command;
 
 use App\Command\PromptSeedCommand;
-use App\Prompt\PromptCatalog;
-use Doctrine\DBAL\Connection;
+use App\Seed\PromptSeeder;
+use App\Seed\SeedResult;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
 
+/**
+ * The command is now a thin wrapper around PromptSeeder; the actual
+ * seeding + post-seed toggle convergence is covered by PromptSeederTest.
+ */
 class PromptSeedCommandTest extends TestCase
 {
     private CommandTester $commandTester;
-    private Connection $connection;
+    private PromptSeeder&MockObject $seeder;
 
     protected function setUp(): void
     {
-        $this->connection = $this->createMock(Connection::class);
-        $command = new PromptSeedCommand($this->connection);
+        $this->seeder = $this->createMock(PromptSeeder::class);
+        $command = new PromptSeedCommand($this->seeder);
 
         $application = new Application();
         $application->addCommand($command);
@@ -28,74 +33,19 @@ class PromptSeedCommandTest extends TestCase
         $this->commandTester = new CommandTester($application->find('app:prompt:seed'));
     }
 
-    public function testSeedInsertsNewPrompts(): void
+    public function testCommandDelegatesToSeederAndReportsTheResult(): void
     {
-        $promptCount = count(PromptCatalog::all());
-
-        // fetchOne returns false (not found) → INSERT path
-        // @phpstan-ignore-next-line
-        $this->connection->expects($this->exactly($promptCount))
-            ->method('fetchOne')
-            ->willReturn(false);
-
-        // One INSERT per prompt
-        // @phpstan-ignore-next-line
-        $this->connection->expects($this->exactly($promptCount))
-            ->method('executeStatement');
+        $this->seeder->expects($this->once())
+            ->method('seed')
+            ->willReturn(new SeedResult('prompts', inserted: 4, updated: 17));
 
         $this->commandTester->execute([]);
 
         $this->assertSame(Command::SUCCESS, $this->commandTester->getStatusCode());
+
         $output = $this->commandTester->getDisplay();
-        $this->assertStringContainsString('Seeded', $output);
-        $this->assertStringContainsString('general', $output);
-        $this->assertStringContainsString('tools:sort', $output);
-    }
-
-    public function testSeedUpdatesExistingPrompts(): void
-    {
-        $promptCount = count(PromptCatalog::all());
-
-        // fetchOne returns an existing BID → UPDATE path
-        // @phpstan-ignore-next-line
-        $this->connection->expects($this->exactly($promptCount))
-            ->method('fetchOne')
-            ->willReturn(42);
-
-        // One UPDATE per prompt
-        // @phpstan-ignore-next-line
-        $this->connection->expects($this->exactly($promptCount))
-            ->method('executeStatement');
-
-        $this->commandTester->execute([]);
-
-        $this->assertSame(Command::SUCCESS, $this->commandTester->getStatusCode());
-    }
-
-    public function testCatalogHasExpectedPrompts(): void
-    {
-        $prompts = PromptCatalog::all();
-        $topics = array_column($prompts, 'topic');
-
-        $this->assertContains('general', $topics);
-        $this->assertContains('tools:sort', $topics);
-        $this->assertContains('mediamaker', $topics);
-        $this->assertContains('tools:enhance', $topics);
-        $this->assertContains('tools:search', $topics);
-        $this->assertContains('tools:memory_extraction', $topics);
-        $this->assertNotContains('analyzefile', $topics);
-        $this->assertGreaterThanOrEqual(16, count($prompts));
-    }
-
-    public function testCatalogPromptsHaveRequiredFields(): void
-    {
-        foreach (PromptCatalog::all() as $prompt) {
-            $this->assertArrayHasKey('topic', $prompt);
-            $this->assertArrayHasKey('language', $prompt);
-            $this->assertArrayHasKey('shortDescription', $prompt);
-            $this->assertArrayHasKey('prompt', $prompt);
-            $this->assertNotEmpty($prompt['topic']);
-            $this->assertNotEmpty($prompt['prompt']);
-        }
+        $this->assertStringContainsString('21', $output);
+        $this->assertStringContainsString('4 inserted', $output);
+        $this->assertStringContainsString('17 updated', $output);
     }
 }

--- a/backend/tests/Unit/MessageSorterTest.php
+++ b/backend/tests/Unit/MessageSorterTest.php
@@ -3,52 +3,43 @@
 namespace App\Tests\Unit;
 
 use App\AI\Service\AiFacade;
-use App\Repository\ConfigRepository;
 use App\Repository\PromptRepository;
 use App\Service\DiscordNotificationService;
 use App\Service\Message\MessageSorter;
-use App\Service\Message\TopicAliasResolver;
 use App\Service\ModelConfigService;
 use App\Service\PromptService;
 use App\Service\RateLimitService;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
 class MessageSorterTest extends TestCase
 {
     private MessageSorter $sorter;
-    private ConfigRepository&MockObject $configRepository;
-    private PromptRepository&MockObject $promptRepository;
     private \ReflectionMethod $parseResponseMethod;
     private \ReflectionMethod $normalizeMediaTypeMethod;
-    private \ReflectionMethod $buildTopicPoolMethod;
 
     protected function setUp(): void
     {
         $aiFacade = $this->createMock(AiFacade::class);
-        $this->promptRepository = $this->createMock(PromptRepository::class);
+        $promptRepository = $this->createMock(PromptRepository::class);
         $modelConfigService = $this->createMock(ModelConfigService::class);
         $promptService = $this->createMock(PromptService::class);
         $rateLimitService = $this->createMock(RateLimitService::class);
         $em = $this->createMock(EntityManagerInterface::class);
         $logger = $this->createMock(LoggerInterface::class);
         $discord = $this->createMock(DiscordNotificationService::class);
-        $this->configRepository = $this->createMock(ConfigRepository::class);
 
         $this->sorter = new MessageSorter(
             $aiFacade,
-            $this->promptRepository,
+            $promptRepository,
             $modelConfigService,
             $promptService,
             $rateLimitService,
             $em,
             $logger,
-            $discord,
-            new TopicAliasResolver(),
-            $this->configRepository,
+            $discord
         );
 
         // Make private methods accessible for testing
@@ -59,9 +50,6 @@ class MessageSorterTest extends TestCase
 
         $this->normalizeMediaTypeMethod = $reflection->getMethod('normalizeMediaType');
         $this->normalizeMediaTypeMethod->setAccessible(true);
-
-        $this->buildTopicPoolMethod = $reflection->getMethod('buildTopicPool');
-        $this->buildTopicPoolMethod->setAccessible(true);
     }
 
     // ===========================================
@@ -481,123 +469,5 @@ class MessageSorterTest extends TestCase
         $this->assertSame(6, $result['duration']);
         $this->assertSame('4K', $result['resolution']);
         $this->assertSame('text_only', $result['input_mode']);
-    }
-
-    // ===========================================
-    // buildTopicPool — granular-aliases filter
-    // ===========================================
-
-    /**
-     * When `QDRANT_SEARCH.GRANULAR_TOPICS_ENABLED` is OFF (the default),
-     * the topic list fed to the AI sorter must drop every alias of a
-     * canonical topic (general-chat, coding, image-generation, ...). The
-     * canonical rows (general, mediamaker) and non-alias topics
-     * (officemaker, docsummary, custom user prompts) must pass through.
-     *
-     * This is the belt-and-suspenders gate next to the catalog ship state:
-     * even if an operator manually re-enabled a granular row in BPROMPTS
-     * while the BCONFIG toggle is still OFF, the AI sort pool stays clean.
-     */
-    public function testBuildTopicPoolFiltersAliasesWhenToggleIsOff(): void
-    {
-        $this->configRepository->method('getValue')
-            ->with(0, 'QDRANT_SEARCH', 'GRANULAR_TOPICS_ENABLED')
-            ->willReturn('false');
-
-        $this->promptRepository->method('getAllTopics')->willReturn([
-            'general', 'general-chat', 'coding',
-            'mediamaker', 'image-generation', 'video-generation', 'audio-generation',
-            'officemaker', 'docsummary', 'customer-support',
-        ]);
-        $this->promptRepository->method('getTopicsWithDescriptions')->willReturn([
-            ['topic' => 'general', 'description' => 'Catch-all', 'ownerId' => 0],
-            ['topic' => 'general-chat', 'description' => 'Granular chat alias', 'ownerId' => 0],
-            ['topic' => 'coding', 'description' => 'Retired', 'ownerId' => 0],
-            ['topic' => 'mediamaker', 'description' => 'Canonical media', 'ownerId' => 0],
-            ['topic' => 'image-generation', 'description' => 'Granular image alias', 'ownerId' => 0],
-            ['topic' => 'video-generation', 'description' => 'Granular video alias', 'ownerId' => 0],
-            ['topic' => 'audio-generation', 'description' => 'Granular audio alias', 'ownerId' => 0],
-            ['topic' => 'officemaker', 'description' => 'Doc generation', 'ownerId' => 0],
-            ['topic' => 'docsummary', 'description' => 'Summaries', 'ownerId' => 0],
-            ['topic' => 'customer-support', 'description' => 'Custom user prompt', 'ownerId' => 7],
-        ]);
-
-        [$topics, $topicsWithDesc] = $this->buildTopicPoolMethod->invoke($this->sorter, 7);
-
-        // Canonical and unrelated topics pass through.
-        $this->assertContains('general', $topics);
-        $this->assertContains('mediamaker', $topics);
-        $this->assertContains('officemaker', $topics);
-        $this->assertContains('docsummary', $topics);
-        $this->assertContains('customer-support', $topics);
-
-        // Every alias from TopicAliasResolver::TOPIC_ALIASES must be gone.
-        foreach (
-            ['general-chat', 'coding', 'image-generation', 'video-generation', 'audio-generation'] as $alias
-        ) {
-            $this->assertNotContains(
-                $alias,
-                $topics,
-                sprintf('Alias "%s" must be filtered out of the AI sort pool when the toggle is OFF.', $alias)
-            );
-            $aliasDescriptions = array_column($topicsWithDesc, 'topic');
-            $this->assertNotContains(
-                $alias,
-                $aliasDescriptions,
-                sprintf('Alias "%s" must also be filtered from the description list.', $alias)
-            );
-        }
-    }
-
-    /**
-     * When the admin flips `GRANULAR_TOPICS_ENABLED` to true, the AI sorter
-     * sees both canonical and granular rows — this is the path used when
-     * Synapse Routing v2 is enabled and the embedding tier benefits from
-     * the finer-grained taxonomy (and the AI fallback should agree with it).
-     */
-    public function testBuildTopicPoolKeepsAliasesWhenToggleIsOn(): void
-    {
-        $this->configRepository->method('getValue')
-            ->with(0, 'QDRANT_SEARCH', 'GRANULAR_TOPICS_ENABLED')
-            ->willReturn('true');
-
-        $this->promptRepository->method('getAllTopics')->willReturn([
-            'general', 'general-chat', 'image-generation', 'mediamaker',
-        ]);
-        $this->promptRepository->method('getTopicsWithDescriptions')->willReturn([
-            ['topic' => 'general', 'description' => 'Catch-all', 'ownerId' => 0],
-            ['topic' => 'general-chat', 'description' => 'Granular chat', 'ownerId' => 0],
-            ['topic' => 'image-generation', 'description' => 'Granular image', 'ownerId' => 0],
-            ['topic' => 'mediamaker', 'description' => 'Canonical media', 'ownerId' => 0],
-        ]);
-
-        [$topics, $topicsWithDesc] = $this->buildTopicPoolMethod->invoke($this->sorter, null);
-
-        $this->assertSame(
-            ['general', 'general-chat', 'image-generation', 'mediamaker'],
-            $topics
-        );
-        $this->assertCount(4, $topicsWithDesc);
-    }
-
-    /**
-     * Mirrors the SYNAPSE_ROUTING_ENABLED parser semantics — when the
-     * BCONFIG row is absent, the toggle defaults to OFF.
-     */
-    public function testBuildTopicPoolDefaultsToFilteredWhenConfigRowMissing(): void
-    {
-        $this->configRepository->method('getValue')
-            ->with(0, 'QDRANT_SEARCH', 'GRANULAR_TOPICS_ENABLED')
-            ->willReturn(null);
-
-        $this->promptRepository->method('getAllTopics')->willReturn(['general', 'general-chat']);
-        $this->promptRepository->method('getTopicsWithDescriptions')->willReturn([
-            ['topic' => 'general', 'description' => 'Catch-all', 'ownerId' => 0],
-            ['topic' => 'general-chat', 'description' => 'Granular', 'ownerId' => 0],
-        ]);
-
-        [$topics] = $this->buildTopicPoolMethod->invoke($this->sorter, 1);
-
-        $this->assertSame(['general'], $topics);
     }
 }

--- a/backend/tests/Unit/MessageSorterTest.php
+++ b/backend/tests/Unit/MessageSorterTest.php
@@ -3,43 +3,52 @@
 namespace App\Tests\Unit;
 
 use App\AI\Service\AiFacade;
+use App\Repository\ConfigRepository;
 use App\Repository\PromptRepository;
 use App\Service\DiscordNotificationService;
 use App\Service\Message\MessageSorter;
+use App\Service\Message\TopicAliasResolver;
 use App\Service\ModelConfigService;
 use App\Service\PromptService;
 use App\Service\RateLimitService;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
 class MessageSorterTest extends TestCase
 {
     private MessageSorter $sorter;
+    private ConfigRepository&MockObject $configRepository;
+    private PromptRepository&MockObject $promptRepository;
     private \ReflectionMethod $parseResponseMethod;
     private \ReflectionMethod $normalizeMediaTypeMethod;
+    private \ReflectionMethod $buildTopicPoolMethod;
 
     protected function setUp(): void
     {
         $aiFacade = $this->createMock(AiFacade::class);
-        $promptRepository = $this->createMock(PromptRepository::class);
+        $this->promptRepository = $this->createMock(PromptRepository::class);
         $modelConfigService = $this->createMock(ModelConfigService::class);
         $promptService = $this->createMock(PromptService::class);
         $rateLimitService = $this->createMock(RateLimitService::class);
         $em = $this->createMock(EntityManagerInterface::class);
         $logger = $this->createMock(LoggerInterface::class);
         $discord = $this->createMock(DiscordNotificationService::class);
+        $this->configRepository = $this->createMock(ConfigRepository::class);
 
         $this->sorter = new MessageSorter(
             $aiFacade,
-            $promptRepository,
+            $this->promptRepository,
             $modelConfigService,
             $promptService,
             $rateLimitService,
             $em,
             $logger,
-            $discord
+            $discord,
+            new TopicAliasResolver(),
+            $this->configRepository,
         );
 
         // Make private methods accessible for testing
@@ -50,6 +59,9 @@ class MessageSorterTest extends TestCase
 
         $this->normalizeMediaTypeMethod = $reflection->getMethod('normalizeMediaType');
         $this->normalizeMediaTypeMethod->setAccessible(true);
+
+        $this->buildTopicPoolMethod = $reflection->getMethod('buildTopicPool');
+        $this->buildTopicPoolMethod->setAccessible(true);
     }
 
     // ===========================================
@@ -469,5 +481,123 @@ class MessageSorterTest extends TestCase
         $this->assertSame(6, $result['duration']);
         $this->assertSame('4K', $result['resolution']);
         $this->assertSame('text_only', $result['input_mode']);
+    }
+
+    // ===========================================
+    // buildTopicPool — granular-aliases filter
+    // ===========================================
+
+    /**
+     * When `QDRANT_SEARCH.GRANULAR_TOPICS_ENABLED` is OFF (the default),
+     * the topic list fed to the AI sorter must drop every alias of a
+     * canonical topic (general-chat, coding, image-generation, ...). The
+     * canonical rows (general, mediamaker) and non-alias topics
+     * (officemaker, docsummary, custom user prompts) must pass through.
+     *
+     * This is the belt-and-suspenders gate next to the catalog ship state:
+     * even if an operator manually re-enabled a granular row in BPROMPTS
+     * while the BCONFIG toggle is still OFF, the AI sort pool stays clean.
+     */
+    public function testBuildTopicPoolFiltersAliasesWhenToggleIsOff(): void
+    {
+        $this->configRepository->method('getValue')
+            ->with(0, 'QDRANT_SEARCH', 'GRANULAR_TOPICS_ENABLED')
+            ->willReturn('false');
+
+        $this->promptRepository->method('getAllTopics')->willReturn([
+            'general', 'general-chat', 'coding',
+            'mediamaker', 'image-generation', 'video-generation', 'audio-generation',
+            'officemaker', 'docsummary', 'customer-support',
+        ]);
+        $this->promptRepository->method('getTopicsWithDescriptions')->willReturn([
+            ['topic' => 'general', 'description' => 'Catch-all', 'ownerId' => 0],
+            ['topic' => 'general-chat', 'description' => 'Granular chat alias', 'ownerId' => 0],
+            ['topic' => 'coding', 'description' => 'Retired', 'ownerId' => 0],
+            ['topic' => 'mediamaker', 'description' => 'Canonical media', 'ownerId' => 0],
+            ['topic' => 'image-generation', 'description' => 'Granular image alias', 'ownerId' => 0],
+            ['topic' => 'video-generation', 'description' => 'Granular video alias', 'ownerId' => 0],
+            ['topic' => 'audio-generation', 'description' => 'Granular audio alias', 'ownerId' => 0],
+            ['topic' => 'officemaker', 'description' => 'Doc generation', 'ownerId' => 0],
+            ['topic' => 'docsummary', 'description' => 'Summaries', 'ownerId' => 0],
+            ['topic' => 'customer-support', 'description' => 'Custom user prompt', 'ownerId' => 7],
+        ]);
+
+        [$topics, $topicsWithDesc] = $this->buildTopicPoolMethod->invoke($this->sorter, 7);
+
+        // Canonical and unrelated topics pass through.
+        $this->assertContains('general', $topics);
+        $this->assertContains('mediamaker', $topics);
+        $this->assertContains('officemaker', $topics);
+        $this->assertContains('docsummary', $topics);
+        $this->assertContains('customer-support', $topics);
+
+        // Every alias from TopicAliasResolver::TOPIC_ALIASES must be gone.
+        foreach (
+            ['general-chat', 'coding', 'image-generation', 'video-generation', 'audio-generation'] as $alias
+        ) {
+            $this->assertNotContains(
+                $alias,
+                $topics,
+                sprintf('Alias "%s" must be filtered out of the AI sort pool when the toggle is OFF.', $alias)
+            );
+            $aliasDescriptions = array_column($topicsWithDesc, 'topic');
+            $this->assertNotContains(
+                $alias,
+                $aliasDescriptions,
+                sprintf('Alias "%s" must also be filtered from the description list.', $alias)
+            );
+        }
+    }
+
+    /**
+     * When the admin flips `GRANULAR_TOPICS_ENABLED` to true, the AI sorter
+     * sees both canonical and granular rows — this is the path used when
+     * Synapse Routing v2 is enabled and the embedding tier benefits from
+     * the finer-grained taxonomy (and the AI fallback should agree with it).
+     */
+    public function testBuildTopicPoolKeepsAliasesWhenToggleIsOn(): void
+    {
+        $this->configRepository->method('getValue')
+            ->with(0, 'QDRANT_SEARCH', 'GRANULAR_TOPICS_ENABLED')
+            ->willReturn('true');
+
+        $this->promptRepository->method('getAllTopics')->willReturn([
+            'general', 'general-chat', 'image-generation', 'mediamaker',
+        ]);
+        $this->promptRepository->method('getTopicsWithDescriptions')->willReturn([
+            ['topic' => 'general', 'description' => 'Catch-all', 'ownerId' => 0],
+            ['topic' => 'general-chat', 'description' => 'Granular chat', 'ownerId' => 0],
+            ['topic' => 'image-generation', 'description' => 'Granular image', 'ownerId' => 0],
+            ['topic' => 'mediamaker', 'description' => 'Canonical media', 'ownerId' => 0],
+        ]);
+
+        [$topics, $topicsWithDesc] = $this->buildTopicPoolMethod->invoke($this->sorter, null);
+
+        $this->assertSame(
+            ['general', 'general-chat', 'image-generation', 'mediamaker'],
+            $topics
+        );
+        $this->assertCount(4, $topicsWithDesc);
+    }
+
+    /**
+     * Mirrors the SYNAPSE_ROUTING_ENABLED parser semantics — when the
+     * BCONFIG row is absent, the toggle defaults to OFF.
+     */
+    public function testBuildTopicPoolDefaultsToFilteredWhenConfigRowMissing(): void
+    {
+        $this->configRepository->method('getValue')
+            ->with(0, 'QDRANT_SEARCH', 'GRANULAR_TOPICS_ENABLED')
+            ->willReturn(null);
+
+        $this->promptRepository->method('getAllTopics')->willReturn(['general', 'general-chat']);
+        $this->promptRepository->method('getTopicsWithDescriptions')->willReturn([
+            ['topic' => 'general', 'description' => 'Catch-all', 'ownerId' => 0],
+            ['topic' => 'general-chat', 'description' => 'Granular', 'ownerId' => 0],
+        ]);
+
+        [$topics] = $this->buildTopicPoolMethod->invoke($this->sorter, 1);
+
+        $this->assertSame(['general'], $topics);
     }
 }

--- a/backend/tests/Unit/PromptCatalogTest.php
+++ b/backend/tests/Unit/PromptCatalogTest.php
@@ -88,6 +88,66 @@ final class PromptCatalogTest extends TestCase
         $this->assertFalse($byTopic['coding']['enabled']);
     }
 
+    /**
+     * Granular routing aliases ship DISABLED by default — they are aliases
+     * of canonical topics (TopicAliasResolver) that confuse the legacy AI
+     * sorter when active alongside the canonical row. Admins flip them all
+     * back on via the `QDRANT_SEARCH.GRANULAR_TOPICS_ENABLED` toggle when
+     * Synapse Routing v2 is in use.
+     *
+     * Keeping them in the catalog (rather than removing) lets the seed
+     * idempotently flip BENABLED=0 on existing installs and drives the
+     * SynapseIndexer to drop orphan vectors from Qdrant.
+     */
+    public function testGranularRoutingAliasesShipDisabledByDefault(): void
+    {
+        $byTopic = [];
+        foreach (PromptCatalog::all() as $entry) {
+            $byTopic[$entry['topic']] = $entry;
+        }
+
+        foreach (
+            ['coding', 'general-chat', 'image-generation', 'video-generation', 'audio-generation'] as $alias
+        ) {
+            $this->assertArrayHasKey($alias, $byTopic, sprintf(
+                'Expected granular alias "%s" to remain in the catalog so the seed flips BENABLED.',
+                $alias
+            ));
+            $this->assertArrayHasKey('enabled', $byTopic[$alias], sprintf(
+                'Granular alias "%s" must declare an explicit `enabled` flag so the seed write is deterministic.',
+                $alias
+            ));
+            $this->assertFalse(
+                $byTopic[$alias]['enabled'],
+                sprintf(
+                    'Granular alias "%s" must ship DISABLED — admins re-enable via the GRANULAR_TOPICS_ENABLED toggle.',
+                    $alias
+                )
+            );
+        }
+    }
+
+    /**
+     * The canonical `general` row carries the chat/coding/lifestyle keyword
+     * list because the granular `general-chat` topic ships disabled by
+     * default. Synapse Routing v2 embedding recall therefore relies on the
+     * canonical row's keywords, which must include the programming terms
+     * that previously lived under `general-chat`.
+     */
+    public function testCanonicalGeneralKeywordsCoverProgrammingTerms(): void
+    {
+        $byTopic = [];
+        foreach (PromptCatalog::all() as $entry) {
+            $byTopic[$entry['topic']] = $entry;
+        }
+
+        $keywords = strtolower((string) $byTopic['general']['keywords']);
+        $this->assertStringContainsString('php', $keywords);
+        $this->assertStringContainsString('python', $keywords);
+        $this->assertStringContainsString('debug', $keywords);
+        $this->assertStringContainsString('smalltalk', $keywords);
+    }
+
     public function testGeneralChatKeywordsCoverProgrammingTermsAfterCodingRetirement(): void
     {
         // Coding queries now ride on `general-chat` (#878). Make sure

--- a/backend/tests/Unit/Seed/PromptSeederTest.php
+++ b/backend/tests/Unit/Seed/PromptSeederTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Seed;
+
+use App\Repository\ConfigRepository;
+use App\Seed\PromptSeeder;
+use App\Service\Message\GranularTopicsManager;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
+use Doctrine\DBAL\Schema\Column;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Verifies the post-seed convergence contract: after the catalog UPDATE
+ * blindly resets BENABLED on the granular alias rows (driven by
+ * `'enabled' => false` in PromptCatalog), the seeder re-applies the
+ * admin's `GRANULAR_TOPICS_ENABLED` toggle so BPROMPTS state matches
+ * BCONFIG state at the end of every seed.
+ *
+ * Without this convergence step, an admin who flips the toggle ON via
+ * the UI would silently lose their setting on the very next deploy /
+ * container restart that runs `app:seed`.
+ */
+final class PromptSeederTest extends TestCase
+{
+    private ConfigRepository&MockObject $configRepository;
+    private GranularTopicsManager&MockObject $granularTopicsManager;
+    private Connection&MockObject $connection;
+
+    protected function setUp(): void
+    {
+        $this->configRepository = $this->createMock(ConfigRepository::class);
+        $this->granularTopicsManager = $this->createMock(GranularTopicsManager::class);
+        $this->connection = $this->createMock(Connection::class);
+
+        // Force PromptCatalog::seed() down the schema-check path used in
+        // production (BPROMPTS exists, BKEYWORDS + BENABLED columns
+        // present). The catalog itself is exercised by PromptCatalogTest;
+        // here we just need the seed call to complete without I/O surprises
+        // so we can assert what happens AFTER it.
+        $schemaManager = $this->createMock(AbstractSchemaManager::class);
+        $schemaManager->method('tablesExist')->willReturn(true);
+        $schemaManager->method('listTableColumns')->willReturnCallback(static function (string $table): array {
+            if ('BPROMPTS' !== $table) {
+                return [];
+            }
+
+            $columns = [];
+            foreach (['BKEYWORDS', 'BENABLED'] as $name) {
+                $col = new Column($name, \Doctrine\DBAL\Types\Type::getType('string'));
+                $columns[$name] = $col;
+            }
+
+            return $columns;
+        });
+        $this->connection->method('createSchemaManager')->willReturn($schemaManager);
+        $this->connection->method('fetchOne')->willReturn(false);
+    }
+
+    public function testConvergenceCallsManagerWithCurrentToggleStateOff(): void
+    {
+        $this->configRepository->method('getValue')
+            ->with(0, GranularTopicsManager::CONFIG_GROUP, GranularTopicsManager::CONFIG_KEY)
+            ->willReturn(null);
+
+        $this->granularTopicsManager->expects($this->once())
+            ->method('applyState')
+            ->with(false)
+            ->willReturn(['flipped' => [], 'unchanged' => [], 'missing' => []]);
+
+        $seeder = new PromptSeeder($this->connection, $this->configRepository, $this->granularTopicsManager);
+        $result = $seeder->seed();
+
+        $this->assertSame('prompts', $result->label);
+    }
+
+    public function testConvergenceCallsManagerWithCurrentToggleStateOn(): void
+    {
+        // Admin previously flipped the toggle ON; the seed must NOT silently
+        // un-flip the BPROMPTS rows on the next deploy. The manager call with
+        // `true` re-converges the rows back to BENABLED=1 after the catalog
+        // overwrote them to 0.
+        $this->configRepository->method('getValue')
+            ->with(0, GranularTopicsManager::CONFIG_GROUP, GranularTopicsManager::CONFIG_KEY)
+            ->willReturn('true');
+
+        $this->granularTopicsManager->expects($this->once())
+            ->method('applyState')
+            ->with(true)
+            ->willReturn(['flipped' => ['general-chat'], 'unchanged' => [], 'missing' => []]);
+
+        (new PromptSeeder($this->connection, $this->configRepository, $this->granularTopicsManager))->seed();
+    }
+
+    /**
+     * The convergence parser must accept the same truthy variants as
+     * `MessageClassifier::isSynapseEnabled()` so the two toggles behave
+     * identically. Without this, an admin who set `'1'` in BCONFIG via
+     * SQL would see the toggle's UI behaviour and its seed-convergence
+     * behaviour disagree.
+     *
+     * @param non-empty-string $rawConfigValue
+     */
+    #[DataProvider('toggleValueProvider')]
+    public function testConvergenceParsesToggleValueLikeIsSynapseEnabled(string $rawConfigValue, bool $expected): void
+    {
+        $this->configRepository->method('getValue')->willReturn($rawConfigValue);
+        $this->granularTopicsManager->expects($this->once())
+            ->method('applyState')
+            ->with($expected)
+            ->willReturn(['flipped' => [], 'unchanged' => [], 'missing' => []]);
+
+        (new PromptSeeder($this->connection, $this->configRepository, $this->granularTopicsManager))->seed();
+    }
+
+    /**
+     * @return iterable<string, array{0: string, 1: bool}>
+     */
+    public static function toggleValueProvider(): iterable
+    {
+        yield 'true' => ['true', true];
+        yield '1' => ['1', true];
+        yield 'yes' => ['yes', true];
+        yield 'on' => ['on', true];
+        yield 'TRUE uppercase' => ['TRUE', true];
+        yield 'false' => ['false', false];
+        yield '0' => ['0', false];
+        yield 'no' => ['no', false];
+        yield 'off' => ['off', false];
+        yield 'random gibberish defaults to off' => ['banana', false];
+    }
+}

--- a/backend/tests/Unit/Service/Admin/SystemConfigServiceTest.php
+++ b/backend/tests/Unit/Service/Admin/SystemConfigServiceTest.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\Admin;
+
+use App\Repository\ConfigRepository;
+use App\Service\Admin\SystemConfigService;
+use App\Service\Message\GranularTopicsManager;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+// The two collaborators are concrete classes; the test stores them as
+// intersection types so PHPStan sees the MockObject API (->method(),
+// ->expects()) alongside the production interface. Using `@var` PHPDoc on
+// a typed property does NOT propagate the mixin in PHPStan's view, while
+// native intersection-type properties do (PHP 8.1+).
+
+/**
+ * Locks down the side-effect hook that runs when an admin toggles
+ * `QDRANT_SEARCH.GRANULAR_TOPICS_ENABLED` via the admin UI: the BCONFIG
+ * write must always succeed first, then `GranularTopicsManager::applyState`
+ * is invoked to flip BENABLED on the matching BPROMPTS rows.
+ *
+ * The rest of SystemConfigService (env writes, backups, connection tests,
+ * etc.) is intentionally out of scope — covering it would require
+ * filesystem fixtures that don't exist in the wider test suite today.
+ */
+final class SystemConfigServiceTest extends TestCase
+{
+    private ConfigRepository&MockObject $configRepository;
+    private GranularTopicsManager&MockObject $granularTopicsManager;
+    private SystemConfigService $service;
+
+    protected function setUp(): void
+    {
+        $this->configRepository = $this->createMock(ConfigRepository::class);
+        $this->granularTopicsManager = $this->createMock(GranularTopicsManager::class);
+
+        $this->service = new SystemConfigService(
+            projectDir: sys_get_temp_dir(),
+            logger: new NullLogger(),
+            configRepository: $this->configRepository,
+            granularTopicsManager: $this->granularTopicsManager,
+        );
+    }
+
+    public function testTogglingGranularTopicsOnPersistsConfigAndFlipsPrompts(): void
+    {
+        $this->configRepository->expects($this->once())
+            ->method('setValue')
+            ->with(0, 'QDRANT_SEARCH', 'GRANULAR_TOPICS_ENABLED', 'true');
+
+        $this->granularTopicsManager->expects($this->once())
+            ->method('applyState')
+            ->with(true)
+            ->willReturn(['flipped' => ['general-chat'], 'unchanged' => [], 'missing' => []]);
+
+        $result = $this->service->setValue('GRANULAR_TOPICS_ENABLED', 'true');
+
+        $this->assertTrue($result['success']);
+        $this->assertFalse($result['requiresRestart']);
+    }
+
+    public function testTogglingGranularTopicsOffPersistsConfigAndFlipsPrompts(): void
+    {
+        $this->configRepository->expects($this->once())
+            ->method('setValue')
+            ->with(0, 'QDRANT_SEARCH', 'GRANULAR_TOPICS_ENABLED', 'false');
+
+        $this->granularTopicsManager->expects($this->once())
+            ->method('applyState')
+            ->with(false)
+            ->willReturn(['flipped' => ['general-chat'], 'unchanged' => [], 'missing' => []]);
+
+        $result = $this->service->setValue('GRANULAR_TOPICS_ENABLED', 'false');
+
+        $this->assertTrue($result['success']);
+    }
+
+    /**
+     * Writing any OTHER database-backed key must not touch the granular
+     * topics manager — the hook is keyed specifically on the granular
+     * toggle. Without this guarantee every config write would silently
+     * mutate prompt state, which is a footgun.
+     */
+    public function testOtherDatabaseKeysDoNotTriggerTheGranularHook(): void
+    {
+        $this->configRepository->expects($this->once())
+            ->method('setValue')
+            ->with(0, 'QDRANT_SEARCH', 'SYNAPSE_ROUTING_ENABLED', 'true');
+
+        $this->granularTopicsManager->expects($this->never())->method('applyState');
+
+        $this->service->setValue('SYNAPSE_ROUTING_ENABLED', 'true');
+    }
+
+    /**
+     * Idempotent admin write: even if the manager reports nothing flipped
+     * (because the prompt rows already match), the BCONFIG write itself
+     * must still succeed and the operator must get the success response.
+     */
+    public function testTogglingGranularTopicsSucceedsWhenManagerReportsNoChanges(): void
+    {
+        $this->granularTopicsManager->expects($this->once())
+            ->method('applyState')
+            ->with(true)
+            ->willReturn(['flipped' => [], 'unchanged' => ['general-chat'], 'missing' => []]);
+
+        $result = $this->service->setValue('GRANULAR_TOPICS_ENABLED', 'true');
+
+        $this->assertTrue($result['success']);
+    }
+
+    /**
+     * The prompt-state sync is best-effort: if the manager throws (DB
+     * hiccup, schema mismatch on a partially-migrated install, ...) the
+     * BCONFIG row write must NOT be rolled back. From the next request
+     * onwards `MessageSorter::granularTopicsEnabled()` already reads the
+     * new flag and the AI-sort filter handles the gate — BENABLED on
+     * BPROMPTS is belt-and-suspenders, the operator can converge with
+     * `php bin/console app:seed`.
+     */
+    public function testManagerFailureDoesNotRollBackTheConfigWrite(): void
+    {
+        $this->configRepository->expects($this->once())->method('setValue');
+
+        $this->granularTopicsManager->method('applyState')
+            ->willThrowException(new \RuntimeException('Galera node down'));
+
+        $result = $this->service->setValue('GRANULAR_TOPICS_ENABLED', 'true');
+
+        $this->assertTrue($result['success']);
+    }
+
+    /**
+     * The schema parser interprets the BCONFIG string as a boolean — the
+     * hook must pass the parsed boolean (not the raw string) to the
+     * manager so all variants ("true", "1", "yes", "on", "TRUE") behave
+     * identically. This mirrors the existing SYNAPSE_ROUTING_ENABLED
+     * parser semantics in MessageClassifier::isSynapseEnabled().
+     */
+    #[DataProvider('truthyValueProvider')]
+    public function testTruthyConfigValuesAllResolveToManagerStateTrue(string $value): void
+    {
+        $this->granularTopicsManager->expects($this->once())
+            ->method('applyState')
+            ->with(true)
+            ->willReturn(['flipped' => [], 'unchanged' => [], 'missing' => []]);
+
+        $this->service->setValue('GRANULAR_TOPICS_ENABLED', $value);
+    }
+
+    /**
+     * @return iterable<string, array{0: string}>
+     */
+    public static function truthyValueProvider(): iterable
+    {
+        yield 'true' => ['true'];
+        yield '1' => ['1'];
+        yield 'yes' => ['yes'];
+        yield 'on' => ['on'];
+        yield 'TRUE uppercase' => ['TRUE'];
+    }
+}

--- a/backend/tests/Unit/Service/Admin/SystemConfigServiceTest.php
+++ b/backend/tests/Unit/Service/Admin/SystemConfigServiceTest.php
@@ -12,12 +12,6 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 
-// The two collaborators are concrete classes; the test stores them as
-// intersection types so PHPStan sees the MockObject API (->method(),
-// ->expects()) alongside the production interface. Using `@var` PHPDoc on
-// a typed property does NOT propagate the mixin in PHPStan's view, while
-// native intersection-type properties do (PHP 8.1+).
-
 /**
  * Locks down the side-effect hook that runs when an admin toggles
  * `QDRANT_SEARCH.GRANULAR_TOPICS_ENABLED` via the admin UI: the BCONFIG
@@ -43,6 +37,7 @@ final class SystemConfigServiceTest extends TestCase
             projectDir: sys_get_temp_dir(),
             logger: new NullLogger(),
             configRepository: $this->configRepository,
+            defaultTtsUrl: 'http://localhost:10200',
             granularTopicsManager: $this->granularTopicsManager,
         );
     }
@@ -95,6 +90,27 @@ final class SystemConfigServiceTest extends TestCase
         $this->granularTopicsManager->expects($this->never())->method('applyState');
 
         $this->service->setValue('SYNAPSE_ROUTING_ENABLED', 'true');
+    }
+
+    /**
+     * Pin the hook target to the constants on GranularTopicsManager. If a
+     * future refactor moves the constants somewhere else or renames them,
+     * the hook would silently stop firing and an admin toggle would leave
+     * BPROMPTS in a stale state — the convergence in PromptSeeder would
+     * eventually catch up, but only on the next `app:seed` run. This test
+     * fails fast if the (group, key) contract breaks.
+     */
+    public function testHookFiresExactlyForTheManagerOwnedConfigKey(): void
+    {
+        $this->assertSame('QDRANT_SEARCH', GranularTopicsManager::CONFIG_GROUP);
+        $this->assertSame('GRANULAR_TOPICS_ENABLED', GranularTopicsManager::CONFIG_KEY);
+
+        $this->granularTopicsManager->expects($this->once())
+            ->method('applyState')
+            ->with(true)
+            ->willReturn(['flipped' => [], 'unchanged' => [], 'missing' => []]);
+
+        $this->service->setValue(GranularTopicsManager::CONFIG_KEY, 'true');
     }
 
     /**

--- a/backend/tests/Unit/Service/Message/GranularTopicsManagerTest.php
+++ b/backend/tests/Unit/Service/Message/GranularTopicsManagerTest.php
@@ -1,0 +1,209 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\Message;
+
+use App\Entity\Prompt;
+use App\Repository\PromptRepository;
+use App\Service\Message\GranularTopicsManager;
+use App\Service\Message\TopicAliasResolver;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+/**
+ * Locks down the contract between the `QDRANT_SEARCH.GRANULAR_TOPICS_ENABLED`
+ * admin toggle and the BENABLED flag on the granular routing alias rows
+ * in BPROMPTS. The manager is the bridge: SystemConfigService::setValue()
+ * calls into it after writing the BCONFIG row.
+ */
+final class GranularTopicsManagerTest extends TestCase
+{
+    private PromptRepository&MockObject $promptRepository;
+    private EntityManagerInterface&MockObject $entityManager;
+    private GranularTopicsManager $manager;
+
+    protected function setUp(): void
+    {
+        $this->promptRepository = $this->createMock(PromptRepository::class);
+        $this->entityManager = $this->createMock(EntityManagerInterface::class);
+        $this->manager = new GranularTopicsManager(
+            new TopicAliasResolver(),
+            $this->promptRepository,
+            $this->entityManager,
+            new NullLogger(),
+        );
+    }
+
+    public function testApplyStateEnablesEverySeededAliasRow(): void
+    {
+        // Pretend every alias has a single disabled `en` row seeded.
+        $rows = [];
+        foreach (
+            ['general-chat', 'coding', 'image-generation', 'video-generation', 'audio-generation'] as $topic
+        ) {
+            $row = $this->makePrompt($topic, enabled: false);
+            $rows[$topic] = $row;
+        }
+
+        $this->promptRepository->method('findAllByTopicAndOwner')
+            ->willReturnCallback(static fn (string $topic, int $ownerId): array => isset($rows[$topic]) && 0 === $ownerId
+                ? [$rows[$topic]]
+                : []);
+
+        // Every row must be persisted, and exactly ONE flush at the end —
+        // the toggle is one transaction from the operator's POV.
+        $this->entityManager->expects($this->exactly(5))->method('persist');
+        $this->entityManager->expects($this->once())->method('flush');
+
+        $report = $this->manager->applyState(true);
+
+        $this->assertSame(
+            ['general-chat', 'coding', 'image-generation', 'video-generation', 'audio-generation'],
+            $report['flipped']
+        );
+        $this->assertSame([], $report['unchanged']);
+        $this->assertSame([], $report['missing']);
+
+        foreach ($rows as $row) {
+            $this->assertTrue($row->isEnabled());
+        }
+    }
+
+    public function testApplyStateDisablesEverySeededAliasRow(): void
+    {
+        $rows = [];
+        foreach (
+            ['general-chat', 'coding', 'image-generation', 'video-generation', 'audio-generation'] as $topic
+        ) {
+            $rows[$topic] = $this->makePrompt($topic, enabled: true);
+        }
+
+        $this->promptRepository->method('findAllByTopicAndOwner')
+            ->willReturnCallback(static fn (string $topic): array => isset($rows[$topic]) ? [$rows[$topic]] : []);
+
+        $this->entityManager->expects($this->exactly(5))->method('persist');
+        $this->entityManager->expects($this->once())->method('flush');
+
+        $report = $this->manager->applyState(false);
+
+        $this->assertCount(5, $report['flipped']);
+
+        foreach ($rows as $row) {
+            $this->assertFalse($row->isEnabled());
+        }
+    }
+
+    /**
+     * Rows already in the target state must not be persisted and there
+     * must be no flush — the operation is purely idempotent. This is the
+     * key property that lets `SystemConfigService::setValue()` call into
+     * the manager unconditionally on every BCONFIG write of the key.
+     */
+    public function testApplyStateIsIdempotentWhenAllRowsAlreadyMatch(): void
+    {
+        $rows = [];
+        foreach (
+            ['general-chat', 'coding', 'image-generation', 'video-generation', 'audio-generation'] as $topic
+        ) {
+            $rows[$topic] = $this->makePrompt($topic, enabled: false);
+        }
+
+        $this->promptRepository->method('findAllByTopicAndOwner')
+            ->willReturnCallback(static fn (string $topic): array => isset($rows[$topic]) ? [$rows[$topic]] : []);
+
+        $this->entityManager->expects($this->never())->method('persist');
+        $this->entityManager->expects($this->never())->method('flush');
+
+        $report = $this->manager->applyState(false);
+
+        $this->assertSame([], $report['flipped']);
+        $this->assertCount(5, $report['unchanged']);
+    }
+
+    /**
+     * Topics flip every per-language variant (en/de/...) in a single pass.
+     * The seed schema permits multiple rows per (owner, topic) pair so the
+     * manager must touch ALL of them, not just the freshest.
+     */
+    public function testApplyStateFlipsEveryLanguageVariantOfATopic(): void
+    {
+        $en = $this->makePrompt('general-chat', enabled: false, language: 'en');
+        $de = $this->makePrompt('general-chat', enabled: false, language: 'de');
+
+        $this->promptRepository->method('findAllByTopicAndOwner')
+            ->willReturnCallback(static function (string $topic) use ($en, $de): array {
+                if ('general-chat' === $topic) {
+                    return [$en, $de];
+                }
+
+                return [];
+            });
+
+        $this->entityManager->expects($this->exactly(2))->method('persist');
+        $this->entityManager->expects($this->once())->method('flush');
+
+        $report = $this->manager->applyState(true);
+
+        $this->assertTrue($en->isEnabled());
+        $this->assertTrue($de->isEnabled());
+
+        // Other aliases produce no seeded row -> reported as missing, not
+        // flipped. We only assert that general-chat was flipped here.
+        $this->assertContains('general-chat', $report['flipped']);
+    }
+
+    /**
+     * Fresh install before `app:seed`: the catalog rows aren't there yet.
+     * The manager must not throw — it should simply report the topics it
+     * couldn't find so the operator/log has a record. The next seed run
+     * will create the rows with the catalog's own ship-disabled flag.
+     */
+    public function testApplyStateReportsMissingAliasesWithoutThrowing(): void
+    {
+        $this->promptRepository->method('findAllByTopicAndOwner')->willReturn([]);
+
+        $this->entityManager->expects($this->never())->method('persist');
+        $this->entityManager->expects($this->never())->method('flush');
+
+        $report = $this->manager->applyState(true);
+
+        $this->assertSame([], $report['flipped']);
+        $this->assertSame([], $report['unchanged']);
+        $this->assertSame(
+            ['general-chat', 'coding', 'image-generation', 'video-generation', 'audio-generation'],
+            $report['missing']
+        );
+    }
+
+    /**
+     * The manager only touches BOWNERID=0 rows. User-created prompts that
+     * happen to share a granular topic name (e.g. a user's custom
+     * `general-chat` override) must not be flipped — the toggle is a
+     * system-default switch, not an admin override mechanism.
+     */
+    public function testApplyStateOnlyLoadsSystemOwnedRows(): void
+    {
+        $this->promptRepository->expects($this->atLeastOnce())
+            ->method('findAllByTopicAndOwner')
+            ->with($this->isType('string'), 0)
+            ->willReturn([]);
+
+        $this->manager->applyState(true);
+    }
+
+    private function makePrompt(string $topic, bool $enabled, string $language = 'en'): Prompt
+    {
+        $prompt = new Prompt();
+        $prompt->setOwnerId(0);
+        $prompt->setLanguage($language);
+        $prompt->setTopic($topic);
+        $prompt->setShortDescription('test');
+        $prompt->setPrompt('test');
+        $prompt->setEnabled($enabled);
+
+        return $prompt;
+    }
+}

--- a/backend/tests/Unit/Service/Message/GranularTopicsManagerTest.php
+++ b/backend/tests/Unit/Service/Message/GranularTopicsManagerTest.php
@@ -82,7 +82,9 @@ final class GranularTopicsManagerTest extends TestCase
         }
 
         $this->promptRepository->method('findAllByTopicAndOwner')
-            ->willReturnCallback(static fn (string $topic): array => isset($rows[$topic]) ? [$rows[$topic]] : []);
+            ->willReturnCallback(static fn (string $topic, int $ownerId): array => isset($rows[$topic]) && 0 === $ownerId
+                ? [$rows[$topic]]
+                : []);
 
         $this->entityManager->expects($this->exactly(5))->method('persist');
         $this->entityManager->expects($this->once())->method('flush');
@@ -112,7 +114,9 @@ final class GranularTopicsManagerTest extends TestCase
         }
 
         $this->promptRepository->method('findAllByTopicAndOwner')
-            ->willReturnCallback(static fn (string $topic): array => isset($rows[$topic]) ? [$rows[$topic]] : []);
+            ->willReturnCallback(static fn (string $topic, int $ownerId): array => isset($rows[$topic]) && 0 === $ownerId
+                ? [$rows[$topic]]
+                : []);
 
         $this->entityManager->expects($this->never())->method('persist');
         $this->entityManager->expects($this->never())->method('flush');
@@ -134,8 +138,8 @@ final class GranularTopicsManagerTest extends TestCase
         $de = $this->makePrompt('general-chat', enabled: false, language: 'de');
 
         $this->promptRepository->method('findAllByTopicAndOwner')
-            ->willReturnCallback(static function (string $topic) use ($en, $de): array {
-                if ('general-chat' === $topic) {
+            ->willReturnCallback(static function (string $topic, int $ownerId) use ($en, $de): array {
+                if ('general-chat' === $topic && 0 === $ownerId) {
                     return [$en, $de];
                 }
 

--- a/docs/SYNAPSE_ROUTING.md
+++ b/docs/SYNAPSE_ROUTING.md
@@ -177,8 +177,18 @@ Synapse Routing is a **beta feature and is OFF by default** — every install sh
 | ----------------------------- | ------- | ----------- |
 | `SYNAPSE_ROUTING_ENABLED`     | `false` | Enable/disable Synapse Routing entirely. While off, every message goes through `MessageSorter` (AI sort). |
 | `SYNAPSE_CONFIDENCE_THRESHOLD`| `0.78`  | Minimum cosine similarity for Tier-1 to win over the AI fallback. Kept conservative on purpose so beta installs only short-circuit on high-confidence hits; lower carefully if you want more Tier-1 wins at the cost of accuracy. |
+| `GRANULAR_TOPICS_ENABLED`     | `false` | Sibling toggle that controls whether the granular routing aliases (`general-chat`, `coding`, `image-generation`, `video-generation`, `audio-generation`) participate in routing. OFF (default) keeps the legacy AI sorter on the cleaner canonical-only choice list. Toggle ON when Synapse v2 is in use so the embedding tier can discriminate finer-grained intents. **Flipping this toggle also flips `BENABLED` on the matching `BPROMPTS` rows in lock-step** via `GranularTopicsManager`, so the AI sort pool, the Synapse Qdrant indexer, and the Task Prompts admin view all stay consistent without a manual reindex / seed run. |
 
 Changes take effect immediately — no restart required.
+
+### Why two separate toggles?
+
+`SYNAPSE_ROUTING_ENABLED` and `GRANULAR_TOPICS_ENABLED` solve different problems and admins may need to flip them independently:
+
+- **Synapse Routing ON, granular topics OFF** — the embedding tier runs against just the canonical taxonomy (`general`, `mediamaker`, `docsummary`, `officemaker`). Simpler, but coarse-grained intent signals.
+- **Synapse Routing ON, granular topics ON** — Tier-1 has all five granular vectors to match against; `TopicAliasResolver` canonicalizes the result before downstream handlers see it. **This is the recommended Synapse v2 configuration.**
+- **Synapse Routing OFF, granular topics OFF** — the legacy AI sorter sees only canonical topics. Matches the post-hot-fix production state and avoids duplicate-target confusion.
+- **Synapse Routing OFF, granular topics ON** — the legacy AI sorter sees both canonical and granular rows. Only useful for debugging or A/B comparisons; production traffic gets noisier picks.
 
 ## Observability
 

--- a/frontend/src/components/config/SortingPromptConfiguration.vue
+++ b/frontend/src/components/config/SortingPromptConfiguration.vue
@@ -1188,14 +1188,25 @@ const loadStatus = async () => {
 }
 
 // --- Beta toggle loading + persistence -------------------------------------
-const loadSynapseEnabled = async () => {
+const parseBoolConfigValue = (raw: string | undefined): boolean =>
+  ['true', '1', 'yes', 'on'].includes((raw ?? 'false').toLowerCase())
+
+/**
+ * Fetch every `QDRANT_SEARCH.*` BCONFIG row once and hydrate both the
+ * Synapse Routing and the Granular Topics toggles from the same response.
+ *
+ * Replaces two independent `getConfigValues()` calls on mount — the
+ * endpoint returns the full BCONFIG map either way, so paying for two
+ * round-trips just to set two refs is wasted latency.
+ */
+const loadRoutingToggles = async () => {
   if (!isAdmin.value) return
   try {
     const values = await getConfigValues()
-    const raw = values['SYNAPSE_ROUTING_ENABLED']?.value ?? 'false'
-    synapseEnabled.value = ['true', '1', 'yes', 'on'].includes(raw.toLowerCase())
+    synapseEnabled.value = parseBoolConfigValue(values['SYNAPSE_ROUTING_ENABLED']?.value)
+    granularTopicsEnabled.value = parseBoolConfigValue(values['GRANULAR_TOPICS_ENABLED']?.value)
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Failed to load Synapse routing state'
+    const message = err instanceof Error ? err.message : 'Failed to load routing configuration'
     showError(message)
   }
 }
@@ -1239,18 +1250,6 @@ const onToggleSynapse = async (next: boolean) => {
 }
 
 // --- Granular routing topics toggle -----------------------------------------
-const loadGranularTopics = async () => {
-  if (!isAdmin.value) return
-  try {
-    const values = await getConfigValues()
-    const raw = values['GRANULAR_TOPICS_ENABLED']?.value ?? 'false'
-    granularTopicsEnabled.value = ['true', '1', 'yes', 'on'].includes(raw.toLowerCase())
-  } catch (err) {
-    const message = err instanceof Error ? err.message : 'Failed to load granular topics state'
-    showError(message)
-  }
-}
-
 const onToggleGranular = async (next: boolean) => {
   if (!isAdmin.value) return
 
@@ -1509,8 +1508,7 @@ const stopSynapseEmbeddingPolling = () => {
 onMounted(async () => {
   loadSortingPrompt()
   if (isAdmin.value) {
-    loadSynapseEnabled()
-    loadGranularTopics()
+    loadRoutingToggles()
     loadStatus()
     await loadSynapseEmbedding()
     if (synapseActiveRun.value) {

--- a/frontend/src/components/config/SortingPromptConfiguration.vue
+++ b/frontend/src/components/config/SortingPromptConfiguration.vue
@@ -123,6 +123,66 @@
     </div>
 
     <!--
+      Granular routing topics toggle — admin-only. Controls whether the
+      granular routing aliases (general-chat, coding, image-generation,
+      video-generation, audio-generation) are active in the routing pool.
+      Sibling of the Synapse Routing toggle above: when Synapse v2 is on,
+      enabling this lets the embedding tier discriminate finer-grained
+      intents; when Synapse is off, leaving this OFF keeps the legacy AI
+      sorter from seeing duplicate near-identical routing targets.
+      The backend flips BENABLED on the matching BPROMPTS rows in
+      lock-step via GranularTopicsManager.
+    -->
+    <div v-if="isAdmin" class="surface-card overflow-hidden" data-testid="section-routing-granular">
+      <div class="p-6">
+        <div class="flex items-start gap-4 flex-wrap">
+          <div
+            class="p-2 rounded-lg bg-[var(--brand)]/10 flex-shrink-0 flex items-center justify-center w-10 h-10"
+          >
+            <Icon icon="heroicons:squares-2x2" class="w-6 h-6 text-[var(--brand)]" />
+          </div>
+          <div class="flex-1 min-w-0">
+            <h3 class="text-lg font-semibold txt-primary mb-1">
+              {{ $t('config.routing.granularTitle') }}
+            </h3>
+            <p class="text-sm txt-secondary">
+              {{ $t('config.routing.granularSubtitle') }}
+            </p>
+            <p class="text-xs txt-secondary mt-2">
+              {{ $t('config.routing.granularPromptHint') }}
+            </p>
+          </div>
+          <label
+            class="inline-flex items-center gap-3 cursor-pointer flex-shrink-0"
+            data-testid="toggle-granular-enabled"
+          >
+            <span class="text-sm font-medium txt-primary">
+              {{
+                granularTopicsEnabled ? $t('config.routing.betaOn') : $t('config.routing.betaOff')
+              }}
+            </span>
+            <span class="relative inline-flex">
+              <input
+                type="checkbox"
+                class="sr-only peer"
+                :checked="granularTopicsEnabled"
+                :disabled="togglingGranular"
+                data-testid="toggle-granular-input"
+                @change="onToggleGranular(($event.target as HTMLInputElement).checked)"
+              />
+              <span
+                class="w-11 h-6 bg-gray-300 dark:bg-gray-700 rounded-full peer-checked:bg-[var(--brand)] peer-disabled:opacity-50 transition-colors"
+              ></span>
+              <span
+                class="absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full shadow transition-transform peer-checked:translate-x-5"
+              ></span>
+            </span>
+          </label>
+        </div>
+      </div>
+    </div>
+
+    <!--
       Embedding-model picker — admin-only. The whole card is wrapped in
       `v-if="isAdmin"` so non-admin users never receive the markup, not
       even disabled. The amber accents and ADMIN pill make it visually
@@ -843,6 +903,16 @@ const topicSearch = ref('')
 const synapseEnabled = ref(false)
 const togglingSynapse = ref(false)
 
+// --- Granular routing topics toggle ----------------------------------------
+// Sibling of `SYNAPSE_ROUTING_ENABLED`. When ON, the granular routing
+// aliases (general-chat, coding, image-generation, video-generation,
+// audio-generation) are included in the AI sort pool AND their matching
+// BPROMPTS rows are flipped to BENABLED=1 (the backend toggle hook does
+// this in lock-step via GranularTopicsManager). OFF (default) keeps the
+// canonical-only routing experience.
+const granularTopicsEnabled = ref(false)
+const togglingGranular = ref(false)
+
 // --- Synapse embedding-model state -----------------------------------------
 const synapseEmbeddingStatus = ref<SynapseEmbeddingStatusResponse | null>(null)
 const synapseEmbeddingSelection = ref<number | null>(null)
@@ -1168,6 +1238,48 @@ const onToggleSynapse = async (next: boolean) => {
   }
 }
 
+// --- Granular routing topics toggle -----------------------------------------
+const loadGranularTopics = async () => {
+  if (!isAdmin.value) return
+  try {
+    const values = await getConfigValues()
+    const raw = values['GRANULAR_TOPICS_ENABLED']?.value ?? 'false'
+    granularTopicsEnabled.value = ['true', '1', 'yes', 'on'].includes(raw.toLowerCase())
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to load granular topics state'
+    showError(message)
+  }
+}
+
+const onToggleGranular = async (next: boolean) => {
+  if (!isAdmin.value) return
+
+  togglingGranular.value = true
+  const previous = granularTopicsEnabled.value
+  granularTopicsEnabled.value = next
+  try {
+    const result = await updateConfigValue('GRANULAR_TOPICS_ENABLED', next ? 'true' : 'false')
+    if (!result.success) {
+      throw new Error(result.error || 'Failed to update granular topics state')
+    }
+    // The backend hook (GranularTopicsManager) flips BENABLED on the
+    // matching catalog rows in the same write transaction. Reload the
+    // task-prompts cache the next time the user navigates there;
+    // nothing on this page depends on per-prompt BENABLED state.
+    success(
+      next
+        ? t('config.routing.granularToggleEnabledNotice')
+        : t('config.routing.granularToggleDisabledNotice')
+    )
+  } catch (err) {
+    granularTopicsEnabled.value = previous
+    const message = err instanceof Error ? err.message : 'Failed to update granular topics state'
+    showError(message)
+  } finally {
+    togglingGranular.value = false
+  }
+}
+
 const reindex = async (opts: { force?: boolean; recreate?: boolean }) => {
   if (!isAdmin.value) {
     warning('Admin access required.')
@@ -1398,6 +1510,7 @@ onMounted(async () => {
   loadSortingPrompt()
   if (isAdmin.value) {
     loadSynapseEnabled()
+    loadGranularTopics()
     loadStatus()
     await loadSynapseEmbedding()
     if (synapseActiveRun.value) {

--- a/frontend/src/components/config/SortingPromptConfiguration.vue
+++ b/frontend/src/components/config/SortingPromptConfiguration.vue
@@ -1192,12 +1192,10 @@ const parseBoolConfigValue = (raw: string | undefined): boolean =>
   ['true', '1', 'yes', 'on'].includes((raw ?? 'false').toLowerCase())
 
 /**
- * Fetch every `QDRANT_SEARCH.*` BCONFIG row once and hydrate both the
- * Synapse Routing and the Granular Topics toggles from the same response.
- *
- * Replaces two independent `getConfigValues()` calls on mount — the
- * endpoint returns the full BCONFIG map either way, so paying for two
- * round-trips just to set two refs is wasted latency.
+ * Hydrate both the Synapse Routing and the Granular Topics toggles from
+ * a single `/api/v1/admin/config/values` response. The endpoint returns
+ * the full BCONFIG map either way, so reading once and routing the same
+ * payload into both refs avoids any duplicate fetch as the page grows.
  */
 const loadRoutingToggles = async () => {
   if (!isAdmin.value) return

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -1329,7 +1329,12 @@
       "confirmEnableConfirm": "Beta aktivieren",
       "confirmEnableCancel": "Bei AI-Sortierung bleiben",
       "toggleEnabledNotice": "Synapse Routing aktiviert. AI-Sortierung wird nur noch als Fallback genutzt.",
-      "toggleDisabledNotice": "Synapse Routing deaktiviert. Alle Nachrichten verwenden jetzt den AI-Sorter."
+      "toggleDisabledNotice": "Synapse Routing deaktiviert. Alle Nachrichten verwenden jetzt den AI-Sorter.",
+      "granularTitle": "Granulare Routing-Themen",
+      "granularSubtitle": "Aktiviert die granularen Routing-Aliase (general-chat, coding, image-generation, video-generation, audio-generation). Sie sind Aliase der kanonischen Themen (general, mediamaker) – sinnvoll für die Embedding-Stufe von Synapse Routing v2, erscheinen für den klassischen AI-Sorter aber als doppelte Auswahloptionen. Lass diesen Schalter auf AUS, wenn du oben kein Synapse Routing aktiviert hast.",
+      "granularPromptHint": "Das Umlegen dieses Schalters setzt parallel das BENABLED-Flag der passenden Task-Prompts auf 1 bzw. 0.",
+      "granularToggleEnabledNotice": "Granulare Routing-Themen aktiviert. Die passenden Task-Prompts wurden wieder aktiviert.",
+      "granularToggleDisabledNotice": "Granulare Routing-Themen deaktiviert. Die passenden Task-Prompts sind ausgeblendet – nur kanonische Themen sind aktiv."
     },
     "sortingPrompt": {
       "title": "Preprocessor",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -1225,7 +1225,12 @@
       "confirmEnableConfirm": "Enable Beta",
       "confirmEnableCancel": "Keep AI Sorting",
       "toggleEnabledNotice": "Synapse Routing enabled. AI sorting will only be used as a fallback.",
-      "toggleDisabledNotice": "Synapse Routing disabled. All messages now use the AI sorter."
+      "toggleDisabledNotice": "Synapse Routing disabled. All messages now use the AI sorter.",
+      "granularTitle": "Granular routing topics",
+      "granularSubtitle": "Enable the granular routing aliases (general-chat, coding, image-generation, video-generation, audio-generation). Aliases of the canonical topics (general, mediamaker) — useful for Synapse Routing v2's embedding tier, but added as duplicate choices for the legacy AI sorter. Keep OFF unless you have Synapse Routing enabled above.",
+      "granularPromptHint": "Toggling this flag also flips the matching task prompts back and forth between BENABLED=1 and BENABLED=0.",
+      "granularToggleEnabledNotice": "Granular routing topics enabled. The matching task prompts have been re-enabled.",
+      "granularToggleDisabledNotice": "Granular routing topics disabled. The matching task prompts have been hidden — only canonical topics are active."
     },
     "sortingPrompt": {
       "title": "Preprocessor",


### PR DESCRIPTION
## Why

The legacy AI sorter on every install was being shown both the canonical routing topics (`general`, `mediamaker`) AND the five granular aliases (`general-chat`, `coding`, `image-generation`, `video-generation`, `audio-generation`) as separate choices in `[KEYLIST]`/`[DYNAMICLIST]`.

`TopicAliasResolver` resolves the granular topic back to the canonical one immediately after the LLM picks it, so the LLM was being asked to disambiguate near-duplicate routing targets that downstream code didn't even care about. That produced brittle, model-dependent picks for everyday chat ("general" vs "general-chat") and media-generation messages ("mediamaker" vs "image-generation" / "video-generation" / "audio-generation").

The duplication was discovered on production where `general-chat` had **0** historical messages despite being live since Synapse v2 shipped — the alias resolver was canonicalising everything to `general` after the fact, but the AI sort prompt was still being polluted by the alias rows on every classification.

`coding` was already retired in #878 with the same pattern (`enabled => false` in catalog). This PR extends that treatment to the other four aliases and adds an admin-controlled escape hatch.

## What

- **`PromptCatalog::all()`** — the four remaining granular aliases now ship `'enabled' => false` (mirrors `coding`). On the next `app:seed` run, the catalog idempotently flips `BENABLED=0` on existing installs; fresh installs come up clean. The `SynapseIndexer` drops their orphan vectors from Qdrant on its next pass.
- **`general` canonical row** absorbs the `general-chat` keyword list (chat / lifestyle / programming terms) so Synapse v2 embedding recall stays strong if/when it ever gets enabled. The AI sorter only reads `BSHORTDESC`, so its prompt is unchanged.
- **New admin toggle `QDRANT_SEARCH.GRANULAR_TOPICS_ENABLED`** (default `false`, schema-registered under the existing **Vector DB → Synapse Routing** section). Flipping it in the admin UI flips `BENABLED` on the matching `BPROMPTS` rows in lock-step via the new `GranularTopicsManager` service — no manual SQL or `app:seed` run required.
- **`MessageSorter::buildTopicPool()`** reads the toggle and strips alias topics from the AI-sort choice list as a belt-and-suspenders gate. Even if an operator manually re-enables a granular row in `BPROMPTS` while the toggle is off, the AI sorter still sees a clean canonical-only pool.
- **Admin UI**: new toggle card directly under the Synapse Routing toggle in **Config → Routing Configuration**. Loads via `getConfigValues()`, writes via `updateConfigValue()`, EN + DE i18n strings included.
- **Docs**: `docs/SYNAPSE_ROUTING.md` gets a new row in the configuration table plus a "Why two separate toggles?" section covering all four (Synapse × Granular) combinations and the recommended setting for each.

## Impact on legacy AI routing (what this PR fixes for everyone, including Synapse-off installs)

| Before | After |
| --- | --- |
| AI sort choice list: ~13 topics including 5 granular aliases | AI sort choice list: ~8 topics, canonical only |
| LLM picks between `general` and `general-chat` | LLM picks `general` (deterministic) |
| LLM picks between `mediamaker`, `image-generation`, `video-generation`, `audio-generation` | LLM picks `mediamaker`, sets `BMEDIA` separately in the JSON (existing behaviour) |

**What this is NOT:** no latency improvement (the legacy path still makes a full LLM call per classification). Latency wins are still Synapse Routing v2 territory — this PR is purely about determinism / correctness of the choice list.

## Toggle semantics

The new `GRANULAR_TOPICS_ENABLED` is independent of `SYNAPSE_ROUTING_ENABLED` so the four combinations are all valid:

| Synapse | Granular | Behaviour |
| --- | --- | --- |
| OFF | OFF (default) | Legacy AI sort with canonical-only choice list. **Cleanest production default.** |
| OFF | ON | Legacy AI sort with both canonical + granular in the pool (only useful for A/B debugging). |
| ON | OFF | Synapse embedding tier discriminates only over canonical topics. |
| ON | ON | Synapse embedding tier discriminates over granular topics; `TopicAliasResolver` canonicalises before downstream handlers see anything. **Recommended Synapse v2 setup.** |

## Production migration

A hot-fix already disabled `general-chat` on web100 last week. After this PR deploys + `app:seed` runs:

- `general-chat` stays `BENABLED=0` (catalog now matches the hot-fix value, no churn).
- `image-generation`, `video-generation`, `audio-generation` flip from `BENABLED=1` to `BENABLED=0` automatically — same cleanup the SQL hot-fix did for `general-chat`, extended to the rest of the granular family.
- `general` keyword list converges with the merged value already on prod.
- The admin toggle defaults to OFF — no behaviour change for admins who don't touch it.

The change is fully reversible: flipping the toggle ON in the admin UI re-enables every alias row in one click.

## Test plan

- [x] `make -C backend lint` — PSR-12 clean
- [x] `make -C backend phpstan` — 0 errors
- [x] `make -C backend test` — all 21 new/modified tests pass; 16 pre-existing `StripeWebhookControllerTest` rate-limit failures confirmed on `origin/main` baseline (stashed my changes, identical 16 failures)
- [x] `docker compose exec -T frontend npm run check:types` — vue-tsc clean
- [x] `make -C frontend lint` — Prettier + ESLint clean
- [x] `make -C frontend test` — 549/549 Vitest tests pass
- [x] Admin UI toggle renders + persists + flips BENABLED end-to-end on local stack
- [x] AI sort pool inspection: log line `MessageSorter: Dynamic list built` shows 5 fewer entries after deploy + seed
- [ ] Post-merge on staging: confirm `app:seed` flips `BENABLED=0` on `image-generation`/`video-generation`/`audio-generation`
- [ ] Post-merge on staging: confirm `Config → Routing Configuration` shows the new toggle next to Synapse Routing

## Files

**Backend (production)**
- `backend/src/Prompt/PromptCatalog.php` — granular aliases ship `enabled => false`; `general` keywords expanded
- `backend/src/Service/Message/GranularTopicsManager.php` (new) — idempotent BENABLED flipper
- `backend/src/Service/Message/MessageSorter.php` — `buildTopicPool()` filter + new constructor deps
- `backend/src/Service/Admin/SystemConfigService.php` — schema entry + write hook
- `backend/src/Repository/PromptRepository.php` — `findAllByTopicAndOwner()` for multi-language flip

**Backend (tests)**
- `backend/tests/Unit/PromptCatalogTest.php` — ship-disabled + canonical-keyword assertions
- `backend/tests/Unit/MessageSorterTest.php` — filter behaviour across toggle states
- `backend/tests/Unit/Service/Message/GranularTopicsManagerTest.php` (new) — enable/disable/idempotent/multi-language/missing-rows/owner-scoping
- `backend/tests/Unit/Service/Admin/SystemConfigServiceTest.php` (new) — write hook including manager-failure isolation and truthy-value parser parity

**Frontend**
- `frontend/src/components/config/SortingPromptConfiguration.vue` — toggle card under the existing Synapse toggle
- `frontend/src/i18n/en.json`, `frontend/src/i18n/de.json` — `config.routing.granular*` keys (both languages)

**Docs**
- `docs/SYNAPSE_ROUTING.md` — configuration table row + four-combination explainer