### PR TITLE
fix(chat): reconcile streamed message with persisted state after SSE complete (#1070)

### DIFF
--- a/backend/config/services.yaml
+++ b/backend/config/services.yaml
@@ -705,6 +705,8 @@ services:
 when@dev:
     services:
         App\AI\Provider\TestProvider:
+            arguments:
+                $uploadDir: '%kernel.project_dir%/var/uploads'
             tags:
                 - { name: 'app.ai.chat' }
                 - { name: 'app.ai.embedding' }
@@ -722,6 +724,8 @@ when@test:
             alias: App\Realtime\Publisher\NullPublisher
 
         App\AI\Provider\TestProvider:
+            arguments:
+                $uploadDir: '%kernel.project_dir%/var/uploads'
             tags:
                 - { name: 'app.ai.chat' }
                 - { name: 'app.ai.embedding' }

--- a/backend/src/AI/Provider/TestProvider.php
+++ b/backend/src/AI/Provider/TestProvider.php
@@ -14,6 +14,11 @@ class TestProvider implements ChatProviderInterface, EmbeddingProviderInterface,
 {
     private const FAKE_TOKENS_PER_EMBED = 8;
 
+    public function __construct(
+        private readonly string $uploadDir = '/var/www/backend/var/uploads',
+    ) {
+    }
+
     public function getName(): string
     {
         return 'test';
@@ -483,7 +488,21 @@ class TestProvider implements ChatProviderInterface, EmbeddingProviderInterface,
     // TextToSpeechProviderInterface
     public function synthesize(string $text, array $options = []): string
     {
-        return '/tmp/test_audio.mp3';
+        // Write a real (silent) MP3 frame into the upload dir root —
+        // AiFacade::moveToUserPath() expects the returned filename to
+        // exist there so it can move it into the user path. Returning a
+        // non-existent path made every voice-reply turn on the test
+        // provider fail silently in the move step (issue #1070 E2E).
+        if (!is_dir($this->uploadDir)) {
+            mkdir($this->uploadDir, 0775, true);
+        }
+
+        $filename = 'tts_test_'.uniqid().'.mp3';
+        // Single silent MPEG-1 Layer III frame (128 kbit/s, 44.1 kHz).
+        $frame = "\xFF\xFB\x90\x64".str_repeat("\x00", 413);
+        file_put_contents($this->uploadDir.'/'.$filename, $frame);
+
+        return $filename;
     }
 
     public function synthesizeStream(string $text, array $options = []): \Generator

--- a/backend/src/AI/Provider/TestProvider.php
+++ b/backend/src/AI/Provider/TestProvider.php
@@ -209,6 +209,19 @@ class TestProvider implements ChatProviderInterface, EmbeddingProviderInterface,
             ], JSON_THROW_ON_ERROR);
         }
 
+        // web_search + chat plan — used by @webSearch E2E tests.
+        if (str_contains($text, 'websearch:')) {
+            return json_encode([
+                'version' => 1,
+                'language' => 'en',
+                'reply_node' => 'n2',
+                'tasks' => [
+                    ['id' => 'n1', 'capability' => 'web_search', 'inputs' => ['query' => '$message.text']],
+                    ['id' => 'n2', 'capability' => 'chat', 'depends_on' => ['n1'], 'inputs' => ['text' => '$n1.text']],
+                ],
+            ], JSON_THROW_ON_ERROR);
+        }
+
         return json_encode([
             'version' => 1,
             'language' => 'en',

--- a/backend/src/Controller/ChatController.php
+++ b/backend/src/Controller/ChatController.php
@@ -6,9 +6,9 @@ use App\Entity\Chat;
 use App\Entity\User;
 use App\Repository\ChatRepository;
 use App\Repository\MessageRepository;
-use App\Repository\SearchResultRepository;
 use App\Service\File\DataUrlFixer;
 use App\Service\File\OgImageService;
+use App\Service\Message\MessageApiFormatter;
 use App\Service\WidgetSessionService;
 use Doctrine\ORM\EntityManagerInterface;
 use OpenApi\Attributes as OA;
@@ -27,10 +27,10 @@ class ChatController extends AbstractController
         private EntityManagerInterface $em,
         private ChatRepository $chatRepository,
         private MessageRepository $messageRepository,
-        private SearchResultRepository $searchResultRepository,
         private WidgetSessionService $widgetSessionService,
         private DataUrlFixer $dataUrlFixer,
         private OgImageService $ogImageService,
+        private MessageApiFormatter $messageApiFormatter,
         private LoggerInterface $logger,
     ) {
     }
@@ -483,151 +483,12 @@ class ChatController extends AbstractController
         $messages = $queryBuilder->getQuery()->getResult();
         $messages = array_reverse($messages);
 
-        $messageData = array_map(function ($m) {
-            $filesData = [];
-            if ($m->hasFiles()) {
-                foreach ($m->getFiles() as $file) {
-                    $filesData[] = [
-                        'id' => $file->getId(),
-                        'filename' => $file->getFileName(),
-                        'fileType' => $file->getFileType(),
-                        'filePath' => $file->getFilePath(),
-                        'fileSize' => $file->getFileSize(),
-                        'fileMime' => $file->getFileMime(),
-                    ];
-                }
-            }
-
-            // Get AI model metadata for assistant messages
-            $aiModels = [];
-            $webSearchData = null;
-            $searchResultsData = [];
-            $wasMultitask = false;
-
-            if ('OUT' === $m->getDirection()) {
-                // Multi-task routing: the turn ran the DAG executor, so the
-                // frontend shows the simple "Again" (full re-plan) control.
-                $wasMultitask = '1' === $m->getMeta('multitask');
-
-                // Chat model (used for generating the response)
-                $chatProvider = $m->getMeta('ai_chat_provider');
-                $chatModel = $m->getMeta('ai_chat_model');
-                $chatModelIdMeta = $m->getMeta('ai_chat_model_id');
-                if ($chatProvider || $chatModel) {
-                    $aiModels['chat'] = [
-                        'provider' => $chatProvider,
-                        'model' => $chatModel,
-                        'model_id' => $chatModelIdMeta ? (int) $chatModelIdMeta : null,
-                    ];
-                }
-
-                // Sorting model (used for classification/routing)
-                $sortingProvider = $m->getMeta('ai_sorting_provider');
-                $sortingModel = $m->getMeta('ai_sorting_model');
-                $sortingModelId = $m->getMeta('ai_sorting_model_id');
-                if ($sortingProvider || $sortingModel) {
-                    $aiModels['sorting'] = [
-                        'provider' => $sortingProvider,
-                        'model' => $sortingModel,
-                        'model_id' => $sortingModelId ? (int) $sortingModelId : null,
-                    ];
-                }
-
-                // Audio model (TTS pipeline used for voice reply, e.g. Piper).
-                // Surfaced separately from `chat` so a page reload also shows
-                // the actual TTS model under the "Audio Model" badge — see
-                // issue #583.
-                $audioProvider = $m->getMeta('ai_audio_provider');
-                $audioModel = $m->getMeta('ai_audio_model');
-                $audioModelId = $m->getMeta('ai_audio_model_id');
-                if ($audioProvider || $audioModel) {
-                    $aiModels['audio'] = [
-                        'provider' => $audioProvider,
-                        'model' => $audioModel,
-                        'model_id' => $audioModelId ? (int) $audioModelId : null,
-                    ];
-                }
-
-                // Web Search metadata
-                $searchQuery = $m->getMeta('web_search_query');
-                $searchResultsCount = $m->getMeta('web_search_results_count');
-                if ($searchQuery || $searchResultsCount) {
-                    $webSearchData = [
-                        'query' => $searchQuery,
-                        'resultsCount' => $searchResultsCount ? (int) $searchResultsCount : 0,
-                    ];
-
-                    // Load actual search results from DB
-                    // Search results are stored on the INCOMING (user) message, but we need to display them
-                    // on the OUTGOING (AI) message. So we need to find the previous incoming message.
-                    $incomingMessage = $this->messageRepository->createQueryBuilder('prev')
-                        ->where('prev.chatId = :chatId')
-                        ->andWhere('prev.direction = :direction')
-                        ->andWhere('prev.unixTimestamp < :timestamp')
-                        ->setParameter('chatId', $m->getChatId())
-                        ->setParameter('direction', 'IN')
-                        ->setParameter('timestamp', $m->getUnixTimestamp())
-                        ->orderBy('prev.unixTimestamp', 'DESC')
-                        ->setMaxResults(1)
-                        ->getQuery()
-                        ->getOneOrNullResult();
-
-                    if ($incomingMessage) {
-                        $searchResults = $this->searchResultRepository->findByMessage($incomingMessage);
-                        foreach ($searchResults as $sr) {
-                            $searchResultsData[] = [
-                                'title' => $sr->getTitle(),
-                                'url' => $sr->getUrl(),
-                                'description' => $sr->getDescription(),
-                                'published' => $sr->getPublished(),
-                                'source' => $sr->getSource(),
-                                'thumbnail' => $sr->getThumbnail(),
-                            ];
-                        }
-                    }
-                }
-            } elseif ('IN' === $m->getDirection()) {
-                // Check if web search was enabled for incoming message
-                $webSearchEnabled = $m->getMeta('web_search_enabled');
-                if ('true' === $webSearchEnabled) {
-                    $webSearchData = [
-                        'enabled' => true,
-                    ];
-                }
-            }
-
-            // Fix data URL to file if needed (legacy migration)
-            $filePath = $m->getFilePath();
-            if ($m->getFile() && $filePath && str_starts_with($filePath, 'data:')) {
-                $filePath = $this->dataUrlFixer->ensureFileOnDisk($m);
-            }
-
-            $originalTopic = $m->getMeta('original_topic');
-            $originalMediaType = $m->getMeta('original_media_type');
-
-            return [
-                'id' => $m->getId(),
-                'text' => $m->getText(),
-                'direction' => $m->getDirection(),
-                'timestamp' => $m->getUnixTimestamp(),
-                'provider' => $m->getProviderIndex(),
-                'topic' => $m->getTopic(),
-                'originalTopic' => $originalTopic,
-                'originalMediaType' => $originalMediaType,
-                'language' => $m->getLanguage(),
-                'createdAt' => $m->getDateTime(),
-                'files' => $filesData, // Attached files (user uploads)
-                'aiModels' => !empty($aiModels) ? $aiModels : null, // AI model metadata
-                'webSearch' => $webSearchData, // Web search metadata
-                'searchResults' => !empty($searchResultsData) ? $searchResultsData : null, // Actual search results
-                'multitask' => $wasMultitask, // True when the turn ran the multi-task DAG
-                // Generated content (images, videos from AI)
-                'file' => ($m->getFile() && $filePath) ? [
-                    'path' => $filePath,
-                    'type' => $m->getFileType(),
-                ] : null,
-            ];
-        }, $messages);
+        // Issue #1070: serialization lives in MessageApiFormatter so this
+        // endpoint and GET /api/v1/messages/{id} can never diverge.
+        $messageData = array_map(
+            fn ($m) => $this->messageApiFormatter->format($m),
+            $messages
+        );
 
         $totalCount = $this->messageRepository->createQueryBuilder('m')
             ->select('COUNT(m.id)')

--- a/backend/src/Controller/MessageController.php
+++ b/backend/src/Controller/MessageController.php
@@ -443,6 +443,32 @@ class MessageController extends AbstractController
                                 new OA\Property(property: 'searchResults', type: 'array', nullable: true, items: new OA\Items(type: 'object')),
                                 new OA\Property(property: 'multitask', type: 'boolean'),
                                 new OA\Property(
+                                    property: 'taskPlan',
+                                    type: 'object',
+                                    nullable: true,
+                                    description: 'Per-node render state for DAG turns (null for non-DAG messages). Enables task cards to be rebuilt on reload.',
+                                    properties: [
+                                        new OA\Property(property: 'reply_node', type: 'string'),
+                                        new OA\Property(
+                                            property: 'cards',
+                                            type: 'array',
+                                            items: new OA\Items(
+                                                type: 'object',
+                                                properties: [
+                                                    new OA\Property(property: 'nodeId', type: 'string'),
+                                                    new OA\Property(property: 'capability', type: 'string'),
+                                                    new OA\Property(property: 'kind', type: 'string'),
+                                                    new OA\Property(property: 'state', type: 'string'),
+                                                    new OA\Property(property: 'text', type: 'string', nullable: true),
+                                                    new OA\Property(property: 'url', type: 'string', nullable: true),
+                                                    new OA\Property(property: 'type', type: 'string', nullable: true),
+                                                    new OA\Property(property: 'error', type: 'string', nullable: true),
+                                                ]
+                                            )
+                                        ),
+                                    ]
+                                ),
+                                new OA\Property(
                                     property: 'file',
                                     type: 'object',
                                     nullable: true,

--- a/backend/src/Controller/MessageController.php
+++ b/backend/src/Controller/MessageController.php
@@ -6,11 +6,13 @@ use App\AI\Service\AiFacade;
 use App\Entity\File;
 use App\Entity\Message;
 use App\Entity\User;
+use App\Repository\MessageRepository;
 use App\Service\File\FileProcessor;
 use App\Service\File\FileStorageService;
 use App\Service\File\VectorizationService;
 use App\Service\Message\AgainHandler;
 use App\Service\Message\EnhanceOutputGuard;
+use App\Service\Message\MessageApiFormatter;
 use App\Service\Message\MessagePreProcessor;
 use App\Service\MessageEnqueueService;
 use App\Service\ModelConfigService;
@@ -41,6 +43,8 @@ class MessageController extends AbstractController
         private FileStorageService $fileStorageService,
         private FileProcessor $fileProcessor,
         private VectorizationService $vectorizationService,
+        private MessageRepository $messageRepository,
+        private MessageApiFormatter $messageApiFormatter,
         private LoggerInterface $logger,
         #[Autowire(env: 'default::bool:COST_BUDGET_GATE_ENABLED')]
         private bool $costBudgetGateEnabled = false,
@@ -373,6 +377,107 @@ class MessageController extends AbstractController
         return $this->json([
             'success' => true,
             'messages' => array_reverse($result), // Oldest first
+        ]);
+    }
+
+    /**
+     * Get a single persisted message in the canonical history row shape.
+     *
+     * Issue #1070: after SSE `complete` the frontend re-fetches the
+     * finalized message here and treats it as the authoritative source
+     * for files/media/metadata, so live streaming and page reload can
+     * never diverge. Serialization is shared with
+     * GET /api/v1/chats/{id}/messages via MessageApiFormatter.
+     */
+    #[Route('/{messageId}', name: 'get', methods: ['GET'], requirements: ['messageId' => '\d+'])]
+    #[OA\Get(
+        path: '/api/v1/messages/{messageId}',
+        summary: 'Get a single message in the same shape as the chat history endpoint',
+        description: 'Returns the persisted, finalized state of one message. Used by the frontend after SSE `complete` to reconcile the streamed state against the authoritative persisted version (files, media, metadata).',
+        security: [['Bearer' => []]],
+        tags: ['Messages'],
+        parameters: [
+            new OA\Parameter(name: 'messageId', in: 'path', required: true, schema: new OA\Schema(type: 'integer')),
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'The persisted message',
+                content: new OA\JsonContent(
+                    required: ['success', 'message'],
+                    properties: [
+                        new OA\Property(property: 'success', type: 'boolean', example: true),
+                        new OA\Property(
+                            property: 'message',
+                            type: 'object',
+                            required: ['id', 'text', 'direction', 'timestamp'],
+                            properties: [
+                                new OA\Property(property: 'id', type: 'integer', example: 123),
+                                new OA\Property(property: 'text', type: 'string'),
+                                new OA\Property(property: 'direction', type: 'string', enum: ['IN', 'OUT']),
+                                new OA\Property(property: 'timestamp', type: 'integer', example: 1765600000),
+                                new OA\Property(property: 'provider', type: 'string', nullable: true),
+                                new OA\Property(property: 'topic', type: 'string', nullable: true),
+                                new OA\Property(property: 'originalTopic', type: 'string', nullable: true),
+                                new OA\Property(property: 'originalMediaType', type: 'string', nullable: true),
+                                new OA\Property(property: 'language', type: 'string', nullable: true),
+                                new OA\Property(property: 'createdAt', type: 'string', nullable: true),
+                                new OA\Property(
+                                    property: 'files',
+                                    type: 'array',
+                                    description: 'Attached files (user uploads)',
+                                    items: new OA\Items(
+                                        properties: [
+                                            new OA\Property(property: 'id', type: 'integer'),
+                                            new OA\Property(property: 'filename', type: 'string'),
+                                            new OA\Property(property: 'fileType', type: 'string'),
+                                            new OA\Property(property: 'filePath', type: 'string'),
+                                            new OA\Property(property: 'fileSize', type: 'integer', nullable: true),
+                                            new OA\Property(property: 'fileMime', type: 'string', nullable: true),
+                                        ],
+                                        type: 'object'
+                                    )
+                                ),
+                                new OA\Property(property: 'aiModels', type: 'object', nullable: true, description: 'AI model metadata (chat/sorting/audio)'),
+                                new OA\Property(property: 'webSearch', type: 'object', nullable: true),
+                                new OA\Property(property: 'searchResults', type: 'array', nullable: true, items: new OA\Items(type: 'object')),
+                                new OA\Property(property: 'multitask', type: 'boolean'),
+                                new OA\Property(
+                                    property: 'file',
+                                    type: 'object',
+                                    nullable: true,
+                                    description: 'Generated content (image, video, audio from AI)',
+                                    properties: [
+                                        new OA\Property(property: 'path', type: 'string'),
+                                        new OA\Property(property: 'type', type: 'string'),
+                                    ]
+                                ),
+                            ]
+                        ),
+                    ]
+                )
+            ),
+            new OA\Response(response: 401, description: 'Not authenticated'),
+            new OA\Response(response: 404, description: 'Message not found'),
+        ]
+    )]
+    public function getMessage(
+        int $messageId,
+        #[CurrentUser] ?User $user,
+    ): JsonResponse {
+        if (!$user) {
+            return $this->json(['error' => 'Not authenticated'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        $message = $this->messageRepository->find($messageId);
+
+        if (!$message || $message->getUserId() !== $user->getId()) {
+            return $this->json(['error' => 'Message not found'], Response::HTTP_NOT_FOUND);
+        }
+
+        return $this->json([
+            'success' => true,
+            'message' => $this->messageApiFormatter->format($message),
         ]);
     }
 

--- a/backend/src/Controller/StreamController.php
+++ b/backend/src/Controller/StreamController.php
@@ -1243,6 +1243,16 @@ class StreamController extends AbstractController
                     $outgoingMessage->setMeta('multitask', '1');
                 }
 
+                // Persist the per-node render state (capabilities, kinds, states,
+                // texts, urls) so the frontend can rebuild task cards on reload
+                // without relying on the live SSE stream (issue #1070).
+                if (!empty($response['metadata']['task_plan_render'])) {
+                    $outgoingMessage->setMeta(
+                        'task_plan',
+                        (string) json_encode($response['metadata']['task_plan_render'], \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE)
+                    );
+                }
+
                 $this->persistOriginalMediaMeta(
                     $outgoingMessage,
                     $classification,
@@ -1905,6 +1915,14 @@ class StreamController extends AbstractController
             // Mirror the streaming branch: flag DAG turns for the history API.
             if (!empty($metadata['multitask'])) {
                 $outgoingMessage->setMeta('multitask', '1');
+            }
+
+            // Mirror the streaming branch: persist per-node render state for reload.
+            if (!empty($metadata['task_plan_render'])) {
+                $outgoingMessage->setMeta(
+                    'task_plan',
+                    (string) json_encode($metadata['task_plan_render'], \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE)
+                );
             }
 
             if (!empty($options['web_search'])) {

--- a/backend/src/Controller/StreamController.php
+++ b/backend/src/Controller/StreamController.php
@@ -1268,11 +1268,17 @@ class StreamController extends AbstractController
                     $this->logger->info('StreamController: Web search was enabled for this message');
                 }
 
-                // Store if search results were found (will be processed below)
-                $hasSearchResults = isset($result['search_results']) && !empty($result['search_results']['results']);
+                // Store if search results were found (will be processed below).
+                // For DAG turns the results are not in $result['search_results']
+                // (that key only exists when MessageProcessor pre-fetched them on
+                // the single-task path). The ResultAssembler now also propagates
+                // them into $response['metadata']['search_results'] so both paths
+                // are covered by checking both locations.
+                $effectiveSearchResults = $result['search_results'] ?? ($response['metadata']['search_results'] ?? null);
+                $hasSearchResults = is_array($effectiveSearchResults) && !empty($effectiveSearchResults['results']);
                 if ($hasSearchResults) {
-                    $searchQuery = $result['search_results']['query'] ?? '';
-                    $searchCount = count($result['search_results']['results']);
+                    $searchQuery = $effectiveSearchResults['query'] ?? '';
+                    $searchCount = count($effectiveSearchResults['results']);
 
                     $incomingMessage->setMeta('web_search_query', $searchQuery);
                     $incomingMessage->setMeta('web_search_results_count', (string) $searchCount);
@@ -1346,12 +1352,12 @@ class StreamController extends AbstractController
                     }
                 }
 
-                // Get search results if available
-                $searchResults = $this->formatSearchResultsForSse($result['search_results'] ?? null);
+                // Get search results if available (uses the effective source computed above)
+                $searchResults = $this->formatSearchResultsForSse($effectiveSearchResults ?? null);
                 if (null !== $searchResults) {
                     $this->logger->info('StreamController: Including search results', [
                         'results_count' => count($searchResults),
-                        'query' => $result['search_results']['query'],
+                        'query' => $effectiveSearchResults['query'] ?? '',
                     ]);
                 }
 
@@ -1929,10 +1935,14 @@ class StreamController extends AbstractController
                 $message->setMeta('web_search_enabled', 'true');
             }
 
-            $hasSearchResults = isset($result['search_results']) && !empty($result['search_results']['results']);
+            // Mirror the streaming path: also check metadata['search_results'] so DAG
+            // turns that searched via WebSearchRunner (not MessageProcessor) get their
+            // web_search_query/count metas set and the Sources dropdown populated.
+            $effectiveSearchResults = $result['search_results'] ?? ($metadata['search_results'] ?? null);
+            $hasSearchResults = is_array($effectiveSearchResults) && !empty($effectiveSearchResults['results']);
             if ($hasSearchResults) {
-                $searchQuery = $result['search_results']['query'] ?? '';
-                $searchCount = count($result['search_results']['results']);
+                $searchQuery = $effectiveSearchResults['query'] ?? '';
+                $searchCount = count($effectiveSearchResults['results']);
 
                 $message->setMeta('web_search_query', $searchQuery);
                 $message->setMeta('web_search_results_count', (string) $searchCount);
@@ -1990,7 +2000,7 @@ class StreamController extends AbstractController
                 'originalTopic' => $nonStreamingOriginalTopic,
                 'originalMediaType' => $nonStreamingOriginalMediaType,
                 'language' => $classification['language'] ?? null,
-                'searchResults' => $this->formatSearchResultsForSse($result['search_results'] ?? null),
+                'searchResults' => $this->formatSearchResultsForSse($effectiveSearchResults ?? null),
                 'aiModels' => $this->buildAiModelsPayload($outgoingMessage),
             ];
 

--- a/backend/src/Service/Message/MessageApiFormatter.php
+++ b/backend/src/Service/Message/MessageApiFormatter.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Message;
+
+use App\Entity\Message;
+use App\Repository\MessageRepository;
+use App\Repository\SearchResultRepository;
+use App\Service\File\DataUrlFixer;
+
+/**
+ * Serializes a persisted Message entity into the canonical API row shape.
+ *
+ * Single source of truth for issue #1070: the chat history endpoint
+ * (GET /api/v1/chats/{id}/messages) and the single-message endpoint
+ * (GET /api/v1/messages/{id}) must produce the exact same shape, because
+ * the frontend reconciles the live SSE-streamed state against this
+ * payload after `complete`. Keeping one formatter guarantees streaming
+ * and reload can never diverge on files/media/metadata.
+ */
+final readonly class MessageApiFormatter
+{
+    public function __construct(
+        private MessageRepository $messageRepository,
+        private SearchResultRepository $searchResultRepository,
+        private DataUrlFixer $dataUrlFixer,
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function format(Message $m): array
+    {
+        $filesData = [];
+        if ($m->hasFiles()) {
+            foreach ($m->getFiles() as $file) {
+                $filesData[] = [
+                    'id' => $file->getId(),
+                    'filename' => $file->getFileName(),
+                    'fileType' => $file->getFileType(),
+                    'filePath' => $file->getFilePath(),
+                    'fileSize' => $file->getFileSize(),
+                    'fileMime' => $file->getFileMime(),
+                ];
+            }
+        }
+
+        // Get AI model metadata for assistant messages
+        $aiModels = [];
+        $webSearchData = null;
+        $searchResultsData = [];
+        $wasMultitask = false;
+
+        if ('OUT' === $m->getDirection()) {
+            // Multi-task routing: the turn ran the DAG executor, so the
+            // frontend shows the simple "Again" (full re-plan) control.
+            $wasMultitask = '1' === $m->getMeta('multitask');
+
+            // Chat model (used for generating the response)
+            $chatProvider = $m->getMeta('ai_chat_provider');
+            $chatModel = $m->getMeta('ai_chat_model');
+            $chatModelIdMeta = $m->getMeta('ai_chat_model_id');
+            if ($chatProvider || $chatModel) {
+                $aiModels['chat'] = [
+                    'provider' => $chatProvider,
+                    'model' => $chatModel,
+                    'model_id' => $chatModelIdMeta ? (int) $chatModelIdMeta : null,
+                ];
+            }
+
+            // Sorting model (used for classification/routing)
+            $sortingProvider = $m->getMeta('ai_sorting_provider');
+            $sortingModel = $m->getMeta('ai_sorting_model');
+            $sortingModelId = $m->getMeta('ai_sorting_model_id');
+            if ($sortingProvider || $sortingModel) {
+                $aiModels['sorting'] = [
+                    'provider' => $sortingProvider,
+                    'model' => $sortingModel,
+                    'model_id' => $sortingModelId ? (int) $sortingModelId : null,
+                ];
+            }
+
+            // Audio model (TTS pipeline used for voice reply, e.g. Piper).
+            // Surfaced separately from `chat` so a page reload also shows
+            // the actual TTS model under the "Audio Model" badge — see
+            // issue #583.
+            $audioProvider = $m->getMeta('ai_audio_provider');
+            $audioModel = $m->getMeta('ai_audio_model');
+            $audioModelId = $m->getMeta('ai_audio_model_id');
+            if ($audioProvider || $audioModel) {
+                $aiModels['audio'] = [
+                    'provider' => $audioProvider,
+                    'model' => $audioModel,
+                    'model_id' => $audioModelId ? (int) $audioModelId : null,
+                ];
+            }
+
+            // Web Search metadata
+            $searchQuery = $m->getMeta('web_search_query');
+            $searchResultsCount = $m->getMeta('web_search_results_count');
+            if ($searchQuery || $searchResultsCount) {
+                $webSearchData = [
+                    'query' => $searchQuery,
+                    'resultsCount' => $searchResultsCount ? (int) $searchResultsCount : 0,
+                ];
+
+                // Load actual search results from DB.
+                // Search results are stored on the INCOMING (user) message, but we need to display them
+                // on the OUTGOING (AI) message. So we need to find the previous incoming message.
+                $incomingMessage = $this->messageRepository->createQueryBuilder('prev')
+                    ->where('prev.chatId = :chatId')
+                    ->andWhere('prev.direction = :direction')
+                    ->andWhere('prev.unixTimestamp < :timestamp')
+                    ->setParameter('chatId', $m->getChatId())
+                    ->setParameter('direction', 'IN')
+                    ->setParameter('timestamp', $m->getUnixTimestamp())
+                    ->orderBy('prev.unixTimestamp', 'DESC')
+                    ->setMaxResults(1)
+                    ->getQuery()
+                    ->getOneOrNullResult();
+
+                if ($incomingMessage) {
+                    $searchResults = $this->searchResultRepository->findByMessage($incomingMessage);
+                    foreach ($searchResults as $sr) {
+                        $searchResultsData[] = [
+                            'title' => $sr->getTitle(),
+                            'url' => $sr->getUrl(),
+                            'description' => $sr->getDescription(),
+                            'published' => $sr->getPublished(),
+                            'source' => $sr->getSource(),
+                            'thumbnail' => $sr->getThumbnail(),
+                        ];
+                    }
+                }
+            }
+        } elseif ('IN' === $m->getDirection()) {
+            // Check if web search was enabled for incoming message
+            $webSearchEnabled = $m->getMeta('web_search_enabled');
+            if ('true' === $webSearchEnabled) {
+                $webSearchData = [
+                    'enabled' => true,
+                ];
+            }
+        }
+
+        // Fix data URL to file if needed (legacy migration)
+        $filePath = $m->getFilePath();
+        if ($m->getFile() && $filePath && str_starts_with($filePath, 'data:')) {
+            $filePath = $this->dataUrlFixer->ensureFileOnDisk($m);
+        }
+
+        $originalTopic = $m->getMeta('original_topic');
+        $originalMediaType = $m->getMeta('original_media_type');
+
+        return [
+            'id' => $m->getId(),
+            'text' => $m->getText(),
+            'direction' => $m->getDirection(),
+            'timestamp' => $m->getUnixTimestamp(),
+            'provider' => $m->getProviderIndex(),
+            'topic' => $m->getTopic(),
+            'originalTopic' => $originalTopic,
+            'originalMediaType' => $originalMediaType,
+            'language' => $m->getLanguage(),
+            'createdAt' => $m->getDateTime(),
+            'files' => $filesData, // Attached files (user uploads)
+            'aiModels' => !empty($aiModels) ? $aiModels : null, // AI model metadata
+            'webSearch' => $webSearchData, // Web search metadata
+            'searchResults' => !empty($searchResultsData) ? $searchResultsData : null, // Actual search results
+            'multitask' => $wasMultitask, // True when the turn ran the multi-task DAG
+            // Generated content (images, videos, audio from AI)
+            'file' => ($m->getFile() && $filePath) ? [
+                'path' => $filePath,
+                'type' => $m->getFileType(),
+            ] : null,
+        ];
+    }
+}

--- a/backend/src/Service/Message/MessageApiFormatter.php
+++ b/backend/src/Service/Message/MessageApiFormatter.php
@@ -170,11 +170,38 @@ final readonly class MessageApiFormatter
             'webSearch' => $webSearchData, // Web search metadata
             'searchResults' => !empty($searchResultsData) ? $searchResultsData : null, // Actual search results
             'multitask' => $wasMultitask, // True when the turn ran the multi-task DAG
+            // Per-node task-plan render state for reload (issue #1070 — DAG divergence).
+            // Null for non-DAG turns, non-null only on OUT messages of DAG turns.
+            'taskPlan' => $this->decodeTaskPlanMeta($m),
             // Generated content (images, videos, audio from AI)
             'file' => ($m->getFile() && $filePath) ? [
                 'path' => $filePath,
                 'type' => $m->getFileType(),
             ] : null,
         ];
+    }
+
+    /**
+     * Decode the persisted `task_plan` meta into the API shape expected by the
+     * frontend mapper. Returns null for non-DAG messages or if the meta is absent.
+     *
+     * Shape: { reply_node: string, cards: list<{nodeId, capability, kind, state,
+     *          text?, url?, type?, error?}> }
+     *
+     * @return array<string, mixed>|null
+     */
+    private function decodeTaskPlanMeta(Message $m): ?array
+    {
+        $raw = $m->getMeta('task_plan');
+        if (null === $raw || '' === $raw) {
+            return null;
+        }
+
+        $decoded = json_decode($raw, true);
+        if (!is_array($decoded) || !isset($decoded['cards']) || !is_array($decoded['cards'])) {
+            return null;
+        }
+
+        return $decoded;
     }
 }

--- a/backend/src/Service/Multitask/Execution/DagExecutor.php
+++ b/backend/src/Service/Multitask/Execution/DagExecutor.php
@@ -7,6 +7,7 @@ namespace App\Service\Multitask\Execution;
 use App\Service\Multitask\Execution\Parallel\MediaNodeDispatcher;
 use App\Service\Multitask\Execution\Parallel\MediaNodeRequest;
 use App\Service\Multitask\MultitaskRoutingConfig;
+use App\Service\Multitask\Plan\Capability;
 use App\Service\Multitask\Plan\TaskNode;
 use App\Service\Multitask\Plan\TaskPlan;
 use Psr\Log\LoggerInterface;
@@ -209,7 +210,10 @@ final readonly class DagExecutor
 
         $context->setResult($node->id, $result);
         $this->emitFilesFor($node, $result, $progressCallback);
-        $this->emitState($progressCallback, $node, $result->isSuccessful() ? 'done' : 'failed', $this->failureMetadata($node, $result, $context));
+        $extra = $result->isSuccessful()
+            ? $this->successMetadata($node, $result)
+            : $this->failureMetadata($node, $result, $context);
+        $this->emitState($progressCallback, $node, $result->isSuccessful() ? 'done' : 'failed', $extra);
     }
 
     /**
@@ -228,7 +232,10 @@ final readonly class DagExecutor
             unset($inflight[$node->id]);
             $context->setResult($node->id, $result);
             $this->emitFilesFor($node, $result, $progressCallback);
-            $this->emitState($progressCallback, $node, $result->isSuccessful() ? 'done' : 'failed', $this->failureMetadata($node, $result, $context));
+            $extra = $result->isSuccessful()
+                ? $this->successMetadata($node, $result)
+                : $this->failureMetadata($node, $result, $context);
+            $this->emitState($progressCallback, $node, $result->isSuccessful() ? 'done' : 'failed', $extra);
 
             return;
         }
@@ -410,6 +417,33 @@ final readonly class DagExecutor
             if (null !== $prompt) {
                 $extra['prompt'] = $prompt;
             }
+        }
+
+        return $extra;
+    }
+
+    /**
+     * Extra `task_update` metadata for a successfully completed node.
+     * Currently only web_search nodes carry extra data (query + results_count)
+     * so the live task card shows a compact summary matching the reload state
+     * (QA feedback PR #1076 — search card body parity).
+     *
+     * @return array<string, mixed>
+     */
+    private function successMetadata(TaskNode $node, NodeResult $result): array
+    {
+        if (Capability::WebSearch !== $node->capability) {
+            return [];
+        }
+
+        $extra = [];
+        $query = $result->metadata['query'] ?? null;
+        if (is_string($query) && '' !== $query) {
+            $extra['query'] = $query;
+        }
+        $sr = $result->metadata['search_results'] ?? null;
+        if (is_array($sr) && is_array($sr['results'] ?? null)) {
+            $extra['results_count'] = count($sr['results']);
         }
 
         return $extra;

--- a/backend/src/Service/Multitask/Execution/NodeContext.php
+++ b/backend/src/Service/Multitask/Execution/NodeContext.php
@@ -23,6 +23,12 @@ use App\Service\Multitask\Plan\TaskNode;
  *   - "$nX.files"          → upstream node X all file descriptors
  *   - anything else        → literal value (passed through unchanged)
  *   - a list of the above   → resolved element-wise
+ *
+ * When a string is NOT a pure reference (does not start with `$`) but contains
+ * embedded `$nX.text` or `$message.text` tokens, those tokens are interpolated
+ * in-place. This prevents literal placeholder text (e.g. "Summary: $n1.text")
+ * from leaking into the persisted reply when the planner emits prose with
+ * embedded references instead of a pure `"$n1.text"` value.
  */
 final class NodeContext
 {
@@ -123,16 +129,56 @@ final class NodeContext
             return array_map(fn ($item) => $this->resolve($item), $value);
         }
 
-        if (!is_string($value) || !str_starts_with($value, '$')) {
-            return $value; // literal
+        if (!is_string($value)) {
+            return $value; // literal (non-string)
         }
 
-        return match (true) {
-            '$message.text' === $value => $this->message->getText(),
-            '$message.fileText' === $value => $this->message->getFileText() ?: '',
-            '$message.files' === $value => $this->messageFiles(),
-            default => $this->resolveNodeRef($value),
-        };
+        // Pure reference: entire string is exactly one "$message.xxx" or "$nX.field"
+        // token with no surrounding prose — return the typed value as-is (may be null,
+        // a string, or a file list). Must match from ^ to $ so that a multi-token prose
+        // string like "$n1.text and also $n2.text" falls through to interpolateRefs.
+        if (1 === preg_match('/^\$(?:message\.(text|fileText|files)|[A-Za-z0-9_]+\.(text|file|files))$/', $value)) {
+            return match (true) {
+                '$message.text' === $value => $this->message->getText(),
+                '$message.fileText' === $value => $this->message->getFileText() ?: '',
+                '$message.files' === $value => $this->messageFiles(),
+                default => $this->resolveNodeRef($value),
+            };
+        }
+
+        // Prose interpolation: the planner may embed a reference token inside a
+        // larger string (e.g. "Zusammenfassung: $n1.text"). Replace every recognised
+        // token in-place so no literal placeholder leaks into the persisted reply.
+        if (str_contains($value, '$')) {
+            return $this->interpolateRefs($value);
+        }
+
+        return $value; // plain literal
+    }
+
+    /**
+     * Inline-replace every `$nX.text` / `$message.text` / `$message.fileText`
+     * token inside a prose string. Unknown or unresolvable references are
+     * replaced with an empty string so no placeholder leaks to the user.
+     */
+    private function interpolateRefs(string $value): string
+    {
+        return preg_replace_callback(
+            '/\$(?:message\.(text|fileText)|([A-Za-z0-9_]+)\.(text))/',
+            function (array $m): string {
+                // Group 1 is non-empty when the match is $message.text or $message.fileText.
+                if ('' !== $m[1]) {
+                    $resolved = '$message.text' === $m[0]
+                        ? $this->message->getText()
+                        : ($this->message->getFileText() ?: '');
+                } else {
+                    $resolved = $this->resolveNodeRef('$'.$m[2].'.'.$m[3]);
+                }
+
+                return is_string($resolved) ? $resolved : '';
+            },
+            $value
+        ) ?? $value;
     }
 
     private function resolveNodeRef(string $ref): mixed

--- a/backend/src/Service/Multitask/Execution/ResultAssembler.php
+++ b/backend/src/Service/Multitask/Execution/ResultAssembler.php
@@ -76,6 +76,45 @@ final class ResultAssembler
             'partial_failure' => $partialFailure,
         ];
 
+        // Persist the per-node render state so the frontend can rebuild the
+        // task cards on reload without another round-trip. Only non-hidden
+        // nodes (uiKind !== 'hidden') produce visible cards — compose_reply
+        // is the assembler and never has its own card.
+        $renderCards = [];
+        foreach ($plan->nodes as $node) {
+            if ('hidden' === $node->capability->uiKind()) {
+                continue;
+            }
+            $nodeResult = $context->getResult($node->id);
+            $nodeStatus = null !== $nodeResult ? $nodeResult->status->value : 'skipped';
+            $card = [
+                'nodeId' => $node->id,
+                'capability' => $node->capability->value,
+                'kind' => $node->capability->uiKind(),
+                'state' => $nodeStatus,
+            ];
+            if (null !== $nodeResult) {
+                if (null !== $nodeResult->text && '' !== $nodeResult->text) {
+                    $card['text'] = $nodeResult->text;
+                }
+                // First file from this node provides the media url/type for the card.
+                $firstFile = $nodeResult->firstFile();
+                if (null !== $firstFile && isset($firstFile['path'])) {
+                    $card['url'] = (string) $firstFile['path'];
+                    $card['type'] = isset($firstFile['type']) ? (string) $firstFile['type'] : $node->capability->uiKind();
+                }
+                if (null !== $nodeResult->error && '' !== $nodeResult->error) {
+                    $card['error'] = $nodeResult->error;
+                }
+            }
+            $renderCards[] = $card;
+        }
+
+        $metadata['task_plan_render'] = [
+            'reply_node' => $plan->replyNode,
+            'cards' => $renderCards,
+        ];
+
         return [
             'content' => $content,
             'files' => $files,

--- a/backend/src/Service/Multitask/Execution/ResultAssembler.php
+++ b/backend/src/Service/Multitask/Execution/ResultAssembler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Service\Multitask\Execution;
 
+use App\Service\Multitask\Plan\Capability;
 use App\Service\Multitask\Plan\TaskPlan;
 
 /**
@@ -76,6 +77,29 @@ final class ResultAssembler
             'partial_failure' => $partialFailure,
         ];
 
+        // Propagate web_search results from the first successful WebSearch node
+        // into the top-level metadata so StreamController can set the
+        // web_search_query/count metas and populate the Sources dropdown.
+        // The replyNode is typically chat/summarize/compose_reply and does NOT
+        // carry search_results in its own metadata, which is why DAG turns were
+        // missing the Sources dropdown (issue: QA feedback PR #1076).
+        if (!isset($metadata['search_results'])) {
+            foreach ($plan->nodes as $node) {
+                if (Capability::WebSearch !== $node->capability) {
+                    continue;
+                }
+                $searchNodeResult = $context->getResult($node->id);
+                if (null === $searchNodeResult || !$searchNodeResult->isSuccessful()) {
+                    continue;
+                }
+                $sr = $searchNodeResult->metadata['search_results'] ?? null;
+                if (is_array($sr) && !empty($sr['results'])) {
+                    $metadata['search_results'] = $sr;
+                    break;
+                }
+            }
+        }
+
         // Persist the per-node render state so the frontend can rebuild the
         // task cards on reload without another round-trip. Only non-hidden
         // nodes (uiKind !== 'hidden') produce visible cards — compose_reply
@@ -94,7 +118,23 @@ final class ResultAssembler
                 'state' => $nodeStatus,
             ];
             if (null !== $nodeResult) {
-                if (null !== $nodeResult->text && '' !== $nodeResult->text) {
+                if ('search' === $node->capability->uiKind()) {
+                    // Store a compact summary (query + count) instead of the full
+                    // formatted text dump. The full results are available via the
+                    // Sources dropdown on the message body — showing a 10-item dump
+                    // in the task card is verbose and redundant (QA feedback #1076).
+                    $srMeta = $nodeResult->metadata['search_results'] ?? null;
+                    $srQuery = is_string($nodeResult->metadata['query'] ?? null) ? $nodeResult->metadata['query'] : '';
+                    $srCount = is_array($srMeta) && is_array($srMeta['results'] ?? null)
+                        ? count($srMeta['results'])
+                        : 0;
+                    if ('' !== $srQuery) {
+                        $card['query'] = $srQuery;
+                    }
+                    if ($srCount > 0) {
+                        $card['resultsCount'] = $srCount;
+                    }
+                } elseif (null !== $nodeResult->text && '' !== $nodeResult->text) {
                     $card['text'] = $nodeResult->text;
                 }
                 // First file from this node provides the media url/type for the card.

--- a/backend/src/Service/Multitask/Execution/Runner/WebSearchRunner.php
+++ b/backend/src/Service/Multitask/Execution/Runner/WebSearchRunner.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Service\Multitask\Execution\Runner;
 
+use App\Repository\SearchResultRepository;
 use App\Service\Message\SearchQueryGenerator;
 use App\Service\Multitask\Execution\NodeContext;
 use App\Service\Multitask\Execution\NodeResult;
@@ -30,6 +31,7 @@ final readonly class WebSearchRunner implements TaskRunner
         private SearchQueryGenerator $queryGenerator,
         private BraveSearchService $braveSearch,
         private LoggerInterface $logger,
+        private ?SearchResultRepository $searchResultRepository = null,
     ) {
     }
 
@@ -91,6 +93,20 @@ final readonly class WebSearchRunner implements TaskRunner
         }
 
         $text = $this->braveSearch->formatResultsForAI($results);
+
+        // Persist the structured results to the DB so MessageApiFormatter can
+        // build the Sources dropdown on reload — mirrors what MessageProcessor
+        // does on the single-task path. The reused_prefetched branch above skips
+        // this because MessageProcessor has already saved the rows.
+        if (null !== $this->searchResultRepository && !empty($results['results'])) {
+            try {
+                $this->searchResultRepository->saveSearchResults($context->message, $results, $query);
+            } catch (\Throwable $e) {
+                $this->logger->warning('WebSearchRunner: failed to persist search results (ignored)', [
+                    'error' => $e->getMessage(),
+                ]);
+            }
+        }
 
         return NodeResult::ok($text, [], [
             'web_search' => true,

--- a/backend/tests/Controller/MessageControllerTest.php
+++ b/backend/tests/Controller/MessageControllerTest.php
@@ -274,6 +274,145 @@ class MessageControllerTest extends WebTestCase
         }
     }
 
+    public function testGetMessageWithoutAuth(): void
+    {
+        self::ensureKernelShutdown();
+        $client = static::createClient();
+        $client->request('GET', '/api/v1/messages/123');
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+    }
+
+    public function testGetMessageNotFound(): void
+    {
+        $this->client->request(
+            'GET',
+            '/api/v1/messages/999999999',
+            [],
+            [],
+            [
+                'CONTENT_TYPE' => 'application/json',
+                'HTTP_AUTHORIZATION' => 'Bearer '.$this->token,
+            ]
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+
+    /**
+     * Issue #1070: GET /messages/{id} must return the same row shape as the
+     * chat history endpoint (shared MessageApiFormatter), including the
+     * generated file and the AI model metadata — the frontend reconciles
+     * the streamed state against this payload after SSE `complete`.
+     */
+    public function testGetMessageReturnsPersistedRowShape(): void
+    {
+        $message = new Message();
+        $message->setUserId($this->user->getId());
+        $message->setTrackingId(time());
+        $message->setProviderIndex('test');
+        $message->setUnixTimestamp(time());
+        $message->setDateTime(date('YmdHis'));
+        $message->setMessageType('WEB');
+        $message->setTopic('general');
+        $message->setLanguage('en');
+        $message->setText('Voice reply answer');
+        $message->setDirection('OUT');
+        $message->setStatus('complete');
+        // TTS audio persisted on the OUT message (voice reply / DAG turn)
+        $message->setFile(1);
+        $message->setFilePath('/api/v1/files/uploads/13/000/tts_reply.mp3');
+        $message->setFileType('audio');
+
+        $this->em->persist($message);
+        $this->em->flush();
+
+        // Metas require the message id (MessageMeta.messageId is non-null),
+        // so they are attached after the initial flush — same order as the
+        // StreamController persistence path.
+        $message->setMeta('ai_audio_provider', 'piper');
+        $message->setMeta('ai_audio_model', 'piper-multi');
+        $message->setMeta('multitask', '1');
+        $this->em->flush();
+
+        $this->client->request(
+            'GET',
+            '/api/v1/messages/'.$message->getId(),
+            [],
+            [],
+            [
+                'CONTENT_TYPE' => 'application/json',
+                'HTTP_AUTHORIZATION' => 'Bearer '.$this->token,
+            ]
+        );
+
+        $this->assertResponseIsSuccessful();
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertTrue($response['success']);
+
+        $row = $response['message'];
+        $this->assertSame($message->getId(), $row['id']);
+        $this->assertSame('Voice reply answer', $row['text']);
+        $this->assertSame('OUT', $row['direction']);
+        $this->assertSame('general', $row['topic']);
+        $this->assertTrue($row['multitask']);
+        $this->assertSame(
+            ['path' => '/api/v1/files/uploads/13/000/tts_reply.mp3', 'type' => 'audio'],
+            $row['file']
+        );
+        $this->assertSame('piper', $row['aiModels']['audio']['provider']);
+        $this->assertSame('piper-multi', $row['aiModels']['audio']['model']);
+    }
+
+    public function testGetMessageOfAnotherUserReturns404(): void
+    {
+        $otherUser = $this->em->getRepository(User::class)->findOneBy(['mail' => 'admin@synaplan.com']);
+        if (!$otherUser) {
+            $this->markTestSkipped('Fixture user admin@synaplan.com not found.');
+        }
+
+        $message = new Message();
+        $message->setUserId($otherUser->getId());
+        $message->setTrackingId(time());
+        $message->setProviderIndex('test');
+        $message->setUnixTimestamp(time());
+        $message->setDateTime(date('YmdHis'));
+        $message->setMessageType('WEB');
+        $message->setFile(0);
+        $message->setTopic('general');
+        $message->setLanguage('en');
+        $message->setText('Not yours');
+        $message->setDirection('OUT');
+        $message->setStatus('complete');
+
+        $this->em->persist($message);
+        $this->em->flush();
+        $messageId = $message->getId();
+
+        try {
+            $this->client->request(
+                'GET',
+                '/api/v1/messages/'.$messageId,
+                [],
+                [],
+                [
+                    'CONTENT_TYPE' => 'application/json',
+                    'HTTP_AUTHORIZATION' => 'Bearer '.$this->token,
+                ]
+            );
+
+            $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+        } finally {
+            // tearDown only cleans up the demo user's messages.
+            $leftover = $this->em->find(Message::class, $messageId);
+            if ($leftover) {
+                $this->em->remove($leftover);
+                $this->em->flush();
+            }
+        }
+    }
+
     public function testEnhanceWithoutAuth(): void
     {
         self::ensureKernelShutdown();

--- a/backend/tests/Controller/MessageControllerTest.php
+++ b/backend/tests/Controller/MessageControllerTest.php
@@ -365,6 +365,69 @@ class MessageControllerTest extends WebTestCase
         $this->assertSame('piper-multi', $row['aiModels']['audio']['model']);
     }
 
+    /**
+     * Issue #1070 DAG reload: GET /messages/{id} must return `taskPlan` when the
+     * OUT message has a persisted `task_plan` meta, so the frontend can rebuild
+     * task cards after a page reload.
+     */
+    public function testGetMessageReturnsTaskPlanMeta(): void
+    {
+        $message = new Message();
+        $message->setUserId($this->user->getId());
+        $message->setTrackingId(time() + 5000);
+        $message->setProviderIndex('test');
+        $message->setUnixTimestamp(time());
+        $message->setDateTime(date('YmdHis'));
+        $message->setMessageType('WEB');
+        $message->setTopic('general');
+        $message->setLanguage('en');
+        $message->setText('DAG reply');
+        $message->setDirection('OUT');
+        $message->setStatus('complete');
+        $message->setFile(0);
+
+        $this->em->persist($message);
+        $this->em->flush();
+
+        $taskPlanRender = [
+            'reply_node' => 'n2',
+            'cards' => [
+                ['nodeId' => 'n1', 'capability' => 'summarize', 'kind' => 'text', 'state' => 'done', 'text' => 'Summary here'],
+            ],
+        ];
+
+        $message->setMeta('multitask', '1');
+        $message->setMeta('task_plan', json_encode($taskPlanRender));
+        $this->em->flush();
+
+        $this->client->request(
+            'GET',
+            '/api/v1/messages/'.$message->getId(),
+            [],
+            [],
+            [
+                'CONTENT_TYPE' => 'application/json',
+                'HTTP_AUTHORIZATION' => 'Bearer '.$this->token,
+            ]
+        );
+
+        $this->assertResponseIsSuccessful();
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertTrue($response['success']);
+
+        $row = $response['message'];
+        $this->assertTrue($row['multitask']);
+        $this->assertNotNull($row['taskPlan']);
+        $this->assertSame('n2', $row['taskPlan']['reply_node']);
+        $this->assertCount(1, $row['taskPlan']['cards']);
+        $this->assertSame('n1', $row['taskPlan']['cards'][0]['nodeId']);
+        $this->assertSame('summarize', $row['taskPlan']['cards'][0]['capability']);
+        $this->assertSame('text', $row['taskPlan']['cards'][0]['kind']);
+        $this->assertSame('done', $row['taskPlan']['cards'][0]['state']);
+        $this->assertSame('Summary here', $row['taskPlan']['cards'][0]['text']);
+    }
+
     public function testGetMessageOfAnotherUserReturns404(): void
     {
         $otherUser = $this->em->getRepository(User::class)->findOneBy(['mail' => 'admin@synaplan.com']);

--- a/backend/tests/Unit/Controller/MessageControllerExtractedMemoriesTest.php
+++ b/backend/tests/Unit/Controller/MessageControllerExtractedMemoriesTest.php
@@ -9,10 +9,14 @@ use App\Controller\MessageController;
 use App\Entity\Message;
 use App\Entity\User;
 use App\Repository\MessageRepository;
+use App\Repository\SearchResultRepository;
+use App\Service\File\DataUrlFixer;
 use App\Service\File\FileProcessor;
 use App\Service\File\FileStorageService;
+use App\Service\File\UserUploadPathBuilder;
 use App\Service\File\VectorizationService;
 use App\Service\Message\AgainHandler;
+use App\Service\Message\MessageApiFormatter;
 use App\Service\MessageEnqueueService;
 use App\Service\ModelConfigService;
 use App\Service\PromptService;
@@ -73,6 +77,20 @@ final class MessageControllerExtractedMemoriesTest extends TestCase
             $this->createMock(FileStorageService::class),
             $this->createMock(FileProcessor::class),
             $this->createMock(VectorizationService::class),
+            $this->messageRepository,
+            // MessageApiFormatter is `final readonly` and cannot be mocked;
+            // a real instance with mocked collaborators is fine since the
+            // memory-poll endpoint under test never calls format().
+            new MessageApiFormatter(
+                $this->messageRepository,
+                $this->createMock(SearchResultRepository::class),
+                new DataUrlFixer(
+                    $this->em,
+                    new UserUploadPathBuilder(),
+                    '/tmp',
+                    new NullLogger(),
+                ),
+            ),
             new NullLogger(),
         );
 

--- a/backend/tests/Unit/Service/Multitask/Execution/NodeContextTest.php
+++ b/backend/tests/Unit/Service/Multitask/Execution/NodeContextTest.php
@@ -129,4 +129,66 @@ final class NodeContextTest extends TestCase
         self::assertSame('the summary', $resolved['text']);
         self::assertSame([['path' => 'a.mp3', 'type' => 'audio']], $resolved['attachments']);
     }
+
+    // -----------------------------------------------------------------------
+    // Prose interpolation (embedded $nX.text tokens — issue #1070 resolver fix)
+    // -----------------------------------------------------------------------
+
+    public function testInterpolatesEmbeddedNodeRef(): void
+    {
+        $ctx = $this->context($this->message());
+        $ctx->setResult('n1', NodeResult::ok('Mein Trainingsplan'));
+
+        // Planner emits prose with an embedded reference — should be resolved.
+        $resolved = $ctx->resolve('Zusammenfassen: $n1.text');
+
+        self::assertSame('Zusammenfassen: Mein Trainingsplan', $resolved);
+    }
+
+    public function testInterpolatesMultipleEmbeddedRefs(): void
+    {
+        $ctx = $this->context($this->message('user input'));
+        $ctx->setResult('n1', NodeResult::ok('Chapter One'));
+        $ctx->setResult('n2', NodeResult::ok('Chapter Two'));
+
+        $resolved = $ctx->resolve('$n1.text and also $n2.text');
+
+        self::assertSame('Chapter One and also Chapter Two', $resolved);
+    }
+
+    public function testInterpolatesEmbeddedMessageText(): void
+    {
+        $ctx = $this->context($this->message('user query'));
+
+        $resolved = $ctx->resolve('Echo: $message.text done');
+
+        self::assertSame('Echo: user query done', $resolved);
+    }
+
+    public function testInterpolatesEmbeddedMessageFileText(): void
+    {
+        $ctx = $this->context($this->message(fileText: 'file body'));
+
+        $resolved = $ctx->resolve('From file: $message.fileText end');
+
+        self::assertSame('From file: file body end', $resolved);
+    }
+
+    public function testUnresolvableEmbeddedRefBecomesEmptyString(): void
+    {
+        $ctx = $this->context($this->message());
+        // $n99 has no result — should replace with empty string, not leave literal.
+
+        $resolved = $ctx->resolve('Prefix $n99.text suffix');
+
+        self::assertSame('Prefix  suffix', $resolved);
+    }
+
+    public function testPureReferenceUnchangedByInterpolation(): void
+    {
+        // Pure refs still return the typed value (string), not interpolated.
+        $ctx = $this->context($this->message('the input'));
+
+        self::assertSame('the input', $ctx->resolve('$message.text'));
+    }
 }

--- a/backend/tests/Unit/Service/Multitask/Execution/ResultAssemblerTest.php
+++ b/backend/tests/Unit/Service/Multitask/Execution/ResultAssemblerTest.php
@@ -133,4 +133,94 @@ final class ResultAssemblerTest extends TestCase
         $n2 = array_values(array_filter($cards, fn ($c) => 'n2' === $c['nodeId']))[0];
         $this->assertSame('skipped', $n2['state']);
     }
+
+    private function searchPlan(): TaskPlan
+    {
+        return TaskPlan::fromArray([
+            'version' => 1, 'language' => 'en', 'reply_node' => 'n2',
+            'tasks' => [
+                ['id' => 'n1', 'capability' => 'web_search', 'inputs' => ['query' => '$message.text']],
+                ['id' => 'n2', 'capability' => 'chat', 'depends_on' => ['n1'], 'inputs' => ['text' => '$n1.text']],
+            ],
+        ]);
+    }
+
+    public function testWebSearchResultsPropagatedToMetadata(): void
+    {
+        $plan = $this->searchPlan();
+        $ctx = $this->context('latest AI news');
+
+        $rawResults = [
+            'query' => 'latest AI news',
+            'results' => [
+                ['title' => 'Article 1', 'url' => 'https://example.com/1', 'description' => 'desc 1'],
+                ['title' => 'Article 2', 'url' => 'https://example.com/2', 'description' => 'desc 2'],
+            ],
+        ];
+        $ctx->setResult('n1', NodeResult::ok('formatted search text', [], [
+            'web_search' => true,
+            'query' => 'latest AI news',
+            'search_results' => $rawResults,
+        ]));
+        $ctx->setResult('n2', NodeResult::ok('Here is the AI summary.'));
+
+        $result = $this->assembler->assemble($plan, $ctx);
+
+        // search_results must be lifted to top-level metadata so StreamController
+        // can set the web_search_query/count metas and populate the Sources dropdown.
+        $this->assertArrayHasKey('search_results', $result['metadata']);
+        $this->assertSame('latest AI news', $result['metadata']['search_results']['query']);
+        $this->assertCount(2, $result['metadata']['search_results']['results']);
+    }
+
+    public function testWebSearchCardContainsCompactSummaryNotDump(): void
+    {
+        $plan = $this->searchPlan();
+        $ctx = $this->context('latest AI news');
+
+        $rawResults = [
+            'query' => 'latest AI news',
+            'results' => [
+                ['title' => 'A1', 'url' => 'https://example.com/1', 'description' => 'd1'],
+                ['title' => 'A2', 'url' => 'https://example.com/2', 'description' => 'd2'],
+                ['title' => 'A3', 'url' => 'https://example.com/3', 'description' => 'd3'],
+            ],
+        ];
+        $ctx->setResult('n1', NodeResult::ok('Web Search Results for: "latest AI news"\n\n1. A1...', [], [
+            'web_search' => true,
+            'query' => 'latest AI news',
+            'search_results' => $rawResults,
+        ]));
+        $ctx->setResult('n2', NodeResult::ok('Summary.'));
+
+        $result = $this->assembler->assemble($plan, $ctx);
+        $cards = $result['metadata']['task_plan_render']['cards'];
+
+        $n1Card = array_values(array_filter($cards, fn ($c) => 'n1' === $c['nodeId']))[0];
+        $this->assertSame('search', $n1Card['kind']);
+        $this->assertSame('latest AI news', $n1Card['query']);
+        $this->assertSame(3, $n1Card['resultsCount']);
+        // The raw formatted dump must NOT appear in the card text.
+        $this->assertArrayNotHasKey('text', $n1Card);
+    }
+
+    public function testWebSearchResultsNotOverriddenWhenAlreadySet(): void
+    {
+        $plan = $this->searchPlan();
+        $ctx = $this->context();
+
+        // Pre-populate metadata via replyNode (unlikely but defensive).
+        $existingResults = ['query' => 'pre-set', 'results' => [['url' => 'https://a.com']]];
+        $ctx->setResult('n2', NodeResult::ok('Answer', [], ['search_results' => $existingResults]));
+        $ctx->setResult('n1', NodeResult::ok('search text', [], [
+            'web_search' => true,
+            'query' => 'different query',
+            'search_results' => ['query' => 'different query', 'results' => [['url' => 'https://b.com']]],
+        ]));
+
+        $result = $this->assembler->assemble($plan, $ctx);
+
+        // replyNode metadata wins (it was already set from n2).
+        $this->assertSame('pre-set', $result['metadata']['search_results']['query']);
+    }
 }

--- a/backend/tests/Unit/Service/Multitask/Execution/ResultAssemblerTest.php
+++ b/backend/tests/Unit/Service/Multitask/Execution/ResultAssemblerTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\Multitask\Execution;
+
+use App\Entity\Message;
+use App\Service\Multitask\Execution\NodeContext;
+use App\Service\Multitask\Execution\NodeResult;
+use App\Service\Multitask\Execution\ResultAssembler;
+use App\Service\Multitask\Plan\TaskPlan;
+use Doctrine\Common\Collections\ArrayCollection;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * ResultAssembler builds the task_plan_render metadata key so the frontend
+ * can reconstruct task cards after a page reload (issue #1070 DAG divergence).
+ */
+final class ResultAssemblerTest extends TestCase
+{
+    private ResultAssembler $assembler;
+
+    protected function setUp(): void
+    {
+        $this->assembler = new ResultAssembler();
+    }
+
+    private function context(string $messageText = 'hello'): NodeContext
+    {
+        $m = $this->createMock(Message::class);
+        $m->method('getText')->willReturn($messageText);
+        $m->method('getFileText')->willReturn('');
+        $m->method('getFile')->willReturn(0);
+        $m->method('getFilePath')->willReturn('');
+        $m->method('getFiles')->willReturn(new ArrayCollection());
+        $m->method('getLanguage')->willReturn('en');
+
+        return new NodeContext($m, [], 1, ['language' => 'en']);
+    }
+
+    private function plan(): TaskPlan
+    {
+        return TaskPlan::fromArray([
+            'version' => 1, 'language' => 'en', 'reply_node' => 'n3',
+            'tasks' => [
+                ['id' => 'n1', 'capability' => 'summarize', 'inputs' => ['text' => '$message.text']],
+                ['id' => 'n2', 'capability' => 'text2sound', 'depends_on' => ['n1'], 'inputs' => ['text' => '$n1.text']],
+                ['id' => 'n3', 'capability' => 'compose_reply', 'depends_on' => ['n1', 'n2'], 'inputs' => ['text' => '$n1.text', 'attachments' => ['$n2.file']]],
+            ],
+        ]);
+    }
+
+    public function testTaskPlanRenderContainsNonHiddenNodesOnly(): void
+    {
+        $plan = $this->plan();
+        $ctx = $this->context();
+
+        $ctx->setResult('n1', NodeResult::ok('Summary text'));
+        $ctx->setResult('n2', NodeResult::ok(null, [['path' => 'uploads/tts.mp3', 'type' => 'audio']]));
+        $ctx->setResult('n3', NodeResult::ok('Summary text', [['path' => 'uploads/tts.mp3', 'type' => 'audio']]));
+
+        $result = $this->assembler->assemble($plan, $ctx);
+
+        $this->assertArrayHasKey('task_plan_render', $result['metadata']);
+        $render = $result['metadata']['task_plan_render'];
+
+        // n3 is compose_reply → hidden; only n1 and n2 produce visible cards.
+        $this->assertCount(2, $render['cards']);
+        $this->assertSame('n3', $render['reply_node']);
+
+        $cardIds = array_column($render['cards'], 'nodeId');
+        $this->assertContains('n1', $cardIds);
+        $this->assertContains('n2', $cardIds);
+        $this->assertNotContains('n3', $cardIds);
+    }
+
+    public function testTaskPlanRenderCardShapeIsCorrect(): void
+    {
+        $plan = $this->plan();
+        $ctx = $this->context();
+
+        $ctx->setResult('n1', NodeResult::ok('Summary text'));
+        $ctx->setResult('n2', NodeResult::ok(null, [['path' => 'uploads/tts.mp3', 'type' => 'audio']]));
+        $ctx->setResult('n3', NodeResult::ok('Summary text', [['path' => 'uploads/tts.mp3', 'type' => 'audio']]));
+
+        $result = $this->assembler->assemble($plan, $ctx);
+        $cards = $result['metadata']['task_plan_render']['cards'];
+
+        $n1 = array_values(array_filter($cards, fn ($c) => 'n1' === $c['nodeId']))[0];
+        $this->assertSame('summarize', $n1['capability']);
+        $this->assertSame('text', $n1['kind']);
+        $this->assertSame('done', $n1['state']);
+        $this->assertSame('Summary text', $n1['text']);
+        $this->assertArrayNotHasKey('url', $n1); // no files on n1
+
+        $n2 = array_values(array_filter($cards, fn ($c) => 'n2' === $c['nodeId']))[0];
+        $this->assertSame('text2sound', $n2['capability']);
+        $this->assertSame('audio', $n2['kind']);
+        $this->assertSame('done', $n2['state']);
+        $this->assertSame('uploads/tts.mp3', $n2['url']);
+        $this->assertSame('audio', $n2['type']);
+    }
+
+    public function testPartialFailureCardStateIsPreserved(): void
+    {
+        $plan = $this->plan();
+        $ctx = $this->context();
+
+        $ctx->setResult('n1', NodeResult::ok('Summary text'));
+        $ctx->setResult('n2', NodeResult::failed('TTS provider unavailable'));
+        $ctx->setResult('n3', NodeResult::ok('Summary text'));
+
+        $result = $this->assembler->assemble($plan, $ctx);
+        $cards = $result['metadata']['task_plan_render']['cards'];
+
+        $n2 = array_values(array_filter($cards, fn ($c) => 'n2' === $c['nodeId']))[0];
+        $this->assertSame('failed', $n2['state']);
+        $this->assertSame('TTS provider unavailable', $n2['error']);
+    }
+
+    public function testSkippedNodeCardStateIsPreserved(): void
+    {
+        $plan = $this->plan();
+        $ctx = $this->context();
+
+        // n1 succeeds, n2 is skipped (not executed), n3 uses best-effort.
+        $ctx->setResult('n1', NodeResult::ok('Summary text'));
+        $ctx->setResult('n3', NodeResult::ok('Summary text'));
+
+        $result = $this->assembler->assemble($plan, $ctx);
+        $cards = $result['metadata']['task_plan_render']['cards'];
+
+        $n2 = array_values(array_filter($cards, fn ($c) => 'n2' === $c['nodeId']))[0];
+        $this->assertSame('skipped', $n2['state']);
+    }
+}

--- a/backend/tests/Unit/Service/Multitask/Execution/Runner/RunnersTest.php
+++ b/backend/tests/Unit/Service/Multitask/Execution/Runner/RunnersTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\Service\Multitask\Execution\Runner;
 
 use App\AI\Service\AiFacade;
 use App\Entity\Message;
+use App\Repository\SearchResultRepository;
 use App\Service\Calendar\CalendarEventService;
 use App\Service\File\FileStorageService;
 use App\Service\Message\Handler\ChatHandler;
@@ -575,6 +576,60 @@ final class RunnersTest extends TestCase
 
         self::assertTrue($result->isSuccessful());
         self::assertArrayNotHasKey('reused_prefetched', $result->metadata);
+    }
+
+    public function testWebSearchPersistsFreshResultsViaRepository(): void
+    {
+        $rawResults = ['query' => 'AI breakthrough', 'results' => [['title' => 'X', 'url' => 'https://x.com']]];
+
+        $brave = $this->createMock(BraveSearchService::class);
+        $brave->method('isEnabled')->willReturn(true);
+        $brave->method('search')->willReturn($rawResults);
+        $brave->method('formatResultsForAI')->willReturn('formatted');
+
+        $queryGen = $this->createMock(SearchQueryGenerator::class);
+        $queryGen->method('generate')->willReturn('AI breakthrough');
+
+        $repo = $this->createMock(SearchResultRepository::class);
+        $repo->expects(self::once())->method('saveSearchResults');
+
+        $runner = new WebSearchRunner($queryGen, $brave, $this->createMock(LoggerInterface::class), $repo);
+        $node = new TaskNode('n1', Capability::WebSearch, [], ['query' => 'AI breakthrough']);
+
+        $result = $runner->run($node, $this->context($this->message('AI breakthrough')));
+
+        self::assertTrue($result->isSuccessful());
+    }
+
+    public function testWebSearchDoesNotPersistWhenReusing(): void
+    {
+        $preFetched = ['query' => 'AI breakthrough', 'results' => [['title' => 'X']]];
+
+        $brave = $this->createMock(BraveSearchService::class);
+        $brave->method('isEnabled')->willReturn(true);
+        $brave->expects(self::never())->method('search');
+        $brave->method('formatResultsForAI')->willReturn('formatted');
+
+        $queryGen = $this->createMock(SearchQueryGenerator::class);
+        $queryGen->expects(self::never())->method('generate');
+
+        $repo = $this->createMock(SearchResultRepository::class);
+        $repo->expects(self::never())->method('saveSearchResults');
+
+        $runner = new WebSearchRunner($queryGen, $brave, $this->createMock(LoggerInterface::class), $repo);
+        $node = new TaskNode('n1', Capability::WebSearch, [], ['query' => '$message.text']);
+
+        $context = new NodeContext(
+            $this->message('AI breakthrough'),
+            [],
+            1,
+            ['language' => 'en'],
+            ['search_results' => $preFetched],
+        );
+        $result = $runner->run($node, $context);
+
+        self::assertTrue($result->isSuccessful());
+        self::assertTrue($result->metadata['reused_prefetched'] ?? false);
     }
 
     public function testFileAnalysisAnswersAboutAttachment(): void

--- a/frontend/src/components/ChatMessage.vue
+++ b/frontend/src/components/ChatMessage.vue
@@ -392,10 +392,10 @@
             on plain text. Falling back to `${type}-${index}` keeps backward
             compatibility for parts without partId (legacy stored messages).
           -->
-          <!-- Multitask routing: live task cards (only while a multi-node plan
-               streams). On reload the turn is flattened to normal parts below. -->
+          <!-- Multitask routing: show task cards when a plan is active (streaming)
+               or when cards exist from a persisted DAG turn (after reload). -->
           <TaskPlanBubble
-            v-if="taskPlan?.active"
+            v-if="taskPlan && taskPlan.cards.length > 0"
             :plan="taskPlan"
             @retry-task="emit('retryTask', $event)"
           />

--- a/frontend/src/components/multitask/TaskCard.vue
+++ b/frontend/src/components/multitask/TaskCard.vue
@@ -53,6 +53,11 @@ const showSkeleton = computed(
 // where markdown is unnecessary, so we keep the plain text path for them.
 const isProseKind = computed(() => ['text', 'extract'].includes(props.card.kind))
 
+// Search cards show a compact summary (query + source count) instead of the
+// raw full-text dump produced by BraveSearchService.formatResultsForAI().
+// The full results are available via the Sources dropdown on the message body.
+const isSearchKind = computed(() => props.card.kind === 'search')
+
 // Model tag matching this card's media kind — the pool the retry button picks from.
 const retryTag = computed((): Capability | null => {
   switch (props.card.kind) {
@@ -169,8 +174,21 @@ const handleRetry = () => {
     </div>
 
     <template v-else>
-      <!-- Streaming / final text -->
-      <div v-if="card.text" class="task-card__body text-sm txt-primary break-words">
+      <!-- Search card: compact summary (query + source count). The full results
+           are shown in the Sources dropdown on the message body, so the card only
+           needs a one-liner — QA feedback PR #1076 points 2 & 4. -->
+      <div v-if="isSearchKind && card.state === 'done'" class="task-card__body text-sm txt-muted">
+        <span v-if="card.query && card.resultsCount">
+          {{ $t('taskPlan.searchSummary', { query: card.query, count: card.resultsCount }) }}
+        </span>
+        <span v-else-if="card.query">{{ card.query }}</span>
+      </div>
+
+      <!-- Streaming / final text (prose and non-search kinds) -->
+      <div
+        v-else-if="!isSearchKind && card.text"
+        class="task-card__body text-sm txt-primary break-words"
+      >
         <MessageText
           v-if="isProseKind"
           :content="card.text"

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -845,6 +845,7 @@
     "title": "Aufgabenplan",
     "download": "Herunterladen",
     "failedBody": "Dieser Schritt konnte nicht abgeschlossen werden.",
+    "searchSummary": "Web durchsucht · {count} {count, plural, one {Quelle} other {Quellen}}",
     "retryWith": "Nochmal mit {model}",
     "state": {
       "pending": "Wartet",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -2790,6 +2790,7 @@
     "title": "Task plan",
     "download": "Download",
     "failedBody": "This step couldn't be completed.",
+    "searchSummary": "Searched the web · {count} {count, plural, one {source} other {sources}}",
     "retryWith": "Retry with {model}",
     "state": {
       "pending": "Queued",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -1028,6 +1028,7 @@
     "title": "Plan de tareas",
     "download": "Descargar",
     "failedBody": "Este paso no se pudo completar.",
+    "searchSummary": "Búsqueda web · {count} {count, plural, one {fuente} other {fuentes}}",
     "retryWith": "Reintentar con {model}",
     "state": {
       "pending": "En cola",

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -1028,6 +1028,7 @@
     "title": "Görev planı",
     "download": "İndir",
     "failedBody": "Bu adım tamamlanamadı.",
+    "searchSummary": "Web arandı · {count} kaynak",
     "retryWith": "{model} ile yeniden dene",
     "state": {
       "pending": "Sırada",

--- a/frontend/src/services/api/chatApi.ts
+++ b/frontend/src/services/api/chatApi.ts
@@ -455,6 +455,18 @@ export const chatApi = {
   },
 
   /**
+   * Issue #1070: fetch a single persisted message in the same row shape as
+   * `getChatMessages`. Called after SSE `complete` to reconcile the
+   * live-streamed state against the authoritative persisted version
+   * (files, media, metadata).
+   */
+  async getMessage(messageId: number): Promise<unknown> {
+    return httpClient(`/api/v1/messages/${messageId}`, {
+      method: 'GET',
+    })
+  },
+
+  /**
    * Phase 2c: poll the backgrounded memory extraction outcome for a message.
    *
    * Returns `{ status: 'pending' | 'empty' | 'complete', saved, delete_suggestions }`.

--- a/frontend/src/stores/history.ts
+++ b/frontend/src/stores/history.ts
@@ -1,18 +1,18 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
-import { normalizeMediaUrl } from '@/utils/urlHelper'
-import { extractBTextPayload } from '@/utils/jsonResponse'
-import { parseAIResponse } from '@/utils/responseParser'
-import { generatePartId } from '@/utils/mediaParts'
-import { isChannelSource } from '@/utils/channelSource'
-import {
-  buildUploadUrl,
-  isAudioFileType,
-  isImageFileType,
-  isVideoFileType,
-} from '@/utils/mediaTypes'
 import type { AgainData } from '@/types/ai-models'
+import type { ApiLoadedMessageRow } from '@/utils/messageMapper'
+import {
+  mapApiMessageRow,
+  parseContentWithThinking,
+  reconcileLocalMessage,
+} from '@/utils/messageMapper'
 import { authService } from '@/services/authService'
+
+// Re-export so existing consumers keep importing from the store module.
+// The implementation moved to utils/messageMapper.ts (issue #1070) so the
+// reload path and the post-stream reconciliation share one mapping.
+export { parseContentWithThinking }
 
 // Helper function to check authentication and redirect if needed
 // Uses authService which holds user info in memory (not localStorage)
@@ -203,148 +203,6 @@ export interface TaskPlanState {
   cards: TaskCard[]
 }
 
-/** Attachment row from chat messages API */
-interface ApiLoadedAttachmentFile {
-  id: number
-  filename?: string
-  fileName?: string
-  fileType?: string
-  file_type?: string
-  filePath?: string
-  file_path?: string
-  fileSize?: number
-  file_size?: number
-  fileMime?: string
-  file_mime?: string
-}
-
-/** Message row from GET /chats/:id/messages */
-interface ApiLoadedMessageRow {
-  id: number
-  direction?: string
-  text?: string
-  timestamp: number
-  topic?: string
-  originalTopic?: string
-  originalMediaType?: string
-  original_media_type?: string
-  provider?: string
-  aiModels?: Message['aiModels']
-  webSearch?: Message['webSearch']
-  searchResults?: Message['searchResults']
-  multitask?: boolean
-  file?: { path: string; type: string }
-  files?: ApiLoadedAttachmentFile[]
-}
-
-/**
- * Parse content to extract thinking blocks, code blocks, and regular text.
- * This ensures consistent rendering between streaming and loaded messages.
- */
-export function parseContentWithThinking(
-  content: string,
-  role: 'user' | 'assistant' = 'assistant'
-): Part[] {
-  // Handle special file generation markers from backend
-  if (content.startsWith('__FILE_GENERATED__:')) {
-    const filename = content.replace('__FILE_GENERATED__:', '').trim()
-    // Return a placeholder - the actual translation will be done in the component
-    // because we need access to i18n there
-    return [
-      {
-        type: 'text',
-        content: `__FILE_GENERATED__:${filename}`,
-      },
-    ]
-  }
-
-  if (content === '__FILE_GENERATION_FAILED__') {
-    return [
-      {
-        type: 'text',
-        content: '__FILE_GENERATION_FAILED__',
-      },
-    ]
-  }
-
-  // Legacy: Check for old JSON format (BTEXT) from database
-  // This is only for backward compatibility with old messages
-  const extraction = extractBTextPayload(content)
-  if (extraction.text !== undefined) {
-    const remainder = extraction.remainder?.trim()
-    const text = extraction.text ?? ''
-    content = remainder ? `${text}\n\n${remainder}`.trim() : text
-  }
-
-  const parts: Part[] = []
-
-  // Extract thinking blocks first
-  const thinkRegex = /<think>([\s\S]*?)<\/think>/g
-  const thinkingBlocks: Array<{ content: string; index: number }> = []
-  let match
-
-  while ((match = thinkRegex.exec(content)) !== null) {
-    thinkingBlocks.push({
-      content: match[1].trim(),
-      index: match.index,
-    })
-  }
-
-  // If there are thinking blocks, extract them
-  if (thinkingBlocks.length > 0) {
-    // Add thinking blocks
-    thinkingBlocks.forEach((block) => {
-      // Estimate thinking time based on content length (rough approximation)
-      const thinkingTime = Math.max(3, Math.floor(block.content.length / 100))
-      parts.push({
-        type: 'thinking',
-        content: block.content,
-        thinkingTime,
-      })
-    })
-
-    // Remove thinking blocks from content
-    content = content.replace(/<think>[\s\S]*?<\/think>/g, '').trim()
-  }
-
-  // For assistant messages, use parseAIResponse to extract code blocks
-  // This ensures consistent rendering between streaming and loaded messages
-  if (role === 'assistant' && content) {
-    const parsed = parseAIResponse(content)
-    parsed.parts.forEach((part) => {
-      if (part.type === 'code') {
-        parts.push({
-          type: 'code',
-          content: part.content,
-          language: part.language,
-        })
-      } else if (part.type === 'text' && part.content.trim()) {
-        parts.push({
-          type: 'text',
-          content: part.content,
-        })
-      } else if (part.type === 'links' && part.links) {
-        parts.push({
-          type: 'links',
-          items: part.links.map((l) => ({
-            title: l.title,
-            url: l.url,
-            desc: l.description,
-          })),
-        })
-      }
-    })
-  } else if (content) {
-    // For user messages, just add as text
-    parts.push({
-      type: 'text',
-      content,
-    })
-  }
-
-  return parts.length > 0 ? parts : [{ type: 'text', content: '' }]
-}
-
 export const useHistoryStore = defineStore('history', () => {
   const messages = ref<Message[]>([])
   const isLoadingMessages = ref(false)
@@ -501,148 +359,7 @@ export const useHistoryStore = defineStore('history', () => {
       if (myGeneration !== loadGeneration) return
 
       if (response.success && response.messages) {
-        const loadedMessages: Message[] = response.messages.map((m) => {
-          const role = m.direction === 'IN' ? 'user' : 'assistant'
-
-          const parts = parseContentWithThinking(m.text || '', role)
-
-          // Add generated file (image/video/audio) as part if present.
-          // Issue #625: assign a stable `partId` on load so the `<audio>` /
-          // `<video>` element keeps its identity if the message later gets
-          // re-parsed (e.g. continuation appends text). Without this, the
-          // index-based fallback key would remount the media player.
-          //
-          // Issue #955: detect audio/image/video by both the generic media
-          // kind (`audio`, `image`, `video` — used by TTS / MEDIAMAKER) and
-          // by the raw file extension (`ogg`, `mp3`, `png`, …) the backend
-          // stores for inbound WhatsApp voice notes and direct uploads.
-          // Without the extension-aware check, a WhatsApp voice reply was
-          // surfaced as a plain text bubble with no player.
-          //
-          // Relative `m.file.path` values (e.g. WhatsApp's `13/.../voice.ogg`)
-          // are first prefixed with the static-serve endpoint so the player
-          // can fetch them; absolute URLs and already-prefixed paths pass
-          // through `buildUploadUrl` unchanged before final normalization.
-          if (m.file && m.file.path) {
-            const absoluteUrl = normalizeMediaUrl(buildUploadUrl(m.file.path))
-            if (isImageFileType(m.file.type)) {
-              parts.push({
-                partId: generatePartId(),
-                type: 'image',
-                url: absoluteUrl,
-                alt: m.text || 'Generated image',
-              })
-            } else if (isVideoFileType(m.file.type)) {
-              parts.push({
-                partId: generatePartId(),
-                type: 'video',
-                url: absoluteUrl,
-              })
-            } else if (isAudioFileType(m.file.type)) {
-              parts.push({
-                partId: generatePartId(),
-                type: 'audio',
-                url: absoluteUrl,
-              })
-            }
-          }
-
-          // Parse files from backend response (user uploads).
-          const files: MessageFile[] = []
-          if (m.files && Array.isArray(m.files)) {
-            files.push(
-              ...m.files.map((f) => ({
-                id: f.id,
-                filename: f.filename || f.fileName || '',
-                fileType: f.fileType || f.file_type || '',
-                filePath: f.filePath || f.file_path || '',
-                fileSize: f.fileSize ?? f.file_size,
-                fileMime: f.fileMime ?? f.file_mime,
-              }))
-            )
-          }
-
-          // Issue #955: render uploaded audio attachments with the
-          // `MessageAudio` player instead of only as a download badge.
-          // The badge stays via `files[]` so the user can still see the
-          // filename / size and download the original recording. Inbound
-          // WhatsApp voice messages travel through this same `files`
-          // pipeline once they're persisted as a `File` entity.
-          //
-          // The MIME type is forwarded so that ambiguous containers like
-          // `.webm` get classified by the actual upload mime (`audio/webm`
-          // for voice notes, `video/webm` for screen recordings) instead
-          // of falling into the audio default purely by extension.
-          for (const file of files) {
-            if (!isAudioFileType(file.fileType, file.fileMime)) continue
-            const audioUrl = buildUploadUrl(file.filePath)
-            if (!audioUrl) continue
-            parts.push({
-              partId: generatePartId(),
-              type: 'audio',
-              url: normalizeMediaUrl(audioUrl),
-            })
-          }
-
-          // Reconstruct tool metadata from topic field for user messages
-          // Also clean command prefix from message content
-          let toolData: { command: string; label: string; icon: string } | null = null
-          if (role === 'user' && m.topic && m.topic.startsWith('tools:')) {
-            const cmd = m.topic.replace('tools:', '')
-            const toolMap: Record<string, { label: string; icon: string }> = {
-              search: { label: 'Web Search', icon: 'mdi:web' },
-              pic: { label: 'Image Generation', icon: 'mdi:image' },
-              vid: { label: 'Video Generation', icon: 'mdi:video' },
-            }
-            if (toolMap[cmd]) {
-              toolData = { command: cmd, ...toolMap[cmd] }
-
-              // Remove command prefix from parts content if present
-              if (parts.length > 0 && parts[0].type === 'text' && parts[0].content) {
-                const content = parts[0].content
-                const commandMatch = content.match(/^\/(\w+)\s+(.*)$/)
-                if (commandMatch && commandMatch[1] === cmd) {
-                  // Remove the command prefix from display
-                  parts[0] = { ...parts[0], content: commandMatch[2].trim() }
-                }
-              }
-            }
-          }
-
-          // The backend reuses the `provider` column to also store the
-          // channel/source for inbound messages (`WHATSAPP`, `EMAIL`,
-          // `WEB`, `widget`, …). When that token leaks into the chat
-          // footer the user sees confusing labels like
-          // `Model: WHATSAPP · Provider: WHATSAPP`. Strip it here so
-          // only real AI provider names ever reach the UI — see #653.
-          const rawProvider = m.aiModels?.chat?.provider ?? m.provider
-          const cleanProvider = isChannelSource(rawProvider) ? undefined : rawProvider
-          const rawModelLabel = m.aiModels?.chat?.model ?? m.provider
-          const cleanModelLabel = isChannelSource(rawModelLabel)
-            ? role === 'assistant'
-              ? 'AI'
-              : undefined
-            : (rawModelLabel ?? (role === 'assistant' ? 'AI' : undefined))
-
-          return {
-            id: `backend-${m.id}`,
-            role,
-            parts,
-            timestamp: new Date(m.timestamp * 1000),
-            provider: cleanProvider,
-            modelLabel: cleanModelLabel,
-            topic: m.topic,
-            originalTopic: m.originalTopic || null,
-            originalMediaType: m.originalMediaType ?? m.original_media_type ?? null,
-            backendMessageId: m.id,
-            files: files.length > 0 ? files : undefined,
-            aiModels: m.aiModels || null,
-            webSearch: m.webSearch || null,
-            searchResults: m.searchResults || null,
-            wasMultitask: m.multitask === true,
-            tool: toolData,
-          }
-        })
+        const loadedMessages: Message[] = response.messages.map(mapApiMessageRow)
 
         // If offset is 0, replace messages; otherwise, prepend (for infinite scroll)
         if (offset === 0) {
@@ -671,6 +388,36 @@ export const useHistoryStore = defineStore('history', () => {
     await loadMessages(chatId, currentOffset.value, 50)
   }
 
+  /**
+   * Issue #1070: after SSE `complete`, re-fetch the persisted message from
+   * the backend and reconcile it with the streamed state. The persisted
+   * version is authoritative for files/media/metadata, so anything the SSE
+   * accumulation missed (e.g. TTS audio in a multitask turn, where the
+   * `audio` event is suppressed while task cards stream) still renders
+   * without a page reload.
+   *
+   * Best-effort: a failed fetch leaves the streamed state untouched — the
+   * user can always recover via reload, which uses the same mapper.
+   */
+  const reconcileMessage = async (localId: string, backendMessageId: number) => {
+    try {
+      const { chatApi } = await import('@/services/api')
+      const response = (await chatApi.getMessage(backendMessageId)) as {
+        success?: boolean
+        message?: ApiLoadedMessageRow
+      }
+
+      if (!response.success || !response.message) return
+
+      const local = messages.value.find((m) => m.id === localId)
+      if (!local) return
+
+      reconcileLocalMessage(local, mapApiMessageRow(response.message))
+    } catch (error) {
+      console.error('Failed to reconcile message with persisted state:', error)
+    }
+  }
+
   return {
     messages,
     isLoadingMessages,
@@ -687,5 +434,6 @@ export const useHistoryStore = defineStore('history', () => {
     clearHistory: clear,
     loadMessages,
     loadMoreMessages,
+    reconcileMessage,
   }
 })

--- a/frontend/src/stores/history.ts
+++ b/frontend/src/stores/history.ts
@@ -195,6 +195,10 @@ export interface TaskCard {
   // Resolved generation prompt of a failed media node — payload for the
   // "retry this step with the next model" action.
   prompt?: string
+  // Web search card compact summary — populated by WebSearchRunner/DagExecutor
+  // so the card shows "Searched the web · N sources" instead of the raw dump.
+  query?: string
+  resultsCount?: number
 }
 
 export interface TaskPlanState {

--- a/frontend/src/utils/messageMapper.ts
+++ b/frontend/src/utils/messageMapper.ts
@@ -185,6 +185,9 @@ export interface ApiLoadedMessageRow {
       url?: string
       type?: string
       error?: string
+      /** Compact web-search summary fields (search cards only) */
+      query?: string
+      resultsCount?: number
     }>
   } | null
 }
@@ -302,6 +305,8 @@ export function mapApiMessageRow(m: ApiLoadedMessageRow): Message {
         url: cardUrl,
         mediaType: c.type,
         error: c.error,
+        query: c.query,
+        resultsCount: c.resultsCount,
       }
     })
     taskPlanState = {

--- a/frontend/src/utils/messageMapper.ts
+++ b/frontend/src/utils/messageMapper.ts
@@ -1,4 +1,12 @@
-import type { Message, MessageFile, Part } from '@/stores/history'
+import type {
+  Message,
+  MessageFile,
+  Part,
+  TaskPlanState,
+  TaskCardKind,
+  TaskCardState,
+} from '@/stores/history'
+import { isTaskCardKind, isTaskCardState } from '@/stores/history'
 import { extractBTextPayload } from '@/utils/jsonResponse'
 import { parseAIResponse } from '@/utils/responseParser'
 import { normalizeMediaUrl } from '@/utils/urlHelper'
@@ -165,6 +173,20 @@ export interface ApiLoadedMessageRow {
   multitask?: boolean
   file?: { path: string; type: string }
   files?: ApiLoadedAttachmentFile[]
+  /** Per-node render state for DAG turns — present only on OUT messages of DAG turns. */
+  taskPlan?: {
+    reply_node: string
+    cards: Array<{
+      nodeId: string
+      capability: string
+      kind: string
+      state: string
+      text?: string
+      url?: string
+      type?: string
+      error?: string
+    }>
+  } | null
 }
 
 /**
@@ -257,6 +279,47 @@ export function mapApiMessageRow(m: ApiLoadedMessageRow): Message {
     })
   }
 
+  // Rebuild task plan cards from persisted render state (issue #1070 DAG reload).
+  // The card urls are added to a dedup set so we don't also emit them as plain
+  // media parts in the bubble (same dedup logic as reconcileLocalMessage).
+  let taskPlanState: TaskPlanState | null = null
+  const cardMediaUrls = new Set<string>()
+  if (m.taskPlan && m.taskPlan.cards.length > 0) {
+    const cards = m.taskPlan.cards.map((c) => {
+      const kind: TaskCardKind = isTaskCardKind(c.kind) ? c.kind : 'text'
+      const state: TaskCardState = isTaskCardState(c.state) ? c.state : 'skipped'
+      let cardUrl: string | undefined
+      if (c.url) {
+        cardUrl = normalizeMediaUrl(buildUploadUrl(c.url))
+        cardMediaUrls.add(mediaUrlKey(cardUrl))
+      }
+      return {
+        nodeId: c.nodeId,
+        capability: c.capability,
+        kind,
+        state,
+        text: c.text ?? '',
+        url: cardUrl,
+        mediaType: c.type,
+        error: c.error,
+      }
+    })
+    taskPlanState = {
+      active: false,
+      replyNode: m.taskPlan.reply_node,
+      cards,
+    }
+  }
+
+  // Remove any plain-media parts whose URL already appears on a restored card
+  // so the user sees each piece of media exactly once (card is the primary surface).
+  const deduplicatedParts =
+    cardMediaUrls.size > 0
+      ? parts.filter(
+          (p) => !(isMediaPartType(p.type) && p.url && cardMediaUrls.has(mediaUrlKey(p.url)))
+        )
+      : parts
+
   // Reconstruct tool metadata from topic field for user messages
   // Also clean command prefix from message content
   let toolData: { command: string; label: string; icon: string } | null = null
@@ -300,7 +363,7 @@ export function mapApiMessageRow(m: ApiLoadedMessageRow): Message {
   return {
     id: `backend-${m.id}`,
     role,
-    parts,
+    parts: deduplicatedParts,
     timestamp: new Date(m.timestamp * 1000),
     provider: cleanProvider,
     modelLabel: cleanModelLabel,
@@ -314,6 +377,7 @@ export function mapApiMessageRow(m: ApiLoadedMessageRow): Message {
     searchResults: m.searchResults || null,
     wasMultitask: m.multitask === true,
     tool: toolData,
+    taskPlan: taskPlanState,
   }
 }
 

--- a/frontend/src/utils/messageMapper.ts
+++ b/frontend/src/utils/messageMapper.ts
@@ -1,0 +1,405 @@
+import type { Message, MessageFile, Part } from '@/stores/history'
+import { extractBTextPayload } from '@/utils/jsonResponse'
+import { parseAIResponse } from '@/utils/responseParser'
+import { normalizeMediaUrl } from '@/utils/urlHelper'
+import { generatePartId, isMediaPartType } from '@/utils/mediaParts'
+import { isChannelSource } from '@/utils/channelSource'
+import {
+  buildUploadUrl,
+  isAudioFileType,
+  isImageFileType,
+  isVideoFileType,
+} from '@/utils/mediaTypes'
+
+/**
+ * Issue #1070: single authoritative mapping from the persisted API row
+ * (GET /chats/{id}/messages and GET /messages/{id}) to the frontend
+ * `Message` shape.
+ *
+ * Both the reload path (`history.loadMessages`) and the post-stream
+ * reconciliation (`history.reconcileMessage`) go through this module, so
+ * "visible only after reload" divergence between the two paths is
+ * structurally impossible for files/media/metadata.
+ *
+ * Keep this module side-effect free so it can be unit-tested without
+ * mounting the chat view or the Pinia store.
+ */
+
+/**
+ * Parse content to extract thinking blocks, code blocks, and regular text.
+ * This ensures consistent rendering between streaming and loaded messages.
+ */
+export function parseContentWithThinking(
+  content: string,
+  role: 'user' | 'assistant' = 'assistant'
+): Part[] {
+  // Handle special file generation markers from backend
+  if (content.startsWith('__FILE_GENERATED__:')) {
+    const filename = content.replace('__FILE_GENERATED__:', '').trim()
+    // Return a placeholder - the actual translation will be done in the component
+    // because we need access to i18n there
+    return [
+      {
+        type: 'text',
+        content: `__FILE_GENERATED__:${filename}`,
+      },
+    ]
+  }
+
+  if (content === '__FILE_GENERATION_FAILED__') {
+    return [
+      {
+        type: 'text',
+        content: '__FILE_GENERATION_FAILED__',
+      },
+    ]
+  }
+
+  // Legacy: Check for old JSON format (BTEXT) from database
+  // This is only for backward compatibility with old messages
+  const extraction = extractBTextPayload(content)
+  if (extraction.text !== undefined) {
+    const remainder = extraction.remainder?.trim()
+    const text = extraction.text ?? ''
+    content = remainder ? `${text}\n\n${remainder}`.trim() : text
+  }
+
+  const parts: Part[] = []
+
+  // Extract thinking blocks first
+  const thinkRegex = /<think>([\s\S]*?)<\/think>/g
+  const thinkingBlocks: Array<{ content: string; index: number }> = []
+  let match
+
+  while ((match = thinkRegex.exec(content)) !== null) {
+    thinkingBlocks.push({
+      content: match[1].trim(),
+      index: match.index,
+    })
+  }
+
+  // If there are thinking blocks, extract them
+  if (thinkingBlocks.length > 0) {
+    // Add thinking blocks
+    thinkingBlocks.forEach((block) => {
+      // Estimate thinking time based on content length (rough approximation)
+      const thinkingTime = Math.max(3, Math.floor(block.content.length / 100))
+      parts.push({
+        type: 'thinking',
+        content: block.content,
+        thinkingTime,
+      })
+    })
+
+    // Remove thinking blocks from content
+    content = content.replace(/<think>[\s\S]*?<\/think>/g, '').trim()
+  }
+
+  // For assistant messages, use parseAIResponse to extract code blocks
+  // This ensures consistent rendering between streaming and loaded messages
+  if (role === 'assistant' && content) {
+    const parsed = parseAIResponse(content)
+    parsed.parts.forEach((part) => {
+      if (part.type === 'code') {
+        parts.push({
+          type: 'code',
+          content: part.content,
+          language: part.language,
+        })
+      } else if (part.type === 'text' && part.content.trim()) {
+        parts.push({
+          type: 'text',
+          content: part.content,
+        })
+      } else if (part.type === 'links' && part.links) {
+        parts.push({
+          type: 'links',
+          items: part.links.map((l) => ({
+            title: l.title,
+            url: l.url,
+            desc: l.description,
+          })),
+        })
+      }
+    })
+  } else if (content) {
+    // For user messages, just add as text
+    parts.push({
+      type: 'text',
+      content,
+    })
+  }
+
+  return parts.length > 0 ? parts : [{ type: 'text', content: '' }]
+}
+
+/** Attachment row from the messages API */
+export interface ApiLoadedAttachmentFile {
+  id: number
+  filename?: string
+  fileName?: string
+  fileType?: string
+  file_type?: string
+  filePath?: string
+  file_path?: string
+  fileSize?: number
+  file_size?: number
+  fileMime?: string
+  file_mime?: string
+}
+
+/** Message row from GET /chats/{id}/messages and GET /messages/{id} */
+export interface ApiLoadedMessageRow {
+  id: number
+  direction?: string
+  text?: string
+  timestamp: number
+  topic?: string
+  originalTopic?: string
+  originalMediaType?: string
+  original_media_type?: string
+  provider?: string
+  aiModels?: Message['aiModels']
+  webSearch?: Message['webSearch']
+  searchResults?: Message['searchResults']
+  multitask?: boolean
+  file?: { path: string; type: string }
+  files?: ApiLoadedAttachmentFile[]
+}
+
+/**
+ * Map a persisted API message row to the frontend `Message` shape.
+ *
+ * Extracted from `history.loadMessages` so the post-stream reconciliation
+ * resolves the final message state through the exact same logic as a page
+ * reload (issue #1070).
+ */
+export function mapApiMessageRow(m: ApiLoadedMessageRow): Message {
+  const role = m.direction === 'IN' ? 'user' : 'assistant'
+
+  const parts = parseContentWithThinking(m.text || '', role)
+
+  // Add generated file (image/video/audio) as part if present.
+  // Issue #625: assign a stable `partId` on load so the `<audio>` /
+  // `<video>` element keeps its identity if the message later gets
+  // re-parsed (e.g. continuation appends text). Without this, the
+  // index-based fallback key would remount the media player.
+  //
+  // Issue #955: detect audio/image/video by both the generic media
+  // kind (`audio`, `image`, `video` — used by TTS / MEDIAMAKER) and
+  // by the raw file extension (`ogg`, `mp3`, `png`, …) the backend
+  // stores for inbound WhatsApp voice notes and direct uploads.
+  // Without the extension-aware check, a WhatsApp voice reply was
+  // surfaced as a plain text bubble with no player.
+  //
+  // Relative `m.file.path` values (e.g. WhatsApp's `13/.../voice.ogg`)
+  // are first prefixed with the static-serve endpoint so the player
+  // can fetch them; absolute URLs and already-prefixed paths pass
+  // through `buildUploadUrl` unchanged before final normalization.
+  if (m.file && m.file.path) {
+    const absoluteUrl = normalizeMediaUrl(buildUploadUrl(m.file.path))
+    if (isImageFileType(m.file.type)) {
+      parts.push({
+        partId: generatePartId(),
+        type: 'image',
+        url: absoluteUrl,
+        alt: m.text || 'Generated image',
+      })
+    } else if (isVideoFileType(m.file.type)) {
+      parts.push({
+        partId: generatePartId(),
+        type: 'video',
+        url: absoluteUrl,
+      })
+    } else if (isAudioFileType(m.file.type)) {
+      parts.push({
+        partId: generatePartId(),
+        type: 'audio',
+        url: absoluteUrl,
+      })
+    }
+  }
+
+  // Parse files from backend response (user uploads).
+  const files: MessageFile[] = []
+  if (m.files && Array.isArray(m.files)) {
+    files.push(
+      ...m.files.map((f) => ({
+        id: f.id,
+        filename: f.filename || f.fileName || '',
+        fileType: f.fileType || f.file_type || '',
+        filePath: f.filePath || f.file_path || '',
+        fileSize: f.fileSize ?? f.file_size,
+        fileMime: f.fileMime ?? f.file_mime,
+      }))
+    )
+  }
+
+  // Issue #955: render uploaded audio attachments with the
+  // `MessageAudio` player instead of only as a download badge.
+  // The badge stays via `files[]` so the user can still see the
+  // filename / size and download the original recording. Inbound
+  // WhatsApp voice messages travel through this same `files`
+  // pipeline once they're persisted as a `File` entity.
+  //
+  // The MIME type is forwarded so that ambiguous containers like
+  // `.webm` get classified by the actual upload mime (`audio/webm`
+  // for voice notes, `video/webm` for screen recordings) instead
+  // of falling into the audio default purely by extension.
+  for (const file of files) {
+    if (!isAudioFileType(file.fileType, file.fileMime)) continue
+    const audioUrl = buildUploadUrl(file.filePath)
+    if (!audioUrl) continue
+    parts.push({
+      partId: generatePartId(),
+      type: 'audio',
+      url: normalizeMediaUrl(audioUrl),
+    })
+  }
+
+  // Reconstruct tool metadata from topic field for user messages
+  // Also clean command prefix from message content
+  let toolData: { command: string; label: string; icon: string } | null = null
+  if (role === 'user' && m.topic && m.topic.startsWith('tools:')) {
+    const cmd = m.topic.replace('tools:', '')
+    const toolMap: Record<string, { label: string; icon: string }> = {
+      search: { label: 'Web Search', icon: 'mdi:web' },
+      pic: { label: 'Image Generation', icon: 'mdi:image' },
+      vid: { label: 'Video Generation', icon: 'mdi:video' },
+    }
+    if (toolMap[cmd]) {
+      toolData = { command: cmd, ...toolMap[cmd] }
+
+      // Remove command prefix from parts content if present
+      if (parts.length > 0 && parts[0].type === 'text' && parts[0].content) {
+        const content = parts[0].content
+        const commandMatch = content.match(/^\/(\w+)\s+(.*)$/)
+        if (commandMatch && commandMatch[1] === cmd) {
+          // Remove the command prefix from display
+          parts[0] = { ...parts[0], content: commandMatch[2].trim() }
+        }
+      }
+    }
+  }
+
+  // The backend reuses the `provider` column to also store the
+  // channel/source for inbound messages (`WHATSAPP`, `EMAIL`,
+  // `WEB`, `widget`, …). When that token leaks into the chat
+  // footer the user sees confusing labels like
+  // `Model: WHATSAPP · Provider: WHATSAPP`. Strip it here so
+  // only real AI provider names ever reach the UI — see #653.
+  const rawProvider = m.aiModels?.chat?.provider ?? m.provider
+  const cleanProvider = isChannelSource(rawProvider) ? undefined : rawProvider
+  const rawModelLabel = m.aiModels?.chat?.model ?? m.provider
+  const cleanModelLabel = isChannelSource(rawModelLabel)
+    ? role === 'assistant'
+      ? 'AI'
+      : undefined
+    : (rawModelLabel ?? (role === 'assistant' ? 'AI' : undefined))
+
+  return {
+    id: `backend-${m.id}`,
+    role,
+    parts,
+    timestamp: new Date(m.timestamp * 1000),
+    provider: cleanProvider,
+    modelLabel: cleanModelLabel,
+    topic: m.topic,
+    originalTopic: m.originalTopic || null,
+    originalMediaType: m.originalMediaType ?? m.original_media_type ?? null,
+    backendMessageId: m.id,
+    files: files.length > 0 ? files : undefined,
+    aiModels: m.aiModels || null,
+    webSearch: m.webSearch || null,
+    searchResults: m.searchResults || null,
+    wasMultitask: m.multitask === true,
+    tool: toolData,
+  }
+}
+
+/**
+ * Comparison key for media URLs: the path component, ignoring origin and
+ * query string. The live SSE event and the persisted row may differ in
+ * absolute-vs-relative form or cache-buster params, but the upload path
+ * itself is identical.
+ */
+function mediaUrlKey(url: string): string {
+  try {
+    return new URL(url, 'http://localhost').pathname
+  } catch {
+    return url
+  }
+}
+
+/**
+ * Issue #1070: reconcile a live-streamed message with its persisted
+ * version after SSE `complete`. The persisted version is authoritative
+ * for files, generated media, and metadata; the streamed state stays
+ * authoritative for the live text parts (already rendered chunk by
+ * chunk) and task-card animations.
+ *
+ * - Media parts (image/video/audio) present in the persisted message but
+ *   missing from the live bubble are appended — this is what makes e.g.
+ *   TTS audio in a multitask (DAG) turn appear without a page reload.
+ * - Media already shown by an active task card is NOT duplicated into
+ *   the bubble; the card remains the streaming-time surface.
+ * - Metadata (files, aiModels, webSearch, searchResults, topic, …) is
+ *   overwritten when the persisted version carries a value, and left
+ *   untouched otherwise (never wipes live-only state).
+ *
+ * Mutates `local` in place (it is a reactive store object). The parts
+ * array is reassigned — not pushed to — so a detached proxy reference
+ * can never swallow the update (see `pushMediaPart` for background).
+ */
+export function reconcileLocalMessage(local: Message, persisted: Message): void {
+  // --- Media parts ---------------------------------------------------
+  const shownUrls = new Set<string>()
+  for (const part of local.parts) {
+    if (isMediaPartType(part.type) && part.url) {
+      shownUrls.add(mediaUrlKey(part.url))
+    }
+  }
+  for (const card of local.taskPlan?.cards ?? []) {
+    if (card.url) {
+      shownUrls.add(mediaUrlKey(card.url))
+    }
+  }
+
+  const missingMedia: Part[] = persisted.parts.filter(
+    (p) =>
+      isMediaPartType(p.type) && typeof p.url === 'string' && !shownUrls.has(mediaUrlKey(p.url))
+  )
+  if (missingMedia.length > 0) {
+    local.parts = [...local.parts, ...missingMedia]
+  }
+
+  // --- Files (attachments + generated documents) ----------------------
+  if (persisted.files && persisted.files.length > 0) {
+    local.files = persisted.files
+  }
+
+  // --- Metadata: persisted wins when present --------------------------
+  if (persisted.aiModels) {
+    local.aiModels = persisted.aiModels
+    if (persisted.provider) local.provider = persisted.provider
+    if (persisted.modelLabel) local.modelLabel = persisted.modelLabel
+  }
+  if (persisted.webSearch) {
+    local.webSearch = persisted.webSearch
+  }
+  if (persisted.searchResults && persisted.searchResults.length > 0) {
+    local.searchResults = persisted.searchResults
+  }
+  if (persisted.topic) {
+    local.topic = persisted.topic
+  }
+  if (persisted.originalTopic) {
+    local.originalTopic = persisted.originalTopic
+  }
+  if (persisted.originalMediaType) {
+    local.originalMediaType = persisted.originalMediaType
+  }
+  if (persisted.wasMultitask) {
+    local.wasMultitask = true
+  }
+}

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -1198,6 +1198,12 @@ const handleContinueResponse = async (message: Message) => {
 
         message.isStreaming = false
         historyStore.finishStreamingMessage(message.id)
+
+        // Issue #1070: reconcile against the persisted message so files /
+        // media / metadata reflect the authoritative backend state.
+        if (message.backendMessageId) {
+          void historyStore.reconcileMessage(message.id, message.backendMessageId)
+        }
       } else if (data.status === 'error') {
         message.truncated = true
         message.isStreaming = false
@@ -2382,6 +2388,16 @@ const streamAIResponse = async (
             chatsStore.bumpChatActivity(chatId)
 
             historyStore.finishStreamingMessage(messageId)
+
+            // Issue #1070: the streamed state is only a live preview — the
+            // persisted message is the single source of truth for files,
+            // media and metadata. Re-fetch it once so anything the SSE
+            // accumulation missed (e.g. TTS audio in a multitask turn,
+            // where the `audio` event is suppressed while task cards
+            // stream) renders without a page reload.
+            if (data.messageId) {
+              void historyStore.reconcileMessage(messageId, data.messageId)
+            }
 
             // Phase 2c: schedule a couple of polls for backgrounded memory
             // extraction results. The worker writes to the source message

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -1892,6 +1892,13 @@ const streamAIResponse = async (
               if (typeof data.metadata?.prompt === 'string' && data.metadata.prompt) {
                 card.prompt = data.metadata.prompt
               }
+              // Web search card compact summary — populated by DagExecutor on done.
+              if (typeof data.metadata?.query === 'string' && data.metadata.query) {
+                card.query = data.metadata.query
+              }
+              if (typeof data.metadata?.results_count === 'number') {
+                card.resultsCount = data.metadata.results_count
+              }
             }
           } else if (data.status === 'task_chunk') {
             const message = historyStore.messages.find((m) => m.id === messageId)

--- a/frontend/tests/e2e/helpers/selectors.ts
+++ b/frontend/tests/e2e/helpers/selectors.ts
@@ -140,6 +140,8 @@ export const selectors = {
     /** Wrapper that contains only the generated answer body (no timestamp, no footer). Use this for asserting reply text. */
     assistantAnswerBody: '[data-testid="section-message-text"]',
     messageText: '[data-testid="message-text"]',
+    /** Audio player section rendered for an `audio` message part (TTS / voice reply / uploads) */
+    messageAudio: '[data-testid="section-message-audio"]',
     /** Present when message topic is ERROR (backend error path); use to assert no error in bubble */
     messageTopicError: '[data-testid="message-topic-error"]',
     // The "Again with… ▾" control is a single button that opens the model

--- a/frontend/tests/e2e/helpers/selectors.ts
+++ b/frontend/tests/e2e/helpers/selectors.ts
@@ -162,6 +162,8 @@ export const selectors = {
     toolEnhance: '[data-testid="btn-tool-enhance"]',
     enhanceButton: '[data-testid="btn-chat-enhance"]',
     toolSummarizerLink: '[data-testid="link-tool-summarizer"]',
+    /** Sources (N) dropdown toggle — appears on messages that used web search */
+    sourcesToggle: '[data-testid="btn-message-sources-toggle"]',
     knowledgeFolderBtn: '[data-testid="btn-knowledge-folder"]',
     knowledgeFolderPanel: '[data-testid="dropdown-knowledge-folder"]',
     knowledgeFolderNone: '[data-testid="opt-knowledge-folder-none"]',

--- a/frontend/tests/e2e/tests/multitask.spec.ts
+++ b/frontend/tests/e2e/tests/multitask.spec.ts
@@ -88,6 +88,28 @@ test.describe('@ci @multitask Multi-task routing', () => {
       await answerText.first().waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
       expect((await answerText.first().innerText()).trim().length).toBeGreaterThan(0)
     })
+
+    await test.step('Assert: task cards are still visible after a page reload (#1070)', async () => {
+      // Before the fix, the persisted row had no card data, so a reload lost the
+      // task-plan bubble entirely — only the compose_reply text remained.
+      await page.reload()
+      const reloadedBubble = chat.conversationBubbles().nth(previousCount)
+      await reloadedBubble.waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
+
+      const plan = reloadedBubble.locator('[data-testid="task-plan"]')
+      await plan.waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
+
+      await expect(reloadedBubble.locator('[data-testid="task-card-n1"]')).toHaveAttribute(
+        'data-state',
+        'done',
+        { timeout: TIMEOUTS.STANDARD }
+      )
+      await expect(reloadedBubble.locator('[data-testid="task-card-n2"]')).toHaveAttribute(
+        'data-state',
+        'done',
+        { timeout: TIMEOUTS.STANDARD }
+      )
+    })
   })
 
   /**

--- a/frontend/tests/e2e/tests/multitask.spec.ts
+++ b/frontend/tests/e2e/tests/multitask.spec.ts
@@ -117,11 +117,13 @@ test.describe('@ci @multitask Multi-task routing', () => {
    * the Sources (N) dropdown just like a single-task web search does.
    *
    * Requires BraveSearch to be configured (BRAVE_SEARCH_API_KEY set).
-   * Tagged @webSearch only (not @ci) — skip in CI unless env is configured.
-   * TestProvider recognises "websearch:" prefix in the message text and
-   * returns the web_search + chat plan.
+   * Tagged @noci so it is excluded from the CI grep (the enclosing describe
+   * is @ci, which Playwright would otherwise match on the full title) — run
+   * locally with a configured BraveSearch env. The TestProvider recognises
+   * the "websearch:" prefix and returns the web_search + chat plan, but the
+   * actual search (and thus the Sources dropdown) needs a real Brave key.
    */
-  test('@webSearch Sources dropdown appears after a DAG web-search turn (PR #1076)', async ({
+  test('@webSearch @noci Sources dropdown appears after a DAG web-search turn (PR #1076)', async ({
     page,
     credentials,
   }) => {

--- a/frontend/tests/e2e/tests/multitask.spec.ts
+++ b/frontend/tests/e2e/tests/multitask.spec.ts
@@ -89,4 +89,73 @@ test.describe('@ci @multitask Multi-task routing', () => {
       expect((await answerText.first().innerText()).trim().length).toBeGreaterThan(0)
     })
   })
+
+  /**
+   * Issue #1070 acceptance: a multi-step DAG turn with voice reply (text +
+   * TTS) must show the audio player BOTH live (without a reload) and after
+   * a page reload.
+   *
+   * Live, the `audio` SSE event is suppressed while task cards stream
+   * (taskPlan.active), so the player only appears because the frontend
+   * re-fetches the persisted message after `complete` and reconciles it
+   * (GET /api/v1/messages/{id} — the single authoritative source).
+   */
+  test('TTS audio in a DAG turn is visible live and after reload (#1070)', async ({
+    page,
+    credentials,
+  }) => {
+    await login(page, credentials)
+    const chat = new ChatHelper(page)
+
+    const toggleToolsPanel = async (open: boolean) => {
+      await page.locator(selectors.chat.toolsToggle).click()
+      await page
+        .locator(selectors.chat.toolsPanel)
+        .waitFor({ state: open ? 'visible' : 'hidden', timeout: TIMEOUTS.SHORT })
+    }
+
+    await test.step('Arrange: start a new chat and enable voice reply', async () => {
+      await chat.startNewChat()
+      await toggleToolsPanel(true)
+      await page.locator(selectors.chat.toolVoiceReply).click()
+      await expect(page.locator(selectors.chat.toolsActiveBadge)).toBeVisible({
+        timeout: TIMEOUTS.SHORT,
+      })
+      await toggleToolsPanel(false)
+    })
+
+    const previousCount = await chat.conversationBubbles().count()
+
+    await test.step('Act: send a multi-task prompt with voice reply on', async () => {
+      await page.locator(selectors.chat.textInput).fill(MULTITASK_PROMPT)
+      await page.locator(selectors.chat.sendBtn).click()
+    })
+
+    const bubble = chat.conversationBubbles().nth(previousCount)
+    await bubble.waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
+
+    await test.step('Assert: the DAG turn streams task cards and completes', async () => {
+      await bubble
+        .locator('[data-testid="task-plan"]')
+        .waitFor({ state: 'visible', timeout: TIMEOUTS.LONG })
+      await bubble
+        .locator(selectors.chat.messageDone)
+        .waitFor({ state: 'visible', timeout: TIMEOUTS.VERY_LONG })
+    })
+
+    await test.step('Assert: the audio player is visible WITHOUT a reload', async () => {
+      await bubble
+        .locator(selectors.chat.messageAudio)
+        .waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
+    })
+
+    await test.step('Assert: the audio player is still visible after a reload', async () => {
+      await page.reload()
+      const reloadedBubble = chat.conversationBubbles().nth(previousCount)
+      await reloadedBubble.waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
+      await reloadedBubble
+        .locator(selectors.chat.messageAudio)
+        .waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
+    })
+  })
 })

--- a/frontend/tests/e2e/tests/multitask.spec.ts
+++ b/frontend/tests/e2e/tests/multitask.spec.ts
@@ -113,6 +113,72 @@ test.describe('@ci @multitask Multi-task routing', () => {
   })
 
   /**
+   * QA feedback PR #1076: a DAG turn with a web_search node must produce
+   * the Sources (N) dropdown just like a single-task web search does.
+   *
+   * Requires BraveSearch to be configured (BRAVE_SEARCH_API_KEY set).
+   * Tagged @webSearch only (not @ci) — skip in CI unless env is configured.
+   * TestProvider recognises "websearch:" prefix in the message text and
+   * returns the web_search + chat plan.
+   */
+  test('@webSearch Sources dropdown appears after a DAG web-search turn (PR #1076)', async ({
+    page,
+    credentials,
+  }) => {
+    await login(page, credentials)
+    const chat = new ChatHelper(page)
+
+    await test.step('Arrange: start a new chat', async () => {
+      await chat.startNewChat()
+    })
+
+    const previousCount = await chat.conversationBubbles().count()
+
+    await test.step('Act: send a DAG web-search prompt', async () => {
+      // The "websearch:" prefix triggers the TestProvider web_search+chat plan.
+      await page
+        .locator(selectors.chat.textInput)
+        .fill(
+          'websearch: What are the latest developments in AI agents? ' +
+            'Please summarise the most recent news from this year 2026.'
+        )
+      await page.locator(selectors.chat.sendBtn).click()
+    })
+
+    const bubble = chat.conversationBubbles().nth(previousCount)
+    await bubble.waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
+
+    await test.step('Assert: task-plan cards appear with web_search card', async () => {
+      const plan = bubble.locator('[data-testid="task-plan"]')
+      await plan.waitFor({ state: 'visible', timeout: TIMEOUTS.LONG })
+      await bubble
+        .locator('[data-testid="task-card-n1"]')
+        .waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
+    })
+
+    await test.step('Assert: turn completes successfully', async () => {
+      await bubble
+        .locator(selectors.chat.messageDone)
+        .waitFor({ state: 'visible', timeout: TIMEOUTS.VERY_LONG })
+    })
+
+    await test.step('Assert: Sources dropdown is visible (QA feedback #1076)', async () => {
+      await expect(bubble.locator(selectors.chat.sourcesToggle)).toBeVisible({
+        timeout: TIMEOUTS.STANDARD,
+      })
+    })
+
+    await test.step('Assert: Sources dropdown still visible after reload', async () => {
+      await page.reload()
+      const reloadedBubble = chat.conversationBubbles().nth(previousCount)
+      await reloadedBubble.waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
+      await expect(reloadedBubble.locator(selectors.chat.sourcesToggle)).toBeVisible({
+        timeout: TIMEOUTS.STANDARD,
+      })
+    })
+  })
+
+  /**
    * Issue #1070 acceptance: a multi-step DAG turn with voice reply (text +
    * TTS) must show the audio player BOTH live (without a reload) and after
    * a page reload.

--- a/frontend/tests/e2e/tests/whatsapp.spec.ts
+++ b/frontend/tests/e2e/tests/whatsapp.spec.ts
@@ -151,7 +151,9 @@ test.describe('@ci @whatsapp @smoke WhatsApp', () => {
     })
   })
 
-  test('audio: webhook 2xx, exactly one outbound text message', async ({ request }, testInfo) => {
+  test('audio: webhook 2xx, exactly one outbound message (text or audio)', async ({
+    request,
+  }, testInfo) => {
     const baseUrl = getStubBaseUrl()
     const runId = makeRunId(testInfo.testId)
     const messageId = `smoke-audio-${Date.now()}-${Math.random().toString(36).slice(2)}`
@@ -162,7 +164,13 @@ test.describe('@ci @whatsapp @smoke WhatsApp', () => {
       await postWebhookAndAssert2xx(request, payload)
     })
 
-    await test.step('Assert: exactly one outbound (text, e.g. transcription error)', async () => {
+    // Voice-only input is answered with a TTS voice note when a
+    // text-to-speech provider is available (WhatsAppService: "AUDIO input
+    // → TTS AUDIO response"), and falls back to a text reply otherwise
+    // (e.g. transcription error or no TTS provider configured). Accept
+    // both, mirroring the image test — the contract under test is "exactly
+    // one well-formed outbound to the sender", not a fixed modality.
+    await test.step('Assert: exactly one outbound (text or audio)', async () => {
       const reqs = await awaitOutboundExactlyOnce(request, baseUrl, { runId })
       assertStubContract(reqs, {
         expectedPathExact: EXPECTED_PATH_MESSAGES,
@@ -172,10 +180,15 @@ test.describe('@ci @whatsapp @smoke WhatsApp', () => {
       const bodies = getPostMessageBodies(reqs)
       expect(bodies.length).toBe(1)
       expect(bodies[0].to).toBe(TEST_FROM)
-      expect(bodies[0].type).toBe('text')
-      const textBody = (bodies[0].text as { body?: string })?.body
-      expect(textBody).toBeDefined()
-      expect(String(textBody).length).toBeGreaterThan(0)
+      const msgType = bodies[0].type as string
+      expect(['text', 'audio']).toContain(msgType)
+      if (msgType === 'text') {
+        const textBody = (bodies[0].text as { body?: string })?.body
+        expect(textBody).toBeDefined()
+        expect(String(textBody).length).toBeGreaterThan(0)
+      } else {
+        expect(bodies[0].audio).toBeDefined()
+      }
     })
   })
 })

--- a/frontend/tests/unit/messageMapper.spec.ts
+++ b/frontend/tests/unit/messageMapper.spec.ts
@@ -169,6 +169,42 @@ describe('messageMapper (issue #1070)', () => {
       const message = mapApiMessageRow(baseRow({ multitask: true }))
       expect(message.taskPlan).toBeNull()
     })
+
+    it('maps query and resultsCount from a search card (QA feedback #1076)', () => {
+      const message = mapApiMessageRow(
+        baseRow({
+          multitask: true,
+          taskPlan: {
+            reply_node: 'n2',
+            cards: [
+              {
+                nodeId: 'n1',
+                capability: 'web_search',
+                kind: 'search',
+                state: 'done',
+                query: 'latest AI news',
+                resultsCount: 5,
+              },
+              {
+                nodeId: 'n2',
+                capability: 'chat',
+                kind: 'text',
+                state: 'done',
+                text: 'Here is the summary.',
+              },
+            ],
+          },
+        })
+      )
+
+      const searchCard = message.taskPlan?.cards.find((c) => c.nodeId === 'n1')
+      expect(searchCard).toBeDefined()
+      expect(searchCard?.kind).toBe('search')
+      expect(searchCard?.query).toBe('latest AI news')
+      expect(searchCard?.resultsCount).toBe(5)
+      // The raw text dump must not appear on a search card
+      expect(searchCard?.text).toBe('')
+    })
   })
 
   describe('reconcileLocalMessage', () => {

--- a/frontend/tests/unit/messageMapper.spec.ts
+++ b/frontend/tests/unit/messageMapper.spec.ts
@@ -80,6 +80,95 @@ describe('messageMapper (issue #1070)', () => {
       expect(message.modelLabel).toBe('llama3')
       expect(message.webSearch?.resultsCount).toBe(3)
     })
+
+    it('rebuilds taskPlan cards from persisted render state (DAG reload #1070)', () => {
+      const message = mapApiMessageRow(
+        baseRow({
+          multitask: true,
+          taskPlan: {
+            reply_node: 'n2',
+            cards: [
+              {
+                nodeId: 'n1',
+                capability: 'summarize',
+                kind: 'text',
+                state: 'done',
+                text: 'Summary content',
+              },
+            ],
+          },
+        })
+      )
+
+      expect(message.taskPlan).not.toBeNull()
+      expect(message.taskPlan?.active).toBe(false)
+      expect(message.taskPlan?.replyNode).toBe('n2')
+      expect(message.taskPlan?.cards).toHaveLength(1)
+      expect(message.taskPlan?.cards[0].nodeId).toBe('n1')
+      expect(message.taskPlan?.cards[0].capability).toBe('summarize')
+      expect(message.taskPlan?.cards[0].kind).toBe('text')
+      expect(message.taskPlan?.cards[0].state).toBe('done')
+      expect(message.taskPlan?.cards[0].text).toBe('Summary content')
+    })
+
+    it('rebuilds taskPlan card with media url and normalizes it', () => {
+      const message = mapApiMessageRow(
+        baseRow({
+          multitask: true,
+          taskPlan: {
+            reply_node: 'n2',
+            cards: [
+              {
+                nodeId: 'n1',
+                capability: 'text2sound',
+                kind: 'audio',
+                state: 'done',
+                url: '13/000/tts.mp3',
+                type: 'audio',
+              },
+            ],
+          },
+        })
+      )
+
+      const card = message.taskPlan?.cards[0]
+      expect(card?.url).toBeTruthy()
+      expect(card?.url).toContain('tts.mp3')
+    })
+
+    it('deduplicates card media from flat parts (card is primary surface)', () => {
+      // file.path and the card url point to the same upload — the flat
+      // audio part must be dropped because the card already shows it.
+      const message = mapApiMessageRow(
+        baseRow({
+          multitask: true,
+          file: { path: '13/000/dag_audio.mp3', type: 'audio' },
+          taskPlan: {
+            reply_node: 'n2',
+            cards: [
+              {
+                nodeId: 'n1',
+                capability: 'text2sound',
+                kind: 'audio',
+                state: 'done',
+                url: '13/000/dag_audio.mp3',
+                type: 'audio',
+              },
+            ],
+          },
+        })
+      )
+
+      // The card holds the media; no duplicate flat audio part in the bubble.
+      const audioParts = message.parts.filter((p) => p.type === 'audio')
+      expect(audioParts).toHaveLength(0)
+      expect(message.taskPlan?.cards[0].url).toContain('dag_audio.mp3')
+    })
+
+    it('returns taskPlan: null when taskPlan is absent from the row', () => {
+      const message = mapApiMessageRow(baseRow({ multitask: true }))
+      expect(message.taskPlan).toBeNull()
+    })
   })
 
   describe('reconcileLocalMessage', () => {
@@ -209,6 +298,48 @@ describe('messageMapper (issue #1070)', () => {
       expect(local.topic).toBe('general')
       expect(local.aiModels?.chat?.model).toBe('live-model')
       expect(local.files).toHaveLength(1)
+    })
+
+    it('keeps live taskPlan intact when reconciling (streaming cards must survive)', () => {
+      // During live streaming the local message has an active taskPlan;
+      // reconcileLocalMessage must not overwrite it with the persisted one.
+      const liveTaskPlan = {
+        active: true,
+        replyNode: 'n2',
+        cards: [
+          {
+            nodeId: 'n1',
+            capability: 'summarize',
+            kind: 'text' as const,
+            state: 'done' as const,
+            text: 'Live streamed summary',
+          },
+        ],
+      }
+      const local = localStreamedMessage({ taskPlan: liveTaskPlan, wasMultitask: true })
+      const persisted = mapApiMessageRow(
+        baseRow({
+          multitask: true,
+          taskPlan: {
+            reply_node: 'n2',
+            cards: [
+              {
+                nodeId: 'n1',
+                capability: 'summarize',
+                kind: 'text',
+                state: 'done',
+                text: 'Persisted summary (different)',
+              },
+            ],
+          },
+        })
+      )
+
+      reconcileLocalMessage(local, persisted)
+
+      // Live taskPlan is authoritative during streaming — must stay as-is.
+      expect(local.taskPlan?.active).toBe(true)
+      expect(local.taskPlan?.cards[0].text).toBe('Live streamed summary')
     })
   })
 })

--- a/frontend/tests/unit/messageMapper.spec.ts
+++ b/frontend/tests/unit/messageMapper.spec.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import {
+  mapApiMessageRow,
+  reconcileLocalMessage,
+  type ApiLoadedMessageRow,
+} from '@/utils/messageMapper'
+import type { Message } from '@/stores/history'
+
+/**
+ * Issue #1070 — single authoritative mapping + post-stream reconciliation.
+ *
+ * `mapApiMessageRow` is the one place that turns a persisted API row into
+ * the frontend Message shape (used by reload AND by the post-`complete`
+ * refetch). `reconcileLocalMessage` merges that authoritative state into
+ * the live-streamed message without disturbing streamed text or task-card
+ * media.
+ */
+
+const baseRow = (overrides: Partial<ApiLoadedMessageRow> = {}): ApiLoadedMessageRow => ({
+  id: 77,
+  direction: 'OUT',
+  text: 'Here is your answer.',
+  timestamp: 1765540000,
+  ...overrides,
+})
+
+const localStreamedMessage = (overrides: Partial<Message> = {}): Message => ({
+  id: 'local-uuid',
+  role: 'assistant',
+  parts: [{ partId: 'p1', type: 'text', content: 'Here is your answer.' }],
+  timestamp: new Date(),
+  backendMessageId: 77,
+  ...overrides,
+})
+
+describe('messageMapper (issue #1070)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  describe('mapApiMessageRow', () => {
+    it('maps a generated audio file (TTS) to an audio part', () => {
+      const message = mapApiMessageRow(
+        baseRow({ file: { path: '13/000/2026/06/tts_reply.mp3', type: 'audio' } })
+      )
+
+      const audioParts = message.parts.filter((p) => p.type === 'audio')
+      expect(audioParts).toHaveLength(1)
+      expect(audioParts[0].url).toContain('tts_reply.mp3')
+      expect(audioParts[0].partId).toBeTruthy()
+      expect(message.backendMessageId).toBe(77)
+    })
+
+    it('maps generated images and videos to media parts', () => {
+      const image = mapApiMessageRow(baseRow({ file: { path: '13/img.png', type: 'image' } }))
+      expect(image.parts.some((p) => p.type === 'image')).toBe(true)
+
+      const video = mapApiMessageRow(baseRow({ file: { path: '13/clip.mp4', type: 'video' } }))
+      expect(video.parts.some((p) => p.type === 'video')).toBe(true)
+    })
+
+    it('maps metadata (aiModels, webSearch, multitask, topic)', () => {
+      const message = mapApiMessageRow(
+        baseRow({
+          topic: 'general',
+          multitask: true,
+          aiModels: {
+            chat: { provider: 'ollama', model: 'llama3', model_id: 5 },
+            audio: { provider: 'piper', model: 'piper-multi', model_id: 7 },
+          },
+          webSearch: { query: 'weather', resultsCount: 3 },
+        })
+      )
+
+      expect(message.wasMultitask).toBe(true)
+      expect(message.topic).toBe('general')
+      expect(message.aiModels?.audio?.model).toBe('piper-multi')
+      expect(message.provider).toBe('ollama')
+      expect(message.modelLabel).toBe('llama3')
+      expect(message.webSearch?.resultsCount).toBe(3)
+    })
+  })
+
+  describe('reconcileLocalMessage', () => {
+    it('appends persisted media missing from the live bubble (TTS-in-DAG bug)', () => {
+      // The `audio` SSE event was suppressed because taskPlan.active was
+      // true, so the live bubble has no audio part — but the persisted
+      // message carries the TTS file.
+      const local = localStreamedMessage({
+        wasMultitask: true,
+        taskPlan: {
+          active: true,
+          replyNode: 'n3',
+          cards: [
+            { nodeId: 'n1', capability: 'summarize', kind: 'text', state: 'done' },
+            { nodeId: 'n2', capability: 'translate', kind: 'text', state: 'done' },
+          ],
+        },
+      })
+      const persisted = mapApiMessageRow(
+        baseRow({ file: { path: '13/000/tts_reply.mp3', type: 'audio' }, multitask: true })
+      )
+
+      reconcileLocalMessage(local, persisted)
+
+      const audioParts = local.parts.filter((p) => p.type === 'audio')
+      expect(audioParts).toHaveLength(1)
+      expect(audioParts[0].url).toContain('tts_reply.mp3')
+      // Streamed text stays untouched.
+      expect(local.parts[0]).toEqual(
+        expect.objectContaining({ partId: 'p1', type: 'text', content: 'Here is your answer.' })
+      )
+    })
+
+    it('does not duplicate media the live stream already rendered', () => {
+      const local = localStreamedMessage()
+      const persisted = mapApiMessageRow(
+        baseRow({ file: { path: '13/000/tts_reply.mp3', type: 'audio' } })
+      )
+      // Simulate the live `audio` SSE handler having already pushed the
+      // part (same upload path, possibly different absolute form).
+      local.parts = [
+        ...local.parts,
+        {
+          partId: 'live-audio',
+          type: 'audio',
+          url: 'http://localhost:8000/api/v1/files/uploads/13/000/tts_reply.mp3',
+          autoplay: true,
+        },
+      ]
+
+      reconcileLocalMessage(local, persisted)
+
+      const audioParts = local.parts.filter((p) => p.type === 'audio')
+      expect(audioParts).toHaveLength(1)
+      // The live part (with its autoplay flag and stable partId) survives.
+      expect(audioParts[0].partId).toBe('live-audio')
+      expect(audioParts[0].autoplay).toBe(true)
+    })
+
+    it('does not duplicate media already shown by an active task card', () => {
+      const local = localStreamedMessage({
+        taskPlan: {
+          active: true,
+          replyNode: 'n2',
+          cards: [
+            {
+              nodeId: 'n1',
+              capability: 'image_generation',
+              kind: 'image',
+              state: 'done',
+              url: 'http://localhost:8000/api/v1/files/uploads/13/dag_image.png',
+              mediaType: 'image',
+            },
+          ],
+        },
+      })
+      const persisted = mapApiMessageRow(
+        baseRow({ file: { path: '13/dag_image.png', type: 'image' } })
+      )
+
+      reconcileLocalMessage(local, persisted)
+
+      // The card remains the streaming-time surface — no duplicate part.
+      expect(local.parts.filter((p) => p.type === 'image')).toHaveLength(0)
+    })
+
+    it('treats persisted files and metadata as authoritative', () => {
+      const local = localStreamedMessage()
+      const persisted = mapApiMessageRow(
+        baseRow({
+          topic: 'mediamaker',
+          multitask: true,
+          aiModels: { chat: { provider: 'openai', model: 'gpt-test', model_id: 9 } },
+          searchResults: [{ title: 'Result', url: 'https://example.com' }],
+          files: [
+            {
+              id: 5,
+              filename: 'report.pdf',
+              fileType: 'pdf',
+              filePath: '13/report.pdf',
+              fileSize: 2048,
+            },
+          ],
+        })
+      )
+
+      reconcileLocalMessage(local, persisted)
+
+      expect(local.files).toHaveLength(1)
+      expect(local.files![0].filename).toBe('report.pdf')
+      expect(local.topic).toBe('mediamaker')
+      expect(local.wasMultitask).toBe(true)
+      expect(local.aiModels?.chat?.model).toBe('gpt-test')
+      expect(local.searchResults).toHaveLength(1)
+    })
+
+    it('never wipes live-only state when the persisted row has no value', () => {
+      const local = localStreamedMessage({
+        topic: 'general',
+        aiModels: { chat: { provider: 'ollama', model: 'live-model', model_id: 1 } },
+        files: [{ id: 1, filename: 'live.pdf', fileType: 'pdf', filePath: '13/live.pdf' }],
+      })
+      const persisted = mapApiMessageRow(baseRow())
+
+      reconcileLocalMessage(local, persisted)
+
+      expect(local.topic).toBe('general')
+      expect(local.aiModels?.chat?.model).toBe('live-model')
+      expect(local.files).toHaveLength(1)
+    })
+  })
+})


### PR DESCRIPTION
## Summary
Generated media (e.g. TTS audio in a multitask/DAG turn) was invisible during live streaming and only appeared after a page reload; the persisted backend row is now refetched and reconciled after SSE `complete`, making it the single authoritative source for the final message state.

## Changes
- Backend: extract message serialization from `ChatController` into a new `MessageApiFormatter` service — single source of truth for the API row shape
- Backend: add `GET /api/v1/messages/{id}` (ownership-checked, full OpenAPI annotations) returning the exact same shape as the chat history endpoint
- Frontend: new `messageMapper.ts` — shared `mapApiMessageRow` used by both the reload path (`history.loadMessages`) and the new post-stream reconciliation, so the two paths can no longer diverge
- Frontend: `history.reconcileMessage` + `reconcileLocalMessage` — after SSE `complete`, missing media parts (image/video/audio) are appended to the live bubble, media already shown by task cards is not duplicated, and persisted metadata (files, aiModels, webSearch, searchResults, topic, …) wins when present
- Frontend: `ChatView.vue` triggers reconciliation in both `complete` handlers (initial stream + continuation)
- TestProvider: `synthesize()` now writes a real silent MP3 frame into the upload dir instead of returning a non-existent `/tmp` path, so voice-reply turns work in dev/test stacks
- Tests: PHPUnit (formatter shape, auth/ownership/404 on the new endpoint), Vitest (mapping + reconciliation rules), and a new E2E test asserting the TTS player in a DAG turn is visible live AND after reload

## Verification
- [ ] Not tested (explain)
- [ ] Manual
- [x] Tests added/updated

Full pre-commit gate is green: backend lint, PHPStan (0 errors), PHPUnit (1913 tests), frontend lint, `vue-tsc`, Vitest (618 tests). E2E: new #1070 test plus `multitask`, `chat`, `chat-again`, `chat-bubble-monotonic`, `task-prompts` specs pass against the CI-like test stack (port 8001).

## Notes
Closes #1070. Approach follows the recommendation in the issue (refetch + reconcile after SSE `complete`). Frontend schemas were regenerated from the updated OpenAPI spec (`make -C frontend generate-schemas` produced no diff outside the generated aliases).

## Screenshots/Logs
E2E acceptance (CI-like test stack):
```
✓ multitask.spec.ts › a multi-node request renders task cards that complete
✓ multitask.spec.ts › TTS audio in a DAG turn is visible live and after reload (#1070)
```