### PR TITLE
feat(mobile): native client identity + cross-origin Bearer auth

### DIFF
--- a/backend/config/packages/security.yaml
+++ b/backend/config/packages/security.yaml
@@ -80,6 +80,8 @@ security:
         - { path: ^/api/v1/auth/reset-password, roles: PUBLIC_ACCESS }
         - { path: ^/api/v1/auth/resend-verification, roles: PUBLIC_ACCESS }
         - { path: ^/api/v1/auth/refresh, roles: PUBLIC_ACCESS }
+        # Native (mobile) OAuth handoff exchange — auth IS the signed handoff token
+        - { path: ^/api/v1/auth/native/exchange, roles: PUBLIC_ACCESS }
 
         # Authenticated auth endpoints
         - { path: ^/api/v1/auth/me, roles: IS_AUTHENTICATED_FULLY }

--- a/backend/config/services.yaml
+++ b/backend/config/services.yaml
@@ -19,6 +19,11 @@ parameters:
     # OIDC scopes requested during login (space-separated)
     env(OIDC_SCOPES): 'openid email profile offline_access'
 
+    # Native mobile deep-link scheme used for the OAuth handoff (Epic 3).
+    # Must match the custom URL scheme registered by the Capacitor app
+    # (synaplan-apps). Default matches the production bundle id.
+    env(NATIVE_DEEPLINK_SCHEME): 'com.synaplan.app'
+
     # Realtime (Centrifugo) defaults so the backend boots even when no realtime
     # gateway is configured (bare/custom deployment). With these unset,
     # CentrifugoPublisher short-circuits (enabled=false → no publish, never
@@ -480,14 +485,12 @@ services:
             $googleClientId: '%env(GOOGLE_CLIENT_ID)%'
             $googleClientSecret: '%env(GOOGLE_CLIENT_SECRET)%'
             $appUrl: '%env(APP_URL)%'
-            $frontendUrl: '%env(FRONTEND_URL)%'
 
     App\Controller\GitHubAuthController:
         arguments:
             $githubClientId: '%env(GITHUB_CLIENT_ID)%'
             $githubClientSecret: '%env(GITHUB_CLIENT_SECRET)%'
             $appUrl: '%env(APP_URL)%'
-            $frontendUrl: '%env(FRONTEND_URL)%'
 
     # OIDC Discovery Controller
     App\Controller\OidcController:
@@ -565,6 +568,17 @@ services:
     App\Service\OAuthStateService:
         arguments:
             $appSecret: '%env(APP_SECRET)%'
+
+    # Native OAuth handoff token (signed, short-lived) for the mobile deep-link flow
+    App\Service\NativeAuthHandoffService:
+        arguments:
+            $appSecret: '%env(APP_SECRET)%'
+
+    # OAuth login responder (web cookies vs native deep-link handoff)
+    App\Service\OAuthLoginResponder:
+        arguments:
+            $frontendUrl: '%env(FRONTEND_URL)%'
+            $nativeDeepLinkScheme: '%env(NATIVE_DEEPLINK_SCHEME)%'
 
     # Token Service (Access/Refresh Tokens)
     App\Service\TokenService:

--- a/backend/src/Controller/AuthController.php
+++ b/backend/src/Controller/AuthController.php
@@ -11,6 +11,7 @@ use App\Repository\VerificationTokenRepository;
 use App\Service\Client\ClientContextResolver;
 use App\Service\ImpersonationService;
 use App\Service\InternalEmailService;
+use App\Service\NativeAuthHandoffService;
 use App\Service\OidcTokenService;
 use App\Service\RecaptchaService;
 use App\Service\TokenService;
@@ -48,6 +49,7 @@ class AuthController extends AbstractController
         private LoggerInterface $logger,
         private ImpersonationService $impersonationService,
         private ClientContextResolver $clientContextResolver,
+        private NativeAuthHandoffService $handoffService,
     ) {
         $this->resendCooldownMinutes = (int) ($_ENV['EMAIL_VERIFICATION_COOLDOWN_MINUTES'] ?? 2);
         $this->maxResendAttempts = (int) ($_ENV['EMAIL_VERIFICATION_MAX_ATTEMPTS'] ?? 5);
@@ -75,6 +77,65 @@ class AuthController extends AbstractController
             'tokenType' => 'Bearer',
             'expiresIn' => TokenService::ACCESS_TOKEN_TTL,
         ];
+    }
+
+    #[Route('/native/exchange', name: 'native_exchange', methods: ['POST'])]
+    #[OA\Post(
+        path: '/api/v1/auth/native/exchange',
+        summary: 'Exchange a native OAuth handoff token for Bearer tokens',
+        description: 'Mobile clients call this after the system-browser OAuth flow returns a short-lived, single-purpose handoff token via the app deep link. Returns access/refresh tokens in the body (no cookies).',
+        tags: ['Authentication']
+    )]
+    #[OA\RequestBody(
+        required: true,
+        content: new OA\JsonContent(
+            required: ['handoff'],
+            properties: [
+                new OA\Property(property: 'handoff', type: 'string', description: 'Signed handoff token from the OAuth deep link'),
+            ]
+        )
+    )]
+    #[OA\Response(response: 200, description: 'Bearer tokens issued')]
+    #[OA\Response(response: 400, description: 'Missing handoff token')]
+    #[OA\Response(response: 401, description: 'Invalid or expired handoff token')]
+    public function nativeExchange(Request $request): JsonResponse
+    {
+        $body = json_decode($request->getContent(), true);
+        $handoff = is_array($body) && isset($body['handoff']) && is_string($body['handoff'])
+            ? $body['handoff']
+            : null;
+
+        if (null === $handoff || '' === $handoff) {
+            return new JsonResponse(['success' => false, 'error' => 'Missing handoff token'], Response::HTTP_BAD_REQUEST);
+        }
+
+        $userId = $this->handoffService->validate($handoff);
+        if (null === $userId) {
+            return new JsonResponse(['success' => false, 'error' => 'Invalid or expired handoff token'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        $user = $this->userRepository->find($userId);
+        if (!$user) {
+            return new JsonResponse(['success' => false, 'error' => 'User not found'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        $accessToken = $this->tokenService->generateAccessToken($user);
+        $refreshToken = $this->tokenService->generateRefreshToken($user, $request->getClientIp());
+
+        $this->logger->info('Native OAuth handoff exchanged', ['user_id' => $user->getId()]);
+
+        return new JsonResponse([
+            'success' => true,
+            'user' => [
+                'id' => $user->getId(),
+                'email' => $user->getMail(),
+                'level' => $user->getUserLevel(),
+                'emailVerified' => $user->isEmailVerified(),
+                'isAdmin' => $user->isAdmin(),
+                'memoriesEnabled' => $user->isMemoriesEnabled(),
+            ],
+            'tokens' => $this->nativeTokenPayload($accessToken, $refreshToken),
+        ]);
     }
 
     #[Route('/register', name: 'register', methods: ['POST'])]

--- a/backend/src/Controller/AuthController.php
+++ b/backend/src/Controller/AuthController.php
@@ -8,6 +8,7 @@ use App\Entity\User;
 use App\Repository\EmailVerificationAttemptRepository;
 use App\Repository\UserRepository;
 use App\Repository\VerificationTokenRepository;
+use App\Service\Client\ClientContextResolver;
 use App\Service\ImpersonationService;
 use App\Service\InternalEmailService;
 use App\Service\OidcTokenService;
@@ -46,9 +47,34 @@ class AuthController extends AbstractController
         private ValidatorInterface $validator,
         private LoggerInterface $logger,
         private ImpersonationService $impersonationService,
+        private ClientContextResolver $clientContextResolver,
     ) {
         $this->resendCooldownMinutes = (int) ($_ENV['EMAIL_VERIFICATION_COOLDOWN_MINUTES'] ?? 2);
         $this->maxResendAttempts = (int) ($_ENV['EMAIL_VERIFICATION_MAX_ATTEMPTS'] ?? 5);
+    }
+
+    /**
+     * Build the Bearer-token payload returned to the native app in the login /
+     * refresh JSON body.
+     *
+     * Web clients keep authenticating via the HttpOnly cookies that are still
+     * set alongside this — only the native shell (cross-origin WebView, where
+     * cookies are unreliable) consumes these tokens, storing them in secure
+     * native storage to send as `Authorization: Bearer` (Epic 3). Detection is
+     * via the server-confirmed User-Agent (ClientContextResolver); a spoofed UA
+     * only ever receives tokens for the account it already authenticated as, so
+     * there is no privilege gain.
+     *
+     * @return array{accessToken: string, refreshToken: string, tokenType: string, expiresIn: int}
+     */
+    private function nativeTokenPayload(string $accessToken, string $refreshToken): array
+    {
+        return [
+            'accessToken' => $accessToken,
+            'refreshToken' => $refreshToken,
+            'tokenType' => 'Bearer',
+            'expiresIn' => TokenService::ACCESS_TOKEN_TTL,
+        ];
     }
 
     #[Route('/register', name: 'register', methods: ['POST'])]
@@ -244,7 +270,7 @@ class AuthController extends AbstractController
         $this->logger->info('User logged in', ['user_id' => $user->getId()]);
 
         // Create response with cookies
-        $response = new JsonResponse([
+        $responseData = [
             'success' => true,
             'user' => [
                 'id' => $user->getId(),
@@ -254,7 +280,15 @@ class AuthController extends AbstractController
                 'isAdmin' => $user->isAdmin(),
                 'memoriesEnabled' => $user->isMemoriesEnabled(),
             ],
-        ]);
+        ];
+
+        // Native shell can't rely on cross-origin cookies → also hand it the
+        // tokens in the body so it can authenticate via Authorization: Bearer.
+        if ($this->clientContextResolver->fromRequest($request)->isMobileApp) {
+            $responseData['tokens'] = $this->nativeTokenPayload($accessToken, $refreshToken);
+        }
+
+        $response = new JsonResponse($responseData);
 
         // Add HttpOnly cookies. Defensive: also wipe any orphan impersonation
         // stash that survived from a previous user on this browser, so the
@@ -314,6 +348,15 @@ class AuthController extends AbstractController
         // Regular user - use our internal refresh token
         $refreshTokenString = $request->cookies->get(TokenService::REFRESH_COOKIE);
 
+        // Native shell has no cross-origin refresh cookie → it sends the refresh
+        // token (from secure native storage) in the request body instead.
+        if (!$refreshTokenString) {
+            $body = json_decode($request->getContent(), true);
+            if (is_array($body) && isset($body['refreshToken']) && is_string($body['refreshToken'])) {
+                $refreshTokenString = $body['refreshToken'];
+            }
+        }
+
         if (!$refreshTokenString) {
             return $this->json([
                 'error' => 'No refresh token',
@@ -334,7 +377,7 @@ class AuthController extends AbstractController
 
         $this->logger->info('Token refreshed', ['user_id' => $result['user']->getId()]);
 
-        $response = new JsonResponse([
+        $responseData = [
             'success' => true,
             'user' => [
                 'id' => $result['user']->getId(),
@@ -343,7 +386,15 @@ class AuthController extends AbstractController
                 'emailVerified' => $result['user']->isEmailVerified(),
                 'isAdmin' => $result['user']->isAdmin(),
             ],
-        ]);
+        ];
+
+        // Native shell consumes the rotated access token from the body (the
+        // refresh token is unchanged — refreshTokens() does not rotate it).
+        if ($this->clientContextResolver->fromRequest($request)->isMobileApp) {
+            $responseData['tokens'] = $this->nativeTokenPayload($result['access_token'], $refreshTokenString);
+        }
+
+        $response = new JsonResponse($responseData);
 
         $response->headers->setCookie(
             $this->tokenService->createAccessCookie($result['access_token'])

--- a/backend/src/Controller/ConfigController.php
+++ b/backend/src/Controller/ConfigController.php
@@ -9,6 +9,7 @@ use App\Entity\User;
 use App\Repository\ConfigRepository;
 use App\Repository\ModelRepository;
 use App\Service\BillingService;
+use App\Service\Client\ClientContextResolver;
 use App\Service\Embedding\EmbeddingMetadataService;
 use App\Service\Embedding\EmbeddingModelChangeGuard;
 use App\Service\Embedding\Exception\PremiumRequiredException;
@@ -46,6 +47,7 @@ class ConfigController extends AbstractController
         private EmbeddingMetadataService $embeddingMetadata,
         private ModelConfigService $modelConfigService,
         private RedisService $redisService,
+        private ClientContextResolver $clientContextResolver,
         #[Autowire('%env(string:default::QDRANT_URL)%')]
         private readonly string $qdrantUrl,
     ) {
@@ -213,6 +215,33 @@ class ConfigController extends AbstractController
                     ]
                 ),
                 new OA\Property(
+                    property: 'client',
+                    type: 'object',
+                    description: 'Server-confirmed identity of the calling client, derived from the User-Agent. Lets the frontend switch behaviour server-truthfully (e.g. payment channel gating) instead of trusting only the client-side Capacitor.isNativePlatform() flag. Identity hint only — never an auth control.',
+                    properties: [
+                        new OA\Property(
+                            property: 'isMobileApp',
+                            type: 'boolean',
+                            example: false,
+                            description: 'True when the request carries the official "Synaplan Mobile Vx.x" User-Agent token.'
+                        ),
+                        new OA\Property(
+                            property: 'appVersion',
+                            type: 'string',
+                            nullable: true,
+                            example: '4.0',
+                            description: 'Parsed app version (major.minor[.patch]) from the User-Agent, or null for web clients.'
+                        ),
+                        new OA\Property(
+                            property: 'platform',
+                            type: 'string',
+                            enum: ['web', 'mobile'],
+                            example: 'web',
+                            description: 'Resolved client platform.'
+                        ),
+                    ]
+                ),
+                new OA\Property(
                     property: 'unavailableProviders',
                     type: 'array',
                     description: 'AI providers that are disabled due to missing API keys (only for authenticated users)',
@@ -222,7 +251,7 @@ class ConfigController extends AbstractController
             ]
         )
     )]
-    public function getRuntimeConfig(#[CurrentUser] ?User $user): JsonResponse
+    public function getRuntimeConfig(Request $request, #[CurrentUser] ?User $user): JsonResponse
     {
         $recaptchaEnabled = ($_ENV['RECAPTCHA_ENABLED'] ?? 'false') === 'true';
         $recaptchaSiteKey = $_ENV['RECAPTCHA_SITE_KEY'] ?? '';
@@ -331,6 +360,17 @@ class ConfigController extends AbstractController
             'wsUrl' => $realtimeWsUrl,
         ];
 
+        // Client identity (Aspect 1 / mobile app Epic 2): server-confirmed signal derived
+        // from the User-Agent. The frontend uses this for server-truthful behaviour switches
+        // (Epic 5 payment gating) instead of trusting only Capacitor.isNativePlatform().
+        // The parsed version also feeds the forced-update gate (Epic 8).
+        $client = $this->clientContextResolver->fromRequest($request);
+        $clientConfig = [
+            'isMobileApp' => $client->isMobileApp,
+            'appVersion' => $client->appVersion,
+            'platform' => $client->platform(),
+        ];
+
         $response = [
             'billing' => [
                 'enabled' => $this->billingService->isEnabled(),
@@ -342,6 +382,7 @@ class ConfigController extends AbstractController
             'googleTag' => $googleTagConfig,
             'build' => $buildInfo,
             'realtime' => $realtimeConfig,
+            'client' => $clientConfig,
         ];
 
         if ($user && !empty($unavailableProviders)) {

--- a/backend/src/Controller/GitHubAuthController.php
+++ b/backend/src/Controller/GitHubAuthController.php
@@ -4,14 +4,12 @@ namespace App\Controller;
 
 use App\Entity\User;
 use App\Repository\UserRepository;
-use App\Service\ImpersonationService;
+use App\Service\OAuthLoginResponder;
 use App\Service\OAuthStateService;
-use App\Service\TokenService;
 use Doctrine\ORM\EntityManagerInterface;
 use OpenApi\Attributes as OA;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
@@ -29,14 +27,12 @@ class GitHubAuthController extends AbstractController
         private HttpClientInterface $httpClient,
         private UserRepository $userRepository,
         private EntityManagerInterface $em,
-        private TokenService $tokenService,
         private OAuthStateService $oauthStateService,
-        private ImpersonationService $impersonationService,
+        private OAuthLoginResponder $oauthLoginResponder,
         private LoggerInterface $logger,
         private string $githubClientId,
         private string $githubClientSecret,
         private string $appUrl,
-        private string $frontendUrl,
     ) {
     }
 
@@ -50,12 +46,16 @@ class GitHubAuthController extends AbstractController
         response: 302,
         description: 'Redirect to GitHub OAuth authorization'
     )]
-    public function login(): Response
+    public function login(Request $request): Response
     {
         $redirectUri = $this->appUrl.'/api/v1/auth/github/callback';
 
+        // Native (mobile) clients open this in the system browser and need the
+        // result via a deep link — remember that intent in the signed state.
+        $native = $request->query->getBoolean('native');
+
         // Generate signed state token (no session required)
-        $state = $this->oauthStateService->generateState('github');
+        $state = $this->oauthStateService->generateState('github', $native ? ['native' => true] : []);
 
         $params = [
             'client_id' => $this->githubClientId,
@@ -89,26 +89,20 @@ class GitHubAuthController extends AbstractController
         $state = $request->query->get('state');
 
         // Validate signed state token (CSRF protection, no session required)
-        if (!$state || !$this->oauthStateService->validateState($state, 'github')) {
+        $statePayload = $state ? $this->oauthStateService->validateState($state, 'github') : null;
+
+        if (!$statePayload) {
             $this->logger->error('GitHub OAuth state validation failed', [
                 'state_present' => !empty($state),
             ]);
 
-            $errorUrl = $this->frontendUrl.'/auth/callback?'.http_build_query([
-                'error' => 'Invalid state parameter',
-                'provider' => 'github',
-            ]);
-
-            return $this->redirect($errorUrl);
+            return $this->oauthLoginResponder->error('github', 'Invalid state parameter', false);
         }
 
-        if (!$code) {
-            $errorUrl = $this->frontendUrl.'/auth/callback?'.http_build_query([
-                'error' => 'Authorization code not received',
-                'provider' => 'github',
-            ]);
+        $native = (bool) ($statePayload['native'] ?? false);
 
-            return $this->redirect($errorUrl);
+        if (!$code) {
+            return $this->oauthLoginResponder->error('github', 'Authorization code not received', $native);
         }
 
         try {
@@ -175,44 +169,21 @@ class GitHubAuthController extends AbstractController
             // Find or create user
             $user = $this->findOrCreateUser($userInfo, $email, $githubAccessToken);
 
-            // Generate our tokens
-            $accessToken = $this->tokenService->generateAccessToken($user);
-            $refreshToken = $this->tokenService->generateRefreshToken($user, $request->getClientIp());
-
-            // Create redirect response with cookies
-            $callbackUrl = $this->frontendUrl.'/auth/callback?'.http_build_query([
-                'success' => 'true',
-                'provider' => 'github',
-            ]);
-
-            $response = new RedirectResponse($callbackUrl);
-
-            // Set fresh auth cookies and defensively wipe any orphan
-            // impersonation stash that survived from a prior session on this
-            // browser. Same rationale as in GoogleAuthController and the
-            // regular login path: a leftover stash must never let the new
-            // signed-in user resurrect a previous admin's session.
-            $this->tokenService->addAuthCookies($response, $accessToken, $refreshToken);
-            $this->impersonationService->attachClearStashCookies($response);
-
-            $this->logger->info('GitHub OAuth successful, redirecting with cookies', [
+            $this->logger->info('GitHub OAuth successful', [
                 'user_id' => $user->getId(),
                 'email' => $user->getMail(),
+                'native' => $native,
             ]);
 
-            return $response;
+            // Web → cookies + SPA redirect; native → deep-link handoff token.
+            return $this->oauthLoginResponder->success($user, $request, 'github', $native);
         } catch (\Exception $e) {
             $this->logger->error('GitHub OAuth callback error', [
                 'error' => $e->getMessage(),
                 'trace' => $e->getTraceAsString(),
             ]);
 
-            $errorUrl = $this->frontendUrl.'/auth/callback?'.http_build_query([
-                'error' => 'Failed to authenticate with GitHub',
-                'provider' => 'github',
-            ]);
-
-            return $this->redirect($errorUrl);
+            return $this->oauthLoginResponder->error('github', 'Failed to authenticate with GitHub', $native);
         }
     }
 

--- a/backend/src/Controller/GoogleAuthController.php
+++ b/backend/src/Controller/GoogleAuthController.php
@@ -4,14 +4,12 @@ namespace App\Controller;
 
 use App\Entity\User;
 use App\Repository\UserRepository;
-use App\Service\ImpersonationService;
+use App\Service\OAuthLoginResponder;
 use App\Service\OAuthStateService;
-use App\Service\TokenService;
 use Doctrine\ORM\EntityManagerInterface;
 use OpenApi\Attributes as OA;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
@@ -28,14 +26,12 @@ class GoogleAuthController extends AbstractController
         private HttpClientInterface $httpClient,
         private UserRepository $userRepository,
         private EntityManagerInterface $em,
-        private TokenService $tokenService,
         private OAuthStateService $oauthStateService,
-        private ImpersonationService $impersonationService,
+        private OAuthLoginResponder $oauthLoginResponder,
         private LoggerInterface $logger,
         private string $googleClientId,
         private string $googleClientSecret,
         private string $appUrl,
-        private string $frontendUrl,
     ) {
     }
 
@@ -49,12 +45,17 @@ class GoogleAuthController extends AbstractController
         response: 302,
         description: 'Redirect to Google OAuth consent screen'
     )]
-    public function login(): Response
+    public function login(Request $request): Response
     {
         $redirectUri = $this->appUrl.'/api/v1/auth/google/callback';
 
+        // Native (mobile) clients open this URL in the system browser and need
+        // the result delivered back via a deep link — remember that intent in
+        // the signed state so the callback knows which flow to complete.
+        $native = $request->query->getBoolean('native');
+
         // Generate signed state token (no session required)
-        $state = $this->oauthStateService->generateState('google');
+        $state = $this->oauthStateService->generateState('google', $native ? ['native' => true] : []);
 
         $params = [
             'client_id' => $this->googleClientId,
@@ -91,26 +92,22 @@ class GoogleAuthController extends AbstractController
         $state = $request->query->get('state');
 
         // Validate signed state token (CSRF protection, no session required)
-        if (!$state || !$this->oauthStateService->validateState($state, 'google')) {
+        $statePayload = $state ? $this->oauthStateService->validateState($state, 'google') : null;
+
+        if (!$statePayload) {
             $this->logger->error('Google OAuth state validation failed', [
                 'state_present' => !empty($state),
             ]);
 
-            $errorUrl = $this->frontendUrl.'/auth/callback?'.http_build_query([
-                'error' => 'Invalid state parameter',
-                'provider' => 'google',
-            ]);
-
-            return $this->redirect($errorUrl);
+            // Native flag lives inside the (here invalid) state, so default to
+            // the web error page when we cannot trust it.
+            return $this->oauthLoginResponder->error('google', 'Invalid state parameter', false);
         }
 
-        if (!$code) {
-            $errorUrl = $this->frontendUrl.'/auth/callback?'.http_build_query([
-                'error' => 'Authorization code not received',
-                'provider' => 'google',
-            ]);
+        $native = (bool) ($statePayload['native'] ?? false);
 
-            return $this->redirect($errorUrl);
+        if (!$code) {
+            return $this->oauthLoginResponder->error('google', 'Authorization code not received', $native);
         }
 
         try {
@@ -150,44 +147,21 @@ class GoogleAuthController extends AbstractController
             // Find or create user
             $user = $this->findOrCreateUser($userInfo, $googleRefreshToken);
 
-            // Generate our tokens
-            $accessToken = $this->tokenService->generateAccessToken($user);
-            $refreshToken = $this->tokenService->generateRefreshToken($user, $request->getClientIp());
-
-            // Create redirect response with cookies
-            $callbackUrl = $this->frontendUrl.'/auth/callback?'.http_build_query([
-                'success' => 'true',
-                'provider' => 'google',
-            ]);
-
-            $response = new RedirectResponse($callbackUrl);
-
-            // Set fresh auth cookies and defensively wipe any orphan
-            // impersonation stash that survived from a prior session on this
-            // browser. Without this, a user signing in via Google could
-            // inherit a stash pointing at a previous admin's refresh token,
-            // which would let them resurrect that admin session via "Exit".
-            $this->tokenService->addAuthCookies($response, $accessToken, $refreshToken);
-            $this->impersonationService->attachClearStashCookies($response);
-
-            $this->logger->info('Google OAuth successful, redirecting with cookies', [
+            $this->logger->info('Google OAuth successful', [
                 'user_id' => $user->getId(),
                 'email' => $user->getMail(),
+                'native' => $native,
             ]);
 
-            return $response;
+            // Web → cookies + SPA redirect; native → deep-link handoff token.
+            return $this->oauthLoginResponder->success($user, $request, 'google', $native);
         } catch (\Exception $e) {
             $this->logger->error('Google OAuth callback error', [
                 'error' => $e->getMessage(),
                 'trace' => substr($e->getTraceAsString(), 0, 1000),
             ]);
 
-            $errorUrl = $this->frontendUrl.'/auth/callback?'.http_build_query([
-                'error' => 'Failed to authenticate with Google',
-                'provider' => 'google',
-            ]);
-
-            return $this->redirect($errorUrl);
+            return $this->oauthLoginResponder->error('google', 'Failed to authenticate with Google', $native);
         }
     }
 

--- a/backend/src/Controller/KeycloakAuthController.php
+++ b/backend/src/Controller/KeycloakAuthController.php
@@ -3,6 +3,7 @@
 namespace App\Controller;
 
 use App\Service\ImpersonationService;
+use App\Service\OAuthLoginResponder;
 use App\Service\OAuthStateService;
 use App\Service\OidcTokenService;
 use App\Service\OidcUserService;
@@ -40,6 +41,7 @@ class KeycloakAuthController extends AbstractController
         private OidcTokenService $oidcTokenService,
         private OidcUserService $oidcUserService,
         private OAuthStateService $oauthStateService,
+        private OAuthLoginResponder $oauthLoginResponder,
         private ImpersonationService $impersonationService,
         private LoggerInterface $logger,
         private string $oidcClientId,
@@ -59,7 +61,7 @@ class KeycloakAuthController extends AbstractController
         description: 'Initiates OAuth 2.0 Authorization Code Flow with PKCE (RFC 7636) for enhanced security',
         tags: ['Authentication']
     )]
-    public function login(): Response
+    public function login(Request $request): Response
     {
         try {
             $discovery = $this->getDiscoveryConfig();
@@ -70,10 +72,15 @@ class KeycloakAuthController extends AbstractController
             $codeVerifier = $this->generateCodeVerifier();
             $codeChallenge = $this->generateCodeChallenge($codeVerifier);
 
+            // Native (mobile) clients open this in the system browser and need
+            // the result via a deep link — remember that intent in the state.
+            $stateData = ['pkce_verifier' => $codeVerifier];
+            if ($request->query->getBoolean('native')) {
+                $stateData['native'] = true;
+            }
+
             // Generate signed state token with PKCE verifier embedded (no session required)
-            $state = $this->oauthStateService->generateState('keycloak', [
-                'pkce_verifier' => $codeVerifier,
-            ]);
+            $state = $this->oauthStateService->generateState('keycloak', $stateData);
 
             $params = [
                 'client_id' => $this->oidcClientId,
@@ -144,22 +151,18 @@ class KeycloakAuthController extends AbstractController
             ]));
         }
 
+        $native = (bool) ($statePayload['native'] ?? false);
+
         // Extract PKCE verifier from validated state
         $codeVerifier = $statePayload['pkce_verifier'] ?? null;
         if (!$codeVerifier) {
             $this->logger->error('PKCE code_verifier missing from state token');
 
-            return $this->redirect($this->frontendUrl.'/auth/callback?'.http_build_query([
-                'error' => 'PKCE verification failed',
-                'provider' => 'keycloak',
-            ]));
+            return $this->oauthLoginResponder->error('keycloak', 'PKCE verification failed', $native);
         }
 
         if (!$code) {
-            return $this->redirect($this->frontendUrl.'/auth/callback?'.http_build_query([
-                'error' => 'Authorization code not received',
-                'provider' => 'keycloak',
-            ]));
+            return $this->oauthLoginResponder->error('keycloak', 'Authorization code not received', $native);
         }
 
         try {
@@ -227,6 +230,19 @@ class KeycloakAuthController extends AbstractController
             // Find or create user + sync roles via shared OIDC user service
             $user = $this->oidcUserService->findOrCreateFromClaims($userInfo, $refreshToken);
 
+            // Native (mobile) cannot use cross-origin OIDC cookies — hand the app
+            // its own Bearer tokens via the deep-link handoff. The Keycloak
+            // refresh-cookie flow stays web-only; native refreshes through our
+            // app refresh token instead.
+            if ($native) {
+                $this->logger->info('Keycloak OAuth successful (native handoff)', [
+                    'user_id' => $user->getId(),
+                    'email' => $user->getMail(),
+                ]);
+
+                return $this->oauthLoginResponder->success($user, $request, 'keycloak', true);
+            }
+
             // Create redirect response
             $callbackUrl = $this->frontendUrl.'/auth/callback?'.http_build_query([
                 'success' => 'true',
@@ -278,10 +294,7 @@ class KeycloakAuthController extends AbstractController
 
             $this->logger->error('Keycloak OAuth callback error', $errorDetails);
 
-            return $this->redirect($this->frontendUrl.'/auth/callback?'.http_build_query([
-                'error' => 'Failed to authenticate with Keycloak',
-                'provider' => 'keycloak',
-            ]));
+            return $this->oauthLoginResponder->error('keycloak', 'Failed to authenticate with Keycloak', $native);
         }
     }
 

--- a/backend/src/Service/Client/ClientContext.php
+++ b/backend/src/Service/Client/ClientContext.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Client;
+
+/**
+ * Server-confirmed identity of the calling client (Aspect 1 / mobile app Epic 2).
+ *
+ * Derived from the request User-Agent: the native app appends a frozen
+ * `Synaplan Mobile V<major>.<minor>[.<patch>]` token (see synaplan-apps
+ * docs/IDENTIFIERS.md). This is an identity HINT for branding/analytics and the
+ * forced-update gate — it is trivially spoofable and must NEVER be used as an
+ * authorization control. Security always rests on the Bearer token + server-side
+ * validation.
+ */
+final readonly class ClientContext
+{
+    public function __construct(
+        public bool $isMobileApp,
+        public ?string $appVersion,
+        public ?int $appVersionMajor,
+        public ?int $appVersionMinor,
+        public ?int $appVersionPatch,
+    ) {
+    }
+
+    /**
+     * The non-app default (browser / API client).
+     */
+    public static function web(): self
+    {
+        return new self(false, null, null, null, null);
+    }
+
+    public function platform(): string
+    {
+        return $this->isMobileApp ? 'mobile' : 'web';
+    }
+}

--- a/backend/src/Service/Client/ClientContextResolver.php
+++ b/backend/src/Service/Client/ClientContextResolver.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Client;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Parses the request User-Agent into a {@see ClientContext}.
+ *
+ * The matched token format is a FROZEN contract shared with the native app
+ * (synaplan-apps capacitor.config.ts `appendUserAgent` + docs/IDENTIFIERS.md):
+ *
+ *     Synaplan Mobile V<major>.<minor>[.<patch>]
+ *
+ * Examples that match: "Synaplan Mobile V4.0", "Synaplan Mobile V4.0.1".
+ * Any UA without this token resolves to the web default. Because the UA rides on
+ * the WebView for ALL transports (fetch/SSE/WebSocket), the same parser works for
+ * every request the app makes.
+ */
+final class ClientContextResolver
+{
+    private const UA_PATTERN = '/Synaplan Mobile V(\d+)\.(\d+)(?:\.(\d+))?/';
+
+    public function fromRequest(Request $request): ClientContext
+    {
+        return $this->fromUserAgent($request->headers->get('User-Agent'));
+    }
+
+    public function fromUserAgent(?string $userAgent): ClientContext
+    {
+        if (null === $userAgent || '' === $userAgent) {
+            return ClientContext::web();
+        }
+
+        if (1 !== preg_match(self::UA_PATTERN, $userAgent, $matches)) {
+            return ClientContext::web();
+        }
+
+        $major = (int) $matches[1];
+        $minor = (int) $matches[2];
+        $patch = isset($matches[3]) ? (int) $matches[3] : null;
+
+        $version = $major.'.'.$minor.(null !== $patch ? '.'.$patch : '');
+
+        return new ClientContext(
+            isMobileApp: true,
+            appVersion: $version,
+            appVersionMajor: $major,
+            appVersionMinor: $minor,
+            appVersionPatch: $patch,
+        );
+    }
+}

--- a/backend/src/Service/NativeAuthHandoffService.php
+++ b/backend/src/Service/NativeAuthHandoffService.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Entity\User;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Short-lived, signed handoff token for native (mobile) OAuth.
+ *
+ * The native OAuth flow runs in the system browser and returns to the app via a
+ * custom-scheme deep link. We must hand the freshly authenticated user back to
+ * the app without exposing long-lived credentials in that URL (deep links land
+ * in browser history and could be observed by a scheme-squatting app).
+ *
+ * Instead the OAuth callback emits a single-purpose, 120s-TTL HMAC token that
+ * embeds only the user id. The app immediately exchanges it at
+ * `POST /api/v1/auth/native/exchange` for real access/refresh tokens, so the
+ * long-lived tokens never travel through the browser/deep-link.
+ *
+ * Stateless (HMAC over the app secret), mirroring OAuthStateService — no server
+ * storage required. NOTE (Epic 7 hardening): make it truly single-use by
+ * tracking the nonce in a short-TTL cache to defeat replay within the window.
+ */
+final readonly class NativeAuthHandoffService
+{
+    private const TTL = 120;
+    private const PURPOSE = 'native_oauth_handoff';
+
+    public function __construct(
+        private LoggerInterface $logger,
+        private string $appSecret,
+    ) {
+    }
+
+    /**
+     * Generate a signed handoff token for the given user.
+     */
+    public function generate(User $user): string
+    {
+        $payload = [
+            'uid' => $user->getId(),
+            'purpose' => self::PURPOSE,
+            'nonce' => bin2hex(random_bytes(16)),
+            'created_at' => time(),
+        ];
+
+        $json = json_encode($payload, JSON_THROW_ON_ERROR);
+        $signature = hash_hmac('sha256', $json, $this->appSecret);
+
+        return rtrim(strtr(base64_encode($json), '+/', '-_'), '=').'.'.$signature;
+    }
+
+    /**
+     * Validate a handoff token and return the embedded user id, or null on any
+     * failure (bad format, bad signature, wrong purpose, expired).
+     */
+    public function validate(string $token): ?int
+    {
+        $parts = explode('.', $token);
+        if (2 !== count($parts)) {
+            return null;
+        }
+
+        [$encodedPayload, $signature] = $parts;
+
+        $json = base64_decode(strtr($encodedPayload, '-_', '+/'), true);
+        if (false === $json || '' === $json) {
+            return null;
+        }
+
+        if (!hash_equals(hash_hmac('sha256', $json, $this->appSecret), $signature)) {
+            $this->logger->warning('Native handoff token signature verification failed');
+
+            return null;
+        }
+
+        try {
+            /** @var array<string, mixed> $payload */
+            $payload = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            return null;
+        }
+
+        if (self::PURPOSE !== ($payload['purpose'] ?? null)) {
+            return null;
+        }
+
+        $createdAt = $payload['created_at'] ?? null;
+        if (!is_int($createdAt) || (time() - $createdAt) > self::TTL) {
+            $this->logger->warning('Native handoff token expired');
+
+            return null;
+        }
+
+        $uid = $payload['uid'] ?? null;
+
+        return is_int($uid) ? $uid : null;
+    }
+}

--- a/backend/src/Service/OAuthLoginResponder.php
+++ b/backend/src/Service/OAuthLoginResponder.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Entity\User;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Builds the final response after a successful (or failed) OAuth callback,
+ * branching between the web and native (mobile) flows.
+ *
+ * Web: redirect to the SPA `/auth/callback` with HttpOnly auth cookies set.
+ * Native: redirect to the app's custom-scheme deep link carrying a short-lived
+ * handoff token (NativeAuthHandoffService) that the app exchanges for Bearer
+ * tokens — cookies are useless cross-origin in the WebView.
+ *
+ * Centralises the per-provider duplication (Google/GitHub/Keycloak controllers
+ * all ended with the same cookie-redirect block).
+ */
+final readonly class OAuthLoginResponder
+{
+    public function __construct(
+        private TokenService $tokenService,
+        private ImpersonationService $impersonationService,
+        private NativeAuthHandoffService $handoffService,
+        private string $frontendUrl,
+        private string $nativeDeepLinkScheme,
+    ) {
+    }
+
+    /**
+     * Success response for an authenticated user.
+     */
+    public function success(User $user, Request $request, string $provider, bool $native): Response
+    {
+        if ($native) {
+            return new RedirectResponse($this->deepLink([
+                'success' => 'true',
+                'provider' => $provider,
+                'handoff' => $this->handoffService->generate($user),
+            ]));
+        }
+
+        $accessToken = $this->tokenService->generateAccessToken($user);
+        $refreshToken = $this->tokenService->generateRefreshToken($user, $request->getClientIp());
+
+        $response = new RedirectResponse($this->frontendUrl.'/auth/callback?'.http_build_query([
+            'success' => 'true',
+            'provider' => $provider,
+        ]));
+
+        // Set fresh auth cookies and defensively wipe any orphan impersonation
+        // stash that survived from a prior session on this browser, so a new
+        // sign-in can never inherit a previous admin's suspended session.
+        $this->tokenService->addAuthCookies($response, $accessToken, $refreshToken);
+        $this->impersonationService->attachClearStashCookies($response);
+
+        return $response;
+    }
+
+    /**
+     * Error response routed to the right place for the client type.
+     */
+    public function error(string $provider, string $error, bool $native): Response
+    {
+        if ($native) {
+            return new RedirectResponse($this->deepLink([
+                'error' => $error,
+                'provider' => $provider,
+            ]));
+        }
+
+        return new RedirectResponse($this->frontendUrl.'/auth/callback?'.http_build_query([
+            'error' => $error,
+            'provider' => $provider,
+        ]));
+    }
+
+    /**
+     * @param array<string, string> $query
+     */
+    private function deepLink(array $query): string
+    {
+        // e.g. com.synaplan.app://oauth/callback?success=true&provider=google&handoff=...
+        return sprintf('%s://oauth/callback?%s', $this->nativeDeepLinkScheme, http_build_query($query));
+    }
+}

--- a/backend/tests/Unit/Controller/ConfigControllerSaveDefaultModelsTest.php
+++ b/backend/tests/Unit/Controller/ConfigControllerSaveDefaultModelsTest.php
@@ -12,6 +12,7 @@ use App\Entity\User;
 use App\Repository\ConfigRepository;
 use App\Repository\ModelRepository;
 use App\Service\BillingService;
+use App\Service\Client\ClientContextResolver;
 use App\Service\Embedding\EmbeddingMetadataService;
 use App\Service\Embedding\EmbeddingModelChangeGuard;
 use App\Service\Embedding\Exception\PremiumRequiredException;
@@ -75,6 +76,7 @@ final class ConfigControllerSaveDefaultModelsTest extends TestCase
             // RedisService is final (not stubbable); a real instance with an
             // empty DSN is inert and saveDefaultModels never touches it.
             new RedisService('', 'test', new NullLogger()),
+            new ClientContextResolver(),
             'http://qdrant.example',
         );
 

--- a/backend/tests/Unit/KeycloakAuthControllerTest.php
+++ b/backend/tests/Unit/KeycloakAuthControllerTest.php
@@ -43,12 +43,24 @@ class KeycloakAuthControllerTest extends TestCase
         // they were written for.
         $impersonationService = $this->createMock(\App\Service\ImpersonationService::class);
 
+        // OAuthLoginResponder + NativeAuthHandoffService are final — build real
+        // instances (with mocked collaborators) like OAuthStateService above.
+        $handoffService = new \App\Service\NativeAuthHandoffService($this->logger, 'test-secret');
+        $oauthLoginResponder = new \App\Service\OAuthLoginResponder(
+            $this->tokenService,
+            $impersonationService,
+            $handoffService,
+            'https://app.example.com',
+            'com.synaplan.app',
+        );
+
         return new KeycloakAuthController(
             $this->httpClient,
             $this->tokenService,
             $this->oidcTokenService,
             $this->oidcUserService,
             $this->oauthStateService,
+            $oauthLoginResponder,
             $impersonationService,
             $this->logger,
             'test-client-id',

--- a/backend/tests/Unit/Service/Client/ClientContextResolverTest.php
+++ b/backend/tests/Unit/Service/Client/ClientContextResolverTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\Client;
+
+use App\Service\Client\ClientContextResolver;
+use PHPUnit\Framework\TestCase;
+
+class ClientContextResolverTest extends TestCase
+{
+    private ClientContextResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $this->resolver = new ClientContextResolver();
+    }
+
+    public function testParsesMajorMinorVersion(): void
+    {
+        $ua = 'Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15 Synaplan Mobile V4.0';
+        $context = $this->resolver->fromUserAgent($ua);
+
+        self::assertTrue($context->isMobileApp);
+        self::assertSame('4.0', $context->appVersion);
+        self::assertSame(4, $context->appVersionMajor);
+        self::assertSame(0, $context->appVersionMinor);
+        self::assertNull($context->appVersionPatch);
+        self::assertSame('mobile', $context->platform());
+    }
+
+    public function testParsesMajorMinorPatchVersion(): void
+    {
+        $context = $this->resolver->fromUserAgent('Android WebView Synaplan Mobile V4.0.1');
+
+        self::assertTrue($context->isMobileApp);
+        self::assertSame('4.0.1', $context->appVersion);
+        self::assertSame(4, $context->appVersionMajor);
+        self::assertSame(0, $context->appVersionMinor);
+        self::assertSame(1, $context->appVersionPatch);
+    }
+
+    public function testHandlesLargerVersionNumbers(): void
+    {
+        $context = $this->resolver->fromUserAgent('Synaplan Mobile V12.34.56');
+
+        self::assertSame('12.34.56', $context->appVersion);
+        self::assertSame(12, $context->appVersionMajor);
+        self::assertSame(34, $context->appVersionMinor);
+        self::assertSame(56, $context->appVersionPatch);
+    }
+
+    public function testPlainBrowserUserAgentIsWeb(): void
+    {
+        $ua = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36';
+        $context = $this->resolver->fromUserAgent($ua);
+
+        self::assertFalse($context->isMobileApp);
+        self::assertNull($context->appVersion);
+        self::assertSame('web', $context->platform());
+    }
+
+    public function testNullUserAgentIsWeb(): void
+    {
+        $context = $this->resolver->fromUserAgent(null);
+
+        self::assertFalse($context->isMobileApp);
+        self::assertNull($context->appVersion);
+    }
+
+    public function testEmptyUserAgentIsWeb(): void
+    {
+        $context = $this->resolver->fromUserAgent('');
+
+        self::assertFalse($context->isMobileApp);
+    }
+
+    /**
+     * Spoof-ish / malformed variants must NOT be detected as the app: the contract is a
+     * capital V immediately followed by digits, so these near-misses fall back to web.
+     */
+    public function testRejectsSpoofAndMalformedTokens(): void
+    {
+        $nonMatches = [
+            'Synaplan Mobile',            // no version
+            'Synaplan Mobile V',          // V without digits
+            'Synaplan Mobile Vx.y',       // non-numeric
+            'Synaplan Mobile v4.0',       // lowercase v
+            'SynaplanMobile V4.0',        // missing space
+            'Synaplan Desktop V4.0',      // wrong product word
+        ];
+
+        foreach ($nonMatches as $ua) {
+            $context = $this->resolver->fromUserAgent($ua);
+            self::assertFalse($context->isMobileApp, sprintf('UA "%s" must not be detected as the mobile app', $ua));
+            self::assertNull($context->appVersion);
+        }
+    }
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "vite-vue-typescript-starter",
       "version": "0.0.0",
       "dependencies": {
+        "@aparajita/capacitor-biometric-auth": "^10.0.0",
         "@aparajita/capacitor-secure-storage": "^8.0.0",
         "@capacitor/app": "^8.1.0",
         "@capacitor/browser": "^8.0.3",
@@ -94,6 +95,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@aparajita/capacitor-biometric-auth": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@aparajita/capacitor-biometric-auth/-/capacitor-biometric-auth-10.0.0.tgz",
+      "integrity": "sha512-azjWaRucB8x1/gSzSTp/NxelaOZyg+m765gSzjwUkSQgg30RrZPmPq6pyLeeXVSZNDY3Rxf5Hj8obgZaXirCFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@capacitor/android": "^8.0.2",
+        "@capacitor/app": "^8.0.0",
+        "@capacitor/core": "^8.0.2",
+        "@capacitor/ios": "^8.0.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aparajita/capacitor-secure-storage": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "vite-vue-typescript-starter",
       "version": "0.0.0",
       "dependencies": {
+        "@aparajita/capacitor-secure-storage": "^8.0.0",
         "@capacitor/app": "^8.1.0",
         "@capacitor/browser": "^8.0.3",
         "@capacitor/core": "^8.4.1",
@@ -90,6 +91,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@aparajita/capacitor-secure-storage": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@aparajita/capacitor-secure-storage/-/capacitor-secure-storage-8.0.0.tgz",
+      "integrity": "sha512-oYnwSjdIh23aRNgz8982+TmFvQH/2yZkEdw1iIg+H2ziFJoOVELPTc7u6Ez2HwOuDIW5AGqBX75GvrzQ+D70Qg==",
+      "license": "MIT",
+      "dependencies": {
+        "@capacitor/android": "^8.0.2",
+        "@capacitor/app": "^8.0.0",
+        "@capacitor/core": "^8.0.2",
+        "@capacitor/ios": "^8.0.2",
+        "@capacitor/keyboard": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
@@ -460,6 +477,15 @@
       "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
       "license": "MIT"
     },
+    "node_modules/@capacitor/android": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-8.4.1.tgz",
+      "integrity": "sha512-igtDCJ7QQn0P2qHFD9p4KXaa6V1b2PRNt+MxjVwtjTm/BJvqmiazOJq6rPjwFSZnfHm6iFoZk8TfzHd44pyBGw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": "^8.4.0"
+      }
+    },
     "node_modules/@capacitor/app": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/@capacitor/app/-/app-8.1.0.tgz",
@@ -485,6 +511,24 @@
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@capacitor/ios": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/ios/-/ios-8.4.1.tgz",
+      "integrity": "sha512-EgcAk7NYheHMTyP3CUrA65qKs4D2UEAKgw44HI6Uk3dTw6KjLQkdLOQWvbeRncHaZ2gklfOojUoc5DlSw2lhYg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": "^8.4.0"
+      }
+    },
+    "node_modules/@capacitor/keyboard": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/@capacitor/keyboard/-/keyboard-8.0.5.tgz",
+      "integrity": "sha512-oFXygC4eKYA5l2MdpTR06L2M/4x6e2SLD5yS1T9+UBDKTkzyvhWKEhbYLUaTIBPpLKqlfGudJw1X73S1H9eUzQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
       }
     },
     "node_modules/@chevrotain/types": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,8 @@
         "@capacitor/app": "^8.1.0",
         "@capacitor/browser": "^8.0.3",
         "@capacitor/core": "^8.4.1",
+        "@capacitor/filesystem": "^8.1.2",
+        "@capacitor/share": "^8.0.1",
         "@heroicons/vue": "^2.2.0",
         "@iconify/vue": "^5.0.0",
         "@intlify/core-base": "^11.1.12",
@@ -513,6 +515,18 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/@capacitor/filesystem": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/@capacitor/filesystem/-/filesystem-8.1.2.tgz",
+      "integrity": "sha512-doaaMfGoFR2hWU6aV6u83I+5ZsGyJVq+Gz4r9lMpJzUKMm1eMu0hLnFdV1aXZlU9FlK/RndFrVD8oRZfNOqWgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@capacitor/synapse": "^1.0.4"
+      },
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
     "node_modules/@capacitor/ios": {
       "version": "8.4.1",
       "resolved": "https://registry.npmjs.org/@capacitor/ios/-/ios-8.4.1.tgz",
@@ -530,6 +544,21 @@
       "peerDependencies": {
         "@capacitor/core": ">=8.0.0"
       }
+    },
+    "node_modules/@capacitor/share": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/share/-/share-8.0.1.tgz",
+      "integrity": "sha512-3cSBKBCJVon54rKDROP2rqGyeGks4pBh9TbaEk9S375Kbek/ZHe72N50zIa0Vn9Eac/SuhwgehO/mmA4CsUOiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
+    "node_modules/@capacitor/synapse": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@capacitor/synapse/-/synapse-1.0.4.tgz",
+      "integrity": "sha512-/C1FUo8/OkKuAT4nCIu/34ny9siNHr9qtFezu4kxm6GY1wNFxrCFWjfYx5C1tUhVGz3fxBABegupkpjXvjCHrw==",
+      "license": "ISC"
     },
     "node_modules/@chevrotain/types": {
       "version": "11.1.2",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,9 @@
       "name": "vite-vue-typescript-starter",
       "version": "0.0.0",
       "dependencies": {
+        "@capacitor/app": "^8.1.0",
+        "@capacitor/browser": "^8.0.3",
+        "@capacitor/core": "^8.4.1",
         "@heroicons/vue": "^2.2.0",
         "@iconify/vue": "^5.0.0",
         "@intlify/core-base": "^11.1.12",
@@ -456,6 +459,33 @@
       "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
       "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
       "license": "MIT"
+    },
+    "node_modules/@capacitor/app": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@capacitor/app/-/app-8.1.0.tgz",
+      "integrity": "sha512-MlmttTOWHDedr/G4SrhNRxsXMqY+R75S4MM4eIgzsgCzOYhb/MpCkA5Q3nuOCfL1oHm26xjUzqZ5aupbOwdfYg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
+    "node_modules/@capacitor/browser": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@capacitor/browser/-/browser-8.0.3.tgz",
+      "integrity": "sha512-WJWPHEPbweiFoHYmVlCbZf5yrqJ2Rchx2Xvbmd+3Lf+Zkpq3nXBThThY2CF69lYEg1NINGF9BcHThIOEU1gZlQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
+    "node_modules/@capacitor/core": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-8.4.1.tgz",
+      "integrity": "sha512-xqhOGLbTAYeOWK+IDUNSjQJAPapQjRHrIcgk9PYp52or9zFTaaMko31uNi16N6W+CRJ8VrRram6fOYILkBG2Hg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
     },
     "node_modules/@chevrotain/types": {
       "version": "11.1.2",
@@ -7473,7 +7503,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/type-check": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "@capacitor/browser": "^8.0.3",
         "@capacitor/core": "^8.4.1",
         "@capacitor/filesystem": "^8.1.2",
+        "@capacitor/network": "^8.0.1",
         "@capacitor/share": "^8.0.1",
         "@heroicons/vue": "^2.2.0",
         "@iconify/vue": "^5.0.0",
@@ -540,6 +541,15 @@
       "version": "8.0.5",
       "resolved": "https://registry.npmjs.org/@capacitor/keyboard/-/keyboard-8.0.5.tgz",
       "integrity": "sha512-oFXygC4eKYA5l2MdpTR06L2M/4x6e2SLD5yS1T9+UBDKTkzyvhWKEhbYLUaTIBPpLKqlfGudJw1X73S1H9eUzQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
+    "node_modules/@capacitor/network": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/network/-/network-8.0.1.tgz",
+      "integrity": "sha512-9xK/FHFmzKGanB6BdoSZOzXk8vF0OFVQSQ4PAsIrzAzLuXHryO317qy8dcHVpgxYeuZq2noI0My9z1DvVDi/9w==",
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": ">=8.0.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,6 +30,7 @@
     "generate:schemas": "node scripts/generate-schemas.js"
   },
   "dependencies": {
+    "@aparajita/capacitor-secure-storage": "^8.0.0",
     "@capacitor/app": "^8.1.0",
     "@capacitor/browser": "^8.0.3",
     "@capacitor/core": "^8.4.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,6 +35,7 @@
     "@capacitor/browser": "^8.0.3",
     "@capacitor/core": "^8.4.1",
     "@capacitor/filesystem": "^8.1.2",
+    "@capacitor/network": "^8.0.1",
     "@capacitor/share": "^8.0.1",
     "@heroicons/vue": "^2.2.0",
     "@iconify/vue": "^5.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,6 +30,7 @@
     "generate:schemas": "node scripts/generate-schemas.js"
   },
   "dependencies": {
+    "@aparajita/capacitor-biometric-auth": "^10.0.0",
     "@aparajita/capacitor-secure-storage": "^8.0.0",
     "@capacitor/app": "^8.1.0",
     "@capacitor/browser": "^8.0.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,6 +30,9 @@
     "generate:schemas": "node scripts/generate-schemas.js"
   },
   "dependencies": {
+    "@capacitor/app": "^8.1.0",
+    "@capacitor/browser": "^8.0.3",
+    "@capacitor/core": "^8.4.1",
     "@heroicons/vue": "^2.2.0",
     "@iconify/vue": "^5.0.0",
     "@intlify/core-base": "^11.1.12",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,6 +34,8 @@
     "@capacitor/app": "^8.1.0",
     "@capacitor/browser": "^8.0.3",
     "@capacitor/core": "^8.4.1",
+    "@capacitor/filesystem": "^8.1.2",
+    "@capacitor/share": "^8.0.1",
     "@heroicons/vue": "^2.2.0",
     "@iconify/vue": "^5.0.0",
     "@intlify/core-base": "^11.1.12",

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -9,6 +9,7 @@
       down — the page stays scroll-free.
     -->
     <ImpersonationBanner />
+    <OfflineBanner />
     <ErrorBoundary>
       <Suspense>
         <template #default>
@@ -37,6 +38,7 @@ import NotificationContainer from '@/components/NotificationContainer.vue'
 import Dialog from '@/components/Dialog.vue'
 import ErrorBoundary from '@/components/ErrorBoundary.vue'
 import ImpersonationBanner from '@/components/ImpersonationBanner.vue'
+import OfflineBanner from '@/components/OfflineBanner.vue'
 import LoadingView from '@/views/LoadingView.vue'
 import CookieConsent from '@/components/CookieConsent.vue'
 import { useGoogleTag } from '@/composables/useGoogleTag'

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -40,6 +40,7 @@ import ImpersonationBanner from '@/components/ImpersonationBanner.vue'
 import LoadingView from '@/views/LoadingView.vue'
 import CookieConsent from '@/components/CookieConsent.vue'
 import { useGoogleTag } from '@/composables/useGoogleTag'
+import { initNativeLifecycle } from '@/services/nativeLifecycle'
 import type { CookieConsent as CookieConsentType } from '@/composables/useCookieConsent'
 
 useTheme()
@@ -92,6 +93,10 @@ const authStore = useAuthStore()
 authStore.checkAuth().catch((err: unknown) => {
   console.error('Initial auth check failed:', err)
 })
+
+// Native shell only: on resume from background, re-validate the session and
+// reconnect realtime (Epic 7.2). No-op on web.
+void initNativeLifecycle()
 
 // Update page title when language changes
 const route = useRoute()

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -23,6 +23,7 @@
     <NotificationContainer />
     <Dialog />
     <CookieConsent @consent="handleCookieConsent" />
+    <BiometricLockScreen />
   </div>
 </template>
 
@@ -39,10 +40,12 @@ import Dialog from '@/components/Dialog.vue'
 import ErrorBoundary from '@/components/ErrorBoundary.vue'
 import ImpersonationBanner from '@/components/ImpersonationBanner.vue'
 import OfflineBanner from '@/components/OfflineBanner.vue'
+import BiometricLockScreen from '@/components/BiometricLockScreen.vue'
 import LoadingView from '@/views/LoadingView.vue'
 import CookieConsent from '@/components/CookieConsent.vue'
 import { useGoogleTag } from '@/composables/useGoogleTag'
 import { initNativeLifecycle } from '@/services/nativeLifecycle'
+import { initBiometricLock } from '@/composables/useBiometricLock'
 import type { CookieConsent as CookieConsentType } from '@/composables/useCookieConsent'
 
 useTheme()
@@ -99,6 +102,10 @@ authStore.checkAuth().catch((err: unknown) => {
 // Native shell only: on resume from background, re-validate the session and
 // reconnect realtime (Epic 7.2). No-op on web.
 void initNativeLifecycle()
+
+// Native shell only: optional biometric app lock (Epic 7.2). No-op on web or
+// when the user hasn't enabled it.
+void initBiometricLock()
 
 // Update page title when language changes
 const route = useRoute()

--- a/frontend/src/api/usageApi.ts
+++ b/frontend/src/api/usageApi.ts
@@ -1,4 +1,5 @@
 import { httpClient } from '@/services/api/httpClient'
+import { saveOrDownloadBlob } from '@/services/api/nativeDownload'
 import { useConfigStore } from '@/stores/config'
 
 // NOTE: this interface is hand-maintained because UsageStatsController's
@@ -211,12 +212,6 @@ export async function downloadUsageExport(sinceTimestamp?: number): Promise<void
     responseType: 'blob',
   })
 
-  const downloadUrl = window.URL.createObjectURL(blob)
-  const link = document.createElement('a')
-  link.href = downloadUrl
-  link.download = `synaplan-usage-${Date.now()}.csv`
-  document.body.appendChild(link)
-  link.click()
-  document.body.removeChild(link)
-  window.URL.revokeObjectURL(downloadUrl)
+  // Web → anchor download; native → Filesystem + share sheet (Epic 7.1).
+  await saveOrDownloadBlob(blob, `synaplan-usage-${Date.now()}.csv`)
 }

--- a/frontend/src/components/BiometricLockScreen.vue
+++ b/frontend/src/components/BiometricLockScreen.vue
@@ -1,0 +1,46 @@
+<template>
+  <Transition name="lock-fade">
+    <div
+      v-if="locked"
+      class="fixed inset-0 z-[2000] flex flex-col items-center justify-center gap-8 bg-app px-6"
+      data-testid="biometric-lock"
+    >
+      <div class="flex flex-col items-center gap-3 text-center">
+        <div
+          class="w-20 h-20 rounded-full bg-[var(--brand)]/15 flex items-center justify-center"
+          aria-hidden="true"
+        >
+          <Icon icon="mdi:fingerprint" class="w-11 h-11 text-[var(--brand)]" />
+        </div>
+        <h1 class="text-2xl font-bold txt-primary">{{ $t('biometricLock.title') }}</h1>
+        <p class="txt-secondary max-w-xs">{{ $t('biometricLock.subtitle') }}</p>
+      </div>
+      <button
+        type="button"
+        class="btn-primary px-8 py-3 rounded-lg font-medium"
+        data-testid="btn-biometric-unlock"
+        @click="unlock"
+      >
+        {{ $t('biometricLock.unlock') }}
+      </button>
+    </div>
+  </Transition>
+</template>
+
+<script setup lang="ts">
+import { Icon } from '@iconify/vue'
+import { useBiometricLock } from '@/composables/useBiometricLock'
+
+const { locked, unlock } = useBiometricLock()
+</script>
+
+<style scoped>
+.lock-fade-enter-active,
+.lock-fade-leave-active {
+  transition: opacity 0.2s ease;
+}
+.lock-fade-enter-from,
+.lock-fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/frontend/src/components/OfflineBanner.vue
+++ b/frontend/src/components/OfflineBanner.vue
@@ -1,0 +1,38 @@
+<template>
+  <Transition name="offline-slide">
+    <div
+      v-if="!isOnline"
+      class="fixed inset-x-0 top-0 z-[1000] flex items-center justify-center gap-2 px-4 py-2 text-sm font-medium text-white bg-[var(--status-warning,#b45309)] shadow-md"
+      role="status"
+      aria-live="polite"
+      data-testid="offline-banner"
+    >
+      <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          d="M18.364 5.636L5.636 18.364m12.728 0L5.636 5.636M12 2a10 10 0 100 20 10 10 0 000-20z"
+        />
+      </svg>
+      <span>{{ $t('network.offline') }}</span>
+    </div>
+  </Transition>
+</template>
+
+<script setup lang="ts">
+import { useNetworkStatus } from '@/composables/useNetworkStatus'
+
+const { isOnline } = useNetworkStatus()
+</script>
+
+<style scoped>
+.offline-slide-enter-active,
+.offline-slide-leave-active {
+  transition: transform 0.25s ease;
+}
+.offline-slide-enter-from,
+.offline-slide-leave-to {
+  transform: translateY(-100%);
+}
+</style>

--- a/frontend/src/composables/useBiometricLock.ts
+++ b/frontend/src/composables/useBiometricLock.ts
@@ -1,0 +1,68 @@
+/**
+ * Shared biometric-lock state + lifecycle (Epic 7.2).
+ *
+ * `locked` drives the full-screen BiometricLockScreen overlay. We lock on first
+ * launch (when enabled) and re-lock whenever the app leaves the foreground, so a
+ * resume always requires biometrics. A `verifying` guard prevents the OS dialog's
+ * own foreground/background churn from re-locking mid-prompt.
+ */
+import { ref } from 'vue'
+import { isNativeApp } from '@/services/api/nativeRuntime'
+import {
+  isBiometricLockEnabled,
+  isBiometricAvailable,
+  verifyBiometric,
+} from '@/services/biometricLock'
+
+const locked = ref(false)
+let initialized = false
+let verifying = false
+
+export function useBiometricLock() {
+  return { locked, unlock }
+}
+
+export async function initBiometricLock(): Promise<void> {
+  if (initialized || !isNativeApp()) {
+    return
+  }
+  initialized = true
+
+  if (isBiometricLockEnabled() && (await isBiometricAvailable())) {
+    locked.value = true
+    void promptUnlock()
+  }
+
+  const { App: CapacitorApp } = await import('@capacitor/app')
+  await CapacitorApp.addListener('appStateChange', ({ isActive }) => {
+    if (!isActive) {
+      // Re-arm the lock when backgrounding — unless a prompt is in flight.
+      if (!verifying && isBiometricLockEnabled()) {
+        locked.value = true
+      }
+      return
+    }
+    if (locked.value) {
+      void promptUnlock()
+    }
+  })
+}
+
+async function unlock(): Promise<void> {
+  await promptUnlock()
+}
+
+async function promptUnlock(): Promise<void> {
+  if (verifying) {
+    return
+  }
+  verifying = true
+  try {
+    const ok = await verifyBiometric('Unlock Synaplan')
+    if (ok) {
+      locked.value = false
+    }
+  } finally {
+    verifying = false
+  }
+}

--- a/frontend/src/composables/useNetworkStatus.ts
+++ b/frontend/src/composables/useNetworkStatus.ts
@@ -1,0 +1,44 @@
+/**
+ * Reactive online/offline status (Epic 7.3).
+ *
+ * Native uses @capacitor/network (the WebView's `navigator.onLine` is
+ * unreliable inside Capacitor); web uses `navigator.onLine` + the online/offline
+ * window events. The listener is wired once and shared via a module-level ref.
+ */
+import { ref } from 'vue'
+import { isNativeApp } from '@/services/api/nativeRuntime'
+
+const isOnline = ref(true)
+let initialized = false
+
+export function useNetworkStatus() {
+  if (!initialized) {
+    initialized = true
+    void initNetworkMonitoring()
+  }
+  return { isOnline }
+}
+
+async function initNetworkMonitoring(): Promise<void> {
+  if (isNativeApp()) {
+    try {
+      const { Network } = await import('@capacitor/network')
+      const status = await Network.getStatus()
+      isOnline.value = status.connected
+      await Network.addListener('networkStatusChange', (status) => {
+        isOnline.value = status.connected
+      })
+      return
+    } catch {
+      // Fall through to the web heuristic if the plugin is unavailable.
+    }
+  }
+
+  isOnline.value = navigator.onLine
+  window.addEventListener('online', () => {
+    isOnline.value = true
+  })
+  window.addEventListener('offline', () => {
+    isOnline.value = false
+  })
+}

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -3478,5 +3478,8 @@
       "disabled": "Live-Updates sind in dieser Umgebung deaktiviert. Lade die Seite neu, um die neuesten Daten zu sehen.",
       "error": "Echtzeit-Verbindung fehlgeschlagen: {message}"
     }
+  },
+  "network": {
+    "offline": "Du bist offline – prüfe deine Verbindung. Wir verbinden automatisch neu."
   }
 }

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -821,6 +821,14 @@
       "confirmPasswordPlaceholder": "Neues Passwort bestätigen",
       "confirmPasswordHint": "Muss mit neuem Passwort übereinstimmen"
     },
+    "appSecurity": {
+      "title": "App-Sicherheit",
+      "subtitle": "Zusätzlicher Schutz für dieses Gerät",
+      "biometricLock": "Biometrische App-Sperre",
+      "biometricLockHint": "Face ID, Touch ID oder Fingerabdruck zum Öffnen der App verlangen.",
+      "verifyReason": "Biometrische Sperre aktivieren",
+      "enableFailed": "Die biometrische Sperre konnte nicht aktiviert werden. Bitte erneut versuchen."
+    },
     "dangerZone": {
       "title": "Gefahrenzone",
       "subtitle": "Irreversible Aktionen",
@@ -3481,5 +3489,10 @@
   },
   "network": {
     "offline": "Du bist offline – prüfe deine Verbindung. Wir verbinden automatisch neu."
+  },
+  "biometricLock": {
+    "title": "Gesperrt",
+    "subtitle": "Entsperre Synaplan, um fortzufahren.",
+    "unlock": "Entsperren"
   }
 }

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -2772,6 +2772,14 @@
       "confirmPasswordPlaceholder": "Confirm new password",
       "confirmPasswordHint": "Must match new password"
     },
+    "appSecurity": {
+      "title": "App Security",
+      "subtitle": "Extra protection for this device",
+      "biometricLock": "Biometric app lock",
+      "biometricLockHint": "Require Face ID, Touch ID or fingerprint to open the app.",
+      "verifyReason": "Enable biometric lock",
+      "enableFailed": "Could not enable the biometric lock. Please try again."
+    },
     "dangerZone": {
       "title": "Danger Zone",
       "subtitle": "Irreversible actions",
@@ -3547,5 +3555,10 @@
   },
   "network": {
     "offline": "You're offline — check your connection. We'll reconnect automatically."
+  },
+  "biometricLock": {
+    "title": "Locked",
+    "subtitle": "Unlock Synaplan to continue.",
+    "unlock": "Unlock"
   }
 }

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -3544,5 +3544,8 @@
       "disabled": "Live updates are turned off in this environment. Refresh to see the latest data.",
       "error": "Realtime connection failed: {message}"
     }
+  },
+  "network": {
+    "offline": "You're offline — check your connection. We'll reconnect automatically."
   }
 }

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -963,6 +963,14 @@
       "confirmPasswordPlaceholder": "Confirma nueva contraseña",
       "confirmPasswordHint": "Debe coincidir con la nueva contraseña"
     },
+    "appSecurity": {
+      "title": "Seguridad de la app",
+      "subtitle": "Protección adicional para este dispositivo",
+      "biometricLock": "Bloqueo biométrico de la app",
+      "biometricLockHint": "Requiere Face ID, Touch ID o huella para abrir la app.",
+      "verifyReason": "Activar el bloqueo biométrico",
+      "enableFailed": "No se pudo activar el bloqueo biométrico. Inténtalo de nuevo."
+    },
     "dangerZone": {
       "title": "Zona de Peligro",
       "subtitle": "Acciones irreversibles",
@@ -2457,5 +2465,10 @@
   },
   "network": {
     "offline": "Estás sin conexión: comprueba tu red. Nos reconectaremos automáticamente."
+  },
+  "biometricLock": {
+    "title": "Bloqueada",
+    "subtitle": "Desbloquea Synaplan para continuar.",
+    "unlock": "Desbloquear"
   }
 }

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -2454,5 +2454,8 @@
       "disabled": "Las actualizaciones en vivo están desactivadas en este entorno. Recarga la página para ver los datos más recientes.",
       "error": "Falló la conexión en tiempo real: {message}"
     }
+  },
+  "network": {
+    "offline": "Estás sin conexión: comprueba tu red. Nos reconectaremos automáticamente."
   }
 }

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -21,13 +21,33 @@ function getInitialLanguage(): SupportedLanguage {
     return urlLang as SupportedLanguage
   }
 
-  // Fall back to localStorage or default
+  // An explicit saved choice always wins.
   const savedLanguage = localStorage.getItem('language')
   if (savedLanguage && supportedLanguages.includes(savedLanguage as SupportedLanguage)) {
     return savedLanguage as SupportedLanguage
   }
 
-  return 'en'
+  // Fall back to the device / browser language (Epic 7.3: in the native shell
+  // navigator.language reflects the OS locale). Not persisted — a manual choice
+  // is what gets stored. Defaults to English when nothing matches.
+  return detectDeviceLanguage() ?? 'en'
+}
+
+// Map the device/browser locale list (e.g. "de-DE", "es-419") onto a supported
+// base language, preferring the user's most-preferred match.
+function detectDeviceLanguage(): SupportedLanguage | null {
+  const candidates = [...(navigator.languages ?? []), navigator.language].filter(
+    (lang): lang is string => 'string' === typeof lang && '' !== lang
+  )
+
+  for (const candidate of candidates) {
+    const base = candidate.toLowerCase().split('-')[0]
+    if (supportedLanguages.includes(base as SupportedLanguage)) {
+      return base as SupportedLanguage
+    }
+  }
+
+  return null
 }
 
 // A message function that ignores the interpolation context and returns the

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -2455,5 +2455,8 @@
       "disabled": "Bu ortamda canlı güncellemeler kapalı. En güncel verileri görmek için sayfayı yenileyin.",
       "error": "Gerçek zamanlı bağlantı başarısız: {message}"
     }
+  },
+  "network": {
+    "offline": "Çevrimdışısın — bağlantını kontrol et. Otomatik olarak yeniden bağlanacağız."
   }
 }

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -963,6 +963,14 @@
       "confirmPasswordPlaceholder": "Yeni şifreyi onaylayın",
       "confirmPasswordHint": "Yeni şifreyle eşleşmeli"
     },
+    "appSecurity": {
+      "title": "Uygulama güvenliği",
+      "subtitle": "Bu cihaz için ek koruma",
+      "biometricLock": "Biyometrik uygulama kilidi",
+      "biometricLockHint": "Uygulamayı açmak için Face ID, Touch ID veya parmak izi iste.",
+      "verifyReason": "Biyometrik kilidi etkinleştir",
+      "enableFailed": "Biyometrik kilit etkinleştirilemedi. Lütfen tekrar deneyin."
+    },
     "dangerZone": {
       "title": "Tehlikeli Bölge",
       "subtitle": "Geri alınamaz işlemler",
@@ -2458,5 +2466,10 @@
   },
   "network": {
     "offline": "Çevrimdışısın — bağlantını kontrol et. Otomatik olarak yeniden bağlanacağız."
+  },
+  "biometricLock": {
+    "title": "Kilitli",
+    "subtitle": "Devam etmek için Synaplan'ın kilidini aç.",
+    "unlock": "Kilidi aç"
   }
 }

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -10,6 +10,8 @@ import App from './App.vue'
 import { useConfigStore } from './stores/config'
 import { useGlobalErrorStore } from './stores/globalError'
 import { installGlobalErrorHandlers } from './utils/installGlobalErrorHandlers'
+import { isNativeApp, getNativeApiBaseUrl } from './services/api/nativeRuntime'
+import { setApiBaseUrl } from './services/api/httpClient'
 
 // Bootstrap app - load config before mounting.
 // We MUST install global error handlers and mount the app even when bootstrap
@@ -25,6 +27,13 @@ import { installGlobalErrorHandlers } from './utils/installGlobalErrorHandlers'
 
   // Pinia is now installed → safe to wire global handlers that depend on stores.
   installGlobalErrorHandlers(app)
+
+  // Native shell runs cross-origin (capacitor://localhost). Point the API client
+  // at the real backend BEFORE the first request (config.init) — otherwise every
+  // call would resolve against the WebView's own localhost origin and fail.
+  if (isNativeApp()) {
+    setApiBaseUrl(getNativeApiBaseUrl())
+  }
 
   const config = useConfigStore()
 

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -12,6 +12,7 @@ import { useGlobalErrorStore } from './stores/globalError'
 import { installGlobalErrorHandlers } from './utils/installGlobalErrorHandlers'
 import { isNativeApp, getNativeApiBaseUrl } from './services/api/nativeRuntime'
 import { setApiBaseUrl } from './services/api/httpClient'
+import { loadNativeTokens } from './services/api/nativeAuth'
 
 // Bootstrap app - load config before mounting.
 // We MUST install global error handlers and mount the app even when bootstrap
@@ -33,6 +34,9 @@ import { setApiBaseUrl } from './services/api/httpClient'
   // call would resolve against the WebView's own localhost origin and fail.
   if (isNativeApp()) {
     setApiBaseUrl(getNativeApiBaseUrl())
+    // Restore Bearer tokens from secure storage (Keychain/Keystore) before the
+    // first authenticated request so a restarted app keeps its session.
+    await loadNativeTokens()
   }
 
   const config = useConfigStore()

--- a/frontend/src/services/api/chatApi.ts
+++ b/frontend/src/services/api/chatApi.ts
@@ -4,9 +4,33 @@
 
 import { z } from 'zod'
 import { httpClient, getApiBaseUrl } from './httpClient'
+import { isNativeApp } from './nativeRuntime'
+import { getNativeAccessToken, hasNativeTokens } from './nativeAuth'
 import { UserMemorySchema } from './userMemoriesApi'
 import { hasSessionHint, clearSessionHint } from '@/services/sessionHint'
 import type { StreamUpdatePayload } from '@/types/chatStream'
+
+/**
+ * SSE auth differs by platform: web sends the session cookie, native sends the
+ * stored Bearer token with cookies omitted (cross-origin). The short-lived
+ * `/auth/token` value is then handed to `EventSource` via the `?token=` query
+ * param (EventSource can't set headers).
+ */
+function sseTokenFetchInit(): RequestInit {
+  if (isNativeApp()) {
+    const token = getNativeAccessToken()
+    return {
+      credentials: 'omit',
+      headers: token ? { Authorization: `Bearer ${token}` } : {},
+    }
+  }
+  return { credentials: 'include' }
+}
+
+/** Native has an SSE-capable session when a Bearer token is stored. */
+function hasSseSessionHint(): boolean {
+  return isNativeApp() ? hasNativeTokens() : hasSessionHint()
+}
 
 /**
  * Phase 2c: response shape of `GET /api/v1/messages/{id}/memories`.
@@ -113,7 +137,7 @@ async function getSseToken(): Promise<string | null> {
   }
 
   // Issue #204: never bootstrap auth for callers that have no session.
-  if (!hasSessionHint()) {
+  if (!hasSseSessionHint()) {
     return null
   }
 
@@ -124,9 +148,7 @@ async function getSseToken(): Promise<string | null> {
 
   tokenFetchPromise = (async () => {
     try {
-      const response = await fetch(`${getApiBaseUrl()}/api/v1/auth/token`, {
-        credentials: 'include',
-      })
+      const response = await fetch(`${getApiBaseUrl()}/api/v1/auth/token`, sseTokenFetchInit())
 
       // Handle 401 - try to refresh access token first
       if (response.status === 401) {
@@ -137,9 +159,10 @@ async function getSseToken(): Promise<string | null> {
 
         if (refreshSuccess) {
           // Retry original request after successful refresh
-          const retryResponse = await fetch(`${getApiBaseUrl()}/api/v1/auth/token`, {
-            credentials: 'include',
-          })
+          const retryResponse = await fetch(
+            `${getApiBaseUrl()}/api/v1/auth/token`,
+            sseTokenFetchInit()
+          )
 
           if (retryResponse.ok) {
             const data = await retryResponse.json()

--- a/frontend/src/services/api/httpClient.ts
+++ b/frontend/src/services/api/httpClient.ts
@@ -6,6 +6,28 @@
 import { z } from 'zod'
 import { GetApiConfigRuntimeConfigResponseSchema } from '@/generated/api-schemas'
 import { hasSessionHint, clearSessionHint } from '@/services/sessionHint'
+import { isNativeApp } from '@/services/api/nativeRuntime'
+import {
+  getNativeAccessToken,
+  getNativeRefreshToken,
+  setNativeTokens,
+  clearNativeTokens,
+  hasNativeTokens,
+} from '@/services/api/nativeAuth'
+
+/**
+ * Credentials mode for backend requests.
+ *
+ * Web runs same-origin and authenticates via HttpOnly cookies → `include`.
+ * The native shell runs cross-origin (`capacitor://localhost`) where the
+ * backend's wildcard CORS (`Access-Control-Allow-Origin: *`) is incompatible
+ * with credentialed requests, and third-party cookies are unreliable in the
+ * WebView. Native therefore omits cookies and authenticates via a Bearer token
+ * (Epic 3); public endpoints (runtime config, guest trial) work immediately.
+ */
+function getCredentialsMode(): RequestCredentials {
+  return isNativeApp() ? 'omit' : 'include'
+}
 
 /**
  * Structured error thrown by httpClient on a non-OK response.
@@ -88,7 +110,7 @@ async function loadRuntimeConfig(): Promise<RuntimeConfig> {
       const timeoutId = setTimeout(() => controller.abort(), 2000) // 2 second timeout
 
       const response = await fetch(`${getApiBaseUrl()}/api/v1/config/runtime`, {
-        credentials: 'include',
+        credentials: getCredentialsMode(),
         signal: controller.signal,
       })
 
@@ -257,7 +279,9 @@ function recordAuthFailure(): void {
  * session in the first place.
  */
 async function refreshAccessToken(): Promise<RefreshResult> {
-  if (!hasSessionHint()) {
+  // Native gates on a stored refresh token (no cookie); web on the UX hint.
+  const native = isNativeApp()
+  if (native ? !hasNativeTokens() : !hasSessionHint()) {
     return { success: false }
   }
 
@@ -270,18 +294,37 @@ async function refreshAccessToken(): Promise<RefreshResult> {
     try {
       const response = await fetch(`${getApiBaseUrl()}/api/v1/auth/refresh`, {
         method: 'POST',
-        credentials: 'include',
+        credentials: getCredentialsMode(),
+        // Native has no refresh cookie → send the stored refresh token in the body.
+        ...(native
+          ? {
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ refreshToken: getNativeRefreshToken() }),
+            }
+          : {}),
       })
 
       if (response.ok) {
         // Reset failure counter on success
         authFailureCount = 0
+        // Native receives the rotated access token in the body → persist it.
+        if (native) {
+          try {
+            const data = await response.json()
+            setNativeTokens(data?.tokens)
+          } catch {
+            // A missing/!json body must not fail the refresh (web ignores it).
+          }
+        }
         return { success: true }
       }
 
       // Refresh definitively failed - the stored cookie is dead. Clear the
       // hint so future visits don't keep retrying against a closed session.
       clearSessionHint()
+      if (native) {
+        clearNativeTokens()
+      }
 
       // Check if this was an OIDC session expiry (user logged out from Keycloak)
       try {
@@ -402,12 +445,20 @@ async function httpClient<T = unknown, S extends z.Schema | undefined = undefine
     headers['Content-Type'] = 'application/json'
   }
 
-  // No Authorization header needed - using HttpOnly cookies
+  // Web authenticates via HttpOnly cookies. The native shell is cross-origin
+  // and cookie-less, so it replays the stored access token as a Bearer header
+  // (the backend's CookieTokenAuthenticator accepts both — Epic 3).
+  if (isNativeApp() && !('Authorization' in headers)) {
+    const nativeToken = getNativeAccessToken()
+    if (nativeToken) {
+      headers['Authorization'] = `Bearer ${nativeToken}`
+    }
+  }
 
   const response = await fetch(url, {
     ...fetchOptions,
     headers,
-    credentials: 'include', // Always include cookies
+    credentials: getCredentialsMode(),
   })
 
   if (!response.ok) {

--- a/frontend/src/services/api/nativeAuth.ts
+++ b/frontend/src/services/api/nativeAuth.ts
@@ -1,0 +1,83 @@
+/**
+ * Native (Capacitor) auth-token storage.
+ *
+ * The web build authenticates via HttpOnly cookies and NEVER touches this
+ * module. The native shell runs cross-origin (`capacitor://localhost`) where
+ * cookies are unreliable, so it consumes the Bearer access/refresh tokens the
+ * backend returns in the login/refresh JSON body (Epic 3) and replays the
+ * access token as `Authorization: Bearer`.
+ *
+ * STORAGE: currently `localStorage`, scoped to the WebView's app sandbox. This
+ * is a deliberate spike/dev choice. Epic 7 (security hardening) replaces the
+ * persistence layer with platform secure storage (iOS Keychain / Android
+ * Keystore) behind THIS SAME interface — so keep every token read/write going
+ * through these functions to make that swap a single-file change.
+ */
+
+const ACCESS_TOKEN_KEY = 'syn_native_at'
+const REFRESH_TOKEN_KEY = 'syn_native_rt'
+
+export interface NativeTokens {
+  accessToken: string
+  refreshToken: string
+}
+
+/**
+ * Shape of the `tokens` object the backend adds to the login/refresh body for
+ * native clients. Extra fields (tokenType, expiresIn) are ignored here.
+ */
+export interface NativeTokenPayload {
+  accessToken?: unknown
+  refreshToken?: unknown
+}
+
+/** Persist the access (and optionally refresh) token from a login/refresh body. */
+export function setNativeTokens(payload: NativeTokenPayload | null | undefined): void {
+  if (!payload) {
+    return
+  }
+
+  try {
+    if ('string' === typeof payload.accessToken && '' !== payload.accessToken) {
+      localStorage.setItem(ACCESS_TOKEN_KEY, payload.accessToken)
+    }
+    // Refresh tokens are only re-issued on full login; a plain access-token
+    // refresh keeps the existing one, so only overwrite when present.
+    if ('string' === typeof payload.refreshToken && '' !== payload.refreshToken) {
+      localStorage.setItem(REFRESH_TOKEN_KEY, payload.refreshToken)
+    }
+  } catch {
+    // Storage unavailable — the session simply won't survive an app restart.
+  }
+}
+
+export function getNativeAccessToken(): string | null {
+  try {
+    return localStorage.getItem(ACCESS_TOKEN_KEY)
+  } catch {
+    return null
+  }
+}
+
+export function getNativeRefreshToken(): string | null {
+  try {
+    return localStorage.getItem(REFRESH_TOKEN_KEY)
+  } catch {
+    return null
+  }
+}
+
+/** True when a Bearer access token is available (native "session hint"). */
+export function hasNativeTokens(): boolean {
+  return null !== getNativeAccessToken()
+}
+
+/** Drop all native tokens (logout / auth failure). */
+export function clearNativeTokens(): void {
+  try {
+    localStorage.removeItem(ACCESS_TOKEN_KEY)
+    localStorage.removeItem(REFRESH_TOKEN_KEY)
+  } catch {
+    // Nothing to clear if storage is unavailable.
+  }
+}

--- a/frontend/src/services/api/nativeAuth.ts
+++ b/frontend/src/services/api/nativeAuth.ts
@@ -7,12 +7,20 @@
  * backend returns in the login/refresh JSON body (Epic 3) and replays the
  * access token as `Authorization: Bearer`.
  *
- * STORAGE: currently `localStorage`, scoped to the WebView's app sandbox. This
- * is a deliberate spike/dev choice. Epic 7 (security hardening) replaces the
- * persistence layer with platform secure storage (iOS Keychain / Android
- * Keystore) behind THIS SAME interface — so keep every token read/write going
- * through these functions to make that swap a single-file change.
+ * STORAGE (Epic 7 hardening): tokens are persisted in platform secure storage
+ * — iOS Keychain / Android Keystore-backed (AES-GCM) storage via
+ * `@aparajita/capacitor-secure-storage`, NOT plain localStorage/preferences.
+ *
+ * Because secure storage is asynchronous but the HTTP layer attaches the Bearer
+ * header synchronously, we keep an in-memory cache as the synchronous source of
+ * truth and treat secure storage as the durable backing store:
+ *   - `loadNativeTokens()` hydrates the cache once at app boot.
+ *   - reads (`getNative*`/`hasNativeTokens`) are synchronous against the cache.
+ *   - writes (`setNativeTokens`/`clearNativeTokens`) update the cache
+ *     immediately and persist to secure storage best-effort in the background.
  */
+import { SecureStorage } from '@aparajita/capacitor-secure-storage'
+import { isNativeApp } from '@/services/api/nativeRuntime'
 
 const ACCESS_TOKEN_KEY = 'syn_native_at'
 const REFRESH_TOKEN_KEY = 'syn_native_rt'
@@ -31,52 +39,95 @@ export interface NativeTokenPayload {
   refreshToken?: unknown
 }
 
+// Synchronous in-memory cache (see module docblock).
+let accessToken: string | null = null
+let refreshToken: string | null = null
+
+/**
+ * Hydrate the in-memory cache from secure storage. Must be awaited once at app
+ * boot (main.ts) before the first authenticated request so a restarted app
+ * restores its session. No-op on web.
+ */
+export async function loadNativeTokens(): Promise<void> {
+  if (!isNativeApp()) {
+    return
+  }
+  accessToken = await readSecure(ACCESS_TOKEN_KEY)
+  refreshToken = await readSecure(REFRESH_TOKEN_KEY)
+}
+
 /** Persist the access (and optionally refresh) token from a login/refresh body. */
 export function setNativeTokens(payload: NativeTokenPayload | null | undefined): void {
   if (!payload) {
     return
   }
 
-  try {
-    if ('string' === typeof payload.accessToken && '' !== payload.accessToken) {
-      localStorage.setItem(ACCESS_TOKEN_KEY, payload.accessToken)
-    }
-    // Refresh tokens are only re-issued on full login; a plain access-token
-    // refresh keeps the existing one, so only overwrite when present.
-    if ('string' === typeof payload.refreshToken && '' !== payload.refreshToken) {
-      localStorage.setItem(REFRESH_TOKEN_KEY, payload.refreshToken)
-    }
-  } catch {
-    // Storage unavailable — the session simply won't survive an app restart.
+  if ('string' === typeof payload.accessToken && '' !== payload.accessToken) {
+    accessToken = payload.accessToken
+    void writeSecure(ACCESS_TOKEN_KEY, payload.accessToken)
+  }
+  // Refresh tokens are only re-issued on full login; a plain access-token
+  // refresh keeps the existing one, so only overwrite when present.
+  if ('string' === typeof payload.refreshToken && '' !== payload.refreshToken) {
+    refreshToken = payload.refreshToken
+    void writeSecure(REFRESH_TOKEN_KEY, payload.refreshToken)
   }
 }
 
 export function getNativeAccessToken(): string | null {
-  try {
-    return localStorage.getItem(ACCESS_TOKEN_KEY)
-  } catch {
-    return null
-  }
+  return accessToken
 }
 
 export function getNativeRefreshToken(): string | null {
-  try {
-    return localStorage.getItem(REFRESH_TOKEN_KEY)
-  } catch {
-    return null
-  }
+  return refreshToken
 }
 
 /** True when a Bearer access token is available (native "session hint"). */
 export function hasNativeTokens(): boolean {
-  return null !== getNativeAccessToken()
+  return null !== accessToken
 }
 
 /** Drop all native tokens (logout / auth failure). */
 export function clearNativeTokens(): void {
+  accessToken = null
+  refreshToken = null
+  void deleteSecure(ACCESS_TOKEN_KEY)
+  void deleteSecure(REFRESH_TOKEN_KEY)
+}
+
+// ── Secure storage helpers (async, native only) ────────────────────────────
+// All wrapped so a storage failure degrades to a non-persisted session rather
+// than throwing into the auth flow.
+
+async function readSecure(key: string): Promise<string | null> {
+  if (!isNativeApp()) {
+    return null
+  }
   try {
-    localStorage.removeItem(ACCESS_TOKEN_KEY)
-    localStorage.removeItem(REFRESH_TOKEN_KEY)
+    const value = await SecureStorage.getItem(key)
+    return 'string' === typeof value ? value : null
+  } catch {
+    return null
+  }
+}
+
+async function writeSecure(key: string, value: string): Promise<void> {
+  if (!isNativeApp()) {
+    return
+  }
+  try {
+    await SecureStorage.setItem(key, value)
+  } catch {
+    // Persist best-effort; the in-memory cache still serves this session.
+  }
+}
+
+async function deleteSecure(key: string): Promise<void> {
+  if (!isNativeApp()) {
+    return
+  }
+  try {
+    await SecureStorage.removeItem(key)
   } catch {
     // Nothing to clear if storage is unavailable.
   }

--- a/frontend/src/services/api/nativeDownload.ts
+++ b/frontend/src/services/api/nativeDownload.ts
@@ -1,0 +1,85 @@
+/**
+ * Cross-platform "save this blob" helper (Epic 7.1).
+ *
+ * On the web we trigger the usual anchor download. Inside the native shell an
+ * `<a download>` on a `blob:`/cross-origin URL does NOT reach the system
+ * downloader, so the file would silently vanish. Instead we persist the blob to
+ * the app's cache directory via `@capacitor/filesystem` and hand it to the OS
+ * share sheet via `@capacitor/share`, letting the user save it to Files/Photos,
+ * send it on, etc.
+ *
+ * Keep ALL app file downloads going through `saveOrDownloadBlob` so web and
+ * native stay in sync. (The embeddable widget is web-only and keeps its own
+ * anchor download.)
+ */
+import { isNativeApp } from '@/services/api/nativeRuntime'
+
+/** Persist/share a blob under `filename`, picking the right transport per platform. */
+export async function saveOrDownloadBlob(blob: Blob, filename: string): Promise<void> {
+  if (isNativeApp()) {
+    await nativeSaveAndShare(blob, filename)
+    return
+  }
+  webDownload(blob, filename)
+}
+
+function webDownload(blob: Blob, filename: string): void {
+  const url = window.URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  document.body.appendChild(a)
+  a.click()
+  window.URL.revokeObjectURL(url)
+  document.body.removeChild(a)
+}
+
+async function nativeSaveAndShare(blob: Blob, filename: string): Promise<void> {
+  // Lazy-load the native plugins so the web bundle never pulls them in.
+  const [{ Filesystem, Directory }, { Share }] = await Promise.all([
+    import('@capacitor/filesystem'),
+    import('@capacitor/share'),
+  ])
+
+  const data = await blobToBase64(blob)
+  const safeName = sanitizeFilename(filename)
+
+  // Cache dir is app-private but shareable via Capacitor's FileProvider.
+  await Filesystem.writeFile({
+    path: safeName,
+    data,
+    directory: Directory.Cache,
+    recursive: true,
+  })
+
+  const { uri } = await Filesystem.getUri({ path: safeName, directory: Directory.Cache })
+
+  await Share.share({ title: filename, url: uri })
+}
+
+/** Strip path separators so a server-provided name can't escape the cache dir. */
+function sanitizeFilename(filename: string): string {
+  const base = filename.split(/[\\/]/).pop() ?? filename
+  const trimmed = base.trim()
+  return '' !== trimmed ? trimmed : 'download'
+}
+
+function blobToBase64(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onerror = () => {
+      reject(reader.error ?? new Error('Failed to read blob'))
+    }
+    reader.onloadend = () => {
+      const result = reader.result
+      if ('string' !== typeof result) {
+        reject(new Error('Unexpected FileReader result'))
+        return
+      }
+      // Drop the `data:<mime>;base64,` prefix — Filesystem wants raw base64.
+      const comma = result.indexOf(',')
+      resolve(comma >= 0 ? result.slice(comma + 1) : result)
+    }
+    reader.readAsDataURL(blob)
+  })
+}

--- a/frontend/src/services/api/nativeOAuth.ts
+++ b/frontend/src/services/api/nativeOAuth.ts
@@ -1,0 +1,116 @@
+/**
+ * Native (Capacitor) OAuth flow.
+ *
+ * Social providers (Google/GitHub/Keycloak) refuse to render their consent
+ * screens inside an embedded WebView, so the native shell drives OAuth through
+ * the system browser and receives the result via a custom-scheme deep link:
+ *
+ *   1. Open `{api}/api/v1/auth/{provider}/login?native=1` in the system browser
+ *      (Custom Tab / SFSafariViewController).
+ *   2. The backend completes OAuth and redirects to
+ *      `com.synaplan.app://oauth/callback?handoff=<signed>` (or `?error=...`).
+ *   3. Android/iOS route that deep link back into the app → `appUrlOpen` fires.
+ *   4. We exchange the short-lived handoff token at `/auth/native/exchange` for
+ *      real Bearer tokens and persist them (nativeAuth).
+ *
+ * The handoff indirection keeps long-lived tokens out of the browser history /
+ * deep-link URL. Web builds never call this (see LoginView) and the Capacitor
+ * imports resolve to harmless web fallbacks there anyway.
+ */
+import { App as CapacitorApp } from '@capacitor/app'
+import { Browser } from '@capacitor/browser'
+import { getNativeApiBaseUrl } from '@/services/api/nativeRuntime'
+import { setNativeTokens } from '@/services/api/nativeAuth'
+
+export interface NativeOAuthResult {
+  success: boolean
+  error?: string
+}
+
+const CALLBACK_MARKER = '://oauth'
+
+export async function startNativeOAuth(provider: string): Promise<NativeOAuthResult> {
+  return new Promise<NativeOAuthResult>((resolve) => {
+    let settled = false
+    let listenerHandle: { remove: () => Promise<void> } | undefined
+
+    const finish = async (result: NativeOAuthResult): Promise<void> => {
+      if (settled) {
+        return
+      }
+      settled = true
+      if (listenerHandle) {
+        try {
+          await listenerHandle.remove()
+        } catch {
+          // Listener already gone — nothing to do.
+        }
+      }
+      try {
+        await Browser.close()
+      } catch {
+        // Browser may have been dismissed by the user already.
+      }
+      resolve(result)
+    }
+
+    CapacitorApp.addListener('appUrlOpen', (event: { url: string }) => {
+      const url = event.url || ''
+      // Ignore unrelated deep links (e.g. universal links handled elsewhere).
+      if (!url.includes(CALLBACK_MARKER)) {
+        return
+      }
+
+      let handoff: string | null
+      let providerError: string | null
+      try {
+        const params = new URL(url).searchParams
+        providerError = params.get('error')
+        handoff = params.get('handoff')
+      } catch {
+        void finish({ success: false, error: 'Invalid callback URL' })
+        return
+      }
+
+      if (providerError) {
+        void finish({ success: false, error: providerError })
+        return
+      }
+      if (!handoff) {
+        void finish({ success: false, error: 'No handoff token received' })
+        return
+      }
+      void exchangeHandoff(handoff).then(finish)
+    }).then((handle) => {
+      listenerHandle = handle
+      // If finish() already ran (extremely fast callback), clean up immediately.
+      if (settled) {
+        void handle.remove()
+      }
+    })
+
+    const authUrl = `${getNativeApiBaseUrl()}/api/v1/auth/${provider}/login?native=1`
+    Browser.open({ url: authUrl }).catch(() => {
+      void finish({ success: false, error: 'Could not open the browser' })
+    })
+  })
+}
+
+async function exchangeHandoff(handoff: string): Promise<NativeOAuthResult> {
+  try {
+    const response = await fetch(`${getNativeApiBaseUrl()}/api/v1/auth/native/exchange`, {
+      method: 'POST',
+      credentials: 'omit',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ handoff }),
+    })
+    if (!response.ok) {
+      return { success: false, error: 'Token exchange failed' }
+    }
+    const data = await response.json()
+    setNativeTokens(data?.tokens)
+    return { success: true }
+  } catch {
+    return { success: false, error: 'Network error during token exchange' }
+  }
+}

--- a/frontend/src/services/api/nativeRuntime.ts
+++ b/frontend/src/services/api/nativeRuntime.ts
@@ -1,0 +1,61 @@
+/**
+ * Native (Capacitor) runtime detection & configuration.
+ *
+ * The SPA is built once and shipped to BOTH the web deployment and the native
+ * app shell (Capacitor WebView, see the `synaplan-apps` repo). Inside the
+ * WebView the page origin is `capacitor://localhost` (iOS) / `https://localhost`
+ * (Android), so every same-origin assumption breaks: the backend lives on a
+ * different host and cross-origin cookies are unreliable. This module is the
+ * single place that answers "are we running inside the native shell, and which
+ * backend should we talk to?".
+ *
+ * Intentionally dependency-free (no `@capacitor/core`): pulling the Capacitor
+ * runtime into the shared web bundle would bloat the web build for a detection
+ * we can do from the User-Agent that the native shell already appends
+ * (Epic 2 contract: `Synaplan Mobile V<major>.<minor>`).
+ */
+
+/** Frozen marker the native shell appends to the WebView User-Agent (Epic 2). */
+const NATIVE_UA_MARKER = 'Synaplan Mobile'
+
+/**
+ * Production backend the native shell talks to (cross-origin).
+ *
+ * Locked in `synaplan-apps/docs/IDENTIFIERS.md`. The native shell may override
+ * this at runtime via `window.__SYNAPLAN_API_BASE_URL__` for staging / dev /
+ * spike builds (set before the SPA bundle executes); the override wins so we
+ * never have to fork the bundle per environment.
+ */
+const DEFAULT_NATIVE_API_BASE_URL = 'https://web.synaplan.com'
+
+/**
+ * True when the page is running inside the Synaplan native app shell.
+ *
+ * Detected from the appended User-Agent so it works before any backend round
+ * trip (we must know this BEFORE `config.init()` to point the very first
+ * request at the right host).
+ */
+export function isNativeApp(): boolean {
+  if ('undefined' === typeof navigator) {
+    return false
+  }
+
+  return navigator.userAgent.includes(NATIVE_UA_MARKER)
+}
+
+/**
+ * Resolve the backend base URL for the native shell.
+ *
+ * Precedence: runtime override (`window.__SYNAPLAN_API_BASE_URL__`) → compiled
+ * default (production). Always returned WITHOUT a trailing slash so callers can
+ * safely concatenate `/api/...` paths.
+ */
+export function getNativeApiBaseUrl(): string {
+  const override = (globalThis as { __SYNAPLAN_API_BASE_URL__?: unknown }).__SYNAPLAN_API_BASE_URL__
+
+  if ('string' === typeof override && '' !== override.trim()) {
+    return override.trim().replace(/\/$/, '')
+  }
+
+  return DEFAULT_NATIVE_API_BASE_URL
+}

--- a/frontend/src/services/apiService.ts
+++ b/frontend/src/services/apiService.ts
@@ -1,5 +1,10 @@
 import type { AIModel } from '@/stores/models'
-import { getApiBaseUrl } from '@/services/api/httpClient'
+import {
+  getApiBaseUrl,
+  refreshAccessToken as refreshTokenViaHttpClient,
+} from '@/services/api/httpClient'
+import { isNativeApp } from '@/services/api/nativeRuntime'
+import { getNativeAccessToken } from '@/services/api/nativeAuth'
 import { hasSessionHint, clearSessionHint } from '@/services/sessionHint'
 import type { z } from 'zod'
 
@@ -16,10 +21,32 @@ export interface DefaultModelConfig {
 }
 
 // Base configuration
-const API_BASE_URL = getApiBaseUrl()
 const API_TIMEOUT = import.meta.env.VITE_API_TIMEOUT || 30000
 const API_UPLOAD_TIMEOUT = import.meta.env.VITE_API_UPLOAD_TIMEOUT || 120000
 const CSRF_HEADER = import.meta.env.VITE_CSRF_HEADER_NAME || 'X-CSRF-Token'
+
+// Resolved per call (not captured once): the native shell sets the real backend
+// origin during bootstrap, which may run after this module is first imported.
+function apiBase(): string {
+  return getApiBaseUrl()
+}
+
+// Web authenticates via HttpOnly cookies (credentialed CORS); the native shell
+// is cross-origin against `Access-Control-Allow-Origin: *` where credentialed
+// mode is rejected, so it omits credentials and replays a Bearer token instead.
+function requestCredentials(): RequestCredentials {
+  return isNativeApp() ? 'omit' : 'include'
+}
+
+function withNativeAuth(headers: Record<string, string>): Record<string, string> {
+  if (isNativeApp()) {
+    const token = getNativeAccessToken()
+    if (token) {
+      headers['Authorization'] = `Bearer ${token}`
+    }
+  }
+  return headers
+}
 
 // Token refresh stampede protection
 let tokenRefreshPromise: Promise<boolean> | null = null
@@ -51,6 +78,14 @@ function redirectToSessionExpired(): void {
  * just to get an expected 401 back.
  */
 async function refreshAccessToken(): Promise<boolean> {
+  // Native uses Bearer tokens — delegate to the canonical refresh which rotates
+  // the secure-stored tokens. apiService's cookie refresh can't work
+  // cross-origin against `Access-Control-Allow-Origin: *`.
+  if (isNativeApp()) {
+    const result = await refreshTokenViaHttpClient()
+    return result.success
+  }
+
   if (!hasSessionHint()) {
     return false
   }
@@ -61,7 +96,7 @@ async function refreshAccessToken(): Promise<boolean> {
 
   tokenRefreshPromise = (async () => {
     try {
-      const refreshResponse = await fetch(`${API_BASE_URL}/api/v1/auth/refresh`, {
+      const refreshResponse = await fetch(`${apiBase()}/api/v1/auth/refresh`, {
         method: 'POST',
         credentials: 'include',
       })
@@ -128,16 +163,19 @@ async function httpClient<T = unknown, S extends z.Schema | undefined = undefine
     headers[CSRF_HEADER] = csrfToken
   }
 
+  // Native shell: attach the Bearer access token (cookies are unavailable).
+  withNativeAuth(headers)
+
   const isUpload = options.body instanceof FormData
   const timeout = isUpload ? API_UPLOAD_TIMEOUT : API_TIMEOUT
   const controller = new AbortController()
   const timeoutId = setTimeout(() => controller.abort(), timeout)
 
   try {
-    const response = await fetch(`${API_BASE_URL}${endpoint}`, {
+    const response = await fetch(`${apiBase()}${endpoint}`, {
       ...requestOptions,
       headers,
-      credentials: 'include', // Use HttpOnly cookies for auth
+      credentials: requestCredentials(),
       signal: controller.signal,
     })
 
@@ -153,10 +191,12 @@ async function httpClient<T = unknown, S extends z.Schema | undefined = undefine
         const retryTimeoutId = setTimeout(() => retryController.abort(), timeout)
 
         try {
-          const retryResponse = await fetch(`${API_BASE_URL}${endpoint}`, {
+          // Refresh rotated the Bearer token on native — re-attach the new one.
+          withNativeAuth(headers)
+          const retryResponse = await fetch(`${apiBase()}${endpoint}`, {
             ...requestOptions,
             headers,
-            credentials: 'include',
+            credentials: requestCredentials(),
             signal: retryController.signal,
           })
 
@@ -361,7 +401,10 @@ export const apiService = {
     let eventSource: EventSource | null = null
 
     // Get SSE token from auth endpoint (EventSource can't send cookies)
-    fetch(`${API_BASE_URL}/auth/token`, { credentials: 'include' })
+    fetch(`${apiBase()}/auth/token`, {
+      credentials: requestCredentials(),
+      headers: withNativeAuth({}),
+    })
       .then((res) => res.json())
       .then(({ token }) => {
         if (!token) {
@@ -370,7 +413,7 @@ export const apiService = {
         }
 
         eventSource = new EventSource(
-          `${API_BASE_URL}/messages/stream?userId=${userId}&message=${encodeURIComponent(message)}&trackId=${trackId || ''}&token=${token}`
+          `${apiBase()}/messages/stream?userId=${userId}&message=${encodeURIComponent(message)}&trackId=${trackId || ''}&token=${token}`
         )
 
         eventSource.onmessage = (event) => {

--- a/frontend/src/services/authService.ts
+++ b/frontend/src/services/authService.ts
@@ -14,8 +14,50 @@
 import { ref, type Ref } from 'vue'
 import { getApiBaseUrl } from '@/services/api/httpClient'
 import { setSessionHint, clearSessionHint, hasSessionHint } from '@/services/sessionHint'
+import { isNativeApp } from '@/services/api/nativeRuntime'
+import {
+  getNativeAccessToken,
+  getNativeRefreshToken,
+  setNativeTokens,
+  clearNativeTokens,
+  hasNativeTokens,
+} from '@/services/api/nativeAuth'
 
-const API_BASE_URL = getApiBaseUrl()
+/**
+ * Fetch wrapper bridging web (same-origin cookies) and native (cross-origin
+ * Bearer) auth. The base URL is resolved per call (NOT captured at import) so it
+ * reflects the native override main.ts applies before the first request.
+ *
+ * Pass `{ bearer: false }` for public endpoints whose access token may be absent
+ * or expired (login / register / refresh): sending an expired Bearer would make
+ * the stateless API firewall reject the request before the controller runs.
+ */
+function authFetch(
+  path: string,
+  init: RequestInit = {},
+  opts: { bearer?: boolean } = {}
+): Promise<Response> {
+  const native = isNativeApp()
+  const headers = new Headers(init.headers)
+
+  if (native && false !== opts.bearer) {
+    const token = getNativeAccessToken()
+    if (token && !headers.has('Authorization')) {
+      headers.set('Authorization', `Bearer ${token}`)
+    }
+  }
+
+  return fetch(`${getApiBaseUrl()}${path}`, {
+    ...init,
+    headers,
+    credentials: native ? 'omit' : 'include',
+  })
+}
+
+/** Native has a session when a Bearer token is stored; web uses the UX hint. */
+function hasAuthHint(): boolean {
+  return isNativeApp() ? hasNativeTokens() : hasSessionHint()
+}
 
 /** User payload from /api/v1/auth/me (in-memory only) */
 export interface AuthUser {
@@ -58,14 +100,15 @@ export const authService = {
     recaptchaToken?: string
   ): Promise<{ success: boolean; error?: string }> {
     try {
-      const response = await fetch(`${API_BASE_URL}/api/v1/auth/login`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
+      const response = await authFetch(
+        '/api/v1/auth/login',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email, password, recaptchaToken }),
         },
-        credentials: 'include', // Important: include cookies
-        body: JSON.stringify({ email, password, recaptchaToken }),
-      })
+        { bearer: false }
+      )
 
       const data = await response.json()
 
@@ -76,6 +119,9 @@ export const authService = {
       // Store user info only in memory (not localStorage for security)
       user.value = data.user
       impersonator.value = (data.impersonator as ImpersonatorInfo | null | undefined) ?? null
+      // Native: persist the Bearer tokens from the body (no-op on web, which has
+      // no `tokens` field and authenticates via the HttpOnly cookies instead).
+      setNativeTokens(data.tokens)
       setSessionHint()
 
       return { success: true }
@@ -94,14 +140,15 @@ export const authService = {
     recaptchaToken?: string
   ): Promise<{ success: boolean; error?: string }> {
     try {
-      const response = await fetch(`${API_BASE_URL}/api/v1/auth/register`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
+      const response = await authFetch(
+        '/api/v1/auth/register',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email, password, recaptchaToken }),
         },
-        credentials: 'include',
-        body: JSON.stringify({ email, password, recaptchaToken }),
-      })
+        { bearer: false }
+      )
 
       const data = await response.json()
 
@@ -131,9 +178,8 @@ export const authService = {
 
     try {
       if (!silent) {
-        const response = await fetch(`${API_BASE_URL}/api/v1/auth/logout`, {
+        const response = await authFetch('/api/v1/auth/logout', {
           method: 'POST',
-          credentials: 'include',
         })
 
         if (response.ok) {
@@ -147,6 +193,7 @@ export const authService = {
       user.value = null
       impersonator.value = null
       clearSessionHint()
+      clearNativeTokens()
       isLoggingOut.value = false
     }
 
@@ -171,14 +218,12 @@ export const authService = {
 
     // Optimization: skip API calls for users who have never logged in.
     // OAuth callbacks pass retries > 0, so always check those.
-    if (!hasSessionHint() && retries === 0) {
+    if (!hasAuthHint() && retries === 0) {
       return null
     }
 
     try {
-      const response = await fetch(`${API_BASE_URL}/api/v1/auth/me`, {
-        credentials: 'include',
-      })
+      const response = await authFetch('/api/v1/auth/me')
 
       if (response.status === 401) {
         // Don't try to refresh if already logging out
@@ -200,9 +245,7 @@ export const authService = {
         const refreshed = await this.refreshToken()
         if (refreshed) {
           // Retry getting user (only once, no recursion)
-          const retryResponse = await fetch(`${API_BASE_URL}/api/v1/auth/me`, {
-            credentials: 'include',
-          })
+          const retryResponse = await authFetch('/api/v1/auth/me')
           if (retryResponse.ok) {
             const data = await retryResponse.json()
             user.value = data.user
@@ -258,10 +301,21 @@ export const authService = {
 
   async _doRefresh(): Promise<boolean> {
     try {
-      const response = await fetch(`${API_BASE_URL}/api/v1/auth/refresh`, {
-        method: 'POST',
-        credentials: 'include',
-      })
+      const native = isNativeApp()
+      const response = await authFetch(
+        '/api/v1/auth/refresh',
+        {
+          method: 'POST',
+          // Native has no refresh cookie → send the stored refresh token.
+          ...(native
+            ? {
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ refreshToken: getNativeRefreshToken() }),
+              }
+            : {}),
+        },
+        { bearer: false }
+      )
 
       if (!response.ok) {
         // Refresh token invalid/expired (expected behavior, don't spam console)
@@ -271,6 +325,11 @@ export const authService = {
       }
 
       const data = await response.json()
+
+      // Native: persist the rotated access token returned in the body.
+      if (native) {
+        setNativeTokens(data?.tokens)
+      }
 
       // Update user info if provided (memory only)
       if (data.user) {
@@ -346,9 +405,8 @@ export const authService = {
    */
   async revokeAllSessions(): Promise<{ success: boolean; sessionsRevoked?: number }> {
     try {
-      const response = await fetch(`${API_BASE_URL}/api/v1/auth/revoke-all`, {
+      const response = await authFetch('/api/v1/auth/revoke-all', {
         method: 'POST',
-        credentials: 'include',
       })
 
       if (!response.ok) {
@@ -361,6 +419,7 @@ export const authService = {
       user.value = null
       impersonator.value = null
       clearSessionHint()
+      clearNativeTokens()
 
       return { success: true, sessionsRevoked: data.sessions_revoked }
     } catch (error) {

--- a/frontend/src/services/biometricLock.ts
+++ b/frontend/src/services/biometricLock.ts
@@ -1,0 +1,60 @@
+/**
+ * Optional biometric app lock (Epic 7.2).
+ *
+ * Gates access to the already-authenticated session behind Face ID / Touch ID /
+ * fingerprint. This is a UI lock layered on top of the secure token storage — it
+ * does not replace it. The opt-in flag is a non-secret boolean kept in
+ * localStorage; the tokens themselves stay in the Keychain/Keystore.
+ *
+ * Native-only; every function degrades to a safe default on web.
+ */
+import { isNativeApp } from '@/services/api/nativeRuntime'
+
+const ENABLED_KEY = 'biometric_lock_enabled'
+
+export function isBiometricLockEnabled(): boolean {
+  return 'true' === localStorage.getItem(ENABLED_KEY)
+}
+
+export function setBiometricLockEnabled(enabled: boolean): void {
+  if (enabled) {
+    localStorage.setItem(ENABLED_KEY, 'true')
+  } else {
+    localStorage.removeItem(ENABLED_KEY)
+  }
+}
+
+/** True only when running natively AND the device has biometrics enrolled. */
+export async function isBiometricAvailable(): Promise<boolean> {
+  if (!isNativeApp()) {
+    return false
+  }
+  try {
+    const { BiometricAuth } = await import('@aparajita/capacitor-biometric-auth')
+    const result = await BiometricAuth.checkBiometry()
+    return result.isAvailable
+  } catch {
+    return false
+  }
+}
+
+/** Prompt the OS biometric dialog. Resolves true on success, false on cancel/fail. */
+export async function verifyBiometric(reason: string): Promise<boolean> {
+  if (!isNativeApp()) {
+    return true
+  }
+  try {
+    const { BiometricAuth } = await import('@aparajita/capacitor-biometric-auth')
+    await BiometricAuth.authenticate({
+      reason,
+      androidTitle: reason,
+      cancelTitle: 'Cancel',
+      // Allow the device PIN/passcode as a fallback so users can't lock
+      // themselves out if biometrics temporarily fail.
+      allowDeviceCredential: true,
+    })
+    return true
+  } catch {
+    return false
+  }
+}

--- a/frontend/src/services/filesService.ts
+++ b/frontend/src/services/filesService.ts
@@ -1,5 +1,8 @@
 import { api } from './apiService'
 import { httpClient, getApiBaseUrl, refreshAccessToken } from './api/httpClient'
+import { saveOrDownloadBlob } from './api/nativeDownload'
+import { isNativeApp } from './api/nativeRuntime'
+import { getNativeAccessToken } from './api/nativeAuth'
 
 export type UploadCheckReason =
   | 'rate_limit_exceeded'
@@ -557,7 +560,22 @@ const uploadFilesBatch = async (
       })
 
       xhr.open('POST', `${baseUrl}/api/v1/files/upload`)
-      xhr.withCredentials = true
+
+      // Web authenticates via HttpOnly cookies (credentialed CORS). The native
+      // shell is cross-origin against `Access-Control-Allow-Origin: *`, where
+      // the browser REJECTS credentialed requests outright (the upload would
+      // fail with a bare network error). So on native we omit credentials and
+      // replay the Bearer access token instead — mirroring httpClient (Epic 3,
+      // required by 7.1's cross-origin upload).
+      if (isNativeApp()) {
+        xhr.withCredentials = false
+        const accessToken = getNativeAccessToken()
+        if (accessToken) {
+          xhr.setRequestHeader('Authorization', `Bearer ${accessToken}`)
+        }
+      } else {
+        xhr.withCredentials = true
+      }
 
       const csrfToken = sessionStorage.getItem('csrf_token')
       if (csrfToken) {
@@ -694,15 +712,8 @@ export const downloadFile = async (fileId: number, filename: string): Promise<vo
     responseType: 'blob',
   })
 
-  // Create blob and trigger download
-  const url = window.URL.createObjectURL(blob)
-  const a = document.createElement('a')
-  a.href = url
-  a.download = filename
-  document.body.appendChild(a)
-  a.click()
-  window.URL.revokeObjectURL(url)
-  document.body.removeChild(a)
+  // Web → anchor download; native → Filesystem + share sheet (Epic 7.1).
+  await saveOrDownloadBlob(blob, filename)
 }
 
 /**

--- a/frontend/src/services/nativeLifecycle.ts
+++ b/frontend/src/services/nativeLifecycle.ts
@@ -1,0 +1,70 @@
+/**
+ * Native app-lifecycle handling (Epic 7.2).
+ *
+ * Mobile OSes freeze a backgrounded WebView: timers pause, the realtime socket
+ * can die silently, and the access token may expire while the app is away. When
+ * the user returns we therefore:
+ *   1. re-validate the session (this transparently refreshes the Bearer token
+ *      via httpClient's 401 handling), and
+ *   2. nudge an existing realtime connection back to life.
+ *
+ * To avoid hammering the backend on quick app switches we only run this when the
+ * app was backgrounded for at least RESUME_RECHECK_AFTER_MS. Web is unaffected
+ * (no Capacitor App plugin, no listener registered).
+ */
+import { isNativeApp } from '@/services/api/nativeRuntime'
+
+const RESUME_RECHECK_AFTER_MS = 30_000
+
+let registered = false
+let backgroundedAt: number | null = null
+
+/** Register the resume handler once. No-op on web or if already registered. */
+export async function initNativeLifecycle(): Promise<void> {
+  if (registered || !isNativeApp()) {
+    return
+  }
+  registered = true
+
+  const { App: CapacitorApp } = await import('@capacitor/app')
+
+  await CapacitorApp.addListener('appStateChange', ({ isActive }) => {
+    if (!isActive) {
+      backgroundedAt = Date.now()
+      return
+    }
+
+    // Only act on a genuine resume after a meaningful time away.
+    if (null === backgroundedAt) {
+      return
+    }
+    const awayMs = Date.now() - backgroundedAt
+    backgroundedAt = null
+    if (awayMs >= RESUME_RECHECK_AFTER_MS) {
+      void handleResume()
+    }
+  })
+}
+
+async function handleResume(): Promise<void> {
+  // 1) Re-validate the session for authenticated users. refreshUser() hits
+  //    /auth/me, which triggers a token refresh on 401 (httpClient) and clears
+  //    the user if the session is truly gone.
+  try {
+    const { useAuthStore } = await import('@/stores/auth')
+    const auth = useAuthStore()
+    if (auth.isAuthenticated) {
+      await auth.refreshUser()
+    }
+  } catch (err) {
+    console.error('Resume session re-check failed', err)
+  }
+
+  // 2) Reconnect realtime if it was in use (no-op otherwise).
+  try {
+    const { useRealtimeStore } = await import('@/stores/realtime')
+    await useRealtimeStore().reconnect()
+  } catch (err) {
+    console.error('Resume realtime reconnect failed', err)
+  }
+}

--- a/frontend/src/services/realtime/RealtimeClient.ts
+++ b/frontend/src/services/realtime/RealtimeClient.ts
@@ -15,6 +15,7 @@
  */
 
 import { Centrifuge, type PublicationContext, type SubscriptionErrorContext } from 'centrifuge'
+import { isNativeApp, getNativeApiBaseUrl } from '@/services/api/nativeRuntime'
 import {
   fetchOperatorConnectionToken,
   fetchVisitorConnectionToken,
@@ -96,6 +97,16 @@ export class RealtimeClient {
 
     if ('visitor' === this.options.identity.kind && this.options.identity.apiBaseUrl) {
       const wsBase = this.options.identity.apiBaseUrl
+        .replace(/^http:/i, 'ws:')
+        .replace(/^https:/i, 'wss:')
+      return `${wsBase.replace(/\/$/, '')}/connection/websocket`
+    }
+
+    // Native shell: window.location.host is the in-app localhost origin, not the
+    // backend. Derive the WS endpoint from the configured native API base so the
+    // operator connection targets the real Centrifugo gateway (Epic 3).
+    if (isNativeApp()) {
+      const wsBase = getNativeApiBaseUrl()
         .replace(/^http:/i, 'ws:')
         .replace(/^https:/i, 'wss:')
       return `${wsBase.replace(/\/$/, '')}/connection/websocket`

--- a/frontend/src/stores/config.ts
+++ b/frontend/src/stores/config.ts
@@ -14,6 +14,7 @@ import {
   reloadConfig,
   getUnavailableProviders,
 } from '@/services/api/httpClient'
+import { isNativeApp, getNativeApiBaseUrl } from '@/services/api/nativeRuntime'
 import { checkMemoryServiceAvailability } from '@/services/api/configApi'
 import { i18n } from '@/i18n'
 import { ref } from 'vue'
@@ -32,9 +33,16 @@ async function loadRuntimeConfig() {
 const config = {
   /**
    * Application base URL - used for building full URLs (OAuth redirects, share links, etc.)
-   * Returns current origin (e.g., https://example.com)
+   * Returns current origin (e.g., https://example.com).
+   *
+   * In the native shell `window.location.origin` is `capacitor://localhost`,
+   * which is useless for OAuth redirects, share links and absolute asset URLs —
+   * so we return the real backend/web origin instead (Epic 3).
    */
   get appBaseUrl(): string {
+    if (isNativeApp()) {
+      return getNativeApiBaseUrl()
+    }
     return window.location.origin
   },
 
@@ -137,6 +145,28 @@ const config = {
     },
     get ip(): string {
       return getConfigSync().build?.ip ?? 'dev'
+    },
+  },
+
+  /**
+   * Client identity (server-confirmed, from the User-Agent).
+   *
+   * Use this for SECURITY-relevant / server-truthful decisions (e.g. payment channel
+   * gating). For pure client-side UI gating prefer Capacitor.isNativePlatform() — but
+   * never trust the client for anything the backend must enforce.
+   */
+  client: {
+    /** True when the backend saw the official "Synaplan Mobile Vx.x" User-Agent. */
+    get isMobileApp(): boolean {
+      return getConfigSync().client?.isMobileApp ?? false
+    },
+    /** Parsed app version (major.minor[.patch]) or null on web. */
+    get appVersion(): string | null {
+      return getConfigSync().client?.appVersion ?? null
+    },
+    /** 'mobile' | 'web' (defaults to 'web' until config loads). */
+    get platform(): string {
+      return getConfigSync().client?.platform ?? 'web'
     },
   },
 

--- a/frontend/src/stores/realtime.ts
+++ b/frontend/src/stores/realtime.ts
@@ -56,6 +56,17 @@ export const useRealtimeStore = defineStore('realtime', () => {
     await c.connect()
   }
 
+  /**
+   * Re-open the socket after an app resume WITHOUT creating a connection that
+   * wasn't already in use. centrifuge-js self-heals on network changes, but a
+   * long background on mobile can leave a silently-dead socket — this nudges an
+   * existing client back to life and is a no-op when realtime isn't active.
+   */
+  async function reconnect(): Promise<void> {
+    if (!client) return
+    await client.connect()
+  }
+
   async function disconnect(): Promise<void> {
     if (!client) return
     await client.disconnect()
@@ -69,6 +80,7 @@ export const useRealtimeStore = defineStore('realtime', () => {
     lastError,
     getOrCreateClient,
     ensureConnected,
+    reconnect,
     disconnect,
   }
 })

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -367,6 +367,9 @@ import { useAuth } from '../composables/useAuth'
 import { useRecaptcha } from '../composables/useRecaptcha'
 import { validateEmail } from '../composables/usePasswordValidation'
 import { useConfigStore } from '@/stores/config'
+import { isNativeApp } from '@/services/api/nativeRuntime'
+import { startNativeOAuth } from '@/services/api/nativeOAuth'
+import { useAuthStore } from '@/stores/auth'
 import {
   consumePendingRedirect,
   isSafeRedirectPath,
@@ -379,6 +382,7 @@ const { locale } = useI18n()
 const themeStore = useTheme()
 const { getToken: getReCaptchaToken } = useRecaptcha()
 const config = useConfigStore()
+const authStore = useAuthStore()
 
 const isDark = computed(() => {
   if (themeStore.theme.value === 'dark') return true
@@ -416,7 +420,9 @@ const toggleTheme = () => {
 
 const { login, error: authError, loading, clearError } = useAuth()
 const emailError = ref('')
-const error = computed(() => authError.value)
+// Native OAuth errors surface through the same banner as password-login errors.
+const socialError = ref('')
+const error = computed(() => socialError.value || authError.value)
 
 const onEmailBlur = () => {
   focusedField.value = null
@@ -491,11 +497,33 @@ const handleLogin = async () => {
   }
 }
 
-const handleSocialLogin = (provider: string) => {
+const handleSocialLogin = async (provider: string) => {
   // OAuth round-trip strips the SPA's URL state, so stash the intent
   // for OAuthCallback to pick up. setPendingRedirect validates internally.
   const redirect = route.query.redirect as string | undefined
   if (redirect) setPendingRedirect(redirect)
+
+  // Native shell: providers block embedded WebViews, so run OAuth in the system
+  // browser and complete via a deep-link handoff (no full-page redirect).
+  if (isNativeApp()) {
+    socialError.value = ''
+    const result = await startNativeOAuth(provider)
+    if (!result.success) {
+      socialError.value = result.error || 'Login failed'
+      return
+    }
+    // Tokens are stored — verify the session via the store so the reactive
+    // auth state + config (guest → authenticated) update everywhere.
+    const ok = await authStore.handleOAuthCallback()
+    if (ok) {
+      const queryPath = isSafeRedirectPath(redirect) ? redirect : null
+      router.push(queryPath ?? consumePendingRedirect() ?? '/')
+    } else {
+      socialError.value = 'Login failed'
+    }
+    return
+  }
+
   window.location.href = `${config.appBaseUrl}/api/v1/auth/${provider}/login`
 }
 </script>

--- a/frontend/src/views/ProfileView.vue
+++ b/frontend/src/views/ProfileView.vue
@@ -365,6 +365,45 @@
             </div>
           </section>
 
+          <section
+            v-if="showBiometricSection"
+            class="surface-card rounded-lg p-6"
+            data-testid="section-app-security"
+          >
+            <h2 class="text-xl font-semibold txt-primary mb-2 flex items-center gap-2">
+              <Icon icon="mdi:fingerprint" class="w-5 h-5" />
+              {{ $t('profile.appSecurity.title') }}
+            </h2>
+            <p class="txt-secondary text-sm mb-6">{{ $t('profile.appSecurity.subtitle') }}</p>
+
+            <div class="flex items-center justify-between gap-4">
+              <div class="min-w-0">
+                <p class="txt-primary font-medium">{{ $t('profile.appSecurity.biometricLock') }}</p>
+                <p class="txt-secondary text-sm">
+                  {{ $t('profile.appSecurity.biometricLockHint') }}
+                </p>
+              </div>
+              <button
+                type="button"
+                role="switch"
+                :aria-checked="biometricLockOn"
+                class="relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-[var(--brand)]"
+                :class="
+                  biometricLockOn
+                    ? 'bg-[var(--brand)]'
+                    : 'bg-light-border/50 dark:bg-dark-border/50'
+                "
+                data-testid="toggle-biometric-lock"
+                @click="toggleBiometricLock"
+              >
+                <span
+                  class="inline-block h-4 w-4 transform rounded-full bg-white transition-transform"
+                  :class="biometricLockOn ? 'translate-x-6' : 'translate-x-1'"
+                />
+              </button>
+            </div>
+          </section>
+
           <div class="info-box-blue" data-testid="section-privacy-notice">
             <p class="text-sm info-box-blue-text flex items-start gap-2">
               <Icon
@@ -530,6 +569,7 @@
 import { getErrorMessage } from '@/utils/errorMessage'
 import { ref, computed, onMounted, onUnmounted, nextTick } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
+import { useI18n } from 'vue-i18n'
 import { Icon } from '@iconify/vue'
 import MainLayout from '@/components/MainLayout.vue'
 import UnsavedChangesBar from '@/components/UnsavedChangesBar.vue'
@@ -539,15 +579,51 @@ import { useUnsavedChanges } from '@/composables/useUnsavedChanges'
 import { profileApi } from '@/services/api'
 import { useAuthStore } from '@/stores/auth'
 import { useConfigStore } from '@/stores/config'
+import { isNativeApp } from '@/services/api/nativeRuntime'
+import {
+  isBiometricAvailable,
+  isBiometricLockEnabled,
+  setBiometricLockEnabled,
+  verifyBiometric,
+} from '@/services/biometricLock'
 
 const router = useRouter()
 const route = useRoute()
 const authStore = useAuthStore()
 const config = useConfigStore()
 const { error } = useNotification()
+const { t } = useI18n()
 
 const memoriesSection = ref<HTMLElement | null>(null)
 const shouldHighlight = ref(false)
+
+// Optional biometric app lock (Epic 7.2) — native-only, shown only when the
+// device actually has biometrics enrolled.
+const biometricAvailable = ref(false)
+const biometricLockOn = ref(isBiometricLockEnabled())
+const showBiometricSection = computed(() => isNativeApp() && biometricAvailable.value)
+
+onMounted(async () => {
+  biometricAvailable.value = await isBiometricAvailable()
+})
+
+async function toggleBiometricLock(): Promise<void> {
+  if (biometricLockOn.value) {
+    setBiometricLockEnabled(false)
+    biometricLockOn.value = false
+    return
+  }
+
+  // Require a successful check before enabling so the user can't lock themselves
+  // out with an unusable/unenrolled sensor.
+  const ok = await verifyBiometric(t('profile.appSecurity.verifyReason'))
+  if (!ok) {
+    error(t('profile.appSecurity.enableFailed'))
+    return
+  }
+  setBiometricLockEnabled(true)
+  biometricLockOn.value = true
+}
 
 const formData = ref<UserProfile>({
   email: '',


### PR DESCRIPTION
## Summary
Enables the Capacitor mobile shell (`synaplan-apps`) to run cross-origin against the backend. The native WebView origin is `capacitor://localhost` and the backend uses wildcard CORS (`Access-Control-Allow-Origin: *`), which is incompatible with credentialed (cookie) requests. Native therefore authenticates via a Bearer token while web stays on HttpOnly cookies.

### Backend
- `ClientContext` + `ClientContextResolver` parse the `Synaplan Mobile V<x.y>` User-Agent into a server-confirmed client identity.
- `ConfigController` exposes that identity in the runtime config so the SPA can make client-aware UI decisions.
- `AuthController` returns access/refresh tokens in the login/refresh JSON body **only for mobile clients** (web clients still get cookies, no tokens in the body). `refresh` also accepts the refresh token from the request body (native has no refresh cookie).

### Frontend
- `nativeRuntime` detects the native shell (UA marker) and resolves the real backend base URL.
- `nativeAuth` stores the Bearer tokens behind a single interface (localStorage for now; iOS Keychain / Android Keystore in Epic 7).
- `httpClient` / `authService` / `chatApi` attach `Authorization: Bearer` + `credentials: 'omit'` on native and keep cookies on web; the SSE token fetch is native-aware.
- `RealtimeClient` derives the Centrifugo WS URL from the native backend base (not the in-app `localhost`).

## Test plan
- [x] Backend: `make -C backend lint`, `make -C backend phpstan`, `make -C backend test` (2153 tests OK)
- [x] Frontend: lint, `vue-tsc` type check, `make -C frontend test` (732 tests pass)
- [x] curl against local backend: mobile UA login returns `tokens` in body, Bearer works on `/auth/me`, refresh via body token; web UA gets no tokens in body
- [x] E2E in Android emulator against local backend: guest trial, email/password login, authenticated SSE chat streaming all verified