### PR TITLE
fix(frontend): center mobile consumption ring under the incognito toggle

### DIFF
--- a/frontend/src/components/usage/ConsumptionRing.vue
+++ b/frontend/src/components/usage/ConsumptionRing.vue
@@ -176,16 +176,26 @@ onBeforeUnmount(() => {
   display: block;
 }
 
-/* On phones (< 768 px) the fixed mobile drawer toggle lives in the top-left
-   corner (MainLayout: left 0.75rem, top = safe-area-inset-top + 10px, 40px
-   tall). Drop the ring below that button — same left inset, offset past the
-   safe-area + button height + a small gap — so it never hides behind the menu.
-   From 768 px up the desktop sidebar replaces the mobile toggle, so the ring
-   can keep its default top-left placement in the chat column. */
+/* On phones (< 768 px) center the ring under the fixed top-right incognito
+   ("anonymous") toggle (MainLayout: right 0.75rem, top = safe-area-inset-top +
+   10px, 40px box). The 48px ring at a 0.5rem right inset lines its centre up
+   with the 40px button centre (both at 32px from the edge), and the vertical
+   offset clears the safe area + button height + a small gap. From 768 px up the
+   desktop sidebar / desktop toggle take over, so the ring keeps its default
+   top-left placement in the chat column. */
 @media (max-width: 767px) {
   .usage-ring {
     top: calc(env(safe-area-inset-top, 0px) + 3.75rem);
-    left: 0.75rem;
+    left: auto;
+    right: 0.5rem;
+  }
+
+  /* Anchor the tooltip / stats panel to the ring's right edge so a wide panel
+     opens leftwards and never overflows the screen edge. */
+  .usage-ring__tooltip,
+  .usage-ring__panel {
+    left: auto;
+    right: 0;
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Follow-up to the earlier mobile ring placement fix: move the taxameter consumption ring to the right and center it under the top-right incognito ("anonymous") toggle, so it no longer looks off against the differently-sized left menu button.

## Changes
- `ConsumptionRing.vue` (`< 768 px` only):
  - Place the ring on the right: `right: 0.5rem` (with `left: auto`). The 48px ring lines its centre up with the 40px incognito toggle (which is `right-3`, so both centres sit 32px from the edge). Vertical offset unchanged (below the safe-area + button height).
  - Anchor the tooltip and stats panel to the ring's right edge (`right: 0; left: auto`) so the up-to-18rem-wide panel opens leftwards and never overflows the screen edge.

## Why
The previous fix dropped the ring below the top-left drawer menu, but the menu and the top-right incognito toggle have different widths/styles, so a left-aligned ring read as misaligned. Centering it under the incognito toggle matches the button it relates to.

## Verification
- [x] Manual — CSS-only, scoped media query; centering math checked (button centre 32px from edge = ring centre)
- [x] Tests — `ConsumptionRing.spec.ts` passes (3/3); `npm run lint` passes

Notes: `vue-tsc` has pre-existing errors from the missing generated `@/generated/api-schemas` module (requires backend/Docker, unavailable here); none reference `ConsumptionRing.vue`, and this is a CSS-only change.

## Notes
Change classification: **ota-candidate** (web-asset-only style fix, default behavior unchanged, no native/API surface touched).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-807adbdf-5ba6-4bc7-81e8-2af0ee34a046"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-807adbdf-5ba6-4bc7-81e8-2af0ee34a046"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

