### PR TITLE
feat(multitask): url_fetch data node — read a specific URL inside the DAG (plan 09 S2)

### DIFF
--- a/backend/src/Prompt/PromptCatalog.php
+++ b/backend/src/Prompt/PromptCatalog.php
@@ -553,6 +553,14 @@ Allowed topic keys: [KEYLIST]
    the `email_me` node. (Exception: a meeting invite alone → rule 7.)
 9. Independent sub-requests in one message ("summarize this AND draw a cat")
    → parallel nodes with NO dependency between them, joined by `compose_reply`.
+9b. The user asks to read/summarize/use the content of a SPECIFIC URL written
+   in the message ("load https://…", "was steht auf dieser Seite?",
+   "summarize this article: https://…") → a `url_fetch` node (put the URL in
+   `inputs.urls`), then feed `$nX.text` into the answering node
+   (`summarize`/`chat`/`translate`). Do NOT emit `url_fetch` for a bare link
+   mention the question does not depend on, and prefer `web_search` when no
+   concrete URL is given. Only use `url_fetch` if it appears in the
+   capability list above.
 10. Plain question / smalltalk / advice → one `chat` node. `reply_node` = that
    node, no `compose_reply` needed.
 11. A SINGLE media request with no follow-up step ("make an image of X",
@@ -718,6 +726,23 @@ User: (attaches photo.png) "Beschreibe in einem Audio, was hier zu sehen ist."
 The attached image is ANALYZED (`file_analysis` on `$message.files`) and the
 description is spoken (`text2sound`). NEVER route this to `image_generation` —
 the user wants the existing picture explained, not a new picture generated.
+
+### Read a specific URL, then summarize it
+User: "Fasse mir diese Seite zusammen: https://example.com/artikel"
+
+{
+  "version": 1,
+  "language": "de",
+  "reply_node": "n3",
+  "tasks": [
+    { "id": "n1", "capability": "url_fetch", "inputs": { "urls": "https://example.com/artikel" } },
+    { "id": "n2", "capability": "summarize", "depends_on": ["n1"], "inputs": { "text": "$n1.text" }, "params": { "style": "short" } },
+    { "id": "n3", "capability": "compose_reply", "depends_on": ["n1","n2"], "inputs": { "text": "$n2.text" } }
+  ]
+}
+
+The page content is FETCHED (`url_fetch`) and the summary consumes `$n1.text` —
+never answer about a URL's content from memory or invent what the page says.
 
 ### Calendar invite ("I need a meeting reminder for tomorrow at 9:00 with Sanam")
 The event fields go in `params`. Resolve the relative time against the time

--- a/backend/src/Service/Multitask/Execution/DagExecutor.php
+++ b/backend/src/Service/Multitask/Execution/DagExecutor.php
@@ -532,16 +532,16 @@ final readonly class DagExecutor
     }
 
     /**
-     * Extra `task_update` metadata for a successfully completed node.
-     * Currently only web_search nodes carry extra data (query + results_count)
-     * so the live task card shows a compact summary matching the reload state
-     * (QA feedback PR #1076 — search card body parity).
+     * Extra `task_update` metadata for a successfully completed node. Nodes
+     * with a search-style card (web_search: query + results_count; url_fetch:
+     * fetched hostnames as the query) carry a compact summary so the live task
+     * card matches the reload state (QA feedback PR #1076 — card body parity).
      *
      * @return array<string, mixed>
      */
     private function successMetadata(TaskNode $node, NodeResult $result): array
     {
-        if (Capability::WebSearch !== $node->capability) {
+        if (!in_array($node->capability, [Capability::WebSearch, Capability::UrlFetch], true)) {
             return [];
         }
 

--- a/backend/src/Service/Multitask/Execution/Runner/UrlFetchRunner.php
+++ b/backend/src/Service/Multitask/Execution/Runner/UrlFetchRunner.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Multitask\Execution\Runner;
+
+use App\Service\Multitask\Execution\NodeContext;
+use App\Service\Multitask\Execution\NodeResult;
+use App\Service\Multitask\Execution\TaskRunner;
+use App\Service\Multitask\MultitaskRoutingConfig;
+use App\Service\Multitask\Plan\Capability;
+use App\Service\Multitask\Plan\TaskNode;
+use App\Service\Multitask\Skill\SkillDescriptor;
+use App\Service\UrlContentResult;
+use App\Service\UrlContentService;
+use Psr\Log\LoggerInterface;
+
+/**
+ * `url_fetch` runner — "load this URL and read the content" as a planner-placed
+ * DAG node (release-4.0 plan 09 §3.1, the first external DATA node).
+ *
+ * Thin adapter over the existing {@see UrlContentService}: SSRF-guarded,
+ * robots.txt + noindex compliant, size-capped. No new fetch code.
+ *
+ * Reuse-first: when MessageProcessor step 2.7 already fetched the same turn's
+ * URLs (topic prompt with `tool_url_screenshot`), the pre-formatted block in
+ * `classification['url_content']` is reused instead of re-fetching — the same
+ * pattern WebSearchRunner uses for pre-fetched search results.
+ *
+ * Uniform data-node contract (plan 09 §2): planner-placed, timeout-bounded,
+ * read-only, isolated failure (`NodeResult::failed()` — never throws), output
+ * is formatted citable text downstream nodes consume via `$nX.text`.
+ */
+final readonly class UrlFetchRunner implements TaskRunner
+{
+    /** Hard cap on the formatted node output (token control, plan 09 §3.1). */
+    private const MAX_OUTPUT_CHARS = 12000;
+
+    public function __construct(
+        private UrlContentService $urlContentService,
+        private MultitaskRoutingConfig $routingConfig,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function supportedCapabilities(): array
+    {
+        return [Capability::UrlFetch];
+    }
+
+    /**
+     * @return list<SkillDescriptor>
+     */
+    public function describe(): array
+    {
+        return [
+            new SkillDescriptor(
+                Capability::UrlFetch,
+                'Fetch and read the content of specific URL(s) the user named in the message (inputs.urls, falls back to URLs in the message text). Use when the answer depends on that page\'s content; prefer web_search when no concrete URL is given.',
+                enabledFlag: MultitaskRoutingConfig::KEY_URL_FETCH_ENABLED,
+                enabledDefault: false,
+            ),
+        ];
+    }
+
+    public function run(TaskNode $node, NodeContext $context): NodeResult
+    {
+        // Defense in depth: the SkillCatalog already hides this block from the
+        // planner when the flag is off; a stale/hallucinated plan still must
+        // not fetch.
+        if (!$this->routingConfig->isFeatureEnabled(
+            MultitaskRoutingConfig::KEY_URL_FETCH_ENABLED,
+            $context->userId,
+            false,
+        )) {
+            return NodeResult::failed('url_fetch is disabled');
+        }
+
+        $urls = $this->resolveUrls($node, $context);
+        if ([] === $urls) {
+            return NodeResult::failed('no URL found to fetch');
+        }
+
+        // Reuse step 2.7's fetch when it already ran for this turn and this
+        // node has no narrower URL selection than the message itself.
+        $preFetched = $context->classification['url_content'] ?? null;
+        if (is_string($preFetched) && '' !== trim($preFetched)
+            && $urls === $this->urlContentService->extractUrls((string) $context->message->getText())) {
+            $this->logger->info('UrlFetchRunner: reusing pre-fetched URL content (step 2.7)');
+
+            return NodeResult::ok($preFetched, [], [
+                'url_fetch' => true,
+                'query' => implode(', ', $this->hostnames($urls)),
+                'urls' => $urls,
+                'reused_prefetched' => true,
+            ]);
+        }
+
+        $results = [];
+        foreach ($urls as $url) {
+            $results[] = $this->urlContentService->fetchForCrawling($url);
+        }
+
+        $successful = array_values(array_filter($results, static fn (UrlContentResult $r): bool => $r->success));
+        if ([] === $successful) {
+            $firstError = $results[0]->error ?? 'fetch failed';
+
+            return NodeResult::failed('could not read the page: '.$firstError);
+        }
+
+        $text = $this->urlContentService->formatForPrompt($successful);
+        if (mb_strlen($text) > self::MAX_OUTPUT_CHARS) {
+            $text = mb_substr($text, 0, self::MAX_OUTPUT_CHARS).'…';
+        }
+
+        $this->logger->info('UrlFetchRunner: fetched URL content', [
+            'requested' => count($urls),
+            'successful' => count($successful),
+            'chars' => mb_strlen($text),
+        ]);
+
+        return NodeResult::ok($text, [], [
+            'url_fetch' => true,
+            'query' => implode(', ', $this->hostnames($urls)),
+            'urls' => $urls,
+            'titles' => array_map(static fn (UrlContentResult $r): string => $r->title, $successful),
+        ]);
+    }
+
+    /**
+     * URLs from the planner's `inputs.urls` / `inputs.url` (literal or list),
+     * falling back to URLs embedded in the user message. Capped at 3
+     * (UrlContentService's per-message limit).
+     *
+     * @return list<string>
+     */
+    private function resolveUrls(TaskNode $node, NodeContext $context): array
+    {
+        $inputs = $context->resolveInputs($node);
+
+        $candidates = [];
+        foreach (['urls', 'url'] as $key) {
+            $value = $inputs[$key] ?? null;
+            if (is_string($value)) {
+                $candidates = array_merge($candidates, $this->urlContentService->extractUrls($value));
+            } elseif (is_array($value)) {
+                foreach ($value as $item) {
+                    if (is_string($item)) {
+                        $candidates = array_merge($candidates, $this->urlContentService->extractUrls($item));
+                    }
+                }
+            }
+        }
+
+        if ([] === $candidates) {
+            $candidates = $this->urlContentService->extractUrls((string) $context->message->getText());
+        }
+
+        return array_slice(array_values(array_unique($candidates)), 0, 3);
+    }
+
+    /**
+     * @param list<string> $urls
+     *
+     * @return list<string>
+     */
+    private function hostnames(array $urls): array
+    {
+        $hosts = [];
+        foreach ($urls as $url) {
+            $host = parse_url($url, \PHP_URL_HOST);
+            if (is_string($host) && '' !== $host) {
+                $hosts[] = $host;
+            }
+        }
+
+        return array_values(array_unique($hosts));
+    }
+}

--- a/backend/src/Service/Multitask/MultitaskRoutingConfig.php
+++ b/backend/src/Service/Multitask/MultitaskRoutingConfig.php
@@ -40,6 +40,7 @@ final readonly class MultitaskRoutingConfig
     public const KEY_PARALLEL_ENABLED = 'PARALLEL_ENABLED';
     public const KEY_MAX_PARALLEL = 'MAX_PARALLEL';
     public const KEY_NODE_TIMEOUT = 'NODE_TIMEOUT';
+    public const KEY_URL_FETCH_ENABLED = 'URL_FETCH_ENABLED';
 
     private const DEFAULT_ROUTING_ENABLED = true;
     private const DEFAULT_SHADOW_MODE = false;
@@ -104,6 +105,18 @@ final readonly class MultitaskRoutingConfig
         $n = null !== $value ? (int) $value : self::DEFAULT_NODE_TIMEOUT;
 
         return max(10, min(600, $n));
+    }
+
+    /**
+     * Generic per-block feature flag (release-4.0 data nodes: URL_FETCH_ENABLED,
+     * MCP_FETCH_ENABLED, EMAIL_SEARCH_ENABLED, …). Same resolution order as the
+     * routing master switch: per-user row → global row → built-in default.
+     * Consumed by the {@see Skill\SkillCatalog} at plan
+     * time and re-checked by the block's runner at run time.
+     */
+    public function isFeatureEnabled(string $setting, ?int $userId, bool $default): bool
+    {
+        return $this->resolveFlag($setting, $userId, $default);
     }
 
     private function resolveFlag(string $setting, ?int $userId, bool $default): bool

--- a/backend/src/Service/Multitask/Plan/Capability.php
+++ b/backend/src/Service/Multitask/Plan/Capability.php
@@ -36,6 +36,9 @@ enum Capability: string
     /** Web search (BraveSearchService + SearchQueryGenerator). */
     case WebSearch = 'web_search';
 
+    /** Fetch + read the content of specific URL(s) named in the request (UrlContentService). */
+    case UrlFetch = 'url_fetch';
+
     /** Vision / OCR / document Q&A (FileAnalysisHandler). */
     case FileAnalysis = 'file_analysis';
 
@@ -77,7 +80,7 @@ enum Capability: string
         return match ($this) {
             self::ExtractText => 'extract',
             self::Chat, self::Summarize, self::Translate, self::RagQuery, self::FileAnalysis => 'text',
-            self::WebSearch => 'search',
+            self::WebSearch, self::UrlFetch => 'search',
             self::ImageGeneration => 'image',
             self::VideoGeneration => 'video',
             self::Text2Sound => 'audio',

--- a/backend/src/Service/Multitask/Skill/SkillCatalog.php
+++ b/backend/src/Service/Multitask/Skill/SkillCatalog.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Service\Multitask\Skill;
 
 use App\Service\Multitask\Execution\TaskRunner;
+use App\Service\Multitask\MultitaskRoutingConfig;
 use App\Service\Multitask\Plan\Capability;
 use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 
@@ -28,11 +29,16 @@ final class SkillCatalog
     private array $byCapability = [];
 
     /**
-     * @param iterable<TaskRunner> $runners
+     * @param iterable<TaskRunner>        $runners
+     * @param MultitaskRoutingConfig|null $routingConfig resolves per-block enable
+     *                                                   flags; null (unit tests)
+     *                                                   falls back to each
+     *                                                   descriptor's enabledDefault
      */
     public function __construct(
         #[AutowireIterator('app.multitask.runner')]
         iterable $runners = [],
+        private readonly ?MultitaskRoutingConfig $routingConfig = null,
     ) {
         foreach ($runners as $runner) {
             foreach ($runner->describe() as $descriptor) {
@@ -55,6 +61,15 @@ final class SkillCatalog
         $lines = [];
         foreach (Capability::cases() as $capability) {
             $descriptor = $this->byCapability[$capability->value] ?? null;
+
+            // Flag-gated blocks (url_fetch, mcp_fetch, email_search …) are
+            // omitted entirely when disabled: the planner never learns they
+            // exist, so it cannot emit them (plan 09 §6 — plan-time gate; the
+            // runner re-checks the flag at run time as defense in depth).
+            if (null !== $descriptor && !$this->isEnabled($descriptor, $userId)) {
+                continue;
+            }
+
             $lines[] = '- "'.$capability->value.'": '.(null !== $descriptor ? $descriptor->summary : '');
 
             $note = null !== $descriptor && null !== $descriptor->dynamicNote
@@ -66,5 +81,17 @@ final class SkillCatalog
         }
 
         return implode("\n", $lines);
+    }
+
+    private function isEnabled(SkillDescriptor $descriptor, ?int $userId): bool
+    {
+        if (null === $descriptor->enabledFlag) {
+            return true;
+        }
+        if (null === $this->routingConfig) {
+            return $descriptor->enabledDefault;
+        }
+
+        return $this->routingConfig->isFeatureEnabled($descriptor->enabledFlag, $userId, $descriptor->enabledDefault);
     }
 }

--- a/backend/src/Service/Multitask/Skill/SkillDescriptor.php
+++ b/backend/src/Service/Multitask/Skill/SkillDescriptor.php
@@ -25,13 +25,20 @@ use App\Service\Multitask\Plan\Capability;
 final readonly class SkillDescriptor
 {
     /**
-     * @param string                         $summary     one-line, planner-facing description ([CAPABILITYLIST] entry)
-     * @param (\Closure(?int): ?string)|null $dynamicNote per-user expansion appended below the summary
+     * @param string                         $summary        one-line, planner-facing description ([CAPABILITYLIST] entry)
+     * @param (\Closure(?int): ?string)|null $dynamicNote    per-user expansion appended below the summary
+     * @param string|null                    $enabledFlag    BCONFIG `MULTITASK.<flag>` gating this block; when the flag
+     *                                                       resolves to false the capability is OMITTED from the planner
+     *                                                       catalog (the planner never learns it exists — plan 09 §6)
+     * @param bool                           $enabledDefault flag value when no BCONFIG row exists (new experimental
+     *                                                       blocks ship default-off and are flipped on when validated)
      */
     public function __construct(
         public Capability $capability,
         public string $summary,
         public ?\Closure $dynamicNote = null,
+        public ?string $enabledFlag = null,
+        public bool $enabledDefault = false,
     ) {
     }
 }

--- a/backend/src/Service/Multitask/TaskPlanExecutor.php
+++ b/backend/src/Service/Multitask/TaskPlanExecutor.php
@@ -48,7 +48,7 @@ final readonly class TaskPlanExecutor
      * must run through the DAG even as a lone single node (see
      * {@see shouldUseLegacyRouter()}).
      */
-    private const DAG_ONLY_CAPABILITIES = [Capability::CalendarEvent];
+    private const DAG_ONLY_CAPABILITIES = [Capability::CalendarEvent, Capability::UrlFetch];
 
     /**
      * Single-shot media generators that the legacy router already delivers

--- a/backend/tests/Characterization/__snapshots__/planner_system_prompt.txt
+++ b/backend/tests/Characterization/__snapshots__/planner_system_prompt.txt
@@ -138,6 +138,14 @@ Allowed topic keys: "general" | "mediamaker" | "officemaker" | "docsummary" | "l
    the `email_me` node. (Exception: a meeting invite alone → rule 7.)
 9. Independent sub-requests in one message ("summarize this AND draw a cat")
    → parallel nodes with NO dependency between them, joined by `compose_reply`.
+9b. The user asks to read/summarize/use the content of a SPECIFIC URL written
+   in the message ("load https://…", "was steht auf dieser Seite?",
+   "summarize this article: https://…") → a `url_fetch` node (put the URL in
+   `inputs.urls`), then feed `$nX.text` into the answering node
+   (`summarize`/`chat`/`translate`). Do NOT emit `url_fetch` for a bare link
+   mention the question does not depend on, and prefer `web_search` when no
+   concrete URL is given. Only use `url_fetch` if it appears in the
+   capability list above.
 10. Plain question / smalltalk / advice → one `chat` node. `reply_node` = that
    node, no `compose_reply` needed.
 11. A SINGLE media request with no follow-up step ("make an image of X",
@@ -303,6 +311,23 @@ User: (attaches photo.png) "Beschreibe in einem Audio, was hier zu sehen ist."
 The attached image is ANALYZED (`file_analysis` on `$message.files`) and the
 description is spoken (`text2sound`). NEVER route this to `image_generation` —
 the user wants the existing picture explained, not a new picture generated.
+
+### Read a specific URL, then summarize it
+User: "Fasse mir diese Seite zusammen: https://example.com/artikel"
+
+{
+  "version": 1,
+  "language": "de",
+  "reply_node": "n3",
+  "tasks": [
+    { "id": "n1", "capability": "url_fetch", "inputs": { "urls": "https://example.com/artikel" } },
+    { "id": "n2", "capability": "summarize", "depends_on": ["n1"], "inputs": { "text": "$n1.text" }, "params": { "style": "short" } },
+    { "id": "n3", "capability": "compose_reply", "depends_on": ["n1","n2"], "inputs": { "text": "$n2.text" } }
+  ]
+}
+
+The page content is FETCHED (`url_fetch`) and the summary consumes `$n1.text` —
+never answer about a URL's content from memory or invent what the page says.
 
 ### Calendar invite ("I need a meeting reminder for tomorrow at 9:00 with Sanam")
 The event fields go in `params`. Resolve the relative time against the time

--- a/backend/tests/Eval/plan_eval_corpus.json
+++ b/backend/tests/Eval/plan_eval_corpus.json
@@ -135,6 +135,16 @@
     }
   },
   {
+    "id": "url_fetch_summarize",
+    "text": "Fasse mir diese Seite zusammen: https://www.synaplan.com/",
+    "language": "de",
+    "expect": {
+      "capabilities": ["url_fetch"],
+      "edges": ["url_fetch->summarize"],
+      "forbid": ["web_search", "image_generation"]
+    }
+  },
+  {
     "id": "translate_then_speak",
     "text": "Übersetze 'Das Leben ist schön' ins Englische und sprich es mir vor.",
     "language": "de",

--- a/backend/tests/Support/SkillCatalogFactory.php
+++ b/backend/tests/Support/SkillCatalogFactory.php
@@ -13,6 +13,7 @@ use App\Service\Multitask\Execution\Runner\ExtractTextRunner;
 use App\Service\Multitask\Execution\Runner\FileAnalysisRunner;
 use App\Service\Multitask\Execution\Runner\MediaGenerationRunner;
 use App\Service\Multitask\Execution\Runner\Text2SoundRunner;
+use App\Service\Multitask\Execution\Runner\UrlFetchRunner;
 use App\Service\Multitask\Execution\Runner\WebSearchRunner;
 use App\Service\Multitask\Execution\TaskRunner;
 use App\Service\Multitask\Skill\SkillCatalog;
@@ -37,6 +38,7 @@ final class SkillCatalogFactory
         ExtractTextRunner::class,
         ChatRunner::class,
         WebSearchRunner::class,
+        UrlFetchRunner::class,
         FileAnalysisRunner::class,
         MediaGenerationRunner::class,
         Text2SoundRunner::class,
@@ -48,6 +50,14 @@ final class SkillCatalogFactory
 
     public static function real(): SkillCatalog
     {
+        return new SkillCatalog(self::runners());
+    }
+
+    /**
+     * @return list<TaskRunner>
+     */
+    public static function runners(): array
+    {
         $runners = [];
         foreach (self::RUNNER_CLASSES as $class) {
             /** @var TaskRunner $runner */
@@ -55,6 +65,6 @@ final class SkillCatalogFactory
             $runners[] = $runner;
         }
 
-        return new SkillCatalog($runners);
+        return $runners;
     }
 }

--- a/backend/tests/Unit/Service/Multitask/Execution/Runner/UrlFetchRunnerTest.php
+++ b/backend/tests/Unit/Service/Multitask/Execution/Runner/UrlFetchRunnerTest.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\Multitask\Execution\Runner;
+
+use App\Entity\Message;
+use App\Repository\ConfigRepository;
+use App\Service\Multitask\Execution\NodeContext;
+use App\Service\Multitask\Execution\Runner\UrlFetchRunner;
+use App\Service\Multitask\MultitaskRoutingConfig;
+use App\Service\Multitask\Plan\Capability;
+use App\Service\Multitask\Plan\TaskNode;
+use App\Service\Security\SsrfGuard;
+use App\Service\UrlContentService;
+use Doctrine\Common\Collections\ArrayCollection;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+/**
+ * `url_fetch` data-node contract (release-4.0 plan 09 §3.1): planner-placed
+ * fetch of a specific URL, flag-gated, SSRF-guarded, isolated failure, and
+ * reuse of the step-2.7 pre-fetch.
+ */
+final class UrlFetchRunnerTest extends TestCase
+{
+    /**
+     * @param list<MockResponse> $responses
+     */
+    private function runner(array $responses = [], bool $flagEnabled = true): UrlFetchRunner
+    {
+        $configRepo = $this->createMock(ConfigRepository::class);
+        $configRepo->method('getValue')->willReturnCallback(
+            static fn (int $owner, string $group, string $setting): ?string => 'MULTITASK' === $group && 'URL_FETCH_ENABLED' === $setting
+                ? ($flagEnabled ? '1' : '0')
+                : null,
+        );
+
+        return new UrlFetchRunner(
+            new UrlContentService(new MockHttpClient($responses), new SsrfGuard(), new NullLogger()),
+            new MultitaskRoutingConfig($configRepo),
+            new NullLogger(),
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $classification
+     */
+    private function context(string $messageText = '', array $classification = []): NodeContext
+    {
+        $message = $this->createMock(Message::class);
+        $message->method('getText')->willReturn($messageText);
+        $message->method('getLanguage')->willReturn('en');
+        $message->method('getFiles')->willReturn(new ArrayCollection([]));
+        $message->method('getFileText')->willReturn('');
+
+        return new NodeContext($message, [], 7, $classification);
+    }
+
+    private function node(array $inputs = []): TaskNode
+    {
+        return new TaskNode('n1', Capability::UrlFetch, [], $inputs);
+    }
+
+    public function testDisabledFlagFailsTheNodeWithoutFetching(): void
+    {
+        $runner = $this->runner([], flagEnabled: false);
+
+        $result = $runner->run($this->node(['urls' => 'https://example.com/a']), $this->context());
+
+        self::assertFalse($result->isSuccessful());
+        self::assertStringContainsString('disabled', (string) $result->error);
+    }
+
+    public function testFetchesUrlFromInputsAndReturnsFormattedContent(): void
+    {
+        $html = '<html><head><title>Example Article</title></head><body><p>The quick brown fox article body.</p></body></html>';
+        $runner = $this->runner([
+            new MockResponse('', ['http_code' => 404]), // robots.txt
+            new MockResponse($html, ['http_code' => 200, 'response_headers' => ['content-type' => 'text/html']]),
+        ]);
+
+        $result = $runner->run(
+            $this->node(['urls' => 'https://example.com/article']),
+            $this->context('Fasse mir diese Seite zusammen: https://example.com/article'),
+        );
+
+        self::assertTrue($result->isSuccessful());
+        self::assertStringContainsString('https://example.com/article', (string) $result->text);
+        self::assertStringContainsString('quick brown fox', (string) $result->text);
+        self::assertSame(['https://example.com/article'], $result->metadata['urls']);
+        self::assertSame('example.com', $result->metadata['query']);
+    }
+
+    public function testFallsBackToUrlsInTheMessageText(): void
+    {
+        $html = '<html><head><title>T</title></head><body>fallback body content here</body></html>';
+        $runner = $this->runner([
+            new MockResponse('', ['http_code' => 404]),
+            new MockResponse($html, ['http_code' => 200, 'response_headers' => ['content-type' => 'text/html']]),
+        ]);
+
+        $result = $runner->run(
+            $this->node(),
+            $this->context('what does https://example.org/page say?'),
+        );
+
+        self::assertTrue($result->isSuccessful());
+        self::assertSame(['https://example.org/page'], $result->metadata['urls']);
+    }
+
+    public function testNoUrlAnywhereFailsGracefully(): void
+    {
+        $result = $this->runner()->run($this->node(), $this->context('no links here'));
+
+        self::assertFalse($result->isSuccessful());
+        self::assertStringContainsString('no URL', (string) $result->error);
+    }
+
+    public function testPrivateTargetIsBlockedBySsrfGuard(): void
+    {
+        $result = $this->runner()->run(
+            $this->node(['urls' => 'http://127.0.0.1/admin']),
+            $this->context(),
+        );
+
+        self::assertFalse($result->isSuccessful());
+        self::assertStringContainsString('could not read the page', (string) $result->error);
+    }
+
+    public function testReusesStepTwoSevenPreFetchForWholeMessageUrls(): void
+    {
+        // No HTTP responses queued: a real fetch attempt would throw.
+        $runner = $this->runner([]);
+
+        $result = $runner->run(
+            $this->node(),
+            $this->context(
+                'read https://example.com/doc please',
+                ['url_content' => "## URL Content\npre-fetched block"],
+            ),
+        );
+
+        self::assertTrue($result->isSuccessful());
+        self::assertStringContainsString('pre-fetched block', (string) $result->text);
+        self::assertTrue((bool) $result->metadata['reused_prefetched']);
+    }
+
+    public function testHttpErrorFailsTheNodeInIsolation(): void
+    {
+        $runner = $this->runner([
+            new MockResponse('', ['http_code' => 404]), // robots.txt
+            new MockResponse('', ['http_code' => 500]),
+        ]);
+
+        $result = $runner->run(
+            $this->node(['urls' => 'https://example.com/broken']),
+            $this->context(),
+        );
+
+        self::assertFalse($result->isSuccessful());
+        self::assertStringContainsString('could not read the page', (string) $result->error);
+    }
+}

--- a/backend/tests/Unit/Service/Multitask/Skill/SkillCatalogTest.php
+++ b/backend/tests/Unit/Service/Multitask/Skill/SkillCatalogTest.php
@@ -33,7 +33,12 @@ final class SkillCatalogTest extends TestCase
             $lines,
         );
 
-        self::assertSame(Capability::values(), $renderedOrder);
+        // Flag-gated blocks (url_fetch, …) may be omitted, but whatever IS
+        // rendered must follow the Capability enum declaration order.
+        $expected = array_values(array_intersect(Capability::values(), $renderedOrder));
+        self::assertSame($expected, $renderedOrder);
+        self::assertContains('chat', $renderedOrder);
+        self::assertContains('compose_reply', $renderedOrder);
     }
 
     public function testDynamicNoteIsAppendedBelowTheSummaryWithTheUserId(): void
@@ -70,5 +75,28 @@ final class SkillCatalogTest extends TestCase
 
         self::assertStringContainsString('- "chat": ', $rendered);
         self::assertCount(count(Capability::cases()), explode("\n", $rendered));
+    }
+
+    public function testFlagGatedCapabilityIsOmittedWhenDisabledAndListedWhenEnabled(): void
+    {
+        // Default (no routing config, enabledDefault=false): url_fetch is
+        // invisible to the planner.
+        $off = SkillCatalogFactory::real()->renderCapabilityList();
+        self::assertStringNotContainsString('"url_fetch"', $off);
+
+        // Flag resolved ON: the capability line appears in enum order.
+        $configRepo = $this->createMock(\App\Repository\ConfigRepository::class);
+        $configRepo->method('getValue')->willReturnCallback(
+            static fn (int $owner, string $group, string $setting): ?string => 'URL_FETCH_ENABLED' === $setting ? '1' : null,
+        );
+        $catalog = new SkillCatalog(
+            SkillCatalogFactory::runners(),
+            new \App\Service\Multitask\MultitaskRoutingConfig($configRepo),
+        );
+
+        $on = $catalog->renderCapabilityList();
+        self::assertStringContainsString('- "url_fetch": ', $on);
+        $lines = explode("\n", $on);
+        self::assertCount(count(Capability::cases()), $lines);
     }
 }

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -934,6 +934,7 @@
       "translate": "Übersetzung",
       "rag_query": "Wissensantwort",
       "web_search": "Websuche",
+      "url_fetch": "Webseite lesen",
       "file_analysis": "Dateianalyse",
       "image_generation": "Bild",
       "video_generation": "Video",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -3113,6 +3113,7 @@
       "translate": "Translation",
       "rag_query": "Knowledge answer",
       "web_search": "Web search",
+      "url_fetch": "Reading web page",
       "file_analysis": "File analysis",
       "image_generation": "Image",
       "video_generation": "Video",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -1131,6 +1131,7 @@
       "translate": "Traducción",
       "rag_query": "Respuesta de conocimiento",
       "web_search": "Búsqueda web",
+      "url_fetch": "Leyendo página web",
       "file_analysis": "Análisis de archivo",
       "image_generation": "Imagen",
       "video_generation": "Vídeo",

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -1131,6 +1131,7 @@
       "translate": "Çeviri",
       "rag_query": "Bilgi yanıtı",
       "web_search": "Web araması",
+      "url_fetch": "Web sayfası okunuyor",
       "file_analysis": "Dosya analizi",
       "image_generation": "Görsel",
       "video_generation": "Video",


### PR DESCRIPTION
## Summary

Sprint 4 (stacked on #1244): the first external **data node**, proving the pattern `mcp_fetch` and `email_search` will follow.

- `Capability::UrlFetch` + `UrlFetchRunner` — thin adapter over the existing `UrlContentService` (shared `SsrfGuard`, robots.txt/noindex compliance, ≤3 URLs, 12k-char cap). Planner-provided `inputs.urls` with message-text fallback; step-2.7 pre-fetch reuse; `NodeResult::failed()` isolation.
- **Two-ended flag gating** (plan 09 §6): `SkillDescriptor.enabledFlag` + `SkillCatalog` omit a disabled block from `[CAPABILITYLIST]` entirely (the planner never learns it exists); the runner re-checks `MULTITASK.URL_FETCH_ENABLED` at run time. Default **off**.
- Planner rule 9b + canonical `url_fetch → summarize` example (prompt snapshot re-recorded, reviewed: only the two additions; the capability list stays unchanged while flag-off).
- Search-style task card (hostnames as the compact query line), i18n ×4, DAG-only execution (no legacy-router equivalent).

## Test plan

- [x] Backend gate green: lint, full phpstan, full test suite (2500 tests, +8 runner/catalog tests)
- [x] Frontend gate green: lint, vue-tsc, 790 Vitest tests
- [x] Prompt snapshot re-recorded with reviewed diff; routing snapshots untouched
- [x] `plan-eval --filter=url_fetch --repeat=3`: 3/3 `url_fetch → summarize` chains
- [x] Live E2E (flag on, local stack): "Fasse mir diese Seite zusammen: https://www.synaplan.com/" → DAG `url_fetch → summarize → compose_reply`, grounded summary, card resolves with hostname query
- [x] Live SSRF check: link-local target (169.254.169.254) is never fetched; the turn answers honestly that the address is unreachable