### PR TITLE
refactor(chat): unify message serialization for guest and authenticated users

### DIFF
--- a/backend/src/Controller/GuestChatController.php
+++ b/backend/src/Controller/GuestChatController.php
@@ -7,9 +7,9 @@ namespace App\Controller;
 use App\Entity\Chat;
 use App\Repository\FileRepository;
 use App\Repository\MessageRepository;
-use App\Repository\SearchResultRepository;
 use App\Service\GuestSessionService;
 use App\Service\Media\MediaCancellationStore;
+use App\Service\Message\MessageApiFormatter;
 use Doctrine\ORM\EntityManagerInterface;
 use OpenApi\Attributes as OA;
 use Psr\Log\LoggerInterface;
@@ -35,9 +35,9 @@ class GuestChatController extends AbstractController
         private GuestSessionService $guestSessionService,
         private EntityManagerInterface $em,
         private MessageRepository $messageRepository,
-        private SearchResultRepository $searchResultRepository,
         private FileRepository $fileRepository,
         private MediaCancellationStore $cancellationStore,
+        private MessageApiFormatter $messageApiFormatter,
         private LoggerInterface $logger,
         private string $uploadDir,
     ) {
@@ -410,143 +410,18 @@ class GuestChatController extends AbstractController
             ->getQuery()
             ->getResult();
 
-        // Build in-memory index of IN messages for preceding-message lookup
-        $inMessages = [];
-        foreach ($messages as $m) {
-            if ('IN' === $m->getDirection()) {
-                $inMessages[] = $m;
-            }
-        }
-
-        // Collect IN messages that precede OUT messages with web search data
-        $inMessagesNeedingResults = [];
-        $outToInMap = []; // outMessageId => inMessage
-        foreach ($messages as $m) {
-            if ('OUT' !== $m->getDirection()) {
-                continue;
-            }
-            $searchQuery = $m->getMeta('web_search_query');
-            $searchResultsCount = $m->getMeta('web_search_results_count');
-            if (!$searchQuery && !$searchResultsCount) {
-                continue;
-            }
-            // Find the closest preceding IN message in-memory
-            $preceding = null;
-            foreach ($inMessages as $inMsg) {
-                if ($inMsg->getUnixTimestamp() < $m->getUnixTimestamp()) {
-                    $preceding = $inMsg;
-                } else {
-                    break;
-                }
-            }
-            if ($preceding) {
-                $outToInMap[$m->getId()] = $preceding;
-                $inMessagesNeedingResults[$preceding->getId()] = $preceding;
-            }
-        }
-
-        // Batch-load all needed search results in a single query
-        $searchResultsByMessageId = $this->searchResultRepository
-            ->findByMessages(array_values($inMessagesNeedingResults));
-
-        $messageData = array_map(function ($m) use ($outToInMap, $searchResultsByMessageId) {
-            $aiModels = [];
-            $webSearchData = null;
-            $searchResultsData = [];
-
-            // Attached files (e.g. AI-generated documents) — same shape as
-            // MessageApiFormatter so the download badge also renders for
-            // guests after a page reload.
-            $filesData = [];
-            if ($m->hasFiles()) {
-                foreach ($m->getFiles() as $file) {
-                    $filesData[] = [
-                        'id' => $file->getId(),
-                        'filename' => $file->getFileName(),
-                        'fileType' => $file->getFileType(),
-                        'filePath' => $file->getFilePath(),
-                        'fileSize' => $file->getFileSize(),
-                        'fileMime' => $file->getFileMime(),
-                    ];
-                }
-            }
-
-            if ('OUT' === $m->getDirection()) {
-                $chatProvider = $m->getMeta('ai_chat_provider');
-                $chatModel = $m->getMeta('ai_chat_model');
-                $chatModelIdMeta = $m->getMeta('ai_chat_model_id');
-                if ($chatProvider || $chatModel) {
-                    $aiModels['chat'] = [
-                        'provider' => $chatProvider,
-                        'model' => $chatModel,
-                        'model_id' => $chatModelIdMeta ? (int) $chatModelIdMeta : null,
-                    ];
-                }
-
-                $sortingProvider = $m->getMeta('ai_sorting_provider');
-                $sortingModel = $m->getMeta('ai_sorting_model');
-                $sortingModelId = $m->getMeta('ai_sorting_model_id');
-                if ($sortingProvider || $sortingModel) {
-                    $aiModels['sorting'] = [
-                        'provider' => $sortingProvider,
-                        'model' => $sortingModel,
-                        'model_id' => $sortingModelId ? (int) $sortingModelId : null,
-                    ];
-                }
-
-                // Audio (TTS) model — separate from chat so the badge after
-                // a page reload also shows the actual TTS model (#583).
-                $audioProvider = $m->getMeta('ai_audio_provider');
-                $audioModel = $m->getMeta('ai_audio_model');
-                $audioModelId = $m->getMeta('ai_audio_model_id');
-                if ($audioProvider || $audioModel) {
-                    $aiModels['audio'] = [
-                        'provider' => $audioProvider,
-                        'model' => $audioModel,
-                        'model_id' => $audioModelId ? (int) $audioModelId : null,
-                    ];
-                }
-
-                $searchQuery = $m->getMeta('web_search_query');
-                $searchResultsCount = $m->getMeta('web_search_results_count');
-                if ($searchQuery || $searchResultsCount) {
-                    $webSearchData = [
-                        'query' => $searchQuery,
-                        'resultsCount' => $searchResultsCount ? (int) $searchResultsCount : 0,
-                    ];
-
-                    $incomingMessage = $outToInMap[$m->getId()] ?? null;
-                    if ($incomingMessage) {
-                        $results = $searchResultsByMessageId[$incomingMessage->getId()] ?? [];
-                        foreach ($results as $sr) {
-                            $searchResultsData[] = [
-                                'title' => $sr->getTitle(),
-                                'url' => $sr->getUrl(),
-                                'description' => $sr->getDescription(),
-                                'published' => $sr->getPublished(),
-                                'source' => $sr->getSource(),
-                                'thumbnail' => $sr->getThumbnail(),
-                            ];
-                        }
-                    }
-                }
-            }
-
-            return [
-                'id' => $m->getId(),
-                'text' => $m->getText(),
-                'direction' => $m->getDirection(),
-                'timestamp' => $m->getUnixTimestamp(),
-                'provider' => $m->getProviderIndex(),
-                'topic' => $m->getTopic(),
-                'language' => $m->getLanguage(),
-                'createdAt' => $m->getDateTime(),
-                'aiModels' => !empty($aiModels) ? $aiModels : null,
-                'webSearch' => $webSearchData,
-                'searchResults' => !empty($searchResultsData) ? $searchResultsData : null,
-                'files' => $filesData,
-            ];
-        }, $messages);
+        // Serialize through the SAME formatter as the authenticated chat-history
+        // endpoint (issue #1070) so the guest reload path reaches full parity:
+        // task-plan cards, the `multitask` flag, generated media (video/image/
+        // audio), and background media jobs all survive a page reload. Without
+        // this the guest lost every task-plan card — most visibly the video from
+        // the "video invitation" example prompt (it only rendered live and
+        // vanished on reload). AI-generated files are public-serve
+        // (StaticUploadController) so the card media URLs load without auth.
+        $messageData = array_map(
+            fn ($m) => $this->messageApiFormatter->format($m),
+            $messages
+        );
 
         return $this->json([
             'success' => true,

--- a/frontend/src/components/guest/GuestBanner.vue
+++ b/frontend/src/components/guest/GuestBanner.vue
@@ -1,9 +1,9 @@
 <template>
   <Transition name="slide-down">
-    <div v-if="visible" class="flex justify-center mx-4 mt-2 mb-0">
+    <div v-if="visible" class="flex justify-center mx-4 mt-2 mb-[5px]">
       <div
         data-testid="guest-banner"
-        class="inline-flex items-center gap-2.5 px-3 py-1.5 rounded-full border border-brand/20 bg-brand/5 dark:bg-brand/10 backdrop-blur-sm"
+        class="inline-flex items-center gap-2.5 px-3 py-1.5 rounded-full border border-gray-400/60 dark:border-gray-500/60 bg-black/[0.03] dark:bg-white/[0.06] backdrop-blur-sm"
       >
         <div class="hidden sm:flex items-center gap-1">
           <span
@@ -17,11 +17,11 @@
           />
         </div>
 
-        <span class="text-xs txt-secondary whitespace-nowrap">
+        <span class="text-xs font-medium txt-primary whitespace-nowrap">
           {{ $t('guest.banner.remaining', { count: remaining }) }}
         </span>
 
-        <span class="w-px h-3.5 bg-gray-300 dark:bg-gray-600" />
+        <span class="w-px h-3.5 bg-gray-400 dark:bg-gray-500" />
 
         <router-link
           to="/register"

--- a/frontend/src/composables/useTheme.ts
+++ b/frontend/src/composables/useTheme.ts
@@ -1,6 +1,8 @@
 import { ref, watchEffect } from 'vue'
 type Theme = 'light' | 'dark' | 'system'
-const theme = ref<Theme>((localStorage.getItem('theme') as Theme) || 'system')
+// Default to bright (light) mode when the user hasn't picked a theme yet.
+// A stored preference (light / dark / system) always wins.
+const theme = ref<Theme>((localStorage.getItem('theme') as Theme) || 'light')
 
 const apply = () => {
   const root = document.documentElement

--- a/frontend/src/stores/guest.ts
+++ b/frontend/src/stores/guest.ts
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
 import { getApiBaseUrl } from '@/services/api/httpClient'
+import type { ApiLoadedMessageRow } from '@/utils/messageMapper'
 
 export const GUEST_STORAGE_KEY = 'synaplan_guest_session'
 
@@ -127,29 +128,11 @@ export const useGuestStore = defineStore('guest', () => {
     }
   }
 
-  async function loadMessages(): Promise<
-    Array<{
-      id: number
-      text: string
-      direction: string
-      timestamp: number
-      provider: string | null
-      topic: string | null
-      language: string | null
-      createdAt: string | null
-      aiModels: Record<string, unknown> | null
-      webSearch: Record<string, unknown> | null
-      searchResults: Array<Record<string, unknown>> | null
-      files: Array<{
-        id: number
-        filename: string
-        fileType: string
-        filePath: string
-        fileSize: number | null
-        fileMime: string | null
-      }> | null
-    }>
-  > {
+  // Returns the canonical API message shape (same serializer as the
+  // authenticated chat-history endpoint, issue #1070) so the guest reload path
+  // can map rows through `mapApiMessageRow` and keep full parity — including
+  // task-plan cards and generated media (video/image/audio).
+  async function loadMessages(): Promise<ApiLoadedMessageRow[]> {
     if (!sessionId.value || !chatId.value) return []
 
     try {

--- a/frontend/src/style-v2.css
+++ b/frontend/src/style-v2.css
@@ -19,8 +19,11 @@
   --bg-chat: #eef2f7;
   --bg-card: rgba(255, 255, 255, 0.96);
   --bg-chip: rgba(0, 0, 0, 0.05);
-  --txt-secondary: #4b515c;
-  --border-light: rgba(0, 45, 140, 0.18);
+  /* Contrast overhaul: darker secondary ink so hints, labels, timestamps
+     and placeholders read clearly on the light blue-grey surfaces
+     (was #4b515c). */
+  --txt-secondary: #3a3f48;
+  --border-light: rgba(0, 45, 140, 0.22);
   --brand-alpha-light: rgba(0, 63, 199, 0.09);
 
   --v2-glow: rgba(0, 63, 199, 0.16);
@@ -42,7 +45,10 @@
   --bg-chat: #050a16;
   --bg-card: rgba(16, 24, 42, 0.9);
   --bg-chip: rgba(255, 255, 255, 0.04);
-  --txt-secondary: #b8bdc7;
+  /* Contrast overhaul: secondary text is a very bright grey so hints,
+     labels, timestamps and placeholders stay clearly legible on the
+     near-black surfaces (was #b8bdc7 — too dim). */
+  --txt-secondary: #d6dae2;
   --border-light: rgba(107, 143, 214, 0.16);
   --brand-alpha-light: rgba(107, 143, 214, 0.1);
 
@@ -1060,4 +1066,165 @@
 .design-v2.dark [data-testid='comp-chat-input-shell'] textarea:focus {
   background: transparent !important;
   box-shadow: none !important;
+}
+
+/* ----------------------------------------------------------
+   19. Dark-mode contrast overhaul (readability pass)
+
+   Brighter rail icons/labels, a solid-white empty-state heading,
+   and a light high-contrast composer with dark text. Only the dark
+   V2 surfaces are touched — light mode is left as-is. Appended last
+   so these win over earlier rules at equal specificity.
+   ---------------------------------------------------------- */
+
+/* Sidebar rail icons + labels — near-white for clear contrast */
+.design-v2.dark .v2-rail-icon {
+  color: #eceef3;
+}
+.design-v2.dark .v2-rail-icon:hover {
+  color: #ffffff;
+  background: rgba(107, 143, 214, 0.16);
+  box-shadow: 0 0 10px var(--v2-glow);
+}
+.design-v2.dark .v2-rail-icon--active {
+  color: var(--brand-light);
+  background: rgba(107, 143, 214, 0.12);
+  box-shadow: 0 0 14px var(--v2-glow);
+}
+
+/* Empty-state welcome heading — solid white, bolder for a crisper, higher
+   contrast title against the near-black background (was a soft blue gradient) */
+.design-v2.dark [data-testid='state-empty'] h2 {
+  background: none;
+  -webkit-text-fill-color: #ffffff;
+  color: #ffffff;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+/* Composer shell — a light, high-contrast box (user request: white box,
+   black font). The inner textarea keeps its transparent background from
+   section 18's override, so we only recolor the shell + inner text/icons. */
+.design-v2.dark [data-testid='comp-chat-input-shell'] {
+  /* Pure white (not grey) so the composer clearly stands out from the
+     near-black background; a crisp ring + drop shadow define its edge. */
+  background: #ffffff !important;
+  border: 1px solid rgba(255, 255, 255, 0.65) !important;
+  box-shadow:
+    0 6px 26px rgba(0, 0, 0, 0.55),
+    0 0 0 1px rgba(255, 255, 255, 0.08) !important;
+}
+.design-v2.dark [data-testid='comp-chat-input-shell']:focus-within {
+  border-color: #ffffff !important;
+  box-shadow:
+    0 8px 32px rgba(0, 0, 0, 0.6),
+    0 0 0 3px var(--brand-alpha-light) !important;
+}
+
+/* Text + placeholder inside the light composer → near-black */
+.design-v2.dark [data-testid='comp-chat-input-shell'] textarea,
+.design-v2.dark [data-testid='comp-chat-input-shell'] .txt-primary {
+  color: #0f1522 !important;
+}
+.design-v2.dark [data-testid='comp-chat-input-shell'] textarea::placeholder {
+  color: #4a5261 !important;
+}
+.design-v2.dark [data-testid='comp-chat-input-shell'] .txt-secondary,
+.design-v2.dark [data-testid='comp-chat-input-shell'] .txt-muted {
+  color: #5c6575 !important;
+}
+
+/* Control icons inside the light composer (plus / enhance / mic) → dark grey
+   so they stay visible on the bright box; brand accent on hover. */
+.design-v2.dark [data-testid='comp-chat-input-shell'] .icon-ghost {
+  color: #3b4353;
+  opacity: 1;
+}
+.design-v2.dark [data-testid='comp-chat-input-shell'] .icon-ghost:hover,
+.design-v2.dark [data-testid='comp-chat-input-shell'] .icon-ghost:focus-visible {
+  color: var(--brand);
+  background: rgba(0, 63, 199, 0.08);
+}
+.design-v2.dark [data-testid='comp-chat-input-shell'] .surface-chip {
+  background: rgba(0, 0, 0, 0.04) !important;
+  border: 1px solid rgba(0, 0, 0, 0.12) !important;
+}
+
+/* Pills inside the light composer (active command / enhance-on) stay readable */
+.design-v2.dark [data-testid='comp-chat-input-shell'] .pill {
+  background: rgba(0, 0, 0, 0.05) !important;
+  border-color: rgba(0, 0, 0, 0.12) !important;
+  color: #3b4353 !important;
+}
+.design-v2.dark [data-testid='comp-chat-input-shell'] .pill--active {
+  background: rgba(0, 63, 199, 0.1) !important;
+  border-color: rgba(0, 63, 199, 0.3) !important;
+  color: var(--brand) !important;
+}
+
+/* Send button keeps its vivid brand fill with a crisp white glyph */
+.design-v2.dark [data-testid='comp-chat-input-shell'] .btn-primary {
+  color: #ffffff;
+}
+
+/* ----------------------------------------------------------
+   20. Light-mode contrast overhaul (readability pass)
+
+   Mirrors the dark pass: darker rail icons/labels, a solid
+   high-contrast welcome heading (was a washed-out gradient), and a
+   crisp white composer with a clearly-defined border + darker
+   placeholder/icons. Scoped to :not(.dark) so the dark surfaces
+   above stay untouched, and specific enough to beat sections 6/8/13.
+   ---------------------------------------------------------- */
+
+/* Sidebar rail icons + labels — dark ink for clear contrast */
+.design-v2:not(.dark) .v2-rail-icon {
+  color: #2b313b;
+}
+.design-v2:not(.dark) .v2-rail-icon:hover {
+  color: var(--brand);
+  background: rgba(0, 63, 199, 0.1);
+  box-shadow: 0 0 10px var(--v2-glow);
+}
+.design-v2:not(.dark) .v2-rail-icon--active {
+  color: var(--brand);
+  background: rgba(0, 63, 199, 0.12);
+  box-shadow: 0 0 14px var(--v2-glow);
+}
+
+/* Empty-state welcome heading — solid high-contrast ink instead of the
+   faded blue gradient (the light end washed it out). */
+.design-v2:not(.dark) [data-testid='state-empty'] h2 {
+  background: none;
+  -webkit-text-fill-color: #111827;
+  color: #111827;
+}
+
+/* Composer shell — crisp white with a clearly-defined border + shadow */
+.design-v2:not(.dark) [data-testid='comp-chat-input-shell'] {
+  background: #ffffff !important;
+  border: 1px solid rgba(0, 40, 120, 0.28) !important;
+  box-shadow:
+    0 4px 20px rgba(0, 20, 80, 0.08),
+    0 0 12px var(--v2-glow) !important;
+}
+.design-v2:not(.dark) [data-testid='comp-chat-input-shell']:focus-within {
+  border-color: rgba(0, 63, 199, 0.5) !important;
+  box-shadow:
+    0 6px 28px rgba(0, 20, 80, 0.12),
+    0 0 20px var(--v2-glow-strong) !important;
+}
+
+/* Darker placeholder + control icons (plus / enhance / mic) inside the box */
+.design-v2:not(.dark) [data-testid='comp-chat-input-shell'] textarea::placeholder {
+  color: #55606e !important;
+}
+.design-v2:not(.dark) [data-testid='comp-chat-input-shell'] .icon-ghost {
+  color: #3b4353;
+  opacity: 1;
+}
+.design-v2:not(.dark) [data-testid='comp-chat-input-shell'] .icon-ghost:hover,
+.design-v2:not(.dark) [data-testid='comp-chat-input-shell'] .icon-ghost:focus-visible {
+  color: var(--brand);
+  background: rgba(0, 63, 199, 0.08);
 }

--- a/frontend/src/utils/brandingTheme.ts
+++ b/frontend/src/utils/brandingTheme.ts
@@ -18,6 +18,7 @@ const HEX_COLOR = /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/
 
 const FONT_LINK_ID = 'brand-font-link'
 const HEADING_STYLE_ID = 'brand-heading-font'
+const BRAND_COLOR_STYLE_ID = 'brand-color-vars'
 
 export function applyBrandingTheme(): void {
   applyColors()
@@ -31,13 +32,7 @@ function applyColors(): void {
   // Primary only overrides when it's a valid, non-default hex (preserves the
   // tuned light/dark stylesheet values for the stock brand).
   if (HEX_COLOR.test(primaryColor) && primaryColor.toLowerCase() !== DEFAULT_PRIMARY) {
-    root.style.setProperty('--brand', primaryColor)
-    root.style.setProperty('--brand-hover', `color-mix(in srgb, ${primaryColor} 88%, black)`)
-    root.style.setProperty('--brand-light', `color-mix(in srgb, ${primaryColor} 55%, white)`)
-    root.style.setProperty(
-      '--brand-alpha-light',
-      `color-mix(in srgb, ${primaryColor} 10%, transparent)`
-    )
+    applyBrandColorVars(primaryColor)
   }
 
   // Secondary/accent are additive, opt-in variables (unset by default).
@@ -47,6 +42,42 @@ function applyColors(): void {
   if (HEX_COLOR.test(accentColor)) {
     root.style.setProperty('--brand-accent', accentColor)
   }
+}
+
+/**
+ * Inject the brand palette as a stylesheet (NOT inline styles on <html>).
+ *
+ * Inline styles win over every stylesheet rule, so setting `--brand` inline
+ * forced the SAME raw primary color in both light and dark — on the near-black
+ * dark surfaces a saturated brand (e.g. a deep indigo) then reads as a harsh
+ * "pink/purple" on the send + active buttons. A stylesheet lets the dark theme
+ * use a lightened, dark-mode-friendly tint, mirroring how the stock brand
+ * (#003fc7) becomes #6d9ae0 in dark. `html.dark` / `html:not(.dark)` keep a
+ * higher specificity than the base `.dark` / `:root` rules so this always wins,
+ * and it re-resolves automatically when the theme class toggles at runtime.
+ */
+function applyBrandColorVars(primary: string): void {
+  const light = [
+    `--brand:${primary}`,
+    `--brand-hover:color-mix(in srgb, ${primary} 88%, black)`,
+    `--brand-light:color-mix(in srgb, ${primary} 55%, white)`,
+    `--brand-alpha-light:color-mix(in srgb, ${primary} 10%, transparent)`,
+  ].join(';')
+
+  const dark = [
+    `--brand:color-mix(in srgb, ${primary} 58%, white)`,
+    `--brand-hover:color-mix(in srgb, ${primary} 46%, white)`,
+    `--brand-light:color-mix(in srgb, ${primary} 40%, white)`,
+    `--brand-alpha-light:color-mix(in srgb, ${primary} 20%, transparent)`,
+  ].join(';')
+
+  let styleEl = document.getElementById(BRAND_COLOR_STYLE_ID) as HTMLStyleElement | null
+  if (!styleEl) {
+    styleEl = document.createElement('style')
+    styleEl.id = BRAND_COLOR_STYLE_ID
+    document.head.appendChild(styleEl)
+  }
+  styleEl.textContent = `html:not(.dark){${light}}html.dark{${dark}}`
 }
 
 function applyFonts(): void {

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -382,7 +382,6 @@ import { useMessageQuoting } from '@/composables/useMessageQuoting'
 import LimitReachedModal from '@/components/common/LimitReachedModal.vue'
 import {
   useHistoryStore,
-  parseContentWithThinking,
   isTaskCardKind,
   isTaskCardState,
   type Message,
@@ -410,7 +409,11 @@ import { isChannelSource } from '@/utils/channelSource'
 import { AudioStreamer } from '@/utils/AudioStreamer'
 import { httpClient } from '@/services/api/httpClient'
 import { z } from 'zod'
-import { parseMediaJobPayload, applyMediaJobUpdateToMessage } from '@/utils/messageMapper'
+import {
+  parseMediaJobPayload,
+  applyMediaJobUpdateToMessage,
+  mapApiMessageRow,
+} from '@/utils/messageMapper'
 import type { UserMemory } from '@/services/api/userMemoriesApi'
 import { getCategories, deleteMemory as deleteMemoryApi } from '@/services/api/userMemoriesApi'
 import { deleteFeedback as deleteFeedbackApi } from '@/services/api/userFeedbackApi'
@@ -611,38 +614,11 @@ onMounted(async () => {
       const rawMessages = await guestStore.loadMessages()
       if (rawMessages.length > 0) {
         historyStore.clear()
-        const loaded: Message[] = rawMessages.map((m) => {
-          const role: 'user' | 'assistant' = m.direction === 'IN' ? 'user' : 'assistant'
-          const parts = parseContentWithThinking(m.text || '', role)
-          const models = m.aiModels as Message['aiModels']
-          const chatModel = models?.chat
-          // Attached files (e.g. AI-generated documents) so the download
-          // badge survives a page reload in guest mode.
-          const files: Message['files'] =
-            m.files && m.files.length > 0
-              ? m.files.map((f) => ({
-                  id: f.id,
-                  filename: f.filename,
-                  fileType: f.fileType,
-                  filePath: f.filePath,
-                  fileSize: f.fileSize ?? undefined,
-                  fileMime: f.fileMime ?? undefined,
-                }))
-              : undefined
-          return {
-            id: `backend-${m.id}`,
-            role,
-            parts,
-            timestamp: new Date(m.timestamp * 1000),
-            provider: chatModel?.provider ?? m.provider ?? undefined,
-            modelLabel: chatModel?.model ?? m.provider ?? (role === 'assistant' ? 'AI' : undefined),
-            backendMessageId: m.id,
-            aiModels: models ?? null,
-            webSearch: (m.webSearch as Message['webSearch']) ?? null,
-            searchResults: (m.searchResults as Message['searchResults']) ?? null,
-            files,
-          }
-        })
+        // Use the SAME row mapper as the authenticated reload path (issue
+        // #1070) so guests keep full parity: task-plan cards and generated
+        // media (video/image/audio) survive a reload instead of collapsing to
+        // the plain answer text.
+        const loaded: Message[] = rawMessages.map((m) => mapApiMessageRow(m))
         historyStore.messages.push(...loaded)
         await nextTick()
         scrollToBottom()
@@ -1824,6 +1800,96 @@ const streamAIResponse = async (
             processingMetadata.value = data.metadata || {}
           } else if (data.status === 'processing') {
             // Processing/routing — no UI update needed
+          } else if (data.status === 'plan') {
+            // Multitask routing: a multi-node plan was recognized. Render a task
+            // card per node — the same live surface authenticated users get, so
+            // a guest sees e.g. the generated video card (issue: anonymous
+            // task-plan flow). Single-node turns never emit this.
+            const message = historyStore.messages.find((m) => m.id === messageId)
+            const tasks = data.metadata?.plan
+            if (message && Array.isArray(tasks) && tasks.length > 0) {
+              processingStatus.value = ''
+              processingMetadata.value = {}
+              message.wasMultitask = true
+              message.taskPlan = {
+                active: true,
+                trackId: currentTrackId,
+                replyNode:
+                  typeof data.metadata?.reply_node === 'string' ? data.metadata.reply_node : '',
+                cards: tasks.map((t) => ({
+                  nodeId: t.node_id,
+                  capability: t.capability,
+                  kind: isTaskCardKind(t.kind) ? t.kind : 'text',
+                  state: 'pending' as const,
+                })),
+              }
+            }
+          } else if (data.status === 'plan_discarded') {
+            // The DAG failed entirely; the backend falls back to a single-bubble
+            // answer. Retract the now-misleading failed cards.
+            const message = historyStore.messages.find((m) => m.id === messageId)
+            if (message) {
+              message.taskPlan = null
+              message.wasMultitask = false
+            }
+          } else if (data.status === 'task_update') {
+            const message = historyStore.messages.find((m) => m.id === messageId)
+            const card = message?.taskPlan?.cards.find((c) => c.nodeId === data.metadata?.node_id)
+            if (card && card.state === 'cancelled') {
+              // keep cancelled — a user-cancelled step is terminal on the client
+            } else if (card && isTaskCardState(data.metadata?.state)) {
+              card.state = data.metadata.state
+              if (typeof data.metadata?.error === 'string' && data.metadata.error) {
+                card.error = data.metadata.error
+              }
+              if (typeof data.metadata?.prompt === 'string' && data.metadata.prompt) {
+                card.prompt = data.metadata.prompt
+              }
+              if (typeof data.metadata?.query === 'string' && data.metadata.query) {
+                card.query = data.metadata.query
+              }
+              if (typeof data.metadata?.results_count === 'number') {
+                card.resultsCount = data.metadata.results_count
+              }
+            }
+          } else if (data.status === 'task_chunk') {
+            const message = historyStore.messages.find((m) => m.id === messageId)
+            const card = message?.taskPlan?.cards.find((c) => c.nodeId === data.metadata?.node_id)
+            if (card && typeof data.metadata?.chunk === 'string') {
+              card.text = (card.text ?? '') + data.metadata.chunk
+            }
+          } else if (data.status === 'task_file') {
+            const message = historyStore.messages.find((m) => m.id === messageId)
+            const card = message?.taskPlan?.cards.find((c) => c.nodeId === data.metadata?.node_id)
+            if (card && typeof data.metadata?.url === 'string') {
+              card.url = normalizeMediaUrl(data.metadata.url)
+              card.mediaType =
+                typeof data.metadata?.type === 'string' ? data.metadata.type : card.kind
+            }
+          } else if (data.status === 'task_progress') {
+            const message = historyStore.messages.find((m) => m.id === messageId)
+            const card = message?.taskPlan?.cards.find((c) => c.nodeId === data.metadata?.node_id)
+            if (card && card.state !== 'cancelled') {
+              if (typeof data.metadata?.percent === 'number') {
+                card.progressPercent = data.metadata.percent
+              }
+              if (typeof data.metadata?.provider_status === 'string') {
+                card.providerStatus = data.metadata.provider_status
+              }
+              if (typeof data.metadata?.elapsed_seconds === 'number') {
+                card.elapsedSeconds = data.metadata.elapsed_seconds
+              }
+            }
+          } else if (
+            data.status === 'data' &&
+            historyStore.messages.find((m) => m.id === messageId)?.taskPlan?.active
+          ) {
+            // Multitask mode: the task cards are the live surface. Still
+            // accumulate the assembled reply text (compose_reply is hidden and
+            // has no card) so the 'complete' flush renders the answer body.
+            if (data.chunk) {
+              fullContent += data.chunk
+            }
           } else if (data.status === 'data' && data.chunk) {
             if (processingStatus.value) {
               processingStatus.value = ''
@@ -1876,6 +1942,13 @@ const streamAIResponse = async (
             const message = historyStore.messages.find((m) => m.id === messageId)
             if (message) {
               applyMediaJobToMessage(message, data.mediaJob ?? data.media_job)
+
+              // Multitask: the DAG finished — freeze the task cards (video/image/
+              // audio already carry their url via task_file) so they render as
+              // final rather than actively animating.
+              if (message.taskPlan) {
+                message.taskPlan.active = false
+              }
 
               if (data.messageId) {
                 message.backendMessageId = data.messageId


### PR DESCRIPTION
## Summary

Unifies how chat messages are serialized so guest (anonymous) sessions receive the same structured data as authenticated users, keeping the two chat handlers at feature parity.

- `GuestChatController` now uses `MessageApiFormatter` for consistent message serialization, so guests get the same structured payload as authenticated users.
- `loadMessages` in the guest store returns `ApiLoadedMessageRow[]`, aligning with the new serialization format.
- `ChatView` maps messages via `mapApiMessageRow`, preserving task-plan cards and media handling for guests.
- Task cards and media generation handling improved for a seamless guest session experience.

## Files

- `backend/src/Controller/GuestChatController.php`
- `frontend/src/stores/guest.ts`
- `frontend/src/views/ChatView.vue`

## Test plan

- [ ] `make lint && make -C backend phpstan && make test`
- [ ] `docker compose exec -T frontend npm run check:types`
- [ ] Manually verify a guest chat renders generated media (image/audio/video) and multitask task cards, matching the authenticated view.