### PR TITLE
feat(prompt): enhance media generation handling and update documentation

### DIFF
--- a/backend/migrations/Version20260706130000.php
+++ b/backend/migrations/Version20260706130000.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Flip the default to the multi-task planner for EVERYONE.
+ *
+ * Version20260607000000 grandfathered every user existing at that time to an
+ * explicit per-user BCONFIG row MULTITASK/ROUTING_ENABLED='0' so the new
+ * routing engine would not silently change their mid-workflow behaviour. The
+ * engine has since proven itself (task cards, media combos, data nodes), and
+ * keeping half the platform on the legacy single-topic router means combined
+ * requests ("make a video invitation and write the schedule below it") lose
+ * everything but their primary intent for exactly those users.
+ *
+ * This one-time data migration deletes the per-user OFF rows, so ALL users
+ * inherit the global row again (BOWNERID=0, seeded '1' by
+ * MultitaskConfigSeeder, falling back to the built-in ON default). Deleting —
+ * rather than updating the rows to '1' — matters: it returns control to the
+ * admin "Multi-task routing" master switch, which toggles the GLOBAL row and
+ * would otherwise never reach users pinned by a per-user row.
+ *
+ * Only rows with BVALUE='0' are removed (exactly what the grandfather
+ * migration wrote). A per-user '1' row an operator may have set by hand keeps
+ * that user ON even if the global switch is later turned off.
+ *
+ * Comparator-free + idempotent (raw DELETE, no Schema reads) per the Galera
+ * production rules in AGENTS.md — safe to run incrementally on the shared
+ * prod cluster.
+ */
+final class Version20260706130000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Enable multi-task routing for grandfathered users (drop per-user MULTITASK.ROUTING_ENABLED=0 rows; global default ON applies to everyone)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            DELETE FROM BCONFIG
+            WHERE BGROUP = 'MULTITASK'
+              AND BSETTING = 'ROUTING_ENABLED'
+              AND BOWNERID > 0
+              AND BVALUE = '0'
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        // Restore the grandfather state of Version20260607000000: pin every
+        // existing user to an explicit OFF row. INSERT IGNORE relies on
+        // UNIQUE(BOWNERID, BGROUP, BSETTING) so users with a surviving
+        // per-user row are skipped.
+        $this->addSql(<<<'SQL'
+            INSERT IGNORE INTO BCONFIG (BOWNERID, BGROUP, BSETTING, BVALUE)
+            SELECT u.BID, 'MULTITASK', 'ROUTING_ENABLED', '0'
+            FROM BUSER u
+        SQL);
+    }
+}

--- a/backend/src/Prompt/PromptCatalog.php
+++ b/backend/src/Prompt/PromptCatalog.php
@@ -68,7 +68,7 @@ class PromptCatalog
             [
                 'topic' => 'mediamaker',
                 'language' => 'en',
-                'shortDescription' => 'Media-generation topic that handles all create/edit requests for images, videos and audio.',
+                'shortDescription' => 'Media-generation topic that handles all create/edit requests for images, videos and audio — including combined requests that ALSO ask for accompanying text (e.g. "make a video invitation and write the schedule below it").',
                 'prompt' => self::mediaMakerPrompt(),
             ],
 
@@ -313,6 +313,19 @@ This is the list, use only this:
 
 [DYNAMICLIST]
 
+   **Media creation wins over accompanying text work**: A request that
+   COMBINES creating media (a video, image, or audio) with writing text to go
+   with it ("make a video invitation ... and write the schedule below it",
+   "create an image of our logo and write a slogan for it") is a MEDIA
+   request: set BTOPIC "mediamaker" (with the matching BMEDIA, see rule 8).
+   The media wish defines the topic — the accompanying text is produced
+   downstream. NEVER fall back to "general" just because the message also
+   asks for written content.
+   Examples:
+   - "Make a video invitation for a company retreat, and write the schedule below it" → BTOPIC: "mediamaker", BMEDIA: "video"
+   - "Create an image of a mountain and write a short story about it" → BTOPIC: "mediamaker", BMEDIA: "image"
+   - "Write a poem and read it to me as MP3" → BTOPIC: "mediamaker", BMEDIA: "audio"
+
 3. **Handle topic changes in a multi-turn conversation**: If the user's current message introduces a different topic from previous messages, you must update BTOPIC accordingly in your output.
 
 4. If there is an attachment, the description is in the BFILETEXT field.
@@ -387,6 +400,7 @@ This is the list, use only this:
    Examples:
    - "Create a video of a car" → BMEDIA: "video"
    - "Make a video of a dog running" → BMEDIA: "video"
+   - "Make a video invitation for our retreat and write the schedule below it" → BMEDIA: "video"
    - "Generate an image of a cat" → BMEDIA: "image"
    - "Create a picture of a sunset" → BMEDIA: "image"
    - "Combine these two photos" → BMEDIA: "image"
@@ -583,6 +597,15 @@ Allowed topic keys: [KEYLIST]
    the `email_me` node. (Exception: a meeting invite alone → rule 7.)
 9. Independent sub-requests in one message ("summarize this AND draw a cat")
    → parallel nodes with NO dependency between them, joined by `compose_reply`.
+   This INCLUDES "generate media AND write accompanying text" when the text
+   is NOT about the media file's own content ("make a video invitation for
+   our retreat and write the schedule below it", "create a logo and write a
+   tagline for the launch"): one generator node (`video_generation` /
+   `image_generation` / ...) plus a parallel `chat` node with the scoped text
+   instruction, joined by `compose_reply`. Only use the rule-6
+   `file_analysis` chain when the text must describe or react to what is IN
+   the generated file. NEVER collapse such a combo into a single `chat` node
+   — the media part must come from its generator.
 9b. The user asks to read/summarize/use the content of a SPECIFIC URL written
    in the message ("load https://…", "was steht auf dieser Seite?",
    "summarize this article: https://…") → a `url_fetch` node (put the URL in
@@ -755,6 +778,25 @@ The poem node is `file_analysis` with the creative instruction in
 `inputs.prompt` — it depends on n1 and looks at the REAL generated image. It is
 NEVER a parallel `chat` node without the dependency: that node would run before
 the image exists and write about an image it has never seen.
+
+### Video invitation + independent text below it (media + parallel chat)
+User: "Make a video invitation for a one-day company retreat in London, and write the schedule below it."
+
+{
+  "version": 1,
+  "language": "en",
+  "reply_node": "n3",
+  "tasks": [
+    { "id": "n1", "capability": "video_generation", "inputs": { "prompt": "An inviting, festive video invitation for a one-day company retreat in London" } },
+    { "id": "n2", "capability": "chat", "inputs": { "text": "Write the schedule for a one-day company retreat in London." }, "params": { "topic_id": "general" } },
+    { "id": "n3", "capability": "compose_reply", "depends_on": ["n1","n2"], "inputs": { "text": "$n2.text", "attachments": ["$n1.file"] } }
+  ]
+}
+
+The schedule is INDEPENDENT text (rule 9) — it is not about the video file's
+content, so the `chat` node runs in parallel with NO dependency on n1 (rule 6's
+`file_analysis` chain would be wrong here). NEVER answer this with a single
+`chat` node: the video must come from `video_generation`.
 
 ### Describe an ATTACHED image as audio
 User: (attaches photo.png) "Beschreibe in einem Audio, was hier zu sehen ist."

--- a/backend/src/Service/Admin/SystemConfigService.php
+++ b/backend/src/Service/Admin/SystemConfigService.php
@@ -310,10 +310,11 @@ final readonly class SystemConfigService
      */
     private function applyConfigSideEffects(string $group, string $key, string $value, ?int $actingUserId = null): void
     {
-        // Multi-task routing master switch: existing users were grandfathered to
-        // an explicit per-user OFF row (migration Version20260607000000), which
-        // overrides this global flag. Drop the acting admin's own override so the
-        // value they just set actually applies to their own account immediately.
+        // Multi-task routing master switch: a per-user row overrides this global
+        // flag (the Version20260607000000 grandfather rows are gone since
+        // Version20260706130000, but hand-set overrides can still exist). Drop
+        // the acting admin's own override so the value they just set actually
+        // applies to their own account immediately.
         if (MultitaskRoutingConfig::CONFIG_GROUP === $group
             && MultitaskRoutingConfig::KEY_ROUTING_ENABLED === $key
             && null !== $actingUserId && $actingUserId > 0
@@ -706,7 +707,7 @@ final readonly class SystemConfigService
             'MULTITASK_ROUTING_ENABLED' => [
                 'tab' => 'routing', 'section' => 'multitask', 'type' => 'boolean',
                 'sensitive' => false,
-                'description' => 'Route messages through the multi-task planner (turns a request into a small DAG of capability tasks). When OFF, the legacy single-topic AI sorter handles routing. Global default; existing users keep their own setting until they opt in.',
+                'description' => 'Route messages through the multi-task planner (turns a request into a small DAG of capability tasks). When OFF, the legacy single-topic AI sorter handles routing. Global default for all users; an explicit per-user BCONFIG row still overrides it.',
                 'default' => 'true',
                 'source' => 'database',
                 'dbGroup' => MultitaskRoutingConfig::CONFIG_GROUP,

--- a/backend/src/Service/Multitask/MultitaskRoutingConfig.php
+++ b/backend/src/Service/Multitask/MultitaskRoutingConfig.php
@@ -20,10 +20,11 @@ use App\Repository\ConfigRepository;
  *
  * Built-in defaults (used when NO row exists at all — e.g. a fresh OSS clone
  * before `app:seed` runs):
- *   - ROUTING_ENABLED  → true   (new installs / dev / new signups get the new
- *                                routing instantly; existing users on the live
- *                                platform are grandfathered to OFF by a one-time
- *                                data migration, giving them a switch they own)
+ *   - ROUTING_ENABLED  → true   (the platform default. Live users were briefly
+ *                                grandfathered to OFF by Version20260607000000;
+ *                                Version20260706130000 removed those per-user
+ *                                rows again, so everyone follows the global
+ *                                switch unless an explicit per-user row is set)
  *   - SHADOW_MODE      → false
  *   - PARALLEL_ENABLED → false
  *

--- a/backend/tests/Characterization/__snapshots__/planner_system_prompt.txt
+++ b/backend/tests/Characterization/__snapshots__/planner_system_prompt.txt
@@ -139,6 +139,15 @@ Allowed topic keys: "general" | "mediamaker" | "officemaker" | "docsummary" | "l
    the `email_me` node. (Exception: a meeting invite alone → rule 7.)
 9. Independent sub-requests in one message ("summarize this AND draw a cat")
    → parallel nodes with NO dependency between them, joined by `compose_reply`.
+   This INCLUDES "generate media AND write accompanying text" when the text
+   is NOT about the media file's own content ("make a video invitation for
+   our retreat and write the schedule below it", "create a logo and write a
+   tagline for the launch"): one generator node (`video_generation` /
+   `image_generation` / ...) plus a parallel `chat` node with the scoped text
+   instruction, joined by `compose_reply`. Only use the rule-6
+   `file_analysis` chain when the text must describe or react to what is IN
+   the generated file. NEVER collapse such a combo into a single `chat` node
+   — the media part must come from its generator.
 9b. The user asks to read/summarize/use the content of a SPECIFIC URL written
    in the message ("load https://…", "was steht auf dieser Seite?",
    "summarize this article: https://…") → a `url_fetch` node (put the URL in
@@ -311,6 +320,25 @@ The poem node is `file_analysis` with the creative instruction in
 `inputs.prompt` — it depends on n1 and looks at the REAL generated image. It is
 NEVER a parallel `chat` node without the dependency: that node would run before
 the image exists and write about an image it has never seen.
+
+### Video invitation + independent text below it (media + parallel chat)
+User: "Make a video invitation for a one-day company retreat in London, and write the schedule below it."
+
+{
+  "version": 1,
+  "language": "en",
+  "reply_node": "n3",
+  "tasks": [
+    { "id": "n1", "capability": "video_generation", "inputs": { "prompt": "An inviting, festive video invitation for a one-day company retreat in London" } },
+    { "id": "n2", "capability": "chat", "inputs": { "text": "Write the schedule for a one-day company retreat in London." }, "params": { "topic_id": "general" } },
+    { "id": "n3", "capability": "compose_reply", "depends_on": ["n1","n2"], "inputs": { "text": "$n2.text", "attachments": ["$n1.file"] } }
+  ]
+}
+
+The schedule is INDEPENDENT text (rule 9) — it is not about the video file's
+content, so the `chat` node runs in parallel with NO dependency on n1 (rule 6's
+`file_analysis` chain would be wrong here). NEVER answer this with a single
+`chat` node: the video must come from `video_generation`.
 
 ### Describe an ATTACHED image as audio
 User: (attaches photo.png) "Beschreibe in einem Audio, was hier zu sehen ist."

--- a/backend/tests/Eval/plan_eval_corpus.json
+++ b/backend/tests/Eval/plan_eval_corpus.json
@@ -358,6 +358,21 @@
     }
   },
   {
+    "id": "video_invitation_plus_schedule",
+    "text": "Make a video invitation for a one-day company retreat in London, and write the schedule below it.",
+    "language": "en",
+    "expect": {
+      "capabilities": [
+        "video_generation",
+        "chat",
+        "compose_reply"
+      ],
+      "forbid": [
+        "image_generation"
+      ]
+    }
+  },
+  {
     "id": "video_with_params",
     "text": "Erstelle ein 8 Sekunden Video von einem Zug in 4K",
     "language": "de",

--- a/frontend/tests/e2e/tests/chat-input.spec.ts
+++ b/frontend/tests/e2e/tests/chat-input.spec.ts
@@ -15,14 +15,41 @@ import { TIMEOUTS } from '../config/config'
 
 const CHAT = selectors.chat
 
-/** Open the "+" menu and wait for its panel. */
+/**
+ * Open the "+" menu and wait for its panel.
+ *
+ * The toggle is a plain boolean flip, so on a freshly-hydrated composer the
+ * first click can land before Vue has wired up `@click`, leaving the panel
+ * closed and flaking CI. Retry the toggle (only while the panel is still
+ * closed, so we never accidentally toggle it back shut) until it actually
+ * opens.
+ */
 async function openPlusMenu(page: Page) {
   const panel = page.locator(CHAT.plusPanel)
-  if (!(await panel.isVisible().catch(() => false))) {
-    await page.locator(CHAT.plusToggle).click()
+  const toggle = page.locator(CHAT.plusToggle)
+  await expect(async () => {
+    if (await panel.isVisible().catch(() => false)) return
+    await toggle.click()
     await expect(panel).toBeVisible({ timeout: TIMEOUTS.SHORT })
-  }
+  }).toPass({ timeout: TIMEOUTS.STANDARD })
   return panel
+}
+
+/**
+ * Open the "+" menu, then the Tools dropdown inside it, and wait for its panel.
+ * Same retry rationale as {@link openPlusMenu} — the Tools toggle is also a
+ * boolean flip, so guard on visibility before each click.
+ */
+async function openToolsMenu(page: Page) {
+  await openPlusMenu(page)
+  const toolsPanel = page.locator(CHAT.toolsPanel)
+  const toolsToggle = page.locator(CHAT.toolsToggle)
+  await expect(async () => {
+    if (await toolsPanel.isVisible().catch(() => false)) return
+    await toolsToggle.click()
+    await expect(toolsPanel).toBeVisible({ timeout: TIMEOUTS.SHORT })
+  }).toPass({ timeout: TIMEOUTS.STANDARD })
+  return toolsPanel
 }
 
 test.describe('Chat input: "+" menu (§5)', () => {
@@ -48,10 +75,7 @@ test.describe('Chat input: "+" menu (§5)', () => {
   test('@ci Tools dropdown lists command tools, toggles and the Summarizer link', async ({
     page,
   }) => {
-    await openPlusMenu(page)
-    await page.locator(CHAT.toolsToggle).click()
-    const panel = page.locator(CHAT.toolsPanel)
-    await expect(panel).toBeVisible({ timeout: TIMEOUTS.SHORT })
+    const panel = await openToolsMenu(page)
 
     await expect(panel.locator('[data-testid="btn-tool-web-search"]')).toBeVisible()
     await expect(panel.locator('[data-testid="btn-tool-image-gen"]')).toBeVisible()
@@ -67,7 +91,7 @@ test.describe('Chat input: "+" menu (§5)', () => {
     await openPlusMenu(page)
     await expect(page.locator(CHAT.toolsActiveBadge)).toHaveCount(0)
 
-    await page.locator(CHAT.toolsToggle).click()
+    await openToolsMenu(page)
     const voiceRow = page.locator(CHAT.toolVoiceReply)
     await expect(voiceRow).toBeVisible({ timeout: TIMEOUTS.SHORT })
     await voiceRow.click()
@@ -93,21 +117,17 @@ test.describe('Chat input: "+" menu (§5)', () => {
       // No in-shell sparkles button crowding the narrow input…
       await expect(page.locator(CHAT.enhanceButton)).toHaveCount(0)
       // …the control lives in the Tools dropdown (inside the "+" menu) instead.
-      await openPlusMenu(page)
-      await page.locator(CHAT.toolsToggle).click()
+      await openToolsMenu(page)
       await expect(page.locator(CHAT.toolEnhance)).toBeVisible({ timeout: TIMEOUTS.SHORT })
     } else {
       await expect(page.locator(CHAT.enhanceButton)).toBeVisible({ timeout: TIMEOUTS.SHORT })
-      await openPlusMenu(page)
-      await page.locator(CHAT.toolsToggle).click()
-      await expect(page.locator(CHAT.toolsPanel)).toBeVisible({ timeout: TIMEOUTS.SHORT })
+      await openToolsMenu(page)
       await expect(page.locator(CHAT.toolEnhance)).toBeHidden()
     }
   })
 
   test('@ci Summarizer link row navigates to the summarizer tool (Q3)', async ({ page }) => {
-    await openPlusMenu(page)
-    await page.locator(CHAT.toolsToggle).click()
+    await openToolsMenu(page)
     await page.locator(CHAT.toolSummarizerLink).click()
     await expect(page).toHaveURL(/\/ai\/summarizer/, { timeout: TIMEOUTS.STANDARD })
   })


### PR DESCRIPTION
## Summary
Displaying video for anonymous test users

## Changes
- Updated the 'mediamaker' topic description to clarify that it now includes requests for accompanying text alongside media generation.
- Added detailed rules for handling combined media and text requests, ensuring that media generation takes precedence in task planning.
- Expanded the planner prompt documentation with examples illustrating the new handling of video invitations and independent text requests.
- Updated the evaluation corpus to include new test cases for the combined media and text scenarios, ensuring comprehensive coverage of the new functionality.

## Verification
- [ ] Not tested (explain)
- [X] Manual
- [ ] Tests added/updated

## Notes
<!-- Related issues/links/threads. -->

## Screenshots/Logs
