### PR TITLE
fix(e2e): stabilize admin impersonation test

### DIFF
--- a/frontend/tests/e2e/tests/admin-impersonation-chat.spec.ts
+++ b/frontend/tests/e2e/tests/admin-impersonation-chat.spec.ts
@@ -33,10 +33,10 @@ test.describe('@ci @smoke Admin impersonation + chat', () => {
       await login(page, adminCreds)
 
       await page.locator(selectors.nav.sidebarV2Admin).click()
-      await page
-        .locator(selectors.nav.navDropdown)
-        .locator(selectors.nav.flyoutLinkAdminDashboard)
-        .click()
+      const dropdown = page.locator(selectors.nav.navDropdown)
+      await expect(dropdown).toBeVisible({ timeout: TIMEOUTS.SHORT })
+      await dropdown.locator(selectors.nav.flyoutLinkAdminDashboard).click()
+
       await page.locator(selectors.pages.admin).waitFor({
         state: 'visible',
         timeout: TIMEOUTS.STANDARD,
@@ -85,13 +85,13 @@ test.describe('@ci @smoke Admin impersonation + chat', () => {
 
       await page
         .locator(selectors.impersonation.banner)
-        .waitFor({ state: 'hidden', timeout: TIMEOUTS.STANDARD })
+        .waitFor({ state: 'hidden', timeout: TIMEOUTS.LONG })
     })
 
     await test.step('Assert: admin session restored — admin page visible', async () => {
       await page.locator(selectors.pages.admin).waitFor({
         state: 'visible',
-        timeout: TIMEOUTS.STANDARD,
+        timeout: TIMEOUTS.LONG,
       })
     })
   })


### PR DESCRIPTION
## Summary

- Fixes intermittent flakiness in the admin impersonation E2E test (marked "flaky" in recent CI runs)
- Two §3 violations identified and fixed:
  1. **Flyout menu race**: clicked the admin-dashboard link inside the nav dropdown without waiting for the dropdown to render first
  2. **Post-impersonation timeout**: session refresh + navigation after exiting impersonation needs more than `STANDARD` (10s) under CI load — bumped to `LONG` (15s)

## Test plan

- [x] CI E2E chromium must pass without "flaky" marker on this test