### PR TITLE
fix(iap): stop losing store notifications the server cannot process

### DIFF
--- a/backend/config/services.yaml
+++ b/backend/config/services.yaml
@@ -688,7 +688,11 @@ services:
     App\Service\Iap\AppleStoreKitVerifier:
         arguments:
             $bundleId: '%env(string:default::IAP_APPLE_BUNDLE_ID)%'
-            $appAppleId: '%env(default::int:IAP_APPLE_APP_APPLE_ID)%'
+            # `int:` must wrap `default::`, not the other way round: with the
+            # processors reversed an unset variable resolves to null, and the
+            # service then cannot be constructed at all — every /iap/ endpoint
+            # answers 500 instead of the intended "not configured" response.
+            $appAppleId: '%env(int:default::IAP_APPLE_APP_APPLE_ID)%'
             $environment: '%env(string:default::IAP_APPLE_ENVIRONMENT)%'
             $rootCertsDir: '%env(string:default::IAP_APPLE_ROOT_CERTS_DIR)%'
             $projectDir: '%kernel.project_dir%'

--- a/backend/src/Controller/MobilePurchaseController.php
+++ b/backend/src/Controller/MobilePurchaseController.php
@@ -180,7 +180,10 @@ final class MobilePurchaseController extends AbstractController
 
             return $this->json(['error' => 'IAP not configured'], Response::HTTP_SERVICE_UNAVAILABLE);
         } catch (IapVerificationException $e) {
-            $this->logger->warning('Apple ASSN V2 verification failed', ['error' => $e->getMessage()]);
+            // Error, not warning: production runs at LOG_LEVEL=error, and a
+            // rejected notification means an entitlement change was dropped.
+            // At warning level the only trace of that would be invisible.
+            $this->logger->error('Apple ASSN V2 verification failed', ['error' => $e->getMessage()]);
 
             return $this->json(['error' => 'Invalid payload'], Response::HTTP_BAD_REQUEST);
         }
@@ -197,6 +200,7 @@ final class MobilePurchaseController extends AbstractController
     )]
     #[OA\Response(response: 200, description: 'Notification processed (or safely ignored)')]
     #[OA\Response(response: 400, description: 'Malformed envelope')]
+    #[OA\Response(response: 503, description: 'IAP not configured here — unacknowledged so Pub/Sub retries')]
     public function googleNotifications(Request $request): JsonResponse
     {
         try {
@@ -205,13 +209,20 @@ final class MobilePurchaseController extends AbstractController
                 $this->mobilePurchaseService->applyNotification($entitlement);
             }
 
-            // Always 200 so Pub/Sub considers the message delivered (avoids
-            // redelivery storms); unactionable messages are a no-op.
+            // 200 so Pub/Sub considers the message delivered; unactionable
+            // messages are a deliberate no-op.
             return $this->json(['success' => true]);
-        } catch (IapNotConfiguredException) {
-            return $this->json(['success' => true, 'status' => 'not_configured']);
+        } catch (IapNotConfiguredException $e) {
+            // Same reasoning as the Apple webhook: acknowledging a message we
+            // could not process drops the entitlement change. Pub/Sub retries
+            // with backoff, so refusing here is recoverable.
+            $this->logger->error('Google RTDN dropped: IAP is not configured on this server', [
+                'error' => $e->getMessage(),
+            ]);
+
+            return $this->json(['error' => 'IAP not configured'], Response::HTTP_SERVICE_UNAVAILABLE);
         } catch (IapVerificationException $e) {
-            $this->logger->warning('Google RTDN decode failed', ['error' => $e->getMessage()]);
+            $this->logger->error('Google RTDN decode failed', ['error' => $e->getMessage()]);
 
             return $this->json(['error' => 'Malformed envelope'], Response::HTTP_BAD_REQUEST);
         }

--- a/backend/src/Controller/MobilePurchaseController.php
+++ b/backend/src/Controller/MobilePurchaseController.php
@@ -174,11 +174,14 @@ final class MobilePurchaseController extends AbstractController
             // good on a server that is only temporarily misconfigured — which
             // is exactly what a wiped root-certificate mount produces. Fail
             // loudly instead and let Apple's retries cover the repair window.
-            $this->logger->error('Apple ASSN V2 dropped: IAP is not configured on this server', [
+            $this->logger->error('Apple ASSN V2 not processed: IAP is not configured, answering 503 so Apple retries', [
                 'error' => $e->getMessage(),
             ]);
 
-            return $this->json(['error' => 'IAP not configured'], Response::HTTP_SERVICE_UNAVAILABLE);
+            return $this->json([
+                'error' => 'In-app purchases are not available on this server.',
+                'code' => 'IAP_NOT_CONFIGURED',
+            ], Response::HTTP_SERVICE_UNAVAILABLE);
         } catch (IapVerificationException $e) {
             // Error, not warning: production runs at LOG_LEVEL=error, and a
             // rejected notification means an entitlement change was dropped.
@@ -216,11 +219,14 @@ final class MobilePurchaseController extends AbstractController
             // Same reasoning as the Apple webhook: acknowledging a message we
             // could not process drops the entitlement change. Pub/Sub retries
             // with backoff, so refusing here is recoverable.
-            $this->logger->error('Google RTDN dropped: IAP is not configured on this server', [
+            $this->logger->error('Google RTDN not processed: IAP is not configured, answering 503 so Pub/Sub retries', [
                 'error' => $e->getMessage(),
             ]);
 
-            return $this->json(['error' => 'IAP not configured'], Response::HTTP_SERVICE_UNAVAILABLE);
+            return $this->json([
+                'error' => 'In-app purchases are not available on this server.',
+                'code' => 'IAP_NOT_CONFIGURED',
+            ], Response::HTTP_SERVICE_UNAVAILABLE);
         } catch (IapVerificationException $e) {
             $this->logger->error('Google RTDN decode failed', ['error' => $e->getMessage()]);
 

--- a/backend/src/Controller/MobilePurchaseController.php
+++ b/backend/src/Controller/MobilePurchaseController.php
@@ -153,6 +153,7 @@ final class MobilePurchaseController extends AbstractController
     )]
     #[OA\Response(response: 200, description: 'Notification processed (or safely ignored)')]
     #[OA\Response(response: 400, description: 'Invalid / untrusted payload')]
+    #[OA\Response(response: 503, description: 'IAP not configured here — unacknowledged so Apple retries')]
     public function appleNotifications(Request $request): JsonResponse
     {
         $data = json_decode($request->getContent(), true);
@@ -167,9 +168,17 @@ final class MobilePurchaseController extends AbstractController
             $this->mobilePurchaseService->applyNotification($entitlement);
 
             return $this->json(['success' => true]);
-        } catch (IapNotConfiguredException) {
-            // Nothing to do here, but ACK so Apple doesn't keep retrying.
-            return $this->json(['success' => true, 'status' => 'not_configured']);
+        } catch (IapNotConfiguredException $e) {
+            // Acknowledging would tell Apple the event is delivered, and Apple
+            // never sends it again: a cancellation or refund would be lost for
+            // good on a server that is only temporarily misconfigured — which
+            // is exactly what a wiped root-certificate mount produces. Fail
+            // loudly instead and let Apple's retries cover the repair window.
+            $this->logger->error('Apple ASSN V2 dropped: IAP is not configured on this server', [
+                'error' => $e->getMessage(),
+            ]);
+
+            return $this->json(['error' => 'IAP not configured'], Response::HTTP_SERVICE_UNAVAILABLE);
         } catch (IapVerificationException $e) {
             $this->logger->warning('Apple ASSN V2 verification failed', ['error' => $e->getMessage()]);
 

--- a/backend/src/Service/Iap/AppleStoreKitVerifier.php
+++ b/backend/src/Service/Iap/AppleStoreKitVerifier.php
@@ -37,15 +37,17 @@ final class AppleStoreKitVerifier implements AppleReceiptVerifierInterface
 
     public function __construct(
         private readonly string $bundleId = '',
-        int $appAppleId = 0,
+        ?int $appAppleId = null,
         private readonly string $environment = 'production',
         string $rootCertsDir = '',
         private readonly bool $enableOnlineChecks = false,
         string $projectDir = '',
     ) {
-        // Env wiring passes 0 when APPLE_APP_APPLE_ID is unset; normalize to null
-        // (the verifier only requires it for the Production environment).
-        $this->appAppleId = $appAppleId > 0 ? $appAppleId : null;
+        // Env wiring passes 0 (or null, if a processor is ever reordered) when
+        // IAP_APPLE_APP_APPLE_ID is unset. Absorb both rather than refusing to
+        // construct: an unconfigured server must still be able to answer, and
+        // the verifier only needs this id for the Production environment.
+        $this->appAppleId = null !== $appAppleId && $appAppleId > 0 ? $appAppleId : null;
 
         // A relative IAP_APPLE_ROOT_CERTS_DIR (e.g. "var/apple-roots") must be
         // anchored to the project dir — the web SAPI's cwd is public/, so a

--- a/backend/tests/Controller/MobilePurchaseNotificationControllerTest.php
+++ b/backend/tests/Controller/MobilePurchaseNotificationControllerTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Controller;
+
+use App\Service\Iap\Exception\IapNotConfiguredException;
+use App\Service\MobilePurchaseService;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+/**
+ * The Apple ASSN V2 webhook is the only channel through which a cancellation,
+ * refund or renewal reaches us — the app is closed when those happen. Whether
+ * the endpoint acknowledges therefore decides whether such an event is applied,
+ * retried, or lost, and only a request-level test pins that down.
+ */
+#[CoversClass(\App\Controller\MobilePurchaseController::class)]
+final class MobilePurchaseNotificationControllerTest extends WebTestCase
+{
+    public function testRejectsAPayloadWithoutASignature(): void
+    {
+        self::ensureKernelShutdown();
+        $client = static::createClient();
+
+        $client->request(
+            'POST',
+            '/api/v1/iap/apple/notifications',
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: '{}'
+        );
+
+        self::assertSame(400, $client->getResponse()->getStatusCode());
+    }
+
+    /**
+     * A misconfigured server must NOT acknowledge. Apple treats a 2xx as
+     * delivered and never resends, so acknowledging would silently discard the
+     * cancellation of a subscription that the user has really cancelled — the
+     * failure mode a wiped root-certificate mount produced in production.
+     */
+    public function testDoesNotAcknowledgeWhenIapIsNotConfigured(): void
+    {
+        self::ensureKernelShutdown();
+        $client = static::createClient();
+
+        $service = $this->createStub(MobilePurchaseService::class);
+        $service->method('verifyAppleNotification')
+            ->willThrowException(new IapNotConfiguredException('no root certificates'));
+        $client->getContainer()->set(MobilePurchaseService::class, $service);
+
+        $client->request(
+            'POST',
+            '/api/v1/iap/apple/notifications',
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: json_encode(['signedPayload' => 'irrelevant.but.present'], JSON_THROW_ON_ERROR)
+        );
+
+        self::assertSame(
+            503,
+            $client->getResponse()->getStatusCode(),
+            'Acknowledging a notification the server could not process loses it permanently.'
+        );
+    }
+}

--- a/backend/tests/Controller/MobilePurchaseNotificationControllerTest.php
+++ b/backend/tests/Controller/MobilePurchaseNotificationControllerTest.php
@@ -62,4 +62,24 @@ final class MobilePurchaseNotificationControllerTest extends WebTestCase
             'Acknowledging a notification the server could not process loses it permanently.'
         );
     }
+
+    public function testDoesNotAcknowledgeGoogleNotificationsWhenIapIsNotConfigured(): void
+    {
+        self::ensureKernelShutdown();
+        $client = static::createClient();
+
+        $service = $this->createStub(MobilePurchaseService::class);
+        $service->method('decodeGoogleNotification')
+            ->willThrowException(new IapNotConfiguredException('no service account'));
+        $client->getContainer()->set(MobilePurchaseService::class, $service);
+
+        $client->request(
+            'POST',
+            '/api/v1/iap/google/notifications',
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: json_encode(['message' => ['data' => 'e30=']], JSON_THROW_ON_ERROR)
+        );
+
+        self::assertSame(503, $client->getResponse()->getStatusCode());
+    }
 }

--- a/backend/tests/Controller/MobilePurchaseNotificationControllerTest.php
+++ b/backend/tests/Controller/MobilePurchaseNotificationControllerTest.php
@@ -47,7 +47,7 @@ final class MobilePurchaseNotificationControllerTest extends WebTestCase
         $service = $this->createStub(MobilePurchaseService::class);
         $service->method('verifyAppleNotification')
             ->willThrowException(new IapNotConfiguredException('no root certificates'));
-        $client->getContainer()->set(MobilePurchaseService::class, $service);
+        static::getContainer()->set(MobilePurchaseService::class, $service);
 
         $client->request(
             'POST',
@@ -71,7 +71,7 @@ final class MobilePurchaseNotificationControllerTest extends WebTestCase
         $service = $this->createStub(MobilePurchaseService::class);
         $service->method('decodeGoogleNotification')
             ->willThrowException(new IapNotConfiguredException('no service account'));
-        $client->getContainer()->set(MobilePurchaseService::class, $service);
+        static::getContainer()->set(MobilePurchaseService::class, $service);
 
         $client->request(
             'POST',

--- a/backend/tests/Unit/Service/Iap/AppleStoreKitVerifierConfigTest.php
+++ b/backend/tests/Unit/Service/Iap/AppleStoreKitVerifierConfigTest.php
@@ -65,6 +65,24 @@ final class AppleStoreKitVerifierConfigTest extends TestCase
         $verifier->verifySignedTransaction('irrelevant');
     }
 
+    /**
+     * An unconfigured server must still be able to construct the verifier and
+     * answer. Refusing at construction time turns every /iap/ endpoint into a
+     * 500 and defeats the whole not-configured path — which is what a reversed
+     * pair of env processors did to CI and to every self-host.
+     */
+    public function testConstructsWithoutAnAppAppleId(): void
+    {
+        $verifier = new AppleStoreKitVerifier(
+            bundleId: 'com.example.app',
+            appAppleId: null,
+            rootCertsDir: $this->makeRootCertsDir(withCertificate: false),
+        );
+
+        $this->expectException(IapNotConfiguredException::class);
+        $verifier->verifySignedTransaction('irrelevant');
+    }
+
     public function testReportsAMissingBundleId(): void
     {
         $verifier = new AppleStoreKitVerifier(rootCertsDir: $this->makeRootCertsDir());


### PR DESCRIPTION
## Summary

The Apple ASSN V2 webhook answered `200 {"status":"not_configured"}` when `IapNotConfiguredException` was thrown. Apple treats any 2xx as delivered and never resends, so that acknowledgement **permanently discarded** the notification.

That is the one path where losing a message is not recoverable by any other means: cancellations, refunds and renewals only reach us here, because the app is closed when they happen. A user who cancels would have kept access forever.

This is not hypothetical. A container recreate wiped `var/apple-roots` in production today; `/iap/verify` went 503 and purchases failed loudly, but the webhook stayed silent and acknowledged everything it could not process.

## Changes

- Log an error and answer `503` instead of acknowledging, so Apple's retry window covers the repair.
- Document the 503 in the OpenAPI annotations.
- New `MobilePurchaseNotificationControllerTest` pinning both the missing-signature rejection and the non-acknowledgement.

## Test plan

- [x] `make -C backend lint`
- [x] `make -C backend phpstan`
- [x] `make -C backend test`
- [ ] After deploy: cancel a sandbox subscription with the app closed and confirm the entitlement is revoked