### PR TITLE
fix(widget): enforce strict chunk execution order for Rolldown

### DIFF
--- a/frontend/vite.config.widget.ts
+++ b/frontend/vite.config.widget.ts
@@ -107,6 +107,7 @@ export default defineConfig(({ mode }) => ({
         entryFileNames: '[name].js',
         chunkFileNames: 'chunks/[name]-[hash].js',
         assetFileNames: 'assets/[name]-[hash][extname]',
+        strictExecutionOrder: true,
       },
     },
 


### PR DESCRIPTION
## Summary
- Adds `strictExecutionOrder: true` to the widget Vite build config to fix a Rolldown regression where chunks load in arbitrary order, preventing the widget from initializing
- This unblocks PR #969 (Vite 8.0.16 upgrade) whose E2E widget tests were failing due to this execution order issue

## Test plan
- [x] Frontend lint passes (0 errors)
- [x] `vue-tsc` type check passes
- [x] Widget build (`build:widget`) succeeds
- [x] Main app build (`build`) succeeds — unaffected by this change
- [x] All 610 frontend unit tests pass
- [x] All 1905 backend tests pass