### PR TITLE
feat: give authenticated tiers the full model max_tokens

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -307,13 +307,19 @@ QDRANT_URL=http://qdrant:6333
 # ==============================================================================
 
 # ------------------------------------------------------------------------------
-# Cost-budget gate (issue #886, off by default)
+# Cost-budget gate (issue #886)
 # ------------------------------------------------------------------------------
-# When true, /messages/send and /messages/stream return HTTP 429 once the
-# user has burned through BCOST_BUDGET_MONTHLY for the current period.
-# Leave unset (or =false) to keep the legacy behaviour where users only ever
-# hit message-count rate limits.
-COST_BUDGET_GATE_ENABLED=false
+# When true, /messages/send and /messages/stream block once the user has burned
+# through BCOST_BUDGET_MONTHLY for the current period. The check runs BEFORE the
+# request, so the in-flight answer always finishes; the NEXT message is blocked.
+#
+# This is the primary spend-bound for authenticated users: the AI output is no
+# longer clamped per plan (every authenticated tier gets the model's full
+# max_tokens), so the cost budget — not an output cap — limits spend. Tiers
+# without a budget (budget = 0) stay unlimited and fall back to message-count
+# limits (e.g. ANONYMOUS). Self-hosted/Open-Source installs without budgets are
+# unaffected.
+COST_BUDGET_GATE_ENABLED=true
 
 # Get keys: https://dashboard.stripe.com/apikeys
 STRIPE_SECRET_KEY=sk_test_your_key_here

--- a/backend/migrations/Version20260625120000.php
+++ b/backend/migrations/Version20260625120000.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Drop the per-plan MAX_OUTPUT_TOKENS cap for authenticated tiers.
+ *
+ * Background: the ChatHandler used to clamp a model's output to
+ * min(plan_limit, model_max), which truncated long answers at the plan's
+ * MAX_OUTPUT_TOKENS value. We now let every authenticated tier
+ * (NEW/PRO/TEAM/BUSINESS) use the selected model's full max_tokens; spend is
+ * bounded by the cost-budget gate (registered users) and message-count limits
+ * instead. Only ANONYMOUS keeps a hard output cap.
+ *
+ * BCONFIG seeder defaults are bootstrap-only (INSERT IGNORE), so removing the
+ * rows from {@see \App\Seed\RateLimitConfigSeeder} does NOT propagate to existing
+ * installs. This migration explicitly deletes the legacy rows so the new
+ * behaviour rolls out everywhere. The ANONYMOUS row is intentionally left intact.
+ *
+ * Pure, idempotent addSql (no Schema introspection) — safe on the prod Galera
+ * cluster (see AGENTS_DEV.md "Production Platform Specifics").
+ */
+final class Version20260625120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Remove per-plan MAX_OUTPUT_TOKENS for NEW/PRO/TEAM/BUSINESS so authenticated tiers use the model full max_tokens (ANONYMOUS cap retained).';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            DELETE FROM BCONFIG
+             WHERE BOWNERID = 0
+               AND BSETTING = 'MAX_OUTPUT_TOKENS'
+               AND BGROUP IN (
+                   'RATELIMITS_NEW',
+                   'RATELIMITS_PRO',
+                   'RATELIMITS_TEAM',
+                   'RATELIMITS_BUSINESS'
+               )
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        // Restore the legacy caps. INSERT IGNORE is race-safe against the
+        // uniq_config_owner_group_setting UNIQUE index and a no-op if an
+        // operator has already re-created the rows.
+        $this->addSql(<<<'SQL'
+            INSERT IGNORE INTO BCONFIG (BOWNERID, BGROUP, BSETTING, BVALUE)
+            VALUES
+                (0, 'RATELIMITS_NEW',      'MAX_OUTPUT_TOKENS', '4096'),
+                (0, 'RATELIMITS_PRO',      'MAX_OUTPUT_TOKENS', '16384'),
+                (0, 'RATELIMITS_TEAM',     'MAX_OUTPUT_TOKENS', '32768'),
+                (0, 'RATELIMITS_BUSINESS', 'MAX_OUTPUT_TOKENS', '65536')
+        SQL);
+    }
+}

--- a/backend/migrations/Version20260625120000.php
+++ b/backend/migrations/Version20260625120000.php
@@ -29,7 +29,7 @@ final class Version20260625120000 extends AbstractMigration
 {
     public function getDescription(): string
     {
-        return 'Remove per-plan MAX_OUTPUT_TOKENS for NEW/PRO/TEAM/BUSINESS so authenticated tiers use the model full max_tokens (ANONYMOUS cap retained).';
+        return "Remove per-plan MAX_OUTPUT_TOKENS for NEW/PRO/TEAM/BUSINESS so authenticated tiers use the model's full max_tokens (ANONYMOUS cap retained).";
     }
 
     public function up(Schema $schema): void

--- a/backend/src/Entity/Model.php
+++ b/backend/src/Entity/Model.php
@@ -305,8 +305,9 @@ class Model
     /**
      * Get max completion tokens from JSON config (the model's technical limit).
      *
-     * The ChatHandler combines this with the user's plan-level cap via
-     * min(plan_limit, model_max) before passing to the provider.
+     * The ChatHandler passes this through as the output limit for authenticated
+     * tiers (full model max); only ANONYMOUS is additionally clamped by a
+     * plan-level cap via min(plan_limit, model_max) before reaching the provider.
      * Returns null when not configured — providers fall back to
      * ChatProviderInterface::DEFAULT_MAX_COMPLETION_TOKENS (4096).
      */

--- a/backend/src/Model/ModelCatalog.php
+++ b/backend/src/Model/ModelCatalog.php
@@ -1898,9 +1898,9 @@ class ModelCatalog
             'rating' => 1,
             'json' => [
                 'description' => 'Claude 4.5 Sonnet - a smart model for complex agents and coding',
-                'max_tokens' => 8192,
+                'max_tokens' => 64000,
                 'params' => ['model' => 'claude-sonnet-4-5-20250929'],
-                'meta' => ['context_window' => '200000', 'max_output' => '8192'],
+                'meta' => ['context_window' => '200000', 'max_output' => '64000'],
             ],
         ],
         [

--- a/backend/src/Seed/RateLimitConfigSeeder.php
+++ b/backend/src/Seed/RateLimitConfigSeeder.php
@@ -15,6 +15,12 @@ use Doctrine\DBAL\Connection;
  * - RATELIMITS_PRO / TEAM / BUSINESS (hourly + monthly)
  *
  * Operator overrides are preserved (insert-if-missing semantics).
+ *
+ * MAX_OUTPUT_TOKENS is intentionally seeded ONLY for ANONYMOUS: authenticated
+ * tiers get the model's full max_tokens (see {@see \App\Service\Message\Handler\ChatHandler}
+ * which clamps to min(requested, plan_limit, model_max) — with plan_limit null for
+ * those tiers). Existing installs are migrated by the dedicated migration that
+ * deletes the legacy NEW/PRO/TEAM/BUSINESS rows (BCONFIG defaults are bootstrap-only).
  */
 final readonly class RateLimitConfigSeeder
 {
@@ -34,6 +40,10 @@ final readonly class RateLimitConfigSeeder
         ['ownerId' => 0, 'group' => 'RATELIMITS_ANONYMOUS', 'setting' => 'FILE_ANALYSIS_TOTAL', 'value' => '3'],
         ['ownerId' => 0, 'group' => 'RATELIMITS_ANONYMOUS', 'setting' => 'FILE_UPLOADS_TOTAL',  'value' => '3'],
         ['ownerId' => 0, 'group' => 'RATELIMITS_ANONYMOUS', 'setting' => 'STORAGE_MB',          'value' => '10'],
+        // ANONYMOUS is the ONLY tier with a hard output cap. Authenticated tiers
+        // (NEW/PRO/TEAM/BUSINESS) intentionally have no MAX_OUTPUT_TOKENS so they
+        // receive the selected model's full max_tokens; their spend is bounded by
+        // the cost-budget gate (registered) and message-count limits instead.
         ['ownerId' => 0, 'group' => 'RATELIMITS_ANONYMOUS', 'setting' => 'MAX_OUTPUT_TOKENS',   'value' => '2048'],
 
         // NEW (phone-verified — lifetime totals)
@@ -44,7 +54,6 @@ final readonly class RateLimitConfigSeeder
         ['ownerId' => 0, 'group' => 'RATELIMITS_NEW', 'setting' => 'FILE_ANALYSIS_TOTAL', 'value' => '10'],
         ['ownerId' => 0, 'group' => 'RATELIMITS_NEW', 'setting' => 'FILE_UPLOADS_TOTAL',  'value' => '10'],
         ['ownerId' => 0, 'group' => 'RATELIMITS_NEW', 'setting' => 'STORAGE_MB',          'value' => '100'],
-        ['ownerId' => 0, 'group' => 'RATELIMITS_NEW', 'setting' => 'MAX_OUTPUT_TOKENS',   'value' => '4096'],
 
         // PRO (hourly + monthly)
         ['ownerId' => 0, 'group' => 'RATELIMITS_PRO', 'setting' => 'MESSAGES_HOURLY',        'value' => '100'],
@@ -55,7 +64,6 @@ final readonly class RateLimitConfigSeeder
         ['ownerId' => 0, 'group' => 'RATELIMITS_PRO', 'setting' => 'FILE_ANALYSIS_MONTHLY',  'value' => '200'],
         ['ownerId' => 0, 'group' => 'RATELIMITS_PRO', 'setting' => 'FILE_UPLOADS_MONTHLY',   'value' => '200'],
         ['ownerId' => 0, 'group' => 'RATELIMITS_PRO', 'setting' => 'STORAGE_GB',             'value' => '5'],
-        ['ownerId' => 0, 'group' => 'RATELIMITS_PRO', 'setting' => 'MAX_OUTPUT_TOKENS',      'value' => '16384'],
 
         // TEAM
         ['ownerId' => 0, 'group' => 'RATELIMITS_TEAM', 'setting' => 'MESSAGES_HOURLY',       'value' => '300'],
@@ -66,7 +74,6 @@ final readonly class RateLimitConfigSeeder
         ['ownerId' => 0, 'group' => 'RATELIMITS_TEAM', 'setting' => 'FILE_ANALYSIS_MONTHLY', 'value' => '1000'],
         ['ownerId' => 0, 'group' => 'RATELIMITS_TEAM', 'setting' => 'FILE_UPLOADS_MONTHLY',  'value' => '1000'],
         ['ownerId' => 0, 'group' => 'RATELIMITS_TEAM', 'setting' => 'STORAGE_GB',            'value' => '20'],
-        ['ownerId' => 0, 'group' => 'RATELIMITS_TEAM', 'setting' => 'MAX_OUTPUT_TOKENS',     'value' => '32768'],
 
         // BUSINESS
         ['ownerId' => 0, 'group' => 'RATELIMITS_BUSINESS', 'setting' => 'MESSAGES_HOURLY',       'value' => '1000'],
@@ -77,7 +84,6 @@ final readonly class RateLimitConfigSeeder
         ['ownerId' => 0, 'group' => 'RATELIMITS_BUSINESS', 'setting' => 'FILE_ANALYSIS_MONTHLY', 'value' => '5000'],
         ['ownerId' => 0, 'group' => 'RATELIMITS_BUSINESS', 'setting' => 'FILE_UPLOADS_MONTHLY',  'value' => '5000'],
         ['ownerId' => 0, 'group' => 'RATELIMITS_BUSINESS', 'setting' => 'STORAGE_GB',            'value' => '100'],
-        ['ownerId' => 0, 'group' => 'RATELIMITS_BUSINESS', 'setting' => 'MAX_OUTPUT_TOKENS',     'value' => '65536'],
     ];
 
     public function __construct(private Connection $connection)

--- a/backend/src/Seed/RateLimitConfigSeeder.php
+++ b/backend/src/Seed/RateLimitConfigSeeder.php
@@ -17,10 +17,12 @@ use Doctrine\DBAL\Connection;
  * Operator overrides are preserved (insert-if-missing semantics).
  *
  * MAX_OUTPUT_TOKENS is intentionally seeded ONLY for ANONYMOUS: authenticated
- * tiers get the model's full max_tokens (see {@see \App\Service\Message\Handler\ChatHandler}
- * which clamps to min(requested, plan_limit, model_max) — with plan_limit null for
- * those tiers). Existing installs are migrated by the dedicated migration that
- * deletes the legacy NEW/PRO/TEAM/BUSINESS rows (BCONFIG defaults are bootstrap-only).
+ * tiers get the model's full max_tokens. {@see \App\Service\Message\Handler\ChatHandler}
+ * applies this plan limit as an additional output clamp only when present — i.e.
+ * only for ANONYMOUS; for all other tiers the limit is null, so the model's own
+ * max_tokens is used unchanged. Existing installs are migrated by the dedicated
+ * migration that deletes the legacy NEW/PRO/TEAM/BUSINESS rows (BCONFIG defaults
+ * are bootstrap-only).
  */
 final readonly class RateLimitConfigSeeder
 {

--- a/backend/src/Service/Message/Handler/ChatHandler.php
+++ b/backend/src/Service/Message/Handler/ChatHandler.php
@@ -396,6 +396,10 @@ final readonly class ChatHandler implements MessageHandlerInterface
         ];
 
         // Clamp max_tokens to min(plan_limit, model_max).
+        // plan_limit is only set for ANONYMOUS (the only tier with a hard
+        // MAX_OUTPUT_TOKENS cap); for all authenticated tiers getMaxOutputTokens()
+        // returns null, so the model's full max_tokens is used. Spend for those
+        // tiers is bounded by the cost-budget gate / message-count limits instead.
         // Reuse the User entity loaded earlier for memories/feedback so
         // we don't hit the repository twice per request.
         $planMaxTokens = null !== $user ? $this->rateLimitService->getMaxOutputTokens($user) : null;
@@ -971,7 +975,9 @@ final readonly class ChatHandler implements MessageHandlerInterface
             'modelFeatures' => $modelFeatures,
         ], $options);
 
-        // Clamp max_tokens to min(requested, plan_limit, model_max)
+        // Clamp max_tokens to min(requested, plan_limit, model_max).
+        // plan_limit is only set for ANONYMOUS; authenticated tiers get the
+        // model's full max_tokens (getMaxOutputTokens() returns null for them).
         $planMaxTokens = null !== $user ? $this->rateLimitService->getMaxOutputTokens($user) : null;
         $tokenLimits = array_filter(
             [$aiOptions['max_tokens'] ?? null, $planMaxTokens, $modelMaxTokens],

--- a/backend/src/Service/RateLimitService.php
+++ b/backend/src/Service/RateLimitService.php
@@ -665,8 +665,11 @@ final class RateLimitService
     /**
      * Get max output tokens allowed for a user based on their subscription level.
      *
-     * Returns null when billing is disabled (Open Source Mode) or for admins,
-     * meaning the model's own max_tokens should be used without restriction.
+     * Returns null when billing is disabled (Open Source Mode), for admins, or
+     * when the level has no MAX_OUTPUT_TOKENS configured — meaning the model's
+     * own max_tokens is used without restriction. By design only ANONYMOUS keeps
+     * a hard cap; authenticated tiers (NEW/PRO/TEAM/BUSINESS) return null here
+     * and are bounded by the cost-budget gate and message-count limits instead.
      */
     public function getMaxOutputTokens(User $user): ?int
     {

--- a/backend/tests/Service/RateLimitServiceMaxOutputTokensTest.php
+++ b/backend/tests/Service/RateLimitServiceMaxOutputTokensTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Service;
+
+use App\Entity\User;
+use App\Repository\ConfigRepository;
+use App\Repository\SubscriptionRepository;
+use App\Repository\TopupRepository;
+use App\Service\BillingService;
+use App\Service\CostCalculationService;
+use App\Service\RateLimitService;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+/**
+ * Guards the runtime contract of {@see RateLimitService::getMaxOutputTokens()}
+ * that {@see \App\Service\Message\Handler\ChatHandler} relies on to clamp the
+ * provider max_tokens.
+ *
+ * By design only ANONYMOUS keeps a hard output cap; authenticated tiers
+ * (NEW/PRO/TEAM/BUSINESS) must return null so the model's full max_tokens is
+ * used. This complements RateLimitConfigSeederTest (which guards the seed data)
+ * by locking the behaviour of the method itself — a refactor that re-clamps
+ * authenticated tiers would silently truncate AI answers again.
+ */
+final class RateLimitServiceMaxOutputTokensTest extends TestCase
+{
+    private function makeUser(string $level): User
+    {
+        $user = $this->createMock(User::class);
+        $user->method('getRateLimitLevel')->willReturn($level);
+
+        return $user;
+    }
+
+    /**
+     * @param array<string, string|null> $configByGroup MAX_OUTPUT_TOKENS value per RATELIMITS_* group
+     */
+    private function makeService(bool $billingEnabled, array $configByGroup): RateLimitService
+    {
+        $config = $this->createMock(ConfigRepository::class);
+        $config->method('getValue')->willReturnCallback(
+            static function (int $owner, string $group, string $setting) use ($configByGroup): ?string {
+                if ('MAX_OUTPUT_TOKENS' !== $setting) {
+                    return null;
+                }
+
+                return $configByGroup[$group] ?? null;
+            }
+        );
+
+        $billing = $billingEnabled
+            ? new BillingService('sk_test_valid_key', 'price_1RealProId')
+            : new BillingService('', '');
+
+        return new RateLimitService(
+            $config,
+            $this->createMock(EntityManagerInterface::class),
+            new NullLogger(),
+            $billing,
+            $this->createMock(CostCalculationService::class),
+            $this->createMock(SubscriptionRepository::class),
+            $this->createMock(TopupRepository::class),
+        );
+    }
+
+    public function testAnonymousKeepsHardCap(): void
+    {
+        $service = $this->makeService(true, ['RATELIMITS_ANONYMOUS' => '2048']);
+
+        $this->assertSame(2048, $service->getMaxOutputTokens($this->makeUser('ANONYMOUS')));
+    }
+
+    /**
+     * @return list<array{0: string}>
+     */
+    public static function authenticatedTierProvider(): array
+    {
+        return [['NEW'], ['PRO'], ['TEAM'], ['BUSINESS']];
+    }
+
+    #[DataProvider('authenticatedTierProvider')]
+    public function testAuthenticatedTiersAreUncapped(string $level): void
+    {
+        // No MAX_OUTPUT_TOKENS row configured for authenticated tiers.
+        $service = $this->makeService(true, ['RATELIMITS_ANONYMOUS' => '2048']);
+
+        $this->assertNull(
+            $service->getMaxOutputTokens($this->makeUser($level)),
+            "Authenticated tier {$level} must be uncapped (full model max_tokens).",
+        );
+    }
+
+    public function testAdminIsUncapped(): void
+    {
+        $service = $this->makeService(true, ['RATELIMITS_ADMIN' => '4096']);
+
+        $this->assertNull($service->getMaxOutputTokens($this->makeUser('ADMIN')));
+    }
+
+    public function testBillingDisabledIsUncappedEvenForAnonymous(): void
+    {
+        $service = $this->makeService(false, ['RATELIMITS_ANONYMOUS' => '2048']);
+
+        $this->assertNull($service->getMaxOutputTokens($this->makeUser('ANONYMOUS')));
+    }
+
+    public function testNonPositiveCapIsTreatedAsUncapped(): void
+    {
+        $service = $this->makeService(true, ['RATELIMITS_ANONYMOUS' => '0']);
+
+        $this->assertNull($service->getMaxOutputTokens($this->makeUser('ANONYMOUS')));
+    }
+}

--- a/backend/tests/Unit/Seed/RateLimitConfigSeederTest.php
+++ b/backend/tests/Unit/Seed/RateLimitConfigSeederTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Seed;
+
+use App\Seed\RateLimitConfigSeeder;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Guards the rate-limit seeding contract for MAX_OUTPUT_TOKENS.
+ *
+ * Authenticated tiers (NEW/PRO/TEAM/BUSINESS) must NOT seed a per-plan output
+ * cap — they receive the model's full max_tokens, bounded by the cost-budget
+ * gate / message-count limits instead. Only ANONYMOUS keeps a hard cap. Without
+ * this guard a future refactor could silently reintroduce per-plan caps and
+ * quietly truncate AI responses again.
+ */
+final class RateLimitConfigSeederTest extends TestCase
+{
+    /**
+     * @return list<array{ownerId: int, group: string, setting: string, value: string}>
+     */
+    private function defaults(): array
+    {
+        $reflection = new \ReflectionClass(RateLimitConfigSeeder::class);
+        $defaults = $reflection->getReflectionConstant('DEFAULTS');
+        $this->assertNotFalse($defaults, 'DEFAULTS constant missing');
+
+        /** @var list<array{ownerId: int, group: string, setting: string, value: string}> $rows */
+        $rows = $defaults->getValue();
+        $this->assertNotEmpty($rows, 'Expected at least one DEFAULTS row');
+
+        return $rows;
+    }
+
+    public function testMaxOutputTokensIsSeededOnlyForAnonymous(): void
+    {
+        $groupsWithCap = [];
+        foreach ($this->defaults() as $row) {
+            if ('MAX_OUTPUT_TOKENS' === $row['setting']) {
+                $groupsWithCap[] = $row['group'];
+            }
+        }
+
+        $this->assertSame(
+            ['RATELIMITS_ANONYMOUS'],
+            $groupsWithCap,
+            'MAX_OUTPUT_TOKENS must be seeded for ANONYMOUS only; authenticated tiers '
+            .'(NEW/PRO/TEAM/BUSINESS) must use the model full max_tokens.',
+        );
+    }
+
+    public function testAnonymousMaxOutputTokensCapIsPositive(): void
+    {
+        foreach ($this->defaults() as $row) {
+            if ('RATELIMITS_ANONYMOUS' === $row['group'] && 'MAX_OUTPUT_TOKENS' === $row['setting']) {
+                $this->assertGreaterThan(
+                    0,
+                    (int) $row['value'],
+                    'ANONYMOUS MAX_OUTPUT_TOKENS must be a positive cap.',
+                );
+
+                return;
+            }
+        }
+
+        $this->fail('Expected a RATELIMITS_ANONYMOUS MAX_OUTPUT_TOKENS default row.');
+    }
+}


### PR DESCRIPTION
## Summary
Authenticated tiers (NEW/PRO/TEAM/BUSINESS) now receive the selected model's full `max_tokens` instead of being truncated at a per-plan `MAX_OUTPUT_TOKENS` cap; spend is bounded by the cost-budget gate and message-count limits instead. Only ANONYMOUS keeps a hard output cap.

## Changes
- `RateLimitConfigSeeder`: seed `MAX_OUTPUT_TOKENS` only for `ANONYMOUS`; removed NEW/PRO/TEAM/BUSINESS rows (authenticated tiers now get full model output).
- New migration `Version20260625120000`: deletes the legacy `MAX_OUTPUT_TOKENS` rows for NEW/PRO/TEAM/BUSINESS from `BCONFIG` (seeder defaults are bootstrap-only, so existing/prod installs need this). `down()` restores them via `INSERT IGNORE`.
- `ModelCatalog`: bump `claude-sonnet-4.5` (BID 112) output `8192 -> 64000` to match the model's documented max. Audited all chat/mem models — every one has a `max_tokens` equal to its documented `meta.max_output`, so no model falls back to the 4096 provider default.
- `.env.example`: enable `COST_BUDGET_GATE_ENABLED=true` by default — the budget is now the primary spend-bound for authenticated users since output is no longer plan-clamped. The pre-send check lets the in-flight answer finish and blocks the next message; tiers without a budget (e.g. ANONYMOUS) stay unlimited and fall back to message-count limits.
- Doc/comment clarifications in `ChatHandler`, `Model::getMaxTokens()`, and `RateLimitService::getMaxOutputTokens()` describing the ANONYMOUS-only clamp.

No frontend code changes needed: `LimitReachedModal` already covers both the `monthly` (budget, with top-up) and `lifetime` (message-limit) cases, and the truncated/continue + limit i18n keys are complete across en/de/es/tr.

## Verification
- [x] Tests added/updated
- [x] Manual
- [x] `make -C backend lint` — clean
- [x] `make -C backend phpstan` (src + tests) — no errors
- [x] `make -C backend test` — 2256 tests OK
- [x] migration `Version20260625120000` dry-run — OK
- [ ] Frontend checks skipped (backend-only change)

## Notes
- ANONYMOUS intentionally retains its output cap (no budget entry) to limit unauthenticated abuse.
- Operator-set budgets in `BSUBSCRIPTIONS` (e.g. prod NEW = 1 EUR) are preserved; `SubscriptionPlanSeeder` only fills budgets that are 0.

## Screenshots/Logs