### PR TITLE
test: mail handler AI routing unit tests + local email dev tooling

### DIFF
--- a/_devextras/mail-handler-test/Makefile
+++ b/_devextras/mail-handler-test/Makefile
@@ -1,0 +1,64 @@
+# Local mail-handler testing (Greenmail + MailHog).
+# Requires the main Synaplan stack: docker compose up -d (from repo root).
+
+ROOT := $(abspath ../..)
+COMPOSE := docker compose -f $(ROOT)/docker-compose.yml \
+	-f $(ROOT)/_devextras/mail-handler-test/docker-compose.greenmail.yml
+
+.PHONY: help up down ps logs setup send process flow watch
+
+help:
+	@echo "Mail handler local testing"
+	@echo ""
+	@echo "  make up       Start Greenmail (main stack must be running)"
+	@echo "  make down     Stop and remove Greenmail"
+	@echo "  make ps       Show Greenmail container status"
+	@echo "  make logs     Follow Greenmail logs"
+	@echo "  make setup    Create/update handler in DB (visible in /channels/email)"
+	@echo "  make send     Send test email (TYPE=sales|support|hr|spam)"
+	@echo "  make process  Run app:process-mail-handlers once"
+	@echo "  make watch    Optional: poll handlers in a loop (INTERVAL=10 seconds)"
+	@echo "  make flow     send + process (TYPE=support by default)"
+	@echo ""
+	@echo "Example:  make up setup && make flow TYPE=support"
+	@echo "Forwards:  http://localhost:8025 (MailHog)"
+
+up:
+	$(COMPOSE) up -d greenmail
+
+down:
+	docker stop synaplan-greenmail 2>/dev/null || true
+	docker rm synaplan-greenmail 2>/dev/null || true
+
+ps:
+	docker ps --filter name=synaplan-greenmail --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}'
+
+logs:
+	docker logs -f synaplan-greenmail
+
+setup:
+	$(COMPOSE) up -d backend
+	$(COMPOSE) exec -T backend php /var/www/mail-test/setup-local-mail-handler.php
+
+send:
+	$(COMPOSE) exec -T backend php /var/www/mail-test/send-test-email.php $(if $(TYPE),--type=$(TYPE),)
+
+process:
+	$(COMPOSE) exec -T backend php bin/console app:process-mail-handlers
+
+# Simulates production cron (* * * * * app:process-mail-handlers). Default: every 10s.
+INTERVAL ?= 10
+
+watch:
+	$(COMPOSE) up -d greenmail
+	@echo "Polling mail handlers every $(INTERVAL)s (Ctrl+C to stop)..."
+	@while true; do \
+		echo "--- $$(date -Iseconds) ---"; \
+		$(COMPOSE) exec -T backend php bin/console app:process-mail-handlers || true; \
+		sleep $(INTERVAL); \
+	done
+
+flow:
+	$(MAKE) send TYPE=$(or $(TYPE),support)
+	sleep 2
+	$(MAKE) process

--- a/_devextras/mail-handler-test/README.md
+++ b/_devextras/mail-handler-test/README.md
@@ -1,0 +1,204 @@
+# Mail Handler Local Testing
+
+Optional dev tooling to exercise the full mail-handler pipeline locally:
+
+**Greenmail** (IMAP inbox) → **Synaplan handler** (AI routing) → **MailHog** (catch-all for forwards)
+
+Not part of the main `docker-compose.yml`. MailHog is already in the main stack.
+
+---
+
+## Prerequisites
+
+1. Main stack running: `docker compose up -d` (from **repo root** — Docker Compose project name defaults to the folder name `synaplan`)
+2. A working **CHAT** model for the handler owner (user ID 1 / admin by default in `setup-local-mail-handler.php`)
+3. System prompt `tools:mailhandler` seeded (`make -C backend seed` or normal dev setup)
+
+> **Network:** Greenmail joins the existing stack network `synaplan_synaplan-network`. If you use a custom `COMPOSE_PROJECT_NAME`, start Greenmail with the same project name or adjust the `external.name` in `docker-compose.greenmail.yml`.
+
+---
+
+## Quick start
+
+```bash
+make -C _devextras/mail-handler-test up
+make -C _devextras/mail-handler-test setup
+make -C _devextras/mail-handler-test flow TYPE=support
+# Open http://localhost:8025 — forwarded mail should appear
+```
+
+| Command | Purpose |
+|---------|---------|
+| `make up` | Start Greenmail |
+| `make down` | Stop Greenmail |
+| `make setup` | Create/update handler in DB (**also visible in UI** at `/channels/email`) |
+| `make send TYPE=support` | Inject test mail via SMTP |
+| `make process` | Run `app:process-mail-handlers` once |
+| `make watch` | Optional: poll handlers in a loop (`INTERVAL=10`, default) |
+| `make flow TYPE=hr` | Send preset + process (one-shot) |
+
+Use `watch` only when you want hands-free polling (e.g. testing with Thunderbird). For quick checks, `make flow` or `make process` is enough.
+
+Presets: `sales`, `support`, `hr`, `spam`
+
+---
+
+## Architecture
+
+```
+send-test-email.php (or any SMTP client)
+    │  smtp://greenmail:3025 (from backend) or localhost:3025 (from host)
+    ▼
+Greenmail — mailbox testhandler@test.local
+    │  IMAP greenmail:3143
+    ▼
+Synaplan Mail Handler — AI routes to department
+    │  SMTP mailhog:1025
+    ▼
+MailHog — http://localhost:8025
+```
+
+**Port rule:** use **3025** to deliver mail *into* Greenmail. Port **1025** is MailHog (handler forwards only — do not send customer test mail there).
+
+**Hostname rule:**
+
+| Client runs on | IMAP/SMTP host |
+|----------------|----------------|
+| Host (desktop mail client) | `localhost` |
+| Backend container | `greenmail` / `mailhog` |
+
+---
+
+## Greenmail (Docker)
+
+**Image:** `greenmail/standalone`
+
+**Users** (IMAP login = local part only):
+
+| Login | Password | Address |
+|-------|----------|---------|
+| `testhandler` | `testpass` | `testhandler@test.local` |
+| `customer` | `customer123` | `customer@test.local` |
+| `admin` | `adminpass` | `admin@synaplan.com` |
+
+**Ports:** SMTP `3025`, IMAP `3143` (host and container)
+
+---
+
+## Handler configuration
+
+`make setup` writes the same data as the UI. Default handler: **Local Mail Handler (Greenmail)** for user **1** (`admin@synaplan.com`).
+
+| IMAP (from backend) | Value |
+|---------------------|-------|
+| Server | `greenmail` |
+| Port | `3143` |
+| Security | None |
+| User / pass | `testhandler` / `testpass` |
+| Filter | New emails only |
+
+| SMTP forward | Value |
+|--------------|-------|
+| Server | `mailhog` |
+| Port | `1025` |
+| Security | None |
+| From | `noreply@test.local` |
+| User / pass | any non-empty (MailHog ignores auth) |
+
+**Departments (setup script defaults):**
+
+| Email | Rules | Default |
+|-------|-------|---------|
+| `sales@test.local` | Sales, orders, pricing, quotes | No |
+| `support@test.local` | Support, bugs, issues, refunds | **Yes** |
+| `hr@test.local` | Jobs, hiring, HR | No |
+
+---
+
+## Sending test mail
+
+**Recommended:** `make send TYPE=support` — no extra software, avoids IMAP read/unread pitfalls.
+
+### Desktop mail client (optional)
+
+Use Thunderbird, Evolution, etc. only if you want a realistic “customer sends mail” workflow.
+
+**Simulate a customer writing to the handler:**
+
+| Setting | Value |
+|---------|-------|
+| Account address | `customer@test.local` |
+| IMAP | `localhost:3143`, security **None**, user **`customer`**, pass `customer123` |
+| SMTP | `localhost:3025`, security **None**, auth **None** |
+| Send **To** | `testhandler@test.local` |
+| After send | `make process` or `make watch` |
+
+**Where to see the result:** forwarded mail appears in **MailHog** (http://localhost:8025), not in the customer account inbox.
+
+> **IMAP username:** Greenmail expects the **local part** only (`customer`, `testhandler`) — not `customer@test.local`.
+
+> **UNSEEN filter:** Opening the handler inbox in a client marks mail as read; the handler then skips it. Prefer `make send`, send fresh mail, or mark unread before `make process`.
+
+---
+
+## AI routing
+
+Routing uses:
+
+1. System prompt **`tools:mailhandler`** (English; semantic intent, not keyword matching)
+2. Handler owner's **default CHAT model** (`ModelConfigService::getDefaultModel('CHAT', userId)`)
+3. Department **rules** text from the handler config
+
+The model must return **exactly one department email** from the list (or `DISCARD`). On failure, invalid output, or missing model → **default department**.
+
+**Why “Rechnung” may hit default:** Rules and prompt are English-oriented; German-only wording may not align strongly enough with `invoice`/`billing` rules. Use clear intent in subject/body (or English keywords matching your department rules). Presets in `send-test-email.php` are tuned for the default departments.
+
+Check which model ran: handler owner → usage/activity logs (`EMAIL_ROUTING`) or backend logs during `make process`.
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| MailHog empty | Handler not processed | `make process` |
+| Handler: no new emails | Mail already SEEN in IMAP | New mail via `make send`; don't open in client first |
+| Wrong department | AI uncertainty / language mismatch | Align mail text with department rules; check default dept |
+| TLS error | Security not None | Set IMAP/SMTP security to None locally |
+| Mail bypasses handler | SMTP to port 1025 | Send to Greenmail SMTP **3025** |
+| IMAP login failed | Full email used as username | Use local part only (`customer`, `testhandler`) |
+| `greenmail` in desktop client | Client runs on host | Use `localhost`, not `greenmail` |
+
+---
+
+## CI
+
+**Greenmail in CI is not recommended** for this pipeline:
+
+- Routing requires a **real AI call** (handler owner's CHAT model + provider keys)
+- CI typically has no Ollama/OpenAI/etc. configured for integration tests
+- Unit tests already cover routing logic (`InboundEmailHandlerServiceTest`)
+
+Greenmail adds value for **manual local E2E** only. Keep it in `_devextras/` as optional dev tooling.
+
+---
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `docker-compose.greenmail.yml` | Greenmail service + script mount into backend |
+| `setup-local-mail-handler.php` | Idempotent handler setup (DB + UI) |
+| `send-test-email.php` | SMTP test mail presets |
+| `Makefile` | Convenience commands |
+| `README.md` | This guide |
+
+---
+
+## Tear down
+
+```bash
+make -C _devextras/mail-handler-test down   # stops Greenmail only (not the main stack)
+```
+
+Delete handler in UI (`/channels/email`) or re-run `make setup` after changes. Greenmail mail is in-memory — restart clears mailboxes.

--- a/_devextras/mail-handler-test/docker-compose.greenmail.yml
+++ b/_devextras/mail-handler-test/docker-compose.greenmail.yml
@@ -1,0 +1,34 @@
+# Optional Greenmail overlay for local mail-handler testing.
+#
+# Usage (from repo root):
+#   docker compose -f docker-compose.yml \
+#     -f _devextras/mail-handler-test/docker-compose.greenmail.yml \
+#     up -d greenmail
+#
+# Or: make -C _devextras/mail-handler-test up
+
+services:
+  greenmail:
+    image: greenmail/standalone
+    container_name: synaplan-greenmail
+    environment:
+      GREENMAIL_OPTS: >-
+        -Dgreenmail.setup.test.all
+        -Dgreenmail.hostname=0.0.0.0
+        -Dgreenmail.users=testhandler:testpass@test.local,customer:customer123@test.local,admin:adminpass@synaplan.com
+    ports:
+      - "3025:3025"   # SMTP
+      - "3143:3143"   # IMAP
+    restart: unless-stopped
+    networks:
+      - synaplan-network
+
+  # Mount test scripts so `make setup` / `make send` can run inside backend
+  backend:
+    volumes:
+      - ./_devextras/mail-handler-test:/var/www/mail-test:ro
+
+networks:
+  synaplan-network:
+    external: true
+    name: synaplan_synaplan-network

--- a/_devextras/mail-handler-test/send-test-email.php
+++ b/_devextras/mail-handler-test/send-test-email.php
@@ -1,0 +1,97 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Send a test email to Greenmail for local mail-handler testing.
+ *
+ * Usage (inside backend container):
+ *   php /var/www/mail-test/send-test-email.php
+ *   php /var/www/mail-test/send-test-email.php --type=sales
+ *   php /var/www/mail-test/send-test-email.php "Custom subject" "Body text"
+ *
+ *   make -C _devextras/mail-handler-test send TYPE=support
+ */
+
+use Symfony\Component\Mailer\Mailer;
+use Symfony\Component\Mailer\Transport;
+use Symfony\Component\Mime\Email;
+
+require '/var/www/backend/vendor/autoload.php';
+
+$presets = [
+    'sales' => [
+        'from' => 'customer@acme-corp.com',
+        'subject' => 'Request for enterprise pricing',
+        'body' => "Hello,\n\nWe are interested in purchasing a license for 50 users.\nCould you send us a quote for the enterprise plan?\n\nBest regards,\nJohn Miller\nACME Corp",
+    ],
+    'support' => [
+        'from' => 'jane.doe@example.com',
+        'subject' => 'Bug: File upload fails with error 500',
+        'body' => "Hi support team,\n\nWhen I try to upload a PDF file larger than 10MB, I get a server error (500).\nThis started happening after the latest update.\n\nBrowser: Chrome 126\nOS: Windows 11\n\nPlease help!\nJane",
+    ],
+    'hr' => [
+        'from' => 'maria.garcia@gmail.com',
+        'subject' => 'Application for Senior Developer position',
+        'body' => "Dear Hiring Team,\n\nI would like to apply for the Senior Developer position posted on your website.\nI have 8 years of experience with PHP/Symfony and Vue.js.\n\nPlease find my CV attached.\n\nBest regards,\nMaria Garcia",
+    ],
+    'spam' => [
+        'from' => 'no-reply@newsletter.spam.com',
+        'subject' => 'You have won $1,000,000!!!',
+        'body' => "CONGRATULATIONS! You are the lucky winner of our sweepstakes!\nClick here to claim your prize: http://totally-not-a-scam.com\n\nThis is an automated message. Do not reply.",
+    ],
+];
+
+$type = null;
+$subject = null;
+$body = null;
+
+foreach ($argv as $i => $arg) {
+    if (0 === $i) {
+        continue;
+    }
+    if (str_starts_with($arg, '--type=')) {
+        $type = substr($arg, 7);
+    } elseif (null === $subject) {
+        $subject = $arg;
+    } elseif (null === $body) {
+        $body = $arg;
+    }
+}
+
+if ($type && isset($presets[$type])) {
+    $preset = $presets[$type];
+    $from = $preset['from'];
+    $subject = $preset['subject'];
+    $body = $preset['body'];
+    echo "Using preset: {$type}\n";
+} elseif ($type && !isset($presets[$type])) {
+    echo "Unknown preset: {$type}\n";
+    echo 'Available: '.implode(', ', array_keys($presets))."\n";
+    exit(1);
+} else {
+    $from = 'customer@example.com';
+    $subject ??= 'Help needed with my order #12345';
+    $body ??= "Hello,\n\nI have a problem with my recent order.\nThe product arrived damaged and I need a replacement.\n\nOrder number: #12345\nProduct: Widget Pro X\n\nPlease advise.\nThanks";
+}
+
+try {
+    $transport = Transport::fromDsn('smtp://greenmail:3025');
+    $mailer = new Mailer($transport);
+
+    $email = (new Email())
+        ->from($from)
+        ->to('testhandler@test.local')
+        ->subject($subject)
+        ->text($body);
+
+    $mailer->send($email);
+
+    echo "\nTest email sent to Greenmail (testhandler@test.local)\n";
+    echo "   From:    {$from}\n";
+    echo "   Subject: {$subject}\n";
+    echo "\nRun: make -C _devextras/mail-handler-test process\n";
+} catch (\Exception $e) {
+    echo "\nFailed to send: {$e->getMessage()}\n";
+    echo "Is Greenmail running? make -C _devextras/mail-handler-test up\n";
+    exit(1);
+}

--- a/_devextras/mail-handler-test/setup-local-mail-handler.php
+++ b/_devextras/mail-handler-test/setup-local-mail-handler.php
@@ -1,0 +1,102 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Create or update a local mail handler (Greenmail IMAP → MailHog SMTP forward).
+ *
+ * Idempotent — safe to run repeatedly. Writes to the same DB table as the UI,
+ * so the handler appears at /channels/email for the configured user.
+ *
+ * Run inside the backend container:
+ *   make -C _devextras/mail-handler-test setup
+ */
+
+use App\Entity\InboundEmailHandler;
+use App\Kernel;
+use App\Service\EncryptionService;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\NullLogger;
+
+require '/var/www/backend/vendor/autoload.php';
+
+$kernel = new Kernel('dev', true);
+$kernel->boot();
+
+/** @var \Doctrine\Persistence\ManagerRegistry $doctrine */
+$doctrine = $kernel->getContainer()->get('doctrine');
+
+/** @var EntityManagerInterface $em */
+$em = $doctrine->getManager();
+
+$appSecret = $_ENV['APP_SECRET'] ?? $_SERVER['APP_SECRET'] ?? '';
+$encryptionService = new EncryptionService($appSecret, new NullLogger());
+
+$handlerName = 'Local Mail Handler (Greenmail)';
+$userId = 1;
+
+$handlerRepo = $em->getRepository(InboundEmailHandler::class);
+$handler = $handlerRepo->findOneBy(['userId' => $userId, 'name' => $handlerName]);
+
+if ($handler) {
+    echo "Updating existing handler (ID: {$handler->getId()})...\n";
+} else {
+    echo "Creating new handler...\n";
+    $handler = new InboundEmailHandler();
+    $handler->setUserId($userId);
+    $handler->setName($handlerName);
+}
+
+$handler->setMailServer('greenmail');
+$handler->setPort(3143);
+$handler->setProtocol('IMAP');
+$handler->setSecurity('None');
+$handler->setUsername('testhandler');
+$handler->setDecryptedPassword('testpass', $encryptionService);
+
+$handler->setCheckInterval(1);
+$handler->setDeleteAfter(false);
+$handler->setStatus('active');
+$handler->setEmailFilter('new', null);
+
+$handler->setDepartments([
+    [
+        'id' => '1',
+        'email' => 'sales@test.local',
+        'rules' => 'Sales inquiries, orders, pricing, quotes, purchasing',
+        'isDefault' => false,
+    ],
+    [
+        'id' => '2',
+        'email' => 'support@test.local',
+        'rules' => 'Technical support, bugs, issues, complaints, refunds',
+        'isDefault' => true,
+    ],
+    [
+        'id' => '3',
+        'email' => 'hr@test.local',
+        'rules' => 'Job applications, HR matters, hiring, interviews',
+        'isDefault' => false,
+    ],
+]);
+
+$handler->setSmtpCredentials(
+    'mailhog',
+    1025,
+    'noreply@test.local',
+    'unused',
+    $encryptionService,
+    'None',
+);
+
+$em->persist($handler);
+$em->flush();
+
+echo "\nLocal mail handler ready.\n";
+echo "   ID:          {$handler->getId()}\n";
+echo "   User:        {$handler->getUserId()}\n";
+echo "   UI:          /channels/email\n";
+echo "   IMAP:        greenmail:3143\n";
+echo "   SMTP fwd:    mailhog:1025\n";
+echo "   Departments: sales@test.local, support@test.local (default), hr@test.local\n";
+echo "\nNext: make send TYPE=support && make process\n";
+echo "Check forwards at http://localhost:8025\n";

--- a/_devextras/smart-email-test/Makefile
+++ b/_devextras/smart-email-test/Makefile
@@ -1,0 +1,41 @@
+# Local Smart Email testing (MailHog → app:process-emails).
+# Requires the main Synaplan stack: docker compose up -d (from repo root).
+
+ROOT := $(abspath ../..)
+COMPOSE := docker compose -f $(ROOT)/docker-compose.yml \
+	-f $(ROOT)/_devextras/smart-email-test/docker-compose.yml
+
+.PHONY: help watch-smart-email process send
+
+help:
+	@echo "Smart Email local testing (MailHog port 1025)"
+	@echo ""
+	@echo "  make watch-smart-email   Poll and process smart@ mails (INTERVAL=10)"
+	@echo "  make process             Process once"
+	@echo "  make send                Send test mail (BODY=..., SUBJECT=..., FROM=..., TO=...)"
+	@echo ""
+	@echo "  KEEP=1                   Keep processed inbound mails in MailHog (debug only)"
+	@echo ""
+	@echo "Example:  make watch-smart-email"
+	@echo "           make send BODY=\"Create an image of a red cat.\""
+	@echo "Inbox:     http://localhost:8025 (Re: … replies stay; inbound smart@ removed after process)"
+
+INTERVAL ?= 10
+# Prod-like default: remove processed smart@ inbound from MailHog (no 3/10 re-poll noise).
+KEEP_FLAG := $(if $(KEEP),--keep,)
+
+watch-smart-email:
+	$(COMPOSE) up -d backend mailhog
+	$(COMPOSE) exec backend php bin/console app:process-emails --watch --interval=$(INTERVAL) $(KEEP_FLAG)
+
+process:
+	$(COMPOSE) up -d backend mailhog
+	$(COMPOSE) exec -T backend php bin/console app:process-emails $(KEEP_FLAG)
+
+send:
+	$(COMPOSE) up -d backend mailhog
+	$(COMPOSE) exec -T backend php /var/www/smart-email-test/send-smart-email.php \
+		$(if $(SUBJECT),--subject=$(SUBJECT),) \
+		$(if $(FROM),--from=$(FROM),) \
+		$(if $(TO),--to=$(TO),) \
+		$(if $(BODY),--body=$(BODY),)

--- a/_devextras/smart-email-test/README.md
+++ b/_devextras/smart-email-test/README.md
@@ -1,0 +1,106 @@
+# Smart Email local testing
+
+Test `smart@synaplan.com` via **MailHog** (SMTP **1025**). Separate from [mail-handler-test](../mail-handler-test/) (Greenmail **3025**).
+
+## Prerequisites
+
+1. Main stack running: `docker compose up -d` from **repo root** (Docker project name defaults to `synaplan`)
+2. Seed/dev data loaded — sender `admin@synaplan.com` must exist (default fixtures)
+3. `GMAIL_USERNAME` and `GMAIL_PASSWORD` **empty** in `.env` (otherwise Synaplan reads real Gmail instead of MailHog)
+4. A configured **CHAT** model (and **TEXT2PIC** if testing image generation)
+
+Commands: `make -C _devextras/smart-email-test …` from repo root (or `make -C ../smart-email-test …` from inside `_devextras/`).
+
+## Quick start
+
+```bash
+# Terminal 1: auto-process incoming smart@ mails
+make -C _devextras/smart-email-test watch-smart-email
+
+# Terminal 2 or Thunderbird: send to smart@synaplan.com via localhost:1025
+make -C _devextras/smart-email-test send BODY="Create an image of a red cat."
+```
+
+Responses appear in **MailHog**: http://localhost:8025 (look for `Re: …`). Processed **inbound** `smart@` mails are removed automatically (prod-like). AI replies (`Re:` to `admin@…`) stay in MailHog.
+
+```bash
+# Debug: keep inbound mails in MailHog (re-polls same mail; idempotency skips AI)
+make -C _devextras/smart-email-test watch-smart-email KEEP=1
+```
+
+## Architecture
+
+```
+Thunderbird / send-smart-email.php
+    │  smtp://localhost:1025 (host) or smtp://mailhog:1025 (backend)
+    ▼
+MailHog — captures all mail
+    │  app:process-emails (polls MailHog API)
+    ▼
+Synaplan webhook — only smart@synaplan.com / .net
+    │  AI pipeline + optional image generation
+    ▼
+MailHog — reply to sender (Re: … at http://localhost:8025)
+Synaplan UI — chat "Email Conversation"
+```
+
+**Port rule:** Smart Email uses MailHog **1025**. Do not send to Greenmail **3025** (that is [mail-handler-test](../mail-handler-test/)).
+
+**Address rule:** Only mail **to** `smart@synaplan.com`, `smart@synaplan.net`, or `smart+keyword@…` is processed. Replies to `admin@…` in MailHog are skipped on the next poll (by design).
+
+## Desktop mail client (optional)
+
+**Recommended:** `make send` (see Quick start). Same workflow works with any SMTP client on `localhost:1025`.
+
+If you also use [mail-handler-test](../mail-handler-test/), configure **two outgoing SMTP servers** in your client — same host, different ports:
+
+| Outgoing server (example) | Port | Purpose |
+|---------------------------|------|---------|
+| Synaplan MailHog | **1025** | Smart Email → `smart@synaplan.com` |
+| Greenmail Mail Handler | **3025** | Mail handler tests only |
+
+**Thunderbird account for Smart Email** (`admin@synaplan.com`):
+
+| Setting | Value |
+|---------|-------|
+| Incoming IMAP | `localhost:3143`, user **`admin`**, pass `adminpass` (Greenmail — needed so Thunderbird can create the account; replies do **not** arrive here) |
+| Outgoing SMTP | `localhost:1025`, security **None**, auth **None** (MailHog) |
+| Send **From** | `admin@synaplan.com` (fixture user) |
+| Send **To** | `smart@synaplan.com` |
+| Processing | `make watch-smart-email` in another terminal |
+
+**Where to read replies:** MailHog http://localhost:8025 (look for `Re: …`) and Synaplan UI → chat **Email Conversation**. Not in the Thunderbird inbox.
+
+**Tips:** Compose in **plain text** (HTML/multipart may show raw MIME in the UI). If Thunderbird prompts for a localhost password, clear saved credentials for `localhost` and confirm the outgoing server is port **1025** without auth.
+
+## Make targets
+
+| Target | Description |
+|--------|-------------|
+| `watch-smart-email` | Poll and process (default every 10s); inbound `smart@` removed after success |
+| `process` | Process once |
+| `send` | Inject test mail via MailHog SMTP |
+| `KEEP=1` | Optional: retain inbound mails in MailHog (debug only) |
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| No reply in MailHog | `process-emails` not running | `make watch-smart-email` or `make process` |
+| Raw MIME in chat/UI | Thunderbird sent HTML multipart | Compose as plain text (Ctrl+Shift+O in TB) |
+| Log shows `3/10` every poll | Old mails in MailHog + `KEEP=1` | Default watch deletes processed inbound; or clear MailHog UI |
+| Mail ignored | Wrong recipient | **To** must be `smart@synaplan.com` or `.net` |
+| Reads real Gmail | `GMAIL_*` set in `.env` | Leave empty for local MailHog |
+| Sent to wrong port | Used Greenmail 3025 | Smart Email = MailHog **1025** only |
+| TB asks for localhost password | Wrong/cached SMTP credentials | Outgoing server = **1025**, no auth; clear saved passwords |
+
+Idempotency: re-processing the same inbound mail does **not** call the AI again — only a quick duplicate check.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `docker-compose.yml` | Mount scripts into backend container |
+| `send-smart-email.php` | Inject test mail via MailHog SMTP |
+| `Makefile` | `watch-smart-email`, `process`, `send` |
+| `README.md` | This guide |

--- a/_devextras/smart-email-test/docker-compose.yml
+++ b/_devextras/smart-email-test/docker-compose.yml
@@ -1,0 +1,10 @@
+# Optional overlay: mount smart-email test scripts into backend.
+#
+# Usage (from repo root):
+#   docker compose -f docker-compose.yml \
+#     -f _devextras/smart-email-test/docker-compose.yml up -d backend
+
+services:
+  backend:
+    volumes:
+      - ./_devextras/smart-email-test:/var/www/smart-email-test:ro

--- a/_devextras/smart-email-test/send-smart-email.php
+++ b/_devextras/smart-email-test/send-smart-email.php
@@ -1,0 +1,65 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Send a test email to MailHog for local Smart Email testing.
+ *
+ * Usage (inside backend container):
+ *   php /var/www/smart-email-test/send-smart-email.php
+ *   php /var/www/smart-email-test/send-smart-email.php "Create an image of a cat."
+ *   php /var/www/smart-email-test/send-smart-email.php --subject=Test --body="Hello"
+ *
+ *   make -C _devextras/smart-email-test send BODY="Create an image of a cat."
+ */
+
+use Symfony\Component\Mailer\Mailer;
+use Symfony\Component\Mailer\Transport;
+use Symfony\Component\Mime\Email;
+
+require '/var/www/backend/vendor/autoload.php';
+
+$from = 'admin@synaplan.com';
+$to = 'smart@synaplan.com';
+$subject = 'Smart Email test';
+$body = 'Create an image of a red cat.';
+
+foreach ($argv as $i => $arg) {
+    if (0 === $i) {
+        continue;
+    }
+    if (str_starts_with($arg, '--from=')) {
+        $from = substr($arg, 7);
+    } elseif (str_starts_with($arg, '--to=')) {
+        $to = substr($arg, 5);
+    } elseif (str_starts_with($arg, '--subject=')) {
+        $subject = substr($arg, 10);
+    } elseif (str_starts_with($arg, '--body=')) {
+        $body = substr($arg, 7);
+    } elseif (!str_starts_with($arg, '--')) {
+        $body = $arg;
+    }
+}
+
+try {
+    $transport = Transport::fromDsn('smtp://mailhog:1025');
+    $mailer = new Mailer($transport);
+
+    $email = (new Email())
+        ->from($from)
+        ->to($to)
+        ->subject($subject)
+        ->text($body);
+
+    $mailer->send($email);
+
+    echo "\nSmart Email test sent via MailHog\n";
+    echo "   From:    {$from}\n";
+    echo "   To:      {$to}\n";
+    echo "   Subject: {$subject}\n";
+    echo "\nRun: make -C _devextras/smart-email-test process\n";
+    echo "Or:  make -C _devextras/smart-email-test watch-smart-email\n";
+} catch (\Exception $e) {
+    echo "\nFailed to send: {$e->getMessage()}\n";
+    echo "Is the main stack running? docker compose up -d\n";
+    exit(1);
+}

--- a/backend/tests/Service/InboundEmailHandlerServiceTest.php
+++ b/backend/tests/Service/InboundEmailHandlerServiceTest.php
@@ -22,9 +22,9 @@ class InboundEmailHandlerServiceTest extends TestCase
 {
     private InboundEmailHandlerService $service;
     private InboundEmailHandlerRepository&MockObject $handlerRepository;
-    private PromptRepository $promptRepository;
-    private AiFacade $aiFacade;
-    private ModelConfigService $modelConfigService;
+    private PromptRepository&MockObject $promptRepository;
+    private AiFacade&MockObject $aiFacade;
+    private ModelConfigService&MockObject $modelConfigService;
     private EncryptionService&MockObject $encryptionService;
     private LoggerInterface $logger;
 
@@ -508,6 +508,191 @@ class InboundEmailHandlerServiceTest extends TestCase
 
         $this->assertSame('Bestellung über 12€', $result['plain']);
     }
+
+    // ────────────────────────────────────────────────────────────────
+    // routeEmailToDepartment() — AI routing orchestration
+    // ────────────────────────────────────────────────────────────────
+
+    public function testRouteEmailRoutesToValidDepartment(): void
+    {
+        $handler = $this->createHandlerWithDepartments();
+        $this->stubPromptAndModel();
+
+        $this->aiFacade
+            ->expects($this->once())
+            ->method('chat')
+            ->willReturn(['content' => 'sales@example.com']);
+
+        $result = $this->service->routeEmailToDepartment($handler, 'New order inquiry', 'I want to buy...');
+
+        $this->assertSame('sales@example.com', $result);
+    }
+
+    public function testRouteEmailAcceptsCaseInsensitiveDepartmentMatch(): void
+    {
+        $handler = $this->createHandlerWithDepartments();
+        $this->stubPromptAndModel();
+
+        $this->aiFacade->method('chat')
+            ->willReturn(['content' => 'SUPPORT@EXAMPLE.COM']);
+
+        $result = $this->service->routeEmailToDepartment($handler, 'Help', 'Broken widget');
+
+        $this->assertSame('SUPPORT@EXAMPLE.COM', $result);
+    }
+
+    public function testRouteEmailDiscardsWhenAiReturnsDiscard(): void
+    {
+        $handler = $this->createHandlerWithDepartments();
+        $this->stubPromptAndModel();
+
+        $this->aiFacade->method('chat')
+            ->willReturn(['content' => 'DISCARD']);
+
+        $result = $this->service->routeEmailToDepartment($handler, 'Newsletter spam', 'Unsubscribe...');
+
+        $this->assertNull($result);
+    }
+
+    public function testRouteEmailDiscardsIsCaseInsensitive(): void
+    {
+        $handler = $this->createHandlerWithDepartments();
+        $this->stubPromptAndModel();
+
+        $this->aiFacade->method('chat')
+            ->willReturn(['content' => 'discard']);
+
+        $result = $this->service->routeEmailToDepartment($handler, 'Spam', 'Buy pills...');
+
+        $this->assertNull($result);
+    }
+
+    public function testRouteEmailFallsBackToDefaultForUnknownAiResponse(): void
+    {
+        $handler = $this->createHandlerWithDepartments();
+        $this->stubPromptAndModel();
+
+        $this->aiFacade->method('chat')
+            ->willReturn(['content' => 'nonexistent@example.com']);
+
+        $result = $this->service->routeEmailToDepartment($handler, 'Hello', 'Some email');
+
+        $this->assertSame('support@example.com', $result, 'Should fall back to default department');
+    }
+
+    /**
+     * LLMs sometimes return verbose answers instead of just an email address.
+     * The routing must not silently forward to a wrong address.
+     */
+    public function testRouteEmailFallsBackToDefaultForVerboseAiResponse(): void
+    {
+        $handler = $this->createHandlerWithDepartments();
+        $this->stubPromptAndModel();
+
+        $this->aiFacade->method('chat')
+            ->willReturn(['content' => 'I recommend routing to sales@example.com because it mentions a purchase.']);
+
+        $result = $this->service->routeEmailToDepartment($handler, 'Order', 'I want to buy...');
+
+        $this->assertSame('support@example.com', $result, 'Verbose AI response is not a valid email match');
+    }
+
+    public function testRouteEmailFallsBackToDefaultWhenAiThrows(): void
+    {
+        $handler = $this->createHandlerWithDepartments();
+        $this->stubPromptAndModel();
+
+        $this->aiFacade->method('chat')
+            ->willThrowException(new \RuntimeException('Provider timeout'));
+
+        $result = $this->service->routeEmailToDepartment($handler, 'Urgent', 'Help!');
+
+        $this->assertSame('support@example.com', $result, 'AI failure must not lose the email');
+    }
+
+    public function testRouteEmailFallsBackToDefaultWhenNoPromptFound(): void
+    {
+        $handler = $this->createHandlerWithDepartments();
+
+        $this->promptRepository->method('findByTopic')->willReturn(null);
+
+        $result = $this->service->routeEmailToDepartment($handler, 'Hello', 'Body');
+
+        $this->assertSame('support@example.com', $result);
+    }
+
+    public function testRouteEmailFallsBackToDefaultWhenNoModelConfigured(): void
+    {
+        $handler = $this->createHandlerWithDepartments();
+
+        $prompt = new \App\Entity\Prompt();
+        $prompt->setTopic('tools:mailhandler');
+        $prompt->setPrompt('Route this email. Departments: [TARGETLIST]');
+        $this->promptRepository->method('findByTopic')->willReturn($prompt);
+
+        $this->modelConfigService->method('getDefaultModel')->willReturn(null);
+
+        $result = $this->service->routeEmailToDepartment($handler, 'Hello', 'Body');
+
+        $this->assertSame('support@example.com', $result);
+    }
+
+    public function testRouteEmailReturnsNullWhenNoDepartments(): void
+    {
+        $handler = new InboundEmailHandler();
+        $handler->setUserId(1);
+        $handler->setDepartments([]);
+
+        $result = $this->service->routeEmailToDepartment($handler, 'Hello', 'Body');
+
+        $this->assertNull($result, 'No departments configured → nothing to route to');
+    }
+
+    public function testRouteEmailTrimsWhitespaceFromAiResponse(): void
+    {
+        $handler = $this->createHandlerWithDepartments();
+        $this->stubPromptAndModel();
+
+        $this->aiFacade->method('chat')
+            ->willReturn(['content' => "  sales@example.com  \n"]);
+
+        $result = $this->service->routeEmailToDepartment($handler, 'Order', 'Buy stuff');
+
+        $this->assertSame('sales@example.com', $result);
+    }
+
+    private function createHandlerWithDepartments(): InboundEmailHandler
+    {
+        $handler = new InboundEmailHandler();
+        $handler->setUserId(1);
+        $handler->setDepartments([
+            ['id' => '1', 'email' => 'sales@example.com', 'rules' => 'Sales inquiries', 'isDefault' => false],
+            ['id' => '2', 'email' => 'support@example.com', 'rules' => 'Technical support', 'isDefault' => true],
+            ['id' => '3', 'email' => 'info@example.com', 'rules' => 'General questions', 'isDefault' => false],
+        ]);
+
+        return $handler;
+    }
+
+    /**
+     * Stubs the prompt lookup and model config so AI routing can proceed
+     * to the actual AiFacade call (which is stubbed separately per test).
+     */
+    private function stubPromptAndModel(): void
+    {
+        $prompt = new \App\Entity\Prompt();
+        $prompt->setTopic('tools:mailhandler');
+        $prompt->setPrompt('Route this email to the correct department. Departments: [TARGETLIST]');
+        $this->promptRepository->method('findByTopic')->willReturn($prompt);
+
+        $this->modelConfigService->method('getDefaultModel')->willReturn(42);
+        $this->modelConfigService->method('getProviderForModel')->willReturn('openai');
+        $this->modelConfigService->method('getModelName')->willReturn('gpt-4');
+    }
+
+    // ────────────────────────────────────────────────────────────────
+    // Private test helpers (MIME / decode)
+    // ────────────────────────────────────────────────────────────────
 
     /**
      * @param array<int, object>       $parts


### PR DESCRIPTION
## Summary

- Add unit tests for `InboundEmailHandlerService::routeEmailToDepartment()` covering valid department routing, case-insensitive matching, DISCARD handling, default-department fallback (unknown/verbose AI output, missing prompt/model, AI exceptions), and empty department lists.
- Add optional local dev tooling under `_devextras/` for exercising email flows without touching main `docker-compose.yml`:
  - **mail-handler-test** — Greenmail (IMAP inbox) → Synaplan mail handler (AI routing) → MailHog (forwards)
  - **smart-email-test** — send to `smart@synaplan.com` via MailHog SMTP and process with `app:process-emails`

No production code changes; dev-only scripts, Makefiles, and READMEs.

## Test plan

- [ ] `docker compose exec -T backend ./vendor/bin/phpunit tests/Service/InboundEmailHandlerServiceTest.php --testdox`
- [ ] Mail handler flow (optional manual): `make -C _devextras/mail-handler-test up setup flow TYPE=support` → check http://localhost:8025
- [ ] Smart email flow (optional manual): `make -C _devextras/smart-email-test watch-smart-email` + `make -C _devextras/smart-email-test send` → reply in MailHog