### PR TITLE
fix(backend): re-index array after filtering in findSimilar

### DIFF
--- a/backend/src/Service/RAG/VectorStorage/MariaDBVectorStorage.php
+++ b/backend/src/Service/RAG/VectorStorage/MariaDBVectorStorage.php
@@ -174,11 +174,11 @@ final readonly class MariaDBVectorStorage implements VectorStorageInterface
 
         $results = $this->search($query);
 
-        // Filter out the source chunk itself
-        return array_filter(
+        // Filter out the source chunk itself and re-index so JSON serialization produces an array
+        return array_values(array_filter(
             $results,
             fn (SearchResult $r) => $r->chunkId !== $intChunkId
-        );
+        ));
     }
 
     public function getStats(int $userId): StorageStats

--- a/backend/src/Service/RAG/VectorStorage/QdrantVectorStorage.php
+++ b/backend/src/Service/RAG/VectorStorage/QdrantVectorStorage.php
@@ -169,11 +169,11 @@ final readonly class QdrantVectorStorage implements VectorStorageInterface
 
         $results = $this->search($query);
 
-        // Filter out source
-        return array_filter(
+        // Filter out source and re-index so JSON serialization produces an array
+        return array_values(array_filter(
             $results,
             fn (SearchResult $r) => (string) $r->chunkId !== (string) $sourceChunkId
-        );
+        ));
     }
 
     public function getStats(int $userId): StorageStats


### PR DESCRIPTION
## Summary

- Fixes #1288 — "Find Similar" always showing "no results" due to `array_filter()` producing non-sequential keys that `json_encode` serializes as a JSON object instead of an array
- Follow-up to #1043 which fixed the 404 routing error for string chunk IDs

**Root cause:** `array_filter()` in both `QdrantVectorStorage::findSimilar()` and `MariaDBVectorStorage::findSimilar()` preserves original array keys. After excluding the source chunk (e.g. index 0), remaining keys `[1, 2, 3, ...]` cause `json_encode` to emit `{"1": {...}}` (object) instead of `[{...}]` (array). The frontend checks `response.results.length` which is `undefined` on objects.

**Fix:** Wrap `array_filter()` with `array_values()` in both storage implementations.

## Test plan

- [x] Verified API returns JSON array `[...]` instead of object `{...}` after fix
- [x] PHPStan: 0 errors
- [x] PHP CS Fixer: 0 issues
- [x] Existing tests pass (VectorSearchServiceTest, RagControllerTest)