### PR TITLE
fix: bug bash for the 7 most recent issues (#1176, #1177, #1190–#1192, #1196, #1197)

### DIFF
--- a/backend/src/Controller/FileController.php
+++ b/backend/src/Controller/FileController.php
@@ -9,6 +9,7 @@ use App\Entity\User;
 use App\Repository\FileRepository;
 use App\Repository\MessageRepository;
 use App\Repository\WidgetSessionRepository;
+use App\Service\File\DocumentGeneratorService;
 use App\Service\File\FileHelper;
 use App\Service\File\FileListService;
 use App\Service\File\FileStorageService;
@@ -43,6 +44,7 @@ class FileController extends AbstractController
         private WidgetService $widgetService,
         private VectorStorageFacade $vectorStorageFacade,
         private VectorMigrationService $migrationService,
+        private DocumentGeneratorService $documentGenerator,
         private LoggerInterface $logger,
         private string $uploadDir,
     ) {
@@ -397,10 +399,65 @@ class FileController extends AbstractController
 
         $absolutePath = $this->uploadDir.'/'.$file->getFilePath();
         if (!FileHelper::fileExistsNfs($absolutePath)) {
+            // Issue #1190: a chat-generated file can lose its on-disk binary
+            // (e.g. a Docker rebuild) while BFILETEXT — the Markdown/text source
+            // it was built from — survives in the DB. Rather than a dead-end 404
+            // (the user can still preview the content), regenerate the binary
+            // from BFILETEXT on the fly so the download stays consistent with
+            // the preview.
+            $regenerated = $this->regenerateMissingBinary($file);
+            if (null !== $regenerated) {
+                return $regenerated;
+            }
+
             return $this->json(['error' => 'File not found on disk'], Response::HTTP_NOT_FOUND);
         }
 
         $response = new BinaryFileResponse($absolutePath);
+        $response->setContentDisposition(ResponseHeaderBag::DISPOSITION_ATTACHMENT, $file->getFileName());
+
+        return $response;
+    }
+
+    /**
+     * Rebuild a missing on-disk binary from the file's stored text source
+     * (BFILETEXT) and return it as a one-shot download. Used as a safety net
+     * for chat-generated files whose binary was lost (issue #1190). Returns
+     * null when the file cannot be regenerated (no text or write failure), so
+     * the caller falls back to a 404.
+     */
+    private function regenerateMissingBinary(File $file): ?BinaryFileResponse
+    {
+        $text = $file->getFileText();
+        if ('' === trim($text)) {
+            return null;
+        }
+
+        $extension = strtolower(pathinfo($file->getFileName(), PATHINFO_EXTENSION))
+            ?: strtolower($file->getFileType());
+        if ('' === $extension) {
+            return null;
+        }
+
+        try {
+            $tmpPath = tempnam(sys_get_temp_dir(), 'regen_').'.'.$extension;
+            $this->documentGenerator->write($text, $extension, $tmpPath);
+        } catch (\Throwable $e) {
+            $this->logger->warning('FileController: failed to regenerate missing binary from BFILETEXT', [
+                'file_id' => $file->getId(),
+                'error' => $e->getMessage(),
+            ]);
+
+            return null;
+        }
+
+        $this->logger->info('FileController: regenerated missing binary from BFILETEXT for download', [
+            'file_id' => $file->getId(),
+            'extension' => $extension,
+        ]);
+
+        $response = new BinaryFileResponse($tmpPath);
+        $response->deleteFileAfterSend(true);
         $response->setContentDisposition(ResponseHeaderBag::DISPOSITION_ATTACHMENT, $file->getFileName());
 
         return $response;

--- a/backend/src/Controller/StreamController.php
+++ b/backend/src/Controller/StreamController.php
@@ -2530,6 +2530,9 @@ class StreamController extends AbstractController
             $file->setFileSize($fileSize);
             $file->setFileMime($this->getMimeTypeForExtension($extension));
             $file->setStatus('generated');
+            // Issue #1190: mark provenance so generated files are distinguishable
+            // from uploads (default 'web_upload') and can be targeted for repair.
+            $file->setSource('generated');
 
             $this->em->persist($file);
             $this->em->flush();
@@ -2617,6 +2620,10 @@ class StreamController extends AbstractController
             // exact current content instead of re-deriving it.
             $file->setFileText($content);
             $file->setStatus('generated');
+            // Issue #1190: mark provenance so generated files are distinguishable
+            // from uploads (default 'web_upload') and can be regenerated from
+            // BFILETEXT on download when the on-disk binary goes missing.
+            $file->setSource('generated');
 
             $this->em->persist($file);
             $this->em->flush();

--- a/backend/src/Controller/StreamController.php
+++ b/backend/src/Controller/StreamController.php
@@ -2555,6 +2555,18 @@ class StreamController extends AbstractController
         $content = $fileData['content'];
         $extension = $fileData['extension'];
 
+        // Issue #1196: never persist a generated document from whitespace-only
+        // content — it would create a DB row plus a blank file with no usable
+        // body. Bail early so the caller can surface a real failure instead.
+        if ('' === trim((string) $content)) {
+            $this->logger->warning('StreamController: refusing to store generated file with empty content', [
+                'filename' => $filename,
+                'extension' => $extension,
+            ]);
+
+            return null;
+        }
+
         try {
             // Generate storage path similar to FileStorageService
             $year = date('Y');

--- a/backend/src/Service/File/DocumentGeneratorService.php
+++ b/backend/src/Service/File/DocumentGeneratorService.php
@@ -83,9 +83,19 @@ final readonly class DocumentGeneratorService
 
         $html = (new \Parsedown())->text($content);
 
+        // PhpWord parses the HTML with DOMDocument::loadXML() (XHTML), which
+        // rejects unclosed void tags. LLMs routinely emit bare `<br>` (and
+        // sometimes `<hr>` / `<img>`) inside markdown table cells; Parsedown
+        // passes those through verbatim, the XML parse then fails mid-table and
+        // PhpWord silently produces a structurally valid but EMPTY document
+        // (no <w:t> runs). Self-closing the void tags first keeps the table
+        // content intact (issue #1196).
+        $html = $this->normalizeVoidTags($html);
+
         // Ensure special characters (like '&', '<', '>') are escaped in the XML to prevent document corruption.
         WordSettings::setOutputEscapingEnabled(true);
 
+        $usedFallback = false;
         try {
             $phpWord = new PhpWord();
             $section = $phpWord->addSection();
@@ -95,18 +105,80 @@ final readonly class DocumentGeneratorService
                 'error' => $e->getMessage(),
             ]);
 
-            $phpWord = new PhpWord();
-            $section = $phpWord->addSection();
-            foreach ($this->splitLines($content) as $line) {
-                if ('' === trim($line)) {
-                    $section->addTextBreak();
-                } else {
-                    $section->addText($line);
-                }
-            }
+            $phpWord = $this->buildPlainTextDocx($content);
+            $usedFallback = true;
         }
 
         WordIOFactory::createWriter($phpWord, 'Word2007')->save($absolutePath);
+
+        // Defense in depth: even when addHtml() does not throw, a malformed
+        // fragment can leave the body without a single text run. Assert the
+        // saved document actually contains text and, if not, rebuild it from
+        // the plain-text fallback so we never ship a blank-but-valid DOCX.
+        if (!$usedFallback && !$this->docxHasText($absolutePath)) {
+            $this->logger->warning('DocumentGeneratorService: DOCX produced no text runs, rebuilding with plain text fallback', [
+                'path' => $absolutePath,
+            ]);
+
+            WordIOFactory::createWriter($this->buildPlainTextDocx($content), 'Word2007')->save($absolutePath);
+        }
+    }
+
+    /**
+     * Build a DOCX from the raw content as plain paragraphs. Used as the
+     * always-valid fallback when HTML conversion fails or yields no text.
+     */
+    private function buildPlainTextDocx(string $content): PhpWord
+    {
+        $phpWord = new PhpWord();
+        $section = $phpWord->addSection();
+        foreach ($this->splitLines($content) as $line) {
+            if ('' === trim($line)) {
+                $section->addTextBreak();
+            } else {
+                $section->addText($line);
+            }
+        }
+
+        return $phpWord;
+    }
+
+    /**
+     * Self-close HTML void tags that PhpWord's XML parser would otherwise
+     * reject (`<br>` → `<br/>`, `<hr>` → `<hr/>`, `<img ...>` → `<img .../>`).
+     * Tags that are already self-closed are left untouched.
+     */
+    private function normalizeVoidTags(string $html): string
+    {
+        // <br> and <hr> with optional attributes, not already self-closed.
+        $html = preg_replace('/<(br|hr)(\s[^>]*?)?\s*(?<!\/)>/i', '<$1$2/>', $html) ?? $html;
+
+        // <img ...> not already self-closed.
+        $html = preg_replace('/<img(\s[^>]*?)?\s*(?<!\/)>/i', '<img$1/>', $html) ?? $html;
+
+        return $html;
+    }
+
+    /**
+     * Whether the saved DOCX contains at least one text run (`<w:t>`), i.e.
+     * the body is not blank. Reads word/document.xml from the OOXML zip.
+     */
+    private function docxHasText(string $absolutePath): bool
+    {
+        $zip = new \ZipArchive();
+        if (true !== $zip->open($absolutePath)) {
+            // Can't inspect it — assume valid rather than forcing a rebuild.
+            return true;
+        }
+
+        $xml = $zip->getFromName('word/document.xml');
+        $zip->close();
+
+        if (false === $xml) {
+            return true;
+        }
+
+        return str_contains($xml, '<w:t>') || str_contains($xml, '<w:t ');
     }
 
     /**

--- a/backend/src/Service/InboundEmailHandlerService.php
+++ b/backend/src/Service/InboundEmailHandlerService.php
@@ -529,6 +529,31 @@ final readonly class InboundEmailHandlerService
             return $this->getDefaultDepartment($departments);
         }
 
+        // Pre-flight cost-budget gate (issue #1177): the routing AI call is
+        // billable, so a high-volume handler could otherwise run up unlimited
+        // cost for an owner who is already over budget. Mirror the gate that
+        // MessageController/StreamController apply before their AI calls and
+        // fall back to the default department when the owner is over budget.
+        $handlerUser = $this->userRepository->find($handler->getUserId());
+        if (null === $handlerUser) {
+            $this->logger->warning('Mail handler owner not found; skipping AI routing', [
+                'handler_id' => $handler->getId(),
+                'user_id' => $handler->getUserId(),
+            ]);
+
+            return $this->getDefaultDepartment($departments);
+        }
+
+        $budgetCheck = $this->rateLimitService->checkCostBudget($handlerUser);
+        if (!$budgetCheck['allowed']) {
+            $this->logger->info('Mail handler owner over cost budget; using default department', [
+                'handler_id' => $handler->getId(),
+                'user_id' => $handler->getUserId(),
+            ]);
+
+            return $this->getDefaultDepartment($departments);
+        }
+
         try {
             // Call AI to route email
             $response = $this->aiFacade->chat(
@@ -544,17 +569,14 @@ final readonly class InboundEmailHandlerService
 
             $routedEmail = trim($response['content'] ?? '');
 
-            $handlerUser = $this->userRepository->find($handler->getUserId());
-            if ($handlerUser) {
-                $this->rateLimitService->recordUsage($handlerUser, 'EMAIL_ROUTING', [
-                    'provider' => $response['provider'] ?? $provider,
-                    'model' => $response['model'] ?? $modelName,
-                    'model_id' => $modelId,
-                    'usage' => $response['usage'] ?? [],
-                    'response_text' => $routedEmail,
-                    'input_text' => $fullPrompt,
-                ]);
-            }
+            $this->rateLimitService->recordUsage($handlerUser, 'EMAIL_ROUTING', [
+                'provider' => $response['provider'] ?? $provider,
+                'model' => $response['model'] ?? $modelName,
+                'model_id' => $modelId,
+                'usage' => $response['usage'] ?? [],
+                'response_text' => $routedEmail,
+                'input_text' => $fullPrompt,
+            ]);
 
             // Check if AI decided to discard the email
             if ('DISCARD' === strtoupper($routedEmail)) {

--- a/backend/src/Service/Message/MessagePreProcessor.php
+++ b/backend/src/Service/Message/MessagePreProcessor.php
@@ -135,6 +135,21 @@ final readonly class MessagePreProcessor
         // File existiert lokal?
         $fullPath = $this->uploadsDir.'/'.$filePath;
         if (!file_exists($fullPath)) {
+            // Issue #1190: a chat-generated file (OfficeMaker path) can lose its
+            // on-disk binary (e.g. a Docker rebuild) while BFILETEXT survives in
+            // the DB. Such a file is still fully usable for chat/analysis and the
+            // binary is regenerable on download, so it must NOT be flagged as
+            // 'error'. Only mark missing files without recoverable text as errors.
+            if (!empty($messageFile->getFileText())) {
+                $this->logger->warning('File binary missing on disk but BFILETEXT present; keeping status', [
+                    'file_id' => $messageFile->getId(),
+                    'path' => $fullPath,
+                    'status' => $messageFile->getStatus(),
+                ]);
+
+                return;
+            }
+
             $this->logger->warning("File not found: {$fullPath}");
             $messageFile->setStatus('error');
 

--- a/backend/src/Service/Message/MessagePreProcessor.php
+++ b/backend/src/Service/Message/MessagePreProcessor.php
@@ -149,7 +149,13 @@ final readonly class MessagePreProcessor
                 'type' => $fileType,
                 'text_length' => strlen($messageFile->getFileText()),
             ]);
-            $messageFile->setStatus('processed');
+            // Issue #1191: re-attaching an already-vectorized file must NOT
+            // downgrade its status to 'processed' — the Qdrant vectors are
+            // still valid, so the DB status would become inconsistent. Only
+            // promote files that have not already reached a terminal state.
+            if (!in_array($messageFile->getStatus(), ['vectorized', 'processed'], true)) {
+                $messageFile->setStatus('processed');
+            }
 
             // Issue #887: even when extraction was already done at upload
             // time, the analysis-billing event fires HERE (the message is

--- a/backend/src/Service/ModelConfigService.php
+++ b/backend/src/Service/ModelConfigService.php
@@ -604,15 +604,19 @@ final readonly class ModelConfigService
     /**
      * Get effective user ID for model selection based on message channel.
      *
-     * For Email messages:
-     *   - smart@synaplan.net (no keyword) → returns user ID 2 for model selection
-     *   - smart+keyword@synaplan.net (with keyword) → returns sender's user ID
+     * For Email messages: always returns the sender's own user ID. The message
+     * only reaches this branch once it has been mapped to a real account
+     * (the null-userId guard above filters out senders we could not identify),
+     * so a registered sender must get the SAME model they use in web chat —
+     * whether or not they used a +keyword address (issue #1176). Unmapped
+     * senders never get here, so there is no longer a hardcoded user-ID-2
+     * fallback that silently overrode the sender's configured model.
      *
      * For WhatsApp messages: Returns user ID only if WhatsApp number is verified.
      * For web/other channels: Always returns the user ID (no verification required).
      *
-     * This ensures unverified WhatsApp users and emails without keywords get default models,
-     * while web users and emails with keywords always get their configured models.
+     * This ensures unverified WhatsApp users get default models, while web users
+     * and identified email senders always get their configured models.
      */
     public function getEffectiveUserIdForMessage(Message $message): ?int
     {
@@ -623,15 +627,9 @@ final readonly class ModelConfigService
 
         $channel = $message->getMeta('channel');
 
-        // For Email: if no keyword (smart@synaplan.net), use user ID 2 for model selection
+        // For Email: the sender is already an identified account (guarded above),
+        // so use their own configured model regardless of +keyword (issue #1176).
         if ('email' === $channel) {
-            $emailKeyword = $message->getMeta('email_keyword');
-            // If no keyword (smart@synaplan.net without +keyword), use user ID 2
-            if (empty($emailKeyword)) {
-                return 2;
-            }
-
-            // If keyword exists (smart+keyword@synaplan.net), use sender's user ID
             return $userId;
         }
 

--- a/backend/src/Service/Multitask/Execution/ResultAssembler.php
+++ b/backend/src/Service/Multitask/Execution/ResultAssembler.php
@@ -85,6 +85,35 @@ final class ResultAssembler
             'partial_failure' => $partialFailure,
         ];
 
+        // Issue #1197: the reply node is frequently `compose_reply`, whose
+        // runner carries NO provider/model metadata, so the inference provider
+        // that actually produced the answer (e.g. groq) is dropped and the chat
+        // bubble falls back to a wrong/default avatar. Backfill the chat-model
+        // meta from the last successful node that recorded a provider (the node
+        // closest to the final answer in execution order), so StreamController
+        // persists the real ai_chat_provider/model.
+        if (empty($metadata['provider'])) {
+            foreach ($plan->topologicalOrder() as $node) {
+                $nodeResult = $context->getResult($node->id);
+                if (null === $nodeResult || !$nodeResult->isSuccessful()) {
+                    continue;
+                }
+                $nodeProvider = $nodeResult->metadata['provider'] ?? null;
+                if (!is_string($nodeProvider) || '' === $nodeProvider) {
+                    continue;
+                }
+                // Last provider-bearing node wins (do not break): it is the one
+                // that produced the user-facing answer text.
+                $metadata['provider'] = $nodeProvider;
+                if (isset($nodeResult->metadata['model'])) {
+                    $metadata['model'] = $nodeResult->metadata['model'];
+                }
+                if (isset($nodeResult->metadata['model_id'])) {
+                    $metadata['model_id'] = $nodeResult->metadata['model_id'];
+                }
+            }
+        }
+
         // Propagate web_search results from the first successful WebSearch node
         // into the top-level metadata so StreamController can set the
         // web_search_query/count metas and populate the Sources dropdown.

--- a/backend/src/Service/Multitask/TaskPlanExecutor.php
+++ b/backend/src/Service/Multitask/TaskPlanExecutor.php
@@ -18,10 +18,14 @@ use Psr\Log\LoggerInterface;
  * MessageProcessor call sites, gated by MULTITASK_ROUTING_ENABLED.
  *
  * Plan source + path selection:
- *   - Only genuinely AI-classified messages (classification source `ai_sorting`)
- *     are sent to the {@see TaskPlanner}. Deterministic/simple branches
- *     (fast-path chat, slash commands, attachments, widget, again) keep using
- *     the proven single-node path — no planner latency, no behaviour change.
+ *   - AI-classified messages (classification source `ai_sorting`) AND non-image
+ *     file attachments (`attachment_document_or_audio`) are sent to the
+ *     {@see TaskPlanner}. Other deterministic/simple branches (fast-path chat,
+ *     slash commands, widget, again) keep using the proven single-node path —
+ *     no planner latency, no behaviour change. File attachments are planned so
+ *     multi-intent messages ("summarize this DOCX, make an image and read it
+ *     aloud") are no longer reduced to a lone file analysis (issue #1192); a
+ *     single-intent attachment still degrades to the legacy single-node path.
  *     Widget conversations are excluded even when AI-classified ("standard
  *     sorting" widgets set `is_widget_mode`) — the embed client has no
  *     task-plan UI.
@@ -182,8 +186,20 @@ final readonly class TaskPlanExecutor
      */
     private function planForExecution(Message $message, array $thread, array $classification, array $options = []): ?TaskPlanResult
     {
-        // Only AI-sorted messages are candidates for multi-task planning.
-        if ('ai_sorting' !== ($classification['source'] ?? null)) {
+        // Messages eligible for multi-task planning:
+        //   - `ai_sorting`: genuinely AI-classified turns.
+        //   - `attachment_document_or_audio`: non-image file attachments. These
+        //     used to be force-routed to single-node file analysis, which
+        //     silently dropped any *additional* intents in the same message
+        //     ("summarize this DOCX, make an image and read it aloud" became just
+        //     a summary). Sending them to the planner restores multi-intent
+        //     support. This is safe because a single-intent attachment yields a
+        //     single-node (or fallback) plan → shouldUseLegacyRouter() delegates
+        //     to the legacy router with the original analyzefile classification,
+        //     i.e. identical behaviour. Only genuinely multi-intent messages run
+        //     the DAG (issue #1192).
+        $source = $classification['source'] ?? null;
+        if (!in_array($source, ['ai_sorting', 'attachment_document_or_audio'], true)) {
             return null;
         }
 

--- a/backend/tests/Controller/FileControllerTest.php
+++ b/backend/tests/Controller/FileControllerTest.php
@@ -363,6 +363,46 @@ class FileControllerTest extends WebTestCase
         $this->assertEquals(401, $response->getStatusCode());
     }
 
+    /**
+     * Issue #1190: a chat-generated file whose on-disk binary is missing but
+     * whose BFILETEXT survives must be downloadable — the controller
+     * regenerates the binary from the stored text instead of returning 404.
+     */
+    public function testDownloadRegeneratesMissingGeneratedBinaryFromText(): void
+    {
+        $file = new \App\Entity\File();
+        $file->setUserId($this->testUser->getId());
+        $file->setFilePath('missing/'.uniqid('regen_', true).'.docx');
+        $file->setFileType('docx');
+        $file->setFileName('Trainingsplan.docx');
+        $file->setFileSize(0);
+        $file->setFileMime('application/vnd.openxmlformats-officedocument.wordprocessingml.document');
+        $file->setFileText("# Trainingsplan\n\nMontag: **Bankdrücken** 3 x 10 Wdh.");
+        $file->setStatus('generated');
+        $file->setSource('generated');
+        $file->setCreatedAt(time());
+
+        $this->em->persist($file);
+        $this->em->flush();
+        $fileId = $file->getId();
+
+        $this->client->request('GET', '/api/v1/files/'.$fileId.'/download', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer '.$this->authToken,
+        ]);
+
+        $response = $this->client->getResponse();
+        // A 200 binary response for a file whose on-disk path does not exist can
+        // ONLY come from the BFILETEXT regeneration fallback — a 404 JSON error
+        // would be returned otherwise.
+        $this->assertEquals(200, $response->getStatusCode(), 'Missing-binary generated file must be regenerated, not 404');
+        $this->assertInstanceOf(\Symfony\Component\HttpFoundation\BinaryFileResponse::class, $response);
+        $this->assertStringContainsString(
+            'Trainingsplan.docx',
+            (string) $response->headers->get('Content-Disposition'),
+            'Regenerated download must keep the original filename'
+        );
+    }
+
     private function createTestFile(string $filename, string $content): string
     {
         $tempFile = tempnam(sys_get_temp_dir(), 'synaplan_test_');

--- a/backend/tests/Service/InboundEmailHandlerServiceTest.php
+++ b/backend/tests/Service/InboundEmailHandlerServiceTest.php
@@ -22,10 +22,12 @@ class InboundEmailHandlerServiceTest extends TestCase
 {
     private InboundEmailHandlerService $service;
     private InboundEmailHandlerRepository&MockObject $handlerRepository;
-    private PromptRepository $promptRepository;
-    private AiFacade $aiFacade;
-    private ModelConfigService $modelConfigService;
+    private PromptRepository&MockObject $promptRepository;
+    private AiFacade&MockObject $aiFacade;
+    private ModelConfigService&MockObject $modelConfigService;
     private EncryptionService&MockObject $encryptionService;
+    private UserRepository&MockObject $userRepository;
+    private RateLimitService&MockObject $rateLimitService;
     private LoggerInterface $logger;
 
     protected function setUp(): void
@@ -35,19 +37,106 @@ class InboundEmailHandlerServiceTest extends TestCase
         $this->aiFacade = $this->createMock(AiFacade::class);
         $this->modelConfigService = $this->createMock(ModelConfigService::class);
         $this->encryptionService = $this->createMock(EncryptionService::class);
+        $this->userRepository = $this->createMock(UserRepository::class);
+        $this->rateLimitService = $this->createMock(RateLimitService::class);
         $this->logger = $this->createMock(LoggerInterface::class);
 
         $this->service = new InboundEmailHandlerService(
             $this->handlerRepository,
             $this->promptRepository,
-            $this->createMock(UserRepository::class),
+            $this->userRepository,
             $this->aiFacade,
             $this->modelConfigService,
-            $this->createMock(RateLimitService::class),
+            $this->rateLimitService,
             $this->encryptionService,
             $this->createMock(MailHandlerLogService::class),
             $this->logger
         );
+    }
+
+    /**
+     * Build a handler + prompt/model mocks shared by the routing budget tests.
+     *
+     * @return InboundEmailHandler handler with two departments (support = default)
+     */
+    private function setUpRoutingHandler(): InboundEmailHandler
+    {
+        $handler = new InboundEmailHandler();
+        $handler->setUserId(42);
+        $handler->setDepartments([
+            ['email' => 'sales@example.com', 'rules' => 'Sales', 'isDefault' => false],
+            ['email' => 'support@example.com', 'rules' => 'Support', 'isDefault' => true],
+        ]);
+
+        $prompt = $this->createMock(\App\Entity\Prompt::class);
+        $prompt->method('getPrompt')->willReturn('Route this email to [TARGETLIST]');
+        $this->promptRepository->method('findByTopic')->willReturn($prompt);
+
+        $this->modelConfigService->method('getDefaultModel')->willReturn(5);
+        $this->modelConfigService->method('getProviderForModel')->willReturn('openai');
+        $this->modelConfigService->method('getModelName')->willReturn('gpt-4');
+
+        return $handler;
+    }
+
+    /**
+     * Issue #1177: when the handler owner is over their cost budget, the
+     * billable AI routing call must be skipped and the default department used.
+     */
+    public function testRouteEmailToDepartmentSkipsAiCallWhenOverCostBudget(): void
+    {
+        $handler = $this->setUpRoutingHandler();
+
+        $this->userRepository->method('find')->with(42)->willReturn($this->createMock(\App\Entity\User::class));
+        $this->rateLimitService->expects($this->once())
+            ->method('checkCostBudget')
+            ->willReturn(['allowed' => false, 'budget' => 0.01, 'used_cost' => 0.5]);
+
+        // The AI call must NOT happen when over budget.
+        $this->aiFacade->expects($this->never())->method('chat');
+        $this->rateLimitService->expects($this->never())->method('recordUsage');
+
+        $result = $this->service->routeEmailToDepartment($handler, 'Subject', 'Body');
+
+        $this->assertSame('support@example.com', $result, 'Over-budget routing must fall back to the default department');
+    }
+
+    /**
+     * Issue #1177: within budget, routing proceeds and usage is recorded.
+     */
+    public function testRouteEmailToDepartmentProceedsWhenWithinBudget(): void
+    {
+        $handler = $this->setUpRoutingHandler();
+
+        $this->userRepository->method('find')->with(42)->willReturn($this->createMock(\App\Entity\User::class));
+        $this->rateLimitService->expects($this->once())
+            ->method('checkCostBudget')
+            ->willReturn(['allowed' => true]);
+
+        $this->aiFacade->expects($this->once())
+            ->method('chat')
+            ->willReturn(['content' => 'sales@example.com', 'provider' => 'openai', 'model' => 'gpt-4', 'usage' => []]);
+        $this->rateLimitService->expects($this->once())->method('recordUsage');
+
+        $result = $this->service->routeEmailToDepartment($handler, 'Subject', 'Body');
+
+        $this->assertSame('sales@example.com', $result);
+    }
+
+    /**
+     * Issue #1177: a deleted/unknown owner must not trigger a billable AI call.
+     */
+    public function testRouteEmailToDepartmentSkipsAiCallWhenOwnerMissing(): void
+    {
+        $handler = $this->setUpRoutingHandler();
+
+        $this->userRepository->method('find')->with(42)->willReturn(null);
+        $this->rateLimitService->expects($this->never())->method('checkCostBudget');
+        $this->aiFacade->expects($this->never())->method('chat');
+
+        $result = $this->service->routeEmailToDepartment($handler, 'Subject', 'Body');
+
+        $this->assertSame('support@example.com', $result);
     }
 
     public function testIsMaskedPasswordPlaceholder(): void

--- a/backend/tests/Unit/MessagePreProcessorTest.php
+++ b/backend/tests/Unit/MessagePreProcessorTest.php
@@ -369,6 +369,62 @@ class MessagePreProcessorTest extends TestCase
     }
 
     /**
+     * Issue #1190 — when a file's on-disk binary is missing but BFILETEXT is
+     * present (chat-generated file whose binary was lost), the preprocessor
+     * must NOT flag it as 'error'; the file is still usable from the DB text.
+     */
+    public function testProcessFileEntityKeepsStatusWhenBinaryMissingButTextPresent(): void
+    {
+        $file = $this->createMock(\App\Entity\File::class);
+        $file->method('getId')->willReturn(60);
+        $file->method('getFilePath')->willReturn('does/not/exist.docx');
+        $file->method('getFileType')->willReturn('docx');
+        $file->method('getFileText')->willReturn('Recoverable markdown body');
+        $file->method('getStatus')->willReturn('generated');
+        $file->method('getUserId')->willReturn(7);
+
+        // Status must not be downgraded to 'error' for a recoverable file.
+        $file->expects($this->never())->method('setStatus');
+
+        $files = new \Doctrine\Common\Collections\ArrayCollection([$file]);
+        $message = $this->createMock(Message::class);
+        $message->method('getFile')->willReturn(0);
+        $message->method('getFilePath')->willReturn('');
+        $message->method('getFiles')->willReturn($files);
+        $message->method('getUserId')->willReturn(7);
+
+        $this->messageRepository->method('save');
+
+        $this->service->process($message);
+    }
+
+    /**
+     * Issue #1190 — a missing binary with NO recoverable text is a genuine
+     * error and must still be flagged as such.
+     */
+    public function testProcessFileEntityMarksErrorWhenBinaryMissingAndNoText(): void
+    {
+        $file = $this->createMock(\App\Entity\File::class);
+        $file->method('getId')->willReturn(61);
+        $file->method('getFilePath')->willReturn('does/not/exist.docx');
+        $file->method('getFileType')->willReturn('docx');
+        $file->method('getFileText')->willReturn('');
+
+        $file->expects($this->atLeastOnce())->method('setStatus')->with('error');
+
+        $files = new \Doctrine\Common\Collections\ArrayCollection([$file]);
+        $message = $this->createMock(Message::class);
+        $message->method('getFile')->willReturn(0);
+        $message->method('getFilePath')->willReturn('');
+        $message->method('getFiles')->willReturn($files);
+        $message->method('getUserId')->willReturn(7);
+
+        $this->messageRepository->method('save');
+
+        $this->service->process($message);
+    }
+
+    /**
      * Issue #954 — '.md', '.csv', and '.ppt' uploads must be routed through
      * FileProcessor like every other document type. Before the fix they were
      * missing from DOCUMENT_EXTENSIONS, so the preprocessor silently skipped

--- a/backend/tests/Unit/MessagePreProcessorTest.php
+++ b/backend/tests/Unit/MessagePreProcessorTest.php
@@ -309,6 +309,66 @@ class MessagePreProcessorTest extends TestCase
     }
 
     /**
+     * Issue #1191 — re-attaching an already-vectorized file (BFILETEXT
+     * present) must NOT downgrade its status to 'processed'. The Qdrant
+     * vectors are still valid, so flipping the DB status to 'processed' would
+     * make the two stores inconsistent.
+     */
+    public function testProcessFileEntityDoesNotDowngradeVectorizedStatusOnReAttach(): void
+    {
+        $tempDir = sys_get_temp_dir();
+        $tempFile = $tempDir.'/test_vec_'.uniqid().'.pdf';
+        touch($tempFile);
+
+        try {
+            $file = $this->createMock(\App\Entity\File::class);
+            $file->method('getId')->willReturn(55);
+            $file->method('getFilePath')->willReturn(basename($tempFile));
+            $file->method('getFileType')->willReturn('pdf');
+            $file->method('getFileName')->willReturn('kb.pdf');
+            $file->method('getFileSize')->willReturn(2048);
+            $file->method('getFileText')->willReturn('Vectorized knowledge contents');
+            $file->method('getUserId')->willReturn(7);
+            $file->method('getStatus')->willReturn('vectorized');
+
+            // The status must never be touched for an already-vectorized file.
+            $file->expects($this->never())->method('setStatus');
+
+            // Owner not resolvable → billing is a no-op (keeps the test focused).
+            $this->userRepository->method('find')->with(7)->willReturn(null);
+
+            $files = new \Doctrine\Common\Collections\ArrayCollection([$file]);
+            $message = $this->createMock(Message::class);
+            $message->method('getFile')->willReturn(0);
+            $message->method('getFilePath')->willReturn('');
+            $message->method('getFiles')->willReturn($files);
+            $message->method('getUserId')->willReturn(7);
+
+            $this->fileProcessor->expects($this->never())->method('extractText');
+
+            $service = new MessagePreProcessor(
+                $this->messageRepository,
+                $this->tikaClient,
+                $this->whisperService,
+                $this->aiFacade,
+                $this->logger,
+                $tempDir,
+                $this->rateLimitService,
+                $this->userRepository,
+                $this->fileProcessor,
+            );
+
+            $this->messageRepository->method('save');
+
+            $service->process($message);
+        } finally {
+            if (file_exists($tempFile)) {
+                unlink($tempFile);
+            }
+        }
+    }
+
+    /**
      * Issue #954 — '.md', '.csv', and '.ppt' uploads must be routed through
      * FileProcessor like every other document type. Before the fix they were
      * missing from DOCUMENT_EXTENSIONS, so the preprocessor silently skipped

--- a/backend/tests/Unit/ModelConfigServiceTest.php
+++ b/backend/tests/Unit/ModelConfigServiceTest.php
@@ -524,7 +524,10 @@ class ModelConfigServiceTest extends TestCase
 
     public function testGetEffectiveUserIdForMessageWithEmailChannelNoKeyword(): void
     {
-        // Mock message with email channel but no keyword (smart@synaplan.net)
+        // Regression test for issue #1176: a keyword-less email from an
+        // identified sender (smart@synaplan.net) must use the SENDER'S own
+        // user id for model selection — same as web chat — not the legacy
+        // hardcoded user ID 2.
         $message = $this->createMock(\App\Entity\Message::class);
         $message->method('getUserId')->willReturn(20);
         $message->method('getMeta')
@@ -533,7 +536,7 @@ class ModelConfigServiceTest extends TestCase
                     return 'email';
                 }
                 if ('email_keyword' === $key) {
-                    return null; // No keyword, so should use user ID 2
+                    return null; // No keyword (smart@synaplan.net)
                 }
 
                 return null;
@@ -546,7 +549,11 @@ class ModelConfigServiceTest extends TestCase
 
         $result = $this->service->getEffectiveUserIdForMessage($message);
 
-        $this->assertEquals(2, $result, 'Email channel without keyword should return user ID 2');
+        $this->assertEquals(
+            20,
+            $result,
+            'Email channel without keyword must return the sender\'s own userId (issue #1176)'
+        );
     }
 
     public function testGetEffectiveUserIdForMessageWithNullChannel(): void

--- a/backend/tests/Unit/Service/File/DocumentGeneratorServiceTest.php
+++ b/backend/tests/Unit/Service/File/DocumentGeneratorServiceTest.php
@@ -56,6 +56,44 @@ class DocumentGeneratorServiceTest extends TestCase
         $this->assertTrue($this->isZipContaining($path, 'word/document.xml'));
     }
 
+    /**
+     * Issue #1196: LLMs emit bare `<br>` inside markdown table cells. PhpWord's
+     * XML parser rejects the unclosed tag and silently produced a structurally
+     * valid but EMPTY DOCX (no <w:t> runs). The generator must now self-close
+     * void tags so the table content survives.
+     */
+    public function testDocxWithBrInTableCellContainsText(): void
+    {
+        $path = $this->tmpDir.'/table_br.docx';
+        $content = "| Day | Exercise |\n| --- | --- |\n| 1 | Bench press<br>Pull-ups |";
+        $this->service->write($content, 'docx', $path);
+
+        $documentXml = $this->readDocxDocument($path);
+        $this->assertStringContainsString('<w:t', $documentXml, 'DOCX with <br> in a table cell must contain text runs');
+        $this->assertStringContainsString('Bench press', $documentXml);
+        $this->assertStringContainsString('Pull-ups', $documentXml);
+    }
+
+    /**
+     * Issue #1196 (defense in depth): even pathological HTML must never yield a
+     * blank-but-valid DOCX — the post-write assertion rebuilds from plain text.
+     */
+    public function testDocxAlwaysContainsTextForNonEmptyContent(): void
+    {
+        $path = $this->tmpDir.'/pathological.docx';
+        $content = "Line one<br>Line two\n\n| a | b |\n| --- | --- |\n| x<br>y | z |";
+        $this->service->write($content, 'docx', $path);
+
+        $documentXml = $this->readDocxDocument($path);
+        $this->assertStringContainsString('<w:t', $documentXml, 'A non-empty source must always yield a non-empty DOCX body');
+    }
+
+    public function testWriteDocxThrowsOnEmptyContent(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->service->write("   \n  ", 'docx', $this->tmpDir.'/empty.docx');
+    }
+
     public function testXlsxIsValidOoxmlZip(): void
     {
         $path = $this->tmpDir.'/test.xlsx';
@@ -90,6 +128,17 @@ class DocumentGeneratorServiceTest extends TestCase
         $this->service->write($content, 'md', $path);
 
         $this->assertSame($content, file_get_contents($path));
+    }
+
+    private function readDocxDocument(string $path): string
+    {
+        $zip = new \ZipArchive();
+        $this->assertTrue(true === $zip->open($path), 'DOCX must be a valid OOXML zip');
+        $xml = $zip->getFromName('word/document.xml');
+        $zip->close();
+        $this->assertNotFalse($xml, 'DOCX must contain word/document.xml');
+
+        return (string) $xml;
     }
 
     private function isZipContaining(string $path, string $entry): bool

--- a/backend/tests/Unit/Service/Multitask/Execution/ResultAssemblerTest.php
+++ b/backend/tests/Unit/Service/Multitask/Execution/ResultAssemblerTest.php
@@ -135,6 +135,55 @@ final class ResultAssemblerTest extends TestCase
         $this->assertSame('skipped', $n2['state']);
     }
 
+    /**
+     * Issue #1197: when the reply node is `compose_reply` (no provider meta of
+     * its own), the assembler must backfill provider/model/model_id from the
+     * upstream LLM node so StreamController persists the real inference
+     * provider (e.g. groq) and the chat bubble shows the correct avatar.
+     */
+    public function testProviderMetadataPropagatedFromUpstreamNodeToReply(): void
+    {
+        $plan = $this->plan();
+        $ctx = $this->context();
+
+        $ctx->setResult('n1', NodeResult::ok('Summary text', [], [
+            'provider' => 'groq',
+            'model' => 'gpt-oss-120b',
+            'model_id' => 76,
+        ]));
+        $ctx->setResult('n2', NodeResult::ok(null, [['path' => 'uploads/tts.mp3', 'type' => 'audio']]));
+        // compose_reply reply node carries no provider metadata.
+        $ctx->setResult('n3', NodeResult::ok('Summary text', [['path' => 'uploads/tts.mp3', 'type' => 'audio']]));
+
+        $result = $this->assembler->assemble($plan, $ctx);
+
+        $this->assertSame('groq', $result['metadata']['provider']);
+        $this->assertSame('gpt-oss-120b', $result['metadata']['model']);
+        $this->assertSame(76, $result['metadata']['model_id']);
+    }
+
+    /**
+     * Issue #1197: an explicit provider on the reply node must NOT be
+     * overwritten by the upstream backfill.
+     */
+    public function testReplyNodeProviderNotOverriddenByBackfill(): void
+    {
+        $plan = $this->plan();
+        $ctx = $this->context();
+
+        $ctx->setResult('n1', NodeResult::ok('Summary text', [], ['provider' => 'groq', 'model' => 'gpt-oss-120b']));
+        $ctx->setResult('n2', NodeResult::ok(null, [['path' => 'uploads/tts.mp3', 'type' => 'audio']]));
+        $ctx->setResult('n3', NodeResult::ok('Summary text', [['path' => 'uploads/tts.mp3', 'type' => 'audio']], [
+            'provider' => 'anthropic',
+            'model' => 'claude-opus',
+        ]));
+
+        $result = $this->assembler->assemble($plan, $ctx);
+
+        $this->assertSame('anthropic', $result['metadata']['provider']);
+        $this->assertSame('claude-opus', $result['metadata']['model']);
+    }
+
     private function searchPlan(): TaskPlan
     {
         return TaskPlan::fromArray([

--- a/backend/tests/Unit/Service/Multitask/TaskPlanExecutorTest.php
+++ b/backend/tests/Unit/Service/Multitask/TaskPlanExecutorTest.php
@@ -256,6 +256,61 @@ final class TaskPlanExecutorTest extends TestCase
         self::assertSame(['content' => 'router answer'], $result);
     }
 
+    public function testFileAttachmentMultiIntentRunsDag(): void
+    {
+        // Issue #1192: a non-image attachment carrying multiple intents
+        // (summarize + image + TTS) must be planned, not reduced to a lone
+        // file analysis. A multi-node plan runs the DAG.
+        $multiNode = TaskPlan::fromArray([
+            'version' => 1, 'language' => 'en', 'reply_node' => 'n4',
+            'tasks' => [
+                ['id' => 'n1', 'capability' => 'file_analysis'],
+                ['id' => 'n2', 'capability' => 'summarize', 'depends_on' => ['n1']],
+                ['id' => 'n3', 'capability' => 'image_generation', 'depends_on' => ['n2']],
+                ['id' => 'n4', 'capability' => 'compose_reply', 'depends_on' => ['n2', 'n3']],
+            ],
+        ]);
+        $this->planner->expects(self::once())->method('plan')->willReturn(new TaskPlanResult($multiNode, fallback: false, modelId: 76));
+        $this->dagExecutor->method('execute')->willReturn($this->assembled([
+            'content' => 'Here is your summary and image',
+            'files' => [['path' => '/api/v1/files/uploads/img.png', 'type' => 'image']],
+            'node_statuses' => ['n1' => 'done', 'n2' => 'done', 'n3' => 'done', 'n4' => 'done'],
+        ]));
+
+        // The legacy single-node router must NOT be used for a multi-node plan.
+        $this->router->expects(self::never())->method('routeStream');
+
+        $result = $this->executor->executeStream(
+            $this->message(),
+            [],
+            ['intent' => 'file_analysis', 'topic' => 'analyzefile', 'language' => 'en', 'source' => 'attachment_document_or_audio'],
+            static function (): void {},
+        );
+
+        self::assertSame('Here is your summary and image', $result['content']);
+        self::assertSame('image', $result['metadata']['file']['type']);
+    }
+
+    public function testSingleIntentFileAttachmentDelegatesToLegacyRouter(): void
+    {
+        // Issue #1192: a single-intent attachment still degrades to the proven
+        // single-node path — the planner returns a single-node plan and the
+        // legacy router answers (no DAG, behaviour preserved).
+        $this->planner->expects(self::once())->method('plan')
+            ->willReturn(new TaskPlanResult(TaskPlan::singleChatPlan('en'), fallback: true, modelId: 76));
+        $this->dagExecutor->expects(self::never())->method('execute');
+        $this->router->expects(self::once())->method('routeStream')->willReturn(['content' => 'file summary']);
+
+        $result = $this->executor->executeStream(
+            $this->message(),
+            [],
+            ['intent' => 'file_analysis', 'topic' => 'analyzefile', 'language' => 'en', 'source' => 'attachment_document_or_audio'],
+            static function (): void {},
+        );
+
+        self::assertSame(['content' => 'file summary'], $result);
+    }
+
     public function testSingleCalendarEventNodeRunsDagNotLegacyRouter(): void
     {
         // A lone calendar_event has NO legacy router equivalent — running it

--- a/frontend/src/components/ChatMessage.vue
+++ b/frontend/src/components/ChatMessage.vue
@@ -1265,7 +1265,11 @@ const displayProvider = computed(() => {
   if (legacy && !isChannelSource(legacy)) {
     return legacy
   }
-  return 'OpenAI'
+  // Issue #1197: when no provider metadata is available, fall back to a
+  // neutral avatar (ServiceIcon renders a generic robot icon for an empty
+  // service) instead of hardcoding OpenAI, which mislabels replies served by
+  // other providers (e.g. Groq).
+  return ''
 })
 
 // Real AI provider/model values for the legacy popover row. Hides

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -1970,6 +1970,7 @@
     "status_vectorized": "Bereit",
     "status_error": "Fehler",
     "status_processed": "Verarbeitet",
+    "status_generated": "Generiert",
     "attached": "Angehängt",
     "standalone": "Eigenständig",
     "attachedToMessage": "Diese Datei ist an eine Nachricht angehängt",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -732,6 +732,7 @@
     "status_vectorized": "Ready",
     "status_error": "Error",
     "status_processed": "Processed",
+    "status_generated": "Generated",
     "attached": "Attached",
     "standalone": "Standalone",
     "attachedToMessage": "This file is attached to a message",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -1467,6 +1467,7 @@
     "status_vectorizing": "Indexando…",
     "status_vectorized": "Vectorizado",
     "status_processed": "Procesado",
+    "status_generated": "Generado",
     "attached": "Adjunto",
     "standalone": "Independiente",
     "attachedToMessage": "Este archivo está adjunto a un mensaje",

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -1468,6 +1468,7 @@
     "status_vectorizing": "İndeksleniyor…",
     "status_vectorized": "Vektörleştirildi",
     "status_processed": "İşlendi",
+    "status_generated": "Oluşturuldu",
     "attached": "Ekli",
     "standalone": "Bağımsız",
     "attachedToMessage": "Bu dosya bir mesaja ekli",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Fixes the 7 most recently filed open issues in one bug-bash branch — a mix of routing, file generation, mail-handler, and chat-UI defects. Each commit references its issue so they auto-close on merge.

## Changes
- **#1176 — Email channel hardcoded user ID 2** (`ModelConfigService`): keyword-less email now resolves the AI model from the *sender's own* config (same as web chat) instead of a hardcoded user ID 2. Unmapped senders are already filtered out by the null-userId guard.
- **#1177 — Mail handler had no cost gate** (`InboundEmailHandlerService`): added a `RateLimitService::checkCostBudget()` pre-flight before the billable routing AI call (mirroring `MessageController`/`StreamController`); over-budget or unknown owners fall back to the default department.
- **#1190 — Generated files broke when on-disk binary was missing**: `MessagePreProcessor` no longer flags such files as `error` when `BFILETEXT` is present; `FileController::downloadFile` regenerates the binary from `BFILETEXT` via `DocumentGeneratorService` instead of a dead-end 404; `StreamController` now tags generated office files with `source='generated'`.
- **#1191 — Missing `files.status_generated` key + status downgrade**: added the locale key to en/de/es/tr; `MessagePreProcessor` no longer downgrades an already `vectorized`/`processed` file to `processed` on re-attach.
- **#1196 — Empty DOCX from `<br>` in markdown table cells** (`DocumentGeneratorService`): self-close void tags (`<br>`/`<hr>`/`<img>`) before `WordHtml::addHtml`, plus a post-write assertion that the DOCX contains text runs (rebuilds from a plain-text fallback otherwise); refuse to persist whitespace-only generated content.
- **#1197 — Wrong provider avatar on multitask replies**: `ResultAssembler` backfills `provider`/`model`/`model_id` from the last successful upstream LLM node when the `compose_reply` reply node carries none, so the real inference provider (e.g. Groq) is persisted; `ChatMessage.vue` falls back to a neutral robot avatar instead of hardcoding OpenAI.
- **#1192 — Multitask planning bypassed when files attached** (`TaskPlanExecutor`): non-image attachments (`attachment_document_or_audio`) are now sent to the planner too, so multi-intent messages ("summarize this DOCX, make an image and read it aloud") get a DAG. Single-intent attachments still degrade to the proven legacy single-node path (identical behaviour).

## Verification
- [x] Tests added/updated
- [x] Manual (reproduced the empty-DOCX bug before/after; confirmed `<br>`-in-table now yields text runs)

Set up a full native toolchain (PHP 8.4 + Composer, MariaDB 11.8 with VECTOR, Redis, frontend deps + generated schemas) since Docker was unavailable, and ran the complete pre-commit gate:
- Backend: `php-cs-fixer` lint **0 issues**; PHPUnit **2393 tests, 0 failures**; PHPStan clean except 3 pre-existing `TritonProvider` protobuf-runtime errors that only appear without the base image's protobuf stubs (untouched by this PR, green in CI).
- Frontend: ESLint **0 issues**; `vue-tsc` **0 errors**; Vitest **780 tests passing**.
- Routing characterization snapshots: **no drift** (144 tests pass), confirming the #1192 change preserves single-intent behaviour.

## Notes
Closes #1176, #1177, #1190, #1191, #1192, #1196, #1197.

`#1192` is the only behaviour-changing routing fix: it adds planner latency to non-image attachment turns (gated by `MULTITASK_ROUTING_ENABLED`). It is deliberately conservative — only genuinely multi-intent attachment messages take the DAG; everything else keeps the exact legacy path. Happy to drop that commit if you'd prefer to keep the conservative single-node path for attachments.

## Screenshots/Logs
DOCX repro before/after the #1196 fix (markdown table cell with `<br>`):
```
before:  br_in_cell  size=7286  text=NO
after:   br_in_cell  size=7435  text=YES
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c2c879ea-fb3b-4d18-b233-db517177b435"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c2c879ea-fb3b-4d18-b233-db517177b435"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

