### PR TITLE
Hotfix/prio1 issues 20260630

### DIFF
--- a/backend/composer.lock
+++ b/backend/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7df5f9dd17308c23b9be3cebc2683ffe",
+    "content-hash": "dccb623fbda6dd95b5d64c343cb556ca",
     "packages": [
         {
             "name": "api-platform/doctrine-common",

--- a/backend/src/Controller/ChatController.php
+++ b/backend/src/Controller/ChatController.php
@@ -6,7 +6,6 @@ use App\Entity\Chat;
 use App\Entity\User;
 use App\Repository\ChatRepository;
 use App\Repository\MessageRepository;
-use App\Service\File\DataUrlFixer;
 use App\Service\File\OgImageService;
 use App\Service\Message\MessageApiFormatter;
 use App\Service\WidgetSessionService;
@@ -28,7 +27,6 @@ class ChatController extends AbstractController
         private ChatRepository $chatRepository,
         private MessageRepository $messageRepository,
         private WidgetSessionService $widgetSessionService,
-        private DataUrlFixer $dataUrlFixer,
         private OgImageService $ogImageService,
         private MessageApiFormatter $messageApiFormatter,
         private LoggerInterface $logger,
@@ -553,36 +551,16 @@ class ChatController extends AbstractController
             ['unixTimestamp' => 'ASC']
         );
 
-        $messageData = array_map(function ($m) {
-            $data = [
-                'id' => $m->getId(),
-                'text' => $m->getText(),
-                'direction' => $m->getDirection(),
-                'timestamp' => $m->getUnixTimestamp(),
-                'provider' => $m->getProviderIndex(),
-                'topic' => $m->getTopic(),
-                'originalTopic' => $m->getMeta('original_topic'),
-                'originalMediaType' => $m->getMeta('original_media_type'),
-                'language' => $m->getLanguage(),
-            ];
-
-            // Include file information if present
-            if ($m->getFile() && $m->getFilePath()) {
-                // Fix data URL to file if needed (legacy migration)
-                $filePath = $m->getFilePath();
-                if (str_starts_with($filePath, 'data:')) {
-                    $filePath = $this->dataUrlFixer->ensureFileOnDisk($m);
-                }
-                if ($filePath) {
-                    $data['file'] = [
-                        'path' => $filePath,
-                        'type' => $m->getFileType(),
-                    ];
-                }
-            }
-
-            return $data;
-        }, $messages);
+        // Issue #1175: serialize shared messages through the canonical
+        // MessageApiFormatter (same as the authenticated history endpoint)
+        // so user-uploaded file attachments (the File entity M2M relation,
+        // exposed as `files[]`) are visible to viewers — the previous inline
+        // serializer only emitted the legacy single `file` field, so uploads
+        // silently disappeared in the shared view.
+        $messageData = array_map(
+            fn ($m) => $this->messageApiFormatter->format($m),
+            $messages
+        );
 
         return $this->json([
             'success' => true,

--- a/backend/src/Controller/StreamController.php
+++ b/backend/src/Controller/StreamController.php
@@ -2518,6 +2518,20 @@ class StreamController extends AbstractController
         }
 
         try {
+            // Issue #1170: a document-generation node persists its File via
+            // ChatHandler::storeGeneratedFile() (with the clean display name)
+            // BEFORE this runs. Re-registering the same on-disk file here would
+            // create a second File row pointing at the identical path, so the
+            // file shows up twice on the Files page. Reuse the existing row
+            // instead — it already carries the nicer display name.
+            $existing = $this->em->getRepository(File::class)->findOneBy([
+                'userId' => $userId,
+                'filePath' => $relativePath,
+            ]);
+            if ($existing instanceof File) {
+                return $existing;
+            }
+
             $absolutePath = $this->uploadDir.'/'.$relativePath;
             $fileSize = is_file($absolutePath) ? (filesize($absolutePath) ?: 0) : 0;
             $extension = strtolower(pathinfo($relativePath, PATHINFO_EXTENSION));

--- a/backend/src/Service/Message/Handler/FileAnalysisHandler.php
+++ b/backend/src/Service/Message/Handler/FileAnalysisHandler.php
@@ -7,6 +7,7 @@ use App\Entity\File;
 use App\Entity\Message;
 use App\Service\Message\MessagePreProcessor;
 use App\Service\ModelConfigService;
+use App\Service\Prompt\LanguageDirectiveBuilder;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
@@ -386,6 +387,7 @@ final readonly class FileAnalysisHandler implements MessageHandlerInterface
         $this->notify($progressCallback, 'generating', 'Replying to voice message...');
 
         $prompts = $this->buildAudioConversationalPrompt($audioFiles, $userPrompt);
+        $prompts['system'] .= $this->buildLanguageDirective($classification);
 
         $effectiveUserId = $this->modelConfigService->getEffectiveUserIdForMessage($message);
         $modelId = $classification['model_id']
@@ -477,6 +479,7 @@ final readonly class FileAnalysisHandler implements MessageHandlerInterface
         $this->notify($progressCallback, 'generating', 'Replying to voice message...');
 
         $prompts = $this->buildAudioConversationalPrompt($audioFiles, $userPrompt);
+        $prompts['system'] .= $this->buildLanguageDirective($classification);
 
         $effectiveUserId = $this->modelConfigService->getEffectiveUserIdForMessage($message);
         $modelId = $classification['model_id']
@@ -568,7 +571,7 @@ final readonly class FileAnalysisHandler implements MessageHandlerInterface
             count($documents) > 1 ? 'Analyzing document contents...' : 'Analyzing document content...',
         );
 
-        $systemPrompt = $this->buildDocumentsSystemPrompt($documents);
+        $systemPrompt = $this->buildDocumentsSystemPrompt($documents).$this->buildLanguageDirective($classification);
         $finalPrompt = $this->buildDocumentsUserPrompt($userPrompt, $documents);
 
         // Model priority: Again model_id > Task-prompt aiModel > DB default (ANALYZE → CHAT)
@@ -660,7 +663,7 @@ final readonly class FileAnalysisHandler implements MessageHandlerInterface
             count($documents) > 1 ? 'Analyzing document contents...' : 'Analyzing document content...',
         );
 
-        $systemPrompt = $this->buildDocumentsSystemPrompt($documents);
+        $systemPrompt = $this->buildDocumentsSystemPrompt($documents).$this->buildLanguageDirective($classification);
         $finalPrompt = $this->buildDocumentsUserPrompt($userPrompt, $documents);
 
         // Model priority: Again model_id > Task-prompt aiModel > DB default (ANALYZE → CHAT)
@@ -829,7 +832,7 @@ final readonly class FileAnalysisHandler implements MessageHandlerInterface
             'image_count' => count($images),
         ]);
 
-        $perImage = $this->analyzeImageBatch($message, $images, $userPrompt, $provider, $modelName, $progressCallback);
+        $perImage = $this->analyzeImageBatch($message, $images, $userPrompt, $provider, $modelName, $progressCallback, $this->buildLanguageDirective($classification));
         $content = $this->combineImageAnalyses($perImage, $images);
 
         $this->notify($progressCallback, 'complete', 'Analysis complete.');
@@ -903,12 +906,17 @@ final readonly class FileAnalysisHandler implements MessageHandlerInterface
         ?string $provider,
         ?string $modelName,
         ?callable $progressCallback,
+        string $languageDirective = '',
     ): array {
         $perImagePrompt = !empty($userPrompt)
             ? $userPrompt
             : (count($images) > 1
                 ? 'Please describe this image in detail. The user uploaded several images in the same message — describe each one independently.'
                 : 'Please describe this image in detail.');
+
+        // Respond in the conversation language instead of defaulting to
+        // English for image descriptions (issue #1163).
+        $perImagePrompt .= $languageDirective;
 
         $results = [];
 
@@ -1564,6 +1572,30 @@ final readonly class FileAnalysisHandler implements MessageHandlerInterface
         }
 
         return ltrim($path, '/');
+    }
+
+    /**
+     * Build a language directive from the detected conversation language so
+     * file-analysis replies match the user's language instead of defaulting
+     * to English (issue #1163). Mirrors ChatHandler's use of
+     * LanguageDirectiveBuilder, including the anti-echo clause. Returns an
+     * empty string when no language was classified, leaving prompts unchanged.
+     *
+     * @param array<string, mixed> $classification
+     */
+    private function buildLanguageDirective(array $classification): string
+    {
+        $language = is_string($classification['language'] ?? null)
+            ? trim($classification['language'])
+            : '';
+
+        if ('' === $language) {
+            return '';
+        }
+
+        return 'auto' === $language
+            ? LanguageDirectiveBuilder::buildAutoDirective()
+            : LanguageDirectiveBuilder::buildForLanguage($language);
     }
 
     /**

--- a/backend/src/Service/Message/Handler/MediaGenerationHandler.php
+++ b/backend/src/Service/Message/Handler/MediaGenerationHandler.php
@@ -719,6 +719,18 @@ final readonly class MediaGenerationHandler implements MessageHandlerInterface
                     );
                 }
 
+                // Stop button / disconnect support for the blocking image path
+                // (issue #1155). Mirrors the video path above: probe the shared
+                // cancellation store plus connection_aborted() so providers that
+                // poll for the result (e.g. fal/HuggingFace) abort mid-flight
+                // instead of running an unwanted generation to completion. For
+                // single-shot providers it is a harmless no-op. Only applied on
+                // the synchronous path — never serialized into an async job.
+                $cancelCheck = $this->buildCancelCheck($options);
+                if (null !== $cancelCheck) {
+                    $imageOptions['cancel_check'] = $cancelCheck;
+                }
+
                 $result = $this->aiFacade->generateImage(
                     $prompt,
                     $message->getUserId(),

--- a/backend/src/Service/Multitask/Execution/Runner/Text2SoundRunner.php
+++ b/backend/src/Service/Multitask/Execution/Runner/Text2SoundRunner.php
@@ -10,6 +10,7 @@ use App\Service\Multitask\Execution\NodeResult;
 use App\Service\Multitask\Execution\TaskRunner;
 use App\Service\Multitask\Plan\Capability;
 use App\Service\Multitask\Plan\TaskNode;
+use App\Service\TtsTextSanitizer;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -38,6 +39,11 @@ final readonly class Text2SoundRunner implements TaskRunner
             $text = implode("\n\n", array_filter($text, 'is_string'));
         }
         $text = is_string($text) ? $text : (string) $context->message->getText();
+
+        // Strip markdown, <think> blocks, [Memory:ID] badges and other
+        // non-speakable artifacts before TTS (issue #1164) — same treatment
+        // TtsController and StreamController already apply before synthesis.
+        $text = TtsTextSanitizer::sanitize($text);
 
         if ('' === trim($text)) {
             return NodeResult::failed('no text to synthesize');

--- a/frontend/src/utils/messageMapper.ts
+++ b/frontend/src/utils/messageMapper.ts
@@ -386,6 +386,7 @@ export function mapApiMessageRow(m: ApiLoadedMessageRow): Message {
   // media parts in the bubble (same dedup logic as reconcileLocalMessage).
   let taskPlanState: TaskPlanState | null = null
   const cardMediaUrls = new Set<string>()
+  const cardTexts = new Set<string>()
   if (m.taskPlan && m.taskPlan.cards.length > 0) {
     const cards = m.taskPlan.cards.map((c) => {
       const kind: TaskCardKind = isTaskCardKind(c.kind) ? c.kind : 'text'
@@ -394,6 +395,10 @@ export function mapApiMessageRow(m: ApiLoadedMessageRow): Message {
       if (c.url) {
         cardUrl = normalizeMediaUrl(buildUploadUrl(c.url))
         cardMediaUrls.add(mediaUrlKey(cardUrl))
+      }
+      const cardText = (c.text ?? '').trim()
+      if (cardText) {
+        cardTexts.add(normalizeCardText(cardText))
       }
       return {
         nodeId: c.nodeId,
@@ -418,12 +423,24 @@ export function mapApiMessageRow(m: ApiLoadedMessageRow): Message {
 
   // Remove any plain-media parts whose URL already appears on a restored card
   // so the user sees each piece of media exactly once (card is the primary surface).
-  const deduplicatedParts =
-    cardMediaUrls.size > 0
-      ? parts.filter(
-          (p) => !(isMediaPartType(p.type) && p.url && cardMediaUrls.has(mediaUrlKey(p.url)))
-        )
-      : parts
+  //
+  // Issue #1165: also drop text parts whose content is identical to a card's
+  // text. On reload `ResultAssembler` persists the reply-node output both as
+  // the message `content` AND inside the task cards, so a node's text would
+  // otherwise appear twice (once in the card, once in the body below it). The
+  // card is the primary surface, so the duplicated body text is removed.
+  const needsDedup = cardMediaUrls.size > 0 || cardTexts.size > 0
+  const deduplicatedParts = needsDedup
+    ? parts.filter((p) => {
+        if (isMediaPartType(p.type) && p.url && cardMediaUrls.has(mediaUrlKey(p.url))) {
+          return false
+        }
+        if (p.type === 'text' && p.content && cardTexts.has(normalizeCardText(p.content))) {
+          return false
+        }
+        return true
+      })
+    : parts
 
   // Reconstruct tool metadata from topic field for user messages
   // Also clean command prefix from message content
@@ -501,6 +518,16 @@ function mediaUrlKey(url: string): string {
   } catch {
     return url
   }
+}
+
+/**
+ * Comparison key for card vs. body text dedup (issue #1165). The persisted
+ * message `content` and a card's `text` come from the same node output but can
+ * differ in trailing/leading whitespace or newline runs, so both sides are
+ * trimmed and inner whitespace is collapsed before comparison.
+ */
+function normalizeCardText(text: string): string {
+  return text.trim().replace(/\s+/g, ' ')
 }
 
 /**

--- a/frontend/src/views/SharedChatView.vue
+++ b/frontend/src/views/SharedChatView.vue
@@ -227,6 +227,54 @@
                 <MessageVideo v-if="message.file.type === 'video'" :url="message.file.path" />
               </div>
 
+              <!-- User-uploaded attachments (issue #1175): rendered from the
+                   File entity relation via public upload URLs, so shared-chat
+                   viewers see images/PDFs/audio uploaded by the chat owner. -->
+              <div
+                v-if="message.files && message.files.length"
+                class="mt-3 space-y-3"
+                data-testid="section-shared-attachments"
+              >
+                <template v-for="file in message.files" :key="file.id">
+                  <MessageImage
+                    v-if="isImageFileType(file.fileType, file.fileMime)"
+                    :url="buildUploadUrl(file.filePath)"
+                    :alt="file.filename"
+                  />
+                  <MessageVideo
+                    v-else-if="isVideoFileType(file.fileType, file.fileMime)"
+                    :url="buildUploadUrl(file.filePath)"
+                  />
+                  <MessageAudio
+                    v-else-if="isAudioFileType(file.fileType, file.fileMime)"
+                    :url="buildUploadUrl(file.filePath)"
+                  />
+                  <a
+                    v-else
+                    :href="buildUploadUrl(file.filePath)"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="inline-flex items-center gap-2 px-3 py-2 rounded-lg surface-chip txt-primary text-sm font-medium hover-surface transition-colors"
+                    data-testid="link-shared-attachment"
+                  >
+                    <svg
+                      class="w-4 h-4 flex-shrink-0"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13"
+                      />
+                    </svg>
+                    <span class="truncate max-w-[12rem]">{{ file.filename }}</span>
+                  </a>
+                </template>
+              </div>
+
               <!-- Topic Badge -->
               <div v-if="message.topic" class="mt-3 flex items-center gap-2 flex-wrap">
                 <span
@@ -309,14 +357,34 @@ import { useI18n } from 'vue-i18n'
 import { useDateFormat } from '@/composables/useDateFormat'
 import MessageImage from '../components/MessageImage.vue'
 import MessageVideo from '../components/MessageVideo.vue'
+import MessageAudio from '../components/MessageAudio.vue'
 import MessageCode from '../components/MessageCode.vue'
 import MessageText from '../components/MessageText.vue'
 import BrandAttribution from '../components/BrandAttribution.vue'
+import {
+  buildUploadUrl,
+  isAudioFileType,
+  isImageFileType,
+  isVideoFileType,
+} from '@/utils/mediaTypes'
 import { useConfigStore } from '@/stores/config'
 import { httpClient } from '@/services/api/httpClient'
 import { z } from 'zod'
 import { supportedLanguages, type SupportedLanguage } from '@/i18n'
 import { parseAIResponse } from '@/utils/responseParser'
+
+// Issue #1175: user-uploaded attachments travel on the File entity M2M
+// relation, serialized by MessageApiFormatter as `files[]`. The shared
+// endpoint now returns them so viewers can see uploaded images, PDFs, audio,
+// etc. — not just the legacy single AI-generated `file`.
+const SharedChatFileSchema = z.object({
+  id: z.number(),
+  filename: z.string(),
+  fileType: z.string(),
+  filePath: z.string(),
+  fileSize: z.number().nullable().optional(),
+  fileMime: z.string().nullable().optional(),
+})
 
 const SharedChatMessageSchema = z.object({
   id: z.number(),
@@ -331,7 +399,9 @@ const SharedChatMessageSchema = z.object({
       path: z.string(),
       type: z.string(),
     })
+    .nullable()
     .optional(),
+  files: z.array(SharedChatFileSchema).optional(),
 })
 
 const SharedChatPayloadSchema = z.object({
@@ -353,6 +423,15 @@ const loading = ref(true)
 const error = ref(false)
 const currentLang = ref<string>('en')
 
+interface SharedChatFile {
+  id: number
+  filename: string
+  fileType: string
+  filePath: string
+  fileSize?: number | null
+  fileMime?: string | null
+}
+
 interface Message {
   id: number
   text: string
@@ -364,7 +443,8 @@ interface Message {
   file?: {
     path: string
     type: string
-  }
+  } | null
+  files?: SharedChatFile[]
 }
 
 interface Chat {


### PR DESCRIPTION
## Summary
Fixing Prio 1

## Changes
Various bugs addressed from the issue list!

## Summary
- **#1164** TTS: sanitize text before multitask TTS synthesis (no more spoken markdown/`<think>`/`[Memory:ID]`)
- **#1163** File analysis: respond in the conversation language (documents, audio, images)
- **#1170** Files: dedupe generated document files so they don't appear twice
- **#1155** Media (prio:1): cancel blocking image generation on Stop/disconnect
- **#1165** Chat: dedupe task-card text from the message body on reload
- **#1175** Shared chat: show user-uploaded attachments to viewers
- 
## Verification
- [ ] Not tested (explain)
- [X] Manual
- [ ] Tests added/updated
