### PR TITLE
fix(TextChunker): prevent data loss when maxChunkSize is smaller than a character

### DIFF
--- a/backend/src/Service/File/TextChunker.php
+++ b/backend/src/Service/File/TextChunker.php
@@ -224,7 +224,14 @@ final readonly class TextChunker
                 while ($offset < $wordLength) {
                     $part = mb_strcut($word, $offset, $this->maxChunkSize, 'UTF-8');
                     if ('' === $part) {
-                        break;
+                        // maxChunkSize is smaller than the next character's byte
+                        // length, so mb_strcut() can't fit a whole character.
+                        // Never drop data: emit that single character (it will
+                        // exceed the byte budget) so the loop keeps advancing.
+                        $part = mb_substr(mb_strcut($word, $offset, 4, 'UTF-8'), 0, 1, 'UTF-8');
+                        if ('' === $part) {
+                            break;
+                        }
                     }
                     $pieces[] = $part;
                     $offset += strlen($part);

--- a/backend/tests/Unit/Service/File/TextChunkerTest.php
+++ b/backend/tests/Unit/Service/File/TextChunkerTest.php
@@ -84,6 +84,30 @@ class TextChunkerTest extends TestCase
         }
     }
 
+    public function testHardSplitKeepsAllDataWhenBudgetSmallerThanCharacter(): void
+    {
+        // maxChunkSize (1 byte) is smaller than a 4-byte emoji, which forces
+        // mb_strcut() to return '' in the hard-split loop. The loop must still
+        // make progress and must not drop the remaining characters — see
+        // PR #1220 Copilot review.
+        $chunker = new TextChunker(maxChunkSize: 1, overlapSize: 1, minChunkSize: 1);
+
+        $emojis = ['😀', '😁', '😂', '🤣'];
+        $chunks = $chunker->chunkify(implode('', $emojis));
+
+        self::assertNotEmpty($chunks);
+
+        $combined = '';
+        foreach ($chunks as $chunk) {
+            self::assertTrue(mb_check_encoding($chunk['content'], 'UTF-8'));
+            $combined .= $chunk['content'];
+        }
+
+        foreach ($emojis as $emoji) {
+            self::assertStringContainsString($emoji, $combined, "Character {$emoji} must survive hard-splitting");
+        }
+    }
+
     public function testShortTextReturnsSingleChunk(): void
     {
         $chunker = new TextChunker(maxChunkSize: 1500, overlapSize: 150, minChunkSize: 200);


### PR DESCRIPTION
## Summary
- Fixes a follow-up issue from PR #1220 (Copilot review): in `TextChunker`'s hard-split loop, when `maxChunkSize` is smaller than the byte length of the next multibyte character, `mb_strcut()` returns `''` and the loop broke out early, silently dropping the remaining characters.
- The loop now falls back to emitting a single character (via `mb_substr`/`mb_strcut`) so it keeps making progress and no data is lost, even though that piece may exceed the configured byte budget.
- Adds a regression test covering a 1-byte `maxChunkSize` against 4-byte emoji characters, asserting every character survives hard-splitting.

## Test plan
- [x] `make -C backend lint`
- [x] `make -C backend phpstan`
- [ ] `make -C backend test`