### PR TITLE
fix(subscription): localize plan benefits on the subscription page

### DIFF
--- a/frontend/src/components/subscription/SubscriptionPaywallModal.vue
+++ b/frontend/src/components/subscription/SubscriptionPaywallModal.vue
@@ -103,7 +103,7 @@
 
                   <ul class="space-y-2.5 mb-6 flex-1">
                     <li
-                      v-for="(benefit, index) in benefitsFor(plan)"
+                      v-for="(benefit, index) in planBenefits(plan)"
                       :key="index"
                       class="flex items-start gap-2.5 text-sm txt-secondary"
                     >
@@ -259,6 +259,8 @@ const {
   currentLevel,
   loadPlans,
   displayPrice,
+  planName,
+  planBenefits,
   isCurrentPlan,
   isLowerPlan,
   selectPlan,
@@ -292,53 +294,10 @@ const planGridClass = computed(() => {
 })
 
 /**
- * Localized benefits per tier, mirroring the server-side plan catalogue. The
- * API returns English-only `features`, which we only fall back to for a tier
- * this build does not know yet.
- *
- * The usage factors mirror the cost budgets of the reference deployment
- * (Free €1 / Pro €15 / Team €40 / Business €80 per month). Plans are
- * budget-based, so never list absolute message/image/video/storage counts
- * here — keep in sync with `SubscriptionController::PLAN_CATALOGUE`.
+ * The tagline falls back to nothing for a tier this build has no copy for —
+ * `t()` would otherwise print the raw key path, e.g.
+ * `paywall.plans.studio.tagline`, right into the card.
  */
-const PLAN_BENEFITS: Record<string, Array<{ key: string; params?: Record<string, number> }>> = {
-  PRO: [
-    { key: 'usage', params: { factor: 15 } },
-    { key: 'advancedModels' },
-    { key: 'prioritySupport' },
-  ],
-  TEAM: [
-    { key: 'everythingInPro' },
-    { key: 'usage', params: { factor: 40 } },
-    { key: 'teamCollaboration' },
-    { key: 'customPrompts' },
-    { key: 'apiAccess' },
-  ],
-  BUSINESS: [
-    { key: 'everythingInTeam' },
-    { key: 'usage', params: { factor: 80 } },
-    { key: 'whiteLabel' },
-    { key: 'dedicatedSupport' },
-    { key: 'slaGuarantee' },
-  ],
-}
-
-function benefitsFor(plan: SubscriptionPlan): string[] {
-  const mapped = PLAN_BENEFITS[plan.id]
-  if (!mapped) return plan.features
-  return mapped.map((benefit) => t(`subscription.features.${benefit.key}`, benefit.params ?? {}))
-}
-
-/**
- * Tier name and tagline fall back to what the server sent (and to nothing) for
- * a tier this build has no copy for — `t()` would otherwise print the raw key
- * path, e.g. `paywall.plans.studio.tagline`, right into the card.
- */
-function planName(plan: SubscriptionPlan): string {
-  const key = `subscription.plans.${plan.id.toLowerCase()}`
-  return te(key) ? t(key) : plan.name
-}
-
 function taglineFor(plan: SubscriptionPlan): string {
   const key = `paywall.plans.${plan.id.toLowerCase()}.tagline`
   return te(key) ? t(key) : ''

--- a/frontend/src/composables/useSubscriptionPurchase.ts
+++ b/frontend/src/composables/useSubscriptionPurchase.ts
@@ -21,6 +21,11 @@ export const PAID_LEVELS = ['PRO', 'TEAM', 'BUSINESS', 'ADMIN'] as const
 /** Purchasable tiers, ordered from cheapest to most expensive. */
 export const PLAN_HIERARCHY = ['NEW', 'PRO', 'TEAM', 'BUSINESS', 'ADMIN'] as const
 
+interface PlanBenefit {
+  key: string
+  params?: Record<string, number>
+}
+
 /**
  * Localized benefits per tier, mirroring the server-side plan catalogue. The
  * API returns English-only `features`, so every surface must translate here
@@ -31,8 +36,12 @@ export const PLAN_HIERARCHY = ['NEW', 'PRO', 'TEAM', 'BUSINESS', 'ADMIN'] as con
  * (Free €1 / Pro €15 / Team €40 / Business €80 per month). Plans are
  * budget-based, so never list absolute message/image/video/storage counts
  * here — keep in sync with `SubscriptionController::PLAN_CATALOGUE`.
+ *
+ * `satisfies` pins the keys to known tiers: a typo would otherwise compile and
+ * silently drop that tier back to the untranslated server list. The declared
+ * index signature stays wide because the lookup key is a runtime plan id.
  */
-const PLAN_BENEFITS: Record<string, Array<{ key: string; params?: Record<string, number> }>> = {
+const PLAN_BENEFITS: Record<string, PlanBenefit[]> = {
   PRO: [
     { key: 'usage', params: { factor: 15 } },
     { key: 'advancedModels' },
@@ -52,7 +61,7 @@ const PLAN_BENEFITS: Record<string, Array<{ key: string; params?: Record<string,
     { key: 'dedicatedSupport' },
     { key: 'slaGuarantee' },
   ],
-}
+} satisfies Partial<Record<(typeof PLAN_HIERARCHY)[number], PlanBenefit[]>>
 
 interface UseSubscriptionPurchaseOptions {
   /**

--- a/frontend/src/composables/useSubscriptionPurchase.ts
+++ b/frontend/src/composables/useSubscriptionPurchase.ts
@@ -21,6 +21,39 @@ export const PAID_LEVELS = ['PRO', 'TEAM', 'BUSINESS', 'ADMIN'] as const
 /** Purchasable tiers, ordered from cheapest to most expensive. */
 export const PLAN_HIERARCHY = ['NEW', 'PRO', 'TEAM', 'BUSINESS', 'ADMIN'] as const
 
+/**
+ * Localized benefits per tier, mirroring the server-side plan catalogue. The
+ * API returns English-only `features`, so every surface must translate here
+ * instead of printing them — otherwise a German user reads English bullets
+ * next to German headings.
+ *
+ * The usage factors mirror the cost budgets of the reference deployment
+ * (Free €1 / Pro €15 / Team €40 / Business €80 per month). Plans are
+ * budget-based, so never list absolute message/image/video/storage counts
+ * here — keep in sync with `SubscriptionController::PLAN_CATALOGUE`.
+ */
+const PLAN_BENEFITS: Record<string, Array<{ key: string; params?: Record<string, number> }>> = {
+  PRO: [
+    { key: 'usage', params: { factor: 15 } },
+    { key: 'advancedModels' },
+    { key: 'prioritySupport' },
+  ],
+  TEAM: [
+    { key: 'everythingInPro' },
+    { key: 'usage', params: { factor: 40 } },
+    { key: 'teamCollaboration' },
+    { key: 'customPrompts' },
+    { key: 'apiAccess' },
+  ],
+  BUSINESS: [
+    { key: 'everythingInTeam' },
+    { key: 'usage', params: { factor: 80 } },
+    { key: 'whiteLabel' },
+    { key: 'dedicatedSupport' },
+    { key: 'slaGuarantee' },
+  ],
+}
+
 interface UseSubscriptionPurchaseOptions {
   /**
    * Invoked after the server-side entitlement may have changed (successful
@@ -40,7 +73,7 @@ interface UseSubscriptionPurchaseOptions {
  * keeps the Stripe redirect.
  */
 export function useSubscriptionPurchase(options: UseSubscriptionPurchaseOptions = {}) {
-  const { t } = useI18n()
+  const { t, te } = useI18n()
   const authStore = useAuthStore()
   const dialog = useDialog()
   const { success } = useNotification()
@@ -99,6 +132,26 @@ export function useSubscriptionPurchase(options: UseSubscriptionPurchaseOptions 
       return formatPlanPrice(plan.appPrice, plan.currency)
     }
     return formatPlanPrice(plan.price, plan.currency)
+  }
+
+  /**
+   * The tier name falls back to what the server sent for a tier this build has
+   * no copy for — `t()` would otherwise print the raw key path,
+   * e.g. `subscription.plans.studio`, as the card heading.
+   */
+  function planName(plan: SubscriptionPlan): string {
+    const key = `subscription.plans.${plan.id.toLowerCase()}`
+    return te(key) ? t(key) : plan.name
+  }
+
+  /**
+   * Falls back to the server's English list only for a tier this build has no
+   * copy for — better an untranslated benefit than an empty card.
+   */
+  function planBenefits(plan: SubscriptionPlan): string[] {
+    const mapped = PLAN_BENEFITS[plan.id]
+    if (!mapped) return plan.features
+    return mapped.map((benefit) => t(`subscription.features.${benefit.key}`, benefit.params ?? {}))
   }
 
   function isCurrentPlan(planId: string): boolean {
@@ -268,6 +321,8 @@ export function useSubscriptionPurchase(options: UseSubscriptionPurchaseOptions 
     hasActivePlan,
     loadPlans,
     displayPrice,
+    planName,
+    planBenefits,
     isCurrentPlan,
     isLowerPlan,
     selectPlan,

--- a/frontend/src/views/SubscriptionView.vue
+++ b/frontend/src/views/SubscriptionView.vue
@@ -179,7 +179,7 @@
               <!-- Plan Header -->
               <div class="mb-6">
                 <h3 class="text-2xl font-bold txt-primary mb-2">
-                  {{ $t(`subscription.plans.${plan.id.toLowerCase()}`) }}
+                  {{ planName(plan) }}
                 </h3>
                 <div class="flex items-baseline gap-1">
                   <span class="text-4xl font-bold txt-primary">{{ displayPrice(plan) }}</span>
@@ -192,7 +192,7 @@
               <!-- Features List -->
               <ul class="space-y-3 mb-8 flex-grow">
                 <li
-                  v-for="(feature, index) in plan.features"
+                  v-for="(feature, index) in planBenefits(plan)"
                   :key="index"
                   class="flex items-start gap-3"
                 >
@@ -308,6 +308,8 @@ const {
   hasActivePlan,
   loadPlans,
   displayPrice,
+  planName,
+  planBenefits,
   isCurrentPlan,
   isLowerPlan,
   selectPlan,

--- a/frontend/tests/unit/views/SubscriptionViewBenefits.spec.ts
+++ b/frontend/tests/unit/views/SubscriptionViewBenefits.spec.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { i18n } from '@/i18n'
+
+/**
+ * `GET /api/v1/subscription/plans` returns English-only `features`. The plan
+ * page used to print them verbatim, so a German user read English bullets
+ * under German headings — visible on the very screen App Review looks at.
+ * Both selling surfaces now translate through `planBenefits()`.
+ */
+
+const mockGetPlans = vi.fn()
+
+vi.mock('@/services/api/nativeRuntime', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/services/api/nativeRuntime')>()
+  return { ...actual, isNativeApp: () => false }
+})
+
+vi.mock('@/services/api/nativeServer', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/services/api/nativeServer')>()
+  return { ...actual, isPurchaseAllowed: () => true }
+})
+
+vi.mock('@/services/api/subscriptionApi', () => ({
+  subscriptionApi: {
+    getPlans: (...args: unknown[]) => mockGetPlans(...args),
+    getSubscriptionStatus: vi.fn().mockResolvedValue({ hasSubscription: false, plan: 'NEW' }),
+    createCheckoutSession: vi.fn(),
+    createPortalSession: vi.fn(),
+  },
+}))
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => ({
+    user: { level: 'NEW' },
+    refreshUser: vi.fn().mockResolvedValue(undefined),
+  }),
+}))
+
+vi.mock('@/stores/config', () => ({
+  useConfigStore: () => ({ billing: { enabled: true } }),
+}))
+
+vi.mock('@/composables/useDialog', () => ({
+  useDialog: () => ({ alert: vi.fn().mockResolvedValue(undefined) }),
+}))
+
+vi.mock('@/composables/useDateFormat', () => ({
+  useDateFormat: () => ({ formatDateTime: () => '' }),
+}))
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  useRoute: () => ({ query: {} }),
+}))
+
+vi.mock('@iconify/vue', () => ({
+  Icon: { template: '<i />' },
+}))
+
+import SubscriptionView from '@/views/SubscriptionView.vue'
+
+const SERVER_FEATURE = 'Advanced AI Models from the server'
+
+function plan(id: string) {
+  return {
+    id,
+    name: id,
+    stripePriceId: `price_${id.toLowerCase()}`,
+    price: 19.95,
+    appPrice: 24.99,
+    currency: 'EUR',
+    interval: 'month',
+    features: [SERVER_FEATURE],
+  }
+}
+
+function mountView() {
+  return mount(SubscriptionView, {
+    global: { stubs: { MainLayout: { template: '<div><slot /></div>' } } },
+  })
+}
+
+describe('SubscriptionView — plan benefits', () => {
+  const previousLocale = i18n.global.locale.value
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    Element.prototype.scrollIntoView = () => {}
+  })
+
+  afterEach(() => {
+    i18n.global.locale.value = previousLocale
+  })
+
+  it('translates the benefits instead of printing the English server list', async () => {
+    i18n.global.locale.value = 'de'
+    mockGetPlans.mockResolvedValue({ plans: [plan('PRO')], stripeConfigured: true })
+
+    const wrapper = mountView()
+    await flushPromises()
+
+    const card = wrapper.get('[data-plan-id="PRO"]')
+    expect(card.text()).toContain('15× mehr Nutzung als im Free-Plan')
+    expect(card.text()).toContain('Erweiterte KI-Modelle')
+    expect(card.text()).not.toContain(SERVER_FEATURE)
+    wrapper.unmount()
+  })
+
+  it('falls back to the server list for a tier this build has no copy for', async () => {
+    mockGetPlans.mockResolvedValue({ plans: [plan('STUDIO')], stripeConfigured: true })
+
+    const wrapper = mountView()
+    await flushPromises()
+
+    const card = wrapper.get('[data-plan-id="STUDIO"]')
+    expect(card.text()).toContain(SERVER_FEATURE)
+    // The heading must not degrade into the raw key path either.
+    expect(card.text()).not.toContain('subscription.plans.studio')
+    wrapper.unmount()
+  })
+})

--- a/frontend/tests/unit/views/SubscriptionViewBenefits.spec.ts
+++ b/frontend/tests/unit/views/SubscriptionViewBenefits.spec.ts
@@ -83,6 +83,9 @@ function mountView() {
 
 describe('SubscriptionView — plan benefits', () => {
   const previousLocale = i18n.global.locale.value
+  // jsdom has no layout, so the view's scroll call would throw. Stubbing the
+  // prototype leaks across files, hence the restore below.
+  const previousScrollIntoView = Element.prototype.scrollIntoView
 
   beforeEach(() => {
     vi.clearAllMocks()
@@ -91,6 +94,7 @@ describe('SubscriptionView — plan benefits', () => {
 
   afterEach(() => {
     i18n.global.locale.value = previousLocale
+    Element.prototype.scrollIntoView = previousScrollIntoView
   })
 
   it('translates the benefits instead of printing the English server list', async () => {


### PR DESCRIPTION
## Summary

- `GET /api/v1/subscription/plans` returns English-only `features`, and `SubscriptionView` printed them verbatim. On a German device the plan page showed German headings ("Wähle deinen Plan", "Plan wählen") next to English bullets ("15× more usage than the free plan", "Advanced AI Models") — found on-device while validating the iOS launch build, and it is exactly the screen App Review inspects for a subscription app.
- The paywall modal already translated the same list, so the two selling surfaces disagreed. The tier copy now lives once in `useSubscriptionPurchase`, the composable both surfaces already use, and is exposed as `planBenefits()` and `planName()`.
- A tier the build has no copy for still falls back to the server's list and name, so an unknown tier from the backend never renders a raw i18n key path as its heading (which `SubscriptionView` did before).

No backend or API change; the server catalogue stays the fallback.

## Test plan

- [x] `make -C frontend lint`
- [x] `docker compose exec -T frontend npm run check:types`
- [x] `make -C frontend test` (963 passed)
- [x] New `SubscriptionViewBenefits.spec.ts` asserts the German bullets render and the English server string does not, plus the unknown-tier fallback