### PR TITLE
fix(e2e): add ChatHelper.sendMessage() to guard against fill→click race

### DIFF
--- a/frontend/tests/e2e/helpers/chat.ts
+++ b/frontend/tests/e2e/helpers/chat.ts
@@ -10,6 +10,26 @@ export class ChatHelper {
     return this.page.locator(selectors.chat.messageContainer).locator(selectors.chat.aiAnswerBubble)
   }
 
+  /**
+   * Fill the chat input and click send. Returns the AI-bubble count before
+   * sending so callers can pass it straight to {@link waitForAnswer}.
+   *
+   * Waits for the send button to become enabled after filling — this guards
+   * against the rare race where Playwright's synthetic fill() event reaches
+   * Vue's @input handler a tick too late for canSend to flip before click().
+   */
+  async sendMessage(text: string): Promise<number> {
+    const previousCount = await this.conversationBubbles().count()
+    const textInput = this.page.locator(selectors.chat.textInput)
+    const sendBtn = this.page.locator(selectors.chat.sendBtn)
+
+    await textInput.fill(text)
+    await expect(sendBtn).toBeEnabled({ timeout: TIMEOUTS.STANDARD })
+    await sendBtn.click()
+
+    return previousCount
+  }
+
   async waitForAnswer(previousCount: number, longTimeout = false): Promise<string> {
     const bubbles = this.conversationBubbles()
     const newBubble = bubbles.nth(previousCount)

--- a/frontend/tests/e2e/tests/chat-again.spec.ts
+++ b/frontend/tests/e2e/tests/chat-again.spec.ts
@@ -20,12 +20,7 @@ test.describe('@ci @smoke Chat Again', () => {
     })
 
     // -- Turn 1: send message, get first AI response --
-    let previousCount = await chat.conversationBubbles().count()
-
-    await test.step('Act: send initial message', async () => {
-      await page.locator(selectors.chat.textInput).fill(PROMPTS.CHAT_SMOKE)
-      await page.locator(selectors.chat.sendBtn).click()
-    })
+    let previousCount = await chat.sendMessage(PROMPTS.CHAT_SMOKE)
 
     const firstAnswer = await chat.waitForAnswer(previousCount)
 

--- a/frontend/tests/e2e/tests/chat-bubble-monotonic.spec.ts
+++ b/frontend/tests/e2e/tests/chat-bubble-monotonic.spec.ts
@@ -30,10 +30,7 @@ test.describe('@noci @nightly Chat bubble flicker guard', () => {
     const chat = new ChatHelper(page)
     await chat.startNewChat()
 
-    const previousCount = await chat.conversationBubbles().count()
-
-    await page.locator(selectors.chat.textInput).fill(PROMPTS.CHAT_SMOKE)
-    await page.locator(selectors.chat.sendBtn).click()
+    const previousCount = await chat.sendMessage(PROMPTS.CHAT_SMOKE)
 
     // Bubble for the new assistant response. Index = previousCount in the
     // bubbles list (assistant bubbles only).

--- a/frontend/tests/e2e/tests/chat-share.spec.ts
+++ b/frontend/tests/e2e/tests/chat-share.spec.ts
@@ -17,12 +17,7 @@ test.describe('@ci @smoke Chat Share', () => {
       await chat.startNewChat()
     })
 
-    const previousCount = await chat.conversationBubbles().count()
-
-    await test.step('Act: send message', async () => {
-      await page.locator(selectors.chat.textInput).fill(uniqueMessage)
-      await page.locator(selectors.chat.sendBtn).click()
-    })
+    const previousCount = await chat.sendMessage(uniqueMessage)
 
     await test.step('Wait for chat terminal state (done or error)', async () => {
       await chat.waitForAnswer(previousCount)

--- a/frontend/tests/e2e/tests/chat.spec.ts
+++ b/frontend/tests/e2e/tests/chat.spec.ts
@@ -1,5 +1,4 @@
 import { test, expect } from '../test-setup'
-import { selectors } from '../helpers/selectors'
 import { login } from '../helpers/auth'
 import { ChatHelper } from '../helpers/chat'
 import { FIXTURE_PATHS, PROMPTS } from '../config/test-data'
@@ -22,12 +21,7 @@ test.describe('@ci @smoke Chat', () => {
       await chat.startNewChat()
     })
 
-    const previousCount = await chat.conversationBubbles().count()
-
-    await test.step('Act: send smoke test message', async () => {
-      await page.locator(selectors.chat.textInput).fill(PROMPTS.CHAT_SMOKE)
-      await page.locator(selectors.chat.sendBtn).click()
-    })
+    const previousCount = await chat.sendMessage(PROMPTS.CHAT_SMOKE)
 
     const aiText = await chat.waitForAnswer(previousCount)
 
@@ -50,10 +44,7 @@ test.describe('@noci @nightly Chat — all models', () => {
     await chat.startNewChat()
 
     try {
-      const previousCount = await chat.conversationBubbles().count()
-      await page.locator(selectors.chat.textInput).fill(PROMPTS.CHAT_SMOKE)
-      await page.locator(selectors.chat.sendBtn).click()
-
+      const previousCount = await chat.sendMessage(PROMPTS.CHAT_SMOKE)
       const aiText = await chat.waitForAnswer(previousCount)
       await expect(aiText, 'Initial model should answer').toContain('success')
     } catch (error) {
@@ -89,10 +80,7 @@ test.describe('@noci @regression Chat — vision', () => {
       buffer: VISION_FIXTURE,
     })
 
-    const previousCount = await chat.conversationBubbles().count()
-    await page.locator(selectors.chat.textInput).fill('What do you see in this image?')
-    await page.locator(selectors.chat.sendBtn).click()
-
+    const previousCount = await chat.sendMessage('What do you see in this image?')
     const aiText = await chat.waitForAnswer(previousCount)
     await expect.soft(aiText.includes('error') || aiText.includes('failed')).toBeFalsy()
 
@@ -114,10 +102,7 @@ test.describe('@noci @regression Chat — image generation', () => {
     await chat.ensureAdvancedMode()
     await chat.startNewChat()
 
-    const previousCount = await chat.conversationBubbles().count()
-    await page.locator(selectors.chat.textInput).fill('draw a tiny blue square')
-    await page.locator(selectors.chat.sendBtn).click()
-
+    const previousCount = await chat.sendMessage('draw a tiny blue square')
     const aiText = await chat.waitForAnswer(previousCount)
     await expect.soft(aiText.includes('error') || aiText.includes('failed')).toBeFalsy()
 
@@ -139,10 +124,7 @@ test.describe('@noci @regression Chat — video generation', () => {
     await chat.ensureAdvancedMode()
     await chat.startNewChat()
 
-    const previousCount = await chat.conversationBubbles().count()
-    await page.locator(selectors.chat.textInput).fill('/vid short demo clip of a robot waving')
-    await page.locator(selectors.chat.sendBtn).click()
-
+    const previousCount = await chat.sendMessage('/vid short demo clip of a robot waving')
     const aiText = await chat.waitForAnswer(previousCount, true)
     await expect.soft(aiText.includes('error') || aiText.includes('failed')).toBeFalsy()
     await chat.runAgainOptions(undefined, failures, 'video generation', true)

--- a/frontend/tests/e2e/tests/multitask.spec.ts
+++ b/frontend/tests/e2e/tests/multitask.spec.ts
@@ -33,12 +33,7 @@ test.describe('@ci @multitask Multi-task routing', () => {
       expect(MULTITASK_PROMPT.length).toBeGreaterThan(280)
     })
 
-    const previousCount = await chat.conversationBubbles().count()
-
-    await test.step('Act: send a multi-task prompt', async () => {
-      await page.locator(selectors.chat.textInput).fill(MULTITASK_PROMPT)
-      await page.locator(selectors.chat.sendBtn).click()
-    })
+    const previousCount = await chat.sendMessage(MULTITASK_PROMPT)
 
     const bubble = chat.conversationBubbles().nth(previousCount)
     await bubble.waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })

--- a/frontend/tests/e2e/tests/ollama-integration.spec.ts
+++ b/frontend/tests/e2e/tests/ollama-integration.spec.ts
@@ -1,6 +1,5 @@
 import { test, expect } from '../test-setup'
 import { request as playwrightRequest } from '@playwright/test'
-import { selectors } from '../helpers/selectors'
 import { login, getAuthHeaders } from '../helpers/auth'
 import { ChatHelper } from '../helpers/chat'
 import { CREDENTIALS } from '../config/credentials'
@@ -71,12 +70,7 @@ test.describe('@ci @smoke Ollama Integration', () => {
       await chat.startNewChat()
     })
 
-    const previousCount = await chat.conversationBubbles().count()
-
-    await test.step('Act: send message', async () => {
-      await page.locator(selectors.chat.textInput).fill(PROMPTS.CHAT_SMOKE)
-      await page.locator(selectors.chat.sendBtn).click()
-    })
+    const previousCount = await chat.sendMessage(PROMPTS.CHAT_SMOKE)
 
     const aiText = await chat.waitForAnswer(previousCount)
 
@@ -110,12 +104,7 @@ test.describe('@ci @smoke Ollama Integration', () => {
       await chat.startNewChat()
     })
 
-    const previousCount = await chat.conversationBubbles().count()
-
-    await test.step('Act: send message', async () => {
-      await page.locator(selectors.chat.textInput).fill(PROMPTS.CHAT_SMOKE)
-      await page.locator(selectors.chat.sendBtn).click()
-    })
+    const previousCount = await chat.sendMessage(PROMPTS.CHAT_SMOKE)
 
     const aiText = await chat.waitForAnswer(previousCount)
 


### PR DESCRIPTION
## Summary

- Adds `ChatHelper.sendMessage(text)` that centralises the fill → toBeEnabled → click pattern
- Replaces 10 duplicated `fill() + sendBtn.click()` call sites across 6 test files
- Explicitly waits for the send button to be enabled (STANDARD timeout) after fill, guarding against the rare race where Playwright's synthetic `fill()` event reaches Vue's `@input` handler too late for `canSend` to flip before `click()`

## Context

The `chat-again` E2E test [failed in CI](https://github.com/metadist/synaplan/actions/runs/27681507200) with a 90s timeout on `sendBtn.click()`. The send button stayed disabled because `fill()` didn't trigger Vue reactivity fast enough on a slow runner. The test is not consistently broken (passed before and after), but the pattern is fragile.

The fix adds a deterministic wait for the resulting DOM state (`toBeEnabled`) after the state-changing action (`fill`), per the E2E testing guidelines.

## Test plan

- [ ] CI E2E suite passes (all 6 affected test files)
- [ ] `chat-again` test specifically passes on retry
- [ ] No TypeScript errors (`vue-tsc -b --noEmit` clean)
- [ ] ESLint clean on all changed files