### PR TITLE
fix(cloudflare): bypass WebSocket upgrade requests in worker

### DIFF
--- a/cloudflare/src/worker.ts
+++ b/cloudflare/src/worker.ts
@@ -33,6 +33,10 @@ function isSseRequest(pathname: string, request: Request): boolean {
   return SSE_PATH_PATTERNS.some((re) => re.test(pathname))
 }
 
+function isWebSocketUpgrade(request: Request): boolean {
+  return (request.headers.get('Upgrade') ?? '').toLowerCase() === 'websocket'
+}
+
 function shouldNeverCache(pathname: string): boolean {
   return NO_CACHE_PATHS.includes(pathname)
 }
@@ -55,6 +59,15 @@ export default {
   async fetch(request: Request, _env: Env): Promise<Response> {
     const url = new URL(request.url)
     const { pathname } = url
+
+    // WebSocket upgrade bypass — the 101 response carries the live socket on
+    // its non-standard `webSocket` property, which `new Response(...)` below
+    // drops. Pass the request straight through so the socket reaches the
+    // client untouched (operator dashboard + embedded widget both dial
+    // wss://.../connection/websocket).
+    if (isWebSocketUpgrade(request)) {
+      return fetch(request)
+    }
 
     // SSE bypass — return the streaming Response unmodified. Don't even
     // wrap it in a new Response(); cloning the body to copy headers can


### PR DESCRIPTION
## Summary
Worker was wrapping every non-SSE response in `new Response(response.body, {...})` to mutate cache headers. For WebSocket upgrades (HTTP 101), the live socket lives on the non-standard `webSocket` property of the response, which `new Response()` does not copy — causing every `wss://web.synaplan.com/connection/websocket` connection to fail silently (both admin dashboard and embedded widget).

## Changes
- Added `isWebSocketUpgrade()` helper (case-insensitive header check, same pattern as `isSseRequest()`)
- Added WebSocket upgrade bypass as the first check in `fetch()`, before `new Response()` is ever reached
- Repeated token 404s (Centrifuge reconnect-loop side effect) resolve automatically once the socket upgrade goes through

## Verification
- [ ] Manual
- Wrangler dry-run passed (exit 0, `Total Upload: 2.44 KiB`)
- Deploy after merge: `cd cloudflare && npm run deploy:production`

## Notes
The same bypass pattern already exists for SSE responses (Phase 1f). WebSocket upgrades were not covered there.

## Screenshots/Logs