### PR TITLE
refactor(chat): unify message serialization

### DIFF
--- a/backend/src/Controller/GuestChatController.php
+++ b/backend/src/Controller/GuestChatController.php
@@ -7,9 +7,9 @@ namespace App\Controller;
 use App\Entity\Chat;
 use App\Repository\FileRepository;
 use App\Repository\MessageRepository;
-use App\Repository\SearchResultRepository;
 use App\Service\GuestSessionService;
 use App\Service\Media\MediaCancellationStore;
+use App\Service\Message\MessageApiFormatter;
 use Doctrine\ORM\EntityManagerInterface;
 use OpenApi\Attributes as OA;
 use Psr\Log\LoggerInterface;
@@ -35,9 +35,9 @@ class GuestChatController extends AbstractController
         private GuestSessionService $guestSessionService,
         private EntityManagerInterface $em,
         private MessageRepository $messageRepository,
-        private SearchResultRepository $searchResultRepository,
         private FileRepository $fileRepository,
         private MediaCancellationStore $cancellationStore,
+        private MessageApiFormatter $messageApiFormatter,
         private LoggerInterface $logger,
         private string $uploadDir,
     ) {
@@ -410,143 +410,18 @@ class GuestChatController extends AbstractController
             ->getQuery()
             ->getResult();
 
-        // Build in-memory index of IN messages for preceding-message lookup
-        $inMessages = [];
-        foreach ($messages as $m) {
-            if ('IN' === $m->getDirection()) {
-                $inMessages[] = $m;
-            }
-        }
-
-        // Collect IN messages that precede OUT messages with web search data
-        $inMessagesNeedingResults = [];
-        $outToInMap = []; // outMessageId => inMessage
-        foreach ($messages as $m) {
-            if ('OUT' !== $m->getDirection()) {
-                continue;
-            }
-            $searchQuery = $m->getMeta('web_search_query');
-            $searchResultsCount = $m->getMeta('web_search_results_count');
-            if (!$searchQuery && !$searchResultsCount) {
-                continue;
-            }
-            // Find the closest preceding IN message in-memory
-            $preceding = null;
-            foreach ($inMessages as $inMsg) {
-                if ($inMsg->getUnixTimestamp() < $m->getUnixTimestamp()) {
-                    $preceding = $inMsg;
-                } else {
-                    break;
-                }
-            }
-            if ($preceding) {
-                $outToInMap[$m->getId()] = $preceding;
-                $inMessagesNeedingResults[$preceding->getId()] = $preceding;
-            }
-        }
-
-        // Batch-load all needed search results in a single query
-        $searchResultsByMessageId = $this->searchResultRepository
-            ->findByMessages(array_values($inMessagesNeedingResults));
-
-        $messageData = array_map(function ($m) use ($outToInMap, $searchResultsByMessageId) {
-            $aiModels = [];
-            $webSearchData = null;
-            $searchResultsData = [];
-
-            // Attached files (e.g. AI-generated documents) — same shape as
-            // MessageApiFormatter so the download badge also renders for
-            // guests after a page reload.
-            $filesData = [];
-            if ($m->hasFiles()) {
-                foreach ($m->getFiles() as $file) {
-                    $filesData[] = [
-                        'id' => $file->getId(),
-                        'filename' => $file->getFileName(),
-                        'fileType' => $file->getFileType(),
-                        'filePath' => $file->getFilePath(),
-                        'fileSize' => $file->getFileSize(),
-                        'fileMime' => $file->getFileMime(),
-                    ];
-                }
-            }
-
-            if ('OUT' === $m->getDirection()) {
-                $chatProvider = $m->getMeta('ai_chat_provider');
-                $chatModel = $m->getMeta('ai_chat_model');
-                $chatModelIdMeta = $m->getMeta('ai_chat_model_id');
-                if ($chatProvider || $chatModel) {
-                    $aiModels['chat'] = [
-                        'provider' => $chatProvider,
-                        'model' => $chatModel,
-                        'model_id' => $chatModelIdMeta ? (int) $chatModelIdMeta : null,
-                    ];
-                }
-
-                $sortingProvider = $m->getMeta('ai_sorting_provider');
-                $sortingModel = $m->getMeta('ai_sorting_model');
-                $sortingModelId = $m->getMeta('ai_sorting_model_id');
-                if ($sortingProvider || $sortingModel) {
-                    $aiModels['sorting'] = [
-                        'provider' => $sortingProvider,
-                        'model' => $sortingModel,
-                        'model_id' => $sortingModelId ? (int) $sortingModelId : null,
-                    ];
-                }
-
-                // Audio (TTS) model — separate from chat so the badge after
-                // a page reload also shows the actual TTS model (#583).
-                $audioProvider = $m->getMeta('ai_audio_provider');
-                $audioModel = $m->getMeta('ai_audio_model');
-                $audioModelId = $m->getMeta('ai_audio_model_id');
-                if ($audioProvider || $audioModel) {
-                    $aiModels['audio'] = [
-                        'provider' => $audioProvider,
-                        'model' => $audioModel,
-                        'model_id' => $audioModelId ? (int) $audioModelId : null,
-                    ];
-                }
-
-                $searchQuery = $m->getMeta('web_search_query');
-                $searchResultsCount = $m->getMeta('web_search_results_count');
-                if ($searchQuery || $searchResultsCount) {
-                    $webSearchData = [
-                        'query' => $searchQuery,
-                        'resultsCount' => $searchResultsCount ? (int) $searchResultsCount : 0,
-                    ];
-
-                    $incomingMessage = $outToInMap[$m->getId()] ?? null;
-                    if ($incomingMessage) {
-                        $results = $searchResultsByMessageId[$incomingMessage->getId()] ?? [];
-                        foreach ($results as $sr) {
-                            $searchResultsData[] = [
-                                'title' => $sr->getTitle(),
-                                'url' => $sr->getUrl(),
-                                'description' => $sr->getDescription(),
-                                'published' => $sr->getPublished(),
-                                'source' => $sr->getSource(),
-                                'thumbnail' => $sr->getThumbnail(),
-                            ];
-                        }
-                    }
-                }
-            }
-
-            return [
-                'id' => $m->getId(),
-                'text' => $m->getText(),
-                'direction' => $m->getDirection(),
-                'timestamp' => $m->getUnixTimestamp(),
-                'provider' => $m->getProviderIndex(),
-                'topic' => $m->getTopic(),
-                'language' => $m->getLanguage(),
-                'createdAt' => $m->getDateTime(),
-                'aiModels' => !empty($aiModels) ? $aiModels : null,
-                'webSearch' => $webSearchData,
-                'searchResults' => !empty($searchResultsData) ? $searchResultsData : null,
-                'files' => $filesData,
-            ];
-        }, $messages);
+        // Serialize through the SAME formatter as the authenticated chat-history
+        // endpoint (issue #1070) so the guest reload path reaches full parity:
+        // task-plan cards, the `multitask` flag, generated media (video/image/
+        // audio), and background media jobs all survive a page reload. Without
+        // this the guest lost every task-plan card — most visibly the video from
+        // the "video invitation" example prompt (it only rendered live and
+        // vanished on reload). AI-generated files are public-serve
+        // (StaticUploadController) so the card media URLs load without auth.
+        $messageData = array_map(
+            fn ($m) => $this->messageApiFormatter->format($m),
+            $messages
+        );
 
         return $this->json([
             'success' => true,

--- a/frontend/src/stores/guest.ts
+++ b/frontend/src/stores/guest.ts
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
 import { getApiBaseUrl } from '@/services/api/httpClient'
+import type { ApiLoadedMessageRow } from '@/utils/messageMapper'
 
 export const GUEST_STORAGE_KEY = 'synaplan_guest_session'
 
@@ -127,29 +128,11 @@ export const useGuestStore = defineStore('guest', () => {
     }
   }
 
-  async function loadMessages(): Promise<
-    Array<{
-      id: number
-      text: string
-      direction: string
-      timestamp: number
-      provider: string | null
-      topic: string | null
-      language: string | null
-      createdAt: string | null
-      aiModels: Record<string, unknown> | null
-      webSearch: Record<string, unknown> | null
-      searchResults: Array<Record<string, unknown>> | null
-      files: Array<{
-        id: number
-        filename: string
-        fileType: string
-        filePath: string
-        fileSize: number | null
-        fileMime: string | null
-      }> | null
-    }>
-  > {
+  // Returns the canonical API message shape (same serializer as the
+  // authenticated chat-history endpoint, issue #1070) so the guest reload path
+  // can map rows through `mapApiMessageRow` and keep full parity — including
+  // task-plan cards and generated media (video/image/audio).
+  async function loadMessages(): Promise<ApiLoadedMessageRow[]> {
     if (!sessionId.value || !chatId.value) return []
 
     try {

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -382,7 +382,6 @@ import { useMessageQuoting } from '@/composables/useMessageQuoting'
 import LimitReachedModal from '@/components/common/LimitReachedModal.vue'
 import {
   useHistoryStore,
-  parseContentWithThinking,
   isTaskCardKind,
   isTaskCardState,
   type Message,
@@ -410,7 +409,11 @@ import { isChannelSource } from '@/utils/channelSource'
 import { AudioStreamer } from '@/utils/AudioStreamer'
 import { httpClient } from '@/services/api/httpClient'
 import { z } from 'zod'
-import { parseMediaJobPayload, applyMediaJobUpdateToMessage } from '@/utils/messageMapper'
+import {
+  parseMediaJobPayload,
+  applyMediaJobUpdateToMessage,
+  mapApiMessageRow,
+} from '@/utils/messageMapper'
 import type { UserMemory } from '@/services/api/userMemoriesApi'
 import { getCategories, deleteMemory as deleteMemoryApi } from '@/services/api/userMemoriesApi'
 import { deleteFeedback as deleteFeedbackApi } from '@/services/api/userFeedbackApi'
@@ -611,38 +614,11 @@ onMounted(async () => {
       const rawMessages = await guestStore.loadMessages()
       if (rawMessages.length > 0) {
         historyStore.clear()
-        const loaded: Message[] = rawMessages.map((m) => {
-          const role: 'user' | 'assistant' = m.direction === 'IN' ? 'user' : 'assistant'
-          const parts = parseContentWithThinking(m.text || '', role)
-          const models = m.aiModels as Message['aiModels']
-          const chatModel = models?.chat
-          // Attached files (e.g. AI-generated documents) so the download
-          // badge survives a page reload in guest mode.
-          const files: Message['files'] =
-            m.files && m.files.length > 0
-              ? m.files.map((f) => ({
-                  id: f.id,
-                  filename: f.filename,
-                  fileType: f.fileType,
-                  filePath: f.filePath,
-                  fileSize: f.fileSize ?? undefined,
-                  fileMime: f.fileMime ?? undefined,
-                }))
-              : undefined
-          return {
-            id: `backend-${m.id}`,
-            role,
-            parts,
-            timestamp: new Date(m.timestamp * 1000),
-            provider: chatModel?.provider ?? m.provider ?? undefined,
-            modelLabel: chatModel?.model ?? m.provider ?? (role === 'assistant' ? 'AI' : undefined),
-            backendMessageId: m.id,
-            aiModels: models ?? null,
-            webSearch: (m.webSearch as Message['webSearch']) ?? null,
-            searchResults: (m.searchResults as Message['searchResults']) ?? null,
-            files,
-          }
-        })
+        // Use the SAME row mapper as the authenticated reload path (issue
+        // #1070) so guests keep full parity: task-plan cards and generated
+        // media (video/image/audio) survive a reload instead of collapsing to
+        // the plain answer text.
+        const loaded: Message[] = rawMessages.map((m) => mapApiMessageRow(m))
         historyStore.messages.push(...loaded)
         await nextTick()
         scrollToBottom()
@@ -1824,6 +1800,96 @@ const streamAIResponse = async (
             processingMetadata.value = data.metadata || {}
           } else if (data.status === 'processing') {
             // Processing/routing — no UI update needed
+          } else if (data.status === 'plan') {
+            // Multitask routing: a multi-node plan was recognized. Render a task
+            // card per node — the same live surface authenticated users get, so
+            // a guest sees e.g. the generated video card (issue: anonymous
+            // task-plan flow). Single-node turns never emit this.
+            const message = historyStore.messages.find((m) => m.id === messageId)
+            const tasks = data.metadata?.plan
+            if (message && Array.isArray(tasks) && tasks.length > 0) {
+              processingStatus.value = ''
+              processingMetadata.value = {}
+              message.wasMultitask = true
+              message.taskPlan = {
+                active: true,
+                trackId: currentTrackId,
+                replyNode:
+                  typeof data.metadata?.reply_node === 'string' ? data.metadata.reply_node : '',
+                cards: tasks.map((t) => ({
+                  nodeId: t.node_id,
+                  capability: t.capability,
+                  kind: isTaskCardKind(t.kind) ? t.kind : 'text',
+                  state: 'pending' as const,
+                })),
+              }
+            }
+          } else if (data.status === 'plan_discarded') {
+            // The DAG failed entirely; the backend falls back to a single-bubble
+            // answer. Retract the now-misleading failed cards.
+            const message = historyStore.messages.find((m) => m.id === messageId)
+            if (message) {
+              message.taskPlan = null
+              message.wasMultitask = false
+            }
+          } else if (data.status === 'task_update') {
+            const message = historyStore.messages.find((m) => m.id === messageId)
+            const card = message?.taskPlan?.cards.find((c) => c.nodeId === data.metadata?.node_id)
+            if (card && card.state === 'cancelled') {
+              // keep cancelled — a user-cancelled step is terminal on the client
+            } else if (card && isTaskCardState(data.metadata?.state)) {
+              card.state = data.metadata.state
+              if (typeof data.metadata?.error === 'string' && data.metadata.error) {
+                card.error = data.metadata.error
+              }
+              if (typeof data.metadata?.prompt === 'string' && data.metadata.prompt) {
+                card.prompt = data.metadata.prompt
+              }
+              if (typeof data.metadata?.query === 'string' && data.metadata.query) {
+                card.query = data.metadata.query
+              }
+              if (typeof data.metadata?.results_count === 'number') {
+                card.resultsCount = data.metadata.results_count
+              }
+            }
+          } else if (data.status === 'task_chunk') {
+            const message = historyStore.messages.find((m) => m.id === messageId)
+            const card = message?.taskPlan?.cards.find((c) => c.nodeId === data.metadata?.node_id)
+            if (card && typeof data.metadata?.chunk === 'string') {
+              card.text = (card.text ?? '') + data.metadata.chunk
+            }
+          } else if (data.status === 'task_file') {
+            const message = historyStore.messages.find((m) => m.id === messageId)
+            const card = message?.taskPlan?.cards.find((c) => c.nodeId === data.metadata?.node_id)
+            if (card && typeof data.metadata?.url === 'string') {
+              card.url = normalizeMediaUrl(data.metadata.url)
+              card.mediaType =
+                typeof data.metadata?.type === 'string' ? data.metadata.type : card.kind
+            }
+          } else if (data.status === 'task_progress') {
+            const message = historyStore.messages.find((m) => m.id === messageId)
+            const card = message?.taskPlan?.cards.find((c) => c.nodeId === data.metadata?.node_id)
+            if (card && card.state !== 'cancelled') {
+              if (typeof data.metadata?.percent === 'number') {
+                card.progressPercent = data.metadata.percent
+              }
+              if (typeof data.metadata?.provider_status === 'string') {
+                card.providerStatus = data.metadata.provider_status
+              }
+              if (typeof data.metadata?.elapsed_seconds === 'number') {
+                card.elapsedSeconds = data.metadata.elapsed_seconds
+              }
+            }
+          } else if (
+            data.status === 'data' &&
+            historyStore.messages.find((m) => m.id === messageId)?.taskPlan?.active
+          ) {
+            // Multitask mode: the task cards are the live surface. Still
+            // accumulate the assembled reply text (compose_reply is hidden and
+            // has no card) so the 'complete' flush renders the answer body.
+            if (data.chunk) {
+              fullContent += data.chunk
+            }
           } else if (data.status === 'data' && data.chunk) {
             if (processingStatus.value) {
               processingStatus.value = ''
@@ -1876,6 +1942,13 @@ const streamAIResponse = async (
             const message = historyStore.messages.find((m) => m.id === messageId)
             if (message) {
               applyMediaJobToMessage(message, data.mediaJob ?? data.media_job)
+
+              // Multitask: the DAG finished — freeze the task cards (video/image/
+              // audio already carry their url via task_file) so they render as
+              // final rather than actively animating.
+              if (message.taskPlan) {
+                message.taskPlan.active = false
+              }
 
               if (data.messageId) {
                 message.backendMessageId = data.messageId


### PR DESCRIPTION
## Summary
For guest and authenticated users: video

## Changes
- Updated GuestChatController to utilize MessageApiFormatter for consistent message serialization, ensuring guests receive the same structured data as authenticated users.
- Refactored loadMessages in guest store to return ApiLoadedMessageRow[], aligning with the new serialization format.
- Adjusted ChatView to map messages using mapApiMessageRow, maintaining parity in task-plan cards and media handling for guest users.
- Enhanced handling of task cards and media generation to ensure seamless user experience during guest sessions.

## Verification
- [ ] Not tested (explain)
- [X] Manual
- [ ] Tests added/updated
