### PR TITLE
fix(models): retire the remaining catalog orphans still active in production

### DIFF
--- a/backend/migrations/Version20260728120000.php
+++ b/backend/migrations/Version20260728120000.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Retire the remaining catalog-orphans found on the production catalog on
+ * 2026-07-28: three OpenAI chat rows and four HuggingFace rows that left
+ * {@see \App\Model\ModelCatalog} without a companion deactivation migration.
+ *
+ * Same contract as {@see Version20260727120000} and {@see Version20260727180000}:
+ * rows are deactivated, never deleted (BMESSAGES references the BIDs), the
+ * BPROVID guard keeps a re-run idempotent, and DEFAULTMODEL bindings (global and
+ * per-user) are repointed to the current catalog-managed equivalent behind an
+ * EXISTS subquery.
+ *
+ *   - gpt-5, gpt-5.2                → GPT-5.6 Terra   (BID 253) — current mid-tier OpenAI chat
+ *   - gpt-5-mini                    → GPT-5.4 mini    (BID 232) — current small OpenAI chat
+ *   - DeepSeek-R1                   → Kimi K2.6       (BID 202) — current HF reasoning chat
+ *   - Qwen2.5-Coder-32B-Instruct    → Kimi K2.7 Code  (BID 242) — current HF coding chat
+ *   - HF stable-diffusion-xl        → TheHive SDXL    (BID 132) — same model, catalog-managed host
+ *
+ * The embedding orphan (HuggingFace multilingual-e5-large, BID 129) is handled
+ * separately below: an embedding model may not be swapped by a repoint alone.
+ */
+final class Version20260728120000 extends AbstractMigration
+{
+    private const SUCCESSOR_GPT_56_TERRA_BID = 253;
+    private const SUCCESSOR_GPT_54_MINI_BID = 232;
+    private const SUCCESSOR_KIMI_K26_BID = 202;
+    private const SUCCESSOR_KIMI_K27_CODE_BID = 242;
+    private const SUCCESSOR_THEHIVE_SDXL_BID = 132;
+
+    /** HuggingFace multilingual-e5-large — deactivated only when nothing binds to it. */
+    private const RETIRED_EMBEDDING_BID = 129;
+    private const RETIRED_EMBEDDING_PROVID = 'intfloat/multilingual-e5-large';
+
+    /**
+     * Retired BID => [upstream API model id (guard), successor BID].
+     *
+     * @var array<int, array{string, int}>
+     */
+    private const RETIRED_MODELS = [
+        70 => ['gpt-5', self::SUCCESSOR_GPT_56_TERRA_BID],
+        106 => ['gpt-5.2-2025-12-11', self::SUCCESSOR_GPT_56_TERRA_BID],
+        150 => ['gpt-5-mini', self::SUCCESSOR_GPT_54_MINI_BID],
+        125 => ['deepseek-ai/DeepSeek-R1', self::SUCCESSOR_KIMI_K26_BID],
+        128 => ['Qwen/Qwen2.5-Coder-32B-Instruct', self::SUCCESSOR_KIMI_K27_CODE_BID],
+        126 => ['stabilityai/stable-diffusion-xl-base-1.0', self::SUCCESSOR_THEHIVE_SDXL_BID],
+    ];
+
+    public function getDescription(): string
+    {
+        return 'Deactivate the remaining OpenAI (70/106/150) and HuggingFace (125/126/128) catalog-orphans, repoint their DEFAULTMODEL bindings, and retire the unbound HuggingFace embedding row (129).';
+    }
+
+    public function up(Schema $schema): void
+    {
+        foreach (self::RETIRED_MODELS as $retiredBid => [$providerId, $successorBid]) {
+            $this->addSql(<<<'SQL'
+                UPDATE BCONFIG
+                   SET BVALUE = :successor
+                 WHERE BGROUP = 'DEFAULTMODEL'
+                   AND BVALUE = :retired
+                   AND EXISTS (SELECT 1 FROM BMODELS WHERE BID = :successor)
+            SQL, [
+                'retired' => (string) $retiredBid,
+                'successor' => (string) $successorBid,
+            ]);
+
+            $this->addSql(<<<'SQL'
+                UPDATE BMODELS
+                   SET BACTIVE = 0,
+                       BSELECTABLE = 0,
+                       BISDEFAULT = 0
+                 WHERE BID = :retired
+                   AND BPROVID = :providerId
+            SQL, [
+                'retired' => $retiredBid,
+                'providerId' => $providerId,
+            ]);
+        }
+
+        // Embeddings are not interchangeable: switching DEFAULTMODEL.VECTORIZE
+        // invalidates every stored vector, which is why the admin path pairs the
+        // switch with a re-vectorize run (see VectorizeBindingService and issue
+        // #948). A migration cannot re-vectorize, so the orphan is only retired
+        // where no binding points at it; an install that still uses it keeps a
+        // working search and can switch through the admin UI.
+        $this->addSql(<<<'SQL'
+            UPDATE BMODELS
+               SET BACTIVE = 0,
+                   BSELECTABLE = 0,
+                   BISDEFAULT = 0
+             WHERE BID = :retired
+               AND BPROVID = :providerId
+               AND NOT EXISTS (
+                   SELECT 1 FROM BCONFIG
+                    WHERE BGROUP = 'DEFAULTMODEL'
+                      AND BVALUE = :retiredValue
+               )
+        SQL, [
+            'retired' => self::RETIRED_EMBEDDING_BID,
+            'retiredValue' => (string) self::RETIRED_EMBEDDING_BID,
+            'providerId' => self::RETIRED_EMBEDDING_PROVID,
+        ]);
+    }
+
+    public function down(Schema $schema): void
+    {
+        // Reactivate the retired rows so they reappear in the admin UI. The
+        // BCONFIG repoints from up() are intentionally not undone: we cannot tell
+        // an auto-migrated binding from one an operator set deliberately
+        // afterwards. Same contract as Version20260727180000::down().
+        $retired = self::RETIRED_MODELS;
+        $retired[self::RETIRED_EMBEDDING_BID] = [self::RETIRED_EMBEDDING_PROVID, 0];
+
+        foreach ($retired as $retiredBid => [$providerId]) {
+            $this->addSql(<<<'SQL'
+                UPDATE BMODELS
+                   SET BACTIVE = 1,
+                       BSELECTABLE = 1
+                 WHERE BID = :retired
+                   AND BPROVID = :providerId
+            SQL, [
+                'retired' => $retiredBid,
+                'providerId' => $providerId,
+            ]);
+        }
+    }
+}

--- a/backend/tests/Unit/Model/ModelCatalogTest.php
+++ b/backend/tests/Unit/Model/ModelCatalogTest.php
@@ -352,6 +352,32 @@ class ModelCatalogTest extends TestCase
         $this->assertNotContains(49, $ids);
     }
 
+    /**
+     * The remaining orphans found on the production catalog on 2026-07-28 and
+     * deactivated by Version20260728120000. Same reasoning as the test above:
+     * re-adding one under its old BID or upstream model id would resurrect a row
+     * we deliberately took out of the picker.
+     */
+    public function testRetiredOpenAiAndHuggingFaceOrphansAreAbsentFromCatalog(): void
+    {
+        $providerIds = array_column(ModelCatalog::all(), 'providerId');
+        $ids = array_column(ModelCatalog::all(), 'id');
+
+        $retired = [
+            70 => 'gpt-5',
+            106 => 'gpt-5.2-2025-12-11',
+            125 => 'deepseek-ai/DeepSeek-R1',
+            126 => 'stabilityai/stable-diffusion-xl-base-1.0',
+            128 => 'Qwen/Qwen2.5-Coder-32B-Instruct',
+            129 => 'intfloat/multilingual-e5-large',
+            150 => 'gpt-5-mini',
+        ];
+        foreach ($retired as $retiredBid => $retiredProviderId) {
+            $this->assertNotContains($retiredProviderId, $providerIds, sprintf('%s was retired and must not be re-added.', $retiredProviderId));
+            $this->assertNotContains($retiredBid, $ids, sprintf('BID %d belongs to a retired model and must not be reused.', $retiredBid));
+        }
+    }
+
     public function testGpt55ProModelsAreMarkedAsNonStreaming(): void
     {
         $chat = ModelCatalog::find('openai:gpt-5.5-pro:chat')[0];

--- a/docs/PRICING_MAINTENANCE.md
+++ b/docs/PRICING_MAINTENANCE.md
@@ -248,6 +248,21 @@ Retired on 2026-07-27 by `Version20260727120000` (rows deactivated, never delete
 
 The same orphan cleanup continues in `Version20260727180000` for two non-Anthropic rows: **OpenAI `gpt-4.1` (BID 30)** → GPT-5.6 Terra (253) and **Groq `llama-4-maverick-17b-128e-instruct` (BID 49)** → Groq `gpt-oss-120b` (76).
 
+### Orphan sweep 2026-07-28 (`Version20260728120000`)
+
+Comparing the production catalog (`GET /api/v1/admin/models`) against `ModelCatalog::all()` surfaced seven more rows that were still `BACTIVE=1, BSELECTABLE=1` in the database with no catalog entry behind them. **Diffing prod against the catalog is the only way to find these** — the code alone cannot tell you what an old install still offers.
+
+| Retired BID | Row | Successor |
+| ----------- | --- | --------- |
+| 70 / 106 | OpenAI `gpt-5`, `gpt-5.2-2025-12-11` | GPT-5.6 Terra (253) |
+| 150 | OpenAI `gpt-5-mini` | GPT-5.4 mini (232) |
+| 125 | HuggingFace `deepseek-ai/DeepSeek-R1` | Kimi K2.6 (202) |
+| 128 | HuggingFace `Qwen/Qwen2.5-Coder-32B-Instruct` | Kimi K2.7 Code (242) |
+| 126 | HuggingFace `stabilityai/stable-diffusion-xl-base-1.0` | TheHive SDXL (132) |
+| 129 | HuggingFace `intfloat/multilingual-e5-large` (vectorize) | none — see below |
+
+> **Never repoint `DEFAULTMODEL.VECTORIZE` from a migration.** Embedding models are not interchangeable: swapping the binding without re-vectorizing leaves every stored vector in the wrong space, which is exactly the failure mode of issue #948 (Qdrant HTTP 400, memory lost). The admin path pairs the switch with a re-vectorize run via `VectorizeBindingService`; a migration cannot. BID 129 is therefore deactivated only where nothing binds to it, guarded by a `NOT EXISTS` on `BCONFIG` — an install still using it keeps working search and switches through the UI.
+
 ### A non-zero price under a "free" unit is silently free
 
 `normaliseToPerUnit()` maps `-`, `` and `free` to **0**, so a price stored under one of those units is displayed but never billed. Two Ollama rows shipped exactly that — BID 3 (`deepseek-r1:32b`, out 0.91) and BID 6 (`mistral:7b`, out 0.475) had `BOUTUNIT = '-'` while their input side was `per1M`, so their output tokens were free while input was charged. `Version20260727190000` corrects the unit only; the price values stay as they were, since Ollama rows are an operator-hosted synthetic resale basis and re-pricing them is a decision, not a fix.


### PR DESCRIPTION
## Summary

Pulling the live catalog from production (`GET /api/v1/admin/models`) and diffing it against `ModelCatalog::all()` surfaced **seven rows that are still `BACTIVE=1, BSELECTABLE=1` with no catalog entry behind them** — the same failure mode that kept Claude Opus 4.1/4.5 alive for several releases. They are pickable in the UI today and billed at whatever price the stale row holds, and `ModelSeeder` can never fix them because it only manages rows the catalog still contains.

`Version20260728120000` deactivates them (never deletes — `BMESSAGES` FKs) and repoints any `DEFAULTMODEL` binding, global or per-user, behind an `EXISTS` guard:

| Retired BID | Row | Successor |
| --- | --- | --- |
| 70 / 106 | OpenAI `gpt-5`, `gpt-5.2-2025-12-11` | GPT-5.6 Terra (253) |
| 150 | OpenAI `gpt-5-mini` | GPT-5.4 mini (232) |
| 125 | HuggingFace `deepseek-ai/DeepSeek-R1` | Kimi K2.6 (202) |
| 128 | HuggingFace `Qwen/Qwen2.5-Coder-32B-Instruct` | Kimi K2.7 Code (242) |
| 126 | HuggingFace `stabilityai/stable-diffusion-xl-base-1.0` | TheHive SDXL (132) |
| 129 | HuggingFace `intfloat/multilingual-e5-large` | none — see below |

### The embedding row is not a normal repoint

Embedding models are not interchangeable. Switching `DEFAULTMODEL.VECTORIZE` without re-vectorizing leaves every stored vector in the wrong space — exactly issue #948 (Qdrant HTTP 400, memory lost), which is why the admin path pairs the switch with a re-vectorize run through `VectorizeBindingService`. A migration cannot re-vectorize, so **BID 129 is deactivated only where no binding points at it**, guarded by `NOT EXISTS` on `BCONFIG`. An install still using it keeps working search and switches through the UI.

`ModelCatalogTest::testRetiredOpenAiAndHuggingFaceOrphansAreAbsentFromCatalog()` fails the build if any of the seven is ever re-added under its old BID or upstream model id.

## Test plan

- [x] `make -C backend lint`
- [x] `make -C backend phpstan`
- [x] `make -C backend test` (2744 tests, unfiltered)
- [x] `doctrine:migrations:migrate` up, `--down`, and up again on the dev DB — reversible and idempotent
- [x] No `Schema $schema` usage (Galera constraint); raw idempotent `addSql()` only
- [ ] Reviewer: confirm the successor choices, in particular HF SDXL → TheHive SDXL (cross-provider, same model)

Made with [Cursor](https://cursor.com)