### PR TITLE
fix(models): apply OpenAI 2026-07-30 GPT-5.6 Terra/Luna price cut

### DIFF
--- a/.github/workflows/price-drift.yml
+++ b/.github/workflows/price-drift.yml
@@ -110,6 +110,7 @@ jobs:
 
       - name: Open or update drift issue
         if: failure() && steps.drift.outputs.exit_code == '2'
+        working-directory: backend
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/backend/migrations/Version20260803120000.php
+++ b/backend/migrations/Version20260803120000.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Roll out OpenAI's 2026-07-30 GPT-5.6 price cut to existing installs.
+ *
+ * OpenAI cut GPT-5.6 API prices on 2026-07-30
+ * (https://developers.openai.com/api/docs/pricing):
+ *
+ *   - Terra: 2.50 / 15.00 -> 2.00 / 12.00 per 1M tokens (-20%)
+ *   - Luna:  1.00 /  6.00 -> 0.20 /  1.20 per 1M tokens (-80%)
+ *   - Sol:   unchanged.
+ *
+ * ModelCatalog is the source of truth and ModelSeeder rolls the new values into
+ * BMODELS on deploy — but only for rows still matching their last-seeded
+ * fingerprint. Rows an operator edited via the admin UI are PRESERVED and never
+ * auto-updated. Because these are billing corrections that must reach every
+ * install (costs are resold at raw + markup, so the stale higher price
+ * OVERCHARGES customers on every Terra/Luna call), this migration force-applies
+ * the new base rates via explicit, idempotent UPDATEs keyed by BPROVID — the
+ * same approach as Version20260713190000. Keying by BPROVID updates the chat and
+ * vision rows of each model together.
+ *
+ * The long-context (>272k) tier lives only in ModelCatalog::CONTEXT_PRICING and
+ * is read from the current catalog at billing time, so the tier update ships
+ * with the deploy and needs no migration.
+ *
+ * Operator-owned columns (BSELECTABLE, BACTIVE, BISDEFAULT, BSHOWWHENFREE) are
+ * never touched. Idempotent (fixed UPDATEs re-run to the same result) and
+ * raw-SQL only (no Schema API), so it is safe on the shared MariaDB Galera
+ * cluster.
+ *
+ * @see \App\Model\ModelCatalog
+ * @see Version20260713190000
+ */
+final class Version20260803120000 extends AbstractMigration
+{
+    /**
+     * providerId => [newIn, newOut, oldIn, oldOut] (per 1M tokens).
+     *
+     * @var array<string, array{0: float, 1: float, 2: float, 3: float}>
+     */
+    private const TOKEN_PRICES = [
+        'gpt-5.6-terra' => [2.00, 12.00, 2.50, 15.00],
+        'gpt-5.6-luna' => [0.20, 1.20, 1.00, 6.00],
+    ];
+
+    public function getDescription(): string
+    {
+        return "Roll out OpenAI's 2026-07-30 GPT-5.6 price cut (Terra 2.50/15 -> 2.00/12, "
+            .'Luna 1.00/6 -> 0.20/1.20) to BMODELS so existing installs bill the current rates '
+            .'regardless of the seeder fingerprint.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        foreach (self::TOKEN_PRICES as $provid => [$in, $out]) {
+            $this->addSql(
+                'UPDATE BMODELS SET BPRICEIN = :in, BPRICEOUT = :out WHERE BPROVID = :provid',
+                ['in' => $in, 'out' => $out, 'provid' => $provid]
+            );
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        foreach (self::TOKEN_PRICES as $provid => [, , $oldIn, $oldOut]) {
+            $this->addSql(
+                'UPDATE BMODELS SET BPRICEIN = :in, BPRICEOUT = :out WHERE BPROVID = :provid',
+                ['in' => $oldIn, 'out' => $oldOut, 'provid' => $provid]
+            );
+        }
+    }
+}

--- a/backend/src/Model/ModelCatalog.php
+++ b/backend/src/Model/ModelCatalog.php
@@ -82,8 +82,8 @@ class ModelCatalog
         'gpt-5.5' => ['threshold_tokens' => 272000, 'price_in_above' => 10.0, 'price_out_above' => 45.0],
         'gpt-5.5-pro' => ['threshold_tokens' => 272000, 'price_in_above' => 60.0, 'price_out_above' => 270.0],
         'gpt-5.6-sol' => ['threshold_tokens' => 272000, 'price_in_above' => 10.0, 'price_out_above' => 45.0],
-        'gpt-5.6-terra' => ['threshold_tokens' => 272000, 'price_in_above' => 5.0, 'price_out_above' => 22.5],
-        'gpt-5.6-luna' => ['threshold_tokens' => 272000, 'price_in_above' => 2.0, 'price_out_above' => 9.0],
+        'gpt-5.6-terra' => ['threshold_tokens' => 272000, 'price_in_above' => 4.0, 'price_out_above' => 18.0],
+        'gpt-5.6-luna' => ['threshold_tokens' => 272000, 'price_in_above' => 0.40, 'price_out_above' => 1.80],
         'gemini-2.5-pro' => ['threshold_tokens' => 200000, 'price_in_above' => 2.5, 'price_out_above' => 15.0],
         'gemini-3.1-pro-preview' => ['threshold_tokens' => 200000, 'price_in_above' => 4.0, 'price_out_above' => 18.0],
         'grok-4.5' => ['threshold_tokens' => 200000, 'price_in_above' => 4.0, 'price_out_above' => 12.0],
@@ -1057,7 +1057,10 @@ class ModelCatalog
         // Sol: flagship. Terra: balanced, ~GPT-5.5-competitive. Luna:
         // fastest / most affordable. All use the Responses API, support
         // configurable reasoning effort and vision.
-        // Pricing per 1M tokens from the launch announcement.
+        // Pricing per 1M tokens from https://developers.openai.com/api/docs/pricing.
+        // 2026-07-30 price cut: Terra 2.50/15 -> 2.00/12 (-20%), Luna 1.00/6 ->
+        // 0.20/1.20 (-80%); Sol unchanged. Long-context (>272k) tiers updated in
+        // CONTEXT_PRICING accordingly.
         // ----------------------------------------------------------------
         [
             'id' => 251,
@@ -1121,9 +1124,9 @@ class ModelCatalog
             'selectable' => 1,
             'active' => 1,
             'providerId' => 'gpt-5.6-terra',
-            'priceIn' => 2.50,
+            'priceIn' => 2.00,
             'inUnit' => 'per1M',
-            'priceOut' => 15,
+            'priceOut' => 12,
             'outUnit' => 'per1M',
             'quality' => 9,
             'rating' => 1,
@@ -1148,9 +1151,9 @@ class ModelCatalog
             'selectable' => 1,
             'active' => 1,
             'providerId' => 'gpt-5.6-terra',
-            'priceIn' => 2.50,
+            'priceIn' => 2.00,
             'inUnit' => 'per1M',
-            'priceOut' => 15,
+            'priceOut' => 12,
             'outUnit' => 'per1M',
             'quality' => 9,
             'rating' => 1,
@@ -1175,9 +1178,9 @@ class ModelCatalog
             'selectable' => 1,
             'active' => 1,
             'providerId' => 'gpt-5.6-luna',
-            'priceIn' => 1,
+            'priceIn' => 0.20,
             'inUnit' => 'per1M',
-            'priceOut' => 6,
+            'priceOut' => 1.20,
             'outUnit' => 'per1M',
             'quality' => 9,
             'rating' => 1,
@@ -1202,9 +1205,9 @@ class ModelCatalog
             'selectable' => 1,
             'active' => 1,
             'providerId' => 'gpt-5.6-luna',
-            'priceIn' => 1,
+            'priceIn' => 0.20,
             'inUnit' => 'per1M',
-            'priceOut' => 6,
+            'priceOut' => 1.20,
             'outUnit' => 'per1M',
             'quality' => 9,
             'rating' => 1,

--- a/docs/PRICING_MAINTENANCE.md
+++ b/docs/PRICING_MAINTENANCE.md
@@ -262,9 +262,11 @@ Dry-run baseline 2026-07-13: **70 unchanged (per-token + same-mode media, no dri
 
 ### Automated weekly drift check (CI)
 
-`.github/workflows/price-drift.yml` runs every Monday (and on manual dispatch): it seeds the catalog and runs `app:sync-model-prices --dry-run --fail-on-drift`. The flag exits with code **2** when any per-token model **or** any same-mode non-per-token model (whisper/tts/veo/imagen) differs from LiteLLM. Mode-mismatch and unmatched rows never trip it (no false alarms). On drift the workflow opens — or comments on an existing — GitHub issue titled "Price drift detected …" with the dry-run report, so a human verifies against the official page and updates `ModelCatalog.php`. It lives outside the PR CI on purpose: it depends on the external LiteLLM source, which must never turn a code PR red.
+`.github/workflows/price-drift.yml` runs every Monday (and on manual dispatch): it seeds the catalog and runs `app:sync-model-prices --dry-run --fail-on-drift`. The flag exits with code **2** when any per-token model **or** any same-mode non-per-token model (whisper/tts/veo/imagen) differs from LiteLLM. Mode-mismatch and unmatched rows never trip it (no false alarms). On drift the workflow opens — or comments on an existing — GitHub issue titled "Price drift detected …" with the dry-run report, so a human verifies against the official page and updates `ModelCatalog.php`. It lives outside the PR CI on purpose: it depends on the external LiteLLM source, which must never turn a code PR red. The report file is written under `backend/` (the check step's `working-directory`), so the issue-opening step must also run with `working-directory: backend` — otherwise `cat drift-report.txt` fails with `No such file or directory` and the step dies under `bash -e` before the issue is created.
 
 You can run the same check locally: `docker compose exec -T backend php bin/console app:sync-model-prices --dry-run --fail-on-drift; echo $?` (0 = no drift, 2 = drift).
+
+> Resolved drift (2026-08-03): the weekly check flagged `gpt-5.6-terra` and `gpt-5.6-luna` (each twice — chat + vision row). Verified against the [official OpenAI pricing](https://developers.openai.com/api/docs/pricing): OpenAI cut GPT-5.6 prices on 2026-07-30 — Terra 2.50/15 → **2.00/12** (−20%), Luna 1.00/6 → **0.20/1.20** (−80%), Sol unchanged. Not a LiteLLM error; keeping the old (higher) rate overcharged every Terra/Luna call. Applied to `ModelCatalog.php` (base rows + `CONTEXT_PRICING` long-context tiers: Terra 4.00/18, Luna 0.40/1.80) and rolled out to existing installs by `Version20260803120000`.
 
 > History (2026-07-13): an earlier draft claimed whisper's `0.111 perhour` was "the same price" as the sync's per-second value. That was wrong at the time — `perhour` fell through `normaliseToPerUnit()` unchanged and whisper carried no `pricing_mode`. #1314 fixed both: whisper/Voxtral now carry `pricing_mode: per_second` and `normaliseToPerUnit()` converts `perhour`/`permin` down to per-second, and `AiFacade::transcribe()` records the provider-reported audio duration (see below).
 
@@ -342,10 +344,11 @@ Some providers charge a higher per-token rate for the **whole request** once the
 
 | Model | Threshold | Base in/out (per 1M) | Above in/out (per 1M) |
 | ----- | --------- | -------------------- | --------------------- |
-| gpt-5.4 / gpt-5.6-terra | 272k | 2.50 / 15 | 5.00 / 22.50 |
+| gpt-5.4 | 272k | 2.50 / 15 | 5.00 / 22.50 |
+| gpt-5.6-terra | 272k | 2.00 / 12 | 4.00 / 18 |
 | gpt-5.5 / gpt-5.6-sol | 272k | 5.00 / 30 | 10.00 / 45 |
 | gpt-5.5-pro | 272k | 30 / 180 | 60 / 270 |
-| gpt-5.6-luna | 272k | 1.00 / 6 | 2.00 / 9 |
+| gpt-5.6-luna | 272k | 0.20 / 1.20 | 0.40 / 1.80 |
 | gemini-2.5-pro | 200k | 1.25 / 10 | 2.50 / 15 |
 | gemini-3.1-pro-preview | 200k | 2.00 / 12 | 4.00 / 18 |
 


### PR DESCRIPTION
## Summary

The weekly [Price Drift Check](../actions/workflows/price-drift.yml) flagged `gpt-5.6-terra` and `gpt-5.6-luna` as diverging from LiteLLM. **Verified against the [official OpenAI pricing page](https://developers.openai.com/api/docs/pricing):** OpenAI cut GPT-5.6 API prices on **2026-07-30** — Terra −20%, Luna −80%, Sol unchanged. This is a real provider change, not a LiteLLM data error. Since costs are resold at a 10% markup, the stale (higher) catalog price **overcharged every Terra/Luna call**.

| Model | Base in/out | Long-context (>272k) in/out |
| --- | --- | --- |
| `gpt-5.6-terra` | 2.50/15 → **2.00/12** | 5.00/22.50 → **4.00/18** |
| `gpt-5.6-luna` | 1.00/6 → **0.20/1.20** | 2.00/9 → **0.40/1.80** |

## Changes

- **`ModelCatalog.php`** — base rows (chat + vision) for Terra/Luna, plus the `CONTEXT_PRICING` long-context tiers (these are **not** covered by the drift check, so they'd otherwise silently stay stale). Source comment updated with the official URL + cut date.
- **`Version20260803120000`** — idempotent raw `UPDATE BMODELS` keyed by `BPROVID`, so the correction reaches existing installs whose rows an operator edited (the seeder preserves those). Same pattern as `Version20260713190000`; no Schema API, Galera-safe.
- **`price-drift.yml`** — the issue-opening step now runs with `working-directory: backend`. The report is written to `backend/drift-report.txt`, but that step ran in the repo root, so `cat drift-report.txt` failed and the step died under `bash -e` **before** creating the issue (this is why run #3 went red at "Open or update drift issue").
- **`PRICING_MAINTENANCE.md`** — split the now-diverging `gpt-5.4 / gpt-5.6-terra` long-context row, recorded the resolved drift, and documented the workflow fix.

## Test plan

- [x] `make -C backend lint` — clean
- [x] `make -C backend phpstan` (src/ + tests/) — no errors
- [x] `make -C backend test` — only pre-existing, environment-dependent failure `ApplyProviderDefaultsCommandTest::testAutoModeExitsSuccessfullyAndReportsWhatItDid` (confirmed it fails identically on the base commit — this sandbox has no cloud provider keys; unrelated to this diff)
- [x] `app:seed` + `app:sync-model-prices --dry-run --fail-on-drift` → **exit 0** (drift resolved, Terra/Luna now match LiteLLM/official)
- [x] Migration applied cleanly locally (`doctrine:migrations:migrate`)
- [ ] CI green (backend PHPUnit runs with a provider-key test env, so the local environmental failure should not appear)