### PR TITLE
fix(mcp): strip trailing slash from outbound MCP server URLs

### DIFF
--- a/backend/src/Controller/McpServerConfigController.php
+++ b/backend/src/Controller/McpServerConfigController.php
@@ -393,7 +393,7 @@ final class McpServerConfigController extends AbstractController
             $server->setName(trim($data['name']));
         }
         if (is_string($data['url'] ?? null)) {
-            $server->setUrl(trim($data['url']));
+            $server->setUrl(rtrim(trim($data['url']), '/'));
         }
         if (array_key_exists('auth_header', $data) && is_string($data['auth_header'])) {
             $server->setAuthHeader(trim($data['auth_header']));


### PR DESCRIPTION
## Summary
- Normalizes outbound MCP server URLs by stripping trailing slashes on save
- Prevents 307 redirects (e.g. uvicorn's `/mcp/` → `/mcp`) that fail silently because the MCP client intentionally disables redirect-following (`max_redirects=0`) as SSRF protection
- One-line change in `McpServerConfigController::apply()`

## Test plan
- [ ] Add an MCP server with URL ending in `/mcp/` — verify it's saved as `/mcp`
- [ ] Verify "Test connection" discovers tools correctly after the normalization
- [ ] Verify URLs without trailing slash are unaffected