### PR TITLE
fix(routing): collapse redundant single-media DAG plans to legacy path (#1072)

### DIFF
--- a/backend/src/Prompt/PromptCatalog.php
+++ b/backend/src/Prompt/PromptCatalog.php
@@ -530,6 +530,12 @@ Allowed topic keys: [KEYLIST]
    → parallel nodes with NO dependency between them, joined by `compose_reply`.
 10. Plain question / smalltalk / advice → one `chat` node. `reply_node` = that
    node, no `compose_reply` needed.
+11. A SINGLE media request with no follow-up step ("make an image of X",
+    "generate a video of Y", "read this aloud", "make an excel table") → ONE
+    generator node (`image_generation` / `video_generation` / `text2sound` /
+    `document_generation`). `reply_node` = that node. Do NOT add a
+    `compose_reply` — the generator's file is delivered on its own. Only add
+    `compose_reply` when there are 2+ nodes to combine (see rule 1).
 
 ## Canonical multi-step examples (MEMORIZE these patterns)
 
@@ -573,6 +579,20 @@ User: sends report.docx and writes "What's in there? Summarize it into a short M
   "reply_node": "n1",
   "tasks": [
     { "id": "n1", "capability": "text2sound", "inputs": { "text": "Hello world" }, "params": { "format": "mp3" } }
+  ]
+}
+
+### Single image, nothing else ("Erstelle ein Bild von einem Sonnenuntergang")
+A lone media request is ONE node — no `compose_reply` (rule 11). This mirrors the
+`/pic` command: the image is delivered directly, no task card. The SAME shape
+applies to a single `video_generation`, `text2sound` or `document_generation`.
+
+{
+  "version": 1,
+  "language": "de",
+  "reply_node": "n1",
+  "tasks": [
+    { "id": "n1", "capability": "image_generation", "inputs": { "prompt": "Ein Sonnenuntergang" } }
   ]
 }
 

--- a/backend/src/Service/Multitask/ClassificationPlanMapper.php
+++ b/backend/src/Service/Multitask/ClassificationPlanMapper.php
@@ -64,11 +64,15 @@ final class ClassificationPlanMapper
 
     /**
      * Map a classification's intent (and media_type) to a plan capability.
-     * Used only for the persisted node label — never for execution routing.
+     *
+     * Used for the persisted node label AND — since #1072 — as the safety guard
+     * that lets {@see TaskPlanExecutor} collapse a redundant single-media plan
+     * back to the legacy single-node path only when the legacy classification
+     * would produce the SAME media. Never used to pick a model.
      *
      * @param array<string, mixed> $classification
      */
-    private function capabilityForClassification(array $classification): Capability
+    public function capabilityForClassification(array $classification): Capability
     {
         $intent = is_string($classification['intent'] ?? null) ? $classification['intent'] : 'chat';
 

--- a/backend/src/Service/Multitask/TaskPlanExecutor.php
+++ b/backend/src/Service/Multitask/TaskPlanExecutor.php
@@ -50,6 +50,20 @@ final readonly class TaskPlanExecutor
      */
     private const DAG_ONLY_CAPABILITIES = [Capability::CalendarEvent];
 
+    /**
+     * Single-shot media generators that the legacy router already delivers
+     * silently as a one-node request (the `/pic`, `/vid`, `/tts`, officemaker
+     * experience). When a plan is just one of these plus a pass-through
+     * `compose_reply`, the `compose_reply` adds nothing — it is collapsed away
+     * so the request no longer spins up the DAG / task-card UI (issue #1072).
+     */
+    private const COLLAPSIBLE_MEDIA_CAPABILITIES = [
+        Capability::ImageGeneration,
+        Capability::VideoGeneration,
+        Capability::Text2Sound,
+        Capability::DocumentGeneration,
+    ];
+
     public function __construct(
         private InferenceRouter $router,
         private ClassificationPlanMapper $mapper,
@@ -215,7 +229,25 @@ final readonly class TaskPlanExecutor
         try {
             $userId = $this->modelConfigService->getEffectiveUserIdForMessage($message);
 
-            return $this->planner->plan($message, $thread, $userId, $options);
+            $result = $this->planner->plan($message, $thread, $userId, $options);
+
+            $collapsed = $this->collapseRedundantSingleMediaPlan($result->plan, $classification);
+            if ($collapsed !== $result->plan) {
+                $this->logger->info('TaskPlanExecutor: collapsed single-media plan to legacy path (issue #1072)', [
+                    'message_id' => $message->getId(),
+                    'capability' => $collapsed->nodes[0]->capability->value,
+                ]);
+
+                return new TaskPlanResult(
+                    $collapsed,
+                    $result->fallback,
+                    $result->modelId,
+                    $result->rawResponse,
+                    $result->errors,
+                );
+            }
+
+            return $result;
         } catch (\Throwable $e) {
             $this->logger->warning('TaskPlanExecutor: planning failed, using single-node path', [
                 'message_id' => $message->getId(),
@@ -224,6 +256,80 @@ final readonly class TaskPlanExecutor
 
             return null;
         }
+    }
+
+    /**
+     * Collapse a redundant `[<single media generator>, compose_reply]` plan into
+     * the lone generator node (issue #1072).
+     *
+     * The planner tends to wrap a plain single-media request ("make an image of
+     * a sunset") in a two-node plan (`image_generation` + `compose_reply`) even
+     * though the `compose_reply` only passes the generated file straight
+     * through. That two-node shape flips `isSingleNode()` to false, spins up the
+     * DAG and shows a "Taskplan 1/1" card for what should be a silent one-shot
+     * generation — inconsistent with the identical `/pic` slash command.
+     *
+     * We rewrite it to a single-node plan so {@see shouldUseLegacyRouter()}
+     * delegates to the proven legacy {@see InferenceRouter} path (no task card),
+     * but ONLY when it is provably safe:
+     *   - exactly two nodes, the reply node being a `compose_reply`;
+     *   - the other is a root media generator (no upstream dependency — never an
+     *     image-edit / animate chain, which genuinely needs the DAG);
+     *   - the `compose_reply` depends solely on that media node (pure passthrough);
+     *   - the ORIGINAL classification maps to the SAME media capability, so the
+     *     legacy router (which runs on that classification, not the plan) still
+     *     produces the intended media. If the planner disagreed with the sorter
+     *     we keep the DAG so the media is not lost.
+     *
+     * @param array<string, mixed> $classification
+     */
+    private function collapseRedundantSingleMediaPlan(TaskPlan $plan, array $classification): TaskPlan
+    {
+        if (2 !== count($plan->nodes)) {
+            return $plan;
+        }
+
+        $reply = $plan->nodeById($plan->replyNode);
+        if (null === $reply || Capability::ComposeReply !== $reply->capability) {
+            return $plan;
+        }
+
+        $media = null;
+        foreach ($plan->nodes as $node) {
+            if ($node->id !== $reply->id) {
+                $media = $node;
+            }
+        }
+
+        if (null === $media
+            || [] !== $media->dependsOn
+            || !in_array($media->capability, self::COLLAPSIBLE_MEDIA_CAPABILITIES, true)) {
+            return $plan;
+        }
+
+        // compose_reply must be a pure pass-through of that single media node.
+        if ([$media->id] !== $reply->dependsOn) {
+            return $plan;
+        }
+
+        // Guard: the legacy router runs on the original classification, so only
+        // collapse when that classification already targets this media.
+        if ($this->mapper->capabilityForClassification($classification) !== $media->capability) {
+            return $plan;
+        }
+
+        return TaskPlan::fromArray([
+            'version' => 1,
+            'language' => $plan->language,
+            'reply_node' => $media->id,
+            'tasks' => [[
+                'id' => $media->id,
+                'capability' => $media->capability->value,
+                'depends_on' => [],
+                'inputs' => $media->inputs,
+                'params' => $media->params,
+            ]],
+        ]);
     }
 
     /**

--- a/backend/tests/Unit/Service/Multitask/TaskPlanExecutorTest.php
+++ b/backend/tests/Unit/Service/Multitask/TaskPlanExecutorTest.php
@@ -311,6 +311,97 @@ final class TaskPlanExecutorTest extends TestCase
         self::assertSame(['content' => 'file summary'], $result);
     }
 
+    public function testSingleMediaPlusComposeReplyCollapsesToLegacyRouter(): void
+    {
+        // Issue #1072: the planner wraps a plain single-media request
+        // ("make an image of a sunset") in [image_generation, compose_reply].
+        // That redundant compose_reply must be collapsed so the request runs
+        // the silent legacy path (no DAG, no task card) — like /pic.
+        $wrapped = TaskPlan::fromArray([
+            'version' => 1, 'language' => 'en', 'reply_node' => 'n2',
+            'tasks' => [
+                ['id' => 'n1', 'capability' => 'image_generation', 'inputs' => ['prompt' => 'a sunset']],
+                ['id' => 'n2', 'capability' => 'compose_reply', 'depends_on' => ['n1'], 'inputs' => ['text' => 'Here is your image.', 'attachments' => ['$n1.file']]],
+            ],
+        ]);
+        $this->planner->method('plan')->willReturn(new TaskPlanResult($wrapped, fallback: false, modelId: 76));
+
+        // Collapsed to single-node → DAG must NOT run; legacy router answers.
+        $this->dagExecutor->expects(self::never())->method('execute');
+        $this->router->expects(self::once())->method('routeStream')->willReturn(['content' => 'IMAGE']);
+
+        $result = $this->executor->executeStream(
+            $this->message(),
+            [],
+            ['intent' => 'image_generation', 'media_type' => 'image', 'topic' => 'mediamaker', 'language' => 'en', 'source' => 'ai_sorting'],
+            static function (): void {},
+        );
+
+        self::assertSame(['content' => 'IMAGE'], $result);
+    }
+
+    public function testSingleMediaPlanNotCollapsedWhenClassificationDisagrees(): void
+    {
+        // Guard: the legacy router runs on the ORIGINAL classification. If the
+        // sorter said "chat" but the planner produced an image, collapsing to
+        // the legacy path would lose the image — so the DAG must still run.
+        $wrapped = TaskPlan::fromArray([
+            'version' => 1, 'language' => 'en', 'reply_node' => 'n2',
+            'tasks' => [
+                ['id' => 'n1', 'capability' => 'image_generation', 'inputs' => ['prompt' => 'a sunset']],
+                ['id' => 'n2', 'capability' => 'compose_reply', 'depends_on' => ['n1'], 'inputs' => ['text' => 'Here is your image.', 'attachments' => ['$n1.file']]],
+            ],
+        ]);
+        $this->planner->method('plan')->willReturn(new TaskPlanResult($wrapped, fallback: false, modelId: 76));
+        $this->dagExecutor->expects(self::once())->method('execute')->willReturn($this->assembled([
+            'content' => 'Here is your image',
+            'files' => [['path' => '/api/v1/files/uploads/img.png', 'type' => 'image']],
+            'node_statuses' => ['n1' => 'done', 'n2' => 'done'],
+        ]));
+
+        // classification intent = chat → does NOT map to image_generation.
+        $this->router->expects(self::never())->method('routeStream');
+
+        $result = $this->executor->executeStream(
+            $this->message(),
+            [],
+            ['intent' => 'chat', 'language' => 'en', 'source' => 'ai_sorting'],
+            static function (): void {},
+        );
+
+        self::assertSame('image', $result['metadata']['file']['type']);
+    }
+
+    public function testMediaEditChainIsNotCollapsed(): void
+    {
+        // A dependent media node ("make a logo, then make it blue") is a genuine
+        // two-step chain — it must keep running the DAG, not be collapsed.
+        $chain = TaskPlan::fromArray([
+            'version' => 1, 'language' => 'en', 'reply_node' => 'n3',
+            'tasks' => [
+                ['id' => 'n1', 'capability' => 'image_generation', 'inputs' => ['prompt' => 'a logo']],
+                ['id' => 'n2', 'capability' => 'image_generation', 'depends_on' => ['n1'], 'inputs' => ['prompt' => 'make it blue', 'image' => '$n1.file']],
+                ['id' => 'n3', 'capability' => 'compose_reply', 'depends_on' => ['n2'], 'inputs' => ['attachments' => ['$n2.file']]],
+            ],
+        ]);
+        $this->planner->method('plan')->willReturn(new TaskPlanResult($chain, fallback: false, modelId: 76));
+        $this->dagExecutor->expects(self::once())->method('execute')->willReturn($this->assembled([
+            'content' => 'Here is the blue logo',
+            'files' => [['path' => '/api/v1/files/uploads/logo.png', 'type' => 'image']],
+            'node_statuses' => ['n1' => 'done', 'n2' => 'done', 'n3' => 'done'],
+        ]));
+        $this->router->expects(self::never())->method('routeStream');
+
+        $result = $this->executor->executeStream(
+            $this->message(),
+            [],
+            ['intent' => 'image_generation', 'media_type' => 'image', 'language' => 'en', 'source' => 'ai_sorting'],
+            static function (): void {},
+        );
+
+        self::assertSame('image', $result['metadata']['file']['type']);
+    }
+
     public function testSingleCalendarEventNodeRunsDagNotLegacyRouter(): void
     {
         // A lone calendar_event has NO legacy router equivalent — running it


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Stops the multi-task planner from spinning up the DAG / showing a "Taskplan 1/1" card for a plain single-media request (e.g. "make an image of a sunset"), making it behave identically to the `/pic` slash command (#1072).

## Context — verification of the "DAG routing & multitask generation" backlog
Before writing any code I re-checked every open DAG/multitask issue against the current tree. Several were already fixed in recent merges and just not closed:

| Issue | Topic | Real status |
|-------|-------|-------------|
| #1069 | DAG ignores user-selected chat model | **Already fixed** — `ChatRunner::resolveModelId()` honors `classification['model_id']`/`override_model_id` (regression test `testChatRunnerHonorsUserSelectedModel`) |
| #1080 | `file_analysis` can't read upstream-generated files | **Already fixed** — `FileAnalysisRunner::attachUpstreamFile()` (regression test `testFileAnalysisUsesUpstreamGeneratedFile`) |
| #1106 | Attachment shortcut blocks multi-modal output | **Already fixed** — `TaskPlanExecutor::planForExecution()` now plans `attachment_document_or_audio` messages |
| #1143 | Expose Planner Model in the UI | **Already implemented** — planner-model section in `SortingPromptConfiguration.vue` + `ConfigControllerPlannerModelTest` |
| **#1072** | Planner adds an unnecessary `compose_reply` to single-media requests | **Genuinely still open** → fixed here |

Only #1072 was still a live DAG-routing defect (previously mitigated by soft prompt guidance only, with no deterministic guard and no test).

## Changes
- `TaskPlanExecutor`: new `collapseRedundantSingleMediaPlan()` deterministically rewrites a `[<single root media generator>, compose_reply-passthrough]` plan into the lone generator node, so `shouldUseLegacyRouter()` delegates to the proven legacy `InferenceRouter` (no task card). Collapse is tightly guarded — it only fires when:
  - there are exactly two nodes and the reply node is a `compose_reply`;
  - the other node is a **root** media generator (`image_generation` / `video_generation` / `text2sound` / `document_generation`) with no upstream dependency (image-edit / animate chains keep the DAG);
  - the `compose_reply` depends solely on that media node (pure passthrough);
  - the **original classification maps to the same media capability** — the legacy router runs on that classification, so if the planner disagreed with the sorter we keep the DAG and never drop the media.
- `ClassificationPlanMapper::capabilityForClassification()` promoted to public to serve as that safety guard.
- `PromptCatalog` planner prompt: added routing rule 11 (single media → one node, no `compose_reply`) and a canonical single-image example, so these requests emit a 1-node plan directly (fewer planner tokens; the code-side collapse remains the guarantee).

## Verification
- [x] Tests added/updated — 3 new `TaskPlanExecutorTest` cases: collapse happens; NOT collapsed when classification disagrees; NOT collapsed for media-edit chains.
- [x] Ran locally on a PHP 8.4 toolchain (Docker unavailable in the agent VM): `php-cs-fixer` clean, PHPStan reports **zero errors in the changed files** (only the unrelated gRPC `Inference\*` stubs error out locally because `protoc`/protobuf runtime live in the Docker base image), and the full `tests/Unit` suite passes (1600 tests) including the routing characterization snapshot (no drift).
- Opening as **draft** to let the Docker-based CI run the full pre-commit gate.

## Notes
Closes #1072. Also confirms #1069, #1080, #1106, #1143 are already resolved and can be closed.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3d1f2e94-202f-42bd-8848-38de7ba0aa26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3d1f2e94-202f-42bd-8848-38de7ba0aa26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

