### PR TITLE
chore(renovate): move QA & Dev Tools after npm catch-all rules

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -26,17 +26,7 @@
       "matchUpdateTypes": ["minor", "patch"]
     },
     {
-      "description": "QA tools isolated — historically broke CI (#580)",
-      "groupName": "QA & Dev Tools",
-      "matchPackageNames": [
-        "phpunit/phpunit", "phpstan/phpstan", "phpstan/phpstan-doctrine",
-        "friendsofphp/php-cs-fixer", "dg/bypass-finals",
-        "@playwright/test", "vitest", "@vitest/**", "happy-dom"
-      ],
-      "matchUpdateTypes": ["minor", "patch"]
-    },
-    {
-      "description": "Catch-all npm patch/minor FIRST — Frontend Core rule below overrides",
+      "description": "Catch-all npm patch/minor — later rules override for Frontend Core and QA",
       "groupName": "Frontend Dependencies",
       "matchManagers": ["npm"],
       "matchUpdateTypes": ["minor", "patch"]
@@ -50,6 +40,16 @@
         "vite", "@vitejs/**",
         "typescript", "@typescript-eslint/**", "vue-tsc",
         "tailwindcss", "@tailwindcss/**"
+      ],
+      "matchUpdateTypes": ["minor", "patch"]
+    },
+    {
+      "description": "QA tools isolated — MUST come after npm catch-all so groupName wins (#580)",
+      "groupName": "QA & Dev Tools",
+      "matchPackageNames": [
+        "phpunit/phpunit", "phpstan/phpstan", "phpstan/phpstan-doctrine",
+        "friendsofphp/php-cs-fixer", "dg/bypass-finals",
+        "@playwright/test", "vitest", "@vitest/**", "happy-dom"
       ],
       "matchUpdateTypes": ["minor", "patch"]
     },


### PR DESCRIPTION
## Summary

- Reorders `packageRules` in `renovate.json5` so **QA & Dev Tools** comes after the npm catch-all and Frontend Core rules
- Fixes incorrect grouping where `happy-dom`, `vitest`, and other QA tools landed in **Frontend Dependencies** PRs (e.g. #1139) because later Renovate rules override `groupName`

## Context

Renovate applies the **last matching** `packageRule` for `groupName`. The npm catch-all rule was positioned after QA & Dev Tools, so it overwrote the QA group assignment for npm packages like `happy-dom`.

## Test plan

- [ ] Merge and verify next Renovate run groups `happy-dom` / `vitest` under **QA & Dev Tools**, not **Frontend Dependencies**
- [ ] Check Dependency Dashboard (#30) on next cycle for correct PR grouping