### PR TITLE
fix(media): persist TTS source text on async job path (#1251)

### DIFF
--- a/backend/src/Service/Media/MediaJobMessageSync.php
+++ b/backend/src/Service/Media/MediaJobMessageSync.php
@@ -301,7 +301,27 @@ final readonly class MediaJobMessageSync
             }
         }
 
-        $file = $this->fileRegistrar->register($job->getUserId(), $relativePath, $job->getType(), $message->getId());
+        // #1251: async TTS stores a GENERIC BFILETYPE ('audio') and, without the
+        // spoken script, a later "what was said?" follow-up / knowledge-base add
+        // falls through to Whisper/Tika and records the MP3 duration instead of
+        // the text. The synchronous MediaGenerationHandler path already persists
+        // the prompt as BFILETEXT; mirror that here for the detached job path so
+        // both channels behave the same. Only audio carries usable source text.
+        $fileText = null;
+        if (MediaJob::TYPE_AUDIO === $job->getType()) {
+            $prompt = $job->getPrompt();
+            if (null !== $prompt && '' !== trim($prompt)) {
+                $fileText = $prompt;
+            }
+        }
+
+        $file = $this->fileRegistrar->register(
+            $job->getUserId(),
+            $relativePath,
+            $job->getType(),
+            $message->getId(),
+            fileText: $fileText,
+        );
         if (null === $file) {
             $this->logger->warning('MediaJobMessageSync: failed to register generated file', [
                 'job_key' => $job->getJobKey(),

--- a/backend/tests/Unit/Service/Media/MediaJobMessageSyncTest.php
+++ b/backend/tests/Unit/Service/Media/MediaJobMessageSyncTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\Media;
+
+use App\Entity\File;
+use App\Entity\Message;
+use App\Repository\MessageRepository;
+use App\Service\Media\GeneratedFileRegistrar;
+use App\Service\Media\MediaJob;
+use App\Service\Media\MediaJobMessageSync;
+use App\Service\Media\MediaJobRealtimeNotifier;
+use App\Service\Media\MediaJobService;
+use App\Service\Media\MediaJobUsageRecorder;
+use App\Service\Multitask\TaskPlanStore;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+/**
+ * #1251: the ASYNC (detached-job) media path must persist the spoken TTS script
+ * as BFILETEXT, exactly like the synchronous MediaGenerationHandler path. Before
+ * this, MediaJobMessageSync::attachGeneratedFile registered the audio File
+ * without source text, so a later "what was said?" follow-up / knowledge-base
+ * add fell through to Whisper/Tika and stored the MP3 duration instead.
+ */
+final class MediaJobMessageSyncTest extends TestCase
+{
+    private MessageRepository&MockObject $messageRepository;
+    private MediaJobService&MockObject $mediaJobService;
+    private GeneratedFileRegistrar&MockObject $fileRegistrar;
+    private MediaJobRealtimeNotifier&MockObject $realtimeNotifier;
+    private MediaJobUsageRecorder&MockObject $usageRecorder;
+    private TaskPlanStore&MockObject $taskPlanStore;
+    private EntityManagerInterface&MockObject $em;
+    private MediaJobMessageSync $sync;
+
+    protected function setUp(): void
+    {
+        $this->messageRepository = $this->createMock(MessageRepository::class);
+        $this->mediaJobService = $this->createMock(MediaJobService::class);
+        $this->fileRegistrar = $this->createMock(GeneratedFileRegistrar::class);
+        $this->realtimeNotifier = $this->createMock(MediaJobRealtimeNotifier::class);
+        $this->usageRecorder = $this->createMock(MediaJobUsageRecorder::class);
+        $this->taskPlanStore = $this->createMock(TaskPlanStore::class);
+        $this->em = $this->createMock(EntityManagerInterface::class);
+
+        $this->sync = new MediaJobMessageSync(
+            $this->messageRepository,
+            $this->mediaJobService,
+            $this->fileRegistrar,
+            $this->realtimeNotifier,
+            $this->usageRecorder,
+            $this->taskPlanStore,
+            $this->em,
+            new NullLogger(),
+        );
+    }
+
+    public function testCompletedAudioJobPersistsSpokenScriptAsFileText(): void
+    {
+        $captured = [];
+        $this->fileRegistrar->expects(self::once())
+            ->method('register')
+            ->willReturnCallback($this->captureRegisterArgs($captured));
+
+        $this->sync->syncTerminalState($this->completedJob(
+            MediaJob::TYPE_AUDIO,
+            'Hello from Synaplan, this is a TTS routing test.',
+        ));
+
+        self::assertSame('Hello from Synaplan, this is a TTS routing test.', $captured['fileText']);
+        self::assertSame('7/2026/07/voice.mp3', $captured['relativePath']);
+        self::assertSame('audio', $captured['type']);
+    }
+
+    public function testCompletedImageJobDoesNotPassFileText(): void
+    {
+        $captured = [];
+        $this->fileRegistrar->expects(self::once())
+            ->method('register')
+            ->willReturnCallback($this->captureRegisterArgs($captured));
+
+        $this->sync->syncTerminalState($this->completedJob(
+            MediaJob::TYPE_IMAGE,
+            'a red balloon over a city',
+        ));
+
+        // A generated image prompt is a description, not spoken content — the
+        // sync path never stored it as BFILETEXT, so neither must this one.
+        self::assertNull($captured['fileText']);
+    }
+
+    public function testCompletedAudioJobWithBlankPromptPassesNullFileText(): void
+    {
+        $captured = [];
+        $this->fileRegistrar->expects(self::once())
+            ->method('register')
+            ->willReturnCallback($this->captureRegisterArgs($captured));
+
+        $this->sync->syncTerminalState($this->completedJob(MediaJob::TYPE_AUDIO, '   '));
+
+        self::assertNull($captured['fileText']);
+    }
+
+    /**
+     * @param array<string, mixed> $captured
+     */
+    private function captureRegisterArgs(array &$captured): callable
+    {
+        return function (
+            int $userId,
+            ?string $relativePath,
+            string $type,
+            ?int $messageId = null,
+            ?string $provider = null,
+            bool $ephemeral = false,
+            ?string $fileText = null,
+        ) use (&$captured): File {
+            $captured = compact('userId', 'relativePath', 'type', 'messageId', 'fileText');
+
+            return new File();
+        };
+    }
+
+    private function completedJob(string $type, string $prompt): MediaJob
+    {
+        $job = (new MediaJob('job-key-1'))
+            ->setUserId(7)
+            ->setType($type)
+            ->setMessageId(55)
+            ->setPrompt($prompt)
+            ->setStatus(MediaJob::STATUS_COMPLETED)
+            ->setResult([
+                'file' => ['url' => '/api/v1/files/uploads/7/2026/07/voice.mp3', 'type' => $type],
+            ]);
+
+        $message = new Message();
+        $message->setDirection('OUT');
+        // Message::getId() has no setter — assign the persisted id via reflection
+        // so setMeta() (which stamps MessageMeta::$messageId) works.
+        $idProp = new \ReflectionProperty(Message::class, 'id');
+        $idProp->setValue($message, 55);
+
+        $this->messageRepository->method('find')->willReturn($message);
+        $this->mediaJobService->method('toStatusArray')->willReturn(['state' => 'completed']);
+        $this->usageRecorder->method('record')->willReturn(null);
+
+        return $job;
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the remaining gap in **#1251**: the async (detached-job) TTS path did not store the spoken script, so a later "what was said?" follow-up or "add to knowledge base" fell through to Whisper/Tika and recorded the MP3 duration instead of the text.

The synchronous `MediaGenerationHandler` path already persisted the prompt as `BFILETEXT` (shipped in #1348), but `MediaJobMessageSync::attachGeneratedFile` — the channel used for detached/async media jobs — registered the audio `File` without source text. Manual QA (`.cursor/notes/manual-test-20260714-15-bug-sprints.md`) reconfirmed this as a FAIL (async Piper job `53`: `LENGTH(BFILETEXT)=0`).

## Changes

- `MediaJobMessageSync`: for a completed **AUDIO** job, pass `$job->getPrompt()` (the spoken script) as `fileText` to `GeneratedFileRegistrar::register()`, mirroring the sync path. Image/video prompts are descriptions, not spoken content, so they stay untouched (as before).
- New unit test `MediaJobMessageSyncTest`: audio → script stored as `fileText`; image → no `fileText`; blank prompt → `null`.

## Verification

- [ ] Not tested (explain)
- [x] Manual
- [x] Tests added/updated

Backend gate green: `make -C backend lint` · `make -C backend phpstan` (src + tests) · `make -C backend test` (2704 tests, 0 errors/failures). Backend-only change — frontend checks skipped.