### PR TITLE
ci(e2e): Discord notify for flaky Playwright tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -658,6 +658,82 @@ jobs:
           PROFILE="${{ matrix.compose_profiles }}"
           $COMPOSE $PROFILE down -v
 
+  # One Discord ping after the whole E2E matrix finishes (not per shard).
+  # merge-multiple must stay false: every shard uploads reports/results.json at
+  # the same relative path — merging would overwrite and under-count flakes.
+  e2e-flaky-notify:
+    name: Notify flaky E2E (Discord)
+    runs-on: ubuntu-latest
+    needs: [e2e]
+    if: always() && needs.e2e.result != 'cancelled'
+    steps:
+      - name: Download Playwright reports
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: playwright-results-*
+          path: artifacts
+          merge-multiple: false
+
+      - name: Notify Discord if any flaky tests
+        env:
+          HOOK: ${{ secrets.DISCORD_E2E_FLAKY_WEBHOOK }}
+          BRANCH: ${{ github.ref_name }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          [ -n "${HOOK:-}" ] || exit 0
+          mapfile -t REPORTS < <(find artifacts -type f -name results.json 2>/dev/null | sort || true)
+          [ "${#REPORTS[@]}" -gt 0 ] || exit 0
+
+          # project · file · title — file avoids collapsing distinct tests with the same title
+          LIST=$(jq -r '
+            .. | objects
+            | select((.specs? | type) == "array")
+            | . as $suite
+            | .specs[]?
+            | . as $spec
+            | .tests[]?
+            | select(.status == "flaky")
+            | "• " + (.projectName // "?")
+              + " · " + ($suite.file // $suite.title // "?")
+              + " · " + ($spec.title // "?")
+          ' "${REPORTS[@]}" | sort -u)
+          [ -n "$LIST" ] || exit 0
+
+          N=$(printf '%s\n' "$LIST" | wc -l | tr -d ' ')
+          SHOWN=$(printf '%s\n' "$LIST" | head -15)
+          EXTRA=$(( N > 15 ? N - 15 : 0 ))
+          [ "$EXTRA" -gt 0 ] && SHOWN=$(printf '%s\n… and %s more' "$SHOWN" "$EXTRA")
+
+          # Match DiscordNotificationService embed shape (title/fields/footer/timestamp).
+          # Field values max 1024; keep the flaky list under that.
+          PAYLOAD=$(jq -n \
+            --arg branch "$BRANCH" \
+            --arg url "$RUN_URL" \
+            --arg n "$N" \
+            --arg list "$SHOWN" \
+            --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            '{
+              embeds: [{
+                title: ("⚠️ Flaky E2E: " + $n + " test(s)"),
+                color: 16776960,
+                fields: [
+                  { name: "Branch", value: ("`" + $branch + "`"), inline: true },
+                  { name: "Count", value: $n, inline: true },
+                  { name: "Flaky tests", value: ($list | .[0:1000]), inline: false },
+                  { name: "CI run", value: ("[Open CI run](" + $url + ")"), inline: false }
+                ],
+                footer: { text: "Synaplan CI" },
+                timestamp: $ts
+              }]
+            }')
+
+          curl --fail-with-body --silent --show-error --retry 3 \
+            -H 'Content-Type: application/json' \
+            -d "$PAYLOAD" \
+            "$HOOK" \
+            || echo "::warning::Discord notification failed"
+
   e2e-visual:
     # Layer 3 of the UI guard: hard-capped visual snapshots (@visual project).
     # Skips gracefully while no baselines are committed — generate them with

--- a/frontend/tests/e2e/playwright.config.ts
+++ b/frontend/tests/e2e/playwright.config.ts
@@ -30,6 +30,7 @@ export default defineConfig({
   reporter: [
     ['list'],
     ['junit', { outputFile: 'reports/junit.xml' }],
+    ['json', { outputFile: 'reports/results.json' }],
     ['html', { outputFolder: 'reports/html', open: 'never' }],
   ],
 


### PR DESCRIPTION
## Summary
- Emit Playwright JSON reports (`reports/results.json`) so CI can detect retries that recovered (`status: flaky`).
- After the full E2E matrix finishes, one job aggregates all shard artifacts (`merge-multiple: false`) and posts a single Discord embed when any flaky tests exist.
- Embed matches the existing `DiscordNotificationService` shape (title, fields, footer, timestamp) with branch, flaky test list, and CI run link.

## Setup
- Add repo secret (Discord incoming webhook).
- Without the secret the job no-ops.

## Test plan
- [ ] Secret `DISCORD_E2E_FLAKY_WEBHOOK` is set on the repo
- [ ] PR CI shows job **Notify flaky E2E (Discord)** after the E2E matrix
- [ ] With no flakes: job succeeds and Discord stays quiet
- [ ] When a flake occurs : one embed with branch, test names, and run link