### PR TITLE
fix(chat): support asking about uploaded video content via transcription

### DIFF
--- a/backend/src/Service/File/FileProcessor.php
+++ b/backend/src/Service/File/FileProcessor.php
@@ -48,6 +48,15 @@ final readonly class FileProcessor
     ];
 
     /**
+     * Video container formats that must always have their audio track stripped
+     * before being sent to an external STT API — even though some containers
+     * (mp4, mkv) appear in API_SUPPORTED_AUDIO_FORMATS. A full video file can
+     * easily be 40+ MB while the extracted audio-only payload is a few MB;
+     * every hosted Whisper endpoint enforces a ~25 MB ceiling.
+     */
+    private const VIDEO_EXTENSIONS = ['mp4', 'mov', 'avi', 'mkv', 'mpeg', 'mpg'];
+
+    /**
      * Audio formats supported by external APIs (OpenAI/Groq Whisper).
      * Formats not in this list need to be converted before sending.
      *
@@ -374,61 +383,109 @@ final readonly class FileProcessor
     }
 
     /**
+     * Public static variant used by FileUploadService to distinguish a
+     * transcription failure (audio/video → empty result is an error) from a
+     * legitimate no-content result (e.g. a blank PDF has no extractable text).
+     */
+    public static function isTranscribableMediaExtension(string $ext): bool
+    {
+        return in_array(strtolower($ext), self::TRANSCRIBABLE_MEDIA_EXTENSIONS, true);
+    }
+
+    /**
      * Extract text from audio/video file using Whisper.cpp with external API fallback.
      *
-     * Strategy order:
-     * 1. Local Whisper.cpp (fast, free, no external dependencies)
-     * 2. External OpenAI Whisper API (fallback when local not available)
+     * Strategy when an external STT provider is configured:
+     *   1. External provider (faster, handles many languages)
+     *   2. Local Whisper.cpp if external returns empty or fails (fallback)
      *
-     * @param string $absolutePath Full path to the audio file
+     * Strategy when no external provider is configured:
+     *   1. Local Whisper.cpp (free, no network dependency)
+     *   2. External provider as last resort
+     *
+     * @param string $absolutePath Full path to the audio/video file
      * @param array  $baseMeta     Base metadata for logging
      *
      * @return array [extractedText, meta]
      */
     private function extractFromAudio(string $absolutePath, array $baseMeta, ?int $userId = null): array
     {
-        // If user has configured an external STT provider, use it directly
         if ($this->aiFacade->hasConfiguredSttProvider($userId)) {
-            $this->logger->info('FileProcessor: User has external STT provider configured, using external API', $baseMeta);
+            $this->logger->info('FileProcessor: Trying external STT provider first', $baseMeta);
+            $externalResult = $this->extractFromAudioExternal($absolutePath, $baseMeta, $userId);
 
-            return $this->extractFromAudioExternal($absolutePath, $baseMeta, $userId);
-        }
-
-        // No external provider configured — try local Whisper.cpp first (preferred)
-        if ($this->whisperService->isAvailable()) {
-            $this->logger->info('FileProcessor: Transcribing audio with local Whisper', $baseMeta);
-
-            try {
-                $result = $this->whisperService->transcribe($absolutePath);
-                $text = $result['text'] ?? '';
-                $text = $this->textCleaner->clean($text);
-
-                if (!empty(trim($text))) {
-                    $this->logger->info('FileProcessor: Local Whisper transcription success', [
-                        'strategy' => 'whisper_local',
-                        'bytes' => strlen($text),
-                        'language' => $result['language'] ?? 'unknown',
-                        'duration' => $result['duration'] ?? 0,
-                    ]);
-
-                    return [$text, [
-                        'strategy' => 'whisper_local',
-                        'language' => $result['language'] ?? 'unknown',
-                        'duration' => $result['duration'] ?? 0,
-                        'model' => $result['model'] ?? 'base',
-                    ] + $baseMeta];
-                }
-
-                $this->logger->warning('FileProcessor: Local Whisper returned empty text, trying external API', $baseMeta);
-            } catch (\Throwable $e) {
-                $this->logger->warning('FileProcessor: Local Whisper failed, trying external API', [
-                    'error' => $e->getMessage(),
-                ] + $baseMeta);
+            if ('' !== trim((string) ($externalResult[0] ?? ''))) {
+                return $externalResult;
             }
+
+            // External returned empty (provider error, file too large, etc.) —
+            // fall back to local Whisper before giving up.
+            $this->logger->info('FileProcessor: External STT returned empty, falling back to local Whisper', $baseMeta);
+            $localResult = $this->transcribeLocally($absolutePath, $baseMeta);
+            if (null !== $localResult) {
+                return $localResult;
+            }
+
+            return $externalResult;
         }
 
-        // Try external speech-to-text provider (user's configured provider or OpenAI)
+        // No external provider configured — prefer local Whisper, fall back to external.
+        $localResult = $this->transcribeLocally($absolutePath, $baseMeta);
+        if (null !== $localResult) {
+            return $localResult;
+        }
+
         return $this->extractFromAudioExternal($absolutePath, $baseMeta, $userId);
+    }
+
+    /**
+     * Attempt transcription with local Whisper.cpp.
+     *
+     * Returns the [text, meta] pair on success, or null when Whisper is
+     * unavailable, throws, or produces an empty transcript.  Callers treat
+     * null as "not available — try something else".
+     *
+     * @param string $absolutePath Full path to the audio/video file
+     * @param array  $baseMeta     Base metadata for logging
+     *
+     * @return array{0: string, 1: array<string, mixed>}|null
+     */
+    private function transcribeLocally(string $absolutePath, array $baseMeta): ?array
+    {
+        if (!$this->whisperService->isAvailable()) {
+            return null;
+        }
+
+        $this->logger->info('FileProcessor: Transcribing with local Whisper', $baseMeta);
+
+        try {
+            $result = $this->whisperService->transcribe($absolutePath);
+            $text = $this->textCleaner->clean($result['text'] ?? '');
+
+            if ('' !== trim($text)) {
+                $this->logger->info('FileProcessor: Local Whisper transcription success', [
+                    'strategy' => 'whisper_local',
+                    'bytes' => strlen($text),
+                    'language' => $result['language'] ?? 'unknown',
+                    'duration' => $result['duration'] ?? 0,
+                ]);
+
+                return [$text, [
+                    'strategy' => 'whisper_local',
+                    'language' => $result['language'] ?? 'unknown',
+                    'duration' => $result['duration'] ?? 0,
+                    'model' => $result['model'] ?? 'base',
+                ] + $baseMeta];
+            }
+
+            $this->logger->warning('FileProcessor: Local Whisper returned empty text', $baseMeta);
+        } catch (\Throwable $e) {
+            $this->logger->warning('FileProcessor: Local Whisper failed', [
+                'error' => $e->getMessage(),
+            ] + $baseMeta);
+        }
+
+        return null;
     }
 
     /**
@@ -512,8 +569,16 @@ final readonly class FileProcessor
     {
         $ext = strtolower(pathinfo($absolutePath, PATHINFO_EXTENSION));
 
-        // Check if format is already supported
-        if (in_array($ext, self::API_SUPPORTED_AUDIO_FORMATS, true)) {
+        // Video files must always be converted to an audio-only MP3 even when
+        // their container extension (mp4, mkv…) is listed in
+        // API_SUPPORTED_AUDIO_FORMATS.  The full video stream easily exceeds
+        // the ~25 MB ceiling enforced by Groq, OpenAI, and every other hosted
+        // Whisper endpoint; the extracted audio-only payload is typically just
+        // a few MB.  The -vn flag in the ffmpeg call below strips the video
+        // track so the conversion applies universally to all future providers.
+        $isVideo = in_array($ext, self::VIDEO_EXTENSIONS, true);
+
+        if (!$isVideo && in_array($ext, self::API_SUPPORTED_AUDIO_FORMATS, true)) {
             return $absolutePath;
         }
 

--- a/backend/src/Service/File/FileUploadService.php
+++ b/backend/src/Service/File/FileUploadService.php
@@ -306,6 +306,18 @@ final readonly class FileUploadService
             );
 
             $file->setFileText($extractedText);
+
+            // For audio/video files an empty transcript means transcription
+            // failed — the file may be silent, in an unsupported codec, or the
+            // STT provider rejected it.  Signal this clearly so the UI can show
+            // a distinct error badge instead of "Extracted (0 chars)".
+            if ('' === trim($extractedText) && FileProcessor::isTranscribableMediaExtension($fileExtension)) {
+                $file->setStatus('error');
+                $this->em->flush();
+
+                return ['success' => false, 'error' => 'Transcription produced no text — the file may be silent or in an unsupported codec.'];
+            }
+
             $file->setStatus('extracted');
             $this->em->flush();
 
@@ -426,6 +438,18 @@ final readonly class FileUploadService
 
         $extractedText = $file->getFileText();
         if ('' === trim($extractedText)) {
+            // Audio/video with no transcript: the STT pipeline returned nothing
+            // (provider rejection, silent file, unsupported codec).  Mark as
+            // error so the UI shows a clear status instead of silently treating
+            // the file as "ready".  Non-media files (blank PDFs, etc.) follow
+            // the old path — a zero-length extraction is legitimate for them.
+            if (FileProcessor::isTranscribableMediaExtension($fileExtension)) {
+                $file->setStatus('error');
+                $this->em->flush();
+
+                return ['success' => false, 'status' => 'error', 'error' => 'Transcription produced no text — the file may be silent or in an unsupported codec.'];
+            }
+
             $file->setStatus('vectorized');
             $this->em->flush();
 

--- a/backend/src/Service/Message/Handler/FileAnalysisHandler.php
+++ b/backend/src/Service/Message/Handler/FileAnalysisHandler.php
@@ -120,6 +120,10 @@ final readonly class FileAnalysisHandler implements MessageHandlerInterface
             case 'audio_not_transcribed':
                 return $this->buildAudioNotTranscribedError($route['audio_files']);
 
+            case 'video_transcription_pending':
+            case 'video_transcription_failed':
+                return $this->buildVideoTranscriptionError($route);
+
             case 'unsupported':
             default:
                 $this->logger->warning('FileAnalysisHandler: Unsupported file types only', [
@@ -209,6 +213,13 @@ final readonly class FileAnalysisHandler implements MessageHandlerInterface
 
             case 'audio_not_transcribed':
                 $error = $this->buildAudioNotTranscribedError($route['audio_files']);
+                $streamCallback($error['content']);
+
+                return ['metadata' => $error['metadata']];
+
+            case 'video_transcription_pending':
+            case 'video_transcription_failed':
+                $error = $this->buildVideoTranscriptionError($route);
                 $streamCallback($error['content']);
 
                 return ['metadata' => $error['metadata']];
@@ -1060,6 +1071,7 @@ final readonly class FileAnalysisHandler implements MessageHandlerInterface
         $isImage = in_array($normalizedType, MessagePreProcessor::IMAGE_EXTENSIONS, true);
         $isAudio = in_array($normalizedType, MessagePreProcessor::AUDIO_EXTENSIONS, true);
         $isDocument = in_array($normalizedType, MessagePreProcessor::DOCUMENT_EXTENSIONS, true);
+        $isVideo = in_array($normalizedType, MessagePreProcessor::VIDEO_EXTENSIONS, true);
 
         // Normalize path to be relative to the upload directory (var/uploads).
         // DB values should be stored relative; older/legacy values may contain "/uploads/" or full URLs.
@@ -1075,6 +1087,7 @@ final readonly class FileAnalysisHandler implements MessageHandlerInterface
             'is_image' => $isImage,
             'is_audio' => $isAudio,
             'is_document' => $isDocument,
+            'is_video' => $isVideo,
         ];
     }
 
@@ -1112,6 +1125,7 @@ final readonly class FileAnalysisHandler implements MessageHandlerInterface
      *     audio?: list<array<string, mixed>>,
      *     images?: list<array<string, mixed>>,
      *     audio_files?: list<array<string, mixed>>,
+     *     video_files?: list<array<string, mixed>>,
      *     pending_documents?: list<array<string, mixed>>,
      *     failed_documents?: list<array<string, mixed>>
      * }
@@ -1123,6 +1137,9 @@ final readonly class FileAnalysisHandler implements MessageHandlerInterface
         $documentsFailed = [];
         $audioWithText = [];
         $audioMissingText = [];
+        $videoWithText = [];
+        $videoPending = [];
+        $videoFailed = [];
         $images = [];
 
         foreach ($filesInfo as $info) {
@@ -1131,6 +1148,28 @@ final readonly class FileAnalysisHandler implements MessageHandlerInterface
                     $audioWithText[] = $info;
                 } else {
                     $audioMissingText[] = $info;
+                }
+                continue;
+            }
+
+            // Issue #722: a video carries its transcript in BFILETEXT after
+            // FileProcessor extracted the audio track and ran Whisper. Treat
+            // it like a document so the user gets a summary/answer rather
+            // than the old "unsupported file type" dead end.
+            if ($info['is_video'] ?? false) {
+                if ('' !== trim((string) ($info['text'] ?? ''))) {
+                    $videoWithText[] = $info;
+                } else {
+                    $isStillExtracting = in_array(
+                        (string) ($info['status'] ?? ''),
+                        ['uploaded', 'extracting'],
+                        true
+                    );
+                    if ($isStillExtracting) {
+                        $videoPending[] = $info;
+                    } else {
+                        $videoFailed[] = $info;
+                    }
                 }
                 continue;
             }
@@ -1189,11 +1228,28 @@ final readonly class FileAnalysisHandler implements MessageHandlerInterface
             ];
         }
 
+        // Video transcription is the slowest media path (ffmpeg audio extract
+        // + Whisper), so surface "still preparing" before acting on a partial
+        // bundle, mirroring the audio/document guards above (issue #722).
+        if ([] !== $videoPending) {
+            return [
+                'kind' => 'video_transcription_pending',
+                'video_files' => $videoPending,
+            ];
+        }
+
         if ([] !== $documentsPending) {
             return [
                 'kind' => 'document_extraction_pending',
                 'pending_documents' => $documentsPending,
                 'failed_documents' => $documentsFailed,
+            ];
+        }
+
+        if ([] !== $videoFailed) {
+            return [
+                'kind' => 'video_transcription_failed',
+                'video_files' => $videoFailed,
             ];
         }
 
@@ -1210,8 +1266,11 @@ final readonly class FileAnalysisHandler implements MessageHandlerInterface
         //    audio into the document set as a virtual transcript file so
         //    the chat model still sees the spoken content alongside the
         //    PDFs/MDs the user attached.
-        if ([] !== $documentsWithText) {
+        if ([] !== $documentsWithText || [] !== $videoWithText) {
             $documents = $documentsWithText;
+            foreach ($videoWithText as $video) {
+                $documents[] = $this->wrapVideoAsTranscriptDocument($video);
+            }
             foreach ($audioWithText as $audio) {
                 $documents[] = $this->wrapAudioAsTranscriptDocument($audio);
             }
@@ -1271,6 +1330,38 @@ final readonly class FileAnalysisHandler implements MessageHandlerInterface
             'is_image' => false,
             'is_audio' => false,
             'is_document' => true,
+            'is_video' => false,
+        ];
+    }
+
+    /**
+     * Treat a transcribed video attachment as a virtual "transcript"
+     * document so the chat-model prompt builder summarises/answers from
+     * the spoken content of the video (issue #722). Unlike a voice note
+     * (which is answered conversationally), a video upload is something
+     * the user wants explained, so the document/summary path is the
+     * correct destination.
+     *
+     * @param array<string, mixed> $video
+     *
+     * @return array<string, mixed>
+     */
+    private function wrapVideoAsTranscriptDocument(array $video): array
+    {
+        $name = (string) ($video['name'] ?? 'video');
+        $type = (string) ($video['type'] ?? 'video');
+
+        return [
+            'id' => $video['id'] ?? null,
+            'name' => $name.' (video transcript)',
+            'type' => $type.' transcript',
+            'path' => $video['path'] ?? '',
+            'text' => "Video transcript:\n".trim((string) ($video['text'] ?? '')),
+            'status' => $video['status'] ?? null,
+            'is_image' => false,
+            'is_audio' => false,
+            'is_document' => true,
+            'is_video' => false,
         ];
     }
 
@@ -1328,6 +1419,36 @@ final readonly class FileAnalysisHandler implements MessageHandlerInterface
     }
 
     /**
+     * Build the user-facing error for video attachments whose transcript
+     * is still being produced or could not be produced at all (issue #722).
+     *
+     * @param array{kind: string, video_files?: list<array<string, mixed>>} $route
+     *
+     * @return array{content: string, metadata: array<string, mixed>}
+     */
+    private function buildVideoTranscriptionError(array $route): array
+    {
+        $videoFiles = $route['video_files'] ?? [];
+        $isStillProcessing = 'video_transcription_pending' === $route['kind'];
+
+        $this->logger->error('FileAnalysisHandler: Video(s) without transcript', [
+            'files' => $this->describeFileList($videoFiles),
+            'still_processing' => $isStillProcessing,
+        ]);
+
+        return [
+            'content' => $isStillProcessing
+                ? 'The video is still being processed — its audio is being transcribed. Please wait a moment and send your question again. Longer videos can take a little while.'
+                : "I couldn't get any speech from this video. It may have no spoken audio, be silent, or be in a format I can't transcribe. Try a different file or describe what you need.",
+            'metadata' => [
+                'error' => $isStillProcessing
+                    ? 'video_transcription_in_progress'
+                    : 'video_transcription_failed',
+            ],
+        ];
+    }
+
+    /**
      * Log a compact summary that covers every attached file. The old
      * single-file logging missed everything past the first row, which
      * made it hard to spot multi-file dropping in production logs.
@@ -1347,6 +1468,7 @@ final readonly class FileAnalysisHandler implements MessageHandlerInterface
                 'is_image' => $info['is_image'] ?? false,
                 'is_audio' => $info['is_audio'] ?? false,
                 'is_document' => $info['is_document'] ?? false,
+                'is_video' => $info['is_video'] ?? false,
                 'has_extracted_text' => '' !== trim((string) ($info['text'] ?? '')),
                 'extracted_text_length' => strlen((string) ($info['text'] ?? '')),
                 'status' => $info['status'] ?? null,

--- a/backend/src/Service/Message/MessageClassifier.php
+++ b/backend/src/Service/Message/MessageClassifier.php
@@ -205,9 +205,9 @@ final readonly class MessageClassifier
             }
         }
 
-        // 3. Document / audio attachments → FileAnalysisHandler (ANALYZE model), before AI sorting (#595)
-        if ($this->messageHasDocumentOrAudioAttachment($message)) {
-            $this->logger->info('MessageClassifier: Forcing analyzefile route (document or audio attachment)', [
+        // 3. Document / audio / video attachments → FileAnalysisHandler (ANALYZE model), before AI sorting (#595, #722)
+        if ($this->messageHasAnalyzableNonImageAttachment($message)) {
+            $this->logger->info('MessageClassifier: Forcing analyzefile route (document, audio, or video attachment)', [
                 'message_id' => $messageId,
             ]);
 
@@ -433,15 +433,19 @@ final readonly class MessageClassifier
     }
 
     /**
-     * True if the message has at least one attached document or audio file (not images only).
-     * Routes to FileAnalysisHandler so ANALYZE default model is used (#595).
+     * True if the message has at least one attached document, audio, or video
+     * file (i.e. an analyzable non-image attachment). Routes to
+     * FileAnalysisHandler so the ANALYZE default model is used (#595). Video is
+     * included because its audio track is transcribed to text the chat model
+     * can reason about (#722); without this gate a video-only message fell
+     * through to the AI sorter and was answered as a plain (text-less) chat.
      */
-    private function messageHasDocumentOrAudioAttachment(Message $message): bool
+    private function messageHasAnalyzableNonImageAttachment(Message $message): bool
     {
         $files = $message->getFiles();
         if ($files->count() > 0) {
             foreach ($files as $file) {
-                if ($this->attachedFileIsDocumentOrAudio($file)) {
+                if ($this->attachedFileIsAnalyzableNonImage($file)) {
                     return true;
                 }
             }
@@ -453,13 +457,14 @@ final readonly class MessageClassifier
             $ext = strtolower(pathinfo($message->getFilePath(), PATHINFO_EXTENSION));
 
             return in_array($ext, MessagePreProcessor::DOCUMENT_EXTENSIONS, true)
-                || in_array($ext, MessagePreProcessor::AUDIO_EXTENSIONS, true);
+                || in_array($ext, MessagePreProcessor::AUDIO_EXTENSIONS, true)
+                || in_array($ext, MessagePreProcessor::VIDEO_EXTENSIONS, true);
         }
 
         return false;
     }
 
-    private function attachedFileIsDocumentOrAudio(File $file): bool
+    private function attachedFileIsAnalyzableNonImage(File $file): bool
     {
         $fromType = strtolower($file->getFileType() ?: '');
         $fromName = strtolower(pathinfo($file->getFileName(), PATHINFO_EXTENSION));
@@ -470,7 +475,8 @@ final readonly class MessageClassifier
         }
 
         return in_array($ext, MessagePreProcessor::DOCUMENT_EXTENSIONS, true)
-            || in_array($ext, MessagePreProcessor::AUDIO_EXTENSIONS, true);
+            || in_array($ext, MessagePreProcessor::AUDIO_EXTENSIONS, true)
+            || in_array($ext, MessagePreProcessor::VIDEO_EXTENSIONS, true);
     }
 
     /**

--- a/backend/src/Service/Message/MessagePreProcessor.php
+++ b/backend/src/Service/Message/MessagePreProcessor.php
@@ -36,6 +36,16 @@ final readonly class MessagePreProcessor
     public const AUDIO_EXTENSIONS = ['ogg', 'mp3', 'wav', 'm4a', 'opus', 'flac', 'webm', 'amr'];
     public const IMAGE_EXTENSIONS = ['jpg', 'jpeg', 'png', 'webp', 'gif'];
 
+    // Issue #722: video uploads (e.g. an MP4 the user wants summarised) were
+    // never converted to text on the chat path, so FileAnalysisHandler reported
+    // "This file type cannot be analyzed". FileProcessor::extractText() already
+    // extracts the audio track and transcribes it via Whisper, so we route
+    // video files through the same extraction pipeline as documents and keep
+    // the resulting transcript in BFILETEXT. 'webm' deliberately stays in
+    // AUDIO_EXTENSIONS (WhatsApp voice notes use it) — listing it here too
+    // would make the membership checks ambiguous.
+    public const VIDEO_EXTENSIONS = ['mp4', 'mov', 'avi', 'mkv', 'mpeg', 'mpg'];
+
     private const OFFICE_EXT_TO_MIME = [
         'xls' => 'application/vnd.ms-excel',
         'xlsx' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
@@ -168,7 +178,13 @@ final readonly class MessagePreProcessor
         // Vision AI fallback for low-quality output) is the same strategy
         // the /api/v1/files upload path already uses, so we get one
         // consistent extraction behaviour across upload entry points.
-        if (in_array($fileType, self::DOCUMENT_EXTENSIONS)) {
+        // Documents and video files share the same extraction pipeline:
+        // FileProcessor::extractText() runs Tika for documents and Whisper
+        // (after extracting the audio track) for video, returning plain text
+        // we store in BFILETEXT so the chat model can reason about it
+        // (issue #722).
+        if (in_array($fileType, self::DOCUMENT_EXTENSIONS) || in_array($fileType, self::VIDEO_EXTENSIONS)) {
+            $isVideo = in_array($fileType, self::VIDEO_EXTENSIONS, true);
             $messageFile->setStatus('extracting');
 
             try {
@@ -181,27 +197,27 @@ final readonly class MessagePreProcessor
                 if ('' !== trim((string) $text)) {
                     $messageFile->setFileText($text);
                     $messageFile->setStatus('processed');
-                    $this->logger->info('PreProcessor: Document parsed', [
+                    $this->logger->info($isVideo ? 'PreProcessor: Video transcribed' : 'PreProcessor: Document parsed', [
                         'file_id' => $messageFile->getId(),
                         'text_length' => strlen($text),
                         'strategy' => $extractMeta['strategy'] ?? 'unknown',
                     ]);
                 } else {
                     $messageFile->setStatus('error');
-                    $this->logger->warning('PreProcessor: Document extraction produced empty text', [
+                    $this->logger->warning($isVideo ? 'PreProcessor: Video transcription produced empty text' : 'PreProcessor: Document extraction produced empty text', [
                         'file_id' => $messageFile->getId(),
                         'strategy' => $extractMeta['strategy'] ?? 'unknown',
                     ]);
                 }
             } catch (\Throwable $e) {
                 $messageFile->setStatus('error');
-                $this->logger->error('PreProcessor: Document extraction failed', [
+                $this->logger->error($isVideo ? 'PreProcessor: Video transcription failed' : 'PreProcessor: Document extraction failed', [
                     'file_id' => $messageFile->getId(),
                     'error' => $e->getMessage(),
                 ]);
             }
 
-            $this->billFileAnalysis($messageFile, $message, 'document');
+            $this->billFileAnalysis($messageFile, $message, $isVideo ? 'video' : 'document');
         }
 
         // Audio mit Whisper (or external STT if user configured one)
@@ -415,6 +431,42 @@ final readonly class MessagePreProcessor
                     'error' => $e->getMessage(),
                 ]);
                 // Don't fail the entire process, just skip transcription
+            }
+        }
+
+        // Video: extract the audio track and transcribe it (issue #722).
+        // FileProcessor::extractText() owns the ffmpeg + Whisper pipeline, so
+        // the legacy single-file path reuses it instead of duplicating logic.
+        if (in_array($fileType, self::VIDEO_EXTENSIONS)) {
+            $this->logger->info('PreProcessor: Transcribing video', [
+                'file' => basename($fullPath),
+                'type' => $fileType,
+            ]);
+
+            try {
+                [$text] = $this->fileProcessor->extractText(
+                    $filePath,
+                    $fileType,
+                    $message->getUserId(),
+                );
+
+                if ('' !== trim((string) $text)) {
+                    $message->setFileText($text);
+
+                    $currentText = $message->getText();
+                    if (empty($currentText) || '[Video message]' === $currentText || '[Video]' === $currentText) {
+                        $message->setText($text);
+                    }
+
+                    $this->logger->info('PreProcessor: Video transcribed successfully', [
+                        'text_length' => strlen($text),
+                    ]);
+                }
+            } catch (\Exception $e) {
+                $this->logger->error('PreProcessor: Video transcription failed', [
+                    'file' => basename($fullPath),
+                    'error' => $e->getMessage(),
+                ]);
             }
         }
 

--- a/backend/tests/Service/File/FileUploadServiceTranscriptionErrorTest.php
+++ b/backend/tests/Service/File/FileUploadServiceTranscriptionErrorTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Service\File;
+
+use App\Entity\File;
+use App\Entity\User;
+use App\Service\File\FileProcessor;
+use App\Service\File\FileStorageService;
+use App\Service\File\FileUploadService;
+use App\Service\File\VectorizationService;
+use App\Service\RAG\VectorStorage\VectorStorageFacade;
+use App\Service\RateLimitService;
+use App\Service\StorageQuotaService;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+/**
+ * Verifies that FileUploadService marks audio/video files whose transcription
+ * produced no text as status='error' rather than the previous misleading
+ * 'vectorized' (async path).  Non-media files (e.g. blank PDFs) must continue
+ * to reach 'vectorized' so existing behaviour is not regressed.
+ *
+ * Covers PR #1095 QA review Finding 3.
+ */
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
+final class FileUploadServiceTranscriptionErrorTest extends TestCase
+{
+    private FileProcessor&MockObject $fileProcessor;
+    private EntityManagerInterface&MockObject $em;
+    private RateLimitService&MockObject $rateLimitService;
+
+    protected function setUp(): void
+    {
+        $this->fileProcessor = $this->createMock(FileProcessor::class);
+        $this->em = $this->createMock(EntityManagerInterface::class);
+        $this->rateLimitService = $this->createMock(RateLimitService::class);
+
+        $this->rateLimitService
+            ->method('checkLimit')
+            ->willReturn(['allowed' => true, 'used' => 0, 'limit' => 100]);
+    }
+
+    private function makeService(): FileUploadService
+    {
+        return new FileUploadService(
+            $this->createStub(FileStorageService::class),
+            $this->fileProcessor,
+            $this->createStub(VectorizationService::class),
+            $this->createStub(VectorStorageFacade::class),
+            $this->createStub(StorageQuotaService::class),
+            $this->rateLimitService,
+            $this->em,
+            new NullLogger(),
+            '/tmp/uploads',
+        );
+    }
+
+    private function makeFileMock(string $type, string $extractedText = ''): File&MockObject
+    {
+        $file = $this->createMock(File::class);
+        $file->method('getStatus')->willReturn('uploaded');
+        $file->method('getFileType')->willReturn($type);
+        $file->method('getFilePath')->willReturn('user/1/test.'.$type);
+        $file->method('getFileText')->willReturn($extractedText);
+        $file->method('getId')->willReturn(42);
+        $file->method('getGroupKey')->willReturn(null);
+        $file->method('getFileName')->willReturn('test.'.$type);
+
+        return $file;
+    }
+
+    private function makeUser(): User&MockObject
+    {
+        $user = $this->createMock(User::class);
+        $user->method('getId')->willReturn(1);
+
+        return $user;
+    }
+
+    public function testProcessFileReturnsErrorForEmptyMp4Transcript(): void
+    {
+        $this->fileProcessor
+            ->method('extractText')
+            ->willReturn(['', ['strategy' => 'audio_api_failed']]);
+
+        $result = $this->makeService()->processFile($this->makeFileMock('mp4'), $this->makeUser());
+
+        $this->assertFalse($result['success']);
+        $this->assertSame('error', $result['status']);
+        $this->assertStringContainsString('Transcription', $result['error']);
+    }
+
+    public function testProcessFileReturnsErrorForEmptyMp3Transcript(): void
+    {
+        $this->fileProcessor
+            ->method('extractText')
+            ->willReturn(['', ['strategy' => 'audio_api_failed']]);
+
+        $result = $this->makeService()->processFile($this->makeFileMock('mp3', ''), $this->makeUser());
+
+        $this->assertFalse($result['success']);
+        $this->assertSame('error', $result['status']);
+    }
+
+    public function testProcessFileReturnsErrorForEmptyMovTranscript(): void
+    {
+        $this->fileProcessor
+            ->method('extractText')
+            ->willReturn(['', ['strategy' => 'audio_api_failed']]);
+
+        $result = $this->makeService()->processFile($this->makeFileMock('mov', ''), $this->makeUser());
+
+        $this->assertFalse($result['success']);
+        $this->assertSame('error', $result['status']);
+    }
+
+    public function testProcessFileDoesNotErrorForEmptyPdf(): void
+    {
+        $this->fileProcessor
+            ->method('extractText')
+            ->willReturn(['', ['strategy' => 'tika_failed']]);
+
+        // A blank or unreadable PDF is not a transcription failure — the file
+        // reaches vectorized with 0 chunks (no content to index).
+        $result = $this->makeService()->processFile($this->makeFileMock('pdf', ''), $this->makeUser());
+
+        $this->assertTrue($result['success']);
+        $this->assertSame('vectorized', $result['status']);
+    }
+}

--- a/backend/tests/Unit/Service/File/FileProcessorAudioFallbackTest.php
+++ b/backend/tests/Unit/Service/File/FileProcessorAudioFallbackTest.php
@@ -1,0 +1,212 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\File;
+
+use App\AI\Exception\ProviderException;
+use App\AI\Service\AiFacade;
+use App\Service\File\FileProcessor;
+use App\Service\File\PdfRasterizer;
+use App\Service\File\TextCleaner;
+use App\Service\File\TikaClient;
+use App\Service\WhisperService;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+/**
+ * Unit tests for the audio/video transcription strategy in FileProcessor.
+ *
+ * Covers the fallback logic introduced to address PR #1095 Finding 2:
+ * when an external STT provider is configured but returns empty text or
+ * throws, local Whisper.cpp must be tried before giving up.
+ *
+ * Also covers the isTranscribableMediaExtension() helper used by
+ * FileUploadService (Finding 3) to distinguish transcription failures
+ * from legitimate empty-extraction results.
+ */
+final class FileProcessorAudioFallbackTest extends TestCase
+{
+    private AiFacade&MockObject $aiFacade;
+    private WhisperService&MockObject $whisperService;
+    private FileProcessor $processor;
+
+    protected function setUp(): void
+    {
+        $this->aiFacade = $this->createMock(AiFacade::class);
+        $this->whisperService = $this->createMock(WhisperService::class);
+
+        $this->processor = new FileProcessor(
+            $this->createStub(TikaClient::class),
+            $this->createStub(PdfRasterizer::class),
+            new TextCleaner(),
+            $this->aiFacade,
+            $this->whisperService,
+            new NullLogger(),
+            sys_get_temp_dir(),
+            100,
+            0.5,
+            '/nonexistent/ffmpeg',
+        );
+    }
+
+    public function testExternalSttFallsBackToLocalWhisperWhenProviderThrows(): void
+    {
+        $this->aiFacade->method('hasConfiguredSttProvider')->willReturn(true);
+        $this->aiFacade->method('transcribe')
+            ->willThrowException(new ProviderException('Service unavailable', 'groq'));
+
+        $this->whisperService->method('isAvailable')->willReturn(true);
+        $this->whisperService->method('transcribe')->willReturn([
+            'text' => 'Local fallback transcript',
+            'language' => 'en',
+            'duration' => 5.0,
+            'model' => 'base',
+        ]);
+
+        [$text, $meta] = $this->processor->extractText('audio.mp3', 'mp3', 1);
+
+        $this->assertSame('Local fallback transcript', $text);
+        $this->assertSame('whisper_local', $meta['strategy']);
+    }
+
+    public function testExternalSttFallsBackToLocalWhisperWhenProviderReturnsEmpty(): void
+    {
+        $this->aiFacade->method('hasConfiguredSttProvider')->willReturn(true);
+        $this->aiFacade->method('transcribe')->willReturn(['text' => '', 'provider' => 'groq']);
+
+        $this->whisperService->method('isAvailable')->willReturn(true);
+        $this->whisperService->method('transcribe')->willReturn([
+            'text' => 'Whisper fallback transcript',
+            'language' => 'de',
+            'duration' => 10.0,
+            'model' => 'base',
+        ]);
+
+        [$text, $meta] = $this->processor->extractText('audio.mp3', 'mp3', 1);
+
+        $this->assertSame('Whisper fallback transcript', $text);
+        $this->assertSame('whisper_local', $meta['strategy']);
+    }
+
+    public function testExternalSttSuccessSkipsLocalWhisper(): void
+    {
+        $this->aiFacade->method('hasConfiguredSttProvider')->willReturn(true);
+        $this->aiFacade->method('transcribe')->willReturn([
+            'text' => 'External transcript',
+            'provider' => 'openai',
+        ]);
+
+        $this->whisperService->expects($this->never())->method('transcribe');
+        $this->whisperService->expects($this->never())->method('isAvailable');
+
+        [$text, $meta] = $this->processor->extractText('audio.mp3', 'mp3', 1);
+
+        $this->assertSame('External transcript', $text);
+        $this->assertSame('whisper_api', $meta['strategy']);
+    }
+
+    public function testLocalWhisperUsedFirstWhenNoExternalProviderConfigured(): void
+    {
+        $this->aiFacade->method('hasConfiguredSttProvider')->willReturn(false);
+        $this->aiFacade->expects($this->never())->method('transcribe');
+
+        $this->whisperService->method('isAvailable')->willReturn(true);
+        $this->whisperService->method('transcribe')->willReturn([
+            'text' => 'Local first transcript',
+            'language' => 'en',
+            'duration' => 2.0,
+            'model' => 'base',
+        ]);
+
+        [$text, $meta] = $this->processor->extractText('audio.wav', 'wav', null);
+
+        $this->assertSame('Local first transcript', $text);
+        $this->assertSame('whisper_local', $meta['strategy']);
+    }
+
+    public function testExternalUsedAsFallbackWhenLocalUnavailableAndNoProviderConfigured(): void
+    {
+        $this->aiFacade->method('hasConfiguredSttProvider')->willReturn(false);
+        $this->aiFacade->method('transcribe')->willReturn([
+            'text' => 'External as last resort',
+            'provider' => 'openai',
+        ]);
+
+        $this->whisperService->method('isAvailable')->willReturn(false);
+        $this->whisperService->expects($this->never())->method('transcribe');
+
+        [$text, $meta] = $this->processor->extractText('audio.mp3', 'mp3', null);
+
+        $this->assertSame('External as last resort', $text);
+        $this->assertSame('whisper_api', $meta['strategy']);
+    }
+
+    public function testBothPathsFailReturnsEmptyString(): void
+    {
+        $this->aiFacade->method('hasConfiguredSttProvider')->willReturn(true);
+        $this->aiFacade->method('transcribe')->willReturn(['text' => '', 'provider' => 'groq']);
+
+        $this->whisperService->method('isAvailable')->willReturn(false);
+
+        [$text, $meta] = $this->processor->extractText('audio.mp3', 'mp3', 1);
+
+        $this->assertSame('', $text);
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('transcribableExtensionsProvider')]
+    public function testIsTranscribableMediaExtensionReturnsTrueForMediaFiles(string $ext): void
+    {
+        $this->assertTrue(FileProcessor::isTranscribableMediaExtension($ext));
+        $this->assertTrue(FileProcessor::isTranscribableMediaExtension(strtoupper($ext)), 'Case-insensitive check');
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function transcribableExtensionsProvider(): array
+    {
+        return [
+            'mp3' => ['mp3'],
+            'mp4' => ['mp4'],
+            'wav' => ['wav'],
+            'ogg' => ['ogg'],
+            'mov' => ['mov'],
+            'avi' => ['avi'],
+            'mkv' => ['mkv'],
+            'mpeg' => ['mpeg'],
+            'mpg' => ['mpg'],
+            'flac' => ['flac'],
+            'm4a' => ['m4a'],
+            'webm' => ['webm'],
+            'aac' => ['aac'],
+            'wma' => ['wma'],
+            'amr' => ['amr'],
+            'opus' => ['opus'],
+        ];
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('nonTranscribableExtensionsProvider')]
+    public function testIsTranscribableMediaExtensionReturnsFalseForNonMedia(string $ext): void
+    {
+        $this->assertFalse(FileProcessor::isTranscribableMediaExtension($ext));
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function nonTranscribableExtensionsProvider(): array
+    {
+        return [
+            'pdf' => ['pdf'],
+            'docx' => ['docx'],
+            'txt' => ['txt'],
+            'jpg' => ['jpg'],
+            'png' => ['png'],
+            'xlsx' => ['xlsx'],
+            'csv' => ['csv'],
+            'pptx' => ['pptx'],
+        ];
+    }
+}

--- a/backend/tests/Unit/Service/Message/Handler/FileAnalysisHandlerMultiFileTest.php
+++ b/backend/tests/Unit/Service/Message/Handler/FileAnalysisHandlerMultiFileTest.php
@@ -255,6 +255,78 @@ class FileAnalysisHandlerMultiFileTest extends TestCase
     }
 
     /**
+     * Issue #722: a video whose audio track has been transcribed must be
+     * answered from its transcript via the document/summary path, instead
+     * of the old "This file type cannot be analyzed" dead end.
+     */
+    public function testVideoTranscriptIsSummarizedViaDocumentPath(): void
+    {
+        $message = $this->buildMessageWithFiles([
+            $this->buildFile(id: 1, name: 'atomic-habits.mp4', type: 'mp4', path: '13/000/atomic-habits.mp4', text: 'Small habits compound over time.'),
+        ], text: 'fasse den inhalt zusammen');
+
+        $captured = null;
+        $this->aiFacade
+            ->expects($this->once())
+            ->method('chat')
+            ->willReturnCallback(function (array $messages) use (&$captured) {
+                $captured = $messages;
+
+                return ['content' => 'The video argues that tiny habits accumulate.', 'provider' => 'openai', 'model' => 'gpt-4'];
+            });
+
+        $result = $this->handler->handle($message, [], []);
+
+        $this->assertNotNull($captured);
+        $system = $captured[0]['content'];
+
+        $this->assertStringContainsString('atomic-habits.mp4 (video transcript)', $system);
+        $this->assertStringContainsString('Video transcript:', $system);
+        $this->assertStringContainsString('Small habits compound over time.', $system);
+        $this->assertSame('fasse den inhalt zusammen', $captured[1]['content']);
+        $this->assertSame('chat_with_extracted_text', $result['metadata']['analysis_type']);
+        $this->assertSame(1, $result['metadata']['analyzed_file_count']);
+    }
+
+    /**
+     * A video that is still being transcribed must tell the user to wait
+     * (not silently fail), mirroring the document/audio pending guards.
+     */
+    public function testVideoStillTranscribingReturnsPendingMessage(): void
+    {
+        $message = $this->buildMessageWithFiles([
+            $this->buildFile(id: 1, name: 'clip.mp4', type: 'mp4', path: '13/000/clip.mp4', text: '', status: 'extracting'),
+        ], text: 'summarize this');
+
+        $this->aiFacade->expects($this->never())->method('chat');
+        $this->aiFacade->expects($this->never())->method('chatStream');
+
+        $result = $this->handler->handle($message, [], []);
+
+        $this->assertSame('video_transcription_in_progress', $result['metadata']['error']);
+        $this->assertStringContainsString('still being processed', $result['content']);
+    }
+
+    /**
+     * A video with no usable speech (finished processing, empty transcript)
+     * must surface a clear, video-specific failure message.
+     */
+    public function testVideoWithoutSpeechReturnsFailedMessage(): void
+    {
+        $message = $this->buildMessageWithFiles([
+            $this->buildFile(id: 1, name: 'silent.mp4', type: 'mp4', path: '13/000/silent.mp4', text: '', status: 'error'),
+        ], text: 'what is in this');
+
+        $this->aiFacade->expects($this->never())->method('chat');
+        $this->aiFacade->expects($this->never())->method('chatStream');
+
+        $result = $this->handler->handle($message, [], []);
+
+        $this->assertSame('video_transcription_failed', $result['metadata']['error']);
+        $this->assertStringContainsString("couldn't get any speech", $result['content']);
+    }
+
+    /**
      * Multi-image uploads previously stopped after the first vision
      * call. The handler must dispatch one vision call per image and
      * combine the per-image descriptions into a single labelled

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -1824,6 +1824,7 @@
     "status_extracted": "Extrahiert",
     "status_vectorizing": "Wird indexiert…",
     "status_vectorized": "Bereit",
+    "status_error": "Fehler",
     "status_processed": "Verarbeitet",
     "attached": "Angehängt",
     "standalone": "Eigenständig",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -688,6 +688,7 @@
     "status_extracted": "Extracted",
     "status_vectorizing": "Indexing…",
     "status_vectorized": "Ready",
+    "status_error": "Error",
     "status_processed": "Processed",
     "attached": "Attached",
     "standalone": "Standalone",


### PR DESCRIPTION
## Summary
Uploaded videos (e.g. MP4) can now be queried in chat: their audio track is transcribed and the assistant answers/summarises from that transcript instead of replying "This file type cannot be analyzed" (#722).

## Changes
- `MessagePreProcessor`: add `VIDEO_EXTENSIONS` and route video through the same extraction pipeline as documents (transcript stored in `BFILETEXT`), for both the multi-file and legacy single-file paths.
- `FileAnalysisHandler`: recognise video, answer/summarise from the transcript via the document path, and surface clear pending/failed messages while transcription is in progress or yields no speech.
- `MessageClassifier`: force messages with a video attachment to the `FileAnalysisHandler` route so video-only messages are no longer answered as text-less chats (methods renamed to `*AnalyzableNonImage*`).
- Reuses the existing `FileProcessor` + `WhisperService` (ffmpeg audio extraction + Whisper) pipeline — no new dependencies.

## Verification
- [ ] Not tested (explain)
- [x] Manual
- [x] Tests added/updated

Backend gate (matches CI):
- `make -C backend lint` — pass
- `make -C backend phpstan` — pass (0 errors)
- `make -C backend test` — pass (1923 tests, 0 failures)

New unit tests in `FileAnalysisHandlerMultiFileTest`: video happy path (summary via document path), still-transcribing (pending), and no-speech (failed).

> Note: an end-to-end manual upload of a real MP4 through the UI was not performed in this environment; the change is covered by unit tests and reuses the already-tested video transcription pipeline.

## Notes
Closes #722. Only backend PHP files changed, so frontend checks are not required per the contribution guide.

## Screenshots/Logs
Before (from the issue): a summarisation request on an uploaded MP4 returned "This file type cannot be analyzed. Supported types include documents..., images..., and audio files...".