### PR TITLE
fix(dev): exclude vue-i18n from Vite dep optimizer (Rolldown bug)

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -96,6 +96,9 @@ export default defineConfig(({ mode }) => {
         },
       },
     },
+    optimizeDeps: {
+      exclude: ['vue-i18n'],
+    },
     resolve: {
       alias: {
         '@': fileURLToPath(new URL('./src', import.meta.url)),


### PR DESCRIPTION
## Summary

- Vite 8.0.16's Rolldown-based dep optimizer omits `init_runtime_dom_esm_bundler` and `init_shared_esm_bundler` from the import statement when pre-bundling `vue-i18n`, causing `ReferenceError: init_runtime_dom_esm_bundler is not defined` and a blank page on `localhost:5173`
- Excludes `vue-i18n` from `optimizeDeps` so Vite serves it as unbundled ESM in dev — same class of Rolldown bug that previously required skipping Vite 8.0.12–8.0.13
- **Zero production impact** — `optimizeDeps` is dev-server only

## Test plan

- [x] `localhost:5173` loads without console errors after clearing `.vite` cache
- [ ] CI passes (no production build impact)