### PR TITLE
fix: resolve second bug-sprint batch

### DIFF
--- a/_devextras/planning/20260715-bug-sprint-round2/README.md
+++ b/_devextras/planning/20260715-bug-sprint-round2/README.md
@@ -1,0 +1,23 @@
+# Bug sprint round 2 — 2026-07-15
+
+Branch: `fix/20260715-bug-sprint-round2` (from `origin/main`)
+
+## Selection (10)
+
+| # | Title | Size | Sprint action | Outcome |
+| --- | --- | --- | --- | --- |
+| [#1345](https://github.com/metadist/synaplan/issues/1345) | Persist composer file attachments | M | Fix | `useAttachmentPersist` wired in `ChatInput.vue` (per-chat localStorage; skipped in incognito) |
+| [#732](https://github.com/metadist/synaplan/issues/732) | New chat after cancel reuses empty chat | S | Fix | `findOrCreateEmptyChat` skips active chat with local history; cancel bumps `messageCount` |
+| [#951](https://github.com/metadist/synaplan/issues/951) | Memories retry button polish | S | Fix | Padding/flex + loading/disabled state on retry |
+| [#430](https://github.com/metadist/synaplan/issues/430) | Line break after memory tags | M | Fix | Named-key badge path splices into previous HTML instead of orphan line |
+| [#344](https://github.com/metadist/synaplan/issues/344) | Profile unsaved banner from autofill | S | Fix | Password dirty only after `@input` (`passwordTouchedByUser`) |
+| [#975](https://github.com/metadist/synaplan/issues/975) | WhatsApp missing model metadata | S | Fix | `storeOutgoingMessage` writes `ai_chat_*` / `ai_sorting_*` |
+| [#1311](https://github.com/metadist/synaplan/issues/1311) | Gemini 3.5 Flash duplicate (prod drift) | S | Migration | `Version20260715120000` restores BID 170 when still named/provid 3.5 Flash |
+| [#995](https://github.com/metadist/synaplan/issues/995) | Widget subtitle not configurable | — | Verify & close | Already fixed (`widgetSubtitle` in AdvancedWidgetConfig + ChatWidget) |
+| [#1079](https://github.com/metadist/synaplan/issues/1079) | Multitask routing toggle vs user override | M | Fix | Admin config returns `effectiveForMe` / `hasPersonalOverride`; UI warning + clear |
+| [#623](https://github.com/metadist/synaplan/issues/623) | Cross-tab session isolation | L | Minimal sync | `BroadcastChannel` + `localStorage` principal marker → re-fetch `/auth/me` + reset stores |
+
+## Notes
+
+- Schema: no new tables; #1311 is idempotent DML only (Galera-safe raw SQL).
+- #995: close with comment pointing at `widgetSubtitle` (default / hide / custom).

--- a/backend/migrations/Version20260715120000.php
+++ b/backend/migrations/Version20260715120000.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * #1311: Repair BID 170 when production still carries the aborted
+ * "Gemini 3.5 Flash" rename. Catalog pins BID 170 to Gemini 2.5 Flash and
+ * publishes 3.5 Flash as BID 237, but the seeder fingerprint guard correctly
+ * refused to overwrite the drifted prod row — leaving two "Gemini 3.5 Flash"
+ * entries in the picker.
+ *
+ * Only updates BID 170 while it still looks like the stale 3.5 Flash rename
+ * (BNAME / BPROVID). Operator toggles (BSELECTABLE, BACTIVE, BISDEFAULT) are
+ * never touched. Raw addSql only (Galera-safe).
+ */
+final class Version20260715120000 extends AbstractMigration
+{
+    private const BID = 170;
+
+    /** Catalog fingerprint for Google / Gemini 2.5 Flash / chat (BID 170). */
+    private const FINGERPRINT = 'dc1c7fb7c02e163a316d91523beb65f0ee9484cfecbb12af54e2b4b4c98727f4';
+
+    public function getDescription(): string
+    {
+        return 'Restore BID 170 to Gemini 2.5 Flash when it still carries the stale 3.5 Flash rename (#1311)';
+    }
+
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
+    public function up(Schema $schema): void
+    {
+        $json = json_encode([
+            'description' => 'Google Gemini 2.5 Flash - best price-performance model, 1M token context, reasoning, vision, audio.',
+            'max_tokens' => 65536,
+            'params' => ['model' => 'gemini-2.5-flash'],
+            'features' => ['reasoning', 'vision', 'audio'],
+            'meta' => ['context_window' => '1000000', 'max_output' => '65536'],
+            '__catalog_fingerprint' => self::FINGERPRINT,
+        ], \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE);
+
+        $this->addSql(
+            <<<'SQL'
+            UPDATE BMODELS
+               SET BNAME = 'Gemini 2.5 Flash',
+                   BPROVID = 'gemini-2.5-flash',
+                   BPRICEIN = 0.30,
+                   BINUNIT = 'per1M',
+                   BPRICEOUT = 2.50,
+                   BOUTUNIT = 'per1M',
+                   BQUALITY = 9,
+                   BRATING = 1,
+                   BJSON = :json
+             WHERE BID = :bid
+               AND BSERVICE = 'Google'
+               AND BTAG = 'chat'
+               AND (
+                    BNAME LIKE '%3.5 Flash%'
+                 OR BPROVID LIKE 'gemini-3.5-flash%'
+               )
+            SQL,
+            [
+                'json' => $json,
+                'bid' => self::BID,
+            ]
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        // Intentionally empty: rolling back would reintroduce the duplicate picker bug.
+    }
+}

--- a/backend/src/Controller/AdminSystemConfigController.php
+++ b/backend/src/Controller/AdminSystemConfigController.php
@@ -100,6 +100,18 @@ final class AdminSystemConfigController extends AbstractController
                             new OA\Property(property: 'value', type: 'string'),
                             new OA\Property(property: 'isSet', type: 'boolean'),
                             new OA\Property(property: 'isMasked', type: 'boolean'),
+                            new OA\Property(
+                                property: 'effectiveForMe',
+                                type: 'string',
+                                nullable: true,
+                                description: 'Effective value for the acting admin when a personal override exists (MULTITASK_ROUTING_ENABLED)'
+                            ),
+                            new OA\Property(
+                                property: 'hasPersonalOverride',
+                                type: 'boolean',
+                                nullable: true,
+                                description: 'True when the acting admin has a per-user BCONFIG override'
+                            ),
                         ]
                     )
                 ),
@@ -108,11 +120,11 @@ final class AdminSystemConfigController extends AbstractController
     )]
     #[OA\Response(response: 401, description: 'Authentication required')]
     #[OA\Response(response: 403, description: 'Admin access required')]
-    public function getValues(): JsonResponse
+    public function getValues(#[CurrentUser] ?User $user = null): JsonResponse
     {
         return $this->json([
             'success' => true,
-            'values' => $this->configService->getValues(),
+            'values' => $this->configService->getValues($user?->getId()),
         ]);
     }
 

--- a/backend/src/Service/Admin/SystemConfigService.php
+++ b/backend/src/Service/Admin/SystemConfigService.php
@@ -151,9 +151,9 @@ final readonly class SystemConfigService
     /**
      * Get current configuration values with sensitive fields masked.
      *
-     * @return array<string, array{value: string, isSet: bool, isMasked: bool}>
+     * @return array<string, array{value: string, isSet: bool, isMasked: bool, effectiveForMe?: string, hasPersonalOverride?: bool}>
      */
-    public function getValues(): array
+    public function getValues(?int $actingUserId = null): array
     {
         $values = [];
 
@@ -190,6 +190,26 @@ final readonly class SystemConfigService
                     ];
                 }
             }
+        }
+
+        // #1079: surface effective multitask routing for the acting admin so the
+        // UI can warn when a personal BCONFIG override shadows the global toggle.
+        if (null !== $actingUserId && $actingUserId > 0 && isset($values['MULTITASK_ROUTING_ENABLED'])) {
+            $personal = $this->configRepository->getValue(
+                $actingUserId,
+                MultitaskRoutingConfig::CONFIG_GROUP,
+                MultitaskRoutingConfig::KEY_ROUTING_ENABLED,
+            );
+            $hasOverride = null !== $personal && '' !== $personal;
+            $effective = $hasOverride
+                ? $personal
+                : $values['MULTITASK_ROUTING_ENABLED']['value'];
+            $values['MULTITASK_ROUTING_ENABLED']['hasPersonalOverride'] = $hasOverride;
+            $values['MULTITASK_ROUTING_ENABLED']['effectiveForMe'] = filter_var(
+                $effective,
+                \FILTER_VALIDATE_BOOL,
+                \FILTER_NULL_ON_FAILURE
+            ) ? 'true' : 'false';
         }
 
         return $values;

--- a/backend/src/Service/WhatsAppService.php
+++ b/backend/src/Service/WhatsAppService.php
@@ -815,6 +815,7 @@ final class WhatsAppService
         $responseText = $result['response']['content'] ?? $collectedResponse;
         $responseText = $this->memoryService->resolveMemoryTags($responseText, $user);
         $metadata = $result['response']['metadata'] ?? [];
+        $classification = is_array($result['classification'] ?? null) ? $result['classification'] : null;
         $fileData = $metadata['file'] ?? null;
 
         // Issue #652: WhatsApp responses must surface web search citations
@@ -939,6 +940,8 @@ final class WhatsAppService
                         $chat,
                         $searchResults,
                         ['path' => $mediaPath, 'type' => $generatedMediaType],
+                        $metadata,
+                        $classification,
                     );
                     $responseSent = true;
 
@@ -974,7 +977,17 @@ final class WhatsAppService
                     // The text already reached the user as its own message —
                     // persist it and don't let PRIORITY 3 send it twice.
                     if ($textSentSeparately) {
-                        $this->storeOutgoingMessage($user, $dto, $responseText, $textMessageId, $chat, $searchResults);
+                        $this->storeOutgoingMessage(
+                            $user,
+                            $dto,
+                            $responseText,
+                            $textMessageId,
+                            $chat,
+                            $searchResults,
+                            null,
+                            $metadata,
+                            $classification,
+                        );
                         $responseSent = true;
                     }
                 }
@@ -1057,6 +1070,8 @@ final class WhatsAppService
                         $chat,
                         $searchResults,
                         ['path' => $ttsServePath, 'type' => 'audio'],
+                        $metadata,
+                        $classification,
                     );
                     $responseSent = true;
 
@@ -1110,7 +1125,17 @@ final class WhatsAppService
                 // Persist the response WITHOUT the appended source block — the
                 // platform UI renders sources from metadata, so duplicating
                 // them in the stored text would clutter the history view.
-                $this->storeOutgoingMessage($user, $dto, $responseText, $sendResult['message_id'], $chat, $searchResults);
+                $this->storeOutgoingMessage(
+                    $user,
+                    $dto,
+                    $responseText,
+                    $sendResult['message_id'],
+                    $chat,
+                    $searchResults,
+                    null,
+                    $metadata,
+                    $classification,
+                );
                 $responseSent = true;
 
                 // Discord notification: Text response sent
@@ -1668,14 +1693,19 @@ final class WhatsAppService
      * the asset via sendMedia(), but the cross-channel mirror lives in the DB
      * row.
      *
-     * @param array{query?: string, results?: array}|null $searchResults web-search payload
-     *                                                                   carried alongside the
-     *                                                                   AI response
-     * @param array{path: string, type: string}|null      $generatedFile optional file metadata
-     *                                                                   produced by
-     *                                                                   MediaGenerationHandler
-     *                                                                   (already normalized to a
-     *                                                                   serve URL)
+     * @param array{query?: string, results?: array}|null $searchResults  web-search payload
+     *                                                                    carried alongside the
+     *                                                                    AI response
+     * @param array{path: string, type: string}|null      $generatedFile  optional file metadata
+     *                                                                    produced by
+     *                                                                    MediaGenerationHandler
+     *                                                                    (already normalized to a
+     *                                                                    serve URL)
+     * @param array<string, mixed>|null                   $aiMetadata     chat model metadata from
+     *                                                                    processStream (provider,
+     *                                                                    model, model_id, usage)
+     * @param array<string, mixed>|null                   $classification sorter metadata for
+     *                                                                    ai_sorting_* MessageMeta
      */
     private function storeOutgoingMessage(
         User $user,
@@ -1685,6 +1715,8 @@ final class WhatsAppService
         ?Chat $chat = null,
         ?array $searchResults = null,
         ?array $generatedFile = null,
+        ?array $aiMetadata = null,
+        ?array $classification = null,
     ): void {
         $outgoingMessage = new Message();
         $outgoingMessage->setUserId($user->getId());
@@ -1699,8 +1731,8 @@ final class WhatsAppService
         $outgoingMessage->setFile(null !== $generatedFile ? 1 : 0);
         $outgoingMessage->setFilePath($generatedFile['path'] ?? '');
         $outgoingMessage->setFileType($generatedFile['type'] ?? '');
-        $outgoingMessage->setTopic('CHAT');
-        $outgoingMessage->setLanguage('en');
+        $outgoingMessage->setTopic($classification['topic'] ?? 'CHAT');
+        $outgoingMessage->setLanguage($classification['language'] ?? 'en');
         $outgoingMessage->setText($text);
         $outgoingMessage->setDirection('OUT');
         $outgoingMessage->setStatus('sent');
@@ -1715,6 +1747,26 @@ final class WhatsAppService
             $outgoingMessage->setMeta('from_display_phone', $dto->displayPhoneNumber);
         }
         $outgoingMessage->setMeta('external_id', $externalId);
+
+        // #975: mirror web StreamController model metadata so the platform
+        // chat lightbulb shows which chat/sorting models produced the reply.
+        $outgoingMessage->setMeta('ai_chat_provider', (string) ($aiMetadata['provider'] ?? 'unknown'));
+        $outgoingMessage->setMeta('ai_chat_model', (string) ($aiMetadata['model'] ?? 'unknown'));
+        if (!empty($aiMetadata['model_id'])) {
+            $outgoingMessage->setMeta('ai_chat_model_id', (string) $aiMetadata['model_id']);
+        }
+        if (!empty($aiMetadata['usage']) && is_array($aiMetadata['usage'])) {
+            $outgoingMessage->setMeta('ai_chat_usage', (string) json_encode($aiMetadata['usage']));
+        }
+        if (!empty($classification['sorting_provider'])) {
+            $outgoingMessage->setMeta('ai_sorting_provider', (string) $classification['sorting_provider']);
+        }
+        if (!empty($classification['sorting_model_name'])) {
+            $outgoingMessage->setMeta('ai_sorting_model', (string) $classification['sorting_model_name']);
+        }
+        if (!empty($classification['sorting_model_id'])) {
+            $outgoingMessage->setMeta('ai_sorting_model_id', (string) $classification['sorting_model_id']);
+        }
 
         $resultsList = $searchResults['results'] ?? null;
         if (is_array($resultsList) && [] !== $resultsList) {

--- a/frontend/src/components/ChatInput.vue
+++ b/frontend/src/components/ChatInput.vue
@@ -359,7 +359,7 @@ import { WebSpeechService, isWebSpeechSupported } from '@/services/webSpeechServ
 import { useConfigStore } from '@/stores/config'
 import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
-import { useAutoPersist } from '@/composables/useInputPersistence'
+import { useAutoPersist, useAttachmentPersist } from '@/composables/useInputPersistence'
 import { useChatsStore } from '@/stores/chats'
 import { useAuthStore } from '@/stores/auth'
 import { useIncognitoStore } from '@/stores/incognito'
@@ -552,6 +552,14 @@ const useWebSpeech = computed(() => {
 // incognito session: drafts must never survive in localStorage.
 const { clearInput: clearPersistedInput } = useAutoPersist(
   message,
+  'chat',
+  computed(() => chatsStore.activeChatId),
+  computed(() => incognitoStore.active)
+)
+
+// #1345: also persist already-uploaded attachments per chat (file_id + meta).
+const { clearAttachments: clearPersistedAttachments } = useAttachmentPersist(
+  uploadedFiles,
   'chat',
   computed(() => chatsStore.activeChatId),
   computed(() => incognitoStore.active)
@@ -781,6 +789,7 @@ const sendMessage = () => {
   enhancedMessage.value = ''
   // Clear persisted input after successful send
   clearPersistedInput()
+  clearPersistedAttachments()
 }
 
 const toggleThinking = () => {

--- a/frontend/src/components/MessageText.vue
+++ b/frontend/src/components/MessageText.vue
@@ -472,11 +472,15 @@ function processMemoryBadges(html: string): string {
         result.push(line)
         continue
       }
+      // #430: never emit a bare badge as its own line — that becomes a block
+      // break after markdown. Splice into the previous HTML chunk when possible.
       const badge = buildMemoryBadgeHtml(memory, String(memory.id))
       if (result.length > 0 && result[result.length - 1].trimEnd().endsWith('</p>')) {
         result[result.length - 1] = result[result.length - 1].replace(/<\/p>\s*$/, ` ${badge}</p>`)
+      } else if (result.length > 0 && result[result.length - 1].trim() !== '') {
+        result[result.length - 1] = `${result[result.length - 1].replace(/\s+$/, '')} ${badge}`
       } else {
-        result.push(badge)
+        result.push(`<span class="memory-badge-inline">${badge}</span>`)
       }
     }
     content = result.join('\n')

--- a/frontend/src/components/config/SortingPromptConfiguration.vue
+++ b/frontend/src/components/config/SortingPromptConfiguration.vue
@@ -56,6 +56,31 @@
             <p class="text-xs txt-secondary mt-2">
               {{ $t('config.routing.masterHint') }}
             </p>
+            <p
+              v-if="multitaskPersonalOverride && multitaskEffectiveForMe !== multitaskEnabled"
+              class="text-xs mt-2 px-3 py-2 rounded-lg border border-amber-300/60 dark:border-amber-700/50 bg-amber-50/80 dark:bg-amber-950/30 text-amber-900 dark:text-amber-100"
+              data-testid="multitask-override-warning"
+            >
+              {{
+                $t('config.routing.personalOverrideWarning', {
+                  effective: multitaskEffectiveForMe
+                    ? $t('config.routing.masterOn')
+                    : $t('config.routing.masterOff'),
+                  global: multitaskEnabled
+                    ? $t('config.routing.masterOn')
+                    : $t('config.routing.masterOff'),
+                })
+              }}
+              <button
+                type="button"
+                class="ml-2 underline font-medium disabled:opacity-50"
+                :disabled="togglingMultitask"
+                data-testid="btn-clear-multitask-override"
+                @click="clearMultitaskPersonalOverride"
+              >
+                {{ $t('config.routing.clearPersonalOverride') }}
+              </button>
+            </p>
           </div>
           <label
             class="inline-flex items-center gap-3 cursor-pointer flex-shrink-0"
@@ -482,6 +507,8 @@ import { getMarkdownRenderer } from '@/composables/useMarkdown'
 // This is the primary router; when OFF, the legacy AI sorter handles routing
 // (see the collapsed "Legacy fallback" section).
 const multitaskEnabled = ref(false)
+const multitaskPersonalOverride = ref(false)
+const multitaskEffectiveForMe = ref(true)
 const togglingMultitask = ref(false)
 
 // --- Planner prompt (tools:plan) editor state ------------------------------
@@ -712,7 +739,12 @@ const loadRoutingToggles = async () => {
   if (!isAdmin.value) return
   try {
     const values = await getConfigValues()
-    multitaskEnabled.value = parseBoolConfigValue(values['MULTITASK_ROUTING_ENABLED']?.value)
+    const routing = values['MULTITASK_ROUTING_ENABLED']
+    multitaskEnabled.value = parseBoolConfigValue(routing?.value)
+    multitaskPersonalOverride.value = routing?.hasPersonalOverride === true
+    multitaskEffectiveForMe.value = parseBoolConfigValue(
+      routing?.effectiveForMe ?? routing?.value ?? 'true'
+    )
   } catch (err) {
     const message = err instanceof Error ? err.message : t('config.routing.togglesLoadFailed')
     showError(message)
@@ -731,6 +763,9 @@ const onToggleMultitask = async (next: boolean) => {
     if (!result.success) {
       throw new Error(result.error || t('config.routing.masterUpdateFailed'))
     }
+    // Side-effect on the backend clears the acting admin's personal override.
+    multitaskPersonalOverride.value = false
+    multitaskEffectiveForMe.value = next
     success(
       next ? t('config.routing.masterEnabledNotice') : t('config.routing.masterDisabledNotice')
     )
@@ -741,6 +776,12 @@ const onToggleMultitask = async (next: boolean) => {
   } finally {
     togglingMultitask.value = false
   }
+}
+
+/** Re-apply the workspace default to this admin account (#1079). */
+const clearMultitaskPersonalOverride = async () => {
+  if (!isAdmin.value) return
+  await onToggleMultitask(multitaskEnabled.value)
 }
 
 // --- Planner prompt (tools:plan) load / save --------------------------------

--- a/frontend/src/composables/useInputPersistence.ts
+++ b/frontend/src/composables/useInputPersistence.ts
@@ -260,3 +260,136 @@ export function useAutoPersist(
     clearInput,
   }
 }
+
+/** Persisted chat-composer attachments (already-uploaded File rows). */
+export interface PersistedChatAttachment {
+  file_id: number
+  filename: string
+  file_type: string
+  name?: string
+}
+
+interface PersistedAttachments {
+  files: PersistedChatAttachment[]
+  timestamp: number
+}
+
+/**
+ * Persist already-uploaded chat attachments across navigation (#1345).
+ * Scoped per chat ID; skipped when `disabled` (incognito).
+ * Accepts richer upload rows (e.g. `processing`); only stable fields are saved.
+ */
+export function useAttachmentPersist<T extends PersistedChatAttachment>(
+  filesRef: Ref<T[]>,
+  baseKey: string,
+  chatId?: Ref<number | null>,
+  disabled?: Ref<boolean>
+) {
+  const ATTACH_PREFIX = `${STORAGE_KEY_PREFIX}attach_${baseKey}`
+
+  function storageKey(idOverride?: number | null): string {
+    const id = idOverride !== undefined ? idOverride : chatId?.value
+    if (id !== undefined && id !== null) {
+      return `${ATTACH_PREFIX}_${id}`
+    }
+    return ATTACH_PREFIX
+  }
+
+  const isDisabled = () => disabled?.value === true
+
+  function save(files: PersistedChatAttachment[], idOverride?: number | null) {
+    const key = storageKey(idOverride)
+    if (files.length === 0) {
+      try {
+        localStorage.removeItem(key)
+      } catch {
+        /* ignore */
+      }
+      return
+    }
+    const data: PersistedAttachments = { files, timestamp: Date.now() }
+    try {
+      localStorage.setItem(key, JSON.stringify(data))
+    } catch (error) {
+      console.error('Failed to save chat attachments:', error)
+    }
+  }
+
+  function load(idOverride?: number | null): PersistedChatAttachment[] {
+    try {
+      const stored = localStorage.getItem(storageKey(idOverride))
+      if (!stored) return []
+      const data: PersistedAttachments = JSON.parse(stored)
+      if (Date.now() - data.timestamp > MAX_AGE_MS) {
+        clear(idOverride)
+        return []
+      }
+      return Array.isArray(data.files) ? data.files : []
+    } catch {
+      return []
+    }
+  }
+
+  function clear(idOverride?: number | null) {
+    try {
+      localStorage.removeItem(storageKey(idOverride))
+    } catch {
+      /* ignore */
+    }
+  }
+
+  function toPersisted(files: T[]): PersistedChatAttachment[] {
+    return files
+      .filter((f) => f.file_id > 0)
+      .map((f) => ({
+        file_id: f.file_id,
+        filename: f.filename,
+        file_type: f.file_type,
+        name: f.name,
+      }))
+  }
+
+  function fromPersisted(files: PersistedChatAttachment[]): T[] {
+    return files.map((f) => ({ ...f, processing: false }) as unknown as T)
+  }
+
+  // Restore on mount for the current chat.
+  if (!isDisabled()) {
+    const restored = load()
+    if (restored.length > 0 && filesRef.value.length === 0) {
+      filesRef.value = fromPersisted(restored)
+    }
+  }
+
+  if (chatId) {
+    watch(
+      chatId,
+      (newId, oldId) => {
+        if (newId === oldId) return
+        if (isDisabled()) {
+          filesRef.value = []
+          return
+        }
+        save(toPersisted(filesRef.value), oldId)
+        filesRef.value = fromPersisted(load(newId))
+      },
+      { immediate: false }
+    )
+  }
+
+  watch(
+    filesRef,
+    (files) => {
+      if (isDisabled()) return
+      save(toPersisted(files))
+    },
+    { deep: true }
+  )
+
+  onBeforeUnmount(() => {
+    if (isDisabled()) return
+    save(toPersisted(filesRef.value))
+  })
+
+  return { clearAttachments: clear }
+}

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -1552,6 +1552,8 @@
       "masterTitle": "Multi-Task-Routing",
       "masterDesc": "Nachrichten über den Planer leiten, sodass eine Anfrage mehrere Aufgaben gleichzeitig auslösen kann. Wenn aus, übernimmt der bisherige Einzelthema-AI-Sorter das Routing.",
       "masterHint": "Globale Voreinstellung für den Workspace. Bestehende Nutzer behalten ihre eigene Einstellung, bis sie zustimmen; das Aktivieren hier schaltet es auch für dein eigenes Konto frei.",
+      "personalOverrideWarning": "Dein Konto hat noch eine persönliche Überschreibung (wirksam: {effective}), die von der Workspace-Voreinstellung ({global}) abweicht.",
+      "clearPersonalOverride": "Workspace-Standard für mich übernehmen",
       "masterOn": "An",
       "masterOff": "Aus",
       "masterEnabledNotice": "Multi-Task-Routing aktiviert.",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -1516,6 +1516,8 @@
       "masterTitle": "Multi-task routing",
       "masterDesc": "Route messages through the planner so one request can trigger several tasks at once. When off, the legacy single-topic AI sorter handles routing instead.",
       "masterHint": "Global default for the workspace. Existing users keep their own setting until they opt in; turning this on here also enables it for your own account.",
+      "personalOverrideWarning": "Your account still has a personal override (effective: {effective}) that differs from the workspace default ({global}).",
+      "clearPersonalOverride": "Use workspace default for me",
       "masterOn": "On",
       "masterOff": "Off",
       "masterEnabledNotice": "Multi-task routing enabled.",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -2035,6 +2035,8 @@
       "masterTitle": "Enrutamiento multitarea",
       "masterDesc": "Enruta los mensajes a través del planificador para que una solicitud pueda desencadenar varias tareas a la vez. Si está desactivado, el clasificador de IA de un solo tema se encarga del enrutamiento.",
       "masterHint": "Valor predeterminado global del espacio de trabajo. Los usuarios existentes conservan su propia configuración hasta que opten por activarlo; activarlo aquí también lo habilita para tu propia cuenta.",
+      "personalOverrideWarning": "Tu cuenta aún tiene una anulación personal (efectiva: {effective}) distinta del valor predeterminado del espacio de trabajo ({global}).",
+      "clearPersonalOverride": "Usar el valor predeterminado para mí",
       "masterOn": "Activado",
       "masterOff": "Desactivado",
       "masterEnabledNotice": "Enrutamiento multitarea activado.",

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -2036,6 +2036,8 @@
       "masterTitle": "Çoklu görev yönlendirmesi",
       "masterDesc": "Bir isteğin aynı anda birden fazla görevi tetikleyebilmesi için mesajları planlayıcı üzerinden yönlendirin. Kapalıyken, eski tek konulu yapay zeka sıralayıcısı yönlendirmeyi üstlenir.",
       "masterHint": "Çalışma alanı için genel varsayılan. Mevcut kullanıcılar kendi tercih edene kadar kendi ayarlarını korur; bunu burada açmak kendi hesabınız için de etkinleştirir.",
+      "personalOverrideWarning": "Hesabınızda hâlâ kişisel bir geçersiz kılma var (geçerli: {effective}); çalışma alanı varsayılanından ({global}) farklı.",
+      "clearPersonalOverride": "Benim için çalışma alanı varsayılanını kullan",
       "masterOn": "Açık",
       "masterOff": "Kapalı",
       "masterEnabledNotice": "Çoklu görev yönlendirmesi etkinleştirildi.",

--- a/frontend/src/services/api/adminConfigApi.ts
+++ b/frontend/src/services/api/adminConfigApi.ts
@@ -38,6 +38,8 @@ const ConfigValueZ = z.object({
   value: z.string(),
   isSet: z.boolean(),
   isMasked: z.boolean(),
+  effectiveForMe: z.string().optional(),
+  hasPersonalOverride: z.boolean().optional(),
 })
 
 const ConfigBackupZ = z.object({

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -15,6 +15,13 @@ export const authReady = new Promise<void>((resolve) => {
   authReadyResolve = resolve
 })
 
+/** Cross-tab principal marker (#623). HttpOnly cookies are shared; this key
+ * lets other tabs notice when login/logout changed the session owner. */
+const AUTH_PRINCIPAL_KEY = 'synaplan_auth_principal'
+const AUTH_PRINCIPAL_CHANNEL = 'synaplan_auth_principal'
+
+type AuthPrincipalPayload = { userId: number | null; ts: number }
+
 export const useAuthStore = defineStore('auth', () => {
   // State
   const user = ref<User | null>(null)
@@ -22,6 +29,77 @@ export const useAuthStore = defineStore('auth', () => {
   const loading = ref(false)
   const error = ref<string | null>(null)
   const initialized = ref(false)
+
+  let applyingRemotePrincipal = false
+  let principalChannel: BroadcastChannel | null = null
+
+  function currentPrincipalId(): number | null {
+    return user.value?.id ?? null
+  }
+
+  function publishPrincipal(userId: number | null = currentPrincipalId()) {
+    if (typeof window === 'undefined' || applyingRemotePrincipal) return
+    const payload: AuthPrincipalPayload = { userId, ts: Date.now() }
+    try {
+      localStorage.setItem(AUTH_PRINCIPAL_KEY, JSON.stringify(payload))
+    } catch {
+      /* ignore quota / private mode */
+    }
+    try {
+      principalChannel?.postMessage(payload)
+    } catch {
+      /* ignore */
+    }
+  }
+
+  async function applyRemotePrincipal(nextUserId: number | null) {
+    if (applyingRemotePrincipal) return
+    if (nextUserId === currentPrincipalId()) return
+    applyingRemotePrincipal = true
+    try {
+      await resetUserScopedClientState()
+      const currentUser = await authService.getCurrentUser()
+      if (currentUser) {
+        syncFromAuthService()
+        await useConfigStore().reload()
+      } else {
+        user.value = null
+        impersonator.value = null
+      }
+    } catch (err) {
+      console.warn('Cross-tab auth sync failed', err)
+      user.value = null
+      impersonator.value = null
+    } finally {
+      applyingRemotePrincipal = false
+    }
+  }
+
+  function setupCrossTabAuthSync() {
+    if (typeof window === 'undefined') return
+    if (typeof BroadcastChannel !== 'undefined') {
+      try {
+        principalChannel = new BroadcastChannel(AUTH_PRINCIPAL_CHANNEL)
+        principalChannel.onmessage = (event: MessageEvent<AuthPrincipalPayload>) => {
+          const nextId = event.data?.userId ?? null
+          void applyRemotePrincipal(nextId)
+        }
+      } catch {
+        principalChannel = null
+      }
+    }
+    window.addEventListener('storage', (event: StorageEvent) => {
+      if (event.key !== AUTH_PRINCIPAL_KEY || event.newValue == null) return
+      try {
+        const payload = JSON.parse(event.newValue) as AuthPrincipalPayload
+        void applyRemotePrincipal(payload.userId ?? null)
+      } catch {
+        /* ignore malformed */
+      }
+    })
+  }
+
+  setupCrossTabAuthSync()
 
   // Computed
   const isAuthenticated = computed(() => !!user.value)
@@ -60,6 +138,7 @@ export const useAuthStore = defineStore('auth', () => {
   function syncFromAuthService(): void {
     user.value = authService.getUser().value
     impersonator.value = authService.getImpersonator().value
+    publishPrincipal()
   }
 
   /**
@@ -154,6 +233,7 @@ export const useAuthStore = defineStore('auth', () => {
     // Clear user immediately to prevent any auth checks during logout
     user.value = null
     impersonator.value = null
+    publishPrincipal(null)
     loading.value = true
     // Drop any in-flight deep-link intent so the next login isn't hijacked
     // by a stale entry from this session.

--- a/frontend/src/stores/chats.ts
+++ b/frontend/src/stores/chats.ts
@@ -4,6 +4,7 @@ import { httpClient } from '@/services/api/httpClient'
 import { GetApiChatsListResponseSchema } from '@/generated/api-schemas'
 import { useConfigStore } from '@/stores/config'
 import { useIncognitoStore } from '@/stores/incognito'
+import { useHistoryStore } from '@/stores/history'
 import { authService } from '@/services/authService'
 import { hasSessionHint } from '@/services/sessionHint'
 import { getErrorMessage } from '@/utils/errorMessage'
@@ -269,8 +270,18 @@ export const useChatsStore = defineStore('chats', () => {
       void incognitoStore.endSession()
     }
 
-    // Find all empty chats (not widget sessions, no messages, default title)
-    const emptyChats = chats.value.filter((chat) => isChatEmpty(chat))
+    // Find all empty chats (not widget sessions, no messages, default title).
+    // #732: exclude the active chat when local history already has messages
+    // (e.g. cancelled stream) — list metadata can still look empty, so reuse
+    // would leave the user on the same thread with no visible change.
+    const historyStore = useHistoryStore()
+    const emptyChats = chats.value.filter((chat) => {
+      if (!isChatEmpty(chat)) return false
+      if (chat.id === activeChatId.value && historyStore.messages.length > 0) {
+        return false
+      }
+      return true
+    })
 
     if (emptyChats.length > 0) {
       // Use the first (most recent) empty chat

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -3583,6 +3583,19 @@ const handleUserStop = async () => {
     }
   }
 
+  // #732: cancelled turns leave local history non-empty while chat list
+  // metadata can still look empty — bump activity so "New chat" won't reuse
+  // this thread via isChatEmpty().
+  if (streamingMessage && chatsStore.activeChatId) {
+    chatsStore.bumpChatActivity(chatsStore.activeChatId, {
+      incrementMessageCount: true,
+      firstMessagePreview: streamingMessage
+        ? (streamingMessage.parts?.find((p) => p.type === 'text')?.content ?? '').slice(0, 120) ||
+          undefined
+        : undefined,
+    })
+  }
+
   // Clear references AFTER saving
   streamingAbortController = null
   currentTrackId = undefined

--- a/frontend/src/views/MemoriesView.vue
+++ b/frontend/src/views/MemoriesView.vue
@@ -83,8 +83,17 @@
                 <li>{{ $t('memories.unavailable.reason3') }}</li>
               </ul>
             </div>
-            <button class="btn-primary" @click="retryConnection">
-              <Icon icon="mdi:refresh" class="w-5 h-5 mr-2" />
+            <button
+              class="btn-primary inline-flex items-center justify-center gap-2 px-5 py-2.5 rounded-lg disabled:opacity-60"
+              :disabled="retryingConnection"
+              data-testid="memories-retry"
+              @click="retryConnection"
+            >
+              <Icon
+                :icon="retryingConnection ? 'mdi:loading' : 'mdi:refresh'"
+                class="w-5 h-5"
+                :class="{ 'animate-spin': retryingConnection }"
+              />
               {{ $t('memories.unavailable.retry') }}
             </button>
           </div>
@@ -336,10 +345,14 @@ watch(
   }
 )
 
+const retryingConnection = ref(false)
+
 async function retryConnection() {
+  if (retryingConnection.value) return
+  retryingConnection.value = true
   isServiceUnavailable.value = false
-  await memoriesStore.init()
   try {
+    await memoriesStore.init()
     availableCategories.value = await getCategories()
     isServiceUnavailable.value = false
   } catch (err) {
@@ -349,6 +362,8 @@ async function retryConnection() {
     ) {
       isServiceUnavailable.value = true
     }
+  } finally {
+    retryingConnection.value = false
   }
 }
 

--- a/frontend/src/views/ProfileView.vue
+++ b/frontend/src/views/ProfileView.vue
@@ -326,6 +326,7 @@
                   class="w-full px-4 py-2.5 rounded-lg bg-chat border border-light-border/30 dark:border-dark-border/20 txt-primary focus:ring-2 focus:ring-[var(--brand)] focus:outline-none"
                   :placeholder="$t('profile.changePassword.currentPasswordPlaceholder')"
                   data-testid="input-current-password"
+                  @input="markPasswordTouched"
                 />
               </div>
 
@@ -340,6 +341,7 @@
                   class="w-full px-4 py-2.5 rounded-lg bg-chat border border-light-border/30 dark:border-dark-border/20 txt-primary focus:ring-2 focus:ring-[var(--brand)] focus:outline-none"
                   :placeholder="$t('profile.changePassword.newPasswordPlaceholder')"
                   data-testid="input-new-password"
+                  @input="markPasswordTouched"
                 />
                 <p class="txt-secondary text-sm mt-1">
                   {{ $t('profile.changePassword.newPasswordHint') }}
@@ -357,6 +359,7 @@
                   class="w-full px-4 py-2.5 rounded-lg bg-chat border border-light-border/30 dark:border-dark-border/20 txt-primary focus:ring-2 focus:ring-[var(--brand)] focus:outline-none"
                   :placeholder="$t('profile.changePassword.confirmPasswordPlaceholder')"
                   data-testid="input-confirm-password"
+                  @input="markPasswordTouched"
                 />
                 <p class="txt-secondary text-sm mt-1">
                   {{ $t('profile.changePassword.confirmPasswordHint') }}
@@ -730,8 +733,14 @@ const canConfirmDelete = computed(() => {
   return deleteConfirmPassword.value.length > 0
 })
 
+// #344: browser password autofill can fill fields without a real user edit.
+// Only treat password fields as dirty after an explicit input/change event.
+const passwordTouchedByUser = ref(false)
+
 const hasPasswordChanges = computed(
-  () => !!(passwordData.value.current || passwordData.value.new || passwordData.value.confirm)
+  () =>
+    passwordTouchedByUser.value &&
+    !!(passwordData.value.current || passwordData.value.new || passwordData.value.confirm)
 )
 
 const { hasUnsavedChanges, saveChanges, discardChanges, setupNavigationGuard } = useUnsavedChanges(
@@ -739,6 +748,10 @@ const { hasUnsavedChanges, saveChanges, discardChanges, setupNavigationGuard } =
   originalData,
   { extraDirtyCheck: hasPasswordChanges }
 )
+
+function markPasswordTouched() {
+  passwordTouchedByUser.value = true
+}
 
 let cleanupGuard: (() => void) | undefined
 
@@ -829,6 +842,7 @@ const handleSave = saveChanges(async () => {
     if (canChangePassword.value && passwordData.value.current && passwordData.value.new) {
       await profileApi.changePassword(passwordData.value.current, passwordData.value.new)
       passwordData.value = { current: '', new: '', confirm: '' }
+      passwordTouchedByUser.value = false
     }
 
     originalData.value = { ...formData.value }
@@ -843,6 +857,7 @@ const handleSave = saveChanges(async () => {
 const handleDiscard = () => {
   discardChanges()
   passwordData.value = { current: '', new: '', confirm: '' }
+  passwordTouchedByUser.value = false
 }
 
 const handleDeleteAccount = async () => {


### PR DESCRIPTION
## Summary
Closes #1345, #732, #951, #430, #344, #975, #1311, #1079, #623.

## Changes
- Persist chat composer attachments per chat (skip incognito)
- New chat: do not reuse cancelled/active thread that still has history
- Memories retry: clearer button + loading state
- Memory badges: keep named-key refs inline
- Profile: ignore password autofill until real input
- WhatsApp: store ai_chat_* / ai_sorting_* message metadata
- Models: restore drifted BID 170 to Gemini 2.5 Flash
- Routing admin UI: show personal override vs workspace default
- Auth: sync principal across tabs via BroadcastChannel/localStorage

#995 already closed (widgetSubtitle was already configurable). Planning notes in _devextras/planning/20260715-bug-sprint-round2/.

- [ ] Not tested (explain)
- [*] Manual
- [ ] Tests added/updated
