### PR TITLE
fix: make generated/re-attached images analyzable (routing + vision payload)

### DIFF
--- a/backend/src/Service/Message/Handler/ChatHandler.php
+++ b/backend/src/Service/Message/Handler/ChatHandler.php
@@ -41,6 +41,15 @@ final readonly class ChatHandler implements MessageHandlerInterface
     /** Maximum length of a quoted-reference excerpt injected into the prompt. */
     private const MAX_QUOTED_REFERENCE_LENGTH = 4000;
 
+    /**
+     * Maximum base64 payload length (characters) for a single inline vision
+     * image. Kept well under Anthropic's 1M-token context limit — base64
+     * tokenizes at roughly 1.7 tokens per character on that provider, so
+     * ~450K characters (~337 KB raw) stays comfortably below the ceiling with
+     * margin for the surrounding prompt (issue #1238).
+     */
+    private const MAX_VISION_BASE64_LENGTH = 450000;
+
     /** @var iterable<PluginContextProviderInterface> */
     private iterable $pluginContextProviders;
 
@@ -1622,9 +1631,100 @@ final readonly class ChatHandler implements MessageHandlerInterface
         }
 
         $mimeType = $this->getImageMimeType($relativePath);
+
+        // Guard against oversized inline vision payloads. A large image
+        // embedded as a base64 data URL can blow the provider's context
+        // window: an ~828 KB generated PNG expands to ~1.1M base64 characters,
+        // which Anthropic tokenizes to ~1.9M tokens — over its 1M limit — and
+        // returns an HTTP 400 that surfaces as an error bubble (issue #1238).
+        // The 10 MB file-size cap above does not prevent this, so downscale
+        // the pixels first and only skip the image when it still cannot be
+        // brought under budget.
+        if ($this->estimateBase64Length(strlen($imageData)) > self::MAX_VISION_BASE64_LENGTH) {
+            $downscaled = $this->downscaleImageForVision($imageData);
+            if (null === $downscaled) {
+                $this->logger->warning('ChatHandler: Skipping vision image that exceeds the inline payload budget', [
+                    'path' => $relativePath,
+                    'original_size_kb' => round(strlen($imageData) / 1024, 1),
+                ]);
+
+                return null;
+            }
+
+            $this->logger->info('ChatHandler: Downscaled oversized vision image', [
+                'path' => $relativePath,
+                'original_size_kb' => round(strlen($imageData) / 1024, 1),
+                'downscaled_size_kb' => round(strlen($downscaled) / 1024, 1),
+            ]);
+
+            $imageData = $downscaled;
+            $mimeType = 'image/jpeg';
+        }
+
         $base64 = base64_encode($imageData);
 
         return 'data:'.$mimeType.';base64,'.$base64;
+    }
+
+    /**
+     * Estimate the character length of the base64 encoding of a byte string
+     * without allocating the encoded string (base64 emits 4 characters per 3
+     * input bytes, padded).
+     */
+    private function estimateBase64Length(int $bytes): int
+    {
+        return intdiv($bytes + 2, 3) * 4;
+    }
+
+    /**
+     * Downscale an oversized image so its base64 payload fits within the
+     * inline-vision budget (issue #1238).
+     *
+     * Re-encodes as JPEG — smaller than PNG for photos and generated renders —
+     * via Imagick, progressively reducing the longest edge until the encoded
+     * size is under budget. 1568 px is Anthropic's own recommended vision cap;
+     * the smaller steps are the fallback for very detailed images that still
+     * exceed the budget at higher resolutions.
+     *
+     * @return string|null JPEG bytes under budget, or null when Imagick is
+     *                     unavailable or the image cannot be reduced enough
+     */
+    private function downscaleImageForVision(string $imageData): ?string
+    {
+        if (!extension_loaded('imagick') || !class_exists(\Imagick::class)) {
+            return null;
+        }
+
+        foreach ([1568, 1024, 768, 512] as $maxEdge) {
+            try {
+                $imagick = new \Imagick();
+                $imagick->readImageBlob($imageData);
+                $imagick->setIteratorIndex(0);
+                $imagick->autoOrient();
+                // bestfit: scale down so neither edge exceeds $maxEdge while
+                // preserving aspect ratio.
+                $imagick->resizeImage($maxEdge, $maxEdge, \Imagick::FILTER_LANCZOS, 1, true);
+                $imagick->setImageFormat('jpeg');
+                $imagick->setImageCompressionQuality(80);
+                $imagick->stripImage();
+                $jpeg = $imagick->getImageBlob();
+                $imagick->clear();
+                $imagick->destroy();
+
+                if ('' !== $jpeg && $this->estimateBase64Length(strlen($jpeg)) <= self::MAX_VISION_BASE64_LENGTH) {
+                    return $jpeg;
+                }
+            } catch (\Throwable $e) {
+                $this->logger->warning('ChatHandler: Vision image downscale attempt failed', [
+                    'max_edge' => $maxEdge,
+                    'error' => $e->getMessage(),
+                ]);
+
+                return null;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/backend/src/Service/Message/Handler/FileAnalysisHandler.php
+++ b/backend/src/Service/Message/Handler/FileAnalysisHandler.php
@@ -1075,19 +1075,29 @@ final readonly class FileAnalysisHandler implements MessageHandlerInterface
         ?string $text,
         ?string $status,
     ): array {
-        $normalizedType = strtolower((string) $type);
-        $isImage = in_array($normalizedType, MessagePreProcessor::IMAGE_EXTENSIONS, true);
-        $isAudio = in_array($normalizedType, MessagePreProcessor::AUDIO_EXTENSIONS, true);
-        $isDocument = in_array($normalizedType, MessagePreProcessor::DOCUMENT_EXTENSIONS, true);
-        $isVideo = in_array($normalizedType, MessagePreProcessor::VIDEO_EXTENSIONS, true);
-
         // Normalize path to be relative to the upload directory (var/uploads).
         // DB values should be stored relative; older/legacy values may contain "/uploads/" or full URLs.
         $path = $this->normalizeRelativeUploadPath((string) $rawPath);
+        $resolvedName = (string) ($name ?? basename($path));
+
+        // Resolve the routing discriminator. Freshly uploaded files store a
+        // concrete extension in BFILETYPE ("png", "pdf", …), but the
+        // generated-media pipelines store a generic kind ("image", "audio",
+        // "video", "document"). Those generic kinds are not in the
+        // *_EXTENSIONS lists, so without normalization a generated PNG (or a
+        // DAG `file_analysis` node consuming one) was mis-routed to
+        // "unsupported" even though its filename/MIME clearly identify it —
+        // the error even listed PNG as supported, which was contradictory
+        // (issue #1236).
+        $resolvedType = $this->resolveFileType((string) $type, $resolvedName, $path);
+        $isImage = in_array($resolvedType, MessagePreProcessor::IMAGE_EXTENSIONS, true);
+        $isAudio = in_array($resolvedType, MessagePreProcessor::AUDIO_EXTENSIONS, true);
+        $isDocument = in_array($resolvedType, MessagePreProcessor::DOCUMENT_EXTENSIONS, true);
+        $isVideo = in_array($resolvedType, MessagePreProcessor::VIDEO_EXTENSIONS, true);
 
         return [
             'id' => $id,
-            'name' => (string) ($name ?? basename($path)),
+            'name' => $resolvedName,
             'type' => (string) $type,
             'path' => $path,
             'text' => (string) ($text ?? ''),
@@ -1097,6 +1107,56 @@ final readonly class FileAnalysisHandler implements MessageHandlerInterface
             'is_document' => $isDocument,
             'is_video' => $isVideo,
         ];
+    }
+
+    /**
+     * Resolve the routing discriminator for a file.
+     *
+     * Returns the concrete file extension whenever one can be determined so
+     * the `is_*` flags in {@see buildFileInfo()} line up with the
+     * `*_EXTENSIONS` lists. A concrete extension in BFILETYPE is trusted
+     * as-is; a generic media kind ("image"/"audio"/"video"/"document") or a
+     * missing type is recovered from the filename/path, falling back to a
+     * representative extension for the kind (issue #1236).
+     */
+    private function resolveFileType(string $type, string $name, string $path): string
+    {
+        $type = strtolower(trim($type));
+
+        // A concrete extension already lines up with the *_EXTENSIONS lists.
+        if ('' !== $type && !$this->isGenericFileKind($type)) {
+            return $type;
+        }
+
+        // Generic kind (or missing type): recover the real extension from the
+        // filename first, then the stored path.
+        $extension = strtolower(pathinfo($name, PATHINFO_EXTENSION));
+        if ('' === $extension) {
+            $extension = strtolower(pathinfo($path, PATHINFO_EXTENSION));
+        }
+        if ('' !== $extension) {
+            return $extension;
+        }
+
+        // No usable extension anywhere — map the generic kind onto a
+        // representative extension so a typeless generated file is still
+        // routed to the correct handler instead of "unsupported".
+        return match ($type) {
+            'image' => 'png',
+            'audio' => 'mp3',
+            'video' => 'mp4',
+            'document' => 'txt',
+            default => $type,
+        };
+    }
+
+    /**
+     * Whether the BFILETYPE value is a generic media kind (as stored by the
+     * generated-media pipelines) rather than a concrete file extension.
+     */
+    private function isGenericFileKind(string $type): bool
+    {
+        return in_array($type, ['image', 'audio', 'video', 'document'], true);
     }
 
     /**

--- a/backend/tests/Unit/Service/Message/Handler/ChatHandlerVisionImageTest.php
+++ b/backend/tests/Unit/Service/Message/Handler/ChatHandlerVisionImageTest.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace App\Tests\Unit\Service\Message\Handler;
+
+use App\AI\Service\AiFacade;
+use App\Repository\ConfigRepository;
+use App\Repository\ModelRepository;
+use App\Repository\PromptRepository;
+use App\Service\FeedbackConfigService;
+use App\Service\File\DocumentGeneratorService;
+use App\Service\File\UserUploadPathBuilder;
+use App\Service\MemoryExtractionDispatcher;
+use App\Service\Message\Handler\ChatHandler;
+use App\Service\ModelConfigService;
+use App\Service\PerfPipelineFlag;
+use App\Service\Prompt\TimeContextBuilder;
+use App\Service\PromptService;
+use App\Service\RAG\VectorSearchService;
+use App\Service\RateLimitService;
+use App\Service\UserMemoryService;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+/**
+ * Issue #1238 — a re-attached generated PNG was embedded into the Anthropic
+ * messages API full-size as a base64 data URL, blowing the prompt to ~1.9M
+ * tokens (HTTP 400). The vision embedder must downscale oversized images so
+ * the inline payload stays within budget, and skip the image entirely if it
+ * still cannot be reduced enough — never send a payload that 400s.
+ */
+class ChatHandlerVisionImageTest extends TestCase
+{
+    /** Mirrors ChatHandler::MAX_VISION_BASE64_LENGTH. */
+    private const MAX_VISION_BASE64_LENGTH = 450000;
+
+    private ChatHandler $handler;
+    private string $uploadDir;
+
+    protected function setUp(): void
+    {
+        $this->uploadDir = sys_get_temp_dir().'/synaplan-chat-vision-'.bin2hex(random_bytes(8));
+        mkdir($this->uploadDir, 0o775, true);
+
+        $this->handler = new ChatHandler(
+            $this->createMock(AiFacade::class),
+            $this->createMock(PromptRepository::class),
+            $this->createMock(PromptService::class),
+            $this->createMock(ModelConfigService::class),
+            $this->createMock(ModelRepository::class),
+            new NullLogger(),
+            $this->createMock(VectorSearchService::class),
+            $this->createMock(EntityManagerInterface::class),
+            $this->uploadDir,
+            new UserUploadPathBuilder(),
+            $this->createMock(UserMemoryService::class),
+            new FeedbackConfigService($this->createStub(ConfigRepository::class)),
+            $this->createMock(RateLimitService::class),
+            $this->createMock(MemoryExtractionDispatcher::class),
+            $this->createMock(PerfPipelineFlag::class),
+            $this->createMock(DocumentGeneratorService::class),
+            new TimeContextBuilder(),
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_dir($this->uploadDir)) {
+            $this->removeDirectoryRecursive($this->uploadDir);
+        }
+    }
+
+    /**
+     * A small image comfortably under budget must be embedded verbatim,
+     * preserving its original PNG mime type.
+     */
+    public function testSmallImageIsEmbeddedUnchanged(): void
+    {
+        // 1x1 transparent PNG.
+        $png = base64_decode(
+            'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=='
+        );
+        file_put_contents($this->uploadDir.'/tiny.png', $png);
+
+        $result = $this->invokeImageToBase64DataUrl('tiny.png');
+
+        $this->assertNotNull($result);
+        $dataUrl = (string) $result;
+        $this->assertStringStartsWith('data:image/png;base64,', $dataUrl);
+        $this->assertLessThanOrEqual(self::MAX_VISION_BASE64_LENGTH, strlen($this->base64Payload($dataUrl)));
+    }
+
+    /**
+     * The core #1238 regression: an oversized image must be downscaled and
+     * re-encoded (as JPEG) so its base64 payload lands within budget instead
+     * of being sent full-size and triggering an HTTP 400.
+     */
+    public function testOversizedImageIsDownscaledUnderBudget(): void
+    {
+        if (!extension_loaded('imagick') || !class_exists(\Imagick::class)) {
+            $this->markTestSkipped('imagick is required to downscale oversized vision images');
+        }
+
+        $bigPng = $this->makeLargePng(1500, 1500);
+        $originalBase64Length = intdiv(strlen($bigPng) + 2, 3) * 4;
+
+        // The fixture must land in the testable window: large enough to exceed
+        // the inline budget (so the downscale path runs), but under the 10 MB
+        // file-size guard that short-circuits before downscaling. ImageMagick
+        // builds compress plasma differently, so skip rather than fail if this
+        // particular environment produced an out-of-range fixture.
+        if ($originalBase64Length <= self::MAX_VISION_BASE64_LENGTH) {
+            $this->markTestSkipped('Generated fixture compressed below the inline budget on this ImageMagick build');
+        }
+        if (strlen($bigPng) > 10 * 1024 * 1024) {
+            $this->markTestSkipped('Generated fixture exceeded the 10 MB pre-downscale size guard on this ImageMagick build');
+        }
+
+        file_put_contents($this->uploadDir.'/big.png', $bigPng);
+
+        $result = $this->invokeImageToBase64DataUrl('big.png');
+
+        $this->assertNotNull($result, 'Oversized image should be downscaled, not skipped');
+        $dataUrl = (string) $result;
+        $this->assertStringStartsWith('data:image/jpeg;base64,', $dataUrl);
+        $this->assertLessThanOrEqual(
+            self::MAX_VISION_BASE64_LENGTH,
+            strlen($this->base64Payload($dataUrl)),
+            'Downscaled payload must fit within the inline vision budget',
+        );
+    }
+
+    /**
+     * When the image cannot be decoded/downscaled (corrupt bytes that still
+     * exceed the budget), the embedder must skip it (return null) rather than
+     * forward an oversized payload that 400s the provider request.
+     */
+    public function testOversizedUndecodableImageIsSkipped(): void
+    {
+        // > budget worth of bytes that are not a valid image. Imagick cannot
+        // decode this, so no downscaled result can be produced.
+        $garbage = str_repeat("\x00\x11\x22\x33", 400000);
+        file_put_contents($this->uploadDir.'/broken.png', $garbage);
+
+        $result = $this->invokeImageToBase64DataUrl('broken.png');
+
+        $this->assertNull($result);
+    }
+
+    private function invokeImageToBase64DataUrl(string $relativePath): ?string
+    {
+        $method = new \ReflectionMethod(ChatHandler::class, 'imageToBase64DataUrl');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($this->handler, $relativePath);
+
+        return null === $result ? null : (string) $result;
+    }
+
+    private function base64Payload(string $dataUrl): string
+    {
+        $commaPos = strpos($dataUrl, ',');
+
+        return false === $commaPos ? '' : substr($dataUrl, $commaPos + 1);
+    }
+
+    /**
+     * Build a large, poorly-compressible PNG so its base64 payload exceeds the
+     * inline vision budget.
+     */
+    private function makeLargePng(int $width, int $height): string
+    {
+        $imagick = new \Imagick();
+        // A fractal plasma render is high-frequency/high-entropy, so it stays
+        // large even as PNG without ballooning past the 10 MB size guard.
+        $imagick->newPseudoImage($width, $height, 'plasma:fractal');
+        $imagick->setImageFormat('png');
+        $blob = $imagick->getImageBlob();
+        $imagick->clear();
+        $imagick->destroy();
+
+        return $blob;
+    }
+
+    private function removeDirectoryRecursive(string $path): void
+    {
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+
+        foreach ($iterator as $item) {
+            /** @var \SplFileInfo $item */
+            if ($item->isDir()) {
+                rmdir($item->getPathname());
+            } else {
+                unlink($item->getPathname());
+            }
+        }
+
+        rmdir($path);
+    }
+}

--- a/backend/tests/Unit/Service/Message/Handler/FileAnalysisHandlerGenericTypeTest.php
+++ b/backend/tests/Unit/Service/Message/Handler/FileAnalysisHandlerGenericTypeTest.php
@@ -1,0 +1,294 @@
+<?php
+
+namespace App\Tests\Unit\Service\Message\Handler;
+
+use App\AI\Service\AiFacade;
+use App\Entity\File;
+use App\Entity\Message;
+use App\Service\Message\Handler\FileAnalysisHandler;
+use App\Service\ModelConfigService;
+use Doctrine\Common\Collections\ArrayCollection;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Issue #1236 — files produced by the generated-media pipelines store a
+ * generic kind ("image", "audio", "video", "document") in BFILETYPE
+ * instead of a concrete extension ("png", …). The previous routing only
+ * accepted extensions, so re-attaching a generated PNG (or a DAG
+ * `file_analysis` node consuming one) dead-ended in the "This file type
+ * cannot be analyzed" branch even though the filename and MIME clearly
+ * identified it — the error message even listed PNG as supported.
+ *
+ * These tests pin the normalization so a generic kind is routed to the
+ * same handler path as its equivalent extension.
+ */
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
+class FileAnalysisHandlerGenericTypeTest extends TestCase
+{
+    private AiFacade&MockObject $aiFacade;
+    private ModelConfigService&MockObject $modelConfigService;
+    private LoggerInterface&MockObject $logger;
+    private FileAnalysisHandler $handler;
+    private string $uploadDir;
+
+    protected function setUp(): void
+    {
+        $this->aiFacade = $this->createMock(AiFacade::class);
+        $this->modelConfigService = $this->createMock(ModelConfigService::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
+
+        $this->uploadDir = sys_get_temp_dir().'/synaplan-file-analysis-generic-'.bin2hex(random_bytes(8));
+        mkdir($this->uploadDir, 0o775, true);
+
+        $this->handler = new FileAnalysisHandler(
+            $this->aiFacade,
+            $this->modelConfigService,
+            $this->logger,
+            $this->uploadDir,
+        );
+
+        $this->modelConfigService->method('getEffectiveUserIdForMessage')->willReturn(7);
+        $this->modelConfigService->method('getDefaultModel')->willReturn(123);
+        $this->modelConfigService->method('getProviderForModel')->willReturn('openai');
+        $this->modelConfigService->method('getModelName')->willReturn('gpt-4');
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_dir($this->uploadDir)) {
+            $this->removeDirectoryRecursive($this->uploadDir);
+        }
+    }
+
+    /**
+     * The core #1236 regression: a generated PNG stored with the generic
+     * BFILETYPE "image" must be analyzed via the Vision path exactly like a
+     * freshly uploaded ".png", instead of failing with "unsupported".
+     */
+    public function testGeneratedImageWithGenericImageTypeRoutesToVision(): void
+    {
+        $path = '13/000/media_1_google_cat.png';
+        $message = $this->buildMessageWithFiles([
+            $this->buildFile(id: 39, name: 'media_1_google_cat.png', type: 'image', path: $path),
+        ], text: 'beschreibe mir was ich hier sehen kann');
+
+        $this->stubImagePathsExist([$path]);
+
+        $this->aiFacade
+            ->expects($this->once())
+            ->method('analyzeImage')
+            ->willReturn([
+                'content' => 'A cat lounging on a sofa.',
+                'provider' => 'openai',
+                'model' => 'gpt-4o',
+            ]);
+
+        $result = $this->handler->handle($message, [], []);
+
+        $this->assertSame('vision', $result['metadata']['analysis_type']);
+        $this->assertStringContainsString('A cat lounging on a sofa.', $result['content']);
+    }
+
+    /**
+     * A generic "image" file with no extension anywhere (neither on the
+     * filename nor the path) must still fall back to the Vision path rather
+     * than dead-ending as unsupported.
+     */
+    public function testGenericImageWithoutExtensionFallsBackToVision(): void
+    {
+        $path = 'present/generated-artifact';
+        $message = $this->buildMessageWithFiles([
+            $this->buildFile(id: 40, name: 'generated-artifact', type: 'image', path: $path),
+        ], text: 'what is this?');
+
+        $this->stubImagePathsExist([$path]);
+
+        $this->aiFacade
+            ->expects($this->once())
+            ->method('analyzeImage')
+            ->willReturn(['content' => 'An abstract render.', 'provider' => 'openai', 'model' => 'gpt-4o']);
+
+        $result = $this->handler->handle($message, [], []);
+
+        $this->assertSame('vision', $result['metadata']['analysis_type']);
+        $this->assertStringContainsString('An abstract render.', $result['content']);
+    }
+
+    /**
+     * A file whose BFILETYPE is empty but whose filename carries a concrete
+     * extension must be recovered from the filename (defensive: legacy rows
+     * or partially-populated File entities).
+     */
+    public function testEmptyTypeWithPngFilenameRoutesToVision(): void
+    {
+        $path = 'present/screenshot.png';
+        $message = $this->buildMessageWithFiles([
+            $this->buildFile(id: 41, name: 'screenshot.png', type: '', path: $path),
+        ], text: '');
+
+        $this->stubImagePathsExist([$path]);
+
+        $this->aiFacade
+            ->expects($this->once())
+            ->method('analyzeImage')
+            ->willReturn(['content' => 'A screenshot.', 'provider' => 'openai', 'model' => 'gpt-4o']);
+
+        $result = $this->handler->handle($message, [], []);
+
+        $this->assertSame('vision', $result['metadata']['analysis_type']);
+    }
+
+    /**
+     * A generated audio artefact stored as the generic kind "audio" with a
+     * transcript must reach the conversational voice-reply path.
+     */
+    public function testGenericAudioTypeRoutesToVoiceReply(): void
+    {
+        $message = $this->buildMessageWithFiles([
+            $this->buildFile(id: 42, name: 'media_1_tts.mp3', type: 'audio', path: '13/000/media_1_tts.mp3', text: 'Hello, remind me tomorrow.'),
+        ], text: '');
+
+        $captured = null;
+        $this->aiFacade
+            ->expects($this->once())
+            ->method('chat')
+            ->willReturnCallback(function (array $messages) use (&$captured): array {
+                $captured = $messages;
+
+                return ['content' => 'Sure!', 'provider' => 'openai', 'model' => 'gpt-4'];
+            });
+
+        $result = $this->handler->handle($message, [], []);
+
+        $this->assertNotNull($captured);
+        $this->assertStringContainsString('Hello, remind me tomorrow.', $captured[0]['content']);
+        $this->assertSame('voice_message_reply', $result['metadata']['analysis_type']);
+    }
+
+    /**
+     * A generated video artefact stored as the generic kind "video" with a
+     * transcript must be summarized via the document/chat path.
+     */
+    public function testGenericVideoTypeRoutesToDocumentPath(): void
+    {
+        $message = $this->buildMessageWithFiles([
+            $this->buildFile(id: 43, name: 'media_1_clip.mp4', type: 'video', path: '13/000/media_1_clip.mp4', text: 'A short product reveal.'),
+        ], text: 'summarize');
+
+        $captured = null;
+        $this->aiFacade
+            ->expects($this->once())
+            ->method('chat')
+            ->willReturnCallback(function (array $messages) use (&$captured): array {
+                $captured = $messages;
+
+                return ['content' => 'It reveals a product.', 'provider' => 'openai', 'model' => 'gpt-4'];
+            });
+
+        $result = $this->handler->handle($message, [], []);
+
+        $this->assertNotNull($captured);
+        $this->assertStringContainsString('A short product reveal.', $captured[0]['content']);
+        $this->assertSame('chat_with_extracted_text', $result['metadata']['analysis_type']);
+    }
+
+    /**
+     * A generated document stored as the generic kind "document" with
+     * extracted text must reach the document analysis path.
+     */
+    public function testGenericDocumentTypeRoutesToDocumentPath(): void
+    {
+        $message = $this->buildMessageWithFiles([
+            $this->buildFile(id: 44, name: 'media_1_report.docx', type: 'document', path: '13/000/media_1_report.docx', text: 'Quarterly numbers are up.'),
+        ], text: 'what does it say?');
+
+        $captured = null;
+        $this->aiFacade
+            ->expects($this->once())
+            ->method('chat')
+            ->willReturnCallback(function (array $messages) use (&$captured): array {
+                $captured = $messages;
+
+                return ['content' => 'Numbers up.', 'provider' => 'openai', 'model' => 'gpt-4'];
+            });
+
+        $result = $this->handler->handle($message, [], []);
+
+        $this->assertNotNull($captured);
+        $this->assertStringContainsString('Quarterly numbers are up.', $captured[0]['content']);
+        $this->assertSame('chat_with_extracted_text', $result['metadata']['analysis_type']);
+    }
+
+    /**
+     * @param list<File> $files
+     */
+    private function buildMessageWithFiles(array $files, string $text): Message&MockObject
+    {
+        $collection = new ArrayCollection($files);
+
+        $message = $this->createMock(Message::class);
+        $message->method('getId')->willReturn(42);
+        $message->method('getUserId')->willReturn(7);
+        $message->method('getFiles')->willReturn($collection);
+        $message->method('getText')->willReturn($text);
+
+        return $message;
+    }
+
+    private function buildFile(
+        int $id,
+        string $name,
+        string $type,
+        string $path,
+        string $text = '',
+        string $status = 'processed',
+    ): File&MockObject {
+        $file = $this->createMock(File::class);
+        $file->method('getId')->willReturn($id);
+        $file->method('getFileName')->willReturn($name);
+        $file->method('getFileType')->willReturn($type);
+        $file->method('getFilePath')->willReturn($path);
+        $file->method('getFileText')->willReturn($text);
+        $file->method('getStatus')->willReturn($status);
+
+        return $file;
+    }
+
+    /**
+     * @param list<string> $relativePaths
+     */
+    private function stubImagePathsExist(array $relativePaths): void
+    {
+        foreach ($relativePaths as $relative) {
+            $full = $this->uploadDir.'/'.$relative;
+            $dir = dirname($full);
+            if (!is_dir($dir) && !mkdir($dir, 0o775, true) && !is_dir($dir)) {
+                throw new \RuntimeException(sprintf('Failed to create test upload directory "%s"', $dir));
+            }
+            if (false === file_put_contents($full, 'fake-image-bytes')) {
+                throw new \RuntimeException(sprintf('Failed to write test upload file "%s"', $full));
+            }
+        }
+    }
+
+    private function removeDirectoryRecursive(string $path): void
+    {
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+
+        foreach ($iterator as $item) {
+            /** @var \SplFileInfo $item */
+            if ($item->isDir()) {
+                rmdir($item->getPathname());
+            } else {
+                unlink($item->getPathname());
+            }
+        }
+
+        rmdir($path);
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Two self-contained backend fixes so generated/re-attached images can be analyzed instead of dead-ending with a misleading "unsupported" error (#1236) or a provider HTTP 400 (#1238).

## Changes
- **#1236 — `FileAnalysisHandler` generic file-type normalization.** Generated-media pipelines store a generic kind (`image`/`audio`/`video`/`document`) in `BFILETYPE` instead of a concrete extension. The router only matched extensions, so a re-attached generated PNG (or a DAG `file_analysis` node consuming one) fell into the "This file type cannot be analyzed" branch — which contradictorily listed PNG as supported. The routing discriminator now trusts a concrete extension and, for a generic kind (or missing type), recovers the real extension from the filename/path, falling back to a representative extension per kind.
- **#1238 — `ChatHandler` oversized vision payload guard.** A re-attached ~828 KB generated PNG was embedded full-size as a base64 data URL, expanding to ~1.9M tokens and blowing Anthropic's 1M-token limit (HTTP 400). The existing 10 MB file-size guard did not prevent this. Images whose base64 payload exceeds a provider-safe budget are now downscaled via Imagick (re-encoded as JPEG, longest edge stepped 1568→512 until under budget) before embedding; if the image still cannot be reduced (or Imagick is unavailable), it is skipped rather than forwarding a payload that 400s.

## Verification
- [x] Tests added/updated
- [x] Not tested locally (this environment has no PHP/Composer/Docker toolchain — relying on CI to run `lint`, `phpstan`, and `phpunit`)

New unit tests:
- `FileAnalysisHandlerGenericTypeTest` — generic `image`/`audio`/`video`/`document` kinds (and empty type / no-extension fallbacks) route to the correct handler path.
- `ChatHandlerVisionImageTest` — small images pass through unchanged; oversized images are downscaled under budget; undecodable oversized bytes are skipped (returns `null`).

Both changes are backend-only and do not touch the routing/classifier code, so the `RoutingCharacterization` snapshots are unaffected. No OpenAPI annotations changed, so no frontend schema regeneration is needed.

## Notes
- Fixes #1236
- Fixes #1238
- These were selected from the newest 10 issues as the cleanest, lowest-risk fixes. The remaining newest issues (#1239 async rebind race, #1237 describe-as-audio routing, #1229 interactive task cards, #1228 images-in-DOCX, #1225/#1223 stream detach on navigation/chat-switch, #1224 knowledge-base description source, #1222 planner dependency) require routing-snapshot changes or larger frontend/executor work and are intentionally out of scope here.

## Screenshots/Logs

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-25a53575-45ed-495f-9aa0-2d6f1a42bbec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-25a53575-45ed-495f-9aa0-2d6f1a42bbec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

