### PR TITLE
fix(chat): stop MP3 scrubbing from redirecting to the error screen

### DIFF
--- a/frontend/src/components/MessageAudio.vue
+++ b/frontend/src/components/MessageAudio.vue
@@ -91,6 +91,7 @@
         <div class="flex-1 min-w-0 space-y-1.5 sm:space-y-2">
           <!-- Progress Bar -->
           <div
+            ref="progressBarRef"
             class="h-2 bg-black/10 dark:bg-white/10 rounded-full overflow-hidden cursor-pointer"
             @click.stop="seek"
             @mousedown.stop.prevent="startDragging"
@@ -202,6 +203,7 @@ const config = useConfigStore()
 const { setActive, clearActive } = useAudioPlayback()
 
 const audioRef = ref<HTMLAudioElement>()
+const progressBarRef = ref<HTMLElement>()
 const isPlaying = ref(false)
 const isMuted = ref(false)
 const progress = ref(0)
@@ -389,9 +391,17 @@ const updateProgress = () => {
 }
 
 const seek = (event: MouseEvent) => {
-  if (!audioRef.value || hasFailed.value) return
-  const rect = (event.currentTarget as HTMLElement).getBoundingClientRect()
-  const percent = (event.clientX - rect.left) / rect.width
+  // Read the geometry from the progress-bar element itself, NOT
+  // `event.currentTarget`: during a drag `seek()` is invoked from the
+  // document-level `mousemove` listener, where `currentTarget` is `document`
+  // (no `getBoundingClientRect`). Relying on it threw a TypeError on every
+  // move, which the global error handler turned into a full-screen error /
+  // redirect while scrubbing.
+  const bar = progressBarRef.value
+  if (!audioRef.value || hasFailed.value || !bar) return
+  const rect = bar.getBoundingClientRect()
+  if (rect.width <= 0) return
+  const percent = Math.min(1, Math.max(0, (event.clientX - rect.left) / rect.width))
   const total = audioRef.value.duration
   if (!isFinite(total) || total <= 0) return
   audioRef.value.currentTime = percent * total


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Dragging (scrubbing) an inline audio player's progress bar threw a `TypeError` on every mouse move, which the global error handler turned into the full-screen error view / redirect — so scrubbing an MP3 kicked the user out of the chat.

## Changes
- `MessageAudio.vue`: `seek()` now reads the progress-bar geometry from a template ref (`progressBarRef`) instead of `event.currentTarget`.
  - Root cause: `startDragging()` attaches a **`document`** `mousemove` listener that calls `seek(e)`. In that path `event.currentTarget` is `document`, which has no `getBoundingClientRect()`, so every drag move threw. The throw escaped into `window` `'error'` → `installGlobalErrorHandlers` → `ErrorBoundary` (full-screen ErrorView with reload / `router.push('/')`).
  - Using the element ref is correct for the `@click`, `@mousedown` and document `mousemove` paths alike.
- Clamp the seek fraction to `[0, 1]` since the pointer routinely leaves the bar during a drag.

## Verification
- [x] Manual (reasoning): the drag path no longer dereferences `document.getBoundingClientRect`.
- [ ] Not tested (explain): this environment has no frontend toolchain (npm/vue-tsc/vitest/eslint), so `make -C frontend lint`, `vue-tsc`, and Vitest were not run here. Please run the frontend gate before merge.

## Notes
Yesterday's audio PR (#1281) fixed the *download* button's tab-navigation (blob download); it did not touch the scrub/seek gesture, so this redirect was still present. Unrelated to the rolling-summary PR (#1282) — kept as its own change.

## Screenshots/Logs

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a81d542f-722b-4df3-a48c-4e8815f93556"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a81d542f-722b-4df3-a48c-4e8815f93556"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

