### PR TITLE
fix(frontend): block data: URI download links in markdown renderer

### DIFF
--- a/backend/src/Controller/StreamController.php
+++ b/backend/src/Controller/StreamController.php
@@ -10,7 +10,6 @@ use App\Entity\Prompt;
 use App\Entity\User;
 use App\Message\ExtractMemoriesCommand;
 use App\Service\File\DocumentGeneratorService;
-use App\Service\File\FileHelper;
 use App\Service\File\UserUploadPathBuilder;
 use App\Service\GuestSessionService;
 use App\Service\MemoryExtractionDispatcher;
@@ -2311,10 +2310,11 @@ class StreamController extends AbstractController
             $file->setFileName($filename);
             $file->setFileSize($fileSize);
             $file->setFileMime($mimeType);
-            // Only store text content for text-based files (not binary formats)
-            if (FileHelper::isTextBasedMimeType($mimeType)) {
-                $file->setFileText($content);
-            }
+            // Persist the source content (Markdown/CSV/text) the document was
+            // built from — even for binary office formats. It is the document's
+            // text for search and, crucially, lets a later edit transform the
+            // exact current content instead of re-deriving it.
+            $file->setFileText($content);
             $file->setStatus('generated');
 
             $this->em->persist($file);

--- a/backend/src/Controller/StreamController.php
+++ b/backend/src/Controller/StreamController.php
@@ -9,6 +9,7 @@ use App\Entity\Message;
 use App\Entity\Prompt;
 use App\Entity\User;
 use App\Message\ExtractMemoriesCommand;
+use App\Service\File\DocumentGeneratorService;
 use App\Service\File\FileHelper;
 use App\Service\File\UserUploadPathBuilder;
 use App\Service\GuestSessionService;
@@ -52,6 +53,7 @@ class StreamController extends AbstractController
         private PromptService $promptService,
         private MessageForwardingService $messageForwardingService,
         private MemoryExtractionDispatcher $memoryExtractionDispatcher,
+        private DocumentGeneratorService $documentGenerator,
         #[Autowire(env: 'default::bool:COST_BUDGET_GATE_ENABLED')]
         private bool $costBudgetGateEnabled = false,
     ) {
@@ -2279,9 +2281,21 @@ class StreamController extends AbstractController
                 }
             }
 
-            // Write file content
-            if (!file_put_contents($absolutePath, $content)) {
-                $this->logger->error('StreamController: Failed to write file', ['path' => $absolutePath]);
+            // Write file content (real OOXML for docx/xlsx/pptx, text otherwise)
+            try {
+                $this->documentGenerator->write($content, $extension, $absolutePath);
+            } catch (\Throwable $e) {
+                $this->logger->error('StreamController: Failed to write file', [
+                    'path' => $absolutePath,
+                    'error' => $e->getMessage(),
+                ]);
+
+                return null;
+            }
+
+            $fileSize = filesize($absolutePath);
+            if (false === $fileSize) {
+                $this->logger->error('StreamController: Failed to read generated file size', ['path' => $absolutePath]);
 
                 return null;
             }
@@ -2295,7 +2309,7 @@ class StreamController extends AbstractController
             $file->setFilePath($relativePath);
             $file->setFileType($extension);
             $file->setFileName($filename);
-            $file->setFileSize(strlen($content));
+            $file->setFileSize($fileSize);
             $file->setFileMime($mimeType);
             // Only store text content for text-based files (not binary formats)
             if (FileHelper::isTextBasedMimeType($mimeType)) {

--- a/backend/src/Prompt/PromptCatalog.php
+++ b/backend/src/Prompt/PromptCatalog.php
@@ -198,8 +198,8 @@ class PromptCatalog
             [
                 'topic' => 'officemaker',
                 'language' => 'en',
-                'shortDescription' => 'The user asks for the generation of an Excel, Powerpoint or Word document. Not for any other format. This prompt can only handle the generation of ONE document with a clear prompt.',
-                'keywords' => 'excel, xlsx, spreadsheet, tabellenkalkulation, csv, word, docx, document, dokument, powerpoint, pptx, presentation, praesentation, slide, folie, sheet, tabelle, office document, office datei, generate excel, erstelle excel, create spreadsheet, create document, dokument erstellen',
+                'shortDescription' => 'The user asks to generate OR to modify/reformat a single Excel, PowerPoint or Word document (CSV, XLSX, DOCX, PPTX). This includes follow-up requests that change the content or formatting of a document the assistant generated earlier in the same conversation (e.g. "make the title bold/bigger in the file", "add a column", "change the document"). Not for any other format. Handles exactly ONE document.',
+                'keywords' => 'excel, xlsx, spreadsheet, tabellenkalkulation, csv, word, docx, document, dokument, powerpoint, pptx, presentation, praesentation, slide, folie, sheet, tabelle, office document, office datei, generate excel, erstelle excel, create spreadsheet, create document, dokument erstellen, dokument aendern, dokument bearbeiten, dokument anpassen, datei aendern, datei bearbeiten, datei anpassen, in der datei, in dem dokument, edit document, modify document, update document, reformat document, change the document, change the file, update the file',
                 'prompt' => self::officeMakerPrompt(),
             ],
             [
@@ -771,6 +771,17 @@ You MUST respond with PURE JSON - NO markdown code blocks, NO backticks, NO form
 - For tables/spreadsheets: Include headers and at least 5-10 sample rows
 - For documents: Include proper sections, headings, and formatted text
 - Use appropriate formatting for the file type
+
+## Modifying a previously generated document
+
+If the user asks to change or reformat a document you generated earlier in this
+conversation (e.g. "make the title bold/bigger", "add a column"):
+- Reconstruct the COMPLETE document, applying the requested change. Never return
+  only the changed part.
+- Reuse the original content from the conversation and keep the same BFILEPATH
+  filename.
+- Apply formatting via Markdown in BFILETEXT (e.g. `# Heading` for a larger,
+  bold title, `**bold**`, lists, tables).
 
 ## Example Output
 

--- a/backend/src/Prompt/PromptCatalog.php
+++ b/backend/src/Prompt/PromptCatalog.php
@@ -748,13 +748,20 @@ You MUST respond with PURE JSON - NO markdown code blocks, NO backticks, NO form
 
 ## Supported Formats
 
-1. **CSV** (.csv):
-   - Use comma-separated values
+1. **CSV** (.csv) and **Excel** (.xlsx):
+   - Provide BFILETEXT as comma-separated values (CSV), even for .xlsx
    - First row should contain headers
    - Each subsequent row is a data record
    - Example: "Name,Age\nJohn,25\nJane,30"
 
-2. **Markdown/Text** (.md, .txt):
+2. **Word** (.docx):
+   - Provide BFILETEXT as Markdown (headings with #, **bold**, lists, tables)
+   - The server converts this Markdown into a real Word document
+
+3. **PowerPoint** (.pptx):
+   - Provide BFILETEXT as Markdown; each top-level heading (#) starts a new slide
+
+4. **Markdown/Text** (.md, .txt):
    - For simple text documents
    - Use markdown formatting when appropriate
 

--- a/backend/src/Prompt/PromptCatalog.php
+++ b/backend/src/Prompt/PromptCatalog.php
@@ -772,16 +772,27 @@ You MUST respond with PURE JSON - NO markdown code blocks, NO backticks, NO form
 - For documents: Include proper sections, headings, and formatted text
 - Use appropriate formatting for the file type
 
-## Modifying a previously generated document
+## Editing a document from earlier in the conversation
 
-If the user asks to change or reformat a document you generated earlier in this
-conversation (e.g. "make the title bold/bigger", "add a column"):
-- Reconstruct the COMPLETE document, applying the requested change. Never return
-  only the changed part.
-- Reuse the original content from the conversation and keep the same BFILEPATH
-  filename.
-- Apply formatting via Markdown in BFILETEXT (e.g. `# Heading` for a larger,
-  bold title, `**bold**`, lists, tables).
+This is a frequent case — handle it carefully. The conversation contains the
+current content of the document, shown either as the user's original text or as
+a block labeled "Current content of the file you previously generated".
+
+When the user asks to change, add to, or reformat that document
+(e.g. "make the title bold/bigger", "add a column", "insert a heading"):
+- START from the existing content. Keep ALL parts the user did not ask to change
+  exactly as they are.
+- Apply EXACTLY the requested change and nothing else.
+- Output the COMPLETE updated document in BFILETEXT. NEVER return only the
+  changed part, and NEVER return the unchanged original — the result must
+  visibly contain the requested change.
+- Keep the same BFILEPATH filename as before.
+- Express all formatting as Markdown in BFILETEXT: `# Title` for a large, bold
+  heading, `**bold**`, `*italic*`, `-` for lists, and Markdown tables.
+
+Example — user says "add a bold, bigger title 'Report' to the file" and the
+current content is "Some body text.":
+{"BFILEPATH":"report.docx","BFILETEXT":"# Report\n\nSome body text."}
 
 ## Example Output
 

--- a/backend/src/Service/File/DocumentGeneratorService.php
+++ b/backend/src/Service/File/DocumentGeneratorService.php
@@ -1,0 +1,227 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\File;
+
+use PhpOffice\PhpPresentation\IOFactory as PresentationIOFactory;
+use PhpOffice\PhpPresentation\PhpPresentation;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Writer\Xlsx as XlsxWriter;
+use PhpOffice\PhpWord\IOFactory as WordIOFactory;
+use PhpOffice\PhpWord\PhpWord;
+use PhpOffice\PhpWord\Shared\Html as WordHtml;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Generates real, openable office documents from AI-generated content.
+ *
+ * AI file generation returns the document body as plain text/markdown. For
+ * text formats (csv, txt, md, …) that content can be written verbatim, but
+ * office formats (docx, xlsx, pptx) are OOXML/ZIP containers. Writing raw text
+ * with an office extension produces a corrupt file that Word/Excel refuse to
+ * open ("unreadable content"). This service builds valid OOXML files using the
+ * PhpOffice libraries instead.
+ */
+final readonly class DocumentGeneratorService
+{
+    /** Office formats that must be produced as real OOXML binaries. */
+    private const BINARY_FORMATS = ['docx', 'xlsx', 'pptx'];
+
+    public function __construct(
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * Whether the given extension requires real binary OOXML generation.
+     */
+    public function isBinaryFormat(string $extension): bool
+    {
+        return in_array(strtolower($extension), self::BINARY_FORMATS, true);
+    }
+
+    /**
+     * Write content to disk using the correct encoding for the extension.
+     *
+     * Office formats are rendered as valid OOXML; all other formats are
+     * written as UTF-8 text.
+     *
+     * @throws \RuntimeException when the file cannot be written
+     */
+    public function write(string $content, string $extension, string $absolutePath): void
+    {
+        switch (strtolower($extension)) {
+            case 'docx':
+                $this->writeDocx($content, $absolutePath);
+                break;
+            case 'xlsx':
+                $this->writeXlsx($content, $absolutePath);
+                break;
+            case 'pptx':
+                $this->writePptx($content, $absolutePath);
+                break;
+            default:
+                if (false === file_put_contents($absolutePath, $content)) {
+                    throw new \RuntimeException('Failed to write file: '.$absolutePath);
+                }
+        }
+    }
+
+    /**
+     * Build a Word document. The AI content is treated as markdown and
+     * converted to HTML so headings, lists, bold text and tables are kept.
+     * If HTML parsing fails, fall back to plain paragraphs so the file is
+     * still valid and openable.
+     */
+    private function writeDocx(string $content, string $absolutePath): void
+    {
+        $html = (new \Parsedown())->text($content);
+
+        try {
+            $phpWord = new PhpWord();
+            $section = $phpWord->addSection();
+            WordHtml::addHtml($section, $html, false, false);
+        } catch (\Throwable $e) {
+            $this->logger->warning('DocumentGeneratorService: DOCX HTML parsing failed, using plain text fallback', [
+                'error' => $e->getMessage(),
+            ]);
+
+            $phpWord = new PhpWord();
+            $section = $phpWord->addSection();
+            foreach ($this->splitLines($content) as $line) {
+                if ('' === trim($line)) {
+                    $section->addTextBreak();
+                } else {
+                    $section->addText($line);
+                }
+            }
+        }
+
+        WordIOFactory::createWriter($phpWord, 'Word2007')->save($absolutePath);
+    }
+
+    /**
+     * Build an Excel workbook. CSV-style content is split into rows/columns,
+     * otherwise each line becomes a single cell in column A.
+     */
+    private function writeXlsx(string $content, string $absolutePath): void
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+
+        $lines = $this->splitLines(trim($content));
+        $looksLikeCsv = $this->looksLikeCsv($lines);
+
+        $rowIndex = 1;
+        foreach ($lines as $line) {
+            if ($looksLikeCsv) {
+                $cells = str_getcsv($line, ',', '"', '');
+                $colIndex = 1;
+                foreach ($cells as $cell) {
+                    $sheet->setCellValueExplicit(
+                        [$colIndex, $rowIndex],
+                        (string) $cell,
+                        \PhpOffice\PhpSpreadsheet\Cell\DataType::TYPE_STRING
+                    );
+                    ++$colIndex;
+                }
+            } else {
+                $sheet->setCellValueExplicit(
+                    [1, $rowIndex],
+                    $line,
+                    \PhpOffice\PhpSpreadsheet\Cell\DataType::TYPE_STRING
+                );
+            }
+            ++$rowIndex;
+        }
+
+        (new XlsxWriter($spreadsheet))->save($absolutePath);
+    }
+
+    /**
+     * Build a PowerPoint presentation. The content is split into slides on
+     * markdown headings; each slide gets a single text box with the (lightly
+     * de-marked) lines of that section.
+     */
+    private function writePptx(string $content, string $absolutePath): void
+    {
+        $presentation = new PhpPresentation();
+        $slides = $this->splitIntoSlides($content);
+
+        $isFirst = true;
+        foreach ($slides as $slideText) {
+            $slide = $isFirst ? $presentation->getActiveSlide() : $presentation->createSlide();
+            $isFirst = false;
+
+            $shape = $slide->createRichTextShape();
+            $shape->setHeight(450)->setWidth(900)->setOffsetX(30)->setOffsetY(30);
+
+            $lines = $this->splitLines(trim($slideText));
+            foreach ($lines as $index => $line) {
+                $paragraph = 0 === $index ? $shape->getActiveParagraph() : $shape->createParagraph();
+                $clean = $this->stripMarkdown($line);
+                $paragraph->createTextRun('' === $clean ? ' ' : $clean);
+            }
+        }
+
+        PresentationIOFactory::createWriter($presentation, 'PowerPoint2007')->save($absolutePath);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function splitLines(string $content): array
+    {
+        return preg_split('/\R/', $content) ?: [];
+    }
+
+    /**
+     * Heuristic: treat content as CSV when most non-empty lines contain a comma.
+     *
+     * @param list<string> $lines
+     */
+    private function looksLikeCsv(array $lines): bool
+    {
+        $nonEmpty = array_filter($lines, static fn (string $line): bool => '' !== trim($line));
+        if ([] === $nonEmpty) {
+            return false;
+        }
+
+        $withComma = array_filter($nonEmpty, static fn (string $line): bool => str_contains($line, ','));
+
+        return count($withComma) >= (count($nonEmpty) / 2);
+    }
+
+    /**
+     * Split markdown content into slide chunks on level 1-3 headings.
+     *
+     * @return list<string>
+     */
+    private function splitIntoSlides(string $content): array
+    {
+        $content = trim($content);
+        if ('' === $content) {
+            return [' '];
+        }
+
+        $parts = preg_split('/\n(?=#{1,3}\s)/', $content) ?: [];
+        $parts = array_values(array_filter(
+            array_map('trim', $parts),
+            static fn (string $part): bool => '' !== $part
+        ));
+
+        return [] === $parts ? [$content] : $parts;
+    }
+
+    /**
+     * Remove common inline markdown markers for plain-text rendering (pptx).
+     */
+    private function stripMarkdown(string $line): string
+    {
+        $line = preg_replace('/^#{1,6}\s*/', '', $line) ?? $line;
+        $line = preg_replace('/(\*\*|__|\*|_|`)/', '', $line) ?? $line;
+
+        return trim($line);
+    }
+}

--- a/backend/src/Service/Message/Handler/ChatHandler.php
+++ b/backend/src/Service/Message/Handler/ChatHandler.php
@@ -1077,7 +1077,14 @@ final readonly class ChatHandler implements MessageHandlerInterface
                     $fileInfo = $msg->getFileType().' file';
                 }
 
-                $content .= "\n\n\n---\n\n\nUser provided $fileInfo:\n\n".
+                // Role-aware label: for assistant turns this is the file the
+                // assistant generated earlier, so present it as the current
+                // document the model can transform when the user asks for edits.
+                $label = 'assistant' === $role
+                    ? "Current content of the file you previously generated ($fileInfo):"
+                    : "User provided $fileInfo:";
+
+                $content .= "\n\n\n---\n\n\n$label\n\n".
                            substr($allFilesText, 0, 10000). // Increased limit for multiple files
                            "\n\n";
             }
@@ -1799,10 +1806,11 @@ final readonly class ChatHandler implements MessageHandlerInterface
             $file->setFileName($filename);
             $file->setFileSize($fileSize);
             $file->setFileMime($mimeType);
-            // Only store text content for text-based files (not binary formats)
-            if (FileHelper::isTextBasedMimeType($mimeType)) {
-                $file->setFileText($content);
-            }
+            // Persist the source content (Markdown/CSV/text) the document was
+            // built from — even for binary office formats. It is the document's
+            // text for search and, crucially, lets a later edit transform the
+            // exact current content instead of re-deriving it.
+            $file->setFileText($content);
             $file->setStatus('generated');
 
             $this->em->persist($file);

--- a/backend/src/Service/Message/Handler/ChatHandler.php
+++ b/backend/src/Service/Message/Handler/ChatHandler.php
@@ -12,6 +12,7 @@ use App\Repository\PromptRepository;
 use App\Service\Exception\VisionModelRequiredException;
 use App\Service\FeedbackConfigService;
 use App\Service\FeedbackConstants;
+use App\Service\File\DocumentGeneratorService;
 use App\Service\File\FileHelper;
 use App\Service\File\UserUploadPathBuilder;
 use App\Service\MemoryExtractionDispatcher;
@@ -55,6 +56,7 @@ final readonly class ChatHandler implements MessageHandlerInterface
         private RateLimitService $rateLimitService,
         private MemoryExtractionDispatcher $memoryExtractionDispatcher,
         private PerfPipelineFlag $perfPipelineFlag,
+        private DocumentGeneratorService $documentGenerator,
         iterable $pluginContextProviders = [],
     ) {
         $this->pluginContextProviders = $pluginContextProviders;
@@ -1740,9 +1742,21 @@ final readonly class ChatHandler implements MessageHandlerInterface
                 }
             }
 
-            // Write file content
-            if (!file_put_contents($absolutePath, $content)) {
-                $this->logger->error('ChatHandler: Failed to write file', ['path' => $absolutePath]);
+            // Write file content (real OOXML for docx/xlsx/pptx, text otherwise)
+            try {
+                $this->documentGenerator->write($content, $extension, $absolutePath);
+            } catch (\Throwable $e) {
+                $this->logger->error('ChatHandler: Failed to write file', [
+                    'path' => $absolutePath,
+                    'error' => $e->getMessage(),
+                ]);
+
+                return null;
+            }
+
+            $fileSize = filesize($absolutePath);
+            if (false === $fileSize) {
+                $this->logger->error('ChatHandler: Failed to read generated file size', ['path' => $absolutePath]);
 
                 return null;
             }
@@ -1756,7 +1770,7 @@ final readonly class ChatHandler implements MessageHandlerInterface
             $file->setFilePath($relativePath);
             $file->setFileType($extension);
             $file->setFileName($filename);
-            $file->setFileSize(strlen($content));
+            $file->setFileSize($fileSize);
             $file->setFileMime($mimeType);
             // Only store text content for text-based files (not binary formats)
             if (FileHelper::isTextBasedMimeType($mimeType)) {

--- a/backend/src/Service/Message/Handler/ChatHandler.php
+++ b/backend/src/Service/Message/Handler/ChatHandler.php
@@ -1065,7 +1065,7 @@ final readonly class ChatHandler implements MessageHandlerInterface
             }
 
             $role = 'IN' === $msg->getDirection() ? 'user' : 'assistant';
-            $content = $msg->getText();
+            $content = $this->humanizeFileMarkersForModel($msg->getText());
 
             // File Text inkludieren wenn vorhanden (Legacy + NEW MessageFiles)
             $allFilesText = $msg->getAllFilesText(); // Combines legacy + file texts
@@ -1291,7 +1291,7 @@ final readonly class ChatHandler implements MessageHandlerInterface
         // Thread Messages (JSON encoded wie im alten System)
         foreach ($thread as $msg) {
             $role = 'IN' === $msg->getDirection() ? 'user' : 'assistant';
-            $content = $msg->getText();
+            $content = $this->humanizeFileMarkersForModel($msg->getText());
 
             // For user messages in thread, include images for vision (if enabled)
             if ('user' === $role && $includeImages) {
@@ -1645,6 +1645,33 @@ final readonly class ChatHandler implements MessageHandlerInterface
      *
      * @return array|null ['filename' => string, 'content' => string, 'extension' => string] or null
      */
+    /**
+     * Replace internal file-generation markers with human-readable text before a
+     * prior assistant turn is sent back to the model as conversation history.
+     *
+     * The stored assistant content for a generated file is the internal marker
+     * "__FILE_GENERATED__:filename". If that raw marker is fed back into the
+     * model context, the model starts imitating it and leaks strings such as
+     * "FILE_GENERATED:report.docx" into its replies. Converting it to plain
+     * prose keeps the context (a file was generated) without the marker syntax.
+     */
+    public function humanizeFileMarkersForModel(?string $content): string
+    {
+        $content = (string) $content;
+
+        if (str_starts_with($content, '__FILE_GENERATED__:')) {
+            $filename = trim(substr($content, strlen('__FILE_GENERATED__:')));
+
+            return sprintf('(I generated the file "%s" and provided it to the user as a download.)', $filename);
+        }
+
+        if ('__FILE_GENERATION_FAILED__' === $content) {
+            return '(The requested file could not be generated.)';
+        }
+
+        return $content;
+    }
+
     private function extractFileGenerationData(string $content): ?array
     {
         // Check if content looks like JSON or is wrapped in markdown code blocks

--- a/backend/src/Service/Message/MessageClassifier.php
+++ b/backend/src/Service/Message/MessageClassifier.php
@@ -560,10 +560,22 @@ final readonly class MessageClassifier
 
         // Follow-up edits to a just-generated document are usually phrased
         // without naming the format again ("mach den Titel fett", "ändere das
-        // in der Datei"). If the most recent assistant turn produced a
-        // generated file, defer to the AI sorter so it can route the edit to
-        // `officemaker` instead of shortcutting to `general` (#1042 review).
+        // in der Datei"). Two cases defer to the AI sorter so the edit reaches
+        // `officemaker` instead of being shortcut to `general` (#1042 review):
+        //
+        // (a) The most recent assistant turn produced a file — the very next
+        //     turn is almost certainly a follow-up about it, regardless of
+        //     wording.
+        // (b) A file was generated earlier in the thread and the current
+        //     message references a document or its structure. This covers
+        //     multi-message editing where normal chat is interleaved between
+        //     edits ("...kannst du in der Datei den Titel ändern").
         if ($this->lastAssistantGeneratedFile($conversationHistory)) {
+            return false;
+        }
+
+        if ($this->threadHasGeneratedFile($conversationHistory)
+            && $this->mentionsDocumentReference($trimmed)) {
             return false;
         }
 
@@ -623,6 +635,40 @@ final readonly class MessageClassifier
         }
 
         return false;
+    }
+
+    /**
+     * Whether any assistant turn in the thread produced a generated file.
+     *
+     * @param array<int, Message> $conversationHistory
+     */
+    private function threadHasGeneratedFile(array $conversationHistory): bool
+    {
+        foreach ($conversationHistory as $msg) {
+            if ('OUT' === $msg->getDirection()
+                && str_starts_with((string) $msg->getText(), '__FILE_GENERATED__:')) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Whether the message refers to a document or one of its structural parts.
+     *
+     * Used together with {@see threadHasGeneratedFile()} to detect document
+     * edits that span multiple turns. The noun list is intentionally
+     * document-specific to keep false positives in normal chat low; the worst
+     * case of a false positive is one extra AI-sorter call.
+     */
+    private function mentionsDocumentReference(string $text): bool
+    {
+        return 1 === preg_match(
+            '/\b(datei|dokument|file|document|doc|tabelle|sheet|spreadsheet|folie|slide|'
+            .'titel|title|überschrift|ueberschrift|heading|spalte|column|zeile|row|zelle|cell)\b/iu',
+            $text
+        );
     }
 
     /**

--- a/backend/src/Service/Message/MessageClassifier.php
+++ b/backend/src/Service/Message/MessageClassifier.php
@@ -80,7 +80,7 @@ final readonly class MessageClassifier
         if (null === $overrideModelId
             && !empty($text)
             && $this->isClassifierFastPathEnabled($userId)
-            && $this->canFastPathClassify($message, $text)
+            && $this->canFastPathClassify($message, $text, $conversationHistory)
         ) {
             $detectedLanguage = $this->detectLanguageHeuristic($text);
 
@@ -514,8 +514,10 @@ final readonly class MessageClassifier
      * The conservative checks below mean only "obviously chat" messages take
      * the fast path. Anything ambiguous — files, tool prefixes, media verbs,
      * Synapse-enabled accounts — still gets the full classifier.
+     *
+     * @param array<int, Message> $conversationHistory oldest-first thread
      */
-    private function canFastPathClassify(Message $message, string $text): bool
+    private function canFastPathClassify(Message $message, string $text, array $conversationHistory = []): bool
     {
         // Synapse routing has its own embedding-based classifier and may surface
         // intent we'd lose with the heuristic (e.g. 'mediamaker' for "draw a
@@ -556,6 +558,15 @@ final readonly class MessageClassifier
             return false;
         }
 
+        // Follow-up edits to a just-generated document are usually phrased
+        // without naming the format again ("mach den Titel fett", "ändere das
+        // in der Datei"). If the most recent assistant turn produced a
+        // generated file, defer to the AI sorter so it can route the edit to
+        // `officemaker` instead of shortcutting to `general` (#1042 review).
+        if ($this->lastAssistantGeneratedFile($conversationHistory)) {
+            return false;
+        }
+
         // Media / media-generation verbs in EN/DE/ES/FR. If any appear, the
         // sorter may pick a topic other than `general`/`chat` (e.g.
         // mediamaker → image_generation), so don't shortcut.
@@ -589,6 +600,29 @@ final readonly class MessageClassifier
         // (see issue #1000). The actual search decision is owned by
         // `WebSearchTopicPolicy` and applied in `MessageProcessor`.
         return true;
+    }
+
+    /**
+     * Whether the most recent assistant turn in the thread produced a generated
+     * file (its stored content is the "__FILE_GENERATED__:filename" marker).
+     *
+     * Only the latest assistant message is considered so the deferral is
+     * limited to the turn directly following a file generation.
+     *
+     * @param array<int, Message> $conversationHistory oldest-first thread
+     */
+    private function lastAssistantGeneratedFile(array $conversationHistory): bool
+    {
+        for ($i = count($conversationHistory) - 1; $i >= 0; --$i) {
+            $msg = $conversationHistory[$i];
+            if ('OUT' !== $msg->getDirection()) {
+                continue;
+            }
+
+            return str_starts_with((string) $msg->getText(), '__FILE_GENERATED__:');
+        }
+
+        return false;
     }
 
     /**

--- a/backend/src/Service/Message/MessageClassifier.php
+++ b/backend/src/Service/Message/MessageClassifier.php
@@ -546,6 +546,16 @@ final readonly class MessageClassifier
             return false;
         }
 
+        // Document-generation requests are usually very short and would
+        // otherwise be shortcut to `general` ("schreibe es als docx",
+        // "mach eine excel tabelle", #1042 review). If the message names a
+        // supported office format/extension, defer to the AI sorter so it can
+        // pick `officemaker`. PDF is intentionally excluded: we cannot produce
+        // real PDFs, so we must not route PDF requests to the office maker.
+        if (preg_match('/\b(docx|xlsx|pptx|csv|word|excel|powerpoint|spreadsheet|tabellenkalkulation|praesentation|präsentation)\b/iu', $trimmed)) {
+            return false;
+        }
+
         // Media / media-generation verbs in EN/DE/ES/FR. If any appear, the
         // sorter may pick a topic other than `general`/`chat` (e.g.
         // mediamaker → image_generation), so don't shortcut.

--- a/backend/tests/Unit/ChatHandlerTest.php
+++ b/backend/tests/Unit/ChatHandlerTest.php
@@ -13,6 +13,7 @@ use App\Repository\ModelRepository;
 use App\Repository\PromptRepository;
 use App\Repository\UserRepository;
 use App\Service\FeedbackConfigService;
+use App\Service\File\DocumentGeneratorService;
 use App\Service\File\UserUploadPathBuilder;
 use App\Service\MemoryExtractionDispatcher;
 use App\Service\Message\Handler\ChatHandler;
@@ -78,6 +79,7 @@ class ChatHandlerTest extends TestCase
             $this->rateLimitService,
             $this->memoryExtractionDispatcher,
             $this->perfPipelineFlag,
+            $this->createMock(DocumentGeneratorService::class),
         );
     }
 

--- a/backend/tests/Unit/ChatHandlerTest.php
+++ b/backend/tests/Unit/ChatHandlerTest.php
@@ -88,6 +88,35 @@ class ChatHandlerTest extends TestCase
         $this->assertEquals('chat', $this->handler->getName());
     }
 
+    public function testHumanizeFileMarkersReplacesGeneratedMarker(): void
+    {
+        $result = $this->handler->humanizeFileMarkersForModel('__FILE_GENERATED__:Zweiter_Weltkrieg.docx');
+
+        $this->assertStringNotContainsString('__FILE_GENERATED__', $result);
+        $this->assertStringNotContainsString('FILE_GENERATED', $result);
+        $this->assertStringContainsString('Zweiter_Weltkrieg.docx', $result);
+    }
+
+    public function testHumanizeFileMarkersReplacesFailedMarker(): void
+    {
+        $result = $this->handler->humanizeFileMarkersForModel('__FILE_GENERATION_FAILED__');
+
+        $this->assertStringNotContainsString('__FILE_GENERATION_FAILED__', $result);
+        $this->assertStringContainsString('could not be generated', $result);
+    }
+
+    public function testHumanizeFileMarkersLeavesRegularContentUntouched(): void
+    {
+        $text = 'Here is a normal assistant reply with no markers.';
+
+        $this->assertSame($text, $this->handler->humanizeFileMarkersForModel($text));
+    }
+
+    public function testHumanizeFileMarkersHandlesNull(): void
+    {
+        $this->assertSame('', $this->handler->humanizeFileMarkersForModel(null));
+    }
+
     public function testHandleUsesUserSelectedModel(): void
     {
         $message = $this->createMock(Message::class);

--- a/backend/tests/Unit/Controller/StreamControllerAiModelsPayloadTest.php
+++ b/backend/tests/Unit/Controller/StreamControllerAiModelsPayloadTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Unit\Controller;
 use App\AI\Service\AiFacade;
 use App\Controller\StreamController;
 use App\Entity\Message;
+use App\Service\File\DocumentGeneratorService;
 use App\Service\File\UserUploadPathBuilder;
 use App\Service\GuestSessionService;
 use App\Service\MemoryExtractionDispatcher;
@@ -56,6 +57,7 @@ class StreamControllerAiModelsPayloadTest extends TestCase
             $this->createMock(PromptService::class),
             $this->createMock(MessageForwardingService::class),
             $this->createMock(MemoryExtractionDispatcher::class),
+            $this->createMock(DocumentGeneratorService::class),
         );
     }
 

--- a/backend/tests/Unit/Controller/StreamControllerDeferredMemoryDispatchTest.php
+++ b/backend/tests/Unit/Controller/StreamControllerDeferredMemoryDispatchTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Unit\Controller;
 use App\AI\Service\AiFacade;
 use App\Controller\StreamController;
 use App\Message\ExtractMemoriesCommand;
+use App\Service\File\DocumentGeneratorService;
 use App\Service\File\UserUploadPathBuilder;
 use App\Service\GuestSessionService;
 use App\Service\MemoryExtractionDispatcher;
@@ -73,6 +74,7 @@ final class StreamControllerDeferredMemoryDispatchTest extends TestCase
             $this->createMock(PromptService::class),
             $this->createMock(MessageForwardingService::class),
             $this->memoryExtractionDispatcher,
+            $this->createMock(DocumentGeneratorService::class),
         );
     }
 

--- a/backend/tests/Unit/Controller/StreamControllerOriginalMediaMetaTest.php
+++ b/backend/tests/Unit/Controller/StreamControllerOriginalMediaMetaTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Unit\Controller;
 use App\AI\Service\AiFacade;
 use App\Controller\StreamController;
 use App\Entity\Message;
+use App\Service\File\DocumentGeneratorService;
 use App\Service\File\UserUploadPathBuilder;
 use App\Service\GuestSessionService;
 use App\Service\MemoryExtractionDispatcher;
@@ -52,6 +53,7 @@ class StreamControllerOriginalMediaMetaTest extends TestCase
             $this->createMock(PromptService::class),
             $this->createMock(MessageForwardingService::class),
             $this->createMock(MemoryExtractionDispatcher::class),
+            $this->createMock(DocumentGeneratorService::class),
         );
     }
 

--- a/backend/tests/Unit/Controller/StreamControllerRagGroupKeyTest.php
+++ b/backend/tests/Unit/Controller/StreamControllerRagGroupKeyTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\Controller;
 
 use App\AI\Service\AiFacade;
 use App\Controller\StreamController;
+use App\Service\File\DocumentGeneratorService;
 use App\Service\File\UserUploadPathBuilder;
 use App\Service\GuestSessionService;
 use App\Service\MemoryExtractionDispatcher;
@@ -57,6 +58,7 @@ final class StreamControllerRagGroupKeyTest extends TestCase
             $this->createMock(PromptService::class),
             $this->createMock(MessageForwardingService::class),
             $this->createMock(MemoryExtractionDispatcher::class),
+            $this->createMock(DocumentGeneratorService::class),
         );
     }
 

--- a/backend/tests/Unit/MessageClassifierTest.php
+++ b/backend/tests/Unit/MessageClassifierTest.php
@@ -707,4 +707,67 @@ class MessageClassifierTest extends TestCase
         $this->assertSame('ai_sorting', $result['source']);
         $this->assertFalse($result['skip_sorting']);
     }
+
+    /**
+     * Regression for #1042 review (FExB17).
+     *
+     * Short document-generation requests must not be shortcut to `general` by
+     * the fast-path. When a supported office format/extension is mentioned, the
+     * AI sorter has to run so it can route to `officemaker`.
+     *
+     * @return iterable<string, array{0: string}>
+     */
+    public static function documentFormatProvider(): iterable
+    {
+        yield 'docx extension' => ['schreibe es erneut in eine docx datei'];
+        yield 'als docx' => ['gib es mir als docx'];
+        yield 'excel word' => ['mach eine excel tabelle daraus'];
+        yield 'powerpoint' => ['erstelle daraus eine powerpoint'];
+        yield 'csv' => ['exportiere das als csv'];
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('documentFormatProvider')]
+    public function testFastPathYieldsToAiSorterOnDocumentFormats(string $text): void
+    {
+        $configRepo = $this->createMock(ConfigRepository::class);
+        // Synapse off, fast-path on (default).
+        $configRepo->method('getValue')->willReturnCallback(static function (int $owner, string $group, string $setting): ?string {
+            return 'QDRANT_SEARCH' === $group ? '0' : null;
+        });
+
+        $sorter = $this->createMock(MessageSorter::class);
+        $sorter->expects($this->once())
+            ->method('classify')
+            ->willReturn(['topic' => 'officemaker', 'language' => 'de']);
+
+        $classifier = new MessageClassifier(
+            $sorter,
+            $this->createMock(SynapseRouter::class),
+            new TopicAliasResolver(),
+            $this->createMock(MessageMetaRepository::class),
+            $this->createMock(ModelConfigService::class),
+            $configRepo,
+            $this->createMock(EntityManagerInterface::class),
+            $this->createMock(LoggerInterface::class),
+        );
+
+        $message = $this->createMock(Message::class);
+        $message->method('getId')->willReturn(204);
+        $message->method('getUserId')->willReturn(10);
+        $message->method('getText')->willReturn($text);
+        $message->method('getLanguage')->willReturn('de');
+        $message->method('getFile')->willReturn(0);
+        $message->method('getFiles')->willReturn(new \Doctrine\Common\Collections\ArrayCollection());
+        $message->method('getDateTime')->willReturn('20260518120000');
+        $message->method('getFilePath')->willReturn('');
+        $message->method('getTopic')->willReturn('');
+        $message->method('getFileText')->willReturn('');
+
+        $result = $classifier->classify($message);
+
+        // Sorter ran → topic comes from the sorter, fast-path was skipped.
+        $this->assertSame('officemaker', $result['topic']);
+        $this->assertSame('ai_sorting', $result['source']);
+        $this->assertFalse($result['skip_sorting']);
+    }
 }

--- a/backend/tests/Unit/MessageClassifierTest.php
+++ b/backend/tests/Unit/MessageClassifierTest.php
@@ -868,4 +868,109 @@ class MessageClassifierTest extends TestCase
         $this->assertSame('fast_path_heuristic', $result['source']);
         $this->assertTrue($result['skip_sorting']);
     }
+
+    /**
+     * Multi-message editing: a normal chat turn is interleaved after the file
+     * was generated. A later edit that references the document must still reach
+     * the AI sorter (tier b), even though the most recent assistant turn was a
+     * plain reply.
+     */
+    public function testFastPathDefersForLaterDocumentEditAfterInterleavedChat(): void
+    {
+        $configRepo = $this->createMock(ConfigRepository::class);
+        $configRepo->method('getValue')->willReturnCallback(static function (int $owner, string $group, string $setting): ?string {
+            return 'QDRANT_SEARCH' === $group ? '0' : null;
+        });
+
+        $sorter = $this->createMock(MessageSorter::class);
+        $sorter->expects($this->once())
+            ->method('classify')
+            ->willReturn(['topic' => 'officemaker', 'language' => 'de']);
+
+        $classifier = new MessageClassifier(
+            $sorter,
+            $this->createMock(SynapseRouter::class),
+            new TopicAliasResolver(),
+            $this->createMock(MessageMetaRepository::class),
+            $this->createMock(ModelConfigService::class),
+            $configRepo,
+            $this->createMock(EntityManagerInterface::class),
+            $this->createMock(LoggerInterface::class),
+        );
+
+        $fileTurn = $this->createMock(Message::class);
+        $fileTurn->method('getDirection')->willReturn('OUT');
+        $fileTurn->method('getText')->willReturn('__FILE_GENERATED__:Zweiter_Weltkrieg.docx');
+
+        $interleavedReply = $this->createMock(Message::class);
+        $interleavedReply->method('getDirection')->willReturn('OUT');
+        $interleavedReply->method('getText')->willReturn('Das bedeutet, dass sehr viele Menschen betroffen waren.');
+
+        $message = $this->createMock(Message::class);
+        $message->method('getId')->willReturn(207);
+        $message->method('getUserId')->willReturn(10);
+        $message->method('getText')->willReturn('Kannst du den Titel in der Datei jetzt zentrieren');
+        $message->method('getLanguage')->willReturn('de');
+        $message->method('getFile')->willReturn(0);
+        $message->method('getFiles')->willReturn(new \Doctrine\Common\Collections\ArrayCollection());
+        $message->method('getDateTime')->willReturn('20260518120000');
+        $message->method('getFilePath')->willReturn('');
+        $message->method('getTopic')->willReturn('');
+        $message->method('getFileText')->willReturn('');
+
+        $result = $classifier->classify($message, [$fileTurn, $interleavedReply]);
+
+        $this->assertSame('officemaker', $result['topic']);
+        $this->assertSame('ai_sorting', $result['source']);
+        $this->assertFalse($result['skip_sorting']);
+    }
+
+    /**
+     * Counterpart: after a file exists earlier and an interleaved reply, a plain
+     * chat message with no document reference still takes the fast path (no
+     * over-deferral).
+     */
+    public function testFastPathTakenForUnrelatedChatAfterEarlierFile(): void
+    {
+        $configRepo = $this->createMock(ConfigRepository::class);
+        $configRepo->method('getValue')->willReturnCallback(static function (int $owner, string $group, string $setting): ?string {
+            return 'QDRANT_SEARCH' === $group ? '0' : null;
+        });
+
+        $sorter = $this->createMock(MessageSorter::class);
+        $sorter->expects($this->never())->method('classify');
+
+        $classifier = new MessageClassifier(
+            $sorter,
+            $this->createMock(SynapseRouter::class),
+            new TopicAliasResolver(),
+            $this->createMock(MessageMetaRepository::class),
+            $this->createMock(ModelConfigService::class),
+            $configRepo,
+            $this->createMock(EntityManagerInterface::class),
+            $this->createMock(LoggerInterface::class),
+        );
+
+        $fileTurn = $this->createMock(Message::class);
+        $fileTurn->method('getDirection')->willReturn('OUT');
+        $fileTurn->method('getText')->willReturn('__FILE_GENERATED__:report.docx');
+
+        $interleavedReply = $this->createMock(Message::class);
+        $interleavedReply->method('getDirection')->willReturn('OUT');
+        $interleavedReply->method('getText')->willReturn('Gerne, hier ist die Erklärung.');
+
+        $message = $this->createMock(Message::class);
+        $message->method('getId')->willReturn(208);
+        $message->method('getUserId')->willReturn(10);
+        $message->method('getText')->willReturn('Super, danke dir vielmals');
+        $message->method('getLanguage')->willReturn('de');
+        $message->method('getFile')->willReturn(0);
+        $message->method('getFiles')->willReturn(new \Doctrine\Common\Collections\ArrayCollection());
+
+        $result = $classifier->classify($message, [$fileTurn, $interleavedReply]);
+
+        $this->assertSame('general', $result['topic']);
+        $this->assertSame('fast_path_heuristic', $result['source']);
+        $this->assertTrue($result['skip_sorting']);
+    }
 }

--- a/backend/tests/Unit/MessageClassifierTest.php
+++ b/backend/tests/Unit/MessageClassifierTest.php
@@ -770,4 +770,102 @@ class MessageClassifierTest extends TestCase
         $this->assertSame('ai_sorting', $result['source']);
         $this->assertFalse($result['skip_sorting']);
     }
+
+    /**
+     * Regression for #1042 review follow-up.
+     *
+     * A short edit request without a format keyword ("mach den Titel fett")
+     * must NOT be fast-pathed to `general` when the previous assistant turn
+     * generated a file — it has to reach the AI sorter so the edit can be
+     * routed to `officemaker`.
+     */
+    public function testFastPathDefersWhenPreviousTurnGeneratedFile(): void
+    {
+        $configRepo = $this->createMock(ConfigRepository::class);
+        $configRepo->method('getValue')->willReturnCallback(static function (int $owner, string $group, string $setting): ?string {
+            return 'QDRANT_SEARCH' === $group ? '0' : null;
+        });
+
+        $sorter = $this->createMock(MessageSorter::class);
+        $sorter->expects($this->once())
+            ->method('classify')
+            ->willReturn(['topic' => 'officemaker', 'language' => 'de']);
+
+        $classifier = new MessageClassifier(
+            $sorter,
+            $this->createMock(SynapseRouter::class),
+            new TopicAliasResolver(),
+            $this->createMock(MessageMetaRepository::class),
+            $this->createMock(ModelConfigService::class),
+            $configRepo,
+            $this->createMock(EntityManagerInterface::class),
+            $this->createMock(LoggerInterface::class),
+        );
+
+        $previousFileMessage = $this->createMock(Message::class);
+        $previousFileMessage->method('getDirection')->willReturn('OUT');
+        $previousFileMessage->method('getText')->willReturn('__FILE_GENERATED__:Zweiter_Weltkrieg.docx');
+
+        $message = $this->createMock(Message::class);
+        $message->method('getId')->willReturn(205);
+        $message->method('getUserId')->willReturn(10);
+        $message->method('getText')->willReturn('Kannst du den Titel bitte fett machen');
+        $message->method('getLanguage')->willReturn('de');
+        $message->method('getFile')->willReturn(0);
+        $message->method('getFiles')->willReturn(new \Doctrine\Common\Collections\ArrayCollection());
+        $message->method('getDateTime')->willReturn('20260518120000');
+        $message->method('getFilePath')->willReturn('');
+        $message->method('getTopic')->willReturn('');
+        $message->method('getFileText')->willReturn('');
+
+        $result = $classifier->classify($message, [$previousFileMessage]);
+
+        $this->assertSame('officemaker', $result['topic']);
+        $this->assertSame('ai_sorting', $result['source']);
+        $this->assertFalse($result['skip_sorting']);
+    }
+
+    /**
+     * Counterpart: when the previous assistant turn was a normal reply (no
+     * generated file), a plain chat message still takes the fast path.
+     */
+    public function testFastPathTakenWhenPreviousTurnIsNormalReply(): void
+    {
+        $configRepo = $this->createMock(ConfigRepository::class);
+        $configRepo->method('getValue')->willReturnCallback(static function (int $owner, string $group, string $setting): ?string {
+            return 'QDRANT_SEARCH' === $group ? '0' : null;
+        });
+
+        $sorter = $this->createMock(MessageSorter::class);
+        $sorter->expects($this->never())->method('classify');
+
+        $classifier = new MessageClassifier(
+            $sorter,
+            $this->createMock(SynapseRouter::class),
+            new TopicAliasResolver(),
+            $this->createMock(MessageMetaRepository::class),
+            $this->createMock(ModelConfigService::class),
+            $configRepo,
+            $this->createMock(EntityManagerInterface::class),
+            $this->createMock(LoggerInterface::class),
+        );
+
+        $previousReply = $this->createMock(Message::class);
+        $previousReply->method('getDirection')->willReturn('OUT');
+        $previousReply->method('getText')->willReturn('Sure, here is the answer to your question.');
+
+        $message = $this->createMock(Message::class);
+        $message->method('getId')->willReturn(206);
+        $message->method('getUserId')->willReturn(10);
+        $message->method('getText')->willReturn('Thanks, that helps a lot!');
+        $message->method('getLanguage')->willReturn('en');
+        $message->method('getFile')->willReturn(0);
+        $message->method('getFiles')->willReturn(new \Doctrine\Common\Collections\ArrayCollection());
+
+        $result = $classifier->classify($message, [$previousReply]);
+
+        $this->assertSame('general', $result['topic']);
+        $this->assertSame('fast_path_heuristic', $result['source']);
+        $this->assertTrue($result['skip_sorting']);
+    }
 }

--- a/backend/tests/Unit/Service/File/DocumentGeneratorServiceTest.php
+++ b/backend/tests/Unit/Service/File/DocumentGeneratorServiceTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\File;
+
+use App\Service\File\DocumentGeneratorService;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+class DocumentGeneratorServiceTest extends TestCase
+{
+    private DocumentGeneratorService $service;
+    private string $tmpDir;
+
+    protected function setUp(): void
+    {
+        $this->service = new DocumentGeneratorService(new NullLogger());
+        $this->tmpDir = sys_get_temp_dir().'/docgen_'.uniqid('', true);
+        mkdir($this->tmpDir, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->tmpDir.'/*') ?: [] as $file) {
+            @unlink($file);
+        }
+        @rmdir($this->tmpDir);
+    }
+
+    public function testIsBinaryFormat(): void
+    {
+        $this->assertTrue($this->service->isBinaryFormat('docx'));
+        $this->assertTrue($this->service->isBinaryFormat('XLSX'));
+        $this->assertTrue($this->service->isBinaryFormat('pptx'));
+        $this->assertFalse($this->service->isBinaryFormat('txt'));
+        $this->assertFalse($this->service->isBinaryFormat('csv'));
+        $this->assertFalse($this->service->isBinaryFormat('md'));
+    }
+
+    public function testDocxIsValidOoxmlZip(): void
+    {
+        $path = $this->tmpDir.'/test.docx';
+        $this->service->write("# Title\n\nSome **bold** text and a paragraph.", 'docx', $path);
+
+        $this->assertFileExists($path);
+        $this->assertTrue($this->isZipContaining($path, 'word/document.xml'));
+        $this->assertGreaterThan(1000, filesize($path), 'A real DOCX is far larger than its text source');
+    }
+
+    public function testDocxFallbackForUnparsableContentStillProducesValidFile(): void
+    {
+        $path = $this->tmpDir.'/plain.docx';
+        $this->service->write("Just a plain line\nAnother line", 'docx', $path);
+
+        $this->assertTrue($this->isZipContaining($path, 'word/document.xml'));
+    }
+
+    public function testXlsxIsValidOoxmlZip(): void
+    {
+        $path = $this->tmpDir.'/test.xlsx';
+        $this->service->write("Name,Age\nJohn,25\nJane,30", 'xlsx', $path);
+
+        $this->assertFileExists($path);
+        $this->assertTrue($this->isZipContaining($path, 'xl/workbook.xml'));
+    }
+
+    public function testPptxIsValidOoxmlZip(): void
+    {
+        $path = $this->tmpDir.'/test.pptx';
+        $this->service->write("# Slide One\nContent\n\n# Slide Two\nMore content", 'pptx', $path);
+
+        $this->assertFileExists($path);
+        $this->assertTrue($this->isZipContaining($path, '[Content_Types].xml'));
+    }
+
+    public function testTextFormatsAreWrittenVerbatim(): void
+    {
+        $path = $this->tmpDir.'/test.csv';
+        $content = "a,b,c\n1,2,3";
+        $this->service->write($content, 'csv', $path);
+
+        $this->assertSame($content, file_get_contents($path));
+    }
+
+    public function testUnknownExtensionIsWrittenAsText(): void
+    {
+        $path = $this->tmpDir.'/test.md';
+        $content = "# Heading\n\ntext";
+        $this->service->write($content, 'md', $path);
+
+        $this->assertSame($content, file_get_contents($path));
+    }
+
+    private function isZipContaining(string $path, string $entry): bool
+    {
+        $zip = new \ZipArchive();
+        if (true !== $zip->open($path)) {
+            return false;
+        }
+        $found = false !== $zip->locateName($entry);
+        $zip->close();
+
+        return $found;
+    }
+}

--- a/frontend/src/composables/useMarkdown.ts
+++ b/frontend/src/composables/useMarkdown.ts
@@ -11,6 +11,28 @@ import { marked, type MarkedExtension, type Tokens } from 'marked'
 import DOMPurify from 'dompurify'
 import { escapeHtml, highlightCode, preloadHighlighter, ensureHighlighter } from './useHighlight'
 
+/**
+ * URI schemes that must never be rendered as clickable links.
+ *
+ * `data:` is the main offender: AI models like to offer "downloads" via
+ * `data:` URIs (e.g. a fake "DOCX herunterladen" button) that produce broken
+ * files containing raw text instead of the real format. The other schemes are
+ * blocked as a defense-in-depth measure against script execution.
+ */
+const UNSAFE_LINK_SCHEMES = ['data:', 'javascript:', 'vbscript:', 'file:'] as const
+
+/**
+ * Detects links whose scheme is unsafe and should be rendered as plain text.
+ *
+ * Whitespace and control characters are stripped before the check so that
+ * obfuscated values like `da\nta:` cannot bypass the scheme prefix match.
+ */
+function isUnsafeLinkHref(href: string): boolean {
+  // eslint-disable-next-line no-control-regex
+  const normalized = href.replace(/[\s\u0000-\u001f]/g, '').toLowerCase()
+  return UNSAFE_LINK_SCHEMES.some((scheme) => normalized.startsWith(scheme))
+}
+
 // Custom renderer for marked
 function createRenderer(): MarkedExtension {
   return {
@@ -39,6 +61,12 @@ function createRenderer(): MarkedExtension {
         const href = token.href || ''
         const title = token.title ? ` title="${escapeHtml(token.title)}"` : ''
         let text = this.parser?.parseInline(token.tokens) || token.text
+
+        // Block unsafe schemes (notably data: URIs used for fake file downloads).
+        // Render the label as plain text so users don't get a broken download button.
+        if (isUnsafeLinkHref(href)) {
+          return text
+        }
 
         // For mailto links, show just the email address if the text is the full mailto URL
         if (href.startsWith('mailto:') && text === href) {

--- a/frontend/src/composables/useMarkdown.ts
+++ b/frontend/src/composables/useMarkdown.ts
@@ -28,8 +28,10 @@ const UNSAFE_LINK_SCHEMES = ['data:', 'javascript:', 'vbscript:', 'file:'] as co
  * obfuscated values like `da\nta:` cannot bypass the scheme prefix match.
  */
 function isUnsafeLinkHref(href: string): boolean {
+  // Strip whitespace plus C0 (\u0000-\u001f), DEL (\u007f) and C1 (\u0080-\u009f)
+  // control characters so obfuscated values like `da\u007fta:` cannot bypass the check.
   // eslint-disable-next-line no-control-regex
-  const normalized = href.replace(/[\s\u0000-\u001f]/g, '').toLowerCase()
+  const normalized = href.replace(/[\s\u0000-\u001f\u007f-\u009f]/g, '').toLowerCase()
   return UNSAFE_LINK_SCHEMES.some((scheme) => normalized.startsWith(scheme))
 }
 

--- a/frontend/tests/unit/composables/useMarkdown.spec.ts
+++ b/frontend/tests/unit/composables/useMarkdown.spec.ts
@@ -220,6 +220,35 @@ describe('useMarkdown', () => {
       expect(html).not.toContain('<script')
     })
 
+    it('should not render data: URI links as clickable downloads', () => {
+      const html = markdown.render(
+        '[DOCX herunterladen](data:text/markdown;charset=utf-8,raw%20text)'
+      )
+      expect(html).not.toContain('href="data:')
+      expect(html).not.toContain('<a')
+      // The label is preserved as plain text so no broken download button is shown
+      expect(html).toContain('DOCX herunterladen')
+    })
+
+    it('should not render obfuscated data: URI links (whitespace/control chars)', () => {
+      const html = markdown.render('[fake](data:\n text/plain,broken)')
+      expect(html).not.toContain('href="data:')
+    })
+
+    it('should not render vbscript: or file: links', () => {
+      const vbscript = markdown.render('[click](vbscript:msgbox(1))')
+      expect(vbscript).not.toContain('href="vbscript:')
+      const file = markdown.render('[open](file:///etc/passwd)')
+      expect(file).not.toContain('href="file:')
+    })
+
+    it('should still render safe http and mailto links', () => {
+      const http = markdown.render('[External](https://example.com)')
+      expect(http).toContain('href="https://example.com"')
+      const mailto = markdown.render('[Mail](mailto:test@example.com)')
+      expect(mailto).toContain('href="mailto:test@example.com"')
+    })
+
     it('should allow safe HTML elements', () => {
       const html = markdown.render('**bold** and *italic*')
       expect(html).toContain('<strong')

--- a/frontend/tests/unit/composables/useMarkdown.spec.ts
+++ b/frontend/tests/unit/composables/useMarkdown.spec.ts
@@ -235,6 +235,13 @@ describe('useMarkdown', () => {
       expect(html).not.toContain('href="data:')
     })
 
+    it('should not render data: URI links obfuscated with DEL/C1 control chars', () => {
+      const del = markdown.render('[fake](da\u007fta:text/plain,broken)')
+      expect(del).not.toContain('<a')
+      const c1 = markdown.render('[fake](da\u0085ta:text/plain,broken)')
+      expect(c1).not.toContain('<a')
+    })
+
     it('should not render vbscript: or file: links', () => {
       const vbscript = markdown.render('[click](vbscript:msgbox(1))')
       expect(vbscript).not.toContain('href="vbscript:')


### PR DESCRIPTION
## Summary
Fixes broken AI-generated file downloads (#1038): real, openable Office documents are now produced, and fake `data:` URI download buttons are blocked in the chat markdown renderer.

## Changes
**Backend — real document generation (root cause of corrupt files):**
- New `DocumentGeneratorService` builds valid OOXML using the already-installed PhpOffice libraries: Markdown→DOCX (PhpWord), CSV→XLSX (PhpSpreadsheet), headings→PPTX slides (PhpPresentation). Text formats (csv/txt/md/…) are written verbatim.
- `ChatHandler` (worker) and `StreamController` (streaming) now use the service instead of `file_put_contents`, and persist the real on-disk file size.
- Clarified the office-maker prompt so the model provides Markdown for DOCX/PPTX and CSV for XLSX.

**Frontend — block fake data: URI downloads:**
- The markdown link renderer treats unsafe schemes (`data:`, `javascript:`, `vbscript:`, `file:`) as non-clickable and renders the label as plain text.
- Normalization strips whitespace plus C0/DEL/C1 control characters so obfuscated schemes (e.g. `da\u007fta:`) cannot bypass the check.

## Verification
- [ ] Not tested (explain)
- [x] Manual
- [x] Tests added/updated

Ran locally (all green):
- Backend: `make -C backend lint`, `make -C backend phpstan`, `make -C backend test` (1795 passed)
- Frontend: `make -C frontend lint`, `npm run check:types`, `make -C frontend test` (553 passed)
- Manual: generated DOCX is a valid OOXML zip (7.8 KB instead of 326 B) and opens in Word with heading/bold/list preserved.

## Notes
Closes #1038.

The original report had two layers: (1) the AI offered downloads via `data:` URIs that rendered as broken buttons, and (2) the server-side file generation wrote raw text with an office extension, so even "real" generated `.docx` files were corrupt. Both are addressed here.

## Screenshots/Logs
Before: `Zweiter_Weltkrieg.docx` (326 B) — Word: "Es wurde nicht lesbarer Inhalt gefunden"; plain text editor shows the raw text.
After: valid `.docx` rendered from markdown, opens normally in Word.