### PR TITLE
fix(subscription): show the renewal terms and legal links where plans are sold

### DIFF
--- a/frontend/src/views/SubscriptionView.vue
+++ b/frontend/src/views/SubscriptionView.vue
@@ -264,6 +264,39 @@
             </button>
             <p class="txt-secondary text-xs">{{ $t('subscription.native.storeNote') }}</p>
           </div>
+
+          <!--
+            MOBILE-APP SEAM (Epic 9.4): App Store Review Guideline 3.1.2 requires the
+            renewal terms and functional links to the terms of use and privacy policy
+            on the surface that sells the subscription. The paywall modal already
+            carries them; this page sells the same plans and needs the same disclosure.
+          -->
+          <div
+            v-if="stripeConfigured || isNative"
+            data-testid="section-purchase-disclosure"
+            class="max-w-2xl mx-auto mt-8 text-center space-y-2"
+          >
+            <p class="text-xs txt-tertiary leading-relaxed">
+              {{ isNative ? $t('paywall.renewalNoteStore') : $t('paywall.renewalNoteWeb') }}
+            </p>
+            <p class="text-xs txt-tertiary">
+              <a
+                :href="config.branding.termsUrl"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="text-brand hover:underline underline-offset-2"
+                >{{ $t('auth.termsOfService') }}</a
+              >
+              <span class="mx-2">·</span>
+              <a
+                :href="config.branding.privacyUrl"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="text-brand hover:underline underline-offset-2"
+                >{{ $t('auth.privacyPolicy') }}</a
+              >
+            </p>
+          </div>
         </template>
       </div>
     </div>

--- a/frontend/tests/unit/views/SubscriptionViewBenefits.spec.ts
+++ b/frontend/tests/unit/views/SubscriptionViewBenefits.spec.ts
@@ -38,7 +38,13 @@ vi.mock('@/stores/auth', () => ({
 }))
 
 vi.mock('@/stores/config', () => ({
-  useConfigStore: () => ({ billing: { enabled: true } }),
+  useConfigStore: () => ({
+    billing: { enabled: true },
+    branding: {
+      termsUrl: 'https://example.test/terms',
+      privacyUrl: 'https://example.test/privacy',
+    },
+  }),
 }))
 
 vi.mock('@/composables/useDialog', () => ({
@@ -121,6 +127,39 @@ describe('SubscriptionView — plan benefits', () => {
     expect(card.text()).toContain(SERVER_FEATURE)
     // The heading must not degrade into the raw key path either.
     expect(card.text()).not.toContain('subscription.plans.studio')
+    wrapper.unmount()
+  })
+})
+
+/**
+ * App Store Review Guideline 3.1.2 wants the renewal terms and working links to
+ * the terms of use and the privacy policy on the screen that sells the
+ * subscription — not only in the paywall modal.
+ */
+describe('SubscriptionView — purchase disclosure', () => {
+  const previousScrollIntoView = Element.prototype.scrollIntoView
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    Element.prototype.scrollIntoView = () => {}
+  })
+
+  afterEach(() => {
+    Element.prototype.scrollIntoView = previousScrollIntoView
+  })
+
+  it('states the renewal terms and links to the terms and the privacy policy', async () => {
+    mockGetPlans.mockResolvedValue({ plans: [plan('PRO')], stripeConfigured: true })
+
+    const wrapper = mountView()
+    await flushPromises()
+
+    const disclosure = wrapper.get('[data-testid="section-purchase-disclosure"]')
+    expect(disclosure.text()).toContain('renew')
+
+    const hrefs = disclosure.findAll('a').map((a) => a.attributes('href'))
+    expect(hrefs).toContain('https://example.test/terms')
+    expect(hrefs).toContain('https://example.test/privacy')
     wrapper.unmount()
   })
 })

--- a/frontend/tests/unit/views/SubscriptionViewBenefits.spec.ts
+++ b/frontend/tests/unit/views/SubscriptionViewBenefits.spec.ts
@@ -137,6 +137,7 @@ describe('SubscriptionView — plan benefits', () => {
  * subscription — not only in the paywall modal.
  */
 describe('SubscriptionView — purchase disclosure', () => {
+  const previousLocale = i18n.global.locale.value
   const previousScrollIntoView = Element.prototype.scrollIntoView
 
   beforeEach(() => {
@@ -145,17 +146,21 @@ describe('SubscriptionView — purchase disclosure', () => {
   })
 
   afterEach(() => {
+    i18n.global.locale.value = previousLocale
     Element.prototype.scrollIntoView = previousScrollIntoView
   })
 
   it('states the renewal terms and links to the terms and the privacy policy', async () => {
+    // Pinned, so the assertion below does not depend on whichever locale the
+    // runner happens to start in.
+    i18n.global.locale.value = 'de'
     mockGetPlans.mockResolvedValue({ plans: [plan('PRO')], stripeConfigured: true })
 
     const wrapper = mountView()
     await flushPromises()
 
     const disclosure = wrapper.get('[data-testid="section-purchase-disclosure"]')
-    expect(disclosure.text()).toContain('renew')
+    expect(disclosure.text()).toContain('Abonnements verlängern sich automatisch')
 
     const hrefs = disclosure.findAll('a').map((a) => a.attributes('href'))
     expect(hrefs).toContain('https://example.test/terms')

--- a/frontend/tests/unit/views/SubscriptionViewNativeGuard.spec.ts
+++ b/frontend/tests/unit/views/SubscriptionViewNativeGuard.spec.ts
@@ -47,7 +47,15 @@ vi.mock('@/stores/auth', () => ({
 }))
 
 vi.mock('@/stores/config', () => ({
-  useConfigStore: () => ({ billing: { enabled: true } }),
+  useConfigStore: () => ({
+    billing: { enabled: true },
+    // The view links to the legal pages (App Store Review Guideline 3.1.2);
+    // the real store always resolves these, falling back to the brand pages.
+    branding: {
+      termsUrl: 'https://example.test/terms',
+      privacyUrl: 'https://example.test/privacy',
+    },
+  }),
 }))
 
 vi.mock('@/composables/useDialog', () => ({

--- a/frontend/tests/unit/views/SubscriptionViewPreselect.spec.ts
+++ b/frontend/tests/unit/views/SubscriptionViewPreselect.spec.ts
@@ -40,7 +40,15 @@ vi.mock('@/stores/auth', () => ({
 }))
 
 vi.mock('@/stores/config', () => ({
-  useConfigStore: () => ({ billing: { enabled: true } }),
+  useConfigStore: () => ({
+    billing: { enabled: true },
+    // The view links to the legal pages (App Store Review Guideline 3.1.2);
+    // the real store always resolves these, falling back to the brand pages.
+    branding: {
+      termsUrl: 'https://example.test/terms',
+      privacyUrl: 'https://example.test/privacy',
+    },
+  }),
 }))
 
 vi.mock('@/composables/useDialog', () => ({


### PR DESCRIPTION
## Summary

App Store Review Guideline 3.1.2 requires four things on the surface that sells an auto-renewable subscription: the title, the length, the price, and **functional links to the terms of use and the privacy policy** — plus a clear statement that the subscription renews automatically.

`SubscriptionPaywallModal.vue` had all of it. `SubscriptionView.vue` — the `/subscription` page — had the title, length and price, but neither the renewal statement nor the legal links. That page is the one the iOS review screenshots point at and the one a reviewer lands on from the upgrade button, so this is a realistic rejection under 3.1.2.

This adds the same disclosure block the modal uses, reusing the existing `paywall.renewalNoteStore` / `paywall.renewalNoteWeb` and `auth.termsOfService` / `auth.privacyPolicy` keys, so all four locales are already covered and no new copy is introduced. The note switches between the store and the web wording exactly as the modal does.

Three `SubscriptionView` specs stubbed `useConfigStore` without `branding`. The real store exposes it unconditionally and falls back to the public brand pages when a deployment leaves it unset, so the stubs were simply incomplete; they now carry the field.

## Release classification

**store-required** — this changes what the purchase screen states about billing, so it must not ship over the air.

## Test plan

- [x] `make -C frontend lint`
- [x] `docker compose exec -T frontend npm run check:types`
- [x] `make -C frontend test` (979 passed)
- [ ] Verify on device that `/subscription` shows the renewal note and that both links open