### PR TITLE
fix(e2e): increase widget message timeouts to reduce CI flakiness

### DIFF
--- a/frontend/tests/e2e/tests/widget.spec.ts
+++ b/frontend/tests/e2e/tests/widget.spec.ts
@@ -183,7 +183,7 @@ test.describe('@ci @smoke Widget', () => {
 
     const userContainer = messageContainers.nth(previousCount)
     await expect(userContainer.locator(selectors.widget.messageUserText)).toBeVisible({
-      timeout: TIMEOUTS.SHORT,
+      timeout: TIMEOUTS.STANDARD,
     })
     await expect(userContainer).toContainText('smoke test')
 
@@ -191,7 +191,7 @@ test.describe('@ci @smoke Widget', () => {
     const newBubble = messageContainers.nth(assistantIndex)
     await newBubble.waitFor({ state: 'attached', timeout: TIMEOUTS.STANDARD })
     await newBubble.scrollIntoViewIfNeeded()
-    await newBubble.waitFor({ state: 'visible', timeout: TIMEOUTS.SHORT })
+    await newBubble.waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
 
     await newBubble
       .locator(selectors.widget.messageDone)


### PR DESCRIPTION
## Summary
- Bumps user-message and assistant-bubble visibility timeouts from `SHORT` (5s) to `STANDARD` (10s) in the `@ci` widget E2E test "embedded chat receives response"
- Addresses the remaining flake after PR #1060 fixed the fundamental Rolldown execution order issue — widget now loads correctly, but under CI load the Shadow DOM message rendering can exceed 5s

## Context
- Before Vite 8: zero widget test failures
- With Vite 8 (no `strictExecutionOrder`): ALL widget tests fail — fixed by #1060
- After #1060: widget loads, but 1/3 tests flakes on tight 5s timeout — this PR

## Test plan
- [x] Only test timeouts changed (5s → 10s), no logic changes
- [x] Consistent with adjacent `STANDARD` timeouts in the same test
- [x] Verified CI failure was at the exact 5s timeout boundary