### PR TITLE
fix(widget): use channels-widgets route for back navigation

### DIFF
--- a/frontend/src/views/WidgetDetailView.vue
+++ b/frontend/src/views/WidgetDetailView.vue
@@ -5,7 +5,7 @@
       <div class="px-4 lg:px-6 py-4 border-b border-light-border/30 dark:border-dark-border/20">
         <button
           class="text-xs txt-secondary hover:txt-primary transition-colors mb-3 inline-flex items-center gap-1.5"
-          @click="router.push({ name: 'tools-chat-widget' })"
+          @click="router.push({ name: 'channels-widgets' })"
         >
           <Icon icon="heroicons:arrow-left" class="w-3.5 h-3.5" />
           {{ $t('widgets.detail.back') }}

--- a/frontend/src/views/WidgetSessionsView.vue
+++ b/frontend/src/views/WidgetSessionsView.vue
@@ -1191,7 +1191,7 @@ const totalSessions = computed(
 )
 
 const goBack = () => {
-  router.push({ name: 'tools-chat-widget' })
+  router.push({ name: 'channels-widgets' })
 }
 
 const loadWidget = async () => {


### PR DESCRIPTION
## Summary

- Fixes back navigation in `WidgetSessionsView` by replacing the removed route name `tools-chat-widget` with `channels-widgets`
- Applies the same fix in `WidgetDetailView`, which had the identical stale route reference

Fixes #1131

## Test plan

- [ ] Open `/channels/widgets`, click a widget, open sessions view
- [ ] Click the back arrow — should navigate to the widget list without ErrorBoundary crash
- [ ] Open a widget detail page (`/channels/widgets/:id`), click back — should also return to the widget list