### PR TITLE
chore(docker): update synaplan-base-php to version 1.2.0 in Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ AI-powered knowledge management with RAG, chat widgets, and multi-channel integr
 - **~9 GB free disk** for the standard install (~5 GB for minimal, +~14 GB if you enable the local chat model)
 - Free TCP ports `5173`, `8000`, `8082`, `8025`, `3307`, `6333`, `11435`
 
-> **Apple Silicon (M1–M4) Macs:** Synaplan's container images are published for `linux/amd64`, so they run under emulation on Apple Silicon. In **Docker Desktop → Settings → General**, enable **"Use Rosetta for x86/amd64 emulation on Apple Silicon"** (macOS 13+) for much faster, more stable containers than the default QEMU. Everything works without it — just slower, and the first build takes longer.
+> **Apple Silicon (M1–M4) Macs — build the backend image, don't pull it.** The Quick Start below already does this: `docker compose up -d` builds the backend and worker locally from a multi-arch base image, so PHP/FrankenPHP runs **natively on `arm64`** with no emulation tax. That is by far the fastest setup, and it is the default — you don't have to do anything special. The pre-built `ghcr.io/metadist/synaplan` image published for production deployments is `linux/amd64` only, so pulling it instead means running the whole backend under emulation. The first local build takes a few minutes; every later start is a cache hit. Two optional dev tools (phpMyAdmin, MailHog) are still amd64-only upstream images — if you keep them, enable **Docker Desktop → Settings → General → "Use Rosetta for x86/amd64 emulation on Apple Silicon"** (macOS 13+) so those two emulate quickly.
 
 ## Quick Start
 

--- a/_docker/backend/Dockerfile
+++ b/_docker/backend/Dockerfile
@@ -1,4 +1,4 @@
-# synaplan-base-php 1.1.0 ships fully-tuned PHP ini files under
+# synaplan-base-php 1.2.0 ships fully-tuned PHP ini files under
 # /usr/local/etc/php/conf.d/ (10-runtime, 20-opcache+JIT, 25-realpath,
 # 27-grpc, 28-apcu, 30-errors, 40-security) and an entrypoint shim at
 # /usr/local/bin/synaplan-php-configure that handles APP_ENV=dev override
@@ -12,7 +12,14 @@
 # moving floating tag. To bump:
 #   docker buildx imagetools inspect ghcr.io/metadist/synaplan-base-php:latest
 # and replace the @sha256:... below.
-FROM ghcr.io/metadist/synaplan-base-php:1.1.0@sha256:6378ce497415579b9a8ded6395bc497e5589110a1b9bbb7544d1d490b1d3e1da AS dev
+#
+# The digest MUST be the manifest-list (OCI index) digest, not one of the
+# per-platform manifest digests listed underneath it. 1.2.0 is the first
+# multi-arch release (linux/amd64 + linux/arm64); pinning a per-platform
+# digest would hard-lock every build — including Apple Silicon dev machines,
+# which now run the backend natively instead of under emulation — to that one
+# architecture.
+FROM ghcr.io/metadist/synaplan-base-php:1.2.0@sha256:1c3381bce4673afb2eb96a163c301100584ce98af4e86cbd3158b5bb694d79ef AS dev
 
 WORKDIR /var/www/backend
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -10,10 +10,13 @@ Complete installation instructions for Synaplan.
 - ~9GB disk space (Standard) or ~5GB (Minimal). Add ~14GB if you enable the local
   chat model (`ENABLE_LOCAL_GPT_OSS=true`, see [Standard Install](#standard-install-recommended))
 
-> **Apple Silicon (M1–M4) Macs:** the images are `linux/amd64` only and run under
-> emulation on Apple Silicon. Enable **Docker Desktop → Settings → General → "Use
-> Rosetta for x86/amd64 emulation on Apple Silicon"** (macOS 13+) for a much faster
-> experience than the default QEMU. See [Troubleshooting](#slow-performance-on-apple-silicon-mac).
+> **Apple Silicon (M1–M4) Macs — build the backend image, don't pull it.** The
+> Quick Install below already does: `docker compose up -d` builds the backend and
+> worker locally from a multi-arch base, so PHP runs natively on `arm64` with no
+> emulation tax. That is the fastest setup and needs no extra steps. The pre-built
+> `ghcr.io/metadist/synaplan` production image is `linux/amd64` only — pulling it
+> instead runs the whole backend emulated. See
+> [Troubleshooting](#slow-performance-on-apple-silicon-mac).
 
 ## Quick Install
 
@@ -197,17 +200,30 @@ docker compose exec ollama ollama pull bge-m3
 
 ### Slow performance on Apple Silicon (Mac)
 
-Synaplan's container images are `linux/amd64` only, so on Apple Silicon (M1–M4)
-they run under emulation. For the best experience:
+On Apple Silicon (M1–M4) the fastest setup is to **build the backend image
+locally**, which is what both compose files do by default (`pull_policy: build`
+on the `backend` and `worker` services). The base image is published for
+`linux/amd64` *and* `linux/arm64`, so a local build produces a native `arm64`
+backend — no emulation.
 
-- Enable **Docker Desktop → Settings → General → "Use Rosetta for x86/amd64
-  emulation on Apple Silicon"** (macOS 13+). Rosetta is significantly faster than
-  the default QEMU translation.
-- The first `docker compose up -d` is slower because the backend image is built
-  locally under emulation; subsequent restarts are fast.
-- `docker compose` may print a platform-mismatch warning
-  (`requested image's platform (linux/amd64) does not match ...`) — it is expected
-  and safe to ignore.
+If PHP still feels slow, check what you are actually running:
+
+```bash
+docker compose exec backend uname -m   # expect: aarch64
+```
+
+- `x86_64` means you are on an emulated image — most likely you pulled the
+  pre-built `ghcr.io/metadist/synaplan` production image (`linux/amd64` only)
+  instead of building. Rebuild with `docker compose build --pull backend worker`,
+  then `docker compose up -d`.
+- The optional `phpmyadmin` and `mailhog` services use amd64-only upstream images
+  and stay emulated. Enable **Docker Desktop → Settings → General → "Use Rosetta
+  for x86/amd64 emulation on Apple Silicon"** (macOS 13+) — much faster than the
+  default QEMU — or drop those two services if you don't need them. The
+  `requested image's platform (linux/amd64) does not match ...` warning refers to
+  them and is safe to ignore.
+- The first `docker compose up -d` is slower because the image is built; every
+  later start is a cache hit.
 
 ### Port conflicts
 Default host ports: 5173 (frontend), 8000 (backend), 3307 (database), 8082 (phpMyAdmin), 8025/1025 (MailHog), 6333 (Qdrant), 11435 (Ollama), 9999 (Tika)


### PR DESCRIPTION
## Summary
Multi-Arch support now live

## Changes
- Bumped the base image version from 1.1.0 to 1.2.0, which is the first multi-arch release supporting both linux/amd64 and linux/arm64 architectures.
- Updated comments to clarify the importance of using the manifest-list digest for compatibility across different architectures.

See https://github.com/metadist/synaplan-base-php

## Verification
- [ ] Not tested (explain)
- [X] Manual
- [ ] Tests added/updated
