### PR TITLE
refactor(health-monitor): replace ENV-based auth with API-Key authentication

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -78,12 +78,6 @@ APP_URL=http://localhost:8000
 # Misc
 AUTO_DOWNLOAD_MODELS=false
 
-# --- Health monitoring (Uptime Robot etc.) ---
-# See docs/HEALTH_MONITORING.md for setup.
-HEALTH_MONITOR_TOKEN=
-HEALTH_MONITOR_USER_EMAIL=
-HEALTH_MONITOR_USER_PASSWORD=
-
 
 # ==============================================================================
 # 2. AI SERVICES

--- a/backend/config/packages/security.yaml
+++ b/backend/config/packages/security.yaml
@@ -67,7 +67,10 @@ security:
         - { path: ^/api/v1/auth/logout, roles: IS_AUTHENTICATED_FULLY }
         - { path: ^/api/v1/auth/revoke-all, roles: IS_AUTHENTICATED_FULLY }
 
-        # Public test endpoints
+        # Health monitoring (API-Key protected probe)
+        - { path: ^/api/health/probe, roles: IS_AUTHENTICATED_FULLY }
+
+        # Public health + test endpoints
         - { path: ^/api/health, roles: PUBLIC_ACCESS }
         - { path: ^/api/test, roles: PUBLIC_ACCESS }
 

--- a/backend/config/services.yaml
+++ b/backend/config/services.yaml
@@ -19,11 +19,6 @@ parameters:
     # OIDC scopes requested during login (space-separated)
     env(OIDC_SCOPES): 'openid email profile offline_access'
 
-    # Health monitoring defaults (so autowiring works when env not set)
-    env(HEALTH_MONITOR_TOKEN): ''
-    env(HEALTH_MONITOR_USER_EMAIL): ''
-    env(HEALTH_MONITOR_USER_PASSWORD): ''
-
     # Realtime (Centrifugo) defaults so the backend boots even when no realtime
     # gateway is configured (bare/custom deployment). With these unset,
     # CentrifugoPublisher short-circuits (enabled=false → no publish, never

--- a/backend/phpunit.xml.dist
+++ b/backend/phpunit.xml.dist
@@ -36,10 +36,6 @@
         <env name="BRAVE_SEARCH_SEARCH_LANG" value="en" />
         <!-- Qdrant (defaults for testing — empty = disabled) -->
         <env name="QDRANT_URL" value="" />
-        <!-- Health monitoring -->
-        <env name="HEALTH_MONITOR_TOKEN" value="test-monitor-token" force="true" />
-        <env name="HEALTH_MONITOR_USER_EMAIL" value="" />
-        <env name="HEALTH_MONITOR_USER_PASSWORD" value="" />
         <!-- Stripe / Billing (force valid-looking keys so BillingService::isEnabled()=true in tests) -->
         <env name="STRIPE_SECRET_KEY" value="sk_test_fakeKeyForTestSuite000000000000" force="true" />
         <!-- Must match StripeWebhookControllerTest + StripeSignatureHelper; Docker/backend/.env must not win -->

--- a/backend/src/Controller/HealthMonitorController.php
+++ b/backend/src/Controller/HealthMonitorController.php
@@ -4,23 +4,20 @@ declare(strict_types=1);
 
 namespace App\Controller;
 
-use App\Repository\UserRepository;
+use App\Entity\User;
 use App\Service\TokenService;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Routing\Attribute\Route;
 
 /**
  * Production health probe for external monitoring (Uptime Robot etc.).
  *
  * Single endpoint: does the auth stack work?
- * Protected by a dedicated monitor token via header or query param.
- * Internally exercises: DB, PasswordHasher, email-verified, TokenService.
+ * Protected by standard API-Key authentication (X-API-Key header).
+ * Internally exercises: DB (implicit via API-Key lookup), email-verified, TokenService.
  *
  * Response body: only STATUS:OK or STATUS:ERROR — no details leaked.
  * Diagnostics are logged server-side only.
@@ -28,98 +25,43 @@ use Symfony\Component\Routing\Attribute\Route;
 final class HealthMonitorController extends AbstractController
 {
     public function __construct(
-        private readonly UserRepository $userRepository,
-        private readonly UserPasswordHasherInterface $passwordHasher,
         private readonly TokenService $tokenService,
         private readonly LoggerInterface $logger,
-        #[Autowire('%env(HEALTH_MONITOR_TOKEN)%')]
-        private readonly string $monitorToken,
-        #[Autowire('%env(HEALTH_MONITOR_USER_EMAIL)%')]
-        private readonly string $monitorEmail,
-        #[Autowire('%env(HEALTH_MONITOR_USER_PASSWORD)%')]
-        private readonly string $monitorPassword,
     ) {
     }
 
-    #[Route('/api/health/login', name: 'api_health_login', methods: ['GET'])]
-    public function login(Request $request): JsonResponse
+    #[Route('/api/health/probe', name: 'api_health_probe', methods: ['GET'])]
+    public function probe(): JsonResponse
     {
-        if (!$this->authorized($request)) {
+        $user = $this->getUser();
+
+        if (!$user instanceof User) {
+            $this->logger->error('Health probe: no authenticated user');
+
             return self::status('STATUS:ERROR', Response::HTTP_UNAUTHORIZED);
         }
 
-        $email = trim($this->monitorEmail);
-        if ('' === $email || '' === $this->monitorPassword) {
-            $this->logger->error('Health login: monitor user not configured');
-
-            return self::status('STATUS:ERROR', Response::HTTP_SERVICE_UNAVAILABLE);
-        }
-
-        try {
-            $user = $this->userRepository->findOneBy(['mail' => $email]);
-        } catch (\Throwable $e) {
-            $this->logger->error('Health login: DB lookup failed', ['error' => $e->getMessage()]);
-
-            return self::status('STATUS:ERROR', Response::HTTP_SERVICE_UNAVAILABLE);
-        }
-
-        if (null === $user || null === $user->getPw()) {
-            $this->logger->error('Health login: monitor user missing or has no password');
-
-            return self::status('STATUS:ERROR', Response::HTTP_SERVICE_UNAVAILABLE);
-        }
-
-        if (!$this->passwordHasher->isPasswordValid($user, $this->monitorPassword)) {
-            $this->logger->error('Health login: password hash mismatch');
-
-            return self::status('STATUS:ERROR', Response::HTTP_SERVICE_UNAVAILABLE);
-        }
-
         if (!$user->isEmailVerified()) {
-            $this->logger->error('Health login: email not verified');
+            $this->logger->error('Health probe: email not verified', ['user_id' => $user->getId()]);
 
             return self::status('STATUS:ERROR', Response::HTTP_SERVICE_UNAVAILABLE);
         }
 
         try {
-            // JWT-only, no DB write — generateRefreshToken() would write,
-            // but we intentionally only test access token generation here.
             $accessToken = $this->tokenService->generateAccessToken($user);
         } catch (\Throwable $e) {
-            $this->logger->error('Health login: token generation failed', ['error' => $e->getMessage()]);
+            $this->logger->error('Health probe: token generation failed', ['error' => $e->getMessage()]);
 
             return self::status('STATUS:ERROR', Response::HTTP_SERVICE_UNAVAILABLE);
         }
 
         if ('' === $accessToken) {
-            $this->logger->error('Health login: empty access token');
+            $this->logger->error('Health probe: empty access token');
 
             return self::status('STATUS:ERROR', Response::HTTP_SERVICE_UNAVAILABLE);
         }
 
         return self::status('STATUS:OK', Response::HTTP_OK);
-    }
-
-    private function authorized(Request $request): bool
-    {
-        $expected = trim($this->monitorToken);
-        if ('' === $expected) {
-            return false;
-        }
-
-        $candidate = (string) $request->headers->get('X-Health-Monitor-Token', '');
-        if ('' !== $candidate && hash_equals($expected, $candidate)) {
-            return true;
-        }
-
-        $candidate = (string) $request->query->get('monitor', '');
-        if ('' !== $candidate && hash_equals($expected, $candidate)) {
-            $this->logger->warning('Health login: token passed via query param — prefer X-Health-Monitor-Token header');
-
-            return true;
-        }
-
-        return false;
     }
 
     private static function status(string $status, int $httpCode): JsonResponse

--- a/backend/tests/Controller/HealthMonitorControllerTest.php
+++ b/backend/tests/Controller/HealthMonitorControllerTest.php
@@ -4,70 +4,88 @@ declare(strict_types=1);
 
 namespace App\Tests\Controller;
 
+use App\Entity\ApiKey;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Response;
 
 final class HealthMonitorControllerTest extends WebTestCase
 {
-    private const TOKEN = 'test-monitor-token';
+    private const API_KEY = 'sk_test_health_monitor_key_1234567890abcdef';
 
     private KernelBrowser $client;
+    private EntityManagerInterface $em;
 
     protected function setUp(): void
     {
         $this->client = static::createClient();
+        $this->em = static::getContainer()->get('doctrine')->getManager();
+
+        $this->createMonitorUserWithApiKey();
     }
 
-    public function testReturns401WithoutToken(): void
+    public function testReturns401WithoutApiKey(): void
     {
-        $this->client->request('GET', '/api/health/login');
+        $this->client->request('GET', '/api/health/probe');
 
         self::assertSame(Response::HTTP_UNAUTHORIZED, $this->client->getResponse()->getStatusCode());
+    }
+
+    public function testReturns401WithInvalidApiKey(): void
+    {
+        $this->client->request(
+            'GET',
+            '/api/health/probe',
+            [],
+            [],
+            ['HTTP_X_API_KEY' => 'sk_invalid_key'],
+        );
+
+        self::assertSame(Response::HTTP_UNAUTHORIZED, $this->client->getResponse()->getStatusCode());
+    }
+
+    public function testReturnsOkWithValidApiKey(): void
+    {
+        $this->client->request(
+            'GET',
+            '/api/health/probe',
+            [],
+            [],
+            ['HTTP_X_API_KEY' => self::API_KEY],
+        );
+
+        self::assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        self::assertStringContainsString('STATUS:OK', (string) $this->client->getResponse()->getContent());
+    }
+
+    public function testReturnsErrorWhenEmailNotVerified(): void
+    {
+        $user = $this->em->getRepository(User::class)->findOneBy(['mail' => 'health-test@synaplan.internal']);
+        $user->setEmailVerified(false);
+        $this->em->flush();
+
+        $this->client->request(
+            'GET',
+            '/api/health/probe',
+            [],
+            [],
+            ['HTTP_X_API_KEY' => self::API_KEY],
+        );
+
+        self::assertSame(Response::HTTP_SERVICE_UNAVAILABLE, $this->client->getResponse()->getStatusCode());
         self::assertStringContainsString('STATUS:ERROR', (string) $this->client->getResponse()->getContent());
-    }
-
-    public function testReturns401WithWrongToken(): void
-    {
-        $this->client->request(
-            'GET',
-            '/api/health/login',
-            [],
-            [],
-            ['HTTP_X_HEALTH_MONITOR_TOKEN' => 'wrong'],
-        );
-
-        self::assertSame(Response::HTTP_UNAUTHORIZED, $this->client->getResponse()->getStatusCode());
-    }
-
-    public function testAcceptsTokenViaHeader(): void
-    {
-        $this->client->request(
-            'GET',
-            '/api/health/login',
-            [],
-            [],
-            ['HTTP_X_HEALTH_MONITOR_TOKEN' => self::TOKEN],
-        );
-
-        self::assertSame(Response::HTTP_SERVICE_UNAVAILABLE, $this->client->getResponse()->getStatusCode());
-    }
-
-    public function testAcceptsTokenViaQueryParam(): void
-    {
-        $this->client->request('GET', '/api/health/login?monitor='.self::TOKEN);
-
-        self::assertSame(Response::HTTP_SERVICE_UNAVAILABLE, $this->client->getResponse()->getStatusCode());
     }
 
     public function testResponseLeaksNoDetails(): void
     {
         $this->client->request(
             'GET',
-            '/api/health/login',
+            '/api/health/probe',
             [],
             [],
-            ['HTTP_X_HEALTH_MONITOR_TOKEN' => self::TOKEN],
+            ['HTTP_X_API_KEY' => self::API_KEY],
         );
 
         $payload = json_decode((string) $this->client->getResponse()->getContent(), true);
@@ -75,5 +93,40 @@ final class HealthMonitorControllerTest extends WebTestCase
         self::assertCount(1, $payload);
         self::assertArrayHasKey('status', $payload);
         self::assertContains($payload['status'], ['STATUS:OK', 'STATUS:ERROR']);
+    }
+
+    private function createMonitorUserWithApiKey(): void
+    {
+        $userRepo = $this->em->getRepository(User::class);
+        $user = $userRepo->findOneBy(['mail' => 'health-test@synaplan.internal']);
+
+        if (null === $user) {
+            $user = new User();
+            $user->setMail('health-test@synaplan.internal');
+            $user->setCreated(date('YmdHis'));
+            $user->setType('WEB');
+            $user->setProviderId('health-monitor-test');
+            $user->setUserLevel('NEW');
+            $user->setEmailVerified(true);
+            $this->em->persist($user);
+            $this->em->flush();
+        } else {
+            $user->setEmailVerified(true);
+            $this->em->flush();
+        }
+
+        $apiKeyRepo = $this->em->getRepository(ApiKey::class);
+        $existingKey = $apiKeyRepo->findOneBy(['key' => self::API_KEY]);
+
+        if (null === $existingKey) {
+            $apiKey = new ApiKey();
+            $apiKey->setOwner($user);
+            $apiKey->setKey(self::API_KEY);
+            $apiKey->setStatus('active');
+            $apiKey->setName('Health Monitor Test');
+            $apiKey->setScopes([]);
+            $this->em->persist($apiKey);
+            $this->em->flush();
+        }
     }
 }

--- a/docs/ADMIN.md
+++ b/docs/ADMIN.md
@@ -46,17 +46,17 @@ See [Installation Guide](INSTALLATION.md) for full setup instructions.
 
 ### Health Check Endpoint
 
-`GET /api/health/login` exercises the full auth stack (DB, password hash, email-verified gate, token generation) and returns `STATUS:OK` or `STATUS:ERROR`.
+`GET /api/health/probe` exercises the auth stack (DB via API-Key lookup, email-verified gate, token generation) and returns `STATUS:OK` or `STATUS:ERROR`.
 
-Protected by `X-Health-Monitor-Token` header. No sensitive details in the response — diagnostics are logged server-side only.
+Protected by standard API-Key authentication (`X-API-Key` header). No sensitive details in the response — diagnostics are logged server-side only.
 
 Quick smoke test:
 
 ```bash
-curl -i -H "X-Health-Monitor-Token: <token>" https://your-domain.com/api/health/login
+curl -i -H "X-API-Key: sk_your-health-monitor-api-key" https://your-domain.com/api/health/probe
 ```
 
-See [Health Monitoring](HEALTH_MONITORING.md) for full setup: token generation, monitor user creation, Uptime Robot configuration.
+See [Health Monitoring](HEALTH_MONITORING.md) for full setup: monitor user creation, API-Key generation, Uptime Robot configuration.
 
 ### Recommended Uptime Robot Settings
 
@@ -130,11 +130,10 @@ Verify the application works after the update. If something breaks, restore from
 
 ### Token Rotation
 
-Rotate `HEALTH_MONITOR_TOKEN`:
+Rotate health monitor API-Key:
 
-1. Generate new token: `openssl rand -hex 32`
-2. Update ENV var, restart backend
-3. Update Uptime Robot header
+1. Log in as the health-monitor user, revoke old API-Key, create new one
+2. Update Uptime Robot header with the new key
 
 Rotate `APP_SECRET`:
 

--- a/docs/HEALTH_MONITORING.md
+++ b/docs/HEALTH_MONITORING.md
@@ -10,50 +10,23 @@ Configure Uptime Robot with keyword `STATUS:OK`, alert when keyword does **NOT**
 
 | Endpoint | What it checks | Suggested interval |
 |---|---|---|
-| `GET /api/health/login` | DB reachable, monitor user exists, password hash valid, email verified, token generation works | every **5 min**, alert after 2 consecutive fails |
+| `GET /api/health/probe` | DB reachable (via API-Key lookup), monitor user exists, email verified, token generation works | every **5 min**, alert after 2 consecutive fails |
 
 ## Auth
 
-Header (preferred): `X-Health-Monitor-Token: <TOKEN>`
-Query param (fallback): `?monitor=<TOKEN>`
+Standard API-Key authentication via `X-API-Key` header.
 
-To rotate: change the ENV var, restart, update Uptime Robot.
+No custom tokens, no additional ENV vars required.
 
 ## Monitor user
 
-Dedicated, isolated account — no admin rights, no real usage, only exists for this health check. User level `NEW`, no UI access needed.
+Dedicated, isolated account — no admin rights, no real usage, only exists for this health check. User level `NEW`, email verified, no UI access needed.
 
 ## Setup
 
-### 1. Generate the token
+### 1. Create the monitor user (one-time SQL)
 
-```bash
-openssl rand -hex 32
-```
-
-### 2. Pick a strong password for the monitor user
-
-```bash
-openssl rand -base64 32
-```
-
-### 3. Set ENV vars in production
-
-```bash
-HEALTH_MONITOR_TOKEN=<token from step 1>
-HEALTH_MONITOR_USER_EMAIL=health-monitor@synaplan.internal
-HEALTH_MONITOR_USER_PASSWORD=<password from step 2>
-```
-
-### 4. Create the monitor user (one-time SQL)
-
-Generate the bcrypt hash:
-
-```bash
-docker compose exec backend php -r 'echo password_hash("<password from step 2>", PASSWORD_BCRYPT), "\n";'
-```
-
-Then in the production database:
+In the production database:
 
 ```sql
 INSERT INTO BUSER (
@@ -63,7 +36,7 @@ INSERT INTO BUSER (
     DATE_FORMAT(NOW(), '%Y%m%d%H%i%s'),
     'WEB',
     'health-monitor@synaplan.internal',
-    '<bcrypt hash from above>',
+    NULL,
     'health-monitor',
     'NEW',
     1,
@@ -72,19 +45,43 @@ INSERT INTO BUSER (
 );
 ```
 
+Note: No password needed — authentication is done via API-Key only.
+
 Verify:
 
 ```sql
 SELECT BID, BMAIL, BEMAILVERIFIED FROM BUSER WHERE BPROVIDERID = 'health-monitor';
 ```
 
+### 2. Create an API-Key for the monitor user
+
+```sql
+INSERT INTO BAPIKEYS (BOWNERID, BKEY, BSTATUS, BLASTUSED, BSCOPES, BCREATED, BNAME)
+VALUES (
+    (SELECT BID FROM BUSER WHERE BPROVIDERID = 'health-monitor'),
+    CONCAT('sk_', LOWER(HEX(RANDOM_BYTES(32)))),
+    'active',
+    0,
+    '[]',
+    UNIX_TIMESTAMP(),
+    'Uptime Robot'
+);
+```
+
+Retrieve the generated key:
+
+```sql
+SELECT BKEY FROM BAPIKEYS WHERE BNAME = 'Uptime Robot'
+  AND BOWNERID = (SELECT BID FROM BUSER WHERE BPROVIDERID = 'health-monitor');
+```
+
 One-time per environment. Galera replication propagates across the cluster.
 
-### 5. Configure Uptime Robot
+### 3. Configure Uptime Robot
 
 - **Type:** Keyword
-- **URL:** `https://api.synaplan.com/api/health/login`
-- **Custom Header:** `X-Health-Monitor-Token: <token from step 1>`
+- **URL:** `https://api.synaplan.com/api/health/probe`
+- **Custom Header:** `X-API-Key: <key from step 2>`
 - **Keyword Type:** Keyword does NOT exist
 - **Keyword:** `STATUS:OK`
 - **Interval:** 5 min
@@ -93,11 +90,18 @@ One-time per environment. Galera replication propagates across the cluster.
 ## Smoke test
 
 ```bash
-curl -i -H "X-Health-Monitor-Token: <token>" https://api.synaplan.com/api/health/login
+curl -i -H "X-API-Key: sk_your-key-here" https://api.synaplan.com/api/health/probe
 ```
+
+## Key rotation
+
+1. Create a new API-Key (step 2 above, or via the admin UI)
+2. Update Uptime Robot with the new key
+3. Revoke the old key: `UPDATE BAPIKEYS SET BSTATUS = 'revoked' WHERE BKEY = 'old-key';`
 
 ## Removing the monitor user
 
 ```sql
+DELETE FROM BAPIKEYS WHERE BOWNERID = (SELECT BID FROM BUSER WHERE BPROVIDERID = 'health-monitor');
 DELETE FROM BUSER WHERE BPROVIDERID = 'health-monitor';
 ```


### PR DESCRIPTION
## Summary

- Remove 3 dedicated ENV vars (`HEALTH_MONITOR_TOKEN`, `HEALTH_MONITOR_USER_EMAIL`, `HEALTH_MONITOR_USER_PASSWORD`)
- Use standard API-Key authentication (`X-API-Key` header) instead of custom token logic
- Rename endpoint from `/api/health/login` to `/api/health/probe` (accurately reflects what it tests)
- Controller now exercises: DB reachability (implicit via API-Key lookup), email-verified gate, JWT token generation
- Zero ENV configuration needed — only a dedicated DB user with an API-Key

## Setup (after merge)

1. Create health-monitor user in prod DB (one-time SQL)
2. Create API-Key for that user (SQL or via admin impersonate)
3. Configure Uptime Robot with the API-Key as `X-API-Key` header

See `docs/HEALTH_MONITORING.md` for full instructions.

## Test plan

- [x] Backend lint passes
- [x] PHPStan passes (for changed files)
- [x] All 1881 backend tests pass
- [x] HealthMonitorControllerTest covers: no key → 401, invalid key → 401, valid key → 200/OK, unverified email → 503/ERROR, no info leak
- [x] Manually tested locally with curl