### PR TITLE
fix(moderation): stop a blank operator inbox from breaking abuse reports

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -180,8 +180,10 @@ APP_SENDER_EMAIL=
 APP_SENDER_NAME=Synaplan
 
 # Operator inbox for incident + content-moderation alerts (Apple Guideline 1.2).
-# Falls back to APP_SENDER_EMAIL, then to team@synaplan.com, so abuse reports are
-# never silently dropped.
+# Set this on any deployment that accepts abuse reports: the store policies expect
+# an operator to review one within 24 hours, and nobody watches the fallbacks.
+# Left blank it falls back to APP_SENDER_EMAIL, then to team@synaplan.com, so a
+# report is never dropped.
 APP_ADMIN_EMAIL=
 
 

--- a/backend/src/Service/InternalEmailService.php
+++ b/backend/src/Service/InternalEmailService.php
@@ -385,12 +385,38 @@ final readonly class InternalEmailService
     }
 
     /**
+     * A configured address, or null when the variable is unset or blank.
+     */
+    private function configuredAddress(string $key): ?string
+    {
+        $address = trim((string) ($_ENV[$key] ?? ''));
+
+        return '' !== $address ? $address : null;
+    }
+
+    /**
+     * The operator inbox for incident and abuse alerts.
+     *
+     * `??` is not enough for this chain: `.env.example` ships APP_ADMIN_EMAIL
+     * blank, so every deployment that copied it has the key set to an empty
+     * string, which `??` happily returns instead of falling through. The
+     * moderation report Apple requires an operator to act on (Guideline 1.2)
+     * was then addressed to nobody and lost in a warning log.
+     */
+    private function operatorInbox(?string $default = null): ?string
+    {
+        return $this->configuredAddress('APP_ADMIN_EMAIL')
+            ?? $this->configuredAddress('APP_SENDER_EMAIL')
+            ?? $default;
+    }
+
+    /**
      * Send a warning email when the embedding fallback provider activates.
      */
     public function sendEmbeddingFallbackWarning(string $primaryProvider, string $fallbackProvider, string $errorMessage): void
     {
-        $adminEmail = $_ENV['APP_ADMIN_EMAIL'] ?? $_ENV['APP_SENDER_EMAIL'] ?? null;
-        if (!$adminEmail) {
+        $adminEmail = $this->operatorInbox();
+        if (null === $adminEmail) {
             $this->logger->debug('No admin email configured, skipping fallback warning');
 
             return;
@@ -455,8 +481,8 @@ final readonly class InternalEmailService
      */
     public function sendModerationReportEmail(array $report): void
     {
-        $adminEmail = $_ENV['APP_ADMIN_EMAIL'] ?? $_ENV['APP_SENDER_EMAIL'] ?? 'team@synaplan.com';
-        $fromEmail = $_ENV['APP_SENDER_EMAIL'] ?? 'noreply@synaplan.com';
+        $adminEmail = $this->operatorInbox('team@synaplan.com');
+        $fromEmail = $this->configuredAddress('APP_SENDER_EMAIL') ?? 'noreply@synaplan.com';
         $fromName = $_ENV['APP_SENDER_NAME'] ?? 'Synaplan';
 
         $reason = htmlspecialchars($report['reason'], ENT_QUOTES);

--- a/backend/src/Service/InternalEmailService.php
+++ b/backend/src/Service/InternalEmailService.php
@@ -65,7 +65,7 @@ final readonly class InternalEmailService
     public function sendVerificationEmail(string $to, string $token, string $locale = 'en'): void
     {
         $frontendUrl = $_ENV['FRONTEND_URL'] ?? $_ENV['APP_URL'] ?? 'http://localhost:5173';
-        $fromEmail = $_ENV['APP_SENDER_EMAIL'] ?? 'noreply@synaplan.com';
+        $fromEmail = $this->configuredAddress('APP_SENDER_EMAIL') ?? 'noreply@synaplan.com';
         $fromName = $_ENV['APP_SENDER_NAME'] ?? 'Synaplan';
 
         $verificationUrl = sprintf('%s/verify-email-callback?token=%s', $frontendUrl, $token);
@@ -99,7 +99,7 @@ final readonly class InternalEmailService
     public function sendPasswordResetEmail(string $to, string $token, string $locale = 'en'): void
     {
         $frontendUrl = $_ENV['FRONTEND_URL'] ?? $_ENV['APP_URL'] ?? 'http://localhost:5173';
-        $fromEmail = $_ENV['APP_SENDER_EMAIL'] ?? 'noreply@synaplan.com';
+        $fromEmail = $this->configuredAddress('APP_SENDER_EMAIL') ?? 'noreply@synaplan.com';
         $fromName = $_ENV['APP_SENDER_NAME'] ?? 'Synaplan';
 
         $resetUrl = sprintf('%s/reset-password?token=%s', $frontendUrl, $token);
@@ -133,7 +133,7 @@ final readonly class InternalEmailService
     public function sendWelcomeEmail(string $to, string $name, string $locale = 'en'): void
     {
         $frontendUrl = $_ENV['FRONTEND_URL'] ?? $_ENV['APP_URL'] ?? 'http://localhost:5173';
-        $fromEmail = $_ENV['APP_SENDER_EMAIL'] ?? 'noreply@synaplan.com';
+        $fromEmail = $this->configuredAddress('APP_SENDER_EMAIL') ?? 'noreply@synaplan.com';
         $fromName = $_ENV['APP_SENDER_NAME'] ?? 'Synaplan';
 
         // Translate subject
@@ -191,7 +191,7 @@ final readonly class InternalEmailService
         $smartAddress = ($originalRecipient && \App\Service\Email\SmartEmailHelper::isValidSmartAddress($originalRecipient))
             ? $originalRecipient
             : $fallbackAddress;
-        $fromEmail = $_ENV['APP_SENDER_EMAIL'] ?? 'smart@synaplan.net';
+        $fromEmail = $this->configuredAddress('APP_SENDER_EMAIL') ?? 'smart@synaplan.net';
         $fromName = $_ENV['APP_SENDER_NAME'] ?? 'Synaplan AI';
         $replyToEmail = $smartAddress;
 
@@ -312,7 +312,7 @@ final readonly class InternalEmailService
      */
     public function sendTaskResultEmail(string $to, string $subject, string $markdown, array $attachments = []): void
     {
-        $fromEmail = $_ENV['APP_SENDER_EMAIL'] ?? 'noreply@synaplan.com';
+        $fromEmail = $this->configuredAddress('APP_SENDER_EMAIL') ?? 'noreply@synaplan.com';
         $fromName = $_ENV['APP_SENDER_NAME'] ?? 'Synaplan';
 
         $parsedown = new \Parsedown();
@@ -399,9 +399,10 @@ final readonly class InternalEmailService
      *
      * `??` is not enough for this chain: `.env.example` ships APP_ADMIN_EMAIL
      * blank, so every deployment that copied it has the key set to an empty
-     * string, which `??` happily returns instead of falling through. The
-     * moderation report Apple requires an operator to act on (Guideline 1.2)
-     * was then addressed to nobody and lost in a warning log.
+     * string, which `??` happily returns instead of falling through. Building
+     * an Email for that empty recipient then throws, and the report controller
+     * turns the exception into a 400 — so the abuse report Apple requires
+     * (Guideline 1.2) failed in the user's face.
      */
     private function operatorInbox(?string $default = null): ?string
     {
@@ -422,7 +423,7 @@ final readonly class InternalEmailService
             return;
         }
 
-        $fromEmail = $_ENV['APP_SENDER_EMAIL'] ?? 'noreply@synaplan.com';
+        $fromEmail = $this->configuredAddress('APP_SENDER_EMAIL') ?? 'noreply@synaplan.com';
         $fromName = $_ENV['APP_SENDER_NAME'] ?? 'Synaplan';
         $timestamp = (new \DateTimeImmutable())->format('Y-m-d H:i:s T');
 
@@ -474,8 +475,9 @@ final readonly class InternalEmailService
      * Notify the operator inbox about a new content report (Apple Guideline 1.2).
      *
      * Sent to APP_ADMIN_EMAIL, falling back to the sender address and finally the
-     * fixed abuse contact so a report is never silently dropped. Best-effort: a
-     * transport failure is logged, never surfaced to the reporting user.
+     * fixed abuse contact so a report is never silently dropped. Best-effort: an
+     * unusable address or a transport failure is logged, never surfaced to the
+     * reporting user — the report itself is already stored.
      *
      * @param array{id:int,contentType:string,contentId:int,reason:string,details:?string,reporterId:int,reporterEmail:?string,reportedUserId:?int,reportedUserEmail:?string,created:string} $report
      */
@@ -521,14 +523,17 @@ final readonly class InternalEmailService
             </div>
             HTML;
 
-        $email = (new Email())
-            ->from(sprintf('%s <%s>', $fromName, $fromEmail))
-            ->to($adminEmail)
-            ->subject('[MODERATION][Synaplan] Content report #'.$report['id'].' — '.$report['reason'])
-            ->priority(Email::PRIORITY_HIGH)
-            ->html($html);
-
+        // Building the Email is inside the guard on purpose: a typo in the
+        // configured address makes ->to() throw an InvalidArgumentException,
+        // which the report controller would hand the user as a 400.
         try {
+            $email = (new Email())
+                ->from(sprintf('%s <%s>', $fromName, $fromEmail))
+                ->to($adminEmail)
+                ->subject('[MODERATION][Synaplan] Content report #'.$report['id'].' — '.$report['reason'])
+                ->priority(Email::PRIORITY_HIGH)
+                ->html($html);
+
             $this->sendWithRetry($email);
             $this->logger->info('Moderation report email sent', ['to' => $adminEmail, 'report_id' => $report['id']]);
         } catch (\Exception $e) {

--- a/backend/tests/Unit/InternalEmailServiceTest.php
+++ b/backend/tests/Unit/InternalEmailServiceTest.php
@@ -8,6 +8,9 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\Mailer\Exception\TransportException;
 use Symfony\Component\Mailer\Exception\UnexpectedResponseException;
 use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\Email;
+use Symfony\Component\Mime\RawMessage;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Environment;
 
@@ -157,7 +160,7 @@ class InternalEmailServiceTest extends TestCase
     /**
      * Service whose mailer captures the (single) sent email into $captured.
      */
-    private function taskResultService(?\Symfony\Component\Mime\Email &$captured): InternalEmailService
+    private function taskResultService(?Email &$captured): InternalEmailService
     {
         $mailer = $this->createMock(MailerInterface::class);
         $mailer->expects($this->once())
@@ -320,5 +323,96 @@ class InternalEmailServiceTest extends TestCase
 
         $this->serviceWithMailer($mailer)
             ->sendTaskResultEmail('owner@example.com', 'Your results', 'Body.');
+    }
+
+    // ---- operator inbox for abuse reports (App Store Review Guideline 1.2) ----
+
+    /**
+     * `.env.example` ships APP_ADMIN_EMAIL blank, so a deployment that copied it
+     * has the key set to an empty string. `??` returns that empty string instead
+     * of falling through, and the report Apple requires an operator to act on
+     * was addressed to nobody.
+     */
+    public function testAbuseReportFallsBackWhenTheAdminInboxIsBlank(): void
+    {
+        $recipients = $this->recipientsOfModerationReport([
+            'APP_ADMIN_EMAIL' => '',
+            'APP_SENDER_EMAIL' => 'ops@example.test',
+        ]);
+
+        self::assertSame(['ops@example.test'], $recipients);
+    }
+
+    /** With neither address configured the report still reaches the abuse contact. */
+    public function testAbuseReportReachesTheFixedContactWhenNothingIsConfigured(): void
+    {
+        $recipients = $this->recipientsOfModerationReport([
+            'APP_ADMIN_EMAIL' => '   ',
+            'APP_SENDER_EMAIL' => '',
+        ]);
+
+        self::assertSame(['team@synaplan.com'], $recipients);
+    }
+
+    /** A configured operator inbox wins over both fallbacks. */
+    public function testAbuseReportPrefersTheConfiguredOperatorInbox(): void
+    {
+        $recipients = $this->recipientsOfModerationReport([
+            'APP_ADMIN_EMAIL' => 'abuse@example.test',
+            'APP_SENDER_EMAIL' => 'ops@example.test',
+        ]);
+
+        self::assertSame(['abuse@example.test'], $recipients);
+    }
+
+    /**
+     * @param array<string, string> $env
+     *
+     * @return list<string>
+     */
+    private function recipientsOfModerationReport(array $env): array
+    {
+        $previous = [];
+        foreach ($env as $key => $value) {
+            $previous[$key] = $_ENV[$key] ?? null;
+            $_ENV[$key] = $value;
+        }
+
+        $recipients = [];
+        $mailer = $this->createMock(MailerInterface::class);
+        $mailer->expects($this->once())
+            ->method('send')
+            ->willReturnCallback(function (RawMessage $message) use (&$recipients): void {
+                self::assertInstanceOf(Email::class, $message);
+                $recipients = array_map(
+                    static fn (Address $address): string => $address->getAddress(),
+                    $message->getTo(),
+                );
+            });
+
+        try {
+            $this->serviceWithMailer($mailer)->sendModerationReportEmail([
+                'id' => 7,
+                'contentType' => 'message',
+                'contentId' => 42,
+                'reason' => 'hate_speech',
+                'details' => null,
+                'reporterId' => 1,
+                'reporterEmail' => 'reporter@example.test',
+                'reportedUserId' => null,
+                'reportedUserEmail' => null,
+                'created' => '2026-08-01 12:00:00',
+            ]);
+        } finally {
+            foreach ($previous as $key => $value) {
+                if (null === $value) {
+                    unset($_ENV[$key]);
+                } else {
+                    $_ENV[$key] = $value;
+                }
+            }
+        }
+
+        return $recipients;
     }
 }

--- a/backend/tests/Unit/InternalEmailServiceTest.php
+++ b/backend/tests/Unit/InternalEmailServiceTest.php
@@ -366,6 +366,31 @@ class InternalEmailServiceTest extends TestCase
     }
 
     /**
+     * A report is stored before the notification is attempted, so a bad operator
+     * address must never travel back to the reporting user. The controller maps
+     * InvalidArgumentException to a 400 with the raw message, which is exactly
+     * what an App Review tester would see.
+     */
+    public function testAnUnusableOperatorAddressNeverReachesTheReportingUser(): void
+    {
+        $previous = $_ENV['APP_ADMIN_EMAIL'] ?? null;
+        $_ENV['APP_ADMIN_EMAIL'] = 'not an address';
+
+        $mailer = $this->createMock(MailerInterface::class);
+        $mailer->expects($this->never())->method('send');
+
+        try {
+            $this->serviceWithMailer($mailer)->sendModerationReportEmail($this->moderationReport());
+        } finally {
+            if (null === $previous) {
+                unset($_ENV['APP_ADMIN_EMAIL']);
+            } else {
+                $_ENV['APP_ADMIN_EMAIL'] = $previous;
+            }
+        }
+    }
+
+    /**
      * @param array<string, string> $env
      *
      * @return list<string>
@@ -391,18 +416,7 @@ class InternalEmailServiceTest extends TestCase
             });
 
         try {
-            $this->serviceWithMailer($mailer)->sendModerationReportEmail([
-                'id' => 7,
-                'contentType' => 'message',
-                'contentId' => 42,
-                'reason' => 'hate_speech',
-                'details' => null,
-                'reporterId' => 1,
-                'reporterEmail' => 'reporter@example.test',
-                'reportedUserId' => null,
-                'reportedUserEmail' => null,
-                'created' => '2026-08-01 12:00:00',
-            ]);
+            $this->serviceWithMailer($mailer)->sendModerationReportEmail($this->moderationReport());
         } finally {
             foreach ($previous as $key => $value) {
                 if (null === $value) {
@@ -414,5 +428,24 @@ class InternalEmailServiceTest extends TestCase
         }
 
         return $recipients;
+    }
+
+    /**
+     * @return array{id:int,contentType:string,contentId:int,reason:string,details:?string,reporterId:int,reporterEmail:?string,reportedUserId:?int,reportedUserEmail:?string,created:string}
+     */
+    private function moderationReport(): array
+    {
+        return [
+            'id' => 7,
+            'contentType' => 'message',
+            'contentId' => 42,
+            'reason' => 'hate_speech',
+            'details' => null,
+            'reporterId' => 1,
+            'reporterEmail' => 'reporter@example.test',
+            'reportedUserId' => null,
+            'reportedUserEmail' => null,
+            'created' => '2026-08-01 12:00:00',
+        ];
     }
 }


### PR DESCRIPTION
## Summary

`InternalEmailService` resolved the operator inbox with `$_ENV['APP_ADMIN_EMAIL'] ?? $_ENV['APP_SENDER_EMAIL'] ?? 'team@synaplan.com'`. `??` only falls through on **null**, and `backend/.env.example` ships `APP_ADMIN_EMAIL=` blank — so every deployment that copied the example has the key set to an empty string, and the chain returns `""` rather than reaching either fallback. The docblock promised a fallback the code could not deliver.

That empty address goes straight into `Email::to()`, which rejects it with an `InvalidArgumentException`. `ContentReportController` catches `InvalidArgumentException` **before** its generic handler and returns it as a `400` with the raw message, so a user tapping "Report" on an AI message sees:

> Email "" does not comply with addr-spec of RFC 2822.

The report row is written first, so nothing is lost — but the user-facing mechanism appears broken and leaks an internal error string. This is the mechanism App Store Review Guideline 1.2 requires for AI-generated content, so a reviewer hitting it is a likely rejection.

Both addresses now resolve through a helper that treats a blank value as unset. The incident-alert path used the same chain with an `if (!$adminEmail)` guard, so it degraded quietly instead of throwing; it shares the helper now and actually reaches `APP_SENDER_EMAIL` when the admin inbox is blank.

## Test plan

- [x] `make -C backend lint`
- [x] `make -C backend phpstan` (no errors)
- [x] `make -C backend test` (3032 passed)
- [x] Confirmed the new tests fail without the fix — `Address` throws on the empty recipient, exactly as production would