### PR TITLE
fix: fix "Select suggested models" button to apply current code defaults

### DIFF
--- a/backend/src/Controller/ConfigController.php
+++ b/backend/src/Controller/ConfigController.php
@@ -843,29 +843,28 @@ class ConfigController extends AbstractController
     }
 
     /**
-     * Reset the calling user's model configuration to platform defaults.
+     * Replace the calling user's model configuration with the
+     * code-recommended defaults from DefaultModelConfigSeeder.
      *
-     * Removes all per-user DEFAULTMODEL overrides for the calling user so they
-     * fall back to the global defaults (ownerId=0). Does NOT modify the global
-     * defaults — other users are unaffected. This mirrors the scope of
-     * saveDefaultModels (which writes per-user) so that the button behaves
-     * exactly like manually reverting each dropdown.
+     * Removes stale per-user overrides and writes fresh ones that
+     * match the catalog-recommended models. Other users and the
+     * global (ownerId=0) row are unaffected.
      */
     #[Route('/models/defaults/reset', name: 'models_defaults_reset', methods: ['POST'])]
     #[OA\Post(
         path: '/api/v1/config/models/defaults/reset',
-        summary: 'Reset own model configuration to platform defaults',
-        description: 'Removes all per-user DEFAULTMODEL overrides for the calling user so they fall back to the global defaults (ownerId=0). Does NOT modify global defaults — other users are unaffected. Returns the effective defaults after reset.',
+        summary: 'Apply recommended model defaults to own configuration',
+        description: 'Replaces all per-user DEFAULTMODEL overrides with the code-recommended defaults (from DefaultModelConfigSeeder). Does NOT modify global defaults — other users are unaffected. Returns the newly written defaults.',
         security: [['Bearer' => []]],
         tags: ['Configuration']
     )]
     #[OA\Response(
         response: 200,
-        description: 'Defaults reset successfully',
+        description: 'Defaults applied successfully',
         content: new OA\JsonContent(
             properties: [
                 new OA\Property(property: 'success', type: 'boolean', example: true),
-                new OA\Property(property: 'message', type: 'string', example: 'Default models reset to recommended defaults'),
+                new OA\Property(property: 'message', type: 'string', example: 'Applied 11 recommended defaults (removed 3 previous overrides)'),
                 new OA\Property(
                     property: 'defaults',
                     type: 'object',
@@ -886,7 +885,11 @@ class ConfigController extends AbstractController
 
         return $this->json([
             'success' => true,
-            'message' => sprintf('Removed %d user-specific override(s), now using platform defaults', $result['removed']),
+            'message' => sprintf(
+                'Applied %d recommended default(s) (removed %d previous override(s))',
+                $result['written'],
+                $result['removed'],
+            ),
             'defaults' => $result['defaults'],
         ]);
     }

--- a/backend/src/Service/ModelConfigService.php
+++ b/backend/src/Service/ModelConfigService.php
@@ -8,6 +8,7 @@ use App\Entity\User;
 use App\Repository\ConfigRepository;
 use App\Repository\ModelRepository;
 use App\Repository\UserRepository;
+use App\Seed\DefaultModelConfigSeeder;
 use Psr\Cache\CacheItemPoolInterface;
 
 /**
@@ -505,10 +506,13 @@ final readonly class ModelConfigService
     }
 
     /**
-     * Remove all per-user DEFAULTMODEL overrides so the user falls back to
-     * the global platform defaults (ownerId=0).
+     * Replace per-user DEFAULTMODEL overrides with the code-recommended
+     * defaults from {@see DefaultModelConfigSeeder::getRecommendedDefaults()}.
      *
-     * @return array{removed: int, defaults: array<string, int>}
+     * VECTORIZE is system-wide (single Qdrant collection) and is never
+     * written as a per-user override.
+     *
+     * @return array{removed: int, written: int, defaults: array<string, int>}
      */
     public function resetUserDefaults(int $userId): array
     {
@@ -518,19 +522,35 @@ final readonly class ModelConfigService
         ]);
 
         $this->configRepository->removeAll($userOverrides);
+        $removed = count($userOverrides);
 
-        $globalRows = $this->configRepository->findBy([
-            'ownerId' => 0,
-            'group' => 'DEFAULTMODEL',
-        ]);
+        try {
+            $recommended = DefaultModelConfigSeeder::getRecommendedDefaults();
+        } catch (\RuntimeException) {
+            $recommended = [];
+        }
 
+        $written = 0;
         $defaults = [];
-        foreach ($globalRows as $row) {
-            $defaults[$row->getSetting()] = (int) $row->getValue();
+
+        foreach ($recommended as $capability => $modelId) {
+            if ('VECTORIZE' === $capability) {
+                continue;
+            }
+
+            $model = $this->modelRepository->find($modelId);
+            if (!$model || 1 !== $model->getActive()) {
+                continue;
+            }
+
+            $this->configRepository->setValue($userId, 'DEFAULTMODEL', $capability, (string) $modelId);
+            $defaults[$capability] = $modelId;
+            ++$written;
         }
 
         return [
-            'removed' => count($userOverrides),
+            'removed' => $removed,
+            'written' => $written,
             'defaults' => $defaults,
         ];
     }


### PR DESCRIPTION
## Summary

- **"Select suggested models" button** now applies the actual code-recommended defaults instead of falling back to stale global DB values that the seeder's `INSERT IGNORE` never updates
- ANALYZE default stays at Claude Sonnet 4.6 (user-facing quality matters more than cost savings for rare file analysis tasks)

## Details

### Problem
The `DefaultModelConfigSeeder` uses `INSERT IGNORE` (via `BConfigSeeder::insertIfMissing`), so it only writes global defaults once. When we later update the recommended models in code, existing production databases keep the old values. The "Select suggested models" button deleted per-user overrides and fell back to these stale global values — defeating its purpose.

### Fix
`ModelConfigService::resetUserDefaults()` now resolves the current code-recommended defaults from `DefaultModelConfigSeeder::getRecommendedDefaults()` and writes them as per-user overrides. This means:
- Existing users keep their current settings (no disruption)
- Clicking "Select suggested models" gives the latest code recommendations
- Global defaults (ownerId=0) are not modified — other users unaffected
- VECTORIZE is excluded (system-wide, single Qdrant collection)
- Inactive/missing models are skipped

## Test plan
- [ ] Run full backend test suite (`make -C backend test`)
- [ ] Test "Select suggested models" button on the models config page — should apply latest code defaults
- [ ] Verify other users' model selections are unaffected after another user clicks reset