### PR TITLE
fix(test): patch happy-dom Node.prototype.nodeName for DOMPurify >=3.4.8

### DIFF
--- a/frontend/tests/unit/setup-env.ts
+++ b/frontend/tests/unit/setup-env.ts
@@ -3,6 +3,38 @@
  * This file sets up browser globals that are required for modules like i18n
  */
 
+// Fix happy-dom's Node.prototype.nodeName getter for DOMPurify >=3.4.8 compatibility.
+// DOMPurify uses lookupGetter(Node.prototype, 'nodeName') as an anti-clobbering measure,
+// but happy-dom's Node.prototype getter returns '' for all node types. The correct
+// values are on subclass prototypes (Element, DocumentType) or implied by nodeType.
+if (typeof window !== 'undefined') {
+  const NP = window.Node?.prototype
+  const origGet = NP && Object.getOwnPropertyDescriptor(NP, 'nodeName')?.get
+  if (origGet) {
+    const elemGet = Object.getOwnPropertyDescriptor(
+      window.Element?.prototype ?? {},
+      'nodeName'
+    )?.get
+    const dtGet = Object.getOwnPropertyDescriptor(
+      window.DocumentType?.prototype ?? {},
+      'nodeName'
+    )?.get
+    Object.defineProperty(NP, 'nodeName', {
+      get(this: Node) {
+        if (elemGet && this instanceof window.Element) return elemGet.call(this)
+        if (dtGet && this instanceof window.DocumentType) return dtGet.call(this)
+        if (this.nodeType === 3) return '#text'
+        if (this.nodeType === 8) return '#comment'
+        if (this.nodeType === 9) return '#document'
+        if (this.nodeType === 11) return '#document-fragment'
+        if (this.nodeType === 7) return (this as ProcessingInstruction).target ?? ''
+        return origGet.call(this)
+      },
+      configurable: true,
+    })
+  }
+}
+
 // Mock localStorage for happy-dom
 const localStorageMock = {
   store: {} as Record<string, string>,


### PR DESCRIPTION
## Summary

- Fixes happy-dom / DOMPurify >=3.4.8 incompatibility that causes all frontend tests using DOMPurify sanitization to fail
- DOMPurify 3.4.8+ uses `lookupGetter(Node.prototype, 'nodeName')` as an anti-clobbering security measure, but happy-dom's `Node.prototype.nodeName` getter returns `''` for all node types instead of delegating to the correct subclass implementation
- Patches the getter in `setup-env.ts` (runs before all tests) to return correct values: Element tag names, `#text`, `#comment`, `#document`, `#document-fragment`

## Context

This blocks merging:
- #1117 (dompurify v3.4.11 security update)
- #1092 (lock file maintenance)

Both pull in dompurify >=3.4.8 which triggers this happy-dom incompatibility.

## Test plan

- [x] All 732 frontend unit tests pass with current dompurify 3.4.7
- [x] All 53 useMarkdown tests pass with dompurify 3.4.11 (previously 10 failed)
- [x] Frontend lint + vue-tsc type check pass