### PR TITLE
fix(auth): keep session on transient 5xx during token refresh

### DIFF
--- a/frontend/src/services/authService.ts
+++ b/frontend/src/services/authService.ts
@@ -320,9 +320,17 @@ export const authService = {
       )
 
       if (!response.ok) {
-        // Refresh token invalid/expired (expected behavior, don't spam console)
-        clearSessionHint()
-        await this.logout(true) // Silent logout
+        // Only a genuine auth rejection (401/403) means the refresh token is
+        // invalid/expired → end the session. A transient server/proxy error
+        // (e.g. 502/503/504 while a backend node is restarting or cold-starting
+        // during a rolling deploy) must NOT log the user out: keep the session
+        // and let the caller retry once the node is back. This matches the
+        // network-error branch below, which also preserves the session.
+        if (401 === response.status || 403 === response.status) {
+          clearSessionHint()
+          await this.logout(true) // Silent logout
+        }
+
         return false
       }
 


### PR DESCRIPTION
## Summary

Active users get logged out during rolling platform deploys. Root cause is client-side, not lost session state: sessions (shared Redis) and refresh tokens (Galera) survive restarts, and `APP_SECRET`/`TOKEN_SECRET` are stable.

`_doRefresh()` in `authService.ts` logged the user out on **any** non-OK response from `/api/v1/auth/refresh`. While a backend node restarts/cold-starts, the load balancer returns **502/503/504**, and an expiring access token that triggers a refresh then hit that 5xx and was treated exactly like an expired/invalid refresh token → silent logout.

## Change

- Restrict the refresh-failure logout to genuine auth rejections (**401/403**).
- On transient **5xx / network** errors, keep the session and return `false` so the caller retries once the node is back — mirroring the existing network-error branch (which already preserved the session).

Applies to both web and native (native refresh path unchanged apart from the status gate).

## Test plan

- [x] `vue-tsc` type check clean
- [x] ESLint clean
- [x] Auth unit tests pass (`httpClient-refresh`, `useAuth`, `auth-impersonation`, `sessionHint` — 22 tests)
- [ ] Manual: expire access token, return a 502 from `/api/v1/auth/refresh`, confirm the user stays logged in and recovers on retry
- [ ] Manual: return 401 from refresh, confirm the user is still logged out