### PR TITLE
Enhance async media job handling and configuration

### DIFF
--- a/_devextras/planning/release4.0/00_master_plan.md
+++ b/_devextras/planning/release4.0/00_master_plan.md
@@ -116,7 +116,7 @@ Full design in [`02_async-media-ux.md`](./02_async-media-ux.md).
 
 | # | Feature | File | Priority | Status |
 |---|---|---|---|---|
-| 1 | **Async media generation ("fire & continue")** — backend/architecture | [`01_async-media-jobs.md`](./01_async-media-jobs.md) | P0 | Sprints A–D shipped; E/F (legacy consolidation, billing, rollout) remain |
+| 1 | **Async media generation ("fire & continue")** — backend/architecture | [`01_async-media-jobs.md`](./01_async-media-jobs.md) | P0 | Sprints A–F shipped (rollout: default ON + grandfather migration + admin switch); legacy consolidation remains |
 | 1·UX | **Async media UX** — dedicated status banner (Option B), realtime completion + actionable toaster, global Jobs tray, cancel | [`02_async-media-ux.md`](./02_async-media-ux.md) | P0 | Banner + toaster + Jobs tray + cancel shipped (A–D) |
 | 2 | **File management world** — one home for every file: sources, vectorized status, groups, generated-media gallery | [`03_file-management.md`](./03_file-management.md) | P0 | Planned |
 | 3 | **Image & first-boot optimization** — multi-arch (arm64) base image, baked dev deps, custom `bge-m3` Ollama image; fast `docker compose up` on Mac | [`04_image-build-optimization.md`](./04_image-build-optimization.md) | P1 | Planned |

--- a/_devextras/planning/release4.0/01_async-media-jobs.md
+++ b/_devextras/planning/release4.0/01_async-media-jobs.md
@@ -218,8 +218,14 @@ Each sprint is independently shippable, gate-green, and flagged.
 
 ### Sprint F — Rollout, observability, docs
 
-- Flip `MEDIA_ASYNC_JOBS_ENABLED` default **on** (OSS/new installs); grandfather
-  existing installs with an explicit off-row + switch (mirror multitask rollout).
+- ✅ **Shipped:** flipped `MEDIA.ASYNC_JOBS_ENABLED` built-in default **on**
+  (`MediaJobConfig`), seeded the explicit global ON row (`MediaJobConfigSeeder`,
+  wired into `app:seed`), and grandfathered existing installs to an explicit
+  per-user OFF row via data migration `Version20260629120000` (mirrors the
+  multitask routing rollout `Version20260607000000`). Operators get a UI switch
+  at **Settings → Processing → Async media generation**
+  (`SystemConfigService` `MEDIA_ASYNC_JOBS_ENABLED`), which also clears the
+  acting admin's own grandfather row so the change applies to them immediately.
 - Admin: a simple jobs view (active/stale/failed counts, recent failures) from
   `MediaJobStore`.
 - Metrics/logs: time-in-queue, render duration, timeout rate, failure reasons.
@@ -250,7 +256,7 @@ Each sprint is independently shippable, gate-green, and flagged.
 
 | Flag (`BCONFIG`) | Default | Purpose |
 |---|---|---|
-| `MEDIA_ASYNC_JOBS_ENABLED` | off → on (Sprint F) | Master switch: chat/multitask media (image **+** video + audio) uses jobs vs inline. |
+| `MEDIA_ASYNC_JOBS_ENABLED` | **on** (default; existing installs grandfathered off, Sprint F) | Master switch: chat/multitask media (image **+** video + audio) uses jobs vs inline. |
 | `MEDIA_JOB_POLL_INTERVAL_SECONDS` | 3 | Advance re-dispatch delay. |
 | `MEDIA_JOB_IMAGE_INLINE_FAST_MS` | 1500 | Grace window: if a (fast) image job finishes within this on the first advance, resolve it in the same turn so quick images still feel instant — otherwise it detaches to the tray like any other job. |
 

--- a/_devextras/planning/release4.0/02_async-media-ux.md
+++ b/_devextras/planning/release4.0/02_async-media-ux.md
@@ -76,6 +76,7 @@ cancel, and a11y/i18n goals are all **unchanged** — they simply read from the
 | **Per-user Redis index** (`mediajob:user:{id}` set, maintained in `MediaJobStore::save`): `findActiveForUser`/`countActiveForUser` are now O(that user's jobs) and tenant-isolated — no global active-set scan. (Sprint E) | ✅ shipped |
 | **Per-user concurrency ceiling** (`MEDIA.JOB_MAX_ACTIVE_PER_USER`, default **16**, clamped 1–100): `detachMediaToAsyncJob` rejects past the limit with a localized message (all 4 locales) and never creates a job / calls the provider. (Sprint E) | ✅ shipped |
 | **Async usage billing** (`MediaJobUsageRecorder`, wired into `MediaJobMessageSync::syncTerminalState`): bills **only `completed`** renders, idempotent (`_usage_recorded` flag), `media_usage` stashed on the job at detach so cost matches the inline path. Failed/cancelled/timed-out are never billed (honours provider refunds). (Sprint E, #1146) | ✅ shipped |
+| **Rollout (Sprint F):** built-in default flipped **ON** + global ON row seeded (`MediaJobConfigSeeder` in `app:seed`); existing users grandfathered to per-user OFF (migration `Version20260629120000`); operator UI switch at **Settings → Processing → Async media generation** (`SystemConfigService`). | ✅ shipped |
 
 ---
 

--- a/backend/migrations/Version20260629120000.php
+++ b/backend/migrations/Version20260629120000.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Grandfather existing users OFF the new async media-job handling.
+ *
+ * Async media (image + video + audio detach to a background job instead of
+ * blocking the turn) ships with a GLOBAL default of ON (BCONFIG ownerId=0,
+ * group=MEDIA, setting=ASYNC_JOBS_ENABLED='1', seeded by MediaJobConfigSeeder).
+ * That is what we want for OSS clones, fresh installs, dev environments, and
+ * NEW signups — they get async media automatically.
+ *
+ * But on the LIVE platform we must NOT silently flip users who are used to the
+ * inline (synchronous) render. So this one-time data migration writes an
+ * explicit per-user OFF row for every user that exists AT MIGRATION TIME. That
+ * row both (a) pins them to the old inline behaviour and (b) is the switch they
+ * later flip ON themselves (Settings → Processing → Async media generation).
+ *
+ * Idempotent: relies on the UNIQUE(BOWNERID, BGROUP, BSETTING) index
+ * (uniq_config_owner_group_setting). INSERT IGNORE skips any user who already
+ * has a row, so re-running the migration — or running it after some users have
+ * already toggled their switch — never clobbers an existing value.
+ *
+ * Fresh-install / dev safety: on an empty DB the BUSER table has no rows yet
+ * (DataFixtures load demo users AFTER migrations), so this writes ZERO rows and
+ * everyone correctly inherits the global ON default.
+ */
+final class Version20260629120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Grandfather existing users to MEDIA.ASYNC_JOBS_ENABLED=off (async media defaults ON for new/OSS installs)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // Guard: if neither table exists (unexpected), do nothing rather than fail.
+        if (!$schema->hasTable('BUSER') || !$schema->hasTable('BCONFIG')) {
+            return;
+        }
+
+        $this->addSql(<<<'SQL'
+            INSERT IGNORE INTO BCONFIG (BOWNERID, BGROUP, BSETTING, BVALUE)
+            SELECT u.BID, 'MEDIA', 'ASYNC_JOBS_ENABLED', '0'
+            FROM BUSER u
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        // Remove the per-user grandfather rows. This also removes any per-user
+        // ASYNC_JOBS_ENABLED row a user set themselves — acceptable for a down
+        // migration (reverts to the global default); the global ownerId=0 row
+        // is left untouched.
+        $this->addSql(<<<'SQL'
+            DELETE FROM BCONFIG
+            WHERE BGROUP = 'MEDIA'
+              AND BSETTING = 'ASYNC_JOBS_ENABLED'
+              AND BOWNERID > 0
+        SQL);
+    }
+}

--- a/backend/src/Command/SeedAllCommand.php
+++ b/backend/src/Command/SeedAllCommand.php
@@ -8,6 +8,7 @@ use App\Seed\BrandingConfigSeeder;
 use App\Seed\DefaultModelConfigSeeder;
 use App\Seed\DemoWidgetConfigSeeder;
 use App\Seed\MarketingNewsConfigSeeder;
+use App\Seed\MediaJobConfigSeeder;
 use App\Seed\MobileConfigSeeder;
 use App\Seed\ModelSeeder;
 use App\Seed\MultitaskConfigSeeder;
@@ -31,10 +32,11 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  *   4. rate-limits   (BCONFIG: SYSTEM_FLAGS, RATELIMITS_*)
  *   5. subscriptions (BSUBSCRIPTIONS — plan cost budgets)
  *   6. multitask     (BCONFIG: MULTITASK routing flags)
- *   7. branding      (BCONFIG: BRANDING white-label defaults, ownerId=0)
- *   8. mobile        (BCONFIG: MOBILE forced-update gate defaults, ownerId=0)
- *   9. marketing-news (BCONFIG: MARKETING_NEWS guest-landing flags, master switch OFF)
- *  10. demo-widget   (BCONFIG: example widget for ownerId=2 — dev/test only, no-op in prod)
+ *   7. media-jobs    (BCONFIG: MEDIA async media flag, ownerId=0 — default ON)
+ *   8. branding      (BCONFIG: BRANDING white-label defaults, ownerId=0)
+ *   9. mobile        (BCONFIG: MOBILE forced-update gate defaults, ownerId=0)
+ *  10. marketing-news (BCONFIG: MARKETING_NEWS guest-landing flags, master switch OFF)
+ *  11. demo-widget   (BCONFIG: example widget for ownerId=2 — dev/test only, no-op in prod)
  *
  * Wired into the Docker entrypoint after `doctrine:migrations:migrate`, so it runs
  * on every container startup in dev AND prod.
@@ -53,6 +55,7 @@ final class SeedAllCommand extends Command
         private readonly DemoWidgetConfigSeeder $demoWidgetConfigSeeder,
         private readonly SubscriptionPlanSeeder $subscriptionPlanSeeder,
         private readonly MultitaskConfigSeeder $multitaskConfigSeeder,
+        private readonly MediaJobConfigSeeder $mediaJobConfigSeeder,
         private readonly BrandingConfigSeeder $brandingConfigSeeder,
         private readonly MobileConfigSeeder $mobileConfigSeeder,
         private readonly MarketingNewsConfigSeeder $marketingNewsConfigSeeder,
@@ -70,10 +73,11 @@ final class SeedAllCommand extends Command
             "  4. app:ratelimit:seed-defaults (BCONFIG, group=RATELIMITS_*/SYSTEM_FLAGS)\n".
             "  5. subscription cost budgets   (BSUBSCRIPTIONS)\n".
             "  6. multitask routing flags     (BCONFIG, group=MULTITASK)\n".
-            "  7. branding defaults           (BCONFIG, group=BRANDING, ownerId=0)\n".
-            "  8. mobile gate defaults        (BCONFIG, group=MOBILE, ownerId=0)\n".
-            "  9. marketing news flags        (BCONFIG, group=MARKETING_NEWS, ownerId=0 — master switch OFF)\n".
-            "  10. demo widget config         (BCONFIG, group=widget_1, ownerId=2 — dev/test only)\n\n".
+            "  7. media-jobs async flag       (BCONFIG, group=MEDIA, ownerId=0 — default ON)\n".
+            "  8. branding defaults           (BCONFIG, group=BRANDING, ownerId=0)\n".
+            "  9. mobile gate defaults        (BCONFIG, group=MOBILE, ownerId=0)\n".
+            "  10. marketing news flags       (BCONFIG, group=MARKETING_NEWS, ownerId=0 — master switch OFF)\n".
+            "  11. demo widget config         (BCONFIG, group=widget_1, ownerId=2 — dev/test only)\n\n".
             'All steps are idempotent and safe to run on every deploy. The demo-widget step is a no-op in prod.'
         );
     }
@@ -90,6 +94,7 @@ final class SeedAllCommand extends Command
             ['rate-limits', fn (): SeedResult => $this->rateLimitConfigSeeder->seed()],
             ['subscriptions', fn (): SeedResult => $this->subscriptionPlanSeeder->seed()],
             ['multitask',   fn (): SeedResult => $this->multitaskConfigSeeder->seed()],
+            ['media-jobs',  fn (): SeedResult => $this->mediaJobConfigSeeder->seed()],
             ['branding',    fn (): SeedResult => $this->brandingConfigSeeder->seed()],
             ['mobile',      fn (): SeedResult => $this->mobileConfigSeeder->seed()],
             ['marketing-news', fn (): SeedResult => $this->marketingNewsConfigSeeder->seed()],

--- a/backend/src/Seed/MediaJobConfigSeeder.php
+++ b/backend/src/Seed/MediaJobConfigSeeder.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Seed;
+
+use App\Service\Media\MediaJobConfig;
+use Doctrine\DBAL\Connection;
+
+/**
+ * Idempotent seeder for the global async media-job flag (BCONFIG, ownerId=0).
+ *
+ * Seeds the explicit global row so the value is visible/toggleable rather than
+ * relying purely on the code default. Insert-if-missing only — operator
+ * overrides are never touched.
+ *
+ * Global default ON means OSS, fresh installs, dev, and new signups get async
+ * media (image + video + audio detach to a background job). Existing users on
+ * the live platform are grandfathered to OFF by the dedicated data migration,
+ * NOT by this seeder.
+ */
+final readonly class MediaJobConfigSeeder
+{
+    public function __construct(
+        private Connection $connection,
+    ) {
+    }
+
+    public function seed(): SeedResult
+    {
+        $rows = [
+            ['ownerId' => 0, 'group' => MediaJobConfig::CONFIG_GROUP, 'setting' => MediaJobConfig::KEY_ASYNC_JOBS_ENABLED, 'value' => '1'],
+        ];
+
+        return BConfigSeeder::insertIfMissing($this->connection, 'media_job_config', $rows);
+    }
+}

--- a/backend/src/Service/Admin/SystemConfigService.php
+++ b/backend/src/Service/Admin/SystemConfigService.php
@@ -9,6 +9,7 @@ use App\Service\Branding\BrandingService;
 use App\Service\Client\MobileVersionService;
 use App\Service\FeedbackConstants;
 use App\Service\MarketingNews\MarketingNewsConfig;
+use App\Service\Media\MediaJobConfig;
 use App\Service\Multitask\MultitaskRoutingConfig;
 use Psr\Log\LoggerInterface;
 
@@ -101,6 +102,7 @@ final readonly class SystemConfigService
                     'rasterize' => ['label' => 'PDF Rasterizer', 'fields' => ['RASTERIZE_DPI', 'RASTERIZE_PAGE_CAP', 'RASTERIZE_TIMEOUT_MS']],
                     'whisper' => ['label' => 'Whisper (Audio)', 'fields' => ['WHISPER_ENABLED', 'WHISPER_DEFAULT_MODEL']],
                     'brave' => ['label' => 'Web Search (Brave)', 'fields' => ['BRAVE_SEARCH_ENABLED', 'BRAVE_SEARCH_API_KEY', 'BRAVE_SEARCH_COUNT']],
+                    'media' => ['label' => 'Async media generation', 'fields' => ['MEDIA_ASYNC_JOBS_ENABLED']],
                 ],
             ],
             'routing' => [
@@ -329,6 +331,33 @@ final readonly class SystemConfigService
                 ]);
             } catch (\Throwable $sideEffect) {
                 $this->logger->error('SystemConfigService: failed clearing per-user multitask override', [
+                    'userId' => $actingUserId,
+                    'error' => $sideEffect->getMessage(),
+                ]);
+            }
+        }
+
+        // Async media master switch: existing users were grandfathered to an
+        // explicit per-user OFF row (migration Version20260629120000), which
+        // overrides this global flag. Drop the acting admin's own override so the
+        // value they just set actually applies to their own account immediately.
+        if (MediaJobConfig::CONFIG_GROUP === $group
+            && MediaJobConfig::KEY_ASYNC_JOBS_ENABLED === $key
+            && null !== $actingUserId && $actingUserId > 0
+        ) {
+            try {
+                $removed = $this->configRepository->deleteValue(
+                    $actingUserId,
+                    MediaJobConfig::CONFIG_GROUP,
+                    MediaJobConfig::KEY_ASYNC_JOBS_ENABLED,
+                );
+                $this->logger->info('SystemConfigService: cleared admin per-user async media override', [
+                    'userId' => $actingUserId,
+                    'removed' => $removed,
+                    'globalValue' => $value,
+                ]);
+            } catch (\Throwable $sideEffect) {
+                $this->logger->error('SystemConfigService: failed clearing per-user async media override', [
                     'userId' => $actingUserId,
                     'error' => $sideEffect->getMessage(),
                 ]);
@@ -682,6 +711,18 @@ final readonly class SystemConfigService
                 'source' => 'database',
                 'dbGroup' => MultitaskRoutingConfig::CONFIG_GROUP,
                 'dbKey' => MultitaskRoutingConfig::KEY_ROUTING_ENABLED,
+            ],
+            // Stored in BCONFIG group MEDIA / setting ASYNC_JOBS_ENABLED (the row
+            // MediaJobConfig reads). Master switch for detaching media renders to
+            // background jobs vs running them inline.
+            'MEDIA_ASYNC_JOBS_ENABLED' => [
+                'tab' => 'processing', 'section' => 'media', 'type' => 'boolean',
+                'sensitive' => false,
+                'description' => 'Run media generation (image, video, audio) as background jobs so the chat is never blocked — the assistant shows a live status banner and a completion toast. When OFF, renders run inline and the turn blocks until they finish. Requires the worker container. Global default; existing users keep their own setting until they opt in.',
+                'default' => 'true',
+                'source' => 'database',
+                'dbGroup' => MediaJobConfig::CONFIG_GROUP,
+                'dbKey' => MediaJobConfig::KEY_ASYNC_JOBS_ENABLED,
             ],
             // === Branding (database-backed, no restart required) ===
             // Stored in BCONFIG group BRANDING (ownerId=0) — the rows BrandingService

--- a/backend/src/Service/Media/MediaJobConfig.php
+++ b/backend/src/Service/Media/MediaJobConfig.php
@@ -13,9 +13,13 @@ use App\Repository\ConfigRepository;
  * Flags live in BCONFIG group {@see self::CONFIG_GROUP}:
  *   - ASYNC_JOBS_ENABLED        — master switch: chat/multitask media (image,
  *                                 video, audio) detaches to a background job
- *                                 instead of running inline. Default OFF in
- *                                 Sprint A (nothing creates jobs yet); flipped
- *                                 on for OSS/new installs in Sprint F.
+ *                                 instead of running inline. Built-in default ON
+ *                                 (Sprint F rollout): OSS clones, fresh installs,
+ *                                 dev, and new signups get async media instantly.
+ *                                 Existing users on the live platform are
+ *                                 grandfathered to an explicit per-user OFF row by
+ *                                 a one-time data migration (mirrors the multitask
+ *                                 routing rollout), giving them a switch they own.
  *   - JOB_POLL_INTERVAL_SECONDS — delay the advancer waits before re-dispatching
  *                                 itself for the next non-blocking poll step.
  *   - JOB_IMAGE_INLINE_FAST_MS  — grace window so a fast image render can still
@@ -40,7 +44,7 @@ final readonly class MediaJobConfig
     public const KEY_HEARTBEAT_STALE_SECONDS = 'JOB_HEARTBEAT_STALE_SECONDS';
     public const KEY_MAX_ACTIVE_PER_USER = 'JOB_MAX_ACTIVE_PER_USER';
 
-    private const DEFAULT_ASYNC_JOBS_ENABLED = false;
+    private const DEFAULT_ASYNC_JOBS_ENABLED = true;
     private const DEFAULT_POLL_INTERVAL_SECONDS = 3;
     private const DEFAULT_IMAGE_INLINE_FAST_MS = 1500;
     private const DEFAULT_HEARTBEAT_STALE_SECONDS = 90;
@@ -52,7 +56,7 @@ final readonly class MediaJobConfig
     }
 
     /**
-     * Master switch. Per-user override wins, then global, then built-in default (OFF).
+     * Master switch. Per-user override wins, then global, then built-in default (ON).
      *
      * Pass the EFFECTIVE user id (see ModelConfigService::getEffectiveUserIdForMessage)
      * so email/WhatsApp remapping resolves the flag for the same identity that

--- a/backend/tests/Unit/Service/Media/MediaJobConfigTest.php
+++ b/backend/tests/Unit/Service/Media/MediaJobConfigTest.php
@@ -20,12 +20,33 @@ final class MediaJobConfigTest extends TestCase
         $this->config = new MediaJobConfig($this->repo);
     }
 
-    public function testAsyncJobsDisabledByDefault(): void
+    public function testAsyncJobsEnabledByDefault(): void
     {
         $this->repo->method('getValue')->willReturn(null);
 
+        self::assertTrue($this->config->isAsyncJobsEnabled());
+        self::assertTrue($this->config->isAsyncJobsEnabled(42));
+    }
+
+    public function testGlobalDisableApplies(): void
+    {
+        $this->repo->method('getValue')->willReturnCallback(
+            static fn (int $owner, string $group, string $setting): ?string => MediaJobConfig::KEY_ASYNC_JOBS_ENABLED === $setting ? 'false' : null
+        );
+
         self::assertFalse($this->config->isAsyncJobsEnabled());
-        self::assertFalse($this->config->isAsyncJobsEnabled(42));
+    }
+
+    public function testPerUserOffOverridesGlobalDefaultOn(): void
+    {
+        // No global row exists (built-in default ON), but an existing user was
+        // grandfathered to an explicit per-user OFF row.
+        $this->repo->method('getValue')->willReturnCallback(
+            static fn (int $owner, string $group, string $setting): ?string => 42 === $owner && MediaJobConfig::KEY_ASYNC_JOBS_ENABLED === $setting ? '0' : null
+        );
+
+        self::assertFalse($this->config->isAsyncJobsEnabled(42), 'grandfathered per-user OFF beats default ON');
+        self::assertTrue($this->config->isAsyncJobsEnabled(99), 'other users inherit default ON');
     }
 
     public function testPerUserOverrideWinsOverGlobal(): void

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -117,6 +117,37 @@ doesn't change on upgrade — enable it per user or globally when ready.
 
 ---
 
+## Async Media Jobs (BCONFIG)
+
+Media generation (image, video, audio) can run as **background jobs** instead of
+blocking the chat turn: the assistant shows a live status banner, a completion
+toast fires when the render is ready, and a global Jobs tray tracks everything.
+Configured via **BCONFIG** (not env vars). Admins manage the master switch in the
+UI (**Settings → Processing → Async media generation**); the rest can be set per
+group in the `BCONFIG` table. Resolution is per-user row → global row
+(`BOWNERID=0`) → built-in code default.
+
+| Group / Key | Default | Description |
+|-------------|---------|-------------|
+| `MEDIA / ASYNC_JOBS_ENABLED` | `true` (new installs)¹ | Master switch: chat/multitask media (image + video + audio) detaches to a background job vs running inline |
+| `MEDIA / JOB_POLL_INTERVAL_SECONDS` | `3` | Delay the advancer waits before re-dispatching itself for the next poll step (clamped 1–30) |
+| `MEDIA / JOB_IMAGE_INLINE_FAST_MS` | `1500` | Grace window: a fast image render that finishes within this on the first advance resolves in the same turn (clamped 0–10000) |
+| `MEDIA / JOB_HEARTBEAT_STALE_SECONDS` | `90` | Seconds without a heartbeat before the reaper presumes the worker died and times the job out (clamped 30–1800) |
+| `MEDIA / JOB_MAX_ACTIVE_PER_USER` | `16` | Max concurrent in-flight media jobs per user (clamped 1–100) |
+
+¹ Existing installations are grandfathered to `0` by migration
+(`Version20260629120000`) so behavior doesn't change on upgrade — each user
+opts in via **Settings → Processing → Async media generation** (or set the
+group/per-user row directly).
+
+> **Requires the `worker` container.** Async jobs are consumed by the dedicated
+> `worker` service (Messenger over Redis Streams). Without it, jobs sit in
+> `queued` and the chat bubble shows "Job still running" indefinitely. The worker
+> **must** run in the same `APP_ENV` as the backend — see
+> [DEVELOPMENT.md](DEVELOPMENT.md#the-worker-service-async-jobs).
+
+---
+
 ## Audio Transcription (Whisper)
 
 ```bash


### PR DESCRIPTION
## Summary
Async Media Generation on by default, updated docs

## Changes
- Updated the master plan to reflect the completion of async media features, including the rollout of the `MEDIA_ASYNC_JOBS_ENABLED` flag, which is now default ON for new installations.
- Implemented a data migration to grandfather existing users to a per-user OFF setting, allowing them to opt-in via the UI.
- Enhanced the `SystemConfigService` to manage the async media generation settings, ensuring immediate application of changes for admins.
- Updated documentation to clarify the async media jobs configuration and its implications for users.
- Added tests to verify the new default behavior and per-user overrides for async media jobs.
- 
## Verification
- [ ] Not tested (explain)
- [X] Manual
- [ ] Tests added/updated
