### PR TITLE
Enhance chat input placeholder for mobile and desktop

### DIFF
--- a/frontend/src/components/ChatInput.vue
+++ b/frontend/src/components/ChatInput.vue
@@ -112,7 +112,9 @@
               <Textarea
                 ref="textareaRef"
                 v-model="message"
-                :placeholder="isMobile ? 'Message...' : $t('chatInput.placeholder')"
+                :placeholder="
+                  isMobile ? $t('chatInput.placeholderShort') : $t('chatInput.placeholder')
+                "
                 :rows="1"
                 class="flex-1 min-w-0"
                 data-testid="input-chat-message"

--- a/frontend/src/components/Textarea.vue
+++ b/frontend/src/components/Textarea.vue
@@ -39,7 +39,19 @@ const adjustHeight = () => {
   if (!el) return
 
   el.style.height = 'auto'
-  el.style.height = el.scrollHeight + 'px'
+  // With `box-sizing: border-box`, scrollHeight (content + padding, no border)
+  // is NOT the value to assign to `height`: the border eats into the content
+  // box, leaving it shorter than one line-height. The single line then top-clips
+  // and the caret detaches from the placeholder baseline — on iOS WKWebView this
+  // shows up as a caret pinned to the top-left while the placeholder sits lower.
+  // Add the border back so the content box always fits a full line. No-op when
+  // there is no border.
+  const style = getComputedStyle(el)
+  const borderY =
+    'border-box' === style.boxSizing
+      ? parseFloat(style.borderTopWidth) + parseFloat(style.borderBottomWidth)
+      : 0
+  el.style.height = `${el.scrollHeight + borderY}px`
 }
 
 const handleInput = (event: Event) => {

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -520,6 +520,7 @@
   "chatInput": {
     "attach": "Anhängen",
     "placeholder": "Schreibe deine Nachricht hier...",
+    "placeholderShort": "Nachricht...",
     "provider": "Anbieter",
     "model": "Modell",
     "modelCaption": "Modell: {name}",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -523,6 +523,7 @@
   },
   "chatInput": {
     "placeholder": "Type your message...",
+    "placeholderShort": "Message...",
     "provider": "Provider",
     "model": "Model",
     "modelCaption": "Model: {name}",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -534,6 +534,7 @@
   },
   "chatInput": {
     "placeholder": "Escribe tu mensaje...",
+    "placeholderShort": "Mensaje...",
     "provider": "Proveedor",
     "model": "Modelo",
     "modelCaption": "Modelo: {name}",

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -534,6 +534,7 @@
   },
   "chatInput": {
     "placeholder": "Mesajınızı yazın...",
+    "placeholderShort": "Mesaj...",
     "provider": "Sağlayıcı",
     "model": "Model",
     "modelCaption": "Model: {name}",


### PR DESCRIPTION
## Summary
Add short placeholder translations

## Changes
- Updated ChatInput.vue to use a shorter placeholder for mobile devices.
- Added new translation keys for short placeholders in German, English, Spanish, and Turkish.
- Improved Textarea.vue height adjustment logic to account for border styles, ensuring proper display of content.

## Verification
- [ ] Not tested (explain)
- [X] Manual
- [ ] Tests added/updated
