### PR TITLE
fix: detect stale vendor/ on dev startup via composer.lock hash

### DIFF
--- a/_devextras/backend/docker-entrypoint.d/10-composer-install.sh
+++ b/_devextras/backend/docker-entrypoint.d/10-composer-install.sh
@@ -1,17 +1,46 @@
 #!/bin/bash
 set -euo pipefail
 
+# Auto-install Composer dependencies when composer.lock changes.
+#
+# The backend source tree is bind-mounted from the host, so vendor/ persists
+# across container restarts. A simple "does vendor/ exist?" check misses the
+# case where someone pulls new code with updated composer.lock — the old
+# vendor/ is still there but stale, and missing packages (e.g. predis/predis)
+# cause silent runtime errors.
+#
+# We store an md5 fingerprint of composer.lock inside vendor/ after every
+# successful install. On the next boot we compare: if the fingerprint differs
+# (or is missing), we re-run `composer install`. When nothing changed, the
+# check is a single md5sum + file read — effectively free.
+
 echo "🔧 [dev] Checking Composer dependencies..."
 
-if [ ! -d "vendor" ] || [ ! -f "vendor/autoload.php" ]; then
-    echo "📦 [dev] Installing Composer dependencies..."
+if [ -f composer.lock ]; then
+    LOCK_HASH=$(md5sum composer.lock | cut -d' ' -f1)
+else
+    LOCK_HASH="missing"
+fi
+
+STORED_HASH=""
+if [ -f vendor/.composer_lock_hash ]; then
+    STORED_HASH=$(cat vendor/.composer_lock_hash)
+fi
+
+if [ ! -d vendor ] || [ ! -f vendor/autoload.php ] || [ "$LOCK_HASH" != "$STORED_HASH" ]; then
+    if [ -f vendor/autoload.php ] && [ "$LOCK_HASH" != "$STORED_HASH" ]; then
+        echo "📦 [dev] composer.lock changed — updating dependencies..."
+    else
+        echo "📦 [dev] Installing Composer dependencies..."
+    fi
     # Disable Composer's per-process timeout (default 300s). On Apple Silicon the
     # amd64 base image runs under qemu emulation, where unzipping large packages
     # (e.g. google/apiclient-services) easily exceeds 300s and aborts the install,
     # leaving vendor/ incomplete and crash-looping the container. 0 = no timeout.
     COMPOSER_PROCESS_TIMEOUT=0 composer install --no-interaction --prefer-dist --optimize-autoloader --no-scripts
+    echo "$LOCK_HASH" > vendor/.composer_lock_hash
     chown -R www-data:www-data vendor/ 2>/dev/null || true
     echo "✅ [dev] Composer dependencies installed"
 else
-    echo "✅ [dev] Composer dependencies already present"
+    echo "✅ [dev] Composer dependencies up to date"
 fi


### PR DESCRIPTION
## Summary

- The dev entrypoint script (`10-composer-install.sh`) only checked whether `vendor/` existed, not whether it matched the current `composer.lock`
- After `git pull` with new dependencies (e.g. `predis/predis`, `mcp/sdk`), the container skipped `composer install` because the old `vendor/` was still present on the bind-mounted host volume — leading to silent "class not found" errors at runtime (e.g. Redis health check failing with `Class "Predis\Client" not found`)
- Now stores an md5 fingerprint of `composer.lock` in `vendor/.composer_lock_hash` after every successful install; on boot, compares the stored hash with the current lock file and re-runs `composer install` only when they differ

## How it works

| Scenario | Before | After |
|---|---|---|
| Fresh clone (no vendor/) | ✅ Installs | ✅ Installs |
| `git pull` with new deps in lock | ❌ Skips (vendor/ exists) | ✅ Detects hash mismatch, installs |
| Container restart, nothing changed | ✅ Skips | ✅ Skips (hash match, ~0ms) |
| Failed install midway | ✅ Retries | ✅ Retries (hash not written on failure) |
| `vendor/` manually deleted | ✅ Installs | ✅ Installs (hash gone too) |

## Test plan

- [ ] `docker compose down && docker compose up -d` — should show "Composer dependencies up to date" (hash matches)
- [ ] Delete `vendor/.composer_lock_hash` and restart — should trigger `composer install`
- [ ] Modify `composer.lock` (e.g. add a space), restart — should detect "composer.lock changed" and re-install
- [ ] Remove `vendor/` entirely, restart — should do fresh install