### PR TITLE
feat(branding): config-driven white-label branding & attribution (Epic 4)

### DIFF
--- a/backend/src/Command/SeedAllCommand.php
+++ b/backend/src/Command/SeedAllCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Command;
 
+use App\Seed\BrandingConfigSeeder;
 use App\Seed\DefaultModelConfigSeeder;
 use App\Seed\DemoWidgetConfigSeeder;
 use App\Seed\ModelSeeder;
@@ -47,6 +48,7 @@ final class SeedAllCommand extends Command
         private readonly DemoWidgetConfigSeeder $demoWidgetConfigSeeder,
         private readonly SubscriptionPlanSeeder $subscriptionPlanSeeder,
         private readonly MultitaskConfigSeeder $multitaskConfigSeeder,
+        private readonly BrandingConfigSeeder $brandingConfigSeeder,
     ) {
         parent::__construct();
     }
@@ -61,7 +63,8 @@ final class SeedAllCommand extends Command
             "  4. app:ratelimit:seed-defaults (BCONFIG, group=RATELIMITS_*/SYSTEM_FLAGS)\n".
             "  5. subscription cost budgets   (BSUBSCRIPTIONS)\n".
             "  6. multitask routing flags     (BCONFIG, group=MULTITASK)\n".
-            "  7. demo widget config          (BCONFIG, group=widget_1, ownerId=2 — dev/test only)\n\n".
+            "  7. branding defaults           (BCONFIG, group=BRANDING, ownerId=0)\n".
+            "  8. demo widget config          (BCONFIG, group=widget_1, ownerId=2 — dev/test only)\n\n".
             'All steps are idempotent and safe to run on every deploy. The demo-widget step is a no-op in prod.'
         );
     }
@@ -78,6 +81,7 @@ final class SeedAllCommand extends Command
             ['rate-limits', fn (): SeedResult => $this->rateLimitConfigSeeder->seed()],
             ['subscriptions', fn (): SeedResult => $this->subscriptionPlanSeeder->seed()],
             ['multitask',   fn (): SeedResult => $this->multitaskConfigSeeder->seed()],
+            ['branding',    fn (): SeedResult => $this->brandingConfigSeeder->seed()],
             ['demo-widget', fn (): SeedResult => $this->demoWidgetConfigSeeder->seed()],
         ];
 

--- a/backend/src/Controller/ConfigController.php
+++ b/backend/src/Controller/ConfigController.php
@@ -9,6 +9,7 @@ use App\Entity\User;
 use App\Repository\ConfigRepository;
 use App\Repository\ModelRepository;
 use App\Service\BillingService;
+use App\Service\Branding\BrandingService;
 use App\Service\Client\ClientContextResolver;
 use App\Service\Embedding\EmbeddingMetadataService;
 use App\Service\Embedding\EmbeddingModelChangeGuard;
@@ -48,6 +49,7 @@ class ConfigController extends AbstractController
         private ModelConfigService $modelConfigService,
         private RedisService $redisService,
         private ClientContextResolver $clientContextResolver,
+        private BrandingService $brandingService,
         #[Autowire('%env(string:default::QDRANT_URL)%')]
         private readonly string $qdrantUrl,
     ) {
@@ -123,6 +125,23 @@ class ConfigController extends AbstractController
                     properties: [
                         new OA\Property(property: 'help', type: 'boolean', example: true, description: 'Enable help system'),
                         new OA\Property(property: 'memoryService', type: 'boolean', example: true, description: 'Qdrant vector database availability'),
+                    ]
+                ),
+                new OA\Property(
+                    property: 'branding',
+                    type: 'object',
+                    description: 'White-label branding (Epic 4). Defaults reproduce the historical Synaplan look. Public — no auth required.',
+                    properties: [
+                        new OA\Property(property: 'name', type: 'string', example: 'Synaplan', description: 'Displayed brand/product name'),
+                        new OA\Property(property: 'tagline', type: 'string', example: '', description: 'Optional short brand description/tagline'),
+                        new OA\Property(property: 'primaryColor', type: 'string', example: '#003fc7', description: 'Accent color injected into the --brand CSS variables at runtime'),
+                        new OA\Property(property: 'logoUrl', type: 'string', example: '', description: 'Light-mode logo URL; empty string falls back to the bundled asset'),
+                        new OA\Property(property: 'logoDarkUrl', type: 'string', example: '', description: 'Dark-mode logo URL; empty string falls back to the bundled asset'),
+                        new OA\Property(property: 'iconUrl', type: 'string', example: '', description: 'Brand icon/favicon URL; empty string falls back to the bundled asset'),
+                        new OA\Property(property: 'homepageUrl', type: 'string', example: 'https://www.synaplan.com', description: 'Brand homepage link used in auth/footer surfaces'),
+                        new OA\Property(property: 'showPoweredBy', type: 'boolean', example: true, description: 'Whether to show the "· powered by <label>" attribution'),
+                        new OA\Property(property: 'poweredByLabel', type: 'string', example: 'Synaplan', description: 'Attribution label (the platform being credited)'),
+                        new OA\Property(property: 'poweredByUrl', type: 'string', example: 'https://www.synaplan.com', description: 'Attribution link target'),
                     ]
                 ),
                 new OA\Property(
@@ -376,6 +395,7 @@ class ConfigController extends AbstractController
                 'enabled' => $this->billingService->isEnabled(),
             ],
             'recaptcha' => $recaptchaConfig,
+            'branding' => $this->brandingService->getBranding(),
             'features' => $features,
             'speech' => $speech,
             'plugins' => $plugins,

--- a/backend/src/Controller/SharedChatPageController.php
+++ b/backend/src/Controller/SharedChatPageController.php
@@ -6,6 +6,7 @@ namespace App\Controller;
 
 use App\Repository\ChatRepository;
 use App\Repository\MessageRepository;
+use App\Service\Branding\BrandingService;
 use App\Service\File\OgImageService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
@@ -40,8 +41,21 @@ class SharedChatPageController extends AbstractController
         private ChatRepository $chatRepository,
         private MessageRepository $messageRepository,
         private OgImageService $ogImageService,
+        private BrandingService $brandingService,
         private string $synaplanUrl,
     ) {
+    }
+
+    /**
+     * Brand name used in titles / og:site_name. Keeps the historical
+     * "Synaplan AI" wording for the default deployment (acceptance: default
+     * looks identical), and uses the configured brand for white-label.
+     */
+    private function titleBrand(): string
+    {
+        $name = $this->brandingService->getBranding()['name'];
+
+        return BrandingService::DEFAULT_NAME === $name ? 'Synaplan AI' : $name;
     }
 
     /**
@@ -116,7 +130,7 @@ class SharedChatPageController extends AbstractController
             // Clean slash commands from chat title
             $cleanTitle = $this->cleanSlashCommands($chatTitle);
             if (!empty(trim($cleanTitle))) {
-                return trim($cleanTitle).' | Synaplan AI';
+                return trim($cleanTitle).' | '.$this->titleBrand();
             }
         }
 
@@ -139,12 +153,12 @@ class SharedChatPageController extends AbstractController
                     $firstSentence = substr($firstSentence, 0, 57).'...';
                 }
                 if (!empty(trim($firstSentence))) {
-                    return trim($firstSentence).' | Synaplan AI';
+                    return trim($firstSentence).' | '.$this->titleBrand();
                 }
             }
         }
 
-        return 'Shared Chat | Synaplan AI';
+        return 'Shared Chat | '.$this->titleBrand();
     }
 
     /**
@@ -279,7 +293,7 @@ class SharedChatPageController extends AbstractController
     <meta property="og:url" content="{$this->escape($canonicalUrl)}">
     <meta property="og:title" content="{$this->escape($title)}">
     <meta property="og:description" content="{$this->escape($description)}">
-    <meta property="og:site_name" content="Synaplan AI">
+    <meta property="og:site_name" content="{$this->escape($this->titleBrand())}">
     <meta property="og:locale" content="{$this->escape($lang)}">
 HTML;
 

--- a/backend/src/Controller/WidgetPublicController.php
+++ b/backend/src/Controller/WidgetPublicController.php
@@ -10,6 +10,7 @@ use App\Repository\ChatRepository;
 use App\Repository\FileRepository;
 use App\Repository\MessageRepository;
 use App\Service\BillingService;
+use App\Service\Branding\BrandingService;
 use App\Service\DiscordNotificationService;
 use App\Service\File\FileProcessor;
 use App\Service\File\FileStorageService;
@@ -64,6 +65,7 @@ class WidgetPublicController extends AbstractController
         private SlackNotificationService $slack,
         private GeneratedFileMetadataNormalizer $generatedFileMetadataNormalizer,
         private GeneratedFileRegistrar $generatedFileRegistrar,
+        private BrandingService $brandingService,
         private string $uploadDir,
     ) {
     }
@@ -151,6 +153,16 @@ class WidgetPublicController extends AbstractController
                 new OA\Property(property: 'config', type: 'object'),
                 new OA\Property(property: 'isActive', type: 'boolean'),
                 new OA\Property(
+                    property: 'branding',
+                    type: 'object',
+                    description: 'White-label attribution (Epic 4.5) from the global branding config. Lets a hoster hide or re-attribute the widget "Powered by" footer.',
+                    properties: [
+                        new OA\Property(property: 'showPoweredBy', type: 'boolean', example: true),
+                        new OA\Property(property: 'poweredByLabel', type: 'string', example: 'Synaplan'),
+                        new OA\Property(property: 'poweredByUrl', type: 'string', example: 'https://www.synaplan.com'),
+                    ]
+                ),
+                new OA\Property(
                     property: 'realtime',
                     type: 'object',
                     description: 'Realtime / Centrifugo settings consumed by the embedded widget. The cross-origin widget cannot read /api/v1/config/runtime, so we surface the relevant subset here.',
@@ -196,12 +208,22 @@ class WidgetPublicController extends AbstractController
             return $domainError;
         }
 
+        // White-label attribution (Epic 4.5). The cross-origin widget cannot read
+        // /api/v1/config/runtime, so we surface the global branding's powered-by
+        // subset here. Defaults keep the historical "powered by synaplan" footer.
+        $branding = $this->brandingService->getBranding();
+
         return $this->json([
             'success' => true,
             'widgetId' => $widget->getWidgetId(),
             'name' => $widget->getName(),
             'config' => self::buildPublicConfig($config),
             'isActive' => true,
+            'branding' => [
+                'showPoweredBy' => $branding['showPoweredBy'],
+                'poweredByLabel' => $branding['poweredByLabel'],
+                'poweredByUrl' => $branding['poweredByUrl'],
+            ],
             'realtime' => [
                 // REALTIME_ENABLED is the global kill-switch shared with the
                 // operator UI (see ConfigController::getRuntimeConfig). Empty

--- a/backend/src/Seed/BrandingConfigSeeder.php
+++ b/backend/src/Seed/BrandingConfigSeeder.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Seed;
+
+use App\Service\Branding\BrandingService;
+use Doctrine\DBAL\Connection;
+
+/**
+ * Idempotent seeder for the white-label branding defaults (BCONFIG, ownerId=0).
+ *
+ * Seeds the explicit global rows so the brand is visible/editable in the admin
+ * System Config UI rather than living only as a code default. Insert-if-missing
+ * only — operator overrides are never touched.
+ *
+ * Defaults reproduce the historical "Synaplan" look, so seeding a fresh install
+ * leaves the product visually unchanged.
+ */
+final readonly class BrandingConfigSeeder
+{
+    public function __construct(
+        private Connection $connection,
+    ) {
+    }
+
+    public function seed(): SeedResult
+    {
+        $g = BrandingService::GROUP;
+        $rows = [
+            ['ownerId' => 0, 'group' => $g, 'setting' => BrandingService::KEY_NAME,            'value' => BrandingService::DEFAULT_NAME],
+            ['ownerId' => 0, 'group' => $g, 'setting' => BrandingService::KEY_TAGLINE,         'value' => BrandingService::DEFAULT_TAGLINE],
+            ['ownerId' => 0, 'group' => $g, 'setting' => BrandingService::KEY_PRIMARY_COLOR,   'value' => BrandingService::DEFAULT_PRIMARY_COLOR],
+            ['ownerId' => 0, 'group' => $g, 'setting' => BrandingService::KEY_LOGO_URL,        'value' => ''],
+            ['ownerId' => 0, 'group' => $g, 'setting' => BrandingService::KEY_LOGO_DARK_URL,   'value' => ''],
+            ['ownerId' => 0, 'group' => $g, 'setting' => BrandingService::KEY_ICON_URL,        'value' => ''],
+            ['ownerId' => 0, 'group' => $g, 'setting' => BrandingService::KEY_HOMEPAGE_URL,    'value' => BrandingService::DEFAULT_HOMEPAGE_URL],
+            ['ownerId' => 0, 'group' => $g, 'setting' => BrandingService::KEY_SHOW_POWERED_BY, 'value' => BrandingService::DEFAULT_SHOW_POWERED_BY],
+            ['ownerId' => 0, 'group' => $g, 'setting' => BrandingService::KEY_POWERED_BY_LABEL, 'value' => BrandingService::DEFAULT_POWERED_BY_LABEL],
+            ['ownerId' => 0, 'group' => $g, 'setting' => BrandingService::KEY_POWERED_BY_URL,  'value' => BrandingService::DEFAULT_POWERED_BY_URL],
+        ];
+
+        return BConfigSeeder::insertIfMissing($this->connection, 'branding_config', $rows);
+    }
+}

--- a/backend/src/Service/Admin/SystemConfigService.php
+++ b/backend/src/Service/Admin/SystemConfigService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Service\Admin;
 
 use App\Repository\ConfigRepository;
+use App\Service\Branding\BrandingService;
 use App\Service\FeedbackConstants;
 use App\Service\Multitask\MultitaskRoutingConfig;
 use Psr\Log\LoggerInterface;
@@ -55,6 +56,14 @@ final readonly class SystemConfigService
                 'label' => 'Email',
                 'sections' => [
                     'mailer' => ['label' => 'Primary Mailer', 'fields' => ['MAILER_DSN', 'APP_SENDER_EMAIL', 'APP_SENDER_NAME']],
+                ],
+            ],
+            'branding' => [
+                'label' => 'Branding',
+                'sections' => [
+                    'identity' => ['label' => 'Brand Identity', 'fields' => ['BRAND_NAME', 'BRAND_TAGLINE', 'BRAND_PRIMARY_COLOR', 'BRAND_HOMEPAGE_URL']],
+                    'logos' => ['label' => 'Logos & Icon', 'fields' => ['BRAND_LOGO_URL', 'BRAND_LOGO_DARK_URL', 'BRAND_ICON_URL']],
+                    'attribution' => ['label' => 'Attribution ("Powered by")', 'fields' => ['BRAND_SHOW_POWERED_BY', 'BRAND_POWERED_BY_LABEL', 'BRAND_POWERED_BY_URL']],
                 ],
             ],
             'auth' => [
@@ -651,6 +660,80 @@ final readonly class SystemConfigService
                 'dbGroup' => MultitaskRoutingConfig::CONFIG_GROUP,
                 'dbKey' => MultitaskRoutingConfig::KEY_ROUTING_ENABLED,
             ],
+            // === Branding (database-backed, no restart required) ===
+            // Stored in BCONFIG group BRANDING (ownerId=0) — the rows BrandingService
+            // reads and the public runtime-config endpoint surfaces to the frontend.
+            'BRAND_NAME' => [
+                'tab' => 'branding', 'section' => 'identity', 'type' => 'text',
+                'sensitive' => false,
+                'description' => 'Displayed brand/product name (document title, auth screens, attribution).',
+                'default' => BrandingService::DEFAULT_NAME,
+                'source' => 'database', 'dbGroup' => BrandingService::GROUP, 'dbKey' => BrandingService::KEY_NAME,
+            ],
+            'BRAND_TAGLINE' => [
+                'tab' => 'branding', 'section' => 'identity', 'type' => 'text',
+                'sensitive' => false,
+                'description' => 'Optional short tagline/description shown beside the brand.',
+                'default' => BrandingService::DEFAULT_TAGLINE,
+                'source' => 'database', 'dbGroup' => BrandingService::GROUP, 'dbKey' => BrandingService::KEY_TAGLINE,
+            ],
+            'BRAND_PRIMARY_COLOR' => [
+                'tab' => 'branding', 'section' => 'identity', 'type' => 'text',
+                'sensitive' => false,
+                'description' => 'Accent color as a hex value (e.g. #003fc7). Injected into the --brand CSS variables at runtime.',
+                'default' => BrandingService::DEFAULT_PRIMARY_COLOR,
+                'source' => 'database', 'dbGroup' => BrandingService::GROUP, 'dbKey' => BrandingService::KEY_PRIMARY_COLOR,
+            ],
+            'BRAND_HOMEPAGE_URL' => [
+                'tab' => 'branding', 'section' => 'identity', 'type' => 'url',
+                'sensitive' => false,
+                'description' => 'Brand homepage link used on auth and footer surfaces.',
+                'default' => BrandingService::DEFAULT_HOMEPAGE_URL,
+                'source' => 'database', 'dbGroup' => BrandingService::GROUP, 'dbKey' => BrandingService::KEY_HOMEPAGE_URL,
+            ],
+            'BRAND_LOGO_URL' => [
+                'tab' => 'branding', 'section' => 'logos', 'type' => 'url',
+                'sensitive' => false,
+                'description' => 'Light-mode logo URL. Leave empty to use the bundled Synaplan logo.',
+                'default' => '',
+                'source' => 'database', 'dbGroup' => BrandingService::GROUP, 'dbKey' => BrandingService::KEY_LOGO_URL,
+            ],
+            'BRAND_LOGO_DARK_URL' => [
+                'tab' => 'branding', 'section' => 'logos', 'type' => 'url',
+                'sensitive' => false,
+                'description' => 'Dark-mode logo URL. Leave empty to use the bundled Synaplan logo.',
+                'default' => '',
+                'source' => 'database', 'dbGroup' => BrandingService::GROUP, 'dbKey' => BrandingService::KEY_LOGO_DARK_URL,
+            ],
+            'BRAND_ICON_URL' => [
+                'tab' => 'branding', 'section' => 'logos', 'type' => 'url',
+                'sensitive' => false,
+                'description' => 'Brand icon/favicon URL. Leave empty to use the bundled asset (app icons are produced by Epic 6).',
+                'default' => '',
+                'source' => 'database', 'dbGroup' => BrandingService::GROUP, 'dbKey' => BrandingService::KEY_ICON_URL,
+            ],
+            'BRAND_SHOW_POWERED_BY' => [
+                'tab' => 'branding', 'section' => 'attribution', 'type' => 'boolean',
+                'sensitive' => false,
+                'description' => 'Show the "· powered by <label>" attribution across auth, logged-out, shared-chat and widget surfaces.',
+                'default' => BrandingService::DEFAULT_SHOW_POWERED_BY,
+                'source' => 'database', 'dbGroup' => BrandingService::GROUP, 'dbKey' => BrandingService::KEY_SHOW_POWERED_BY,
+            ],
+            'BRAND_POWERED_BY_LABEL' => [
+                'tab' => 'branding', 'section' => 'attribution', 'type' => 'text',
+                'sensitive' => false,
+                'description' => 'Attribution label — the platform being credited (e.g. "Synaplan").',
+                'default' => BrandingService::DEFAULT_POWERED_BY_LABEL,
+                'source' => 'database', 'dbGroup' => BrandingService::GROUP, 'dbKey' => BrandingService::KEY_POWERED_BY_LABEL,
+            ],
+            'BRAND_POWERED_BY_URL' => [
+                'tab' => 'branding', 'section' => 'attribution', 'type' => 'url',
+                'sensitive' => false,
+                'description' => 'Attribution link target for the "powered by" label.',
+                'default' => BrandingService::DEFAULT_POWERED_BY_URL,
+                'source' => 'database', 'dbGroup' => BrandingService::GROUP, 'dbKey' => BrandingService::KEY_POWERED_BY_URL,
+            ],
+
             // === AI Services ===
             'OLLAMA_BASE_URL' => [
                 'tab' => 'ai', 'section' => 'ollama', 'type' => 'url',

--- a/backend/src/Service/Branding/BrandingService.php
+++ b/backend/src/Service/Branding/BrandingService.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Branding;
+
+use App\Repository\ConfigRepository;
+
+/**
+ * Single source of truth for white-label branding (Epic 4).
+ *
+ * Reads the BRANDING config group (BCONFIG, ownerId=0) and exposes it as a
+ * typed array. Defaults reproduce the historical hardcoded "Synaplan" look, so
+ * an unconfigured deployment is byte-identical to before this epic.
+ *
+ * Consumed by the public runtime-config endpoint (frontend) and the SSR
+ * shared-chat page (og:site_name) so every surface agrees on one brand.
+ */
+final readonly class BrandingService
+{
+    public const GROUP = 'BRANDING';
+    public const OWNER_ID = 0;
+
+    public const KEY_NAME = 'BRAND_NAME';
+    public const KEY_TAGLINE = 'BRAND_TAGLINE';
+    public const KEY_PRIMARY_COLOR = 'BRAND_PRIMARY_COLOR';
+    public const KEY_LOGO_URL = 'BRAND_LOGO_URL';
+    public const KEY_LOGO_DARK_URL = 'BRAND_LOGO_DARK_URL';
+    public const KEY_ICON_URL = 'BRAND_ICON_URL';
+    public const KEY_HOMEPAGE_URL = 'BRAND_HOMEPAGE_URL';
+    public const KEY_SHOW_POWERED_BY = 'BRAND_SHOW_POWERED_BY';
+    public const KEY_POWERED_BY_LABEL = 'BRAND_POWERED_BY_LABEL';
+    public const KEY_POWERED_BY_URL = 'BRAND_POWERED_BY_URL';
+
+    public const DEFAULT_NAME = 'Synaplan';
+    public const DEFAULT_TAGLINE = '';
+    public const DEFAULT_PRIMARY_COLOR = '#003fc7';
+    public const DEFAULT_HOMEPAGE_URL = 'https://www.synaplan.com';
+    public const DEFAULT_SHOW_POWERED_BY = '1';
+    public const DEFAULT_POWERED_BY_LABEL = 'Synaplan';
+    public const DEFAULT_POWERED_BY_URL = 'https://www.synaplan.com';
+
+    public function __construct(
+        private ConfigRepository $configRepository,
+    ) {
+    }
+
+    /**
+     * @return array{
+     *     name: string,
+     *     tagline: string,
+     *     primaryColor: string,
+     *     logoUrl: string,
+     *     logoDarkUrl: string,
+     *     iconUrl: string,
+     *     homepageUrl: string,
+     *     showPoweredBy: bool,
+     *     poweredByLabel: string,
+     *     poweredByUrl: string
+     * }
+     */
+    public function getBranding(): array
+    {
+        return [
+            'name' => $this->value(self::KEY_NAME, self::DEFAULT_NAME),
+            'tagline' => $this->value(self::KEY_TAGLINE, self::DEFAULT_TAGLINE),
+            'primaryColor' => $this->value(self::KEY_PRIMARY_COLOR, self::DEFAULT_PRIMARY_COLOR),
+            'logoUrl' => $this->value(self::KEY_LOGO_URL, ''),
+            'logoDarkUrl' => $this->value(self::KEY_LOGO_DARK_URL, ''),
+            'iconUrl' => $this->value(self::KEY_ICON_URL, ''),
+            'homepageUrl' => $this->value(self::KEY_HOMEPAGE_URL, self::DEFAULT_HOMEPAGE_URL),
+            'showPoweredBy' => $this->boolValue(self::KEY_SHOW_POWERED_BY, self::DEFAULT_SHOW_POWERED_BY),
+            'poweredByLabel' => $this->value(self::KEY_POWERED_BY_LABEL, self::DEFAULT_POWERED_BY_LABEL),
+            'poweredByUrl' => $this->value(self::KEY_POWERED_BY_URL, self::DEFAULT_POWERED_BY_URL),
+        ];
+    }
+
+    private function value(string $setting, string $default): string
+    {
+        $raw = $this->configRepository->getValue(self::OWNER_ID, self::GROUP, $setting);
+
+        return (null === $raw || '' === $raw) ? $default : $raw;
+    }
+
+    private function boolValue(string $setting, string $default): bool
+    {
+        $raw = $this->configRepository->getValue(self::OWNER_ID, self::GROUP, $setting) ?? $default;
+
+        return '1' === $raw || 'true' === strtolower(trim($raw));
+    }
+}

--- a/backend/tests/Unit/Controller/ConfigControllerSaveDefaultModelsTest.php
+++ b/backend/tests/Unit/Controller/ConfigControllerSaveDefaultModelsTest.php
@@ -12,6 +12,7 @@ use App\Entity\User;
 use App\Repository\ConfigRepository;
 use App\Repository\ModelRepository;
 use App\Service\BillingService;
+use App\Service\Branding\BrandingService;
 use App\Service\Client\ClientContextResolver;
 use App\Service\Embedding\EmbeddingMetadataService;
 use App\Service\Embedding\EmbeddingModelChangeGuard;
@@ -77,6 +78,7 @@ final class ConfigControllerSaveDefaultModelsTest extends TestCase
             // empty DSN is inert and saveDefaultModels never touches it.
             new RedisService('', 'test', new NullLogger()),
             new ClientContextResolver(),
+            $this->createStub(BrandingService::class),
             'http://qdrant.example',
         );
 

--- a/backend/tests/Unit/Service/Branding/BrandingServiceTest.php
+++ b/backend/tests/Unit/Service/Branding/BrandingServiceTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\Branding;
+
+use App\Repository\ConfigRepository;
+use App\Service\Branding\BrandingService;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class BrandingServiceTest extends TestCase
+{
+    private ConfigRepository&MockObject $configRepository;
+    private BrandingService $service;
+
+    protected function setUp(): void
+    {
+        $this->configRepository = $this->createMock(ConfigRepository::class);
+        $this->service = new BrandingService($this->configRepository);
+    }
+
+    /**
+     * An unconfigured deployment must reproduce the historical Synaplan look.
+     */
+    public function testReturnsDefaultsWhenNothingConfigured(): void
+    {
+        $this->configRepository->method('getValue')->willReturn(null);
+
+        $branding = $this->service->getBranding();
+
+        $this->assertSame('Synaplan', $branding['name']);
+        $this->assertSame('#003fc7', $branding['primaryColor']);
+        $this->assertSame('https://www.synaplan.com', $branding['homepageUrl']);
+        $this->assertSame('', $branding['logoUrl']);
+        $this->assertTrue($branding['showPoweredBy']);
+        $this->assertSame('Synaplan', $branding['poweredByLabel']);
+    }
+
+    /**
+     * Empty-string overrides must fall back to the default, not blank the brand.
+     */
+    public function testEmptyOverrideFallsBackToDefault(): void
+    {
+        $this->configRepository->method('getValue')->willReturnCallback(
+            static fn (int $owner, string $group, string $setting): ?string => BrandingService::KEY_NAME === $setting ? '' : null
+        );
+
+        $this->assertSame('Synaplan', $this->service->getBranding()['name']);
+    }
+
+    public function testReadsConfiguredOverrides(): void
+    {
+        $this->configRepository->method('getValue')->willReturnCallback(
+            static fn (int $owner, string $group, string $setting): ?string => match (true) {
+                BrandingService::OWNER_ID !== $owner || BrandingService::GROUP !== $group => null,
+                BrandingService::KEY_NAME === $setting => 'Acme',
+                BrandingService::KEY_PRIMARY_COLOR === $setting => '#ff0000',
+                BrandingService::KEY_LOGO_URL === $setting => 'https://acme.test/logo.svg',
+                BrandingService::KEY_SHOW_POWERED_BY === $setting => '0',
+                default => null,
+            }
+        );
+
+        $branding = $this->service->getBranding();
+
+        $this->assertSame('Acme', $branding['name']);
+        $this->assertSame('#ff0000', $branding['primaryColor']);
+        $this->assertSame('https://acme.test/logo.svg', $branding['logoUrl']);
+        $this->assertFalse($branding['showPoweredBy']);
+    }
+
+    public function testShowPoweredByAcceptsTrueString(): void
+    {
+        $this->configRepository->method('getValue')->willReturnCallback(
+            static fn (int $owner, string $group, string $setting): ?string => BrandingService::KEY_SHOW_POWERED_BY === $setting ? 'true' : null
+        );
+
+        $this->assertTrue($this->service->getBranding()['showPoweredBy']);
+    }
+}

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -34,7 +34,7 @@ import { useI18n } from 'vue-i18n'
 import { useTheme } from './composables/useTheme'
 import { useAuthStore } from '@/stores/auth'
 import { useConfigStore } from '@/stores/config'
-import { APP_NAME } from '@/router'
+import { brandName } from '@/router'
 import NotificationContainer from '@/components/NotificationContainer.vue'
 import Dialog from '@/components/Dialog.vue'
 import ErrorBoundary from '@/components/ErrorBoundary.vue'
@@ -115,7 +115,7 @@ watch(locale, () => {
   const titleKey = route.meta.titleKey as string | undefined
   if (titleKey) {
     const pageTitle = t(titleKey)
-    document.title = `${pageTitle} | ${APP_NAME}`
+    document.title = `${pageTitle} | ${brandName()}`
   }
 })
 

--- a/frontend/src/components/BrandAttribution.vue
+++ b/frontend/src/components/BrandAttribution.vue
@@ -1,0 +1,50 @@
+<template>
+  <span v-if="config.branding.showPoweredBy" class="inline-flex items-center gap-1 flex-wrap">
+    <template v-if="distinctBrand">
+      <a
+        :href="config.branding.homepageUrl"
+        target="_blank"
+        rel="noopener noreferrer"
+        :class="props.linkClass"
+        data-testid="brand-attribution-brand"
+        >{{ config.branding.name }}</a
+      >
+      <span aria-hidden="true">·</span>
+    </template>
+    <span>{{ $t('branding.poweredBy') }}</span>
+    <a
+      :href="config.branding.poweredByUrl"
+      target="_blank"
+      rel="noopener noreferrer"
+      :class="props.linkClass"
+      data-testid="brand-attribution-powered-by"
+      >{{ config.branding.poweredByLabel }}</a
+    >
+  </span>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useConfigStore } from '@/stores/config'
+
+const props = withDefaults(
+  defineProps<{
+    /** Tailwind classes applied to the links (lets each surface match its style). */
+    linkClass?: string
+  }>(),
+  {
+    linkClass: 'font-medium hover:underline',
+  }
+)
+
+const config = useConfigStore()
+
+// Collapse "<name> · powered by <label>" to just "powered by <label>" when the
+// brand IS the platform (default Synaplan deployment) so the default reads
+// "Powered by Synaplan" exactly like before this epic.
+const distinctBrand = computed(
+  () =>
+    config.branding.name.trim().toLowerCase() !==
+    config.branding.poweredByLabel.trim().toLowerCase()
+)
+</script>

--- a/frontend/src/components/widgets/ChatWidget.vue
+++ b/frontend/src/components/widgets/ChatWidget.vue
@@ -619,6 +619,7 @@
 
         <!-- Powered By -->
         <div
+          v-if="showPoweredBy"
           class="px-4 py-2 text-center border-t"
           :class="{
             'pb-[calc(env(safe-area-inset-bottom,0px)+12px)]': isMobile && !isPreview,
@@ -626,14 +627,14 @@
           :style="{ borderColor: widgetTheme === 'dark' ? '#333' : '#e5e7eb' }"
         >
           <p class="text-xs" :style="{ color: widgetTheme === 'dark' ? '#9ca3af' : '#6b7280' }">
-            Powered by
+            {{ $t('branding.poweredBy') }}
             <a
-              href="https://www.synaplan.com/"
+              :href="poweredByUrl"
               target="_blank"
               rel="noopener noreferrer"
               class="font-semibold hover:underline"
               :style="{ color: primaryColor }"
-              >synaplan</a
+              >{{ poweredByLabel }}</a
             >
           </p>
         </div>
@@ -716,6 +717,13 @@ interface Props {
    * realtime backend) keep working — undefined is treated as "disabled".
    */
   realtime?: WidgetRealtimeRuntime
+  /**
+   * White-label attribution (Epic 4.5), echoed from the backend's global
+   * branding config. Defaults reproduce the historical "powered by synaplan".
+   */
+  showPoweredBy?: boolean
+  poweredByLabel?: string
+  poweredByUrl?: string
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -748,6 +756,9 @@ const props = withDefaults(defineProps<Props>(), {
   testMode: false,
   internalMode: false,
   realtime: undefined,
+  showPoweredBy: true,
+  poweredByLabel: 'synaplan',
+  poweredByUrl: 'https://www.synaplan.com/',
 })
 
 const emit = defineEmits<{

--- a/frontend/src/composables/useBrandLogo.ts
+++ b/frontend/src/composables/useBrandLogo.ts
@@ -1,0 +1,22 @@
+import { computed, type Ref } from 'vue'
+import { useConfigStore } from '@/stores/config'
+
+/**
+ * Resolve the brand wordmark logo, config-addressable with a safe fallback
+ * (Epic 4.4). A white-label hoster can point `branding.logoUrl` /
+ * `branding.logoDarkUrl` at their own asset; when empty we fall back to the
+ * bundled Synaplan SVGs so the default look is unchanged.
+ */
+export function useBrandLogo(isDark: Ref<boolean>) {
+  const config = useConfigStore()
+
+  const logoSrc = computed(() => {
+    const configured = isDark.value ? config.branding.logoDarkUrl : config.branding.logoUrl
+    if (configured) {
+      return configured
+    }
+    return `${import.meta.env.BASE_URL}${isDark.value ? 'synaplan-light.svg' : 'synaplan-dark.svg'}`
+  })
+
+  return { logoSrc }
+}

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -1,4 +1,7 @@
 {
+  "branding": {
+    "poweredBy": "Bereitgestellt von"
+  },
   "pageTitles": {
     "login": "Anmelden",
     "register": "Registrieren",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -1,4 +1,7 @@
 {
+  "branding": {
+    "poweredBy": "Powered by"
+  },
   "pageTitles": {
     "login": "Login",
     "register": "Register",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -1,4 +1,7 @@
 {
+  "branding": {
+    "poweredBy": "Desarrollado por"
+  },
   "pageTitles": {
     "login": "Iniciar sesión",
     "register": "Registrarse",

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -1,4 +1,7 @@
 {
+  "branding": {
+    "poweredBy": "Sunan"
+  },
   "pageTitles": {
     "login": "Giriş",
     "register": "Kayıt Ol",

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -13,6 +13,7 @@ import { installGlobalErrorHandlers } from './utils/installGlobalErrorHandlers'
 import { isNativeApp, getNativeApiBaseUrl } from './services/api/nativeRuntime'
 import { setApiBaseUrl } from './services/api/httpClient'
 import { loadNativeTokens } from './services/api/nativeAuth'
+import { applyBrandingTheme } from './utils/brandingTheme'
 
 // Bootstrap app - load config before mounting.
 // We MUST install global error handlers and mount the app even when bootstrap
@@ -52,6 +53,9 @@ import { loadNativeTokens } from './services/api/nativeAuth'
       stack: err instanceof Error ? (err.stack ?? '') : '',
     })
   }
+
+  // Apply white-label accent color from runtime branding config (Epic 4).
+  applyBrandingTheme()
 
   const recaptchaEnabled = config.recaptcha.enabled
   const recaptchaSiteKey = config.recaptcha.siteKey

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -39,7 +39,17 @@ const guardDevOnlyAdminFeatures = (
   next()
 }
 
+/**
+ * Build-time fallback brand name. The live name comes from the runtime branding
+ * config (`useConfigStore().branding.name`, Epic 4); this constant only covers
+ * the window before config has loaded and the static index.html title.
+ */
 export const APP_NAME = 'Synaplan'
+
+/** Live brand name with a safe fallback before runtime config has loaded. */
+export function brandName(): string {
+  return useConfigStore().branding.name || APP_NAME
+}
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -395,10 +405,10 @@ router.afterEach((to) => {
   if (titleKey) {
     const t = i18n.global.t
     const pageTitle = t(titleKey)
-    document.title = `${pageTitle} | ${APP_NAME}`
+    document.title = `${pageTitle} | ${brandName()}`
   } else {
     // Fallback for routes without titleKey (e.g., shared chat handles its own title)
-    document.title = APP_NAME
+    document.title = brandName()
   }
 })
 

--- a/frontend/src/stores/config.ts
+++ b/frontend/src/stores/config.ts
@@ -129,6 +129,48 @@ const config = {
   },
 
   /**
+   * White-label branding (Epic 4), loaded from backend at runtime.
+   * Defaults reproduce the historical hardcoded "Synaplan" look so an
+   * unconfigured deployment is visually identical to before.
+   *
+   * Empty-string semantics differ by field on purpose: name/color/links
+   * fall back to a default (|| ), while logo/icon/tagline keep '' so the
+   * consumer can decide to use the bundled asset / render nothing.
+   */
+  branding: {
+    get name(): string {
+      return getConfigSync().branding?.name || 'Synaplan'
+    },
+    get tagline(): string {
+      return getConfigSync().branding?.tagline ?? ''
+    },
+    get primaryColor(): string {
+      return getConfigSync().branding?.primaryColor || '#003fc7'
+    },
+    get logoUrl(): string {
+      return getConfigSync().branding?.logoUrl ?? ''
+    },
+    get logoDarkUrl(): string {
+      return getConfigSync().branding?.logoDarkUrl ?? ''
+    },
+    get iconUrl(): string {
+      return getConfigSync().branding?.iconUrl ?? ''
+    },
+    get homepageUrl(): string {
+      return getConfigSync().branding?.homepageUrl || 'https://www.synaplan.com'
+    },
+    get showPoweredBy(): boolean {
+      return getConfigSync().branding?.showPoweredBy ?? true
+    },
+    get poweredByLabel(): string {
+      return getConfigSync().branding?.poweredByLabel || 'Synaplan'
+    },
+    get poweredByUrl(): string {
+      return getConfigSync().branding?.poweredByUrl || 'https://www.synaplan.com'
+    },
+  },
+
+  /**
    * Installed plugins for the current user
    */
   get plugins(): NonNullable<ReturnType<typeof getConfigSync>['plugins']> {

--- a/frontend/src/utils/brandingTheme.ts
+++ b/frontend/src/utils/brandingTheme.ts
@@ -1,0 +1,26 @@
+/**
+ * Runtime accent-color theming (Epic 4).
+ *
+ * When a white-label deployment configures a custom `branding.primaryColor`, we
+ * override the `--brand*` CSS variables on :root at runtime. The default color
+ * is left untouched so the carefully tuned light/dark stylesheet values (incl.
+ * the lighter dark-mode brand) keep working for the stock Synaplan look.
+ */
+import config from '@/stores/config'
+
+const DEFAULT_PRIMARY = '#003fc7'
+const HEX_COLOR = /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/
+
+export function applyBrandingTheme(): void {
+  const color = config.branding.primaryColor
+
+  if (!HEX_COLOR.test(color) || color.toLowerCase() === DEFAULT_PRIMARY) {
+    return
+  }
+
+  const root = document.documentElement
+  root.style.setProperty('--brand', color)
+  root.style.setProperty('--brand-hover', `color-mix(in srgb, ${color} 88%, black)`)
+  root.style.setProperty('--brand-light', `color-mix(in srgb, ${color} 55%, white)`)
+  root.style.setProperty('--brand-alpha-light', `color-mix(in srgb, ${color} 10%, transparent)`)
+}

--- a/frontend/src/views/LoggedOutView.vue
+++ b/frontend/src/views/LoggedOutView.vue
@@ -29,7 +29,7 @@
 
     <div class="w-full max-w-md" data-testid="section-card">
       <div class="text-center mb-8" data-testid="section-header">
-        <img :src="logoSrc" alt="synaplan" class="h-12 mx-auto mb-6" />
+        <img :src="logoSrc" :alt="config.branding.name" class="h-12 mx-auto mb-6" />
       </div>
 
       <div class="surface-card p-8 text-center" data-testid="section-content">
@@ -54,15 +54,9 @@
       </div>
 
       <p class="mt-6 text-center text-xs text-gray-500 dark:text-gray-400">
-        <a
-          href="https://www.synaplan.com"
-          class="hover:underline opacity-75 hover:opacity-100 transition-opacity"
-          target="_blank"
-          rel="noopener noreferrer"
-          data-testid="link-powered-by"
-        >
-          {{ $t('auth.poweredBySynaplan') }}
-        </a>
+        <BrandAttribution
+          link-class="hover:underline opacity-75 hover:opacity-100 transition-opacity font-medium"
+        />
       </p>
     </div>
   </div>
@@ -75,10 +69,14 @@ import { useI18n } from 'vue-i18n'
 import { SunIcon, MoonIcon, ArrowRightOnRectangleIcon } from '@heroicons/vue/24/outline'
 import { useTheme } from '../composables/useTheme'
 import Button from '../components/Button.vue'
+import BrandAttribution from '../components/BrandAttribution.vue'
+import { useBrandLogo } from '@/composables/useBrandLogo'
+import { useConfigStore } from '@/stores/config'
 
 const router = useRouter()
 const { locale } = useI18n()
 const themeStore = useTheme()
+const config = useConfigStore()
 
 const isDark = computed(() => {
   if (themeStore.theme.value === 'dark') return true
@@ -86,9 +84,7 @@ const isDark = computed(() => {
   return matchMedia('(prefers-color-scheme: dark)').matches
 })
 
-const logoSrc = computed(
-  () => `${import.meta.env.BASE_URL}${isDark.value ? 'synaplan-light.svg' : 'synaplan-dark.svg'}`
-)
+const { logoSrc } = useBrandLogo(isDark)
 
 const currentLanguage = computed(() => locale.value)
 

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -338,16 +338,20 @@
       <!-- Footer -->
       <div class="mt-8 flex justify-center">
         <a
-          href="https://www.synaplan.com"
+          :href="config.branding.homepageUrl"
           target="_blank"
           rel="noopener noreferrer"
           class="group inline-flex items-center gap-1.5 opacity-40 hover:opacity-60 transition-all duration-300"
           :data-testid="config.billing.enabled ? 'link-homepage' : 'link-powered-by'"
         >
-          <span class="text-[10px] txt-secondary tracking-wide">Powered by</span>
+          <span
+            v-if="config.branding.showPoweredBy"
+            class="text-[10px] txt-secondary tracking-wide"
+            >{{ $t('branding.poweredBy') }}</span
+          >
           <img
             :src="logoSrc"
-            alt="Synaplan"
+            :alt="config.branding.name"
             class="h-3.5 opacity-70 group-hover:opacity-100 transition-opacity duration-300"
           />
         </a>
@@ -367,6 +371,7 @@ import { useAuth } from '../composables/useAuth'
 import { useRecaptcha } from '../composables/useRecaptcha'
 import { validateEmail } from '../composables/usePasswordValidation'
 import { useConfigStore } from '@/stores/config'
+import { useBrandLogo } from '@/composables/useBrandLogo'
 import { isNativeApp } from '@/services/api/nativeRuntime'
 import { startNativeOAuth } from '@/services/api/nativeOAuth'
 import { useAuthStore } from '@/stores/auth'
@@ -390,9 +395,7 @@ const isDark = computed(() => {
   return matchMedia('(prefers-color-scheme: dark)').matches
 })
 
-const logoSrc = computed(
-  () => `${import.meta.env.BASE_URL}${isDark.value ? 'synaplan-light.svg' : 'synaplan-dark.svg'}`
-)
+const { logoSrc } = useBrandLogo(isDark)
 const birdSrc = computed(
   () =>
     `${import.meta.env.BASE_URL}${isDark.value ? 'single_bird-light.svg' : 'single_bird-dark.svg'}`

--- a/frontend/src/views/RegisterView.vue
+++ b/frontend/src/views/RegisterView.vue
@@ -354,16 +354,20 @@
       <!-- Footer -->
       <div class="mt-8 flex justify-center">
         <a
-          href="https://www.synaplan.com"
+          :href="config.branding.homepageUrl"
           target="_blank"
           rel="noopener noreferrer"
           class="group inline-flex items-center gap-1.5 opacity-40 hover:opacity-60 transition-all duration-300"
           :data-testid="config.billing.enabled ? 'link-homepage' : 'link-powered-by'"
         >
-          <span class="text-[10px] txt-secondary tracking-wide">Powered by</span>
+          <span
+            v-if="config.branding.showPoweredBy"
+            class="text-[10px] txt-secondary tracking-wide"
+            >{{ $t('branding.poweredBy') }}</span
+          >
           <img
             :src="logoSrc"
-            alt="Synaplan"
+            :alt="config.branding.name"
             class="h-3.5 opacity-70 group-hover:opacity-100 transition-opacity duration-300"
           />
         </a>
@@ -383,6 +387,7 @@ import { useAuth } from '../composables/useAuth'
 import { useRecaptcha } from '../composables/useRecaptcha'
 import { usePasswordValidation, validateEmail } from '../composables/usePasswordValidation'
 import { useConfigStore } from '@/stores/config'
+import { useBrandLogo } from '@/composables/useBrandLogo'
 
 const router = useRouter()
 const { locale } = useI18n()
@@ -396,9 +401,7 @@ const isDark = computed(() => {
   return matchMedia('(prefers-color-scheme: dark)').matches
 })
 
-const logoSrc = computed(
-  () => `${import.meta.env.BASE_URL}${isDark.value ? 'synaplan-light.svg' : 'synaplan-dark.svg'}`
-)
+const { logoSrc } = useBrandLogo(isDark)
 const birdSrc = computed(
   () =>
     `${import.meta.env.BASE_URL}${isDark.value ? 'single_bird-light.svg' : 'single_bird-dark.svg'}`

--- a/frontend/src/views/SharedChatView.vue
+++ b/frontend/src/views/SharedChatView.vue
@@ -286,14 +286,7 @@
       <footer class="mt-20 border-t border-light-border dark:border-dark-border py-8">
         <div class="max-w-4xl mx-auto px-4 text-center txt-secondary text-sm">
           <p>
-            {{ $t('shared.poweredBy') }}
-            <a
-              href="https://synaplan.com"
-              target="_blank"
-              class="text-[var(--brand)] hover:underline font-medium"
-            >
-              Synaplan AI
-            </a>
+            <BrandAttribution link-class="text-[var(--brand)] hover:underline font-medium" />
             ·
             <a href="https://synaplan.com/privacy" target="_blank" class="hover:underline">{{
               $t('shared.privacy')
@@ -318,6 +311,7 @@ import MessageImage from '../components/MessageImage.vue'
 import MessageVideo from '../components/MessageVideo.vue'
 import MessageCode from '../components/MessageCode.vue'
 import MessageText from '../components/MessageText.vue'
+import BrandAttribution from '../components/BrandAttribution.vue'
 import { useConfigStore } from '@/stores/config'
 import { httpClient } from '@/services/api/httpClient'
 import { z } from 'zod'

--- a/frontend/src/widget.ts
+++ b/frontend/src/widget.ts
@@ -72,6 +72,12 @@ interface WidgetConfig {
   // the operator left the in-widget button enabled). Surfaced via the public
   // /widget/{id}/config endpoint, never the raw Slack URL itself.
   humanHandoffEnabled?: boolean
+  // White-label attribution (Epic 4.5), derived from the backend's global
+  // branding config and surfaced via /widget/{id}/config. Defaults reproduce
+  // the historical "powered by synaplan" footer.
+  showPoweredBy?: boolean
+  poweredByLabel?: string
+  poweredByUrl?: string
 }
 
 const DEFAULT_VUE_CDN = 'https://cdn.jsdelivr.net/npm/vue@3/dist/vue.global.prod.js'
@@ -108,6 +114,9 @@ class SynaplanWidget {
       allowedDomains: [],
       allowFileUpload: false,
       fileUploadLimit: 3,
+      showPoweredBy: true,
+      poweredByLabel: 'synaplan',
+      poweredByUrl: 'https://www.synaplan.com/',
       lazy: true, // Default to lazy loading
       fullscreenMode: false,
       allowFullscreen: false,
@@ -194,6 +203,21 @@ class SynaplanWidget {
           ...this.config,
           ...data.config,
           widgetTitle: data.name || this.config.widgetTitle,
+          // White-label attribution from the backend's global branding config.
+          // Omitted by older backends → keep the defaults set in init().
+          ...(data.branding
+            ? {
+                showPoweredBy: Boolean(data.branding.showPoweredBy ?? true),
+                poweredByLabel:
+                  typeof data.branding.poweredByLabel === 'string'
+                    ? data.branding.poweredByLabel
+                    : 'synaplan',
+                poweredByUrl:
+                  typeof data.branding.poweredByUrl === 'string'
+                    ? data.branding.poweredByUrl
+                    : 'https://www.synaplan.com/',
+              }
+            : {}),
           // Fail closed: only dial WebSockets when the backend explicitly says
           // realtime is on. An older backend that omits the `realtime` block
           // can't serve token/WS endpoints, so attempting to connect would
@@ -469,6 +493,9 @@ class SynaplanWidget {
         buttonIconUrl: this.config!.buttonIconUrl,
         isPreview: false,
         realtime: this.config!.realtime,
+        showPoweredBy: this.config!.showPoweredBy,
+        poweredByLabel: this.config!.poweredByLabel,
+        poweredByUrl: this.config!.poweredByUrl,
       })
 
       this.app.use(i18n)


### PR DESCRIPTION
## Summary

Implements **Epic 4 — White-Label Branding & Attribution**. Introduces a single, config-driven branding layer so a self-hoster can change the brand name, accent color, logos and the "powered by" attribution from configuration — **no source edits, no rebuild**. Defaults reproduce today's Synaplan look exactly.

> Stacked on top of `feat/native-mobile-auth` (PR #1153) because several shared files (`main.ts`, `App.vue`, `stores/config.ts`) already carry that branch's changes. Rebase onto `main` once #1153 merges.

### Backend
- `BrandingService` reads the `BRANDING` BCONFIG group (ownerId=0) with safe defaults.
- `BrandingConfigSeeder` seeds defaults idempotently via `app:seed`.
- `GET /api/v1/config/runtime` now returns a public `branding` block.
- Admin **System Config → Branding** tab (name, tagline, color, logos, homepage, powered-by hide/label/url).
- Shared-chat SSR title + `og:site_name` honor the brand.
- Public widget config endpoint emits the powered-by subset.

### Frontend
- `config.branding` getter (defaults reproduce today's look).
- Runtime accent color injected into `--brand*` CSS variables (only when a custom color is configured, leaving the tuned light/dark defaults intact).
- Document title + auth / logged-out / shared-chat use the brand name.
- `<BrandAttribution>` component: collapses to "Powered by &lt;label&gt;" by default, "&lt;brand&gt; · Powered by &lt;label&gt;" when white-labeled, hideable.
- `useBrandLogo` composable: logos config-addressable with bundled fallback.
- Widget footer honors the hide / re-attribute flag.
- `branding.poweredBy` added to all four locales (en/de/es/tr).

## Test plan
- [x] Backend lint (php-cs-fixer)
- [x] Backend PHPStan
- [x] Backend full test suite (2157 tests) + new `BrandingServiceTest`
- [x] Frontend lint (prettier + eslint)
- [x] Frontend type check (vue-tsc)
- [x] Frontend tests (732 tests)
- [x] `make -C frontend generate-schemas` (runtime config now includes `branding`)
- [ ] Manual: unconfigured deployment looks identical to today (regression)
- [ ] Manual: set brand "Acme", red accent, custom logo, powered-by → verify every surface (login, register, logged-out, shared-chat, widget), light + dark
- [ ] Manual: hide attribution via `BRAND_SHOW_POWERED_BY=false`