### PR TITLE
chore(renovate): disable Redis major updates (8.x breaks Centrifugo)

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -65,6 +65,13 @@
       "matchUpdateTypes": ["major"],
       "automerge": false,
       "labels": ["dependencies", "breaking"]
+    },
+    {
+      "description": "Redis 8.x broke Centrifugo pub/sub fan-out — stay on 7.4 until Centrifugo adds support",
+      "matchManagers": ["docker-compose", "dockerfile"],
+      "matchPackageNames": ["redis"],
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds a Renovate package rule to disable major Redis updates (Docker images)
- Redis 8.x dropped pub/sub fan-out to the Centrifugo node, silently breaking realtime delivery
- Digest and patch updates within Redis 7.4 remain enabled
- Closes the stale Redis 8 PR (#1090) that could never be merged

## Context
The `docker-compose.yml` already documents the pinning rationale. This rule prevents Renovate from repeatedly opening PRs that waste CI runner minutes.