### PR TITLE
fix(chat): improve message handling in human mode and optimize

### DIFF
--- a/frontend/src/components/widgets/ChatWidget.vue
+++ b/frontend/src/components/widgets/ChatWidget.vue
@@ -1532,17 +1532,27 @@ const sendMessage = async () => {
   await scrollToBottom()
 
   isSending.value = true
-  isTyping.value = true
 
-  const assistantMessageId = Date.now().toString()
-  messages.value.push({
-    id: assistantMessageId,
-    role: 'assistant',
-    type: 'text',
-    content: '',
-    timestamp: new Date(),
-    sender: 'ai',
-  })
+  // During human takeover there is no AI reply: the backend only persists the
+  // visitor message and notifies the operator via SSE. Adding an empty assistant
+  // placeholder (and later reloading history to fill it) is what made the
+  // visitor's own message vanish until a manual reload. So skip it in human mode
+  // and keep the optimistic user message we just pushed.
+  const isHumanMode = chatMode.value === 'human' || chatMode.value === 'waiting'
+
+  let assistantMessageId: string | null = null
+  if (!isHumanMode) {
+    isTyping.value = true
+    assistantMessageId = Date.now().toString()
+    messages.value.push({
+      id: assistantMessageId,
+      role: 'assistant',
+      type: 'text',
+      content: '',
+      timestamp: new Date(),
+      sender: 'ai',
+    })
+  }
 
   try {
     const result = await sendWidgetMessage(props.widgetId, userMessage, sessionId.value, {

--- a/frontend/src/views/WidgetSessionsView.vue
+++ b/frontend/src/views/WidgetSessionsView.vue
@@ -1751,12 +1751,43 @@ const sendMessage = async () => {
     if (selectedSession.value.mode === 'internal') {
       await sendInternalMessage(messageText.value.trim(), fileIds)
     } else {
-      await widgetSessionsApi.sendHumanMessage(
+      const outgoingText = messageText.value.trim() || t('widgetSessions.fileAttached')
+      const result = await widgetSessionsApi.sendHumanMessage(
         widgetId.value,
         selectedSession.value.sessionId,
-        messageText.value.trim() || t('widgetSessions.fileAttached'),
+        outgoingText,
         fileIds
       )
+
+      // Render the operator's own message immediately. We use the real message id
+      // returned by the API so the subsequent SSE echo is de-duplicated by
+      // handleSessionEvent() instead of being appended a second time.
+      if (result?.messageId && !sessionMessages.value.some((m) => m.id === result.messageId)) {
+        const optimisticFiles: widgetSessionsApi.SessionMessageFile[] = selectedFiles.value.map(
+          (file, index) => ({
+            id: fileIds[index],
+            filename: file.name,
+            mimeType: file.type,
+            size: file.size,
+          })
+        )
+        sessionMessages.value.push({
+          id: result.messageId,
+          direction: 'OUT',
+          text: outgoingText,
+          timestamp: Math.floor(Date.now() / 1000),
+          sender: 'human',
+          files: optimisticFiles.length > 0 ? optimisticFiles : undefined,
+        })
+
+        const previewText = outgoingText.substring(0, 100)
+        selectedSession.value.lastMessagePreview = previewText
+        const sessionIndex = sessions.value.findIndex((s) => s.id === selectedSession.value?.id)
+        if (sessionIndex !== -1) {
+          sessions.value[sessionIndex].lastMessagePreview = previewText
+        }
+        nextTick(() => scrollToBottom())
+      }
 
       if (selectedSession.value.mode === 'waiting') {
         selectedSession.value.mode = 'human'


### PR DESCRIPTION
## Summary
Takover fix

## Changes
- Adjusted message sending logic to prevent empty assistant messages during human takeover, ensuring the user's message remains visible.
- Enhanced optimistic message rendering by using the actual message ID returned from the API, improving user experience during message sending.
- Updated session message previews to reflect the latest outgoing messages accurately.
- 
## Verification
- [ ] Not tested (explain)
- [x] Manual
- [ ] Tests added/updated

## Notes
<!-- Related issues/links/threads. -->

## Screenshots/Logs
