### PR TITLE
Feedback on issues with higgsfield solved

### DIFF
--- a/backend/src/Controller/StreamController.php
+++ b/backend/src/Controller/StreamController.php
@@ -2773,17 +2773,29 @@ class StreamController extends AbstractController
             // token/usage counters still move, so the turn is never completely
             // free. Media (IMAGES/VIDEOS/AUDIOS) is billed separately and more
             // precisely inside MediaGenerationHandler.
-            $cancelledModelId = $incomingMessage->getMeta('ai_chat_model_id');
-            $this->rateLimitService->recordUsage($user, 'MESSAGES', [
-                'provider' => $chatProvider ?? 'unknown',
-                'model' => $chatModel ?? 'unknown',
-                'model_id' => null !== $cancelledModelId && '' !== $cancelledModelId ? (int) $cancelledModelId : null,
-                'chat_id' => (int) $chatId,
-                'source' => 'WEB',
-                'response_text' => is_string($content) ? $content : '',
-                'input_text' => $incomingMessage->getText(),
-                'status' => 'cancelled',
-            ]);
+            // Truly best-effort: the cancelled message is already persisted above,
+            // so a failure to record usage must NOT turn a successful cancellation
+            // into an HTTP 500. Swallow any error here (it is only accounting) and
+            // let the endpoint return success.
+            try {
+                $cancelledModelId = $incomingMessage->getMeta('ai_chat_model_id');
+                $this->rateLimitService->recordUsage($user, 'MESSAGES', [
+                    'provider' => $chatProvider ?? 'unknown',
+                    'model' => $chatModel ?? 'unknown',
+                    'model_id' => null !== $cancelledModelId && '' !== $cancelledModelId ? (int) $cancelledModelId : null,
+                    'chat_id' => (int) $chatId,
+                    'source' => 'WEB',
+                    'response_text' => is_string($content) ? $content : '',
+                    'input_text' => $incomingMessage->getText(),
+                    'status' => 'cancelled',
+                ]);
+            } catch (\Throwable $usageError) {
+                $this->logger->warning('Failed to record usage for cancelled chat turn', [
+                    'user_id' => $user->getId(),
+                    'track_id' => $trackId,
+                    'error' => $usageError->getMessage(),
+                ]);
+            }
 
             $this->logger->info('Cancelled message saved', [
                 'user_id' => $user->getId(),

--- a/backend/tests/Unit/Service/Multitask/Execution/Runner/RunnersTest.php
+++ b/backend/tests/Unit/Service/Multitask/Execution/Runner/RunnersTest.php
@@ -358,6 +358,85 @@ final class RunnersTest extends TestCase
         self::assertSame('png', $seenMessage->getFileType());
     }
 
+    /**
+     * Regression for issue #1146: a multitask media node is billed by the
+     * provider, so the runner must ask MediaGenerationHandler to record the
+     * IMAGES/VIDEOS/AUDIOS usage itself (record_media_usage). Without it the DAG
+     * path bypassed the user's cost budget.
+     */
+    public function testMediaGenerationRunnerEnablesMediaUsageRecording(): void
+    {
+        $handler = $this->createMock(MediaGenerationHandler::class);
+        $capturedOptions = null;
+        $handler->method('handle')->willReturnCallback(
+            function ($msg, $thread, $classification, $progress, $options) use (&$capturedOptions): array {
+                $capturedOptions = $options;
+
+                return [
+                    'content' => 'Generated image',
+                    'metadata' => [
+                        'file' => ['path' => '/api/v1/files/uploads/1/000/dog.png', 'type' => 'image'],
+                        'local_path' => '1/000/dog.png',
+                    ],
+                ];
+            }
+        );
+
+        $runner = new MediaGenerationRunner($handler, $this->createMock(LoggerInterface::class));
+        $node = new TaskNode('n1', Capability::ImageGeneration, [], ['prompt' => 'a happy dog']);
+
+        $result = $runner->run($node, $this->context($this->message('a happy dog')));
+
+        self::assertTrue($result->isSuccessful());
+        self::assertIsArray($capturedOptions);
+        self::assertTrue($capturedOptions['record_media_usage'] ?? false);
+    }
+
+    /**
+     * Regression for issue #1144: when a media node depends on an upstream node's
+     * file output (e.g. inputs.image = "$n1.file"), the runner must lift the
+     * resolved file path into reference_image_paths so MediaGenerationHandler can
+     * run IMG2VID / PIC2PIC instead of silently degrading to TEXT2VID / TEXT2PIC.
+     */
+    public function testMediaGenerationRunnerForwardsUpstreamFileAsReference(): void
+    {
+        $handler = $this->createMock(MediaGenerationHandler::class);
+        $capturedOptions = null;
+        $handler->method('handle')->willReturnCallback(
+            function ($msg, $thread, $classification, $progress, $options) use (&$capturedOptions): array {
+                $capturedOptions = $options;
+
+                return [
+                    'content' => 'Generated video',
+                    'metadata' => [
+                        'file' => ['path' => '/api/v1/files/uploads/1/000/dog.mp4', 'type' => 'video'],
+                        'local_path' => '1/000/dog.mp4',
+                    ],
+                ];
+            }
+        );
+
+        $ctx = $this->context($this->message('animate this'));
+        // Upstream image node output (NodeResult file descriptor), referenced via $n1.file.
+        $ctx->setResult('n1', NodeResult::ok(null, [[
+            'path' => '/api/v1/files/uploads/1/000/dog.png',
+            'type' => 'image',
+            'local_path' => '1/000/dog.png',
+        ]]));
+
+        $runner = new MediaGenerationRunner($handler, $this->createMock(LoggerInterface::class));
+        $node = new TaskNode('n2', Capability::VideoGeneration, ['n1'], [
+            'prompt' => 'animate this',
+            'image' => '$n1.file',
+        ]);
+
+        $result = $runner->run($node, $ctx);
+
+        self::assertTrue($result->isSuccessful());
+        self::assertIsArray($capturedOptions);
+        self::assertContains('1/000/dog.png', $capturedOptions['reference_image_paths'] ?? []);
+    }
+
     private function calendarRunner(): CalendarEventRunner
     {
         $storage = $this->createMock(FileStorageService::class);

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -3027,7 +3027,16 @@ const handleTaskRetry = async (payload: { prompt: string; modelId: number }) => 
 // Mark the card cancelled immediately (the user's intent is the source of truth)
 // and signal the backend so the provider poll aborts and stops billing.
 const handleTaskCancel = async (nodeId: string) => {
-  const message = historyStore.messages.find((m) => m.taskPlan?.active)
+  // Resolve the CURRENT turn's task-plan message via the streaming flag, mirroring
+  // finishStreamingTurnLocally(). Node ids repeat across turns ("n1", "n2", …) and
+  // taskPlan.active is only cleared on local teardown (not on a normal/error
+  // completion), so finding the FIRST active plan can match a stale earlier turn and
+  // cancel the wrong card / send the wrong trackId. The streaming message is the
+  // unambiguous active turn; fall back to the active-plan lookup only if none is
+  // currently streaming.
+  const message =
+    historyStore.messages.find((m) => m.isStreaming && m.taskPlan?.active) ??
+    historyStore.messages.find((m) => m.taskPlan?.active)
   const card = message?.taskPlan?.cards.find((c) => c.nodeId === nodeId)
   if (card) {
     card.state = 'cancelled'


### PR DESCRIPTION
## Summary

Follow-up to #1147 addressing the three GitHub Copilot review comments on that PR. These are correctness/robustness fixes for the streaming-cancellation + multitask media work, plus the test coverage that #1147 was missing.

## Changes

### 1. `StreamController::saveCancelled` — usage recording is now truly best-effort (re #1146)
The cancel-time `recordUsage('MESSAGES')` call sat inside the main `try` whose `catch (\Exception)` returns HTTP 500, and it ran *after* the cancelled message was already persisted. A failure in accounting could therefore turn a successful cancellation into a 500 for the client. Wrapped it in its own `try/catch (\Throwable)` with a warning log so the endpoint stays reliable and the cancellation always persists.

### 2. `ChatView.handleTaskCancel` — resolve the correct (streaming) turn (re #1141)
The per-card Stop handler resolved the task-plan message with `messages.find(m => m.taskPlan?.active)`, which returns the **oldest** active plan. Because `taskPlan.active` is only cleared on local teardown (not on a normal/error completion) and node ids repeat across turns (`n1`, `n2`, …), a Stop on a later turn could match an earlier turn's message — cancelling the wrong card and sending the wrong `trackId`. It now resolves via the **streaming** message (`m.isStreaming && m.taskPlan?.active`), mirroring `finishStreamingTurnLocally`, with a fallback to the previous lookup.

### 3. `RunnersTest` — cover the new `MediaGenerationRunner` behaviors (re #1144 / #1146)
#1147 added `record_media_usage` and `reference_image_paths` forwarding but asserted neither. Added two unit tests:
- `testMediaGenerationRunnerEnablesMediaUsageRecording` — asserts the handler is invoked with `record_media_usage: true` (closes the multitask budget-bypass).
- `testMediaGenerationRunnerForwardsUpstreamFileAsReference` — asserts an upstream `$n1.file` image is lifted into `reference_image_paths` so IMG2VID/PIC2PIC chaining works.

## Verification

- [x] Tests added/updated
- [x] Backend: `make -C backend lint` ✓, `make -C backend phpstan` ✓ (no errors), `make -C backend test` ✓ (2108 tests, +2 new)
- [x] Frontend: Prettier ✓, ESLint ✓, `vue-tsc -b` ✓, Vitest ✓ (709 tests)