### PR TITLE
fix(docker): fix fresh install onboarding issues

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,8 @@ services:
        # Anonymous volume to prevent host node_modules from being mounted (avoids platform-specific binary conflicts)
       - /app/node_modules
     depends_on:
-      - backend
+      backend:
+        condition: service_healthy
     restart: unless-stopped
     networks:
       - synaplan-network
@@ -118,6 +119,7 @@ services:
       DATABASE_WRITE_URL: mysql://synaplan_user:synaplan_password@db:3306/synaplan?serverVersion=mariadb-12.2.2&charset=utf8mb4
       DATABASE_READ_URL: mysql://synaplan_user:synaplan_password@db:3306/synaplan?serverVersion=mariadb-12.2.2&charset=utf8mb4
       OLLAMA_BASE_URL: http://ollama:11434
+      QDRANT_URL: http://qdrant:6333
       TRITON_SERVER_URL: ${TRITON_SERVER_URL:-}
       TIKA_BASE_URL: http://tika:9998
       AI_DEFAULT_PROVIDER: ollama
@@ -242,6 +244,7 @@ services:
       DATABASE_WRITE_URL: mysql://synaplan_user:synaplan_password@db:3306/synaplan?serverVersion=mariadb-12.2.2&charset=utf8mb4
       DATABASE_READ_URL: mysql://synaplan_user:synaplan_password@db:3306/synaplan?serverVersion=mariadb-12.2.2&charset=utf8mb4
       OLLAMA_BASE_URL: http://ollama:11434
+      QDRANT_URL: http://qdrant:6333
       TIKA_BASE_URL: http://tika:9998
       AI_DEFAULT_PROVIDER: ollama
       TOKEN_SECRET: 'change_me_in_production_use_openssl_rand_hex_32'

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -207,6 +207,27 @@ make test    # Run tests
 | MailHog | http://localhost:8025 |
 | Ollama | http://localhost:11435 |
 
+### GPU Support for Local AI Models
+
+To use Ollama with your NVIDIA GPU, create a `docker-compose.override.yml`:
+
+```yaml
+services:
+  ollama:
+    runtime: nvidia
+    environment:
+      NVIDIA_VISIBLE_DEVICES: all
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+```
+
+Requires NVIDIA driver 550+ (for CUDA 13 compatibility with current Ollama images).
+
 ---
 
 ## Test Users


### PR DESCRIPTION
## Summary
- Add missing `QDRANT_URL` environment variable to backend and worker services — memories/vector search silently failed on fresh installs because the backend couldn't reach the Qdrant container
- Fix frontend schema generation race condition by using `depends_on: condition: service_healthy` instead of bare `depends_on` — ensures backend API is ready before the frontend tries to generate TypeScript schemas
- Document NVIDIA GPU setup for local Ollama models in `docs/DEVELOPMENT.md`

## Test plan
- [ ] `docker compose down -v && docker compose up -d` on a clean install — verify memories work without manual `QDRANT_URL` config
- [ ] Verify frontend schema generation succeeds on first boot (no "Schema generation failed" in logs)
- [ ] Verify existing setups are not broken (QDRANT_URL from .env still takes precedence over compose default)