### PR TITLE
fix(admin): clear stale dirty indicator on boolean config toggle

### DIFF
--- a/frontend/src/components/admin/ConfigField.vue
+++ b/frontend/src/components/admin/ConfigField.vue
@@ -69,7 +69,6 @@ function handleInput(event: Event) {
 function handleToggle() {
   const newValue = localValue.value === 'true' ? 'false' : 'true'
   localValue.value = newValue
-  isDirty.value = true
   emit('update', props.fieldKey, newValue)
 }
 


### PR DESCRIPTION
## Summary

- Boolean config toggles (e.g. `MEDIA_ASYNC_JOBS_ENABLED`) auto-save immediately via `emit('update', ...)`, but `handleToggle()` also set `isDirty = true` — so the "unsaved changes" badge stayed visible even though the save toast confirmed success. Removed the stale `isDirty` assignment; text/select fields keep their explicit-save flow unchanged.

## Test plan

- [ ] Toggle any boolean config field in Admin → Settings (e.g. Async media generation)
- [ ] Verify the green "Saved" toast appears and no "unsaved changes" badge is shown
- [ ] Verify text/password/select fields still show "unsaved changes" until explicitly saved