### PR TITLE
fix(iap): stop treating the real store product IDs as "not configured"

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -376,15 +376,19 @@ STRIPE_PRICE_BUSINESS=price_business_monthly
 # ── Native in-app purchase (IAP) products — mobile app only (Epic 5.5) ──────
 # Store product IDs that map an Apple/Google IAP back to a Synaplan tier
 # (the IAP mirror of STRIPE_PRICE_* above). Create the products in App Store
-# Connect / Play Console, then set the IDs here. Defaults are the documented
-# placeholder convention, so web-only / open-source deployments keep IAP off
-# (IapPricingService::isConfigured() stays false).
+# Connect / Play Console, then set the IDs here. Leave them EMPTY to keep IAP
+# off (IapPricingService::isConfigured() stays false), which is what web-only /
+# open-source deployments want.
+#
+# A deployment that sells through the stores MUST set all three explicitly —
+# there is deliberately no built-in default, so a forgotten value disables IAP
+# loudly instead of pointing at a product that does not exist in that account.
 #
 # IMPORTANT: the STORE price for each tier BAKES IN the store commission
 # (≈30 %, sometimes 15 %). See docs/PAYMENTS_CHANNELS.md before setting prices.
-IAP_PRODUCT_PRO=com.synaplan.app.pro.monthly
-IAP_PRODUCT_TEAM=com.synaplan.app.team.monthly
-IAP_PRODUCT_BUSINESS=com.synaplan.app.business.monthly
+IAP_PRODUCT_PRO=
+IAP_PRODUCT_TEAM=
+IAP_PRODUCT_BUSINESS=
 
 # Fixed App Store / Play EUR price points (must match ASC / Play Console).
 # Exposed as `appPrice` on /subscription/plans for the native-app fallback.

--- a/backend/config/services.yaml
+++ b/backend/config/services.yaml
@@ -99,11 +99,13 @@ parameters:
     env(STRIPE_PRICE_TEAM): ''
     env(STRIPE_PRICE_BUSINESS): ''
     env(STRIPE_PAYMENT_METHODS): ''
-    # Native IAP store product IDs (Epic 5.5). Defaults are the documented
-    # placeholder convention so web-only / open-source deployments stay IAP-off.
-    env(IAP_PRODUCT_PRO): 'com.synaplan.app.pro.monthly'
-    env(IAP_PRODUCT_TEAM): 'com.synaplan.app.team.monthly'
-    env(IAP_PRODUCT_BUSINESS): 'com.synaplan.app.business.monthly'
+    # Native IAP store product IDs (Epic 5.5). Empty by default so web-only /
+    # open-source deployments stay IAP-off; a deployment that sells through the
+    # stores sets its own IDs. Never default these to real store IDs — that is
+    # what broke `iapConfigured` before (see IapPricingService).
+    env(IAP_PRODUCT_PRO): ''
+    env(IAP_PRODUCT_TEAM): ''
+    env(IAP_PRODUCT_BUSINESS): ''
     # Store commission passed on to app buyers (percent on top of the web price).
     # Used only when a tier has no fixed IAP_STORE_PRICE_* (0 / unset).
     env(IAP_PRICE_MARKUP_PERCENT): '30'

--- a/backend/src/Service/IapPricingService.php
+++ b/backend/src/Service/IapPricingService.php
@@ -19,17 +19,19 @@ namespace App\Service;
  * ASC/Play catalogue prices used as the in-app display fallback.
  *
  * Product IDs and store price points are injected from env (configured once the
- * store products exist, Epic 5.5). Defaults match the App Store Connect
- * catalogue for the German launch. Open-source / web-only deployments keep
- * working with IAP effectively disabled via {@see isConfigured()}.
+ * store products exist, Epic 5.5). A tier without a product ID is simply not
+ * purchasable via IAP, so open-source / web-only deployments keep working with
+ * IAP disabled via {@see isConfigured()} without any extra configuration.
+ *
+ * The product IDs therefore default to EMPTY rather than to sample values. An
+ * earlier revision shipped `com.synaplan.app.<tier>.monthly` as "placeholder"
+ * defaults and treated exactly those strings as "not configured" — but those
+ * are the real App Store Connect IDs of the German launch, so a fully
+ * configured deployment reported `iapConfigured: false`. Never reintroduce a
+ * sentinel that a real store product could legitimately use.
  */
 final readonly class IapPricingService
 {
-    /** Placeholder product IDs shipped as defaults (no real store products yet). */
-    private const PLACEHOLDER_PRO = 'com.synaplan.app.pro.monthly';
-    private const PLACEHOLDER_TEAM = 'com.synaplan.app.team.monthly';
-    private const PLACEHOLDER_BUSINESS = 'com.synaplan.app.business.monthly';
-
     /** Default store commission passed on to app buyers (Apple/Google ≈30 %). */
     private const DEFAULT_STORE_MARKUP_PERCENT = 30.0;
 
@@ -42,9 +44,9 @@ final readonly class IapPricingService
     private const DEFAULT_STORE_PRICE_BUSINESS = 129.99;
 
     public function __construct(
-        private string $iapProductPro = self::PLACEHOLDER_PRO,
-        private string $iapProductTeam = self::PLACEHOLDER_TEAM,
-        private string $iapProductBusiness = self::PLACEHOLDER_BUSINESS,
+        private string $iapProductPro = '',
+        private string $iapProductTeam = '',
+        private string $iapProductBusiness = '',
         private float $storeMarkupPercent = self::DEFAULT_STORE_MARKUP_PERCENT,
         private float $storePricePro = self::DEFAULT_STORE_PRICE_PRO,
         private float $storePriceTeam = self::DEFAULT_STORE_PRICE_TEAM,
@@ -126,47 +128,43 @@ final readonly class IapPricingService
 
     /**
      * The store product ID configured for a given tier, or null for a tier that
-     * is not purchasable via IAP (e.g. NEW / ADMIN).
+     * is not purchasable via IAP (e.g. NEW / ADMIN, or an unconfigured tier).
      */
     public function productIdForTier(string $tier): ?string
     {
-        return match ($tier) {
+        $productId = match ($tier) {
             'PRO' => $this->iapProductPro,
             'TEAM' => $this->iapProductTeam,
             'BUSINESS' => $this->iapProductBusiness,
-            default => null,
+            default => '',
         };
+
+        return '' !== $productId ? $productId : null;
     }
 
     /**
-     * Tier → store product ID for every IAP-purchasable tier, in ascending order.
+     * Tier → store product ID for every tier that HAS a configured product, in
+     * ascending order. Tiers without one are omitted: they cannot be bought via
+     * IAP, and the app must not register an empty product with the store.
      *
      * @return array<string, string>
      */
     public function productCatalogue(): array
     {
-        return [
+        return array_filter([
             'PRO' => $this->iapProductPro,
             'TEAM' => $this->iapProductTeam,
             'BUSINESS' => $this->iapProductBusiness,
-        ];
+        ], static fn (string $productId): bool => '' !== $productId);
     }
 
     /**
-     * True once at least one tier points at a real (non-placeholder) store
-     * product — i.e. the deployment has actually configured IAP. Mirrors
+     * True once at least one tier points at a store product — i.e. the
+     * deployment has actually configured IAP. Mirrors
      * {@see BillingService::isEnabled()} for the Stripe side.
      */
     public function isConfigured(): bool
     {
-        $placeholders = [self::PLACEHOLDER_PRO, self::PLACEHOLDER_TEAM, self::PLACEHOLDER_BUSINESS, ''];
-
-        foreach ($this->productCatalogue() as $productId) {
-            if (!in_array($productId, $placeholders, true)) {
-                return true;
-            }
-        }
-
-        return false;
+        return [] !== $this->productCatalogue();
     }
 }

--- a/backend/tests/Unit/Service/IapPricingServiceTest.php
+++ b/backend/tests/Unit/Service/IapPricingServiceTest.php
@@ -52,19 +52,26 @@ final class IapPricingServiceTest extends TestCase
         $this->assertSame(['PRO', 'TEAM', 'BUSINESS'], array_keys($svc->productCatalogue()));
     }
 
-    public function testIsConfiguredFalseForPlaceholderDefaults(): void
+    public function testIsConfiguredFalseWithoutAnyProductId(): void
     {
-        // Default constructor = documented placeholders → IAP effectively off.
+        // No product IDs configured → IAP off, which is the web-only default.
         $svc = new IapPricingService();
 
         $this->assertFalse($svc->isConfigured());
+        $this->assertSame([], $svc->productCatalogue());
+        $this->assertNull($svc->productIdForTier('PRO'));
     }
 
-    public function testIsConfiguredTrueWhenAnyRealProductSet(): void
+    public function testIsConfiguredTrueWhenAnyProductSet(): void
     {
-        $svc = new IapPricingService('com.real.pro', 'com.synaplan.app.team.monthly', 'com.synaplan.app.business.monthly');
+        $svc = new IapPricingService('com.synaplan.app.pro.monthly');
 
         $this->assertTrue($svc->isConfigured());
+        // A tier without its own product stays unpurchasable, and the catalogue
+        // omits it so the app never registers an empty product with the store.
+        $this->assertSame(['PRO' => 'com.synaplan.app.pro.monthly'], $svc->productCatalogue());
+        $this->assertNull($svc->productIdForTier('TEAM'));
+        $this->assertSame('NEW', $svc->mapProductIdToLevel('com.synaplan.app.team.monthly'));
     }
 
     public function testAppPriceAddsDefaultStoreMarkupAndSnapsToPricePoint(): void

--- a/docs/PAYMENTS_CHANNELS.md
+++ b/docs/PAYMENTS_CHANNELS.md
@@ -94,11 +94,16 @@ app shows once loaded.
 | Stripe | price ID → tier | `SubscriptionController::mapPriceIdToLevel()` |
 | IAP | store product ID → tier | `IapPricingService::mapProductIdToLevel()` |
 
-IAP product IDs are configured via env (`IAP_PRODUCT_PRO` / `_TEAM` / `_BUSINESS`). Defaults are
-the documented placeholder convention (`com.synaplan.app.<tier>.monthly`), so web-only /
-open-source deployments keep IAP **off** (`IapPricingService::isConfigured()` is false, mirroring
-`BillingService::isEnabled()` for Stripe). `GET /api/v1/subscription/plans` exposes the resolved
-`iapProductId` per tier plus an `iapConfigured` flag so the app knows whether to offer a purchase.
+IAP product IDs are configured via env (`IAP_PRODUCT_PRO` / `_TEAM` / `_BUSINESS`) and default to
+**empty**, so web-only / open-source deployments keep IAP **off**
+(`IapPricingService::isConfigured()` is false, mirroring `BillingService::isEnabled()` for Stripe).
+A deployment that sells through the stores must set all three explicitly.
+`GET /api/v1/subscription/plans` exposes the resolved `iapProductId` per tier (null for a tier
+without a product) plus an `iapConfigured` flag so the app knows whether to offer a purchase.
+
+> Do not reintroduce sample product IDs as defaults. The previous
+> `com.synaplan.app.<tier>.monthly` "placeholder convention" collided with the real App Store
+> Connect IDs, so a fully configured production deployment reported `iapConfigured: false`.
 
 ## Server-side IAP validation (Epic 5.4)
 


### PR DESCRIPTION
## Summary
- `IapPricingService` shipped `com.synaplan.app.<tier>.monthly` as "placeholder" defaults **and** used those exact strings as the sentinel for "this deployment has no IAP". Those are the real App Store Connect product IDs of the German launch, so a fully configured production deployment answers `GET /api/v1/subscription/plans` with `iapConfigured: false` — the flag documented as the signal for whether the app may offer a purchase.
- Product IDs now default to **empty**. A tier without an ID is simply not purchasable, which keeps IAP off for web-only/self-hosted deployments without a sentinel that a real product could collide with. `productCatalogue()` omits unconfigured tiers (so the app never registers an empty product with the store) and `productIdForTier()` returns `null` for them, as the OpenAPI schema already promised.
- Found while wiring the first real App Store subscription products; the app currently gates purchases on `iapProductId` + native availability rather than on this flag, so nothing is broken in production today — but the flag is documented as *the* gate, so it was a trap waiting for the first client that trusts it.

## Deployment note (breaking for store-selling deployments)
There is deliberately no built-in default any more: a deployment that sells through Apple/Google **must** set `IAP_PRODUCT_PRO`, `IAP_PRODUCT_TEAM` and `IAP_PRODUCT_BUSINESS` explicitly, otherwise IAP stays off. Web-only and self-hosted installs are unaffected (they were IAP-off before and remain so).

## Test plan
- [x] `make -C backend lint`, `make -C backend phpstan`, `make -C backend test` (2950 tests green)
- [x] Extended `IapPricingServiceTest`: unconfigured service reports `isConfigured() === false`, an empty catalogue and `null` product IDs; a partially configured service exposes only the configured tier and refuses to map the others
- [ ] After deploy: `GET /api/v1/subscription/plans` on production reports `iapConfigured: true`