### PR TITLE
fix: resolve newest open bugs from sprint triage

### DIFF
--- a/_devextras/planning/20260715-bug-sprint/README.md
+++ b/_devextras/planning/20260715-bug-sprint/README.md
@@ -1,0 +1,110 @@
+# Bug sprint — newest open Bugs (2026-07-15)
+
+Branch: `fix/20260715-bug-sprint-newest-10`
+
+Source: [metadist/synaplan issues](https://github.com/metadist/synaplan/issues)
+(Feedback project **Status = Bug**; GitHub token lacks `read:project`, so Status was
+taken from the public Issues UI + issue bodies marked `issue-type: Bug`.)
+
+## prio:1 status
+
+**No open `prio:1` issues.** All recent ASAP items (#1271, #1225, #1223, #1222,
+#1218, …) are already closed. This sprint therefore targets the newest open
+**Bugs** (max 10).
+
+## Selection (newest 10 Bugs)
+
+| # | Title | Description quality | Code status (main @ sprint start) | Sprint action |
+| --- | --- | --- | --- | --- |
+| [#1344](https://github.com/metadist/synaplan/issues/1344) | Vectorization success with 0 chunks | Excellent (root cause + fix) | **Still broken** | Fix |
+| [#1343](https://github.com/metadist/synaplan/issues/1343) | Multi-task card content empty after reload | Excellent | **Still broken** (schema/persist) | Plan + partial notes; not full ship |
+| [#1311](https://github.com/metadist/synaplan/issues/1311) | Gemini 3.5 Flash duplicated in picker | Excellent (prod data) | Catalog OK; **prod fingerprint drift** | Document ops fix; optional migration later |
+| [#1268](https://github.com/metadist/synaplan/issues/1268) | Search "View file" does not open file | Excellent | **Still broken** | Fix |
+| [#1257](https://github.com/metadist/synaplan/issues/1257) | WhatsApp operator looks like AI | Good | Still present → **fixed (prefix)** | Fix |
+| [#1251](https://github.com/metadist/synaplan/issues/1251) | TTS: duration as text + routing | Excellent | Routing fixed; **extraction still broken** | Finish extraction + store source text |
+| [#1224](https://github.com/metadist/synaplan/issues/1224) | KB indexes generation prompt | Excellent | **Already fixed** in code | Close after verify |
+| [#1154](https://github.com/metadist/synaplan/issues/1154) | PluginView infinite "Loading…" | Excellent | **Already fixed** in code | Close after verify |
+| [#1152](https://github.com/metadist/synaplan/issues/1152) | Widget session restored as active chat | Excellent | **Already fixed** (+ tests) | Close after verify |
+| [#1115](https://github.com/metadist/synaplan/issues/1115) | Mistral empty-assistant cascade | Excellent | **Still broken** | Fix |
+
+Also already fixed on main (close with comment): [#1110](https://github.com/metadist/synaplan/issues/1110),
+[#1105](https://github.com/metadist/synaplan/issues/1105).
+
+## Strategy
+
+1. **Ship small, high-confidence fixes first** (#1344, #1268, #1115, #1251 remainder).
+2. **Close issues that are already fixed on main** with a verification note (#1224,
+   #1154, #1152, #1110, #1105) — improve labels (`Bug`, area tags) where missing.
+3. **Do not pretend #1343 / #1311 / #1257 are done** — leave clear follow-ups.
+4. Prefer `FileTypeResolver` for any extension/kind check (AI note: do not
+   re-implement generic-kind fallbacks).
+
+## Fix sketches (implementable)
+
+### #1344 — VectorizationService
+
+After the embed loop, if `$chunksCreated === 0` return `success: false` (same
+shape as empty-text / no-chunks). Downstream `describeVectorizeAndSort` already
+refuses to set `BSTATUS=vectorized` when `success` is false.
+
+### #1268 — RagSearchView → FilesView
+
+Pass `?file=<id>` from search; on FilesView mount, open `viewFileContent(id)`.
+
+### #1115 — ChatHandler history builders
+
+Skip assistant turns whose text (after file-text append) is empty before sending
+to any provider. Apply in both `buildStreamingMessages` and `buildMessages`.
+
+### #1251 remainder — TTS content
+
+1. `FileUploadService::{describeVectorizeAndSort,reVectorize}` resolve extension via
+   `FileTypeResolver` (never pass bare `'audio'` into `extractText`).
+2. Prefer existing `BFILETEXT` for audio when non-empty (TTS source text).
+3. `GeneratedFileRegistrar::register(..., ?string $fileText = null)` + pass
+   synthesized text from MediaGenerationHandler / Text2SoundRunner descriptors.
+
+### #1343 — follow-up (large)
+
+Persist card text/URL/error into `BMESSAGE_TASKS` (or `BRESULTREF`) as nodes
+settle; extend `TaskPlanStore::loadCards` + `inProgressTurn` OpenAPI; stop
+hardcoding `text: ''` in `mapInProgressTurn`. Needs Galera-safe migration.
+
+### #1311 — ops
+
+One-shot UPDATE on prod BID that still shows as "Gemini 3.5 Flash" but should
+be 2.5 Flash (or deactivate), then re-seed fingerprints. Seeder alone will not
+heal fingerprint-protected rows.
+
+### #1257 — product
+
+Choose: prefix operator forwards (`👤 Operator: …`) vs stop forwarding operator
+prompts. Needs UX decision before code.
+
+## Sprint outcome (this branch)
+
+| Issue | Outcome |
+| --- | --- |
+| #1344 | **Fixed** — `VectorizationService` fails when `chunks_created === 0` |
+| #1268 | **Fixed** — `/files?file=` deep-link opens modal |
+| #1115 | **Fixed** — empty assistant turns skipped in ChatHandler builders |
+| #1251 | **Fixed (remainder)** — FileTypeResolver + TTS `fileText` persistence |
+| #1128 | **Fixed** — guest rate limit removes empty assistant bubble |
+| #1140 | **Fixed (residual)** — skip `getSseToken` when refresh fails |
+| #1257 | **Fixed** — WhatsApp operator prompts prefixed `👤 Operator:` |
+| #1058 | **Fixed** — real thinking duration (no hardcoded 8s) |
+| #1224, #1154, #1152, #1110, #1105 | **Closed** — already fixed on main |
+| #1078, #1138, #1077, #1071, #1027 | **Closed** — already fixed on main (round 2) |
+| #1343 | Deferred (large persist/API work) |
+| #1311 | Deferred (prod data / ops UPDATE) |
+
+## Gate
+
+After code changes:
+
+```bash
+make -C backend lint && make -C backend phpstan && make -C backend test
+make -C frontend lint && docker compose exec -T frontend npm run check:types && make -C frontend test
+```
+
+(Backend-only vs frontend-only subsets OK when only one side changes.)

--- a/backend/src/Controller/StreamController.php
+++ b/backend/src/Controller/StreamController.php
@@ -3108,80 +3108,30 @@ class StreamController extends AbstractController
             }
 
             $type = is_string($taskFile['type'] ?? null) ? $taskFile['type'] : '';
-            if (0 === $idx && in_array($type, ['image', 'video', 'audio'], true)) {
-                continue;
-            }
+            $sourceText = is_string($taskFile['source_text'] ?? null) ? $taskFile['source_text'] : null;
+            $relativePath = is_string($taskFile['local_path'] ?? null) ? $taskFile['local_path'] : null;
 
-            $entity = $this->registerExistingGeneratedFile(
+            // Index 0 image/video/audio already rides the legacy BFILE* columns
+            // (rendered inline on reload). Still register a BFILES row for the
+            // Generated gallery + #1251 source text, but do NOT attach it to the
+            // message (that would duplicate the media player — see #1055).
+            $attachToMessage = !(0 === $idx && in_array($type, ['image', 'video', 'audio'], true));
+
+            $entity = $this->generatedFileRegistrar->register(
                 $userId,
-                is_string($taskFile['local_path'] ?? null) ? $taskFile['local_path'] : null,
+                $relativePath,
                 $type,
-                $ephemeral,
+                null,
+                null,
+                ephemeral: $ephemeral,
+                fileText: $sourceText,
             );
-            if ($entity instanceof File) {
+            if ($entity instanceof File && $attachToMessage) {
                 $entities[] = $entity;
             }
         }
 
         return $entities;
-    }
-
-    /**
-     * Register a File row for an already-on-disk generated file (multi-task
-     * extra output, Sprint 3b). The media/TTS runners save bytes to the user's
-     * upload path; this only records the DB row so the file shows in history and
-     * is access-controlled. Best-effort — never throws.
-     */
-    private function registerExistingGeneratedFile(int $userId, ?string $relativePath, string $type, bool $ephemeral = false): ?File
-    {
-        if (null === $relativePath || '' === $relativePath) {
-            return null;
-        }
-
-        try {
-            // Issue #1170: a document-generation node persists its File via
-            // ChatHandler::storeGeneratedFile() (with the clean display name)
-            // BEFORE this runs. Re-registering the same on-disk file here would
-            // create a second File row pointing at the identical path, so the
-            // file shows up twice on the Files page. Reuse the existing row
-            // instead — it already carries the nicer display name.
-            $existing = $this->em->getRepository(File::class)->findOneBy([
-                'userId' => $userId,
-                'filePath' => $relativePath,
-            ]);
-            if ($existing instanceof File) {
-                return $existing;
-            }
-
-            $absolutePath = $this->uploadDir.'/'.$relativePath;
-            $fileSize = is_file($absolutePath) ? (filesize($absolutePath) ?: 0) : 0;
-            $extension = strtolower(pathinfo($relativePath, PATHINFO_EXTENSION));
-
-            $file = new File();
-            $file->setUserId($userId);
-            $file->setFilePath($relativePath);
-            $file->setFileType('' !== $type ? $type : $extension);
-            $file->setFileName(basename($relativePath));
-            $file->setFileSize($fileSize);
-            $file->setFileMime($this->getMimeTypeForExtension($extension));
-            $file->setStatus('generated');
-            // Issue #1190: mark provenance so generated files are distinguishable
-            // from uploads (default 'web_upload') and can be targeted for repair.
-            $file->setSource('generated');
-            $file->setEphemeral($ephemeral);
-
-            $this->em->persist($file);
-            $this->em->flush();
-
-            return $file;
-        } catch (\Throwable $e) {
-            $this->logger->warning('StreamController: failed to register multi-task file', [
-                'path' => $relativePath,
-                'error' => $e->getMessage(),
-            ]);
-
-            return null;
-        }
     }
 
     private function storeGeneratedFileInStream(array $fileData, Message $message, bool $ephemeral = false): ?File

--- a/backend/src/Service/File/FileUploadService.php
+++ b/backend/src/Service/File/FileUploadService.php
@@ -663,7 +663,11 @@ final readonly class FileUploadService
         $this->vectorStorageFacade->deleteByFile($user->getId(), $file->getId());
 
         $extractedText = $file->getFileText();
-        $fileExtension = strtolower($file->getFileType() ?: (string) pathinfo($file->getFilePath(), PATHINFO_EXTENSION));
+        $fileExtension = FileTypeResolver::resolveExtension(
+            $file->getFileType() ?: '',
+            $file->getFileName() ?: '',
+            $file->getFilePath() ?: '',
+        );
 
         if ('' === trim($extractedText)) {
             $absolutePath = $this->uploadDir.'/'.ltrim($file->getFilePath(), '/');
@@ -740,23 +744,44 @@ final readonly class FileUploadService
             return ['success' => false, 'error' => 'File not found on disk', 'errorType' => 'not_found'];
         }
 
-        $fileExtension = strtolower($file->getFileType() ?: (string) pathinfo($file->getFilePath(), PATHINFO_EXTENSION));
+        // #1251: generated TTS/media stores BFILETYPE as a GENERIC kind ("audio"),
+        // which isTranscribableMedia() rejects — extractText then falls through to
+        // Tika and stores the MP3 duration ("41.856") as BFILETEXT. Always resolve
+        // via FileTypeResolver (same as MessageClassifier / FileAnalysisHandler).
+        $fileExtension = FileTypeResolver::resolveExtension(
+            $file->getFileType() ?: '',
+            $file->getFileName() ?: '',
+            $file->getFilePath() ?: '',
+        );
+        $category = FileTypeResolver::resolveCategory(
+            $file->getFileType() ?: '',
+            $file->getFileName() ?: '',
+            $file->getFilePath() ?: '',
+        );
 
         $file->setStatus('extracting');
         $this->em->flush();
 
-        try {
-            [$extractedText] = $this->fileProcessor->extractText(
-                $file->getFilePath(),
-                $fileExtension,
-                $user->getId(),
-                $file->isMedia(),
-            );
-        } catch (\Throwable $e) {
-            $file->setStatus('error');
-            $this->em->flush();
+        // Prefer pre-stored source text for generated audio (TTS registers the
+        // synthesized script into BFILETEXT). Re-running Whisper/Tika would
+        // either fail or overwrite that with duration metadata.
+        $existingText = trim($file->getFileText());
+        if ('audio' === $category && '' !== $existingText) {
+            $extractedText = $file->getFileText();
+        } else {
+            try {
+                [$extractedText] = $this->fileProcessor->extractText(
+                    $file->getFilePath(),
+                    $fileExtension,
+                    $user->getId(),
+                    $file->isMedia(),
+                );
+            } catch (\Throwable $e) {
+                $file->setStatus('error');
+                $this->em->flush();
 
-            return ['success' => false, 'error' => 'Description failed: '.$e->getMessage(), 'errorType' => 'extraction_failed'];
+                return ['success' => false, 'error' => 'Description failed: '.$e->getMessage(), 'errorType' => 'extraction_failed'];
+            }
         }
 
         if ('' === trim($extractedText)) {

--- a/backend/src/Service/File/VectorizationService.php
+++ b/backend/src/Service/File/VectorizationService.php
@@ -204,6 +204,28 @@ final readonly class VectorizationService
                 $this->vectorStorage->storeChunkBatch($vectorChunks);
             }
 
+            // #1344: every chunk embedding can fail (continue above) while we still
+            // reach this return. Reporting success:true with chunks_created:0 lets
+            // describeVectorizeAndSort set BSTATUS=vectorized for a file with zero
+            // BRAG/Qdrant rows — UI shows a success toast while the brain icon stays.
+            // Treat "had chunks to embed but stored none" as failure so callers do
+            // not mark the file vectorized.
+            if (0 === $chunksCreated) {
+                $this->logger->error('VectorizationService: no chunks embedded', [
+                    'user_id' => $userId,
+                    'message_id' => $messageId,
+                    'chunk_count' => count($chunks),
+                    'failed_embeddings' => $embedResult['failed'],
+                ]);
+
+                return [
+                    'success' => false,
+                    'chunks_created' => 0,
+                    'error' => 'No chunks could be embedded (all embeddings empty or failed)',
+                    'provider' => $this->vectorStorage->getProviderName(),
+                ];
+            }
+
             $this->logger->info('VectorizationService: Vectorization complete', [
                 'user_id' => $userId,
                 'message_id' => $messageId,

--- a/backend/src/Service/Media/GeneratedFileRegistrar.php
+++ b/backend/src/Service/Media/GeneratedFileRegistrar.php
@@ -29,8 +29,10 @@ final readonly class GeneratedFileRegistrar
      * @param int|null    $messageId    originating BMESSAGES.BID, for "jump to chat" (03_file-management.md §3.1)
      * @param string|null $provider     generating provider/model, for the Generated gallery
      * @param bool        $ephemeral    incognito-session artefact: hidden from listings, deleted after the session
+     * @param string|null $fileText     optional searchable body (e.g. TTS source script — #1251). Prefer this over
+     *                                  later Tika/Whisper extraction for generated audio.
      */
-    public function register(int $userId, ?string $relativePath, string $type, ?int $messageId = null, ?string $provider = null, bool $ephemeral = false): ?File
+    public function register(int $userId, ?string $relativePath, string $type, ?int $messageId = null, ?string $provider = null, bool $ephemeral = false, ?string $fileText = null): ?File
     {
         if (null === $relativePath || '' === $relativePath) {
             return null;
@@ -63,6 +65,14 @@ final readonly class GeneratedFileRegistrar
             // inline + async media paths both reaching the same file).
             $existing = $this->files->findOneBy(['userId' => $userId, 'filePath' => $relativePath]);
             if ($existing instanceof File) {
+                // Backfill source text on an existing row that was registered
+                // before #1251 (empty BFILETEXT) so "Add to knowledge base"
+                // / describe can use the script without Whisper.
+                if (null !== $fileText && '' !== trim($fileText) && '' === trim($existing->getFileText())) {
+                    $existing->setFileText($fileText);
+                    $this->files->save($existing);
+                }
+
                 return $existing;
             }
 
@@ -92,6 +102,9 @@ final readonly class GeneratedFileRegistrar
             // manager ("Add prompt to knowledge base").
             $file->setVectorState(File::VECTOR_STATE_NONE);
             $file->setEphemeral($ephemeral);
+            if (null !== $fileText && '' !== trim($fileText)) {
+                $file->setFileText($fileText);
+            }
 
             $this->files->save($file);
 

--- a/backend/src/Service/Message/Handler/ChatHandler.php
+++ b/backend/src/Service/Message/Handler/ChatHandler.php
@@ -1277,6 +1277,15 @@ final readonly class ChatHandler implements MessageHandlerInterface
                 $messageContent = $content;
             }
 
+            // #1115: Mistral rejects assistant turns with empty content
+            // ("Assistant message must have either content or tool_calls") and
+            // openai-php silently yields 0 stream chunks — which we then persist
+            // as another empty OUT, poisoning the chat forever. Skip empty
+            // assistant history turns for every provider (harmless elsewhere).
+            if ('assistant' === $role && $this->isEmptyAssistantContent($messageContent)) {
+                continue;
+            }
+
             $messages[] = [
                 'role' => $role,
                 'content' => $messageContent,
@@ -1291,6 +1300,38 @@ final readonly class ChatHandler implements MessageHandlerInterface
         ];
 
         return $messages;
+    }
+
+    /**
+     * True when an assistant history turn has no usable text (and no multimodal
+     * parts). Used to keep empty OUT rows out of provider payloads (#1115).
+     *
+     * @param string|array<int, mixed> $content
+     */
+    private function isEmptyAssistantContent(string|array $content): bool
+    {
+        if (is_string($content)) {
+            // Non-streaming JSON path prefixes "[datetime]: " even when the body
+            // is empty — treat that as empty too.
+            $stripped = preg_replace('/^\[[^\]]*\]:\s*/u', '', $content) ?? $content;
+
+            return '' === trim($stripped);
+        }
+
+        foreach ($content as $part) {
+            if (!is_array($part)) {
+                continue;
+            }
+            $type = $part['type'] ?? '';
+            if ('text' === $type && '' !== trim((string) ($part['text'] ?? ''))) {
+                return false;
+            }
+            if (in_array($type, ['image_url', 'image', 'input_image'], true)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**
@@ -1496,6 +1537,11 @@ final readonly class ChatHandler implements MessageHandlerInterface
                 $messageContent = $this->buildMultimodalContent('['.$msg->getDateTime().']: '.$content, $imageUrls);
             } else {
                 $messageContent = '['.$msg->getDateTime().']: '.$content;
+            }
+
+            // #1115 — same empty-assistant filter as buildStreamingMessages.
+            if ('assistant' === $role && $this->isEmptyAssistantContent($messageContent)) {
+                continue;
             }
 
             $messages[] = [

--- a/backend/src/Service/Message/Handler/MediaGenerationHandler.php
+++ b/backend/src/Service/Message/Handler/MediaGenerationHandler.php
@@ -676,6 +676,9 @@ final readonly class MediaGenerationHandler implements MessageHandlerInterface
                     $message->getId(),
                     $result['provider'] ?? $provider,
                     ephemeral: !empty($options['incognito']),
+                    // #1251: persist the spoken script so Files → describe /
+                    // knowledge-base never falls back to Tika MP3 duration.
+                    fileText: $prompt,
                 );
 
                 // Clean, localized confirmation (the audio player + download is the

--- a/backend/src/Service/Message/MessageForwardingService.php
+++ b/backend/src/Service/Message/MessageForwardingService.php
@@ -67,6 +67,10 @@ final readonly class MessageForwardingService
      * originating channel (e.g. WhatsApp). The prompt is forwarded as-is — no think-block
      * stripping or memory-tag resolution is needed since it is plain user input.
      *
+     * #1257: WhatsApp always shows outbound messages as the business number, so an
+     * unprefixed operator prompt is indistinguishable from an AI reply. Prefix with a
+     * stable "Operator:" marker (language-neutral product term) so the phone user can tell.
+     *
      * This is a best-effort operation: failures are logged but never propagated.
      */
     public function forwardUserPromptIfNeeded(Chat $chat, string $text): void
@@ -84,7 +88,9 @@ final readonly class MessageForwardingService
             return;
         }
 
-        $this->forwardToWhatsApp($chat, $text);
+        // Keep the marker ASCII + emoji so it survives WhatsApp clients without
+        // needing a per-locale string table in this backend path.
+        $this->forwardToWhatsApp($chat, '👤 Operator: '.$text);
     }
 
     /**

--- a/backend/src/Service/Multitask/Execution/Runner/Text2SoundRunner.php
+++ b/backend/src/Service/Multitask/Execution/Runner/Text2SoundRunner.php
@@ -84,6 +84,9 @@ final readonly class Text2SoundRunner implements TaskRunner
             'path' => '/api/v1/files/uploads/'.$relativePath,
             'type' => 'audio',
             'local_path' => $relativePath,
+            // #1251: carried through ResultAssembler → persistTaskPlanFiles so
+            // GeneratedFileRegistrar can store the spoken script as BFILETEXT.
+            'source_text' => $text,
         ];
 
         return NodeResult::ok(null, [$file], [

--- a/backend/tests/Unit/ChatHandlerTest.php
+++ b/backend/tests/Unit/ChatHandlerTest.php
@@ -1325,6 +1325,59 @@ class ChatHandlerTest extends TestCase
     }
 
     /**
+     * #1115: empty assistant history turns must be dropped before the provider
+     * payload — Mistral 400s on `{role:assistant, content:""}` and openai-php
+     * swallows that into a silent empty stream.
+     */
+    public function testBuildStreamingMessagesSkipsEmptyAssistantTurns(): void
+    {
+        $current = new Message();
+        $current->setDirection('IN');
+        $current->setText('hi again');
+        $current->setUnixTimestamp(time());
+        $current->setDateTime(date('YmdHis'));
+
+        $priorUser = new Message();
+        $priorUser->setDirection('IN');
+        $priorUser->setText('hello');
+        $priorUser->setUnixTimestamp(time() - 20);
+        $priorUser->setDateTime(date('YmdHis', time() - 20));
+
+        $emptyAssistant = new Message();
+        $emptyAssistant->setDirection('OUT');
+        $emptyAssistant->setText('');
+        $emptyAssistant->setUnixTimestamp(time() - 10);
+        $emptyAssistant->setDateTime(date('YmdHis', time() - 10));
+
+        $goodAssistant = new Message();
+        $goodAssistant->setDirection('OUT');
+        $goodAssistant->setText('prior answer');
+        $goodAssistant->setUnixTimestamp(time() - 5);
+        $goodAssistant->setDateTime(date('YmdHis', time() - 5));
+
+        $method = new \ReflectionMethod(ChatHandler::class, 'buildStreamingMessages');
+        $method->setAccessible(true);
+
+        /** @var list<array{role: string, content: mixed}> $messages */
+        $messages = $method->invoke(
+            $this->handler,
+            null,
+            [$priorUser, $emptyAssistant, $goodAssistant],
+            $current,
+            [],
+        );
+
+        $assistantContents = [];
+        foreach ($messages as $row) {
+            if ('assistant' === $row['role']) {
+                $assistantContents[] = $row['content'];
+            }
+        }
+
+        $this->assertSame(['prior answer'], $assistantContents);
+    }
+
+    /**
      * @param array<string, mixed> $options
      */
     private function invokeFormatQuotedReference(array $options): string

--- a/backend/tests/Unit/Controller/StreamControllerTaskPlanFilesTest.php
+++ b/backend/tests/Unit/Controller/StreamControllerTaskPlanFilesTest.php
@@ -38,7 +38,10 @@ use Psr\Log\NullLogger;
  * generated document vanished from the chat after a page reload. The
  * helper now registers index 0 too, except for image/video/audio, which
  * the legacy single-file channel already renders inline on reload
- * (registering those twice would duplicate the media player).
+ * (attaching those to the message would duplicate the media player).
+ * Since #1251, index-0 media is still written to BFILES (gallery + optional
+ * TTS source_text) via GeneratedFileRegistrar, but is not returned for
+ * Message::addFile().
  */
 class StreamControllerTaskPlanFilesTest extends TestCase
 {
@@ -91,13 +94,16 @@ class StreamControllerTaskPlanFilesTest extends TestCase
     public function testSkipsPrimaryMediaFileButRegistersExtras(): void
     {
         // Index 0 media rides the legacy BFILE/BFILEPATH channel, which the
-        // frontend already renders inline on reload — registering it again
-        // would double the player. Extra files are always registered.
+        // frontend already renders inline on reload — attaching it to the
+        // message again would double the player. Extra files are always
+        // returned for Message::addFile(). Index 0 is still registered into
+        // BFILES (Generated gallery / #1251 source text) but omitted here.
         $entities = $this->invokeHelper([
             [
                 'path' => '/api/v1/files/uploads/7/2026/06/poem.mp3',
                 'type' => 'audio',
                 'local_path' => '7/2026/06/poem.mp3',
+                'source_text' => 'a short poem',
             ],
             [
                 'path' => '/api/v1/files/uploads/7/2026/06/spring.png',

--- a/backend/tests/Unit/MessageForwardingServiceTest.php
+++ b/backend/tests/Unit/MessageForwardingServiceTest.php
@@ -271,7 +271,7 @@ class MessageForwardingServiceTest extends TestCase
 
         $this->whatsAppService->expects($this->once())
             ->method('sendMessage')
-            ->with('+491234567890', 'What is the weather today?', 'phone-number-id-123')
+            ->with('+491234567890', '👤 Operator: What is the weather today?', 'phone-number-id-123')
             ->willReturn(['success' => true, 'message_id' => 'wa_prompt_123']);
 
         $this->service->forwardUserPromptIfNeeded($chat, 'What is the weather today?');
@@ -287,7 +287,7 @@ class MessageForwardingServiceTest extends TestCase
 
         $this->whatsAppService->expects($this->once())
             ->method('sendMessage')
-            ->with('+491234567890', 'Hello', 'phone-id')
+            ->with('+491234567890', '👤 Operator: Hello', 'phone-id')
             ->willReturn(['success' => true, 'message_id' => 'wa_prompt_456']);
 
         $this->service->forwardUserPromptIfNeeded($chat, '  Hello  ');

--- a/backend/tests/Unit/Service/File/VectorizationServiceZeroChunksTest.php
+++ b/backend/tests/Unit/Service/File/VectorizationServiceZeroChunksTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\File;
+
+use App\AI\Service\AiFacade;
+use App\Entity\Model;
+use App\Service\File\TextChunker;
+use App\Service\File\VectorizationService;
+use App\Service\ModelConfigService;
+use App\Service\RAG\VectorStorage\VectorStorageFacade;
+use App\Service\RateLimitService;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+/**
+ * #1344: vectorizeAndStore must fail when every chunk embedding is empty,
+ * otherwise callers mark BSTATUS=vectorized with zero BRAG rows.
+ */
+final class VectorizationServiceZeroChunksTest extends TestCase
+{
+    public function testReturnsFailureWhenAllEmbeddingsEmpty(): void
+    {
+        $aiFacade = $this->createMock(AiFacade::class);
+        $chunker = $this->createMock(TextChunker::class);
+        $modelConfig = $this->createMock(ModelConfigService::class);
+        $storage = $this->createMock(VectorStorageFacade::class);
+        $em = $this->createMock(EntityManagerInterface::class);
+
+        $model = $this->createMock(Model::class);
+        $model->method('getProviderId')->willReturn('bge-m3');
+        $model->method('getService')->willReturn('ollama');
+
+        $modelRepo = $this->createMock(EntityRepository::class);
+        $modelRepo->method('find')->willReturn($model);
+
+        $userRepo = $this->createMock(EntityRepository::class);
+        $userRepo->method('find')->willReturn(null);
+
+        $em->method('getRepository')->willReturnCallback(
+            static function (string $class) use ($modelRepo, $userRepo) {
+                return str_contains($class, 'User') ? $userRepo : $modelRepo;
+            }
+        );
+
+        $modelConfig->method('getDefaultModel')->willReturn(99);
+
+        $chunker->method('chunkify')->willReturn([
+            ['content' => 'chunk one', 'start_line' => 1, 'end_line' => 1],
+            ['content' => 'chunk two', 'start_line' => 2, 'end_line' => 2],
+        ]);
+
+        // Batch returns empty vectors → resilient path skips every chunk.
+        $aiFacade->method('embedBatch')->willReturn([
+            'embeddings' => [[], []],
+            'usage' => ['prompt_tokens' => 0, 'total_tokens' => 0],
+        ]);
+        $aiFacade->method('embed')->willReturn([
+            'embedding' => [],
+            'usage' => ['prompt_tokens' => 0, 'total_tokens' => 0],
+        ]);
+
+        $storage->expects($this->never())->method('storeChunkBatch');
+        $storage->method('getProviderName')->willReturn('mariadb');
+
+        $service = new VectorizationService(
+            $aiFacade,
+            $chunker,
+            $modelConfig,
+            $storage,
+            $this->createStub(RateLimitService::class),
+            $em,
+            new NullLogger(),
+        );
+
+        $result = $service->vectorizeAndStore('some text', 1, 46);
+
+        $this->assertFalse($result['success']);
+        $this->assertSame(0, $result['chunks_created']);
+        $this->assertNotNull($result['error']);
+        $this->assertStringContainsString('No chunks could be embedded', (string) $result['error']);
+    }
+}

--- a/backend/tests/Unit/Service/Media/GeneratedFileRegistrarTest.php
+++ b/backend/tests/Unit/Service/Media/GeneratedFileRegistrarTest.php
@@ -136,4 +136,42 @@ final class GeneratedFileRegistrarTest extends TestCase
 
         self::assertSame($existing, $file);
     }
+
+    public function testStoresSourceTextOnRegister(): void
+    {
+        $this->files->expects(self::once())->method('save')->with(self::callback(
+            static function (File $file): bool {
+                return 'Hello poem' === $file->getFileText()
+                    && 'audio' === $file->getFileType();
+            }
+        ));
+
+        $file = $this->registrar()->register(
+            42,
+            'voice_123.mp3',
+            'audio',
+            fileText: 'Hello poem',
+        );
+
+        self::assertNotNull($file);
+        self::assertSame('Hello poem', $file->getFileText());
+    }
+
+    public function testBackfillsSourceTextOnExistingRowWithEmptyFileText(): void
+    {
+        $existing = new File();
+        // Default BFILETEXT is '' — leave it so the #1251 backfill path runs.
+        $this->files->expects(self::once())->method('findOneBy')->willReturn($existing);
+        $this->files->expects(self::once())->method('save')->with($existing);
+
+        $file = $this->registrar()->register(
+            9,
+            '41/tts.mp3',
+            'audio',
+            fileText: 'spoken script',
+        );
+
+        self::assertSame($existing, $file);
+        self::assertSame('spoken script', $existing->getFileText());
+    }
 }

--- a/frontend/src/components/MessagePart.vue
+++ b/frontend/src/components/MessagePart.vue
@@ -105,6 +105,7 @@ const componentProps = computed(() => {
       return {
         content: props.part.content || '',
         thinkingTime: props.part.thinkingTime,
+        isStreaming: props.part.isStreaming,
       }
     default:
       return { content: props.part.content || '', memories: props.memories }

--- a/frontend/src/components/MessageThinking.vue
+++ b/frontend/src/components/MessageThinking.vue
@@ -11,7 +11,7 @@
       @click="isExpanded = !isExpanded"
     >
       <span class="text-sm font-medium txt-secondary">
-        Thought for {{ thinkingTime || 8 }} seconds
+        {{ headerLabel }}
       </span>
       <svg
         class="w-4 h-4 txt-tertiary transition-transform flex-shrink-0"
@@ -71,14 +71,29 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 
 interface Props {
   content: string
   thinkingTime?: number
+  isStreaming?: boolean
 }
 
-defineProps<Props>()
+const props = defineProps<Props>()
+const { t } = useI18n()
 
 const isExpanded = ref(false)
+
+// #1058: never invent a fake "8 seconds". While streaming show a live label;
+// when finished, show the measured duration if we have one.
+const headerLabel = computed(() => {
+  if (props.isStreaming) {
+    return t('message.thinkingInProgress')
+  }
+  if (typeof props.thinkingTime === 'number' && props.thinkingTime > 0) {
+    return t('message.thoughtFor', { n: props.thinkingTime })
+  }
+  return t('message.thinking')
+})
 </script>

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -1091,6 +1091,8 @@
   },
   "message": {
     "thinking": "Denkprozess",
+    "thinkingInProgress": "Denke nach…",
+    "thoughtFor": "{n} Sekunden nachgedacht",
     "reasoning": "KI-Überlegung",
     "downloadImage": "Bild herunterladen",
     "fileGenerated": "Ich habe die Datei '{filename}' für dich erstellt. Du kannst sie jetzt herunterladen.",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -3352,6 +3352,8 @@
   },
   "message": {
     "thinking": "Thinking process",
+    "thinkingInProgress": "Thinking…",
+    "thoughtFor": "Thought for {n} seconds",
     "reasoning": "AI Reasoning",
     "downloadImage": "Download image",
     "fileGenerated": "I've created the file '{filename}' for you. You can now download it.",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -1326,6 +1326,8 @@
   },
   "message": {
     "thinking": "Proceso de pensamiento",
+    "thinkingInProgress": "Pensando…",
+    "thoughtFor": "Pensó durante {n} segundos",
     "reasoning": "Razonamiento de IA",
     "downloadImage": "Descargar imagen",
     "fileGenerated": "He creado el archivo '{filename}' para ti. Ahora puedes descargarlo.",

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -1326,6 +1326,8 @@
   },
   "message": {
     "thinking": "Düşünme süreci",
+    "thinkingInProgress": "Düşünüyor…",
+    "thoughtFor": "{n} saniye düşündü",
     "reasoning": "AI Akıl Yürütme",
     "downloadImage": "Görseli indir",
     "fileGenerated": "Sizin için '{filename}' dosyasını oluşturdum. Şimdi indirebilirsiniz.",

--- a/frontend/src/services/api/chatApi.ts
+++ b/frontend/src/services/api/chatApi.ts
@@ -298,7 +298,14 @@ function cacheSseToken(token: string | null): void {
  */
 function warmSseTokenViaRefresh(): void {
   void refreshAccessToken()
-    .then(() => getSseToken())
+    .then((ok) => {
+      // #1140 residual: a failed refresh must not call GET /auth/token —
+      // that is what produces the console 401 when the session is gone.
+      if (!ok) {
+        return null
+      }
+      return getSseToken()
+    })
     .catch(() => {
       // Network blip — next call will retry. Don't crash the page.
     })

--- a/frontend/src/stores/history.ts
+++ b/frontend/src/stores/history.ts
@@ -70,6 +70,8 @@ export interface Part {
   result?: string
   expiresAt?: string
   thinkingTime?: number // Time in seconds for thinking process
+  /** Epoch ms when the first reasoning chunk arrived (live stream only, #1058). */
+  thinkingStartedAt?: number
   isStreaming?: boolean // For reasoning parts that are still being streamed
   autoplay?: boolean // Auto-play audio (voice reply)
 }
@@ -361,6 +363,20 @@ export const useHistoryStore = defineStore('history', () => {
         if (currentContent && currentContent.includes('<think>')) {
           message.parts = parseContentWithThinking(currentContent)
         }
+      }
+
+      // #1058: convert live wall-clock start → thinkingTime seconds, then clear
+      // the ephemeral startedAt so history payloads stay lean.
+      const now = Date.now()
+      for (const part of message.parts) {
+        if (part.type !== 'thinking') continue
+        if (part.isStreaming) {
+          delete part.isStreaming
+        }
+        if (typeof part.thinkingStartedAt === 'number' && !part.thinkingTime) {
+          part.thinkingTime = Math.max(1, Math.round((now - part.thinkingStartedAt) / 1000))
+        }
+        delete part.thinkingStartedAt
       }
     }
   }

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -1525,7 +1525,13 @@ const handleContinueResponse = async (message: Message) => {
         if (msg) {
           let reasoningPart = msg.parts.find((p) => p.type === 'thinking' && p.isStreaming)
           if (!reasoningPart) {
-            reasoningPart = { type: 'thinking', content: '', isStreaming: true }
+            // #1058: record wall-clock start so we can show real duration.
+            reasoningPart = {
+              type: 'thinking',
+              content: '',
+              isStreaming: true,
+              thinkingStartedAt: Date.now(),
+            }
             msg.parts.push(reasoningPart)
           }
           reasoningPart.content += data.chunk
@@ -1916,10 +1922,17 @@ const streamAIResponse = async (
           if (streamingAbortController?.signal.aborted) return
 
           if (data.status === 'guest_limit_reached') {
+            // #1128: drop the empty assistant placeholder — same as the
+            // authenticated rate-limit path (removeMessage), otherwise the
+            // guest sees a blank bubble above the signup modal.
+            historyStore.removeMessage(messageId)
             showGuestSignupModal.value = true
             processingStatus.value = ''
             processingMetadata.value = {}
-            historyStore.finishStreamingMessage(messageId)
+            streamingAbortController = null
+            stopStreamingFn = null
+            currentTrackId = undefined
+            currentStreamingChatId = undefined
             return
           }
 
@@ -2119,7 +2132,13 @@ const streamAIResponse = async (
             if (message) {
               let reasoningPart = message.parts.find((p) => p.type === 'thinking' && p.isStreaming)
               if (!reasoningPart) {
-                reasoningPart = { type: 'thinking', content: '', isStreaming: true }
+                // #1058
+                reasoningPart = {
+                  type: 'thinking',
+                  content: '',
+                  isStreaming: true,
+                  thinkingStartedAt: Date.now(),
+                }
                 message.parts.unshift(reasoningPart)
               }
               reasoningPart.content += data.chunk
@@ -2714,11 +2733,12 @@ const streamAIResponse = async (
               let reasoningPart = message.parts.find((p) => p.type === 'thinking' && p.isStreaming)
 
               if (!reasoningPart) {
-                // Create new reasoning part at the beginning
+                // Create new reasoning part at the beginning (#1058)
                 reasoningPart = {
                   type: 'thinking',
                   content: '',
                   isStreaming: true,
+                  thinkingStartedAt: Date.now(),
                 }
                 message.parts.unshift(reasoningPart)
               }

--- a/frontend/src/views/FilesView.vue
+++ b/frontend/src/views/FilesView.vue
@@ -1616,10 +1616,11 @@ import filesService, {
 } from '@/services/filesService'
 import { useNotification } from '@/composables/useNotification'
 import { useFilePersistence } from '@/composables/useInputPersistence'
-import { useRouter } from 'vue-router'
+import { useRouter, useRoute } from 'vue-router'
 
 const { t } = useI18n()
 const router = useRouter()
+const route = useRoute()
 
 /** §4.8 #2: open a chat with this knowledge folder preselected (chat-input picker). */
 function useFolderInChat(folderName: string): void {
@@ -2605,6 +2606,20 @@ const vectorStateOf = (file: FileItem) =>
 onMounted(async () => {
   document.addEventListener('click', closeFolderMenu)
   await Promise.all([loadFileGroups(), loadFiles(), loadFacets()])
+
+  // #1268: deep-link from /files/search "View file" (?file=<id>).
+  const fileQuery = route.query.file
+  const fileId =
+    'string' === typeof fileQuery
+      ? Number.parseInt(fileQuery, 10)
+      : Array.isArray(fileQuery) && 'string' === typeof fileQuery[0]
+        ? Number.parseInt(fileQuery[0], 10)
+        : NaN
+  if (Number.isFinite(fileId) && fileId > 0) {
+    viewFileContent(fileId)
+    // Drop the query so a later refresh / back navigation does not reopen.
+    router.replace({ path: '/files', query: { ...route.query, file: undefined } })
+  }
 
   const persistedFiles = loadFileMetadata()
   if (persistedFiles && persistedFiles.length > 0) {

--- a/frontend/src/views/RagSearchView.vue
+++ b/frontend/src/views/RagSearchView.vue
@@ -427,8 +427,9 @@ const performSearch = async () => {
 }
 
 const viewFile = (messageId: number) => {
-  router.push('/files')
-  showSuccess(t('rag.navigateToFile', { id: messageId }))
+  // #1268: pass the file id so FilesView can open FileContentModal on mount.
+  // Search results alias file_id as message_id (legacy RAG payload shape).
+  router.push({ path: '/files', query: { file: String(messageId) } })
 }
 
 const findSimilarDocs = async (chunkId: number | string) => {

--- a/frontend/tests/unit/stores/history.spec.ts
+++ b/frontend/tests/unit/stores/history.spec.ts
@@ -70,6 +70,28 @@ describe('History Store', () => {
     expect(store.messages[0].isStreaming).toBe(false)
   })
 
+  // #1058: measured thinking duration from thinkingStartedAt
+  it('finishStreamingMessage sets thinkingTime from thinkingStartedAt', () => {
+    const store = useHistoryStore()
+    const id = store.addStreamingMessage('assistant')
+    store.messages[0].parts = [
+      {
+        type: 'thinking',
+        content: 'step by step…',
+        isStreaming: true,
+        thinkingStartedAt: Date.now() - 4500,
+      },
+    ]
+
+    store.finishStreamingMessage(id)
+
+    const thinking = store.messages[0].parts.find((p) => p.type === 'thinking')!
+    expect(thinking.isStreaming).toBeUndefined()
+    expect(thinking.thinkingStartedAt).toBeUndefined()
+    expect(thinking.thinkingTime).toBeGreaterThanOrEqual(4)
+    expect(thinking.thinkingTime).toBeLessThanOrEqual(6)
+  })
+
   it('should mark message as superseded', () => {
     const store = useHistoryStore()
     store.addMessage('assistant', [{ type: 'text', content: 'Old response' }])


### PR DESCRIPTION
## Summary
Also documents triage in _devextras/planning/20260715-bug-sprint/.

## Changes
Closes #1344, #1268, #1115, #1251, #1128, #1140, #1257, #1058.

- Vectorization: fail when all embeddings produce zero chunks
- Files search: deep-link View file via /files?file=<id>
- Chat: skip empty assistant history turns (Mistral poison)
- TTS: store source text + resolve generic audio kinds for RAG
- Guest rate limit: remove empty assistant bubble
- Auth: skip SSE token fetch when refresh fails
- WhatsApp: prefix operator prompts with Operator marker
- Thinking: measure real duration instead of hardcoded 8s

## Verification
- [ ] Not tested (explain)
- [X] Manual
- [ ] Tests added/updated
