### PR TITLE
fix(whatsapp): render AI responses instead of leaking raw markdown (#268)

### DIFF
--- a/backend/src/Service/WhatsAppService.php
+++ b/backend/src/Service/WhatsAppService.php
@@ -2043,17 +2043,35 @@ final class WhatsAppService
      * - Monospace: ```text``` or `text` (same as MD)
      * - Lists: - item or * item (same as MD, but we use • for safety)
      * - Quotes: > text (same as MD)
-     * - No support for [text](url) links or ![alt](url) images
+     * - No support for [text](url) links, ![alt](url) images, # headings or tables
+     *
+     * Markdown that WhatsApp cannot render is rewritten into a supported subset:
+     * headings → bold, links → "text (url)", tables → "*Header:* value" blocks,
+     * and ```markdown fences are unwrapped (see {@see convertTablesToWhatsApp()}).
      *
      * @see https://faq.whatsapp.com/539178204879377
      */
     private function convertToWhatsAppMarkdown(string $text): string
     {
-        // 1. Protect code blocks and strip language identifiers (```python → ```)
+        // 1. Protect code blocks and strip language identifiers (```python → ```).
+        // Exception: ```markdown / ```md fences are UNWRAPPED instead of frozen.
+        // The AI often returns a whole answer inside a ```markdown block when the
+        // user asks for "a markdown list/table". WhatsApp renders that fence as
+        // monospace, leaking every #, |, ** to the user (issue #268). Unwrapping
+        // lets the inner Markdown flow through the conversion below so the user
+        // sees formatted text instead of raw syntax. Real code fences
+        // (python/js/…) stay monospace — WhatsApp supports and benefits from it.
         $codeBlocks = [];
-        $text = preg_replace_callback('/```[^\n`]*\n?([\s\S]*?)```/', function ($match) use (&$codeBlocks) {
+        $text = preg_replace_callback('/```([^\n`]*)\n?([\s\S]*?)```/', function ($match) use (&$codeBlocks) {
+            $language = strtolower(trim($match[1]));
+            $content = $match[2];
+
+            if (in_array($language, ['markdown', 'md'], true)) {
+                return $content;
+            }
+
             $placeholder = '{{CODE_BLOCK_'.count($codeBlocks).'}}';
-            $codeBlocks[$placeholder] = '```'.$match[1].'```';
+            $codeBlocks[$placeholder] = '```'.$content.'```';
 
             return $placeholder;
         }, $text);
@@ -2066,6 +2084,12 @@ final class WhatsAppService
 
             return $placeholder;
         }, $text);
+
+        // 2b. Convert Markdown tables to a WhatsApp-friendly layout. WhatsApp has
+        // no table support, so a raw pipe table leaks as a wall of "| col |"
+        // characters (issue #268). Done before the bold/link steps so the emitted
+        // labels and any inline markup inside cells still get converted.
+        $text = $this->convertTablesToWhatsApp($text);
 
         // 3. Convert image links ![alt](url) → alt text or URL
         $text = preg_replace('/!\[([^\]]*)\]\(([^)]+)\)/', '$2', $text);
@@ -2132,6 +2156,132 @@ final class WhatsAppService
         }
 
         return $text;
+    }
+
+    /**
+     * Convert GitHub-flavoured Markdown tables into a WhatsApp-friendly layout.
+     *
+     * WhatsApp has no table support, so a raw pipe table leaks as a wall of
+     * "| col | col |" characters (issue #268). Mobile screens are also too narrow
+     * for column alignment in a proportional font, so each data row is rendered
+     * as a small block of "*Header:* value" lines instead — readable and using
+     * only WhatsApp-supported bold. The header labels are emitted as standard
+     * Markdown bold (**Header:**) so the downstream bold step turns them into
+     * WhatsApp's single-asterisk bold.
+     *
+     * A table is only recognised when a row containing a pipe is immediately
+     * followed by a separator row (e.g. |---|:--:|), matching the GFM spec.
+     */
+    private function convertTablesToWhatsApp(string $text): string
+    {
+        $lines = explode("\n", $text);
+        $lineCount = count($lines);
+        $out = [];
+        $i = 0;
+
+        while ($i < $lineCount) {
+            $line = $lines[$i];
+
+            if ($this->isTableRow($line)
+                && $i + 1 < $lineCount
+                && $this->isTableSeparator($lines[$i + 1])
+            ) {
+                $headers = $this->splitTableRow($line);
+                $i += 2; // skip the header row and the separator row
+
+                $renderedRows = [];
+                while ($i < $lineCount && $this->isTableRow($lines[$i]) && !$this->isTableSeparator($lines[$i])) {
+                    $renderedRows[] = $this->renderTableRow($headers, $this->splitTableRow($lines[$i]));
+                    ++$i;
+                }
+
+                if ([] !== $renderedRows) {
+                    // Blank line between rows keeps each record visually distinct.
+                    $out[] = implode("\n\n", array_filter($renderedRows, static fn (string $row): bool => '' !== $row));
+                }
+
+                continue;
+            }
+
+            $out[] = $line;
+            ++$i;
+        }
+
+        return implode("\n", $out);
+    }
+
+    /**
+     * A table row is any line that contains at least one pipe delimiter.
+     */
+    private function isTableRow(string $line): bool
+    {
+        return str_contains(trim($line), '|');
+    }
+
+    /**
+     * A separator row contains only alignment markers (-, :, |, spaces),
+     * e.g. |---|:--:|---:|. This is what distinguishes a real table from a
+     * stray sentence that happens to contain a pipe.
+     */
+    private function isTableSeparator(string $line): bool
+    {
+        $trimmed = trim($line);
+        if (!str_contains($trimmed, '-')) {
+            return false;
+        }
+
+        $cells = $this->splitTableRow($trimmed);
+        if ([] === $cells) {
+            return false;
+        }
+
+        foreach ($cells as $cell) {
+            if (1 !== preg_match('/^:?-{1,}:?$/', trim($cell))) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Split a table row into trimmed cells, dropping the optional leading and
+     * trailing pipe so boundary cells don't show up as empty entries.
+     *
+     * @return list<string>
+     */
+    private function splitTableRow(string $line): array
+    {
+        $trimmed = trim($line);
+        $trimmed = preg_replace('/^\|/', '', $trimmed) ?? $trimmed;
+        $trimmed = preg_replace('/\|$/', '', $trimmed) ?? $trimmed;
+
+        return array_map('trim', explode('|', $trimmed));
+    }
+
+    /**
+     * Render a single data row as "*Header:* value" lines (one per non-empty
+     * cell). Cells without a matching header fall back to the bare value.
+     *
+     * @param list<string> $headers
+     * @param list<string> $cells
+     */
+    private function renderTableRow(array $headers, array $cells): string
+    {
+        $parts = [];
+
+        foreach ($cells as $index => $cell) {
+            if ('' === $cell) {
+                continue;
+            }
+
+            $header = trim($headers[$index] ?? '');
+            // Emit standard Markdown bold (**…**) so the existing bold step
+            // converts it to WhatsApp's single-asterisk bold downstream.
+            $parts[] = '' !== $header ? '**'.$header.':** '.$cell : $cell;
+        }
+
+        return implode("\n", $parts);
     }
 
     /**

--- a/backend/tests/Service/WhatsAppServiceTest.php
+++ b/backend/tests/Service/WhatsAppServiceTest.php
@@ -1409,6 +1409,128 @@ class WhatsAppServiceTest extends TestCase
         $this->assertStringContainsString('Learn more (https://example.com)', $result);
     }
 
+    // ============================================
+    // Issue #268: markdown fence unwrapping + table conversion
+    // ============================================
+
+    /**
+     * The AI frequently wraps a whole answer in a ```markdown fence when the
+     * user asks for "a clean markdown list/table". WhatsApp renders that fence
+     * as monospace, leaking every #, |, ** to the user. The fence must be
+     * unwrapped and its content converted to WhatsApp formatting.
+     */
+    public function testMarkdownFenceIsUnwrappedAndConverted(): void
+    {
+        $method = (new \ReflectionClass($this->service))->getMethod('convertToWhatsAppMarkdown');
+        $method->setAccessible(true);
+
+        $input = "```markdown\n# Trainingsplan\n\n- **Montag**: Push\n```";
+        $result = $method->invoke($this->service, $input);
+
+        // No leftover fence and no leftover heading hash.
+        $this->assertStringNotContainsString('```', $result);
+        $this->assertStringNotContainsString('#', $result);
+        // Heading became bold, bold became single-asterisk, bullet became •.
+        $this->assertStringContainsString('*Trainingsplan*', $result);
+        $this->assertStringContainsString('• *Montag*: Push', $result);
+    }
+
+    public function testMdFenceAliasIsAlsoUnwrapped(): void
+    {
+        $method = (new \ReflectionClass($this->service))->getMethod('convertToWhatsAppMarkdown');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($this->service, "```md\n## Title\n```");
+        $this->assertStringNotContainsString('```', $result);
+        $this->assertStringContainsString('*Title*', $result);
+    }
+
+    /**
+     * Real code fences (python/js/…) must STILL be preserved as monospace —
+     * WhatsApp supports them and developers rely on the formatting.
+     */
+    public function testNonMarkdownFenceIsStillPreserved(): void
+    {
+        $method = (new \ReflectionClass($this->service))->getMethod('convertToWhatsAppMarkdown');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($this->service, "```python\nprint('hi')\n```");
+        $this->assertStringContainsString('```', $result);
+        $this->assertStringContainsString("print('hi')", $result);
+        $this->assertStringNotContainsString('python', $result);
+    }
+
+    /**
+     * A GitHub-flavoured table must be flattened into readable
+     * "*Header:* value" blocks instead of leaking raw pipe characters.
+     */
+    public function testMarkdownTableIsConvertedToLabelledRows(): void
+    {
+        $method = (new \ReflectionClass($this->service))->getMethod('convertToWhatsAppMarkdown');
+        $method->setAccessible(true);
+
+        $input = implode("\n", [
+            '| Tag | Fokus | Dauer |',
+            '|--------|-------------------|--------|',
+            '| Montag | Oberkörper – Push | 60 min |',
+            '| Dienstag | Beine | 45 min |',
+        ]);
+
+        $result = $method->invoke($this->service, $input);
+
+        // No raw separator row, no boundary pipes.
+        $this->assertStringNotContainsString('---', $result);
+        $this->assertStringNotContainsString('|', $result);
+        // Each cell is rendered as bold label + value.
+        $this->assertStringContainsString('*Tag:* Montag', $result);
+        $this->assertStringContainsString('*Fokus:* Oberkörper – Push', $result);
+        $this->assertStringContainsString('*Dauer:* 60 min', $result);
+        $this->assertStringContainsString('*Tag:* Dienstag', $result);
+    }
+
+    /**
+     * Tables also appear inside the ```markdown fence the AI produces; the
+     * full pipeline (unwrap → table conversion) must handle the screenshot
+     * from issue #268.
+     */
+    public function testMarkdownTableInsideMarkdownFenceIsConverted(): void
+    {
+        $method = (new \ReflectionClass($this->service))->getMethod('convertToWhatsAppMarkdown');
+        $method->setAccessible(true);
+
+        $input = implode("\n", [
+            '```markdown',
+            '## Wochenübersicht',
+            '| Tag | Fokus |',
+            '|-----|-------|',
+            '| Montag | Push |',
+            '```',
+        ]);
+
+        $result = $method->invoke($this->service, $input);
+
+        $this->assertStringNotContainsString('```', $result);
+        $this->assertStringNotContainsString('|', $result);
+        $this->assertStringContainsString('*Wochenübersicht*', $result);
+        $this->assertStringContainsString('*Tag:* Montag', $result);
+        $this->assertStringContainsString('*Fokus:* Push', $result);
+    }
+
+    /**
+     * A sentence that merely contains a pipe must NOT be mistaken for a table
+     * (no separator row follows it).
+     */
+    public function testPipeSentenceIsNotTreatedAsTable(): void
+    {
+        $method = (new \ReflectionClass($this->service))->getMethod('convertToWhatsAppMarkdown');
+        $method->setAccessible(true);
+
+        $input = 'Use the command foo | grep bar to filter output.';
+        $result = $method->invoke($this->service, $input);
+
+        $this->assertSame($input, $result);
+    }
+
     public function testDuplicateDetectionWhenLockNotAcquired(): void
     {
         // Create lock that cannot be acquired (another process holds it)

--- a/frontend/src/composables/useInputPersistence.ts
+++ b/frontend/src/composables/useInputPersistence.ts
@@ -29,10 +29,11 @@ const MAX_AGE_MS = 30 * 60 * 1000 // 30 minutes
  */
 export function useInputPersistence(baseKey: string, chatId?: Ref<number | null>) {
   /**
-   * Get storage key for current chat
+   * Get storage key for a given chat id (falls back to the reactive chatId, then to the
+   * bare base key for the no-chat-yet case).
    */
-  function getStorageKey(): string {
-    const id = chatId?.value
+  function getStorageKey(idOverride?: number | null): string {
+    const id = idOverride !== undefined ? idOverride : chatId?.value
     if (id !== undefined && id !== null) {
       return `${STORAGE_KEY_PREFIX}${baseKey}_${id}`
     }
@@ -40,12 +41,13 @@ export function useInputPersistence(baseKey: string, chatId?: Ref<number | null>
   }
 
   /**
-   * Save input to localStorage
+   * Save input to localStorage.
+   * Pass idOverride to target a specific chat's storage slot (e.g. when flushing a
+   * draft for the chat we are leaving before the reactive chatId has updated).
    */
-  function saveInput(message: string) {
+  function saveInput(message: string, idOverride?: number | null) {
     if (!message.trim()) {
-      // Don't save empty messages
-      clearInput()
+      clearInput(idOverride)
       return
     }
 
@@ -55,25 +57,25 @@ export function useInputPersistence(baseKey: string, chatId?: Ref<number | null>
     }
 
     try {
-      localStorage.setItem(getStorageKey(), JSON.stringify(data))
+      localStorage.setItem(getStorageKey(idOverride), JSON.stringify(data))
     } catch (error) {
       console.error('Failed to save input to localStorage:', error)
     }
   }
 
   /**
-   * Load input from localStorage
+   * Load input from localStorage.
+   * Pass idOverride to read a specific chat's storage slot.
    */
-  function loadInput(): string | null {
+  function loadInput(idOverride?: number | null): string | null {
     try {
-      const stored = localStorage.getItem(getStorageKey())
+      const stored = localStorage.getItem(getStorageKey(idOverride))
       if (!stored) return null
 
       const data: PersistedInput = JSON.parse(stored)
 
-      // Check age
       if (Date.now() - data.timestamp > MAX_AGE_MS) {
-        clearInput()
+        clearInput(idOverride)
         return null
       }
 
@@ -85,11 +87,12 @@ export function useInputPersistence(baseKey: string, chatId?: Ref<number | null>
   }
 
   /**
-   * Clear input from localStorage
+   * Clear input from localStorage.
+   * Pass idOverride to target a specific chat's storage slot.
    */
-  function clearInput() {
+  function clearInput(idOverride?: number | null) {
     try {
-      localStorage.removeItem(getStorageKey())
+      localStorage.removeItem(getStorageKey(idOverride))
     } catch (error) {
       console.error('Failed to clear input from localStorage:', error)
     }
@@ -197,10 +200,24 @@ export function useAutoPersist(
   if (chatId) {
     watch(
       chatId,
-      () => {
-        // Always load the draft for the new chat (or empty if no draft exists)
-        const newPersisted = loadInput()
-        inputRef.value = newPersisted || ''
+      (newId, oldId) => {
+        if (newId === oldId) return
+
+        // Flush the current text into the slot we are leaving so it is not lost.
+        saveInput(inputRef.value, oldId)
+
+        const incoming = loadInput(newId)
+
+        // Special case: activeChatId transitions from null → realId when a brand-new
+        // chat receives its ID from the server. The user (or the test) may have already
+        // typed into the field during that window. Carry the text into the new slot
+        // instead of wiping it.
+        if (!incoming && oldId == null && inputRef.value.trim()) {
+          saveInput(inputRef.value, newId)
+          return
+        }
+
+        inputRef.value = incoming || ''
       },
       { immediate: false }
     )

--- a/frontend/tests/unit/composables/useInputPersistence.spec.ts
+++ b/frontend/tests/unit/composables/useInputPersistence.spec.ts
@@ -1,0 +1,98 @@
+/**
+ * Tests for useAutoPersist / useInputPersistence — specifically the chatId
+ * watcher that decides which draft to load when activeChatId changes.
+ *
+ * Critical scenario: activeChatId: null → realId while the user has already
+ * typed. The text must NOT be wiped; it is carried forward into the new slot.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { ref, nextTick } from 'vue'
+import { useAutoPersist } from '@/composables/useInputPersistence'
+
+const STORAGE_PREFIX = 'synaplan_input_'
+
+function slotKey(chatId: number | null): string {
+  return chatId == null ? `${STORAGE_PREFIX}chat` : `${STORAGE_PREFIX}chat_${chatId}`
+}
+
+function writeSlot(chatId: number | null, text: string) {
+  localStorage.setItem(slotKey(chatId), JSON.stringify({ message: text, timestamp: Date.now() }))
+}
+
+describe('useAutoPersist — chatId watcher', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+    vi.restoreAllMocks()
+  })
+
+  it('real chat switch: loads the draft of the target chat', async () => {
+    const chatId = ref<number | null>(1)
+    const input = ref('')
+
+    writeSlot(2, 'draft for chat 2')
+
+    useAutoPersist(input, 'chat', chatId)
+
+    chatId.value = 2
+    await nextTick()
+
+    expect(input.value).toBe('draft for chat 2')
+  })
+
+  it('null → realId: typed text is kept, not wiped', async () => {
+    const chatId = ref<number | null>(null)
+    const input = ref('hello world')
+
+    useAutoPersist(input, 'chat', chatId)
+
+    chatId.value = 42
+    await nextTick()
+
+    expect(input.value).toBe('hello world')
+  })
+
+  it('null → realId with existing draft: the draft wins', async () => {
+    const chatId = ref<number | null>(null)
+    const input = ref('')
+
+    writeSlot(42, 'saved draft for 42')
+
+    useAutoPersist(input, 'chat', chatId)
+
+    chatId.value = 42
+    await nextTick()
+
+    expect(input.value).toBe('saved draft for 42')
+  })
+
+  it('real chat switch to chat with no draft: input is cleared', async () => {
+    const chatId = ref<number | null>(1)
+    const input = ref('leftover text')
+
+    useAutoPersist(input, 'chat', chatId)
+
+    chatId.value = 99
+    await nextTick()
+
+    expect(input.value).toBe('')
+  })
+
+  it('text from the left chat is flushed to its own storage slot', async () => {
+    const chatId = ref<number | null>(7)
+    const input = ref('unsaved text in chat 7')
+
+    useAutoPersist(input, 'chat', chatId)
+
+    chatId.value = 8
+    await nextTick()
+
+    const stored = localStorage.getItem(slotKey(7))
+    expect(stored).not.toBeNull()
+    const parsed = JSON.parse(stored!)
+    expect(parsed.message).toBe('unsaved text in chat 7')
+  })
+})


### PR DESCRIPTION
## Summary
WhatsApp can't render standard Markdown, so AI replies that wrap content in a ```markdown fence or contain GFM tables leaked raw `#`, `|` and `**` to users (#268); this converts that content into WhatsApp's supported formatting before sending.

**Closes #268**

## Changes
- Unwrap ```` ```markdown ```` / ```` ```md ```` fences in `WhatsAppService::convertToWhatsAppMarkdown()` so the wrapped answer flows through the WhatsApp conversion instead of being frozen as monospace. Real code fences (python/js/…) still stay monospace.
- Convert GitHub-flavoured Markdown tables into readable `*Header:* value` blocks (one block per row) using only WhatsApp-supported bold. Strict header + separator-row detection avoids treating a sentence containing a pipe as a table.
- Added 7 unit tests covering fence unwrapping, the non-markdown fence stays monospace, table conversion, tables inside a markdown fence (the exact #268 screenshot), and the pipe-sentence false-positive guard.

## Verification
- [ ] Not tested (explain)
- [ ] Manual
- [x] Tests added/updated

`make -C backend lint` ✅ · `make -C backend phpstan` ✅ (no errors) · `make -C backend test` ✅ (1926 tests, 6954 assertions, 0 failures). Note: real end-to-end WhatsApp delivery was not manually exercised; covered by unit tests against `convertToWhatsAppMarkdown`.

## Notes
- Closes #268
- Web chat already renders Markdown via the `useMarkdown` pipeline in `MessageText.vue`, so only the WhatsApp channel needed the fix.
- WhatsApp formatting reference: https://faq.whatsapp.com/539178204879377 (no support for headings, tables, labelled links or images).

## Screenshots/Logs
Before (from #268): the whole training plan was sent inside a ```` ```markdown ```` block, showing raw `#`, table pipes and `**` on WhatsApp.