### PR TITLE
feat(models): add Claude Fable 5 to the AI model catalog

### DIFF
--- a/backend/src/AI/Provider/AnthropicProvider.php
+++ b/backend/src/AI/Provider/AnthropicProvider.php
@@ -41,6 +41,7 @@ class AnthropicProvider implements ChatProviderInterface, VisionProviderInterfac
         'claude-opus-4-8',
         'claude-sonnet-4-6',
         'claude-haiku-4-5',
+        'claude-fable-5',
     ];
 
     /** Models that require adaptive thinking format instead of manual budget_tokens. */
@@ -49,6 +50,7 @@ class AnthropicProvider implements ChatProviderInterface, VisionProviderInterfac
         'claude-opus-4-7',
         'claude-opus-4-8',
         'claude-sonnet-4-6',
+        'claude-fable-5',
     ];
 
     /**
@@ -61,6 +63,7 @@ class AnthropicProvider implements ChatProviderInterface, VisionProviderInterfac
     private const TEMPERATURE_DEPRECATED_MODELS = [
         'claude-opus-4-7',
         'claude-opus-4-8',
+        'claude-fable-5',
     ];
 
     public function __construct(

--- a/backend/src/Model/ModelCatalog.php
+++ b/backend/src/Model/ModelCatalog.php
@@ -1184,6 +1184,52 @@ class ModelCatalog
             ],
         ],
         [
+            // Snapshot 2026-06-09 (https://platform.claude.com/docs/en/about-claude/models/overview).
+            // Claude Fable 5 — Anthropic's most capable widely released model.
+            // Generally available on the Claude API since 2026-06-09.
+            'id' => 240,
+            'service' => 'Anthropic',
+            'name' => 'Claude Fable 5',
+            'tag' => 'chat',
+            'selectable' => 1,
+            'active' => 1,
+            'providerId' => 'claude-fable-5',
+            'priceIn' => 10,
+            'inUnit' => 'per1M',
+            'priceOut' => 50,
+            'outUnit' => 'per1M',
+            'quality' => 10,
+            'rating' => 1,
+            'json' => [
+                'description' => 'Claude Fable 5 - Anthropic\'s most capable widely released model for the most demanding reasoning and long-horizon agentic work. Adaptive thinking (always on). 1M context, 128K max output.',
+                'max_tokens' => 128000,
+                'params' => ['model' => 'claude-fable-5'],
+                'features' => ['vision', 'reasoning'],
+                'meta' => ['context_window' => '1000000', 'max_output' => '128000'],
+            ],
+        ],
+        [
+            'id' => 241,
+            'service' => 'Anthropic',
+            'name' => 'Claude Fable 5 (Vision)',
+            'tag' => 'pic2text',
+            'selectable' => 1,
+            'active' => 1,
+            'providerId' => 'claude-fable-5',
+            'priceIn' => 10,
+            'inUnit' => 'per1M',
+            'priceOut' => 50,
+            'outUnit' => 'per1M',
+            'quality' => 10,
+            'rating' => 1,
+            'json' => [
+                'description' => 'Claude Fable 5 for image analysis and vision tasks. Anthropic\'s most capable widely released vision model.',
+                'prompt' => 'Describe the image in detail. Extract any text you see.',
+                'params' => ['model' => 'claude-fable-5'],
+                'meta' => ['supports_images' => true],
+            ],
+        ],
+        [
             // Snapshot 2026-05-27 (https://platform.claude.com/docs/en/about-claude/models/overview).
             'id' => 235,
             'service' => 'Anthropic',

--- a/backend/tests/Unit/Model/ModelCatalogTest.php
+++ b/backend/tests/Unit/Model/ModelCatalogTest.php
@@ -201,6 +201,22 @@ class ModelCatalogTest extends TestCase
         }
     }
 
+    public function testClaudeFable5ModelsAreAvailableWithExpectedApiIds(): void
+    {
+        $fable5 = ModelCatalog::find('anthropic:claude-fable-5');
+
+        $this->assertCount(2, $fable5, 'Expected claude-fable-5 chat + vision variants');
+        $this->assertSame(['chat', 'pic2text'], array_column($fable5, 'tag'));
+
+        foreach ($fable5 as $variant) {
+            $this->assertSame('Anthropic', $variant['service']);
+            $this->assertSame('claude-fable-5', $variant['providerId']);
+            $this->assertSame('claude-fable-5', $variant['json']['params']['model'] ?? null);
+            $this->assertEqualsWithDelta(10.0, (float) $variant['priceIn'], 1e-9);
+            $this->assertEqualsWithDelta(50.0, (float) $variant['priceOut'], 1e-9);
+        }
+    }
+
     public function testGpt55ProModelsAreMarkedAsNonStreaming(): void
     {
         $chat = ModelCatalog::find('openai:gpt-5.5-pro:chat')[0];


### PR DESCRIPTION
## Summary
Add Claude Fable 5 (`claude-fable-5`) to the AI model catalog now that it is generally available on the Claude API (2026-06-09).

## Changes
- Add `Claude Fable 5` (chat, BID 240) and `Claude Fable 5 (Vision)` (pic2text, BID 241) to `ModelCatalog`, following the existing Claude Opus 4.8 pattern — pricing `$10 / $50 per MTok`, 1M context window, 128K max output, as published in the Anthropic model overview.
- Register `claude-fable-5` in `AnthropicProvider`:
  - `THINKING_MODELS` + `ADAPTIVE_THINKING_MODELS` — Fable 5 uses adaptive thinking (always on), no extended thinking.
  - `TEMPERATURE_DEPRECATED_MODELS` — consistent with the Opus 4.7/4.8 generation, which no longer accepts `temperature`.
- Add a `ModelCatalog` test pinning the API IDs, chat + vision variants, and pricing of Claude Fable 5.

## Verification
- [ ] Not tested (explain)
- [ ] Manual
- [x] Tests added/updated

`make -C backend lint` → 0 issues. `make -C backend test` → 1808 tests green. `make -C backend phpstan` reports only pre-existing baseline errors in `TritonProvider.php` (missing generated gRPC stubs), unrelated to this change (verified via `git stash`).

## Notes
Catalog-driven: the new model rolls out via the idempotent `app:seed` flow (`make -C backend seed-models`), which runs automatically on container start. Operator-owned toggles (`BSELECTABLE`/`BACTIVE`/`BISDEFAULT`) on existing installs are not overwritten. Default-model bindings (`DefaultModelConfigSeeder`) and the `MEM` tag are intentionally left unchanged.

Ref: https://platform.claude.com/docs/en/about-claude/models/overview

## Screenshots/Logs