### PR TITLE
fix(tests): stub cost-budget gate in mail-routing unit tests

### DIFF
--- a/backend/tests/Service/InboundEmailHandlerServiceTest.php
+++ b/backend/tests/Service/InboundEmailHandlerServiceTest.php
@@ -777,6 +777,14 @@ class InboundEmailHandlerServiceTest extends TestCase
         $this->modelConfigService->method('getDefaultModel')->willReturn(42);
         $this->modelConfigService->method('getProviderForModel')->willReturn('openai');
         $this->modelConfigService->method('getModelName')->willReturn('gpt-4');
+
+        // Issue #1177 added a pre-flight cost-budget gate before the AI call:
+        // the handler owner must exist and be within budget, otherwise routing
+        // falls back to the default department without consulting the AI.
+        // Stub the gate as "owner exists, within budget" so these tests keep
+        // exercising the AI-driven routing paths.
+        $this->userRepository->method('find')->willReturn($this->createMock(\App\Entity\User::class));
+        $this->rateLimitService->method('checkCostBudget')->willReturn(['allowed' => true]);
     }
 
     // ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Fixes the red `Backend (PHP/Symfony)` job on `main` after the #1193 merge ([failing run](https://github.com/metadist/synaplan/actions/runs/28590329833/job/84771973150)).
- Semantic merge conflict: the #1193 routing unit tests and the #1177 pre-flight cost-budget gate were each green on their own branch, but combined, the gate's `userRepository->find()` returns `null` in the tests' mock setup, so `routeEmailToDepartment()` falls back to the default department before reaching the stubbed `AiFacade` — 5 tests fail (`sales@…` vs `support@…`, discard vs non-null).
- Fix: `stubPromptAndModel()` now also stubs the gate as "owner exists, within budget". The dedicated #1177 gate tests (over budget / owner missing) keep their own explicit stubs and still pass.

## Test plan
- [x] `docker compose exec -T backend ./vendor/bin/phpunit tests/Service/InboundEmailHandlerServiceTest.php` — 39/39 green
- [x] Full backend gate: `make -C backend lint && make -C backend phpstan && make -C backend test` — green (2453 tests)