### PR TITLE
fix(subscription): replace invented plan quantity claims with usage multipliers

### DIFF
--- a/backend/src/Controller/SubscriptionController.php
+++ b/backend/src/Controller/SubscriptionController.php
@@ -48,6 +48,14 @@ class SubscriptionController extends AbstractController
      * inserts them on `app:seed`); once a row exists, the operator-configured
      * DB values win. Feature bullets stay code-owned.
      *
+     * The usage multipliers mirror the cost budgets configured on the
+     * reference deployment (Free EUR 1 / Pro EUR 15 / Team EUR 40 /
+     * Business EUR 80 per month). Never advertise absolute message, image,
+     * video, or storage quantities here — plans are budget-based, so any
+     * fixed count would be a false claim. Keep these bullets in sync with
+     * the localized paywall copy (`SubscriptionPaywallModal.vue` +
+     * `subscription.features.*` in the frontend i18n files).
+     *
      * @var array<string, array{name: string, price: float, features: list<string>}>
      */
     private const PLAN_CATALOGUE = [
@@ -55,11 +63,9 @@ class SubscriptionController extends AbstractController
             'name' => 'Pro',
             'price' => 19.95,
             'features' => [
-                'Unlimited Messages',
-                '100 Images/Month',
+                '15× more usage than the free plan',
                 'Advanced AI Models',
                 'Priority Support',
-                '5GB Storage',
             ],
         ],
         'TEAM' => [
@@ -67,10 +73,9 @@ class SubscriptionController extends AbstractController
             'price' => 49.95,
             'features' => [
                 'Everything in Pro',
-                '500 Images/Month',
+                '40× more usage than the free plan',
                 'Team Collaboration',
                 'Custom Prompts',
-                '20GB Storage',
                 'API Access',
             ],
         ],
@@ -79,10 +84,8 @@ class SubscriptionController extends AbstractController
             'price' => 99.95,
             'features' => [
                 'Everything in Team',
-                'Unlimited Images',
-                'Unlimited Video Generation',
+                '80× more usage than the free plan',
                 'White-label Widgets',
-                '100GB Storage',
                 'Dedicated Support',
                 'SLA Guarantee',
             ],

--- a/frontend/src/components/subscription/SubscriptionPaywallModal.vue
+++ b/frontend/src/components/subscription/SubscriptionPaywallModal.vue
@@ -295,29 +295,29 @@ const planGridClass = computed(() => {
  * Localized benefits per tier, mirroring the server-side plan catalogue. The
  * API returns English-only `features`, which we only fall back to for a tier
  * this build does not know yet.
+ *
+ * The usage factors mirror the cost budgets of the reference deployment
+ * (Free €1 / Pro €15 / Team €40 / Business €80 per month). Plans are
+ * budget-based, so never list absolute message/image/video/storage counts
+ * here — keep in sync with `SubscriptionController::PLAN_CATALOGUE`.
  */
 const PLAN_BENEFITS: Record<string, Array<{ key: string; params?: Record<string, number> }>> = {
   PRO: [
-    { key: 'unlimitedMessages' },
-    { key: 'images', params: { count: 100 } },
+    { key: 'usage', params: { factor: 15 } },
     { key: 'advancedModels' },
     { key: 'prioritySupport' },
-    { key: 'storage', params: { size: 5 } },
   ],
   TEAM: [
     { key: 'everythingInPro' },
-    { key: 'images', params: { count: 500 } },
+    { key: 'usage', params: { factor: 40 } },
     { key: 'teamCollaboration' },
     { key: 'customPrompts' },
-    { key: 'storage', params: { size: 20 } },
     { key: 'apiAccess' },
   ],
   BUSINESS: [
     { key: 'everythingInTeam' },
-    { key: 'unlimitedImages' },
-    { key: 'unlimitedVideo' },
+    { key: 'usage', params: { factor: 80 } },
     { key: 'whiteLabel' },
-    { key: 'storage', params: { size: 100 } },
     { key: 'dedicatedSupport' },
     { key: 'slaGuarantee' },
   ],

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -2152,18 +2152,14 @@
       "business": "Business"
     },
     "features": {
-      "unlimitedMessages": "Unbegrenzte Nachrichten",
-      "images": "{count} Bilder/Monat",
-      "unlimitedImages": "Unbegrenzte Bilder",
+      "usage": "{factor}× mehr Nutzung als im Free-Plan",
       "advancedModels": "Erweiterte KI-Modelle",
       "prioritySupport": "Priority Support",
-      "storage": "{size}GB Speicher",
       "everythingInPro": "Alles aus Pro",
       "everythingInTeam": "Alles aus Team",
       "teamCollaboration": "Team-Zusammenarbeit",
       "customPrompts": "Benutzerdefinierte Prompts",
       "apiAccess": "API-Zugriff",
-      "unlimitedVideo": "Unbegrenzte Video-Generierung",
       "whiteLabel": "White-label Widgets",
       "dedicatedSupport": "Dedizierter Support",
       "slaGuarantee": "SLA-Garantie"

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -2137,18 +2137,14 @@
       "business": "Business"
     },
     "features": {
-      "unlimitedMessages": "Unlimited Messages",
-      "images": "{count} Images/Month",
-      "unlimitedImages": "Unlimited Images",
+      "usage": "{factor}× more usage than the free plan",
       "advancedModels": "Advanced AI Models",
       "prioritySupport": "Priority Support",
-      "storage": "{size}GB Storage",
       "everythingInPro": "Everything in Pro",
       "everythingInTeam": "Everything in Team",
       "teamCollaboration": "Team Collaboration",
       "customPrompts": "Custom Prompts",
       "apiAccess": "API Access",
-      "unlimitedVideo": "Unlimited Video Generation",
       "whiteLabel": "White-label Widgets",
       "dedicatedSupport": "Dedicated Support",
       "slaGuarantee": "SLA Guarantee"

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -1672,18 +1672,14 @@
       "business": "Empresa"
     },
     "features": {
-      "unlimitedMessages": "Mensajes Ilimitados",
-      "images": "{count} Imágenes/Mes",
-      "unlimitedImages": "Imágenes Ilimitadas",
+      "usage": "{factor}× más uso que el plan gratuito",
       "advancedModels": "Modelos de IA Avanzados",
       "prioritySupport": "Soporte Prioritario",
-      "storage": "{size}GB de Almacenamiento",
       "everythingInPro": "Todo en Pro",
       "everythingInTeam": "Todo en Equipo",
       "teamCollaboration": "Colaboración en Equipo",
       "customPrompts": "Prompts Personalizados",
       "apiAccess": "Acceso a API",
-      "unlimitedVideo": "Generación de Video Ilimitada",
       "whiteLabel": "Widgets White-label",
       "dedicatedSupport": "Soporte Dedicado",
       "slaGuarantee": "Garantía SLA"

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -1673,18 +1673,14 @@
       "business": "İşletme"
     },
     "features": {
-      "unlimitedMessages": "Sınırsız Mesaj",
-      "images": "{count} Görsel/Ay",
-      "unlimitedImages": "Sınırsız Görsel",
+      "usage": "Ücretsiz plana göre {factor}× daha fazla kullanım",
       "advancedModels": "Gelişmiş AI Modelleri",
       "prioritySupport": "Öncelikli Destek",
-      "storage": "{size}GB Depolama",
       "everythingInPro": "Pro'daki Her Şey",
       "everythingInTeam": "Takım'daki Her Şey",
       "teamCollaboration": "Takım İşbirliği",
       "customPrompts": "Özel Promptlar",
       "apiAccess": "API Erişimi",
-      "unlimitedVideo": "Sınırsız Video Oluşturma",
       "whiteLabel": "White-label Widgetlar",
       "dedicatedSupport": "Özel Destek",
       "slaGuarantee": "SLA Garantisi"

--- a/frontend/tests/unit/components/subscription/SubscriptionPaywallModal.spec.ts
+++ b/frontend/tests/unit/components/subscription/SubscriptionPaywallModal.spec.ts
@@ -126,7 +126,7 @@ describe('SubscriptionPaywallModal', () => {
     const wrapper = await mountPaywall()
 
     const proCard = wrapper.find('[data-plan-id="PRO"]')
-    expect(proCard.text()).toContain('Unlimited Messages')
+    expect(proCard.text()).toContain('15× more usage than the free plan')
     expect(proCard.text()).not.toContain('from the server')
   })
 


### PR DESCRIPTION
## Summary
- The subscription plan bullets advertised absolute quantities — "Unlimited Messages", "100/500 Images/Month", "5/20/100GB Storage", "Unlimited Video Generation" — that nothing in the platform enforces. Plans are cost-budget based, so every fixed count was a false claim (and an App Review risk for the mobile app).
- Replaces them with honest usage multipliers derived from the reference deployment's monthly cost budgets (Free €1 / Pro €15 / Team €40 / Business €80): **Pro 15×**, **Team 40×**, **Business 80×** more usage than the free plan.
- Applied consistently in the server-side plan catalogue (`SubscriptionController::PLAN_CATALOGUE`, rendered by the web subscription page), the localized paywall copy (`SubscriptionPaywallModal.vue` + `subscription.features.*` in all four locales), and the paywall unit spec.

## Test plan
- [x] `make -C backend lint` / `phpstan` / `test` (2945 tests green)
- [x] `make -C frontend lint`, `vue-tsc`, `make -C frontend test` (961 tests green, incl. updated paywall spec)