### PR TITLE
Hotfix/migrations blocker

### DIFF
--- a/AGENTS_DEV.md
+++ b/AGENTS_DEV.md
@@ -147,7 +147,8 @@ production-only migration failures that never reproduce in local dev. Internaliz
   fix only needs to run on **one** node.
 - Migrations run on backend container start. On the shared DB the first node to come up
   runs them; the others then see them already applied.
-- Galera node IPs: `web1=10.0.0.2`, `web2=10.0.0.7`, `web3=10.0.0.8`.
+- Node IPs and the cluster inventory live in the **private** `synaplan-platform` repo —
+  never commit them here (this repo is public).
 
 **1. `DATABASE_*_URL` MUST use the `mariadb-` serverVersion prefix**
 - `synaplan-platform/.env` sets `DATABASE_WRITE_URL` / `DATABASE_READ_URL`. The
@@ -157,8 +158,9 @@ production-only migration failures that never reproduce in local dev. Internaliz
   (`AbstractMySQLDriver` does `stripos($version, 'mariadb')`). A bare `12.1.2` falls
   through to the **MySQL** platform, whose introspection mishandles identifiers and
   MariaDB's quoted string defaults → phantom diffs and lowercase `TableDoesNotExist`.
-- The cluster version string is `12.1.2-MariaDB-...` — confirm with `SELECT VERSION();`
-  and keep the number in sync, but the **prefix** is what selects the platform.
+- Confirm the cluster's version string with `SELECT VERSION();` (it reads like
+  `<x.y.z>-MariaDB-...`) and keep the number in sync, but the **prefix** is what selects
+  the platform.
 
 **2. Migrations that may run incrementally on prod MUST NOT touch `Schema $schema`**
 - Reading the injected schema (`$schema->hasTable()/getTable()/hasColumn()`) forces

--- a/AGENTS_DEV.md
+++ b/AGENTS_DEV.md
@@ -133,6 +133,67 @@ make -C backend test
 - ⚠️ **`BCONFIG` defaults are bootstrap-only.** Changing a value in `DefaultModelConfigSeeder` / `RateLimitConfigSeeder` does NOT propagate to existing installs (the `INSERT IGNORE` skips rows that already exist). To force-roll-out a new default everywhere, ship a dedicated migration that explicitly UPDATEs the affected `BCONFIG` rows.
 - ✅ On first boot against a legacy prod DB (`BUSER` exists but `doctrine_migration_versions` does not): the entrypoint registers ONLY the baseline migration. Every post-baseline migration runs normally via `doctrine:migrations:migrate`, so legacy installs receive new schema changes the same way fresh installs do.
 
+### ⚠️ Production Platform Specifics (`synaplan-platform` + external Galera cluster)
+
+Production is **NOT** the `synaplan/` docker-compose stack. It is the `synaplan-platform/`
+repo deploying the pre-built `ghcr.io/metadist/synaplan:latest` image, talking to a
+**MariaDB Galera cluster that runs OUTSIDE Docker**. These facts have caused several
+production-only migration failures that never reproduce in local dev. Internalize them.
+
+**Topology**
+- Nodes `web1` / `web2` / `web3` all point at the **same** Galera database
+  (`host.docker.internal:3306` from each node's backend container). There is **one**
+  shared schema, not three. Galera replicates DDL **synchronously**, so any manual SQL
+  fix only needs to run on **one** node.
+- Migrations run on backend container start. On the shared DB the first node to come up
+  runs them; the others then see them already applied.
+- Galera node IPs: `web1=10.0.0.2`, `web2=10.0.0.7`, `web3=10.0.0.8`.
+
+**1. `DATABASE_*_URL` MUST use the `mariadb-` serverVersion prefix**
+- `synaplan-platform/.env` sets `DATABASE_WRITE_URL` / `DATABASE_READ_URL`. The
+  `serverVersion=` query param **overrides** `doctrine.yaml` per connection.
+- It **must** read `serverVersion=mariadb-<x.y.z>` (e.g. `mariadb-12.1.2`). DBAL picks
+  `MariaDBPlatform` only when the version string contains `mariadb`
+  (`AbstractMySQLDriver` does `stripos($version, 'mariadb')`). A bare `12.1.2` falls
+  through to the **MySQL** platform, whose introspection mishandles identifiers and
+  MariaDB's quoted string defaults → phantom diffs and lowercase `TableDoesNotExist`.
+- The cluster version string is `12.1.2-MariaDB-...` — confirm with `SELECT VERSION();`
+  and keep the number in sync, but the **prefix** is what selects the platform.
+
+**2. Migrations that may run incrementally on prod MUST NOT touch `Schema $schema`**
+- Reading the injected schema (`$schema->hasTable()/getTable()/hasColumn()`) forces
+  doctrine/migrations' `LazySchemaDiffProvider` to introspect and run the **DBAL schema
+  comparator**. On this Galera DB the comparator throws
+  `There is no table with name "<x>" in the schema.` — a MariaDB FK identifier-resolution
+  quirk. The named table **varies per run** (`buser`, `bsessions`, `bprompts`, …) because
+  `information_schema` is returned unordered across the cluster, which is the fingerprint
+  of this bug. Pure `addSql()` migrations never materialize the diff and are unaffected.
+- ✅ Use raw, comparator-free, **idempotent** SQL instead of Schema reads:
+  - `CREATE TABLE IF NOT EXISTS ...`
+  - `ALTER TABLE x ADD COLUMN IF NOT EXISTS ...` / `DROP COLUMN IF EXISTS ...`
+  - `DROP TABLE IF EXISTS ...`
+  - For conditional DML, guard with a plain query on `$this->connection` (NOT the Schema
+    API), e.g.
+    `((int) $this->connection->fetchOne("SELECT COUNT(*) FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'X' AND COLUMN_NAME = 'Y')) > 0`.
+- ❌ Never gate prod-reachable migration DDL on `$schema->hasTable(...)` etc.
+
+**3. Foreign keys without `ON DELETE CASCADE`**
+- Several FKs (e.g. `BPROMPTMETA.BPROMPTID → BPROMPTS.BID`) have **no** cascade. A
+  migration that deletes parent rows must delete the child rows **first**, or it fails
+  with `1451 Cannot delete or update a parent row`. Local dev often has no child rows, so
+  this only surfaces on prod.
+
+**4. Manual cluster heal scripts live in `synaplan-platform/`**
+- `heal-migrations-baseline.sh` — fixes the baseline `doctrine_migration_versions` row
+  (stripped namespace separator).
+- `heal-migration-state-20260608.sh` — applies the 2026-06-08 batch idempotently and
+  registers its version rows (use when the deployed image still has Schema-reading
+  migrations).
+- Pattern for any future heal: run idempotent effect SQL, then
+  `INSERT IGNORE INTO doctrine_migration_versions (version, executed_at, execution_time)`
+  with the **escaped** FQN `DoctrineMigrations\\Version...` (double backslash in a
+  single-quoted SQL heredoc), on one node only.
+
 ### API Documentation (Swagger UI)
 - **ALWAYS use Swagger UI** to test endpoints: `http://localhost:8000/api/doc`
 - Interactive API testing (no need for Postman/curl)

--- a/_devextras/SYSADMIN-help.md
+++ b/_devextras/SYSADMIN-help.md
@@ -32,7 +32,7 @@ Synaplan uses a multi-repository architecture:
 | --------- | -------------------------- | ---------------------------------- |
 | Image     | Built locally (dev stage, incl. phpredis) | `ghcr.io/metadist/synaplan:latest` |
 | Database  | Local MariaDB container    | Galera cluster (multi-node)        |
-| Ollama    | Local container            | Shared server (10.0.1.10)          |
+| Ollama    | Local container            | Shared GPU server (internal IP)    |
 | Frontend  | Vite dev server (5173)     | Built assets in Docker image       |
 | Dev tools | phpMyAdmin, MailHog        | None                               |
 | Qdrant    | Docker service (port 6333) | Docker service or external         |
@@ -150,9 +150,8 @@ docker compose exec db bash         # Database
         │                    │                    │
         ▼                    ▼                    ▼
 ┌───────────────┐    ┌───────────────┐    ┌───────────────┐
-│   synweb100   │    │   synweb101   │    │   synweb102   │
-│   (web1)      │    │   (web2)      │    │   (web3)      │
-│   10.0.0.2    │    │   10.0.0.3    │    │   10.0.0.4    │
+│     web1      │    │     web2      │    │     web3      │
+│  <node-ip-1>  │    │  <node-ip-2>  │    │  <node-ip-3>  │
 └───────┬───────┘    └───────┬───────┘    └───────┬───────┘
         │                    │                    │
         └────────────────────┼────────────────────┘
@@ -174,12 +173,12 @@ docker compose exec db bash         # Database
 cd synaplan-platform/
 
 # Start on specific node (sets SYNDBHOST for Galera)
-./startweb1.sh   # On synweb100
-./startweb2.sh   # On synweb101
-./startweb3.sh   # On synweb102
+./startweb1.sh   # On node web1
+./startweb2.sh   # On node web2
+./startweb3.sh   # On node web3
 
 # Or manually:
-export SYNDBHOST=10.0.0.2   # Local Galera node IP
+export SYNDBHOST=<local-galera-node-ip>
 docker compose up --pull always -d
 ```
 
@@ -194,8 +193,8 @@ environment:
   FRONTEND_URL: https://web.synaplan.com
   APP_URL: https://web.synaplan.com
   DATABASE_WRITE_URL: mysql://...@host.docker.internal:3306/synaplan
-  OLLAMA_BASE_URL: http://10.0.1.10:11434        # Shared Ollama server
-  TIKA_URL: http://tika.synaplan.com             # External Tika
+  OLLAMA_BASE_URL: http://<gpu-server-ip>:11434  # Shared Ollama server
+  TIKA_URL: http://<tika-host>                   # External Tika
   QDRANT_URL: http://qdrant:6333                # Qdrant vector database
 ```
 

--- a/_devextras/planning/human-takeover-realtime-clustering.md
+++ b/_devextras/planning/human-takeover-realtime-clustering.md
@@ -39,12 +39,12 @@ Real-time widget events were stored in a **node-local filesystem cache**
 
 ### Cluster facts (from `synaplan-platform`)
 
-- Nodes: web1 `10.0.0.2`, web2 `10.0.0.7`, web3 `10.0.0.8`. LB = `web.synaplan.com`
-  round-robin on :80.
+- Nodes: web1 / web2 / web3 (internal IPs: see the private `synaplan-platform`
+  inventory). LB = `web.synaplan.com` round-robin on :80.
 - **MariaDB Galera** cluster — each node talks to its local Galera; DB is replicated
   (shared) → this is why "reload works".
-- **NFS** shared storage `10.0.0.4` (uploads/config), but the app's `var/cache` is
-  per-container (node-local).
+- **NFS** shared storage on a separate storage box (uploads/config), but the app's
+  `var/cache` is per-container (node-local).
 - **No Redis** (deliberately removed; `cache.yaml` was filesystem-only).
 
 ---
@@ -129,16 +129,16 @@ logical endpoint that survives reboots" we want.
 
 - **3 web nodes:** 1 Valkey primary + 2 replicas, **3 Sentinels** (one per node).
   Mirrors the Galera-per-web-node pattern.
-- **Storage box (`10.0.0.4`):** Redis here is **not required**. Keep the Sentinel count
+- **Storage box:** Redis here is **not required**. Keep the Sentinel count
   **odd (3)** for a clean majority — do NOT add a 4th Sentinel (even = worse quorum).
   Optionally host a non-voting extra replica for backups; little SSE benefit.
 - Quorum = 2 of 3 Sentinels → tolerates losing one node and still auto-fails-over.
 
 ```
-web1 10.0.0.2:  Valkey PRIMARY + Sentinel
-web2 10.0.0.7:  Valkey replica + Sentinel   (async replication from primary)
-web3 10.0.0.8:  Valkey replica + Sentinel
-storage 10.0.0.4: (optional non-voting replica, NO sentinel)
+web1:     Valkey PRIMARY + Sentinel
+web2:     Valkey replica + Sentinel   (async replication from primary)
+web3:     Valkey replica + Sentinel
+storage:  (optional non-voting replica, NO sentinel)
 ```
 
 ### Rolling reboot without stopping the cluster

--- a/_devextras/planning/voice-conversations/piper-provider.md
+++ b/_devextras/planning/voice-conversations/piper-provider.md
@@ -110,8 +110,8 @@ SYNAPLAN_TTS_URL: ${SYNAPLAN_TTS_URL:-http://host.docker.internal:10200}
 
 **Layer 2: `backend/.env`** (production, gitignored):
 ```env
-# Production: TTS service on GPU server 10.0.1.10
-SYNAPLAN_TTS_URL=http://10.0.1.10:10200
+# Production: TTS service on the shared GPU server
+SYNAPLAN_TTS_URL=http://<gpu-server-ip>:10200
 ```
 
 **Layer 3: `SystemConfigService` schema** (Admin UI):

--- a/_devextras/planning/voice-conversations/plan.md
+++ b/_devextras/planning/voice-conversations/plan.md
@@ -57,7 +57,7 @@ Register `synaplan-tts` (Piper) as a provider in the AI system so it can be sele
 **Deliverables:**
 - `PiperProvider.php` implementing `TextToSpeechProviderInterface`
 - BMODELS fixture entry (tag `text2sound`, service `Piper`)
-- Config: `SYNAPLAN_TTS_URL` env var (dev: `http://host.docker.internal:10200`, prod: `http://10.0.1.10:10200`)
+- Config: `SYNAPLAN_TTS_URL` env var (dev: `http://host.docker.internal:10200`, prod: `http://<gpu-server-ip>:10200`)
 - WAV→MP3 conversion (ffmpeg) since Piper outputs WAV
 - Set as default TTS model via BCONFIG seed
 
@@ -193,7 +193,7 @@ Phase 1 is prerequisite (need a working free TTS provider). Phases 4 and 5 can s
 
 | Variable | Dev default | Production | Where |
 |----------|-------------|------------|-------|
-| `SYNAPLAN_TTS_URL` | `http://host.docker.internal:10200` | `http://10.0.1.10:10200` | `docker-compose.yml` (dev default), `backend/.env` (prod override), Admin UI |
+| `SYNAPLAN_TTS_URL` | `http://host.docker.internal:10200` | `http://<gpu-server-ip>:10200` | `docker-compose.yml` (dev default), `backend/.env` (prod override), Admin UI |
 
 Named after the service (`synaplan-tts`), not the engine (Piper). Follows the same pattern as `OLLAMA_BASE_URL`, `TIKA_BASE_URL`, `QDRANT_URL`. See `piper-provider.md` §5 for all 4 config layers.
 

--- a/_docker/backend/Caddyfile
+++ b/_docker/backend/Caddyfile
@@ -80,6 +80,22 @@
 	}
 
 	# ------------------------------------------------------------------
+	# Block scanners probing for dotfiles (.env, .git, ...) before they
+	# reach PHP. Bots hammer the raw node IP for leaked secrets (e.g.
+	# GET /api/.env); without this they fall through to @backend_php and
+	# Symfony logs a NotFoundHttpException at ERROR level on every hit.
+	# Returning a clean 404 at the edge keeps the request log readable and
+	# avoids waking the PHP worker for obviously hostile traffic.
+	# Placed before all other handles so it always wins.
+	# ------------------------------------------------------------------
+	@dotfiles {
+		path */.env */.env.* */.git */.git/* /.env /.env.* /.git /.git/*
+	}
+	handle @dotfiles {
+		respond 404
+	}
+
+	# ------------------------------------------------------------------
 	# Realtime / WebSockets — proxied to the local Centrifugo instance.
 	#
 	# Browsers connect to /connection/websocket on the same origin so we

--- a/backend/docs/SMART_EMAIL_CRONJOB_SETUP.md
+++ b/backend/docs/SMART_EMAIL_CRONJOB_SETUP.md
@@ -62,7 +62,7 @@ Add this line (adjust path and interval as needed):
 
 ```cron
 # Synaplan Smart Email Processor - runs every 2 minutes
-*/2 * * * * cd /netroot/synaplanCluster/synaplan-compose && docker compose exec -T backend php bin/console app:process-emails >> /var/log/synaplan-email.log 2>&1
+*/2 * * * * cd /path/to/your/deployment && docker compose exec -T backend php bin/console app:process-emails >> /var/log/synaplan-email.log 2>&1
 ```
 
 **Note:** If you already have a cronjob for `app:process-mail-handlers`, you can add this as a second line. Both commands can run simultaneously.
@@ -74,19 +74,19 @@ Create `/etc/cron.d/synaplan-smart-email`:
 ```cron
 # Synaplan Smart Email Processor
 # Runs every 2 minutes
-*/2 * * * * root cd /netroot/synaplanCluster/synaplan-compose && docker compose exec -T backend php bin/console app:process-emails >> /var/log/synaplan-email.log 2>&1
+*/2 * * * * root cd /path/to/your/deployment && docker compose exec -T backend php bin/console app:process-emails >> /var/log/synaplan-email.log 2>&1
 ```
 
 **Or add to existing cron script:**
 
-If you have `/netroot/synaplanCluster/synaplan-compose/cron-gmail.sh`, you can add a second line:
+If you have a cron script in your deployment directory (e.g. `cron-gmail.sh`), you can add a second line:
 
 ```bash
 #!/bin/bash
 
-export SYNDBHOST=10.0.0.2
+export SYNDBHOST=<local-galera-node-ip>
 
-cd /netroot/synaplanCluster/synaplan-compose
+cd /path/to/your/deployment
 
 # Mail Handler (existing - for department routing)
 docker compose exec -T backend php bin/console app:process-mail-handlers
@@ -97,7 +97,7 @@ docker compose exec -T backend php bin/console app:process-emails
 
 Replace:
 - `root` with the appropriate user (if different)
-- `/netroot/synaplanCluster/synaplan-compose` with your actual project path
+- `/path/to/your/deployment` with your actual project path
 
 Make it executable:
 ```bash

--- a/backend/migrations/Version20260607010000.php
+++ b/backend/migrations/Version20260607010000.php
@@ -52,12 +52,14 @@ final class Version20260607010000 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        if ($schema->hasTable('BMESSAGE_TASKS')) {
-            return;
-        }
-
+        // NOTE: deliberately no `$schema->hasTable(...)` guard. Touching the
+        // injected Schema forces doctrine/migrations' LazySchemaDiffProvider to
+        // introspect + run the DBAL comparator, which throws TableDoesNotExist
+        // on this production DB (MariaDB FK identifier-resolution quirk). Pure
+        // `addSql` migrations never materialize that diff, so we use raw
+        // idempotent DDL (`CREATE TABLE IF NOT EXISTS`) instead of a Schema read.
         $this->addSql(<<<'SQL'
-            CREATE TABLE BMESSAGE_TASKS (
+            CREATE TABLE IF NOT EXISTS BMESSAGE_TASKS (
               BID BIGINT AUTO_INCREMENT NOT NULL,
               BMESSAGEID BIGINT NOT NULL,
               BNODEID VARCHAR(16) NOT NULL,

--- a/backend/migrations/Version20260608000000.php
+++ b/backend/migrations/Version20260608000000.php
@@ -55,6 +55,12 @@ final class Version20260608000000 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
+        // NOTE: deliberately no reads of the injected `Schema $schema`. Touching
+        // it forces doctrine/migrations' LazySchemaDiffProvider to introspect +
+        // run the DBAL comparator, which throws TableDoesNotExist on this
+        // production DB (a MariaDB FK identifier-resolution quirk). Existence
+        // checks instead go through `$this->connection` (a plain query), which
+        // never materializes that schema diff.
         $placeholders = implode(', ', array_fill(0, count(self::GRANULAR_TOPICS), '?'));
 
         // Remove dependent BPROMPTMETA rows FIRST. The FK
@@ -64,9 +70,12 @@ final class Version20260608000000 extends AbstractMigration
         // violation. Fresh dev/CI installs had no meta for these system prompts,
         // so this only surfaced on a real deploy (web3). The meta is derived
         // data of the exact prompts we are discarding below, so dropping it is
-        // safe and intended. Guarded with hasTable so the migration stays
-        // re-runnable on any schema shape.
-        if ($schema->hasTable('BPROMPTMETA')) {
+        // safe and intended. Guarded via information_schema so the migration
+        // stays re-runnable on any schema shape.
+        $promptMetaExists = ((int) $this->connection->fetchOne(
+            "SELECT COUNT(*) FROM information_schema.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'BPROMPTMETA'",
+        )) > 0;
+        if ($promptMetaExists) {
             $this->addSql(
                 sprintf(
                     'DELETE pm FROM BPROMPTMETA pm JOIN BPROMPTS p ON p.BID = pm.BPROMPTID WHERE p.BOWNERID = 0 AND p.BTOPIC IN (%s)',
@@ -89,11 +98,13 @@ final class Version20260608000000 extends AbstractMigration
         // against this DB: old code still filters `BENABLED = 1`, new code
         // ignores the column. The experiment only ever disabled the granular
         // rows deleted above, so this is a safety net for stray rows. Guarded
-        // so the migration stays re-runnable on healed schemas where phase 2
-        // already dropped the column (see heal-migrations-baseline.sh in the
-        // platform repo).
-        $prompts = $schema->hasTable('BPROMPTS') ? $schema->getTable('BPROMPTS') : null;
-        if (null !== $prompts && $prompts->hasColumn('BENABLED')) {
+        // (via information_schema, NOT the Schema API) so the migration stays
+        // re-runnable on healed schemas where a future phase 2 already dropped
+        // the column — we must NOT recreate it here.
+        $benabledExists = ((int) $this->connection->fetchOne(
+            "SELECT COUNT(*) FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'BPROMPTS' AND COLUMN_NAME = 'BENABLED'",
+        )) > 0;
+        if ($benabledExists) {
             $this->addSql('UPDATE BPROMPTS SET BENABLED = 1 WHERE BENABLED = 0');
         }
     }

--- a/backend/migrations/Version20260608000000.php
+++ b/backend/migrations/Version20260608000000.php
@@ -21,8 +21,10 @@ use Doctrine\Migrations\AbstractMigration;
  * every SELECT — dropping the columns here would instantly break routing on
  * every node still running the old image. So phase 1 (this migration) only:
  *
- *   1. deletes the leftover granular system topic rows, and
- *   2. normalizes any stray BENABLED=0 to 1, so old code (which filters
+ *   1. deletes the dependent BPROMPTMETA children of those rows (their FK to
+ *      BPROMPTS has no ON DELETE CASCADE, so this must happen first — see up()),
+ *   2. deletes the leftover granular system topic rows, and
+ *   3. normalizes any stray BENABLED=0 to 1, so old code (which filters
  *      `enabled = true`) and new code (no filter) see the SAME topic pool
  *      during the rollout window.
  *
@@ -53,11 +55,31 @@ final class Version20260608000000 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
+        $placeholders = implode(', ', array_fill(0, count(self::GRANULAR_TOPICS), '?'));
+
+        // Remove dependent BPROMPTMETA rows FIRST. The FK
+        // BPROMPTMETA.BPROMPTID -> BPROMPTS.BID (FK_D44C7DE359DEE83D, baseline
+        // Version20260417000000) has NO ON DELETE CASCADE, so deleting a parent
+        // prompt that still has meta children fails with a 1451 constraint
+        // violation. Fresh dev/CI installs had no meta for these system prompts,
+        // so this only surfaced on a real deploy (web3). The meta is derived
+        // data of the exact prompts we are discarding below, so dropping it is
+        // safe and intended. Guarded with hasTable so the migration stays
+        // re-runnable on any schema shape.
+        if ($schema->hasTable('BPROMPTMETA')) {
+            $this->addSql(
+                sprintf(
+                    'DELETE pm FROM BPROMPTMETA pm JOIN BPROMPTS p ON p.BID = pm.BPROMPTID WHERE p.BOWNERID = 0 AND p.BTOPIC IN (%s)',
+                    $placeholders,
+                ),
+                self::GRANULAR_TOPICS,
+            );
+        }
+
         // Remove the leftover granular system topic rows (ownerId=0) so the
         // canonical-only routing pool is restored. User-created prompts are
         // never touched. Deliberately destructive: these rows belong to the
         // retired embedding-routing experiment and are NOT restored by down().
-        $placeholders = implode(', ', array_fill(0, count(self::GRANULAR_TOPICS), '?'));
         $this->addSql(
             sprintf('DELETE FROM BPROMPTS WHERE BOWNERID = 0 AND BTOPIC IN (%s)', $placeholders),
             self::GRANULAR_TOPICS,

--- a/backend/migrations/Version20260608130000.php
+++ b/backend/migrations/Version20260608130000.php
@@ -38,17 +38,14 @@ final class Version20260608130000 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $prompts = $schema->hasTable('BPROMPTS') ? $schema->getTable('BPROMPTS') : null;
-        if (null === $prompts) {
-            return;
-        }
-
-        if (!$prompts->hasColumn('BKEYWORDS')) {
-            $this->addSql('ALTER TABLE BPROMPTS ADD COLUMN BKEYWORDS LONGTEXT DEFAULT NULL AFTER BSELECTION_RULES');
-        }
-        if (!$prompts->hasColumn('BENABLED')) {
-            $this->addSql('ALTER TABLE BPROMPTS ADD COLUMN BENABLED TINYINT(1) NOT NULL DEFAULT 1 AFTER BKEYWORDS');
-        }
+        // NOTE: deliberately no `$schema->hasTable()/hasColumn()` reads. Touching
+        // the injected Schema forces doctrine/migrations' LazySchemaDiffProvider
+        // to introspect + run the DBAL comparator, which throws TableDoesNotExist
+        // on this production DB (MariaDB FK identifier-resolution quirk). MariaDB's
+        // native `ADD COLUMN IF NOT EXISTS` gives the same "add only if missing"
+        // semantics as raw, comparator-free SQL.
+        $this->addSql('ALTER TABLE BPROMPTS ADD COLUMN IF NOT EXISTS BKEYWORDS LONGTEXT DEFAULT NULL AFTER BSELECTION_RULES');
+        $this->addSql('ALTER TABLE BPROMPTS ADD COLUMN IF NOT EXISTS BENABLED TINYINT(1) NOT NULL DEFAULT 1 AFTER BKEYWORDS');
     }
 
     public function down(Schema $schema): void

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -295,13 +295,13 @@
      text-shadow so selected text stays crisp. */
   .bubble-user::selection,
   .bubble-user *::selection {
-    background: #ffffff !important;
+    background-color: #ffffff !important;
     color: var(--brand) !important;
     text-shadow: none !important;
   }
   .bubble-user::-moz-selection,
   .bubble-user *::-moz-selection {
-    background: #ffffff !important;
+    background-color: #ffffff !important;
     color: var(--brand) !important;
     text-shadow: none !important;
   }

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -288,6 +288,24 @@
     }
   }
 
+  /* Selection inside the user bubble: the forced white text becomes invisible
+     against the browser's pale default highlight. Flip it to a white highlight
+     with brand-colored text so the user can actually read what they select to
+     copy. Covers the bubble itself and all descendants; resets the light-mode
+     text-shadow so selected text stays crisp. */
+  .bubble-user::selection,
+  .bubble-user *::selection {
+    background: #ffffff !important;
+    color: var(--brand) !important;
+    text-shadow: none !important;
+  }
+  .bubble-user::-moz-selection,
+  .bubble-user *::-moz-selection {
+    background: #ffffff !important;
+    color: var(--brand) !important;
+    text-shadow: none !important;
+  }
+
   /* Textfarben */
   .txt-primary {
     color: var(--txt-primary);


### PR DESCRIPTION
## Summary

Hotfix for production migration failures on the external MariaDB Galera cluster, plus two small operational fixes picked up while deploying, and a docs scrub requested in review.

## Changes

### Migrations (the actual blocker)
- `Version20260608000000`: delete `BPROMPTMETA` children before removing retired granular prompts (no `ON DELETE CASCADE` on the FK → `1451` on installs with prompt meta); guard DML via `information_schema` instead of the `Schema` API.
- `Version20260607010000`: `CREATE TABLE IF NOT EXISTS` for `BMESSAGE_TASKS` (idempotent, avoids the DBAL schema comparator).
- `Version20260608130000`: re-add `BPROMPTS.BKEYWORDS` / `BENABLED` via `ADD COLUMN IF NOT EXISTS` — no schema introspection (the comparator throws spurious `TableDoesNotExist` on this Galera cluster).
- `AGENTS_DEV.md`: documents the production platform specifics behind these failures (`serverVersion=mariadb-` prefix, no `Schema $schema` reads in prod-reachable migrations, FK cascade gotchas, heal-script pattern).

### Operational fixes (deployed alongside)
- **Caddyfile**: return 404 at the edge for dotfile probes (`/.env`, `/.git`, …) so scanners stop waking PHP and flooding the error log.
- **style.css**: readable text selection inside the user bubble (white highlight, brand-colored text). Per review: use `background-color` instead of the `background` shorthand in `::selection` rules.

### Docs scrub (review follow-up)
- Removed internal node IPs, hostnames, and deployment filesystem paths from public docs (`AGENTS_DEV.md`, `_devextras/SYSADMIN-help.md`, planning notes, cronjob guide). Cluster specifics now live only in the private `synaplan-platform` repo; public docs use placeholders.

## Verification

- [x] Manual: ran the repaired migrations against a copy of the affected production schema (web node) — clean
- [x] CI green (backend + frontend + E2E)
- [x] `rg` sweep: no `10.0.x.x` IPs / internal hostnames / internal paths left in tracked docs