### PR TITLE
fix(chat): stop dropping system prompts for models without system-role support (office maker hotfix)

### DIFF
--- a/backend/src/Model/ModelCatalog.php
+++ b/backend/src/Model/ModelCatalog.php
@@ -861,6 +861,11 @@ class ModelCatalog
                 'params' => ['model' => 'gpt-5.5-pro'],
                 'features' => ['reasoning', 'vision'],
                 'supportsStreaming' => false,
+                // Responses API takes system prompts via `instructions` — only
+                // streaming is unsupported. Without this flag the legacy
+                // "no streaming ⇒ no system messages" heuristic silently drops
+                // every topic prompt (broke officemaker document generation).
+                'supportsSystemMessages' => true,
                 'meta' => [
                     'api' => 'responses',
                     'context_window' => '1050000',
@@ -890,6 +895,7 @@ class ModelCatalog
                 'params' => ['model' => 'gpt-5.5-pro'],
                 'features' => ['reasoning', 'vision'],
                 'supportsStreaming' => false,
+                'supportsSystemMessages' => true,
                 'meta' => [
                     'api' => 'responses',
                     'supports_images' => true,

--- a/backend/src/Service/Message/Handler/ChatHandler.php
+++ b/backend/src/Service/Message/Handler/ChatHandler.php
@@ -351,12 +351,17 @@ final readonly class ChatHandler implements MessageHandlerInterface
         $systemPrompt .= $this->buildTimeContext($user, $options);
 
         $modelMaxTokens = null;
+        $systemPromptFallback = null;
         if ($modelId) {
             $model = $this->modelRepository->find($modelId);
             if ($model) {
                 $modelMaxTokens = $model->getMaxTokens();
                 $json = $model->getJson();
                 if (!$this->modelSupportsSystemMessages($json)) {
+                    // Model rejects the `system` role: carry the prompt into the
+                    // first user turn instead of dropping it (dropping discards
+                    // the whole topic prompt — broke officemaker on GPT-5.5 Pro).
+                    $systemPromptFallback = $systemPrompt;
                     $systemPrompt = null;
                 }
             }
@@ -396,6 +401,10 @@ final readonly class ChatHandler implements MessageHandlerInterface
             'quoted_text' => $options['quoted_text'] ?? null,
             'quoted_message_id' => $options['quoted_message_id'] ?? null,
         ]);
+
+        if (null !== $systemPromptFallback) {
+            $messages = $this->prependSystemPromptToFirstUserMessage($messages, $systemPromptFallback);
+        }
 
         $aiOptions = [
             'provider' => $provider,
@@ -895,12 +904,16 @@ final readonly class ChatHandler implements MessageHandlerInterface
         $systemPrompt .= $this->buildTimeContext($user, $options);
 
         // Check if model supports system messages (o1 models don't)
+        $systemPromptFallback = null;
         if ($modelId) {
             $model = $this->modelRepository->find($modelId);
             if ($model) {
                 $json = $model->getJson();
                 if (!$this->modelSupportsSystemMessages($json)) {
-                    // Don't use system message - it will be prepended to first user message instead
+                    // Model rejects the `system` role: carry the prompt into the
+                    // first user turn instead of dropping it (dropping discards
+                    // the whole topic prompt — broke officemaker on GPT-5.5 Pro).
+                    $systemPromptFallback = $systemPrompt;
                     $systemPrompt = null;
                 }
             }
@@ -975,6 +988,10 @@ final readonly class ChatHandler implements MessageHandlerInterface
 
         // Build conversation history (TEXT only for streaming)
         $messages = $this->buildStreamingMessages($systemPrompt, $thread, $message, $options);
+
+        if (null !== $systemPromptFallback) {
+            $messages = $this->prependSystemPromptToFirstUserMessage($messages, $systemPromptFallback);
+        }
 
         // Call AI streaming - merge processing options with model config
         $aiOptions = array_merge([
@@ -1555,6 +1572,55 @@ final readonly class ChatHandler implements MessageHandlerInterface
         }
 
         return true;
+    }
+
+    /**
+     * Fallback for models that reject the `system` role: fold the system
+     * prompt into the FIRST user turn so the instructions still reach the
+     * model. Before this, the prompt was silently dropped, which discarded
+     * the entire topic prompt (officemaker's JSON file contract, RAG context,
+     * language directive, …) and produced free-form answers instead of
+     * generated documents (GPT-5.5 Pro officemaker bug).
+     *
+     * @param list<array{role: string, content: string|array<int, mixed>}> $messages
+     *
+     * @return list<array{role: string, content: string|array<int, mixed>}>
+     */
+    private function prependSystemPromptToFirstUserMessage(array $messages, string $systemPrompt): array
+    {
+        if ('' === trim($systemPrompt)) {
+            return $messages;
+        }
+
+        foreach ($messages as $i => $msg) {
+            if ('user' !== $msg['role']) {
+                continue;
+            }
+
+            $content = $msg['content'];
+            if (is_string($content)) {
+                $messages[$i]['content'] = $systemPrompt."\n\n---\n\n".$content;
+            } elseif (is_array($content)) {
+                // Multimodal content: prepend to the first text part, or add
+                // a text part if the turn is image-only.
+                $prepended = false;
+                foreach ($content as $j => $part) {
+                    if (is_array($part) && 'text' === ($part['type'] ?? null) && is_string($part['text'] ?? null)) {
+                        $content[$j]['text'] = $systemPrompt."\n\n---\n\n".$part['text'];
+                        $prepended = true;
+                        break;
+                    }
+                }
+                if (!$prepended) {
+                    array_unshift($content, ['type' => 'text', 'text' => $systemPrompt]);
+                }
+                $messages[$i]['content'] = $content;
+            }
+
+            return $messages;
+        }
+
+        return $messages;
     }
 
     /**

--- a/backend/tests/Unit/ChatHandlerTest.php
+++ b/backend/tests/Unit/ChatHandlerTest.php
@@ -984,6 +984,186 @@ class ChatHandlerTest extends TestCase
         $this->handler->dispatchPendingMemoryExtraction($command);
     }
 
+    /**
+     * GPT-5.5 Pro officemaker regression: models whose JSON says
+     * `supportsStreaming: false` (and nothing else) are treated as "no
+     * system-role support" by the legacy heuristic. The system prompt —
+     * including the whole topic prompt — used to be silently DROPPED,
+     * so officemaker never received its JSON file contract and produced
+     * prose instead of a document. The prompt must now be folded into
+     * the first user turn instead.
+     */
+    public function testHandleFoldsSystemPromptIntoFirstUserTurnWhenModelRejectsSystemRole(): void
+    {
+        $message = $this->createMock(Message::class);
+        $message->method('getUserId')->willReturn(1);
+        $message->method('getText')->willReturn('Erstelle mir ein Word-Dokument');
+        $message->method('getUnixTimestamp')->willReturn(time());
+        $message->method('getDateTime')->willReturn('20260703090000');
+        $message->method('getFilePath')->willReturn('');
+        $message->method('getFileType')->willReturn('');
+        $message->method('getTopic')->willReturn('officemaker');
+        $message->method('getLanguage')->willReturn('de');
+        $message->method('getFileText')->willReturn('');
+
+        $prompt = $this->createMock(Prompt::class);
+        $prompt->method('getPrompt')->willReturn('OFFICEMAKER-PROMPT-MARKER: respond with {"BFILEPATH":...}');
+        $this->promptService
+            ->method('getPromptWithMetadata')
+            ->willReturn(['prompt' => $prompt, 'metadata' => []]);
+
+        $this->promptRepository->method('findOneBy')->willReturn(null);
+        $this->modelConfigService->method('getProviderForModel')->with(206)->willReturn('openai');
+        $this->modelConfigService->method('getModelName')->with(206)->willReturn('gpt-5.5-pro');
+
+        // No supportsSystemMessages key → legacy "no streaming ⇒ no system role" heuristic fires.
+        $model = $this->createMock(Model::class);
+        $model->method('getJson')->willReturn(['supportsStreaming' => false]);
+        $this->modelRepository->method('find')->with(206)->willReturn($model);
+
+        $capturedMessages = null;
+        $this->aiFacade
+            ->method('chat')
+            ->willReturnCallback(function (array $messages) use (&$capturedMessages): array {
+                $capturedMessages = $messages;
+
+                return ['content' => '{"BFILEPATH":"doc.docx","BFILETEXT":"..."}', 'provider' => 'openai', 'model' => 'gpt-5.5-pro'];
+            });
+
+        $this->handler->handle($message, [], ['topic' => 'officemaker', 'language' => 'de', 'model_id' => 206]);
+
+        self::assertIsArray($capturedMessages);
+        foreach ($capturedMessages as $msg) {
+            self::assertNotSame('system', $msg['role'], 'model without system-role support must not receive a system message');
+        }
+
+        $firstUser = null;
+        foreach ($capturedMessages as $msg) {
+            if ('user' === $msg['role']) {
+                $firstUser = $msg;
+                break;
+            }
+        }
+        self::assertNotNull($firstUser, 'there must be a user turn');
+        $content = is_string($firstUser['content']) ? $firstUser['content'] : (string) json_encode($firstUser['content']);
+        self::assertStringContainsString(
+            'OFFICEMAKER-PROMPT-MARKER',
+            $content,
+            'the system prompt must be folded into the first user turn instead of being dropped'
+        );
+        self::assertStringContainsString('Erstelle mir ein Word-Dokument', $content);
+    }
+
+    /**
+     * Companion to the catalog fix: an explicit `supportsSystemMessages: true`
+     * must override the legacy "no streaming ⇒ no system role" convention, so
+     * GPT-5.5 Pro (Responses API, takes system prompts via `instructions`)
+     * keeps its system message even though streaming is unsupported.
+     */
+    public function testHandleKeepsSystemRoleWhenExplicitFlagOverridesStreamingHeuristic(): void
+    {
+        $message = $this->createMock(Message::class);
+        $message->method('getUserId')->willReturn(1);
+        $message->method('getText')->willReturn('Erstelle mir ein Word-Dokument');
+        $message->method('getUnixTimestamp')->willReturn(time());
+        $message->method('getDateTime')->willReturn('20260703090000');
+        $message->method('getFilePath')->willReturn('');
+        $message->method('getFileType')->willReturn('');
+        $message->method('getTopic')->willReturn('officemaker');
+        $message->method('getLanguage')->willReturn('de');
+        $message->method('getFileText')->willReturn('');
+
+        $prompt = $this->createMock(Prompt::class);
+        $prompt->method('getPrompt')->willReturn('OFFICEMAKER-PROMPT-MARKER: respond with {"BFILEPATH":...}');
+        $this->promptService
+            ->method('getPromptWithMetadata')
+            ->willReturn(['prompt' => $prompt, 'metadata' => []]);
+
+        $this->promptRepository->method('findOneBy')->willReturn(null);
+        $this->modelConfigService->method('getProviderForModel')->with(206)->willReturn('openai');
+        $this->modelConfigService->method('getModelName')->with(206)->willReturn('gpt-5.5-pro');
+
+        $model = $this->createMock(Model::class);
+        $model->method('getJson')->willReturn(['supportsStreaming' => false, 'supportsSystemMessages' => true]);
+        $this->modelRepository->method('find')->with(206)->willReturn($model);
+
+        $capturedMessages = null;
+        $this->aiFacade
+            ->method('chat')
+            ->willReturnCallback(function (array $messages) use (&$capturedMessages): array {
+                $capturedMessages = $messages;
+
+                return ['content' => 'ok', 'provider' => 'openai', 'model' => 'gpt-5.5-pro'];
+            });
+
+        $this->handler->handle($message, [], ['topic' => 'officemaker', 'language' => 'de', 'model_id' => 206]);
+
+        self::assertIsArray($capturedMessages);
+        self::assertSame('system', $capturedMessages[0]['role']);
+        self::assertStringContainsString('OFFICEMAKER-PROMPT-MARKER', $capturedMessages[0]['content']);
+    }
+
+    /**
+     * Streaming variant of the fold-into-user-turn fallback: handleStream()
+     * had the identical silent-drop bug (its comment even claimed the prompt
+     * "will be prepended to first user message instead" — it never was).
+     */
+    public function testHandleStreamFoldsSystemPromptIntoFirstUserTurnWhenModelRejectsSystemRole(): void
+    {
+        $message = $this->createMock(Message::class);
+        $message->method('getUserId')->willReturn(1);
+        $message->method('getText')->willReturn('Erstelle mir ein Word-Dokument');
+        $message->method('getFileText')->willReturn('');
+        $message->method('getFiles')->willReturn(new \Doctrine\Common\Collections\ArrayCollection());
+
+        $prompt = $this->createMock(Prompt::class);
+        $prompt->method('getPrompt')->willReturn('OFFICEMAKER-PROMPT-MARKER: respond with {"BFILEPATH":...}');
+        $this->promptService
+            ->method('getPromptWithMetadata')
+            ->willReturn(['prompt' => $prompt, 'metadata' => []]);
+
+        $this->promptRepository->method('findOneBy')->willReturn(null);
+        $this->modelConfigService->method('getProviderForModel')->with(206)->willReturn('openai');
+        $this->modelConfigService->method('getModelName')->with(206)->willReturn('gpt-5.5-pro');
+
+        $model = $this->createMock(Model::class);
+        $model->method('getFeatures')->willReturn([]);
+        $model->method('getJson')->willReturn(['supportsStreaming' => false]);
+        $this->modelRepository->method('find')->with(206)->willReturn($model);
+
+        $capturedMessages = null;
+        $this->aiFacade
+            ->method('chatStream')
+            ->willReturnCallback(function (array $messages, callable $cb) use (&$capturedMessages): array {
+                $capturedMessages = $messages;
+                $cb('chunk');
+
+                return ['provider' => 'openai', 'model' => 'gpt-5.5-pro'];
+            });
+
+        $this->handler->handleStream(
+            $message,
+            [],
+            ['topic' => 'officemaker', 'language' => 'de', 'model_id' => 206],
+            static function ($chunk): void {},
+        );
+
+        self::assertIsArray($capturedMessages);
+        foreach ($capturedMessages as $msg) {
+            self::assertNotSame('system', $msg['role']);
+        }
+        $firstUser = null;
+        foreach ($capturedMessages as $msg) {
+            if ('user' === $msg['role']) {
+                $firstUser = $msg;
+                break;
+            }
+        }
+        self::assertNotNull($firstUser);
+        $content = is_string($firstUser['content']) ? $firstUser['content'] : (string) json_encode($firstUser['content']);
+        self::assertStringContainsString('OFFICEMAKER-PROMPT-MARKER', $content);
+    }
+
     public function testFormatQuotedReferenceReturnsEmptyWhenNoQuote(): void
     {
         $this->assertSame('', $this->invokeFormatQuotedReference([]));


### PR DESCRIPTION
## Summary
- **Bug:** Document generation (officemaker) returned an empty/prose answer instead of a DOCX whenever the chat model was **GPT-5.5 Pro** (IDs 206/207). Root cause: the model JSON has `supportsStreaming: false` and the legacy "no streaming ⇒ no system messages" heuristic in `ChatHandler::modelSupportsSystemMessages()` misread that as "no system role" — the **entire system prompt (topic prompt, RAG context, language directive) was then silently dropped**, so the model never saw officemaker's `{"BFILEPATH":...,"BFILETEXT":...}` contract.
- **Catalog fix:** `ModelCatalog` entries 206/207 now carry `supportsSystemMessages: true` — the Responses API takes system prompts via `instructions`; only streaming is unsupported. Reseed (`app:seed`) propagates it to `BMODELS` via the catalog fingerprint.
- **Defense in depth:** when a model genuinely rejects the system role (e.g. o1 via chat completions), `ChatHandler` now folds the system prompt into the **first user turn** (both `handle()` and `handleStream()`) instead of discarding it — which is what the code comment always claimed but never did.

## Test plan
- [x] 3 new regression tests in `ChatHandlerTest`: fold-into-user-turn (non-streaming + streaming) and explicit-flag override keeps the system role.
- [x] `make -C backend lint` / `make -C backend phpstan` / `make -C backend test` (2467 tests) — all green.
- [x] Live API verification on local stack: "Erstelle mir ein Word-Dokument mit einem kurzen Gedicht über Katzen." with GPT-5.5 Pro as chat model → `__FILE_GENERATED__:katzengedicht.docx`, valid OOXML zip (7.5 KB) downloadable via `/api/v1/files/uploads/...` (before the fix: prose answer, no file).
- [ ] After deploy: reseed models (`app:seed`) so live `BMODELS` rows 206/207 pick up the flag, then re-test document generation on live.

Frontend untouched (backend-only change).