### PR TITLE
fix: show error message in bubble when provider fails during multitask

### DIFF
--- a/backend/src/Service/File/DocumentGeneratorService.php
+++ b/backend/src/Service/File/DocumentGeneratorService.php
@@ -77,6 +77,10 @@ final readonly class DocumentGeneratorService
      */
     private function writeDocx(string $content, string $absolutePath): void
     {
+        if ('' === trim($content)) {
+            throw new \RuntimeException('Cannot generate DOCX from empty content');
+        }
+
         $html = (new \Parsedown())->text($content);
 
         // Ensure special characters (like '&', '<', '>') are escaped in the XML to prevent document corruption.

--- a/backend/src/Service/Message/Handler/ChatHandler.php
+++ b/backend/src/Service/Message/Handler/ChatHandler.php
@@ -1871,7 +1871,7 @@ final readonly class ChatHandler implements MessageHandlerInterface
                 $filename = trim($jsonData['BFILEPATH']);
                 $fileContent = $jsonData['BFILETEXT'];
 
-                if (empty($filename) || empty($fileContent)) {
+                if (empty($filename) || !is_string($fileContent) || '' === trim($fileContent)) {
                     return null;
                 }
 

--- a/backend/src/Service/Multitask/Execution/Runner/DocumentGenerationRunner.php
+++ b/backend/src/Service/Multitask/Execution/Runner/DocumentGenerationRunner.php
@@ -75,6 +75,12 @@ final readonly class DocumentGenerationRunner implements TaskRunner
             return NodeResult::failed('document_generation failed: '.$e->getMessage());
         }
 
+        if (!($result['success'] ?? true)) {
+            $error = is_string($result['error'] ?? null) ? $result['error'] : 'unknown handler error';
+
+            return NodeResult::failed('document_generation failed: '.$error);
+        }
+
         $metadata = is_array($result['metadata'] ?? null) ? $result['metadata'] : [];
         $descriptor = $this->fileDescriptor($metadata);
         if (null === $descriptor) {

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -2739,13 +2739,16 @@ const streamAIResponse = async (
               displayError += '*' + t('aiProvider.error.restartNote') + '*'
             }
 
-            // Always show error as message (not in streaming message, but as new assistant message)
+            // Show error in the streaming message bubble
             const message = historyStore.messages.find((m) => m.id === messageId)
-            if (message && message.parts.length > 0) {
-              // If there's already content, finish it and create a new error message
+            const hasContent = message?.parts.some(
+              (p) => p.type === 'text' && p.content && p.content.trim() !== ''
+            )
+            if (message && hasContent) {
+              // Already has meaningful content (partial response streamed before error)
               historyStore.finishStreamingMessage(messageId)
             } else {
-              // No content yet, replace with error message
+              // No visible content yet — display the error message
               historyStore.updateStreamingMessage(messageId, displayError)
               historyStore.finishStreamingMessage(messageId)
             }


### PR DESCRIPTION
## Summary

- **Empty bubble bug**: The SSE error handler checked `message.parts.length > 0` to decide whether to display an error message. Since streaming messages always start with one empty text part `[{ type: 'text', content: '' }]`, this condition was always true — the else branch that sets the error text was unreachable. Users saw an empty bubble instead of "⚠️ Overloaded" when a provider failed during multitask execution.
- **Empty DOCX guard**: When an AI model returned whitespace-only `BFILETEXT` (e.g. `"\n"`), PHP's `empty()` didn't catch it, leading to a valid-but-empty 7.3kb DOCX. Added `trim()` checks at three levels: `parseFileGeneration()`, `DocumentGeneratorService::writeDocx()`, and `DocumentGenerationRunner` success check.

## Root Cause

When a provider is overloaded during a multitask DAG:
1. All DAG nodes fail → `plan_discarded` sent → task cards disappear
2. Legacy fallback throws `ProviderException` → caught by StreamController → sends SSE `error` event
3. Frontend error handler: `parts.length > 0` always true → just finishes streaming without setting error text → empty bubble

The direct (non-multitask) path works fine because the error is sent as a `data` chunk + `complete`, not as an `error` event.

## Test plan

- [x] Frontend lint passes
- [x] Frontend type check (`vue-tsc`) passes
- [x] Frontend tests (732) pass
- [x] Backend lint passes
- [x] Backend tests (2174) pass
- [x] PHPStan: 52 pre-existing gRPC-stub errors (unrelated, `Inference\ModelInferRequest`)