### PR TITLE
Enhance IAP pricing configuration and service logic

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -368,12 +368,17 @@ IAP_PRODUCT_PRO=com.synaplan.app.pro.monthly
 IAP_PRODUCT_TEAM=com.synaplan.app.team.monthly
 IAP_PRODUCT_BUSINESS=com.synaplan.app.business.monthly
 
-# Store commission passed on to app buyers, in percent ON TOP of the web price.
-# The /subscription/plans endpoint exposes `appPrice = price * (1 + markup/100)`,
-# snapped to the nearest x.99 store price point (e.g. 19.95 + 30 % → 25.99).
-# The native app shows it as its fallback price (the store's own localized
-# price wins once loaded); the web always shows the plain `price`. Set the
-# App Store Connect / Play Console product prices to match this value.
+# Fixed App Store / Play EUR price points (must match ASC / Play Console).
+# Exposed as `appPrice` on /subscription/plans for the native-app fallback.
+# PRO €24.99 decided 2026-07-20; set a tier to 0 to fall back to markup snap.
+IAP_STORE_PRICE_PRO=24.99
+IAP_STORE_PRICE_TEAM=64.99
+IAP_STORE_PRICE_BUSINESS=129.99
+
+# Store commission fallback (percent ON TOP of the web price) when a tier's
+# IAP_STORE_PRICE_* is 0. Snapped to the nearest x.99 store price point
+# (e.g. 19.95 + 30 % → 25.99). The native app shows `appPrice` as fallback
+# (store localized price wins once loaded); the web always shows `price`.
 IAP_PRICE_MARKUP_PERCENT=30
 
 # ── IAP server-side receipt validation — mobile app only (Epic 5.4) ─────────

--- a/backend/config/services.yaml
+++ b/backend/config/services.yaml
@@ -101,7 +101,13 @@ parameters:
     env(IAP_PRODUCT_TEAM): 'com.synaplan.app.team.monthly'
     env(IAP_PRODUCT_BUSINESS): 'com.synaplan.app.business.monthly'
     # Store commission passed on to app buyers (percent on top of the web price).
+    # Used only when a tier has no fixed IAP_STORE_PRICE_* (0 / unset).
     env(IAP_PRICE_MARKUP_PERCENT): '30'
+    # Fixed App Store / Play EUR price points (German launch catalogue).
+    # PRO €24.99 decided 2026-07-20; TEAM/BUSINESS keep the ~30 % pass-through.
+    env(IAP_STORE_PRICE_PRO): '24.99'
+    env(IAP_STORE_PRICE_TEAM): '64.99'
+    env(IAP_STORE_PRICE_BUSINESS): '129.99'
     env(WHATSAPP_ACCESS_TOKEN): ''
     env(WHATSAPP_WEBHOOK_VERIFY_TOKEN): ''
     env(CLOUDFLARE_ACCOUNT_ID): ''
@@ -595,6 +601,9 @@ services:
             $iapProductTeam: '%env(IAP_PRODUCT_TEAM)%'
             $iapProductBusiness: '%env(IAP_PRODUCT_BUSINESS)%'
             $storeMarkupPercent: '%env(float:IAP_PRICE_MARKUP_PERCENT)%'
+            $storePricePro: '%env(float:IAP_STORE_PRICE_PRO)%'
+            $storePriceTeam: '%env(float:IAP_STORE_PRICE_TEAM)%'
+            $storePriceBusiness: '%env(float:IAP_STORE_PRICE_BUSINESS)%'
 
     # Native IAP server-side receipt validation (Epic 5.4). Both verifiers are
     # no-ops until store credentials are configured (isConfigured() === false),

--- a/backend/src/Controller/SubscriptionController.php
+++ b/backend/src/Controller/SubscriptionController.php
@@ -177,11 +177,12 @@ class SubscriptionController extends AbstractController
                             new OA\Property(
                                 property: 'appPrice',
                                 type: 'number',
-                                example: 25.99,
-                                description: 'Price when bought in the mobile app: the web price plus '
-                                    .'the store-commission markup (IAP_PRICE_MARKUP_PERCENT), snapped to '
-                                    .'the nearest x.99 store price point. The native app shows this as '
-                                    .'its fallback; the store\'s own localized price wins once loaded. '
+                                example: 24.99,
+                                description: 'Price when bought in the mobile app: the configured store '
+                                    .'catalogue price (IAP_STORE_PRICE_*), or web price plus '
+                                    .'IAP_PRICE_MARKUP_PERCENT snapped to the nearest x.99 point when no '
+                                    .'fixed store price is set. The native app shows this as its '
+                                    .'fallback; the store\'s own localized price wins once loaded. '
                                     .'The web NEVER shows this.',
                             ),
                             new OA\Property(property: 'currency', type: 'string', example: 'EUR'),
@@ -231,10 +232,11 @@ class SubscriptionController extends AbstractController
                 // MOBILE-APP SEAM (Epic 5.5): the store product the app buys for this tier.
                 'iapProductId' => $this->iapPricingService->productIdForTier($tier),
                 'price' => $price,
-                // MOBILE-APP SEAM: in-app price = web price + store-commission
-                // markup. Shown ONLY by the native app (store price wins once
-                // its catalogue is loaded); the web always shows `price`.
-                'appPrice' => $this->iapPricingService->appPrice($price),
+                // MOBILE-APP SEAM: in-app price = ASC/Play catalogue price
+                // (or markup snap as fallback). Shown ONLY by the native app
+                // (store price wins once its catalogue is loaded); the web
+                // always shows `price`.
+                'appPrice' => $this->iapPricingService->appPriceForTier($tier, $price),
                 'currency' => null !== $subscription ? $subscription->getCurrency() : 'EUR',
                 'interval' => 'month',
                 'features' => $defaults['features'],

--- a/backend/src/Service/IapPricingService.php
+++ b/backend/src/Service/IapPricingService.php
@@ -15,11 +15,13 @@ namespace App\Service;
  * The STORE price for each tier intentionally BAKES IN the store commission
  * (≈30 %, sometimes 15 % — first $1M/yr or Google subs in year 2+). That
  * assumption is documented in `docs/PAYMENTS_CHANNELS.md` so finance can reason
- * about net revenue; this service only owns the product-id ↔ tier mapping.
+ * about net revenue; this service owns the product-id ↔ tier mapping and the
+ * ASC/Play catalogue prices used as the in-app display fallback.
  *
- * Product IDs are injected from env (configured once the store products exist,
- * Epic 5.5). Defaults are the documented placeholder naming convention so that
- * open-source / web-only deployments keep working with IAP effectively disabled.
+ * Product IDs and store price points are injected from env (configured once the
+ * store products exist, Epic 5.5). Defaults match the App Store Connect
+ * catalogue for the German launch. Open-source / web-only deployments keep
+ * working with IAP effectively disabled via {@see isConfigured()}.
  */
 final readonly class IapPricingService
 {
@@ -31,21 +33,29 @@ final readonly class IapPricingService
     /** Default store commission passed on to app buyers (Apple/Google ≈30 %). */
     private const DEFAULT_STORE_MARKUP_PERCENT = 30.0;
 
+    /**
+     * Default App Store / Play EUR price points (German launch catalogue).
+     * PRO is intentionally €24.99 (slightly under a pure 30 % pass-through).
+     */
+    private const DEFAULT_STORE_PRICE_PRO = 24.99;
+    private const DEFAULT_STORE_PRICE_TEAM = 64.99;
+    private const DEFAULT_STORE_PRICE_BUSINESS = 129.99;
+
     public function __construct(
         private string $iapProductPro = self::PLACEHOLDER_PRO,
         private string $iapProductTeam = self::PLACEHOLDER_TEAM,
         private string $iapProductBusiness = self::PLACEHOLDER_BUSINESS,
         private float $storeMarkupPercent = self::DEFAULT_STORE_MARKUP_PERCENT,
+        private float $storePricePro = self::DEFAULT_STORE_PRICE_PRO,
+        private float $storePriceTeam = self::DEFAULT_STORE_PRICE_TEAM,
+        private float $storePriceBusiness = self::DEFAULT_STORE_PRICE_BUSINESS,
     ) {
     }
 
     /**
-     * The price a tier costs when bought IN THE APP: the operator's web price
-     * plus the configured store-commission markup (IAP_PRICE_MARKUP_PERCENT),
-     * snapped to the nearest store price point (x.99 — Apple/Google only allow
-     * fixed price points). Used as the app's display fallback and as the
-     * reference when creating the store products — the store's own localized
-     * price always wins in the purchase sheet.
+     * Markup-only price: web price + store-commission markup, snapped to the
+     * nearest x.99 store price point. Used when no fixed store price is set for
+     * a tier, and by unit tests of the snap math.
      */
     public function appPrice(float $webPrice): float
     {
@@ -60,6 +70,30 @@ final readonly class IapPricingService
         }
 
         return round($pricePoint, 2);
+    }
+
+    /**
+     * Price shown as the native-app fallback for a tier: the configured store
+     * catalogue price (App Store Connect / Play) when set, otherwise the
+     * markup snap of {@see appPrice()}. Never below the web price.
+     *
+     * The store's own localized price always wins in the purchase sheet once
+     * the native catalogue is loaded.
+     */
+    public function appPriceForTier(string $tier, float $webPrice): float
+    {
+        $fixed = match ($tier) {
+            'PRO' => $this->storePricePro,
+            'TEAM' => $this->storePriceTeam,
+            'BUSINESS' => $this->storePriceBusiness,
+            default => 0.0,
+        };
+
+        if ($fixed > 0.0) {
+            return round(max($fixed, $webPrice), 2);
+        }
+
+        return $this->appPrice($webPrice);
     }
 
     /** The configured store-commission markup in percent (never negative). */

--- a/backend/tests/Integration/Stripe/SubscriptionControllerEndpointTest.php
+++ b/backend/tests/Integration/Stripe/SubscriptionControllerEndpointTest.php
@@ -104,15 +104,17 @@ class SubscriptionControllerEndpointTest extends WebTestCase
             $this->assertNotEmpty($plan['features']);
             $this->assertSame('EUR', $plan['currency']);
             $this->assertSame('month', $plan['interval']);
-            // MOBILE-APP SEAM: the in-app fallback price carries the store
-            // commission on top of the web price (IAP_PRICE_MARKUP_PERCENT,
-            // default 30 %), snapped to the nearest x.99 store price point —
-            // never below the web price.
+            // MOBILE-APP SEAM: in-app fallback = ASC/Play catalogue price
+            // (IAP_STORE_PRICE_*), never below the web price, on a x.99 point.
             $this->assertArrayHasKey('appPrice', $plan);
             $this->assertGreaterThan($plan['price'], $plan['appPrice']);
-            $this->assertEqualsWithDelta($plan['price'] * 1.3, $plan['appPrice'], 0.5);
             $this->assertEqualsWithDelta(0.99, fmod($plan['appPrice'], 1.0), 0.001, 'appPrice must sit on a x.99 store price point');
         }
+
+        // German-launch ASC catalogue (PRO €24.99 decided 2026-07-20).
+        $this->assertSame(24.99, $byId['PRO']['appPrice']);
+        $this->assertSame(64.99, $byId['TEAM']['appPrice']);
+        $this->assertSame(129.99, $byId['BUSINESS']['appPrice']);
     }
 
     public function testGetSubscriptionStatusReturns401WhenUnauthenticated(): void

--- a/backend/tests/Unit/Service/IapPricingServiceTest.php
+++ b/backend/tests/Unit/Service/IapPricingServiceTest.php
@@ -69,14 +69,35 @@ final class IapPricingServiceTest extends TestCase
 
     public function testAppPriceAddsDefaultStoreMarkupAndSnapsToPricePoint(): void
     {
-        // Default markup is 30 % — the Apple/Google commission passed on to app
-        // buyers — snapped to the nearest x.99 store price point.
-        $svc = new IapPricingService();
+        // Markup snap (used when a tier has no fixed store price). Default
+        // constructor still ships ASC catalogue prices for appPriceForTier().
+        $svc = new IapPricingService(
+            storePricePro: 0.0,
+            storePriceTeam: 0.0,
+            storePriceBusiness: 0.0,
+        );
 
         $this->assertSame(25.99, $svc->appPrice(19.95)); // 25.935 → 25.99
         $this->assertSame(64.99, $svc->appPrice(49.95)); // 64.935 → 64.99
         $this->assertSame(129.99, $svc->appPrice(99.95)); // 129.935 → 129.99
         $this->assertSame(30.0, $svc->storeMarkupPercent());
+    }
+
+    public function testAppPriceForTierUsesAscCatalogueDefaults(): void
+    {
+        // German-launch ASC price points: PRO €24.99 (decided 2026-07-20).
+        $svc = new IapPricingService();
+
+        $this->assertSame(24.99, $svc->appPriceForTier('PRO', 19.95));
+        $this->assertSame(64.99, $svc->appPriceForTier('TEAM', 49.95));
+        $this->assertSame(129.99, $svc->appPriceForTier('BUSINESS', 99.95));
+    }
+
+    public function testAppPriceForTierNeverUndercutsWebPrice(): void
+    {
+        $svc = new IapPricingService(storePricePro: 10.0);
+
+        $this->assertSame(19.95, $svc->appPriceForTier('PRO', 19.95));
     }
 
     public function testAppPriceHonoursConfiguredMarkup(): void

--- a/docs/PAYMENTS_CHANNELS.md
+++ b/docs/PAYMENTS_CHANNELS.md
@@ -61,24 +61,26 @@ the store keeps a commission:
 comparable to the Stripe (web) price. Concretely: the web (Stripe) price and the store (IAP) price
 are configured **independently per channel**, and the store price is set higher to absorb the cut.
 
-The markup is operator-configurable via `IAP_PRICE_MARKUP_PERCENT` (default `30`).
-`GET /api/v1/subscription/plans` exposes it as `appPrice = price × (1 + markup/100)`, snapped to
-the nearest x.99 store price point (stores only allow fixed price points), never below the web
-price:
+Store EUR price points are operator-configurable via `IAP_STORE_PRICE_{PRO,TEAM,BUSINESS}`
+(must match App Store Connect / Play Console). `GET /api/v1/subscription/plans` exposes them as
+`appPrice`. If a tier's store price is `0`, the fallback is
+`price × (1 + IAP_PRICE_MARKUP_PERCENT/100)` (default markup `30`), snapped to the nearest x.99
+price point, never below the web price:
 
 - the **web** always displays the plain `price`;
 - the **native app** displays the store's own localized price once its catalogue is loaded, and
   `appPrice` as the fallback before that — the cheaper web price is never shown in the app
   (anti-steering).
 
-| Tier | Web reference price (Stripe) | App price (30 % markup, .99-snapped) |
-|------|------------------------------|--------------------------------------|
-| PRO | €19.95 | €25.99 |
+| Tier | Web reference price (Stripe) | App / ASC price (EUR, DE) |
+|------|------------------------------|---------------------------|
+| PRO | €19.95 | **€24.99** (decided 2026-07-20; slightly under pure 30 % pass-through) |
 | TEAM | €49.95 | €64.99 |
 | BUSINESS | €99.95 | €129.99 |
 
-When creating the store products in App Store Connect / Play Console, set exactly the `appPrice`
-price point — the store price is what the buyer actually pays and what the app shows once loaded.
+When creating the store products in App Store Connect / Play Console, set exactly these
+`IAP_STORE_PRICE_*` price points — the store price is what the buyer actually pays and what the
+app shows once loaded.
 
 > Finance/tax note: on web, Synaplan is Merchant of Record (Stripe Tax/OSS handles VAT). On IAP,
 > Apple/Google are MoR — they collect/remit consumer VAT and pay net after their 15–30 %. Book

--- a/frontend/tests/unit/components/onboarding/OnboardingPlansStep.spec.ts
+++ b/frontend/tests/unit/components/onboarding/OnboardingPlansStep.spec.ts
@@ -47,7 +47,7 @@ const proPlan = {
   name: 'Pro',
   stripePriceId: 'price_pro',
   price: 19.95,
-  appPrice: 25.99,
+  appPrice: 24.99,
   currency: 'EUR',
   interval: 'month',
   features: ['Feature A', 'Feature B', 'Feature C', 'Feature D', 'Feature E'],
@@ -130,7 +130,7 @@ describe('OnboardingPlansStep', () => {
       const wrapper = mount(OnboardingPlansStep)
       await flushPromises()
 
-      expect(wrapper.text()).toContain('€25.99')
+      expect(wrapper.text()).toContain('€24.99')
       expect(wrapper.text()).not.toContain('€19.95')
     } finally {
       mockIsNativeApp.mockReturnValue(false)

--- a/frontend/tests/unit/views/SubscriptionViewNativeGuard.spec.ts
+++ b/frontend/tests/unit/views/SubscriptionViewNativeGuard.spec.ts
@@ -89,7 +89,7 @@ describe('SubscriptionView — native purchase guard (Epic 5.2)', () => {
           name: 'Pro',
           stripePriceId: 'price_pro',
           price: 19.95,
-          appPrice: 25.99,
+          appPrice: 24.99,
           currency: 'EUR',
           interval: 'month',
           features: ['a'],


### PR DESCRIPTION
## Summary
More mobile fixes

## Changes
- Updated services.yaml to include fixed App Store/Play price points for PRO, TEAM, and BUSINESS tiers.
- Modified IapPricingService to incorporate new store price constants and adjusted appPriceForTier method to utilize these prices as fallbacks when available.
- Improved documentation within IapPricingService to clarify the role of injected environment variables and pricing logic.

## Verification
- [ ] Not tested (explain)
- [X] Manual
- [ ] Tests added/updated
