### PR TITLE
fix(chat): keep markdown formatted while streaming, stop treating currency as math

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,6 +19,7 @@
         "lucide-vue-next": "^1.0.0",
         "marked": "^18.0.0",
         "mermaid": "^11.12.2",
+        "morphdom": "^2.7.8",
         "pinia": "^3.0.3",
         "three": "^0.184.0",
         "vue": "^3.4.38",
@@ -6218,6 +6219,12 @@
         "pkg-types": "^1.3.1",
         "ufo": "^1.6.3"
       }
+    },
+    "node_modules/morphdom": {
+      "version": "2.7.8",
+      "resolved": "https://registry.npmjs.org/morphdom/-/morphdom-2.7.8.tgz",
+      "integrity": "sha512-D/fR4xgGUyVRbdMGU6Nejea1RFzYxYtyurG4Fbv2Fi/daKlWKuXGLOdXtl+3eIwL110cI2hz1ZojGICjjFLgTg==",
+      "license": "MIT"
     },
     "node_modules/mrmime": {
       "version": "2.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -41,6 +41,7 @@
     "lucide-vue-next": "^1.0.0",
     "marked": "^18.0.0",
     "mermaid": "^11.12.2",
+    "morphdom": "^2.7.8",
     "pinia": "^3.0.3",
     "three": "^0.184.0",
     "vue": "^3.4.38",

--- a/frontend/src/assets/markdown.css
+++ b/frontend/src/assets/markdown.css
@@ -332,6 +332,18 @@
   background-color: var(--bg-chip, rgba(0, 0, 0, 0.05));
 }
 
+/* Once rendered in place (SVG injected into the <pre>), drop the code-block
+ * chrome so the diagram is not boxed like source code. */
+.markdown-content .mermaid-block.mermaid-rendered {
+  padding: 0;
+  background-color: transparent;
+}
+
+.markdown-content .mermaid-block.mermaid-rendered svg {
+  max-width: 100%;
+  height: auto;
+}
+
 .markdown-content .mermaid-error {
   border: 2px solid #f87171;
   border-radius: 0.5rem;
@@ -364,6 +376,10 @@
 .dark .markdown-content .code-block,
 .dark .markdown-content .mermaid-block {
   background-color: rgba(255, 255, 255, 0.08);
+}
+
+.dark .markdown-content .mermaid-block.mermaid-rendered {
+  background-color: transparent;
 }
 
 .dark .markdown-content code:not(pre code),

--- a/frontend/src/components/MessageText.vue
+++ b/frontend/src/components/MessageText.vue
@@ -4,13 +4,23 @@
     class="prose prose-sm max-w-none txt-primary markdown-content"
     data-testid="section-message-text"
   >
-    <!-- eslint-disable-next-line vue/no-v-html -- content from DOMPurify + markdown pipeline -->
-    <div data-testid="message-text" v-html="renderedContent"></div>
+    <!--
+      Rendered markdown is applied to this container imperatively via morphdom
+      (see `applyHtml`), NOT through v-html. v-html sets innerHTML wholesale,
+      which tears down and rebuilds the entire subtree on every SSE chunk —
+      the cause of the streaming flash. morphdom diffs the existing DOM against
+      the new HTML and only touches the nodes that actually changed, so
+      finished paragraphs keep their DOM nodes and never flicker. Vue does not
+      manage this element's children (the template leaves it empty), so our
+      imperative writes are safe and persistent.
+    -->
+    <div ref="contentRef" data-testid="message-text"></div>
   </div>
 </template>
 
 <script setup lang="ts">
 import { ref, computed, watch, nextTick, onMounted, onBeforeUnmount } from 'vue'
+import morphdom from 'morphdom'
 import { useI18n } from 'vue-i18n'
 import { useMarkdown } from '@/composables/useMarkdown'
 import { useTheme } from '@/composables/useTheme'
@@ -21,6 +31,7 @@ import { useFeedbackStore } from '@/stores/userFeedback'
 import { useConfigStore } from '@/stores/config'
 import { useNotification } from '@/composables/useNotification'
 import { findStableMarkdownBoundary } from '@/utils/streamingBoundary'
+import { completeInlineMarkdown } from '@/utils/partialMarkdown'
 import type { UserMemory } from '@/services/api/userMemoriesApi'
 
 interface Props {
@@ -38,7 +49,43 @@ const { theme } = useTheme()
 const configStore = useConfigStore()
 const { warning } = useNotification()
 const containerRef = ref<HTMLElement | null>(null)
-const renderedContent = ref('')
+// The element that holds the rendered markdown. Written imperatively via
+// `applyHtml` (morphdom), never via v-html — see the template comment.
+const contentRef = ref<HTMLElement | null>(null)
+// Last HTML string applied to the DOM. Tracked so post-render passes
+// (mermaid) can react and so a render that happens before mount can be
+// flushed in onMounted.
+const lastRenderedHtml = ref('')
+
+// Apply a fully-rendered (sanitized) HTML string to the content element by
+// MORPHING the existing DOM toward it instead of replacing innerHTML. This is
+// the core anti-flash mechanism: morphdom keeps untouched nodes (finished
+// paragraphs, already-highlighted code, rendered mermaid) physically identical
+// and only patches the parts that actually changed.
+function applyHtml(html: string): void {
+  lastRenderedHtml.value = html
+  const el = contentRef.value
+  if (!el) return
+
+  morphdom(el, `<div>${html}</div>`, {
+    childrenOnly: true,
+    // Keep rendered mermaid diagrams: their live DOM (SVG inside the <pre>)
+    // diverges from the source `<pre class="mermaid-block">` in the new HTML,
+    // so without this morphdom would revert them on the next patch.
+    skipFromChildren(fromEl) {
+      return fromEl.classList?.contains('mermaid-rendered') === true
+    },
+    onBeforeElUpdated(fromEl, toEl) {
+      if (fromEl.classList?.contains('mermaid-rendered')) return false
+      // Skip deep work on identical subtrees (finished paragraphs / code).
+      if (fromEl.isEqualNode(toEl)) return false
+      return true
+    },
+    onBeforeNodeDiscarded(node) {
+      return !(node instanceof Element && node.classList.contains('mermaid-rendered'))
+    },
+  })
+}
 const memoriesStore = useMemoriesStore()
 const feedbackStore = useFeedbackStore()
 
@@ -521,9 +568,9 @@ function postProcessHtml(html: string): string {
  * Synchronous full-pipeline render. Used for the post-stream final render of
  * non-math content. Critical for E2E tests that read `innerText` immediately
  * after `data-testid="message-done"` becomes visible — anything async here
- * would push the final renderedContent update onto the next microtask, after
- * Vue has already committed `message-done` to the DOM. Tests would then read
- * a stale half-rendered bubble (only the cheap streaming HTML).
+ * would push the final `applyHtml` call onto the next microtask, after Vue has
+ * already committed `message-done` to the DOM. Tests would then read a stale
+ * half-rendered bubble (only the cheap streaming HTML).
  */
 function processContentSync(content: string): string {
   const normalized = normalizeInlineReferences(normalizeContentForRender(content))
@@ -600,34 +647,30 @@ function renderStreamingIncremental(content: string): string {
 
   let tailHtml = ''
   if (trailingTail.length > 0) {
-    tailHtml = renderStreamingFast(trailingTail)
+    tailHtml = renderStreamingTail(trailingTail)
     tailHtml = processFeedbackBadges(processMemoryBadges(tailHtml))
   }
 
+  // Concatenation is fine now: morphdom diffs the combined HTML against the
+  // live DOM, so the unchanged stable prefix produces zero DOM mutations while
+  // only the growing tail is patched. The cache still avoids recomputing the
+  // prefix HTML on every chunk (CPU win).
   return stableHtml + tailHtml
 }
 
-function escapeHtml(input: string): string {
-  return input
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;')
-}
-
 /**
- * Cheap streaming-mode renderer. Preserves whitespace, inserts <br> for
- * newlines, leaves a placeholder where an unclosed code fence would have
- * been so long code blocks don't appear as one giant escaped wall of text.
- * Memory/feedback badges still get resolved via `processFeedbackBadges` /
- * `processMemoryBadges` so existing `[Memory:ID]` markers turn into pills
- * in real time.
+ * Renders the in-progress trailing paragraph through the FULL markdown
+ * pipeline (marked + DOMPurify) so already-typed inline formatting
+ * (`**bold**`, `*italic*`, `~~strike~~`, inline code, links) stays rendered
+ * while the user is still typing the rest of the line. Open inline markers are
+ * temporarily balanced via `completeInlineMarkdown` so the token currently
+ * being streamed also shows formatted instead of leaking raw `**`.
+ *
+ * Code fences in the tail keep the cheap, un-highlighted treatment: running
+ * highlight.js on every chunk is expensive and produces a rainbow flash, and
+ * the final post-stream render highlights them properly anyway.
  */
-function renderStreamingFast(content: string): string {
-  // Split on triple-backtick fences. Fenced regions are wrapped in <pre>
-  // (un-highlighted) so visually they look like a code block immediately,
-  // but skipping highlight.js avoids the ~10-50 ms hit per fence per tick.
+function renderStreamingTail(content: string): string {
   const parts: Array<{ kind: 'prose' | 'code'; text: string; lang?: string }> = []
   const fenceRe = /```([a-zA-Z0-9_+-]*)\n([\s\S]*?)(?:```|$)/g
   let lastIdx = 0
@@ -648,11 +691,20 @@ function renderStreamingFast(content: string): string {
       if (p.kind === 'code') {
         return `<pre class="code-block streaming-code-block"><code class="hljs language-${escapeHtml(p.lang ?? 'text')}">${escapeHtml(p.text)}</code></pre>`
       }
-      // For prose, escape HTML and convert newlines to <br>. Memory/feedback
-      // badges still flow through later regex replacement.
-      return escapeHtml(p.text).replace(/\n/g, '<br>')
+      const balanced = completeInlineMarkdown(p.text)
+      const normalized = normalizeInlineReferences(balanced)
+      return render(normalized, { processFileMarkers: false })
     })
     .join('')
+}
+
+function escapeHtml(input: string): string {
+  return input
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
 }
 
 // Update rendered content when props change.
@@ -677,15 +729,21 @@ watch(
     const currentVersion = ++renderVersion
 
     if (props.isStreaming) {
-      // Issue #903: math content keeps the legacy debounced-async path
-      // because KaTeX is genuinely async and we must not show partial
-      // formulas. Plain content uses the incremental renderer so stable
-      // paragraphs do not flicker between raw and rendered markdown.
-      if (hasMathFormulas(newContent)) {
-        let html = renderStreamingFast(newContent)
-        html = processFeedbackBadges(processMemoryBadges(html))
-        renderedContent.value = html
+      // Issue #903: ALWAYS paint formatted markdown immediately (via the
+      // incremental renderer) so inline formatting — **bold**, *italic*,
+      // lists, inline code — never flashes as raw text between chunks.
+      //
+      // Math must NOT fall back to a raw escape pass: a single `$` (prices
+      // like "19 $", shell vars, regexes, …) used to route the WHOLE message
+      // through an un-formatted renderer, which is exactly what made
+      // already-rendered bold briefly revert to literal `**bold**` on every
+      // chunk. Instead we render markdown now and, only for genuine math
+      // content, upgrade the formulas to KaTeX on a debounce (KaTeX is async
+      // and we must not render half-typed formulas). morphdom keeps the
+      // unchanged markdown nodes identical, so only the formula spans update.
+      applyHtml(renderStreamingIncremental(newContent))
 
+      if (hasMathFormulas(newContent)) {
         if (renderDebounceTimer !== null) {
           clearTimeout(renderDebounceTimer)
         }
@@ -695,14 +753,11 @@ watch(
           if (!props.isStreaming) return
           void processContentAsync(newContent, currentVersion).then((result) => {
             if (result !== null) {
-              renderedContent.value = result
+              applyHtml(result)
             }
           })
         }, RENDER_DEBOUNCE_STREAMING_MS)
-        return
       }
-
-      renderedContent.value = renderStreamingIncremental(newContent)
       return
     }
 
@@ -713,11 +768,11 @@ watch(
     if (hasMathFormulas(newContent)) {
       void processContentAsync(newContent, currentVersion).then((result) => {
         if (result !== null) {
-          renderedContent.value = result
+          applyHtml(result)
         }
       })
     } else {
-      renderedContent.value = processContentSync(newContent)
+      applyHtml(processContentSync(newContent))
     }
   },
   { immediate: true }
@@ -744,11 +799,11 @@ watch(
     if (hasMathFormulas(props.content)) {
       void processContentAsync(props.content, currentVersion).then((result) => {
         if (result !== null) {
-          renderedContent.value = result
+          applyHtml(result)
         }
       })
     } else {
-      renderedContent.value = processContentSync(props.content)
+      applyHtml(processContentSync(props.content))
     }
   }
 )
@@ -761,11 +816,13 @@ function getActualTheme(): 'light' | 'dark' {
   return theme.value
 }
 
-// Render mermaid diagrams after content is mounted/updated (debounced)
+// Render mermaid diagrams after content is mounted/updated (debounced).
+// `inPlace: true` keeps the <pre> element identity so the next morphdom patch
+// does not revert the rendered diagram (skipFromChildren in applyHtml).
 async function processMermaidBlocks(): Promise<void> {
   await nextTick()
   if (containerRef.value && hasMermaidBlocks(containerRef.value)) {
-    await renderMermaidBlocks(containerRef.value, getActualTheme())
+    await renderMermaidBlocks(containerRef.value, getActualTheme(), true)
   }
 }
 
@@ -811,6 +868,13 @@ onBeforeUnmount(() => {
 })
 
 onMounted(() => {
+  // Flush the initial render: the content watcher (immediate) ran during setup
+  // before contentRef existed, so the first HTML was computed but not yet
+  // written to the DOM.
+  if (lastRenderedHtml.value) {
+    applyHtml(lastRenderedHtml.value)
+  }
+
   // Setup memory and feedback badge event listeners
   if (containerRef.value) {
     containerRef.value.addEventListener('click', handleMemoryBadgeClick)
@@ -824,7 +888,7 @@ onMounted(() => {
   scheduleMermaidProcessing()
 })
 
-watch(renderedContent, scheduleMermaidProcessing)
+watch(lastRenderedHtml, scheduleMermaidProcessing)
 
 // If config finishes loading and memory service becomes available, ensure we load memories
 watch(
@@ -874,7 +938,7 @@ watch(
       const currentVersion = ++renderVersion
       const result = await processContent(props.content, currentVersion)
       if (result !== null) {
-        renderedContent.value = result
+        applyHtml(result)
       }
     }
   },
@@ -890,7 +954,7 @@ watch(
       const currentVersion = ++renderVersion
       const result = await processContent(props.content, currentVersion)
       if (result !== null) {
-        renderedContent.value = result
+        applyHtml(result)
       }
     }
   },

--- a/frontend/src/composables/useMarkdownKatex.ts
+++ b/frontend/src/composables/useMarkdownKatex.ts
@@ -82,7 +82,9 @@ export async function processKatexInMarkdown(markdown: string): Promise<string> 
   let result = markdown
 
   // Process block math ($$...$$) first
-  const blockMathRegex = /\$\$([\s\S]*?)\$\$/g
+  // Require at least one character between delimiters so empty `$$$$` is not
+  // rendered as a formula — keeps this in sync with `hasMathFormulas`.
+  const blockMathRegex = /\$\$([\s\S]+?)\$\$/g
   const blockMatches = [...result.matchAll(blockMathRegex)]
 
   for (const match of blockMatches.reverse()) {
@@ -93,7 +95,7 @@ export async function processKatexInMarkdown(markdown: string): Promise<string> 
   }
 
   // Process LaTeX-style block math (\[...\])
-  const latexBlockRegex = /\\\[([\s\S]*?)\\\]/g
+  const latexBlockRegex = /\\\[([\s\S]+?)\\\]/g
   const latexBlockMatches = [...result.matchAll(latexBlockRegex)]
 
   for (const match of latexBlockMatches.reverse()) {
@@ -127,7 +129,7 @@ export async function processKatexInMarkdown(markdown: string): Promise<string> 
   }
 
   // Process LaTeX-style inline math (\(...\))
-  const latexInlineRegex = /\\\(([\s\S]*?)\\\)/g
+  const latexInlineRegex = /\\\(([\s\S]+?)\\\)/g
   const latexInlineMatches = [...result.matchAll(latexInlineRegex)]
 
   for (const match of latexInlineMatches.reverse()) {

--- a/frontend/src/composables/useMarkdownKatex.ts
+++ b/frontend/src/composables/useMarkdownKatex.ts
@@ -17,6 +17,15 @@
 
 let katexModule: typeof import('katex') | null = null
 
+// Strict inline-math delimiter pattern: `$…$` whose content has NO whitespace
+// directly inside the delimiters (standard remark-math/pandoc rule). This is
+// what keeps currency such as "19 $/Monat … 39 $" from being parsed as a
+// formula. Single-char formulas (`$x$`) are allowed via the alternation; `$$`
+// is excluded by the negative lookaheads. Kept as a source string so both the
+// matcher (global flag) and the detector (`hasMathFormulas`, stateless `.test`)
+// build their own fresh RegExp and never share `lastIndex`.
+const INLINE_MATH_SOURCE = '\\$(?!\\$)((?:[^\\s$][^$\\n]*?[^\\s$]|[^\\s$]))\\$(?!\\$)'
+
 /**
  * Lazy-load KaTeX module and CSS together
  */
@@ -95,8 +104,14 @@ export async function processKatexInMarkdown(markdown: string): Promise<string> 
   }
 
   // Process inline math ($...$) - be careful not to match $$
-  // Avoid lookbehind for Safari compatibility; filter $$ matches manually
-  const inlineMathRegex = /\$(?!\$)([^$\n]+?)\$(?!\$)/g
+  // Avoid lookbehind for Safari compatibility; filter $$ matches manually.
+  //
+  // Currency guard (issue #903): a valid inline formula must NOT have
+  // whitespace directly inside the delimiters (standard remark-math/pandoc
+  // rule). Without this, "19 $/Monat … 39 $" matched as a formula, eating
+  // both `$` and rendering the text between (incl. **bold**) in math italic.
+  // The content therefore must start and end with a non-space, non-`$` char.
+  const inlineMathRegex = new RegExp(INLINE_MATH_SOURCE, 'g')
   const inlineMatches = [...result.matchAll(inlineMathRegex)]
 
   for (const match of inlineMatches.reverse()) {
@@ -126,10 +141,23 @@ export async function processKatexInMarkdown(markdown: string): Promise<string> 
 }
 
 /**
- * Check if content contains math formulas
+ * Check if content contains REAL math formulas.
+ *
+ * Must mirror what `processKatexInMarkdown` actually renders, otherwise the
+ * streaming renderer flags currency-only text ("19 $/Monat") as math and runs
+ * the (formula-mangling, raw-markdown) KaTeX path on it. We therefore require
+ * a complete, well-formed delimiter pair — not just a lone `$`.
  */
 export function hasMathFormulas(content: string): boolean {
-  return content.includes('$') || content.includes('\\(') || content.includes('\\[')
+  if (!content) return false
+  // Block math $$…$$
+  if (/\$\$[\s\S]+?\$\$/.test(content)) return true
+  // LaTeX block \[ … \]
+  if (/\\\[[\s\S]+?\\\]/.test(content)) return true
+  // LaTeX inline \( … \)
+  if (/\\\([\s\S]+?\\\)/.test(content)) return true
+  // Inline $…$ with the strict currency-safe rule
+  return new RegExp(INLINE_MATH_SOURCE).test(content)
 }
 
 /**

--- a/frontend/src/composables/useMarkdownMermaid.ts
+++ b/frontend/src/composables/useMarkdownMermaid.ts
@@ -98,7 +98,13 @@ function isDiagramCodeComplete(code: string): boolean {
  */
 export async function renderMermaidBlocks(
   container: HTMLElement,
-  theme: 'light' | 'dark' = 'light'
+  theme: 'light' | 'dark' = 'light',
+  // When true, the rendered SVG is injected INTO the existing
+  // `<pre class="mermaid-block">` element (which is then marked
+  // `mermaid-rendered`) instead of replacing it with a new node. This keeps
+  // element identity stable so a DOM-morphing renderer (morphdom) can protect
+  // the rendered diagram from being reverted on the next streaming patch.
+  inPlace: boolean = false
 ): Promise<void> {
   const mermaidBlocks = container.querySelectorAll('pre.mermaid-block')
 
@@ -142,13 +148,20 @@ export async function renderMermaidBlocks(
         const id = `mermaid-${Math.random().toString(36).slice(2, 11)}`
         const { svg } = await mermaid.render(id, diagramCode)
 
-        // Create a container for the rendered diagram
-        const diagramContainer = document.createElement('div')
-        diagramContainer.className = 'mermaid-diagram my-4 overflow-x-auto'
-        diagramContainer.innerHTML = svg
+        if (inPlace) {
+          // Keep the <pre> element (stable identity for morphdom) and swap its
+          // code child for the rendered SVG.
+          block.classList.add('mermaid-rendered')
+          block.innerHTML = svg
+        } else {
+          // Create a container for the rendered diagram
+          const diagramContainer = document.createElement('div')
+          diagramContainer.className = 'mermaid-diagram my-4 overflow-x-auto'
+          diagramContainer.innerHTML = svg
 
-        // Replace the code block with the rendered diagram
-        block.replaceWith(diagramContainer)
+          // Replace the code block with the rendered diagram
+          block.replaceWith(diagramContainer)
+        }
       } catch {
         // Mark as error to prevent re-rendering attempts
         block.classList.add('mermaid-error')

--- a/frontend/src/composables/useMarkdownMermaid.ts
+++ b/frontend/src/composables/useMarkdownMermaid.ts
@@ -112,15 +112,15 @@ function isDiagramCodeComplete(code: string): boolean {
  *
  * @param container - The DOM element containing markdown content
  * @param theme - Optional theme ('light' or 'dark')
+ * @param inPlace - When `false` (default) each `<pre class="mermaid-block">` is
+ *   REPLACED by a new `<div>` holding the SVG. When `true` the SVG is injected
+ *   INTO the existing `<pre>` (then marked `mermaid-rendered`), keeping element
+ *   identity stable so a DOM-morphing renderer (morphdom) can protect the
+ *   rendered diagram from being reverted on the next streaming patch.
  */
 export async function renderMermaidBlocks(
   container: HTMLElement,
   theme: 'light' | 'dark' = 'light',
-  // When true, the rendered SVG is injected INTO the existing
-  // `<pre class="mermaid-block">` element (which is then marked
-  // `mermaid-rendered`) instead of replacing it with a new node. This keeps
-  // element identity stable so a DOM-morphing renderer (morphdom) can protect
-  // the rendered diagram from being reverted on the next streaming patch.
   inPlace: boolean = false
 ): Promise<void> {
   const mermaidBlocks = container.querySelectorAll('pre.mermaid-block')

--- a/frontend/src/composables/useMarkdownMermaid.ts
+++ b/frontend/src/composables/useMarkdownMermaid.ts
@@ -10,8 +10,25 @@
  * 3. Call renderMermaidBlocks() to convert mermaid code blocks to SVG diagrams
  */
 
+import DOMPurify from 'dompurify'
+
 let mermaidInitialized = false
 let mermaidModule: typeof import('mermaid') | null = null
+
+/**
+ * Sanitize a mermaid-rendered SVG before it is injected via innerHTML.
+ *
+ * Mermaid already sanitizes with `securityLevel: 'strict'`, but assigning the
+ * raw string to innerHTML is flagged by static analysis (CodeQL: "DOM text
+ * reinterpreted as HTML"). This is defense-in-depth: DOMPurify with the SVG
+ * (+ SVG filters + HTML for foreignObject labels) profiles strips scripts and
+ * event handlers while preserving everything mermaid needs to render.
+ */
+function sanitizeSvg(svg: string): string {
+  return DOMPurify.sanitize(svg, {
+    USE_PROFILES: { svg: true, svgFilters: true, html: true },
+  })
+}
 
 /**
  * Lazy-load and initialize mermaid
@@ -147,17 +164,18 @@ export async function renderMermaidBlocks(
       try {
         const id = `mermaid-${Math.random().toString(36).slice(2, 11)}`
         const { svg } = await mermaid.render(id, diagramCode)
+        const safeSvg = sanitizeSvg(svg)
 
         if (inPlace) {
           // Keep the <pre> element (stable identity for morphdom) and swap its
           // code child for the rendered SVG.
           block.classList.add('mermaid-rendered')
-          block.innerHTML = svg
+          block.innerHTML = safeSvg
         } else {
           // Create a container for the rendered diagram
           const diagramContainer = document.createElement('div')
           diagramContainer.className = 'mermaid-diagram my-4 overflow-x-auto'
-          diagramContainer.innerHTML = svg
+          diagramContainer.innerHTML = safeSvg
 
           // Replace the code block with the rendered diagram
           block.replaceWith(diagramContainer)

--- a/frontend/src/utils/partialMarkdown.ts
+++ b/frontend/src/utils/partialMarkdown.ts
@@ -1,0 +1,266 @@
+/**
+ * Streaming markdown helper — makes an in-progress markdown fragment safe to
+ * feed through the full markdown renderer by appending closers for any inline
+ * markup that the author has opened but not yet closed.
+ *
+ * Why: during SSE streaming the trailing in-progress paragraph keeps growing
+ * one token at a time. If we render it as-is, an already-closed `**bold**`
+ * span looks fine, but the moment a *new* unclosed `**` arrives the markdown
+ * parser swallows everything up to it and the earlier formatting visibly
+ * "breaks" until the line finishes. By temporarily balancing the open
+ * markers we keep every completed span rendered and even show the token that
+ * is currently being typed.
+ *
+ * Guarantees:
+ *   - Only APPENDS closers at the very end (plus hides a single trailing,
+ *     still-incomplete link/image). Already-typed characters are never
+ *     rewritten, so the rendered output for the stable part stays identical
+ *     between chunks — no flicker.
+ *   - Markup inside inline code spans is treated as literal.
+ *   - Uses CommonMark-style flanking rules so `2 * 3`, bullet lists
+ *     (`* item`), and `snake_case` are not mistaken for emphasis.
+ */
+
+type InlineMarker = '~~' | '**' | '*' | '_'
+
+type Segment =
+  | { type: 'text'; value: string }
+  | { type: 'code'; value: string }
+  | { type: 'codeOpen'; value: string; ticks: number }
+
+export function completeInlineMarkdown(input: string): string {
+  if (input.length === 0) return input
+
+  const segments = tokenizeCode(input)
+  const last = segments[segments.length - 1]
+
+  // Inside an unterminated inline code span: close the code, then close any
+  // emphasis opened in earlier text segments so it wraps the inline code.
+  if (last.type === 'codeOpen') {
+    const proseText = joinTextSegments(segments)
+    return input + '`'.repeat(last.ticks) + computeEmphasisClosers(proseText)
+  }
+
+  let trailingWhitespace = ''
+  if (last.type === 'text') {
+    // Hide a still-incomplete trailing link/image so raw `[text](http…`
+    // syntax never flashes on screen.
+    last.value = hideIncompleteLink(last.value)
+    // Drop the marker the author is still typing (e.g. the lone `*` of a
+    // half-arrived `**`, or a fresh `**` with no content yet) plus any
+    // trailing whitespace. The open markers are re-derived from the stack
+    // below, so a partially-typed closer never leaks raw and an empty opener
+    // is hidden until its content arrives.
+    const stripped = stripTrailingInProgress(last.value)
+    last.value = stripped.core
+    trailingWhitespace = stripped.trailingWhitespace
+  }
+
+  // Markup opened inside (closed) code spans is literal — only the text
+  // segments contribute open emphasis/strong/strikethrough markers.
+  const closers = computeEmphasisClosers(joinTextSegments(segments))
+  const base = segments.map((segment) => segment.value).join('')
+
+  // Closers MUST land directly after the last non-whitespace character:
+  // CommonMark only treats a `**`/`*`/`_`/`~~` run as a closer when it is not
+  // preceded by whitespace (right-flanking). Appending after a trailing space
+  // would make marked render the whole span as raw text.
+  return base + closers + trailingWhitespace
+}
+
+function joinTextSegments(segments: Segment[]): string {
+  return segments
+    .filter((segment) => segment.type === 'text')
+    .map((segment) => segment.value)
+    .join('')
+}
+
+/**
+ * Splits off the trailing "in-progress" tail of a streamed fragment: optional
+ * whitespace, an optional run of emphasis markers (the closer/opener the
+ * author is currently typing), and optional whitespace again. The marker run
+ * is discarded (re-derived from the open-delimiter stack) while the whitespace
+ * is preserved so spacing between words stays intact.
+ */
+function stripTrailingInProgress(text: string): { core: string; trailingWhitespace: string } {
+  let core = text
+  let trailingWhitespace = ''
+
+  const ws1 = core.match(/\s+$/)
+  if (ws1) {
+    trailingWhitespace = ws1[0] + trailingWhitespace
+    core = core.slice(0, -ws1[0].length)
+  }
+
+  const markerRun = core.match(/[*_~]+$/)
+  if (markerRun) {
+    core = core.slice(0, -markerRun[0].length)
+  }
+
+  const ws2 = core.match(/\s+$/)
+  if (ws2) {
+    trailingWhitespace = ws2[0] + trailingWhitespace
+    core = core.slice(0, -ws2[0].length)
+  }
+
+  return { core, trailingWhitespace }
+}
+
+/**
+ * Splits the input into text and inline-code segments. A code span opens on a
+ * run of N backticks and closes on the next run of exactly N backticks. An
+ * unterminated run produces a trailing `codeOpen` segment.
+ */
+function tokenizeCode(input: string): Segment[] {
+  const segments: Segment[] = []
+  let textStart = 0
+  let i = 0
+
+  while (i < input.length) {
+    if (input[i] !== '`') {
+      i++
+      continue
+    }
+
+    let ticks = 1
+    while (input[i + ticks] === '`') ticks++
+
+    const closing = findClosingBackticks(input, i + ticks, ticks)
+
+    if (i > textStart) {
+      segments.push({ type: 'text', value: input.slice(textStart, i) })
+    }
+
+    if (closing === -1) {
+      segments.push({ type: 'codeOpen', value: input.slice(i), ticks })
+      return segments
+    }
+
+    const end = closing + ticks
+    segments.push({ type: 'code', value: input.slice(i, end) })
+    i = end
+    textStart = end
+  }
+
+  if (textStart < input.length) {
+    segments.push({ type: 'text', value: input.slice(textStart) })
+  }
+
+  if (segments.length === 0) {
+    segments.push({ type: 'text', value: '' })
+  }
+
+  return segments
+}
+
+function findClosingBackticks(input: string, from: number, ticks: number): number {
+  let j = from
+  while (j < input.length) {
+    if (input[j] !== '`') {
+      j++
+      continue
+    }
+    let run = 1
+    while (input[j + run] === '`') run++
+    if (run === ticks) return j
+    j += run
+  }
+  return -1
+}
+
+function hideIncompleteLink(text: string): string {
+  // `[label](dest` / `![alt](dest` — destination started but not closed: hide
+  // the whole token so a half-typed URL never appears.
+  let result = text.replace(/!?\[[^\]]*\]\([^)]*$/, '')
+  // `[label` / `![alt` — opening bracket without a closing one yet: keep only
+  // the visible label/alt text.
+  result = result.replace(/!?\[([^\]]*)$/, '$1')
+  return result
+}
+
+function computeEmphasisClosers(text: string): string {
+  const stack: InlineMarker[] = []
+  let i = 0
+
+  while (i < text.length) {
+    const ch = text[i]
+    if (ch !== '*' && ch !== '_' && ch !== '~') {
+      i++
+      continue
+    }
+
+    const marker = detectMarker(text, i)
+    if (marker === null) {
+      i++
+      continue
+    }
+
+    const prev = i > 0 ? text[i - 1] : ''
+    const next = text[i + marker.length] ?? ''
+    const { canOpen, canClose } = classifyFlanking(prev, next, marker)
+
+    if (canClose && stack.includes(marker)) {
+      popMarker(stack, marker)
+    } else if (canOpen) {
+      stack.push(marker)
+    }
+
+    i += marker.length
+  }
+
+  // Close innermost (last opened) first.
+  return stack.reverse().join('')
+}
+
+function detectMarker(text: string, i: number): InlineMarker | null {
+  const ch = text[i]
+  if (ch === '~') {
+    return text[i + 1] === '~' ? '~~' : null
+  }
+  if (ch === '*') {
+    return text[i + 1] === '*' ? '**' : '*'
+  }
+  if (ch === '_') {
+    return '_'
+  }
+  return null
+}
+
+function classifyFlanking(
+  prev: string,
+  next: string,
+  marker: InlineMarker
+): { canOpen: boolean; canClose: boolean } {
+  const nextIsWhitespace = next === '' || /\s/.test(next)
+  const prevIsWhitespace = prev === '' || /\s/.test(prev)
+  const nextIsPunct = isPunctuation(next)
+  const prevIsPunct = isPunctuation(prev)
+
+  const leftFlanking = !nextIsWhitespace && (!nextIsPunct || prevIsWhitespace || prevIsPunct)
+  const rightFlanking = !prevIsWhitespace && (!prevIsPunct || nextIsWhitespace || nextIsPunct)
+
+  // `_` may not be used for intra-word emphasis (stricter rule than `*`).
+  if (marker === '_') {
+    return {
+      canOpen: leftFlanking && (!rightFlanking || prevIsPunct),
+      canClose: rightFlanking && (!leftFlanking || nextIsPunct),
+    }
+  }
+
+  return { canOpen: leftFlanking, canClose: rightFlanking }
+}
+
+function isPunctuation(ch: string): boolean {
+  if (ch === '') return false
+  if (/\s/.test(ch)) return false
+  return !/[\p{L}\p{N}]/u.test(ch)
+}
+
+function popMarker(stack: InlineMarker[], marker: InlineMarker): void {
+  for (let k = stack.length - 1; k >= 0; k--) {
+    if (stack[k] === marker) {
+      stack.splice(k, 1)
+      return
+    }
+  }
+}

--- a/frontend/tests/unit/components/MessageText.spec.ts
+++ b/frontend/tests/unit/components/MessageText.spec.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import MessageText from '@/components/MessageText.vue'
+
+// These tests lock in the anti-flash guarantee (no streaming flicker): while a
+// message streams, morphdom must keep the DOM nodes of already-finished blocks
+// PHYSICALLY identical between chunks. If a finished paragraph were torn down
+// and rebuilt on every chunk (the old v-html behaviour) its element reference
+// would change — that is exactly the flash the user reported.
+
+function messageTextEl(wrapper: ReturnType<typeof mount>): HTMLElement {
+  return wrapper.get('[data-testid="message-text"]').element as HTMLElement
+}
+
+describe('MessageText streaming (anti-flash)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('keeps a finished paragraph node identical as the in-progress tail grows', async () => {
+    const wrapper = mount(MessageText, {
+      props: { content: '', isStreaming: true, readonly: true },
+    })
+
+    // Two paragraphs: the first is "sealed" (followed by a blank line), the
+    // second is still streaming.
+    await wrapper.setProps({ content: 'Para A done.\n\nPara B start' })
+
+    const paragraphsBefore = messageTextEl(wrapper).querySelectorAll('p')
+    expect(paragraphsBefore.length).toBe(2)
+    const sealedParagraph = paragraphsBefore[0]
+    expect(sealedParagraph.textContent).toBe('Para A done.')
+
+    // The tail grows with more streamed text.
+    await wrapper.setProps({ content: 'Para A done.\n\nPara B start more text' })
+
+    const paragraphsAfter = messageTextEl(wrapper).querySelectorAll('p')
+    // The sealed paragraph must be the SAME DOM node (not re-created).
+    expect(paragraphsAfter[0]).toBe(sealedParagraph)
+    expect(paragraphsAfter[0].textContent).toBe('Para A done.')
+    // The tail did update.
+    expect(messageTextEl(wrapper).textContent).toContain('more text')
+  })
+
+  it('keeps earlier sealed paragraphs stable when a new paragraph is appended', async () => {
+    const wrapper = mount(MessageText, {
+      props: { content: 'First.\n\nSecond in progress', isStreaming: true, readonly: true },
+    })
+
+    const firstBefore = messageTextEl(wrapper).querySelectorAll('p')[0]
+    expect(firstBefore.textContent).toBe('First.')
+
+    // Second paragraph completes and a third one begins — a fresh paragraph
+    // boundary, which previously re-rendered the WHOLE message.
+    await wrapper.setProps({ content: 'First.\n\nSecond done.\n\nThird in progress' })
+
+    const paragraphsAfter = messageTextEl(wrapper).querySelectorAll('p')
+    expect(paragraphsAfter.length).toBe(3)
+    // The first paragraph node survived untouched.
+    expect(paragraphsAfter[0]).toBe(firstBefore)
+    expect(paragraphsAfter[2].textContent).toContain('Third in progress')
+  })
+
+  it('renders inline markdown in the streaming tail (bold stays bold)', async () => {
+    const wrapper = mount(MessageText, {
+      props: { content: 'Intro **bold** and ', isStreaming: true, readonly: true },
+    })
+
+    const strong = messageTextEl(wrapper).querySelector('strong')
+    expect(strong?.textContent).toBe('bold')
+  })
+
+  // Regression (issue #903): a single `$` (prices like "19 $", shell vars, …)
+  // used to flag the whole message as "math" and route it through a RAW
+  // (un-formatted) streaming renderer that only upgraded to formatted markdown
+  // after a debounce — so **bold** flashed as literal `**bold**` on every
+  // chunk. Markdown must render immediately even when a `$` is present.
+  it('renders bold immediately when content contains a $ (no raw-markdown flash)', async () => {
+    const wrapper = mount(MessageText, {
+      props: {
+        content: 'Der Preis ist 19 $ und das ist **wichtig**',
+        isStreaming: true,
+        readonly: true,
+      },
+    })
+
+    const el = messageTextEl(wrapper)
+    expect(el.querySelector('strong')?.textContent).toBe('wichtig')
+    // The raw markers must NOT be visible as text.
+    expect(el.textContent).not.toContain('**wichtig**')
+  })
+
+  // Regression (issue #903): two currency dollars on one line ("19 $/Monat …
+  // 39 $/Monat") were parsed as a KaTeX formula, eating both `$`, rendering
+  // the span (incl. the second **bold**) in math italic and leaking raw `**`.
+  it('renders both bolds and keeps currency when a line has two dollar signs', async () => {
+    const line =
+      '**Copilot Business** (ca. 19 $/Nutzer/Monat) und **Copilot Enterprise** (ca. 39 $/Nutzer/Monat).'
+    const wrapper = mount(MessageText, {
+      props: { content: line, isStreaming: true, readonly: true },
+    })
+
+    const el = messageTextEl(wrapper)
+    const strongs = [...el.querySelectorAll('strong')].map((s) => s.textContent)
+    expect(strongs).toContain('Copilot Business')
+    expect(strongs).toContain('Copilot Enterprise')
+    // Raw markers must not leak, and the dollars must survive.
+    expect(el.textContent).not.toContain('**')
+    expect(el.textContent).toContain('19 $')
+    expect(el.textContent).toContain('39 $')
+  })
+
+  it('keeps bold formatted across chunks when a $ is present', async () => {
+    const wrapper = mount(MessageText, {
+      props: { content: 'Kostet 5 $. **Fett** bleibt', isStreaming: true, readonly: true },
+    })
+
+    expect(messageTextEl(wrapper).querySelector('strong')?.textContent).toBe('Fett')
+
+    // Next chunk arrives — bold must stay rendered, never revert to raw text.
+    await wrapper.setProps({ content: 'Kostet 5 $. **Fett** bleibt fett und mehr Text' })
+
+    const el = messageTextEl(wrapper)
+    expect(el.querySelector('strong')?.textContent).toBe('Fett')
+    expect(el.textContent).not.toContain('**Fett**')
+    expect(el.textContent).toContain('mehr Text')
+  })
+})

--- a/frontend/tests/unit/composables/useMarkdownKatex.spec.ts
+++ b/frontend/tests/unit/composables/useMarkdownKatex.spec.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import { hasMathFormulas, processKatexInMarkdown } from '@/composables/useMarkdownKatex'
+
+// Regression (issue #903): currency like "19 $/Monat … 39 $" must NOT be
+// detected/rendered as a math formula. The naive `$…$` matcher used to eat
+// both dollar signs and render everything between them (incl. **bold**) as a
+// KaTeX formula in math italic.
+
+describe('hasMathFormulas', () => {
+  it('does NOT treat currency with two dollar signs as math', () => {
+    const text =
+      'Copilot Business (ca. 19 $/Nutzer/Monat) und Copilot Enterprise (ca. 39 $/Nutzer/Monat).'
+    expect(hasMathFormulas(text)).toBe(false)
+  })
+
+  it('does NOT treat a single lone dollar sign as math', () => {
+    expect(hasMathFormulas('Der Preis ist 5 $ pro Monat')).toBe(false)
+  })
+
+  it('does NOT treat space-padded dollars as math', () => {
+    expect(hasMathFormulas('kostet 5 $ und spart 10 $')).toBe(false)
+  })
+
+  it('detects a real inline formula $x^2$', () => {
+    expect(hasMathFormulas('Die Formel $x^2$ ist einfach')).toBe(true)
+  })
+
+  it('detects a single-char inline formula $x$', () => {
+    expect(hasMathFormulas('Sei $x$ gegeben')).toBe(true)
+  })
+
+  it('detects block math $$…$$', () => {
+    expect(hasMathFormulas('$$a^2 + b^2 = c^2$$')).toBe(true)
+  })
+
+  it('detects LaTeX inline \\(…\\) and block \\[…\\]', () => {
+    expect(hasMathFormulas('Sei \\(x\\) gegeben')).toBe(true)
+    expect(hasMathFormulas('\\[ E = mc^2 \\]')).toBe(true)
+  })
+
+  it('returns false for plain text', () => {
+    expect(hasMathFormulas('Einfach nur Text ohne alles')).toBe(false)
+    expect(hasMathFormulas('')).toBe(false)
+  })
+})
+
+describe('processKatexInMarkdown', () => {
+  it('leaves currency untouched (no KaTeX span, dollars preserved)', async () => {
+    const text =
+      '**Copilot Business** (ca. 19 $/Nutzer/Monat) und **Copilot Enterprise** (ca. 39 $/Nutzer/Monat).'
+    const result = await processKatexInMarkdown(text)
+    expect(result).toBe(text)
+    expect(result).not.toContain('katex')
+  })
+})

--- a/frontend/tests/unit/composables/useMarkdownKatex.spec.ts
+++ b/frontend/tests/unit/composables/useMarkdownKatex.spec.ts
@@ -42,6 +42,12 @@ describe('hasMathFormulas', () => {
     expect(hasMathFormulas('Einfach nur Text ohne alles')).toBe(false)
     expect(hasMathFormulas('')).toBe(false)
   })
+
+  it('does NOT treat empty delimiters as math (consistent with the renderer)', () => {
+    expect(hasMathFormulas('$$$$')).toBe(false)
+    expect(hasMathFormulas('\\(\\)')).toBe(false)
+    expect(hasMathFormulas('\\[\\]')).toBe(false)
+  })
 })
 
 describe('processKatexInMarkdown', () => {
@@ -51,5 +57,10 @@ describe('processKatexInMarkdown', () => {
     const result = await processKatexInMarkdown(text)
     expect(result).toBe(text)
     expect(result).not.toContain('katex')
+  })
+
+  it('leaves empty delimiters untouched (no empty formula rendered)', async () => {
+    expect(await processKatexInMarkdown('Leeres $$$$ hier')).toBe('Leeres $$$$ hier')
+    expect(await processKatexInMarkdown('Leeres \\(\\) hier')).toBe('Leeres \\(\\) hier')
   })
 })

--- a/frontend/tests/unit/utils/partialMarkdown.spec.ts
+++ b/frontend/tests/unit/utils/partialMarkdown.spec.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect } from 'vitest'
+import { completeInlineMarkdown } from '@/utils/partialMarkdown'
+
+describe('completeInlineMarkdown', () => {
+  describe('completed markup is left untouched', () => {
+    it('keeps balanced bold unchanged', () => {
+      expect(completeInlineMarkdown('**bold**')).toBe('**bold**')
+    })
+
+    it('keeps balanced italic, strike and inline code unchanged', () => {
+      expect(completeInlineMarkdown('*italic*')).toBe('*italic*')
+      expect(completeInlineMarkdown('~~gone~~')).toBe('~~gone~~')
+      expect(completeInlineMarkdown('`code`')).toBe('`code`')
+      expect(completeInlineMarkdown('_under_')).toBe('_under_')
+    })
+
+    it('keeps a fully typed paragraph with multiple closed spans unchanged', () => {
+      const input = 'This is **bold** and *italic* and `code` done.'
+      expect(completeInlineMarkdown(input)).toBe(input)
+    })
+
+    it('returns empty input unchanged', () => {
+      expect(completeInlineMarkdown('')).toBe('')
+    })
+  })
+
+  describe('open inline markers are closed', () => {
+    it('closes an open bold marker', () => {
+      expect(completeInlineMarkdown('**blabla')).toBe('**blabla**')
+    })
+
+    it('preserves an earlier closed bold while closing the new open one', () => {
+      expect(completeInlineMarkdown('**done** and **start')).toBe('**done** and **start**')
+    })
+
+    it('closes an open italic marker', () => {
+      expect(completeInlineMarkdown('*blabla')).toBe('*blabla*')
+    })
+
+    it('closes an open underscore italic marker', () => {
+      expect(completeInlineMarkdown('_blabla')).toBe('_blabla_')
+    })
+
+    it('closes an open strikethrough marker', () => {
+      expect(completeInlineMarkdown('~~blabla')).toBe('~~blabla~~')
+    })
+
+    it('closes an open inline code span', () => {
+      expect(completeInlineMarkdown('here is `code')).toBe('here is `code`')
+    })
+
+    it('closes a multi-backtick inline code span with the same run length', () => {
+      expect(completeInlineMarkdown('here is ``co`de')).toBe('here is ``co`de``')
+    })
+
+    it('closes nested emphasis innermost-first', () => {
+      expect(completeInlineMarkdown('**bold and *italic')).toBe('**bold and *italic***')
+    })
+
+    it('closes bold that wraps an inline code span still open', () => {
+      expect(completeInlineMarkdown('**bold `code')).toBe('**bold `code`**')
+    })
+  })
+
+  // Regression: a closer must never be appended AFTER trailing whitespace,
+  // otherwise CommonMark right-flanking fails and marked renders raw `**`.
+  describe('trailing whitespace (closer goes before the space)', () => {
+    it('closes bold when the fragment ends with a space', () => {
+      expect(completeInlineMarkdown('**Was ')).toBe('**Was** ')
+    })
+
+    it('closes bold when several words are followed by a trailing space', () => {
+      expect(completeInlineMarkdown('**Was du ')).toBe('**Was du** ')
+    })
+
+    it('closes italic before a trailing space', () => {
+      expect(completeInlineMarkdown('*italic ')).toBe('*italic* ')
+    })
+
+    it('closes strikethrough before a trailing space', () => {
+      expect(completeInlineMarkdown('~~strike ')).toBe('~~strike~~ ')
+    })
+
+    it('only closes the in-progress span, keeping earlier closed spans intact', () => {
+      expect(completeInlineMarkdown('a **b** c **d ')).toBe('a **b** c **d** ')
+    })
+
+    it('preserves a trailing newline while placing the closer correctly', () => {
+      expect(completeInlineMarkdown('**done**\n**new ')).toBe('**done**\n**new** ')
+    })
+  })
+
+  // Regression: a half-arrived closer (only one `*` of `**`) must not be
+  // turned into italic — this was the "shows italic instead of bold" bug.
+  describe('half-typed closing markers', () => {
+    it('treats a single trailing asterisk as a partial bold closer', () => {
+      expect(completeInlineMarkdown('**bold*')).toBe('**bold**')
+    })
+
+    it('handles a partial bold closer followed by a space', () => {
+      expect(completeInlineMarkdown('**bold* ')).toBe('**bold** ')
+    })
+
+    it('handles a fresh italic opener inside bold that has no content yet', () => {
+      expect(completeInlineMarkdown('**bold *')).toBe('**bold** ')
+    })
+  })
+
+  describe('dangling opener with no content is hidden', () => {
+    it('hides a trailing bold opener until content arrives', () => {
+      expect(completeInlineMarkdown('Das Feature heißt **')).toBe('Das Feature heißt ')
+    })
+
+    it('hides a trailing italic opener after a closed bold span', () => {
+      expect(completeInlineMarkdown('text **bold** and more *')).toBe('text **bold** and more ')
+    })
+  })
+
+  describe('false positives are NOT treated as markdown', () => {
+    it('does not close a spaced asterisk (multiplication)', () => {
+      expect(completeInlineMarkdown('2 * 3')).toBe('2 * 3')
+    })
+
+    it('does not close a bullet list marker', () => {
+      expect(completeInlineMarkdown('* item')).toBe('* item')
+    })
+
+    it('does not treat a dash bullet as a marker', () => {
+      expect(completeInlineMarkdown('- item')).toBe('- item')
+    })
+
+    it('does not treat underscores in snake_case as emphasis', () => {
+      expect(completeInlineMarkdown('call some_function_name')).toBe('call some_function_name')
+    })
+
+    it('hides a lone trailing asterisk (in-progress marker, no content yet)', () => {
+      expect(completeInlineMarkdown('a list: *')).toBe('a list: ')
+    })
+
+    it('ignores a single tilde (not strikethrough)', () => {
+      expect(completeInlineMarkdown('about ~10 items')).toBe('about ~10 items')
+    })
+
+    it('does not touch markup inside a closed inline code span', () => {
+      expect(completeInlineMarkdown('use `**not bold**` here')).toBe('use `**not bold**` here')
+    })
+  })
+
+  describe('incomplete links and images are hidden', () => {
+    it('shows only the label when the bracket is not closed', () => {
+      expect(completeInlineMarkdown('see [the docs')).toBe('see the docs')
+    })
+
+    it('hides a link whose destination is still being typed', () => {
+      expect(completeInlineMarkdown('see [the docs](https://exa')).toBe('see ')
+    })
+
+    it('hides an image whose destination is still being typed', () => {
+      expect(completeInlineMarkdown('look ![alt](https://exa')).toBe('look ')
+    })
+
+    it('shows the alt text when an image bracket is not closed', () => {
+      expect(completeInlineMarkdown('look ![alt text')).toBe('look alt text')
+    })
+
+    it('keeps a fully formed link untouched', () => {
+      const input = 'see [the docs](https://example.com) now'
+      expect(completeInlineMarkdown(input)).toBe(input)
+    })
+
+    it('does not mistake a completed bracket pair for an incomplete link', () => {
+      expect(completeInlineMarkdown('array[0] = 1')).toBe('array[0] = 1')
+    })
+  })
+})


### PR DESCRIPTION
## Summary
Stops streamed AI messages from flickering between raw and rendered markdown — caused by currency `$` being mistaken for math and by the streaming tail rendering raw.

## Changes
- **Streaming renderer (`MessageText.vue`)**: markdown is now rendered formatted *immediately* on every chunk via the incremental renderer. Genuine math formulas are upgraded to KaTeX on a debounce instead of dropping the whole message to a raw, unformatted render pass. Removed the dead `renderStreamingFast` raw renderer.
- **Currency-safe math detection (`useMarkdownKatex.ts`)**: `hasMathFormulas` now requires a well-formed delimiter pair (not a lone `$`), and inline `$…$` must have no whitespace directly inside the delimiters (standard remark-math rule). This stops `"19 $/Monat … 39 $/Monat"` from being parsed as a formula (which ate both `$` and rendered the text — incl. `**bold**` — in math italic).
- **Streaming tail**: rendered through the full markdown pipeline with balanced inline markers (`partialMarkdown.ts`), and the DOM is patched with `morphdom` so already-finished blocks keep their nodes and never flicker. Mermaid diagrams render in place to stay morph-stable (`useMarkdownMermaid.ts`, `markdown.css`).

## Verification
- [ ] Not tested (explain)
- [x] Manual — `:5173`, streamed answers containing prices/`$` and `**bold**`: formatting stays stable, no raw-markdown flash, dollars preserved.
- [x] Tests added/updated — `partialMarkdown.spec.ts`, `useMarkdownKatex.spec.ts` (currency guard), `MessageText.spec.ts` (anti-flash + two-dollar line).

Pre-commit gate (frontend only changed): `make -C frontend lint`, `npm run check:types`, `make -C frontend test` (703 tests) — all green.

## Notes
Adds the `morphdom` dependency (~6 KB, MIT) for node-level DOM diffing during streaming.

## Screenshots/Logs