### PR TITLE
fix(usage): reconcile turn costs across channels

### DIFF
--- a/backend/src/AI/Service/AiFacade.php
+++ b/backend/src/AI/Service/AiFacade.php
@@ -1189,7 +1189,7 @@ class AiFacade
         // local whisper.cpp bypasses AiFacade and is free — so recording here
         // meters all channels exactly once (#1314). No-ops without a user, a
         // priced model_id, or a positive duration.
-        $this->transcriptionUsageRecorder->record(
+        $recordedTranscriptionUsage = $this->transcriptionUsageRecorder->record(
             userId: $userId,
             modelId: $sttModelId,
             provider: $provider->getName(),
@@ -1197,6 +1197,13 @@ class AiFacade
             durationSeconds: (float) ($result['duration'] ?? 0),
             extraMetadata: ['language' => $result['language'] ?? 'unknown'],
         );
+        if (null !== $recordedTranscriptionUsage) {
+            $enriched['transcription_usage'] = $recordedTranscriptionUsage->toMessageUsage(
+                $provider->getName(),
+                (string) $enriched['model'],
+                'TRANSCRIPTION',
+            );
+        }
 
         return $enriched;
     }

--- a/backend/src/Controller/MessageController.php
+++ b/backend/src/Controller/MessageController.php
@@ -271,7 +271,7 @@ class MessageController extends AbstractController
             // above (same DEFAULTMODEL/CHAT lookup the facade uses).
             $resolvedModelId = $modelId;
 
-            $this->rateLimitService->recordUsage($user, 'MESSAGES', [
+            $recordedChatUsage = $this->rateLimitService->recordUsage($user, 'MESSAGES', [
                 'provider' => $aiResponse['provider'] ?? 'unknown',
                 'model' => $aiResponse['model'] ?? 'unknown',
                 'model_id' => $resolvedModelId,
@@ -280,6 +280,7 @@ class MessageController extends AbstractController
                 'response_text' => $responseText,
                 'source' => 'WEB',
             ]);
+            $outgoingMessage->setMeta('ai_chat_cost', $recordedChatUsage->chargedCost);
 
             // NOTE: MessageController doesn't use MessageProcessor, so there's no sorting model info here
             // Only StreamController (which uses MessageProcessor) has sorting model metadata

--- a/backend/src/Controller/StreamController.php
+++ b/backend/src/Controller/StreamController.php
@@ -1852,13 +1852,14 @@ class StreamController extends AbstractController
                         'completionTokens' => (int) ($classification['sorting_usage']['completion_tokens'] ?? 0),
                         'totalTokens' => (int) ($classification['sorting_usage']['tokens'] ?? 0),
                         'cost' => (string) ($classification['sorting_usage']['cost'] ?? '0'),
-                        'modelKey' => $this->buildUsageModelKey(
+                        'modelKey' => RecordedUsage::modelKey(
                             $classification['sorting_provider'] ?? null,
                             $classification['sorting_model_name'] ?? null,
                         ),
                         'kind' => 'SORT',
                     ];
                 }
+                $usageExtra = $this->appendContextUsage($usageExtra, $response['metadata'] ?? [], $incomingMessage);
 
                 // Record AI-generated media usage (IMAGES, VIDEOS, AUDIOS) separately.
                 // Issue #1146: MediaGenerationHandler now records this itself (the
@@ -2634,13 +2635,14 @@ class StreamController extends AbstractController
                     'completionTokens' => (int) ($classification['sorting_usage']['completion_tokens'] ?? 0),
                     'totalTokens' => (int) ($classification['sorting_usage']['tokens'] ?? 0),
                     'cost' => (string) ($classification['sorting_usage']['cost'] ?? '0'),
-                    'modelKey' => $this->buildUsageModelKey(
+                    'modelKey' => RecordedUsage::modelKey(
                         $classification['sorting_provider'] ?? null,
                         $classification['sorting_model_name'] ?? null,
                     ),
                     'kind' => 'SORT',
                 ];
             }
+            $usageExtra = $this->appendContextUsage($usageExtra, $metadata, $message);
             $recordedMediaUsage = ($metadata['media_recorded_usage'] ?? null) instanceof RecordedUsage
                 ? $metadata['media_recorded_usage']
                 : null;
@@ -2991,14 +2993,7 @@ class StreamController extends AbstractController
         // ai_chat_usage meta; the model identity comes from ai_chat_model(_*).
         $message->setMeta('ai_chat_cost', $recorded->chargedCost);
 
-        return [
-            'promptTokens' => $recorded->promptTokens,
-            'completionTokens' => $recorded->completionTokens,
-            'totalTokens' => $recorded->totalTokens,
-            'cost' => $recorded->chargedCost,
-            'modelKey' => $this->buildUsageModelKey($provider, $model),
-            'kind' => 'LLM',
-        ];
+        return $recorded->toMessageUsage($provider, $model, 'LLM');
     }
 
     /**
@@ -3009,31 +3004,35 @@ class StreamController extends AbstractController
      */
     private function buildExtraUsageEntry(string $kind, ?string $provider, ?string $model, RecordedUsage $recorded): array
     {
-        return [
-            'promptTokens' => $recorded->promptTokens,
-            'completionTokens' => $recorded->completionTokens,
-            'totalTokens' => $recorded->totalTokens,
-            'cost' => $recorded->chargedCost,
-            'modelKey' => $this->buildUsageModelKey($provider, $model),
-            'kind' => $kind,
-        ];
+        return $recorded->toMessageUsage($provider, $model, $kind);
     }
 
     /**
-     * Compose a stable model key ("provider:model") for taximeter session
-     * grouping. Never hard-codes model names — the parts come from the
-     * response metadata (which originates from the model catalog).
+     * Add usage that happened before or around the answer generation itself:
+     * multi-task planning from response metadata and transcription from the
+     * incoming message. Both already use the canonical message-usage shape.
+     *
+     * @param list<array<string, mixed>> $usageExtra
+     * @param array<string, mixed>       $responseMetadata
+     *
+     * @return list<array<string, mixed>>
      */
-    private function buildUsageModelKey(?string $provider, ?string $model): string
+    private function appendContextUsage(array $usageExtra, array $responseMetadata, Message $incomingMessage): array
     {
-        $p = strtolower(trim((string) $provider));
-        $m = trim((string) $model);
-
-        if ('' !== $p && '' !== $m) {
-            return $p.':'.$m;
+        $planningUsage = $responseMetadata['planning_usage'] ?? null;
+        if (is_array($planningUsage)) {
+            $usageExtra[] = $planningUsage;
         }
 
-        return '' !== $m ? $m : ('' !== $p ? $p : 'unknown');
+        $rawTranscriptionUsage = $incomingMessage->getMeta('ai_transcription_usage');
+        if (null !== $rawTranscriptionUsage && '' !== $rawTranscriptionUsage) {
+            $transcriptionUsage = json_decode($rawTranscriptionUsage, true);
+            if (is_array($transcriptionUsage)) {
+                $usageExtra[] = $transcriptionUsage;
+            }
+        }
+
+        return $usageExtra;
     }
 
     private function sendSSE(string $status, array $data): void

--- a/backend/src/Controller/WebhookController.php
+++ b/backend/src/Controller/WebhookController.php
@@ -16,6 +16,7 @@ use App\Service\Message\MessageProcessor;
 use App\Service\ModelConfigService;
 use App\Service\RateLimitService;
 use App\Service\TtsTextSanitizer;
+use App\Service\Usage\RecordedUsage;
 use App\Service\WhatsAppService;
 use Doctrine\ORM\EntityManagerInterface;
 use OpenApi\Attributes as OA;
@@ -404,7 +405,7 @@ class WebhookController extends AbstractController
             $provider = $metadata['provider'] ?? null;
             $model = $metadata['model'] ?? null;
 
-            $this->rateLimitService->recordUsage($user, 'MESSAGES', [
+            $recordedChatUsage = $this->rateLimitService->recordUsage($user, 'MESSAGES', [
                 'provider' => $provider ?? 'unknown',
                 'model' => $model ?? 'unknown',
                 'usage' => $metadata['usage'] ?? [],
@@ -511,6 +512,35 @@ class WebhookController extends AbstractController
             }
             if (!empty($metadata['model_id'])) {
                 $outgoingMessage->setMeta('ai_chat_model_id', (string) $metadata['model_id']);
+            }
+            $outgoingMessage->setMeta('ai_chat_cost', $recordedChatUsage->chargedCost);
+
+            $usageExtra = [];
+            if (is_array($classification['sorting_usage'] ?? null)) {
+                $usageExtra[] = [
+                    'promptTokens' => (int) ($classification['sorting_usage']['prompt_tokens'] ?? 0),
+                    'completionTokens' => (int) ($classification['sorting_usage']['completion_tokens'] ?? 0),
+                    'totalTokens' => (int) ($classification['sorting_usage']['tokens'] ?? 0),
+                    'cost' => (string) ($classification['sorting_usage']['cost'] ?? '0'),
+                    'modelKey' => RecordedUsage::modelKey(
+                        $classification['sorting_provider'] ?? null,
+                        $classification['sorting_model_name'] ?? null,
+                    ),
+                    'kind' => 'SORT',
+                ];
+            }
+            if (is_array($metadata['planning_usage'] ?? null)) {
+                $usageExtra[] = $metadata['planning_usage'];
+            }
+            $rawTranscriptionUsage = $message->getMeta('ai_transcription_usage');
+            if (null !== $rawTranscriptionUsage && '' !== $rawTranscriptionUsage) {
+                $transcriptionUsage = json_decode($rawTranscriptionUsage, true);
+                if (is_array($transcriptionUsage)) {
+                    $usageExtra[] = $transcriptionUsage;
+                }
+            }
+            if ([] !== $usageExtra) {
+                $outgoingMessage->setMeta('ai_usage_extra', (string) json_encode($usageExtra));
             }
 
             $chat->updateTimestamp();

--- a/backend/src/Service/File/FileProcessor.php
+++ b/backend/src/Service/File/FileProcessor.php
@@ -813,6 +813,7 @@ final readonly class FileProcessor
             return [$text, [
                 'strategy' => 'whisper_api',
                 'provider' => $result['provider'] ?? 'unknown',
+                'transcription_usage' => $result['transcription_usage'] ?? null,
             ] + $baseMeta];
         } catch (ProviderException $e) {
             $this->logger->error('FileProcessor: External API transcription failed (provider error)', [

--- a/backend/src/Service/Message/MessageApiFormatter.php
+++ b/backend/src/Service/Message/MessageApiFormatter.php
@@ -196,7 +196,7 @@ final readonly class MessageApiFormatter
             'webSearch' => $webSearchData, // Web search metadata
             'searchResults' => !empty($searchResultsData) ? $searchResultsData : null, // Actual search results
             'usage' => $usage, // Per-message token/cost usage (taximeter); null when absent
-            'usageExtra' => $usageExtra, // Auxiliary usage of this turn (sorting/media/TTS); null when absent
+            'usageExtra' => $usageExtra, // Auxiliary usage of this turn (sorting/planning/transcription/media/TTS); null when absent
             'multitask' => $wasMultitask, // True when the turn ran the multi-task DAG
             // Per-node task-plan render state for reload (issue #1070 — DAG divergence).
             // Null for non-DAG turns, non-null only on OUT messages of DAG turns.
@@ -263,7 +263,7 @@ final readonly class MessageApiFormatter
 
     /**
      * Decode the persisted `ai_usage_extra` meta (auxiliary usage of the turn:
-     * sorting/routing call, media renders, TTS) back into the API list shape.
+     * sorting, planning, transcription, media renders, TTS) back into the API list shape.
      * Null when absent or malformed — the field is simply omitted.
      *
      * @return list<array{promptTokens: int, completionTokens: int, totalTokens: int, cost: string, modelKey: string, kind: string}>|null

--- a/backend/src/Service/Message/MessagePreProcessor.php
+++ b/backend/src/Service/Message/MessagePreProcessor.php
@@ -223,6 +223,7 @@ final readonly class MessagePreProcessor
                     $fileType,
                     $messageFile->getUserId(),
                 );
+                $this->persistTranscriptionUsage($message, $extractMeta);
 
                 if ('' !== trim((string) $text)) {
                     $messageFile->setFileText($text);
@@ -268,6 +269,7 @@ final readonly class MessagePreProcessor
                 $result = $useExternal
                     ? $this->aiFacade->transcribe($fullPath, $userId)
                     : $this->transcribeWithWhisper($fullPath, null);
+                $this->persistTranscriptionUsage($message, $result);
                 if ($result && !empty($result['text'])) {
                     $transcribedText = $result['text'];
                     $messageFile->setFileText($transcribedText);
@@ -433,6 +435,7 @@ final readonly class MessagePreProcessor
                 $result = $useExternal
                     ? $this->aiFacade->transcribe($fullPath, $userId)
                     : $this->transcribeWithWhisper($fullPath, $message->getLanguage());
+                $this->persistTranscriptionUsage($message, $result);
                 if ($result && !empty($result['text'])) {
                     $transcribedText = $result['text'];
                     $message->setFileText($transcribedText);
@@ -476,11 +479,12 @@ final readonly class MessagePreProcessor
             ]);
 
             try {
-                [$text] = $this->fileProcessor->extractText(
+                [$text, $extractMeta] = $this->fileProcessor->extractText(
                     $filePath,
                     $fileType,
                     $message->getUserId(),
                 );
+                $this->persistTranscriptionUsage($message, $extractMeta);
 
                 if ('' !== trim((string) $text)) {
                     $message->setFileText($text);
@@ -581,6 +585,22 @@ final readonly class MessagePreProcessor
 
             return null;
         }
+    }
+
+    /**
+     * Keep the billed external STT call attached to the incoming turn so the
+     * eventual assistant message can expose it in its complete usage details.
+     *
+     * @param array<string, mixed>|null $result
+     */
+    private function persistTranscriptionUsage(Message $message, ?array $result): void
+    {
+        $usage = $result['transcription_usage'] ?? null;
+        if (null === $message->getId() || !is_array($usage)) {
+            return;
+        }
+
+        $message->setMeta('ai_transcription_usage', (string) json_encode($usage));
     }
 
     /**

--- a/backend/src/Service/Multitask/Execution/ResultAssembler.php
+++ b/backend/src/Service/Multitask/Execution/ResultAssembler.php
@@ -147,7 +147,7 @@ final class ResultAssembler
             $completionTokens += $nodeCompletion;
             $totalTokens += (int) ($nodeUsage['total_tokens'] ?? ($nodePrompt + $nodeCompletion));
         }
-        if ($totalTokens > 0 && empty($metadata['usage'])) {
+        if ($totalTokens > 0) {
             $metadata['usage'] = [
                 'prompt_tokens' => $promptTokens,
                 'completion_tokens' => $completionTokens,

--- a/backend/src/Service/Multitask/TaskPlanExecutor.php
+++ b/backend/src/Service/Multitask/TaskPlanExecutor.php
@@ -94,11 +94,21 @@ final readonly class TaskPlanExecutor
     ): array {
         $plan = $this->planForExecution($message, $thread, $classification, $options);
 
-        if (null === $plan || $this->shouldUseLegacyRouter($plan->plan)) {
+        if (null === $plan) {
             return $this->runSingleNode(
                 fn () => $this->router->routeStream($message, $thread, $this->effectiveClassification($classification), $streamCallback, $progressCallback, $options),
                 $message,
                 $classification,
+            );
+        }
+        if ($this->shouldUseLegacyRouter($plan->plan)) {
+            return $this->withPlanningUsage(
+                $this->runSingleNode(
+                    fn () => $this->router->routeStream($message, $thread, $this->effectiveClassification($classification), $streamCallback, $progressCallback, $options),
+                    $message,
+                    $classification,
+                ),
+                $plan,
             );
         }
 
@@ -114,10 +124,13 @@ final readonly class TaskPlanExecutor
             // "step failed" box sitting above a correct reply.
             $this->discardPlan($progressCallback);
 
-            return $this->runSingleNode(
-                fn () => $this->router->routeStream($message, $thread, $this->effectiveClassification($classification), $streamCallback, $progressCallback, $options),
-                $message,
-                $classification,
+            return $this->withPlanningUsage(
+                $this->runSingleNode(
+                    fn () => $this->router->routeStream($message, $thread, $this->effectiveClassification($classification), $streamCallback, $progressCallback, $options),
+                    $message,
+                    $classification,
+                ),
+                $plan,
             );
         }
 
@@ -146,11 +159,21 @@ final readonly class TaskPlanExecutor
     ): array {
         $plan = $this->planForExecution($message, $thread, $classification, $options);
 
-        if (null === $plan || $this->shouldUseLegacyRouter($plan->plan)) {
+        if (null === $plan) {
             return $this->runSingleNode(
                 fn () => $this->router->route($message, $thread, $this->effectiveClassification($classification), $progressCallback, $options),
                 $message,
                 $classification,
+            );
+        }
+        if ($this->shouldUseLegacyRouter($plan->plan)) {
+            return $this->withPlanningUsage(
+                $this->runSingleNode(
+                    fn () => $this->router->route($message, $thread, $this->effectiveClassification($classification), $progressCallback, $options),
+                    $message,
+                    $classification,
+                ),
+                $plan,
             );
         }
 
@@ -159,10 +182,13 @@ final readonly class TaskPlanExecutor
         if ($assembled['all_failed']) {
             $this->discardPlan($progressCallback);
 
-            return $this->runSingleNode(
-                fn () => $this->router->route($message, $thread, $this->effectiveClassification($classification), $progressCallback, $options),
-                $message,
-                $classification,
+            return $this->withPlanningUsage(
+                $this->runSingleNode(
+                    fn () => $this->router->route($message, $thread, $this->effectiveClassification($classification), $progressCallback, $options),
+                    $message,
+                    $classification,
+                ),
+                $plan,
             );
         }
 
@@ -246,6 +272,7 @@ final readonly class TaskPlanExecutor
                     $result->modelId,
                     $result->rawResponse,
                     $result->errors,
+                    $result->planningUsage,
                 );
             }
 
@@ -406,6 +433,9 @@ final readonly class TaskPlanExecutor
         $trackedCallback = $this->wrapProgressForPersistence($messageId, $progressCallback);
 
         $assembled = $this->dagExecutor->execute($plan->plan, $context, $trackedCallback);
+        if (null !== $plan->planningUsage) {
+            $assembled['metadata']['planning_usage'] = $plan->planningUsage;
+        }
 
         if (null !== $messageId) {
             try {
@@ -427,6 +457,34 @@ final readonly class TaskPlanExecutor
         }
 
         return $assembled;
+    }
+
+    /**
+     * Preserve the billable planner call when a generated plan is delegated
+     * back to the legacy router or when a failed DAG falls back to it.
+     *
+     * @param array<string, mixed> $handlerResult
+     *
+     * @return array<string, mixed>
+     */
+    private function withPlanningUsage(array $handlerResult, TaskPlanResult $plan): array
+    {
+        if (null === $plan->planningUsage) {
+            return $handlerResult;
+        }
+
+        $response = $handlerResult['response'] ?? null;
+        if (!is_array($response)) {
+            return $handlerResult;
+        }
+        $metadata = $response['metadata'] ?? [];
+        if (!is_array($metadata)) {
+            $metadata = [];
+        }
+        $metadata['planning_usage'] = $plan->planningUsage;
+        $handlerResult['response']['metadata'] = $metadata;
+
+        return $handlerResult;
     }
 
     /**

--- a/backend/src/Service/Multitask/TaskPlanResult.php
+++ b/backend/src/Service/Multitask/TaskPlanResult.php
@@ -16,8 +16,9 @@ use App\Service\Multitask\Plan\TaskPlan;
 final readonly class TaskPlanResult
 {
     /**
-     * @param list<string>                                                                                                         $errors
-     * @param array{promptTokens: int, completionTokens: int, totalTokens: int, cost: string, modelKey: string, kind: string}|null $planningUsage
+     * @param list<string> $errors
+     *
+     * @phpstan-param array{promptTokens: int, completionTokens: int, totalTokens: int, cost: string, modelKey: string, kind: string}|null $planningUsage
      */
     public function __construct(
         public TaskPlan $plan,

--- a/backend/src/Service/Multitask/TaskPlanResult.php
+++ b/backend/src/Service/Multitask/TaskPlanResult.php
@@ -16,7 +16,8 @@ use App\Service\Multitask\Plan\TaskPlan;
 final readonly class TaskPlanResult
 {
     /**
-     * @param list<string> $errors
+     * @param list<string>                                                                                                         $errors
+     * @param array{promptTokens: int, completionTokens: int, totalTokens: int, cost: string, modelKey: string, kind: string}|null $planningUsage
      */
     public function __construct(
         public TaskPlan $plan,
@@ -24,6 +25,7 @@ final readonly class TaskPlanResult
         public ?int $modelId = null,
         public string $rawResponse = '',
         public array $errors = [],
+        public ?array $planningUsage = null,
     ) {
     }
 }

--- a/backend/src/Service/Multitask/TaskPlanner.php
+++ b/backend/src/Service/Multitask/TaskPlanner.php
@@ -168,8 +168,9 @@ final readonly class TaskPlanner
     }
 
     /**
-     * @param list<string>                                                                                                         $errors
-     * @param array{promptTokens: int, completionTokens: int, totalTokens: int, cost: string, modelKey: string, kind: string}|null $planningUsage
+     * @param list<string> $errors
+     *
+     * @phpstan-param array{promptTokens: int, completionTokens: int, totalTokens: int, cost: string, modelKey: string, kind: string}|null $planningUsage
      */
     private function fallback(
         string $language,

--- a/backend/src/Service/Multitask/TaskPlanner.php
+++ b/backend/src/Service/Multitask/TaskPlanner.php
@@ -83,7 +83,7 @@ final readonly class TaskPlanner
             // The planner call is a billable LLM request like the sorter's —
             // record it so DAG turns don't get their routing tokens for free.
             // Never let a recording hiccup break planning.
-            $this->recordPlanningUsage($userId, $modelId, $response);
+            $planningUsage = $this->recordPlanningUsage($userId, $modelId, $response);
         } catch (\Throwable $e) {
             $this->logger->warning('TaskPlanner: planner model call failed, falling back', [
                 'error' => $e->getMessage(),
@@ -94,7 +94,7 @@ final readonly class TaskPlanner
 
         $decoded = $this->decodeJson($raw);
         if (null === $decoded) {
-            return $this->fallback($language, ['planner output was not valid JSON'], $modelId, $raw);
+            return $this->fallback($language, ['planner output was not valid JSON'], $modelId, $raw, $planningUsage);
         }
 
         $errors = $this->validator->validate($decoded);
@@ -103,17 +103,24 @@ final readonly class TaskPlanner
                 'errors' => $errors,
             ]);
 
-            return $this->fallback($language, $errors, $modelId, $raw);
+            return $this->fallback($language, $errors, $modelId, $raw, $planningUsage);
         }
 
         try {
             /** @var array<string, mixed> $decoded */
             $plan = TaskPlan::fromArray($decoded, $this->validator);
         } catch (\Throwable $e) {
-            return $this->fallback($language, ['plan build failed: '.$e->getMessage()], $modelId, $raw);
+            return $this->fallback($language, ['plan build failed: '.$e->getMessage()], $modelId, $raw, $planningUsage);
         }
 
-        return new TaskPlanResult($plan, fallback: false, modelId: $modelId, rawResponse: $raw, errors: []);
+        return new TaskPlanResult(
+            $plan,
+            fallback: false,
+            modelId: $modelId,
+            rawResponse: $raw,
+            errors: [],
+            planningUsage: $planningUsage,
+        );
     }
 
     /**
@@ -121,20 +128,22 @@ final readonly class TaskPlanner
      * MessageSorter::recordSortingUsage — never throws, best-effort.
      *
      * @param array<string, mixed> $response
+     *
+     * @return array{promptTokens: int, completionTokens: int, totalTokens: int, cost: string, modelKey: string, kind: string}|null
      */
-    private function recordPlanningUsage(?int $userId, ?int $modelId, array $response): void
+    private function recordPlanningUsage(?int $userId, ?int $modelId, array $response): ?array
     {
         if (null === $userId || $userId <= 0) {
-            return;
+            return null;
         }
 
         try {
             $user = $this->userRepository->find($userId);
             if (null === $user) {
-                return;
+                return null;
             }
 
-            $this->rateLimitService->recordUsage($user, 'PLANNING', [
+            $recorded = $this->rateLimitService->recordUsage($user, 'PLANNING', [
                 'usage' => $response['usage'] ?? [],
                 'model_id' => $modelId,
                 'provider' => $response['provider'] ?? '',
@@ -142,25 +151,40 @@ final readonly class TaskPlanner
                 'input_text' => '',
                 'response_text' => $response['content'] ?? '',
             ]);
+
+            return $recorded->toMessageUsage(
+                $response['provider'] ?? null,
+                $response['model'] ?? null,
+                'PLANNING',
+            );
         } catch (\Throwable $e) {
             $this->logger->warning('TaskPlanner: failed to record planning usage', [
                 'error' => $e->getMessage(),
                 'user_id' => $userId,
             ]);
+
+            return null;
         }
     }
 
     /**
-     * @param list<string> $errors
+     * @param list<string>                                                                                                         $errors
+     * @param array{promptTokens: int, completionTokens: int, totalTokens: int, cost: string, modelKey: string, kind: string}|null $planningUsage
      */
-    private function fallback(string $language, array $errors, ?int $modelId = null, string $raw = ''): TaskPlanResult
-    {
+    private function fallback(
+        string $language,
+        array $errors,
+        ?int $modelId = null,
+        string $raw = '',
+        ?array $planningUsage = null,
+    ): TaskPlanResult {
         return new TaskPlanResult(
             TaskPlan::singleChatPlan($language),
             fallback: true,
             modelId: $modelId,
             rawResponse: $raw,
             errors: $errors,
+            planningUsage: $planningUsage,
         );
     }
 

--- a/backend/src/Service/Usage/RecordedUsage.php
+++ b/backend/src/Service/Usage/RecordedUsage.php
@@ -26,4 +26,38 @@ final readonly class RecordedUsage
         public int $totalTokens,
     ) {
     }
+
+    /**
+     * Build the canonical message-usage shape shared by live SSE events and
+     * persisted message metadata.
+     *
+     * @return array{promptTokens: int, completionTokens: int, totalTokens: int, cost: string, modelKey: string, kind: string}
+     */
+    public function toMessageUsage(?string $provider, ?string $model, string $kind): array
+    {
+        return [
+            'promptTokens' => $this->promptTokens,
+            'completionTokens' => $this->completionTokens,
+            'totalTokens' => $this->totalTokens,
+            'cost' => $this->chargedCost,
+            'modelKey' => self::modelKey($provider, $model),
+            'kind' => $kind,
+        ];
+    }
+
+    /**
+     * Compose a stable provider/model key for session grouping.
+     */
+    public static function modelKey(?string $provider, ?string $model): string
+    {
+        $normalizedProvider = strtolower(trim((string) $provider));
+        $normalizedModel = trim((string) $model);
+        if ('' !== $normalizedProvider && '' !== $normalizedModel) {
+            return $normalizedProvider.':'.$normalizedModel;
+        }
+
+        return '' !== $normalizedModel
+            ? $normalizedModel
+            : ('' !== $normalizedProvider ? $normalizedProvider : 'unknown');
+    }
 }

--- a/backend/src/Service/Usage/TranscriptionUsageRecorder.php
+++ b/backend/src/Service/Usage/TranscriptionUsageRecorder.php
@@ -37,6 +37,8 @@ final readonly class TranscriptionUsageRecorder
 
     /**
      * @param array<string, mixed> $extraMetadata Non-billing context (e.g. language) stored on the row
+     *
+     * @return RecordedUsage|null The billed row details, or null when recording was skipped or failed
      */
     public function record(
         ?int $userId,
@@ -45,11 +47,11 @@ final readonly class TranscriptionUsageRecorder
         string $model,
         float $durationSeconds,
         array $extraMetadata = [],
-    ): void {
+    ): ?RecordedUsage {
         // No user or no priced model → nothing to bill. (model_id is required
         // because the per-second price lives on the model.)
         if (null === $userId || $userId <= 0 || null === $modelId) {
-            return;
+            return null;
         }
 
         // A priced STT call without a usable duration would silently bill $0 —
@@ -64,16 +66,16 @@ final readonly class TranscriptionUsageRecorder
                 'model' => $model,
             ]);
 
-            return;
+            return null;
         }
 
         $user = $this->userRepository->find($userId);
         if (null === $user) {
-            return;
+            return null;
         }
 
         try {
-            $this->rateLimitService->recordUsage($user, self::ACTION, [
+            return $this->rateLimitService->recordUsage($user, self::ACTION, [
                 'provider' => $provider,
                 'model' => $model,
                 'model_id' => $modelId,
@@ -86,6 +88,8 @@ final readonly class TranscriptionUsageRecorder
                 'provider' => $provider,
                 'error' => $e->getMessage(),
             ]);
+
+            return null;
         }
     }
 }

--- a/backend/src/Service/WhatsAppService.php
+++ b/backend/src/Service/WhatsAppService.php
@@ -12,6 +12,7 @@ use App\Entity\User;
 use App\Service\File\FileProcessor;
 use App\Service\File\UserUploadPathBuilder;
 use App\Service\Message\MessageProcessor;
+use App\Service\Usage\RecordedUsage;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Lock\LockFactory;
@@ -837,7 +838,7 @@ final class WhatsAppService
             $this->em->flush();
         }
 
-        $this->rateLimitService->recordUsage($user, 'MESSAGES', [
+        $recordedChatUsage = $this->rateLimitService->recordUsage($user, 'MESSAGES', [
             'provider' => $metadata['provider'] ?? 'unknown',
             'model' => $metadata['model'] ?? 'unknown',
             'usage' => $metadata['usage'] ?? [],
@@ -846,6 +847,14 @@ final class WhatsAppService
             'response_text' => $responseText,
             'input_text' => $message->getText(),
         ]);
+        $metadata['recorded_chat_usage'] = $recordedChatUsage;
+        $rawTranscriptionUsage = $message->getMeta('ai_transcription_usage');
+        if (null !== $rawTranscriptionUsage && '' !== $rawTranscriptionUsage) {
+            $transcriptionUsage = json_decode($rawTranscriptionUsage, true);
+            if (is_array($transcriptionUsage)) {
+                $metadata['transcription_usage'] = $transcriptionUsage;
+            }
+        }
 
         // 8. Send Response based on input type
         $responseSent = false;
@@ -1758,6 +1767,10 @@ final class WhatsAppService
         if (!empty($aiMetadata['usage']) && is_array($aiMetadata['usage'])) {
             $outgoingMessage->setMeta('ai_chat_usage', (string) json_encode($aiMetadata['usage']));
         }
+        $recordedChatUsage = $aiMetadata['recorded_chat_usage'] ?? null;
+        if ($recordedChatUsage instanceof RecordedUsage) {
+            $outgoingMessage->setMeta('ai_chat_cost', $recordedChatUsage->chargedCost);
+        }
         if (!empty($classification['sorting_provider'])) {
             $outgoingMessage->setMeta('ai_sorting_provider', (string) $classification['sorting_provider']);
         }
@@ -1766,6 +1779,29 @@ final class WhatsAppService
         }
         if (!empty($classification['sorting_model_id'])) {
             $outgoingMessage->setMeta('ai_sorting_model_id', (string) $classification['sorting_model_id']);
+        }
+
+        $usageExtra = [];
+        if (is_array($classification['sorting_usage'] ?? null)) {
+            $usageExtra[] = [
+                'promptTokens' => (int) ($classification['sorting_usage']['prompt_tokens'] ?? 0),
+                'completionTokens' => (int) ($classification['sorting_usage']['completion_tokens'] ?? 0),
+                'totalTokens' => (int) ($classification['sorting_usage']['tokens'] ?? 0),
+                'cost' => (string) ($classification['sorting_usage']['cost'] ?? '0'),
+                'modelKey' => RecordedUsage::modelKey(
+                    $classification['sorting_provider'] ?? null,
+                    $classification['sorting_model_name'] ?? null,
+                ),
+                'kind' => 'SORT',
+            ];
+        }
+        foreach (['planning_usage', 'transcription_usage'] as $usageKey) {
+            if (is_array($aiMetadata[$usageKey] ?? null)) {
+                $usageExtra[] = $aiMetadata[$usageKey];
+            }
+        }
+        if ([] !== $usageExtra) {
+            $outgoingMessage->setMeta('ai_usage_extra', (string) json_encode($usageExtra));
         }
 
         $resultsList = $searchResults['results'] ?? null;

--- a/backend/tests/Service/WhatsAppServiceTest.php
+++ b/backend/tests/Service/WhatsAppServiceTest.php
@@ -15,6 +15,7 @@ use App\Service\File\FileProcessor;
 use App\Service\File\UserUploadPathBuilder;
 use App\Service\Message\MessageProcessor;
 use App\Service\RateLimitService;
+use App\Service\Usage\RecordedUsage;
 use App\Service\UserMemoryService;
 use App\Service\WhatsAppService;
 use Doctrine\ORM\EntityManagerInterface;
@@ -76,6 +77,9 @@ class WhatsAppServiceTest extends TestCase
         $this->logger = $this->createMock(LoggerInterface::class);
         $this->em = $this->createMock(EntityManagerInterface::class);
         $this->rateLimitService = $this->createMock(RateLimitService::class);
+        $this->rateLimitService->method('recordUsage')->willReturn(
+            new RecordedUsage('0.001000', '0.001000', 10, 5, 15),
+        );
         $this->messageProcessor = $this->createMock(MessageProcessor::class);
         $this->fileProcessor = $this->createMock(FileProcessor::class);
         $this->aiFacade = $this->createMock(AiFacade::class);

--- a/backend/tests/Unit/AI/Service/AiFacadeTranscribeTest.php
+++ b/backend/tests/Unit/AI/Service/AiFacadeTranscribeTest.php
@@ -13,6 +13,7 @@ use App\Service\DiscordNotificationService;
 use App\Service\File\UserUploadPathBuilder;
 use App\Service\InternalEmailService;
 use App\Service\ModelConfigService;
+use App\Service\Usage\RecordedUsage;
 use App\Service\Usage\TranscriptionUsageRecorder;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -101,6 +102,9 @@ class AiFacadeTranscribeTest extends TestCase
         $this->registry->expects(self::any())->method('getSpeechToTextProvider')
             ->with('groq')
             ->willReturn($groq);
+        $this->transcriptionUsageRecorder->expects(self::once())
+            ->method('record')
+            ->willReturn(new RecordedUsage('0.004000', '0.004000', 0, 0, 0));
 
         $result = $this->facade->transcribe('audio.mp3', 42);
 
@@ -110,6 +114,9 @@ class AiFacadeTranscribeTest extends TestCase
         // model_id must be surfaced so the message-details popover can resolve
         // the concrete BMODELS row (and the "AI Model" badge stays clickable).
         $this->assertSame(21, $result['model_id']);
+        $this->assertSame('0.004000', $result['transcription_usage']['cost']);
+        $this->assertSame('groq:whisper-large-v3', $result['transcription_usage']['modelKey']);
+        $this->assertSame('TRANSCRIPTION', $result['transcription_usage']['kind']);
     }
 
     public function testTranscribeForwardsNonTurboModelWhenSameProviderHasMultiple(): void

--- a/backend/tests/Unit/Service/Message/MessageApiFormatterUsageTest.php
+++ b/backend/tests/Unit/Service/Message/MessageApiFormatterUsageTest.php
@@ -113,6 +113,25 @@ final class MessageApiFormatterUsageTest extends TestCase
         self::assertSame(42, $usage['totalTokens']);
     }
 
+    public function testAuxiliaryTurnUsageSurvivesHistorySerialization(): void
+    {
+        $m = $this->makeOutMessage();
+        $m->setMeta('ai_usage_extra', json_encode([[
+            'promptTokens' => 12,
+            'completionTokens' => 3,
+            'totalTokens' => 15,
+            'cost' => '0.004200',
+            'modelKey' => 'openai:planner',
+            'kind' => 'PLANNING',
+        ]]));
+
+        $usageExtra = $this->formatter->format($m)['usageExtra'];
+
+        self::assertIsArray($usageExtra);
+        self::assertSame('PLANNING', $usageExtra[0]['kind']);
+        self::assertSame('0.004200', $usageExtra[0]['cost']);
+    }
+
     public function testIncomingMessageHasNoUsage(): void
     {
         $m = $this->makeMessage('IN', 'question');

--- a/backend/tests/Unit/Service/Multitask/Execution/ResultAssemblerTest.php
+++ b/backend/tests/Unit/Service/Multitask/Execution/ResultAssemblerTest.php
@@ -74,6 +74,25 @@ final class ResultAssemblerTest extends TestCase
         $this->assertNotContains('n3', $cardIds);
     }
 
+    public function testUsageIncludesEarlierNodesWhenReplyNodeAlreadyHasUsage(): void
+    {
+        $plan = $this->plan();
+        $ctx = $this->context();
+        $ctx->setResult('n1', NodeResult::ok('Summary', metadata: [
+            'usage' => ['prompt_tokens' => 40, 'completion_tokens' => 10, 'total_tokens' => 50],
+        ]));
+        $ctx->setResult('n2', NodeResult::ok());
+        $ctx->setResult('n3', NodeResult::ok('Summary', metadata: [
+            'usage' => ['prompt_tokens' => 20, 'completion_tokens' => 5, 'total_tokens' => 25],
+        ]));
+
+        $usage = $this->assembler->assemble($plan, $ctx)['metadata']['usage'];
+
+        self::assertSame(60, $usage['prompt_tokens']);
+        self::assertSame(15, $usage['completion_tokens']);
+        self::assertSame(75, $usage['total_tokens']);
+    }
+
     public function testRedundantFlagMarksProseContainedInTheFinalAnswer(): void
     {
         // #1229 smart collapse: n1's text is passed through by the reply node

--- a/backend/tests/Unit/Service/Multitask/TaskPlanExecutorTest.php
+++ b/backend/tests/Unit/Service/Multitask/TaskPlanExecutorTest.php
@@ -256,6 +256,36 @@ final class TaskPlanExecutorTest extends TestCase
         self::assertSame(['content' => 'router answer'], $result);
     }
 
+    public function testPlanningUsageSurvivesDelegationToLegacyRouter(): void
+    {
+        $planningUsage = [
+            'promptTokens' => 40,
+            'completionTokens' => 10,
+            'totalTokens' => 50,
+            'cost' => '0.001500',
+            'modelKey' => 'openai:planner',
+            'kind' => 'PLANNING',
+        ];
+        $this->planner->method('plan')->willReturn(new TaskPlanResult(
+            TaskPlan::singleChatPlan('en'),
+            fallback: false,
+            modelId: 76,
+            planningUsage: $planningUsage,
+        ));
+        $this->router->method('routeStream')->willReturn([
+            'response' => ['content' => 'router answer', 'metadata' => []],
+        ]);
+
+        $result = $this->executor->executeStream(
+            $this->message(),
+            [],
+            ['intent' => 'chat', 'language' => 'en', 'source' => 'ai_sorting'],
+            static function (): void {},
+        );
+
+        self::assertSame($planningUsage, $result['response']['metadata']['planning_usage']);
+    }
+
     public function testFileAttachmentMultiIntentRunsDag(): void
     {
         // Issue #1192: a non-image attachment carrying multiple intents

--- a/backend/tests/Unit/Service/Usage/TranscriptionUsageRecorderTest.php
+++ b/backend/tests/Unit/Service/Usage/TranscriptionUsageRecorderTest.php
@@ -36,6 +36,7 @@ class TranscriptionUsageRecorderTest extends TestCase
         $user = $this->createMock(User::class);
         $this->userRepository->expects($this->any())->method('find')->with(42)->willReturn($user);
 
+        $recordedUsage = $this->recordedUsage();
         $this->rateLimitService->expects($this->once())
             ->method('recordUsage')
             ->with(
@@ -48,9 +49,12 @@ class TranscriptionUsageRecorderTest extends TestCase
                         && 'en' === $meta['language'];
                 })
             )
-            ->willReturn($this->recordedUsage());
+            ->willReturn($recordedUsage);
 
-        $this->recorder->record(42, 21, 'groq', 'whisper-large-v3', 12.5, ['language' => 'en']);
+        self::assertSame(
+            $recordedUsage,
+            $this->recorder->record(42, 21, 'groq', 'whisper-large-v3', 12.5, ['language' => 'en']),
+        );
     }
 
     public function testSkipsWhenNoUserId(): void

--- a/frontend/src/components/ChatMessage.vue
+++ b/frontend/src/components/ChatMessage.vue
@@ -1051,7 +1051,7 @@ import ExternalLinkWarning from '@/components/common/ExternalLinkWarning.vue'
 import { useExternalLink } from '@/composables/useExternalLink'
 import { useDateFormat } from '@/composables/useDateFormat'
 import type { Part, MessageFile, MediaJobInfo, TaskPlanState } from '@/stores/history'
-import type { MessageUsage } from '@/stores/usageTaximeter'
+import { aggregateTurnUsage, type MessageUsage } from '@/stores/usageTaximeter'
 import { formatCostDisplay, formatTokens } from '@/utils/usageFormat'
 import TaskPlanBubble from '@/components/multitask/TaskPlanBubble.vue'
 import MediaJobStatus from '@/components/MediaJobStatus.vue'
@@ -1153,6 +1153,8 @@ interface Props {
   // Usage taximeter: per-message token/cost usage (assistant only). When the
   // display is enabled, a small hover badge shows "<tokens> · <cost>".
   usage?: MessageUsage | null
+  // Other billed steps in the same turn (sorting, planning, transcription, media).
+  usageExtra?: MessageUsage[] | null
   // Whether the taximeter display is active (admin switch + authed web user).
   usageTaximeterActive?: boolean
   // Status for failed/pending messages
@@ -1173,23 +1175,19 @@ interface Props {
 const props = defineProps<Props>()
 
 /**
- * Usage taximeter hover badge: "<tokens> · <cost>" for an assistant reply that
- * recorded usage, shown only while the display is active. Cost below one cent
- * renders "< 0.01 €".
+ * Usage taximeter hover badge: "<tokens> · <cost>" for the complete assistant
+ * turn, including routing, planning, transcription and media usage.
  */
 const usageBadge = computed<{ tokens: string; cost: string } | null>(() => {
-  if (props.role !== 'assistant' || !props.usageTaximeterActive || !props.usage) {
+  if (props.role !== 'assistant' || !props.usageTaximeterActive) {
     return null
   }
-  const u = props.usage
-  const costValue = u.cost != null ? Number.parseFloat(u.cost) : 0
+  const total = aggregateTurnUsage(props.usage, props.usageExtra)
+  if (!total) return null
+
   return {
-    tokens: formatTokens(u.totalTokens, locale.value),
-    cost: formatCostDisplay(
-      Number.isFinite(costValue) ? costValue : 0,
-      locale.value,
-      t('usageTaximeter.lessThanCent')
-    ),
+    tokens: formatTokens(total.totalTokens, locale.value),
+    cost: formatCostDisplay(total.cost, locale.value, t('usageTaximeter.lessThanCent')),
   }
 })
 

--- a/frontend/src/stores/usageTaximeter.ts
+++ b/frontend/src/stores/usageTaximeter.ts
@@ -67,6 +67,23 @@ function parseCost(raw: string | number | null | undefined): number {
   return Number.isFinite(n) && n > 0 ? n : 0
 }
 
+/** Sum every billed step that belongs to one assistant turn. */
+export function aggregateTurnUsage(
+  usage?: MessageUsage | null,
+  extra?: MessageUsage[] | null
+): { totalTokens: number; cost: number } | null {
+  const entries = [...(usage ? [usage] : []), ...(extra ?? [])]
+  if (entries.length === 0) return null
+
+  return entries.reduce(
+    (total, entry) => ({
+      totalTokens: total.totalTokens + entry.totalTokens,
+      cost: total.cost + parseCost(entry.cost),
+    }),
+    { totalTokens: 0, cost: 0 }
+  )
+}
+
 /** Human label from a "provider:model" key (strip the provider prefix). */
 function labelFromModelKey(key: string): string {
   const idx = key.indexOf(':')

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -195,6 +195,7 @@
               :media-job="message.mediaJob"
               :was-multitask="message.wasMultitask"
               :usage="message.usage"
+              :usage-extra="message.usageExtra"
               :usage-taximeter-active="usageTaximeterStore.active"
               :is-guest-mode="isGuestMode"
               @regenerate="handleRegenerate(message, $event)"

--- a/frontend/tests/unit/stores/usageTaximeter.spec.ts
+++ b/frontend/tests/unit/stores/usageTaximeter.spec.ts
@@ -29,7 +29,11 @@ vi.mock('@/api/usageApi', () => ({
   getUsageSummary: () => getUsageSummary(),
 }))
 
-import { useUsageTaximeterStore, type MessageUsage } from '@/stores/usageTaximeter'
+import {
+  aggregateTurnUsage,
+  useUsageTaximeterStore,
+  type MessageUsage,
+} from '@/stores/usageTaximeter'
 
 function usage(modelKey: string, cost: string, tokens = 100, kind = 'LLM'): MessageUsage {
   return {
@@ -48,6 +52,19 @@ describe('usageTaximeter store', () => {
     mockEnabled = true
     getUsageSummary.mockReset()
     setActivePinia(createPinia())
+  })
+
+  describe('turn aggregation', () => {
+    it('includes chat, sorting, planning, and transcription in the badge total', () => {
+      const total = aggregateTurnUsage(usage('openai:gpt-4o', '0.02', 80), [
+        { ...usage('groq:sorter', '0.001', 20), kind: 'SORT' },
+        { ...usage('openai:planner', '0.002', 30), kind: 'PLANNING' },
+        { ...usage('groq:whisper', '0.003', 0), kind: 'TRANSCRIPTION' },
+      ])
+
+      expect(total?.totalTokens).toBe(130)
+      expect(total?.cost).toBeCloseTo(0.026, 6)
+    })
   })
 
   describe('active gate', () => {


### PR DESCRIPTION
## Summary
Fixes the usage taximeter so per-turn badges and model totals include all billed steps, while WhatsApp and Email persist the same charged costs as web replies.

## Changes
- Aggregate chat, sorting, planning, transcription, and media usage in the per-message badge.
- Propagate and persist planning/transcription usage for live responses and reloaded chat history.
- Persist charged chat costs for WhatsApp, Email, and the non-streaming web path.
- Preserve usage from every successful multitask node, including turns whose reply node already reports usage.
- Add regression coverage for turn aggregation, channel cost persistence, planning propagation, transcription usage, and history serialization.

## Verification
- [ ] Not tested (explain)
- [ ] Manual
- [x] Tests added/updated
- [x] `make -C backend lint`
- [x] `make -C backend phpstan`
- [x] `make -C backend test` (2,723 tests, 9,537 assertions)
- [x] `make -C frontend lint`
- [x] `docker compose exec -T frontend npm run check:types`
- [x] `make -C frontend test` (909 tests)

## Notes
Closes #1373.

No merge or auto-merge has been requested. The branch must pass all required GitHub checks and review requirements before the maintainer merges it.

## Screenshots/Logs
No screenshots were attached to the issue, and this change does not alter visual styling.