### PR TITLE
fix(widget): prevent stale widget.js from breaking embeds after deploy

### DIFF
--- a/_docker/backend/Caddyfile
+++ b/_docker/backend/Caddyfile
@@ -129,6 +129,19 @@
 		file_server
 	}
 
+	# Missing widget assets must NOT fall through to the SPA fallback, which
+	# would serve index.html as HTTP 200 without CORS and break cross-origin
+	# <script type="module"> loads (the post-deploy stale-widget.js failure
+	# mode). Return a clean 404 that still carries CORS, and never cache it.
+	@widget_missing {
+		path /widget.js /chunks/*
+	}
+	handle @widget_missing {
+		header Access-Control-Allow-Origin "*"
+		header Cache-Control "no-store"
+		respond 404
+	}
+
 	# Frontend files second (static files from frontend build)
 	@frontend_file {
 		file {

--- a/cloudflare/src/worker.ts
+++ b/cloudflare/src/worker.ts
@@ -1,6 +1,6 @@
 interface Env {}
 
-const NO_CACHE_PATHS = ['/sw.js', '/site.webmanifest']
+const NO_CACHE_PATHS = ['/sw.js', '/site.webmanifest', '/widget.js']
 
 /**
  * SSE endpoints. The Worker MUST pass these through with zero header
@@ -42,7 +42,7 @@ function shouldNeverCache(pathname: string): boolean {
 }
 
 function isHashedAsset(pathname: string): boolean {
-  return pathname.startsWith('/assets/')
+  return pathname.startsWith('/assets/') || pathname.startsWith('/chunks/')
 }
 
 function isHtmlNavigation(request: Request, pathname: string): boolean {
@@ -79,7 +79,16 @@ export default {
       return fetch(request)
     }
 
-    const response = await fetch(request)
+    // For never-cache paths (hashless entry points like /widget.js, /sw.js)
+    // bypass Cloudflare's edge cache entirely: `cache: 'no-store'` makes the
+    // runtime skip any cached match AND refuse to store the response. This
+    // self-heals a stale entry already sitting in the edge cache after a
+    // deploy — no manual dashboard purge required (needs compatibility_date
+    // >= 2024-11-11; see wrangler.toml). The origin (Caddy) already sends the
+    // matching no-cache headers, so we always serve the freshest build.
+    const response = shouldNeverCache(pathname)
+      ? await fetch(request, { cache: 'no-store' })
+      : await fetch(request)
     const headers = new Headers(response.headers)
 
     if (shouldNeverCache(pathname)) {


### PR DESCRIPTION
## Summary
Fixes #1133 — embedded widgets broke with CORS errors after every deploy because a long-cached, hashless `widget.js` referenced chunk hashes that no longer existed.

## Changes
- **Caddy** (`_docker/backend/Caddyfile`): missing widget assets (`/widget.js`, `/chunks/*`) now return a clean `404` with the CORS header and `Cache-Control: no-store`, instead of falling through to the SPA fallback that served `index.html` as HTTP 200 without CORS (the root cause behind the "CORS error", steps 4-6 of the issue).
- **Cloudflare Worker** (`cloudflare/src/worker.ts`):
  - `/widget.js` added to `NO_CACHE_PATHS` (hashless entry must always revalidate).
  - `/chunks/*` now treated as immutable (content-hashed, safe to long-cache).
  - Never-cache paths bypass the edge cache via `fetch(request, { cache: 'no-store' })`, so a stale edge copy self-heals on the next deploy — no manual Cloudflare dashboard purge required (compatibility_date `2026-03-01` satisfies the `>= 2024-11-11` requirement).
- The cache-control headers for `widget.js`/`chunks` already existed in the Caddyfile (added 2025-12-09); this PR closes the remaining root-cause gaps.

## Verification
- [ ] Not tested (explain)
- [x] Manual
- [ ] Tests added/updated

Manual verification against the running local stack:

| Request | Result |
|---|---|
| `/widget.js` (present) | `200`, `Access-Control-Allow-Origin: *`, `Cache-Control: no-cache, no-store, must-revalidate` |
| `/chunks/<existing>.js` | `200`, CORS `*`, `Cache-Control: public, max-age=31536000, immutable` |
| `/chunks/<missing>.js` | `404`, CORS `*`, `Cache-Control: no-store` (previously: 200 HTML, no CORS) |

- `frankenphp validate --config /etc/caddy/Caddyfile` -> "Valid configuration"
- `wrangler deploy --dry-run --env production` -> bundles cleanly (`cache: 'no-store'` is type-safe)
- No automated tests added: only the Caddyfile (Docker routing config) and the Cloudflare Worker changed; neither is covered by the PHPUnit or Vitest suites, and no backend PHP or frontend app code was touched.

## Notes
- Closes #1133.
- Related: #1109 (Cloudflare Cache Rules) — the worker-level `cache: 'no-store'` bypass makes a dashboard Cache Rule unnecessary for the widget entry point.
- Worker auto-deploys via the existing `cloudflare-deploy` CI job on push to `main`/tags.

## Screenshots/Logs
n/a