### PR TITLE
fix(widget): split comma-separated handoff trigger entries

### DIFF
--- a/backend/config/packages/security.yaml
+++ b/backend/config/packages/security.yaml
@@ -101,6 +101,7 @@ security:
         - { path: ^/api/v1/widget/[^/]+/message, roles: PUBLIC_ACCESS }
         - { path: ^/api/v1/widget/[^/]+/upload, roles: PUBLIC_ACCESS }
         - { path: ^/api/v1/widget/[^/]+/typing, roles: PUBLIC_ACCESS }
+        - { path: ^/api/v1/widget/[^/]+/human-handoff, roles: PUBLIC_ACCESS }
         - { path: ^/api/v1/widget/[^/]+/files/[^/]+/download, roles: PUBLIC_ACCESS }
         - { path: ^/api/v1/messages/stream, roles: PUBLIC_ACCESS }
         - { path: ^/api, methods: [OPTIONS], roles: PUBLIC_ACCESS }

--- a/backend/src/Service/WidgetService.php
+++ b/backend/src/Service/WidgetService.php
@@ -446,6 +446,14 @@ HTML;
         // Trigger phrases: list of strings (case-insensitive substring match
         // against incoming user messages). Cap count + length to prevent
         // pathological config and oversized JSON payloads.
+        //
+        // We also split each stored entry on commas: operators occasionally
+        // pasted multi-phrase lists into a single tag (the v1 placeholder
+        // suggested that pattern), producing mega-strings like
+        // `"real person, human agent, talk to someone"` which the auto-handoff
+        // matcher would search for verbatim and never match. Splitting here
+        // self-heals those legacy entries on the next admin save AND makes
+        // the API more forgiving for clients that build the list themselves.
         if (!is_array($config['humanHandoffTriggers'] ?? null)) {
             $config['humanHandoffTriggers'] = [];
         }
@@ -454,13 +462,15 @@ HTML;
             if (!is_string($trigger)) {
                 continue;
             }
-            $trimmed = trim($trigger);
-            if ('' === $trimmed) {
-                continue;
-            }
-            $sanitizedTriggers[] = mb_substr($trimmed, 0, 100);
-            if (count($sanitizedTriggers) >= 20) {
-                break;
+            foreach (explode(',', $trigger) as $piece) {
+                $trimmed = trim($piece);
+                if ('' === $trimmed) {
+                    continue;
+                }
+                $sanitizedTriggers[] = mb_substr($trimmed, 0, 100);
+                if (count($sanitizedTriggers) >= 20) {
+                    break 2;
+                }
             }
         }
         $config['humanHandoffTriggers'] = array_values(array_unique($sanitizedTriggers));

--- a/frontend/src/components/widgets/AdvancedWidgetConfig.vue
+++ b/frontend/src/components/widgets/AdvancedWidgetConfig.vue
@@ -2010,17 +2010,23 @@ const handoffTestSubmitting = ref(false)
 const handoffTestResult = ref<'idle' | 'success' | 'error'>('idle')
 
 const addHandoffTrigger = () => {
-  const value = newHandoffTrigger.value.trim()
-  if (!value) return
   if (!Array.isArray(config.humanHandoffTriggers)) {
     config.humanHandoffTriggers = []
   }
-  if (config.humanHandoffTriggers.length >= 20) return
-  if (config.humanHandoffTriggers.includes(value)) {
-    newHandoffTrigger.value = ''
-    return
+  // Split comma-separated bulk entries into individual trigger tags.
+  // Operators naturally paste comma-joined phrases from notes; storing
+  // them as one mega-string makes the backend's substring matcher
+  // search for the entire list verbatim, which never fires. Each piece
+  // becomes its own tag so the matcher works one phrase at a time.
+  const pieces = newHandoffTrigger.value
+    .split(',')
+    .map((piece) => piece.trim())
+    .filter((piece) => piece.length > 0)
+  for (const value of pieces) {
+    if (config.humanHandoffTriggers.length >= 20) break
+    if (config.humanHandoffTriggers.includes(value)) continue
+    config.humanHandoffTriggers.push(value)
   }
-  config.humanHandoffTriggers.push(value)
   newHandoffTrigger.value = ''
 }
 

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -2383,7 +2383,7 @@
         "buttonEnabled": "Button „Mit einem Menschen sprechen” im Widget anzeigen",
         "buttonEnabledHelp": "Wenn aus, lösen nur Trigger-Phrasen die Benachrichtigung aus.",
         "triggers": "Trigger-Phrasen für automatische Übergabe",
-        "triggerPlaceholder": "z. B. echter Mensch, Mitarbeiter sprechen",
+        "triggerPlaceholder": "z. B. mit Mitarbeiter sprechen (eine Phrase pro Tag oder komma-getrennt einfügen)",
         "triggersHelp": "Groß-/Kleinschreibung wird ignoriert, einfacher Teilstring-Vergleich pro Besuchernachricht. Bis zu 20 Phrasen à 100 Zeichen. Sobald eine Übergabe gefeuert ist, bleibt die Session ruhig, bis der Mitarbeiter sie zurückgibt.",
         "testButton": "Slack-Test senden",
         "testSuccess": "Test-Nachricht zugestellt.",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -2336,7 +2336,7 @@
         "buttonEnabled": "Show \"Talk to a human\" button in the widget",
         "buttonEnabledHelp": "When off, only trigger phrases will page Slack.",
         "triggers": "Auto-page trigger phrases",
-        "triggerPlaceholder": "e.g. talk to a human, real person",
+        "triggerPlaceholder": "e.g. talk to a human (one phrase per tag, or paste comma-separated)",
         "triggersHelp": "Case-insensitive substring match against each visitor message. Up to 20 phrases, 100 chars each. Once a handoff fires, repeat triggers stay quiet until the operator hands the chat back.",
         "testButton": "Send Slack test",
         "testSuccess": "Test message delivered.",


### PR DESCRIPTION
## Summary

Auto-handoff Slack pings never fired in production despite the test webhook
working: the customer had entered trigger phrases as a comma-separated list,
which v1 stored as one mega-string. The auto-handoff matcher does
`str_contains(visitorMessage, trigger)` — searching for the entire list
verbatim against a visitor's short message — and consequently never matched.

## Changes

* **`AdvancedWidgetConfig.addHandoffTrigger`**: split comma-separated input
  into individual tags on add (dedup + 20-tag cap applied per piece).
* **`WidgetService::sanitizeConfig`**: also split stored entries on commas
  during sanitization. Self-heals existing mega-string tags — operators
  just hit Save once, no manual cleanup.
* **i18n EN + DE**: trigger placeholder copy now says "one phrase per tag,
  or paste comma-separated" instead of suggesting commas as the format.

## Verification

* `make -C backend lint && make -C backend phpstan && make -C backend test`
  (1763 tests, all green)
* `make -C frontend lint && npm run check:types && make -C frontend test`
  (549 tests, all green)
* Manual: paste `"a, b, c"` in the trigger input → three tags appear.
* Manual: save a widget with legacy mega-string trigger → tags split on next
  load, auto-handoff fires on a single matching phrase.