### PR TITLE
fix(routing): stop async media DAG double-gen, prompt loss and dropped compound intent (#1218)

### DIFF
--- a/backend/src/Service/Media/MediaJobMessageSync.php
+++ b/backend/src/Service/Media/MediaJobMessageSync.php
@@ -58,16 +58,20 @@ final readonly class MediaJobMessageSync
         // only rebound to OUT once StreamController has persisted it. If the
         // worker finishes a fast image render BEFORE that rebind, this sync would
         // hit the IN row — clearing the user's prompt (data loss) and pinning the
-        // image to their own message. Never touch an IN message here; billing and
-        // the realtime push are still emitted (both idempotent/best-effort).
+        // image to their own message. Never touch an IN message here, and DO NOT
+        // publish the realtime update either: it carries the IN message_id + file,
+        // so the client would patch the user bubble and append the media part
+        // there — re-introducing the "image on the user's message" bug through
+        // realtime even though the DB row is untouched. The client's job poll
+        // (keyed by job_id) resolves the OUT banner as the fallback. Billing is
+        // still recorded (the render happened; idempotent).
         if ('IN' === $message->getDirection()) {
-            $this->logger->info('MediaJobMessageSync: skipped terminal mutation on IN message (awaiting rebind)', [
+            $this->logger->info('MediaJobMessageSync: skipped terminal mutation + realtime push on IN message (awaiting rebind)', [
                 'job_key' => $job->getJobKey(),
                 'message_id' => $messageId,
                 'state' => $status['state'],
             ]);
             $this->usageRecorder->record($job);
-            $this->realtimeNotifier->publishUpdate($job);
 
             return;
         }

--- a/backend/src/Service/Media/MediaJobMessageSync.php
+++ b/backend/src/Service/Media/MediaJobMessageSync.php
@@ -51,6 +51,27 @@ final readonly class MediaJobMessageSync
         }
 
         $status = $this->mediaJobService->toStatusArray($job);
+
+        // Direction guard (#1218): the generated media, its status meta and text
+        // belong on the OUT (assistant) bubble the user sees. A job is created
+        // bound to the INCOMING message id (the OUT row does not exist yet) and
+        // only rebound to OUT once StreamController has persisted it. If the
+        // worker finishes a fast image render BEFORE that rebind, this sync would
+        // hit the IN row — clearing the user's prompt (data loss) and pinning the
+        // image to their own message. Never touch an IN message here; billing and
+        // the realtime push are still emitted (both idempotent/best-effort).
+        if ('IN' === $message->getDirection()) {
+            $this->logger->info('MediaJobMessageSync: skipped terminal mutation on IN message (awaiting rebind)', [
+                'job_key' => $job->getJobKey(),
+                'message_id' => $messageId,
+                'state' => $status['state'],
+            ]);
+            $this->usageRecorder->record($job);
+            $this->realtimeNotifier->publishUpdate($job);
+
+            return;
+        }
+
         $mediaJobMeta = [
             'job_id' => $job->getJobKey(),
             'type' => $job->getType(),

--- a/backend/src/Service/Message/Handler/MediaGenerationHandler.php
+++ b/backend/src/Service/Message/Handler/MediaGenerationHandler.php
@@ -575,7 +575,7 @@ final readonly class MediaGenerationHandler implements MessageHandlerInterface
                 }
 
                 $effectiveUserId = $this->modelConfigService->getEffectiveUserIdForMessage($message);
-                if ($this->mediaJobConfig->isAsyncJobsEnabled($effectiveUserId)
+                if ($this->asyncJobsAllowed($effectiveUserId, $options)
                     && $this->aiFacade->supportsAsyncVideo($provider)) {
                     return $this->detachVideoToAsyncJob(
                         $message,
@@ -607,7 +607,7 @@ final readonly class MediaGenerationHandler implements MessageHandlerInterface
                 ]);
 
                 $effectiveUserId = $this->modelConfigService->getEffectiveUserIdForMessage($message);
-                if ($this->mediaJobConfig->isAsyncJobsEnabled($effectiveUserId)) {
+                if ($this->asyncJobsAllowed($effectiveUserId, $options)) {
                     return $this->detachMediaToAsyncJob(
                         MediaJob::TYPE_AUDIO,
                         $message,
@@ -712,7 +712,7 @@ final readonly class MediaGenerationHandler implements MessageHandlerInterface
                 }
 
                 $effectiveUserId = $this->modelConfigService->getEffectiveUserIdForMessage($message);
-                if ($this->mediaJobConfig->isAsyncJobsEnabled($effectiveUserId)) {
+                if ($this->asyncJobsAllowed($effectiveUserId, $options)) {
                     $inputRef = $attachedImagePaths[0] ?? null;
 
                     return $this->detachMediaToAsyncJob(
@@ -1505,6 +1505,26 @@ final readonly class MediaGenerationHandler implements MessageHandlerInterface
         }
 
         return $out;
+    }
+
+    /**
+     * Whether this render may detach to a background {@see MediaJob}.
+     *
+     * The async backbone is the default, but a caller can force the blocking
+     * inline path via `options['force_inline_media']`. The multitask DAG uses
+     * this for a media node another node depends on: the downstream
+     * `file_analysis`/`compose_reply` needs the produced file in the SAME turn,
+     * which an async detach could never deliver (#1218).
+     *
+     * @param array<string, mixed> $options
+     */
+    private function asyncJobsAllowed(int $effectiveUserId, array $options): bool
+    {
+        if (!empty($options['force_inline_media'])) {
+            return false;
+        }
+
+        return $this->mediaJobConfig->isAsyncJobsEnabled($effectiveUserId);
     }
 
     /**

--- a/backend/src/Service/Multitask/Execution/DagExecutor.php
+++ b/backend/src/Service/Multitask/Execution/DagExecutor.php
@@ -58,6 +58,16 @@ final readonly class DagExecutor
      */
     public function execute(TaskPlan $plan, NodeContext $context, ?callable $progressCallback = null): array
     {
+        // A media node whose file is CONSUMED by a downstream processing node
+        // (e.g. `file_analysis` reading `$n1.file` to describe the image) must
+        // render synchronously — the bytes have to exist in-turn or that
+        // dependent is blocked forever. Detaching it to an async job left the
+        // dependent stuck, which (before #1218) was masked by the all_failed
+        // legacy fallback re-generating the media. A media node attached ONLY to
+        // `compose_reply` (pure delivery) keeps the async detach: compose_reply
+        // waits and the background job delivers the file when it completes.
+        $context->setInlineMediaNodeIds($this->mediaNodesConsumedByProcessingNodes($plan));
+
         // Wire the per-node token-chunk sink so streaming runners can emit
         // task_chunk events tagged with the running node id.
         if (null !== $progressCallback) {
@@ -307,6 +317,15 @@ final readonly class DagExecutor
             ? $context->classification['language']
             : ($context->message->getLanguage() ?: 'en');
 
+        // The media subprocess rebuilds a fresh NodeContext, so the inline-media
+        // decision (a dependent needs this node's file in-turn, #1218) cannot
+        // ride the context — forward it through options, which MediaGenerationRunner
+        // honours as an equivalent to NodeContext::mustRunMediaInline().
+        $options = $context->options;
+        if ($context->mustRunMediaInline($node->id)) {
+            $options['force_inline_media'] = true;
+        }
+
         return new MediaNodeRequest(
             nodeId: $node->id,
             capability: $node->capability->value,
@@ -319,7 +338,7 @@ final readonly class DagExecutor
             // and options ride along for handler parity with the inline path.
             messageId: $context->message->getId(),
             thread: $this->normalizeThread($context->thread),
-            options: $context->options,
+            options: $options,
         );
     }
 
@@ -353,6 +372,32 @@ final readonly class DagExecutor
     private function isMediaKind(TaskNode $node): bool
     {
         return in_array($node->capability->uiKind(), ['image', 'video', 'audio'], true);
+    }
+
+    /**
+     * Node ids that a PROCESSING node depends on — i.e. every dependency of a
+     * node that actually consumes its input (`file_analysis`, `summarize`, …),
+     * excluding the `compose_reply` assembler whose dependencies are only
+     * gathered for delivery. A media node in this set must render synchronously
+     * so the produced file is available in-turn (see {@see execute()} /
+     * NodeContext::mustRunMediaInline()); a media node depended on ONLY by
+     * compose_reply keeps its async detach.
+     *
+     * @return list<string>
+     */
+    private function mediaNodesConsumedByProcessingNodes(TaskPlan $plan): array
+    {
+        $ids = [];
+        foreach ($plan->nodes as $node) {
+            if (Capability::ComposeReply === $node->capability) {
+                continue;
+            }
+            foreach ($node->dependsOn as $dep) {
+                $ids[$dep] = true;
+            }
+        }
+
+        return array_keys($ids);
     }
 
     private function dependenciesSatisfied(NodeContext $context, TaskNode $node): bool

--- a/backend/src/Service/Multitask/Execution/NodeContext.php
+++ b/backend/src/Service/Multitask/Execution/NodeContext.php
@@ -44,6 +44,16 @@ final class NodeContext
     private ?string $currentNodeId = null;
 
     /**
+     * Ids of media-generation nodes that MUST render synchronously in-turn
+     * because another node depends on their file output (a downstream
+     * `file_analysis` reads the bytes, `compose_reply` attaches them). Async
+     * detach would leave those dependents blocked forever (#1218).
+     *
+     * @var array<string, true>
+     */
+    private array $inlineMediaNodeIds = [];
+
+    /**
      * @param array<int, Message|array{role: string, content: string}> $thread
      *                                                                                   Message entities in-process; plain `{role, content}`
      *                                                                                   snapshots inside a media-node subprocess (entities cannot
@@ -112,6 +122,26 @@ final class NodeContext
         if (null !== $this->progressSink && '' !== $nodeId) {
             ($this->progressSink)($nodeId, $progress);
         }
+    }
+
+    /**
+     * Register the media-generation node ids that must render inline (blocking)
+     * instead of detaching to an async job — see {@see $inlineMediaNodeIds}.
+     *
+     * @param list<string> $nodeIds
+     */
+    public function setInlineMediaNodeIds(array $nodeIds): void
+    {
+        $this->inlineMediaNodeIds = array_fill_keys($nodeIds, true);
+    }
+
+    /**
+     * Whether the given media node has a dependent and therefore must generate
+     * synchronously so the produced file is available to it in the same turn.
+     */
+    public function mustRunMediaInline(string $nodeId): bool
+    {
+        return isset($this->inlineMediaNodeIds[$nodeId]);
     }
 
     public function setResult(string $nodeId, NodeResult $result): void

--- a/backend/src/Service/Multitask/Execution/ResultAssembler.php
+++ b/backend/src/Service/Multitask/Execution/ResultAssembler.php
@@ -49,6 +49,7 @@ final class ResultAssembler
         $jobKeys = [];
         $successCount = 0;
         $failureCount = 0;
+        $inProgressCount = 0;
         foreach ($plan->nodes as $node) {
             $result = $context->getResult($node->id);
             $status = null !== $result ? $result->status : NodeStatus::Pending;
@@ -63,10 +64,20 @@ final class ResultAssembler
                 ++$successCount;
             } elseif (NodeStatus::Failed === $status) {
                 ++$failureCount;
+            } elseif (NodeStatus::Running === $status || NodeStatus::Pending === $status) {
+                // A node still running (async media detached to a background job)
+                // or pending (blocked by such a dependency) means the plan is
+                // IN PROGRESS, not failed. Counting these as failures made
+                // `all_failed` true for async media plans, which triggered the
+                // legacy fallback and a second, duplicate generation (#1218).
+                ++$inProgressCount;
             }
         }
 
-        $allFailed = 0 === $successCount;
+        // Only a genuinely dead plan — nothing succeeded AND nothing is still
+        // in progress (every node settled as Failed/Skipped) — warrants the
+        // legacy fallback. A single Running/Pending node keeps the plan alive.
+        $allFailed = 0 === $successCount && 0 === $inProgressCount;
         $replyResult = $context->getResult($plan->replyNode);
 
         if (null !== $replyResult && $replyResult->isSuccessful()) {

--- a/backend/src/Service/Multitask/Execution/Runner/MediaGenerationRunner.php
+++ b/backend/src/Service/Multitask/Execution/Runner/MediaGenerationRunner.php
@@ -101,6 +101,18 @@ final readonly class MediaGenerationRunner implements TaskRunner
             $handlerOptions['node_id'] = $node->id;
         }
 
+        // Force synchronous (blocking) generation when another node depends on
+        // this media node's file: the downstream `file_analysis`/`compose_reply`
+        // needs the bytes in-turn, which an async detach could never deliver
+        // (#1218). A terminal media node keeps the async detach for a
+        // non-blocking "generating…" UX. The options flag is the parallel path's
+        // carrier: the media subprocess rebuilds a fresh NodeContext (without the
+        // inline-set), so DagExecutor::mediaRequest() forwards the decision via
+        // options instead.
+        if ($context->mustRunMediaInline($node->id) || !empty($context->options['force_inline_media'])) {
+            $handlerOptions['force_inline_media'] = true;
+        }
+
         // Media-to-media chaining (issue #1144): when this node depends on an
         // upstream node's file output (e.g. planner emits
         // `inputs.image = "$n1.file"` / `dependsOn: ["n1"]`), NodeContext has

--- a/backend/tests/Integration/Service/Media/AsyncMediaJobLifecycleIntegrationTest.php
+++ b/backend/tests/Integration/Service/Media/AsyncMediaJobLifecycleIntegrationTest.php
@@ -408,6 +408,41 @@ final class AsyncMediaJobLifecycleIntegrationTest extends KernelTestCase
         }
     }
 
+    public function testCompletedJobStillBoundToIncomingMessageNeverClobbersPrompt(): void
+    {
+        // Issue #1218: the job is created bound to the INCOMING message id and
+        // only rebound to the OUT message once StreamController has persisted
+        // it. If a fast image render completes on the worker BEFORE that rebind,
+        // the terminal sync hits the IN row. It must NOT clear the user's prompt
+        // (data loss) nor pin the generated image to their own bubble — the
+        // direction guard leaves the IN message completely untouched.
+        $user = $this->createUser();
+        $incoming = $this->createIncomingMessage($user, 'erstelle ein Bild einer Katze und beschreibe es');
+
+        $job = $this->jobService->create([
+            'userId' => $user->getId(),
+            'type' => MediaJob::TYPE_IMAGE,
+            'provider' => 'openai',
+            'prompt' => 'a cat',
+            'model' => 'gpt-image-1',
+            'messageId' => $incoming->getId(), // rebind lost the race → still IN
+            'options' => ['lang' => 'de'],
+        ]);
+        $this->createdJobKeys[] = $job->getJobKey();
+        $this->jobService->markCompleted($job, [
+            'file' => ['url' => '/api/v1/files/uploads/cat.png', 'type' => 'image'],
+            'provider' => 'openai',
+            'model' => 'gpt-image-1',
+        ]);
+
+        $this->messageSync->syncTerminalState($job);
+
+        $this->em->refresh($incoming);
+        self::assertSame('erstelle ein Bild einer Katze und beschreibe es', $incoming->getText(), 'IN prompt must be preserved');
+        self::assertSame(0, $incoming->getFiles()->count(), 'generated image must not attach to the IN message');
+        self::assertNull($incoming->getMeta('media_job'), 'no media_job meta must be written to the IN message');
+    }
+
     public function testSyncImageJobRendersSavesAndAttachesToMessage(): void
     {
         $user = $this->createUser();
@@ -727,6 +762,23 @@ final class AsyncMediaJobLifecycleIntegrationTest extends KernelTestCase
         $message->setMessageType('WW');
         $message->setText('');
         $message->setDirection('OUT');
+        $this->em->persist($message);
+        $this->em->flush();
+        $this->createdMessageIds[] = $message->getId();
+
+        return $message;
+    }
+
+    private function createIncomingMessage(User $user, string $text): Message
+    {
+        $message = new Message();
+        $message->setUserId($user->getId());
+        $message->setTrackingId(0);
+        $message->setUnixTimestamp(time());
+        $message->setDateTime(date('YmdHis'));
+        $message->setMessageType('WW');
+        $message->setText($text);
+        $message->setDirection('IN');
         $this->em->persist($message);
         $this->em->flush();
         $this->createdMessageIds[] = $message->getId();

--- a/backend/tests/Integration/Service/Media/AsyncMediaJobLifecycleIntegrationTest.php
+++ b/backend/tests/Integration/Service/Media/AsyncMediaJobLifecycleIntegrationTest.php
@@ -441,6 +441,16 @@ final class AsyncMediaJobLifecycleIntegrationTest extends KernelTestCase
         self::assertSame('erstelle ein Bild einer Katze und beschreibe es', $incoming->getText(), 'IN prompt must be preserved');
         self::assertSame(0, $incoming->getFiles()->count(), 'generated image must not attach to the IN message');
         self::assertNull($incoming->getMeta('media_job'), 'no media_job meta must be written to the IN message');
+
+        // The realtime push must also be suppressed while bound to IN: it carries
+        // the IN message_id + file, so publishing it would make the client patch
+        // the user bubble and append the image there — the same "image on the
+        // user's message" bug through realtime (Copilot review, PR #1219).
+        $pushedForIncoming = array_values(array_filter(
+            $this->publishedEvents,
+            static fn (array $e): bool => 'media_job.update' === $e['event'] && ($e['payload']['message_id'] ?? null) === $incoming->getId(),
+        ));
+        self::assertSame([], $pushedForIncoming, 'no media_job.update may be pushed for the IN message');
     }
 
     public function testSyncImageJobRendersSavesAndAttachesToMessage(): void

--- a/backend/tests/Unit/Service/Multitask/Execution/DagExecutorTest.php
+++ b/backend/tests/Unit/Service/Multitask/Execution/DagExecutorTest.php
@@ -142,6 +142,72 @@ final class DagExecutorTest extends TestCase
         );
     }
 
+    /**
+     * Issue #1218: a media node another node depends on (here `file_analysis`
+     * reads `$n1.file`) must be flagged for synchronous in-turn generation, so
+     * the produced file is available to that dependent — an async detach could
+     * never deliver it. NodeContext::mustRunMediaInline() is how the runner
+     * learns this; assert the executor sets it and the compound chain completes.
+     */
+    public function testMediaNodeWithDependentRunsInlineAndCompletesCompoundChain(): void
+    {
+        $plan = TaskPlan::fromArray([
+            'version' => 1, 'language' => 'en', 'reply_node' => 'n3',
+            'tasks' => [
+                ['id' => 'n1', 'capability' => 'image_generation', 'inputs' => ['prompt' => 'a cat']],
+                ['id' => 'n2', 'capability' => 'file_analysis', 'depends_on' => ['n1'], 'inputs' => ['prompt' => 'describe it', 'file' => '$n1.file']],
+                ['id' => 'n3', 'capability' => 'compose_reply', 'depends_on' => ['n1', 'n2'], 'inputs' => ['text' => '$n2.text', 'attachments' => ['$n1.file']]],
+            ],
+        ]);
+
+        $inlineSeen = [];
+        $runner = $this->runner(function (TaskNode $node, NodeContext $ctx) use (&$inlineSeen): NodeResult {
+            $inlineSeen[$node->id] = $ctx->mustRunMediaInline($node->id);
+            $in = $ctx->resolveInputs($node);
+
+            return match ($node->capability) {
+                Capability::ImageGeneration => NodeResult::ok(null, [['path' => '/api/v1/files/uploads/n1.png', 'type' => 'image']]),
+                Capability::FileAnalysis => NodeResult::ok('a cat on a windowsill'),
+                Capability::ComposeReply => NodeResult::ok(is_string($in['text']) ? $in['text'] : '', array_values(array_filter((array) ($in['attachments'] ?? []), 'is_array'))),
+                default => NodeResult::failed('unexpected'),
+            };
+        });
+
+        $result = $this->executor($runner)->execute($plan, $this->context());
+
+        self::assertTrue($inlineSeen['n1'], 'image node with a dependent must run inline');
+        self::assertFalse($result['all_failed']);
+        self::assertFalse($result['partial_failure']);
+        self::assertSame('a cat on a windowsill', $result['content']);
+        self::assertCount(1, $result['files']);
+        self::assertSame('image', $result['files'][0]['type']);
+        self::assertSame(['n1' => 'done', 'n2' => 'done', 'n3' => 'done'], $result['node_statuses']);
+    }
+
+    /**
+     * Control: a terminal media node (nothing depends on it) is NOT flagged for
+     * inline generation — it keeps the async detach for the non-blocking
+     * "generating…" UX.
+     */
+    public function testTerminalMediaNodeIsNotFlaggedForInline(): void
+    {
+        $plan = TaskPlan::fromArray([
+            'version' => 1, 'language' => 'en', 'reply_node' => 'n1',
+            'tasks' => [['id' => 'n1', 'capability' => 'image_generation', 'inputs' => ['prompt' => 'a cat']]],
+        ]);
+
+        $inline = null;
+        $runner = $this->runner(function (TaskNode $node, NodeContext $ctx) use (&$inline): NodeResult {
+            $inline = $ctx->mustRunMediaInline($node->id);
+
+            return NodeResult::ok(null, [['path' => '/api/v1/files/uploads/n1.png', 'type' => 'image']]);
+        });
+
+        $this->executor($runner)->execute($plan, $this->context());
+
+        self::assertFalse($inline, 'terminal media node must keep the async detach');
+    }
+
     public function testFailureIsolationSkipsDependentsButRunsIndependentBranch(): void
     {
         // n1 fails -> n2 (depends n1) skipped; n3 (independent) still runs; reply = n3.

--- a/backend/tests/Unit/Service/Multitask/Execution/ResultAssemblerTest.php
+++ b/backend/tests/Unit/Service/Multitask/Execution/ResultAssemblerTest.php
@@ -136,6 +136,63 @@ final class ResultAssemblerTest extends TestCase
     }
 
     /**
+     * Issue #1218 (root cause): a node still `Running` (async media detached to a
+     * background job) or `Pending` (blocked by such a dependency) means the plan
+     * is IN PROGRESS — it must NOT be reported as `all_failed`, otherwise
+     * TaskPlanExecutor discards the plan and re-runs the legacy router, producing
+     * a SECOND (duplicate) generation.
+     */
+    public function testRunningNodeIsNotReportedAsAllFailed(): void
+    {
+        $plan = $this->plan();
+        $ctx = $this->context();
+
+        // n1 detaches async → Running; n2/n3 stay Pending (blocked by n1).
+        $ctx->setResult('n1', NodeResult::running(['media_job' => ['job_id' => 'abc', 'type' => 'image']]));
+
+        $result = $this->assembler->assemble($plan, $ctx);
+
+        $this->assertFalse($result['all_failed']);
+    }
+
+    /**
+     * The genuinely dead plan — every node settled Failed/Skipped, nothing
+     * running and nothing succeeded — still reports `all_failed` so the legacy
+     * fallback can produce an answer.
+     */
+    public function testAllSettledUnsuccessfulIsReportedAsAllFailed(): void
+    {
+        $plan = $this->plan();
+        $ctx = $this->context();
+
+        $ctx->setResult('n1', NodeResult::failed('boom'));
+        $ctx->setResult('n2', NodeResult::skipped('dependency failed'));
+        $ctx->setResult('n3', NodeResult::skipped('dependency failed'));
+
+        $result = $this->assembler->assemble($plan, $ctx);
+
+        $this->assertTrue($result['all_failed']);
+    }
+
+    /**
+     * A single successful node is enough to keep the assembled result out of the
+     * all-failed fallback path.
+     */
+    public function testOneSuccessfulNodeIsNotAllFailed(): void
+    {
+        $plan = $this->plan();
+        $ctx = $this->context();
+
+        $ctx->setResult('n1', NodeResult::ok('Summary text'));
+        $ctx->setResult('n2', NodeResult::failed('TTS provider unavailable'));
+        $ctx->setResult('n3', NodeResult::ok('Summary text'));
+
+        $result = $this->assembler->assemble($plan, $ctx);
+
+        $this->assertFalse($result['all_failed']);
+    }
+
+    /**
      * Issue #1197: when the reply node is `compose_reply` (no provider meta of
      * its own), the assembler must backfill provider/model/model_id from the
      * upstream LLM node so StreamController persists the real inference


### PR DESCRIPTION
## Summary
Fixes the async media DAG path so a compound "generate an image AND describe it" request no longer loses the user's prompt, no longer generates the image twice, and actually runs the follow-up describe step. Closes #1218.

## Changes
- `ResultAssembler`: `Running`/`Pending` nodes now count as in-progress; `all_failed` is only true when nothing succeeded AND nothing is still in progress. This stops `TaskPlanExecutor` from discarding a detached-media plan and re-running the legacy router (the second, duplicate image generation).
- `MediaJobMessageSync`: added a direction guard — a terminal sync never mutates an `IN` message (no `setText('')`, no file attach, no meta), so a fast render completing before `StreamController` rebinds the job to the `OUT` message can no longer wipe the user's prompt or pin the image to their own bubble. Billing and the realtime push still fire (both idempotent).
- `DagExecutor` / `NodeContext` / `MediaGenerationRunner` / `MediaGenerationHandler`: a media node whose file is consumed by a downstream processing node (e.g. `file_analysis` reading `$n1.file`) now renders synchronously via a new `force_inline_media` option, so the produced file is available in-turn and the describe/compose steps run. A media node depended on ONLY by `compose_reply` (pure delivery) keeps its async detach, preserving the non-blocking "generating…" UX.

## Verification
- [ ] Not tested (explain)
- [ ] Manual
- [x] Tests added/updated

Backend gate (all green, unfiltered):
- `make -C backend lint`
- `make -C backend phpstan` (src + tests)
- `make -C backend test` (2424 tests)

Added/updated tests:
- `ResultAssemblerTest`: a `Running` node is not reported as `all_failed`; a fully settled-unsuccessful plan still is.
- `DagExecutorTest`: a media node with a consuming dependent runs inline and completes the compound chain; a terminal media node keeps the async detach.
- `AsyncMediaJobLifecycleIntegrationTest`: a completed job still bound to the `IN` message never clobbers the prompt.

## Notes
- Closes #1218.
- Backend-only change → frontend checks not required.
- No new i18n keys (`__IMAGE_GENERATING__` etc. already exist).
- The local test DB had 4 pending migrations (`BSOURCE` schema drift); applied via `doctrine:migrations:migrate --env=test` — environment only, no code/schema change in this PR.

## Screenshots/Logs