### PR TITLE
feat(mcp): outbound MCP client plumbing — server registry, client, tool discovery, settings UI (plan 09 S3)

### DIFF
--- a/backend/migrations/Version20260702180000.php
+++ b/backend/migrations/Version20260702180000.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * BMCPSERVERS — per-user registry of EXTERNAL MCP servers for the outbound
+ * MCP client (release-4.0 plan 09 §3.2). Auth header values are stored
+ * encrypted (AES-256-CBC via EncryptionService), mirroring the
+ * BINBOUNDEMAILHANDLER credential pattern.
+ *
+ * Comparator-free + idempotent (CREATE TABLE IF NOT EXISTS, no Schema reads)
+ * per the Galera production rules in AGENTS.md — safe to run
+ * incrementally on the shared prod cluster.
+ */
+final class Version20260702180000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add BMCPSERVERS table: per-user external MCP server connections (outbound MCP client)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE IF NOT EXISTS BMCPSERVERS (
+                BID BIGINT AUTO_INCREMENT NOT NULL,
+                BUSERID BIGINT NOT NULL,
+                BNAME VARCHAR(255) NOT NULL,
+                BURL VARCHAR(1024) NOT NULL,
+                BAUTHHEADER VARCHAR(128) DEFAULT '' NOT NULL,
+                BAUTHTOKEN LONGTEXT NOT NULL,
+                BENABLED TINYINT(1) DEFAULT 1 NOT NULL,
+                BCREATED VARCHAR(20) NOT NULL,
+                BUPDATED VARCHAR(20) NOT NULL,
+                INDEX idx_mcp_user (BUSERID),
+                PRIMARY KEY (BID)
+            ) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB
+            SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE IF EXISTS BMCPSERVERS');
+    }
+}

--- a/backend/src/Controller/McpServerConfigController.php
+++ b/backend/src/Controller/McpServerConfigController.php
@@ -1,0 +1,442 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Entity\McpServerConfig;
+use App\Entity\User;
+use App\Repository\McpServerConfigRepository;
+use App\Service\EncryptionService;
+use App\Service\Mcp\McpClientConfig;
+use App\Service\Mcp\McpClientException;
+use App\Service\Mcp\McpToolRegistry;
+use App\Service\Security\SsrfGuard;
+use OpenApi\Attributes as OA;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
+
+/**
+ * Settings → Connections → MCP servers (release-4.0 plan 09 §3.2).
+ *
+ * User-scoped CRUD for external MCP server connections plus live tool
+ * discovery ("test connection"). Auth header values are encrypted at rest and
+ * NEVER serialized back to the client — responses only carry `hasAuthToken`.
+ */
+#[Route('/api/v1/mcp-servers', name: 'api_mcp_servers_')]
+#[OA\Tag(name: 'MCP Servers')]
+final class McpServerConfigController extends AbstractController
+{
+    public function __construct(
+        private readonly McpServerConfigRepository $repository,
+        private readonly EncryptionService $encryptionService,
+        private readonly McpToolRegistry $toolRegistry,
+        private readonly McpClientConfig $clientConfig,
+        private readonly SsrfGuard $ssrfGuard,
+    ) {
+    }
+
+    #[Route('', name: 'list', methods: ['GET'])]
+    #[OA\Get(
+        path: '/api/v1/mcp-servers',
+        summary: "List the current user's external MCP server connections",
+        security: [['Bearer' => []]],
+        tags: ['MCP Servers'],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Connections (auth values omitted)',
+                content: new OA\JsonContent(
+                    properties: [
+                        new OA\Property(property: 'success', type: 'boolean', example: true),
+                        new OA\Property(property: 'client_enabled', type: 'boolean', example: false),
+                        new OA\Property(property: 'servers', type: 'array', items: new OA\Items(
+                            properties: [
+                                new OA\Property(property: 'id', type: 'integer', example: 1),
+                                new OA\Property(property: 'name', type: 'string', example: 'Company CRM'),
+                                new OA\Property(property: 'url', type: 'string', example: 'https://crm.example.com/mcp'),
+                                new OA\Property(property: 'auth_header', type: 'string', example: 'Authorization'),
+                                new OA\Property(property: 'has_auth_token', type: 'boolean', example: true),
+                                new OA\Property(property: 'enabled', type: 'boolean', example: true),
+                                new OA\Property(property: 'created', type: 'string', example: '20260702180000'),
+                                new OA\Property(property: 'updated', type: 'string', example: '20260702180000'),
+                            ],
+                            type: 'object'
+                        )),
+                    ]
+                )
+            ),
+            new OA\Response(response: 401, description: 'Not authenticated'),
+        ]
+    )]
+    public function list(#[CurrentUser] ?User $user): JsonResponse
+    {
+        if (!$user) {
+            return $this->json(['error' => 'Not authenticated'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        return $this->json([
+            'success' => true,
+            'client_enabled' => $this->clientConfig->isClientEnabled($user->getId()),
+            'servers' => array_map(
+                fn (McpServerConfig $s): array => $this->serialize($s),
+                $this->repository->findByUser($user->getId()),
+            ),
+        ]);
+    }
+
+    #[Route('', name: 'create', methods: ['POST'])]
+    #[OA\Post(
+        path: '/api/v1/mcp-servers',
+        summary: 'Connect a new external MCP server',
+        security: [['Bearer' => []]],
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                required: ['name', 'url'],
+                properties: [
+                    new OA\Property(property: 'name', type: 'string', example: 'Company CRM'),
+                    new OA\Property(property: 'url', type: 'string', example: 'https://crm.example.com/mcp'),
+                    new OA\Property(property: 'auth_header', type: 'string', example: 'Authorization'),
+                    new OA\Property(property: 'auth_token', type: 'string', example: 'Bearer sk-…'),
+                    new OA\Property(property: 'enabled', type: 'boolean', example: true),
+                ]
+            )
+        ),
+        tags: ['MCP Servers'],
+        responses: [
+            new OA\Response(
+                response: 201,
+                description: 'Connection created',
+                content: new OA\JsonContent(
+                    properties: [
+                        new OA\Property(property: 'success', type: 'boolean', example: true),
+                        new OA\Property(
+                            property: 'server',
+                            properties: [
+                                new OA\Property(property: 'id', type: 'integer', example: 1),
+                                new OA\Property(property: 'name', type: 'string', example: 'Company CRM'),
+                                new OA\Property(property: 'url', type: 'string', example: 'https://crm.example.com/mcp'),
+                                new OA\Property(property: 'auth_header', type: 'string', example: 'Authorization'),
+                                new OA\Property(property: 'has_auth_token', type: 'boolean', example: true),
+                                new OA\Property(property: 'enabled', type: 'boolean', example: true),
+                                new OA\Property(property: 'created', type: 'string', example: '20260702180000'),
+                                new OA\Property(property: 'updated', type: 'string', example: '20260702180000'),
+                            ],
+                            type: 'object'
+                        ),
+                    ]
+                )
+            ),
+            new OA\Response(response: 400, description: 'Validation error'),
+            new OA\Response(response: 401, description: 'Not authenticated'),
+        ]
+    )]
+    public function create(Request $request, #[CurrentUser] ?User $user): JsonResponse
+    {
+        if (!$user) {
+            return $this->json(['error' => 'Not authenticated'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        $data = $this->payload($request);
+        $error = $this->validate($data, requireAll: true);
+        if (null !== $error) {
+            return $this->json(['success' => false, 'error' => $error], Response::HTTP_BAD_REQUEST);
+        }
+
+        $server = new McpServerConfig();
+        $server->setUserId($user->getId());
+        $this->apply($server, $data);
+
+        $this->repository->save($server);
+
+        return $this->json(['success' => true, 'server' => $this->serialize($server)], Response::HTTP_CREATED);
+    }
+
+    #[Route('/{id}', name: 'update', requirements: ['id' => '\d+'], methods: ['PATCH'])]
+    #[OA\Patch(
+        path: '/api/v1/mcp-servers/{id}',
+        summary: 'Update an MCP server connection',
+        security: [['Bearer' => []]],
+        tags: ['MCP Servers'],
+        parameters: [new OA\Parameter(name: 'id', in: 'path', required: true, schema: new OA\Schema(type: 'integer'))],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Connection updated',
+                content: new OA\JsonContent(
+                    properties: [
+                        new OA\Property(property: 'success', type: 'boolean', example: true),
+                        new OA\Property(
+                            property: 'server',
+                            properties: [
+                                new OA\Property(property: 'id', type: 'integer', example: 1),
+                                new OA\Property(property: 'name', type: 'string', example: 'Company CRM'),
+                                new OA\Property(property: 'url', type: 'string', example: 'https://crm.example.com/mcp'),
+                                new OA\Property(property: 'auth_header', type: 'string', example: 'Authorization'),
+                                new OA\Property(property: 'has_auth_token', type: 'boolean', example: true),
+                                new OA\Property(property: 'enabled', type: 'boolean', example: true),
+                                new OA\Property(property: 'created', type: 'string', example: '20260702180000'),
+                                new OA\Property(property: 'updated', type: 'string', example: '20260702180000'),
+                            ],
+                            type: 'object'
+                        ),
+                    ]
+                )
+            ),
+            new OA\Response(response: 404, description: 'Not found'),
+        ]
+    )]
+    public function update(int $id, Request $request, #[CurrentUser] ?User $user): JsonResponse
+    {
+        if (!$user) {
+            return $this->json(['error' => 'Not authenticated'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        $server = $this->repository->findByIdAndUser($id, $user->getId());
+        if (null === $server) {
+            return $this->json(['success' => false, 'error' => 'Server not found'], Response::HTTP_NOT_FOUND);
+        }
+
+        $data = $this->payload($request);
+        $error = $this->validate($data, requireAll: false);
+        if (null !== $error) {
+            return $this->json(['success' => false, 'error' => $error], Response::HTTP_BAD_REQUEST);
+        }
+
+        $this->apply($server, $data);
+        $this->repository->save($server);
+
+        return $this->json(['success' => true, 'server' => $this->serialize($server)]);
+    }
+
+    #[Route('/{id}', name: 'delete', requirements: ['id' => '\d+'], methods: ['DELETE'])]
+    #[OA\Delete(
+        path: '/api/v1/mcp-servers/{id}',
+        summary: 'Remove an MCP server connection',
+        security: [['Bearer' => []]],
+        tags: ['MCP Servers'],
+        parameters: [new OA\Parameter(name: 'id', in: 'path', required: true, schema: new OA\Schema(type: 'integer'))],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Connection removed',
+                content: new OA\JsonContent(properties: [new OA\Property(property: 'success', type: 'boolean', example: true)])
+            ),
+            new OA\Response(response: 404, description: 'Not found'),
+        ]
+    )]
+    public function delete(int $id, #[CurrentUser] ?User $user): JsonResponse
+    {
+        if (!$user) {
+            return $this->json(['error' => 'Not authenticated'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        $server = $this->repository->findByIdAndUser($id, $user->getId());
+        if (null === $server) {
+            return $this->json(['success' => false, 'error' => 'Server not found'], Response::HTTP_NOT_FOUND);
+        }
+
+        $this->repository->remove($server);
+
+        return $this->json(['success' => true]);
+    }
+
+    #[Route('/{id}/tools', name: 'tools', requirements: ['id' => '\d+'], methods: ['GET'])]
+    #[OA\Get(
+        path: '/api/v1/mcp-servers/{id}/tools',
+        summary: 'List the tools discovered on a connected MCP server (cached)',
+        security: [['Bearer' => []]],
+        tags: ['MCP Servers'],
+        parameters: [new OA\Parameter(name: 'id', in: 'path', required: true, schema: new OA\Schema(type: 'integer'))],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Discovered tools',
+                content: new OA\JsonContent(
+                    properties: [
+                        new OA\Property(property: 'success', type: 'boolean', example: true),
+                        new OA\Property(property: 'error', type: 'string', nullable: true, example: null),
+                        new OA\Property(property: 'tools', type: 'array', items: new OA\Items(
+                            properties: [
+                                new OA\Property(property: 'name', type: 'string', example: 'search_customers'),
+                                new OA\Property(property: 'description', type: 'string', example: 'Find customers by name'),
+                            ],
+                            type: 'object'
+                        )),
+                    ]
+                )
+            ),
+            new OA\Response(response: 404, description: 'Not found'),
+        ]
+    )]
+    public function tools(int $id, #[CurrentUser] ?User $user): JsonResponse
+    {
+        if (!$user) {
+            return $this->json(['error' => 'Not authenticated'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        $server = $this->repository->findByIdAndUser($id, $user->getId());
+        if (null === $server) {
+            return $this->json(['success' => false, 'error' => 'Server not found'], Response::HTTP_NOT_FOUND);
+        }
+
+        if (!$this->clientConfig->isClientEnabled($user->getId())) {
+            return $this->json(['success' => false, 'error' => 'The outbound MCP client is disabled', 'tools' => []]);
+        }
+
+        return $this->json([
+            'success' => true,
+            'tools' => $this->publicTools($this->toolRegistry->toolsFor($server)),
+        ]);
+    }
+
+    #[Route('/{id}/test', name: 'test', requirements: ['id' => '\d+'], methods: ['POST'])]
+    #[OA\Post(
+        path: '/api/v1/mcp-servers/{id}/test',
+        summary: 'Test the connection: live initialize + tool discovery',
+        security: [['Bearer' => []]],
+        tags: ['MCP Servers'],
+        parameters: [new OA\Parameter(name: 'id', in: 'path', required: true, schema: new OA\Schema(type: 'integer'))],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Connection result (success flag + tools or error)',
+                content: new OA\JsonContent(
+                    properties: [
+                        new OA\Property(property: 'success', type: 'boolean', example: true),
+                        new OA\Property(property: 'error', type: 'string', nullable: true, example: null),
+                        new OA\Property(property: 'tools', type: 'array', items: new OA\Items(
+                            properties: [
+                                new OA\Property(property: 'name', type: 'string', example: 'search_customers'),
+                                new OA\Property(property: 'description', type: 'string', example: 'Find customers by name'),
+                            ],
+                            type: 'object'
+                        )),
+                    ]
+                )
+            ),
+            new OA\Response(response: 404, description: 'Not found'),
+        ]
+    )]
+    public function test(int $id, #[CurrentUser] ?User $user): JsonResponse
+    {
+        if (!$user) {
+            return $this->json(['error' => 'Not authenticated'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        $server = $this->repository->findByIdAndUser($id, $user->getId());
+        if (null === $server) {
+            return $this->json(['success' => false, 'error' => 'Server not found'], Response::HTTP_NOT_FOUND);
+        }
+
+        // Master switch (plan 09 §6): no outbound MCP traffic while disabled —
+        // connections can be prepared, but not exercised.
+        if (!$this->clientConfig->isClientEnabled($user->getId())) {
+            return $this->json(['success' => false, 'error' => 'The outbound MCP client is disabled', 'tools' => []]);
+        }
+
+        try {
+            $tools = $this->toolRegistry->refresh($server);
+        } catch (McpClientException $e) {
+            return $this->json(['success' => false, 'error' => $e->getMessage()]);
+        }
+
+        return $this->json(['success' => true, 'tools' => $this->publicTools($tools)]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function payload(Request $request): array
+    {
+        $decoded = json_decode($request->getContent(), true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function validate(array $data, bool $requireAll): ?string
+    {
+        if ($requireAll || array_key_exists('name', $data)) {
+            $name = $data['name'] ?? null;
+            if (!is_string($name) || '' === trim($name) || mb_strlen($name) > 255) {
+                return 'A name (max 255 characters) is required';
+            }
+        }
+
+        if ($requireAll || array_key_exists('url', $data)) {
+            $url = $data['url'] ?? null;
+            if (!is_string($url) || '' === trim($url) || mb_strlen($url) > 1024) {
+                return 'A server URL is required';
+            }
+            if ($this->ssrfGuard->isBlockedUrl(trim($url))) {
+                return 'This server URL is not allowed (must be a public http(s) endpoint)';
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function apply(McpServerConfig $server, array $data): void
+    {
+        if (is_string($data['name'] ?? null)) {
+            $server->setName(trim($data['name']));
+        }
+        if (is_string($data['url'] ?? null)) {
+            $server->setUrl(trim($data['url']));
+        }
+        if (array_key_exists('auth_header', $data) && is_string($data['auth_header'])) {
+            $server->setAuthHeader(trim($data['auth_header']));
+        }
+        // The auth value is write-only: absent key = keep the stored secret;
+        // empty string = clear it; anything else = replace it.
+        if (array_key_exists('auth_token', $data) && is_string($data['auth_token'])) {
+            $server->setDecryptedAuthToken($data['auth_token'], $this->encryptionService);
+        }
+        if (array_key_exists('enabled', $data)) {
+            $server->setEnabled((bool) $data['enabled']);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function serialize(McpServerConfig $server): array
+    {
+        return [
+            'id' => $server->getId(),
+            'name' => $server->getName(),
+            'url' => $server->getUrl(),
+            'auth_header' => $server->getAuthHeader(),
+            'has_auth_token' => $server->hasAuthToken(),
+            'enabled' => $server->isEnabled(),
+            'created' => $server->getCreated(),
+            'updated' => $server->getUpdated(),
+        ];
+    }
+
+    /**
+     * Tool list shape for the UI (no input schemas — keep the payload lean).
+     *
+     * @param list<array{name: string, description: string, inputSchema: array<string, mixed>}> $tools
+     *
+     * @return list<array{name: string, description: string}>
+     */
+    private function publicTools(array $tools): array
+    {
+        return array_map(
+            static fn (array $t): array => ['name' => $t['name'], 'description' => $t['description']],
+            $tools,
+        );
+    }
+}

--- a/backend/src/Entity/McpServerConfig.php
+++ b/backend/src/Entity/McpServerConfig.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use App\Repository\McpServerConfigRepository;
+use App\Service\EncryptionService;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * A user's connection to an EXTERNAL MCP server (release-4.0 plan 09 §3.2).
+ *
+ * Synaplan is an MCP server itself (`/mcp`); this entity is the other
+ * direction — the outbound MCP CLIENT's per-user server registry. Tools
+ * discovered on these servers feed the planner's dynamic `mcp_fetch`
+ * sub-catalog (Sprint 6).
+ *
+ * First-class entity (not plugin_data) following the proven
+ * {@see InboundEmailHandler} pattern: dedicated table, encrypted secret via
+ * {@see EncryptionService}, user-scoped repository lookups so cross-tenant
+ * access is structurally impossible.
+ */
+#[ORM\Entity(repositoryClass: McpServerConfigRepository::class)]
+#[ORM\Table(name: 'BMCPSERVERS')]
+#[ORM\Index(columns: ['BUSERID'], name: 'idx_mcp_user')]
+class McpServerConfig
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(name: 'BID', type: 'bigint')]
+    private ?int $id = null;
+
+    #[ORM\Column(name: 'BUSERID', type: 'bigint')]
+    private int $userId;
+
+    #[ORM\Column(name: 'BNAME', length: 255)]
+    private string $name = '';
+
+    /** Streamable HTTP endpoint URL (https://host/mcp). */
+    #[ORM\Column(name: 'BURL', length: 1024)]
+    private string $url = '';
+
+    /**
+     * HTTP header carrying the credential (e.g. "Authorization" or
+     * "X-API-KEY"). Empty = no authentication.
+     */
+    #[ORM\Column(name: 'BAUTHHEADER', length: 128, options: ['default' => ''])]
+    private string $authHeader = '';
+
+    /** Encrypted header value (AES-256-CBC via EncryptionService). */
+    #[ORM\Column(name: 'BAUTHTOKEN', type: 'text')]
+    private string $authToken = '';
+
+    #[ORM\Column(name: 'BENABLED', type: 'boolean', options: ['default' => true])]
+    private bool $enabled = true;
+
+    #[ORM\Column(name: 'BCREATED', type: 'string', length: 20)]
+    private string $created;
+
+    #[ORM\Column(name: 'BUPDATED', type: 'string', length: 20)]
+    private string $updated;
+
+    public function __construct()
+    {
+        $this->created = date('YmdHis');
+        $this->updated = date('YmdHis');
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getUserId(): int
+    {
+        return $this->userId;
+    }
+
+    public function setUserId(int $userId): self
+    {
+        $this->userId = $userId;
+
+        return $this;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+        $this->touch();
+
+        return $this;
+    }
+
+    public function getUrl(): string
+    {
+        return $this->url;
+    }
+
+    public function setUrl(string $url): self
+    {
+        $this->url = $url;
+        $this->touch();
+
+        return $this;
+    }
+
+    public function getAuthHeader(): string
+    {
+        return $this->authHeader;
+    }
+
+    public function setAuthHeader(string $authHeader): self
+    {
+        $this->authHeader = $authHeader;
+        $this->touch();
+
+        return $this;
+    }
+
+    /** Encrypted value — use {@see getDecryptedAuthToken()} in the service layer. */
+    public function getAuthToken(): string
+    {
+        return $this->authToken;
+    }
+
+    public function hasAuthToken(): bool
+    {
+        return '' !== $this->authToken;
+    }
+
+    public function getDecryptedAuthToken(EncryptionService $encryptionService): string
+    {
+        if ('' === $this->authToken) {
+            return '';
+        }
+
+        return $encryptionService->decrypt($this->authToken);
+    }
+
+    public function setDecryptedAuthToken(string $plaintext, EncryptionService $encryptionService): self
+    {
+        $this->authToken = '' === $plaintext ? '' : $encryptionService->encrypt($plaintext);
+        $this->touch();
+
+        return $this;
+    }
+
+    public function isEnabled(): bool
+    {
+        return $this->enabled;
+    }
+
+    public function setEnabled(bool $enabled): self
+    {
+        $this->enabled = $enabled;
+        $this->touch();
+
+        return $this;
+    }
+
+    public function getCreated(): string
+    {
+        return $this->created;
+    }
+
+    public function getUpdated(): string
+    {
+        return $this->updated;
+    }
+
+    public function touch(): self
+    {
+        $this->updated = date('YmdHis');
+
+        return $this;
+    }
+}

--- a/backend/src/Repository/McpServerConfigRepository.php
+++ b/backend/src/Repository/McpServerConfigRepository.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\McpServerConfig;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * User-scoped access to external MCP server connections. Every lookup is
+ * keyed by the owning user id — cross-tenant reads are structurally
+ * impossible (release-4.0 plan 09 §2.6).
+ *
+ * @extends ServiceEntityRepository<McpServerConfig>
+ */
+class McpServerConfigRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, McpServerConfig::class);
+    }
+
+    /**
+     * @return list<McpServerConfig>
+     */
+    public function findByUser(int $userId): array
+    {
+        return $this->findBy(['userId' => $userId], ['id' => 'ASC']);
+    }
+
+    /**
+     * @return list<McpServerConfig>
+     */
+    public function findEnabledByUser(int $userId): array
+    {
+        return $this->findBy(['userId' => $userId, 'enabled' => true], ['id' => 'ASC']);
+    }
+
+    public function findByIdAndUser(int $id, int $userId): ?McpServerConfig
+    {
+        return $this->findOneBy(['id' => $id, 'userId' => $userId]);
+    }
+
+    public function save(McpServerConfig $config, bool $flush = true): void
+    {
+        $this->getEntityManager()->persist($config);
+        if ($flush) {
+            $this->getEntityManager()->flush();
+        }
+    }
+
+    public function remove(McpServerConfig $config, bool $flush = true): void
+    {
+        $this->getEntityManager()->remove($config);
+        if ($flush) {
+            $this->getEntityManager()->flush();
+        }
+    }
+}

--- a/backend/src/Service/Mcp/McpClient.php
+++ b/backend/src/Service/Mcp/McpClient.php
@@ -1,0 +1,270 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Mcp;
+
+use App\Entity\McpServerConfig;
+use App\Service\EncryptionService;
+use App\Service\Security\SsrfGuard;
+use Psr\Log\LoggerInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * Outbound MCP client over Streamable HTTP (release-4.0 plan 09 §3.2; locked
+ * transport decision — SSE-only transport is deprecated).
+ *
+ * One short-lived session per operation: `initialize` →
+ * `notifications/initialized` → the actual request → best-effort session
+ * DELETE. Servers that answer with `text/event-stream` are supported by
+ * parsing the JSON-RPC response out of the SSE `data:` events.
+ *
+ * Guard rails (plan 09 §2): every target is {@see SsrfGuard}-checked, every
+ * call is timeout-bounded ({@see McpClientConfig::nodeTimeoutSeconds}),
+ * responses are size-capped, and every expected failure surfaces as
+ * {@see McpClientException} — callers degrade gracefully, nothing hangs a
+ * user turn.
+ */
+final readonly class McpClient
+{
+    public const PROTOCOL_VERSION = '2025-11-25';
+
+    /** Cap on a single JSON-RPC response body (tool results can be huge). */
+    private const MAX_RESPONSE_BYTES = 524288; // 512 KiB
+
+    public function __construct(
+        private HttpClientInterface $httpClient,
+        private SsrfGuard $ssrfGuard,
+        private EncryptionService $encryptionService,
+        private McpClientConfig $config,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * Discover the server's tools.
+     *
+     * @return list<array{name: string, description: string, inputSchema: array<string, mixed>}>
+     */
+    public function listTools(McpServerConfig $server): array
+    {
+        $result = $this->withSession($server, fn (string $url, array $headers): array => $this->request($url, $headers, 'tools/list', []));
+
+        $tools = [];
+        foreach ((array) ($result['tools'] ?? []) as $tool) {
+            if (!is_array($tool) || !is_string($tool['name'] ?? null)) {
+                continue;
+            }
+            $tools[] = [
+                'name' => $tool['name'],
+                'description' => is_string($tool['description'] ?? null) ? $tool['description'] : '',
+                'inputSchema' => is_array($tool['inputSchema'] ?? null) ? $tool['inputSchema'] : [],
+            ];
+        }
+
+        return $tools;
+    }
+
+    /**
+     * Call one tool and return its result block.
+     *
+     * @param array<string, mixed> $arguments
+     *
+     * @return array{content: list<array<string, mixed>>, isError: bool}
+     */
+    public function callTool(McpServerConfig $server, string $tool, array $arguments): array
+    {
+        $result = $this->withSession(
+            $server,
+            fn (string $url, array $headers): array => $this->request($url, $headers, 'tools/call', [
+                'name' => $tool,
+                'arguments' => (object) $arguments,
+            ]),
+        );
+
+        $content = [];
+        foreach ((array) ($result['content'] ?? []) as $block) {
+            if (is_array($block)) {
+                $content[] = $block;
+            }
+        }
+
+        return [
+            'content' => $content,
+            'isError' => (bool) ($result['isError'] ?? false),
+        ];
+    }
+
+    /**
+     * Run one operation inside a fresh MCP session.
+     *
+     * @param callable(string, array<string, string>): array<string, mixed> $operation
+     *
+     * @return array<string, mixed>
+     */
+    private function withSession(McpServerConfig $server, callable $operation): array
+    {
+        $url = trim($server->getUrl());
+        if ($this->ssrfGuard->isBlockedUrl($url)) {
+            throw new McpClientException('MCP server URL is not allowed (private or invalid target)');
+        }
+
+        $headers = [
+            'Content-Type' => 'application/json',
+            'Accept' => 'application/json, text/event-stream',
+            'MCP-Protocol-Version' => self::PROTOCOL_VERSION,
+        ];
+
+        $authHeader = trim($server->getAuthHeader());
+        if ('' !== $authHeader && $server->hasAuthToken()) {
+            $headers[$authHeader] = $server->getDecryptedAuthToken($this->encryptionService);
+        }
+
+        // 1. initialize — negotiates the session; the server may hand back a
+        //    session id header every subsequent request must carry.
+        $initResponse = $this->post($url, $headers, [
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'initialize',
+            'params' => [
+                'protocolVersion' => self::PROTOCOL_VERSION,
+                'capabilities' => new \stdClass(),
+                'clientInfo' => ['name' => 'synaplan-mcp-client', 'version' => '1.0'],
+            ],
+        ]);
+        $this->decodeRpcResult($initResponse);
+
+        $sessionId = $initResponse->getHeaders(false)['mcp-session-id'][0] ?? null;
+        if (is_string($sessionId) && '' !== $sessionId) {
+            $headers['Mcp-Session-Id'] = $sessionId;
+        }
+
+        try {
+            // 2. initialized notification (no response expected).
+            $this->post($url, $headers, [
+                'jsonrpc' => '2.0',
+                'method' => 'notifications/initialized',
+            ])->getStatusCode();
+
+            // 3. The actual operation.
+            return $operation($url, $headers);
+        } finally {
+            // 4. Best-effort session teardown.
+            if (isset($headers['Mcp-Session-Id'])) {
+                try {
+                    $this->httpClient->request('DELETE', $url, [
+                        'headers' => $headers,
+                        'timeout' => 5,
+                    ])->getStatusCode();
+                } catch (\Throwable) {
+                    // Session cleanup is cosmetic — the server expires it anyway.
+                }
+            }
+        }
+    }
+
+    /**
+     * @param array<string, string> $headers
+     * @param array<string, mixed>  $params
+     *
+     * @return array<string, mixed>
+     */
+    private function request(string $url, array $headers, string $method, array $params): array
+    {
+        $response = $this->post($url, $headers, [
+            'jsonrpc' => '2.0',
+            'id' => 2,
+            'method' => $method,
+            'params' => [] === $params ? new \stdClass() : $params,
+        ]);
+
+        return $this->decodeRpcResult($response);
+    }
+
+    /**
+     * @param array<string, string> $headers
+     * @param array<string, mixed>  $payload
+     */
+    private function post(string $url, array $headers, array $payload): ResponseInterface
+    {
+        try {
+            return $this->httpClient->request('POST', $url, [
+                'headers' => $headers,
+                'json' => $payload,
+                'timeout' => $this->config->nodeTimeoutSeconds(),
+                'max_redirects' => 0,
+            ]);
+        } catch (\Throwable $e) {
+            throw new McpClientException('MCP request failed: '.$e->getMessage(), 0, $e);
+        }
+    }
+
+    /**
+     * Decode a JSON-RPC response body (plain JSON or SSE-framed) into its
+     * `result` object; JSON-RPC errors become exceptions.
+     *
+     * @return array<string, mixed>
+     */
+    private function decodeRpcResult(ResponseInterface $response): array
+    {
+        try {
+            $status = $response->getStatusCode();
+            $body = $response->getContent(false);
+        } catch (\Throwable $e) {
+            throw new McpClientException('MCP response could not be read: '.$e->getMessage(), 0, $e);
+        }
+
+        if ($status >= 400) {
+            throw new McpClientException(sprintf('MCP server answered HTTP %d', $status));
+        }
+        if ('' === trim($body)) {
+            // Notifications legitimately return 202/empty bodies.
+            return [];
+        }
+        if (strlen($body) > self::MAX_RESPONSE_BYTES) {
+            throw new McpClientException('MCP response exceeds the size limit');
+        }
+
+        $contentType = strtolower($response->getHeaders(false)['content-type'][0] ?? '');
+        if (str_contains($contentType, 'text/event-stream')) {
+            $body = $this->extractLastSseData($body);
+        }
+
+        $decoded = json_decode($body, true);
+        if (!is_array($decoded)) {
+            throw new McpClientException('MCP server returned invalid JSON');
+        }
+
+        if (isset($decoded['error']) && is_array($decoded['error'])) {
+            $message = is_string($decoded['error']['message'] ?? null) ? $decoded['error']['message'] : 'unknown error';
+            $this->logger->info('McpClient: JSON-RPC error from server', ['error' => $decoded['error']]);
+            throw new McpClientException('MCP server error: '.$message);
+        }
+
+        $result = $decoded['result'] ?? [];
+
+        return is_array($result) ? $result : [];
+    }
+
+    /**
+     * Pull the last JSON payload out of an SSE-framed response — the
+     * Streamable HTTP transport delivers the JSON-RPC response as the final
+     * `data:` event of the stream.
+     */
+    private function extractLastSseData(string $body): string
+    {
+        $last = '';
+        foreach (preg_split('/\r?\n/', $body) ?: [] as $line) {
+            if (str_starts_with($line, 'data:')) {
+                $last = trim(substr($line, 5));
+            }
+        }
+
+        if ('' === $last) {
+            throw new McpClientException('MCP server returned an empty event stream');
+        }
+
+        return $last;
+    }
+}

--- a/backend/src/Service/Mcp/McpClientConfig.php
+++ b/backend/src/Service/Mcp/McpClientConfig.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Mcp;
+
+use App\Repository\ConfigRepository;
+
+/**
+ * Feature flags for the OUTBOUND MCP client (release-4.0 plan 09 §6).
+ *
+ * BCONFIG group `MCP`:
+ *   - CLIENT_ENABLED — master switch for any outbound MCP traffic
+ *     (per-user row overrides global row overrides built-in default OFF).
+ *   - NODE_TIMEOUT   — per-call hard timeout in seconds (global only,
+ *     clamped; a slow server degrades one call, never the turn).
+ */
+final readonly class McpClientConfig
+{
+    public const CONFIG_GROUP = 'MCP';
+
+    public const KEY_CLIENT_ENABLED = 'CLIENT_ENABLED';
+    public const KEY_NODE_TIMEOUT = 'NODE_TIMEOUT';
+
+    private const DEFAULT_CLIENT_ENABLED = false;
+    private const DEFAULT_NODE_TIMEOUT = 15;
+
+    public function __construct(
+        private ConfigRepository $configRepository,
+    ) {
+    }
+
+    public function isClientEnabled(?int $userId): bool
+    {
+        if (null !== $userId && $userId > 0) {
+            $perUser = $this->configRepository->getValue($userId, self::CONFIG_GROUP, self::KEY_CLIENT_ENABLED);
+            if (null !== $perUser) {
+                return $this->toBool($perUser);
+            }
+        }
+
+        $global = $this->configRepository->getValue(0, self::CONFIG_GROUP, self::KEY_CLIENT_ENABLED);
+        if (null !== $global) {
+            return $this->toBool($global);
+        }
+
+        return self::DEFAULT_CLIENT_ENABLED;
+    }
+
+    public function nodeTimeoutSeconds(): int
+    {
+        $value = $this->configRepository->getValue(0, self::CONFIG_GROUP, self::KEY_NODE_TIMEOUT);
+        $n = null !== $value ? (int) $value : self::DEFAULT_NODE_TIMEOUT;
+
+        return max(3, min(120, $n));
+    }
+
+    private function toBool(string $value): bool
+    {
+        return filter_var($value, \FILTER_VALIDATE_BOOL, \FILTER_NULL_ON_FAILURE) ?? self::DEFAULT_CLIENT_ENABLED;
+    }
+}

--- a/backend/src/Service/Mcp/McpClientException.php
+++ b/backend/src/Service/Mcp/McpClientException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Mcp;
+
+/**
+ * Raised by {@see McpClient} for any expected outbound-MCP failure (blocked
+ * target, timeout, HTTP error, malformed JSON-RPC, tool error). Callers turn
+ * it into a graceful degradation (a failed node / a 4xx API response) — it
+ * must never escape as a 500.
+ */
+final class McpClientException extends \RuntimeException
+{
+}

--- a/backend/src/Service/Mcp/McpToolRegistry.php
+++ b/backend/src/Service/Mcp/McpToolRegistry.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Mcp;
+
+use App\Entity\McpServerConfig;
+use App\Repository\McpServerConfigRepository;
+use Psr\Log\LoggerInterface;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+
+/**
+ * Cached per-server tool discovery for the outbound MCP client (plan 09
+ * §3.2). Feeds two consumers:
+ *   - the Settings UI ("browse this server's tools"), and
+ *   - the planner's dynamic `mcp_fetch` sub-catalog (Sprint 6), which is
+ *     rendered on EVERY planned turn — hence the short-TTL cache so plan
+ *     latency never includes a live `tools/list` round-trip.
+ *
+ * Discovery failures degrade to an empty tool list (logged); the Settings
+ * "test connection" path uses {@see refresh()} to surface the real error.
+ */
+final readonly class McpToolRegistry
+{
+    /** Tool catalogs change rarely; five minutes keeps planning snappy. */
+    private const CACHE_TTL_SECONDS = 300;
+
+    public function __construct(
+        private McpClient $client,
+        private McpServerConfigRepository $servers,
+        private CacheInterface $cache,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * Cached tools of one server. Never throws — planning must not break on
+     * an unreachable server.
+     *
+     * @return list<array{name: string, description: string, inputSchema: array<string, mixed>}>
+     */
+    public function toolsFor(McpServerConfig $server): array
+    {
+        try {
+            return $this->cache->get($this->cacheKey($server), function (ItemInterface $item) use ($server): array {
+                $item->expiresAfter(self::CACHE_TTL_SECONDS);
+
+                return $this->client->listTools($server);
+            });
+        } catch (\Throwable $e) {
+            $this->logger->warning('McpToolRegistry: tool discovery failed', [
+                'server_id' => $server->getId(),
+                'error' => $e->getMessage(),
+            ]);
+
+            return [];
+        }
+    }
+
+    /**
+     * Live (uncached) discovery — Settings "test connection". Lets
+     * {@see McpClientException} propagate so the UI can show the reason, and
+     * primes the cache on success.
+     *
+     * @return list<array{name: string, description: string, inputSchema: array<string, mixed>}>
+     */
+    public function refresh(McpServerConfig $server): array
+    {
+        $tools = $this->client->listTools($server);
+
+        $this->cache->delete($this->cacheKey($server));
+        $this->cache->get($this->cacheKey($server), function (ItemInterface $item) use ($tools): array {
+            $item->expiresAfter(self::CACHE_TTL_SECONDS);
+
+            return $tools;
+        });
+
+        return $tools;
+    }
+
+    /**
+     * Every enabled server of a user with its cached tools — the shape the
+     * planner sub-catalog renders from.
+     *
+     * @return list<array{server: McpServerConfig, tools: list<array{name: string, description: string, inputSchema: array<string, mixed>}>}>
+     */
+    public function catalogForUser(int $userId): array
+    {
+        $catalog = [];
+        foreach ($this->servers->findEnabledByUser($userId) as $server) {
+            $catalog[] = ['server' => $server, 'tools' => $this->toolsFor($server)];
+        }
+
+        return $catalog;
+    }
+
+    private function cacheKey(McpServerConfig $server): string
+    {
+        // The URL/auth revision is part of the key so editing a server never
+        // serves the previous endpoint's cached tools.
+        return sprintf('mcp_tools_%d_%s', (int) $server->getId(), md5($server->getUrl().'|'.$server->getUpdated()));
+    }
+}

--- a/backend/tests/Eval/plan_eval_corpus.json
+++ b/backend/tests/Eval/plan_eval_corpus.json
@@ -4,8 +4,14 @@
     "text": "Wer bist du?",
     "language": "de",
     "expect": {
-      "capabilities": ["chat"],
-      "forbid": ["image_generation", "text2sound", "web_search"]
+      "capabilities": [
+        "chat"
+      ],
+      "forbid": [
+        "image_generation",
+        "text2sound",
+        "web_search"
+      ]
     }
   },
   {
@@ -13,8 +19,13 @@
     "text": "Erstelle ein Bild von einem Sonnenuntergang",
     "language": "de",
     "expect": {
-      "capabilities": ["image_generation"],
-      "forbid": ["chat", "file_analysis"]
+      "capabilities": [
+        "image_generation"
+      ],
+      "forbid": [
+        "chat",
+        "file_analysis"
+      ]
     }
   },
   {
@@ -22,9 +33,17 @@
     "text": "Schreib mir ein Liebesgedicht und lies es mir als MP3 vor.",
     "language": "de",
     "expect": {
-      "capabilities": ["chat", "text2sound", "compose_reply"],
-      "edges": ["chat->text2sound"],
-      "forbid": ["image_generation"]
+      "capabilities": [
+        "chat",
+        "text2sound",
+        "compose_reply"
+      ],
+      "edges": [
+        "chat->text2sound"
+      ],
+      "forbid": [
+        "image_generation"
+      ]
     }
   },
   {
@@ -32,8 +51,17 @@
     "text": "Write a spring poem, read it aloud and make a fitting picture with it. Mail everything to me.",
     "language": "en",
     "expect": {
-      "capabilities": ["chat", "text2sound", "image_generation", "email_me", "compose_reply"],
-      "edges": ["chat->text2sound", "chat->email_me"]
+      "capabilities": [
+        "chat",
+        "text2sound",
+        "image_generation",
+        "email_me",
+        "compose_reply"
+      ],
+      "edges": [
+        "chat->text2sound",
+        "chat->email_me"
+      ]
     }
   },
   {
@@ -41,9 +69,16 @@
     "text": "Erstelle ein Bild einer Katze und danach beschreibe das erstellte Bild.",
     "language": "de",
     "expect": {
-      "capabilities": ["image_generation", "file_analysis"],
-      "edges": ["image_generation->file_analysis"],
-      "forbid": ["chat"]
+      "capabilities": [
+        "image_generation",
+        "file_analysis"
+      ],
+      "edges": [
+        "image_generation->file_analysis"
+      ],
+      "forbid": [
+        "chat"
+      ]
     }
   },
   {
@@ -51,41 +86,78 @@
     "text": "Erstelle das Bild einer Katze, dann schreibe ein Gedicht darüber und lies es mir am Ende vor.",
     "language": "de",
     "expect": {
-      "capabilities": ["image_generation", "file_analysis", "text2sound"],
-      "edges": ["image_generation->file_analysis", "file_analysis->text2sound"],
-      "forbid": ["chat"]
+      "capabilities": [
+        "image_generation",
+        "file_analysis",
+        "text2sound"
+      ],
+      "edges": [
+        "image_generation->file_analysis",
+        "file_analysis->text2sound"
+      ],
+      "forbid": [
+        "chat"
+      ]
     }
   },
   {
     "id": "describe_attached_image_as_audio_1237",
     "text": "Beschreibe in einem Audio, was hier zu sehen ist.",
     "language": "de",
-    "attach": { "type": "png", "path": "photo.png" },
+    "attach": {
+      "type": "png",
+      "path": "photo.png"
+    },
     "expect": {
-      "capabilities": ["file_analysis", "text2sound"],
-      "edges": ["file_analysis->text2sound"],
-      "forbid": ["image_generation"]
+      "capabilities": [
+        "file_analysis",
+        "text2sound"
+      ],
+      "edges": [
+        "file_analysis->text2sound"
+      ],
+      "forbid": [
+        "image_generation"
+      ]
     }
   },
   {
     "id": "describe_attached_generated_image_as_audio_1237",
     "text": "beschreibe in einem audio was hier zu sehen ist",
     "language": "de",
-    "attach": { "type": "image", "path": "media_1_google_abc.png" },
+    "attach": {
+      "type": "image",
+      "path": "media_1_google_abc.png"
+    },
     "expect": {
-      "capabilities": ["file_analysis", "text2sound"],
-      "edges": ["file_analysis->text2sound"],
-      "forbid": ["image_generation"]
+      "capabilities": [
+        "file_analysis",
+        "text2sound"
+      ],
+      "edges": [
+        "file_analysis->text2sound"
+      ],
+      "forbid": [
+        "image_generation"
+      ]
     }
   },
   {
     "id": "doc_summary_to_mp3",
     "text": "What's in there? Summarize it into a short MP3.",
     "language": "en",
-    "attach": { "type": "docx", "path": "report.docx", "file_text": "Quarterly report: revenue grew 12%, churn fell to 2.1%, hiring plan on track." },
+    "attach": {
+      "type": "docx",
+      "path": "report.docx",
+      "file_text": "Quarterly report: revenue grew 12%, churn fell to 2.1%, hiring plan on track."
+    },
     "expect": {
-      "capabilities": ["text2sound"],
-      "forbid": ["image_generation"]
+      "capabilities": [
+        "text2sound"
+      ],
+      "forbid": [
+        "image_generation"
+      ]
     }
   },
   {
@@ -93,8 +165,13 @@
     "text": "Create a picture of a sailboat on a lake, then animate it as a short video.",
     "language": "en",
     "expect": {
-      "capabilities": ["image_generation", "video_generation"],
-      "edges": ["image_generation->video_generation"]
+      "capabilities": [
+        "image_generation",
+        "video_generation"
+      ],
+      "edges": [
+        "image_generation->video_generation"
+      ]
     }
   },
   {
@@ -102,8 +179,13 @@
     "text": "Read this aloud: Hello world, welcome to the demo.",
     "language": "en",
     "expect": {
-      "capabilities": ["text2sound"],
-      "forbid": ["chat", "image_generation"]
+      "capabilities": [
+        "text2sound"
+      ],
+      "forbid": [
+        "chat",
+        "image_generation"
+      ]
     }
   },
   {
@@ -111,18 +193,30 @@
     "text": "Mach mir eine Excel-Tabelle mit den Monaten des Jahres und je einem Feiertag.",
     "language": "de",
     "expect": {
-      "capabilities": ["document_generation"],
-      "forbid": ["image_generation", "chat"]
+      "capabilities": [
+        "document_generation"
+      ],
+      "forbid": [
+        "image_generation",
+        "chat"
+      ]
     }
   },
   {
     "id": "calendar_event",
     "text": "I need a meeting reminder for tomorrow at 9:00 with Sanam.",
     "language": "en",
-    "options": { "client_country": "DE" },
+    "options": {
+      "client_country": "DE"
+    },
     "expect": {
-      "capabilities": ["calendar_event"],
-      "forbid": ["chat", "email_me"]
+      "capabilities": [
+        "calendar_event"
+      ],
+      "forbid": [
+        "chat",
+        "email_me"
+      ]
     }
   },
   {
@@ -130,8 +224,13 @@
     "text": "Summarize the concept of photosynthesis in two sentences and draw a cat.",
     "language": "en",
     "expect": {
-      "capabilities": ["image_generation", "compose_reply"],
-      "forbid": ["file_analysis"]
+      "capabilities": [
+        "image_generation",
+        "compose_reply"
+      ],
+      "forbid": [
+        "file_analysis"
+      ]
     }
   },
   {
@@ -139,9 +238,16 @@
     "text": "Fasse mir diese Seite zusammen: https://www.synaplan.com/",
     "language": "de",
     "expect": {
-      "capabilities": ["url_fetch"],
-      "edges": ["url_fetch->summarize"],
-      "forbid": ["web_search", "image_generation"]
+      "capabilities": [
+        "url_fetch"
+      ],
+      "edges": [
+        "url_fetch->summarize"
+      ],
+      "forbid": [
+        "web_search",
+        "image_generation"
+      ]
     }
   },
   {
@@ -149,8 +255,266 @@
     "text": "Übersetze 'Das Leben ist schön' ins Englische und sprich es mir vor.",
     "language": "de",
     "expect": {
-      "capabilities": ["text2sound"],
-      "forbid": ["image_generation"]
+      "capabilities": [
+        "text2sound"
+      ],
+      "forbid": [
+        "image_generation"
+      ]
+    }
+  },
+  {
+    "id": "poem_then_mp3_en",
+    "text": "Write a short love poem and read it to me as an MP3.",
+    "language": "en",
+    "expect": {
+      "capabilities": [
+        "chat",
+        "text2sound"
+      ],
+      "edges": [
+        "chat->text2sound"
+      ],
+      "forbid": [
+        "image_generation"
+      ]
+    }
+  },
+  {
+    "id": "poem_then_speak_es",
+    "text": "Escribe un poema corto sobre el mar y léemelo en voz alta.",
+    "language": "es",
+    "expect": {
+      "capabilities": [
+        "chat",
+        "text2sound"
+      ],
+      "edges": [
+        "chat->text2sound"
+      ],
+      "forbid": [
+        "image_generation"
+      ]
+    }
+  },
+  {
+    "id": "single_image_tr",
+    "text": "Bir kedi resmi oluştur",
+    "language": "tr",
+    "expect": {
+      "capabilities": [
+        "image_generation"
+      ],
+      "forbid": [
+        "chat",
+        "file_analysis"
+      ]
+    }
+  },
+  {
+    "id": "image_edit_chain",
+    "text": "Erstelle ein Logo mit einem Fuchs und mach es danach blau.",
+    "language": "de",
+    "expect": {
+      "capabilities": [
+        "image_generation"
+      ],
+      "edges": [
+        "image_generation->image_generation"
+      ],
+      "forbid": [
+        "chat"
+      ]
+    }
+  },
+  {
+    "id": "video_then_describe",
+    "text": "Generate a short video of a rocket launch and tell me what happens in it.",
+    "language": "en",
+    "expect": {
+      "capabilities": [
+        "video_generation",
+        "file_analysis"
+      ],
+      "edges": [
+        "video_generation->file_analysis"
+      ],
+      "forbid": [
+        "chat"
+      ]
+    }
+  },
+  {
+    "id": "video_with_params",
+    "text": "Erstelle ein 8 Sekunden Video von einem Zug in 4K",
+    "language": "de",
+    "expect": {
+      "capabilities": [
+        "video_generation"
+      ],
+      "forbid": [
+        "image_generation",
+        "chat"
+      ]
+    }
+  },
+  {
+    "id": "email_explicit",
+    "text": "Fasse die wichtigsten Regeln für gutes Zeitmanagement zusammen und schicke mir das Ergebnis per E-Mail.",
+    "language": "de",
+    "expect": {
+      "capabilities": [
+        "email_me"
+      ],
+      "forbid": [
+        "image_generation"
+      ]
+    }
+  },
+  {
+    "id": "email_trap_write_a_mail",
+    "text": "Schreibe eine höfliche E-Mail-Antwort an meinen Kollegen, der nach dem Projektstatus fragt.",
+    "language": "de",
+    "expect": {
+      "capabilities": [
+        "chat"
+      ],
+      "forbid": [
+        "email_me",
+        "text2sound"
+      ]
+    }
+  },
+  {
+    "id": "calendar_mail_me_exception",
+    "text": "Mail me a meeting note for tomorrow 15:00 with Tom.",
+    "language": "en",
+    "options": {
+      "client_country": "DE"
+    },
+    "expect": {
+      "capabilities": [
+        "calendar_event"
+      ],
+      "forbid": [
+        "chat"
+      ]
+    }
+  },
+  {
+    "id": "audio_topic_not_tts",
+    "text": "Was ist der Unterschied zwischen MP3 und WAV Dateien?",
+    "language": "de",
+    "expect": {
+      "capabilities": [
+        "chat"
+      ],
+      "forbid": [
+        "text2sound",
+        "image_generation"
+      ]
+    }
+  },
+  {
+    "id": "bare_link_no_urlfetch",
+    "text": "Mein Blog ist übrigens https://blog.example.com — wie gewinne ich generell mehr Leser?",
+    "language": "de",
+    "expect": {
+      "capabilities": [
+        "chat"
+      ],
+      "forbid": [
+        "url_fetch",
+        "web_search"
+      ]
+    }
+  },
+  {
+    "id": "pdf_not_supported",
+    "text": "Erstelle mir ein PDF mit meinem Lebenslauf.",
+    "language": "de",
+    "expect": {
+      "capabilities": [
+        "chat"
+      ],
+      "forbid": [
+        "document_generation",
+        "image_generation"
+      ]
+    }
+  },
+  {
+    "id": "image_talk_not_generation",
+    "text": "Warum wirken Bilder mit goldenem Schnitt harmonischer?",
+    "language": "de",
+    "expect": {
+      "capabilities": [
+        "chat"
+      ],
+      "forbid": [
+        "image_generation",
+        "file_analysis"
+      ]
+    }
+  },
+  {
+    "id": "attached_doc_summary_plus_image",
+    "text": "Fasse das Dokument kurz zusammen und erstelle ein passendes Titelbild dazu.",
+    "language": "de",
+    "attach": {
+      "type": "docx",
+      "path": "bericht.docx",
+      "file_text": "Jahresbericht über die Entwicklung des Stadtparks: neue Spielplätze, mehr Bäume, höhere Besucherzahlen."
+    },
+    "expect": {
+      "capabilities": [
+        "image_generation"
+      ],
+      "forbid": []
+    }
+  },
+  {
+    "id": "attached_image_describe_text",
+    "text": "Beschreibe, was auf diesem Bild zu sehen ist.",
+    "language": "de",
+    "attach": {
+      "type": "png",
+      "path": "photo.png"
+    },
+    "expect": {
+      "capabilities": [
+        "file_analysis"
+      ],
+      "forbid": [
+        "image_generation",
+        "text2sound"
+      ]
+    }
+  },
+  {
+    "id": "websearch_current_info",
+    "text": "Wie ist das Wetter morgen in Berlin?",
+    "language": "de",
+    "expect": {
+      "capabilities": [
+        "web_search"
+      ],
+      "forbid": [
+        "image_generation"
+      ]
+    }
+  },
+  {
+    "id": "translate_then_speak_variant",
+    "text": "Translate 'Der Apfel fällt nicht weit vom Stamm' into English and read the translation aloud.",
+    "language": "en",
+    "expect": {
+      "capabilities": [
+        "text2sound"
+      ],
+      "forbid": [
+        "image_generation"
+      ]
     }
   }
 ]

--- a/backend/tests/Integration/Controller/McpServerConfigControllerTest.php
+++ b/backend/tests/Integration/Controller/McpServerConfigControllerTest.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Controller;
+
+use App\Entity\McpServerConfig;
+use App\Entity\User;
+use App\Tests\Trait\AuthenticatedTestTrait;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Settings → Connections → MCP servers CRUD contract: user-scoped access,
+ * SSRF-validated URLs, and the write-only auth secret (never serialized).
+ */
+class McpServerConfigControllerTest extends WebTestCase
+{
+    use AuthenticatedTestTrait;
+    private KernelBrowser $client;
+    private string $token;
+    private User $user;
+
+    /** @var list<int> */
+    private array $createdIds = [];
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+
+        $userRepository = $this->client->getContainer()->get('doctrine')->getRepository(User::class);
+        $user = $userRepository->findOneBy(['mail' => 'admin@synaplan.com']);
+        if (!$user) {
+            self::markTestSkipped('Test user admin@synaplan.com not found. Run fixtures first.');
+        }
+
+        $this->user = $user;
+        $this->token = $this->authenticateClient($this->client, $user);
+    }
+
+    protected function tearDown(): void
+    {
+        $em = $this->client->getContainer()->get('doctrine')->getManager();
+        foreach ($this->createdIds as $id) {
+            $entity = $em->find(McpServerConfig::class, $id);
+            if ($entity) {
+                $em->remove($entity);
+            }
+        }
+        $em->flush();
+
+        parent::tearDown();
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     *
+     * @return array<string, mixed>
+     */
+    private function request(string $method, string $uri, array $payload = []): array
+    {
+        $this->client->request($method, $uri, [], [], [
+            'CONTENT_TYPE' => 'application/json',
+            'HTTP_AUTHORIZATION' => 'Bearer '.$this->token,
+        ], [] === $payload ? null : (string) json_encode($payload));
+
+        $decoded = json_decode((string) $this->client->getResponse()->getContent(), true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    public function testCreateListUpdateDeleteRoundTripNeverLeaksTheSecret(): void
+    {
+        $data = $this->request('POST', '/api/v1/mcp-servers', [
+            'name' => 'CRM (integration test)',
+            'url' => 'https://crm.example.com/mcp',
+            'auth_header' => 'X-API-KEY',
+            'auth_token' => 'super-secret-value',
+            'enabled' => true,
+        ]);
+        self::assertSame(Response::HTTP_CREATED, $this->client->getResponse()->getStatusCode());
+        self::assertTrue($data['success']);
+        $serverId = (int) $data['server']['id'];
+        $this->createdIds[] = $serverId;
+
+        // The secret must never appear in any response payload.
+        self::assertTrue($data['server']['has_auth_token']);
+        self::assertStringNotContainsString('super-secret-value', (string) $this->client->getResponse()->getContent());
+        // …and must be encrypted at rest.
+        $em = $this->client->getContainer()->get('doctrine')->getManager();
+        $stored = $em->find(McpServerConfig::class, $serverId);
+        self::assertNotNull($stored);
+        self::assertNotSame('super-secret-value', $stored->getAuthToken());
+        self::assertNotSame('', $stored->getAuthToken());
+
+        $list = $this->request('GET', '/api/v1/mcp-servers');
+        self::assertTrue($list['success']);
+        self::assertArrayHasKey('client_enabled', $list);
+        $ids = array_map(static fn (array $s): int => (int) $s['id'], $list['servers']);
+        self::assertContains($serverId, $ids);
+
+        $updated = $this->request('PATCH', "/api/v1/mcp-servers/{$serverId}", [
+            'name' => 'CRM renamed',
+            'enabled' => false,
+        ]);
+        self::assertTrue($updated['success']);
+        self::assertSame('CRM renamed', $updated['server']['name']);
+        self::assertFalse($updated['server']['enabled']);
+        // Auth token untouched when the key is absent from the payload.
+        self::assertTrue($updated['server']['has_auth_token']);
+
+        $deleted = $this->request('DELETE', "/api/v1/mcp-servers/{$serverId}");
+        self::assertTrue($deleted['success']);
+        $this->createdIds = [];
+    }
+
+    public function testPrivateUrlIsRejected(): void
+    {
+        $data = $this->request('POST', '/api/v1/mcp-servers', [
+            'name' => 'Evil',
+            'url' => 'http://169.254.169.254/mcp',
+        ]);
+
+        self::assertSame(Response::HTTP_BAD_REQUEST, $this->client->getResponse()->getStatusCode());
+        self::assertFalse($data['success']);
+        self::assertStringContainsString('not allowed', (string) $data['error']);
+    }
+
+    public function testForeignServersAreInvisible(): void
+    {
+        // Create a row owned by ANOTHER user directly in the DB.
+        $em = $this->client->getContainer()->get('doctrine')->getManager();
+        $foreign = new McpServerConfig();
+        $foreign->setUserId($this->user->getId() + 999999)
+            ->setName('foreign')
+            ->setUrl('https://foreign.example.com/mcp');
+        $em->persist($foreign);
+        $em->flush();
+        $this->createdIds[] = (int) $foreign->getId();
+
+        $list = $this->request('GET', '/api/v1/mcp-servers');
+        $ids = array_map(static fn (array $s): int => (int) $s['id'], $list['servers']);
+        self::assertNotContains((int) $foreign->getId(), $ids, 'another user\'s connection must be invisible');
+
+        $this->request('DELETE', '/api/v1/mcp-servers/'.$foreign->getId());
+        self::assertSame(Response::HTTP_NOT_FOUND, $this->client->getResponse()->getStatusCode());
+    }
+
+    public function testConnectionTestIsBlockedWhileClientDisabled(): void
+    {
+        // No MCP.CLIENT_ENABLED row exists in the test DB → built-in default OFF.
+        $created = $this->request('POST', '/api/v1/mcp-servers', [
+            'name' => 'Gated',
+            'url' => 'https://gated.example.com/mcp',
+        ]);
+        $serverId = (int) $created['server']['id'];
+        $this->createdIds[] = $serverId;
+
+        $test = $this->request('POST', "/api/v1/mcp-servers/{$serverId}/test");
+        self::assertFalse($test['success']);
+        self::assertStringContainsString('disabled', (string) $test['error']);
+
+        $tools = $this->request('GET', "/api/v1/mcp-servers/{$serverId}/tools");
+        self::assertFalse($tools['success']);
+        self::assertSame([], $tools['tools']);
+    }
+
+    public function testUnauthenticatedRequestsAreRejected(): void
+    {
+        // setUp authenticates the shared client with a session cookie too —
+        // drop it so this request is genuinely anonymous.
+        $this->client->getCookieJar()->clear();
+
+        $this->client->request('GET', '/api/v1/mcp-servers');
+        self::assertSame(Response::HTTP_UNAUTHORIZED, $this->client->getResponse()->getStatusCode());
+    }
+}

--- a/backend/tests/Unit/Service/Mcp/McpClientTest.php
+++ b/backend/tests/Unit/Service/Mcp/McpClientTest.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\Mcp;
+
+use App\Entity\McpServerConfig;
+use App\Repository\ConfigRepository;
+use App\Service\EncryptionService;
+use App\Service\Mcp\McpClient;
+use App\Service\Mcp\McpClientConfig;
+use App\Service\Mcp\McpClientException;
+use App\Service\Security\SsrfGuard;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+/**
+ * Outbound MCP client contract (plan 09 §3.2): Streamable HTTP session
+ * handshake, JSON + SSE response framing, auth header injection, SSRF guard,
+ * and graceful error surfaces.
+ */
+final class McpClientTest extends TestCase
+{
+    private EncryptionService $encryption;
+
+    protected function setUp(): void
+    {
+        $this->encryption = new EncryptionService('test-secret', new NullLogger());
+    }
+
+    /**
+     * @param list<MockResponse>                                                      $responses
+     * @param list<array{method: string, url: string, options: array<string, mixed>}> $captured
+     */
+    private function client(array $responses, array &$captured = []): McpClient
+    {
+        $factory = function (string $method, string $url, array $options) use (&$captured, &$responses): MockResponse {
+            $captured[] = ['method' => $method, 'url' => $url, 'options' => $options];
+            $next = array_shift($responses);
+
+            return $next ?? new MockResponse('', ['http_code' => 202]);
+        };
+
+        $configRepo = $this->createMock(ConfigRepository::class);
+        $configRepo->method('getValue')->willReturn(null);
+
+        return new McpClient(
+            new MockHttpClient($factory),
+            new SsrfGuard(),
+            $this->encryption,
+            new McpClientConfig($configRepo),
+            new NullLogger(),
+        );
+    }
+
+    private function server(string $url = 'https://8.8.8.8/mcp', string $authHeader = '', string $token = ''): McpServerConfig
+    {
+        $server = new McpServerConfig();
+        $server->setUserId(7)->setName('fixture')->setUrl($url);
+        if ('' !== $authHeader) {
+            $server->setAuthHeader($authHeader);
+            $server->setDecryptedAuthToken($token, $this->encryption);
+        }
+
+        return $server;
+    }
+
+    private static function rpc(array $result, array $headers = []): MockResponse
+    {
+        return new MockResponse(
+            (string) json_encode(['jsonrpc' => '2.0', 'id' => 1, 'result' => $result]),
+            ['http_code' => 200, 'response_headers' => array_merge(['content-type' => 'application/json'], $headers)],
+        );
+    }
+
+    public function testListToolsRunsTheSessionHandshakeAndParsesTools(): void
+    {
+        $captured = [];
+        $client = $this->client([
+            self::rpc(['protocolVersion' => McpClient::PROTOCOL_VERSION], ['mcp-session-id' => 'sess-1']),
+            new MockResponse('', ['http_code' => 202]), // initialized notification
+            self::rpc(['tools' => [
+                ['name' => 'search_customers', 'description' => 'Find CRM customers', 'inputSchema' => ['type' => 'object']],
+                ['name' => 'broken-entry'],
+            ]]),
+            new MockResponse('', ['http_code' => 200]), // session DELETE
+        ], $captured);
+
+        $tools = $client->listTools($this->server());
+
+        self::assertCount(2, $tools);
+        self::assertSame('search_customers', $tools[0]['name']);
+        self::assertSame('Find CRM customers', $tools[0]['description']);
+        self::assertSame('broken-entry', $tools[1]['name']);
+
+        // initialize → notification → tools/list → DELETE, session id forwarded.
+        self::assertCount(4, $captured);
+        self::assertSame('DELETE', $captured[3]['method']);
+        $toolsListHeaders = implode("\n", $captured[2]['options']['headers'] ?? []);
+        self::assertStringContainsString('Mcp-Session-Id: sess-1', $toolsListHeaders);
+    }
+
+    public function testCallToolSendsArgumentsAndReturnsContentBlocks(): void
+    {
+        $captured = [];
+        $client = $this->client([
+            self::rpc([], []),
+            new MockResponse('', ['http_code' => 202]),
+            self::rpc(['content' => [['type' => 'text', 'text' => 'result payload']], 'isError' => false]),
+        ], $captured);
+
+        $result = $client->callTool($this->server(), 'search_customers', ['query' => 'acme']);
+
+        self::assertFalse($result['isError']);
+        self::assertSame('result payload', $result['content'][0]['text']);
+
+        $body = json_decode((string) $captured[2]['options']['body'], true);
+        self::assertSame('tools/call', $body['method']);
+        self::assertSame('search_customers', $body['params']['name']);
+        self::assertSame(['query' => 'acme'], $body['params']['arguments']);
+    }
+
+    public function testAuthHeaderIsDecryptedAndSent(): void
+    {
+        $captured = [];
+        $client = $this->client([
+            self::rpc([]),
+            new MockResponse('', ['http_code' => 202]),
+            self::rpc(['tools' => []]),
+        ], $captured);
+
+        $client->listTools($this->server(authHeader: 'X-API-KEY', token: 'secret-key-123'));
+
+        $initHeaders = implode("\n", $captured[0]['options']['headers'] ?? []);
+        self::assertStringContainsString('X-API-KEY: secret-key-123', $initHeaders);
+    }
+
+    public function testSseFramedResponseIsParsed(): void
+    {
+        $sse = "event: message\ndata: "
+            .json_encode(['jsonrpc' => '2.0', 'id' => 1, 'result' => ['tools' => [['name' => 't1', 'description' => '', 'inputSchema' => []]]]])
+            ."\n\n";
+        $client = $this->client([
+            self::rpc([]),
+            new MockResponse('', ['http_code' => 202]),
+            new MockResponse($sse, ['http_code' => 200, 'response_headers' => ['content-type' => 'text/event-stream']]),
+        ]);
+
+        $tools = $client->listTools($this->server());
+
+        self::assertSame('t1', $tools[0]['name']);
+    }
+
+    public function testPrivateTargetIsBlockedBeforeAnyRequest(): void
+    {
+        $captured = [];
+        $client = $this->client([], $captured);
+
+        $this->expectException(McpClientException::class);
+        $this->expectExceptionMessageMatches('/not allowed/');
+
+        try {
+            $client->listTools($this->server(url: 'http://127.0.0.1/mcp'));
+        } finally {
+            self::assertSame([], $captured, 'no HTTP request may be made to a blocked target');
+        }
+    }
+
+    public function testJsonRpcErrorSurfacesAsException(): void
+    {
+        $client = $this->client([
+            new MockResponse(
+                (string) json_encode(['jsonrpc' => '2.0', 'id' => 1, 'error' => ['code' => -32602, 'message' => 'Unknown tool']]),
+                ['http_code' => 200, 'response_headers' => ['content-type' => 'application/json']],
+            ),
+        ]);
+
+        $this->expectException(McpClientException::class);
+        $this->expectExceptionMessageMatches('/Unknown tool/');
+
+        $client->listTools($this->server());
+    }
+
+    public function testHttpErrorSurfacesAsException(): void
+    {
+        $client = $this->client([new MockResponse('', ['http_code' => 503])]);
+
+        $this->expectException(McpClientException::class);
+        $this->expectExceptionMessageMatches('/HTTP 503/');
+
+        $client->listTools($this->server());
+    }
+}

--- a/backend/tests/Unit/Service/Mcp/McpToolRegistryTest.php
+++ b/backend/tests/Unit/Service/Mcp/McpToolRegistryTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\Mcp;
+
+use App\Entity\McpServerConfig;
+use App\Repository\ConfigRepository;
+use App\Repository\McpServerConfigRepository;
+use App\Service\EncryptionService;
+use App\Service\Mcp\McpClient;
+use App\Service\Mcp\McpClientConfig;
+use App\Service\Mcp\McpClientException;
+use App\Service\Mcp\McpToolRegistry;
+use App\Service\Security\SsrfGuard;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+/**
+ * Tool-discovery cache contract: planning must never pay a live tools/list
+ * round-trip twice within the TTL, and discovery failures must degrade to an
+ * empty catalog instead of breaking the turn.
+ */
+final class McpToolRegistryTest extends TestCase
+{
+    private int $httpCalls = 0;
+
+    private function registry(callable $responseFactory, ?McpServerConfigRepository $servers = null): McpToolRegistry
+    {
+        $configRepo = $this->createMock(ConfigRepository::class);
+        $configRepo->method('getValue')->willReturn(null);
+
+        $client = new McpClient(
+            new MockHttpClient(function (string $method, string $url, array $options) use ($responseFactory): MockResponse {
+                ++$this->httpCalls;
+
+                return $responseFactory($method, $url, $options);
+            }),
+            new SsrfGuard(),
+            new EncryptionService('test-secret', new NullLogger()),
+            new McpClientConfig($configRepo),
+            new NullLogger(),
+        );
+
+        return new McpToolRegistry(
+            $client,
+            $servers ?? $this->createMock(McpServerConfigRepository::class),
+            new ArrayAdapter(),
+            new NullLogger(),
+        );
+    }
+
+    private function server(): McpServerConfig
+    {
+        $server = new McpServerConfig();
+        $server->setUserId(7)->setName('fixture')->setUrl('https://8.8.8.8/mcp');
+        $ref = new \ReflectionProperty($server, 'id');
+        $ref->setValue($server, 42);
+
+        return $server;
+    }
+
+    private function happySession(): callable
+    {
+        return function (string $method, string $url, array $options): MockResponse {
+            $body = json_decode((string) ($options['body'] ?? ''), true);
+            $rpcMethod = is_array($body) ? ($body['method'] ?? '') : '';
+
+            if ('tools/list' === $rpcMethod) {
+                return new MockResponse(
+                    (string) json_encode(['jsonrpc' => '2.0', 'id' => 2, 'result' => ['tools' => [
+                        ['name' => 'lookup', 'description' => 'Look something up', 'inputSchema' => []],
+                    ]]]),
+                    ['http_code' => 200, 'response_headers' => ['content-type' => 'application/json']],
+                );
+            }
+
+            return new MockResponse(
+                (string) json_encode(['jsonrpc' => '2.0', 'id' => 1, 'result' => []]),
+                ['http_code' => 200, 'response_headers' => ['content-type' => 'application/json']],
+            );
+        };
+    }
+
+    public function testToolsAreCachedAcrossCallsWithinTheTtl(): void
+    {
+        $registry = $this->registry($this->happySession());
+        $server = $this->server();
+
+        $first = $registry->toolsFor($server);
+        $callsAfterFirst = $this->httpCalls;
+        $second = $registry->toolsFor($server);
+
+        self::assertSame('lookup', $first[0]['name']);
+        self::assertSame($first, $second);
+        self::assertSame($callsAfterFirst, $this->httpCalls, 'second lookup must be served from cache');
+    }
+
+    public function testDiscoveryFailureDegradesToEmptyList(): void
+    {
+        $registry = $this->registry(
+            static fn (): MockResponse => new MockResponse('', ['http_code' => 500]),
+        );
+
+        self::assertSame([], $registry->toolsFor($this->server()));
+    }
+
+    public function testRefreshPropagatesTheErrorForTheSettingsUi(): void
+    {
+        $registry = $this->registry(
+            static fn (): MockResponse => new MockResponse('', ['http_code' => 503]),
+        );
+
+        $this->expectException(McpClientException::class);
+        $registry->refresh($this->server());
+    }
+
+    public function testCatalogForUserListsEnabledServersWithTheirTools(): void
+    {
+        $servers = $this->createMock(McpServerConfigRepository::class);
+        $servers->method('findEnabledByUser')->with(7)->willReturn([$this->server()]);
+
+        $registry = $this->registry($this->happySession(), $servers);
+        $catalog = $registry->catalogForUser(7);
+
+        self::assertCount(1, $catalog);
+        self::assertSame(42, $catalog[0]['server']->getId());
+        self::assertSame('lookup', $catalog[0]['tools'][0]['name']);
+    }
+}

--- a/frontend/src/components/config/McpServersConfiguration.vue
+++ b/frontend/src/components/config/McpServersConfiguration.vue
@@ -1,0 +1,315 @@
+<template>
+  <div class="space-y-6" data-testid="page-config-mcp-servers">
+    <!-- Header -->
+    <div class="surface-card p-6" data-testid="section-mcp-overview">
+      <div class="flex items-start gap-3">
+        <div class="p-2 rounded-lg bg-[var(--brand)]/10">
+          <Icon icon="heroicons:server-stack" class="w-6 h-6 text-[var(--brand)]" />
+        </div>
+        <div class="flex-1 min-w-0">
+          <h2 class="text-2xl font-semibold txt-primary mb-1">{{ $t('mcpServers.title') }}</h2>
+          <p class="txt-secondary text-sm leading-relaxed">{{ $t('mcpServers.description') }}</p>
+          <p
+            v-if="!clientEnabled"
+            class="text-sm mt-3 px-3 py-2 rounded bg-amber-500/10 text-amber-600 dark:text-amber-400"
+            data-testid="mcp-client-disabled-hint"
+          >
+            {{ $t('mcpServers.clientDisabledHint') }}
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <!-- Server list -->
+    <div class="surface-card p-6" data-testid="section-mcp-list">
+      <div class="flex items-center justify-between mb-4">
+        <h3 class="text-lg font-semibold txt-primary">{{ $t('mcpServers.listTitle') }}</h3>
+        <button
+          type="button"
+          class="btn-primary px-4 py-2 rounded-lg text-sm font-medium"
+          data-testid="btn-mcp-add"
+          @click="startCreate"
+        >
+          {{ $t('mcpServers.add') }}
+        </button>
+      </div>
+
+      <p v-if="!loading && servers.length === 0" class="txt-secondary text-sm">
+        {{ $t('mcpServers.empty') }}
+      </p>
+
+      <ul v-else class="divide-y divide-light-border/20 dark:divide-dark-border/20">
+        <li
+          v-for="server in servers"
+          :key="server.id"
+          class="py-3 flex flex-wrap items-center gap-3"
+          :data-testid="`mcp-server-${server.id}`"
+        >
+          <div class="flex-1 min-w-0">
+            <p class="txt-primary text-sm font-medium truncate">{{ server.name }}</p>
+            <p class="txt-secondary text-xs font-mono truncate">{{ server.url }}</p>
+          </div>
+          <span
+            class="text-xs px-2 py-1 rounded-full"
+            :class="
+              server.enabled
+                ? 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400'
+                : 'bg-gray-500/10 txt-secondary'
+            "
+          >
+            {{ server.enabled ? $t('mcpServers.enabled') : $t('mcpServers.disabled') }}
+          </span>
+          <div class="flex items-center gap-2">
+            <button
+              type="button"
+              class="text-sm text-[var(--brand)] hover:underline"
+              :disabled="testingId === server.id"
+              :data-testid="`btn-mcp-test-${server.id}`"
+              @click="testServer(server)"
+            >
+              {{ testingId === server.id ? $t('mcpServers.testing') : $t('mcpServers.test') }}
+            </button>
+            <button
+              type="button"
+              class="text-sm text-[var(--brand)] hover:underline"
+              @click="startEdit(server)"
+            >
+              {{ $t('actions.edit') }}
+            </button>
+            <button
+              type="button"
+              class="text-sm text-red-500 hover:underline"
+              @click="removeServer(server)"
+            >
+              {{ $t('actions.delete') }}
+            </button>
+          </div>
+          <div v-if="toolsByServer[server.id ?? -1]" class="w-full pl-1">
+            <p class="text-xs txt-secondary mb-1">
+              {{
+                $t('mcpServers.discoveredTools', { count: toolsByServer[server.id ?? -1].length })
+              }}
+            </p>
+            <ul class="flex flex-wrap gap-2">
+              <li
+                v-for="tool in toolsByServer[server.id ?? -1]"
+                :key="tool.name"
+                class="text-xs px-2 py-1 rounded bg-[var(--brand)]/10 txt-primary font-mono"
+                :title="tool.description"
+              >
+                {{ tool.name }}
+              </li>
+            </ul>
+          </div>
+        </li>
+      </ul>
+    </div>
+
+    <!-- Editor -->
+    <div v-if="editorOpen" class="surface-card p-6" data-testid="section-mcp-editor">
+      <h3 class="text-lg font-semibold txt-primary mb-1">
+        {{ editingId ? $t('mcpServers.editTitle') : $t('mcpServers.addTitle') }}
+      </h3>
+      <p class="txt-secondary text-sm mb-5">{{ $t('mcpServers.formHint') }}</p>
+
+      <div class="space-y-4">
+        <label class="block">
+          <span class="text-sm font-medium txt-primary">{{ $t('mcpServers.nameLabel') }}</span>
+          <input
+            v-model="form.name"
+            type="text"
+            class="mt-1 w-full px-3 py-2 rounded surface-card border border-light-border/30 dark:border-dark-border/20 txt-primary text-sm focus:outline-none focus:ring-2 focus:ring-[var(--brand)]"
+            data-testid="input-mcp-name"
+          />
+        </label>
+        <label class="block">
+          <span class="text-sm font-medium txt-primary">{{ $t('mcpServers.urlLabel') }}</span>
+          <input
+            v-model="form.url"
+            type="url"
+            placeholder="https://example.com/mcp"
+            class="mt-1 w-full px-3 py-2 rounded surface-card border border-light-border/30 dark:border-dark-border/20 txt-primary text-sm focus:outline-none focus:ring-2 focus:ring-[var(--brand)] font-mono"
+            data-testid="input-mcp-url"
+          />
+        </label>
+        <div class="grid sm:grid-cols-2 gap-4">
+          <label class="block">
+            <span class="text-sm font-medium txt-primary">{{
+              $t('mcpServers.authHeaderLabel')
+            }}</span>
+            <input
+              v-model="form.authHeader"
+              type="text"
+              placeholder="Authorization"
+              class="mt-1 w-full px-3 py-2 rounded surface-card border border-light-border/30 dark:border-dark-border/20 txt-primary text-sm focus:outline-none focus:ring-2 focus:ring-[var(--brand)] font-mono"
+              data-testid="input-mcp-auth-header"
+            />
+          </label>
+          <label class="block">
+            <span class="text-sm font-medium txt-primary">{{
+              $t('mcpServers.authTokenLabel')
+            }}</span>
+            <input
+              v-model="form.authToken"
+              type="password"
+              autocomplete="off"
+              :placeholder="editingHasToken ? '••••••••' : $t('mcpServers.authTokenPlaceholder')"
+              class="mt-1 w-full px-3 py-2 rounded surface-card border border-light-border/30 dark:border-dark-border/20 txt-primary text-sm focus:outline-none focus:ring-2 focus:ring-[var(--brand)] font-mono"
+              data-testid="input-mcp-auth-token"
+            />
+          </label>
+        </div>
+        <label class="inline-flex items-center gap-2 text-sm txt-primary">
+          <input v-model="form.enabled" type="checkbox" class="accent-[var(--brand)]" />
+          {{ $t('mcpServers.enabledLabel') }}
+        </label>
+      </div>
+
+      <div class="flex flex-wrap items-center gap-3 mt-6">
+        <button
+          type="button"
+          class="btn-primary px-4 py-2 rounded-lg text-sm font-medium disabled:opacity-50"
+          :disabled="saving || !form.name.trim() || !form.url.trim()"
+          data-testid="btn-mcp-save"
+          @click="save"
+        >
+          {{ saving ? $t('actions.saving') : $t('actions.save') }}
+        </button>
+        <button
+          type="button"
+          class="px-4 py-2 rounded-lg text-sm txt-secondary hover:txt-primary"
+          @click="closeEditor"
+        >
+          {{ $t('actions.cancel') }}
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, reactive, ref } from 'vue'
+import { Icon } from '@iconify/vue'
+import { useI18n } from 'vue-i18n'
+import { useDialog } from '@/composables/useDialog'
+import { useNotification } from '@/composables/useNotification'
+import { mcpServersApi, type McpServer, type McpTool } from '@/services/api/mcpServersApi'
+
+const { t } = useI18n()
+const { confirm } = useDialog()
+const { success, error } = useNotification()
+
+const loading = ref(true)
+const saving = ref(false)
+const clientEnabled = ref(false)
+const servers = ref<McpServer[]>([])
+const toolsByServer = reactive<Record<number, McpTool[]>>({})
+const testingId = ref<number | null>(null)
+
+const editorOpen = ref(false)
+const editingId = ref<number | null>(null)
+const editingHasToken = ref(false)
+const form = reactive({ name: '', url: '', authHeader: '', authToken: '', enabled: true })
+
+const load = async () => {
+  loading.value = true
+  try {
+    const data = await mcpServersApi.list()
+    clientEnabled.value = data.clientEnabled
+    servers.value = data.servers
+  } catch {
+    error(t('mcpServers.loadFailed'))
+  } finally {
+    loading.value = false
+  }
+}
+
+const startCreate = () => {
+  editingId.value = null
+  editingHasToken.value = false
+  Object.assign(form, { name: '', url: '', authHeader: '', authToken: '', enabled: true })
+  editorOpen.value = true
+}
+
+const startEdit = (server: McpServer) => {
+  editingId.value = server.id ?? null
+  editingHasToken.value = server.has_auth_token ?? false
+  Object.assign(form, {
+    name: server.name ?? '',
+    url: server.url ?? '',
+    authHeader: server.auth_header ?? '',
+    authToken: '',
+    enabled: server.enabled ?? true,
+  })
+  editorOpen.value = true
+}
+
+const closeEditor = () => {
+  editorOpen.value = false
+}
+
+const save = async () => {
+  saving.value = true
+  try {
+    const payload = {
+      name: form.name.trim(),
+      url: form.url.trim(),
+      auth_header: form.authHeader.trim(),
+      enabled: form.enabled,
+      // Only send the secret when the user actually typed one — absent keeps
+      // the stored value.
+      ...(form.authToken !== '' ? { auth_token: form.authToken } : {}),
+    }
+    if (editingId.value !== null) {
+      await mcpServersApi.update(editingId.value, payload)
+    } else {
+      await mcpServersApi.create(payload)
+    }
+    success(t('mcpServers.saved'))
+    editorOpen.value = false
+    await load()
+  } catch (err) {
+    error(err instanceof Error && err.message ? err.message : t('mcpServers.saveFailed'))
+  } finally {
+    saving.value = false
+  }
+}
+
+const removeServer = async (server: McpServer) => {
+  const confirmed = await confirm({
+    title: t('mcpServers.deleteTitle'),
+    message: t('mcpServers.deleteMessage', { name: server.name ?? '' }),
+    confirmText: t('actions.delete'),
+    danger: true,
+  })
+  if (!confirmed || server.id === undefined) return
+
+  try {
+    await mcpServersApi.remove(server.id)
+    success(t('mcpServers.deleted'))
+    await load()
+  } catch {
+    error(t('mcpServers.deleteFailed'))
+  }
+}
+
+const testServer = async (server: McpServer) => {
+  if (server.id === undefined) return
+  testingId.value = server.id
+  try {
+    const result = await mcpServersApi.test(server.id)
+    if (result.success) {
+      toolsByServer[server.id] = result.tools
+      success(t('mcpServers.testSuccess', { count: result.tools.length }))
+    } else {
+      error(result.error || t('mcpServers.testFailed'))
+    }
+  } catch {
+    error(t('mcpServers.testFailed'))
+  } finally {
+    testingId.value = null
+  }
+}
+
+onMounted(load)
+</script>

--- a/frontend/src/components/files/FilesTabs.vue
+++ b/frontend/src/components/files/FilesTabs.vue
@@ -79,7 +79,7 @@ const props = defineProps<{
   active: FilesTab
 }>()
 
-// Tailwind-only tab styling (AGENTS_DEV: no component-scoped CSS). The `-mb-px`
+// Tailwind-only tab styling (AGENTS.md: no component-scoped CSS). The `-mb-px`
 // pulls the active 2px bottom border over the nav's own border for the
 // classic tab look; brand color comes from the CSS token.
 const BASE_TAB =

--- a/frontend/src/composables/useNavItems.ts
+++ b/frontend/src/composables/useNavItems.ts
@@ -110,6 +110,7 @@ export function useNavItems() {
       { key: 'inbound', path: '/channels', label: t('nav.configInbound') },
       { key: 'chat-widget', path: '/channels/widgets', label: t('nav.toolsChatWidget') },
       { key: 'mail-handler', path: '/channels/email', label: t('nav.toolsMailHandler') },
+      { key: 'mcp-servers', path: '/channels/mcp', label: t('nav.mcpServers') },
       { key: 'api-keys', path: '/channels/api', label: t('nav.configApiKeys') },
       { key: 'api-docs', path: '/channels/api/docs', label: t('pageTitles.configApiDocs') },
     ]

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -69,7 +69,8 @@
     "widgetChats": "Widget-Chats",
     "widgetDetail": "Widget-Detail",
     "liveSupport": "Live-Support",
-    "addinConnect": "Outlook-Add-in verbinden"
+    "addinConnect": "Outlook-Add-in verbinden",
+    "mcpServers": "MCP-Server"
   },
   "addinConnect": {
     "title": "Mit Synaplan verbinden",
@@ -346,6 +347,7 @@
     "toolsChatWidget": "Chat-Widget",
     "toolsDocSummary": "Zusammenfasser",
     "toolsMailHandler": "E-Mail-Automatisierung",
+    "mcpServers": "MCP-Server",
     "plugins": "Plugins",
     "files": "Dateien",
     "filesDescription": "Dateien & Wissen",
@@ -3767,5 +3769,36 @@
     "subtitle": "Diese App-Version wird nicht mehr unterstützt. Bitte aktualisiere auf die neueste Version, um fortzufahren.",
     "minVersion": "Mindestens erforderliche Version: {version}",
     "cta": "Jetzt aktualisieren"
+  },
+  "mcpServers": {
+    "title": "MCP-Server",
+    "description": "Verbinde externe MCP-Server, damit der Assistent beim Antworten Daten aus deinen eigenen Systemen (CRM, Wiki, interne APIs) abrufen kann. Die hier entdeckten Tools stehen dem Task-Planner zur Verfügung.",
+    "clientDisabledHint": "Der ausgehende MCP-Client ist derzeit in der Plattformkonfiguration deaktiviert. Verbindungen können vorbereitet werden, es werden aber keine Aufrufe ausgeführt, bis er aktiviert ist.",
+    "listTitle": "Verbundene Server",
+    "add": "Server hinzufügen",
+    "addTitle": "Neuen Server verbinden",
+    "editTitle": "Server bearbeiten",
+    "formHint": "Die URL muss ein öffentlicher HTTPS-MCP-Endpunkt (Streamable HTTP) sein. Der Auth-Wert wird verschlüsselt gespeichert und nie wieder angezeigt.",
+    "empty": "Noch keine MCP-Server verbunden.",
+    "nameLabel": "Name",
+    "urlLabel": "Server-URL",
+    "authHeaderLabel": "Auth-Header-Name (optional)",
+    "authTokenLabel": "Auth-Header-Wert",
+    "authTokenPlaceholder": "z. B. Bearer sk-…",
+    "enabledLabel": "Aktiviert",
+    "enabled": "Aktiviert",
+    "disabled": "Deaktiviert",
+    "test": "Verbindung testen",
+    "testing": "Teste…",
+    "testSuccess": "Verbindung OK — {count} Tool(s) gefunden",
+    "testFailed": "Verbindung fehlgeschlagen",
+    "discoveredTools": "{count} Tool(s) gefunden:",
+    "saved": "Server gespeichert",
+    "saveFailed": "Server konnte nicht gespeichert werden",
+    "deleted": "Server entfernt",
+    "deleteFailed": "Server konnte nicht entfernt werden",
+    "deleteTitle": "MCP-Server entfernen",
+    "deleteMessage": "Verbindung \"{name}\" entfernen? Der Assistent kann dessen Tools dann nicht mehr nutzen.",
+    "loadFailed": "MCP-Server konnten nicht geladen werden"
   }
 }

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -69,7 +69,8 @@
     "widgetChats": "Widget Chats",
     "widgetDetail": "Widget Detail",
     "liveSupport": "Live Support",
-    "addinConnect": "Connect Outlook Add-in"
+    "addinConnect": "Connect Outlook Add-in",
+    "mcpServers": "MCP Servers"
   },
   "addinConnect": {
     "title": "Connect to Synaplan",
@@ -351,6 +352,7 @@
     "toolsChatWidget": "Chat Widget",
     "toolsDocSummary": "Summarizer",
     "toolsMailHandler": "Email Automation",
+    "mcpServers": "MCP Servers",
     "plugins": "Plugins",
     "files": "Files",
     "filesDescription": "Files & knowledge",
@@ -3833,5 +3835,36 @@
     "subtitle": "This version of the app is no longer supported. Please update to the latest version to continue.",
     "minVersion": "Minimum required version: {version}",
     "cta": "Update now"
+  },
+  "mcpServers": {
+    "title": "MCP Servers",
+    "description": "Connect external MCP servers so the assistant can pull data from your own systems (CRM, wiki, internal APIs) while answering. Tools discovered here become available to the task planner.",
+    "clientDisabledHint": "The outbound MCP client is currently disabled by the platform configuration. Connections can be prepared, but no calls will be made until it is enabled.",
+    "listTitle": "Connected servers",
+    "add": "Add server",
+    "addTitle": "Connect a new server",
+    "editTitle": "Edit server",
+    "formHint": "The URL must be a public HTTPS MCP endpoint (Streamable HTTP). The auth value is stored encrypted and never shown again.",
+    "empty": "No MCP servers connected yet.",
+    "nameLabel": "Name",
+    "urlLabel": "Server URL",
+    "authHeaderLabel": "Auth header name (optional)",
+    "authTokenLabel": "Auth header value",
+    "authTokenPlaceholder": "e.g. Bearer sk-…",
+    "enabledLabel": "Enabled",
+    "enabled": "Enabled",
+    "disabled": "Disabled",
+    "test": "Test connection",
+    "testing": "Testing…",
+    "testSuccess": "Connection OK — {count} tool(s) discovered",
+    "testFailed": "Connection failed",
+    "discoveredTools": "{count} tool(s) discovered:",
+    "saved": "Server saved",
+    "saveFailed": "Could not save the server",
+    "deleted": "Server removed",
+    "deleteFailed": "Could not remove the server",
+    "deleteTitle": "Remove MCP server",
+    "deleteMessage": "Remove the connection \"{name}\"? The assistant will no longer be able to use its tools.",
+    "loadFailed": "Could not load MCP servers"
   }
 }

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -68,7 +68,8 @@
     "widgetSessions": "Sesiones de Widget",
     "widgetChats": "Chats de Widget",
     "liveSupport": "Soporte en vivo",
-    "addinConnect": "Conectar complemento de Outlook"
+    "addinConnect": "Conectar complemento de Outlook",
+    "mcpServers": "Servidores MCP"
   },
   "addinConnect": {
     "title": "Conectar a Synaplan",
@@ -319,6 +320,7 @@
     "toolsChatWidget": "Widget de Chat",
     "toolsDocSummary": "Resumidor",
     "toolsMailHandler": "Automatización de correo",
+    "mcpServers": "Servidores MCP",
     "plugins": "Plugins",
     "files": "Archivos",
     "filesDescription": "Archivos y conocimiento",
@@ -2738,5 +2740,36 @@
     "subtitle": "Esta versión de la app ya no es compatible. Actualiza a la última versión para continuar.",
     "minVersion": "Versión mínima requerida: {version}",
     "cta": "Actualizar ahora"
+  },
+  "mcpServers": {
+    "title": "Servidores MCP",
+    "description": "Conecta servidores MCP externos para que el asistente pueda obtener datos de tus propios sistemas (CRM, wiki, APIs internas) al responder. Las herramientas descubiertas aquí quedan disponibles para el planificador de tareas.",
+    "clientDisabledHint": "El cliente MCP saliente está desactivado en la configuración de la plataforma. Puedes preparar conexiones, pero no se harán llamadas hasta que se active.",
+    "listTitle": "Servidores conectados",
+    "add": "Añadir servidor",
+    "addTitle": "Conectar un servidor nuevo",
+    "editTitle": "Editar servidor",
+    "formHint": "La URL debe ser un endpoint MCP HTTPS público (Streamable HTTP). El valor de autenticación se guarda cifrado y no se vuelve a mostrar.",
+    "empty": "Aún no hay servidores MCP conectados.",
+    "nameLabel": "Nombre",
+    "urlLabel": "URL del servidor",
+    "authHeaderLabel": "Nombre de la cabecera de autenticación (opcional)",
+    "authTokenLabel": "Valor de la cabecera de autenticación",
+    "authTokenPlaceholder": "p. ej. Bearer sk-…",
+    "enabledLabel": "Activado",
+    "enabled": "Activado",
+    "disabled": "Desactivado",
+    "test": "Probar conexión",
+    "testing": "Probando…",
+    "testSuccess": "Conexión correcta — {count} herramienta(s) descubiertas",
+    "testFailed": "La conexión falló",
+    "discoveredTools": "{count} herramienta(s) descubiertas:",
+    "saved": "Servidor guardado",
+    "saveFailed": "No se pudo guardar el servidor",
+    "deleted": "Servidor eliminado",
+    "deleteFailed": "No se pudo eliminar el servidor",
+    "deleteTitle": "Eliminar servidor MCP",
+    "deleteMessage": "¿Eliminar la conexión \"{name}\"? El asistente ya no podrá usar sus herramientas.",
+    "loadFailed": "No se pudieron cargar los servidores MCP"
   }
 }

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -68,7 +68,8 @@
     "widgetSessions": "Widget Oturumları",
     "widgetChats": "Widget Sohbetleri",
     "liveSupport": "Canlı Destek",
-    "addinConnect": "Outlook eklentisini bağla"
+    "addinConnect": "Outlook eklentisini bağla",
+    "mcpServers": "MCP Sunucuları"
   },
   "addinConnect": {
     "title": "Synaplan'a bağlan",
@@ -319,6 +320,7 @@
     "toolsChatWidget": "Sohbet Widgetı",
     "toolsDocSummary": "Özetleyici",
     "toolsMailHandler": "E-posta Otomasyonu",
+    "mcpServers": "MCP Sunucuları",
     "plugins": "Eklentiler",
     "files": "Dosyalar",
     "filesDescription": "Dosyalar ve bilgi",
@@ -2739,5 +2741,36 @@
     "subtitle": "Uygulamanın bu sürümü artık desteklenmiyor. Devam etmek için lütfen en son sürüme güncelleyin.",
     "minVersion": "Gerekli en düşük sürüm: {version}",
     "cta": "Şimdi güncelle"
+  },
+  "mcpServers": {
+    "title": "MCP Sunucuları",
+    "description": "Asistanın yanıt verirken kendi sistemlerinizden (CRM, wiki, dahili API'ler) veri çekebilmesi için harici MCP sunucularını bağlayın. Burada keşfedilen araçlar görev planlayıcısına sunulur.",
+    "clientDisabledHint": "Giden MCP istemcisi şu anda platform yapılandırmasında devre dışı. Bağlantılar hazırlanabilir, ancak etkinleştirilene kadar çağrı yapılmaz.",
+    "listTitle": "Bağlı sunucular",
+    "add": "Sunucu ekle",
+    "addTitle": "Yeni sunucu bağla",
+    "editTitle": "Sunucuyu düzenle",
+    "formHint": "URL, herkese açık bir HTTPS MCP uç noktası (Streamable HTTP) olmalıdır. Kimlik doğrulama değeri şifrelenmiş olarak saklanır ve bir daha gösterilmez.",
+    "empty": "Henüz bağlı MCP sunucusu yok.",
+    "nameLabel": "Ad",
+    "urlLabel": "Sunucu URL'si",
+    "authHeaderLabel": "Kimlik doğrulama başlığı adı (isteğe bağlı)",
+    "authTokenLabel": "Kimlik doğrulama başlığı değeri",
+    "authTokenPlaceholder": "örn. Bearer sk-…",
+    "enabledLabel": "Etkin",
+    "enabled": "Etkin",
+    "disabled": "Devre dışı",
+    "test": "Bağlantıyı test et",
+    "testing": "Test ediliyor…",
+    "testSuccess": "Bağlantı başarılı — {count} araç bulundu",
+    "testFailed": "Bağlantı başarısız",
+    "discoveredTools": "{count} araç bulundu:",
+    "saved": "Sunucu kaydedildi",
+    "saveFailed": "Sunucu kaydedilemedi",
+    "deleted": "Sunucu kaldırıldı",
+    "deleteFailed": "Sunucu kaldırılamadı",
+    "deleteTitle": "MCP sunucusunu kaldır",
+    "deleteMessage": "\"{name}\" bağlantısı kaldırılsın mı? Asistan artık bu sunucunun araçlarını kullanamaz.",
+    "loadFailed": "MCP sunucuları yüklenemedi"
   }
 }

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -203,6 +203,12 @@ const router = createRouter({
       meta: { requiresAuth: true, helpId: 'tools.mailHandler', titleKey: 'pageTitles.mailHandler' },
     },
     {
+      path: '/channels/mcp',
+      name: 'channels-mcp',
+      component: () => import('@/views/ConfigView.vue'),
+      meta: { requiresAuth: true, titleKey: 'pageTitles.mcpServers' },
+    },
+    {
       path: '/channels/api',
       name: 'channels-api',
       component: () => import('@/views/ConfigView.vue'),

--- a/frontend/src/services/api/higgsfieldCredentialsApi.ts
+++ b/frontend/src/services/api/higgsfieldCredentialsApi.ts
@@ -22,7 +22,7 @@ import {
 } from '@/generated/api-schemas'
 import { httpClient } from './httpClient'
 
-// Response types are inferred from the generated Zod schemas (per AGENTS_DEV:
+// Response types are inferred from the generated Zod schemas (per AGENTS.md:
 // never hand-write interfaces for API responses). The request body type below
 // is NOT an API response, so it stays a plain interface.
 export type HiggsfieldEffectiveSource = 'user' | 'platform' | 'none'

--- a/frontend/src/services/api/mcpServersApi.ts
+++ b/frontend/src/services/api/mcpServersApi.ts
@@ -1,0 +1,92 @@
+import { z } from 'zod'
+import { httpClient } from './httpClient'
+import {
+  GetApiMcpServersListResponseSchema,
+  PostApiMcpServersCreateResponseSchema,
+  PatchApiMcpServersUpdateResponseSchema,
+  DeleteApiMcpServersDeleteResponseSchema,
+  PostApiMcpServersTestResponseSchema,
+  GetApiMcpServersToolsResponseSchema,
+} from '@/generated/api-schemas'
+
+/**
+ * Settings → Connections → MCP servers (release 4.0 external data nodes).
+ *
+ * The auth header value is WRITE-ONLY: it is sent on create/update but never
+ * returned by the API — responses only carry `has_auth_token`.
+ */
+
+export type McpServer = NonNullable<
+  z.infer<typeof GetApiMcpServersListResponseSchema>['servers']
+>[number]
+
+export type McpTool = NonNullable<
+  z.infer<typeof PostApiMcpServersTestResponseSchema>['tools']
+>[number]
+
+export interface McpServerPayload {
+  name?: string
+  url?: string
+  auth_header?: string
+  /** Absent = keep the stored secret; empty string = clear it. */
+  auth_token?: string
+  enabled?: boolean
+}
+
+export const mcpServersApi = {
+  async list(): Promise<{ clientEnabled: boolean; servers: McpServer[] }> {
+    const data = await httpClient('/api/v1/mcp-servers', {
+      method: 'GET',
+      schema: GetApiMcpServersListResponseSchema,
+    })
+    return { clientEnabled: data.client_enabled ?? false, servers: data.servers ?? [] }
+  },
+
+  async create(payload: McpServerPayload): Promise<McpServer> {
+    const data = await httpClient('/api/v1/mcp-servers', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+      schema: PostApiMcpServersCreateResponseSchema,
+    })
+    if (!data.server) throw new Error('Malformed create response')
+    return data.server
+  },
+
+  async update(id: number, payload: McpServerPayload): Promise<McpServer> {
+    const data = await httpClient(`/api/v1/mcp-servers/${id}`, {
+      method: 'PATCH',
+      body: JSON.stringify(payload),
+      schema: PatchApiMcpServersUpdateResponseSchema,
+    })
+    if (!data.server) throw new Error('Malformed update response')
+    return data.server
+  },
+
+  async remove(id: number): Promise<void> {
+    await httpClient(`/api/v1/mcp-servers/${id}`, {
+      method: 'DELETE',
+      schema: DeleteApiMcpServersDeleteResponseSchema,
+    })
+  },
+
+  /** Live connection test: initialize + tool discovery. */
+  async test(id: number): Promise<{ success: boolean; tools: McpTool[]; error?: string }> {
+    const data = await httpClient(`/api/v1/mcp-servers/${id}/test`, {
+      method: 'POST',
+      schema: PostApiMcpServersTestResponseSchema,
+    })
+    return {
+      success: data.success ?? false,
+      tools: data.tools ?? [],
+      error: data.error ?? undefined,
+    }
+  },
+
+  async tools(id: number): Promise<McpTool[]> {
+    const data = await httpClient(`/api/v1/mcp-servers/${id}/tools`, {
+      method: 'GET',
+      schema: GetApiMcpServersToolsResponseSchema,
+    })
+    return data.tools ?? []
+  },
+}

--- a/frontend/src/services/api/subscriptionApi.ts
+++ b/frontend/src/services/api/subscriptionApi.ts
@@ -84,11 +84,11 @@ export interface PortalSession {
  * MOBILE-APP SEAM (Epic 5.4): result of server-side IAP receipt validation.
  * The server is the single source of truth — the app shows the outcome but
  * never grants a tier itself. Inferred from the generated schema (per
- * AGENTS_DEV: never hand-write interfaces for API responses).
+ * AGENTS.md: never hand-write interfaces for API responses).
  */
 export type IapVerifyResult = z.infer<typeof PostIapVerifyResponseSchema>
 
-// Inferred from the generated Zod schemas (per AGENTS_DEV: never hand-write
+// Inferred from the generated Zod schemas (per AGENTS.md: never hand-write
 // interfaces for API responses).
 export type TopupSession = z.infer<typeof PostSubscriptionTopupResponseSchema>
 

--- a/frontend/src/services/filesService.ts
+++ b/frontend/src/services/filesService.ts
@@ -171,7 +171,7 @@ export interface UploadResponse {
 // Zod schemas are the single source of truth for the file API data shapes:
 // each schema both validates the JSON at runtime (where we call `.parse()`)
 // and produces the static TypeScript type via `z.infer` — so the types can
-// never drift from the validation (AGENTS_DEV.md "Type Safety & Validation").
+// never drift from the validation (AGENTS.md "Type Safety & Validation").
 export const fileSourceSchema = z.enum([
   'web_upload',
   'chat_attachment',

--- a/frontend/src/views/ConfigView.vue
+++ b/frontend/src/views/ConfigView.vue
@@ -32,6 +32,10 @@
           <APIKeysConfiguration />
         </div>
 
+        <div v-else-if="currentPage === 'mcp-servers'" data-testid="section-mcp-servers">
+          <McpServersConfiguration />
+        </div>
+
         <div
           v-else-if="currentPage === 'api-documentation'"
           data-testid="section-api-documentation"
@@ -54,6 +58,7 @@ import TaskPromptsConfiguration from '@/components/config/TaskPromptsConfigurati
 import SortingPromptConfiguration from '@/components/config/SortingPromptConfiguration.vue'
 import APIKeysConfiguration from '@/components/config/APIKeysConfiguration.vue'
 import ApiDocumentation from '@/components/config/ApiDocumentation.vue'
+import McpServersConfiguration from '@/components/config/McpServersConfiguration.vue'
 
 const route = useRoute()
 
@@ -63,6 +68,7 @@ const currentPage = computed(() => {
   const path = route.path
   if (path.startsWith('/channels/api/docs')) return 'api-documentation'
   if (path.startsWith('/channels/api')) return 'api-keys'
+  if (path.startsWith('/channels/mcp')) return 'mcp-servers'
   if (path.startsWith('/channels')) return 'inbound'
   if (path.startsWith('/ai/providers/higgsfield')) return 'ai-provider-higgsfield'
   if (path.startsWith('/ai/models')) return 'ai-models'


### PR DESCRIPTION
## Summary

Sprint 5 (stacked on #1245): Synaplan becomes an outbound MCP **client**. Per-user server connections whose discovered tools feed the planner's `mcp_fetch` sub-catalog in Sprint 6.

- **`McpServerConfig` entity** (`BMCPSERVERS`, user-scoped repository, AES-encrypted auth header value via `EncryptionService`) + comparator-free idempotent migration (`CREATE TABLE IF NOT EXISTS`, Galera-safe).
- **`McpClient`** — Streamable HTTP JSON-RPC (`initialize` → `notifications/initialized` → `tools/list`/`tools/call` → session DELETE), SSE-framed response parsing, shared `SsrfGuard` on every target, `MCP.NODE_TIMEOUT`-bounded, 512 KiB response cap, expected failures as `McpClientException`.
- **`McpToolRegistry`** — 5-minute cached discovery per server (planning never pays a live round-trip); `refresh()` propagates errors for the settings "Test connection".
- **Flags:** `MCP.CLIENT_ENABLED` (master, default **off** — controller refuses live test/tools calls while off) + `MCP.NODE_TIMEOUT`.
- **API:** `/api/v1/mcp-servers` CRUD + `/test` + `/tools`, full OpenAPI response schemas; the auth secret is write-only (responses carry `has_auth_token` only).
- **Frontend:** Channels → MCP Servers page (list/editor/test with discovered-tool chips), generated Zod schemas, nav/route/i18n ×4.

## Test plan

- [x] Full gate green: backend lint/phpstan/tests (2516), frontend lint/vue-tsc/Vitest (790)
- [x] 11 new unit tests (client protocol incl. SSRF/SSE/auth-header injection; registry caching + degradation) + 5 controller integration tests (CRUD, secret never leaked and encrypted at rest, cross-tenant invisibility, SSRF-rejected URL, master-switch gate) — integration tests verified locally against loaded fixtures
- [x] Migration applied to dev + test DBs; `doctrine:schema:update --dump-sql` shows no drift for the new table
- [x] **Live verification:** connected the public DeepWiki MCP server — "Test connection" performed the real Streamable HTTP handshake and discovered its 3 tools; cached `/tools` + delete round-trip confirmed; flag-off path refuses outbound calls
- [x] Extensive DAG-router testing (requested): plan-eval corpus expanded 16 → 33 cases (multilingual compounds, generator chains, email traps, negative must-not-trigger cases, attachments) — **66/66 over two full live passes**