### PR TITLE
fix(multitask): resolve async media rebind race — task cards stuck on running (#1239)

### DIFF
--- a/backend/src/Controller/StreamController.php
+++ b/backend/src/Controller/StreamController.php
@@ -14,6 +14,7 @@ use App\Service\File\DocumentGeneratorService;
 use App\Service\File\UserUploadPathBuilder;
 use App\Service\GuestSessionService;
 use App\Service\Media\MediaCancellationStore;
+use App\Service\Media\MediaJobMessageSync;
 use App\Service\Media\MediaJobService;
 use App\Service\MemoryExtractionDispatcher;
 use App\Service\Message\MessageForwardingService;
@@ -69,6 +70,7 @@ class StreamController extends AbstractController
         private DocumentGeneratorService $documentGenerator,
         private MediaCancellationStore $cancellationStore,
         private MediaJobService $mediaJobService,
+        private MediaJobMessageSync $mediaJobMessageSync,
         #[Autowire(env: 'default::bool:COST_BUDGET_GATE_ENABLED')]
         private bool $costBudgetGateEnabled = false,
     ) {
@@ -1378,7 +1380,15 @@ class StreamController extends AbstractController
                     // on completion (otherwise it stays stuck on "running").
                     $mediaJobKey = $response['metadata']['media_job']['job_id'] ?? null;
                     if (is_string($mediaJobKey) && '' !== $mediaJobKey && null !== $outgoingMessage->getId()) {
-                        $this->mediaJobService->rebindMessage($mediaJobKey, $outgoingMessage->getId());
+                        $rebound = $this->mediaJobService->rebindMessage($mediaJobKey, $outgoingMessage->getId());
+                        // Second-chance sync (#1239): a fast render can finish
+                        // BEFORE this rebind, while still bound to the IN message
+                        // where the terminal sync is deliberately skipped (#1218).
+                        // Now that the job points at the OUT message, run the sync
+                        // it missed so the finished media reaches the bubble.
+                        if (null !== $rebound && $rebound->isTerminal()) {
+                            $this->mediaJobMessageSync->syncTerminalState($rebound);
+                        }
                     }
                 }
 
@@ -1410,15 +1420,20 @@ class StreamController extends AbstractController
                 // image as if the user had sent it (the "generated image appears as
                 // the user's prompt after reload" regression). Rebind every node
                 // job (the job_id lives on each task card) to the OUT message the
-                // user actually sees. rebindMessage is idempotent and a no-op on
-                // already-terminal jobs.
+                // user actually sees. A job that already finished while bound to
+                // the IN message (fast render losing the race, #1239) is rebound
+                // too and immediately given the terminal sync it skipped, so the
+                // task card resolves instead of spinning forever.
                 if (null !== $outgoingMessage->getId()
                     && isset($response['metadata']['task_plan_render']['cards'])
                     && is_array($response['metadata']['task_plan_render']['cards'])) {
                     foreach ($response['metadata']['task_plan_render']['cards'] as $card) {
                         $cardJobKey = is_array($card) ? ($card['job_id'] ?? null) : null;
                         if (is_string($cardJobKey) && '' !== $cardJobKey) {
-                            $this->mediaJobService->rebindMessage($cardJobKey, $outgoingMessage->getId());
+                            $rebound = $this->mediaJobService->rebindMessage($cardJobKey, $outgoingMessage->getId());
+                            if (null !== $rebound && $rebound->isTerminal()) {
+                                $this->mediaJobMessageSync->syncTerminalState($rebound);
+                            }
                         }
                     }
                 }

--- a/backend/src/Controller/StreamController.php
+++ b/backend/src/Controller/StreamController.php
@@ -2124,6 +2124,24 @@ class StreamController extends AbstractController
                 );
             }
 
+            // Mirror the streaming branch: rebind every async node job to the OUT
+            // message, and give a job that already finished while bound to the IN
+            // message (fast render losing the race, #1239) its missed terminal
+            // sync so the task card resolves instead of spinning forever.
+            if (null !== $outgoingMessage->getId()
+                && isset($metadata['task_plan_render']['cards'])
+                && is_array($metadata['task_plan_render']['cards'])) {
+                foreach ($metadata['task_plan_render']['cards'] as $card) {
+                    $cardJobKey = is_array($card) ? ($card['job_id'] ?? null) : null;
+                    if (is_string($cardJobKey) && '' !== $cardJobKey) {
+                        $rebound = $this->mediaJobService->rebindMessage($cardJobKey, $outgoingMessage->getId());
+                        if (null !== $rebound && $rebound->isTerminal()) {
+                            $this->mediaJobMessageSync->syncTerminalState($rebound);
+                        }
+                    }
+                }
+            }
+
             if (!empty($options['web_search'])) {
                 $message->setMeta('web_search_enabled', 'true');
             }

--- a/backend/src/Service/Media/MediaJobMessageSync.php
+++ b/backend/src/Service/Media/MediaJobMessageSync.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Service\Media;
 
 use App\Repository\MessageRepository;
+use App\Service\Multitask\TaskPlanStore;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 
@@ -20,6 +21,15 @@ use Psr\Log\LoggerInterface;
  *      and attach it to the message — this is the single channel history
  *      endpoints serialize (`getFiles()`), so without it a reload shows an
  *      empty bubble even though the file is on disk and the job is `done`.
+ *
+ * Multitask node jobs (the job carries a `nodeId`) are synced differently
+ * (#1239): the OUT message of a DAG turn holds the ASSEMBLED reply (poem +
+ * connector text), so the single-task text mutation (clear on done / error on
+ * failed) would destroy it, and the `media_job` banner meta belongs only to
+ * single-task turns. Instead the matching card inside the persisted
+ * `task_plan` meta is patched (state/url/error) and the BMESSAGE_TASKS row is
+ * healed via the job key — the reload then shows the finished card exactly
+ * like a card that completed inside the live turn.
  */
 final readonly class MediaJobMessageSync
 {
@@ -29,6 +39,7 @@ final readonly class MediaJobMessageSync
         private GeneratedFileRegistrar $fileRegistrar,
         private MediaJobRealtimeNotifier $realtimeNotifier,
         private MediaJobUsageRecorder $usageRecorder,
+        private TaskPlanStore $taskPlanStore,
         private EntityManagerInterface $em,
         private LoggerInterface $logger,
     ) {
@@ -76,28 +87,39 @@ final readonly class MediaJobMessageSync
             return;
         }
 
-        $mediaJobMeta = [
-            'job_id' => $job->getJobKey(),
-            'type' => $job->getType(),
-            'state' => $status['state'],
-        ];
-        if (null !== $job->getError() && '' !== $job->getError()) {
-            $mediaJobMeta['error'] = $job->getError();
-        }
-
-        $message->setMeta(
-            'media_job',
-            (string) json_encode($mediaJobMeta, \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE)
-        );
-
-        if (MediaJob::STATUS_FAILED === $job->getStatus() || MediaJob::STATUS_TIMED_OUT === $job->getStatus()) {
-            $errorText = $job->getError();
-            if (null !== $errorText && '' !== trim($errorText)) {
-                $message->setText($errorText);
+        $nodeId = $job->getNodeId();
+        if (null !== $nodeId && '' !== $nodeId) {
+            // Multitask node job: the task card is the surface — patch the
+            // persisted card state and NEVER touch the assembled reply text
+            // or the single-task `media_job` banner meta (see class docblock).
+            $this->syncTaskPlanCard($job, $message, $status['state']);
+            if (MediaJob::STATUS_COMPLETED === $job->getStatus()) {
+                $this->attachGeneratedFile($job, $message);
             }
-        } elseif (MediaJob::STATUS_COMPLETED === $job->getStatus()) {
-            $message->setText('');
-            $this->attachGeneratedFile($job, $message);
+        } else {
+            $mediaJobMeta = [
+                'job_id' => $job->getJobKey(),
+                'type' => $job->getType(),
+                'state' => $status['state'],
+            ];
+            if (null !== $job->getError() && '' !== $job->getError()) {
+                $mediaJobMeta['error'] = $job->getError();
+            }
+
+            $message->setMeta(
+                'media_job',
+                (string) json_encode($mediaJobMeta, \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE)
+            );
+
+            if (MediaJob::STATUS_FAILED === $job->getStatus() || MediaJob::STATUS_TIMED_OUT === $job->getStatus()) {
+                $errorText = $job->getError();
+                if (null !== $errorText && '' !== trim($errorText)) {
+                    $message->setText($errorText);
+                }
+            } elseif (MediaJob::STATUS_COMPLETED === $job->getStatus()) {
+                $message->setText('');
+                $this->attachGeneratedFile($job, $message);
+            }
         }
 
         $this->em->flush();
@@ -117,6 +139,67 @@ final readonly class MediaJobMessageSync
         // (best-effort; the persisted state above + the client poll are the
         // fallback if realtime is disabled/unreachable).
         $this->realtimeNotifier->publishUpdate($job);
+    }
+
+    /**
+     * Patch the terminal outcome of an async media node into the OUT message's
+     * persisted `task_plan` render meta and the BMESSAGE_TASKS row (#1239).
+     *
+     * The DAG turn persisted the card as 'running' (the job outlives the
+     * request); without this heal a reload keeps showing the skeleton/spinner
+     * even though the render finished. The card is matched by nodeId — the
+     * plan validator guarantees node ids are unique within a plan.
+     */
+    private function syncTaskPlanCard(MediaJob $job, \App\Entity\Message $message, string $state): void
+    {
+        $this->taskPlanStore->updateStatusByJobKey($job->getJobKey(), $state);
+
+        $raw = $message->getMeta('task_plan');
+        if (null === $raw || '' === $raw) {
+            return;
+        }
+        $decoded = json_decode($raw, true);
+        if (!is_array($decoded) || !is_array($decoded['cards'] ?? null)) {
+            return;
+        }
+
+        $patched = false;
+        foreach ($decoded['cards'] as &$card) {
+            if (!is_array($card) || ($card['nodeId'] ?? null) !== $job->getNodeId()) {
+                continue;
+            }
+            $card['state'] = $state;
+            if (null !== $job->getError() && '' !== $job->getError()) {
+                $card['error'] = $job->getError();
+            }
+            $result = $job->getResult();
+            $file = is_array($result['file'] ?? null) ? $result['file'] : null;
+            if (null !== $file && is_string($file['url'] ?? null) && '' !== $file['url']) {
+                // Stored as the public upload URL — the frontend mapper's
+                // buildUploadUrl() passes that form through unchanged.
+                $card['url'] = $file['url'];
+                $card['type'] = is_string($file['type'] ?? null) ? $file['type'] : $job->getType();
+            }
+            $patched = true;
+            break;
+        }
+        unset($card);
+
+        if (!$patched) {
+            return;
+        }
+
+        $message->setMeta(
+            'task_plan',
+            (string) json_encode($decoded, \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE)
+        );
+
+        $this->logger->info('MediaJobMessageSync: healed task card for terminal node job', [
+            'job_key' => $job->getJobKey(),
+            'message_id' => $message->getId(),
+            'node_id' => $job->getNodeId(),
+            'state' => $state,
+        ]);
     }
 
     /**

--- a/backend/src/Service/Media/MediaJobService.php
+++ b/backend/src/Service/Media/MediaJobService.php
@@ -242,6 +242,7 @@ final class MediaJobService
      */
     public function markCompleted(MediaJob $job, array $result): void
     {
+        $this->adoptFreshMessageBinding($job);
         $job->setResult($result)
             ->setPercent(100)
             ->setError(null)
@@ -257,6 +258,7 @@ final class MediaJobService
 
     public function markFailed(MediaJob $job, string $error): void
     {
+        $this->adoptFreshMessageBinding($job);
         $job->setError($this->truncateError($error))
             ->setFinishedAt(time())
             ->setStatus(MediaJob::STATUS_FAILED);
@@ -271,6 +273,7 @@ final class MediaJobService
 
     public function markCancelled(MediaJob $job): void
     {
+        $this->adoptFreshMessageBinding($job);
         $job->setFinishedAt(time())
             ->setStatus(MediaJob::STATUS_CANCELLED);
         $this->store->save($job);
@@ -278,6 +281,7 @@ final class MediaJobService
 
     public function markTimedOut(MediaJob $job, string $reason): void
     {
+        $this->adoptFreshMessageBinding($job);
         $job->setError($this->truncateError($reason))
             ->setFinishedAt(time())
             ->setStatus(MediaJob::STATUS_TIMED_OUT);
@@ -288,6 +292,36 @@ final class MediaJobService
             'reason' => $reason,
             'elapsed_seconds' => $job->getElapsedSeconds(),
         ]);
+    }
+
+    /**
+     * Re-adopt the stored message binding before a terminal save (#1239).
+     *
+     * The worker holds its MediaJob object in memory for the whole render.
+     * When StreamController rebinds the job to the freshly persisted OUT
+     * message DURING that render, the worker's terminal save would overwrite
+     * the rebind with its stale IN-message id — the terminal sync then hits
+     * the IN row, is (correctly) skipped by the #1218 direction guard, and the
+     * bubble/task card never resolves. Refreshing the binding right before the
+     * terminal transition makes the last write carry the freshest target.
+     * (A rebind landing inside the refresh→save window is still lost, but the
+     * window is milliseconds instead of the whole render.)
+     */
+    private function adoptFreshMessageBinding(MediaJob $job): void
+    {
+        $stored = $this->store->find($job->getJobKey());
+        if (null === $stored) {
+            return;
+        }
+        $storedMessageId = $stored->getMessageId();
+        if (null !== $storedMessageId && $storedMessageId !== $job->getMessageId()) {
+            $this->logger->info('MediaJob adopting rebound message id at terminal transition', [
+                'job_key' => $job->getJobKey(),
+                'stale_message_id' => $job->getMessageId(),
+                'message_id' => $storedMessageId,
+            ]);
+            $job->setMessageId($storedMessageId);
+        }
     }
 
     public function heartbeat(MediaJob $job): void

--- a/backend/src/Service/Media/MediaJobService.php
+++ b/backend/src/Service/Media/MediaJobService.php
@@ -160,23 +160,30 @@ final class MediaJobService
     }
 
     /**
-     * Point an active job at the assistant (OUT) message the user actually sees.
+     * Point a job at the assistant (OUT) message the user actually sees.
      *
      * The chat detach path creates the job inside the media handler, which only
      * has the INCOMING user message — the OUTGOING assistant message (the one
      * that carries the `media_job` meta and renders the banner) is persisted
      * later by StreamController. Without rebinding, the worker would sync the
      * wrong (incoming) message on completion and the visible bubble would stay
-     * stuck on "running" forever. No-op once the job is terminal.
+     * stuck on "running" forever.
+     *
+     * Terminal jobs are rebound too (#1239): a fast render can complete while
+     * still bound to the IN message, where the terminal sync is deliberately
+     * skipped (#1218 direction guard). Returning the job lets the caller run a
+     * second-chance {@see MediaJobMessageSync::syncTerminalState()} against the
+     * fresh OUT binding — otherwise the finished media never reaches the bubble
+     * and the task card spins forever. Returns null when the job is unknown.
      */
-    public function rebindMessage(string $jobKey, int $messageId): void
+    public function rebindMessage(string $jobKey, int $messageId): ?MediaJob
     {
         $job = $this->store->find($jobKey);
-        if (null === $job || $job->isTerminal()) {
-            return;
+        if (null === $job) {
+            return null;
         }
         if ($job->getMessageId() === $messageId) {
-            return;
+            return $job;
         }
 
         $job->setMessageId($messageId);
@@ -185,7 +192,10 @@ final class MediaJobService
         $this->logger->info('MediaJob rebound to outgoing message', [
             'job_key' => $jobKey,
             'message_id' => $messageId,
+            'terminal' => $job->isTerminal(),
         ]);
+
+        return $job;
     }
 
     public function markSubmitting(MediaJob $job): void

--- a/backend/src/Service/Message/MessageProcessor.php
+++ b/backend/src/Service/Message/MessageProcessor.php
@@ -870,10 +870,15 @@ final readonly class MessageProcessor
                 'model_name' => $chatModelName,
             ]);
 
+            // Forward the processing options exactly like processStream() does:
+            // without them the DAG runners get an EMPTY NodeContext options array,
+            // so track_id/node_id never reach MediaGenerationHandler — async node
+            // jobs are then created without their node binding and the per-card
+            // Stop / terminal card heal (#1239) cannot address them.
             $clsForRoute = $classification;
             $response = $this->isMultitaskRoutingEnabled($message)
-                ? $this->taskPlanExecutor->execute($message, $conversationHistory, $clsForRoute, $statusCallback)
-                : $this->router->route($message, $conversationHistory, $clsForRoute, $statusCallback);
+                ? $this->taskPlanExecutor->execute($message, $conversationHistory, $clsForRoute, $statusCallback, $options)
+                : $this->router->route($message, $conversationHistory, $clsForRoute, $statusCallback, $options);
 
             $this->notify($statusCallback, 'complete', 'Response generated', [
                 'provider' => $response['metadata']['provider'] ?? 'unknown',

--- a/backend/src/Service/Multitask/TaskPlanStore.php
+++ b/backend/src/Service/Multitask/TaskPlanStore.php
@@ -90,4 +90,29 @@ final readonly class TaskPlanStore
             return 0;
         }
     }
+
+    /**
+     * Record the terminal outcome of an async media node after the turn ended.
+     *
+     * The DAG persists such nodes as 'running' (the background job outlives the
+     * request); when the job reaches its terminal state the worker heals the row
+     * via the job key stamped at persist time (#1239). Best-effort like the rest
+     * of this store — a miss only affects observability, never the user turn.
+     */
+    public function updateStatusByJobKey(string $jobKey, string $status): void
+    {
+        if ('' === $jobKey) {
+            return;
+        }
+
+        try {
+            $this->connection->update('BMESSAGE_TASKS', ['BSTATUS' => $status], ['BJOBKEY' => $jobKey]);
+        } catch (\Throwable $e) {
+            $this->logger->warning('TaskPlanStore: failed to update node status by job key', [
+                'job_key' => $jobKey,
+                'status' => $status,
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
 }

--- a/backend/tests/Integration/Service/Media/AsyncMediaJobLifecycleIntegrationTest.php
+++ b/backend/tests/Integration/Service/Media/AsyncMediaJobLifecycleIntegrationTest.php
@@ -135,6 +135,7 @@ final class AsyncMediaJobLifecycleIntegrationTest extends KernelTestCase
             $container->get(GeneratedFileRegistrar::class),
             new MediaJobRealtimeNotifier($this->realtimePublisher, $this->jobService, $jobLogger),
             $usageRecorder,
+            $container->get(\App\Service\Multitask\TaskPlanStore::class),
             $this->em,
             $jobLogger,
         );
@@ -451,6 +452,119 @@ final class AsyncMediaJobLifecycleIntegrationTest extends KernelTestCase
             static fn (array $e): bool => 'media_job.update' === $e['event'] && ($e['payload']['message_id'] ?? null) === $incoming->getId(),
         ));
         self::assertSame([], $pushedForIncoming, 'no media_job.update may be pushed for the IN message');
+    }
+
+    public function testTerminalJobLateRebindSyncsOutMessageAndHealsTaskCard(): void
+    {
+        // Issue #1239: an async DAG image node finishes BEFORE StreamController
+        // persists the OUT message. The terminal sync correctly skips the IN
+        // message (#1218 direction guard) — but the later rebind must then give
+        // the job its missed sync against the OUT message: heal the persisted
+        // task card to `done` with the file, attach the File entity, update the
+        // BMESSAGE_TASKS row, and NEVER touch the assembled reply text or set
+        // the single-task `media_job` banner meta on a DAG turn.
+        $user = $this->createUser();
+        $incoming = $this->createIncomingMessage($user, 'erstelle das bild einer katze dann schreibe ein gedicht darüber');
+
+        $job = $this->jobService->create([
+            'userId' => $user->getId(),
+            'type' => MediaJob::TYPE_IMAGE,
+            'provider' => 'google',
+            'prompt' => 'a cat',
+            'model' => 'gemini-image',
+            'messageId' => $incoming->getId(),
+            'nodeId' => 'n1',
+            'options' => ['lang' => 'de'],
+        ]);
+        $this->createdJobKeys[] = $job->getJobKey();
+        $this->jobService->markCompleted($job, [
+            'file' => ['url' => '/api/v1/files/uploads/cat-1239.png', 'type' => 'image'],
+            'provider' => 'google',
+            'model' => 'gemini-image',
+        ]);
+
+        // Worker sync fires while still bound to IN → skipped (existing guard).
+        $this->messageSync->syncTerminalState($job);
+        $this->em->refresh($incoming);
+        self::assertSame(0, $incoming->getFiles()->count());
+
+        // StreamController persists the OUT message: assembled reply text + the
+        // per-node render state with the image card still 'running'.
+        $assembledText = "Hier ist dein Gedicht über die Katze.\n\nMiau.";
+        $outgoing = $this->createMessage($user);
+        $outgoing->setText($assembledText);
+        $outgoing->setMeta('task_plan', (string) json_encode([
+            'reply_node' => 'n3',
+            'cards' => [
+                ['nodeId' => 'n1', 'capability' => 'image_generation', 'kind' => 'image', 'state' => 'running', 'job_id' => $job->getJobKey()],
+                ['nodeId' => 'n2', 'capability' => 'chat', 'kind' => 'text', 'state' => 'done', 'text' => 'Miau.'],
+            ],
+        ], \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE));
+        $this->em->flush();
+
+        // The DAG also persisted the node row as running, stamped with the job key.
+        $connection = $this->em->getConnection();
+        $connection->insert('BMESSAGE_TASKS', [
+            'BMESSAGEID' => $incoming->getId(),
+            'BNODEID' => 'n1',
+            'BCAPABILITY' => 'image_generation',
+            'BDEPENDSON' => '[]',
+            'BSTATUS' => 'running',
+            'BJOBKEY' => $job->getJobKey(),
+        ]);
+
+        try {
+            // StreamController's rebind loop: terminal job → rebind + missed sync.
+            $rebound = $this->jobService->rebindMessage($job->getJobKey(), $outgoing->getId());
+            self::assertNotNull($rebound, 'terminal jobs must still be rebindable');
+            self::assertTrue($rebound->isTerminal());
+            self::assertSame($outgoing->getId(), $rebound->getMessageId());
+            $this->messageSync->syncTerminalState($rebound);
+
+            $this->em->refresh($outgoing);
+
+            // The assembled reply text survives — the single-task "clear text on
+            // done" mutation must not run for node jobs.
+            self::assertSame($assembledText, $outgoing->getText());
+            // No single-task banner meta on a DAG turn.
+            self::assertNull($outgoing->getMeta('media_job'));
+
+            // The generated file is attached for reload + Files world.
+            self::assertGreaterThan(0, $outgoing->getFiles()->count());
+            if ($outgoing->getFiles()->count() > 0) {
+                $this->createdFileIds[] = $outgoing->getFiles()->first()->getId();
+            }
+
+            // The persisted card resolved to done with the file URL.
+            $taskPlan = json_decode((string) $outgoing->getMeta('task_plan'), true);
+            self::assertIsArray($taskPlan);
+            $imageCard = $taskPlan['cards'][0];
+            self::assertSame('done', $imageCard['state']);
+            self::assertSame('/api/v1/files/uploads/cat-1239.png', $imageCard['url']);
+            self::assertSame('image', $imageCard['type']);
+            // The unrelated card is untouched.
+            self::assertSame('done', $taskPlan['cards'][1]['state']);
+            self::assertSame('Miau.', $taskPlan['cards'][1]['text']);
+
+            // The observability row healed too.
+            $rowStatus = $connection->fetchOne(
+                'SELECT BSTATUS FROM BMESSAGE_TASKS WHERE BJOBKEY = ?',
+                [$job->getJobKey()],
+            );
+            self::assertSame('done', $rowStatus);
+
+            // The realtime push carries the node id so the live card resolves.
+            $nodePush = array_values(array_filter(
+                $this->publishedEvents,
+                static fn (array $e): bool => 'media_job.update' === $e['event']
+                    && 'n1' === ($e['payload']['node_id'] ?? null)
+                    && 'done' === ($e['payload']['state'] ?? null),
+            ));
+            self::assertNotEmpty($nodePush, 'terminal node sync must push a media_job.update with the node id');
+            self::assertSame($outgoing->getId(), $nodePush[0]['payload']['message_id']);
+        } finally {
+            $connection->delete('BMESSAGE_TASKS', ['BJOBKEY' => $job->getJobKey()]);
+        }
     }
 
     public function testSyncImageJobRendersSavesAndAttachesToMessage(): void

--- a/backend/tests/Integration/Service/Media/AsyncMediaJobLifecycleIntegrationTest.php
+++ b/backend/tests/Integration/Service/Media/AsyncMediaJobLifecycleIntegrationTest.php
@@ -567,6 +567,43 @@ final class AsyncMediaJobLifecycleIntegrationTest extends KernelTestCase
         }
     }
 
+    public function testTerminalSaveAdoptsReboundMessageIdFromStore(): void
+    {
+        // Issue #1239, worker-side half: a single-step image render holds its
+        // MediaJob in memory for the whole render. If StreamController rebinds
+        // the job to the OUT message DURING that render, the worker's terminal
+        // markCompleted() used to save the stale IN-message binding back over
+        // the rebind — the sync then hit the IN row and was skipped forever.
+        // The terminal transition must re-adopt the freshest stored binding.
+        $user = $this->createUser();
+        $incoming = $this->createIncomingMessage($user, 'erstelle das bild einer katze');
+        $outgoing = $this->createMessage($user);
+
+        $job = $this->jobService->create([
+            'userId' => $user->getId(),
+            'type' => MediaJob::TYPE_IMAGE,
+            'provider' => 'openai',
+            'prompt' => 'a cat',
+            'messageId' => $incoming->getId(),
+            'nodeId' => 'n1',
+            'options' => ['lang' => 'de'],
+        ]);
+        $this->createdJobKeys[] = $job->getJobKey();
+
+        // Rebind lands while the worker's in-memory copy still points at IN.
+        $this->jobService->rebindMessage($job->getJobKey(), $outgoing->getId());
+        self::assertSame($incoming->getId(), $job->getMessageId(), 'in-memory copy is intentionally stale');
+
+        $this->jobService->markCompleted($job, [
+            'file' => ['url' => '/api/v1/files/uploads/cat-race.png', 'type' => 'image'],
+        ]);
+
+        self::assertSame($outgoing->getId(), $job->getMessageId(), 'terminal save must adopt the rebound OUT binding');
+        $fresh = $this->store->find($job->getJobKey());
+        self::assertNotNull($fresh);
+        self::assertSame($outgoing->getId(), $fresh->getMessageId());
+    }
+
     public function testSyncImageJobRendersSavesAndAttachesToMessage(): void
     {
         $user = $this->createUser();

--- a/backend/tests/Unit/Controller/StreamControllerAiModelsPayloadTest.php
+++ b/backend/tests/Unit/Controller/StreamControllerAiModelsPayloadTest.php
@@ -11,6 +11,7 @@ use App\Service\File\DocumentGeneratorService;
 use App\Service\File\UserUploadPathBuilder;
 use App\Service\GuestSessionService;
 use App\Service\Media\MediaCancellationStore;
+use App\Service\Media\MediaJobMessageSync;
 use App\Service\Media\MediaJobService;
 use App\Service\MemoryExtractionDispatcher;
 use App\Service\Message\MessageForwardingService;
@@ -62,6 +63,7 @@ class StreamControllerAiModelsPayloadTest extends TestCase
             $this->createMock(DocumentGeneratorService::class),
             $this->createMock(MediaCancellationStore::class),
             $this->createMock(MediaJobService::class),
+            $this->createMock(MediaJobMessageSync::class),
         );
     }
 

--- a/backend/tests/Unit/Controller/StreamControllerDeferredMemoryDispatchTest.php
+++ b/backend/tests/Unit/Controller/StreamControllerDeferredMemoryDispatchTest.php
@@ -11,6 +11,7 @@ use App\Service\File\DocumentGeneratorService;
 use App\Service\File\UserUploadPathBuilder;
 use App\Service\GuestSessionService;
 use App\Service\Media\MediaCancellationStore;
+use App\Service\Media\MediaJobMessageSync;
 use App\Service\Media\MediaJobService;
 use App\Service\MemoryExtractionDispatcher;
 use App\Service\Message\MessageForwardingService;
@@ -79,6 +80,7 @@ final class StreamControllerDeferredMemoryDispatchTest extends TestCase
             $this->createMock(DocumentGeneratorService::class),
             $this->createMock(MediaCancellationStore::class),
             $this->createMock(MediaJobService::class),
+            $this->createMock(MediaJobMessageSync::class),
         );
     }
 

--- a/backend/tests/Unit/Controller/StreamControllerOriginalMediaMetaTest.php
+++ b/backend/tests/Unit/Controller/StreamControllerOriginalMediaMetaTest.php
@@ -11,6 +11,7 @@ use App\Service\File\DocumentGeneratorService;
 use App\Service\File\UserUploadPathBuilder;
 use App\Service\GuestSessionService;
 use App\Service\Media\MediaCancellationStore;
+use App\Service\Media\MediaJobMessageSync;
 use App\Service\Media\MediaJobService;
 use App\Service\MemoryExtractionDispatcher;
 use App\Service\Message\MessageForwardingService;
@@ -58,6 +59,7 @@ class StreamControllerOriginalMediaMetaTest extends TestCase
             $this->createMock(DocumentGeneratorService::class),
             $this->createMock(MediaCancellationStore::class),
             $this->createMock(MediaJobService::class),
+            $this->createMock(MediaJobMessageSync::class),
         );
     }
 

--- a/backend/tests/Unit/Controller/StreamControllerRagGroupKeyTest.php
+++ b/backend/tests/Unit/Controller/StreamControllerRagGroupKeyTest.php
@@ -10,6 +10,7 @@ use App\Service\File\DocumentGeneratorService;
 use App\Service\File\UserUploadPathBuilder;
 use App\Service\GuestSessionService;
 use App\Service\Media\MediaCancellationStore;
+use App\Service\Media\MediaJobMessageSync;
 use App\Service\Media\MediaJobService;
 use App\Service\MemoryExtractionDispatcher;
 use App\Service\Message\MessageForwardingService;
@@ -63,6 +64,7 @@ final class StreamControllerRagGroupKeyTest extends TestCase
             $this->createMock(DocumentGeneratorService::class),
             $this->createMock(MediaCancellationStore::class),
             $this->createMock(MediaJobService::class),
+            $this->createMock(MediaJobMessageSync::class),
         );
     }
 

--- a/backend/tests/Unit/Controller/StreamControllerTaskPlanFilesTest.php
+++ b/backend/tests/Unit/Controller/StreamControllerTaskPlanFilesTest.php
@@ -11,6 +11,7 @@ use App\Service\File\DocumentGeneratorService;
 use App\Service\File\UserUploadPathBuilder;
 use App\Service\GuestSessionService;
 use App\Service\Media\MediaCancellationStore;
+use App\Service\Media\MediaJobMessageSync;
 use App\Service\Media\MediaJobService;
 use App\Service\MemoryExtractionDispatcher;
 use App\Service\Message\MessageForwardingService;
@@ -59,6 +60,7 @@ class StreamControllerTaskPlanFilesTest extends TestCase
             $this->createMock(DocumentGeneratorService::class),
             $this->createMock(MediaCancellationStore::class),
             $this->createMock(MediaJobService::class),
+            $this->createMock(MediaJobMessageSync::class),
         );
     }
 

--- a/frontend/src/utils/messageMapper.ts
+++ b/frontend/src/utils/messageMapper.ts
@@ -57,8 +57,32 @@ export interface MediaJobUpdate {
  *
  * Shared by the realtime `mediaJobs` store (push) and ChatView's completion
  * handler so the push and poll paths can never diverge.
+ *
+ * Multitask node jobs (the update carries a `node_id` matching a task card)
+ * patch the CARD instead (#1239): the card is the surface for DAG media — the
+ * single-task banner and a bubble-level media part would be wrong/duplicative
+ * next to it.
  */
 export function applyMediaJobUpdateToMessage(message: Message, update: MediaJobUpdate): void {
+  if (update.node_id && message.taskPlan) {
+    const card = message.taskPlan.cards.find((c) => c.nodeId === update.node_id)
+    if (card) {
+      // A user-cancelled card is terminal on the client (same rule as the SSE
+      // task_update handler) — never overwrite it with a late job state.
+      if (card.state !== 'cancelled' && isTaskCardState(update.state)) {
+        card.state = update.state
+      }
+      if (update.error) {
+        card.error = update.error
+      }
+      if (update.file?.url) {
+        card.url = normalizeMediaUrl(update.file.url)
+        card.mediaType = update.file.type ?? update.type
+      }
+      return
+    }
+  }
+
   message.mediaJob = {
     ...(message.mediaJob ?? {}),
     jobId: update.job_id,

--- a/frontend/tests/unit/utils/applyMediaJobUpdate.spec.ts
+++ b/frontend/tests/unit/utils/applyMediaJobUpdate.spec.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeEach } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
 import { applyMediaJobUpdateToMessage } from '@/utils/messageMapper'
-import type { Message } from '@/stores/history'
+import type { Message, TaskPlanState } from '@/stores/history'
 
 /**
  * Sprint C: the shared helper that applies a realtime/poll media-job update to a
@@ -20,7 +21,30 @@ function makeMessage(overrides: Partial<Message> = {}): Message {
   } as Message
 }
 
+function makeTaskPlan(overrides: Partial<TaskPlanState> = {}): TaskPlanState {
+  return {
+    active: false,
+    replyNode: 'n3',
+    cards: [
+      {
+        nodeId: 'n1',
+        capability: 'image_generation',
+        kind: 'image',
+        state: 'running',
+        jobId: 'job-1',
+      },
+      { nodeId: 'n2', capability: 'chat', kind: 'text', state: 'done', text: 'Miau.' },
+    ],
+    ...overrides,
+  }
+}
+
 describe('applyMediaJobUpdateToMessage', () => {
+  beforeEach(() => {
+    // normalizeMediaUrl (task-card patch path) reads the config store.
+    setActivePinia(createPinia())
+  })
+
   it('flips the job to done and appends the generated media part', () => {
     const m = makeMessage()
     applyMediaJobUpdateToMessage(m, {
@@ -78,5 +102,76 @@ describe('applyMediaJobUpdateToMessage', () => {
     expect(m.mediaJob?.state).toBe('failed')
     expect(m.mediaJob?.error).toBe('Your video took too long.')
     expect(m.parts.some((p) => p.type === 'video')).toBe(false)
+  })
+
+  // Multitask node jobs (#1239): the task card is the surface — the update
+  // patches the card and must NOT set the single-task banner or append a
+  // duplicate bubble-level media part next to the card.
+  describe('multitask node job (node_id set)', () => {
+    it('resolves the matching task card to done with the file url', () => {
+      const m = makeMessage({ mediaJob: undefined, taskPlan: makeTaskPlan() })
+      applyMediaJobUpdateToMessage(m, {
+        job_id: 'job-1',
+        message_id: 305,
+        node_id: 'n1',
+        type: 'image',
+        state: 'done',
+        file: { url: '/api/v1/files/uploads/cat.png', type: 'image' },
+      })
+
+      const card = m.taskPlan?.cards.find((c) => c.nodeId === 'n1')
+      expect(card?.state).toBe('done')
+      expect(card?.url).toContain('cat.png')
+      expect(m.mediaJob).toBeUndefined()
+      expect(m.parts.some((p) => p.type === 'image')).toBe(false)
+    })
+
+    it('marks the card failed with the error text', () => {
+      const m = makeMessage({ mediaJob: undefined, taskPlan: makeTaskPlan() })
+      applyMediaJobUpdateToMessage(m, {
+        job_id: 'job-1',
+        message_id: 305,
+        node_id: 'n1',
+        type: 'image',
+        state: 'failed',
+        error: 'Image generation failed.',
+      })
+
+      const card = m.taskPlan?.cards.find((c) => c.nodeId === 'n1')
+      expect(card?.state).toBe('failed')
+      expect(card?.error).toBe('Image generation failed.')
+      expect(m.mediaJob).toBeUndefined()
+    })
+
+    it('never resurrects a user-cancelled card', () => {
+      const plan = makeTaskPlan()
+      plan.cards[0].state = 'cancelled'
+      const m = makeMessage({ mediaJob: undefined, taskPlan: plan })
+      applyMediaJobUpdateToMessage(m, {
+        job_id: 'job-1',
+        message_id: 305,
+        node_id: 'n1',
+        type: 'image',
+        state: 'failed',
+        error: 'aborted',
+      })
+
+      expect(m.taskPlan?.cards[0].state).toBe('cancelled')
+    })
+
+    it('falls back to the single-task path when no card matches the node id', () => {
+      const m = makeMessage({ taskPlan: makeTaskPlan() })
+      applyMediaJobUpdateToMessage(m, {
+        job_id: 'job-9',
+        message_id: 305,
+        node_id: 'n9',
+        type: 'video',
+        state: 'done',
+        file: { url: '/api/v1/files/uploads/x.mp4', type: 'video' },
+      })
+
+      expect(m.mediaJob?.state).toBe('done')
+      expect(m.parts.some((p) => p.type === 'video')).toBe(true)
+    })
   })
 })


### PR DESCRIPTION
## Summary

Sprint 1 of the multitask-DAG stabilization plan: fixes #1239 (async image job completes before OUT rebind → task card stuck on **running** forever) in all three variants of the race, and verifies #1225/#1223 detach-on-navigation still holds end-to-end.

- **Terminal-before-rebind:** `MediaJobService::rebindMessage()` no longer no-ops on terminal jobs; it returns the job so `StreamController` runs the missed `syncTerminalState()` against the fresh OUT binding (streaming **and** non-streaming persist branches).
- **Rebind-during-render:** terminal transitions (`markCompleted`/`markFailed`/`markCancelled`/`markTimedOut`) re-read the stored snapshot and adopt a rebound message id before saving, so the worker's stale in-memory IN binding can no longer overwrite the rebind.
- **Options dropped on the non-streaming path:** `MessageProcessor::process()` now forwards the processing options to `TaskPlanExecutor`/`InferenceRouter` like `processStream()` does — without this, DAG runners got an empty `NodeContext::options`, so `track_id`/`node_id` never reached `MediaGenerationHandler` and node jobs were created without their node binding (breaking per-card Stop and any card heal).
- **Card heal:** `MediaJobMessageSync` is multitask-aware — node jobs patch the matching card in the persisted `task_plan` meta (state/url/error) + heal the `BMESSAGE_TASKS` row via the stamped job key, instead of mutating the assembled reply text / single-task `media_job` banner meta (which previously **wiped the composed answer** when a slow node job finished after the turn).
- **Frontend:** `applyMediaJobUpdateToMessage()` resolves the matching task card for node-scoped `media_job.update` pushes (card is the surface; no duplicate banner/bubble part), keeping user-cancelled cards terminal.

Fixes #1239

## Test plan

- [x] `make lint && make -C backend phpstan && make test` green (2464 tests)
- [x] `make -C frontend lint`, `vue-tsc`, `make -C frontend test` green (790 tests)
- [x] New integration coverage: `testTerminalJobLateRebindSyncsOutMessageAndHealsTaskCard`, `testTerminalSaveAdoptsReboundMessageIdFromStore`; 4 new node-card unit tests for `applyMediaJobUpdateToMessage`
- [x] Live scenario A (local stack, real OpenAI image render): "erstelle das bild einer katze dann schreibe ein gedicht darüber und lies es mir am ende vor" → image card resolves to **done** with the file, poem text intact, `BMESSAGE_TASKS` row healed
- [x] Live scenario B (detach): client disconnects 4 s into the same prompt → turn completes in background, no cancelled bubble, image card **done** with file on reload (#1225/#1223 behaviour intact)