### PR TITLE
fix(landing): render generated media for anonymous guests + drop flaky video prompt

### DIFF
--- a/frontend/src/components/ExamplePrompts.vue
+++ b/frontend/src/components/ExamplePrompts.vue
@@ -35,6 +35,6 @@ const emit = defineEmits<{
 const examples = [
   { id: 'poemMp3', icon: 'mdi:music-note' },
   { id: 'everglades', icon: 'mdi:file-word-box' },
-  { id: 'retreat', icon: 'mdi:movie-open' },
+  { id: 'cabinImage', icon: 'mdi:image' },
 ] as const
 </script>

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -96,7 +96,7 @@
     "items": {
       "poemMp3": "Schreibe ein Gedicht über eine Katze und wandle es in eine MP3 um.",
       "everglades": "Schreibe einen Artikel über die Everglades in Florida und lege ihn als Word-Dokument zum Download an.",
-      "retreat": "Erstelle eine Video-Einladung für ein eintägiges Firmen-Retreat in London und schreibe den Ablaufplan darunter."
+      "cabinImage": "Erstelle ein Bild einer gemütlichen Berghütte im Sonnenuntergang."
     }
   },
   "marketingNews": {

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -96,7 +96,7 @@
     "items": {
       "poemMp3": "Create a poem about a cat and convert it into an MP3.",
       "everglades": "Write an article about the Florida Everglades and put it into a Word document for download.",
-      "retreat": "Make a video invitation for a one-day company retreat in London, and write the schedule below it."
+      "cabinImage": "Create an image of a cozy mountain cabin at sunset."
     }
   },
   "marketingNews": {

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -95,7 +95,7 @@
     "items": {
       "poemMp3": "Crea un poema sobre un gato y conviértelo en un MP3.",
       "everglades": "Escribe un artículo sobre los Everglades de Florida y ponlo en un documento de Word para descargar.",
-      "retreat": "Crea una invitación en vídeo para un retiro de empresa de un día en Londres y escribe el programa debajo."
+      "cabinImage": "Crea una imagen de una acogedora cabaña de montaña al atardecer."
     }
   },
   "marketingNews": {

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -95,7 +95,7 @@
     "items": {
       "poemMp3": "Bir kedi hakkında şiir yaz ve onu MP3'e dönüştür.",
       "everglades": "Florida Everglades hakkında bir makale yaz ve indirilebilir bir Word belgesine koy.",
-      "retreat": "Londra'da bir günlük şirket kampı için video davetiye oluştur ve programı altına yaz."
+      "cabinImage": "Gün batımında şirin bir dağ kulübesinin resmini oluştur."
     }
   },
   "marketingNews": {

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -1824,6 +1824,104 @@ const streamAIResponse = async (
             processingMetadata.value = data.metadata || {}
           } else if (data.status === 'processing') {
             // Processing/routing — no UI update needed
+          } else if (data.status === 'plan') {
+            // Multitask routing: a multi-node plan was recognized. Render a task
+            // card per node. Mirrors the authenticated handler so anonymous
+            // (guest) users see the exact same DAG surface (issue: guest media
+            // rendered as text-only because these events were dropped).
+            const message = historyStore.messages.find((m) => m.id === messageId)
+            const tasks = data.metadata?.plan
+            if (message && Array.isArray(tasks) && tasks.length > 0) {
+              processingStatus.value = ''
+              processingMetadata.value = {}
+              message.wasMultitask = true
+              message.taskPlan = {
+                active: true,
+                trackId: currentTrackId,
+                replyNode:
+                  typeof data.metadata?.reply_node === 'string' ? data.metadata.reply_node : '',
+                cards: tasks.map((tk) => ({
+                  nodeId: tk.node_id,
+                  capability: tk.capability,
+                  kind: isTaskCardKind(tk.kind) ? tk.kind : 'text',
+                  state: 'pending' as const,
+                })),
+              }
+            }
+          } else if (data.status === 'plan_discarded') {
+            const message = historyStore.messages.find((m) => m.id === messageId)
+            if (message) {
+              message.taskPlan = null
+              message.wasMultitask = false
+            }
+          } else if (data.status === 'task_update') {
+            const message = historyStore.messages.find((m) => m.id === messageId)
+            const card = message?.taskPlan?.cards.find((c) => c.nodeId === data.metadata?.node_id)
+            if (card && card.state === 'cancelled') {
+              // keep cancelled
+            } else if (card && isTaskCardState(data.metadata?.state)) {
+              card.state = data.metadata.state
+              if (typeof data.metadata?.error === 'string' && data.metadata.error) {
+                card.error = data.metadata.error
+              }
+              if (typeof data.metadata?.prompt === 'string' && data.metadata.prompt) {
+                card.prompt = data.metadata.prompt
+              }
+              if (typeof data.metadata?.query === 'string' && data.metadata.query) {
+                card.query = data.metadata.query
+              }
+              if (typeof data.metadata?.results_count === 'number') {
+                card.resultsCount = data.metadata.results_count
+              }
+            }
+          } else if (data.status === 'task_chunk') {
+            const message = historyStore.messages.find((m) => m.id === messageId)
+            const card = message?.taskPlan?.cards.find((c) => c.nodeId === data.metadata?.node_id)
+            if (card && typeof data.metadata?.chunk === 'string') {
+              card.text = (card.text ?? '') + data.metadata.chunk
+            }
+          } else if (data.status === 'task_file') {
+            const message = historyStore.messages.find((m) => m.id === messageId)
+            const card = message?.taskPlan?.cards.find((c) => c.nodeId === data.metadata?.node_id)
+            if (card && typeof data.metadata?.url === 'string') {
+              card.url = normalizeMediaUrl(data.metadata.url)
+              card.mediaType =
+                typeof data.metadata?.type === 'string' ? data.metadata.type : card.kind
+            }
+          } else if (data.status === 'task_progress') {
+            const message = historyStore.messages.find((m) => m.id === messageId)
+            const card = message?.taskPlan?.cards.find((c) => c.nodeId === data.metadata?.node_id)
+            if (card && card.state !== 'cancelled') {
+              if (typeof data.metadata?.percent === 'number') {
+                card.progressPercent = data.metadata.percent
+              }
+              if (typeof data.metadata?.provider_status === 'string') {
+                card.providerStatus = data.metadata.provider_status
+              }
+              if (typeof data.metadata?.elapsed_seconds === 'number') {
+                card.elapsedSeconds = data.metadata.elapsed_seconds
+              }
+            }
+          } else if (
+            data.status === 'data' &&
+            historyStore.messages.find((m) => m.id === messageId)?.taskPlan?.active
+          ) {
+            // Multitask: the assembled reply text streams once after the DAG
+            // finishes (the task cards are the live surface). Accumulate it so the
+            // 'complete' flush renders it.
+            if (data.chunk) {
+              fullContent += data.chunk
+            }
+          } else if (
+            (data.status === 'file' ||
+              data.status === 'audio' ||
+              data.status === 'tts_generating' ||
+              data.status === 'links') &&
+            historyStore.messages.find((m) => m.id === messageId)?.taskPlan?.active
+          ) {
+            // Multitask: task cards are the live media surface, so suppress the
+            // normal single-bubble media events (they still persist on the OUT
+            // message and re-render from history on reload).
           } else if (data.status === 'data' && data.chunk) {
             if (processingStatus.value) {
               processingStatus.value = ''
@@ -1849,6 +1947,55 @@ const streamAIResponse = async (
                 message.parts.unshift(reasoningPart)
               }
               reasoningPart.content += data.chunk
+            }
+          } else if (data.status === 'file') {
+            // Single-capability media (image / video / audio) delivered outside a
+            // DAG. Without this branch the generated file never rendered for
+            // guests — they only saw the "Generated image:" text chunk.
+            const message = historyStore.messages.find((m) => m.id === messageId)
+            if (message && data.url) {
+              const absoluteUrl = normalizeMediaUrl(data.url)
+              if (data.type === 'image' || data.type === 'video' || data.type === 'audio') {
+                pushMediaPart(message, data.type, absoluteUrl)
+              }
+            }
+          } else if (data.status === 'tts_generating') {
+            const message = historyStore.messages.find((m) => m.id === messageId)
+            if (message) {
+              message.parts.push({ type: 'tts_loading' })
+            }
+          } else if (data.status === 'audio') {
+            const message = historyStore.messages.find((m) => m.id === messageId)
+            if (message && data.url) {
+              const loadingIdx = message.parts.findIndex((p) => p.type === 'tts_loading')
+              if (loadingIdx !== -1) {
+                message.parts.splice(loadingIdx, 1)
+              }
+              pushMediaPart(message, 'audio', normalizeMediaUrl(data.url))
+            }
+          } else if (data.status === 'links') {
+            const message = historyStore.messages.find((m) => m.id === messageId)
+            if (message && data.links) {
+              message.parts.push({
+                type: 'links',
+                items: data.links.map((l) => {
+                  try {
+                    return {
+                      title: l.title || l.url,
+                      url: l.url,
+                      desc: l.description,
+                      host: new URL(l.url).hostname,
+                    }
+                  } catch {
+                    return {
+                      title: l.title || l.url,
+                      url: l.url,
+                      desc: l.description,
+                      host: l.url,
+                    }
+                  }
+                }),
+              })
             }
           } else if (data.status === 'complete') {
             if (streamingRafId !== null) {
@@ -1876,6 +2023,14 @@ const streamAIResponse = async (
             const message = historyStore.messages.find((m) => m.id === messageId)
             if (message) {
               applyMediaJobToMessage(message, data.mediaJob ?? data.media_job)
+
+              // Multitask turn finished: stop the live task-card spinners. Guests
+              // cannot reconcile against the persisted message (that endpoint is
+              // auth-only), so the terminal card states already streamed via
+              // task_update are authoritative here.
+              if (message.taskPlan) {
+                message.taskPlan.active = false
+              }
 
               if (data.messageId) {
                 message.backendMessageId = data.messageId
@@ -1949,6 +2104,10 @@ const streamAIResponse = async (
             }
             processingStatus.value = ''
             processingMetadata.value = {}
+            const message = historyStore.messages.find((m) => m.id === messageId)
+            if (message?.taskPlan) {
+              message.taskPlan.active = false
+            }
             historyStore.finishStreamingMessage(messageId)
           }
         },


### PR DESCRIPTION
## Problem

The anonymous landing page pushes thousands of visitors/minute at three example prompts that **must** work. They didn't:

1. **Guests only ever saw text — never the generated media.** The guest chat stream handler (`ChatView.vue`) silently dropped every media/DAG SSE event the authenticated handler processes (`file`, `audio`, `tts_generating`, `links`, `plan`, `task_*`), even though its comment claimed *"mirrors the authenticated handler for full feature parity"*. So a generated image/audio/video never rendered for a not-logged-in user, and the DAG task cards only appeared **after login** — exactly the reported *"the answer is a text, but not the video."*
2. **The video prompt is a bad fit for a broke, high-traffic page.** Google Veo video generation is slow, expensive, and returns intermittent internal errors (`code: 13`), plus RAI content filtering — unreliable for a page that must convert every time.

## Fix

- **Guest handler parity (`ChatView.vue`)** — the guest `onUpdate` now handles the same events as the authenticated path:
  - Single-bubble media: `file` (image/video/audio), `audio`, `tts_generating`, `links`.
  - Multitask DAG lifecycle: `plan`, `plan_discarded`, `task_update`, `task_chunk`, `task_file`, `task_progress`, plus the two multitask suppression guards, and task-card spinner teardown on `complete`/`error`. Guests can't reconcile against the persisted message (that endpoint is auth-only), so the terminal card states streamed via `task_update` are authoritative.
  - This also fixes the existing **poem → MP3** example, which was silently broken for guests for the same reason.
- **Reliable example prompt** — replaced the video-invitation prompt with a single-capability image prompt *"Create an image of a cozy mountain cabin at sunset."* in all four locales (`en/de/es/tr`) and updated the `ExamplePrompts` icon. Single-capability = the legacy media path, the cheapest and most reliable modality.

The three landing prompts are now: **poem → MP3** (audio), **article → Word doc** (document), **image** — each a distinct, cheap, reliable capability.

## Testing

- `make -C frontend lint` ✅
- `docker compose exec -T frontend npm run check:types` ✅ (regenerated stale `api-schemas.ts` first; unrelated pre-existing MCP errors)
- `make -C frontend test` ✅ 802/802
- **Live browser verification** on the anonymous page: `/pic` now renders a real inline `<img>` for a guest (previously text-only), no console errors. Backend curl confirms the `file` SSE event is emitted and image generation succeeds (~52s via the configured image provider).

## Notes

- Backend unchanged (frontend-only change), so backend gate not required.
- The Veo teaching examples in the classifier/planner prompts are intentionally kept — they train the model to handle video requests for logged-in users; only the anonymous landing prompt changed.

Made with [Cursor](https://cursor.com)