### PR TITLE
fix(frontend): render user cancellation as a consistent notice, not an error heading

### DIFF
--- a/frontend/src/utils/streamError.ts
+++ b/frontend/src/utils/streamError.ts
@@ -18,6 +18,16 @@
 /** The transport-drop messages emitted by the SSE client (chatApi.ts). */
 const TRANSPORT_DROP_MESSAGES = new Set(['Connection interrupted', 'Failed to connect'])
 
+/**
+ * The backend never emits a structured "cancelled" signal on the happy path
+ * (StreamController swallows StreamCancelledException silently). But a text node
+ * in a multitask/DAG turn re-surfaces the raw exception message
+ * ('Stream cancelled by user') through its generic failure path, which then
+ * reaches the SSE `error` handler. Matching the message keeps a benign user
+ * cancellation from rendering as a big, scary, untranslated error heading.
+ */
+const CANCELLATION_MESSAGE = /cancell?ed by user/i
+
 /** Minimal shape of the `error` status payload the stream delivers. */
 export interface StreamErrorData {
   status?: string
@@ -44,4 +54,20 @@ export function isRecoverableStreamError(data: StreamErrorData): boolean {
 
   const text = typeof data.error === 'string' ? data.error : ''
   return TRANSPORT_DROP_MESSAGES.has(text)
+}
+
+/**
+ * True when the `error` payload is really a user-initiated cancellation. Such a
+ * turn is not a failure and must render as the same lightweight, translated
+ * notice the Stop button uses — never as a prominent error heading.
+ */
+export function isCancellationError(data: StreamErrorData): boolean {
+  if (data.status !== 'error') return false
+  const text =
+    typeof data.error === 'string'
+      ? data.error
+      : typeof data.message === 'string'
+        ? data.message
+        : ''
+  return CANCELLATION_MESSAGE.test(text)
 }

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -451,7 +451,7 @@ import { generatePartId, pushMediaPart, extractMediaParts } from '@/utils/mediaP
 import { buildUploadUrl, isAudioFileType } from '@/utils/mediaTypes'
 import { isChannelSource } from '@/utils/channelSource'
 import { AudioStreamer } from '@/utils/AudioStreamer'
-import { isRecoverableStreamError } from '@/utils/streamError'
+import { isRecoverableStreamError, isCancellationError } from '@/utils/streamError'
 import { httpClient } from '@/services/api/httpClient'
 import { z } from 'zod'
 import {
@@ -3359,6 +3359,28 @@ const streamAIResponse = async (
                 phoneVerified: data.phone_verified || false,
                 topupAvailable: data.topup_available === true,
               })
+
+              streamingAbortController = null
+              stopStreamingFn = null
+              currentTrackId = undefined
+              currentStreamingChatId = undefined
+              return
+            }
+
+            // A user-initiated cancellation is not a failure: render the same
+            // lightweight, translated notice as the Stop button (handleUserStop)
+            // instead of the big `## ⚠️` heading. This keeps every cancellation
+            // notice identical in size/wording and avoids leaking the raw
+            // English backend message ('Stream cancelled by user').
+            if (isCancellationError(data)) {
+              const message = historyStore.messages.find((m) => m.id === messageId)
+              const hasContent = message?.parts.some(
+                (p) => p.type === 'text' && p.content && p.content.trim() !== ''
+              )
+              if (!(message && hasContent)) {
+                historyStore.updateStreamingMessage(messageId, t('message.cancelledByUser'))
+              }
+              historyStore.finishStreamingMessage(messageId)
 
               streamingAbortController = null
               stopStreamingFn = null

--- a/frontend/tests/unit/streamError.spec.ts
+++ b/frontend/tests/unit/streamError.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { isRecoverableStreamError } from '@/utils/streamError'
+import { isRecoverableStreamError, isCancellationError } from '@/utils/streamError'
 
 /**
  * Issue #1265: a pure SSE transport drop must be recoverable (reconcile with the
@@ -50,5 +50,40 @@ describe('isRecoverableStreamError (issue #1265)', () => {
         install_command: 'ollama pull llama3',
       })
     ).toBe(false)
+  })
+})
+
+/**
+ * A user-initiated cancellation of a multitask/DAG text node re-surfaces the raw
+ * StreamCancelledException message through the generic error path. It must be
+ * detected so the chat renders the lightweight translated cancel notice instead
+ * of a big `## ⚠️` error heading (and never leaks the English backend text).
+ */
+describe('isCancellationError', () => {
+  it('detects the raw backend cancellation message', () => {
+    expect(isCancellationError({ status: 'error', error: 'Stream cancelled by user' })).toBe(true)
+  })
+
+  it('detects the message when wrapped by the generic failure prefix', () => {
+    expect(
+      isCancellationError({
+        status: 'error',
+        error: 'Failed to process message: Stream cancelled by user',
+      })
+    ).toBe(true)
+  })
+
+  it('reads the cancellation text from the message field too', () => {
+    expect(isCancellationError({ status: 'error', message: 'Stream cancelled by user' })).toBe(true)
+  })
+
+  it('is false for a non-error status', () => {
+    expect(isCancellationError({ status: 'complete', error: 'Stream cancelled by user' })).toBe(
+      false
+    )
+  })
+
+  it('is false for a genuine backend error', () => {
+    expect(isCancellationError({ status: 'error', error: 'No model configured' })).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary
- A user-cancelled text node in a multitask/DAG turn re-surfaces the raw `StreamCancelledException` message (`Stream cancelled by user`) through the generic SSE `error` path, which the chat wrapped as a `## ⚠️` markdown H2 heading. That rendered much larger (1.25rem bold) than the Stop button's plain-paragraph notice (`t('message.cancelledByUser')`, 0.875rem) — the visible "different sizes" bug — and leaked the untranslated English backend text.
- Added `isCancellationError()` in `frontend/src/utils/streamError.ts` to detect a user cancellation in the `error` payload.
- In `ChatView.vue`'s main error handler, a detected cancellation now renders the same lightweight, translated cancel notice used by `handleUserStop`, and returns early (like the other benign branches). Genuine errors keep the prominent `## ⚠️` heading treatment.
- Added unit coverage for `isCancellationError`.

## Before / After
- Before: two cancellation notices in one turn — `⚠️ Vom Benutzer abgebrochen` (small paragraph) and `⚠️ Stream cancelled by user` (large H2, English).
- After: both render as the same small, translated `⚠️ Vom Benutzer abgebrochen` notice.

## Test plan
- [x] `make -C frontend lint` (+ prettier format check)
- [x] `docker compose exec -T frontend npm run check:types` (vue-tsc)
- [x] `vitest run tests/unit/streamError.spec.ts` (9/9 passing)
- [ ] Manual: cancel a multitask turn (Stop button) and confirm all cancellation notices render at the same size, translated, with no `## ⚠️` heading; confirm genuine errors (e.g. no model configured) still show the prominent heading + install hints.

Frontend-only, web/self-host default behavior unchanged. Not a mobile-risk path.