### PR TITLE
fix(chat): keep streaming answer start visible instead of scrolling to bottom

### DIFF
--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -420,6 +420,17 @@ const chatContainer = ref<HTMLElement | null>(null)
 const chatInputRef = ref<InstanceType<typeof ChatInput> | null>(null)
 const quoting = useMessageQuoting(chatContainer)
 const autoScroll = ref(true)
+// While streaming we pin the start of the answer to the top once it grows past
+// the viewport. If the user deliberately scrolls to the very bottom, switch to
+// following the bottom instead (so the freshest text stays visible). Reset to
+// pin mode whenever a new message is sent.
+let stickToBottom = false
+// Tracks the scrollTop value we last set programmatically so handleScroll can
+// tell our own scroll adjustments apart from genuine user scrolling.
+let expectedScrollTop = 0
+// Optical breathing room kept below the container's top edge once a long
+// streaming message gets pinned there.
+const STREAM_TOP_GAP = 12
 const isDragging = ref(false)
 const dragCounter = ref(0)
 const historyStore = useHistoryStore()
@@ -643,9 +654,15 @@ const handleVisibilityChangeForToken = () => {
 }
 
 const handleViewportResize = () => {
-  if (autoScroll.value && chatContainer.value) {
-    chatContainer.value.scrollTop = chatContainer.value.scrollHeight
+  if (!autoScroll.value || !chatContainer.value) return
+  // While streaming, keep the pin behaviour intact instead of jumping to the
+  // bottom (e.g. when the mobile keyboard resizes the visual viewport).
+  if (historyStore.messages.some((m) => m.isStreaming)) {
+    followStreamingScroll()
+    return
   }
+  chatContainer.value.scrollTop = chatContainer.value.scrollHeight
+  expectedScrollTop = chatContainer.value.scrollTop
 }
 
 if (window.visualViewport) {
@@ -783,10 +800,44 @@ const scrollToBottom = (force = false) => {
     nextTick(() => {
       if (chatContainer.value) {
         chatContainer.value.scrollTop = chatContainer.value.scrollHeight
+        // Read the clamped value back so the handleScroll guard recognises
+        // this as a programmatic scroll.
+        expectedScrollTop = chatContainer.value.scrollTop
         autoScroll.value = true
       }
     })
   }
+}
+
+// Follow a growing streaming message, but stop scrolling once its top edge
+// reaches the top of the container. Computed purely from measured DOM offsets
+// so it behaves identically on small and large screens.
+const followStreamingScroll = () => {
+  if (!autoScroll.value || !chatContainer.value) return
+  nextTick(() => {
+    const container = chatContainer.value
+    if (!container) return
+    const bottomMax = container.scrollHeight - container.clientHeight
+    let target = bottomMax
+    // The streaming assistant message is always the last rendered message
+    // (the input is locked while streaming, so nothing can be appended after
+    // it). We measure that node directly instead of relying on attribute
+    // fallthrough, which ChatMessage does not forward to its root element.
+    const messageEls = container.querySelectorAll<HTMLElement>('[data-testid="message-container"]')
+    const el = messageEls[messageEls.length - 1]
+    // When the user has scrolled to the bottom, keep following the bottom
+    // instead of pinning the start to the top.
+    if (!stickToBottom && el) {
+      const messageTop =
+        el.getBoundingClientRect().top - container.getBoundingClientRect().top + container.scrollTop
+      // Short message: bottomMax wins (keep following the end). Once the
+      // message grows past the viewport, messageTop stays fixed and wins the
+      // min(), pinning the start at the top edge.
+      target = Math.min(bottomMax, Math.max(0, messageTop - STREAM_TOP_GAP))
+    }
+    container.scrollTop = target
+    expectedScrollTop = container.scrollTop
+  })
 }
 
 // Drag & Drop handlers for file upload
@@ -826,9 +877,17 @@ const handleScroll = async () => {
 
   const { scrollTop, scrollHeight, clientHeight } = chatContainer.value
 
-  // Check if at bottom for auto-scroll
-  const isAtBottom = Math.abs(scrollHeight - clientHeight - scrollTop) < 50
-  autoScroll.value = isAtBottom
+  // Distinguish our own programmatic scrolls (including the pinned position
+  // that is NOT at the bottom) from real user scrolling. Only the latter may
+  // toggle auto-follow off/on.
+  const isProgrammatic = Math.abs(scrollTop - expectedScrollTop) <= 1
+  if (!isProgrammatic) {
+    const isAtBottom = Math.abs(scrollHeight - clientHeight - scrollTop) < 50
+    autoScroll.value = isAtBottom
+    // Scrolling to the very bottom opts into bottom-following; scrolling up
+    // (anywhere above the bottom) leaves pin mode for the next stream.
+    stickToBottom = isAtBottom
+  }
 
   // Check if at top for loading more messages (Infinite Scroll)
   const isAtTop = scrollTop < 100
@@ -883,7 +942,7 @@ watch(
     return total
   },
   () => {
-    scrollToBottom()
+    followStreamingScroll()
   }
 )
 
@@ -1244,6 +1303,7 @@ const handleSendMessage = async (
   }
 ) => {
   autoScroll.value = true
+  stickToBottom = false
 
   // Prepare files info if fileIds are provided
   let files: import('@/stores/history').MessageFile[] | undefined = undefined

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -904,6 +904,9 @@ const handleScroll = async () => {
     if (chatContainer.value) {
       const newScrollHeight = chatContainer.value.scrollHeight
       chatContainer.value.scrollTop = newScrollHeight - currentScrollHeight + scrollTop
+      // Keep the guard in sync so this position restore is recognised as a
+      // programmatic scroll and does not toggle autoScroll/stickToBottom.
+      expectedScrollTop = chatContainer.value.scrollTop
     }
   }
 }


### PR DESCRIPTION
## Summary
While an answer is streaming, the chat now keeps the start of long assistant messages visible (pinned to the top) instead of always auto-scrolling to the bottom.

## Changes
- `frontend/src/views/ChatView.vue`: new `followStreamingScroll()` that pins the streaming message's top edge to the container top once it grows past the viewport (`target = min(bottomMax, messageTop - GAP)`), measured purely from DOM offsets so it works on any screen size.
- Targets the last `[data-testid="message-container"]` directly (the streaming message) instead of relying on Vue attribute fallthrough, which `ChatMessage` does not forward to its root element.
- Added an `expectedScrollTop` guard in `handleScroll` to tell programmatic scrolls apart from genuine user scrolling.
- Added a `stickToBottom` mode: scrolling to the very bottom mid-stream follows the bottom; scrolling up stops auto-scroll; sending a new message resets to pin mode.
- The streaming-growth watcher now calls `followStreamingScroll()`; `handleViewportResize` keeps the pin during mobile-keyboard viewport changes.

## Verification
- [ ] Not tested (explain)
- [x] Manual
- [ ] Tests added/updated

Manual verification in the browser (guest mode), measured live via DevTools during real SSE streams:
- Long answer: `scrollTop` pins at `messageTop - 12` while `bottomMax` keeps growing -> start stays visible, beginning at top.
- Short answer: keeps following the end (whole message incl. start visible).
- Scroll to bottom mid-stream: `scrollTop` tracks `bottomMax` (follows the end), no jump back to the pin.
- Scroll up mid-stream: auto-scroll stops, position stays put while `bottomMax` grows.

Pre-merge gate (frontend-only change):
- `make -C frontend lint` (Prettier + ESLint) - pass
- `docker compose exec -T frontend npm run check:types` (vue-tsc) - pass
- `make -C frontend test` (Vitest) - 651 passed

## Notes
Frontend-only change; no API/schema/i18n changes. Backend checks not applicable (no backend files touched).

## Screenshots/Logs
Verified manually; the AI message heading remains pinned at the top of the chat container during streaming while the rest of the text flows below.