### PR TITLE
fix: minor i18n gaps and Gemini TTS suggested default

### DIFF
--- a/backend/src/Seed/DefaultModelConfigSeeder.php
+++ b/backend/src/Seed/DefaultModelConfigSeeder.php
@@ -50,7 +50,10 @@ final readonly class DefaultModelConfigSeeder
         // Standard — an image-to-video model. Shares the text2vid BTAG (see
         // ModelCatalog::CAPABILITY_TAGS) but has its own default slot.
         ['group' => 'DEFAULTMODEL', 'setting' => 'IMG2VID',    'modelKey' => 'higgsfield:higgsfield-ai/dop/standard:text2vid'],
-        ['group' => 'DEFAULTMODEL', 'setting' => 'TEXT2SOUND', 'modelKey' => 'piper:piper-multi:text2sound'],
+        // Gemini 2.5 Flash TTS: natural DE/EN without Piper's accent issues.
+        // Applied via "select suggested models" / new-user defaults; existing
+        // installs are not silently rewritten (seeder is insert-if-missing).
+        ['group' => 'DEFAULTMODEL', 'setting' => 'TEXT2SOUND', 'modelKey' => 'google:gemini-2.5-flash-preview-tts:text2sound'],
         ['group' => 'DEFAULTMODEL', 'setting' => 'PIC2TEXT',   'modelKey' => 'groq:meta-llama/llama-4-scout-17b-16e-instruct:pic2text'],
         ['group' => 'DEFAULTMODEL', 'setting' => 'SOUND2TEXT', 'modelKey' => 'groq:whisper-large-v3:sound2text'],
         ['group' => 'DEFAULTMODEL', 'setting' => 'ANALYZE',    'modelKey' => 'anthropic:claude-sonnet-5:chat'],

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -1141,7 +1141,8 @@
     "copied": "In die Zwischenablage kopiert",
     "copyFailed": "Kopieren fehlgeschlagen",
     "expand": "Text anzeigen",
-    "collapse": "Text ausblenden"
+    "collapse": "Text ausblenden",
+    "redundantCollapsed": "Schrittausgabe eingeklappt — zum Prüfen aufklappen oder die Antwort unten lesen."
   },
   "processing": {
     "started": "Starte Verarbeitung...",
@@ -2345,7 +2346,8 @@
     "remove": "Entfernen",
     "clearSelection": "Auswahl aufheben",
     "view": "Ansehen",
-    "expand": "Erweitern"
+    "expand": "Erweitern",
+    "noResults": "Keine Ergebnisse"
   },
   "search": {
     "sources": "Quellen",
@@ -2499,9 +2501,14 @@
     "noSearchResults": "Keine Dateien für \"{query}\" gefunden",
     "noSearchResultsHint": "Versuche einen anderen Begriff oder passe die Filter an.",
     "filterToggle": "Filter",
+    "filterType": "Typ",
     "filterTypeAll": "Alle Typen",
+    "filterTypePdf": "PDF",
+    "filterTypeDocx": "Word (DOCX)",
+    "filterTypeTxt": "Text",
     "filterTypeImages": "Bilder",
     "filterTypeAudio": "Audio/Video",
+    "filterTypeSpreadsheet": "Tabelle",
     "filterDateFrom": "Von",
     "filterDateTo": "Bis",
     "tabFiles": "Dateien",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -967,9 +967,14 @@
     "noSearchResults": "No files matching \"{query}\"",
     "noSearchResultsHint": "Try a different term or adjust the filters.",
     "filterToggle": "Filters",
+    "filterType": "Type",
     "filterTypeAll": "All types",
+    "filterTypePdf": "PDF",
+    "filterTypeDocx": "Word (DOCX)",
+    "filterTypeTxt": "Text",
     "filterTypeImages": "Images",
     "filterTypeAudio": "Audio/Video",
+    "filterTypeSpreadsheet": "Spreadsheet",
     "filterDateFrom": "From",
     "filterDateTo": "To",
     "tabFiles": "Files",
@@ -2322,7 +2327,8 @@
     "remove": "Remove",
     "clearSelection": "Clear selection",
     "view": "View",
-    "expand": "Expand"
+    "expand": "Expand",
+    "noResults": "No results"
   },
   "search": {
     "sources": "Sources",
@@ -3561,7 +3567,8 @@
     "copied": "Copied to clipboard",
     "copyFailed": "Could not copy",
     "expand": "Show text",
-    "collapse": "Hide text"
+    "collapse": "Hide text",
+    "redundantCollapsed": "Step output collapsed — expand to inspect, or read the answer below."
   },
   "processing": {
     "started": "Starting processing...",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -976,7 +976,8 @@
     "enabled": "Habilitado",
     "disabled": "Deshabilitado",
     "reset": "Restablecer",
-    "expand": "Expandir"
+    "expand": "Expandir",
+    "noResults": "Sin resultados"
   },
   "search": {
     "sources": "Fuentes",
@@ -1480,7 +1481,8 @@
     "copied": "Copiado al portapapeles",
     "copyFailed": "No se pudo copiar",
     "expand": "Mostrar texto",
-    "collapse": "Ocultar texto"
+    "collapse": "Ocultar texto",
+    "redundantCollapsed": "Salida del paso oculta — expande para verla o lee la respuesta abajo."
   },
   "processing": {
     "started": "Iniciando procesamiento...",
@@ -1935,9 +1937,14 @@
     "noSearchResults": "No hay archivos que coincidan con \"{query}\"",
     "noSearchResultsHint": "Prueba con otro término o ajusta los filtros.",
     "filterToggle": "Filtros",
+    "filterType": "Tipo",
     "filterTypeAll": "Todos los tipos",
+    "filterTypePdf": "PDF",
+    "filterTypeDocx": "Word (DOCX)",
+    "filterTypeTxt": "Texto",
     "filterTypeImages": "Imágenes",
     "filterTypeAudio": "Audio/Vídeo",
+    "filterTypeSpreadsheet": "Hoja de cálculo",
     "filterDateFrom": "Desde",
     "filterDateTo": "Hasta",
     "tabFiles": "Archivos",

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -976,7 +976,8 @@
     "enabled": "Etkin",
     "disabled": "Devre Dışı",
     "reset": "Sıfırla",
-    "expand": "Genişlet"
+    "expand": "Genişlet",
+    "noResults": "Sonuç bulunamadı"
   },
   "search": {
     "sources": "Kaynaklar",
@@ -1480,7 +1481,8 @@
     "copied": "Panoya kopyalandı",
     "copyFailed": "Kopyalanamadı",
     "expand": "Metni göster",
-    "collapse": "Metni gizle"
+    "collapse": "Metni gizle",
+    "redundantCollapsed": "Adım çıktısı daraltıldı — incelemek için genişletin veya aşağıdaki yanıtı okuyun."
   },
   "processing": {
     "started": "İşlem başlatılıyor...",
@@ -1936,9 +1938,14 @@
     "noSearchResults": "\"{query}\" ile eşleşen dosya yok",
     "noSearchResultsHint": "Farklı bir terim dene veya filtreleri ayarla.",
     "filterToggle": "Filtreler",
+    "filterType": "Tür",
     "filterTypeAll": "Tüm türler",
+    "filterTypePdf": "PDF",
+    "filterTypeDocx": "Word (DOCX)",
+    "filterTypeTxt": "Metin",
     "filterTypeImages": "Görseller",
     "filterTypeAudio": "Ses/Video",
+    "filterTypeSpreadsheet": "Tablo",
     "filterDateFrom": "Başlangıç",
     "filterDateTo": "Bitiş",
     "tabFiles": "Dosyalar",


### PR DESCRIPTION
## Summary
- Restore missing i18n keys that showed as raw labels: `common.noResults`, `taskPlan.redundantCollapsed`, and Sources file-type filter labels (`files.filterType*`).
- Change the recommended TEXT2SOUND default from Piper to Gemini 2.5 Flash TTS for natural DE/EN speech when users click "Select suggested models" or get new-user defaults.
- Existing installs are not silently rewritten (seeder is insert-if-missing only).

## Test plan
- [ ] Open Recent Conversations, search for something with no hits → shows translated "No results" (not `common.noResults`)
- [ ] Run a multitask turn with a collapsed Answer card → collapsed hint is translated (not `taskPlan.redundantCollapsed`)
- [ ] Sources → Filters → Type dropdown → label and PDF/Word/Text/Spreadsheet options are translated
- [ ] AI Models → Select suggested models → Speech synthesis is Gemini 2.5 Flash TTS
- [ ] Confirm a user who already had a custom TTS selection keeps it until they click suggested models