### PR TITLE
fix(iap): say what Apple IAP configuration is missing instead of failing blindly

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -417,10 +417,14 @@ IAP_PRICE_MARKUP_PERCENT=30
 #                               A sandbox receipt verified against Production is
 #                               rejected, so a store build under test needs
 #                               Sandbox and must be flipped before going live.
-#   IAP_APPLE_ROOT_CERTS_DIR    dir containing Apple root CA cert files (.cer/.pem)
-#                               Download ALL roots from
+#   IAP_APPLE_ROOT_CERTS_DIR    dir containing Apple root CA certificates, as
+#                               DER-encoded `.cer` files. Download ALL roots from
 #                               https://www.apple.com/certificateauthority/ and
-#                               keep them in DER form (do not convert to PEM).
+#                               keep them exactly as Apple ships them — the
+#                               library parses every file with
+#                               Certificate::fromDER(), so a PEM conversion
+#                               passes the "is anything configured" check and
+#                               then fails at verification time.
 #                               MOUNT this directory into the container — a copy
 #                               made inside it is lost on the next recreate, and
 #                               every purchase then fails while the deployment

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -413,8 +413,20 @@ IAP_PRICE_MARKUP_PERCENT=30
 # Apple (App Store Server Library / StoreKit 2 JWS verification):
 #   IAP_APPLE_BUNDLE_ID         your app bundle id, e.g. com.synaplan.app
 #   IAP_APPLE_APP_APPLE_ID      numeric App Store app id (required in production)
-#   IAP_APPLE_ENVIRONMENT       Sandbox | Production (default Production)
+#   IAP_APPLE_ENVIRONMENT       Sandbox | Production (default Production).
+#                               A sandbox receipt verified against Production is
+#                               rejected, so a store build under test needs
+#                               Sandbox and must be flipped before going live.
 #   IAP_APPLE_ROOT_CERTS_DIR    dir containing Apple root CA cert files (.cer/.pem)
+#                               Download ALL roots from
+#                               https://www.apple.com/certificateauthority/ and
+#                               keep them in DER form (do not convert to PEM).
+#                               MOUNT this directory into the container — a copy
+#                               made inside it is lost on the next recreate, and
+#                               every purchase then fails while the deployment
+#                               still looks healthy (the `iapConfigured` flag in
+#                               /api/v1/subscription/plans covers the product IDs,
+#                               not the verifier).
 IAP_APPLE_BUNDLE_ID=
 IAP_APPLE_APP_APPLE_ID=
 IAP_APPLE_ENVIRONMENT=Production

--- a/backend/src/Service/Iap/AppleStoreKitVerifier.php
+++ b/backend/src/Service/Iap/AppleStoreKitVerifier.php
@@ -179,16 +179,29 @@ final class AppleStoreKitVerifier implements AppleReceiptVerifierInterface
         if ('' === $this->bundleId) {
             $missing[] = 'IAP_APPLE_BUNDLE_ID is empty';
         }
+
+        // A directory that ceased to exist (what a container recreate does to an
+        // unmounted one) is named separately from an empty one: the first points
+        // at a missing bind mount, the second at a failed download.
+        $certificates = null;
         if ('' === $this->rootCertsDir) {
-            $missing[] = 'IAP_APPLE_ROOT_CERTS_DIR is empty';
+            $certificates = 'IAP_APPLE_ROOT_CERTS_DIR is empty';
+        } elseif (!is_dir($this->rootCertsDir)) {
+            $certificates = sprintf('the root certificate directory "%s" does not exist', $this->rootCertsDir);
         } elseif ([] === $this->rootCertificates()) {
-            $missing[] = sprintf(
-                'no Apple root certificates in "%s" (download them from https://www.apple.com/certificateauthority/ and keep them in DER form; a bind mount survives container recreation, a copy into the container does not)',
-                $this->rootCertsDir
-            );
+            $certificates = sprintf('the root certificate directory "%s" holds no files', $this->rootCertsDir);
+        }
+        if (null !== $certificates) {
+            $missing[] = $certificates;
         }
 
-        return 'Apple IAP is not configured on this server: '.implode('; ', $missing).'.';
+        $message = 'Apple IAP is not configured on this server: '.implode('; ', $missing).'.';
+        if (null !== $certificates) {
+            $message .= ' Download the roots from https://www.apple.com/certificateauthority/ and keep them'
+                .' DER-encoded; a bind mount survives container recreation, a copy into the container does not.';
+        }
+
+        return $message;
     }
 
     /**

--- a/backend/src/Service/Iap/AppleStoreKitVerifier.php
+++ b/backend/src/Service/Iap/AppleStoreKitVerifier.php
@@ -20,10 +20,12 @@ use AppStoreServerLibrary\SignedDataVerifier\VerificationException;
  * against Apple's root CAs. All store-specific shapes are normalized to
  * {@see IapEntitlement} here so the rest of the app stays store-agnostic.
  *
- * NOTE: this class is intentionally NOT unit tested — it needs real Apple root
- * certificates + bundle id and produces values only Apple can sign. The
- * business logic that consumes it ({@see \App\Service\MobilePurchaseService})
- * is tested against {@see AppleReceiptVerifierInterface} fakes instead.
+ * NOTE: the verification path is intentionally NOT unit tested — it needs real
+ * Apple root certificates + bundle id and produces values only Apple can sign.
+ * The business logic that consumes it ({@see \App\Service\MobilePurchaseService})
+ * is tested against {@see AppleReceiptVerifierInterface} fakes instead. The
+ * configuration guards below run before any Apple data is touched and ARE
+ * covered, because a misconfigured deployment fails silently in production.
  */
 final class AppleStoreKitVerifier implements AppleReceiptVerifierInterface
 {
@@ -144,11 +146,11 @@ final class AppleStoreKitVerifier implements AppleReceiptVerifierInterface
     private function verifier(): SignedDataVerifier
     {
         if (!$this->isConfigured()) {
-            throw new IapNotConfiguredException('Apple IAP is not configured on this server.');
+            throw new IapNotConfiguredException($this->missingConfigurationMessage());
         }
 
         if (null === $this->verifier) {
-            $environment = Environment::tryFrom($this->environment) ?? Environment::PRODUCTION;
+            $environment = $this->environment();
             try {
                 $this->verifier = new SignedDataVerifier(
                     rootCertificates: $this->rootCertificates(),
@@ -163,6 +165,51 @@ final class AppleStoreKitVerifier implements AppleReceiptVerifierInterface
         }
 
         return $this->verifier;
+    }
+
+    /**
+     * Names what is actually missing. The generic "not configured" message cost
+     * hours once: a container recreate wiped the root-cert directory, every
+     * purchase failed with an opaque client-side error, and the server log did
+     * not say which half of the configuration was gone.
+     */
+    private function missingConfigurationMessage(): string
+    {
+        $missing = [];
+        if ('' === $this->bundleId) {
+            $missing[] = 'IAP_APPLE_BUNDLE_ID is empty';
+        }
+        if ('' === $this->rootCertsDir) {
+            $missing[] = 'IAP_APPLE_ROOT_CERTS_DIR is empty';
+        } elseif ([] === $this->rootCertificates()) {
+            $missing[] = sprintf(
+                'no Apple root certificates in "%s" (download them from https://www.apple.com/certificateauthority/ and keep them in DER form; a bind mount survives container recreation, a copy into the container does not)',
+                $this->rootCertsDir
+            );
+        }
+
+        return 'Apple IAP is not configured on this server: '.implode('; ', $missing).'.';
+    }
+
+    /**
+     * Apple spells the environment `Sandbox`/`Production`. Accept any casing but
+     * refuse an outright unknown value instead of silently falling back to
+     * Production — that fallback turns a typo into every sandbox receipt being
+     * rejected, with nothing in the log pointing at the environment.
+     */
+    private function environment(): Environment
+    {
+        if ('' === $this->environment) {
+            return Environment::PRODUCTION;
+        }
+
+        foreach (Environment::cases() as $case) {
+            if (0 === strcasecmp($case->value, $this->environment)) {
+                return $case;
+            }
+        }
+
+        throw new IapNotConfiguredException(sprintf('IAP_APPLE_ENVIRONMENT is "%s"; expected one of %s.', $this->environment, implode(', ', array_map(static fn (Environment $c): string => $c->value, Environment::cases()))));
     }
 
     /**

--- a/backend/tests/Unit/Service/Iap/AppleStoreKitVerifierConfigTest.php
+++ b/backend/tests/Unit/Service/Iap/AppleStoreKitVerifierConfigTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\Iap;
+
+use App\Service\Iap\AppleStoreKitVerifier;
+use App\Service\Iap\Exception\IapNotConfiguredException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Guards the configuration checks that run before any Apple data is touched.
+ *
+ * Both failures below happened on the production cluster: a container recreate
+ * wiped the root-certificate directory, and every purchase then failed with an
+ * opaque "purchase could not be completed" while the server log said only
+ * "not configured". These messages have to name the cause.
+ */
+final class AppleStoreKitVerifierConfigTest extends TestCase
+{
+    /** @var list<string> */
+    private array $tempPaths = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->tempPaths as $path) {
+            if (is_file($path)) {
+                unlink($path);
+            } elseif (is_dir($path)) {
+                rmdir($path);
+            }
+        }
+        $this->tempPaths = [];
+    }
+
+    public function testReportsAnEmptyRootCertificateDirectoryByPath(): void
+    {
+        $dir = $this->makeRootCertsDir(withCertificate: false);
+
+        $verifier = new AppleStoreKitVerifier(
+            bundleId: 'com.example.app',
+            rootCertsDir: $dir,
+        );
+
+        $this->expectException(IapNotConfiguredException::class);
+        $this->expectExceptionMessage($dir);
+        $verifier->verifySignedTransaction('irrelevant');
+    }
+
+    public function testReportsAMissingBundleId(): void
+    {
+        $verifier = new AppleStoreKitVerifier(rootCertsDir: $this->makeRootCertsDir());
+
+        $this->expectException(IapNotConfiguredException::class);
+        $this->expectExceptionMessage('IAP_APPLE_BUNDLE_ID is empty');
+        $verifier->verifySignedTransaction('irrelevant');
+    }
+
+    public function testRefusesAnUnknownEnvironmentInsteadOfFallingBackToProduction(): void
+    {
+        $verifier = new AppleStoreKitVerifier(
+            bundleId: 'com.example.app',
+            environment: 'staging',
+            rootCertsDir: $this->makeRootCertsDir(),
+        );
+
+        $this->expectException(IapNotConfiguredException::class);
+        $this->expectExceptionMessage('expected one of Sandbox, Production');
+        $verifier->verifySignedTransaction('irrelevant');
+    }
+
+    public function testAcceptsTheEnvironmentRegardlessOfCasing(): void
+    {
+        $verifier = new AppleStoreKitVerifier(
+            bundleId: 'com.example.app',
+            environment: 'sandbox',
+            rootCertsDir: $this->makeRootCertsDir(),
+        );
+
+        // The environment passes, so the failure comes from the placeholder
+        // certificate the verifier is then handed — not from the spelling.
+        $this->expectException(IapNotConfiguredException::class);
+        $this->expectExceptionMessage('could not be initialized');
+        $verifier->verifySignedTransaction('irrelevant');
+    }
+
+    /**
+     * A root-certificate directory; the contents only have to be non-empty for
+     * the "is anything there at all" check this class performs.
+     */
+    private function makeRootCertsDir(bool $withCertificate = true): string
+    {
+        $dir = sys_get_temp_dir().'/apple-roots-'.bin2hex(random_bytes(6));
+        mkdir($dir);
+        $this->tempPaths[] = $dir;
+
+        if ($withCertificate) {
+            $path = $dir.'/placeholder.cer';
+            file_put_contents($path, 'not a real certificate');
+            // Removed before the directory (tearDown unwinds in order).
+            array_splice($this->tempPaths, -1, 0, [$path]);
+        }
+
+        return $dir;
+    }
+}

--- a/backend/tests/Unit/Service/Iap/AppleStoreKitVerifierConfigTest.php
+++ b/backend/tests/Unit/Service/Iap/AppleStoreKitVerifierConfigTest.php
@@ -43,7 +43,25 @@ final class AppleStoreKitVerifierConfigTest extends TestCase
         );
 
         $this->expectException(IapNotConfiguredException::class);
-        $this->expectExceptionMessage($dir);
+        $this->expectExceptionMessage(sprintf('directory "%s" holds no files', $dir));
+        $verifier->verifySignedTransaction('irrelevant');
+    }
+
+    /**
+     * A vanished directory means the bind mount is missing, which is a different
+     * repair than an empty one — that distinction is the whole point here.
+     */
+    public function testDistinguishesAVanishedDirectoryFromAnEmptyOne(): void
+    {
+        $dir = sys_get_temp_dir().'/apple-roots-never-created';
+
+        $verifier = new AppleStoreKitVerifier(
+            bundleId: 'com.example.app',
+            rootCertsDir: $dir,
+        );
+
+        $this->expectException(IapNotConfiguredException::class);
+        $this->expectExceptionMessage(sprintf('directory "%s" does not exist', $dir));
         $verifier->verifySignedTransaction('irrelevant');
     }
 


### PR DESCRIPTION
## Summary

Found while running the first real StoreKit sandbox purchase against production. A container recreate had wiped the Apple root-certificate directory (`IAP_APPLE_ROOT_CERTS_DIR=var/apple-roots`, a path inside the container rather than a mount). Every purchase then failed: Apple charged nothing, the app showed the generic "purchase could not be completed", and the only server-side trace was `Apple IAP is not configured on this server.` — with no hint which half of the configuration was gone. The deployment looked healthy throughout, because the `iapConfigured` flag in `/api/v1/subscription/plans` describes the product IDs, not the verifier.

- `IapNotConfiguredException` now names the cause: empty bundle id, empty directory setting, or a configured directory holding no certificates — including its resolved path and where to download them.
- `IAP_APPLE_ENVIRONMENT` no longer falls back to Production when unparseable. The library enum only accepts `Sandbox`/`Production`, so a lowercase value silently verified sandbox receipts against Production and rejected all of them. Casing is now irrelevant; a genuinely unknown value fails loudly.
- `.env.example` records that the directory must be **mounted** (a copy made inside the container is lost on the next recreate) and that all roots come from Apple PKI in DER form.

No behavior change for a correctly configured deployment, and none for web-only installs, which still get a clean not-configured path.

## Test plan

- [x] `make -C backend lint`
- [x] `make -C backend phpstan` (no errors)
- [x] `make -C backend test` (2954 passed)
- [x] New `AppleStoreKitVerifierConfigTest` covers the empty directory (asserting the path is in the message), the missing bundle id, an unknown environment, and case-insensitive `sandbox`