### PR TITLE
feat(multitask): mcp_fetch data node — pull from connected MCP servers inside the DAG (plan 09 S4)

### DIFF
--- a/backend/src/Prompt/PromptCatalog.php
+++ b/backend/src/Prompt/PromptCatalog.php
@@ -561,6 +561,15 @@ Allowed topic keys: [KEYLIST]
    mention the question does not depend on, and prefer `web_search` when no
    concrete URL is given. Only use `url_fetch` if it appears in the
    capability list above.
+9c. The request needs data from one of the user's CONNECTED systems and the
+   capability list above shows `mcp_fetch` with available connections
+   ("look up customer X in our CRM", "check the wiki for the onboarding
+   page") → an `mcp_fetch` node with `params.server_id` + `params.tool`
+   taken EXACTLY from the listed connections and the tool arguments in
+   `inputs.arguments`; feed `$nX.text` into the answering node. NEVER
+   invent a server_id or tool name, and NEVER emit `mcp_fetch` when it is
+   not in the capability list or no listed tool fits — use `chat` or
+   `web_search` instead.
 10. Plain question / smalltalk / advice → one `chat` node. `reply_node` = that
    node, no `compose_reply` needed.
 11. A SINGLE media request with no follow-up step ("make an image of X",
@@ -743,6 +752,25 @@ User: "Fasse mir diese Seite zusammen: https://example.com/artikel"
 
 The page content is FETCHED (`url_fetch`) and the summary consumes `$n1.text` —
 never answer about a URL's content from memory or invent what the page says.
+
+### Pull data from a connected system, then answer (mcp_fetch)
+User: "Look up the customer Acme GmbH in our CRM and summarize their last order."
+(The capability list shows: server_id 3 "Company CRM" — tools: search_customers(query), get_last_order(customer_id))
+
+{
+  "version": 1,
+  "language": "en",
+  "reply_node": "n3",
+  "tasks": [
+    { "id": "n1", "capability": "mcp_fetch", "inputs": { "arguments": { "query": "Acme GmbH" } }, "params": { "server_id": 3, "tool": "search_customers" } },
+    { "id": "n2", "capability": "chat", "depends_on": ["n1"], "inputs": { "text": "Summarize the last order of this customer based on the following data:\n$n1.text" }, "params": { "topic_id": "general" } },
+    { "id": "n3", "capability": "compose_reply", "depends_on": ["n1","n2"], "inputs": { "text": "$n2.text" } }
+  ]
+}
+
+`params.server_id` and `params.tool` come EXACTLY from the listed connections
+(never invented), the tool arguments ride in `inputs.arguments`, and the
+answering node consumes `$n1.text` — the reply is grounded in the pulled data.
 
 ### Calendar invite ("I need a meeting reminder for tomorrow at 9:00 with Sanam")
 The event fields go in `params`. Resolve the relative time against the time

--- a/backend/src/Service/Mcp/McpClient.php
+++ b/backend/src/Service/Mcp/McpClient.php
@@ -45,7 +45,7 @@ final readonly class McpClient
     /**
      * Discover the server's tools.
      *
-     * @return list<array{name: string, description: string, inputSchema: array<string, mixed>}>
+     * @return list<array{name: string, description: string, inputSchema: array<string, mixed>, annotations: array<string, mixed>}>
      */
     public function listTools(McpServerConfig $server): array
     {
@@ -60,6 +60,10 @@ final readonly class McpClient
                 'name' => $tool['name'],
                 'description' => is_string($tool['description'] ?? null) ? $tool['description'] : '',
                 'inputSchema' => is_array($tool['inputSchema'] ?? null) ? $tool['inputSchema'] : [],
+                // Spec tool annotations (readOnlyHint/destructiveHint/…) — the
+                // pull-only guard in McpFetchRunner refuses tools that declare
+                // themselves mutating (plan 09 §2.4).
+                'annotations' => is_array($tool['annotations'] ?? null) ? $tool['annotations'] : [],
             ];
         }
 

--- a/backend/src/Service/Mcp/McpToolRegistry.php
+++ b/backend/src/Service/Mcp/McpToolRegistry.php
@@ -38,7 +38,7 @@ final readonly class McpToolRegistry
      * Cached tools of one server. Never throws — planning must not break on
      * an unreachable server.
      *
-     * @return list<array{name: string, description: string, inputSchema: array<string, mixed>}>
+     * @return list<array{name: string, description: string, inputSchema: array<string, mixed>, annotations: array<string, mixed>}>
      */
     public function toolsFor(McpServerConfig $server): array
     {
@@ -63,7 +63,7 @@ final readonly class McpToolRegistry
      * {@see McpClientException} propagate so the UI can show the reason, and
      * primes the cache on success.
      *
-     * @return list<array{name: string, description: string, inputSchema: array<string, mixed>}>
+     * @return list<array{name: string, description: string, inputSchema: array<string, mixed>, annotations: array<string, mixed>}>
      */
     public function refresh(McpServerConfig $server): array
     {
@@ -83,7 +83,7 @@ final readonly class McpToolRegistry
      * Every enabled server of a user with its cached tools — the shape the
      * planner sub-catalog renders from.
      *
-     * @return list<array{server: McpServerConfig, tools: list<array{name: string, description: string, inputSchema: array<string, mixed>}>}>
+     * @return list<array{server: McpServerConfig, tools: list<array{name: string, description: string, inputSchema: array<string, mixed>, annotations: array<string, mixed>}>}>
      */
     public function catalogForUser(int $userId): array
     {

--- a/backend/src/Service/Multitask/Execution/DagExecutor.php
+++ b/backend/src/Service/Multitask/Execution/DagExecutor.php
@@ -541,7 +541,7 @@ final readonly class DagExecutor
      */
     private function successMetadata(TaskNode $node, NodeResult $result): array
     {
-        if (!in_array($node->capability, [Capability::WebSearch, Capability::UrlFetch], true)) {
+        if (!in_array($node->capability, [Capability::WebSearch, Capability::UrlFetch, Capability::McpFetch], true)) {
             return [];
         }
 

--- a/backend/src/Service/Multitask/Execution/Runner/McpFetchRunner.php
+++ b/backend/src/Service/Multitask/Execution/Runner/McpFetchRunner.php
@@ -1,0 +1,355 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Multitask\Execution\Runner;
+
+use App\Entity\McpServerConfig;
+use App\Repository\McpServerConfigRepository;
+use App\Service\Mcp\McpClient;
+use App\Service\Mcp\McpClientConfig;
+use App\Service\Mcp\McpClientException;
+use App\Service\Mcp\McpToolRegistry;
+use App\Service\Multitask\Execution\NodeContext;
+use App\Service\Multitask\Execution\NodeResult;
+use App\Service\Multitask\Execution\TaskRunner;
+use App\Service\Multitask\MultitaskRoutingConfig;
+use App\Service\Multitask\Plan\Capability;
+use App\Service\Multitask\Plan\TaskNode;
+use App\Service\Multitask\Skill\SkillDescriptor;
+use App\Service\PromptService;
+use Psr\Log\LoggerInterface;
+
+/**
+ * `mcp_fetch` runner — pull data from one of the user's connected external
+ * MCP servers inside the DAG (release-4.0 plan 09 §3.2, the customer
+ * deliverable; node shape = locked Option A: one generic capability, the
+ * server/tool live in `params`, the tool arguments in `inputs.arguments`).
+ *
+ * The FIRST dynamic skill block: its planner-facing description expands into
+ * the per-user tool sub-catalog at plan time (via {@see describe()}'s dynamic
+ * note), and only when the matched topic opted in via the `tool_mcp` prompt
+ * metadata — a topic without the flag never even shows the planner that MCP
+ * tools exist.
+ *
+ * Gate chain (each re-checked at run time, defense in depth):
+ *   MCP.CLIENT_ENABLED (master) → MULTITASK.MCP_FETCH_ENABLED (routing flag)
+ *   → topic `tool_mcp` (+ optional `mcp_servers` allowlist) → server owned by
+ *   the user + enabled → tool exists on the server → tool not self-declared
+ *   mutating (pull-only v1). A hallucinated or stale plan can never reach a
+ *   server the topic isn't entitled to.
+ */
+final readonly class McpFetchRunner implements TaskRunner
+{
+    /** Cap on the formatted node output (token control, like url_fetch). */
+    private const MAX_OUTPUT_CHARS = 12000;
+
+    public function __construct(
+        private McpClient $client,
+        private McpToolRegistry $toolRegistry,
+        private McpServerConfigRepository $servers,
+        private McpClientConfig $clientConfig,
+        private MultitaskRoutingConfig $routingConfig,
+        private PromptService $promptService,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function supportedCapabilities(): array
+    {
+        return [Capability::McpFetch];
+    }
+
+    /**
+     * @return list<SkillDescriptor>
+     */
+    public function describe(): array
+    {
+        return [
+            new SkillDescriptor(
+                Capability::McpFetch,
+                'Pull data from one of the user\'s connected external systems (read-only) before answering. Set params.server_id and params.tool from the connections listed below; pass the tool arguments in inputs.arguments. ONLY use a server/tool listed below — if none fits, do NOT emit mcp_fetch.',
+                dynamicNote: fn (?int $userId, array $context): ?string => $this->renderToolSubCatalog($userId, $context),
+                enabledFlag: MultitaskRoutingConfig::KEY_MCP_FETCH_ENABLED,
+                enabledDefault: false,
+                requiresDynamicNote: true,
+            ),
+        ];
+    }
+
+    public function run(TaskNode $node, NodeContext $context): NodeResult
+    {
+        $userId = $context->userId ?? $context->message->getUserId();
+
+        // Flags (defense in depth — the catalog already hid the block).
+        if (!$this->clientConfig->isClientEnabled($userId)
+            || !$this->routingConfig->isFeatureEnabled(MultitaskRoutingConfig::KEY_MCP_FETCH_ENABLED, $userId, false)) {
+            return NodeResult::failed('mcp_fetch is disabled');
+        }
+
+        $serverId = is_numeric($node->params['server_id'] ?? null) ? (int) $node->params['server_id'] : 0;
+        $tool = is_string($node->params['tool'] ?? null) ? trim($node->params['tool']) : '';
+        if ($serverId <= 0 || '' === $tool) {
+            return NodeResult::failed('mcp_fetch needs params.server_id and params.tool');
+        }
+
+        // Ownership + enabled — cross-tenant access is structurally impossible.
+        $server = $this->servers->findByIdAndUser($serverId, (int) $userId);
+        if (null === $server || !$server->isEnabled()) {
+            return NodeResult::failed('this data connection is not available');
+        }
+
+        // Topic entitlement re-check (plan 09 §3.2 run-time gate).
+        if (!$this->topicAllowsServer($userId, $context->classification, $serverId)) {
+            return NodeResult::failed('this topic is not allowed to use MCP data sources');
+        }
+
+        // The tool must actually exist on the server (hallucination guard) and
+        // must not declare itself mutating (pull-only v1, plan 09 §2.4).
+        $catalogTool = $this->findTool($server, $tool);
+        if (null === $catalogTool) {
+            return NodeResult::failed(sprintf("the tool '%s' does not exist on this connection", $tool));
+        }
+        if ($this->isMutatingTool($catalogTool['annotations'])) {
+            return NodeResult::failed(sprintf("the tool '%s' can modify data and is not allowed (read-only)", $tool));
+        }
+
+        $arguments = $this->resolveArguments($node, $context);
+
+        try {
+            $result = $this->client->callTool($server, $tool, $arguments);
+        } catch (McpClientException $e) {
+            $this->logger->warning('McpFetchRunner: tool call failed', [
+                'server_id' => $serverId,
+                'tool' => $tool,
+                'error' => $e->getMessage(),
+            ]);
+
+            return NodeResult::failed('could not reach the data source: '.$e->getMessage());
+        }
+
+        $text = $this->formatContent($result['content']);
+        if ($result['isError']) {
+            return NodeResult::failed('the data source reported an error: '.mb_substr($text, 0, 300));
+        }
+        if ('' === trim($text)) {
+            return NodeResult::failed('the data source returned no usable content');
+        }
+
+        $this->logger->info('McpFetchRunner: tool call succeeded', [
+            'server_id' => $serverId,
+            'tool' => $tool,
+            'chars' => mb_strlen($text),
+        ]);
+
+        return NodeResult::ok($text, [], [
+            'mcp' => ['server_id' => $serverId, 'server' => $server->getName(), 'tool' => $tool],
+            // Compact summary line for the search-style task card.
+            'query' => $server->getName().' · '.$tool,
+        ]);
+    }
+
+    /**
+     * The per-user tool sub-catalog injected under the capability summary —
+     * only when every plan-time gate passes; null keeps the whole block
+     * invisible ({@see SkillDescriptor::$requiresDynamicNote}).
+     *
+     * @param array<string, mixed> $context
+     */
+    private function renderToolSubCatalog(?int $userId, array $context): ?string
+    {
+        if (null === $userId || $userId <= 0 || !$this->clientConfig->isClientEnabled($userId)) {
+            return null;
+        }
+
+        $topicMetadata = is_array($context['topic_metadata'] ?? null) ? $context['topic_metadata'] : [];
+        if (true !== ($topicMetadata['tool_mcp'] ?? null)) {
+            return null;
+        }
+        $allowlist = $this->serverAllowlist($topicMetadata);
+
+        $lines = [];
+        foreach ($this->toolRegistry->catalogForUser($userId) as $entry) {
+            $server = $entry['server'];
+            $serverId = (int) $server->getId();
+            if (null !== $allowlist && !in_array($serverId, $allowlist, true)) {
+                continue;
+            }
+
+            $tools = [];
+            foreach ($entry['tools'] as $tool) {
+                if ($this->isMutatingTool($tool['annotations'])) {
+                    continue;
+                }
+                $tools[] = $tool['name'].$this->renderArgumentHint($tool['inputSchema'])
+                    .('' !== $tool['description'] ? ' — '.$this->oneLine($tool['description']) : '');
+            }
+            if ([] === $tools) {
+                continue;
+            }
+
+            $lines[] = sprintf('    • server_id %d "%s" — tools:', $serverId, $server->getName());
+            foreach ($tools as $toolLine) {
+                $lines[] = '      - '.$toolLine;
+            }
+        }
+
+        if ([] === $lines) {
+            return null;
+        }
+
+        return "  Available connections for this user:\n".implode("\n", $lines);
+    }
+
+    /**
+     * @param array<string, mixed> $classification
+     */
+    private function topicAllowsServer(?int $userId, array $classification, int $serverId): bool
+    {
+        $topic = is_string($classification['topic'] ?? null) ? $classification['topic'] : '';
+        if ('' === $topic) {
+            return false;
+        }
+
+        try {
+            $promptData = $this->promptService->getPromptWithMetadata($topic, (int) $userId);
+        } catch (\Throwable) {
+            return false;
+        }
+        $metadata = is_array($promptData['metadata'] ?? null) ? $promptData['metadata'] : [];
+
+        if (true !== ($metadata['tool_mcp'] ?? null)) {
+            return false;
+        }
+
+        $allowlist = $this->serverAllowlist($metadata);
+
+        return null === $allowlist || in_array($serverId, $allowlist, true);
+    }
+
+    /**
+     * Parse the optional `mcp_servers` prompt metadata (comma-separated
+     * McpServerConfig ids). Null = no restriction (all connected servers).
+     *
+     * @param array<string, mixed> $topicMetadata
+     *
+     * @return list<int>|null
+     */
+    private function serverAllowlist(array $topicMetadata): ?array
+    {
+        $raw = $topicMetadata['mcp_servers'] ?? null;
+        if (!is_string($raw) || '' === trim($raw)) {
+            return null;
+        }
+
+        $ids = [];
+        foreach (explode(',', $raw) as $part) {
+            $part = trim($part);
+            if (is_numeric($part) && (int) $part > 0) {
+                $ids[] = (int) $part;
+            }
+        }
+
+        return [] === $ids ? null : $ids;
+    }
+
+    /**
+     * @return array{name: string, description: string, inputSchema: array<string, mixed>, annotations: array<string, mixed>}|null
+     */
+    private function findTool(McpServerConfig $server, string $tool): ?array
+    {
+        foreach ($this->toolRegistry->toolsFor($server) as $candidate) {
+            if ($candidate['name'] === $tool) {
+                return $candidate;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Pull-only v1: refuse tools that DECLARE themselves mutating via the
+     * spec's tool annotations. Tools without annotations are allowed — most
+     * read tools don't carry them, and the planner catalog only offered
+     * read-safe entries in the first place.
+     *
+     * @param array<string, mixed> $annotations
+     */
+    private function isMutatingTool(array $annotations): bool
+    {
+        if (false === ($annotations['readOnlyHint'] ?? null)) {
+            return true;
+        }
+
+        return true === ($annotations['destructiveHint'] ?? null);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function resolveArguments(TaskNode $node, NodeContext $context): array
+    {
+        $inputs = $context->resolveInputs($node);
+        $arguments = $inputs['arguments'] ?? null;
+
+        if (is_array($arguments)) {
+            return $arguments;
+        }
+        if (is_string($arguments) && '' !== trim($arguments)) {
+            $decoded = json_decode($arguments, true);
+            if (is_array($decoded)) {
+                return $decoded;
+            }
+        }
+
+        return [];
+    }
+
+    /**
+     * Flatten the tool result's content blocks into one citable text block
+     * for downstream `$nX.text` consumers (plan 09 §2.7 uniform shape).
+     *
+     * @param list<array<string, mixed>> $content
+     */
+    private function formatContent(array $content): string
+    {
+        $parts = [];
+        foreach ($content as $block) {
+            $type = $block['type'] ?? null;
+            if ('text' === $type && is_string($block['text'] ?? null)) {
+                $parts[] = $block['text'];
+            } elseif (is_array($block['resource'] ?? null) && is_string($block['resource']['text'] ?? null)) {
+                $parts[] = $block['resource']['text'];
+            }
+        }
+
+        $text = trim(implode("\n\n", $parts));
+        if (mb_strlen($text) > self::MAX_OUTPUT_CHARS) {
+            $text = mb_substr($text, 0, self::MAX_OUTPUT_CHARS).'…';
+        }
+
+        return $text;
+    }
+
+    /**
+     * Compact `(arg1, arg2, …)` hint from a tool's JSON input schema.
+     *
+     * @param array<string, mixed> $inputSchema
+     */
+    private function renderArgumentHint(array $inputSchema): string
+    {
+        $properties = is_array($inputSchema['properties'] ?? null) ? array_keys($inputSchema['properties']) : [];
+        if ([] === $properties) {
+            return '';
+        }
+
+        return '('.implode(', ', array_slice(array_map('strval', $properties), 0, 6)).')';
+    }
+
+    private function oneLine(string $text): string
+    {
+        $line = trim((string) preg_replace('/\s+/', ' ', $text));
+
+        return mb_strlen($line) > 140 ? mb_substr($line, 0, 137).'…' : $line;
+    }
+}

--- a/backend/src/Service/Multitask/MultitaskRoutingConfig.php
+++ b/backend/src/Service/Multitask/MultitaskRoutingConfig.php
@@ -41,6 +41,7 @@ final readonly class MultitaskRoutingConfig
     public const KEY_MAX_PARALLEL = 'MAX_PARALLEL';
     public const KEY_NODE_TIMEOUT = 'NODE_TIMEOUT';
     public const KEY_URL_FETCH_ENABLED = 'URL_FETCH_ENABLED';
+    public const KEY_MCP_FETCH_ENABLED = 'MCP_FETCH_ENABLED';
 
     private const DEFAULT_ROUTING_ENABLED = true;
     private const DEFAULT_SHADOW_MODE = false;

--- a/backend/src/Service/Multitask/Plan/Capability.php
+++ b/backend/src/Service/Multitask/Plan/Capability.php
@@ -39,6 +39,9 @@ enum Capability: string
     /** Fetch + read the content of specific URL(s) named in the request (UrlContentService). */
     case UrlFetch = 'url_fetch';
 
+    /** Pull data from one of the user's connected external MCP servers (McpClient, read-only v1). */
+    case McpFetch = 'mcp_fetch';
+
     /** Vision / OCR / document Q&A (FileAnalysisHandler). */
     case FileAnalysis = 'file_analysis';
 
@@ -80,7 +83,7 @@ enum Capability: string
         return match ($this) {
             self::ExtractText => 'extract',
             self::Chat, self::Summarize, self::Translate, self::RagQuery, self::FileAnalysis => 'text',
-            self::WebSearch, self::UrlFetch => 'search',
+            self::WebSearch, self::UrlFetch, self::McpFetch => 'search',
             self::ImageGeneration => 'image',
             self::VideoGeneration => 'video',
             self::Text2Sound => 'audio',

--- a/backend/src/Service/Multitask/Skill/SkillCatalog.php
+++ b/backend/src/Service/Multitask/Skill/SkillCatalog.php
@@ -55,8 +55,13 @@ final class SkillCatalog
     /**
      * Render the `[CAPABILITYLIST]` block: one `- "capability": summary` line
      * per capability, plus any per-user dynamic note a descriptor contributes.
+     *
+     * @param array<string, mixed> $context per-turn render context for dynamic
+     *                                      blocks: `topic` (resolved routing
+     *                                      topic) and `topic_metadata` (its
+     *                                      BPROMPTMETA key/value map)
      */
-    public function renderCapabilityList(?int $userId = null): string
+    public function renderCapabilityList(?int $userId = null, array $context = []): string
     {
         $lines = [];
         foreach (Capability::cases() as $capability) {
@@ -70,12 +75,19 @@ final class SkillCatalog
                 continue;
             }
 
-            $lines[] = '- "'.$capability->value.'": '.(null !== $descriptor ? $descriptor->summary : '');
-
             $note = null !== $descriptor && null !== $descriptor->dynamicNote
-                ? ($descriptor->dynamicNote)($userId)
+                ? ($descriptor->dynamicNote)($userId, $context)
                 : null;
-            if (is_string($note) && '' !== trim($note)) {
+            $hasNote = is_string($note) && '' !== trim($note);
+
+            // A dynamic block with nothing to offer this user/turn (no
+            // connected servers, topic not entitled) stays invisible.
+            if (null !== $descriptor && $descriptor->requiresDynamicNote && !$hasNote) {
+                continue;
+            }
+
+            $lines[] = '- "'.$capability->value.'": '.(null !== $descriptor ? $descriptor->summary : '');
+            if ($hasNote) {
                 $lines[] = rtrim($note);
             }
         }

--- a/backend/src/Service/Multitask/Skill/SkillDescriptor.php
+++ b/backend/src/Service/Multitask/Skill/SkillDescriptor.php
@@ -25,13 +25,20 @@ use App\Service\Multitask\Plan\Capability;
 final readonly class SkillDescriptor
 {
     /**
-     * @param string                         $summary        one-line, planner-facing description ([CAPABILITYLIST] entry)
-     * @param (\Closure(?int): ?string)|null $dynamicNote    per-user expansion appended below the summary
-     * @param string|null                    $enabledFlag    BCONFIG `MULTITASK.<flag>` gating this block; when the flag
-     *                                                       resolves to false the capability is OMITTED from the planner
-     *                                                       catalog (the planner never learns it exists — plan 09 §6)
-     * @param bool                           $enabledDefault flag value when no BCONFIG row exists (new experimental
-     *                                                       blocks ship default-off and are flipped on when validated)
+     * @param string                                               $summary             one-line, planner-facing description ([CAPABILITYLIST] entry)
+     * @param (\Closure(?int, array<string, mixed>): ?string)|null $dynamicNote         per-user/per-turn expansion appended below the
+     *                                                                                  summary; receives the user id and the render
+     *                                                                                  context (`topic`, `topic_metadata`)
+     * @param string|null                                          $enabledFlag         BCONFIG `MULTITASK.<flag>` gating this block; when the
+     *                                                                                  flag resolves to false the capability is OMITTED from
+     *                                                                                  the planner catalog (the planner never learns it
+     *                                                                                  exists — plan 09 §6)
+     * @param bool                                                 $enabledDefault      flag value when no BCONFIG row exists (new experimental
+     *                                                                                  blocks ship default-off and are flipped on when validated)
+     * @param bool                                                 $requiresDynamicNote when true the capability line is rendered ONLY when the
+     *                                                                                  dynamic note expands to something — a dynamic block with
+     *                                                                                  nothing to offer (no connected servers, topic not
+     *                                                                                  entitled) stays invisible to the planner entirely
      */
     public function __construct(
         public Capability $capability,
@@ -39,6 +46,7 @@ final readonly class SkillDescriptor
         public ?\Closure $dynamicNote = null,
         public ?string $enabledFlag = null,
         public bool $enabledDefault = false,
+        public bool $requiresDynamicNote = false,
     ) {
     }
 }

--- a/backend/src/Service/Multitask/TaskPlanExecutor.php
+++ b/backend/src/Service/Multitask/TaskPlanExecutor.php
@@ -48,7 +48,7 @@ final readonly class TaskPlanExecutor
      * must run through the DAG even as a lone single node (see
      * {@see shouldUseLegacyRouter()}).
      */
-    private const DAG_ONLY_CAPABILITIES = [Capability::CalendarEvent, Capability::UrlFetch];
+    private const DAG_ONLY_CAPABILITIES = [Capability::CalendarEvent, Capability::UrlFetch, Capability::McpFetch];
 
     /**
      * Single-shot media generators that the legacy router already delivers
@@ -229,7 +229,9 @@ final readonly class TaskPlanExecutor
         try {
             $userId = $this->modelConfigService->getEffectiveUserIdForMessage($message);
 
-            $result = $this->planner->plan($message, $thread, $userId, $options);
+            // Forward the classification so dynamic skill blocks (mcp_fetch)
+            // can resolve the matched topic's per-prompt gates at plan time.
+            $result = $this->planner->plan($message, $thread, $userId, $options + ['classification' => $classification]);
 
             $collapsed = $this->collapseRedundantSingleMediaPlan($result->plan, $classification);
             if ($collapsed !== $result->plan) {

--- a/backend/src/Service/Multitask/TaskPlanner.php
+++ b/backend/src/Service/Multitask/TaskPlanner.php
@@ -13,6 +13,7 @@ use App\Service\Multitask\Plan\TaskPlan;
 use App\Service\Multitask\Plan\TaskPlanValidator;
 use App\Service\Multitask\Skill\SkillCatalog;
 use App\Service\Prompt\TimeContextBuilder;
+use App\Service\PromptService;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -38,6 +39,7 @@ final readonly class TaskPlanner
         private UserRepository $userRepository,
         private TimeContextBuilder $timeContextBuilder,
         private SkillCatalog $skillCatalog,
+        private PromptService $promptService,
     ) {
     }
 
@@ -141,7 +143,10 @@ final readonly class TaskPlanner
 
         // Catalog-lite (release 4.0): the capability list is assembled from the
         // SkillDescriptors the runners declare — one source of truth per block.
-        $capabilityList = $this->skillCatalog->renderCapabilityList($userId);
+        // Dynamic blocks (mcp_fetch) additionally receive the resolved routing
+        // topic + its metadata so per-prompt gates (`tool_mcp`) decide whether
+        // their sub-catalog is injected at all (plan 09 §3.2).
+        $capabilityList = $this->skillCatalog->renderCapabilityList($userId, $this->catalogContext($userId, $options));
 
         $dynamicList = [];
         foreach ($topicsWithDesc as $item) {
@@ -155,6 +160,40 @@ final readonly class TaskPlanner
         $text = str_replace('[KEYLIST]', $keyList, $text);
 
         return $text."\n\n".$this->timeContextBlock($message, $options);
+    }
+
+    /**
+     * Render context for dynamic skill blocks: the turn's resolved routing
+     * topic (from the classification the executor forwards in the options)
+     * and that topic's BPROMPTMETA map. Failures degrade to an empty context
+     * — a metadata hiccup must never break planning.
+     *
+     * @param array<string, mixed> $options
+     *
+     * @return array<string, mixed>
+     */
+    private function catalogContext(?int $userId, array $options): array
+    {
+        $classification = is_array($options['classification'] ?? null) ? $options['classification'] : [];
+        $topic = is_string($classification['topic'] ?? null) ? $classification['topic'] : '';
+        if ('' === $topic) {
+            return [];
+        }
+
+        $topicMetadata = [];
+        try {
+            $promptData = $this->promptService->getPromptWithMetadata($topic, $userId ?? 0);
+            if (null !== $promptData && is_array($promptData['metadata'] ?? null)) {
+                $topicMetadata = $promptData['metadata'];
+            }
+        } catch (\Throwable $e) {
+            $this->logger->warning('TaskPlanner: failed to resolve topic metadata for the skill catalog (ignored)', [
+                'topic' => $topic,
+                'error' => $e->getMessage(),
+            ]);
+        }
+
+        return ['topic' => $topic, 'topic_metadata' => $topicMetadata];
     }
 
     /**

--- a/backend/tests/Characterization/PlannerPromptCharacterizationTest.php
+++ b/backend/tests/Characterization/PlannerPromptCharacterizationTest.php
@@ -6,13 +6,16 @@ namespace App\Tests\Characterization;
 
 use App\AI\Service\AiFacade;
 use App\Prompt\PromptCatalog;
+use App\Repository\PromptMetaRepository;
 use App\Repository\PromptRepository;
 use App\Repository\UserRepository;
 use App\Service\ModelConfigService;
 use App\Service\Multitask\Plan\TaskPlanValidator;
 use App\Service\Multitask\TaskPlanner;
 use App\Service\Prompt\TimeContextBuilder;
+use App\Service\PromptService;
 use App\Tests\Support\SkillCatalogFactory;
+use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Symfony\Component\Clock\MockClock;
@@ -108,6 +111,12 @@ final class PlannerPromptCharacterizationTest extends TestCase
             // snapshot prove the catalog-lite assembly is equivalent to the
             // previous hard-coded CAPABILITY_DESCRIPTIONS array.
             SkillCatalogFactory::real(),
+            new PromptService(
+                $this->createMock(PromptRepository::class),
+                $this->createMock(PromptMetaRepository::class),
+                $this->createMock(EntityManagerInterface::class),
+                new NullLogger(),
+            ),
         );
     }
 

--- a/backend/tests/Characterization/__snapshots__/planner_system_prompt.txt
+++ b/backend/tests/Characterization/__snapshots__/planner_system_prompt.txt
@@ -146,6 +146,15 @@ Allowed topic keys: "general" | "mediamaker" | "officemaker" | "docsummary" | "l
    mention the question does not depend on, and prefer `web_search` when no
    concrete URL is given. Only use `url_fetch` if it appears in the
    capability list above.
+9c. The request needs data from one of the user's CONNECTED systems and the
+   capability list above shows `mcp_fetch` with available connections
+   ("look up customer X in our CRM", "check the wiki for the onboarding
+   page") → an `mcp_fetch` node with `params.server_id` + `params.tool`
+   taken EXACTLY from the listed connections and the tool arguments in
+   `inputs.arguments`; feed `$nX.text` into the answering node. NEVER
+   invent a server_id or tool name, and NEVER emit `mcp_fetch` when it is
+   not in the capability list or no listed tool fits — use `chat` or
+   `web_search` instead.
 10. Plain question / smalltalk / advice → one `chat` node. `reply_node` = that
    node, no `compose_reply` needed.
 11. A SINGLE media request with no follow-up step ("make an image of X",
@@ -328,6 +337,25 @@ User: "Fasse mir diese Seite zusammen: https://example.com/artikel"
 
 The page content is FETCHED (`url_fetch`) and the summary consumes `$n1.text` —
 never answer about a URL's content from memory or invent what the page says.
+
+### Pull data from a connected system, then answer (mcp_fetch)
+User: "Look up the customer Acme GmbH in our CRM and summarize their last order."
+(The capability list shows: server_id 3 "Company CRM" — tools: search_customers(query), get_last_order(customer_id))
+
+{
+  "version": 1,
+  "language": "en",
+  "reply_node": "n3",
+  "tasks": [
+    { "id": "n1", "capability": "mcp_fetch", "inputs": { "arguments": { "query": "Acme GmbH" } }, "params": { "server_id": 3, "tool": "search_customers" } },
+    { "id": "n2", "capability": "chat", "depends_on": ["n1"], "inputs": { "text": "Summarize the last order of this customer based on the following data:\n$n1.text" }, "params": { "topic_id": "general" } },
+    { "id": "n3", "capability": "compose_reply", "depends_on": ["n1","n2"], "inputs": { "text": "$n2.text" } }
+  ]
+}
+
+`params.server_id` and `params.tool` come EXACTLY from the listed connections
+(never invented), the tool arguments ride in `inputs.arguments`, and the
+answering node consumes `$n1.text` — the reply is grounded in the pulled data.
 
 ### Calendar invite ("I need a meeting reminder for tomorrow at 9:00 with Sanam")
 The event fields go in `params`. Resolve the relative time against the time

--- a/backend/tests/Eval/plan_eval_corpus.json
+++ b/backend/tests/Eval/plan_eval_corpus.json
@@ -492,6 +492,14 @@
     }
   },
   {
+    "id": "mcp_not_offered_no_hallucination",
+    "text": "Look up the customer Acme GmbH in our CRM and summarize their last order.",
+    "language": "en",
+    "expect": {
+      "forbid": ["mcp_fetch", "image_generation"]
+    }
+  },
+  {
     "id": "websearch_current_info",
     "text": "Wie ist das Wetter morgen in Berlin?",
     "language": "de",

--- a/backend/tests/Support/SkillCatalogFactory.php
+++ b/backend/tests/Support/SkillCatalogFactory.php
@@ -11,6 +11,7 @@ use App\Service\Multitask\Execution\Runner\DocumentGenerationRunner;
 use App\Service\Multitask\Execution\Runner\EmailMeRunner;
 use App\Service\Multitask\Execution\Runner\ExtractTextRunner;
 use App\Service\Multitask\Execution\Runner\FileAnalysisRunner;
+use App\Service\Multitask\Execution\Runner\McpFetchRunner;
 use App\Service\Multitask\Execution\Runner\MediaGenerationRunner;
 use App\Service\Multitask\Execution\Runner\Text2SoundRunner;
 use App\Service\Multitask\Execution\Runner\UrlFetchRunner;
@@ -39,6 +40,7 @@ final class SkillCatalogFactory
         ChatRunner::class,
         WebSearchRunner::class,
         UrlFetchRunner::class,
+        McpFetchRunner::class,
         FileAnalysisRunner::class,
         MediaGenerationRunner::class,
         Text2SoundRunner::class,

--- a/backend/tests/Unit/Controller/PromptControllerTestRoutingTest.php
+++ b/backend/tests/Unit/Controller/PromptControllerTestRoutingTest.php
@@ -74,6 +74,12 @@ final class PromptControllerTestRoutingTest extends TestCase
                 $this->createMock(UserRepository::class),
                 new TimeContextBuilder(),
                 SkillCatalogFactory::real(),
+                new PromptService(
+                    $this->createMock(PromptRepository::class),
+                    $this->createMock(PromptMetaRepository::class),
+                    $this->createMock(EntityManagerInterface::class),
+                    new NullLogger(),
+                ),
             ),
         );
 

--- a/backend/tests/Unit/Service/Multitask/Execution/Runner/McpFetchRunnerTest.php
+++ b/backend/tests/Unit/Service/Multitask/Execution/Runner/McpFetchRunnerTest.php
@@ -1,0 +1,237 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\Multitask\Execution\Runner;
+
+use App\Entity\McpServerConfig;
+use App\Entity\Message;
+use App\Entity\Prompt;
+use App\Entity\PromptMeta;
+use App\Repository\ConfigRepository;
+use App\Repository\McpServerConfigRepository;
+use App\Repository\PromptMetaRepository;
+use App\Repository\PromptRepository;
+use App\Service\EncryptionService;
+use App\Service\Mcp\McpClient;
+use App\Service\Mcp\McpClientConfig;
+use App\Service\Mcp\McpToolRegistry;
+use App\Service\Multitask\Execution\NodeContext;
+use App\Service\Multitask\Execution\Runner\McpFetchRunner;
+use App\Service\Multitask\MultitaskRoutingConfig;
+use App\Service\Multitask\Plan\Capability;
+use App\Service\Multitask\Plan\TaskNode;
+use App\Service\PromptService;
+use App\Service\Security\SsrfGuard;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+/**
+ * `mcp_fetch` node contract (plan 09 §3.2, locked Option A): the full gate
+ * chain (flags → topic entitlement → ownership → tool existence → pull-only),
+ * grounded result formatting, and the dynamic planner sub-catalog.
+ */
+final class McpFetchRunnerTest extends TestCase
+{
+    private const USER_ID = 7;
+
+    /** @var list<array<string, mixed>> */
+    private array $serverTools = [
+        ['name' => 'search_customers', 'description' => 'Find CRM customers', 'inputSchema' => ['properties' => ['query' => ['type' => 'string']]], 'annotations' => []],
+        ['name' => 'delete_customer', 'description' => 'Remove a customer', 'inputSchema' => [], 'annotations' => ['readOnlyHint' => false]],
+    ];
+
+    private function server(bool $enabled = true): McpServerConfig
+    {
+        $server = new McpServerConfig();
+        $server->setUserId(self::USER_ID)->setName('Company CRM')->setUrl('https://8.8.8.8/mcp')->setEnabled($enabled);
+        (new \ReflectionProperty($server, 'id'))->setValue($server, 3);
+
+        return $server;
+    }
+
+    /**
+     * @param array<string, string> $flags         BCONFIG values by "GROUP.SETTING"
+     * @param array<string, string> $topicMetaRows BPROMPTMETA key => value for the resolved topic
+     */
+    private function runner(
+        array $flags = ['MCP.CLIENT_ENABLED' => '1', 'MULTITASK.MCP_FETCH_ENABLED' => '1'],
+        array $topicMetaRows = ['tool_mcp' => '1'],
+        ?McpServerConfig $server = null,
+        string $callToolResultText = 'Customer: Acme GmbH, last order #42.',
+    ): McpFetchRunner {
+        $configRepo = $this->createMock(ConfigRepository::class);
+        $configRepo->method('getValue')->willReturnCallback(
+            static fn (int $owner, string $group, string $setting): ?string => $flags["{$group}.{$setting}"] ?? null,
+        );
+
+        $httpFactory = function (string $method, string $url, array $options) use ($callToolResultText): MockResponse {
+            $body = json_decode((string) ($options['body'] ?? ''), true);
+            $rpcMethod = is_array($body) ? ($body['method'] ?? '') : '';
+
+            $result = match ($rpcMethod) {
+                'tools/list' => ['tools' => $this->serverTools],
+                'tools/call' => ['content' => [['type' => 'text', 'text' => $callToolResultText]], 'isError' => false],
+                default => [],
+            };
+
+            return new MockResponse(
+                (string) json_encode(['jsonrpc' => '2.0', 'id' => 1, 'result' => $result]),
+                ['http_code' => 200, 'response_headers' => ['content-type' => 'application/json']],
+            );
+        };
+
+        $clientConfig = new McpClientConfig($configRepo);
+        $client = new McpClient(
+            new MockHttpClient($httpFactory),
+            new SsrfGuard(),
+            new EncryptionService('test-secret', new NullLogger()),
+            $clientConfig,
+            new NullLogger(),
+        );
+
+        $servers = $this->createMock(McpServerConfigRepository::class);
+        $resolved = $server ?? $this->server();
+        $servers->method('findByIdAndUser')->willReturnCallback(
+            static fn (int $id, int $userId): ?McpServerConfig => 3 === $id && self::USER_ID === $userId ? $resolved : null,
+        );
+        $servers->method('findEnabledByUser')->willReturn([$resolved]);
+
+        return new McpFetchRunner(
+            $client,
+            new McpToolRegistry($client, $servers, new ArrayAdapter(), new NullLogger()),
+            $servers,
+            $clientConfig,
+            new MultitaskRoutingConfig($configRepo),
+            $this->promptService($topicMetaRows),
+            new NullLogger(),
+        );
+    }
+
+    /**
+     * @param array<string, string> $metaRows
+     */
+    private function promptService(array $metaRows): PromptService
+    {
+        $prompt = $this->createMock(Prompt::class);
+        $prompt->method('getId')->willReturn(99);
+        $prompts = $this->createMock(PromptRepository::class);
+        $prompts->method('findByTopicAndUser')->willReturn($prompt);
+
+        $metaEntities = [];
+        foreach ($metaRows as $key => $value) {
+            $meta = $this->createMock(PromptMeta::class);
+            $meta->method('getMetaKey')->willReturn($key);
+            $meta->method('getMetaValue')->willReturn($value);
+            $metaEntities[] = $meta;
+        }
+        $metaRepo = $this->createMock(PromptMetaRepository::class);
+        $metaRepo->method('findBy')->willReturn($metaEntities);
+
+        return new PromptService($prompts, $metaRepo, $this->createMock(EntityManagerInterface::class), new NullLogger());
+    }
+
+    private function context(): NodeContext
+    {
+        $message = $this->createMock(Message::class);
+        $message->method('getText')->willReturn('Look up Acme GmbH in our CRM');
+        $message->method('getUserId')->willReturn(self::USER_ID);
+        $message->method('getFiles')->willReturn(new ArrayCollection([]));
+        $message->method('getFileText')->willReturn('');
+
+        return new NodeContext($message, [], self::USER_ID, ['topic' => 'general']);
+    }
+
+    private function node(string $tool = 'search_customers', int $serverId = 3): TaskNode
+    {
+        return new TaskNode('n1', Capability::McpFetch, [], ['arguments' => ['query' => 'Acme GmbH']], [
+            'server_id' => $serverId,
+            'tool' => $tool,
+        ]);
+    }
+
+    public function testPullsDataAndReturnsGroundedText(): void
+    {
+        $result = $this->runner()->run($this->node(), $this->context());
+
+        self::assertTrue($result->isSuccessful());
+        self::assertStringContainsString('Acme GmbH, last order #42', (string) $result->text);
+        self::assertSame('Company CRM · search_customers', $result->metadata['query']);
+        self::assertSame(3, $result->metadata['mcp']['server_id']);
+    }
+
+    public function testDisabledFlagsFailTheNode(): void
+    {
+        $result = $this->runner(flags: [])->run($this->node(), $this->context());
+
+        self::assertFalse($result->isSuccessful());
+        self::assertStringContainsString('disabled', (string) $result->error);
+    }
+
+    public function testTopicWithoutToolMcpIsRefused(): void
+    {
+        $result = $this->runner(topicMetaRows: [])->run($this->node(), $this->context());
+
+        self::assertFalse($result->isSuccessful());
+        self::assertStringContainsString('not allowed', (string) $result->error);
+    }
+
+    public function testTopicServerAllowlistIsEnforced(): void
+    {
+        $result = $this->runner(topicMetaRows: ['tool_mcp' => '1', 'mcp_servers' => '55,56'])
+            ->run($this->node(), $this->context());
+
+        self::assertFalse($result->isSuccessful());
+        self::assertStringContainsString('not allowed', (string) $result->error);
+    }
+
+    public function testHallucinatedToolIsRefused(): void
+    {
+        $result = $this->runner()->run($this->node(tool: 'made_up_tool'), $this->context());
+
+        self::assertFalse($result->isSuccessful());
+        self::assertStringContainsString('does not exist', (string) $result->error);
+    }
+
+    public function testSelfDeclaredMutatingToolIsRefusedPullOnly(): void
+    {
+        $result = $this->runner()->run($this->node(tool: 'delete_customer'), $this->context());
+
+        self::assertFalse($result->isSuccessful());
+        self::assertStringContainsString('read-only', (string) $result->error);
+    }
+
+    public function testForeignOrUnknownServerIsInvisible(): void
+    {
+        $result = $this->runner()->run($this->node(serverId: 999), $this->context());
+
+        self::assertFalse($result->isSuccessful());
+        self::assertStringContainsString('not available', (string) $result->error);
+    }
+
+    public function testDynamicSubCatalogRendersOnlyForEntitledTopicsAndReadSafeTools(): void
+    {
+        $runner = $this->runner();
+        $descriptor = $runner->describe()[0];
+        self::assertNotNull($descriptor->dynamicNote);
+        self::assertTrue($descriptor->requiresDynamicNote);
+
+        // Entitled topic → sub-catalog with the read-safe tool only.
+        $note = ($descriptor->dynamicNote)(self::USER_ID, ['topic' => 'general', 'topic_metadata' => ['tool_mcp' => true]]);
+        self::assertIsString($note);
+        self::assertStringContainsString('server_id 3 "Company CRM"', $note);
+        self::assertStringContainsString('search_customers(query)', $note);
+        self::assertStringNotContainsString('delete_customer', $note, 'mutating tools must not be offered to the planner');
+
+        // Topic without tool_mcp → the block stays invisible.
+        self::assertNull(($descriptor->dynamicNote)(self::USER_ID, ['topic' => 'general', 'topic_metadata' => []]));
+
+        // Allowlist excluding this server → invisible.
+        self::assertNull(($descriptor->dynamicNote)(self::USER_ID, ['topic' => 'general', 'topic_metadata' => ['tool_mcp' => true, 'mcp_servers' => '55']]));
+    }
+}

--- a/backend/tests/Unit/Service/Multitask/Skill/SkillCatalogTest.php
+++ b/backend/tests/Unit/Service/Multitask/Skill/SkillCatalogTest.php
@@ -54,7 +54,7 @@ final class SkillCatalogTest extends TestCase
                 return [new SkillDescriptor(
                     Capability::WebSearch,
                     'Search the web.',
-                    static fn (?int $userId): string => "  Available for user {$userId}.",
+                    static fn (?int $userId, array $context): string => "  Available for user {$userId}.",
                 )];
             }
 
@@ -96,7 +96,11 @@ final class SkillCatalogTest extends TestCase
 
         $on = $catalog->renderCapabilityList();
         self::assertStringContainsString('- "url_fetch": ', $on);
+        // mcp_fetch is a DYNAMIC block (requiresDynamicNote): without a
+        // connected-server sub-catalog it stays invisible even when its flag
+        // is on — so exactly one capability line is missing here.
+        self::assertStringNotContainsString('"mcp_fetch"', $on);
         $lines = explode("\n", $on);
-        self::assertCount(count(Capability::cases()), $lines);
+        self::assertCount(count(Capability::cases()) - 1, $lines);
     }
 }

--- a/backend/tests/Unit/Service/Multitask/TaskPlannerTest.php
+++ b/backend/tests/Unit/Service/Multitask/TaskPlannerTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Unit\Service\Multitask;
 use App\AI\Service\AiFacade;
 use App\Entity\Message;
 use App\Entity\Prompt;
+use App\Repository\PromptMetaRepository;
 use App\Repository\PromptRepository;
 use App\Repository\UserRepository;
 use App\Service\ModelConfigService;
@@ -14,11 +15,14 @@ use App\Service\Multitask\Plan\Capability;
 use App\Service\Multitask\Plan\TaskPlanValidator;
 use App\Service\Multitask\TaskPlanner;
 use App\Service\Prompt\TimeContextBuilder;
+use App\Service\PromptService;
 use App\Tests\Support\SkillCatalogFactory;
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
 final class TaskPlannerTest extends TestCase
 {
@@ -54,6 +58,12 @@ final class TaskPlannerTest extends TestCase
             $this->createMock(UserRepository::class),
             new TimeContextBuilder(),
             SkillCatalogFactory::real(),
+            new PromptService(
+                $this->createMock(PromptRepository::class),
+                $this->createMock(PromptMetaRepository::class),
+                $this->createMock(EntityManagerInterface::class),
+                new NullLogger(),
+            ),
         );
     }
 

--- a/frontend/src/components/config/TaskPromptsConfiguration.vue
+++ b/frontend/src/components/config/TaskPromptsConfiguration.vue
@@ -1511,6 +1511,9 @@ const loadingModels = ref(false)
 const availableTools: ToolOption[] = [
   { value: 'files-search', label: 'Files Search', icon: 'heroicons:document-magnifying-glass' },
   { value: 'url-screenshot', label: 'URL Content', icon: 'heroicons:globe-alt' },
+  // Per-topic gate for external MCP data sources (Channels → MCP Servers).
+  // Default off — external calls are opt-in per topic (release 4.0 plan 09).
+  { value: 'mcp-data', label: 'MCP Data Sources', icon: 'heroicons:server-stack' },
 ]
 
 const groupedModels = computed(() => {
@@ -1682,6 +1685,7 @@ const loadPrompts = async () => {
       const tools: string[] = []
       if (metadata.tool_files ?? metadata.tool_files_search) tools.push('files-search')
       if (metadata.tool_url_screenshot) tools.push('url-screenshot')
+      if (metadata.tool_mcp) tools.push('mcp-data')
 
       return {
         ...p,
@@ -1813,6 +1817,7 @@ const handleSave = saveChanges(async () => {
 
     metadata.tool_files = (formData.value.availableTools || []).includes('files-search')
     metadata.tool_url_screenshot = (formData.value.availableTools || []).includes('url-screenshot')
+    metadata.tool_mcp = (formData.value.availableTools || []).includes('mcp-data')
 
     // Tri-state internet search (#1138): only persist an explicit boolean for
     // 'on'/'off'. 'auto' omits the key so the backend keeps the "classifier
@@ -1958,6 +1963,8 @@ const handleCreateNew = async () => {
     // classifier decides) instead of hard-forcing web search on every message.
     metadata.tool_files = true
     metadata.tool_url_screenshot = false
+    // External MCP calls are opt-in per topic (release 4.0 plan 09).
+    metadata.tool_mcp = false
 
     const requestPayload = {
       topic: newPromptTopic.value.trim().toLowerCase().replace(/\s+/g, '-'),

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -937,6 +937,7 @@
       "rag_query": "Wissensantwort",
       "web_search": "Websuche",
       "url_fetch": "Webseite lesen",
+      "mcp_fetch": "Verbundene Daten abrufen",
       "file_analysis": "Dateianalyse",
       "image_generation": "Bild",
       "video_generation": "Video",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -3116,6 +3116,7 @@
       "rag_query": "Knowledge answer",
       "web_search": "Web search",
       "url_fetch": "Reading web page",
+      "mcp_fetch": "Fetching connected data",
       "file_analysis": "File analysis",
       "image_generation": "Image",
       "video_generation": "Video",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -1134,6 +1134,7 @@
       "rag_query": "Respuesta de conocimiento",
       "web_search": "Búsqueda web",
       "url_fetch": "Leyendo página web",
+      "mcp_fetch": "Obteniendo datos conectados",
       "file_analysis": "Análisis de archivo",
       "image_generation": "Imagen",
       "video_generation": "Vídeo",

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -1134,6 +1134,7 @@
       "rag_query": "Bilgi yanıtı",
       "web_search": "Web araması",
       "url_fetch": "Web sayfası okunuyor",
+      "mcp_fetch": "Bağlı veriler alınıyor",
       "file_analysis": "Dosya analizi",
       "image_generation": "Görsel",
       "video_generation": "Video",

--- a/frontend/src/services/api/promptsApi.ts
+++ b/frontend/src/services/api/promptsApi.ts
@@ -7,6 +7,10 @@ export interface PromptMetadata {
   tool_internet?: boolean
   tool_files?: boolean
   tool_url_screenshot?: boolean
+  /** Per-topic gate for the mcp_fetch data node (external MCP servers). */
+  tool_mcp?: boolean
+  /** Optional comma-separated McpServerConfig ids restricting tool_mcp. */
+  mcp_servers?: string
   tool_transfer?: boolean
   widgetBehaviorRules?: string | WidgetBehaviorRules
   widgetBehaviorVersion?: string | number


### PR DESCRIPTION
## Summary

Sprint 6 (stacked on #1246) — **the customer milestone**: the planner can now place an `mcp_fetch` node that pulls data from one of the user's connected external MCP servers, chained into the answering node.

- **Locked Option A node shape:** one generic `Capability::McpFetch`; `params.server_id` + `params.tool`, tool arguments in `inputs.arguments`; content blocks flattened into citable `$nX.text`.
- **First dynamic skill block:** the `SkillCatalog` now passes a per-turn context (resolved topic + its prompt metadata) into descriptors' dynamic notes; `mcp_fetch` renders the per-user tool sub-catalog under its capability line — and stays entirely **invisible** unless every plan-time gate passes (`requiresDynamicNote`).
- **Gate chain (plan-time and re-checked at run time):** `MCP.CLIENT_ENABLED` → `MULTITASK.MCP_FETCH_ENABLED` → topic `tool_mcp` metadata (+ optional `mcp_servers` allowlist) → server ownership + enabled → tool existence (hallucination guard) → pull-only (tools self-declaring as mutating via spec annotations are refused AND excluded from the planner catalog).
- Planner rule 9c + canonical example (prompt snapshot re-recorded, diff reviewed); "MCP Data Sources" per-topic toggle in AI Instructions; task-card label i18n ×4. The per-topic server multi-select UI is deferred (backend allowlist already enforced).

## Test plan

- [x] Full gate green: backend lint/phpstan/tests (2524), frontend lint/vue-tsc/Vitest (790)
- [x] 8 new `McpFetchRunner` unit tests covering the full gate chain, pull-only refusal, hallucinated-tool refusal, allowlist, and dynamic sub-catalog rendering
- [x] **Live customer scenario** (local stack, real DeepWiki MCP server): "Use our DeepWiki connection to find out what the vuejs/core repository is about…" → plan `mcp_fetch → summarize → compose_reply`, answer grounded in the actually-pulled wiki data, card resolved with "DeepWiki · ask_question"
- [x] Live negative check: removing `tool_mcp` from the topic makes the identical request plan **without** any `mcp_fetch` node (the planner never sees the tools)
- [x] Eval corpus: no-hallucination case (`mcp_fetch` never emitted when not offered) — passes