### PR TITLE
feat(chat): enhance chat readiness logic to support per-user model 

### DIFF
--- a/backend/src/AI/Credential/ChatReadinessService.php
+++ b/backend/src/AI/Credential/ChatReadinessService.php
@@ -71,12 +71,14 @@ final class ChatReadinessService
     }
 
     /**
-     * The provider serving the GLOBAL default chat model, or null when the
-     * binding does not resolve (fresh DB, retired model).
+     * The provider serving the default chat model — the per-user override when
+     * a user id is given (mirroring the lookup the chat pipeline itself uses),
+     * otherwise the GLOBAL default. Null when the binding does not resolve
+     * (fresh DB, retired model).
      */
-    public function defaultChatService(): ?string
+    public function defaultChatService(?int $userId = null): ?string
     {
-        $bid = $this->modelConfigService->getDefaultModel('CHAT');
+        $bid = $this->modelConfigService->getDefaultModel('CHAT', $userId);
         if (null === $bid) {
             return null;
         }
@@ -88,15 +90,19 @@ final class ChatReadinessService
 
     /**
      * Whether a plain chat message can be answered right now: the provider
-     * behind the global default chat model must be usable. Falls back to "any
-     * chat-capable provider is usable" only when the binding does not resolve.
+     * behind the effective default chat model must be usable. Pass the user id
+     * so a per-user model override is honoured — the chat pipeline resolves
+     * the model per user, and readiness must measure the same thing, or a user
+     * whose chat works fine is shown a "no AI provider connected" banner.
+     * Falls back to "any chat-capable provider is usable" only when the
+     * binding does not resolve.
      *
      * @param array<string, bool>|null $availability defaults to the cached snapshot
      */
-    public function isChatReady(?array $availability = null, ?string $defaultChatService = null): bool
+    public function isChatReady(?array $availability = null, ?string $defaultChatService = null, ?int $userId = null): bool
     {
         $availability ??= $this->providerAvailability();
-        $defaultChatService ??= $this->defaultChatService();
+        $defaultChatService ??= $this->defaultChatService($userId);
 
         if (null !== $defaultChatService && isset($availability[$defaultChatService])) {
             return $availability[$defaultChatService];
@@ -183,7 +189,7 @@ final class ChatReadinessService
         // Ollama answers as soon as the server is up, even with zero models
         // pulled. Treating that as "available" would route chat at a model
         // nobody downloaded and falsely hide the setup banner.
-        if (($available['ollama'] ?? false) && !$this->recommendedOllamaChatModelPulled()) {
+        if (($available['ollama'] ?? false) && !$this->ollamaChatModelPulled()) {
             $available['ollama'] = false;
         }
 
@@ -194,6 +200,26 @@ final class ChatReadinessService
         $this->cache->save($item);
 
         return $snapshot;
+    }
+
+    /**
+     * Is the Ollama chat model this install would actually use pulled? When
+     * the configured GLOBAL default chat model is an Ollama model, that exact
+     * model is checked — an operator who deliberately bound chat to a pulled
+     * local model must not be flagged "not ready" just because the recommended
+     * model is absent. Otherwise falls back to the recommended binding.
+     */
+    private function ollamaChatModelPulled(): bool
+    {
+        $bid = $this->modelConfigService->getDefaultModel('CHAT');
+        if (null !== $bid) {
+            $model = $this->modelRepository->find($bid);
+            if (null !== $model && 'ollama' === strtolower($model->getService())) {
+                return $this->isOllamaModelPulled($model->getProviderId());
+            }
+        }
+
+        return $this->recommendedOllamaChatModelPulled();
     }
 
     /**

--- a/backend/src/Controller/ConfigController.php
+++ b/backend/src/Controller/ConfigController.php
@@ -364,7 +364,7 @@ class ConfigController extends AbstractController
                             property: 'chatReady',
                             type: 'boolean',
                             example: true,
-                            description: 'True when the provider serving the global default chat model is available (key configured / local AI reachable), i.e. sending a chat message can work.'
+                            description: 'True when the provider serving the requesting user\'s effective default chat model (per-user override, then global default) is available (key configured / local AI reachable), i.e. sending a chat message can work for this user.'
                         ),
                     ]
                 ),
@@ -457,11 +457,13 @@ class ConfigController extends AbstractController
             // saving a key) — never a side effect of this GET.
             $unavailableProviders = $this->chatReadiness->unavailableProviderNames();
 
-            // First-run signal: can a plain chat message work right now? The
-            // frontend shows a "connect an AI provider" banner (admins get a
-            // wizard CTA) while this is false — e.g. a fresh install whose
-            // default chat model points at a provider without a key.
-            $setup = ['chatReady' => $this->chatReadiness->isChatReady()];
+            // First-run signal: can a plain chat message work right now for
+            // THIS user? The frontend shows a "connect an AI provider" banner
+            // (admins get a wizard CTA) while this is false — e.g. a fresh
+            // install whose default chat model points at a provider without a
+            // key. Evaluated per user so a working per-user model override is
+            // honoured, exactly like the chat pipeline resolves it.
+            $setup = ['chatReady' => $this->chatReadiness->isChatReady(userId: $user->getId())];
         }
 
         // Realtime / WebSocket gateway settings.

--- a/backend/tests/Unit/AI/Credential/ChatReadinessServiceTest.php
+++ b/backend/tests/Unit/AI/Credential/ChatReadinessServiceTest.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\AI\Credential;
+
+use App\AI\Credential\ChatReadinessService;
+use App\AI\Credential\ProviderDefaultsService;
+use App\AI\Service\ProviderRegistry;
+use App\Entity\Config;
+use App\Entity\Model;
+use App\Repository\ConfigRepository;
+use App\Repository\ModelRepository;
+use App\Repository\UserRepository;
+use App\Service\ModelConfigService;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+/**
+ * Unit tests for {@see ChatReadinessService::isChatReady()}.
+ *
+ * Regression coverage for the live false positive where every authenticated
+ * user saw the "no AI provider connected" banner although their chat worked:
+ * readiness only checked the GLOBAL default chat model's provider, while the
+ * chat pipeline resolves the model per user (per-user override first).
+ *
+ * ModelConfigService is final (cannot be mocked), so a real instance is built
+ * on mocked repositories; ProviderDefaultsService is final too and never
+ * reached by these paths, so a real instance on mocks is safe.
+ */
+class ChatReadinessServiceTest extends TestCase
+{
+    private const USER_ID = 42;
+    private const USER_MODEL_BID = 7;
+    private const GLOBAL_MODEL_BID = 9;
+
+    private ProviderRegistry&MockObject $providerRegistry;
+    private ConfigRepository&MockObject $configRepository;
+    private ModelRepository&MockObject $modelRepository;
+
+    protected function setUp(): void
+    {
+        $this->providerRegistry = $this->createMock(ProviderRegistry::class);
+        $this->configRepository = $this->createMock(ConfigRepository::class);
+        $this->modelRepository = $this->createMock(ModelRepository::class);
+    }
+
+    private function service(): ChatReadinessService
+    {
+        $modelConfigService = new ModelConfigService(
+            $this->configRepository,
+            $this->modelRepository,
+            $this->createMock(UserRepository::class),
+            new ArrayAdapter(),
+            $this->providerRegistry,
+            'test',
+        );
+
+        return new ChatReadinessService(
+            $this->providerRegistry,
+            new ProviderDefaultsService($this->configRepository, new ArrayAdapter(), new NullLogger()),
+            $modelConfigService,
+            $this->modelRepository,
+            new ArrayAdapter(),
+            new NullLogger(),
+        );
+    }
+
+    /**
+     * @param array<int, string> $bindings ownerId => provider service of the bound CHAT model
+     */
+    private function givenDefaultChatBindings(array $bindings): void
+    {
+        $bidByOwner = [
+            self::USER_ID => self::USER_MODEL_BID,
+            0 => self::GLOBAL_MODEL_BID,
+        ];
+
+        $this->configRepository->method('findOneBy')->willReturnCallback(
+            function (array $criteria) use ($bindings, $bidByOwner): ?Config {
+                $ownerId = $criteria['ownerId'] ?? null;
+                if ('DEFAULTMODEL' !== ($criteria['group'] ?? null) || 'CHAT' !== ($criteria['setting'] ?? null)) {
+                    return null;
+                }
+                if (!isset($bindings[$ownerId])) {
+                    return null;
+                }
+
+                $config = new Config();
+                $config->setOwnerId((int) $ownerId);
+                $config->setGroup('DEFAULTMODEL');
+                $config->setSetting('CHAT');
+                $config->setValue((string) $bidByOwner[$ownerId]);
+
+                return $config;
+            }
+        );
+
+        $modelsByBid = [];
+        foreach ($bindings as $ownerId => $serviceName) {
+            $model = new Model();
+            $model->setService($serviceName);
+            $modelsByBid[$bidByOwner[$ownerId]] = $model;
+        }
+
+        $this->modelRepository->method('find')->willReturnCallback(
+            static fn ($bid): ?Model => $modelsByBid[(int) $bid] ?? null
+        );
+    }
+
+    public function testUserWithWorkingOverrideIsReadyEvenThoughGlobalDefaultIsBroken(): void
+    {
+        $this->givenDefaultChatBindings([
+            self::USER_ID => 'Anthropic',
+            0 => 'Ollama',
+        ]);
+
+        $availability = ['anthropic' => true, 'ollama' => false];
+
+        $this->assertTrue(
+            $this->service()->isChatReady($availability, null, self::USER_ID),
+            'A user whose own default chat model has a usable provider must be ready, regardless of the global default.'
+        );
+    }
+
+    public function testGlobalDefaultOnBrokenProviderIsNotReadyWithoutUserOverride(): void
+    {
+        $this->givenDefaultChatBindings([
+            0 => 'Ollama',
+        ]);
+
+        $availability = ['anthropic' => true, 'ollama' => false];
+
+        $this->assertFalse(
+            $this->service()->isChatReady($availability, null, self::USER_ID),
+            'Without a per-user override the global default applies — its provider is down, so chat is not ready.'
+        );
+        $this->assertFalse(
+            $this->service()->isChatReady($availability),
+            'The install-level (global) readiness must also report not ready.'
+        );
+    }
+
+    public function testGlobalDefaultWithUsableProviderIsReady(): void
+    {
+        $this->givenDefaultChatBindings([
+            0 => 'Groq',
+        ]);
+
+        $this->assertTrue($this->service()->isChatReady(['groq' => true], null, self::USER_ID));
+    }
+
+    public function testFallsBackToAnyChatProviderWhenBindingDoesNotResolve(): void
+    {
+        $this->givenDefaultChatBindings([]);
+        $this->providerRegistry->expects($this->once())
+            ->method('getAvailableProviders')
+            ->with('chat', false)
+            ->willReturn(['Groq']);
+
+        $this->assertTrue($this->service()->isChatReady(['groq' => true]));
+    }
+
+    public function testNotReadyWhenNothingIsSetAndNoProviderIsUsable(): void
+    {
+        $this->givenDefaultChatBindings([]);
+        $this->providerRegistry->expects($this->once())
+            ->method('getAvailableProviders')
+            ->with('chat', false)
+            ->willReturn([]);
+
+        $this->assertFalse($this->service()->isChatReady([]));
+    }
+}

--- a/frontend/src/stores/config.ts
+++ b/frontend/src/stores/config.ts
@@ -243,9 +243,10 @@ const config = {
 
   /**
    * First-run setup status (authenticated users only).
-   * chatReady is false when the provider serving the global default chat
-   * model has no usable key/connection — the chat shows a "connect an AI
-   * provider" banner and admins are pointed at /admin/setup.
+   * chatReady is false when the provider serving the current user's effective
+   * default chat model (per-user override, then global default) has no usable
+   * key/connection — the chat shows a "connect an AI provider" banner and
+   * admins are pointed at /admin/setup.
    * Defaults to true so anonymous pages and the pre-config phase never flash
    * the banner.
    */


### PR DESCRIPTION
## Summary
Per user defaults in DB

## Changes
- Updated the `defaultChatService` method to accept an optional user ID, allowing for per-user chat model overrides.
- Modified the `isChatReady` method to evaluate readiness based on the effective default chat model for the requesting user.
- Added a new private method `ollamaChatModelPulled` to check if the specific Ollama chat model is downloaded, improving readiness checks.
- Updated documentation and comments to reflect changes in chat model resolution and readiness evaluation for individual users.

## Verification
- [ ] Not tested (explain)
- [X] Manual
- [ ] Tests added/updated

## Notes
<!-- Related issues/links/threads. -->

## Screenshots/Logs
