### PR TITLE
fix(frontend): move mobile consumption ring below the drawer menu

### DIFF
--- a/frontend/src/components/usage/ConsumptionRing.vue
+++ b/frontend/src/components/usage/ConsumptionRing.vue
@@ -176,6 +176,19 @@ onBeforeUnmount(() => {
   display: block;
 }
 
+/* On phones (< 768 px) the fixed mobile drawer toggle lives in the top-left
+   corner (MainLayout: left 0.75rem, top = safe-area-inset-top + 10px, 40px
+   tall). Drop the ring below that button — same left inset, offset past the
+   safe-area + button height + a small gap — so it never hides behind the menu.
+   From 768 px up the desktop sidebar replaces the mobile toggle, so the ring
+   can keep its default top-left placement in the chat column. */
+@media (max-width: 767px) {
+  .usage-ring {
+    top: calc(env(safe-area-inset-top, 0px) + 3.75rem);
+    left: 0.75rem;
+  }
+}
+
 /* Compact view up to 1023 px; the full bar takes over on wide desktops
    (>= 1024 px), where it can never overlap the chat column. */
 @media (min-width: 1024px) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
On phones the taxameter consumption ring rendered behind the fixed drawer menu button; this drops it below the menu so it's fully visible.

## Changes
- `ConsumptionRing.vue`: on `< 768 px`, offset the ring down (`top: calc(env(safe-area-inset-top, 0px) + 3.75rem)`) past the safe-area inset + the 40px menu button, and align its `left` to the toggle (`0.75rem`). Default top-left placement is preserved from 768px up (where the desktop sidebar replaces the mobile toggle, so no overlap exists).

## Root cause
`MainLayout` renders the mobile drawer toggle `fixed` at `left-3`, `top: calc(env(safe-area-inset-top) + 10px)`, 40px tall. The ring was `absolute; top: 0.5rem; left: 0.5rem`, placing it directly under/behind that button on phone widths.

## Verification
- [x] Tests added/updated — existing `ConsumptionRing.spec.ts` passes (3/3)
- [x] Manual — CSS-only, scoped media query; `npm run lint` passes

Notes: `vue-tsc` reports pre-existing errors from the missing generated `@/generated/api-schemas` module (requires the backend OpenAPI spec / Docker, unavailable in this environment). None reference `ConsumptionRing.vue`, and this change is CSS-only so it cannot introduce type errors.

## Notes
Change classification: **ota-candidate** (web-asset-only style fix, default behavior unchanged, no native/API surface touched).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-807adbdf-5ba6-4bc7-81e8-2af0ee34a046"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-807adbdf-5ba6-4bc7-81e8-2af0ee34a046"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

