### PR TITLE
fix(mobile): add touch-action manipulation to chat plus and tools toggles

### DIFF
--- a/frontend/src/components/ChatInput.vue
+++ b/frontend/src/components/ChatInput.vue
@@ -124,7 +124,7 @@
           <button
             type="button"
             :class="[
-              'surface-chip icon-ghost h-[36px] min-w-[36px] flex items-center justify-center rounded-lg relative',
+              'surface-chip icon-ghost h-[36px] min-w-[36px] flex items-center justify-center rounded-lg relative touch-manipulation',
               plusMenuOpen && 'pill--active',
             ]"
             :aria-label="$t('chatInput.plusMenu.label')"

--- a/frontend/src/components/ToolsDropdown.vue
+++ b/frontend/src/components/ToolsDropdown.vue
@@ -2,7 +2,7 @@
   <div ref="dropdownRef" class="relative" data-testid="comp-tools-dropdown">
     <button
       type="button"
-      :class="['pill', isOpen && 'pill--active']"
+      :class="['pill touch-manipulation', isOpen && 'pill--active']"
       :aria-label="$t('chatInput.tools.label')"
       data-testid="btn-tools-toggle"
       @click="toggleOpen"


### PR DESCRIPTION
## Summary

- Adds `touch-manipulation` CSS utility to the "+" menu toggle (`btn-chat-plus`) and Tools dropdown toggle (`btn-tools-toggle`)
- Eliminates 300ms tap-delay on mobile browsers that wait for double-tap-zoom gestures
- Same pattern already used in `MobileNav.vue` for tab bar buttons and More-sheet rows
- No effect on desktop (mouse input ignores `touch-action`)

## Context

The E2E test "Enhance sits in-shell on desktop and inside Tools on mobile" (`chat-input.spec.ts`) fails intermittently on `chromium-mobile` because the browser swallows the tap event during layout shifts. The `toPass()` retry helps but isn't sufficient when the browser's tap-delay overlaps with Vue's `v-if` toggle timing.

## Test plan

- [ ] Local: Chrome DevTools mobile emulation → "+" menu opens instantly on tap
- [ ] Real device: iOS Safari + Android Chrome → plus menu and tools dropdown respond without delay
- [ ] Verify pinch-zoom on the chat page still works (property only applies to the button, not the page)
- [ ] CI: E2E chromium-mobile should stop marking chat-input tests as flaky