### PR TITLE
refactor(TextChunker): enhance multibyte character handling

### DIFF
--- a/backend/src/Service/File/TextChunker.php
+++ b/backend/src/Service/File/TextChunker.php
@@ -107,8 +107,10 @@ final readonly class TextChunker
             return $text;
         }
 
-        // Get last N characters, but try to break at word boundary
-        $overlap = substr($text, -$this->overlapSize);
+        // Get the last N bytes, but never start in the middle of a multibyte
+        // UTF-8 character (mb_strcut snaps to a character boundary; a raw
+        // substr(-N) would corrupt the leading character of the overlap).
+        $overlap = mb_strcut($text, strlen($text) - $this->overlapSize, null, 'UTF-8');
         $spacePos = strpos($overlap, ' ');
 
         if (false !== $spacePos && $spacePos < $this->overlapSize / 2) {
@@ -211,8 +213,21 @@ final readonly class TextChunker
                     $pieces[] = $current;
                     $current = '';
                 }
-                foreach (str_split($word, $this->maxChunkSize) as $part) {
+                // Hard-split an over-long word by byte budget, but never cut
+                // through a multibyte UTF-8 character. str_split() splits on raw
+                // bytes and can emit invalid UTF-8 (this method works on /u
+                // Unicode input), which later breaks json_encode(), DB storage
+                // and embeddings. mb_strcut() honours the byte budget while
+                // snapping to a character boundary.
+                $wordLength = strlen($word);
+                $offset = 0;
+                while ($offset < $wordLength) {
+                    $part = mb_strcut($word, $offset, $this->maxChunkSize, 'UTF-8');
+                    if ('' === $part) {
+                        break;
+                    }
                     $pieces[] = $part;
+                    $offset += strlen($part);
                 }
 
                 continue;

--- a/backend/tests/Unit/Service/File/TextChunkerTest.php
+++ b/backend/tests/Unit/Service/File/TextChunkerTest.php
@@ -63,6 +63,27 @@ class TextChunkerTest extends TestCase
         }
     }
 
+    public function testHardSplitPreservesMultibyteCharacters(): void
+    {
+        // Small budget forces the hard character-split fallback; the "word" is
+        // built from 2-byte (ä) and 4-byte (😀) UTF-8 characters with no
+        // separators. A byte-based split would cut mid-character and produce
+        // invalid UTF-8 — see PR #1215 Copilot review.
+        $chunker = new TextChunker(maxChunkSize: 10, overlapSize: 3, minChunkSize: 4);
+
+        $text = str_repeat('ä😀', 40);
+
+        $chunks = $chunker->chunkify($text);
+
+        self::assertGreaterThan(1, count($chunks));
+        foreach ($chunks as $chunk) {
+            self::assertTrue(
+                mb_check_encoding($chunk['content'], 'UTF-8'),
+                'Every chunk (including its overlap prefix) must be valid UTF-8'
+            );
+        }
+    }
+
     public function testShortTextReturnsSingleChunk(): void
     {
         $chunker = new TextChunker(maxChunkSize: 1500, overlapSize: 150, minChunkSize: 200);

--- a/frontend/src/widget.ts
+++ b/frontend/src/widget.ts
@@ -58,7 +58,9 @@ interface WidgetConfig {
   allowFileUpload?: boolean
   fileUploadLimit?: number
   lazy?: boolean
-  vueUrl?: string | null // undefined = default CDN, null = skip, string = custom URL
+  // Vue is bundled into widget.js. undefined/null = use the bundled Vue (no
+  // external load); a non-empty string = load Vue from that URL instead.
+  vueUrl?: string | null
   fullscreenMode?: boolean
   allowFullscreen?: boolean
   hideButton?: boolean


### PR DESCRIPTION
## Summary
Copilot feedback

## Changes
In chunking logic

- Updated the overlap calculation to use mb_strcut for safe multibyte character handling, preventing corruption of UTF-8 characters.
- Improved the word splitting logic to ensure that long words are split without cutting through multibyte characters, maintaining valid UTF-8 encoding.
- Added a new test to verify that hard-splitting preserves multibyte characters, ensuring robustness in chunking functionality.

## Verification
- [ ] Not tested (explain)
- [X] Manual
- [ ] Tests added/updated
