### PR TITLE
feat(multitask): email_search data node — live read-only mailbox search inside the DAG (plan 09 S5)

### DIFF
--- a/backend/src/Prompt/PromptCatalog.php
+++ b/backend/src/Prompt/PromptCatalog.php
@@ -570,6 +570,14 @@ Allowed topic keys: [KEYLIST]
    invent a server_id or tool name, and NEVER emit `mcp_fetch` when it is
    not in the capability list or no listed tool fits — use `chat` or
    `web_search` instead.
+9d. The user explicitly asks about their OWN emails/mailbox ("search my
+   emails for the Acme offer", "was hat mir Tom letzte Woche gemailt?") AND
+   the capability list above shows `email_search` with a connected mailbox
+   → an `email_search` node with `params.query` (keywords), optional
+   `params.from` (sender) and `params.since` (YYYY-MM-DD, resolve relative
+   times against the time context); feed `$nX.text` into the answering
+   node. NEVER emit `email_search` for generic questions or when it is not
+   in the capability list.
 10. Plain question / smalltalk / advice → one `chat` node. `reply_node` = that
    node, no `compose_reply` needed.
 11. A SINGLE media request with no follow-up step ("make an image of X",
@@ -771,6 +779,25 @@ User: "Look up the customer Acme GmbH in our CRM and summarize their last order.
 `params.server_id` and `params.tool` come EXACTLY from the listed connections
 (never invented), the tool arguments ride in `inputs.arguments`, and the
 answering node consumes `$n1.text` — the reply is grounded in the pulled data.
+
+### Search the user's own mailbox, then answer (email_search)
+User: "Search my emails for the Acme offer from last week and summarize it."
+(The capability list shows email_search with a connected mailbox; assume today is 2026-06-17.)
+
+{
+  "version": 1,
+  "language": "en",
+  "reply_node": "n3",
+  "tasks": [
+    { "id": "n1", "capability": "email_search", "params": { "query": "Acme offer", "since": "2026-06-10" } },
+    { "id": "n2", "capability": "summarize", "depends_on": ["n1"], "inputs": { "text": "$n1.text" }, "params": { "style": "short" } },
+    { "id": "n3", "capability": "compose_reply", "depends_on": ["n1","n2"], "inputs": { "text": "$n2.text" } }
+  ]
+}
+
+The mailbox is searched LIVE and read-only; the summary consumes the real
+hits via `$n1.text`. Without an explicit "my emails" intent this node is
+never emitted.
 
 ### Calendar invite ("I need a meeting reminder for tomorrow at 9:00 with Sanam")
 The event fields go in `params`. Resolve the relative time against the time

--- a/backend/src/Service/Email/ImapMailboxSearcher.php
+++ b/backend/src/Service/Email/ImapMailboxSearcher.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Email;
+
+use App\Entity\InboundEmailHandler;
+use App\Service\EncryptionService;
+
+/**
+ * IMAP implementation of {@see MailboxSearcher}.
+ *
+ * Reuses the InboundEmailHandler connection settings (server string identical
+ * to InboundEmailHandlerService) and is strictly READ-ONLY: bodies are
+ * fetched with FT_PEEK so the \Seen flag is never set, and no flag/delete
+ * operation is ever issued (plan 09 §2.4).
+ */
+final readonly class ImapMailboxSearcher implements MailboxSearcher
+{
+    /** Per-message snippet cap — token control for the node output. */
+    private const SNIPPET_CHARS = 2000;
+
+    public function __construct(
+        private EncryptionService $encryptionService,
+    ) {
+    }
+
+    public function search(InboundEmailHandler $handler, string $query, ?string $from = null, ?string $since = null, int $limit = 10): array
+    {
+        if (!function_exists('imap_open')) {
+            throw new \RuntimeException('IMAP extension is not available');
+        }
+
+        $connection = @imap_open(
+            $this->serverString($handler),
+            $handler->getUsername(),
+            $handler->getDecryptedPassword($this->encryptionService),
+            \OP_READONLY,
+        );
+        if (false === $connection) {
+            $errors = imap_errors();
+            throw new \RuntimeException('mailbox connection failed: '.implode(', ', $errors ?: ['unknown error']));
+        }
+
+        try {
+            $criteria = self::buildCriteria($query, $from, $since);
+            $uids = imap_search($connection, $criteria, \SE_UID);
+            if (false === $uids || [] === $uids) {
+                return [];
+            }
+
+            // Newest first, capped.
+            rsort($uids);
+            $uids = array_slice($uids, 0, max(1, $limit));
+
+            $hits = [];
+            $overviews = imap_fetch_overview($connection, implode(',', $uids), \FT_UID);
+            foreach (is_array($overviews) ? $overviews : [] as $overview) {
+                $uid = (int) ($overview->uid ?? 0);
+                if ($uid <= 0) {
+                    continue;
+                }
+                $hits[] = [
+                    'from' => $this->decodeHeader((string) ($overview->from ?? '')),
+                    'subject' => $this->decodeHeader((string) ($overview->subject ?? '')),
+                    'date' => (string) ($overview->date ?? ''),
+                    'snippet' => $this->fetchSnippet($connection, $uid),
+                ];
+            }
+
+            // imap_fetch_overview returns mailbox order — restore newest first.
+            usort($hits, static fn (array $a, array $b): int => strtotime($b['date']) <=> strtotime($a['date']));
+
+            return $hits;
+        } finally {
+            imap_close($connection);
+        }
+    }
+
+    /**
+     * Build the IMAP SEARCH criteria string. Quotes are stripped from inputs —
+     * IMAP has no escaping inside quoted strings, so embedded quotes would
+     * break out of the criterion.
+     */
+    public static function buildCriteria(string $query, ?string $from = null, ?string $since = null): string
+    {
+        $sanitize = static fn (string $v): string => trim(str_replace('"', '', $v));
+
+        $parts = [];
+        $query = $sanitize($query);
+        if ('' !== $query) {
+            $parts[] = sprintf('TEXT "%s"', $query);
+        }
+        if (null !== $from && '' !== $sanitize($from)) {
+            $parts[] = sprintf('FROM "%s"', $sanitize($from));
+        }
+        if (null !== $since) {
+            $timestamp = strtotime($since);
+            if (false !== $timestamp) {
+                $parts[] = sprintf('SINCE "%s"', date('d-M-Y', $timestamp));
+            }
+        }
+
+        return [] === $parts ? 'ALL' : implode(' ', $parts);
+    }
+
+    private function serverString(InboundEmailHandler $handler): string
+    {
+        $securityFlag = match ($handler->getSecurity()) {
+            'SSL/TLS' => 'ssl',
+            'STARTTLS' => 'tls',
+            default => 'notls',
+        };
+
+        return sprintf(
+            '{%s:%d/%s/%s/readonly}INBOX',
+            $handler->getMailServer(),
+            $handler->getPort(),
+            strtolower($handler->getProtocol()),
+            $securityFlag,
+        );
+    }
+
+    /**
+     * First text part of the message, peek-fetched (never sets \Seen),
+     * decoded best-effort and truncated.
+     *
+     * @param \IMAP\Connection $connection
+     */
+    private function fetchSnippet($connection, int $uid): string
+    {
+        $raw = @imap_fetchbody($connection, $uid, '1', \FT_UID | \FT_PEEK);
+        if (!is_string($raw) || '' === $raw) {
+            $raw = @imap_body($connection, $uid, \FT_UID | \FT_PEEK);
+        }
+        if (!is_string($raw)) {
+            return '';
+        }
+
+        // Best-effort transfer-encoding decode: try quoted-printable (a no-op
+        // for plain text) and base64 when the payload looks like it.
+        $decoded = quoted_printable_decode($raw);
+        if (1 === preg_match('/^[A-Za-z0-9+\/=\r\n]+$/', trim($raw)) && strlen(trim($raw)) > 40) {
+            $b64 = base64_decode(trim($raw), true);
+            if (false !== $b64 && mb_check_encoding($b64, 'UTF-8')) {
+                $decoded = $b64;
+            }
+        }
+
+        $text = trim((string) preg_replace('/\s+/', ' ', strip_tags($decoded)));
+
+        return mb_strlen($text) > self::SNIPPET_CHARS
+            ? mb_substr($text, 0, self::SNIPPET_CHARS - 1).'…'
+            : $text;
+    }
+
+    private function decodeHeader(string $header): string
+    {
+        $decoded = '';
+        foreach (imap_mime_header_decode($header) ?: [] as $element) {
+            $charset = strtolower((string) ($element->charset ?? 'default'));
+            $text = (string) ($element->text ?? '');
+            if (in_array($charset, ['default', '', 'utf-8', 'us-ascii'], true)) {
+                $decoded .= $text;
+                continue;
+            }
+            $converted = @mb_convert_encoding($text, 'UTF-8', strtoupper($charset));
+            $decoded .= is_string($converted) ? $converted : $text;
+        }
+
+        return trim($decoded);
+    }
+}

--- a/backend/src/Service/Email/MailboxSearcher.php
+++ b/backend/src/Service/Email/MailboxSearcher.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Email;
+
+use App\Entity\InboundEmailHandler;
+
+/**
+ * Read-only live search over one connected mailbox (release-4.0 plan 09
+ * §3.3, shape (a): stateless IMAP search at question time — mail content is
+ * never persisted, it exists only in the turn context).
+ *
+ * Implementations MUST be strictly read-only: peek fetches, no flag changes,
+ * no deletes.
+ */
+interface MailboxSearcher
+{
+    /**
+     * @param string      $query keyword(s) for the IMAP TEXT criterion
+     * @param string|null $from  optional sender filter (FROM criterion)
+     * @param string|null $since optional ISO date (YYYY-MM-DD) lower bound
+     *
+     * @return list<array{from: string, subject: string, date: string, snippet: string}> newest first
+     *
+     * @throws \RuntimeException when the mailbox cannot be reached/searched
+     */
+    public function search(InboundEmailHandler $handler, string $query, ?string $from = null, ?string $since = null, int $limit = 10): array;
+}

--- a/backend/src/Service/Multitask/Execution/DagExecutor.php
+++ b/backend/src/Service/Multitask/Execution/DagExecutor.php
@@ -541,7 +541,7 @@ final readonly class DagExecutor
      */
     private function successMetadata(TaskNode $node, NodeResult $result): array
     {
-        if (!in_array($node->capability, [Capability::WebSearch, Capability::UrlFetch, Capability::McpFetch], true)) {
+        if (!in_array($node->capability, [Capability::WebSearch, Capability::UrlFetch, Capability::McpFetch, Capability::EmailSearch], true)) {
             return [];
         }
 
@@ -553,6 +553,10 @@ final readonly class DagExecutor
         $sr = $result->metadata['search_results'] ?? null;
         if (is_array($sr) && is_array($sr['results'] ?? null)) {
             $extra['results_count'] = count($sr['results']);
+        } elseif (is_int($result->metadata['results_count'] ?? null)) {
+            // Data nodes without the web-search result shape (email_search)
+            // report their hit count directly.
+            $extra['results_count'] = $result->metadata['results_count'];
         }
 
         return $extra;

--- a/backend/src/Service/Multitask/Execution/Runner/EmailSearchRunner.php
+++ b/backend/src/Service/Multitask/Execution/Runner/EmailSearchRunner.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Multitask\Execution\Runner;
+
+use App\Entity\InboundEmailHandler;
+use App\Repository\InboundEmailHandlerRepository;
+use App\Service\Email\MailboxSearcher;
+use App\Service\Multitask\Execution\NodeContext;
+use App\Service\Multitask\Execution\NodeResult;
+use App\Service\Multitask\Execution\TaskRunner;
+use App\Service\Multitask\MultitaskRoutingConfig;
+use App\Service\Multitask\Plan\Capability;
+use App\Service\Multitask\Plan\TaskNode;
+use App\Service\Multitask\Skill\SkillDescriptor;
+use Psr\Log\LoggerInterface;
+
+/**
+ * `email_search` runner — "search for infos in my emails" as a DAG data node
+ * (release-4.0 plan 09 §3.3, locked shape (a): stateless LIVE IMAP search at
+ * question time; nothing is indexed or persisted).
+ *
+ * Reuses the user's active {@see InboundEmailHandler} accounts (encrypted
+ * creds, existing connection settings) via the read-only
+ * {@see MailboxSearcher}. Multi-account: every active mailbox is searched,
+ * hits merged newest-first and capped.
+ *
+ * A DYNAMIC skill block: the planner only learns this capability exists when
+ * the flag is on AND the user actually has a connected mailbox — a user
+ * without one never sees it, so the planner cannot plan around a missing
+ * account (plan 09 §3.3 availability note).
+ */
+final readonly class EmailSearchRunner implements TaskRunner
+{
+    /** Max merged hits across all accounts (token control). */
+    private const MAX_RESULTS = 10;
+
+    /** Per-mailbox hard time budget: a dead IMAP server degrades one node, not the turn. */
+    private const PER_MAILBOX_TIMEOUT_SECONDS = 15;
+
+    public function __construct(
+        private InboundEmailHandlerRepository $handlers,
+        private MailboxSearcher $searcher,
+        private MultitaskRoutingConfig $routingConfig,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function supportedCapabilities(): array
+    {
+        return [Capability::EmailSearch];
+    }
+
+    /**
+     * @return list<SkillDescriptor>
+     */
+    public function describe(): array
+    {
+        return [
+            new SkillDescriptor(
+                Capability::EmailSearch,
+                'Search the user\'s OWN connected email mailbox(es) live (read-only) and return the newest matching mails. Use ONLY when the user explicitly asks about their own emails ("in my emails", "what did X mail me about …"). params: query (keywords), optional from (sender), optional since (YYYY-MM-DD).',
+                dynamicNote: fn (?int $userId, array $context): ?string => $this->renderAvailabilityNote($userId),
+                enabledFlag: MultitaskRoutingConfig::KEY_EMAIL_SEARCH_ENABLED,
+                enabledDefault: false,
+                requiresDynamicNote: true,
+            ),
+        ];
+    }
+
+    public function run(TaskNode $node, NodeContext $context): NodeResult
+    {
+        $userId = $context->userId ?? $context->message->getUserId();
+
+        if (!$this->routingConfig->isFeatureEnabled(MultitaskRoutingConfig::KEY_EMAIL_SEARCH_ENABLED, $userId, false)) {
+            return NodeResult::failed('email_search is disabled');
+        }
+
+        $accounts = $this->handlers->findActiveByUser((int) $userId);
+        if ([] === $accounts) {
+            return NodeResult::failed('no email account is connected — connect one under Channels → Email Automation');
+        }
+
+        $inputs = $context->resolveInputs($node);
+        $query = $this->stringValue($node->params['query'] ?? null)
+            ?? $this->stringValue($inputs['query'] ?? $inputs['text'] ?? null)
+            ?? (string) $context->message->getText();
+        if ('' === trim($query)) {
+            return NodeResult::failed('no search query for email_search');
+        }
+
+        $from = $this->stringValue($node->params['from'] ?? null);
+        $since = $this->stringValue($node->params['since'] ?? null);
+
+        $hits = [];
+        $errors = [];
+        $deadline = time() + self::PER_MAILBOX_TIMEOUT_SECONDS * count($accounts);
+        foreach ($accounts as $account) {
+            if (time() > $deadline) {
+                break;
+            }
+            try {
+                foreach ($this->searcher->search($account, $query, $from, $since, self::MAX_RESULTS) as $hit) {
+                    $hit['account'] = $account->getName();
+                    $hits[] = $hit;
+                }
+            } catch (\Throwable $e) {
+                $this->logger->warning('EmailSearchRunner: mailbox search failed', [
+                    'handler_id' => $account->getId(),
+                    'error' => $e->getMessage(),
+                ]);
+                $errors[] = $account->getName().': '.$e->getMessage();
+            }
+        }
+
+        if ([] === $hits) {
+            if ([] !== $errors && count($errors) === count($accounts)) {
+                return NodeResult::failed('could not search the mailbox: '.mb_substr(implode('; ', $errors), 0, 300));
+            }
+
+            return NodeResult::ok(
+                sprintf('No emails matching "%s" were found in the connected mailbox(es).', $query),
+                [],
+                ['email_search' => true, 'query' => $query, 'results_count' => 0],
+            );
+        }
+
+        // Merge newest first across accounts, cap the total.
+        usort($hits, static fn (array $a, array $b): int => strtotime($b['date'] ?: 'now') <=> strtotime($a['date'] ?: 'now'));
+        $hits = array_slice($hits, 0, self::MAX_RESULTS);
+
+        return NodeResult::ok($this->format($query, $hits), [], [
+            'email_search' => true,
+            'query' => $query,
+            'results_count' => count($hits),
+        ]);
+    }
+
+    /**
+     * Availability note for the planner catalog — null (block invisible)
+     * when the user has no active mailbox.
+     */
+    private function renderAvailabilityNote(?int $userId): ?string
+    {
+        if (null === $userId || $userId <= 0) {
+            return null;
+        }
+
+        try {
+            $accounts = $this->handlers->findActiveByUser($userId);
+        } catch (\Throwable) {
+            return null;
+        }
+        if ([] === $accounts) {
+            return null;
+        }
+
+        $names = array_map(
+            static fn (InboundEmailHandler $h): string => '"'.$h->getName().'"',
+            array_slice($accounts, 0, 5),
+        );
+
+        return sprintf('  Connected mailbox(es) for this user: %s.', implode(', ', $names));
+    }
+
+    /**
+     * Citable, web-search-style sections for downstream `$nX.text` consumers.
+     *
+     * @param list<array{from: string, subject: string, date: string, snippet: string, account?: string}> $hits
+     */
+    private function format(string $query, array $hits): string
+    {
+        $sections = [sprintf('## Email search results for "%s" (%d found, newest first)', $query, count($hits))];
+        foreach ($hits as $i => $hit) {
+            $section = sprintf(
+                "--- Email %d ---\nFrom: %s\nDate: %s\nSubject: %s",
+                $i + 1,
+                $hit['from'],
+                $hit['date'],
+                $hit['subject'],
+            );
+            if ('' !== trim($hit['snippet'])) {
+                $section .= "\n".$hit['snippet'];
+            }
+            $sections[] = $section;
+        }
+
+        return implode("\n\n", $sections);
+    }
+
+    private function stringValue(mixed $value): ?string
+    {
+        return is_string($value) && '' !== trim($value) ? trim($value) : null;
+    }
+}

--- a/backend/src/Service/Multitask/MultitaskRoutingConfig.php
+++ b/backend/src/Service/Multitask/MultitaskRoutingConfig.php
@@ -42,6 +42,7 @@ final readonly class MultitaskRoutingConfig
     public const KEY_NODE_TIMEOUT = 'NODE_TIMEOUT';
     public const KEY_URL_FETCH_ENABLED = 'URL_FETCH_ENABLED';
     public const KEY_MCP_FETCH_ENABLED = 'MCP_FETCH_ENABLED';
+    public const KEY_EMAIL_SEARCH_ENABLED = 'EMAIL_SEARCH_ENABLED';
 
     private const DEFAULT_ROUTING_ENABLED = true;
     private const DEFAULT_SHADOW_MODE = false;

--- a/backend/src/Service/Multitask/Plan/Capability.php
+++ b/backend/src/Service/Multitask/Plan/Capability.php
@@ -42,6 +42,9 @@ enum Capability: string
     /** Pull data from one of the user's connected external MCP servers (McpClient, read-only v1). */
     case McpFetch = 'mcp_fetch';
 
+    /** Live read-only IMAP search over the user's connected mailboxes (InboundEmailHandler accounts). */
+    case EmailSearch = 'email_search';
+
     /** Vision / OCR / document Q&A (FileAnalysisHandler). */
     case FileAnalysis = 'file_analysis';
 
@@ -83,7 +86,7 @@ enum Capability: string
         return match ($this) {
             self::ExtractText => 'extract',
             self::Chat, self::Summarize, self::Translate, self::RagQuery, self::FileAnalysis => 'text',
-            self::WebSearch, self::UrlFetch, self::McpFetch => 'search',
+            self::WebSearch, self::UrlFetch, self::McpFetch, self::EmailSearch => 'search',
             self::ImageGeneration => 'image',
             self::VideoGeneration => 'video',
             self::Text2Sound => 'audio',

--- a/backend/src/Service/Multitask/TaskPlanExecutor.php
+++ b/backend/src/Service/Multitask/TaskPlanExecutor.php
@@ -48,7 +48,7 @@ final readonly class TaskPlanExecutor
      * must run through the DAG even as a lone single node (see
      * {@see shouldUseLegacyRouter()}).
      */
-    private const DAG_ONLY_CAPABILITIES = [Capability::CalendarEvent, Capability::UrlFetch, Capability::McpFetch];
+    private const DAG_ONLY_CAPABILITIES = [Capability::CalendarEvent, Capability::UrlFetch, Capability::McpFetch, Capability::EmailSearch];
 
     /**
      * Single-shot media generators that the legacy router already delivers

--- a/backend/tests/Characterization/__snapshots__/planner_system_prompt.txt
+++ b/backend/tests/Characterization/__snapshots__/planner_system_prompt.txt
@@ -155,6 +155,14 @@ Allowed topic keys: "general" | "mediamaker" | "officemaker" | "docsummary" | "l
    invent a server_id or tool name, and NEVER emit `mcp_fetch` when it is
    not in the capability list or no listed tool fits — use `chat` or
    `web_search` instead.
+9d. The user explicitly asks about their OWN emails/mailbox ("search my
+   emails for the Acme offer", "was hat mir Tom letzte Woche gemailt?") AND
+   the capability list above shows `email_search` with a connected mailbox
+   → an `email_search` node with `params.query` (keywords), optional
+   `params.from` (sender) and `params.since` (YYYY-MM-DD, resolve relative
+   times against the time context); feed `$nX.text` into the answering
+   node. NEVER emit `email_search` for generic questions or when it is not
+   in the capability list.
 10. Plain question / smalltalk / advice → one `chat` node. `reply_node` = that
    node, no `compose_reply` needed.
 11. A SINGLE media request with no follow-up step ("make an image of X",
@@ -356,6 +364,25 @@ User: "Look up the customer Acme GmbH in our CRM and summarize their last order.
 `params.server_id` and `params.tool` come EXACTLY from the listed connections
 (never invented), the tool arguments ride in `inputs.arguments`, and the
 answering node consumes `$n1.text` — the reply is grounded in the pulled data.
+
+### Search the user's own mailbox, then answer (email_search)
+User: "Search my emails for the Acme offer from last week and summarize it."
+(The capability list shows email_search with a connected mailbox; assume today is 2026-06-17.)
+
+{
+  "version": 1,
+  "language": "en",
+  "reply_node": "n3",
+  "tasks": [
+    { "id": "n1", "capability": "email_search", "params": { "query": "Acme offer", "since": "2026-06-10" } },
+    { "id": "n2", "capability": "summarize", "depends_on": ["n1"], "inputs": { "text": "$n1.text" }, "params": { "style": "short" } },
+    { "id": "n3", "capability": "compose_reply", "depends_on": ["n1","n2"], "inputs": { "text": "$n2.text" } }
+  ]
+}
+
+The mailbox is searched LIVE and read-only; the summary consumes the real
+hits via `$n1.text`. Without an explicit "my emails" intent this node is
+never emitted.
 
 ### Calendar invite ("I need a meeting reminder for tomorrow at 9:00 with Sanam")
 The event fields go in `params`. Resolve the relative time against the time

--- a/backend/tests/Eval/plan_eval_corpus.json
+++ b/backend/tests/Eval/plan_eval_corpus.json
@@ -496,7 +496,10 @@
     "text": "Look up the customer Acme GmbH in our CRM and summarize their last order.",
     "language": "en",
     "expect": {
-      "forbid": ["mcp_fetch", "image_generation"]
+      "forbid": [
+        "mcp_fetch",
+        "image_generation"
+      ]
     }
   },
   {
@@ -521,6 +524,18 @@
         "text2sound"
       ],
       "forbid": [
+        "image_generation"
+      ]
+    }
+  },
+  {
+    "id": "email_search_not_offered_no_hallucination",
+    "text": "Search my emails for the Acme offer from last week and summarize it.",
+    "language": "en",
+    "expect": {
+      "forbid": [
+        "email_search",
+        "mcp_fetch",
         "image_generation"
       ]
     }

--- a/backend/tests/Support/SkillCatalogFactory.php
+++ b/backend/tests/Support/SkillCatalogFactory.php
@@ -9,6 +9,7 @@ use App\Service\Multitask\Execution\Runner\ChatRunner;
 use App\Service\Multitask\Execution\Runner\ComposeReplyRunner;
 use App\Service\Multitask\Execution\Runner\DocumentGenerationRunner;
 use App\Service\Multitask\Execution\Runner\EmailMeRunner;
+use App\Service\Multitask\Execution\Runner\EmailSearchRunner;
 use App\Service\Multitask\Execution\Runner\ExtractTextRunner;
 use App\Service\Multitask\Execution\Runner\FileAnalysisRunner;
 use App\Service\Multitask\Execution\Runner\McpFetchRunner;
@@ -41,6 +42,7 @@ final class SkillCatalogFactory
         WebSearchRunner::class,
         UrlFetchRunner::class,
         McpFetchRunner::class,
+        EmailSearchRunner::class,
         FileAnalysisRunner::class,
         MediaGenerationRunner::class,
         Text2SoundRunner::class,

--- a/backend/tests/Unit/Service/Multitask/Execution/Runner/EmailSearchRunnerTest.php
+++ b/backend/tests/Unit/Service/Multitask/Execution/Runner/EmailSearchRunnerTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\Multitask\Execution\Runner;
+
+use App\Entity\InboundEmailHandler;
+use App\Entity\Message;
+use App\Repository\ConfigRepository;
+use App\Repository\InboundEmailHandlerRepository;
+use App\Service\Email\MailboxSearcher;
+use App\Service\Multitask\Execution\NodeContext;
+use App\Service\Multitask\Execution\Runner\EmailSearchRunner;
+use App\Service\Multitask\MultitaskRoutingConfig;
+use App\Service\Multitask\Plan\Capability;
+use App\Service\Multitask\Plan\TaskNode;
+use Doctrine\Common\Collections\ArrayCollection;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+/**
+ * `email_search` node contract (plan 09 §3.3): live read-only mailbox search,
+ * flag-gated, honest no-account degradation, multi-account merge, and the
+ * per-user availability note that keeps the block invisible without a
+ * connected mailbox.
+ */
+final class EmailSearchRunnerTest extends TestCase
+{
+    private const USER_ID = 7;
+
+    private function account(string $name = 'Work inbox', int $id = 5): InboundEmailHandler
+    {
+        $account = new InboundEmailHandler();
+        $account->setUserId(self::USER_ID)->setName($name);
+        (new \ReflectionProperty($account, 'id'))->setValue($account, $id);
+
+        return $account;
+    }
+
+    /**
+     * @param list<InboundEmailHandler>                                                            $accounts
+     * @param list<array{from: string, subject: string, date: string, snippet: string}>|\Throwable $searchResult
+     */
+    private function runner(array $accounts, array|\Throwable $searchResult = [], bool $flagEnabled = true): EmailSearchRunner
+    {
+        $configRepo = $this->createMock(ConfigRepository::class);
+        $configRepo->method('getValue')->willReturnCallback(
+            static fn (int $owner, string $group, string $setting): ?string => 'EMAIL_SEARCH_ENABLED' === $setting ? ($flagEnabled ? '1' : '0') : null,
+        );
+
+        $handlers = $this->createMock(InboundEmailHandlerRepository::class);
+        $handlers->method('findActiveByUser')->with(self::USER_ID)->willReturn($accounts);
+
+        $searcher = $this->createMock(MailboxSearcher::class);
+        if ($searchResult instanceof \Throwable) {
+            $searcher->method('search')->willThrowException($searchResult);
+        } else {
+            $searcher->method('search')->willReturn($searchResult);
+        }
+
+        return new EmailSearchRunner($handlers, $searcher, new MultitaskRoutingConfig($configRepo), new NullLogger());
+    }
+
+    private function context(): NodeContext
+    {
+        $message = $this->createMock(Message::class);
+        $message->method('getText')->willReturn('search my emails for the acme offer');
+        $message->method('getUserId')->willReturn(self::USER_ID);
+        $message->method('getFiles')->willReturn(new ArrayCollection([]));
+        $message->method('getFileText')->willReturn('');
+
+        return new NodeContext($message, [], self::USER_ID, ['topic' => 'general']);
+    }
+
+    private function node(array $params = ['query' => 'Acme offer']): TaskNode
+    {
+        return new TaskNode('n1', Capability::EmailSearch, [], [], $params);
+    }
+
+    public function testReturnsFormattedNewestFirstHits(): void
+    {
+        $runner = $this->runner([$this->account()], [
+            ['from' => 'sales@acme.com', 'subject' => 'Acme offer v2', 'date' => 'Tue, 16 Jun 2026 10:00:00 +0200', 'snippet' => 'Here is the updated offer with 10% discount.'],
+            ['from' => 'sales@acme.com', 'subject' => 'Acme offer', 'date' => 'Mon, 08 Jun 2026 09:00:00 +0200', 'snippet' => 'First offer draft.'],
+        ]);
+
+        $result = $runner->run($this->node(), $this->context());
+
+        self::assertTrue($result->isSuccessful());
+        self::assertStringContainsString('Acme offer v2', (string) $result->text);
+        self::assertStringContainsString('10% discount', (string) $result->text);
+        self::assertSame(2, $result->metadata['results_count']);
+        self::assertSame('Acme offer', $result->metadata['query']);
+        // Newest first.
+        $text = (string) $result->text;
+        self::assertLessThan(strpos($text, 'First offer draft'), strpos($text, '10% discount'));
+    }
+
+    public function testDisabledFlagFailsTheNode(): void
+    {
+        $result = $this->runner([$this->account()], flagEnabled: false)->run($this->node(), $this->context());
+
+        self::assertFalse($result->isSuccessful());
+        self::assertStringContainsString('disabled', (string) $result->error);
+    }
+
+    public function testNoConnectedAccountDegradesHonestly(): void
+    {
+        $result = $this->runner([])->run($this->node(), $this->context());
+
+        self::assertFalse($result->isSuccessful());
+        self::assertStringContainsString('no email account is connected', (string) $result->error);
+    }
+
+    public function testNoHitsIsASuccessfulHonestAnswerNotAFailure(): void
+    {
+        $result = $this->runner([$this->account()], [])->run($this->node(), $this->context());
+
+        self::assertTrue($result->isSuccessful());
+        self::assertStringContainsString('No emails matching', (string) $result->text);
+        self::assertSame(0, $result->metadata['results_count']);
+    }
+
+    public function testDeadMailboxFailsTheNodeInIsolation(): void
+    {
+        $result = $this->runner([$this->account()], new \RuntimeException('mailbox connection failed: timeout'))
+            ->run($this->node(), $this->context());
+
+        self::assertFalse($result->isSuccessful());
+        self::assertStringContainsString('could not search the mailbox', (string) $result->error);
+    }
+
+    public function testAvailabilityNoteOnlyRendersWithAConnectedMailbox(): void
+    {
+        $withAccount = $this->runner([$this->account('Work inbox')]);
+        $descriptor = $withAccount->describe()[0];
+        self::assertTrue($descriptor->requiresDynamicNote);
+
+        $note = ($descriptor->dynamicNote)(self::USER_ID, []);
+        self::assertIsString($note);
+        self::assertStringContainsString('"Work inbox"', $note);
+
+        $without = $this->runner([]);
+        self::assertNull(($without->describe()[0]->dynamicNote)(self::USER_ID, []));
+    }
+}

--- a/backend/tests/Unit/Service/Multitask/Skill/SkillCatalogTest.php
+++ b/backend/tests/Unit/Service/Multitask/Skill/SkillCatalogTest.php
@@ -96,11 +96,13 @@ final class SkillCatalogTest extends TestCase
 
         $on = $catalog->renderCapabilityList();
         self::assertStringContainsString('- "url_fetch": ', $on);
-        // mcp_fetch is a DYNAMIC block (requiresDynamicNote): without a
-        // connected-server sub-catalog it stays invisible even when its flag
-        // is on — so exactly one capability line is missing here.
+        // mcp_fetch and email_search are DYNAMIC blocks (requiresDynamicNote):
+        // without a per-user sub-catalog / availability note they stay
+        // invisible even when their flags are on — so exactly two capability
+        // lines are missing here.
         self::assertStringNotContainsString('"mcp_fetch"', $on);
+        self::assertStringNotContainsString('"email_search"', $on);
         $lines = explode("\n", $on);
-        self::assertCount(count(Capability::cases()) - 1, $lines);
+        self::assertCount(count(Capability::cases()) - 2, $lines);
     }
 }

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -938,6 +938,7 @@
       "web_search": "Websuche",
       "url_fetch": "Webseite lesen",
       "mcp_fetch": "Verbundene Daten abrufen",
+      "email_search": "E-Mails durchsuchen",
       "file_analysis": "Dateianalyse",
       "image_generation": "Bild",
       "video_generation": "Video",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -3117,6 +3117,7 @@
       "web_search": "Web search",
       "url_fetch": "Reading web page",
       "mcp_fetch": "Fetching connected data",
+      "email_search": "Searching your emails",
       "file_analysis": "File analysis",
       "image_generation": "Image",
       "video_generation": "Video",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -1135,6 +1135,7 @@
       "web_search": "Búsqueda web",
       "url_fetch": "Leyendo página web",
       "mcp_fetch": "Obteniendo datos conectados",
+      "email_search": "Buscando en tus correos",
       "file_analysis": "Análisis de archivo",
       "image_generation": "Imagen",
       "video_generation": "Vídeo",

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -1135,6 +1135,7 @@
       "web_search": "Web araması",
       "url_fetch": "Web sayfası okunuyor",
       "mcp_fetch": "Bağlı veriler alınıyor",
+      "email_search": "E-postalarınızda aranıyor",
       "file_analysis": "Dosya analizi",
       "image_generation": "Görsel",
       "video_generation": "Video",


### PR DESCRIPTION
## Summary

Sprint 7 (stacked on #1247): the third external data node — "search for infos in my emails" as a live, stateless, **read-only** IMAP search at question time (locked shape (a): nothing indexed, nothing persisted).

- `Capability::EmailSearch` + `EmailSearchRunner`: searches every **active** `InboundEmailHandler` account (existing encrypted creds/connection settings), merges hits newest-first (≤10), and emits citable web-search-style sections for `$nX.text`. Zero hits = honest success; dead mailbox = isolated node failure; no account = clear pointer to Channels → Email Automation.
- `MailboxSearcher` interface + `ImapMailboxSearcher`: `OP_READONLY` connection, `FT_PEEK` fetches (never sets `\Seen`), no flag/delete ops, quote-stripped `TEXT`/`FROM`/`SINCE` criteria, 2k-char snippets.
- Second **dynamic skill block**: flag `MULTITASK.EMAIL_SEARCH_ENABLED` (default off) + per-user availability note — a user without a connected mailbox never shows the planner this capability, so it cannot plan around a missing account.
- Planner rule 9d + canonical example (prompt snapshot re-recorded, reviewed), search-card hit counts, i18n ×4, eval corpus negative case (35 total).

## Test plan

- [x] Full gate green: backend lint/phpstan/tests (2530), frontend lint/vue-tsc/Vitest (790)
- [x] 6 new runner unit tests (mocked `MailboxSearcher`): formatting/ordering, flag gate, no-account degradation, honest zero-hit answer, dead-mailbox isolation, availability-note gating
- [x] Live plan-level verification (no real IMAP server available in dev; MailHog is SMTP-only, so the doc's "MailHog E2E" isn't feasible): with an active-but-unreachable account the turn planned `email_search → summarize → compose_reply`, the node failed in isolation, and the reply honestly asked for the email content; with no account the identical request never emitted `email_search`