### PR TITLE
feat(models): add Claude Sonnet 5 to Anthropic catalog

### DIFF
--- a/backend/src/AI/Provider/AnthropicProvider.php
+++ b/backend/src/AI/Provider/AnthropicProvider.php
@@ -40,6 +40,7 @@ class AnthropicProvider implements ChatProviderInterface, VisionProviderInterfac
         'claude-opus-4-7',
         'claude-opus-4-8',
         'claude-sonnet-4-6',
+        'claude-sonnet-5',
         'claude-haiku-4-5',
         'claude-fable-5',
     ];
@@ -50,6 +51,7 @@ class AnthropicProvider implements ChatProviderInterface, VisionProviderInterfac
         'claude-opus-4-7',
         'claude-opus-4-8',
         'claude-sonnet-4-6',
+        'claude-sonnet-5',
         'claude-fable-5',
     ];
 
@@ -63,6 +65,7 @@ class AnthropicProvider implements ChatProviderInterface, VisionProviderInterfac
     private const TEMPERATURE_DEPRECATED_MODELS = [
         'claude-opus-4-7',
         'claude-opus-4-8',
+        'claude-sonnet-5',
         'claude-fable-5',
     ];
 
@@ -98,8 +101,8 @@ class AnthropicProvider implements ChatProviderInterface, VisionProviderInterfac
     public function getDefaultModels(): array
     {
         return [
-            'chat' => 'claude-sonnet-4-6',
-            'vision' => 'claude-sonnet-4-6',
+            'chat' => 'claude-sonnet-5',
+            'vision' => 'claude-sonnet-5',
         ];
     }
 
@@ -417,7 +420,7 @@ class AnthropicProvider implements ChatProviderInterface, VisionProviderInterfac
     public function compareImages(string $imageUrl1, string $imageUrl2): array
     {
         // Claude supports multiple images in a single request
-        $model = 'claude-sonnet-4-6';
+        $model = 'claude-sonnet-5';
 
         try {
             $image1Data = $this->prepareImageData($imageUrl1);
@@ -477,7 +480,7 @@ class AnthropicProvider implements ChatProviderInterface, VisionProviderInterfac
         }
 
         try {
-            $model = $options['model'] ?? 'claude-sonnet-4-6';
+            $model = $options['model'] ?? 'claude-sonnet-5';
 
             $imageData = $this->prepareImageData($imagePath);
 

--- a/backend/src/Model/ModelCatalog.php
+++ b/backend/src/Model/ModelCatalog.php
@@ -1250,6 +1250,56 @@ class ModelCatalog
             ],
         ],
         [
+            // Snapshot 2026-06-30 (https://www.anthropic.com/news/claude-sonnet-5).
+            // Claude Sonnet 5 — Anthropic's most agentic Sonnet yet; performance
+            // close to Opus 4.8 at a lower price. Uses adaptive thinking and
+            // effort levels, and (like Opus 4.7+) no longer accepts `temperature`.
+            // Introductory API pricing through 2026-08-31 is $2/MTok in and
+            // $10/MTok out; standard pricing (authored here) is $3/MTok in and
+            // $15/MTok out.
+            'id' => 249,
+            'service' => 'Anthropic',
+            'name' => 'Claude Sonnet 5',
+            'tag' => 'chat',
+            'selectable' => 1,
+            'active' => 1,
+            'providerId' => 'claude-sonnet-5',
+            'priceIn' => 3,
+            'inUnit' => 'per1M',
+            'priceOut' => 15,
+            'outUnit' => 'per1M',
+            'quality' => 10,
+            'rating' => 1,
+            'json' => [
+                'description' => 'Claude Sonnet 5 - Anthropic\'s most agentic Sonnet model. Plans, uses tools (browsers, terminals) and runs autonomously with performance close to Opus 4.8 at a lower price. Adaptive thinking. 1M context, 64K max output.',
+                'max_tokens' => 64000,
+                'params' => ['model' => 'claude-sonnet-5'],
+                'features' => ['vision', 'reasoning'],
+                'meta' => ['context_window' => '1000000', 'max_output' => '64000'],
+            ],
+        ],
+        [
+            'id' => 250,
+            'service' => 'Anthropic',
+            'name' => 'Claude Sonnet 5 (Vision)',
+            'tag' => 'pic2text',
+            'selectable' => 1,
+            'active' => 1,
+            'providerId' => 'claude-sonnet-5',
+            'priceIn' => 3,
+            'inUnit' => 'per1M',
+            'priceOut' => 15,
+            'outUnit' => 'per1M',
+            'quality' => 10,
+            'rating' => 1,
+            'json' => [
+                'description' => 'Claude Sonnet 5 for image analysis and vision tasks. Agentic Sonnet-tier vision with near-Opus capability.',
+                'prompt' => 'Describe the image in detail. Extract any text you see.',
+                'params' => ['model' => 'claude-sonnet-5'],
+                'meta' => ['supports_images' => true],
+            ],
+        ],
+        [
             // Snapshot 2026-05-27 (https://platform.claude.com/docs/en/about-claude/models/overview).
             'id' => 235,
             'service' => 'Anthropic',

--- a/backend/src/Seed/DefaultModelConfigSeeder.php
+++ b/backend/src/Seed/DefaultModelConfigSeeder.php
@@ -30,8 +30,8 @@ final readonly class DefaultModelConfigSeeder
      * @var list<array{group: string, setting: string, modelKey: string}>
      */
     private const PROD_MODEL_DEFAULTS = [
-        ['group' => 'DEFAULTMODEL', 'setting' => 'CHAT',       'modelKey' => 'anthropic:claude-sonnet-4-6:chat'],
-        ['group' => 'DEFAULTMODEL', 'setting' => 'TOOLS',      'modelKey' => 'anthropic:claude-sonnet-4-6:chat'],
+        ['group' => 'DEFAULTMODEL', 'setting' => 'CHAT',       'modelKey' => 'anthropic:claude-sonnet-5:chat'],
+        ['group' => 'DEFAULTMODEL', 'setting' => 'TOOLS',      'modelKey' => 'anthropic:claude-sonnet-5:chat'],
         ['group' => 'DEFAULTMODEL', 'setting' => 'SORT',       'modelKey' => 'groq:openai/gpt-oss-120b:chat'],
         // Multi-task routing planner. Same fast/cheap tier as SORT but a
         // dedicated binding so it can be tuned without touching the legacy
@@ -53,7 +53,7 @@ final readonly class DefaultModelConfigSeeder
         ['group' => 'DEFAULTMODEL', 'setting' => 'TEXT2SOUND', 'modelKey' => 'piper:piper-multi:text2sound'],
         ['group' => 'DEFAULTMODEL', 'setting' => 'PIC2TEXT',   'modelKey' => 'groq:meta-llama/llama-4-scout-17b-16e-instruct:pic2text'],
         ['group' => 'DEFAULTMODEL', 'setting' => 'SOUND2TEXT', 'modelKey' => 'groq:whisper-large-v3:sound2text'],
-        ['group' => 'DEFAULTMODEL', 'setting' => 'ANALYZE',    'modelKey' => 'anthropic:claude-sonnet-4-6:chat'],
+        ['group' => 'DEFAULTMODEL', 'setting' => 'ANALYZE',    'modelKey' => 'anthropic:claude-sonnet-5:chat'],
         ['group' => 'DEFAULTMODEL', 'setting' => 'VECTORIZE',  'modelKey' => 'ollama:bge-m3:vectorize'],
     ];
 

--- a/backend/tests/Unit/Model/ModelCatalogTest.php
+++ b/backend/tests/Unit/Model/ModelCatalogTest.php
@@ -217,6 +217,22 @@ class ModelCatalogTest extends TestCase
         }
     }
 
+    public function testClaudeSonnet5ModelsAreAvailableWithExpectedApiIds(): void
+    {
+        $sonnet5 = ModelCatalog::find('anthropic:claude-sonnet-5');
+
+        $this->assertCount(2, $sonnet5, 'Expected claude-sonnet-5 chat + vision variants');
+        $this->assertSame(['chat', 'pic2text'], array_column($sonnet5, 'tag'));
+
+        foreach ($sonnet5 as $variant) {
+            $this->assertSame('Anthropic', $variant['service']);
+            $this->assertSame('claude-sonnet-5', $variant['providerId']);
+            $this->assertSame('claude-sonnet-5', $variant['json']['params']['model'] ?? null);
+            $this->assertEqualsWithDelta(3.0, (float) $variant['priceIn'], 1e-9);
+            $this->assertEqualsWithDelta(15.0, (float) $variant['priceOut'], 1e-9);
+        }
+    }
+
     public function testGpt55ProModelsAreMarkedAsNonStreaming(): void
     {
         $chat = ModelCatalog::find('openai:gpt-5.5-pro:chat')[0];


### PR DESCRIPTION
## Summary
Add Claude Sonnet 5 (chat + vision) to the Anthropic model catalog so users can select Anthropic's most agentic Sonnet model, which offers performance close to Opus 4.8 at a lower price.

## Changes
- **ModelCatalog**: new `claude-sonnet-5` chat (BID 249) and vision (BID 250, `pic2text`) variants, both selectable + active. Standard pricing $3/MTok in and $15/MTok out (introductory API pricing runs through 2026-08-31 at $2/$10, noted in a code comment).
- **AnthropicProvider**: register `claude-sonnet-5` for extended + adaptive thinking and as a temperature-deprecated model (effort-driven sampling, like Opus 4.7+); make it the provider's default chat + vision model.
- **DefaultModelConfigSeeder**: point the `CHAT`, `TOOLS` and `ANALYZE` default bindings at Sonnet 5 for fresh installs (existing installs keep their operator-set bindings, since seeding is `insertIfMissing`).
- **Tests**: add a `ModelCatalog` regression test covering the Sonnet 5 chat + vision variants.

## Verification
- [x] Tests added/updated
- [x] Manual
- [ ] Not tested (explain)

Ran locally:
- `make -C backend lint` — passed.
- Filtered unit tests `ModelCatalog|DefaultModelConfigSeeder|ModelSeeder|AnthropicProvider` — 41 tests, 1560 assertions, OK.
- Seeded locally (`app:model:seed`): `inserted=2` (BID 249 + 250), verified present, selectable and active in `BMODELS`.

## Notes
Model metadata based on the Claude Sonnet 5 announcement (2026-06-30): agentic tool use, adaptive thinking, 1M context / 64K max output. Introductory API pricing ($2/$10 per MTok) through 2026-08-31, then standard ($3/$15).

## Screenshots/Logs