### PR TITLE
fix(chat/ai): WhatsApp image + provider message-handling fixes

### DIFF
--- a/backend/src/AI/Provider/AnthropicProvider.php
+++ b/backend/src/AI/Provider/AnthropicProvider.php
@@ -154,22 +154,11 @@ class AnthropicProvider implements ChatProviderInterface, VisionProviderInterfac
             $model = $options['model'];
             $reasoning = $options['reasoning'] ?? false;
 
-            // Convert multimodal content (images) to Anthropic format
+            // Convert multimodal content (images) to Anthropic format, then
+            // normalise the thread to Anthropic's stricter Messages API rules
+            // (non-empty content, alternating roles, leading `user` turn).
             $convertedMessages = $this->convertMessagesToAnthropicFormat($messages);
-
-            // Separate system message from conversation
-            $systemMessage = null;
-            $conversationMessages = [];
-
-            foreach ($convertedMessages as $message) {
-                if (($message['role'] ?? '') === 'system') {
-                    $systemMessage = is_string($message['content']) ? $message['content'] : json_encode($message['content']);
-                } else {
-                    $conversationMessages[] = $message;
-                }
-            }
-
-            $conversationMessages = $this->mergeConsecutiveRoles($conversationMessages);
+            [$systemMessage, $conversationMessages] = $this->prepareConversation($convertedMessages);
 
             $thinkingEnabled = $reasoning && $this->supportsThinking($model);
 
@@ -289,22 +278,11 @@ class AnthropicProvider implements ChatProviderInterface, VisionProviderInterfac
             $model = $options['model'];
             $reasoning = $options['reasoning'] ?? false;
 
-            // Convert multimodal content (images) to Anthropic format
+            // Convert multimodal content (images) to Anthropic format, then
+            // normalise the thread to Anthropic's stricter Messages API rules
+            // (non-empty content, alternating roles, leading `user` turn).
             $convertedMessages = $this->convertMessagesToAnthropicFormat($messages);
-
-            // Separate system message from conversation
-            $systemMessage = null;
-            $conversationMessages = [];
-
-            foreach ($convertedMessages as $message) {
-                if (($message['role'] ?? '') === 'system') {
-                    $systemMessage = is_string($message['content']) ? $message['content'] : json_encode($message['content']);
-                } else {
-                    $conversationMessages[] = $message;
-                }
-            }
-
-            $conversationMessages = $this->mergeConsecutiveRoles($conversationMessages);
+            [$systemMessage, $conversationMessages] = $this->prepareConversation($convertedMessages);
 
             $thinkingEnabled = $reasoning && $this->supportsThinking($model);
 
@@ -348,12 +326,28 @@ class AnthropicProvider implements ChatProviderInterface, VisionProviderInterfac
                 'buffer' => false, // Don't buffer the response
             ]);
 
+            // Surface HTTP errors BEFORE streaming. With `buffer: false` the SSE
+            // body cannot be re-read once parseSSEStream() has consumed it, so a
+            // 400 would otherwise reach the user as the opaque Symfony message
+            // "HTTP/2 400 returned for …" with Anthropic's real reason lost.
+            // getStatusCode() waits for the response headers but never throws on
+            // a 4xx/5xx, and getContent(false) is still readable here because the
+            // stream has not been consumed yet.
+            $statusCode = $response->getStatusCode();
+            if ($statusCode >= 400) {
+                throw new ProviderException($this->formatStreamHttpError($response, $model, $statusCode), 'anthropic');
+            }
+
             // Parse SSE stream and collect usage
             $usage = $this->parseSSEStream($response, $callback);
 
             $this->logger->info('🔵 Anthropic: Streaming completed', ['usage' => $usage]);
 
             return ['usage' => $usage];
+        } catch (ProviderException $e) {
+            // Already carries a formatted, user-safe message (e.g. the up-front
+            // HTTP error detection above) — surface it as-is without re-wrapping.
+            throw $e;
         } catch (\Exception $e) {
             $errorMessage = $e->getMessage();
 
@@ -614,6 +608,142 @@ class AnthropicProvider implements ChatProviderInterface, VisionProviderInterfac
         }
 
         return ['type' => 'enabled', 'budget_tokens' => 5000];
+    }
+
+    /**
+     * Split the system message out and normalise the conversation so it
+     * satisfies Anthropic's Messages API constraints, which are stricter than
+     * the OpenAI-style providers the rest of the app targets:
+     *   - every message must have non-empty content,
+     *   - user/assistant turns must strictly alternate,
+     *   - the first message must be a `user` turn.
+     *
+     * WhatsApp/e-mail threads routinely carry blank-text rows (media-only,
+     * placeholder or error rows) and the loaded history window can begin on an
+     * assistant turn; either one makes Anthropic reject the WHOLE request with
+     * an HTTP 400 invalid_request_error, while other providers silently accept
+     * it. Sanitising here fixes every channel (WhatsApp, e-mail, web, task DAG)
+     * in one place.
+     *
+     * @param list<array<string, mixed>> $convertedMessages
+     *
+     * @return array{0: string|null, 1: list<array<string, mixed>>}
+     */
+    private function prepareConversation(array $convertedMessages): array
+    {
+        $systemMessage = null;
+        $conversationMessages = [];
+
+        foreach ($convertedMessages as $message) {
+            if (($message['role'] ?? '') === 'system') {
+                $content = $message['content'] ?? '';
+                $systemMessage = is_string($content) ? $content : (json_encode($content) ?: null);
+
+                continue;
+            }
+
+            // Drop empty-content turns: Anthropic rejects "" / empty content
+            // blocks with a 400, unlike OpenAI/Groq/Gemini.
+            if (!$this->hasMeaningfulContent($message['content'] ?? null)) {
+                continue;
+            }
+
+            $conversationMessages[] = $message;
+        }
+
+        $conversationMessages = $this->mergeConsecutiveRoles($conversationMessages);
+        $conversationMessages = $this->dropLeadingAssistantTurns($conversationMessages);
+
+        return [$systemMessage, $conversationMessages];
+    }
+
+    /**
+     * Whether a message's content carries anything Anthropic will accept.
+     *
+     * A string must be non-blank; a multimodal array must contain at least one
+     * non-text block (image, …) or a non-blank text block — an array whose only
+     * text block is empty is treated as empty, since Anthropic rejects empty
+     * text content blocks too.
+     */
+    private function hasMeaningfulContent(mixed $content): bool
+    {
+        if (is_string($content)) {
+            return '' !== trim($content);
+        }
+
+        if (is_array($content)) {
+            foreach ($content as $block) {
+                if (!is_array($block)) {
+                    continue;
+                }
+
+                if ('text' === ($block['type'] ?? '')) {
+                    if ('' !== trim((string) ($block['text'] ?? ''))) {
+                        return true;
+                    }
+
+                    continue;
+                }
+
+                // Any non-text block (image, document, …) is real content.
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Drop leading assistant turns so the conversation starts with a `user`
+     * message. The loaded chat history window can begin on an assistant/OUT row
+     * (e.g. the char-limit trim cut off the opening user turn), which Anthropic
+     * rejects with a 400.
+     *
+     * @param list<array<string, mixed>> $messages
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function dropLeadingAssistantTurns(array $messages): array
+    {
+        while ([] !== $messages && 'user' !== ($messages[0]['role'] ?? '')) {
+            array_shift($messages);
+        }
+
+        return $messages;
+    }
+
+    /**
+     * Build a human-readable error for a failed streaming request, preferring
+     * Anthropic's own `error.message`/`error.type` over the opaque transport
+     * message. Safe to call before the SSE stream is consumed (see caller).
+     */
+    private function formatStreamHttpError(ResponseInterface $response, string $model, int $statusCode): string
+    {
+        $detail = null;
+
+        try {
+            $body = $response->getContent(false);
+            $decoded = json_decode($body, true);
+            if (is_array($decoded) && isset($decoded['error']) && is_array($decoded['error'])) {
+                $detail = sprintf(
+                    'Anthropic API Error: %s (type: %s)',
+                    $decoded['error']['message'] ?? 'Unknown error',
+                    $decoded['error']['type'] ?? 'unknown'
+                );
+            }
+        } catch (\Throwable) {
+            // Body unavailable — fall back to the generic status message.
+        }
+
+        $message = $detail ?? sprintf('Anthropic API request failed with HTTP %d', $statusCode);
+
+        $this->logger->error('Anthropic streaming request failed', [
+            'model' => $model,
+            'status_code' => $statusCode,
+            'error' => $message,
+        ]);
+
+        return $message;
     }
 
     /**

--- a/backend/src/AI/Provider/GoogleProvider.php
+++ b/backend/src/AI/Provider/GoogleProvider.php
@@ -1854,18 +1854,32 @@ class GoogleProvider implements ChatProviderInterface, ImageGenerationProviderIn
         $contents = [];
 
         foreach ($messages as $message) {
-            $role = 'assistant' === $message['role'] ? 'model' : 'user';
+            $role = 'assistant' === ($message['role'] ?? 'user') ? 'model' : 'user';
+            $content = $message['content'] ?? '';
 
             $parts = [];
-            if (is_string($message['content'])) {
-                $parts[] = ['text' => $message['content']];
-            } elseif (is_array($message['content'])) {
-                foreach ($message['content'] as $part) {
-                    if ('text' === $part['type']) {
-                        $parts[] = ['text' => $part['text']];
-                    } elseif ('image_url' === $part['type']) {
+            if (is_string($content)) {
+                // Skip blank turns: Gemini rejects empty text parts with a 400
+                // ("empty text parameter"), so a blank history row (WhatsApp
+                // media-only / placeholder / error rows) would break the turn.
+                if ('' !== trim($content)) {
+                    $parts[] = ['text' => $content];
+                }
+            } elseif (is_array($content)) {
+                foreach ($content as $part) {
+                    if (!is_array($part)) {
+                        continue;
+                    }
+
+                    $type = $part['type'] ?? '';
+                    if ('text' === $type) {
+                        $text = (string) ($part['text'] ?? '');
+                        if ('' !== trim($text)) {
+                            $parts[] = ['text' => $text];
+                        }
+                    } elseif ('image_url' === $type) {
                         $imageUrl = $part['image_url']['url'] ?? $part['image_url'];
-                        if (str_starts_with($imageUrl, 'data:image')) {
+                        if (is_string($imageUrl) && str_starts_with($imageUrl, 'data:image')) {
                             // Base64 image
                             list($mime, $data) = explode(';', $imageUrl);
                             list(, $data) = explode(',', $data);
@@ -1880,10 +1894,70 @@ class GoogleProvider implements ChatProviderInterface, ImageGenerationProviderIn
                 }
             }
 
+            // Drop turns that produced no usable parts — an empty `parts` array
+            // is itself a 400 on Gemini.
+            if ([] === $parts) {
+                continue;
+            }
+
             $contents[] = [
                 'role' => $role,
                 'parts' => $parts,
             ];
+        }
+
+        // Gemini requires strictly alternating user/model turns that begin with
+        // a `user` turn. Dropping blank rows above can leave two same-role turns
+        // adjacent, and the loaded history window can begin on an assistant/OUT
+        // row — both are 400s. Mirror the AnthropicProvider normalisation.
+        $contents = $this->mergeConsecutiveGeminiContents($contents);
+        $contents = $this->dropLeadingModelContents($contents);
+
+        return $contents;
+    }
+
+    /**
+     * Merge consecutive same-role Gemini contents by concatenating their parts.
+     *
+     * @param list<array{role: string, parts: list<array<string, mixed>>}> $contents
+     *
+     * @return list<array{role: string, parts: list<array<string, mixed>>}>
+     */
+    private function mergeConsecutiveGeminiContents(array $contents): array
+    {
+        if (count($contents) < 2) {
+            return $contents;
+        }
+
+        $merged = [$contents[0]];
+
+        for ($i = 1, $count = count($contents); $i < $count; ++$i) {
+            $last = &$merged[count($merged) - 1];
+
+            if ($contents[$i]['role'] === $last['role']) {
+                $last['parts'] = array_merge($last['parts'], $contents[$i]['parts']);
+            } else {
+                $merged[] = $contents[$i];
+            }
+
+            unset($last);
+        }
+
+        return $merged;
+    }
+
+    /**
+     * Drop leading `model` turns so the conversation starts with a `user` turn,
+     * as Gemini requires.
+     *
+     * @param list<array{role: string, parts: list<array<string, mixed>>}> $contents
+     *
+     * @return list<array{role: string, parts: list<array<string, mixed>>}>
+     */
+    private function dropLeadingModelContents(array $contents): array
+    {
+        while ([] !== $contents && 'user' !== $contents[0]['role']) {
+            array_shift($contents);
         }
 
         return $contents;

--- a/backend/src/Service/Message/Handler/ChatHandler.php
+++ b/backend/src/Service/Message/Handler/ChatHandler.php
@@ -5,6 +5,7 @@ namespace App\Service\Message\Handler;
 use App\AI\Service\AiFacade;
 use App\Entity\File;
 use App\Entity\Message;
+use App\Entity\Model;
 use App\Entity\User;
 use App\Message\ExtractMemoriesCommand;
 use App\Repository\ModelRepository;
@@ -263,10 +264,12 @@ final readonly class ChatHandler implements MessageHandlerInterface
                 $includeImagesInMessages = true;
                 $this->logger->info('ChatHandler: Current model supports vision, including images (non-streaming)');
             } else {
-                $this->logger->info('ChatHandler: Message has images but model does not support vision, searching for vision model (non-streaming)');
+                $this->logger->info('ChatHandler: Message has images but model does not support vision, resolving configured vision model (non-streaming)');
 
-                // Find a vision-capable model
-                $visionModel = $this->modelRepository->findByFeature('vision', 'chat', true);
+                // Prefer the account's configured image model (PIC2TEXT); only
+                // fall back to the global catalog pick when none is usable.
+                $effectiveUserId = $this->modelConfigService->getEffectiveUserIdForMessage($message);
+                $visionModel = $this->resolveVisionFallbackModel($effectiveUserId);
 
                 if ($visionModel) {
                     $modelId = $visionModel->getId();
@@ -809,10 +812,12 @@ final readonly class ChatHandler implements MessageHandlerInterface
                 $includeImagesInMessages = true;
                 $this->logger->info('ChatHandler: Current model supports vision, including images (streaming)');
             } else {
-                $this->logger->info('ChatHandler: Message has images but model does not support vision, searching for vision model');
+                $this->logger->info('ChatHandler: Message has images but model does not support vision, resolving configured vision model');
 
-                // Find a vision-capable model
-                $visionModel = $this->modelRepository->findByFeature('vision', 'chat', true);
+                // Prefer the account's configured image model (PIC2TEXT); only
+                // fall back to the global catalog pick when none is usable.
+                $effectiveUserId = $this->modelConfigService->getEffectiveUserIdForMessage($message);
+                $visionModel = $this->resolveVisionFallbackModel($effectiveUserId);
 
                 if ($visionModel) {
                     $modelId = $visionModel->getId();
@@ -1642,6 +1647,36 @@ final readonly class ChatHandler implements MessageHandlerInterface
         }
 
         return $messages;
+    }
+
+    /**
+     * Resolve the vision-capable model to use when the active chat model cannot
+     * see images.
+     *
+     * Order of preference:
+     *   1. The account's CONFIGURED image-recognition model
+     *      (DEFAULTMODEL.PIC2TEXT), when it exists and is vision-capable.
+     *   2. The global catalog fallback (highest-quality selectable vision chat
+     *      model) — used only when the account has no usable configured model.
+     *
+     * Before this, the vision fallback always used the global catalog pick, so
+     * an account whose chat model lacks vision got answers from whichever
+     * provider happened to rank highest (Anthropic Claude), even though the
+     * account never configured that provider — e.g. a WhatsApp image reply
+     * arriving as an Anthropic answer. Honouring PIC2TEXT keeps image turns on
+     * the standard configured multimodal model.
+     */
+    private function resolveVisionFallbackModel(?int $effectiveUserId): ?Model
+    {
+        $configuredId = $this->modelConfigService->getDefaultModel('PIC2TEXT', $effectiveUserId);
+        if ($configuredId) {
+            $configured = $this->modelRepository->find($configuredId);
+            if ($configured instanceof Model && $configured->hasFeature('vision')) {
+                return $configured;
+            }
+        }
+
+        return $this->modelRepository->findByFeature('vision', 'chat', true);
     }
 
     /**

--- a/backend/tests/AI/Provider/AnthropicProviderStreamingTest.php
+++ b/backend/tests/AI/Provider/AnthropicProviderStreamingTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\AI\Provider;
 
+use App\AI\Exception\ProviderException;
 use App\AI\Provider\AnthropicProvider;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
@@ -226,6 +227,106 @@ class AnthropicProviderStreamingTest extends TestCase
         $this->assertSame(20, $result['usage']['total_tokens']);
     }
 
+    // ==================== MESSAGE SANITISATION (WhatsApp 400 fix) ====================
+
+    /**
+     * Empty-content turns (e.g. a WhatsApp media-only / placeholder / error row
+     * stored with blank text) must be dropped before the request — Anthropic
+     * rejects empty content with a 400 while OpenAI-style providers tolerate it.
+     * The two surviving user turns collapse into one via role merging.
+     */
+    public function testEmptyHistoryTurnsAreDroppedBeforeRequest(): void
+    {
+        $captured = null;
+        $sse = $this->buildOkStream();
+        $client = new MockHttpClient(function (string $method, string $url, array $options) use (&$captured, $sse): MockResponse {
+            $captured = $this->decodeRequestBody($options);
+
+            return new MockResponse($sse, ['response_headers' => ['content-type' => 'text/event-stream']]);
+        });
+
+        $this->makeProvider(httpClient: $client)->chatStream(
+            [
+                ['role' => 'system', 'content' => 'You are helpful.'],
+                ['role' => 'user', 'content' => 'first question'],
+                ['role' => 'assistant', 'content' => '   '], // blank OUT row
+                ['role' => 'user', 'content' => 'second question'],
+            ],
+            static fn () => null,
+            ['model' => 'claude-haiku-4-5'],
+        );
+
+        $this->assertNotNull($captured);
+        $messages = $captured['messages'];
+
+        foreach ($messages as $message) {
+            $this->assertNotSame('', trim((string) $message['content']), 'no empty-content message may be sent to Anthropic');
+        }
+
+        $this->assertCount(1, $messages, 'the two user turns merge once the blank assistant row is dropped');
+        $this->assertSame('user', $messages[0]['role']);
+        $this->assertStringContainsString('first question', $messages[0]['content']);
+        $this->assertStringContainsString('second question', $messages[0]['content']);
+    }
+
+    /**
+     * When the loaded history window begins on an assistant turn (the opening
+     * user message was trimmed off), the leading assistant turn must be dropped
+     * so the request starts with a `user` message — Anthropic 400s otherwise.
+     */
+    public function testLeadingAssistantTurnsAreDropped(): void
+    {
+        $captured = null;
+        $sse = $this->buildOkStream();
+        $client = new MockHttpClient(function (string $method, string $url, array $options) use (&$captured, $sse): MockResponse {
+            $captured = $this->decodeRequestBody($options);
+
+            return new MockResponse($sse, ['response_headers' => ['content-type' => 'text/event-stream']]);
+        });
+
+        $this->makeProvider(httpClient: $client)->chatStream(
+            [
+                ['role' => 'assistant', 'content' => 'leftover reply from trimmed history'],
+                ['role' => 'user', 'content' => 'actual question'],
+            ],
+            static fn () => null,
+            ['model' => 'claude-haiku-4-5'],
+        );
+
+        $this->assertNotNull($captured);
+        $messages = $captured['messages'];
+        $this->assertNotEmpty($messages);
+        $this->assertSame('user', $messages[0]['role'], 'conversation must start with a user turn');
+        $this->assertSame('actual question', $messages[0]['content']);
+    }
+
+    /**
+     * A streaming HTTP error (buffer:false) must surface Anthropic's real
+     * error.message/type — not the opaque "HTTP 400 returned for …" transport
+     * message the WhatsApp user previously saw.
+     */
+    public function testStreamingSurfacesAnthropicErrorDetailOnHttpError(): void
+    {
+        $errorJson = json_encode([
+            'type' => 'error',
+            'error' => [
+                'type' => 'invalid_request_error',
+                'message' => 'messages: text content blocks must be non-empty',
+            ],
+        ]);
+
+        $client = new MockHttpClient(static fn (): MockResponse => new MockResponse((string) $errorJson, ['http_code' => 400]));
+
+        $this->expectException(ProviderException::class);
+        $this->expectExceptionMessage('messages: text content blocks must be non-empty');
+
+        $this->makeProvider(httpClient: $client)->chatStream(
+            [['role' => 'user', 'content' => 'hi']],
+            static fn () => null,
+            ['model' => 'claude-haiku-4-5'],
+        );
+    }
+
     // ==================== HELPERS ====================
 
     /**
@@ -243,6 +344,62 @@ class AnthropicProviderStreamingTest extends TestCase
         }
 
         return implode("\n\n", $parts)."\n\n";
+    }
+
+    /**
+     * A minimal, well-formed success SSE stream (single text delta) for tests
+     * that only care about the outgoing request body.
+     */
+    private function buildOkStream(): string
+    {
+        return $this->buildSseStream([
+            ['event' => 'message_start', 'data' => [
+                'type' => 'message_start',
+                'message' => ['usage' => ['input_tokens' => 1, 'output_tokens' => 0]],
+            ]],
+            ['event' => 'content_block_start', 'data' => [
+                'type' => 'content_block_start',
+                'index' => 0,
+                'content_block' => ['type' => 'text', 'text' => ''],
+            ]],
+            ['event' => 'content_block_delta', 'data' => [
+                'type' => 'content_block_delta',
+                'index' => 0,
+                'delta' => ['type' => 'text_delta', 'text' => 'ok'],
+            ]],
+            ['event' => 'content_block_stop', 'data' => ['type' => 'content_block_stop', 'index' => 0]],
+            ['event' => 'message_delta', 'data' => [
+                'type' => 'message_delta',
+                'delta' => ['stop_reason' => 'end_turn'],
+                'usage' => ['output_tokens' => 1],
+            ]],
+            ['event' => 'message_stop', 'data' => ['type' => 'message_stop']],
+        ]);
+    }
+
+    /**
+     * Decode the JSON request body captured from the MockHttpClient callback.
+     * Symfony normalises the `json` option into a `body` string before the
+     * response factory runs, so read that back.
+     *
+     * @param array<string, mixed> $options
+     *
+     * @return array<string, mixed>
+     */
+    private function decodeRequestBody(array $options): array
+    {
+        if (isset($options['json']) && is_array($options['json'])) {
+            return $options['json'];
+        }
+
+        $body = $options['body'] ?? '';
+        if (is_string($body) && '' !== $body) {
+            $decoded = json_decode($body, true);
+
+            return is_array($decoded) ? $decoded : [];
+        }
+
+        return [];
     }
 
     private function makeProvider(?HttpClientInterface $httpClient = null): AnthropicProvider

--- a/backend/tests/AI/Provider/GoogleProviderMessageNormalizationTest.php
+++ b/backend/tests/AI/Provider/GoogleProviderMessageNormalizationTest.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\AI\Provider;
+
+use App\AI\Provider\GoogleProvider;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+/**
+ * Gemini rejects empty `parts`, empty text parts, non-alternating roles and a
+ * non-`user` leading turn with HTTP 400 — the same class of failure that broke
+ * WhatsApp turns on Anthropic. These tests lock in that
+ * convertMessagesToGeminiFormat() sanitises the thread before the request.
+ */
+class GoogleProviderMessageNormalizationTest extends TestCase
+{
+    public function testBlankTurnsAreDroppedAndAlternationPreserved(): void
+    {
+        $captured = null;
+        $client = new MockHttpClient(function (string $method, string $url, array $options) use (&$captured): MockResponse {
+            $captured = $this->decodeRequestBody($options);
+
+            return $this->okStream();
+        });
+
+        $this->makeProvider($client)->chatStream(
+            [
+                ['role' => 'user', 'content' => 'q1'],
+                ['role' => 'assistant', 'content' => 'a1'],
+                ['role' => 'assistant', 'content' => '   '], // blank model row → dropped
+                ['role' => 'user', 'content' => 'q2'],
+            ],
+            static fn () => null,
+            ['model' => 'gemini-2.5-flash'],
+        );
+
+        $this->assertNotNull($captured);
+        $contents = $captured['contents'];
+
+        $this->assertSame(['user', 'model', 'user'], array_column($contents, 'role'));
+        $this->assertNoEmptyTextParts($contents);
+        $this->assertSame('q1', $contents[0]['parts'][0]['text']);
+        $this->assertSame('a1', $contents[1]['parts'][0]['text']);
+        $this->assertSame('q2', $contents[2]['parts'][0]['text']);
+    }
+
+    public function testLeadingModelTurnsAreDropped(): void
+    {
+        $captured = null;
+        $client = new MockHttpClient(function (string $method, string $url, array $options) use (&$captured): MockResponse {
+            $captured = $this->decodeRequestBody($options);
+
+            return $this->okStream();
+        });
+
+        $this->makeProvider($client)->chatStream(
+            [
+                ['role' => 'assistant', 'content' => 'leftover reply from trimmed history'],
+                ['role' => 'user', 'content' => 'actual question'],
+            ],
+            static fn () => null,
+            ['model' => 'gemini-2.5-flash'],
+        );
+
+        $this->assertNotNull($captured);
+        $contents = $captured['contents'];
+        $this->assertNotEmpty($contents);
+        $this->assertSame('user', $contents[0]['role'], 'conversation must start with a user turn');
+        $this->assertSame('actual question', $contents[0]['parts'][0]['text']);
+    }
+
+    public function testConsecutiveSameRoleTurnsAreMerged(): void
+    {
+        $captured = null;
+        $client = new MockHttpClient(function (string $method, string $url, array $options) use (&$captured): MockResponse {
+            $captured = $this->decodeRequestBody($options);
+
+            return $this->okStream();
+        });
+
+        // system folds to a user turn; the following user turn must merge with it
+        // instead of producing two consecutive user turns (a Gemini 400).
+        $this->makeProvider($client)->chatStream(
+            [
+                ['role' => 'system', 'content' => 'You are helpful.'],
+                ['role' => 'user', 'content' => 'hello'],
+            ],
+            static fn () => null,
+            ['model' => 'gemini-2.5-flash'],
+        );
+
+        $this->assertNotNull($captured);
+        $contents = $captured['contents'];
+        $this->assertCount(1, $contents);
+        $this->assertSame('user', $contents[0]['role']);
+        $this->assertSame(['You are helpful.', 'hello'], array_column($contents[0]['parts'], 'text'));
+    }
+
+    // ==================== HELPERS ====================
+
+    /**
+     * @param list<array{role: string, parts: list<array<string, mixed>>}> $contents
+     */
+    private function assertNoEmptyTextParts(array $contents): void
+    {
+        foreach ($contents as $content) {
+            foreach ($content['parts'] as $part) {
+                if (isset($part['text'])) {
+                    $this->assertNotSame('', trim((string) $part['text']), 'Gemini rejects empty text parts');
+                }
+            }
+        }
+    }
+
+    /**
+     * A minimal, well-formed Gemini SSE stream (single text chunk).
+     */
+    private function okStream(): MockResponse
+    {
+        $event = 'data: '.json_encode([
+            'candidates' => [[
+                'content' => ['parts' => [['text' => 'ok']]],
+                'finishReason' => 'STOP',
+            ]],
+            'usageMetadata' => ['promptTokenCount' => 1, 'candidatesTokenCount' => 1],
+        ])."\n\n";
+
+        return new MockResponse($event, ['response_headers' => ['content-type' => 'text/event-stream']]);
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     *
+     * @return array<string, mixed>
+     */
+    private function decodeRequestBody(array $options): array
+    {
+        if (isset($options['json']) && is_array($options['json'])) {
+            return $options['json'];
+        }
+
+        $body = $options['body'] ?? '';
+        if (is_string($body) && '' !== $body) {
+            $decoded = json_decode($body, true);
+
+            return is_array($decoded) ? $decoded : [];
+        }
+
+        return [];
+    }
+
+    private function makeProvider(MockHttpClient $httpClient): GoogleProvider
+    {
+        return new GoogleProvider(new NullLogger(), $httpClient, 'test-key');
+    }
+}

--- a/backend/tests/Unit/Service/Message/Handler/ChatHandlerVisionModelResolutionTest.php
+++ b/backend/tests/Unit/Service/Message/Handler/ChatHandlerVisionModelResolutionTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace App\Tests\Unit\Service\Message\Handler;
+
+use App\AI\Service\AiFacade;
+use App\Entity\Model;
+use App\Repository\ConfigRepository;
+use App\Repository\ModelRepository;
+use App\Repository\PromptRepository;
+use App\Service\FeedbackConfigService;
+use App\Service\File\DocumentGeneratorService;
+use App\Service\File\UserUploadPathBuilder;
+use App\Service\MemoryExtractionDispatcher;
+use App\Service\Message\Handler\ChatHandler;
+use App\Service\ModelConfigService;
+use App\Service\PerfPipelineFlag;
+use App\Service\Prompt\TimeContextBuilder;
+use App\Service\PromptService;
+use App\Service\RAG\VectorSearchService;
+use App\Service\RateLimitService;
+use App\Service\UserMemoryService;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+/**
+ * When the account's chat model can't see images, the vision fallback must
+ * honour the CONFIGURED image model (DEFAULTMODEL.PIC2TEXT) instead of grabbing
+ * the globally highest-quality vision model. Previously the global pick meant a
+ * WhatsApp image reply could arrive as an Anthropic answer even though the
+ * account never configured that provider.
+ */
+class ChatHandlerVisionModelResolutionTest extends TestCase
+{
+    public function testPrefersConfiguredPic2TextModel(): void
+    {
+        $configured = $this->createMock(Model::class);
+        $configured->method('getId')->willReturn(42);
+        $configured->method('hasFeature')->willReturn(true);
+
+        $modelConfig = $this->createMock(ModelConfigService::class);
+        $modelConfig->method('getDefaultModel')->willReturn(42);
+
+        $repo = $this->createMock(ModelRepository::class);
+        $repo->method('find')->willReturn($configured);
+        // The global catalog pick must NOT be consulted when a configured
+        // vision model is available.
+        $repo->expects($this->never())->method('findByFeature');
+
+        $result = $this->invokeResolve($this->makeHandler($modelConfig, $repo), 7);
+
+        $this->assertSame($configured, $result);
+    }
+
+    public function testFallsBackToCatalogWhenNoConfiguredModel(): void
+    {
+        $catalog = $this->createMock(Model::class);
+
+        $modelConfig = $this->createMock(ModelConfigService::class);
+        $modelConfig->method('getDefaultModel')->willReturn(null);
+
+        $repo = $this->createMock(ModelRepository::class);
+        $repo->method('findByFeature')->willReturn($catalog);
+
+        $result = $this->invokeResolve($this->makeHandler($modelConfig, $repo), 7);
+
+        $this->assertSame($catalog, $result);
+    }
+
+    public function testFallsBackToCatalogWhenConfiguredModelLacksVision(): void
+    {
+        $configured = $this->createMock(Model::class);
+        $configured->method('hasFeature')->willReturn(false);
+        $catalog = $this->createMock(Model::class);
+
+        $modelConfig = $this->createMock(ModelConfigService::class);
+        $modelConfig->method('getDefaultModel')->willReturn(99);
+
+        $repo = $this->createMock(ModelRepository::class);
+        $repo->method('find')->willReturn($configured);
+        $repo->method('findByFeature')->willReturn($catalog);
+
+        $result = $this->invokeResolve($this->makeHandler($modelConfig, $repo), 7);
+
+        $this->assertSame($catalog, $result);
+    }
+
+    private function invokeResolve(ChatHandler $handler, ?int $userId): ?Model
+    {
+        $method = new \ReflectionMethod(ChatHandler::class, 'resolveVisionFallbackModel');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($handler, $userId);
+
+        return $result instanceof Model ? $result : null;
+    }
+
+    private function makeHandler(ModelConfigService $modelConfig, ModelRepository $repo): ChatHandler
+    {
+        return new ChatHandler(
+            $this->createMock(AiFacade::class),
+            $this->createMock(PromptRepository::class),
+            $this->createMock(PromptService::class),
+            $modelConfig,
+            $repo,
+            new NullLogger(),
+            $this->createMock(VectorSearchService::class),
+            $this->createMock(EntityManagerInterface::class),
+            sys_get_temp_dir(),
+            new UserUploadPathBuilder(),
+            $this->createMock(UserMemoryService::class),
+            new FeedbackConfigService($this->createStub(ConfigRepository::class)),
+            $this->createMock(RateLimitService::class),
+            $this->createMock(MemoryExtractionDispatcher::class),
+            $this->createMock(PerfPipelineFlag::class),
+            $this->createMock(DocumentGeneratorService::class),
+            new TimeContextBuilder(),
+        );
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Three related WhatsApp/provider fixes:
1. Stop provider `400`s caused by WhatsApp history rows (Anthropic + Gemini message normalization).
2. Surface the real Anthropic streaming error instead of the opaque `HTTP/2 400 returned …`.
3. **Stop WhatsApp image turns from silently using an unconfigured Anthropic model** — honor the account's configured image model instead.

## 1 & 2 — provider message handling
WhatsApp/e-mail threads carry blank-text rows (media-only, placeholder, error rows) and the loaded history window can begin on an assistant turn. Anthropic and Gemini reject empty content / non-user leading turn / non-alternating roles with `400 invalid_request_error` (OpenAI-style providers tolerate it).
- **`AnthropicProvider::prepareConversation()`**: drop empty-content turns, merge consecutive roles, drop leading assistant turns; plus up-front HTTP-error detection in `chatStream()` so the real `error.message`/`type` is shown (the SSE body is unreadable under `buffer:false` after streaming).
- **`GoogleProvider::convertMessagesToGeminiFormat()`**: skip blank/empty text parts, drop empty turns, merge consecutive same-role contents, drop leading `model` turns.

### Provider audit (works with WhatsApp?)
Anthropic (fixed), Google/Gemini (fixed); OpenAI (Responses), Groq, Ollama, HuggingFace, OpenAI-compatible, Mistral — OK (lenient OpenAI-style contract).

## 3 — WhatsApp image answered by the wrong (Anthropic) model
Reported: sending an image to the WhatsApp number produced an **Anthropic** answer, even though the account isn't configured to use any Anthropic model.

Root cause: in `ChatHandler`, when the active chat model lacks the `vision` feature, the vision fallback used `ModelRepository::findByFeature('vision', 'chat', true)`, which returns the **globally highest-quality selectable vision chat model** (`findByTag` orders by `quality DESC`) — an Anthropic Claude model — regardless of the account's configuration. It ignored the account's configured image model (`DEFAULTMODEL.PIC2TEXT`).

Fix — new `ChatHandler::resolveVisionFallbackModel()` (used by both the streaming and non-streaming vision branches):
1. Prefer the account's configured image model (`DEFAULTMODEL.PIC2TEXT`, resolved for the effective user id) when it is vision-capable.
2. Fall back to the global catalog pick only when no usable configured model exists (user config → global config → catalog).

So WhatsApp image replies now use the standard configured chat model (if vision-capable) or the standard configured image/multimodal model — never an arbitrary provider.

## Verification
- [ ] Not tested (explain)
- [ ] Manual
- [x] Tests added/updated

Locally (PHP 8.4): `php-cs-fixer check` clean (0/817); `phpstan` clean for changed files (remaining 52 errors are pre-existing, baselined `TritonProvider` gRPC-stub warnings); new + affected unit tests green (`AnthropicProviderStreamingTest`, `GoogleProviderMessageNormalizationTest`, `ChatHandlerVisionModelResolutionTest`, `ChatHandlerVisionImageTest`). Full `make test` / Triton tests need Docker services + the gRPC extension, unavailable here.

## Notes
Change classification: **backend-only**. No API/schema/runtime-config changes.

## Screenshots/Logs

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4f4ee81f-05e6-4fd3-9ea6-97d61a2d9fe4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4f4ee81f-05e6-4fd3-9ea6-97d61a2d9fe4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

