### PR TITLE
fix(e2e): handle genuine mobile click miss with clean toPass retry

### DIFF
--- a/frontend/tests/e2e/tests/chat-input.spec.ts
+++ b/frontend/tests/e2e/tests/chat-input.spec.ts
@@ -15,21 +15,47 @@ import { TIMEOUTS } from '../config/config'
 
 const CHAT = selectors.chat
 
-/** Open the "+" menu and wait for its content to settle. */
+/**
+ * Open the "+" menu and wait for its content to settle.
+ *
+ * On mobile, touch event normalization can swallow a single click on the
+ * toggle (the handler IS wired up, but the browser discards the pointer event
+ * during layout shifts). We retry the click via toPass() — but unlike the old
+ * helper, we never mask failures with .catch(() => false).
+ */
 async function openPlusMenu(page: Page) {
   const panel = page.locator(CHAT.plusPanel)
   if (await panel.isVisible()) return panel
-  await page.locator(CHAT.plusToggle).click()
-  await expect(panel).toBeVisible({ timeout: TIMEOUTS.STANDARD })
+
+  const toggle = page.locator(CHAT.plusToggle)
+  await expect(toggle).toBeVisible({ timeout: TIMEOUTS.STANDARD })
+
+  await expect(async () => {
+    if (await panel.isVisible()) return
+    await toggle.click()
+    await expect(panel).toBeVisible({ timeout: 2000 })
+  }).toPass({ timeout: TIMEOUTS.STANDARD })
+
   await expect(panel.locator(CHAT.attachBtn)).toBeVisible({ timeout: TIMEOUTS.SHORT })
   return panel
 }
 
-/** Open the Tools dropdown inside the "+" menu and wait for it to settle. */
+/**
+ * Open the Tools dropdown inside the "+" menu and wait for it to settle.
+ * Same retry rationale as openPlusMenu — the tools toggle can also miss on mobile.
+ */
 async function openToolsDropdown(page: Page) {
   await openPlusMenu(page)
-  await page.locator(CHAT.toolsToggle).click()
-  await expect(page.locator(CHAT.toolsPanel)).toBeVisible({ timeout: TIMEOUTS.SHORT })
+
+  const toolsPanel = page.locator(CHAT.toolsPanel)
+  const toolsToggle = page.locator(CHAT.toolsToggle)
+  await expect(toolsToggle).toBeVisible({ timeout: TIMEOUTS.SHORT })
+
+  await expect(async () => {
+    if (await toolsPanel.isVisible()) return
+    await toolsToggle.click()
+    await expect(toolsPanel).toBeVisible({ timeout: 2000 })
+  }).toPass({ timeout: TIMEOUTS.STANDARD })
 }
 
 test.describe('Chat input: "+" menu (§5)', () => {
@@ -92,7 +118,9 @@ test.describe('Chat input: "+" menu (§5)', () => {
     const isMobile = (page.viewportSize()?.width ?? 1280) < 768
 
     // The control only appears once there is text to act on.
-    await page.locator(CHAT.textInput).fill('Wo wohnt der Esel?')
+    const input = page.locator(CHAT.textInput)
+    await input.fill('Wo wohnt der Esel?')
+    await expect(input).toHaveValue('Wo wohnt der Esel?', { timeout: TIMEOUTS.SHORT })
 
     if (isMobile) {
       // No in-shell sparkles button crowding the narrow input…
@@ -101,7 +129,7 @@ test.describe('Chat input: "+" menu (§5)', () => {
       await openToolsDropdown(page)
       await expect(page.locator(CHAT.toolEnhance)).toBeVisible({ timeout: TIMEOUTS.SHORT })
     } else {
-      await expect(page.locator(CHAT.enhanceButton)).toBeVisible({ timeout: TIMEOUTS.SHORT })
+      await expect(page.locator(CHAT.enhanceButton)).toBeVisible({ timeout: TIMEOUTS.STANDARD })
       await openToolsDropdown(page)
       await expect(page.locator(CHAT.toolEnhance)).toBeHidden()
     }

--- a/frontend/tests/e2e/tests/layout.spec.ts
+++ b/frontend/tests/e2e/tests/layout.spec.ts
@@ -242,12 +242,16 @@ test.describe('@ci @layout UI guard — chat surface', () => {
     await login(page, credentials)
     await ensureAdvancedMode(page)
 
-    // Wait for the chat input to be hydrated before interacting with the "+" menu.
     const toggle = page.locator(CHAT.plusToggle)
     await expect(toggle).toBeVisible({ timeout: TIMEOUTS.STANDARD })
-    await toggle.click()
+
+    // On mobile, the first click can be swallowed during layout shifts.
     const panel = page.locator(CHAT.plusPanel)
-    await expect(panel).toBeVisible({ timeout: TIMEOUTS.STANDARD })
+    await expect(async () => {
+      if (await panel.isVisible()) return
+      await toggle.click()
+      await expect(panel).toBeVisible({ timeout: 2000 })
+    }).toPass({ timeout: TIMEOUTS.STANDARD })
 
     // Contract: the menu picks context / toggles behaviour but never navigates —
     // so the panel itself must contain no link elements (navigation lives inside

--- a/frontend/tests/e2e/tests/multitask.spec.ts
+++ b/frontend/tests/e2e/tests/multitask.spec.ts
@@ -195,8 +195,13 @@ test.describe('@ci @multitask Multi-task routing', () => {
     const openPlusMenu = async () => {
       const panel = page.locator(selectors.chat.plusPanel)
       if (await panel.isVisible()) return
-      await page.locator(selectors.chat.plusToggle).click()
-      await panel.waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
+      const toggle = page.locator(selectors.chat.plusToggle)
+      await expect(toggle).toBeVisible({ timeout: TIMEOUTS.STANDARD })
+      await expect(async () => {
+        if (await panel.isVisible()) return
+        await toggle.click()
+        await expect(panel).toBeVisible({ timeout: 2000 })
+      }).toPass({ timeout: TIMEOUTS.STANDARD })
       await expect(page.locator(selectors.chat.attachBtn)).toBeVisible({
         timeout: TIMEOUTS.SHORT,
       })


### PR DESCRIPTION
## Summary

Follow-up to #1264 — the E2E plus-menu tests still failed on main after merge because:

1. **Mobile click miss**: Touch event normalization can discard the pointer event during layout shifts. A single `click()` + long wait will never succeed in these cases. Fixed with a clean `toPass()` retry (no `.catch(() => false)` error masking).

2. **Enhance button race**: After `fill()`, the Vue computed (`showEnhanceInInput`) needs a reactivity tick. Confirmed the v-model propagated with `toHaveValue()` and bumped the button assertion to `STANDARD` timeout.

Pattern applied consistently across: `chat-input.spec.ts`, `layout.spec.ts`, `multitask.spec.ts`.

### Key difference from the previous approach
- Toggle visibility verified BEFORE the retry loop (§3 compliant)
- NO `.catch(() => false)` anywhere — real errors surface immediately
- Content-settle wait (`attachBtn` visible) confirms panel is interactive
- Explicit `isVisible()` guard prevents accidentally toggling panel back shut

## Test plan

- [x] CI must pass: E2E chromium, chromium-mobile, firefox
- [x] Flaky `multitask.spec.ts` TTS test stabilized by same pattern