### PR TITLE
test(e2e): stabilize flaky impersonation, logout, and chat specs

### DIFF
--- a/frontend/tests/e2e/helpers/chat.ts
+++ b/frontend/tests/e2e/helpers/chat.ts
@@ -44,7 +44,14 @@ export class ChatHelper {
     // waitFor({ state: 'visible' }) re-resolves the locator and is stable.
     // Subsequent inner-locator waits and Playwright's own auto-scroll handle
     // any viewport positioning needed for downstream interactions.
-    await newBubble.waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
+    //
+    // The bubble mounts on the first SSE token / optimistic render. Under CI
+    // parallel load (2 shards × chromium/firefox) that first paint routinely
+    // exceeds STANDARD (10s) — "waiting assistant-message-bubble (10s)" was the
+    // single most common flaky signature across the chat specs. VERY_LONG for
+    // this prerequisite wait absorbs the load; a genuine stream hang still fails
+    // fast at the done/error race below, so this does not mask real breakage.
+    await newBubble.waitFor({ state: 'visible', timeout: TIMEOUTS.VERY_LONG })
 
     const result = await Promise.race([
       newBubble

--- a/frontend/tests/e2e/tests/admin-impersonation-chat.spec.ts
+++ b/frontend/tests/e2e/tests/admin-impersonation-chat.spec.ts
@@ -60,7 +60,7 @@ test.describe('@ci @smoke Admin impersonation + chat', () => {
 
       await page
         .locator(selectors.dialog.confirmBtn)
-        .waitFor({ state: 'visible', timeout: TIMEOUTS.SHORT })
+        .waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
       await page.locator(selectors.dialog.confirmBtn).click()
     })
 
@@ -76,7 +76,11 @@ test.describe('@ci @smoke Admin impersonation + chat', () => {
     await test.step('Act: send a message and receive TestProvider response', async () => {
       await chat.startNewChat()
       const previousCount = await chat.sendMessage(PROMPTS.CHAT_SMOKE)
-      const aiText = await chat.waitForAnswer(previousCount)
+      // The first turn runs right after an impersonation session swap
+      // (realtime teardown/resubscribe + config reload in startImpersonation),
+      // so the full stream to `message-done` legitimately needs the VERY_LONG
+      // tier, not LONG — otherwise it flakes on a 15s timeout under CI load.
+      const aiText = await chat.waitForAnswer(previousCount, true)
       expect(aiText.length).toBeGreaterThan(0)
     })
 

--- a/frontend/tests/e2e/tests/admin-impersonation-chat.spec.ts
+++ b/frontend/tests/e2e/tests/admin-impersonation-chat.spec.ts
@@ -12,6 +12,9 @@ test.describe('@ci @smoke Admin impersonation + chat', () => {
     request,
     credentials,
   }) => {
+    // Admin UI login + navigation + impersonate + a full chat stream (on the
+    // longTimeout tier) exceed the 60s default under CI load; give headroom.
+    test.setTimeout(TIMEOUTS.EXTREME + TIMEOUTS.VERY_LONG)
     const chat = new ChatHelper(page)
     const adminCreds = CREDENTIALS.getAdminCredentials()
     let targetUserId: number

--- a/frontend/tests/e2e/tests/auth.spec.ts
+++ b/frontend/tests/e2e/tests/auth.spec.ts
@@ -39,7 +39,13 @@ test.describe('@ci @auth Authentication', () => {
     })
 
     await test.step('Assert: navigating to protected route does not restore session', async () => {
-      await page.goto('/profile')
+      // Resolve as soon as the /profile document commits: booting the app fires
+      // a store request that 401s and hard-redirects via window.location to
+      // /login?reason=auth_required. Waiting for `load` races that redirect and
+      // aborts the navigation (NS_BINDING_ABORTED / "interrupted by another
+      // navigation"). `commit` decouples goto from the follow-up redirect; the
+      // assertions below verify we actually land on the logged-out surface.
+      await page.goto('/profile', { waitUntil: 'commit' })
       await expect(
         page.locator(`${selectors.login.email}, ${selectors.loggedOut.page}`).first()
       ).toBeVisible({ timeout: 15_000 })

--- a/frontend/tests/e2e/tests/chat-again.spec.ts
+++ b/frontend/tests/e2e/tests/chat-again.spec.ts
@@ -7,8 +7,10 @@ import { PROMPTS } from '../config/test-data'
 
 test.describe('@ci @smoke Chat Again', () => {
   test('again via button then dropdown works repeatedly without refresh', async ({ page }) => {
-    // 3 sequential AI responses require extended timeout
-    test.setTimeout(90_000)
+    // 3 sequential full AI streams, each on the VERY_LONG/EXTREME tier under
+    // load — give the whole test enough headroom that a single slow turn does
+    // not trip the wall-clock timeout.
+    test.setTimeout(120_000)
     const chat = new ChatHelper(page)
 
     await test.step('Arrange: login and start new chat', async () => {
@@ -19,7 +21,7 @@ test.describe('@ci @smoke Chat Again', () => {
     // -- Turn 1: send message, get first AI response --
     let previousCount = await chat.sendMessage(PROMPTS.CHAT_SMOKE)
 
-    const firstAnswer = await chat.waitForAnswer(previousCount)
+    const firstAnswer = await chat.waitForAnswer(previousCount, true)
 
     await test.step('Assert: first response is a real answer', async () => {
       expect(firstAnswer.trim().length).toBeGreaterThan(5)
@@ -47,7 +49,7 @@ test.describe('@ci @smoke Chat Again', () => {
       }
     )
 
-    const secondAnswer = await chat.waitForAnswer(previousCount)
+    const secondAnswer = await chat.waitForAnswer(previousCount, true)
     const secondResponseIndex = previousCount
 
     await test.step('Assert: second response (from Again dropdown) is a real answer', async () => {
@@ -92,11 +94,11 @@ test.describe('@ci @smoke Chat Again', () => {
 
         // 'hidden' also resolves when the panel left the DOM; a timeout means
         // the dropdown is stuck open after selection — a real bug, so fail.
-        await dropdown.waitFor({ state: 'hidden', timeout: TIMEOUTS.SHORT })
+        await dropdown.waitFor({ state: 'hidden', timeout: TIMEOUTS.STANDARD })
       }
     )
 
-    const thirdAnswer = await chat.waitForAnswer(previousCount)
+    const thirdAnswer = await chat.waitForAnswer(previousCount, true)
     const thirdResponseIndex = previousCount
 
     await test.step('Assert: third response (from dropdown after Again) is a real answer', async () => {

--- a/frontend/tests/e2e/tests/file-manage.spec.ts
+++ b/frontend/tests/e2e/tests/file-manage.spec.ts
@@ -24,6 +24,11 @@ test.describe('@ci File Management', () => {
   test('user can create a folder, upload into it, use it in chat and delete the file', async ({
     page,
   }) => {
+    // Upload + vectorization plus create/open/use-in-chat/delete navigations
+    // routinely push this past the 60s default under CI load — the recorded
+    // flake was always "Test timeout of 60000ms exceeded". Give the same
+    // headroom rag-search.spec.ts uses for the upload path.
+    test.setTimeout(TIMEOUTS.EXTREME + TIMEOUTS.VERY_LONG)
     const folderName = `e2e-folder-${Date.now()}`
 
     await test.step('Arrange: open the Files page', async () => {
@@ -54,10 +59,12 @@ test.describe('@ci File Management', () => {
       await page.locator(FILES.folderCard(folderName)).click()
       await page.locator(FILES.table).waitFor({ state: 'visible', timeout: TIMEOUTS.VERY_LONG })
       // Each file renders twice (mobile card + desktop table row, one hidden
-      // via CSS) — count only the visible representation.
+      // via CSS) — count only the visible representation. VERY_LONG because the
+      // row only appears once the upload+vectorize round-trip finishes, which
+      // can lag well past STANDARD under CI load.
       await expect(
         page.locator(FILES.fileRow).filter({ hasText: fixtureName }).filter({ visible: true })
-      ).toHaveCount(1, { timeout: TIMEOUTS.STANDARD })
+      ).toHaveCount(1, { timeout: TIMEOUTS.VERY_LONG })
     })
 
     await test.step('Act: "Use in chat" opens a chat scoped to the folder', async () => {
@@ -86,7 +93,7 @@ test.describe('@ci File Management', () => {
         .locator(FILES.fileRow)
         .filter({ hasText: fixtureName })
         .filter({ visible: true })
-      await row.waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
+      await row.waitFor({ state: 'visible', timeout: TIMEOUTS.VERY_LONG })
       await row.locator(FILES.btnDeleteFile).click()
       await page.locator(selectors.confirmDialog.accept).click()
     })

--- a/frontend/tests/e2e/tests/ollama-integration.spec.ts
+++ b/frontend/tests/e2e/tests/ollama-integration.spec.ts
@@ -3,7 +3,7 @@ import { request as playwrightRequest } from '@playwright/test'
 import { openApp, getAuthHeaders } from '../helpers/auth'
 import { ChatHelper } from '../helpers/chat'
 import { CREDENTIALS } from '../config/credentials'
-import { getApiUrl, URLS } from '../config/config'
+import { getApiUrl, URLS, TIMEOUTS } from '../config/config'
 import { PROMPTS } from '../config/test-data'
 import { resetStub, configureStub, getStubRequests, getChatRequests } from '../helpers/ollama-stub'
 
@@ -63,6 +63,11 @@ test.describe('@ci @smoke Ollama Integration', () => {
   })
 
   test('chat via Ollama provider produces response', async ({ page }) => {
+    // Stub reply still flows through the full backend chat pipeline + SSE; under
+    // CI load the bubble mount alone can approach VERY_LONG, so give headroom
+    // over the 60s default. The recorded flake was "waiting
+    // assistant-message-bubble (10s)", now absorbed by the helper wait.
+    test.setTimeout(TIMEOUTS.EXTREME + TIMEOUTS.VERY_LONG)
     const chat = new ChatHelper(page)
 
     await test.step('Arrange: login and start new chat', async () => {
@@ -92,6 +97,7 @@ test.describe('@ci @smoke Ollama Integration', () => {
   })
 
   test('thinking/reasoning tokens are forwarded', async ({ page }) => {
+    test.setTimeout(TIMEOUTS.EXTREME + TIMEOUTS.VERY_LONG)
     await test.step('Arrange: configure stub with thinking enabled', async () => {
       await resetStub(apiCtx)
       await configureStub(apiCtx, { enableThinking: true })

--- a/frontend/tests/e2e/tests/redirects.spec.ts
+++ b/frontend/tests/e2e/tests/redirects.spec.ts
@@ -36,7 +36,10 @@ test.describe('Redirects: legacy URLs land on canonical paths (§4.6)', () => {
 
     for (const [oldPath, newPath] of REDIRECTS) {
       await test.step(`${oldPath} → ${newPath}`, async () => {
-        await page.goto(oldPath)
+        // Resolve on document commit, not `load`: the app boots and immediately
+        // redirects to the canonical path, which aborts a `load`-gated goto
+        // (NS_BINDING_ABORTED on firefox). toHaveURL below is the real assertion.
+        await page.goto(oldPath, { waitUntil: 'commit' })
         const expected = new RegExp(`${newPath.replace(/[/]/g, '\\/')}$`)
         await expect(page, `${oldPath} should land on ${newPath}`).toHaveURL(expected, {
           timeout: TIMEOUTS.STANDARD,
@@ -47,7 +50,7 @@ test.describe('Redirects: legacy URLs land on canonical paths (§4.6)', () => {
 
   test('@ci redirect preserves the query string', async ({ page }) => {
     await openApp(page)
-    await page.goto('/config/task-prompts?topic=mail')
+    await page.goto('/config/task-prompts?topic=mail', { waitUntil: 'commit' })
     await expect(page).toHaveURL(/\/ai\/instructions\?topic=mail$/, {
       timeout: TIMEOUTS.STANDARD,
     })


### PR DESCRIPTION
## Summary
- Stabilize the top CI flaky E2E specs from the last ~2 weeks of Discord/CI retry data, led by `admin-impersonation-chat` and `auth` logout.
- Align chat/stream waits and test wall-clock headroom under CI parallel load; use `waitUntil: 'commit'` for logout/redirect navigations that race hard redirects.
- Also harden `file-manage`, `chat-again`, `ollama-integration` (deterministic stub), and `redirects`.

## Test plan
- [ ] CI `@ci` E2E matrix green (chromium/firefox shards)
- [ ] Confirm Discord flaky notify no longer pings impersonation/logout on subsequent main runs
- [ ] Optional local: `BASE_URL=http://localhost:8001` + `OLLAMA_STUB_URL` pointed at the stub host port; run the touched specs with `--retries=0`