### PR TITLE
chore(renovate): ignore greenmail in _devextras

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -11,6 +11,7 @@
   "prCreation": "immediate",
   "dependencyDashboard": true,
   "labels": ["dependencies"],
+  "ignorePaths": ["_devextras/mail-handler-test/**"],
   "packageRules": [
     {
       "description": "Catch-all composer patch/minor FIRST — later rules override groupName for Framework/QA",


### PR DESCRIPTION
## Summary
- Adds `_devextras/mail-handler-test/**` to Renovate's `ignorePaths` so it stops creating digest-pinning PRs for the greenmail Docker image.
- Greenmail is a local-only dev extra for mail handler/channel testing — not used in CI or production.
- Closed the existing pin PR #1252 for the same reason.

## Test plan
- Verify Renovate no longer creates PRs for files in `_devextras/mail-handler-test/`.