### PR TITLE
test(e2e): cover high-value gaps (chat manage, memories, files)

### DIFF
--- a/backend/config/packages/messenger.yaml
+++ b/backend/config/packages/messenger.yaml
@@ -121,3 +121,11 @@ when@test:
                 legacy_async_extract: 'in-memory://'
                 legacy_async_index: 'in-memory://'
                 legacy_failed: 'in-memory://'
+                # Synchronous execution for memory extraction: the test env
+                # runs no messenger worker, so an in-memory queue would mean
+                # extraction never happens and the feature is untestable E2E.
+                sync: 'sync://'
+            routing:
+                # Only this key is overridden — the rest of the routing map
+                # from the base config is merged in unchanged.
+                'App\Message\ExtractMemoriesCommand': sync

--- a/backend/src/AI/Provider/TestProvider.php
+++ b/backend/src/AI/Provider/TestProvider.php
@@ -103,6 +103,13 @@ class TestProvider implements ChatProviderInterface, EmbeddingProviderInterface,
             return $this->mockTaskPlan($userContent);
         }
 
+        // Memory extraction (tools:memory_extraction): the user prompt built by
+        // MemoryExtractionService carries these two stable markers.
+        if (str_contains($userContent, 'Current Message (from the user):')
+            && str_contains($userContent, '"action": "create"')) {
+            return $this->mockMemoryExtraction($userContent);
+        }
+
         // Search-query-style request (e.g. SearchQueryGenerator with tools:search prompt): return cleaned query like fallbackExtraction
         if (str_contains($systemContent, 'search') && str_contains($systemContent, 'query')) {
             return $this->mockSearchQueryExtraction($userContent);
@@ -232,6 +239,35 @@ class TestProvider implements ChatProviderInterface, EmbeddingProviderInterface,
                 ['id' => 'n1', 'capability' => 'chat', 'inputs' => ['text' => '$message.text']],
             ],
         ], JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * Mock memory extraction: deterministic contract for E2E tests.
+     *
+     * The current user message may contain an explicit instruction of the
+     * form `memorize: some_key = some value` — exactly that becomes a
+     * `create` action (category `preferences`). Everything else returns `[]`
+     * so ordinary E2E chat turns never pollute the user's memory list.
+     */
+    private function mockMemoryExtraction(string $userContent): string
+    {
+        $currentMessage = '';
+        if (preg_match('/Current Message \(from the user\):\n(.*?)(?:\n\n|$)/s', $userContent, $m)) {
+            $currentMessage = $m[1];
+        }
+
+        if (preg_match('/memorize:\s*([a-z0-9_]+)\s*=\s*([^\n]+)/i', $currentMessage, $m)) {
+            return json_encode([
+                [
+                    'action' => 'create',
+                    'category' => 'preferences',
+                    'key' => strtolower($m[1]),
+                    'value' => trim($m[2]),
+                ],
+            ], JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
+        }
+
+        return '[]';
     }
 
     private function detectLanguage(string $text, string $fallback = 'en'): string

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -39,6 +39,9 @@ services:
       DATABASE_READ_URL: mysql://synaplan_test:synaplan_test@db_test:3306/synaplan?serverVersion=mariadb-12.2.2&charset=utf8mb4
       OLLAMA_BASE_URL: http://ollama-stub:11434
       TIKA_BASE_URL: http://tika_test:9998
+      # Real Qdrant for memory/vector E2E flows (overrides the empty
+      # QDRANT_URL in backend/.env.test, which keeps PHPUnit Qdrant-free).
+      QDRANT_URL: http://qdrant_test:6333
       AI_DEFAULT_PROVIDER: test
       MAILER_DSN: smtp://mailhog_test:1025
       AUTO_DOWNLOAD_MODELS: "false"
@@ -63,6 +66,8 @@ services:
       mailhog_test:
         condition: service_started
       ollama-stub:
+        condition: service_started
+      qdrant_test:
         condition: service_started
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost/api/health"]
@@ -96,6 +101,17 @@ services:
       timeout: 5s
       retries: 5
       start_period: 30s
+    restart: "no"
+    networks:
+      - synaplan-test-network
+
+  # Qdrant vector store — required by the memory service (user memories).
+  # Ephemeral by design: no volume, every stack start begins with empty
+  # collections (the backend auto-creates them on first use). Not published
+  # to a host port; only app_test talks to it.
+  qdrant_test:
+    image: qdrant/qdrant:v1.18.2@sha256:75eab8c4ba42096724fdcfde8b4de0b5713d529dde32f285a1f86fdcb2c9e50c
+    container_name: synaplan-qdrant-test
     restart: "no"
     networks:
       - synaplan-test-network

--- a/frontend/src/components/MemoryFormDialog.vue
+++ b/frontend/src/components/MemoryFormDialog.vue
@@ -8,6 +8,7 @@
       >
         <div
           class="modal-panel surface-card rounded-2xl shadow-2xl max-w-lg w-full overflow-y-auto scroll-thin"
+          data-testid="modal-memory-form"
           @click.stop
         >
           <!-- Header -->
@@ -49,6 +50,7 @@
                     ? 'mode-toggle-active'
                     : 'txt-secondary hover:txt-primary hover:bg-black/5 dark:hover:bg-white/10'
                 "
+                data-testid="btn-memory-mode-advanced"
                 @click="mode = 'advanced'"
               >
                 <Icon icon="mdi:form-textbox" class="w-4 h-4" />
@@ -333,6 +335,7 @@
                 :placeholder="$t('memories.create.categoryPlaceholder')"
                 required
                 list="category-suggestions"
+                data-testid="input-memory-category"
                 class="w-full px-4 py-2.5 rounded-xl surface-chip txt-primary placeholder:txt-secondary focus:outline-none focus:ring-2 focus:ring-brand/50 transition-all"
               />
               <datalist id="category-suggestions">
@@ -352,6 +355,7 @@
                 type="text"
                 required
                 :placeholder="$t('memories.create.keyPlaceholder')"
+                data-testid="input-memory-key"
                 class="w-full px-4 py-2.5 rounded-xl surface-chip txt-primary placeholder:txt-secondary focus:outline-none focus:ring-2 focus:ring-brand/50 transition-all"
               />
             </div>
@@ -365,6 +369,7 @@
                 required
                 :placeholder="$t('memories.create.valuePlaceholder')"
                 rows="4"
+                data-testid="input-memory-value"
                 class="w-full px-4 py-2.5 rounded-xl surface-chip txt-primary placeholder:txt-secondary focus:outline-none focus:ring-2 focus:ring-brand/50 resize-none transition-all"
               ></textarea>
             </div>
@@ -378,7 +383,11 @@
               >
                 {{ $t('common.cancel') }}
               </button>
-              <button type="submit" class="flex-1 btn-primary px-4 py-2.5 rounded-xl font-medium">
+              <button
+                type="submit"
+                class="flex-1 btn-primary px-4 py-2.5 rounded-xl font-medium"
+                data-testid="btn-memory-save"
+              >
                 {{ $t('common.save') }}
               </button>
             </div>

--- a/frontend/src/components/MemoryListView.vue
+++ b/frontend/src/components/MemoryListView.vue
@@ -83,7 +83,11 @@
           <Icon icon="mdi:checkbox-multiple-marked" class="w-4 h-4 inline mr-1" />
           {{ $t('memories.selectAll') }}
         </button>
-        <button class="btn-primary px-4 py-2.5 rounded-lg" @click="$emit('create')">
+        <button
+          class="btn-primary px-4 py-2.5 rounded-lg"
+          data-testid="btn-memory-create"
+          @click="$emit('create')"
+        >
           <Icon icon="mdi:plus" class="w-4 h-4 inline mr-1" />
           {{ $t('memories.createButton') }}
         </button>
@@ -128,6 +132,7 @@
             v-for="memory in filteredMemories"
             :key="memory.id"
             :data-memory-id="memory.id"
+            data-testid="item-memory"
             class="border-b border-light-border/10 dark:border-dark-border/10 hover:bg-surface-soft transition-colors cursor-pointer"
             :class="{ 'bg-brand-500/10': isSelected(memory.id) }"
             @click="toggleSelect(memory.id)"
@@ -167,6 +172,7 @@
                 <button
                   class="p-2 rounded-lg hover:bg-brand-500/10 txt-brand transition-colors"
                   :title="$t('common.edit')"
+                  data-testid="btn-memory-edit"
                   @click="$emit('edit', memory)"
                 >
                   <Icon icon="mdi:pencil" class="w-4 h-4" />
@@ -174,6 +180,7 @@
                 <button
                   class="p-2 rounded-lg hover:bg-red-500/10 text-red-500 transition-colors"
                   :title="$t('common.delete')"
+                  data-testid="btn-memory-delete"
                   @click="$emit('delete', memory)"
                 >
                   <Icon icon="mdi:delete" class="w-4 h-4" />
@@ -190,6 +197,7 @@
           v-for="memory in filteredMemories"
           :key="memory.id"
           :data-memory-id="memory.id"
+          data-testid="item-memory"
           class="surface-card rounded-xl p-4 cursor-pointer"
           :class="isSelected(memory.id) ? 'ring-2 ring-brand' : ''"
           @click="toggleSelect(memory.id)"
@@ -228,6 +236,7 @@
                   <button
                     class="p-2 rounded-lg hover:bg-brand-500/10 txt-brand transition-colors"
                     :title="$t('common.edit')"
+                    data-testid="btn-memory-edit"
                     @click="$emit('edit', memory)"
                   >
                     <Icon icon="mdi:pencil" class="w-4 h-4" />
@@ -235,6 +244,7 @@
                   <button
                     class="p-2 rounded-lg hover:bg-red-500/10 text-red-500 transition-colors"
                     :title="$t('common.delete')"
+                    data-testid="btn-memory-delete"
                     @click="$emit('delete', memory)"
                   >
                     <Icon icon="mdi:delete" class="w-4 h-4" />
@@ -247,7 +257,11 @@
       </div>
 
       <!-- Empty State -->
-      <div v-if="filteredMemories.length === 0" class="text-center py-12">
+      <div
+        v-if="filteredMemories.length === 0"
+        class="text-center py-12"
+        data-testid="state-memories-empty"
+      >
         <Icon icon="mdi:brain-off" class="w-16 h-16 mx-auto txt-secondary mb-4" />
         <p class="txt-secondary text-lg">{{ $t('memories.noResults') }}</p>
       </div>

--- a/frontend/src/components/SidebarV2.vue
+++ b/frontend/src/components/SidebarV2.vue
@@ -564,12 +564,17 @@
             <Icon icon="mdi:share-variant-outline" class="w-4 h-4" />
             {{ $t('common.share') }}
           </button>
-          <button class="dropdown-item" @click="handleChatRename(chatMenuOpenId!)">
+          <button
+            class="dropdown-item"
+            data-testid="btn-chat-v2-rename"
+            @click="handleChatRename(chatMenuOpenId!)"
+          >
             <Icon icon="mdi:pencil-outline" class="w-4 h-4" />
             {{ $t('common.rename') }}
           </button>
           <button
             class="dropdown-item dropdown-item--danger"
+            data-testid="btn-chat-v2-delete"
             @click="handleChatDelete(chatMenuOpenId!)"
           >
             <Icon icon="mdi:delete-outline" class="w-4 h-4" />

--- a/frontend/tests/e2e/helpers/selectors.ts
+++ b/frontend/tests/e2e/helpers/selectors.ts
@@ -448,6 +448,12 @@ export const selectors = {
     btnCreate: '[data-testid="btn-create-prompt"]',
     btnDelete: '[data-testid="btn-delete"]',
     cardForTopic: (topic: string) => `[data-testid="card-prompt-${topic}"]`,
+    sectionDanger: '[data-testid="section-danger"]',
+    createModal: '[data-testid="modal-task-prompt-create"]',
+    inputNewTopic: '[data-testid="input-new-topic"]',
+    inputNewName: '[data-testid="input-new-name"]',
+    inputNewContent: '[data-testid="input-new-content"]',
+    btnConfirmCreate: '[data-testid="btn-confirm-create"]',
   },
   pages: {
     chat: '[data-testid="page-chat"]',

--- a/frontend/tests/e2e/helpers/selectors.ts
+++ b/frontend/tests/e2e/helpers/selectors.ts
@@ -263,6 +263,20 @@ export const selectors = {
     table: '[data-testid="section-table"]',
     fileRow: '[data-testid="item-file"]',
     emptyState: '[data-testid="state-empty"]',
+    /** Toolbar: opens the inline "New folder" input row */
+    btnNewFolder: '[data-testid="btn-new-folder"]',
+    inputNewFolderToolbar: '[data-testid="input-new-folder-toolbar"]',
+    btnNewFolderCreate: '[data-testid="btn-new-folder-create"]',
+    /** Root view: one card per knowledge folder */
+    folderCard: (name: string) => `[data-testid="folder-card-${name}"]`,
+    /** Folder card hover action: open a chat scoped to this folder */
+    btnUseInChat: (name: string) => `[data-testid="btn-use-in-chat-${name}"]`,
+    /** Folder view: back to the root file list */
+    btnBackToRoot: '[data-testid="btn-back-to-root"]',
+    /** Folder view: shown when the open folder has no files left */
+    stateEmptyFolder: '[data-testid="state-empty-folder"]',
+    /** File row action: delete this file (opens ConfirmDialog) */
+    btnDeleteFile: '[data-testid="btn-delete"]',
     /** §4.8: knowledge-base tabs shared by /files and /files/search */
     tabsBar: '[data-testid="tabs-files"]',
     tabBrowse: '[data-testid="tab-files-browse"]',
@@ -467,6 +481,11 @@ export const selectors = {
     cancelBtn: '[data-testid="btn-dialog-cancel"]',
     /** Text input rendered by useDialog().prompt() */
     promptInput: '[data-testid="input-dialog-prompt"]',
+  },
+  /** ConfirmDialog.vue component (used by FilesView etc. — NOT useDialog()) */
+  confirmDialog: {
+    accept: '[data-testid="btn-confirm-accept"]',
+    cancel: '[data-testid="btn-confirm-cancel"]',
   },
   guest: {
     banner: '[data-testid="guest-banner"]',

--- a/frontend/tests/e2e/helpers/selectors.ts
+++ b/frontend/tests/e2e/helpers/selectors.ts
@@ -492,6 +492,21 @@ export const selectors = {
     inputNewPassword: '[data-testid="input-new-password"]',
     inputConfirmPassword: '[data-testid="input-confirm-password"]',
   },
+  memories: {
+    btnCreate: '[data-testid="btn-memory-create"]',
+    /** Rendered twice per memory (desktop row + mobile card) — filter visible */
+    item: '[data-testid="item-memory"]',
+    btnEdit: '[data-testid="btn-memory-edit"]',
+    btnDelete: '[data-testid="btn-memory-delete"]',
+    stateEmpty: '[data-testid="state-memories-empty"]',
+    formModal: '[data-testid="modal-memory-form"]',
+    /** Form dialog: switch to the AI-free advanced form */
+    btnModeAdvanced: '[data-testid="btn-memory-mode-advanced"]',
+    inputCategory: '[data-testid="input-memory-category"]',
+    inputKey: '[data-testid="input-memory-key"]',
+    inputValue: '[data-testid="input-memory-value"]',
+    btnSave: '[data-testid="btn-memory-save"]',
+  },
   /** UnsavedChangesBar.vue (profile & config pages) */
   unsavedBar: {
     save: '[data-testid="btn-unsaved-save"]',

--- a/frontend/tests/e2e/helpers/selectors.ts
+++ b/frontend/tests/e2e/helpers/selectors.ts
@@ -194,6 +194,14 @@ export const selectors = {
     legacyVoiceReplyPill: '[data-testid="btn-chat-voice-reply"]',
     legacyManageKnowledgeGroupsBtn: '[data-testid="btn-manage-knowledge-groups"]',
   },
+  incognito: {
+    /** Session toggle button — rendered twice (mobile + desktop), scope via desktopSection */
+    toggle: '[data-testid="btn-incognito-toggle"]',
+    /** Desktop wrapper of the toggle (floats over the message area) */
+    desktopSection: '[data-testid="section-incognito-toggle-desktop"]',
+    /** Banner above the composer while an incognito session is active */
+    banner: '[data-testid="banner-incognito"]',
+  },
   multitask: {
     /** Task-plan block inside the assistant bubble (multi-node DAG turns) */
     plan: '[data-testid="task-plan"]',

--- a/frontend/tests/e2e/helpers/selectors.ts
+++ b/frontend/tests/e2e/helpers/selectors.ts
@@ -101,6 +101,8 @@ export const selectors = {
     flyoutLinkAdminDashboard: '[data-testid="link-sidebar-v2-admin-dashboard"]',
     /** V2 chat list modal */
     modalChatManager: '[data-testid="modal-chat-manager"]',
+    /** V2 chat list modal: backdrop — click outside the panel to close */
+    modalChatManagerBackdrop: '[data-testid="modal-chat-manager-backdrop"]',
     /** V2 chat list: container visible when at least one chat exists; use to wait before targeting rows */
     chatManagerListRows: '[data-testid="list-chat-manager-rows"]',
     /** V2 chat list: one row per chat; scope menu to this */
@@ -109,6 +111,10 @@ export const selectors = {
     chatV2RowMenu: '[data-testid="btn-chat-v2-row-menu"]',
     /** V2 chat context menu: Share button */
     chatV2Share: '[data-testid="btn-chat-v2-share"]',
+    /** V2 chat context menu: Rename button (opens dialog prompt) */
+    chatV2Rename: '[data-testid="btn-chat-v2-rename"]',
+    /** V2 chat context menu: Delete button (opens danger confirm) */
+    chatV2Delete: '[data-testid="btn-chat-v2-delete"]',
   },
   models: {
     page: '[data-testid="page-config-ai-models"]',
@@ -445,6 +451,8 @@ export const selectors = {
   dialog: {
     confirmBtn: '[data-testid="btn-dialog-confirm"]',
     cancelBtn: '[data-testid="btn-dialog-cancel"]',
+    /** Text input rendered by useDialog().prompt() */
+    promptInput: '[data-testid="input-dialog-prompt"]',
   },
   guest: {
     banner: '[data-testid="guest-banner"]',

--- a/frontend/tests/e2e/helpers/selectors.ts
+++ b/frontend/tests/e2e/helpers/selectors.ts
@@ -487,6 +487,15 @@ export const selectors = {
     accept: '[data-testid="btn-confirm-accept"]',
     cancel: '[data-testid="btn-confirm-cancel"]',
   },
+  profile: {
+    inputCurrentPassword: '[data-testid="input-current-password"]',
+    inputNewPassword: '[data-testid="input-new-password"]',
+    inputConfirmPassword: '[data-testid="input-confirm-password"]',
+  },
+  /** UnsavedChangesBar.vue (profile & config pages) */
+  unsavedBar: {
+    save: '[data-testid="btn-unsaved-save"]',
+  },
   guest: {
     banner: '[data-testid="guest-banner"]',
     bannerSignup: '[data-testid="guest-banner-signup"]',

--- a/frontend/tests/e2e/tests/chat-manage.spec.ts
+++ b/frontend/tests/e2e/tests/chat-manage.spec.ts
@@ -1,0 +1,93 @@
+import type { Page } from '@playwright/test'
+import { test, expect } from '../test-setup'
+import { selectors } from '../helpers/selectors'
+import { openApp } from '../helpers/auth'
+import { ChatHelper } from '../helpers/chat'
+import { TIMEOUTS } from '../config/config'
+
+/**
+ * Chat manager row actions: rename (dialog prompt) and delete (danger
+ * confirm). Complements chat-share.spec.ts, which covers the third row
+ * action (Share) through the same menu.
+ */
+
+async function openChatManager(page: Page): Promise<void> {
+  await page.locator(selectors.nav.sidebarV2ChatNav).click()
+  const modal = page.locator(selectors.nav.modalChatManager)
+  await modal.waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
+  await modal
+    .locator(selectors.nav.chatManagerListRows)
+    .waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
+}
+
+test.describe('@ci Chat Management', () => {
+  test('user can rename a chat and delete it via the chat manager', async ({ page }) => {
+    const renamedTitle = `Renamed chat ${Date.now()}`
+    const chat = new ChatHelper(page)
+
+    await test.step('Arrange: open app and start a fresh chat', async () => {
+      await openApp(page)
+      // The fresh chat is the newest entry → guaranteed first row in the
+      // manager (sorted by activity, newest first).
+      await chat.startNewChat()
+    })
+
+    await test.step('Act: rename the newest chat via the row menu', async () => {
+      await openChatManager(page)
+      const modal = page.locator(selectors.nav.modalChatManager)
+      const newestRow = modal.locator(selectors.nav.chatV2Row).first()
+      await newestRow.hover()
+      await newestRow.locator(selectors.nav.chatV2RowMenu).click({ force: true })
+      await page.locator(selectors.nav.chatV2Rename).click()
+
+      const promptInput = page.locator(selectors.dialog.promptInput)
+      await promptInput.waitFor({ state: 'visible', timeout: TIMEOUTS.SHORT })
+      await promptInput.fill(renamedTitle)
+      await page.locator(selectors.dialog.confirmBtn).click()
+    })
+
+    await test.step('Assert: the row shows the new title', async () => {
+      const modal = page.locator(selectors.nav.modalChatManager)
+      await expect(
+        modal.locator(selectors.nav.chatV2Row).filter({ hasText: renamedTitle })
+      ).toHaveCount(1, { timeout: TIMEOUTS.STANDARD })
+    })
+
+    await test.step('Assert: the new title survives a reload', async () => {
+      await openApp(page)
+      await openChatManager(page)
+      const modal = page.locator(selectors.nav.modalChatManager)
+      await expect(
+        modal.locator(selectors.nav.chatV2Row).filter({ hasText: renamedTitle })
+      ).toHaveCount(1, { timeout: TIMEOUTS.STANDARD })
+    })
+
+    await test.step('Act: delete the renamed chat with confirmation', async () => {
+      const modal = page.locator(selectors.nav.modalChatManager)
+      const row = modal.locator(selectors.nav.chatV2Row).filter({ hasText: renamedTitle })
+      await row.hover()
+      await row.locator(selectors.nav.chatV2RowMenu).click({ force: true })
+      await page.locator(selectors.nav.chatV2Delete).click()
+
+      const confirmBtn = page.locator(selectors.dialog.confirmBtn)
+      await confirmBtn.waitFor({ state: 'visible', timeout: TIMEOUTS.SHORT })
+      await confirmBtn.click()
+    })
+
+    await test.step('Assert: the chat is gone and the surface stays usable', async () => {
+      const modal = page.locator(selectors.nav.modalChatManager)
+      await expect(
+        modal.locator(selectors.nav.chatV2Row).filter({ hasText: renamedTitle })
+      ).toHaveCount(0, { timeout: TIMEOUTS.STANDARD })
+
+      // Close the modal via the backdrop and verify the chat surface still works
+      // (deleting the active chat must fall back to another/new chat).
+      await page.locator(selectors.nav.modalChatManagerBackdrop).click({ position: { x: 8, y: 8 } })
+      await modal.waitFor({ state: 'hidden', timeout: TIMEOUTS.SHORT })
+      await expect(page.locator(selectors.chat.textInput)).toBeVisible({
+        timeout: TIMEOUTS.STANDARD,
+      })
+      await expect(page.locator(selectors.chat.textInput)).toBeEnabled()
+    })
+  })
+})

--- a/frontend/tests/e2e/tests/file-manage.spec.ts
+++ b/frontend/tests/e2e/tests/file-manage.spec.ts
@@ -1,0 +1,104 @@
+import path from 'path'
+import { fileURLToPath } from 'url'
+import { test, expect } from '../test-setup'
+import { selectors } from '../helpers/selectors'
+import { openApp } from '../helpers/auth'
+import { FIXTURE_PATHS } from '../config/test-data'
+import { TIMEOUTS } from '../config/config'
+
+const __filename = fileURLToPath(import.meta.url)
+const e2eDir = path.join(path.dirname(__filename), '..')
+const fixturePath = path.join(e2eDir, FIXTURE_PATHS.RAG_MOST_IMPORTANT)
+const fixtureName = path.basename(fixturePath)
+
+const FILES = selectors.files
+const CHAT = selectors.chat
+
+/**
+ * Knowledge-folder management: create a folder, upload into it, scope a chat
+ * to it ("Use in chat"), delete the contained file. Complements
+ * rag-search.spec.ts, which covers upload + semantic search but no
+ * management actions.
+ */
+test.describe('@ci File Management', () => {
+  test('user can create a folder, upload into it, use it in chat and delete the file', async ({
+    page,
+  }) => {
+    const folderName = `e2e-folder-${Date.now()}`
+
+    await test.step('Arrange: open the Files page', async () => {
+      await openApp(page)
+      await page.locator(selectors.nav.sidebarV2Files).click()
+      await page.locator(FILES.page).waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
+    })
+
+    await test.step('Act: create a new knowledge folder', async () => {
+      await page.locator(FILES.btnNewFolder).click()
+      const nameInput = page.locator(FILES.inputNewFolderToolbar)
+      await nameInput.waitFor({ state: 'visible', timeout: TIMEOUTS.SHORT })
+      await nameInput.fill(folderName)
+      await page.locator(FILES.btnNewFolderCreate).click()
+      // The new (empty) folder appears as a pending card and is preselected
+      // as the upload target.
+      await expect(page.locator(FILES.folderCard(folderName))).toBeVisible({
+        timeout: TIMEOUTS.SHORT,
+      })
+    })
+
+    await test.step('Act: upload the fixture into the folder', async () => {
+      await page.locator(FILES.fileInput).setInputFiles(fixturePath)
+      await page.locator(FILES.uploadButton).click()
+    })
+
+    await test.step('Assert: the folder contains the uploaded file', async () => {
+      await page.locator(FILES.folderCard(folderName)).click()
+      await page.locator(FILES.table).waitFor({ state: 'visible', timeout: TIMEOUTS.VERY_LONG })
+      // Each file renders twice (mobile card + desktop table row, one hidden
+      // via CSS) — count only the visible representation.
+      await expect(
+        page.locator(FILES.fileRow).filter({ hasText: fixtureName }).filter({ visible: true })
+      ).toHaveCount(1, { timeout: TIMEOUTS.STANDARD })
+    })
+
+    await test.step('Act: "Use in chat" opens a chat scoped to the folder', async () => {
+      await page.locator(FILES.btnBackToRoot).click()
+      const card = page.locator(FILES.folderCard(folderName))
+      await card.waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
+      await card.hover()
+      await page.locator(FILES.btnUseInChat(folderName)).click({ force: true })
+      await page.locator(CHAT.textInput).waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
+    })
+
+    await test.step('Assert: the knowledge-folder pill shows the folder', async () => {
+      await page.locator(CHAT.plusToggle).click()
+      const panel = page.locator(CHAT.plusPanel)
+      await panel.waitFor({ state: 'visible', timeout: TIMEOUTS.SHORT })
+      await expect(panel.locator(CHAT.knowledgeFolderBtn)).toContainText(folderName, {
+        timeout: TIMEOUTS.STANDARD,
+      })
+    })
+
+    await test.step('Act: delete the file inside the folder', async () => {
+      await page.goto('/files')
+      await page.locator(FILES.page).waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
+      await page.locator(FILES.folderCard(folderName)).click()
+      const row = page
+        .locator(FILES.fileRow)
+        .filter({ hasText: fixtureName })
+        .filter({ visible: true })
+      await row.waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
+      await row.locator(FILES.btnDeleteFile).click()
+      await page.locator(selectors.confirmDialog.accept).click()
+    })
+
+    await test.step('Assert: the folder is empty and disappears from the root grid', async () => {
+      await page
+        .locator(FILES.stateEmptyFolder)
+        .waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
+      await page.locator(FILES.btnBackToRoot).click()
+      await expect(page.locator(FILES.folderCard(folderName))).toHaveCount(0, {
+        timeout: TIMEOUTS.STANDARD,
+      })
+    })
+  })
+})

--- a/frontend/tests/e2e/tests/incognito.spec.ts
+++ b/frontend/tests/e2e/tests/incognito.spec.ts
@@ -1,0 +1,116 @@
+import { test, expect } from '../test-setup'
+import { selectors } from '../helpers/selectors'
+import { openApp } from '../helpers/auth'
+import { ChatHelper } from '../helpers/chat'
+import { TIMEOUTS } from '../config/config'
+
+/**
+ * Incognito sessions are fully ephemeral: the backend processes turns
+ * in-memory (no chat/message rows) and the transcript lives only in the
+ * in-memory history store. These tests pin down the two exit paths
+ * (toggle with confirmation, New Chat) and the no-persistence guarantee.
+ *
+ * The toggle renders twice (mobile + desktop instance); tests scope it via
+ * the desktop wrapper since @ci functional specs run on desktop viewports.
+ */
+
+test.describe('@ci Incognito Chat', () => {
+  test('incognito turn is not persisted and ending the session discards it', async ({ page }) => {
+    // Kept short so the full text fits into both the chat title (50 chars)
+    // and the sidebar preview (30 chars) if it ever leaked into a row.
+    const uniqueMessage = `Incognito E2E ${Date.now()}`
+    const chat = new ChatHelper(page)
+
+    await test.step('Arrange: open app on a fresh chat', async () => {
+      await openApp(page)
+      await chat.startNewChat()
+    })
+
+    await test.step('Act: start an incognito session', async () => {
+      await page
+        .locator(selectors.incognito.desktopSection)
+        .locator(selectors.incognito.toggle)
+        .click()
+      await page
+        .locator(selectors.incognito.banner)
+        .waitFor({ state: 'visible', timeout: TIMEOUTS.SHORT })
+    })
+
+    let previousCount: number
+    await test.step('Act: send a message inside the session', async () => {
+      previousCount = await chat.sendMessage(uniqueMessage)
+    })
+
+    await test.step('Assert: assistant answers without error', async () => {
+      const answer = await chat.waitForAnswer(previousCount!)
+      expect(answer.length).toBeGreaterThan(0)
+    })
+
+    await test.step('Assert: the chat manager lists no chat for the incognito turn', async () => {
+      await page.locator(selectors.nav.sidebarV2ChatNav).click()
+      const modal = page.locator(selectors.nav.modalChatManager)
+      await modal.waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
+      await expect(
+        modal.locator(selectors.nav.chatV2Row).filter({ hasText: uniqueMessage })
+      ).toHaveCount(0)
+      await page.locator(selectors.nav.modalChatManagerBackdrop).click({ position: { x: 8, y: 8 } })
+      await modal.waitFor({ state: 'hidden', timeout: TIMEOUTS.SHORT })
+    })
+
+    await test.step('Act: end the session via toggle and confirm the discard warning', async () => {
+      await page
+        .locator(selectors.incognito.desktopSection)
+        .locator(selectors.incognito.toggle)
+        .click()
+      const confirmBtn = page.locator(selectors.dialog.confirmBtn)
+      await confirmBtn.waitFor({ state: 'visible', timeout: TIMEOUTS.SHORT })
+      await confirmBtn.click()
+      await page
+        .locator(selectors.incognito.banner)
+        .waitFor({ state: 'hidden', timeout: TIMEOUTS.SHORT })
+    })
+
+    await test.step('Assert: the transcript is discarded from the restored surface', async () => {
+      await expect(page.getByText(uniqueMessage)).toHaveCount(0)
+    })
+
+    await test.step('Assert: nothing survived a reload', async () => {
+      await openApp(page)
+      await expect(page.getByText(uniqueMessage)).toHaveCount(0)
+      await page.locator(selectors.nav.sidebarV2ChatNav).click()
+      const modal = page.locator(selectors.nav.modalChatManager)
+      await modal.waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
+      await expect(
+        modal.locator(selectors.nav.chatV2Row).filter({ hasText: uniqueMessage })
+      ).toHaveCount(0)
+    })
+  })
+
+  test('starting a new chat leaves the incognito session', async ({ page }) => {
+    const chat = new ChatHelper(page)
+
+    await test.step('Arrange: open app and start an incognito session', async () => {
+      await openApp(page)
+      await page
+        .locator(selectors.incognito.desktopSection)
+        .locator(selectors.incognito.toggle)
+        .click()
+      await page
+        .locator(selectors.incognito.banner)
+        .waitFor({ state: 'visible', timeout: TIMEOUTS.SHORT })
+    })
+
+    await test.step('Act: click New Chat in the sidebar rail', async () => {
+      await chat.startNewChat()
+    })
+
+    await test.step('Assert: the session ended and a normal empty chat is active', async () => {
+      await page
+        .locator(selectors.incognito.banner)
+        .waitFor({ state: 'hidden', timeout: TIMEOUTS.SHORT })
+      await expect(page.locator(selectors.chat.stateEmpty)).toBeVisible({
+        timeout: TIMEOUTS.STANDARD,
+      })
+    })
+  })
+})

--- a/frontend/tests/e2e/tests/memories.spec.ts
+++ b/frontend/tests/e2e/tests/memories.spec.ts
@@ -1,0 +1,109 @@
+import { test, expect } from '../test-setup'
+import { selectors } from '../helpers/selectors'
+import { openApp } from '../helpers/auth'
+import { ChatHelper } from '../helpers/chat'
+import { TIMEOUTS, INTERVALS, getApiUrl } from '../config/config'
+
+const MEM = selectors.memories
+
+/**
+ * User memories live in Qdrant (qdrant_test service in the test stack).
+ *
+ * Manual CRUD uses the AI-free "advanced" form of the memory dialog, so no
+ * model call is involved. Automatic extraction runs synchronously in the
+ * test env (messenger.yaml `when@test` routes ExtractMemoriesCommand to the
+ * sync transport) with a deterministic TestProvider contract: a chat message
+ * containing `memorize: some_key = some value` yields exactly one `create`
+ * action; everything else extracts nothing.
+ */
+test.describe('@ci Memories', () => {
+  test('user can create a memory manually and delete it', async ({ page }) => {
+    const key = `e2e_key_${Date.now()}`
+    const value = `E2E memory value ${Date.now()}`
+
+    await test.step('Arrange: open the memories page', async () => {
+      await openApp(page)
+      await page.goto('/memories')
+      await page.locator(MEM.btnCreate).waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
+    })
+
+    await test.step('Act: create a memory via the advanced form', async () => {
+      await page.locator(MEM.btnCreate).click()
+      await page.locator(MEM.formModal).waitFor({ state: 'visible', timeout: TIMEOUTS.SHORT })
+      await page.locator(MEM.btnModeAdvanced).click()
+      await page.locator(MEM.inputCategory).fill('preferences')
+      await page.locator(MEM.inputKey).fill(key)
+      await page.locator(MEM.inputValue).fill(value)
+      await page.locator(MEM.btnSave).click()
+      await page.locator(MEM.formModal).waitFor({ state: 'hidden', timeout: TIMEOUTS.STANDARD })
+    })
+
+    await test.step('Assert: the memory appears in the list', async () => {
+      await expect(
+        page.locator(MEM.item).filter({ hasText: key }).filter({ visible: true })
+      ).toHaveCount(1, { timeout: TIMEOUTS.STANDARD })
+    })
+
+    await test.step('Assert: the memory survives a reload', async () => {
+      await page.reload()
+      await expect(
+        page.locator(MEM.item).filter({ hasText: key }).filter({ visible: true })
+      ).toHaveCount(1, { timeout: TIMEOUTS.STANDARD })
+    })
+
+    await test.step('Act: delete the memory with confirmation', async () => {
+      const row = page.locator(MEM.item).filter({ hasText: key }).filter({ visible: true })
+      await row.locator(MEM.btnDelete).click()
+      const confirmBtn = page.locator(selectors.dialog.confirmBtn)
+      await confirmBtn.waitFor({ state: 'visible', timeout: TIMEOUTS.SHORT })
+      await confirmBtn.click()
+    })
+
+    await test.step('Assert: the memory is gone', async () => {
+      await expect(
+        page.locator(MEM.item).filter({ hasText: key }).filter({ visible: true })
+      ).toHaveCount(0, { timeout: TIMEOUTS.STANDARD })
+    })
+  })
+
+  test('a chat turn with a memorizable fact creates a memory automatically', async ({ page }) => {
+    const value = `teal-${Date.now()}`
+    const chat = new ChatHelper(page)
+
+    await test.step('Arrange: open app on a fresh chat', async () => {
+      await openApp(page)
+      await chat.startNewChat()
+    })
+
+    await test.step('Act: state a fact the extractor should pick up', async () => {
+      const previousCount = await chat.sendMessage(`Please memorize: favorite_color = ${value}`)
+      const answer = await chat.waitForAnswer(previousCount)
+      expect(answer.length).toBeGreaterThan(0)
+    })
+
+    await test.step('Assert: the memory shows up via the API', async () => {
+      // Extraction is dispatched right after the SSE stream completes;
+      // poll briefly instead of assuming strict ordering.
+      await expect
+        .poll(
+          async () => {
+            const res = await page.request.get(`${getApiUrl()}/api/v1/user/memories`)
+            if (!res.ok()) return false
+            const data = await res.json()
+            return (data.memories ?? []).some(
+              (m: { key: string; value: string }) => m.key === 'favorite_color' && m.value === value
+            )
+          },
+          { timeout: TIMEOUTS.LONG, intervals: INTERVALS.STANDARD() }
+        )
+        .toBe(true)
+    })
+
+    await test.step('Assert: the memory is visible on the memories page', async () => {
+      await page.goto('/memories')
+      await expect(
+        page.locator(MEM.item).filter({ hasText: value }).filter({ visible: true })
+      ).toHaveCount(1, { timeout: TIMEOUTS.STANDARD })
+    })
+  })
+})

--- a/frontend/tests/e2e/tests/profile-password.spec.ts
+++ b/frontend/tests/e2e/tests/profile-password.spec.ts
@@ -1,0 +1,69 @@
+import { test, expect, LOGGED_OUT } from '../test-setup'
+import { selectors } from '../helpers/selectors'
+import { provisionUser, deleteUser, login } from '../helpers/auth'
+import { TIMEOUTS } from '../config/config'
+
+/**
+ * Password-change roundtrip with a DISPOSABLE user: the worker user's
+ * password must stay untouched (other tests log in with it), so this spec
+ * provisions its own account and deletes it afterwards. Starting logged out
+ * because the login flow itself is part of the assertion.
+ */
+test.use(LOGGED_OUT)
+
+test.describe('@ci Profile Password Change', () => {
+  test('user can change the password and log in with the new one', async ({ page, request }) => {
+    const email = `e2e-pwchange-${Date.now()}@test.synaplan.com`
+    const oldPassword = 'E2eOldPass1234!'
+    const newPassword = 'E2eNewPass5678!'
+
+    await test.step('Arrange: provision a disposable user and log in', async () => {
+      await provisionUser(request, { email, password: oldPassword })
+      await login(page, { user: email, pass: oldPassword })
+    })
+
+    try {
+      await test.step('Act: change the password on the profile page', async () => {
+        await page.goto('/profile')
+        await page
+          .locator(selectors.profile.inputCurrentPassword)
+          .waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
+        await page.locator(selectors.profile.inputCurrentPassword).fill(oldPassword)
+        await page.locator(selectors.profile.inputNewPassword).fill(newPassword)
+        await page.locator(selectors.profile.inputConfirmPassword).fill(newPassword)
+        await page.locator(selectors.unsavedBar.save).click()
+      })
+
+      await test.step('Assert: save succeeded (password fields reset, no error toast)', async () => {
+        await expect(page.locator(selectors.profile.inputCurrentPassword)).toHaveValue('', {
+          timeout: TIMEOUTS.STANDARD,
+        })
+        await expect(page.locator(selectors.notification.error)).toHaveCount(0)
+      })
+
+      await test.step('Act: log out via the user menu', async () => {
+        await page.locator(selectors.userMenu.button).click()
+        await page
+          .locator(selectors.userMenu.logoutBtn)
+          .waitFor({ state: 'visible', timeout: TIMEOUTS.SHORT })
+        await page.locator(selectors.userMenu.logoutBtn).click()
+        await page.waitForURL(/\/login/, { timeout: TIMEOUTS.STANDARD })
+      })
+
+      await test.step('Assert: the old password is rejected', async () => {
+        await page.locator(selectors.login.email).fill(email)
+        await page.locator(selectors.login.password).fill(oldPassword)
+        await page.locator(selectors.login.submit).click()
+        await expect(page.locator(selectors.login.errorAlert)).toBeVisible({
+          timeout: TIMEOUTS.STANDARD,
+        })
+      })
+
+      await test.step('Assert: the new password logs in', async () => {
+        await login(page, { user: email, pass: newPassword })
+      })
+    } finally {
+      await deleteUser(request, email)
+    }
+  })
+})

--- a/frontend/tests/e2e/tests/task-prompts.spec.ts
+++ b/frontend/tests/e2e/tests/task-prompts.spec.ts
@@ -85,4 +85,63 @@ test.describe('@ci Task Prompts', () => {
       await expect(page.locator(SEL.promptDetails)).toBeVisible({ timeout: TIMEOUTS.STANDARD })
     })
   })
+
+  test('user can create a custom prompt, reload, and delete it', async ({ page }) => {
+    // Lowercase without spaces so the topic passes the create-normalization
+    // unchanged and the card testid is predictable (card-prompt-<topic>).
+    const topic = `e2e-prompt-${Date.now()}`
+    const promptContent = 'You are a test prompt created by an E2E test. Answer briefly.'
+
+    await test.step('Arrange: login and open task prompts page', async () => {
+      await openApp(page)
+      await page.goto(PAGE)
+      await expect(page.locator(SEL.overview)).toBeVisible({ timeout: TIMEOUTS.STANDARD })
+    })
+
+    await test.step('Act: create a custom prompt via the modal', async () => {
+      await page.locator(SEL.btnCreate).click()
+      await page.locator(SEL.createModal).waitFor({ state: 'visible', timeout: TIMEOUTS.SHORT })
+      await page.locator(SEL.inputNewTopic).fill(topic)
+      await page.locator(SEL.inputNewName).fill(`E2E Prompt ${topic}`)
+      await page.locator(SEL.inputNewContent).fill(promptContent)
+      await page.locator(SEL.btnConfirmCreate).click()
+      await page.locator(SEL.createModal).waitFor({ state: 'hidden', timeout: TIMEOUTS.STANDARD })
+    })
+
+    await test.step('Assert: the new prompt opens in the editor and appears in the list', async () => {
+      await expect(page.locator(SEL.promptDetails)).toBeVisible({ timeout: TIMEOUTS.STANDARD })
+      await expect(page.locator(SEL.cardForTopic(topic))).toBeVisible({
+        timeout: TIMEOUTS.STANDARD,
+      })
+    })
+
+    await test.step('Assert: the prompt content survives a reload', async () => {
+      await page.reload()
+      await expect(page.locator(SEL.overview)).toBeVisible({ timeout: TIMEOUTS.STANDARD })
+      const card = page.locator(SEL.cardForTopic(topic))
+      await expect(card).toBeVisible({ timeout: TIMEOUTS.STANDARD })
+      await card.click()
+      await expect(page.locator(SEL.promptDetails)).toBeVisible({ timeout: TIMEOUTS.STANDARD })
+      await page.locator(SEL.tabPrompt).click()
+      await expect(page.locator(SEL.content)).toHaveValue(promptContent, {
+        timeout: TIMEOUTS.STANDARD,
+      })
+    })
+
+    await test.step('Act: delete the prompt from the danger tab', async () => {
+      await page.locator(SEL.tabDanger).click()
+      await expect(page.locator(SEL.sectionDanger)).toBeVisible({ timeout: TIMEOUTS.SHORT })
+      await page.locator(SEL.btnDelete).click()
+
+      const confirmBtn = page.locator(selectors.dialog.confirmBtn)
+      await confirmBtn.waitFor({ state: 'visible', timeout: TIMEOUTS.SHORT })
+      await confirmBtn.click()
+    })
+
+    await test.step('Assert: the prompt is gone from the list', async () => {
+      await expect(page.locator(SEL.cardForTopic(topic))).toHaveCount(0, {
+        timeout: TIMEOUTS.STANDARD,
+      })
+    })
+  })
 })


### PR DESCRIPTION
## Summary
- Add `@ci` E2E coverage for chat rename/delete, incognito lifecycle, task-prompt create/reload/delete, knowledge-folder management, and profile password change.
- Make memories testable in the test stack: ephemeral `qdrant_test`, sync routing for `ExtractMemoriesCommand` under `when@test`, and a deterministic `TestProvider` memory-extraction contract (`memorize: key = value`).
- Cover manual memory CRUD plus automatic extraction; add the needed `data-testid`s on memory UI and chat-manager actions.

## Test plan
- [ ] CI E2E matrix green (password Chromium/Firefox shards)
- [ ] Spot-check: `memories.spec.ts` (manual create/delete + chat extraction)
- [ ] Spot-check: `chat-manage.spec.ts`, `incognito.spec.ts`, `file-manage.spec.ts`, `profile-password.spec.ts`
- [ ] Confirm `qdrant_test` starts with the test compose stack and PHPUnit stays Qdrant-free via empty `QDRANT_URL` in `.env.test`