### PR TITLE
feat(chat): add quote selection ("Mention in chat")

### DIFF
--- a/backend/src/Controller/ChatController.php
+++ b/backend/src/Controller/ChatController.php
@@ -605,6 +605,11 @@ class ChatController extends AbstractController
             $originalTopic = $m->getMeta('original_topic');
             $originalMediaType = $m->getMeta('original_media_type');
 
+            // Quoted reference the user attached when composing this message
+            // ("Mention in chat"). Stored as message meta so it survives reload.
+            $quotedText = $m->getMeta('quoted_text');
+            $quotedMessageIdMeta = $m->getMeta('quoted_message_id');
+
             return [
                 'id' => $m->getId(),
                 'text' => $m->getText(),
@@ -616,6 +621,8 @@ class ChatController extends AbstractController
                 'originalMediaType' => $originalMediaType,
                 'language' => $m->getLanguage(),
                 'createdAt' => $m->getDateTime(),
+                'quotedText' => $quotedText,
+                'quotedMessageId' => null !== $quotedMessageIdMeta ? (int) $quotedMessageIdMeta : null,
                 'files' => $filesData, // Attached files (user uploads)
                 'aiModels' => !empty($aiModels) ? $aiModels : null, // AI model metadata
                 'webSearch' => $webSearchData, // Web search metadata

--- a/backend/src/Controller/StreamController.php
+++ b/backend/src/Controller/StreamController.php
@@ -37,8 +37,16 @@ use Symfony\Component\Security\Http\Attribute\CurrentUser;
 #[OA\Tag(name: 'Messages')]
 class StreamController extends AbstractController
 {
-    /** Server-side cap for a quoted-reference excerpt ("Mention in chat"). */
-    private const MAX_QUOTED_TEXT_LENGTH = 4000;
+    /**
+     * Server-side cap for a quoted-reference excerpt ("Mention in chat").
+     *
+     * The quote travels as a query parameter on the SSE (GET) stream URL, so an
+     * over-long excerpt could exceed reverse-proxy request limits (e.g. Nginx's
+     * 8 KB default). Kept in sync with the frontend cap (MAX_QUOTE_LENGTH in
+     * useMessageQuoting.ts); 1000 chars is generous for a reference point and
+     * stays URL-safe even worst-case encoded.
+     */
+    private const MAX_QUOTED_TEXT_LENGTH = 1000;
 
     public function __construct(
         private EntityManagerInterface $em,

--- a/backend/src/Controller/StreamController.php
+++ b/backend/src/Controller/StreamController.php
@@ -37,6 +37,9 @@ use Symfony\Component\Security\Http\Attribute\CurrentUser;
 #[OA\Tag(name: 'Messages')]
 class StreamController extends AbstractController
 {
+    /** Server-side cap for a quoted-reference excerpt ("Mention in chat"). */
+    private const MAX_QUOTED_TEXT_LENGTH = 4000;
+
     public function __construct(
         private EntityManagerInterface $em,
         private AiFacade $aiFacade,
@@ -310,10 +313,18 @@ class StreamController extends AbstractController
         // behaves the same as an absent parameter.
         $ragGroupKey = $request->query->getString('ragGroupKey') ?: null;
         // Quoted reference the user selected from an earlier message ("Mention
-        // in chat"). `getString()` rejects array input with a clean 400, and we
-        // normalize the empty string to null so an absent quote behaves the same.
-        $quotedText = $request->query->getString('quotedText') ?: null;
-        $quotedMessageId = $request->query->get('quotedMessageId');
+        // in chat"). `getString()` rejects array input with a clean 400. We trim
+        // and cap the excerpt server-side so a crafted request cannot bloat the
+        // stored meta or the AI prompt, and normalize empty to null.
+        $quotedText = trim($request->query->getString('quotedText'));
+        if (mb_strlen($quotedText) > self::MAX_QUOTED_TEXT_LENGTH) {
+            $quotedText = mb_substr($quotedText, 0, self::MAX_QUOTED_TEXT_LENGTH);
+        }
+        $quotedText = '' !== $quotedText ? $quotedText : null;
+        // `getInt()` rejects array input (e.g. `quotedMessageId[]=…`) with a clean
+        // 400 instead of silently coercing it to 0/1 and resolving the wrong
+        // message. 0 (absent/invalid) collapses to null.
+        $quotedMessageId = $request->query->getInt('quotedMessageId') ?: null;
         $continueMessageId = $request->query->get('continueMessageId');
         // Explicit opt-out from memory loading + extraction (used by public demo via synaplan.com/try-chat)
         $disableMemories = '1' === $request->query->get('disableMemories', '0');

--- a/backend/src/Controller/StreamController.php
+++ b/backend/src/Controller/StreamController.php
@@ -150,6 +150,20 @@ class StreamController extends AbstractController
         description: 'Knowledge-base folder (file group key) to scope this message\'s RAG retrieval to. Use GET /api/v1/files/groups to list available folders.',
         schema: new OA\Schema(type: 'string', example: 'project:helios')
     )]
+    #[OA\Parameter(
+        name: 'quotedText',
+        in: 'query',
+        required: false,
+        description: 'Text the user selected from an earlier message to use as the primary reference point for this request ("Mention in chat"). Injected into the AI system prompt as a quoted-reference context block.',
+        schema: new OA\Schema(type: 'string', example: 'The deployment runs on FrankenPHP.')
+    )]
+    #[OA\Parameter(
+        name: 'quotedMessageId',
+        in: 'query',
+        required: false,
+        description: 'Optional backend id of the message the quoted text was taken from. Must belong to the same chat and user.',
+        schema: new OA\Schema(type: 'integer', example: 456)
+    )]
     #[OA\Response(
         response: 200,
         description: 'SSE stream of AI response chunks',
@@ -295,6 +309,11 @@ class StreamController extends AbstractController
         // and we normalize the empty string to null so "no folder selected"
         // behaves the same as an absent parameter.
         $ragGroupKey = $request->query->getString('ragGroupKey') ?: null;
+        // Quoted reference the user selected from an earlier message ("Mention
+        // in chat"). `getString()` rejects array input with a clean 400, and we
+        // normalize the empty string to null so an absent quote behaves the same.
+        $quotedText = $request->query->getString('quotedText') ?: null;
+        $quotedMessageId = $request->query->get('quotedMessageId');
         $continueMessageId = $request->query->get('continueMessageId');
         // Explicit opt-out from memory loading + extraction (used by public demo via synaplan.com/try-chat)
         $disableMemories = '1' === $request->query->get('disableMemories', '0');
@@ -395,7 +414,7 @@ class StreamController extends AbstractController
         $response->headers->set('X-Accel-Buffering', 'no');
         $response->headers->set('Connection', 'keep-alive');
 
-        $response->setCallback(function () use ($user, $messageText, $trackId, $chatId, $includeReasoning, $webSearch, $modelId, $isAgain, $fileIdArray, $isWidgetMode, $isGuestMode, $fixedTaskPromptTopic, $ragGroupKey, $widgetSession, $guestSession, $rateLimitError, $voiceReply, $continueMessageId, $disableMemories, $clientCountry) {
+        $response->setCallback(function () use ($user, $messageText, $trackId, $chatId, $includeReasoning, $webSearch, $modelId, $isAgain, $fileIdArray, $isWidgetMode, $isGuestMode, $fixedTaskPromptTopic, $ragGroupKey, $widgetSession, $guestSession, $rateLimitError, $voiceReply, $continueMessageId, $disableMemories, $clientCountry, $quotedText, $quotedMessageId) {
             // Disable output buffering
             while (ob_get_level()) {
                 ob_end_clean();
@@ -515,6 +534,20 @@ class StreamController extends AbstractController
                     $messageText = 'Continue your previous response.';
                 }
 
+                // Validate the quoted reference (if any): the source message must
+                // belong to the same chat and user. An invalid id simply drops the
+                // structured back-reference — the quoted text itself is still used.
+                $resolvedQuotedMessageId = null;
+                if ($quotedText && $quotedMessageId) {
+                    $quotedSource = $this->em->getRepository(Message::class)->find((int) $quotedMessageId);
+                    if ($quotedSource
+                        && $quotedSource->getUserId() === $user->getId()
+                        && $quotedSource->getChatId() === (int) $chatId
+                    ) {
+                        $resolvedQuotedMessageId = (int) $quotedMessageId;
+                    }
+                }
+
                 // Create incoming message
                 $incomingMessage = new Message();
                 $incomingMessage->setUserId($user->getId());
@@ -533,6 +566,18 @@ class StreamController extends AbstractController
 
                 $this->em->persist($incomingMessage);
                 $this->em->flush(); // Flush first so message has an ID
+
+                // Persist the quoted reference as message meta so it survives a
+                // reload (rendered as a blockquote in the user bubble). Flushed
+                // here independently of the em->clear() that the file path below
+                // performs, so the meta rows are safe on disk before any detach.
+                if ($quotedText) {
+                    $incomingMessage->setMeta('quoted_text', $quotedText);
+                    if (null !== $resolvedQuotedMessageId) {
+                        $incomingMessage->setMeta('quoted_message_id', (string) $resolvedQuotedMessageId);
+                    }
+                    $this->em->flush();
+                }
 
                 // Attach multiple files if uploaded (NEW: File entities with ManyToMany)
                 if (!empty($fileIdArray)) {
@@ -630,6 +675,15 @@ class StreamController extends AbstractController
                     // location-awareness line appended to the chat system prompt.
                     'client_country' => $clientCountry,
                 ];
+
+                // Quoted reference ("Mention in chat"): ChatHandler injects this
+                // as a dedicated context block in the system prompt.
+                if ($quotedText) {
+                    $processingOptions['quoted_text'] = $quotedText;
+                    if (null !== $resolvedQuotedMessageId) {
+                        $processingOptions['quoted_message_id'] = $resolvedQuotedMessageId;
+                    }
+                }
 
                 if ($isWidgetMode || $isGuestMode || $disableMemories) {
                     $processingOptions['disable_memories'] = true;

--- a/backend/src/Service/Message/Handler/ChatHandler.php
+++ b/backend/src/Service/Message/Handler/ChatHandler.php
@@ -326,14 +326,6 @@ final readonly class ChatHandler implements MessageHandlerInterface
             ]);
         }
 
-        // Quoted reference ("Mention in chat") — non-streaming/channel parity.
-        if (!empty($options['quoted_text'])) {
-            $systemPrompt .= $this->formatQuotedReferenceForPrompt($options);
-            $this->logger->info('ChatHandler: Quoted reference appended to system prompt (non-streaming)', [
-                'quoted_message_id' => $options['quoted_message_id'] ?? null,
-            ]);
-        }
-
         // Append explicit language directive based on detected language from classification.
         // Built via LanguageDirectiveBuilder so the wording stays consistent
         // across handlers and includes the anti-echo clause that prevents
@@ -373,6 +365,17 @@ final readonly class ChatHandler implements MessageHandlerInterface
             $searchResults = null;
         }
 
+        // Quoted reference ("Mention in chat") — injected after the capability
+        // check so it lands in the SYSTEM role when supported, and falls back to
+        // the user turn (via buildMessages) for models without system messages.
+        if (null !== $systemPrompt && !empty($options['quoted_text'])) {
+            $systemPrompt .= $this->formatQuotedReferenceForPrompt($options);
+            $this->logger->info('ChatHandler: Quoted reference appended to system prompt (non-streaming)', [
+                'quoted_message_id' => $options['quoted_message_id'] ?? null,
+            ]);
+            unset($options['quoted_text'], $options['quoted_message_id']);
+        }
+
         if ($hasImages && !$includeImagesInMessages) {
             throw new VisionModelRequiredException();
         }
@@ -381,6 +384,8 @@ final readonly class ChatHandler implements MessageHandlerInterface
             'search_results' => $searchResults,
             'rag_context' => $ragContext,
             'include_images' => $includeImagesInMessages,
+            'quoted_text' => $options['quoted_text'] ?? null,
+            'quoted_message_id' => $options['quoted_message_id'] ?? null,
         ]);
 
         $aiOptions = [
@@ -1468,6 +1473,13 @@ final readonly class ChatHandler implements MessageHandlerInterface
                 'results_count' => count($options['search_results']['results']),
                 'query' => $options['search_results']['query'] ?? '',
             ]);
+        }
+
+        // Fallback only: handle() injects the quote into the system prompt and
+        // clears this option for models with system-message support. Models
+        // without it (e.g. o1) keep the quote here on the user turn.
+        if (!empty($options['quoted_text'])) {
+            $msgArr['BTEXT'] .= "\n\n".$this->formatQuotedReferenceForPrompt($options);
         }
 
         // Extract images from current message for vision support (only if enabled)

--- a/backend/src/Service/Message/Handler/ChatHandler.php
+++ b/backend/src/Service/Message/Handler/ChatHandler.php
@@ -38,6 +38,9 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 #[AutoconfigureTag('app.message.handler')]
 final readonly class ChatHandler implements MessageHandlerInterface
 {
+    /** Maximum length of a quoted-reference excerpt injected into the prompt. */
+    private const MAX_QUOTED_REFERENCE_LENGTH = 4000;
+
     /** @var iterable<PluginContextProviderInterface> */
     private iterable $pluginContextProviders;
 
@@ -320,6 +323,14 @@ final readonly class ChatHandler implements MessageHandlerInterface
             $systemPrompt .= "\n\n".$urlContent;
             $this->logger->info('ChatHandler: URL content appended to system prompt', [
                 'url_content_length' => strlen($urlContent),
+            ]);
+        }
+
+        // Quoted reference ("Mention in chat") — non-streaming/channel parity.
+        if (!empty($options['quoted_text'])) {
+            $systemPrompt .= $this->formatQuotedReferenceForPrompt($options);
+            $this->logger->info('ChatHandler: Quoted reference appended to system prompt (non-streaming)', [
+                'quoted_message_id' => $options['quoted_message_id'] ?? null,
             ]);
         }
 
@@ -877,6 +888,19 @@ final readonly class ChatHandler implements MessageHandlerInterface
             }
         }
 
+        // Quoted reference ("Mention in chat"): the user selected an excerpt from
+        // an earlier message as the focus of this request. Inject it into the
+        // SYSTEM role for the same trust-boundary reasons as web search. When the
+        // model has no system-message support the option stays set and
+        // buildCurrentMessageContent() appends it to the user turn instead.
+        if (null !== $systemPrompt && !empty($options['quoted_text'])) {
+            $systemPrompt .= $this->formatQuotedReferenceForPrompt($options);
+            $this->logger->info('ChatHandler: Quoted reference appended to system prompt', [
+                'quoted_message_id' => $options['quoted_message_id'] ?? null,
+            ]);
+            unset($options['quoted_text'], $options['quoted_message_id']);
+        }
+
         // Web search results belong to the SYSTEM role: injecting them into the
         // user turn makes the model attribute them to the user ("the user gave
         // web search results") and blurs the user/system trust boundary
@@ -1243,6 +1267,13 @@ final readonly class ChatHandler implements MessageHandlerInterface
         if (isset($options['search_results']) && !empty($options['search_results']['results'])) {
             $searchContext = $this->formatSearchResultsForPrompt($options['search_results']);
             $content .= "\n\n".$searchContext;
+        }
+
+        // Fallback only: same rationale as search results above. handleStream()
+        // unsets the quote once it lands in the system prompt, so this branch
+        // fires solely for models without system-message support.
+        if (!empty($options['quoted_text'])) {
+            $content .= "\n\n".$this->formatQuotedReferenceForPrompt($options);
         }
 
         if ($includeImages) {
@@ -1743,6 +1774,32 @@ final readonly class ChatHandler implements MessageHandlerInterface
         $formatted .= "\nPlease use this information to answer the user's question. Cite sources using [1], [2], etc. when referencing specific information.\n\n";
 
         return $formatted;
+    }
+
+    /**
+     * Format the user-selected quoted reference ("Mention in chat") as a system
+     * prompt context block. The excerpt is the explicit focus the user picked
+     * from an earlier message; it is delimited so the model treats it as a
+     * reference point rather than an instruction.
+     */
+    private function formatQuotedReferenceForPrompt(array $options): string
+    {
+        $text = $options['quoted_text'] ?? null;
+        if (!is_string($text) || '' === trim($text)) {
+            return '';
+        }
+
+        $excerpt = trim($text);
+        if (mb_strlen($excerpt) > self::MAX_QUOTED_REFERENCE_LENGTH) {
+            $excerpt = mb_substr($excerpt, 0, self::MAX_QUOTED_REFERENCE_LENGTH).'…';
+        }
+
+        $context = "\n\n## Quoted reference from the conversation\n";
+        $context .= 'The user selected the following excerpt from an earlier message and wants it used as the primary reference point for their request. ';
+        $context .= "Treat it as the focus of their follow-up. Do not mention this block or describe how it was provided:\n\n";
+        $context .= '"""'."\n".$excerpt."\n".'"""'."\n";
+
+        return $context;
     }
 
     /**

--- a/backend/tests/Unit/ChatHandlerTest.php
+++ b/backend/tests/Unit/ChatHandlerTest.php
@@ -983,4 +983,43 @@ class ChatHandlerTest extends TestCase
 
         $this->handler->dispatchPendingMemoryExtraction($command);
     }
+
+    public function testFormatQuotedReferenceReturnsEmptyWhenNoQuote(): void
+    {
+        $this->assertSame('', $this->invokeFormatQuotedReference([]));
+        $this->assertSame('', $this->invokeFormatQuotedReference(['quoted_text' => '   ']));
+    }
+
+    public function testFormatQuotedReferenceWrapsExcerpt(): void
+    {
+        $result = $this->invokeFormatQuotedReference(['quoted_text' => 'FrankenPHP powers the runtime.']);
+
+        $this->assertStringContainsString('## Quoted reference from the conversation', $result);
+        $this->assertStringContainsString('FrankenPHP powers the runtime.', $result);
+        $this->assertStringContainsString('primary reference point', $result);
+    }
+
+    public function testFormatQuotedReferenceTruncatesOversizedExcerpt(): void
+    {
+        $longText = str_repeat('a', 5000);
+        $result = $this->invokeFormatQuotedReference(['quoted_text' => $longText]);
+
+        // 4000 char cap + ellipsis, plus the surrounding template text.
+        $this->assertStringContainsString('…', $result);
+        $this->assertLessThan(5000, mb_strlen($result));
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    private function invokeFormatQuotedReference(array $options): string
+    {
+        $method = new \ReflectionMethod(ChatHandler::class, 'formatQuotedReferenceForPrompt');
+        $method->setAccessible(true);
+
+        /** @var string $result */
+        $result = $method->invoke($this->handler, $options);
+
+        return $result;
+    }
 }

--- a/frontend/src/components/ChatInput.vue
+++ b/frontend/src/components/ChatInput.vue
@@ -21,7 +21,13 @@
   >
     <div class="max-w-4xl mx-auto px-4 py-2 md:py-4">
       <!-- Active Command and File Display (above input) -->
-      <div v-if="activeCommand || uploadedFiles.length > 0" class="mb-3 flex flex-wrap gap-2">
+      <div
+        v-if="activeCommand || uploadedFiles.length > 0 || quote"
+        class="mb-3 flex flex-wrap gap-2"
+      >
+        <!-- Quoted reference chip -->
+        <QuoteChip v-if="quote" :quote="quote" @remove="emit('clearQuote')" />
+
         <!-- Uploaded Files -->
         <div
           v-for="(file, index) in uploadedFiles"
@@ -315,6 +321,8 @@ import { useAutoPersist } from '@/composables/useInputPersistence'
 import { useChatsStore } from '@/stores/chats'
 import { useAppModeStore } from '@/stores/appMode'
 import { useAuthStore } from '@/stores/auth'
+import QuoteChip from './QuoteChip.vue'
+import type { QuotedReference } from '@/composables/useMessageQuoting'
 
 interface UploadedFile {
   file_id: number
@@ -327,6 +335,7 @@ interface UploadedFile {
 interface Props {
   isStreaming?: boolean
   isGuestMode?: boolean
+  quote?: QuotedReference | null
 }
 
 const props = defineProps<Props>()
@@ -464,10 +473,13 @@ const emit = defineEmits<{
       voiceReply?: boolean
       modelId?: number
       ragGroupKey?: string
+      quotedText?: string
+      quotedMessageId?: number
     },
   ]
   stop: []
   guestFeatureGate: [featureKey: string]
+  clearQuote: []
 }>()
 
 const commandsStore = useCommandsStore()
@@ -652,6 +664,8 @@ const sendMessage = () => {
     voiceReply: voiceReply.value,
     modelId: selectedModelId.value || undefined,
     ragGroupKey: selectedGroupKey.value || undefined,
+    quotedText: props.quote?.text || undefined,
+    quotedMessageId: props.quote?.messageId || undefined,
   }
   emit('send', messageToSend, options)
   message.value = ''
@@ -661,6 +675,7 @@ const sendMessage = () => {
   mentionQuery.value = ''
   activeCommand.value = null
   voiceReply.value = false
+  emit('clearQuote')
   // Reset enhance state after sending
   enhanceEnabled.value = false
   originalMessage.value = ''

--- a/frontend/src/components/ChatMessage.vue
+++ b/frontend/src/components/ChatMessage.vue
@@ -309,7 +309,21 @@
         </div>
 
         <!-- Bubble content (only non-thinking parts) -->
-        <div class="px-4 py-3 overflow-x-clip overflow-y-visible space-y-3">
+        <div
+          class="px-4 py-3 overflow-x-clip overflow-y-visible space-y-3"
+          data-quotable
+          :data-message-id="backendMessageId"
+          :data-message-role="role"
+        >
+          <!-- Quoted reference the user attached when sending this message -->
+          <div
+            v-if="quotedText"
+            class="border-l-2 border-[var(--brand)]/60 pl-3 py-0.5 text-sm italic opacity-80 whitespace-pre-wrap break-words"
+            data-testid="message-quote"
+          >
+            {{ quotedText }}
+          </div>
+
           <!-- Combined Badges: Files + Web Search + Tool (NEW) -->
           <div v-if="(files && files.length > 0) || webSearch || tool" class="space-y-2">
             <!-- Show badges with smart collapsing -->
@@ -969,6 +983,10 @@ interface Props {
   originalMediaType?: string | null
   againData?: AgainData
   backendMessageId?: number
+  /** Text the user quoted from an earlier message when composing this one. */
+  quotedText?: string | null
+  /** Backend id of the message the quote was taken from. */
+  quotedMessageId?: number | null
   processingStatus?: string
   processingMetadata?: {
     model_name?: string

--- a/frontend/src/components/QuoteChip.vue
+++ b/frontend/src/components/QuoteChip.vue
@@ -1,0 +1,35 @@
+<template>
+  <div
+    class="flex items-start gap-2 px-3 py-2 surface-chip rounded-lg max-w-full md:max-w-md"
+    data-testid="chip-quote"
+  >
+    <Icon icon="mdi:format-quote-close" class="w-4 h-4 mt-0.5 flex-shrink-0 text-[var(--brand)]" />
+    <span class="text-sm txt-secondary line-clamp-2 break-words min-w-0">{{ quote.text }}</span>
+    <button
+      type="button"
+      class="icon-ghost p-0 min-w-0 w-auto h-auto flex-shrink-0"
+      :aria-label="t('chat.quote.remove')"
+      data-testid="btn-quote-remove"
+      @click="emit('remove')"
+    >
+      <XMarkIcon class="w-4 h-4" />
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+import { Icon } from '@iconify/vue'
+import { XMarkIcon } from '@heroicons/vue/24/outline'
+import type { QuotedReference } from '@/composables/useMessageQuoting'
+
+defineProps<{
+  quote: QuotedReference
+}>()
+
+const emit = defineEmits<{
+  remove: []
+}>()
+
+const { t } = useI18n()
+</script>

--- a/frontend/src/components/QuoteSelectionButton.vue
+++ b/frontend/src/components/QuoteSelectionButton.vue
@@ -1,0 +1,48 @@
+<template>
+  <Teleport to="body">
+    <button
+      v-if="visible"
+      type="button"
+      class="fixed z-[9999] flex items-center gap-1.5 px-3 py-1.5 rounded-lg surface-card shadow-lg border border-light-border/30 dark:border-dark-border/20 text-sm font-medium txt-primary hover:bg-black/5 dark:hover:bg-white/10 transition-colors"
+      :style="style"
+      data-testid="btn-quote-selection"
+      @mousedown.prevent
+      @click="emit('quote')"
+    >
+      <Icon icon="mdi:format-quote-close" class="w-4 h-4 text-[var(--brand)]" />
+      {{ t('chat.quote.button') }}
+    </button>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { Icon } from '@iconify/vue'
+import type { FloatingButtonPosition } from '@/composables/useMessageQuoting'
+
+const props = defineProps<{
+  visible: boolean
+  position: FloatingButtonPosition
+}>()
+
+const emit = defineEmits<{
+  quote: []
+}>()
+
+const { t } = useI18n()
+
+const GAP = 8
+const MIN_TOP_SPACE = 56
+
+// Place the button centered above the selection, flipping below when the
+// selection sits too close to the viewport's top edge.
+const style = computed(() => {
+  const openBelow = props.position.top < MIN_TOP_SPACE
+  return {
+    left: `${props.position.left}px`,
+    top: openBelow ? `${props.position.bottom + GAP}px` : `${props.position.top - GAP}px`,
+    transform: openBelow ? 'translate(-50%, 0)' : 'translate(-50%, -100%)',
+  }
+})
+</script>

--- a/frontend/src/composables/useMessageQuoting.ts
+++ b/frontend/src/composables/useMessageQuoting.ts
@@ -1,0 +1,185 @@
+import { onMounted, onUnmounted, ref, type Ref } from 'vue'
+
+/**
+ * A piece of text the user selected inside a chat message and wants to
+ * reference in their next message ("Mention in chat", like Claude).
+ */
+export interface QuotedReference {
+  text: string
+  /** Backend message id of the source message, when available. */
+  messageId?: number
+  /** Role of the source message ('user' | 'assistant'). */
+  role?: string
+}
+
+export interface FloatingButtonPosition {
+  /** Viewport-relative top edge of the selection rect. */
+  top: number
+  /** Viewport-relative bottom edge of the selection rect. */
+  bottom: number
+  /** Viewport-relative horizontal center of the selection rect. */
+  left: number
+}
+
+const MIN_SELECTION_LENGTH = 2
+const MAX_QUOTE_LENGTH = 4000
+
+/**
+ * Render a quoted reference as a Markdown blockquote prefix for messages that
+ * are sent verbatim to a human recipient (e.g. operator replies in LiveSupport
+ * and Widget Sessions, where there is no structured backend quote field).
+ */
+export function formatQuoteAsBlockquote(text: string): string {
+  return text
+    .split('\n')
+    .map((line) => `> ${line}`)
+    .join('\n')
+}
+
+/**
+ * Tracks text selections inside a chat scroll container and exposes the state
+ * needed to render a floating "quote" button above the selection plus the
+ * confirmed quote that the composer should attach to the next message.
+ *
+ * Only selections that originate inside an element marked with
+ * `data-quotable` (and live within `rootRef`) are considered quotable. The
+ * source message id/role are read from `data-message-id` / `data-message-role`
+ * on that element.
+ */
+export function useMessageQuoting(rootRef: Ref<HTMLElement | null>) {
+  const floatingVisible = ref(false)
+  const floatingPosition = ref<FloatingButtonPosition>({ top: 0, bottom: 0, left: 0 })
+  const pendingQuote = ref<QuotedReference | null>(null)
+
+  // Raw selection captured on mouseup, awaiting confirmation via the button.
+  let activeSelection: QuotedReference | null = null
+  let activeRange: Range | null = null
+
+  const hideButton = () => {
+    floatingVisible.value = false
+    activeSelection = null
+    activeRange = null
+  }
+
+  const findQuotable = (node: Node | null): HTMLElement | null => {
+    let current: Node | null = node
+    while (current && current !== rootRef.value) {
+      if (current instanceof HTMLElement && current.hasAttribute('data-quotable')) {
+        return current
+      }
+      current = current.parentNode
+    }
+    return null
+  }
+
+  const positionFromRange = (range: Range): FloatingButtonPosition | null => {
+    const rect = range.getBoundingClientRect()
+    if (rect.width === 0 && rect.height === 0) return null
+    return {
+      top: rect.top,
+      bottom: rect.bottom,
+      left: rect.left + rect.width / 2,
+    }
+  }
+
+  const evaluateSelection = () => {
+    const root = rootRef.value
+    if (!root) {
+      hideButton()
+      return
+    }
+
+    const selection = window.getSelection()
+    if (!selection || selection.isCollapsed || selection.rangeCount === 0) {
+      hideButton()
+      return
+    }
+
+    const text = selection.toString().trim()
+    if (text.length < MIN_SELECTION_LENGTH) {
+      hideButton()
+      return
+    }
+
+    const range = selection.getRangeAt(0)
+    const quotable = findQuotable(range.commonAncestorContainer)
+    if (!quotable || !root.contains(quotable)) {
+      hideButton()
+      return
+    }
+
+    const position = positionFromRange(range)
+    if (!position) {
+      hideButton()
+      return
+    }
+
+    const messageIdRaw = quotable.dataset.messageId
+    const messageId = messageIdRaw ? Number(messageIdRaw) : undefined
+
+    activeSelection = {
+      text: text.slice(0, MAX_QUOTE_LENGTH),
+      messageId: messageId !== undefined && Number.isFinite(messageId) ? messageId : undefined,
+      role: quotable.dataset.messageRole,
+    }
+    activeRange = range
+    floatingPosition.value = position
+    floatingVisible.value = true
+  }
+
+  const onMouseUp = () => {
+    // Defer so the browser has finalized the selection before we read it.
+    window.setTimeout(evaluateSelection, 0)
+  }
+
+  const onSelectionChange = () => {
+    const selection = window.getSelection()
+    if (!selection || selection.isCollapsed || selection.toString().trim().length === 0) {
+      hideButton()
+    }
+  }
+
+  const reposition = () => {
+    if (!floatingVisible.value || !activeRange) return
+    const position = positionFromRange(activeRange)
+    if (position) {
+      floatingPosition.value = position
+    } else {
+      hideButton()
+    }
+  }
+
+  const confirmQuote = () => {
+    if (!activeSelection) return
+    pendingQuote.value = { ...activeSelection }
+    hideButton()
+    window.getSelection()?.removeAllRanges()
+  }
+
+  const clearPendingQuote = () => {
+    pendingQuote.value = null
+  }
+
+  onMounted(() => {
+    document.addEventListener('mouseup', onMouseUp)
+    document.addEventListener('selectionchange', onSelectionChange)
+    window.addEventListener('scroll', reposition, true)
+    window.addEventListener('resize', reposition)
+  })
+
+  onUnmounted(() => {
+    document.removeEventListener('mouseup', onMouseUp)
+    document.removeEventListener('selectionchange', onSelectionChange)
+    window.removeEventListener('scroll', reposition, true)
+    window.removeEventListener('resize', reposition)
+  })
+
+  return {
+    floatingVisible,
+    floatingPosition,
+    pendingQuote,
+    confirmQuote,
+    clearPendingQuote,
+    hideButton,
+  }
+}

--- a/frontend/src/composables/useMessageQuoting.ts
+++ b/frontend/src/composables/useMessageQuoting.ts
@@ -22,7 +22,12 @@ export interface FloatingButtonPosition {
 }
 
 const MIN_SELECTION_LENGTH = 2
-const MAX_QUOTE_LENGTH = 4000
+// Kept URL-safe: the quote travels as a query param on the EventSource (GET)
+// stream URL, so an over-long excerpt could blow past reverse-proxy request
+// limits (e.g. Nginx's 8 KB default). 1000 chars is plenty for a reference
+// point and stays well within budget even worst-case URL-encoded. The backend
+// enforces the same cap (StreamController::MAX_QUOTED_TEXT_LENGTH).
+const MAX_QUOTE_LENGTH = 1000
 
 /**
  * Render a quoted reference as a Markdown blockquote prefix for messages that
@@ -117,8 +122,15 @@ export function useMessageQuoting(rootRef: Ref<HTMLElement | null>) {
     const messageIdRaw = quotable.dataset.messageId
     const messageId = messageIdRaw ? Number(messageIdRaw) : undefined
 
+    // Trim over-long selections to the URL-safe budget, appending an ellipsis
+    // so the user can see the quote was shortened (chip + bubble blockquote).
+    // The ellipsis is counted in the budget so the final string never exceeds
+    // MAX_QUOTE_LENGTH and the backend cap can't chop it off.
+    const quoteText =
+      text.length > MAX_QUOTE_LENGTH ? `${text.slice(0, MAX_QUOTE_LENGTH - 1)}…` : text
+
     activeSelection = {
-      text: text.slice(0, MAX_QUOTE_LENGTH),
+      text: quoteText,
       messageId: messageId !== undefined && Number.isFinite(messageId) ? messageId : undefined,
       role: quotable.dataset.messageRole,
     }

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -62,6 +62,10 @@
   "chat": {
     "title": "Chat",
     "newChat": "Neuer Chat",
+    "quote": {
+      "button": "Im Chat erwähnen",
+      "remove": "Zitat entfernen"
+    },
     "noChats": "Keine Chats vorhanden",
     "timeNow": "jetzt",
     "timeMinutes": "{n}m",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -67,6 +67,10 @@
     "config": "AI Config",
     "statistics": "Statistics",
     "newChat": "New Chat",
+    "quote": {
+      "button": "Mention in chat",
+      "remove": "Remove quote"
+    },
     "noChats": "No chats available",
     "timeNow": "now",
     "timeMinutes": "{n}m",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -66,6 +66,10 @@
     "config": "Configuración de IA",
     "statistics": "Estadísticas",
     "newChat": "Nuevo Chat",
+    "quote": {
+      "button": "Mencionar en el chat",
+      "remove": "Quitar cita"
+    },
     "noChats": "No hay chats disponibles",
     "showMore": "Mostrar más",
     "showLess": "Mostrar menos",

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -66,6 +66,10 @@
     "config": "AI Yapılandırması",
     "statistics": "İstatistikler",
     "newChat": "Yeni Sohbet",
+    "quote": {
+      "button": "Sohbette belirt",
+      "remove": "Alıntıyı kaldır"
+    },
     "noChats": "Sohbet yok",
     "showMore": "Daha fazla göster",
     "showLess": "Daha az göster",

--- a/frontend/src/services/api/chatApi.ts
+++ b/frontend/src/services/api/chatApi.ts
@@ -300,6 +300,8 @@ export const chatApi = {
     isAgain?: boolean
     continueMessageId?: number
     ragGroupKey?: string
+    quotedText?: string
+    quotedMessageId?: number
   }): () => void {
     const paramsObj: Record<string, string> = {
       message: opts.message,
@@ -315,6 +317,8 @@ export const chatApi = {
     if (opts.isAgain) paramsObj.isAgain = '1'
     if (opts.continueMessageId) paramsObj.continueMessageId = opts.continueMessageId.toString()
     if (opts.ragGroupKey) paramsObj.ragGroupKey = opts.ragGroupKey
+    if (opts.quotedText) paramsObj.quotedText = opts.quotedText
+    if (opts.quotedMessageId) paramsObj.quotedMessageId = opts.quotedMessageId.toString()
 
     if (opts.fileIds && opts.fileIds.length > 0) {
       paramsObj.fileIds = opts.fileIds.join(',')
@@ -557,6 +561,8 @@ export const chatApi = {
     chatId: number
     trackId?: number
     onUpdate: (data: StreamUpdatePayload) => void
+    quotedText?: string
+    quotedMessageId?: number
   }): () => void {
     const paramsObj: Record<string, string> = {
       message: opts.message,
@@ -565,6 +571,8 @@ export const chatApi = {
     }
 
     if (opts.trackId) paramsObj.trackId = opts.trackId.toString()
+    if (opts.quotedText) paramsObj.quotedText = opts.quotedText
+    if (opts.quotedMessageId) paramsObj.quotedMessageId = opts.quotedMessageId.toString()
 
     const params = new URLSearchParams(paramsObj)
     const url = `${getApiBaseUrl()}/api/v1/messages/stream?${params}`

--- a/frontend/src/stores/history.ts
+++ b/frontend/src/stores/history.ts
@@ -94,6 +94,10 @@ export interface Message {
   againData?: AgainData
   originalMessageId?: number
   backendMessageId?: number
+  /** Text the user quoted from an earlier message when composing this one. */
+  quotedText?: string | null
+  /** Backend id of the message the quote was taken from. */
+  quotedMessageId?: number | null
   files?: MessageFile[] // Attached files
   // Status for failed/pending messages
   status?: 'sent' | 'failed' | 'rate_limited'
@@ -233,6 +237,8 @@ interface ApiLoadedMessageRow {
   webSearch?: Message['webSearch']
   searchResults?: Message['searchResults']
   multitask?: boolean
+  quotedText?: string | null
+  quotedMessageId?: number | null
   file?: { path: string; type: string }
   files?: ApiLoadedAttachmentFile[]
 }
@@ -367,7 +373,9 @@ export const useHistoryStore = defineStore('history', () => {
     backendMessageId?: number,
     originalMessageId?: number,
     webSearch?: { enabled?: boolean; query?: string; resultsCount?: number } | null,
-    tool?: { command: string; label: string; icon: string } | null
+    tool?: { command: string; label: string; icon: string } | null,
+    quotedText?: string | null,
+    quotedMessageId?: number | null
   ) => {
     messages.value.push({
       id: crypto.randomUUID(),
@@ -382,6 +390,8 @@ export const useHistoryStore = defineStore('history', () => {
       originalMessageId,
       webSearch,
       tool,
+      quotedText,
+      quotedMessageId,
     })
   }
 
@@ -635,6 +645,8 @@ export const useHistoryStore = defineStore('history', () => {
             originalTopic: m.originalTopic || null,
             originalMediaType: m.originalMediaType ?? m.original_media_type ?? null,
             backendMessageId: m.id,
+            quotedText: m.quotedText ?? null,
+            quotedMessageId: m.quotedMessageId ?? null,
             files: files.length > 0 ? files : undefined,
             aiModels: m.aiModels || null,
             webSearch: m.webSearch || null,

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -151,6 +151,8 @@
               :original-media-type="message.originalMediaType"
               :again-data="message.againData"
               :backend-message-id="message.backendMessageId"
+              :quoted-text="message.quotedText"
+              :quoted-message-id="message.quotedMessageId"
               :processing-status="message.isStreaming ? processingStatus : undefined"
               :processing-metadata="message.isStreaming ? processingMetadata : undefined"
               :files="message.files"
@@ -197,13 +199,21 @@
         @action="handlePromoAction"
       />
 
+      <QuoteSelectionButton
+        :visible="quoting.floatingVisible.value"
+        :position="quoting.floatingPosition.value"
+        @quote="quoting.confirmQuote"
+      />
+
       <ChatInput
         ref="chatInputRef"
         :is-streaming="isStreaming"
         :is-guest-mode="isGuestMode"
+        :quote="quoting.pendingQuote.value"
         @send="handleSendMessage"
         @stop="handleStopStreaming"
         @guest-feature-gate="handleGuestFeatureGate"
+        @clear-quote="quoting.clearPendingQuote"
       />
 
       <!--
@@ -335,6 +345,8 @@ import { Icon } from '@iconify/vue'
 import MainLayout from '@/components/MainLayout.vue'
 import ChatInput from '@/components/ChatInput.vue'
 import ChatMessage from '@/components/ChatMessage.vue'
+import QuoteSelectionButton from '@/components/QuoteSelectionButton.vue'
+import { useMessageQuoting } from '@/composables/useMessageQuoting'
 import LimitReachedModal from '@/components/common/LimitReachedModal.vue'
 import {
   useHistoryStore,
@@ -405,6 +417,7 @@ const { error: showErrorToast, success: showSuccessToast } = useNotification()
 
 const chatContainer = ref<HTMLElement | null>(null)
 const chatInputRef = ref<InstanceType<typeof ChatInput> | null>(null)
+const quoting = useMessageQuoting(chatContainer)
 const autoScroll = ref(true)
 const isDragging = ref(false)
 const dragCounter = ref(0)
@@ -1219,6 +1232,8 @@ const handleSendMessage = async (
     fileIds?: number[]
     voiceReply?: boolean
     ragGroupKey?: string
+    quotedText?: string
+    quotedMessageId?: number
   }
 ) => {
   autoScroll.value = true
@@ -1346,7 +1361,9 @@ const handleSendMessage = async (
     undefined, // backendMessageId
     undefined, // originalMessageId
     webSearchData, // webSearch
-    toolData // tool
+    toolData, // tool
+    options?.quotedText ?? null, // quotedText
+    options?.quotedMessageId ?? null // quotedMessageId
   )
 
   // Lift the active chat to the top of the sidebar lists right away so the
@@ -1454,6 +1471,8 @@ const streamAIResponse = async (
     voiceReply?: boolean
     isAgain?: boolean
     ragGroupKey?: string
+    quotedText?: string
+    quotedMessageId?: number
   }
 ) => {
   streamingAbortController = new AbortController()
@@ -1508,6 +1527,8 @@ const streamAIResponse = async (
         message: userMessage,
         chatId: guestChatId,
         trackId,
+        quotedText: options?.quotedText,
+        quotedMessageId: options?.quotedMessageId,
         onUpdate: (data) => {
           if (streamingAbortController?.signal.aborted) return
 
@@ -1728,6 +1749,8 @@ const streamAIResponse = async (
         voiceReply: options?.voiceReply,
         isAgain: options?.isAgain,
         ragGroupKey: options?.ragGroupKey,
+        quotedText: options?.quotedText,
+        quotedMessageId: options?.quotedMessageId,
         onUpdate: (data) => {
           // CRITICAL: Check abort signal at the very beginning
           if (streamingAbortController?.signal.aborted) {

--- a/frontend/src/views/LiveSupportView.vue
+++ b/frontend/src/views/LiveSupportView.vue
@@ -172,13 +172,26 @@
                   }}
                   · {{ formatMessageTime(message.timestamp) }}
                 </p>
-                <p class="txt-primary text-sm whitespace-pre-wrap">{{ message.text }}</p>
+                <p
+                  class="txt-primary text-sm whitespace-pre-wrap"
+                  data-quotable
+                  :data-message-id="message.id"
+                  :data-message-role="message.direction === 'IN' ? 'visitor' : 'agent'"
+                >
+                  {{ message.text }}
+                </p>
               </div>
             </template>
           </div>
 
           <!-- Input -->
           <div class="p-4 border-t border-light-border/30 dark:border-dark-border/20">
+            <QuoteChip
+              v-if="quoting.pendingQuote.value"
+              :quote="quoting.pendingQuote.value"
+              class="mb-2"
+              @remove="quoting.clearPendingQuote"
+            />
             <div class="flex gap-2">
               <textarea
                 v-model="replyText"
@@ -211,6 +224,12 @@
         </div>
       </div>
     </div>
+
+    <QuoteSelectionButton
+      :visible="quoting.floatingVisible.value"
+      :position="quoting.floatingPosition.value"
+      @quote="quoting.confirmQuote"
+    />
   </MainLayout>
 </template>
 
@@ -229,6 +248,9 @@ import {
   type WidgetSubscription,
 } from '@/services/realtime/widgetOperatorRealtime'
 import ConnectionStatusBadge from '@/components/realtime/ConnectionStatusBadge.vue'
+import QuoteSelectionButton from '@/components/QuoteSelectionButton.vue'
+import QuoteChip from '@/components/QuoteChip.vue'
+import { useMessageQuoting, formatQuoteAsBlockquote } from '@/composables/useMessageQuoting'
 
 const { t } = useI18n()
 const { formatRelativeTime, formatTime: formatTimeStr } = useDateFormat()
@@ -245,6 +267,7 @@ const activeTab = ref<'waiting' | 'active'>('waiting')
 const replyText = ref('')
 const sending = ref(false)
 const messagesContainer = ref<HTMLElement | null>(null)
+const quoting = useMessageQuoting(messagesContainer)
 
 let notificationSubscriptions: WidgetSubscription[] = []
 
@@ -328,6 +351,13 @@ const sendReply = async () => {
     selectedWidgetId.value || selectedSession.value.widgetId || widgets.value[0]?.widgetId
   if (!widgetId) return
 
+  // Prepend the quoted excerpt (if any) as a Markdown blockquote so the
+  // visitor sees what part of the conversation the agent is replying to.
+  const quote = quoting.pendingQuote.value
+  const outgoingText = quote
+    ? `${formatQuoteAsBlockquote(quote.text)}\n\n${replyText.value}`
+    : replyText.value
+
   sending.value = true
   try {
     // Take over if not already in human mode
@@ -339,19 +369,20 @@ const sendReply = async () => {
     await widgetSessionsApi.sendHumanMessage(
       widgetId,
       selectedSession.value.sessionId,
-      replyText.value
+      outgoingText
     )
 
     // Add message to local list
     sessionMessages.value.push({
       id: Date.now(),
       direction: 'OUT',
-      text: replyText.value,
+      text: outgoingText,
       timestamp: Math.floor(Date.now() / 1000),
       sender: 'human',
     })
 
     replyText.value = ''
+    quoting.clearPendingQuote()
     await nextTick()
     scrollToBottom()
     success(t('liveSupport.messageSent'))

--- a/frontend/src/views/WidgetSessionsView.vue
+++ b/frontend/src/views/WidgetSessionsView.vue
@@ -583,6 +583,9 @@
                         ? 'bg-gradient-to-br from-emerald-600 to-emerald-500 text-white rounded-2xl rounded-br-md'
                         : 'bg-white/5 dark:bg-white/5 rounded-2xl rounded-bl-md',
                     ]"
+                    data-quotable
+                    :data-message-id="message.id"
+                    :data-message-role="message.direction === 'OUT' ? 'agent' : 'visitor'"
                   >
                     <MessageText
                       :content="message.text"
@@ -748,6 +751,13 @@
               "
               class="p-4 flex-shrink-0 border-t border-white/5 dark:border-white/5 shadow-[0_-1px_3px_rgba(0,0,0,0.08)]"
             >
+              <!-- Quoted reference chip -->
+              <QuoteChip
+                v-if="quoting.pendingQuote.value"
+                :quote="quoting.pendingQuote.value"
+                class="mb-3"
+                @remove="quoting.clearPendingQuote"
+              />
               <!-- File Preview -->
               <div v-if="selectedFiles.length > 0" class="mb-3 flex flex-wrap gap-2">
                 <div
@@ -951,6 +961,12 @@
         @close="showWidgetConfig = false"
         @saved="handleWidgetConfigSaved"
       />
+
+      <QuoteSelectionButton
+        :visible="quoting.floatingVisible.value"
+        :position="quoting.floatingPosition.value"
+        @quote="quoting.confirmQuote"
+      />
     </div>
   </MainLayout>
 </template>
@@ -981,6 +997,9 @@ import type { WidgetTypingHandle } from '@/services/realtime/widgetTypingChannel
 // Centrifugo connection-state badge — reads from the realtime Pinia store
 // that the operator helpers warm up on first subscribe.
 import ConnectionStatusBadge from '@/components/realtime/ConnectionStatusBadge.vue'
+import QuoteSelectionButton from '@/components/QuoteSelectionButton.vue'
+import QuoteChip from '@/components/QuoteChip.vue'
+import { useMessageQuoting, formatQuoteAsBlockquote } from '@/composables/useMessageQuoting'
 
 const route = useRoute()
 const router = useRouter()
@@ -1017,6 +1036,7 @@ let typingChannel: WidgetTypingHandle | null = null
 // rapid second click.
 let viewSessionToken = 0
 const messagesContainer = ref<HTMLElement | null>(null)
+const quoting = useMessageQuoting(messagesContainer)
 
 // File upload state
 const fileInputRef = ref<HTMLInputElement | null>(null)
@@ -1845,6 +1865,12 @@ const sendMessage = async () => {
   const targetSession = selectedSession.value
   const targetSessionId = targetSession.sessionId
   const filesToSend = [...selectedFiles.value]
+  // Prepend the quoted excerpt (if any) as a Markdown blockquote so the
+  // visitor sees which part of the conversation the agent is replying to.
+  const quote = quoting.pendingQuote.value
+  const composedText = quote
+    ? `${formatQuoteAsBlockquote(quote.text)}\n\n${messageText.value.trim()}`.trim()
+    : messageText.value.trim()
   try {
     // Upload files first if any
     let fileIds: number[] = []
@@ -1853,9 +1879,9 @@ const sendMessage = async () => {
     }
 
     if (targetSession.mode === 'internal') {
-      await sendInternalMessage(messageText.value.trim(), fileIds)
+      await sendInternalMessage(composedText, fileIds)
     } else {
-      const outgoingText = messageText.value.trim() || t('widgetSessions.fileAttached')
+      const outgoingText = composedText || t('widgetSessions.fileAttached')
       const result = await widgetSessionsApi.sendHumanMessage(
         widgetId.value,
         targetSessionId,
@@ -1915,6 +1941,7 @@ const sendMessage = async () => {
       messageText.value = ''
       selectedFiles.value = []
       uploadedFileIds.value = []
+      quoting.clearPendingQuote()
     }
   } catch (err: unknown) {
     error(err instanceof Error ? err.message : t('widgetSessions.sendFailed'))

--- a/frontend/tests/unit/components/QuoteChip.spec.ts
+++ b/frontend/tests/unit/components/QuoteChip.spec.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import QuoteChip from '@/components/QuoteChip.vue'
+
+describe('QuoteChip', () => {
+  it('renders the quoted text', () => {
+    const wrapper = mount(QuoteChip, {
+      props: { quote: { text: 'A quoted excerpt', messageId: 42, role: 'assistant' } },
+    })
+    expect(wrapper.get('[data-testid="chip-quote"]').text()).toContain('A quoted excerpt')
+  })
+
+  it('emits remove when the remove button is clicked', async () => {
+    const wrapper = mount(QuoteChip, {
+      props: { quote: { text: 'something' } },
+    })
+    await wrapper.get('[data-testid="btn-quote-remove"]').trigger('click')
+    expect(wrapper.emitted('remove')).toBeTruthy()
+  })
+})

--- a/frontend/tests/unit/components/QuoteSelectionButton.spec.ts
+++ b/frontend/tests/unit/components/QuoteSelectionButton.spec.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import QuoteSelectionButton from '@/components/QuoteSelectionButton.vue'
+
+const findButton = () =>
+  document.body.querySelector<HTMLButtonElement>('[data-testid="btn-quote-selection"]')
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+describe('QuoteSelectionButton', () => {
+  it('does not render when not visible', () => {
+    mount(QuoteSelectionButton, {
+      props: { visible: false, position: { top: 100, bottom: 120, left: 200 } },
+    })
+    expect(findButton()).toBeNull()
+  })
+
+  it('renders centered above the selection when there is room', () => {
+    mount(QuoteSelectionButton, {
+      props: { visible: true, position: { top: 300, bottom: 320, left: 200 } },
+    })
+    const button = findButton()
+    expect(button).not.toBeNull()
+    expect(button?.style.left).toBe('200px')
+    // 300 (top) - 8 (gap)
+    expect(button?.style.top).toBe('292px')
+    expect(button?.style.transform).toBe('translate(-50%, -100%)')
+  })
+
+  it('flips below the selection when too close to the viewport top', () => {
+    mount(QuoteSelectionButton, {
+      props: { visible: true, position: { top: 10, bottom: 40, left: 150 } },
+    })
+    const button = findButton()
+    // 40 (bottom) + 8 (gap)
+    expect(button?.style.top).toBe('48px')
+    expect(button?.style.transform).toBe('translate(-50%, 0)')
+  })
+
+  it('emits quote when clicked', async () => {
+    const wrapper = mount(QuoteSelectionButton, {
+      props: { visible: true, position: { top: 300, bottom: 320, left: 200 } },
+    })
+    findButton()?.click()
+    await wrapper.vm.$nextTick()
+    expect(wrapper.emitted('quote')).toBeTruthy()
+  })
+})

--- a/frontend/tests/unit/composables/useMessageQuoting.spec.ts
+++ b/frontend/tests/unit/composables/useMessageQuoting.spec.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest'
+import { formatQuoteAsBlockquote } from '@/composables/useMessageQuoting'
+
+describe('formatQuoteAsBlockquote', () => {
+  it('prefixes a single line with a Markdown blockquote marker', () => {
+    expect(formatQuoteAsBlockquote('hello world')).toBe('> hello world')
+  })
+
+  it('prefixes every line of a multi-line excerpt', () => {
+    expect(formatQuoteAsBlockquote('line one\nline two')).toBe('> line one\n> line two')
+  })
+
+  it('preserves empty lines as blockquote separators', () => {
+    expect(formatQuoteAsBlockquote('a\n\nb')).toBe('> a\n> \n> b')
+  })
+})


### PR DESCRIPTION
## Summary
Adds a Claude-style "Mention in chat" quote feature: select text in any chat message, click a floating button, and a shortened quote chip is attached above the composer to use as a reference.

## Changes
- **Composable `useMessageQuoting.ts`** (new): detects text selections inside `[data-quotable]` elements, positions a floating button over the selection, exposes `pendingQuote` / `confirmQuote` / `clearPendingQuote`, cleans up listeners on unmount. Plus `formatQuoteAsBlockquote` helper.
- **`QuoteSelectionButton.vue` / `QuoteChip.vue`** (new): teleported floating button centered above the selection (flips below near the viewport top) and a truncated, removable quote chip.
- **Main chat**: `ChatView` + `ChatInput` wire the button/chip and pass `quotedText` / `quotedMessageId` through the send flow (auth + guest). The quote is rendered as a blockquote in the user bubble.
- **Backend (AI main chat only)**: `StreamController` reads + validates the params (same chat/user), stores them in `processingOptions`, and persists them via `MessageMeta` (survives reload, no migration). `ChatHandler::formatQuotedReferenceForPrompt()` injects a dedicated "Quoted reference" context block into the system prompt (streaming + non-streaming + no-system-role fallback). `ChatController` serializes the quote from `getMeta()` for history.
- **Operator surfaces**: `LiveSupportView` and `WidgetSessionsView` reuse the same composable/button/chip; the quote is prepended to the outgoing message as a Markdown blockquote (human-to-human, no AI binding).
- **i18n**: new `chat.quote.*` keys in en/de/es/tr.

## Verification
- [ ] Not tested (explain)
- [ ] Manual
- [x] Tests added/updated

Full gate green locally:
- `make -C backend lint` · `make -C backend phpstan` (No errors)
- `make -C backend test` — 1974 passed
- `make -C frontend lint` · `npm run check:types` (vue-tsc)
- `make -C frontend test` — 624 passed
- New tests: `useMessageQuoting`, `QuoteChip`, `QuoteSelectionButton` (Vitest); `ChatHandler::formatQuotedReferenceForPrompt` (PHPUnit). Routing characterization snapshots unchanged.
- `make -C frontend generate-schemas` produced no schema drift.

## Notes
- Persistence uses the existing `MessageMeta` key-value store — no Doctrine migration needed.
- Shared chat is read-only (selection only, no quote→send).
- One active quote at a time (replaceable).

## Screenshots/Logs