### PR TITLE
ci: shard E2E tests and optimize runner allocation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [main, develop]
 
+permissions:
+  contents: read
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,8 +262,7 @@ jobs:
 
   docker-build:
     name: Build Docker Image
-    # Image build (FrankenPHP + extensions) is CPU-heavy on cache misses.
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     needs: [frontend]
     outputs:
       image-tags: ${{ steps.meta.outputs.tags }}
@@ -325,29 +324,47 @@ jobs:
           retention-days: 1
 
   e2e:
-    name: E2E Tests (${{ matrix.browser }}${{ matrix.variant && format(' {0}', matrix.variant) || '' }}${{ matrix.auth_method == 'oidc' && ' OIDC' || matrix.auth_method == 'oidc-redirect' && ' OIDC Redirect' || '' }})
-    # Full docker-compose stack + Playwright per matrix leg; 16 cores/64 GB
-    # keeps the app responsive under test load. Runner allows max 10 concurrent
-    # jobs, so all 5 legs still run in parallel.
-    runs-on: ubuntu-latest-m
+    name: E2E Tests (${{ matrix.browser }}${{ matrix.variant && format(' {0}', matrix.variant) || '' }}${{ matrix.auth_method == 'oidc' && ' OIDC' || matrix.auth_method == 'oidc-redirect' && ' OIDC Redirect' || '' }}${{ matrix.shard && format(' [{0}]', matrix.shard) || '' }})
+    # E2E jobs run on free ubuntu-latest runners (unlimited capacity for public
+    # repos) to avoid queue contention from the limited ubuntu-latest-m pool.
+    # Chromium and Firefox are sharded (--shard=N/M) so each half finishes in
+    # ~50% of the time; the free runner pool ensures all shards start instantly.
+    runs-on: ubuntu-latest
     needs: [docker-build]
     strategy:
       fail-fast: false
       matrix:
         include:
-          # Standard password auth (both browsers) — exclude @oidc tests (no Keycloak running)
+          # Standard password auth — chromium sharded into 2 parallel jobs
           - browser: chromium
             variant: ""
             auth_method: password
             compose_profiles: ""
             npm_script: "test:e2e"
             grep_filter: "@ci"
+            shard: "1/2"
+          - browser: chromium
+            variant: ""
+            auth_method: password
+            compose_profiles: ""
+            npm_script: "test:e2e"
+            grep_filter: "@ci"
+            shard: "2/2"
+          # Standard password auth — firefox sharded into 2 parallel jobs
           - browser: firefox
             variant: ""
             auth_method: password
             compose_profiles: ""
             npm_script: "test:e2e:firefox"
             grep_filter: "@ci"
+            shard: "1/2"
+          - browser: firefox
+            variant: ""
+            auth_method: password
+            compose_profiles: ""
+            npm_script: "test:e2e:firefox"
+            grep_filter: "@ci"
+            shard: "2/2"
           # Mobile viewport layout guard (chromium device emulation; runs the
           # @layout suite only — see frontend/tests/e2e/playwright.config.ts)
           - browser: chromium
@@ -356,6 +373,7 @@ jobs:
             compose_profiles: ""
             npm_script: "test:e2e:mobile"
             grep_filter: "@ci"
+            shard: ""
           # OIDC auth (chromium only — auth flow testing, not browser compat)
           - browser: chromium
             variant: ""
@@ -363,6 +381,7 @@ jobs:
             compose_profiles: "--profile oidc"
             npm_script: "test:e2e:oidc"
             grep_filter: "@oidc"
+            shard: ""
           # OIDC auto-redirect (starts app with OIDC_AUTO_REDIRECT=true)
           - browser: chromium
             variant: ""
@@ -370,6 +389,7 @@ jobs:
             compose_profiles: "--profile oidc"
             npm_script: "test:e2e:oidc-redirect"
             grep_filter: ""
+            shard: ""
     env:
       APP_IMAGE: synaplan-test:ci
       APP_URL: http://localhost:8001
@@ -483,15 +503,21 @@ jobs:
           MAILHOG_URL: http://localhost:8026
         run: |
           echo "============================================"
-          echo "Running E2E tests with ${{ matrix.browser }} (${{ matrix.auth_method }})"
+          echo "Running E2E tests with ${{ matrix.browser }} (${{ matrix.auth_method }})${{ matrix.shard && format(' shard {0}', matrix.shard) || '' }}"
           echo "============================================"
-          npm run ${{ matrix.npm_script }}${{ matrix.grep_filter && format(' -- --grep "{0}"', matrix.grep_filter) || '' }}
+          EXTRA_ARGS="${{ matrix.grep_filter && format('--grep "{0}"', matrix.grep_filter) || '' }} ${{ matrix.shard && format('--shard={0}', matrix.shard) || '' }}"
+          EXTRA_ARGS=$(echo "$EXTRA_ARGS" | xargs)
+          if [ -n "$EXTRA_ARGS" ]; then
+            npm run ${{ matrix.npm_script }} -- $EXTRA_ARGS
+          else
+            npm run ${{ matrix.npm_script }}
+          fi
 
       - name: Upload Playwright test results
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: playwright-results-${{ matrix.browser }}${{ matrix.variant && format('-{0}', matrix.variant) || '' }}-${{ matrix.auth_method }}
+          name: playwright-results-${{ strategy.job-index }}-${{ matrix.browser }}${{ matrix.variant && format('-{0}', matrix.variant) || '' }}-${{ matrix.auth_method }}
           path: |
             frontend/tests/e2e/test-results/
             frontend/tests/e2e/reports/
@@ -511,9 +537,9 @@ jobs:
     # the "Update visual baselines" workflow dispatch (same runner image,
     # never from a laptop).
     name: E2E Visual Snapshots
-    # MUST match the runner image used by visual-baselines.yml — snapshots are
+    # MUST match the runner used by visual-baselines.yml — snapshots are
     # rendering-environment sensitive.
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     needs: [docker-build]
     env:
       APP_IMAGE: synaplan-test:ci

--- a/.github/workflows/visual-baselines.yml
+++ b/.github/workflows/visual-baselines.yml
@@ -24,7 +24,7 @@ jobs:
     name: Regenerate visual snapshot baselines
     # MUST match the runner used by CI's e2e-visual job — baselines recorded
     # on a different image would be permanently red.
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     env:
       APP_IMAGE: synaplan-test:ci
       APP_URL: http://localhost:8001


### PR DESCRIPTION
## Summary

- **E2E Sharding**: Split chromium and firefox E2E tests into 2 shards each (`--shard=1/2`, `--shard=2/2`), halving the wallclock time of the slowest pipeline leg (~350s → ~175s for firefox)
- **Runner optimization**: Move E2E, docker-build, and visual-snapshot jobs back to free `ubuntu-latest` runners (unlimited capacity) to eliminate queue contention from the limited `ubuntu-latest-m` pool. Keep only backend + frontend on `ubuntu-latest-m` where PHPStan (3.2x faster) and Vitest (3.4x faster) benefit most from 16 cores
- **Cost reduction**: ~$0.32/run (2 sequential jobs on `-m`) vs ~$1.40/run (all on `-m`), saving ~$500/month at 15 runs/day

### Runner allocation

| Job | Runner | Reason |
|---|---|---|
| Backend | `ubuntu-latest-m` | PHPStan 51s→16s (3.2x), critical path |
| Frontend | `ubuntu-latest-m` | Vitest 34s→10s (3.4x), critical path |
| Docker Build | `ubuntu-latest` | Cache-dependent, no CPU benefit |
| E2E (7 jobs) | `ubuntu-latest` | Unlimited free capacity, no queue delays |
| E2E Visual | `ubuntu-latest` | Follows E2E runner |

Backend and frontend run sequentially (frontend needs OpenAPI spec), so they never compete for `-m` runners.

### E2E matrix (before → after)

| Before (5 jobs) | After (7 jobs) |
|---|---|
| chromium | chromium [1/2], chromium [2/2] |
| firefox | firefox [1/2], firefox [2/2] |
| chromium Mobile | chromium Mobile |
| chromium OIDC | chromium OIDC |
| chromium OIDC Redirect | chromium OIDC Redirect |

### CI results (this PR)

Total wallclock: **10 min 34s** (down from 16–67 min)

| Job | Duration | Queue delay | Runner |
|---|---|---|---|
| Backend | 107s | 0s | `ubuntu-latest-m` ✅ |
| Frontend | 172s | 4s | `ubuntu-latest-m` ✅ |
| Docker Build | 45s | 3s | `ubuntu-latest` ✅ |
| chromium [1/2] | 216s (108s tests) | 3s | `ubuntu-latest` ✅ |
| chromium [2/2] | 259s (91s tests) | 5s | `ubuntu-latest` ✅ |
| firefox [1/2] | 291s (115s tests) | 5s | `ubuntu-latest` ✅ |
| firefox [2/2] | 286s (115s tests) | 4s | `ubuntu-latest` ✅ |
| Mobile | 169s | 3s | `ubuntu-latest` ✅ |
| OIDC | 174s | 3s | `ubuntu-latest` ✅ |
| OIDC Redirect | 189s | 3s | `ubuntu-latest` ✅ |

## Test plan

- [x] CI passes on this PR
- [x] E2E job names show shard indicators: `chromium [1/2]`, `chromium [2/2]`, etc.
- [x] All sharded tests run (no tests silently skipped)
- [x] No queue delays on E2E jobs (all started 3–5s after docker-build)
- [x] Backend + Frontend use `ubuntu-latest-m` (confirmed via runner labels)