### PR TITLE
feat(deploy): Elestio managed one-click deployment via portable production stack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,13 @@ jobs:
         working-directory: backend
         run: composer lint
 
+      # Host-side deployment helpers (deploy/scripts/lib.sh), including the
+      # first-admin preflight. The suite stubs `compose()`/`resolved_app_image()`,
+      # so it needs nothing but bash and a checkout — this is the leanest job in
+      # the gate that already provides both.
+      - name: Run deploy-lifecycle bash tests
+        run: bash deploy/scripts/tests/test-lifecycle.sh
+
   mobile-tooling:
     name: Mobile Release Tooling
     runs-on: ubuntu-latest
@@ -205,6 +212,32 @@ jobs:
 
       - name: Run migrations-bootstrap bash tests
         run: bash _docker/backend/tests/test-migrations-bootstrap.sh
+
+      - name: Run container-runtime bash tests
+        run: bash _docker/backend/tests/test-container-runtime.sh
+
+      # The lint job runs the same suite Docker-free, which SKIPS its tier-1
+      # (host shell) vs tier-2 (PHP filter_var) email contract case — the very
+      # drift that once shipped and crash-looped managed deployments. This job
+      # already pulls the backend base image for protoc, so re-running the suite
+      # against the exact PHP that production ships costs a container start.
+      - name: Run deploy-lifecycle bash tests (email contract)
+        run: |
+          set -euo pipefail
+          BASE_IMAGE="$(grep -oP 'FROM \K\S+' _docker/backend/Dockerfile | head -1 || true)"
+          [ -n "$BASE_IMAGE" ] || {
+            echo "::error::Could not resolve the backend base image from _docker/backend/Dockerfile"
+            exit 1
+          }
+          SYNAPLAN_CONTRACT_PHP_IMAGE="$BASE_IMAGE" \
+            bash deploy/scripts/tests/test-lifecycle.sh | tee /tmp/lifecycle-contract.log
+          # The suite skips the contract case and still exits 0 when the image
+          # variable is empty, so a green step alone would not prove the contract
+          # ran. Assert the verification line instead of trusting the exit code.
+          grep -q 'Bootstrap email contract verified against' /tmp/lifecycle-contract.log || {
+            echo "::error::The bootstrap email contract case did not run; it must never be skipped in this job"
+            exit 1
+          }
 
   frontend-build:
     name: Frontend Build
@@ -435,6 +468,8 @@ jobs:
           push: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            APP_VERSION=${{ steps.meta.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           # Export to tar file for sharing between jobs
@@ -846,32 +881,60 @@ jobs:
           docker compose -f docker-compose.test.yml -f docker-compose.test.ci.yml down -v
 
   docker-push:
-    name: Push Docker Image
+    name: Publish Multi-Arch Docker Image
     runs-on: ubuntu-latest
-    # backend and frontend-checks are listed explicitly: docker-build no longer
-    # depends on them transitively (frontend-build has no `needs`), and a
-    # `latest` image must never be published when tests or checks fail —
-    # e.g. a semantic conflict between two individually green PRs surfacing
-    # only on the merged main. Costs no time: e2e always finishes last.
-    needs: [docker-build, e2e, backend, frontend-checks]
-    # Only run on main branch or tags (e2e tests already passed)
+    # The amd64 tar produced by docker-build is the exact image consumed by E2E
+    # and later published. Only arm64 is built after the gates pass; the final
+    # manifest combines that build with the tested amd64 digest.
+    needs: [lint, mobile-tooling, backend, frontend-build, frontend-checks, docker-build, e2e, e2e-visual]
+    # Only publish green main pushes and release tags.
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
     permissions:
       contents: read
       packages: write
 
     steps:
-      - name: Download Docker image artifact
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Download frontend build artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: frontend-dist
+          path: frontend/dist/
+
+      - name: Download widget build artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: widget-dist
+          path: frontend/dist-widget/
+
+      - name: Download tested amd64 image artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: docker-image
           path: /tmp
 
-      - name: Load Docker image
-        run: |
-          docker load -i /tmp/docker-image.tar
-          echo "Loaded images:"
-          docker images
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+      - name: Extract release metadata
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # Prevent metadata-action's SemVer flavor from moving latest on tags.
+          flavor: latest=false
+          tags: |
+            # Only the default branch moves latest.
+            type=raw,value=latest,enable={{is_default_branch}}
+            # Release tags vX.Y.Z publish the immutable version and aliases.
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
 
       - name: Log in to the Container registry
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
@@ -880,14 +943,140 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Push Docker image
+      - name: Push the tested amd64 image
+        id: amd64
+        env:
+          TESTED_IMAGE_TAGS: ${{ needs.docker-build.outputs.image-tags }}
+          REGISTRY_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
         run: |
-          echo "Pushing all tags..."
-          docker images --format "{{.Repository}}:{{.Tag}}" | grep "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}" | while read -r tag; do
-            echo "Pushing: $tag"
-            docker push "$tag"
-          done
-          echo "✅ All images pushed successfully"
+          set -euo pipefail
+          docker load -i /tmp/docker-image.tar
+          source_tag="$(printf '%s\n' "$TESTED_IMAGE_TAGS" | sed -n '/./{p;q;}')"
+          [ -n "$source_tag" ] || {
+            echo "::error::docker-build did not provide a tested image tag"
+            exit 1
+          }
+
+          temporary_tag="${REGISTRY_IMAGE}:ci-${GITHUB_SHA}-amd64"
+          docker tag "$source_tag" "$temporary_tag"
+          docker push "$temporary_tag"
+          digest="$(
+            docker buildx imagetools inspect "$temporary_tag" \
+              --format '{{ .Manifest.Digest }}'
+          )"
+          echo "ref=${temporary_tag}@${digest}" >> "$GITHUB_OUTPUT"
+          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push arm64 image
+        id: arm64
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: .
+          file: _docker/backend/Dockerfile
+          platforms: linux/arm64
+          push: true
+          provenance: false
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:ci-${{ github.sha }}-arm64
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            APP_VERSION=${{ steps.meta.outputs.version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Publish multi-arch manifest
+        id: release
+        env:
+          AMD64_REF: ${{ steps.amd64.outputs.ref }}
+          ARM64_DIGEST: ${{ steps.arm64.outputs.digest }}
+          IMAGE_TAGS: ${{ steps.meta.outputs.tags }}
+          REGISTRY_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        run: |
+          set -euo pipefail
+          arm64_ref="${REGISTRY_IMAGE}@${ARM64_DIGEST}"
+          manifest_digest=""
+
+          while IFS= read -r image; do
+            [ -n "$image" ] || continue
+            docker buildx imagetools create \
+              --tag "$image" \
+              "$AMD64_REF" \
+              "$arm64_ref"
+            current_digest="$(
+              docker buildx imagetools inspect "$image" \
+                --format '{{ .Manifest.Digest }}'
+            )"
+            if [ -z "$manifest_digest" ]; then
+              manifest_digest="$current_digest"
+            elif [ "$current_digest" != "$manifest_digest" ]; then
+              echo "::error::${image} resolved to ${current_digest}, expected ${manifest_digest}"
+              exit 1
+            fi
+          done <<< "$IMAGE_TAGS"
+
+          [ -n "$manifest_digest" ] || {
+            echo "::error::No release tags were generated"
+            exit 1
+          }
+          echo "digest=${manifest_digest}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify manifest and platforms
+        env:
+          IMAGE_DIGEST: ${{ steps.release.outputs.digest }}
+          IMAGE_TAGS: ${{ steps.meta.outputs.tags }}
+          TESTED_AMD64_DIGEST: ${{ steps.amd64.outputs.digest }}
+          ARM64_DIGEST: ${{ steps.arm64.outputs.digest }}
+        run: |
+          set -euo pipefail
+          expected='["linux/amd64","linux/arm64"]'
+
+          while IFS= read -r image; do
+            [ -n "$image" ] || continue
+            echo "Verifying ${image}"
+
+            resolved_digest="$(
+              docker buildx imagetools inspect "$image" \
+                --format '{{ .Manifest.Digest }}'
+            )"
+            if [ "$resolved_digest" != "$IMAGE_DIGEST" ]; then
+              echo "::error::${image} resolved to ${resolved_digest}, expected ${IMAGE_DIGEST}"
+              exit 1
+            fi
+
+            platforms="$(
+              docker buildx imagetools inspect --raw "$image" |
+                jq -c '[.manifests[].platform
+                  | select(.os == "linux" and (.architecture == "amd64" or .architecture == "arm64"))
+                  | "\(.os)/\(.architecture)"] | unique | sort'
+            )"
+            if [ "$platforms" != "$expected" ]; then
+              echo "::error::${image} exposes ${platforms}, expected ${expected}"
+              exit 1
+            fi
+
+            raw_manifest="$(docker buildx imagetools inspect --raw "$image")"
+            amd64_digest="$(
+              jq -r '.manifests[]
+                | select(.platform.os == "linux" and .platform.architecture == "amd64")
+                | .digest' <<< "$raw_manifest"
+            )"
+            arm64_digest="$(
+              jq -r '.manifests[]
+                | select(.platform.os == "linux" and .platform.architecture == "arm64")
+                | .digest' <<< "$raw_manifest"
+            )"
+            if [ "$amd64_digest" != "$TESTED_AMD64_DIGEST" ]; then
+              echo "::error::${image} amd64 digest ${amd64_digest} is not the tested ${TESTED_AMD64_DIGEST}"
+              exit 1
+            fi
+            if [ "$arm64_digest" != "$ARM64_DIGEST" ]; then
+              echo "::error::${image} arm64 digest ${arm64_digest} is not the built ${ARM64_DIGEST}"
+              exit 1
+            fi
+          done <<< "$IMAGE_TAGS"
+
+          # Also verify the immutable digest directly, independent of tag lookup.
+          docker buildx imagetools inspect \
+            "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${IMAGE_DIGEST}"
 
   cloudflare-deploy:
     name: Deploy Cloudflare Worker

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ Thumbs.db
 # Docker volumes and data
 volumes/
 /data/
+/deploy/data/
+/deploy/.lifecycle/
 # But allow frontend source data
 !frontend/src/data/
 

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ test-stack-build: ## Build frontend + widget + test Docker image + start test st
 		docker run --rm -v "$(CURDIR)/frontend:/t" alpine:3.20 sh -c 'rm -rf /t/dist /t/dist-widget' )
 	cd frontend && npm run build && npm run build:widget
 	docker compose -f docker-compose.test.yml build
-	docker compose -f docker-compose.test.yml up -d
+	docker compose -f docker-compose.test.yml up -d --wait --wait-timeout 600
 
 audit: ## Run security audit (backend)
 	$(MAKE) -C backend audit

--- a/_docker/backend/Dockerfile
+++ b/_docker/backend/Dockerfile
@@ -21,6 +21,8 @@
 # architecture.
 FROM ghcr.io/metadist/synaplan-base-php:1.2.0@sha256:1c3381bce4673afb2eb96a163c301100584ce98af4e86cbd3158b5bb694d79ef AS dev
 
+ARG APP_VERSION=dev
+
 WORKDIR /var/www/backend
 
 # iOS HDR "tmap"/gain-map HEIC photos (newer iPhones) require libheif >= 1.18 to
@@ -48,6 +50,7 @@ RUN echo "deb http://deb.debian.org/debian bookworm-backports main" > /etc/apt/s
 # Set default environment variables for paths and constants
 # These are baked into the image since they reference local filesystem paths
 ENV BRAVE_SEARCH_API_URL=https://api.search.brave.com/res/v1 \
+    APP_VERSION=${APP_VERSION} \
     BRAVE_SEARCH_ENABLED=false \
     BRAVE_SEARCH_COUNT=10 \
     BRAVE_SEARCH_COUNTRY=us \
@@ -59,7 +62,8 @@ ENV BRAVE_SEARCH_API_URL=https://api.search.brave.com/res/v1 \
     TIKA_MIN_ENTROPY=3.0 \
     RASTERIZE_DPI=150 \
     RASTERIZE_PAGE_CAP=10 \
-    RASTERIZE_TIMEOUT_MS=30000
+    RASTERIZE_TIMEOUT_MS=30000 \
+    SYNAPLAN_ROLE=web
 
 # Entrypoint scripts (entrypoint + sourced migrations-bootstrap library).
 # These MUST live in the `dev` stage: the dev/worker compose services bind-mount
@@ -68,13 +72,16 @@ ENV BRAVE_SEARCH_API_URL=https://api.search.brave.com/res/v1 \
 # it the container inherits the base image's default and only launches FrankenPHP,
 # leaving vendor/ unpopulated (which then breaks the worker's bin/console).
 COPY _docker/backend/docker-entrypoint.sh /usr/local/bin/
+COPY _docker/backend/container-healthcheck.sh /usr/local/bin/container-healthcheck
 COPY _docker/backend/lib/ /usr/local/bin/lib/
 COPY _docker/backend/synaplan /usr/local/bin/
-RUN chmod +x /usr/local/bin/docker-entrypoint.sh /usr/local/bin/synaplan
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh /usr/local/bin/container-healthcheck /usr/local/bin/synaplan
 
 EXPOSE 80
 
 ENTRYPOINT ["docker-entrypoint.sh"]
+HEALTHCHECK --interval=30s --timeout=5s --start-period=120s --retries=3 \
+    CMD ["/usr/local/bin/container-healthcheck"]
 
 # ---------------------------------------------------------------------------
 # `dev` target ends here: base image (phpredis included) + ENV defaults + entrypoint.

--- a/_docker/backend/container-healthcheck.sh
+++ b/_docker/backend/container-healthcheck.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+set -eu
+
+role="${SYNAPLAN_ROLE:-web}"
+runtime_dir="${SYNAPLAN_RUNTIME_DIR:-/var/www/backend/var/run/synaplan}"
+
+process_exists() {
+    needle="$1"
+
+    for cmdline in /proc/[0-9]*/cmdline; do
+        [ -r "$cmdline" ] || continue
+        if tr '\000' ' ' < "$cmdline" | grep -Fq "$needle"; then
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+case "$role" in
+    web)
+        exec curl --fail --silent --show-error \
+            --max-time "${SYNAPLAN_HEALTH_TIMEOUT_SECONDS:-5}" \
+            "http://127.0.0.1/api/health"
+        ;;
+    worker)
+        process_exists 'messenger:consume' || {
+            echo "Messenger consumer process is not running." >&2
+            exit 1
+        }
+        ;;
+    scheduler)
+        heartbeat="${runtime_dir}/scheduler.heartbeat"
+        max_age="${SYNAPLAN_SCHEDULER_HEALTH_MAX_AGE_SECONDS:-180}"
+        [ -r "$heartbeat" ] || {
+            echo "Scheduler heartbeat is missing." >&2
+            exit 1
+        }
+
+        now="$(date +%s)"
+        last_alive="$(tr -cd '0-9' < "$heartbeat")"
+        [ -n "$last_alive" ] && [ "$last_alive" -le "$now" ] || {
+            echo "Scheduler heartbeat is invalid." >&2
+            exit 1
+        }
+        [ $((now - last_alive)) -le "$max_age" ] || {
+            echo "Scheduler heartbeat is stale." >&2
+            exit 1
+        }
+        process_exists 'docker-entrypoint.sh' || {
+            echo "Scheduler entrypoint process is not running." >&2
+            exit 1
+        }
+        ;;
+    *)
+        echo "Unsupported SYNAPLAN_ROLE: ${role}" >&2
+        exit 64
+        ;;
+esac

--- a/_docker/backend/docker-entrypoint.sh
+++ b/_docker/backend/docker-entrypoint.sh
@@ -10,6 +10,36 @@ set -euo pipefail
 # shellcheck source=/dev/null
 source /usr/local/bin/synaplan-php-configure
 
+# Locate shared role helpers both in the production image and when the script is
+# run directly from a repository checkout by shell characterization tests.
+_RUNTIME_LIB=""
+for _candidate in \
+    "$(dirname "$0")/lib/container-runtime.sh" \
+    "/usr/local/bin/lib/container-runtime.sh"; do
+    if [ -r "$_candidate" ]; then
+        _RUNTIME_LIB="$_candidate"
+        break
+    fi
+done
+
+if [ -z "$_RUNTIME_LIB" ]; then
+    echo "❌ ERROR: container-runtime.sh not found"
+    exit 1
+fi
+
+# shellcheck disable=SC1090
+. "$_RUNTIME_LIB"
+
+SYNAPLAN_ROLE="${SYNAPLAN_ROLE:-web}"
+export SYNAPLAN_ROLE
+case "$SYNAPLAN_ROLE" in
+    web|worker|scheduler) ;;
+    *)
+        echo "❌ ERROR: Unsupported SYNAPLAN_ROLE '${SYNAPLAN_ROLE}'. Expected web, worker, or scheduler."
+        exit 64
+        ;;
+esac
+
 # Test mode: disable the PHP 8.4 tracing JIT and re-stat .php files.
 #
 # The base image (synaplan-base-php >= 1.0.0) ships production-tuned OPcache
@@ -104,6 +134,15 @@ if [ -z "${APP_URL:-}" ]; then
     exit 1
 fi
 
+# Tier 1 of the first-admin bootstrap guard: the pairing rule, checked here
+# because it is free — it needs only the environment that was just loaded, no
+# vendor/ and no PHP — so the most common mistake fails within milliseconds.
+# Tier 2 (require_valid_bootstrap_admin_config) validates the remaining rules
+# with the application's own validator once vendor/ is guaranteed to exist; see
+# below, after the /docker-entrypoint.d block. Both tiers apply to every role,
+# since all of them receive the same environment.
+require_bootstrap_admin_pair
+
 # Build DATABASE URLs from environment variables if not already set
 # Fallback for deployments that provide DB credentials as separate env vars
 if [ -z "${DATABASE_WRITE_URL:-}" ] && [ -n "${DB_HOST:-}" ]; then
@@ -179,13 +218,34 @@ if [ -d "$PLUGINS_DIR" ] && [ "$(ls -A "$PLUGINS_DIR" 2>/dev/null)" ]; then
     echo "✅ Autoloader regenerated with plugin support"
 fi
 
+# Tier 2 of the first-admin bootstrap guard: the complete rule set, decided by
+# the application's own validator (App\Service\Admin\BootstrapAdminConfiguration).
+#
+# This is the earliest point where that is possible: it needs vendor/, which the
+# dev stack only populates in the /docker-entrypoint.d block above, and it must
+# see the plugin-aware autoloader regenerated just above it. It still runs before
+# the role dispatch, the database wait, the migrations and the seeders below, so
+# an invalid email or password fails in seconds instead of crash-looping the
+# container after every full initialization attempt.
+#
+# Completely inert when neither bootstrap variable is set.
+require_valid_bootstrap_admin_config
+
+# Non-web roles share the same environment and filesystem preparation above,
+# but never run migrations or seeders. They wait for the web role to complete
+# database initialization before starting their long-running process.
+case "$SYNAPLAN_ROLE" in
+    worker)
+        run_worker_role
+        ;;
+    scheduler)
+        run_scheduler_role
+        exit $?
+        ;;
+esac
+
 # Wait for database to be ready
-echo "⏳ Waiting for database connection..."
-until php bin/console dbal:run-sql "SELECT 1" 2>&1; do
-    echo "   Database is not ready yet - sleeping..."
-    sleep 2
-done
-echo "✅ Database is ready!"
+wait_for_database 0 2
 
 # Run database migrations.
 #
@@ -318,6 +378,15 @@ echo "🔌 Checking default AI provider..."
 php bin/console app:provider:apply-defaults --auto --no-interaction || {
     echo "⚠️  Could not verify the default AI provider — continuing startup."
 }
+
+# Managed deployments may provide first-admin credentials. The command is
+# intentionally called only when at least one bootstrap value is present, so
+# existing development and self-host behavior remains unchanged. The command
+# validates incomplete configuration and is idempotent after an admin exists.
+if [ -n "${BOOTSTRAP_ADMIN_EMAIL:-}" ] || [ -n "${BOOTSTRAP_ADMIN_PASSWORD:-}" ]; then
+    echo "👤 Bootstrapping initial administrator..."
+    php bin/console app:bootstrap-admin --no-interaction
+fi
 
 # Ollama model downloads (optional, only if AUTO_DOWNLOAD_MODELS=true).
 # Progress is mirrored to var/ollama-download.json for GET /api/v1/config/local-ai/status.

--- a/_docker/backend/lib/container-runtime.sh
+++ b/_docker/backend/lib/container-runtime.sh
@@ -26,10 +26,12 @@ runtime_warn() {
     runtime_log "⚠️  $*" >&2
 }
 
+# The `|| return 64` is not decoration: the entrypoint runs under `set -e`, where
+# runtime_fatal's own non-zero status would end the shell before this function
+# reaches its return statement — with exit code 1 instead of the documented 64.
 require_console() {
     if [ ! -f bin/console ]; then
-        runtime_fatal "bin/console is missing under $(pwd); the application code is not mounted or copied correctly."
-        return 64
+        runtime_fatal "bin/console is missing under $(pwd); the application code is not mounted or copied correctly." || return 64
     fi
 }
 
@@ -216,7 +218,13 @@ wait_for_database() {
             return 66
         fi
         if [ $((attempt % 10)) -eq 1 ]; then
-            runtime_log "Database is not ready (attempt ${attempt}${max_attempts:+/${max_attempts}})."
+            if [ "$max_attempts" -gt 0 ]; then
+                runtime_log "Database is not ready (attempt ${attempt}/${max_attempts})."
+            else
+                # The web role waits without a limit, so there is no denominator
+                # to show. "attempt 1/0" read like a broken counter.
+                runtime_log "Database is not ready (attempt ${attempt}, waiting indefinitely)."
+            fi
         fi
         sleep "$delay"
     done

--- a/_docker/backend/lib/container-runtime.sh
+++ b/_docker/backend/lib/container-runtime.sh
@@ -1,0 +1,376 @@
+#!/bin/bash
+# Shared runtime helpers for Synaplan's web, worker, and scheduler roles.
+#
+# This file is sourced by docker-entrypoint.sh and intentionally has no
+# top-level side effects so its control flow can be characterized in shell tests.
+
+SYNAPLAN_RUNTIME_DIR="${SYNAPLAN_RUNTIME_DIR:-/var/www/backend/var/run/synaplan}"
+SYNAPLAN_WORKER_TRANSPORTS="${SYNAPLAN_WORKER_TRANSPORTS:-async_ai_high async_extract async_index}"
+# Composer autoloader used by the first-admin configuration check. Relative to
+# the application directory the entrypoint already runs in, like `bin/console`.
+SYNAPLAN_AUTOLOAD_PATH="${SYNAPLAN_AUTOLOAD_PATH:-vendor/autoload.php}"
+
+runtime_log() {
+    printf '[%s] %s\n' "${SYNAPLAN_ROLE:-web}" "$*"
+}
+
+runtime_fatal() {
+    runtime_log "FATAL: $*" >&2
+    return 1
+}
+
+# An operator-relevant warning, marked like every other one in the entrypoint.
+# Without the marker a line such as "your credentials were never validated"
+# reads like ordinary status output and is lost in the startup log.
+runtime_warn() {
+    runtime_log "⚠️  $*" >&2
+}
+
+require_console() {
+    if [ ! -f bin/console ]; then
+        runtime_fatal "bin/console is missing under $(pwd); the application code is not mounted or copied correctly."
+        return 64
+    fi
+}
+
+# BOOTSTRAP_ADMIN_EMAIL as the PHP authority sees it.
+#
+# BootstrapAdminConfiguration trims the email (and only the email) before it
+# decides whether the bootstrap is configured at all. Both tiers below normalize
+# the same way, otherwise a whitespace-only address would mean "not configured"
+# in PHP and "configured" in shell: tier 1 would abort a boot PHP accepts, and
+# tier 2 would report an accepted configuration for a bootstrap that never runs.
+#
+# This is normalization, not a rule: it decides nothing about the value.
+bootstrap_admin_trimmed_email() {
+    local email="${BOOTSTRAP_ADMIN_EMAIL:-}"
+
+    email="${email#"${email%%[![:space:]]*}"}"
+    email="${email%"${email##*[![:space:]]}"}"
+
+    printf '%s' "$email"
+}
+
+# Tier 1 of the first-admin bootstrap guard: the pairing rule only.
+#
+# This is the earliest possible check. It needs nothing but the environment — no
+# vendor/, no PHP, no application code — so it can run before the
+# /docker-entrypoint.d scripts that populate vendor/ in the dev stack, and it
+# catches the most common operator mistake within milliseconds of container
+# start. It is deliberately limited to the one rule that cannot drift: whether
+# both values are present.
+#
+# Everything else (email format and length, password length and composition) is
+# decided by tier 2, require_valid_bootstrap_admin_config, which calls the
+# authoritative PHP validator instead of reimplementing it here. Keep the two
+# tiers in that order: tier 1 is free, tier 2 costs one PHP process.
+#
+# Both variables set is valid, neither set is valid (the bootstrap is then
+# skipped); exactly one of them is an operator configuration error.
+require_bootstrap_admin_pair() {
+    local email password
+    email="$(bootstrap_admin_trimmed_email)"
+    password="${BOOTSTRAP_ADMIN_PASSWORD:-}"
+
+    if [ -z "$email" ] && [ -z "$password" ]; then
+        return 0
+    fi
+    if [ -n "$email" ] && [ -n "$password" ]; then
+        return 0
+    fi
+
+    local present="BOOTSTRAP_ADMIN_EMAIL"
+    local missing="BOOTSTRAP_ADMIN_PASSWORD"
+    if [ -z "$email" ]; then
+        present="BOOTSTRAP_ADMIN_PASSWORD"
+        missing="BOOTSTRAP_ADMIN_EMAIL"
+    fi
+
+    echo "❌ ERROR: Incomplete first-admin bootstrap configuration!" >&2
+    echo "   ${present} is set, but ${missing} is empty." >&2
+    echo "   BOOTSTRAP_ADMIN_EMAIL and BOOTSTRAP_ADMIN_PASSWORD must either both be set or both be empty." >&2
+    echo "   Set ${missing} to bootstrap the first administrator, or unset ${present} to skip the bootstrap." >&2
+    return 78
+}
+
+# Tier 2 of the first-admin bootstrap guard: the COMPLETE rule set.
+#
+# Tier 1 above can only decide the pairing rule. Everything else — email format,
+# email length, password length, password composition — lives in
+# App\Service\Admin\BootstrapAdminConfiguration, and this guard calls THAT class
+# instead of mirroring it in shell. A shell mirror is free to drift, and an early
+# check that is looser than the authority is worse than no early check at all:
+# it accepts a value the bootstrap later rejects and so reintroduces exactly the
+# crash loop this guard exists to prevent.
+#
+# No Symfony kernel is booted. The validator has no dependencies, so a single
+# plain PHP process with the Composer autoloader decides the same rules in a few
+# tens of milliseconds, and it cannot fail for reasons unrelated to the
+# credentials (a missing service, an unreachable database, a cold cache).
+#
+# Requirements on the call site, all satisfied in docker-entrypoint.sh:
+#   - vendor/ must exist, so this must run after the /docker-entrypoint.d block
+#     (the dev stack installs the Composer dependencies there);
+#   - it must precede the database wait, the migrations and the seeders;
+#   - it applies to web, worker and scheduler alike, so it runs before the role
+#     dispatch.
+#
+# The values are read from the environment inside PHP and never passed as
+# arguments, so the password never reaches the process list, and only the
+# validator's own message is printed — never a configured value.
+require_valid_bootstrap_admin_config() {
+    # An unconfigured bootstrap is a valid, supported choice, so stay completely
+    # inert: no PHP process is started at all when neither value is present. The
+    # email is normalized exactly like the authority normalizes it, so a
+    # whitespace-only address without a password is "not configured" here too,
+    # instead of spawning PHP and logging an accepted configuration for a
+    # bootstrap that will never run.
+    local email
+    email="$(bootstrap_admin_trimmed_email)"
+    if [ -z "$email" ] && [ -z "${BOOTSTRAP_ADMIN_PASSWORD:-}" ]; then
+        return 0
+    fi
+
+    # Without the autoloader the authority is unreachable. Warn and continue
+    # instead of failing: this guard may never be the reason a container stops.
+    # The bootstrap command still validates the same values later.
+    if [ ! -r "$SYNAPLAN_AUTOLOAD_PATH" ]; then
+        runtime_warn "Skipping the early first-admin configuration check: ${SYNAPLAN_AUTOLOAD_PATH} is not readable from $(pwd)."
+        return 0
+    fi
+
+    local program
+    program="$(
+        cat <<'PHP'
+require getenv('SYNAPLAN_AUTOLOAD_PATH');
+
+try {
+    App\Service\Admin\BootstrapAdminConfiguration::fromConfiguration(
+        (string) getenv('BOOTSTRAP_ADMIN_EMAIL'),
+        (string) getenv('BOOTSTRAP_ADMIN_PASSWORD'),
+    );
+} catch (InvalidArgumentException $violation) {
+    fwrite(STDERR, $violation->getMessage());
+    exit(1);
+} catch (Throwable $unexpected) {
+    // Exit 2 is treated leniently below, and only "the authority could not run"
+    // deserves that. The class name is part of the message so the log also
+    // distinguishes the other possibility: a rule violation thrown as something
+    // other than InvalidArgumentException, which the branch above would miss.
+    // BootstrapAdminConfigurationTest locks that contract on the PHP side.
+    fwrite(STDERR, sprintf('%s: %s', get_class($unexpected), $unexpected->getMessage()));
+    exit(2);
+}
+PHP
+    )"
+
+    local message verdict=0
+    message="$(SYNAPLAN_AUTOLOAD_PATH="$SYNAPLAN_AUTOLOAD_PATH" php -r "$program" 2>&1)" || verdict=$?
+
+    if [ "$verdict" -eq 0 ]; then
+        runtime_log "First-admin bootstrap configuration accepted."
+        return 0
+    fi
+
+    # 1, not 78: exit 78 stays reserved for the half-configured pair that tier 1
+    # rejects, so the two failures remain distinguishable from the exit code
+    # alone. 1 is also what the bootstrap command itself returns for a rejected
+    # value, so the documented contract is unchanged — only the timing improves.
+    if [ "$verdict" -eq 1 ]; then
+        echo "❌ ERROR: Invalid first-admin bootstrap configuration!" >&2
+        printf '   %s\n' "$message" >&2
+        echo "   Fix the value in your deployment configuration, then start the container again." >&2
+        echo "   Nothing was written to the database: this check runs before the database wait, the migrations and the seeders." >&2
+        return 1
+    fi
+
+    # Any other status means the check itself could not run (for example an
+    # incomplete autoloader). Never block the boot on that; the bootstrap
+    # command validates the same values with the same class later on. It is a
+    # warning, not status output: the configured credentials are unvalidated at
+    # this point, and the message below names what the authority reported.
+    runtime_warn "Could not run the early first-admin configuration check; continuing startup."
+    if [ -n "$message" ]; then
+        printf '   %s\n' "$message" >&2
+    fi
+    return 0
+}
+
+# Wait until the application database accepts a trivial query.
+#
+# Args:
+#   $1 maximum attempts (0 means unlimited)
+#   $2 delay in seconds
+wait_for_database() {
+    local max_attempts="${1:-0}"
+    local delay="${2:-3}"
+    local attempt=0
+    local env="${APP_ENV:-prod}"
+
+    runtime_log "Waiting for database connection..."
+    while ! php bin/console --env="$env" dbal:run-sql 'SELECT 1' >/dev/null 2>&1; do
+        attempt=$((attempt + 1))
+        if [ "$max_attempts" -gt 0 ] && [ "$attempt" -ge "$max_attempts" ]; then
+            runtime_log "Database did not become ready after $((max_attempts * delay)) seconds." >&2
+            php bin/console --env="$env" dbal:run-sql 'SELECT 1' >&2 || true
+            return 66
+        fi
+        if [ $((attempt % 10)) -eq 1 ]; then
+            runtime_log "Database is not ready (attempt ${attempt}${max_attempts:+/${max_attempts}})."
+        fi
+        sleep "$delay"
+    done
+    runtime_log "Database is ready."
+}
+
+# Worker and scheduler containers must not race the web container's migrations.
+# Doctrine's command returns non-zero while migrations remain pending.
+wait_for_web_initialization() {
+    local max_attempts="${SYNAPLAN_INIT_WAIT_ATTEMPTS:-120}"
+    local delay="${SYNAPLAN_INIT_WAIT_SECONDS:-3}"
+    local attempt=0
+    local env="${APP_ENV:-prod}"
+
+    wait_for_database "$max_attempts" "$delay" || return
+
+    runtime_log "Waiting for web database initialization..."
+    while ! php bin/console --env="$env" doctrine:migrations:up-to-date --no-interaction >/dev/null 2>&1; do
+        attempt=$((attempt + 1))
+        if [ "$max_attempts" -gt 0 ] && [ "$attempt" -ge "$max_attempts" ]; then
+            runtime_log "Web initialization did not complete after $((max_attempts * delay)) seconds." >&2
+            runtime_log "The database is reachable, but Doctrine still reports pending migrations, so the web role never finished applying them." >&2
+            runtime_log "This role refuses to start against a half-migrated schema. Check the web container's log (for example 'docker compose logs backend') for the error that stopped its startup sequence." >&2
+            runtime_log "Output of the pending-migrations check that kept failing:" >&2
+            php bin/console --env="$env" doctrine:migrations:up-to-date --no-interaction >&2 || true
+            return 67
+        fi
+        if [ $((attempt % 10)) -eq 1 ]; then
+            runtime_log "Migrations are still pending (attempt ${attempt}/${max_attempts})."
+        fi
+        sleep "$delay"
+    done
+    runtime_log "Web database initialization is complete."
+
+    wait_for_web_health "$max_attempts" "$delay"
+}
+
+wait_for_web_health() {
+    local max_attempts="${1:-120}"
+    local delay="${2:-3}"
+    local attempt=0
+    local health_url="${SYNAPLAN_WEB_HEALTH_URL:-http://backend/api/health}"
+
+    runtime_log "Waiting for web health endpoint (${health_url})..."
+    while ! curl --fail --silent --max-time 5 "$health_url" >/dev/null 2>&1; do
+        attempt=$((attempt + 1))
+        if [ "$max_attempts" -gt 0 ] && [ "$attempt" -ge "$max_attempts" ]; then
+            runtime_log "Web health endpoint did not become ready after $((max_attempts * delay)) seconds." >&2
+            runtime_log "Migrations are applied, so the web container is started but not serving ${health_url}. Check the web container's log (for example 'docker compose logs backend') and whether that URL is reachable from this container." >&2
+            return 68
+        fi
+        if [ $((attempt % 10)) -eq 1 ]; then
+            runtime_log "Web endpoint is not healthy (attempt ${attempt}/${max_attempts})."
+        fi
+        sleep "$delay"
+    done
+    runtime_log "Web endpoint is healthy."
+}
+
+prepare_role_cache() {
+    local env="${APP_ENV:-prod}"
+
+    runtime_log "Clearing and warming ${env} cache..."
+    rm -rf "var/cache/${env}"
+    php bin/console --env="$env" cache:warmup
+}
+
+run_worker_role() {
+    local env="${APP_ENV:-prod}"
+
+    require_console || return
+    prepare_role_cache || return
+    wait_for_web_initialization || return
+
+    mkdir -p "$SYNAPLAN_RUNTIME_DIR"
+    date +%s > "${SYNAPLAN_RUNTIME_DIR}/worker.started"
+    runtime_log "Starting Messenger consumer (env=${env})."
+
+    # Word splitting is intentional: transports are a space-separated list of
+    # trusted Symfony transport names, with the current three as the default.
+    # shellcheck disable=SC2086
+    exec php bin/console --env="$env" messenger:consume \
+        $SYNAPLAN_WORKER_TRANSPORTS \
+        --time-limit="${SYNAPLAN_WORKER_TIME_LIMIT:-3600}" \
+        --memory-limit="${SYNAPLAN_WORKER_MEMORY_LIMIT:-512M}" -v
+}
+
+_scheduler_stopping=0
+_scheduler_sleep_pid=''
+_scheduler_child_pid=''
+
+stop_scheduler() {
+    _scheduler_stopping=1
+    if [ -n "$_scheduler_child_pid" ]; then
+        kill -TERM "$_scheduler_child_pid" 2>/dev/null || true
+    fi
+    if [ -n "$_scheduler_sleep_pid" ]; then
+        kill "$_scheduler_sleep_pid" 2>/dev/null || true
+    fi
+}
+
+run_scheduler_command() {
+    php "$@" &
+    _scheduler_child_pid=$!
+    wait "$_scheduler_child_pid"
+    local status=$?
+    _scheduler_child_pid=''
+    return "$status"
+}
+
+run_scheduler_role() {
+    local env="${APP_ENV:-prod}"
+    local tick_seconds="${SYNAPLAN_SCHEDULER_TICK_SECONDS:-60}"
+    local hourly_seconds="${SYNAPLAN_SCHEDULER_HOURLY_SECONDS:-3600}"
+    local now
+    local next_hourly=0
+    local cycles=0
+    local max_cycles="${SYNAPLAN_SCHEDULER_MAX_CYCLES:-0}"
+
+    require_console || return
+    prepare_role_cache || return
+    wait_for_web_initialization || return
+    mkdir -p "$SYNAPLAN_RUNTIME_DIR"
+    trap stop_scheduler TERM INT
+
+    runtime_log "Starting scheduler (media reaper every ${tick_seconds}s, ephemeral-file reaper every ${hourly_seconds}s)."
+    while [ "$_scheduler_stopping" -eq 0 ]; do
+        now="$(date +%s)"
+        printf '%s\n' "$now" > "${SYNAPLAN_RUNTIME_DIR}/scheduler.heartbeat"
+
+        if ! run_scheduler_command bin/console --env="$env" app:media:reap-jobs --no-interaction; then
+            runtime_log "Media reaper failed; it will be retried on the next tick." >&2
+        fi
+
+        if [ "$now" -ge "$next_hourly" ]; then
+            if ! run_scheduler_command bin/console --env="$env" app:files:reap-ephemeral --no-interaction; then
+                runtime_log "Ephemeral-file reaper failed; it will be retried next hour." >&2
+            fi
+            next_hourly=$((now + hourly_seconds))
+        fi
+
+        cycles=$((cycles + 1))
+        if [ "$max_cycles" -gt 0 ] && [ "$cycles" -ge "$max_cycles" ]; then
+            break
+        fi
+        if [ "$_scheduler_stopping" -ne 0 ]; then
+            break
+        fi
+
+        sleep "$tick_seconds" &
+        _scheduler_sleep_pid=$!
+        wait "$_scheduler_sleep_pid" 2>/dev/null || true
+        _scheduler_sleep_pid=''
+    done
+
+    runtime_log "Scheduler stopped."
+}

--- a/_docker/backend/tests/test-container-runtime.sh
+++ b/_docker/backend/tests/test-container-runtime.sh
@@ -463,6 +463,34 @@ assert_contains "Doctrine still reports pending migrations" "$TIMEOUT_LOG" \
 assert_contains "docker compose logs backend" "$TIMEOUT_LOG" \
     "the timeout points at the web container's log"
 
+echo "Case 11: the documented exit codes survive the entrypoint's 'set -e'"
+
+# This suite runs with `set -u` only, but the entrypoint that calls these
+# functions runs with `set -euo pipefail` — and under `set -e` a helper whose own
+# non-zero status is not guarded ends the shell right there, with ITS status
+# instead of the code the function was about to return. That is how the
+# documented 64 silently became a 1. Each guard is therefore exercised in a
+# subshell with the entrypoint's options.
+runtime_status_under_set_e() {
+    local status=0
+    bash -c "
+        set -euo pipefail
+        . '$RUNTIME_LIB'
+        cd '$1'
+        $2
+    " >/dev/null 2>&1 || status=$?
+
+    printf '%s\n' "$status"
+}
+
+assert_eq 64 "$(runtime_status_under_set_e "$TMP_DIR" require_console)" \
+    "a missing bin/console keeps exit code 64 under set -e"
+assert_eq 0 "$(runtime_status_under_set_e "$TMP_DIR/app" require_console)" \
+    "an existing bin/console is accepted under set -e"
+assert_eq 78 "$(BOOTSTRAP_ADMIN_EMAIL=admin@example.com BOOTSTRAP_ADMIN_PASSWORD= \
+    runtime_status_under_set_e "$TMP_DIR/app" require_bootstrap_admin_pair)" \
+    "a half-configured bootstrap pair keeps exit code 78 under set -e"
+
 TOTAL=$((PASS + FAIL))
 echo "${PASS}/${TOTAL} assertions passed"
 [ "$FAIL" -eq 0 ]

--- a/_docker/backend/tests/test-container-runtime.sh
+++ b/_docker/backend/tests/test-container-runtime.sh
@@ -1,0 +1,468 @@
+#!/usr/bin/env bash
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+RUNTIME_LIB="${SCRIPT_DIR}/../lib/container-runtime.sh"
+HEALTHCHECK="${SCRIPT_DIR}/../container-healthcheck.sh"
+
+# shellcheck disable=SC1090
+. "$RUNTIME_LIB"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+    local expected="$1"
+    local actual="$2"
+    local message="$3"
+
+    if [ "$expected" = "$actual" ]; then
+        PASS=$((PASS + 1))
+        echo "PASS: ${message}"
+    else
+        FAIL=$((FAIL + 1))
+        echo "FAIL: ${message} (expected=${expected}, actual=${actual})" >&2
+    fi
+}
+
+assert_contains() {
+    local needle="$1"
+    local file="$2"
+    local message="$3"
+
+    if grep -Fq -- "$needle" "$file"; then
+        PASS=$((PASS + 1))
+        echo "PASS: ${message}"
+    else
+        FAIL=$((FAIL + 1))
+        echo "FAIL: ${message} (missing '${needle}')" >&2
+    fi
+}
+
+assert_not_contains() {
+    local needle="$1"
+    local file="$2"
+    local message="$3"
+
+    if grep -Fq -- "$needle" "$file"; then
+        FAIL=$((FAIL + 1))
+        echo "FAIL: ${message} (found '${needle}')" >&2
+    else
+        PASS=$((PASS + 1))
+        echo "PASS: ${message}"
+    fi
+}
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+mkdir -p "$TMP_DIR/bin" "$TMP_DIR/app/bin" "$TMP_DIR/runtime"
+touch "$TMP_DIR/app/bin/console"
+COMMAND_LOG="$TMP_DIR/commands.log"
+
+cat > "$TMP_DIR/bin/php" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$*" >> "$COMMAND_LOG"
+exit 0
+EOF
+cat > "$TMP_DIR/bin/curl" <<'EOF'
+#!/bin/sh
+exit 0
+EOF
+chmod +x "$TMP_DIR/bin/php" "$TMP_DIR/bin/curl"
+
+echo "Case 1: worker waits for initialization and preserves Messenger defaults"
+(
+    cd "$TMP_DIR/app" || exit
+    export PATH="$TMP_DIR/bin:$PATH"
+    export COMMAND_LOG
+    export SYNAPLAN_ROLE=worker
+    export SYNAPLAN_RUNTIME_DIR="$TMP_DIR/runtime"
+    # shellcheck disable=SC1090
+    . "$RUNTIME_LIB"
+    run_worker_role
+)
+assert_contains "doctrine:migrations:up-to-date --no-interaction" "$COMMAND_LOG" "worker waits until migrations are current"
+assert_contains "messenger:consume async_ai_high async_extract async_index --time-limit=3600 --memory-limit=512M -v" "$COMMAND_LOG" "worker consumes all current transports with current limits"
+
+echo "Case 2: scheduler runs both commands initially and writes a heartbeat"
+: > "$COMMAND_LOG"
+(
+    cd "$TMP_DIR/app" || exit
+    export PATH="$TMP_DIR/bin:$PATH"
+    export COMMAND_LOG
+    export SYNAPLAN_ROLE=scheduler
+    export SYNAPLAN_RUNTIME_DIR="$TMP_DIR/runtime"
+    export SYNAPLAN_SCHEDULER_MAX_CYCLES=1
+    # shellcheck disable=SC1090
+    . "$RUNTIME_LIB"
+    prepare_role_cache() { :; }
+    wait_for_web_initialization() { :; }
+    php() {
+        printf '%s\n' "$*" >> "$COMMAND_LOG"
+    }
+    run_scheduler_role
+)
+assert_contains "app:media:reap-jobs --no-interaction" "$COMMAND_LOG" "scheduler runs media reaper"
+assert_contains "app:files:reap-ephemeral --no-interaction" "$COMMAND_LOG" "scheduler runs ephemeral-file reaper"
+if [ -s "$TMP_DIR/runtime/scheduler.heartbeat" ]; then
+    assert_eq 1 1 "scheduler writes liveness heartbeat"
+else
+    assert_eq 1 0 "scheduler writes liveness heartbeat"
+fi
+
+echo "Case 3: initialization wait retries pending migrations"
+DB_CALLS=0
+MIGRATION_CALLS=0
+HEALTH_CALLS=0
+sleep() { :; }
+curl() { HEALTH_CALLS=$((HEALTH_CALLS + 1)); return 0; }
+php() {
+    case "$*" in
+        *dbal:run-sql*) DB_CALLS=$((DB_CALLS + 1)); return 0 ;;
+        *doctrine:migrations:up-to-date*)
+            MIGRATION_CALLS=$((MIGRATION_CALLS + 1))
+            [ "$MIGRATION_CALLS" -ge 3 ]
+            ;;
+    esac
+}
+SYNAPLAN_INIT_WAIT_ATTEMPTS=5 SYNAPLAN_INIT_WAIT_SECONDS=0 wait_for_web_initialization >/dev/null
+assert_eq 1 "$DB_CALLS" "database readiness is checked"
+assert_eq 3 "$MIGRATION_CALLS" "pending migrations are retried"
+assert_eq 1 "$HEALTH_CALLS" "web health is checked after migrations"
+unset -f php curl sleep
+
+echo "Case 4: healthcheck rejects unsupported roles and stale scheduler heartbeats"
+if SYNAPLAN_ROLE=invalid bash "$HEALTHCHECK" >/dev/null 2>&1; then
+    assert_eq 1 0 "unsupported role is rejected"
+else
+    assert_eq 1 1 "unsupported role is rejected"
+fi
+printf '1\n' > "$TMP_DIR/runtime/scheduler.heartbeat"
+if SYNAPLAN_ROLE=scheduler SYNAPLAN_RUNTIME_DIR="$TMP_DIR/runtime" bash "$HEALTHCHECK" >/dev/null 2>&1; then
+    assert_eq 1 0 "stale scheduler heartbeat is rejected"
+else
+    assert_eq 1 1 "stale scheduler heartbeat is rejected"
+fi
+
+if [ -d /proc/1 ]; then
+    echo "Case 5: Linux process probes recognize live worker and scheduler roles"
+    bash -c 'exec -a "php bin/console messenger:consume" sleep 10' &
+    worker_pid=$!
+    sleep 0.1
+    if SYNAPLAN_ROLE=worker bash "$HEALTHCHECK" >/dev/null 2>&1; then
+        assert_eq 1 1 "worker process probe recognizes Messenger consumer"
+    else
+        assert_eq 1 0 "worker process probe recognizes Messenger consumer"
+    fi
+    kill "$worker_pid" 2>/dev/null || true
+    wait "$worker_pid" 2>/dev/null || true
+
+    date +%s > "$TMP_DIR/runtime/scheduler.heartbeat"
+    bash -c 'exec -a "docker-entrypoint.sh scheduler" sleep 10' &
+    scheduler_pid=$!
+    sleep 0.1
+    if SYNAPLAN_ROLE=scheduler SYNAPLAN_RUNTIME_DIR="$TMP_DIR/runtime" bash "$HEALTHCHECK" >/dev/null 2>&1; then
+        assert_eq 1 1 "scheduler probe accepts fresh heartbeat and live process"
+    else
+        assert_eq 1 0 "scheduler probe accepts fresh heartbeat and live process"
+    fi
+    kill "$scheduler_pid" 2>/dev/null || true
+    wait "$scheduler_pid" 2>/dev/null || true
+fi
+
+echo "Case 6: first-admin bootstrap credentials are validated as a pair"
+
+# $3 is a per-case log path: sharing one file would make every assert_contains
+# depend on the call immediately above it.
+bootstrap_pair_status() {
+    local log="$3"
+    local status=0
+
+    # Subshell so the credentials never leak into the following assertions.
+    (
+        export BOOTSTRAP_ADMIN_EMAIL="$1"
+        export BOOTSTRAP_ADMIN_PASSWORD="$2"
+        require_bootstrap_admin_pair
+    ) > "$log" 2>&1 || status=$?
+
+    printf '%s\n' "$status"
+}
+
+BOTH_EMPTY_LOG="$TMP_DIR/bootstrap-both-empty.log"
+BOTH_SET_LOG="$TMP_DIR/bootstrap-both-set.log"
+EMAIL_ONLY_LOG="$TMP_DIR/bootstrap-email-only.log"
+PASSWORD_ONLY_LOG="$TMP_DIR/bootstrap-password-only.log"
+BLANK_EMAIL_LOG="$TMP_DIR/bootstrap-blank-email.log"
+
+assert_eq 0 "$(bootstrap_pair_status "" "" "$BOTH_EMPTY_LOG")" "both variables empty keeps the bootstrap optional"
+assert_eq 0 "$(bootstrap_pair_status "admin@example.com" "Str0ngPass" "$BOTH_SET_LOG")" "both variables set is accepted"
+assert_eq 78 "$(bootstrap_pair_status "admin@example.com" "" "$EMAIL_ONLY_LOG")" "only BOOTSTRAP_ADMIN_EMAIL set is rejected"
+assert_contains "BOOTSTRAP_ADMIN_PASSWORD is empty" "$EMAIL_ONLY_LOG" "the error names the missing password variable"
+assert_eq 78 "$(bootstrap_pair_status "" "Str0ngPass" "$PASSWORD_ONLY_LOG")" "only BOOTSTRAP_ADMIN_PASSWORD set is rejected"
+assert_contains "BOOTSTRAP_ADMIN_EMAIL is empty" "$PASSWORD_ONLY_LOG" "the error names the missing email variable"
+# BootstrapAdminService trims the email before its emptiness check, so a
+# whitespace-only email without a password is "not configured" there — the
+# shell guard must not be stricter and abort the boot instead.
+assert_eq 0 "$(bootstrap_pair_status "   " "" "$BLANK_EMAIL_LOG")" "whitespace-only email without a password matches the PHP validator"
+
+echo "Case 7: the full configuration check delegates to the PHP validator"
+
+# A php stub whose exit status and stderr are driven by the environment: this
+# case characterizes how the shell REACTS to the authority's verdict, never the
+# rules themselves — those are owned by BootstrapAdminConfiguration and tested in
+# backend/tests/Unit/Service/Admin/BootstrapAdminConfigurationTest.php.
+mkdir -p "$TMP_DIR/php-stub" "$TMP_DIR/app/vendor"
+: > "$TMP_DIR/app/vendor/autoload.php"
+PHP_STUB_LOG="$TMP_DIR/php-stub-invocations.log"
+cat > "$TMP_DIR/php-stub/php" <<'EOF'
+#!/bin/sh
+printf 'invoked\n' >> "$PHP_STUB_LOG"
+if [ -n "${PHP_STUB_MESSAGE:-}" ]; then
+    printf '%s' "$PHP_STUB_MESSAGE" >&2
+fi
+exit "${PHP_STUB_EXIT:-0}"
+EOF
+chmod +x "$TMP_DIR/php-stub/php"
+
+# $1 email  $2 password  $3 stub exit  $4 stub stderr  $5 log path
+bootstrap_config_status() {
+    local status=0
+
+    : > "$PHP_STUB_LOG"
+    (
+        cd "$TMP_DIR/app" || exit 70
+        export PATH="$TMP_DIR/php-stub:$PATH"
+        export PHP_STUB_LOG
+        export BOOTSTRAP_ADMIN_EMAIL="$1"
+        export BOOTSTRAP_ADMIN_PASSWORD="$2"
+        export PHP_STUB_EXIT="$3"
+        export PHP_STUB_MESSAGE="$4"
+        # shellcheck disable=SC1090
+        . "$RUNTIME_LIB"
+        require_valid_bootstrap_admin_config
+    ) > "$5" 2>&1 || status=$?
+
+    printf '%s\n' "$status"
+}
+
+CONFIG_INERT_LOG="$TMP_DIR/config-inert.log"
+CONFIG_BLANK_EMAIL_LOG="$TMP_DIR/config-blank-email.log"
+CONFIG_VALID_LOG="$TMP_DIR/config-valid.log"
+CONFIG_INVALID_LOG="$TMP_DIR/config-invalid.log"
+CONFIG_UNAVAILABLE_LOG="$TMP_DIR/config-unavailable.log"
+CONFIG_NO_AUTOLOAD_LOG="$TMP_DIR/config-no-autoload.log"
+
+assert_eq 0 "$(bootstrap_config_status "" "" 1 "should never run" "$CONFIG_INERT_LOG")" \
+    "an unconfigured bootstrap is accepted without consulting PHP"
+if [ -s "$PHP_STUB_LOG" ]; then
+    assert_eq 1 0 "an unconfigured bootstrap starts no PHP process"
+else
+    assert_eq 1 1 "an unconfigured bootstrap starts no PHP process"
+fi
+
+# The authority trims the email before deciding whether the bootstrap is
+# configured, so a whitespace-only address without a password is not configured
+# at all. Without the same normalization the guard spawns PHP and then reports an
+# accepted configuration for a bootstrap that never runs.
+assert_eq 0 "$(bootstrap_config_status "   " "" 1 "should never run" "$CONFIG_BLANK_EMAIL_LOG")" \
+    "a whitespace-only email without a password stays unconfigured"
+if [ -s "$PHP_STUB_LOG" ]; then
+    assert_eq 1 0 "a whitespace-only email without a password starts no PHP process"
+else
+    assert_eq 1 1 "a whitespace-only email without a password starts no PHP process"
+fi
+assert_not_contains "First-admin bootstrap configuration accepted." "$CONFIG_BLANK_EMAIL_LOG" \
+    "an unconfigured bootstrap never claims that a configuration was accepted"
+
+assert_eq 0 "$(bootstrap_config_status "admin@example.com" "Str0ngPass" 0 "" "$CONFIG_VALID_LOG")" \
+    "a configuration the validator accepts continues the startup"
+if [ -s "$PHP_STUB_LOG" ]; then
+    assert_eq 1 1 "a configured bootstrap is validated by the PHP authority"
+else
+    assert_eq 1 0 "a configured bootstrap is validated by the PHP authority"
+fi
+
+assert_eq 1 "$(bootstrap_config_status "not-an-email" "Str0ngPass" 1 "BOOTSTRAP_ADMIN_EMAIL must be a valid email address of at most 128 characters." "$CONFIG_INVALID_LOG")" \
+    "a rejected value aborts the startup with exit code 1"
+assert_contains "BOOTSTRAP_ADMIN_EMAIL must be a valid email address" "$CONFIG_INVALID_LOG" \
+    "the validator's own message is surfaced verbatim"
+assert_contains "before the database wait, the migrations and the seeders" "$CONFIG_INVALID_LOG" \
+    "the error states that nothing was written to the database"
+
+# Exit code 2 means the check itself could not run. It must never be the reason
+# a container stops: the bootstrap command still validates the same values.
+assert_eq 0 "$(bootstrap_config_status "admin@example.com" "Str0ngPass" 2 "autoloader is incomplete" "$CONFIG_UNAVAILABLE_LOG")" \
+    "an unavailable validator does not block the startup"
+assert_contains "Could not run the early first-admin configuration check" "$CONFIG_UNAVAILABLE_LOG" \
+    "an unavailable validator is reported as a warning"
+# This is the one line that tells an operator "your credentials were never
+# validated", so it must carry the entrypoint's warning marker instead of
+# looking like ordinary status output.
+assert_contains "⚠️" "$CONFIG_UNAVAILABLE_LOG" \
+    "the unvalidated-configuration warning is marked as a warning"
+
+CONFIG_NO_AUTOLOAD_STATUS=0
+(
+    cd "$TMP_DIR" || exit 70
+    export PATH="$TMP_DIR/php-stub:$PATH"
+    export PHP_STUB_LOG
+    export BOOTSTRAP_ADMIN_EMAIL="admin@example.com"
+    export BOOTSTRAP_ADMIN_PASSWORD="Str0ngPass"
+    export SYNAPLAN_AUTOLOAD_PATH="$TMP_DIR/missing/autoload.php"
+    # shellcheck disable=SC1090
+    . "$RUNTIME_LIB"
+    require_valid_bootstrap_admin_config
+) > "$CONFIG_NO_AUTOLOAD_LOG" 2>&1 || CONFIG_NO_AUTOLOAD_STATUS=$?
+assert_eq 0 "$CONFIG_NO_AUTOLOAD_STATUS" "a missing autoloader skips the check instead of failing"
+assert_contains "Skipping the early first-admin configuration check" "$CONFIG_NO_AUTOLOAD_LOG" \
+    "the skipped check says why it was skipped"
+assert_contains "⚠️" "$CONFIG_NO_AUTOLOAD_LOG" \
+    "the skipped check is marked as a warning"
+
+echo "Case 8: the full configuration check owns no rules of its own"
+
+# CONTRACT: the guard must only pass the environment to
+# BootstrapAdminConfiguration and report its verdict. The moment either half of
+# it grows a rule, that copy can drift looser than the authority — which is
+# exactly how an invalid address once survived a preflight and crash-looped the
+# backend.
+#
+# The function has two halves and BOTH are scanned. Splitting them at the
+# embedded heredoc is what makes that possible: a scan that simply stops at the
+# first line consisting of a closing brace stops at the heredoc's PHP brace and
+# silently leaves the entire verdict evaluation unchecked — a shell copy of a
+# password rule placed after the heredoc then passes unnoticed.
+GUARD_PROGRAM="$TMP_DIR/require-valid-config-program.php"
+GUARD_SHELL="$TMP_DIR/require-valid-config-shell.sh"
+: > "$GUARD_PROGRAM"
+: > "$GUARD_SHELL"
+awk -v opener="<<'PHP'" -v program="$GUARD_PROGRAM" -v shell_body="$GUARD_SHELL" '
+    !capture {
+        if ($0 == "require_valid_bootstrap_admin_config() {") {
+            capture = 1
+        }
+        next
+    }
+    heredoc {
+        if ($0 == "PHP") {
+            heredoc = 0
+        } else {
+            print > program
+        }
+        next
+    }
+    index($0, opener) {
+        heredoc = 1
+        next
+    }
+    $0 == "}" {
+        exit
+    }
+    {
+        print > shell_body
+    }
+' "$RUNTIME_LIB"
+
+# An empty region would make every "does not reimplement" assertion below pass
+# for free, so both halves are first proven to contain what they must.
+assert_contains "App\\Service\\Admin\\BootstrapAdminConfiguration::fromConfiguration" "$GUARD_PROGRAM" \
+    "the guard calls the authoritative validator"
+# The first line after the heredoc and a line just before the function's own
+# closing brace: together they prove the second half is scanned to the end.
+assert_contains 'local message verdict=0' "$GUARD_SHELL" \
+    "the scanned shell half reaches the verdict evaluation behind the heredoc"
+assert_contains "Nothing was written to the database" "$GUARD_SHELL" \
+    "the scanned shell half reaches the end of the function"
+
+# The PHP program may only call the authority: these are the mechanisms the
+# authority's own rules are built from.
+for FORBIDDEN_MECHANISM in filter_var FILTER_VALIDATE_EMAIL preg_match strlen; do
+    assert_not_contains "$FORBIDDEN_MECHANISM" "$GUARD_PROGRAM" \
+        "the PHP program does not reimplement a rule with '${FORBIDDEN_MECHANISM}'"
+done
+
+# The shell half is checked by MECHANISM, not by threshold. '${#' is the only way
+# shell measures a length, so it covers every length rule (email maximum,
+# password minimum and maximum, composition waiver) no matter which variable a
+# drifted copy measures; '=~' and a character class are the only ways it inspects
+# content. Matching bare numbers instead would miss a rule written against a
+# local variable AND false-positive on any legitimate number — a '--max-time 128',
+# an 'exit 128', a "128" inside a comment.
+for FORBIDDEN_MECHANISM in filter_var FILTER_VALIDATE_EMAIL preg_match '${#' '=~' '[[:upper:]]' '[[:lower:]]' '[[:digit:]]' '*@*'; do
+    assert_not_contains "$FORBIDDEN_MECHANISM" "$GUARD_SHELL" \
+        "the shell half does not reimplement a rule with '${FORBIDDEN_MECHANISM}'"
+done
+
+echo "Case 9: the entrypoint wires both bootstrap guards in before any expensive work"
+ENTRYPOINT="${SCRIPT_DIR}/../docker-entrypoint.sh"
+
+# First matching line number, or empty when the pattern is absent.
+entrypoint_line_of() {
+    grep -n -E -- "$1" "$ENTRYPOINT" | head -n 1 | cut -d: -f1
+}
+
+GUARD_LINE="$(entrypoint_line_of '^[[:space:]]*require_bootstrap_admin_pair[[:space:]]*$')"
+CONFIG_GUARD_LINE="$(entrypoint_line_of '^[[:space:]]*require_valid_bootstrap_admin_config[[:space:]]*$')"
+# The full check needs vendor/, which the dev stack only populates in the
+# /docker-entrypoint.d block.
+STARTUP_SCRIPTS_LINE="$(entrypoint_line_of '^[[:space:]]*echo "✅ Additional startup scripts completed"')"
+# The guards only pay off ahead of the first expensive step: the role dispatch
+# for worker/scheduler and the database wait for web.
+EXPENSIVE_LINE="$(entrypoint_line_of '^[[:space:]]*(run_worker_role|run_scheduler_role|wait_for_database)')"
+
+if [ -n "$GUARD_LINE" ]; then
+    assert_eq 1 1 "the entrypoint calls require_bootstrap_admin_pair"
+else
+    assert_eq 1 0 "the entrypoint calls require_bootstrap_admin_pair"
+fi
+if [ -n "$GUARD_LINE" ] && [ -n "$EXPENSIVE_LINE" ] && [ "$GUARD_LINE" -lt "$EXPENSIVE_LINE" ]; then
+    assert_eq 1 1 "the pairing guard runs before the role dispatch and the database wait"
+else
+    assert_eq 1 0 "the pairing guard runs before the role dispatch and the database wait"
+fi
+if [ -n "$CONFIG_GUARD_LINE" ]; then
+    assert_eq 1 1 "the entrypoint calls require_valid_bootstrap_admin_config"
+else
+    assert_eq 1 0 "the entrypoint calls require_valid_bootstrap_admin_config"
+fi
+if [ -n "$CONFIG_GUARD_LINE" ] && [ -n "$EXPENSIVE_LINE" ] && [ "$CONFIG_GUARD_LINE" -lt "$EXPENSIVE_LINE" ]; then
+    assert_eq 1 1 "the full configuration check runs before the role dispatch and the database wait"
+else
+    assert_eq 1 0 "the full configuration check runs before the role dispatch and the database wait"
+fi
+if [ -n "$CONFIG_GUARD_LINE" ] && [ -n "$STARTUP_SCRIPTS_LINE" ] && [ "$CONFIG_GUARD_LINE" -gt "$STARTUP_SCRIPTS_LINE" ]; then
+    assert_eq 1 1 "the full configuration check runs after /docker-entrypoint.d has populated vendor/"
+else
+    assert_eq 1 0 "the full configuration check runs after /docker-entrypoint.d has populated vendor/"
+fi
+if [ -n "$GUARD_LINE" ] && [ -n "$CONFIG_GUARD_LINE" ] && [ "$GUARD_LINE" -lt "$CONFIG_GUARD_LINE" ]; then
+    assert_eq 1 1 "the free pairing guard stays ahead of the PHP-backed check"
+else
+    assert_eq 1 0 "the free pairing guard stays ahead of the PHP-backed check"
+fi
+
+echo "Case 10: a worker timeout explains what never happened and where to look"
+TIMEOUT_LOG="$TMP_DIR/init-timeout.log"
+(
+    # shellcheck disable=SC1090
+    . "$RUNTIME_LIB"
+    php() {
+        case "$*" in
+            *dbal:run-sql*) return 0 ;;
+            *) return 1 ;;
+        esac
+    }
+    sleep() { :; }
+    SYNAPLAN_ROLE=worker SYNAPLAN_INIT_WAIT_ATTEMPTS=2 SYNAPLAN_INIT_WAIT_SECONDS=0 \
+        wait_for_web_initialization
+) > "$TIMEOUT_LOG" 2>&1
+TIMEOUT_STATUS=$?
+assert_eq 67 "$TIMEOUT_STATUS" "a pending-migration timeout keeps exit code 67"
+assert_contains "Doctrine still reports pending migrations" "$TIMEOUT_LOG" \
+    "the timeout names what was being waited for"
+assert_contains "docker compose logs backend" "$TIMEOUT_LOG" \
+    "the timeout points at the web container's log"
+
+TOTAL=$((PASS + FAIL))
+echo "${PASS}/${TOTAL} assertions passed"
+[ "$FAIL" -eq 0 ]

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -266,6 +266,17 @@ OIDC_ROLE_CLAIMS=realm_access.roles,resource_access.{client_id}.roles,groups
 # Recommended for SSO-/OIDC-only instances. Defaults to true.
 REGISTRATION_ENABLED=true
 
+# --- First administrator bootstrap (optional) ---
+# Set both values or leave both empty — a container that receives only one of the
+# two refuses to start. The Docker entrypoint runs app:bootstrap-admin on start
+# whenever at least one value is set.
+# The command only acts while no administrator exists. Re-running it never
+# changes an existing administrator or resets an administrator password.
+# Password: 8-64 characters; below 16 characters it also needs uppercase,
+# lowercase, and a number. Full rules: docs/INSTALLATION.md.
+BOOTSTRAP_ADMIN_EMAIL=
+BOOTSTRAP_ADMIN_PASSWORD=
+
 # --- MCP (Model Context Protocol) server ---
 # Synaplan exposes a Streamable HTTP MCP endpoint at POST /mcp (authenticated by
 # API key or OIDC bearer). MCP_ALLOWED_HOSTS is a comma-separated list of extra

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -77,7 +77,9 @@ cache-clear: ## Clear Symfony cache
 	docker compose -f ../docker-compose.yml exec -T backend php bin/console cache:clear
 
 test: ## Run all PHPUnit tests
-	docker compose -f ../docker-compose.yml exec -T backend php bin/phpunit
+	# The backend's HTTP timeout also applies to CLI in the container. The full
+	# suite legitimately exceeds it, so disable only the CLI execution limit.
+	docker compose -f ../docker-compose.yml exec -T backend php -d max_execution_time=0 bin/phpunit
 
 plan-eval: ## Evaluate the multitask planner against the golden corpus (LIVE model — not part of the CI gate)
 	docker compose -f ../docker-compose.yml exec -T backend php bin/console app:multitask:plan-eval

--- a/backend/config/services.yaml
+++ b/backend/config/services.yaml
@@ -140,6 +140,11 @@ parameters:
     # "web.synaplan.com".
     env(MCP_ALLOWED_HOSTS): ''
 
+    # Optional first-admin bootstrap. Both values must be set together; once an
+    # admin exists, app:bootstrap-admin never changes any account or password.
+    env(BOOTSTRAP_ADMIN_EMAIL): ''
+    env(BOOTSTRAP_ADMIN_PASSWORD): ''
+
 services:
     _defaults:
         autowire: true
@@ -594,6 +599,11 @@ services:
             $appUrl: '%env(APP_URL)%'
         tags:
             - { name: 'console.command' }
+
+    App\Command\BootstrapAdminCommand:
+        arguments:
+            $bootstrapAdminEmail: '%env(string:BOOTSTRAP_ADMIN_EMAIL)%'
+            $bootstrapAdminPassword: '%env(string:BOOTSTRAP_ADMIN_PASSWORD)%'
 
     # Encryption Service (for sensitive data like IMAP passwords)
     App\Service\EncryptionService:

--- a/backend/migrations/Version20260429000000.php
+++ b/backend/migrations/Version20260429000000.php
@@ -26,11 +26,9 @@ use Doctrine\Migrations\AbstractMigration;
  *   - messenger_messages.{created,available,delivered}_at      (strip DC2Type:datetime_immutable)
  *   - BUSELOG.BERROR                                           (drop `DEFAULT ''` if present on legacy DBs)
  *
- * Idempotency: every statement uses `ALTER TABLE ... CHANGE col col <full-def>`, which
- * MariaDB treats as absolute — re-running the migration after it has already been
- * applied is a no-op at the SQL layer. The table / column existence checks below also
- * skip statements whose targets don't exist (e.g. the messenger_messages block is a
- * no-op on an install that disabled the doctrine transport before this migration).
+ * Idempotency: every statement uses `ALTER TABLE IF EXISTS ... CHANGE COLUMN IF EXISTS`,
+ * so re-running the migration converges to the same metadata and missing optional
+ * tables or columns are skipped by MariaDB itself.
  *
  * Failure mode: since the migration cannot run in a transaction on MariaDB, a partial
  * failure in statement N leaves statements 1..N-1 applied. That's not an integrity
@@ -55,39 +53,31 @@ final class Version20260429000000 extends AbstractMigration
     public function up(Schema $schema): void
     {
         // BRAG.BEMBED — strip vector DC2Type comment
-        if ($schema->hasTable('BRAG') && $schema->getTable('BRAG')->hasColumn('BEMBED')) {
-            $this->addSql("ALTER TABLE BRAG CHANGE BEMBED BEMBED VECTOR(1024) NOT NULL COMMENT ''");
-        }
+        $this->addSql("ALTER TABLE IF EXISTS BRAG CHANGE COLUMN IF EXISTS BEMBED BEMBED VECTOR(1024) NOT NULL COMMENT ''");
 
         // plugin_data — strip datetime_immutable DC2Type comments
-        if ($schema->hasTable('plugin_data')) {
-            $this->addSql(<<<'SQL'
-                ALTER TABLE plugin_data
-                  CHANGE created_at created_at DATETIME NOT NULL COMMENT '',
-                  CHANGE updated_at updated_at DATETIME NOT NULL COMMENT ''
-            SQL);
-        }
+        $this->addSql(<<<'SQL'
+            ALTER TABLE IF EXISTS plugin_data
+              CHANGE COLUMN IF EXISTS created_at created_at DATETIME NOT NULL COMMENT '',
+              CHANGE COLUMN IF EXISTS updated_at updated_at DATETIME NOT NULL COMMENT ''
+        SQL);
 
         // messenger_messages — strip datetime_immutable DC2Type comments. Guarded
         // so the migration is a no-op for installs that provision messenger via a
         // different transport (e.g. redis) and therefore never created the table.
-        if ($schema->hasTable('messenger_messages')) {
-            $this->addSql(<<<'SQL'
-                ALTER TABLE messenger_messages
-                  CHANGE created_at   created_at   DATETIME NOT NULL      COMMENT '',
-                  CHANGE available_at available_at DATETIME NOT NULL      COMMENT '',
-                  CHANGE delivered_at delivered_at DATETIME DEFAULT NULL  COMMENT ''
-            SQL);
-        }
+        $this->addSql(<<<'SQL'
+            ALTER TABLE IF EXISTS messenger_messages
+              CHANGE COLUMN IF EXISTS created_at   created_at   DATETIME NOT NULL      COMMENT '',
+              CHANGE COLUMN IF EXISTS available_at available_at DATETIME NOT NULL      COMMENT '',
+              CHANGE COLUMN IF EXISTS delivered_at delivered_at DATETIME DEFAULT NULL  COMMENT ''
+        SQL);
 
         // BUSELOG.BERROR — some legacy hand-crafted DBs have `LONGTEXT DEFAULT ''`
         // (baseline 20260417 correctly has no default). The entity no longer declares
         // a default, so `schema:validate` would flag drift on those installs. Dropping
         // the default is a metadata-only change with no effect on existing rows —
         // writers always pass an explicit value (see RateLimitService::recordUsage).
-        if ($schema->hasTable('BUSELOG') && $schema->getTable('BUSELOG')->hasColumn('BERROR')) {
-            $this->addSql('ALTER TABLE BUSELOG CHANGE BERROR BERROR LONGTEXT NOT NULL');
-        }
+        $this->addSql('ALTER TABLE IF EXISTS BUSELOG CHANGE COLUMN IF EXISTS BERROR BERROR LONGTEXT NOT NULL');
     }
 
     public function down(Schema $schema): void
@@ -97,25 +87,19 @@ final class Version20260429000000 extends AbstractMigration
         // created DB or on installs that never ran DBAL 3.x. BUSELOG.BERROR's
         // default is intentionally NOT restored — baseline 20260417 has no default
         // and that's the correct target for a rollback.
-        if ($schema->hasTable('BRAG') && $schema->getTable('BRAG')->hasColumn('BEMBED')) {
-            $this->addSql("ALTER TABLE BRAG CHANGE BEMBED BEMBED VECTOR(1024) NOT NULL COMMENT '(DC2Type:vector)'");
-        }
+        $this->addSql("ALTER TABLE IF EXISTS BRAG CHANGE COLUMN IF EXISTS BEMBED BEMBED VECTOR(1024) NOT NULL COMMENT '(DC2Type:vector)'");
 
-        if ($schema->hasTable('plugin_data')) {
-            $this->addSql(<<<'SQL'
-                ALTER TABLE plugin_data
-                  CHANGE created_at created_at DATETIME NOT NULL COMMENT '(DC2Type:datetime_immutable)',
-                  CHANGE updated_at updated_at DATETIME NOT NULL COMMENT '(DC2Type:datetime_immutable)'
-            SQL);
-        }
+        $this->addSql(<<<'SQL'
+            ALTER TABLE IF EXISTS plugin_data
+              CHANGE COLUMN IF EXISTS created_at created_at DATETIME NOT NULL COMMENT '(DC2Type:datetime_immutable)',
+              CHANGE COLUMN IF EXISTS updated_at updated_at DATETIME NOT NULL COMMENT '(DC2Type:datetime_immutable)'
+        SQL);
 
-        if ($schema->hasTable('messenger_messages')) {
-            $this->addSql(<<<'SQL'
-                ALTER TABLE messenger_messages
-                  CHANGE created_at   created_at   DATETIME NOT NULL      COMMENT '(DC2Type:datetime_immutable)',
-                  CHANGE available_at available_at DATETIME NOT NULL      COMMENT '(DC2Type:datetime_immutable)',
-                  CHANGE delivered_at delivered_at DATETIME DEFAULT NULL  COMMENT '(DC2Type:datetime_immutable)'
-            SQL);
-        }
+        $this->addSql(<<<'SQL'
+            ALTER TABLE IF EXISTS messenger_messages
+              CHANGE COLUMN IF EXISTS created_at   created_at   DATETIME NOT NULL      COMMENT '(DC2Type:datetime_immutable)',
+              CHANGE COLUMN IF EXISTS available_at available_at DATETIME NOT NULL      COMMENT '(DC2Type:datetime_immutable)',
+              CHANGE COLUMN IF EXISTS delivered_at delivered_at DATETIME DEFAULT NULL  COMMENT '(DC2Type:datetime_immutable)'
+        SQL);
     }
 }

--- a/backend/migrations/Version20260530000000.php
+++ b/backend/migrations/Version20260530000000.php
@@ -43,12 +43,8 @@ final class Version20260530000000 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        if ($schema->hasTable('BWIDGET_EVENTS')) {
-            return;
-        }
-
         $this->addSql(<<<'SQL'
-            CREATE TABLE BWIDGET_EVENTS (
+            CREATE TABLE IF NOT EXISTS BWIDGET_EVENTS (
               BID BIGINT AUTO_INCREMENT NOT NULL,
               BWIDGETID VARCHAR(64) NOT NULL,
               BSESSIONID VARCHAR(128) NOT NULL,

--- a/backend/migrations/Version20260607000000.php
+++ b/backend/migrations/Version20260607000000.php
@@ -39,8 +39,7 @@ final class Version20260607000000 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        // Guard: if neither table exists (unexpected), do nothing rather than fail.
-        if (!$schema->hasTable('BUSER') || !$schema->hasTable('BCONFIG')) {
+        if (!$this->requiredTablesExist()) {
             return;
         }
 
@@ -53,6 +52,10 @@ final class Version20260607000000 extends AbstractMigration
 
     public function down(Schema $schema): void
     {
+        if (!$this->configTableExists()) {
+            return;
+        }
+
         // Remove the per-user grandfather rows. This also removes any per-user
         // ROUTING_ENABLED row a user set themselves — acceptable for a down
         // migration (reverts to the global default); the global ownerId=0 row
@@ -63,5 +66,29 @@ final class Version20260607000000 extends AbstractMigration
               AND BSETTING = 'ROUTING_ENABLED'
               AND BOWNERID > 0
         SQL);
+    }
+
+    private function requiredTablesExist(): bool
+    {
+        $tableCount = $this->connection->fetchOne(<<<'SQL'
+            SELECT COUNT(DISTINCT TABLE_NAME)
+            FROM information_schema.TABLES
+            WHERE TABLE_SCHEMA = DATABASE()
+              AND TABLE_NAME IN ('BUSER', 'BCONFIG')
+        SQL);
+
+        return 2 === (int) $tableCount;
+    }
+
+    private function configTableExists(): bool
+    {
+        $tableCount = $this->connection->fetchOne(<<<'SQL'
+            SELECT COUNT(*)
+            FROM information_schema.TABLES
+            WHERE TABLE_SCHEMA = DATABASE()
+              AND TABLE_NAME = 'BCONFIG'
+        SQL);
+
+        return (int) $tableCount > 0;
     }
 }

--- a/backend/migrations/Version20260629120000.php
+++ b/backend/migrations/Version20260629120000.php
@@ -40,8 +40,7 @@ final class Version20260629120000 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        // Guard: if neither table exists (unexpected), do nothing rather than fail.
-        if (!$schema->hasTable('BUSER') || !$schema->hasTable('BCONFIG')) {
+        if (!$this->requiredTablesExist()) {
             return;
         }
 
@@ -54,6 +53,10 @@ final class Version20260629120000 extends AbstractMigration
 
     public function down(Schema $schema): void
     {
+        if (!$this->configTableExists()) {
+            return;
+        }
+
         // Remove the per-user grandfather rows. This also removes any per-user
         // ASYNC_JOBS_ENABLED row a user set themselves — acceptable for a down
         // migration (reverts to the global default); the global ownerId=0 row
@@ -64,5 +67,29 @@ final class Version20260629120000 extends AbstractMigration
               AND BSETTING = 'ASYNC_JOBS_ENABLED'
               AND BOWNERID > 0
         SQL);
+    }
+
+    private function requiredTablesExist(): bool
+    {
+        $tableCount = $this->connection->fetchOne(<<<'SQL'
+            SELECT COUNT(DISTINCT TABLE_NAME)
+            FROM information_schema.TABLES
+            WHERE TABLE_SCHEMA = DATABASE()
+              AND TABLE_NAME IN ('BUSER', 'BCONFIG')
+        SQL);
+
+        return 2 === (int) $tableCount;
+    }
+
+    private function configTableExists(): bool
+    {
+        $tableCount = $this->connection->fetchOne(<<<'SQL'
+            SELECT COUNT(*)
+            FROM information_schema.TABLES
+            WHERE TABLE_SCHEMA = DATABASE()
+              AND TABLE_NAME = 'BCONFIG'
+        SQL);
+
+        return (int) $tableCount > 0;
     }
 }

--- a/backend/scripts/create_admin.php
+++ b/backend/scripts/create_admin.php
@@ -1,75 +1,25 @@
 #!/usr/bin/env php
 <?php
 
-/**
- * Create Admin User Script.
- *
- * Usage: php scripts/create_admin.php email@example.com password123
- */
+declare(strict_types=1);
+
+use Symfony\Component\Process\Process;
 
 require_once __DIR__.'/../vendor/autoload.php';
 
-use App\Entity\User;
-use Doctrine\ORM\EntityManagerInterface;
-use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+if ($argc > 1) {
+    fwrite(
+        STDERR,
+        'Command-line credentials are no longer accepted. Set BOOTSTRAP_ADMIN_EMAIL and '.
+        "BOOTSTRAP_ADMIN_PASSWORD, then run this script without arguments.\n"
+    );
 
-// Bootstrap Symfony kernel
-$kernel = new App\Kernel($_SERVER['APP_ENV'] ?? 'dev', (bool) ($_SERVER['APP_DEBUG'] ?? true));
-$kernel->boot();
-$container = $kernel->getContainer();
-
-/** @var EntityManagerInterface $em */
-$em = $container->get('doctrine')->getManager();
-
-/** @var UserPasswordHasherInterface $passwordHasher */
-$passwordHasher = $container->get(UserPasswordHasherInterface::class);
-
-// Get arguments
-if ($argc < 3) {
-    echo "Usage: php scripts/create_admin.php email@example.com password123\n";
     exit(1);
 }
 
-$email = $argv[1];
-$password = $argv[2];
+$process = new Process([PHP_BINARY, __DIR__.'/../bin/console', 'app:bootstrap-admin']);
+$process->setTimeout(null);
 
-// Check if user already exists
-$userRepo = $em->getRepository(User::class);
-$existingUser = $userRepo->findOneBy(['mail' => $email]);
-
-if ($existingUser) {
-    // Update existing user to admin
-    $existingUser->setUserLevel('ADMIN');
-    $existingUser->setEmailVerified(true);
-
-    if ($password) {
-        $hashedPassword = $passwordHasher->hashPassword($existingUser, $password);
-        $existingUser->setPw($hashedPassword);
-    }
-
-    $em->flush();
-
-    echo "✅ User '$email' updated to ADMIN level\n";
-} else {
-    // Create new admin user
-    $user = new User();
-    $user->setMail($email);
-    $user->setType('WEB');
-    $user->setProviderId('local');
-    $user->setUserLevel('ADMIN');
-    $user->setEmailVerified(true);
-    $user->setCreated(date('Y-m-d H:i:s'));
-
-    $hashedPassword = $passwordHasher->hashPassword($user, $password);
-    $user->setPw($hashedPassword);
-
-    $em->persist($user);
-    $em->flush();
-
-    echo "✅ Admin user created successfully!\n";
-    echo "   Email: $email\n";
-    echo "   Password: $password\n";
-    echo "   Level: ADMIN\n";
-}
-
-exit(0);
+exit($process->run(static function (string $type, string $buffer): void {
+    fwrite(Process::ERR === $type ? STDERR : STDOUT, $buffer);
+}));

--- a/backend/src/Command/BootstrapAdminCommand.php
+++ b/backend/src/Command/BootstrapAdminCommand.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Service\Admin\BootstrapAdminService;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:bootstrap-admin',
+    description: 'Creates or promotes the first administrator from deployment environment variables',
+)]
+final class BootstrapAdminCommand extends Command
+{
+    public function __construct(
+        private readonly BootstrapAdminService $bootstrapAdminService,
+        private readonly string $bootstrapAdminEmail,
+        #[\SensitiveParameter]
+        private readonly string $bootstrapAdminPassword,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        try {
+            $result = $this->bootstrapAdminService->bootstrap(
+                $this->bootstrapAdminEmail,
+                $this->bootstrapAdminPassword,
+            );
+        } catch (\Throwable $exception) {
+            $io->error('First-admin bootstrap failed: '.$exception->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        match ($result) {
+            BootstrapAdminService::RESULT_NOT_CONFIGURED => $io->note(
+                'First-admin bootstrap is not configured; no changes were made.'
+            ),
+            BootstrapAdminService::RESULT_ADMIN_EXISTS => $io->note(
+                'An administrator already exists; no changes were made.'
+            ),
+            BootstrapAdminService::RESULT_PROMOTED => $io->success(
+                'The configured user was promoted to administrator and verified.'
+            ),
+            BootstrapAdminService::RESULT_CREATED => $io->success(
+                'The first administrator was created and verified.'
+            ),
+            default => throw new \LogicException(sprintf('Unknown bootstrap result "%s".', $result)),
+        };
+
+        return Command::SUCCESS;
+    }
+}

--- a/backend/src/Repository/UserRepository.php
+++ b/backend/src/Repository/UserRepository.php
@@ -23,6 +23,11 @@ class UserRepository extends ServiceEntityRepository
         return $this->findOneBy(['providerId' => $providerId]);
     }
 
+    public function hasAdmin(): bool
+    {
+        return $this->count(['userLevel' => 'ADMIN']) > 0;
+    }
+
     /**
      * Find user by Stripe customer ID (searches in paymentDetails JSON).
      */

--- a/backend/src/Service/Admin/BootstrapAdminConfiguration.php
+++ b/backend/src/Service/Admin/BootstrapAdminConfiguration.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Admin;
+
+/**
+ * The validated first-admin bootstrap configuration.
+ *
+ * This class is the single authority for the BOOTSTRAP_ADMIN_EMAIL and
+ * BOOTSTRAP_ADMIN_PASSWORD rules. It deliberately has no dependencies — no
+ * container, no database, no Symfony kernel — so the exact same rules can be
+ * decided in three places without a second implementation that could drift:
+ *
+ *   1. the container entrypoint, seconds after start and before the database
+ *      wait, the migrations and the seeders (see require_valid_bootstrap_admin_config
+ *      in _docker/backend/lib/container-runtime.sh);
+ *   2. BootstrapAdminService, which performs the actual bootstrap;
+ *   3. the host-side deployment preflight, through the application image.
+ *
+ * Values are only ever validated here, never echoed: the password is a secret,
+ * so no rule violation message may contain it.
+ */
+final readonly class BootstrapAdminConfiguration
+{
+    public const MAXIMUM_EMAIL_LENGTH = 128;
+    public const MINIMUM_PASSWORD_LENGTH = 8;
+    public const MAXIMUM_PASSWORD_LENGTH = 64;
+    public const COMPOSITION_WAIVER_LENGTH = 16;
+
+    /**
+     * The accepted password, wrapped so that only password() can read it.
+     *
+     * A public string property would be printed verbatim by anything that ever
+     * receives this object — var_dump(), json_encode(), a log context, a
+     * Symfony error page. A SensitiveParameterValue exposes nothing to any of
+     * them and refuses serialization outright, which #[\SensitiveParameter] on
+     * a promoted property cannot do: that attribute only redacts stack traces.
+     */
+    private \SensitiveParameterValue $password;
+
+    private function __construct(
+        public string $email,
+        #[\SensitiveParameter]
+        string $acceptedPassword,
+    ) {
+        $this->password = new \SensitiveParameterValue($acceptedPassword);
+    }
+
+    /**
+     * The plaintext password, for the single caller that has to hash it.
+     */
+    public function password(): string
+    {
+        $password = $this->password->getValue();
+        \assert(\is_string($password));
+
+        return $password;
+    }
+
+    /**
+     * Validates raw deployment configuration.
+     *
+     * Both values empty is a valid choice and means "do not bootstrap an
+     * administrator"; exactly one of them is an operator error.
+     *
+     * @return self|null null when the bootstrap is not configured at all
+     *
+     * @throws \InvalidArgumentException when the configuration is incomplete or breaks a rule
+     */
+    public static function fromConfiguration(
+        string $configuredEmail,
+        #[\SensitiveParameter]
+        string $configuredPassword,
+    ): ?self {
+        // Only the email is trimmed: leading or trailing whitespace in a
+        // password is a legitimate part of the secret.
+        $email = trim($configuredEmail);
+        $hasEmail = '' !== $email;
+        $hasPassword = '' !== $configuredPassword;
+
+        if ($hasEmail !== $hasPassword) {
+            throw new \InvalidArgumentException('BOOTSTRAP_ADMIN_EMAIL and BOOTSTRAP_ADMIN_PASSWORD must either both be set or both be empty.');
+        }
+
+        if (!$hasEmail) {
+            return null;
+        }
+
+        if (strlen($email) > self::MAXIMUM_EMAIL_LENGTH || false === filter_var($email, FILTER_VALIDATE_EMAIL)) {
+            throw new \InvalidArgumentException(sprintf('BOOTSTRAP_ADMIN_EMAIL must be a valid email address of at most %d characters.', self::MAXIMUM_EMAIL_LENGTH));
+        }
+
+        if (strlen($configuredPassword) < self::MINIMUM_PASSWORD_LENGTH) {
+            throw new \InvalidArgumentException(sprintf('BOOTSTRAP_ADMIN_PASSWORD must be at least %d characters.', self::MINIMUM_PASSWORD_LENGTH));
+        }
+
+        if (strlen($configuredPassword) > self::MAXIMUM_PASSWORD_LENGTH) {
+            throw new \InvalidArgumentException(sprintf('BOOTSTRAP_ADMIN_PASSWORD must be at most %d characters.', self::MAXIMUM_PASSWORD_LENGTH));
+        }
+
+        // Following NIST SP 800-63B, composition rules only apply to short
+        // passwords. Long values are waived because managed platforms (for
+        // example Elestio) inject a high-entropy generated password and show it
+        // to the operator as the login credential: such a value can legitimately
+        // lack a digit, and rejecting it would crash-loop the whole deployment.
+        if (strlen($configuredPassword) < self::COMPOSITION_WAIVER_LENGTH
+            && 1 !== preg_match('/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)/', $configuredPassword)
+        ) {
+            throw new \InvalidArgumentException(sprintf('BOOTSTRAP_ADMIN_PASSWORD must contain at least one uppercase letter, one lowercase letter, and one number, or be at least %d characters long.', self::COMPOSITION_WAIVER_LENGTH));
+        }
+
+        return new self($email, $configuredPassword);
+    }
+}

--- a/backend/src/Service/Admin/BootstrapAdminService.php
+++ b/backend/src/Service/Admin/BootstrapAdminService.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Admin;
+
+use App\Repository\UserRepository;
+use App\Service\UserLifecycleService;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Creates the first administrator from deployment credentials.
+ *
+ * Once any administrator exists, this service is deliberately a no-op. This
+ * makes it safe to run on every container start without turning the bootstrap
+ * secret into a permanent password-reset mechanism.
+ *
+ * The rules for the configured values are not implemented here: they belong to
+ * BootstrapAdminConfiguration, which the container entrypoint also calls long
+ * before this service runs. One implementation, no drift.
+ */
+final readonly class BootstrapAdminService
+{
+    public const RESULT_NOT_CONFIGURED = 'not_configured';
+    public const RESULT_ADMIN_EXISTS = 'admin_exists';
+    public const RESULT_PROMOTED = 'promoted';
+    public const RESULT_CREATED = 'created';
+
+    private const LOCK_TTL_SECONDS = 60.0;
+
+    public function __construct(
+        private UserRepository $userRepository,
+        private UserLifecycleService $userLifecycleService,
+        private EntityManagerInterface $entityManager,
+        private UserPasswordHasherInterface $passwordHasher,
+        private LockFactory $lockFactory,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function bootstrap(
+        string $configuredEmail,
+        #[\SensitiveParameter]
+        string $configuredPassword,
+    ): string {
+        $configuration = BootstrapAdminConfiguration::fromConfiguration($configuredEmail, $configuredPassword);
+        if (null === $configuration) {
+            return self::RESULT_NOT_CONFIGURED;
+        }
+
+        $email = $configuration->email;
+        $password = $configuration->password();
+
+        $lock = $this->lockFactory->createLock('bootstrap-first-admin', self::LOCK_TTL_SECONDS, false);
+        if (!$lock->acquire(true)) {
+            throw new \RuntimeException('Could not acquire the first-admin bootstrap lock.');
+        }
+
+        try {
+            if ($this->userRepository->hasAdmin()) {
+                return self::RESULT_ADMIN_EXISTS;
+            }
+
+            $user = $this->userRepository->findByEmail($email);
+            if (null !== $user) {
+                $user->setUserLevel('ADMIN');
+                $user->setEmailVerified(true);
+                $user->setPw($this->passwordHasher->hashPassword($user, $password));
+                $this->entityManager->flush();
+
+                $this->logger->notice('Promoted existing user during first-admin bootstrap', [
+                    'user_id' => $user->getId(),
+                ]);
+
+                return self::RESULT_PROMOTED;
+            }
+
+            $user = $this->userLifecycleService->createUser(
+                email: $email,
+                plainPassword: $password,
+                userLevel: 'ADMIN',
+                emailVerified: true,
+            );
+
+            $this->logger->notice('Created user during first-admin bootstrap', [
+                'user_id' => $user->getId(),
+            ]);
+
+            return self::RESULT_CREATED;
+        } finally {
+            $lock->release();
+        }
+    }
+}

--- a/backend/tests/AI/Provider/XaiProviderTest.php
+++ b/backend/tests/AI/Provider/XaiProviderTest.php
@@ -39,6 +39,10 @@ class XaiProviderTest extends TestCase
             array_map('unlink', $files);
             rmdir($this->tempDir);
         }
+
+        // generateVideo() re-arms the process-wide execution budget while
+        // polling. Restore unlimited CLI time so later tests cannot inherit it.
+        set_time_limit(0);
     }
 
     // ==================== METADATA ====================

--- a/backend/tests/Command/BootstrapAdminCommandTest.php
+++ b/backend/tests/Command/BootstrapAdminCommandTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Command;
+
+use App\Command\BootstrapAdminCommand;
+use App\Service\Admin\BootstrapAdminService;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+#[AllowMockObjectsWithoutExpectations]
+final class BootstrapAdminCommandTest extends TestCase
+{
+    private BootstrapAdminService&MockObject $bootstrapAdminService;
+
+    protected function setUp(): void
+    {
+        $this->bootstrapAdminService = $this->createMock(BootstrapAdminService::class);
+    }
+
+    public function testReportsUnconfiguredBootstrapAsSuccessfulNoOp(): void
+    {
+        $tester = $this->tester('', '');
+        $this->bootstrapAdminService->expects($this->once())
+            ->method('bootstrap')
+            ->with('', '')
+            ->willReturn(BootstrapAdminService::RESULT_NOT_CONFIGURED);
+
+        $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $this->assertStringContainsString('not configured', $tester->getDisplay());
+    }
+
+    public function testReportsExistingAdminAsSuccessfulNoOp(): void
+    {
+        $tester = $this->tester('admin@example.com', 'SecurePass123!');
+        $this->bootstrapAdminService->method('bootstrap')
+            ->willReturn(BootstrapAdminService::RESULT_ADMIN_EXISTS);
+
+        $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $this->assertStringContainsString('already exists', $tester->getDisplay());
+    }
+
+    public function testReportsCreatedAdminWithoutPrintingPassword(): void
+    {
+        $password = 'SecurePass123!';
+        $tester = $this->tester('admin@example.com', $password);
+        $this->bootstrapAdminService->method('bootstrap')
+            ->willReturn(BootstrapAdminService::RESULT_CREATED);
+
+        $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $this->assertStringContainsString('administrator was created', $tester->getDisplay());
+        $this->assertStringNotContainsString($password, $tester->getDisplay());
+    }
+
+    public function testReportsPromotedUser(): void
+    {
+        $tester = $this->tester('admin@example.com', 'SecurePass123!');
+        $this->bootstrapAdminService->method('bootstrap')
+            ->willReturn(BootstrapAdminService::RESULT_PROMOTED);
+
+        $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $this->assertStringContainsString('promoted to administrator', $tester->getDisplay());
+    }
+
+    public function testReturnsFailureForInvalidConfiguration(): void
+    {
+        $tester = $this->tester('admin@example.com', '');
+        $this->bootstrapAdminService->method('bootstrap')
+            ->willThrowException(new \InvalidArgumentException('Both bootstrap variables are required.'));
+
+        $tester->execute([]);
+
+        $this->assertSame(Command::FAILURE, $tester->getStatusCode());
+        $this->assertStringContainsString('First-admin bootstrap failed', $tester->getDisplay());
+        $this->assertStringContainsString('Both bootstrap variables are required', $tester->getDisplay());
+    }
+
+    public function testSurfacesTheFullPasswordRuleGuidance(): void
+    {
+        $tester = $this->tester('admin@example.com', 'lowercase-only');
+        $this->bootstrapAdminService->method('bootstrap')
+            ->willThrowException(new \InvalidArgumentException('BOOTSTRAP_ADMIN_PASSWORD must contain at least one uppercase letter, one lowercase letter, and one number, or be at least 16 characters long.'));
+
+        $tester->execute([]);
+
+        // The error block wraps at the terminal width, so compare on a single line.
+        $display = (string) preg_replace('/\s+/', ' ', $tester->getDisplay());
+
+        $this->assertSame(Command::FAILURE, $tester->getStatusCode());
+        $this->assertStringContainsString('one uppercase letter, one lowercase letter, and one number, or be at least 16 characters long', $display);
+    }
+
+    private function tester(string $email, string $password): CommandTester
+    {
+        $application = new Application();
+        $application->addCommand(new BootstrapAdminCommand(
+            $this->bootstrapAdminService,
+            $email,
+            $password,
+        ));
+
+        return new CommandTester($application->find('app:bootstrap-admin'));
+    }
+}

--- a/backend/tests/Migration/ProductionMigrationSafetyTest.php
+++ b/backend/tests/Migration/ProductionMigrationSafetyTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Migration;
+
+use PHPUnit\Framework\TestCase;
+
+final class ProductionMigrationSafetyTest extends TestCase
+{
+    public function testMigrationsNeverIntrospectTheDoctrineSchemaObject(): void
+    {
+        $migrationFiles = glob(dirname(__DIR__, 2).'/migrations/Version*.php') ?: [];
+
+        self::assertNotEmpty($migrationFiles);
+
+        foreach ($migrationFiles as $migrationFile) {
+            $contents = file_get_contents($migrationFile);
+            self::assertNotFalse($contents, sprintf('Unable to read migration %s', $migrationFile));
+
+            $tokens = token_get_all($contents);
+            $tokenCount = count($tokens);
+
+            for ($index = 0; $index < $tokenCount; ++$index) {
+                $token = $tokens[$index];
+                if (!is_array($token) || T_VARIABLE !== $token[0] || '$schema' !== $token[1]) {
+                    continue;
+                }
+
+                for ($nextIndex = $index + 1; $nextIndex < $tokenCount; ++$nextIndex) {
+                    $nextToken = $tokens[$nextIndex];
+                    if (is_array($nextToken) && in_array($nextToken[0], [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], true)) {
+                        continue;
+                    }
+
+                    self::assertNotSame(
+                        T_OBJECT_OPERATOR,
+                        is_array($nextToken) ? $nextToken[0] : null,
+                        sprintf(
+                            'Migration %s calls a method on Doctrine DBAL Schema; use idempotent SQL or information_schema instead.',
+                            basename($migrationFile),
+                        ),
+                    );
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/backend/tests/Unit/Service/Admin/BootstrapAdminConfigurationTest.php
+++ b/backend/tests/Unit/Service/Admin/BootstrapAdminConfigurationTest.php
@@ -1,0 +1,283 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\Admin;
+
+use App\Service\Admin\BootstrapAdminConfiguration;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The authoritative first-admin rules, tested where they live.
+ *
+ * The container entrypoint and BootstrapAdminService both call this class, so
+ * these cases define the behavior of the early container check as well.
+ */
+final class BootstrapAdminConfigurationTest extends TestCase
+{
+    public function testBothValuesEmptyMeansNotConfigured(): void
+    {
+        $this->assertNull(BootstrapAdminConfiguration::fromConfiguration('', ''));
+    }
+
+    public function testWhitespaceOnlyEmailWithoutPasswordMeansNotConfigured(): void
+    {
+        $this->assertNull(BootstrapAdminConfiguration::fromConfiguration("  \t ", ''));
+    }
+
+    public function testRejectsEmailWithoutPassword(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('must either both be set or both be empty');
+
+        BootstrapAdminConfiguration::fromConfiguration('admin@example.com', '');
+    }
+
+    public function testRejectsPasswordWithoutEmail(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('must either both be set or both be empty');
+
+        BootstrapAdminConfiguration::fromConfiguration('', 'SecurePass123!');
+    }
+
+    public function testTrimsTheEmailOnly(): void
+    {
+        $configuration = BootstrapAdminConfiguration::fromConfiguration(' admin@example.com ', ' SecurePass123! ');
+
+        $this->assertNotNull($configuration);
+        $this->assertSame('admin@example.com', $configuration->email);
+        $this->assertSame(' SecurePass123! ', $configuration->password());
+    }
+
+    /**
+     * Exit code 2 of the container guard (see require_valid_bootstrap_admin_config
+     * in _docker/backend/lib/container-runtime.sh) means "the authority could not
+     * run" and is deliberately lenient: it warns and continues the boot. Every
+     * RULE violation must therefore arrive as an InvalidArgumentException, the one
+     * class that guard maps to a hard failure. A rule thrown as anything else —
+     * a \LengthException, a \ValueError — would be silently downgraded to
+     * warn-and-continue and crash-loop the container later on instead.
+     */
+    #[DataProvider('ruleViolationProvider')]
+    public function testEveryRuleViolationIsAnInvalidArgumentException(string $email, string $password): void
+    {
+        try {
+            BootstrapAdminConfiguration::fromConfiguration($email, $password);
+        } catch (\Throwable $violation) {
+            $this->assertInstanceOf(\InvalidArgumentException::class, $violation);
+
+            return;
+        }
+
+        $this->fail('Expected the configuration to be rejected by a rule.');
+    }
+
+    /**
+     * One case per rule, so a rule added later without a case here is visible.
+     *
+     * @return iterable<string, array{string, string}>
+     */
+    public static function ruleViolationProvider(): iterable
+    {
+        yield 'pairing: email without password' => ['admin@example.com', ''];
+        yield 'pairing: password without email' => ['', 'SecurePass123!'];
+        yield 'email format' => ['not-an-email', 'SecurePass123!'];
+        yield 'email length' => [str_repeat('a', 64).'@'.str_repeat('b', 60).'.com', 'SecurePass123!'];
+        yield 'password minimum length' => ['admin@example.com', 'Abcdef1'];
+        yield 'password maximum length' => ['admin@example.com', 'Secure1'.str_repeat('x', 58)];
+        yield 'password composition' => ['admin@example.com', 'abcdefgh1'];
+    }
+
+    /**
+     * The whole object is handed around, so a generic dumper must not be able to
+     * print the secret. #[\SensitiveParameter] only redacts stack traces; it does
+     * not protect a property, which is why the password is not one.
+     */
+    public function testGenericOutputNeverExposesThePassword(): void
+    {
+        $password = 'SecurePass123!';
+        $configuration = BootstrapAdminConfiguration::fromConfiguration('admin@example.com', $password);
+
+        $this->assertNotNull($configuration);
+        $this->assertSame($password, $configuration->password());
+
+        ob_start();
+        var_dump($configuration);
+        var_export($configuration);
+        $dumped = (string) ob_get_clean();
+
+        $this->assertStringNotContainsString($password, $dumped);
+        $this->assertStringNotContainsString($password, print_r($configuration, true));
+        $this->assertStringNotContainsString($password, (string) json_encode($configuration));
+    }
+
+    /**
+     * The host-side preflight in deploy/scripts/lib.sh mirrors filter_var() for
+     * the addresses an operator can realistically configure. These are the forms
+     * whose looser handling once let a deployment start and then crash-loop.
+     */
+    #[DataProvider('invalidEmailProvider')]
+    public function testRejectsInvalidEmail(string $email): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('BOOTSTRAP_ADMIN_EMAIL must be a valid email address of at most 128 characters.');
+
+        BootstrapAdminConfiguration::fromConfiguration($email, 'SecurePass123!');
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function invalidEmailProvider(): iterable
+    {
+        yield 'no at sign' => ['not-an-email'];
+        yield 'doubled dot in the local part' => ['a..b@example.com'];
+        yield 'leading dot in the local part' => ['.admin@example.com'];
+        yield 'trailing dot in the local part' => ['admin.@example.com'];
+        yield 'leading hyphen in a domain label' => ['admin@-example.com'];
+        yield 'trailing hyphen in a domain label' => ['admin@example-.com'];
+        yield 'numeric top-level label' => ['admin@example.123'];
+        yield 'local part longer than 64 characters' => [str_repeat('a', 65).'@example.com'];
+        yield 'domain label longer than 63 characters' => ['admin@'.str_repeat('a', 64).'.com'];
+    }
+
+    #[DataProvider('validEmailProvider')]
+    public function testAcceptsValidEmail(string $email): void
+    {
+        $configuration = BootstrapAdminConfiguration::fromConfiguration($email, 'SecurePass123!');
+
+        $this->assertNotNull($configuration);
+        $this->assertSame($email, $configuration->email);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function validEmailProvider(): iterable
+    {
+        yield 'plain address' => ['admin@example.com'];
+        yield 'plus addressing' => ['admin+tag@example.com'];
+        yield 'subdomains' => ['admin@sub.example.co.uk'];
+        yield 'hyphen inside a domain label' => ['admin@ex--ample.com'];
+        yield 'digits at the start of a domain label' => ['admin@1example.com'];
+        yield 'local part at the 64-character limit' => [str_repeat('a', 64).'@example.com'];
+        yield 'exactly at the maximum length' => [str_repeat('a', 64).'@'.str_repeat('b', 59).'.com'];
+    }
+
+    public function testAcceptsEmailAtTheMaximumLength(): void
+    {
+        $email = str_repeat('a', 64).'@'.str_repeat('b', 59).'.com';
+
+        $this->assertSame(BootstrapAdminConfiguration::MAXIMUM_EMAIL_LENGTH, strlen($email));
+        $this->assertNotNull(BootstrapAdminConfiguration::fromConfiguration($email, 'SecurePass123!'));
+    }
+
+    public function testRejectsEmailOneCharacterAboveTheMaximumLength(): void
+    {
+        $email = str_repeat('a', 64).'@'.str_repeat('b', 60).'.com';
+
+        $this->assertSame(BootstrapAdminConfiguration::MAXIMUM_EMAIL_LENGTH + 1, strlen($email));
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('at most 128 characters');
+
+        BootstrapAdminConfiguration::fromConfiguration($email, 'SecurePass123!');
+    }
+
+    public function testRejectsShortPassword(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('BOOTSTRAP_ADMIN_PASSWORD must be at least 8 characters.');
+
+        BootstrapAdminConfiguration::fromConfiguration('admin@example.com', 'Abcdef1');
+    }
+
+    public function testAcceptsPasswordAtTheMinimumLength(): void
+    {
+        $this->assertNotNull(BootstrapAdminConfiguration::fromConfiguration('admin@example.com', 'Abcdefg1'));
+    }
+
+    public function testRejectsOverlongPassword(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('BOOTSTRAP_ADMIN_PASSWORD must be at most 64 characters.');
+
+        BootstrapAdminConfiguration::fromConfiguration('admin@example.com', 'Secure1'.str_repeat('x', 58));
+    }
+
+    public function testAcceptsPasswordAtTheMaximumLength(): void
+    {
+        $password = 'Secure1'.str_repeat('x', 57);
+
+        $this->assertSame(BootstrapAdminConfiguration::MAXIMUM_PASSWORD_LENGTH, strlen($password));
+        $this->assertNotNull(BootstrapAdminConfiguration::fromConfiguration('admin@example.com', $password));
+    }
+
+    #[DataProvider('incompleteCompositionProvider')]
+    public function testRejectsIncompleteCompositionBelowTheWaiverLength(string $password): void
+    {
+        $this->assertLessThan(BootstrapAdminConfiguration::COMPOSITION_WAIVER_LENGTH, strlen($password));
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('one uppercase letter, one lowercase letter, and one number, or be at least 16 characters long');
+
+        BootstrapAdminConfiguration::fromConfiguration('admin@example.com', $password);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function incompleteCompositionProvider(): iterable
+    {
+        yield 'no uppercase letter' => ['abcdefgh1'];
+        yield 'no lowercase letter' => ['ABCDEFGH1'];
+        yield 'no number' => ['Abcdefghij'];
+        yield 'one character below the waiver length' => ['Ab'.str_repeat('c', 13)];
+    }
+
+    /**
+     * The waiver boundary is `<`, not `<=`: a 16-character password needs no
+     * character classes at all. Managed platforms inject exactly such values.
+     */
+    #[DataProvider('waivedCompositionProvider')]
+    public function testWaivesCompositionAtTheWaiverLength(string $password): void
+    {
+        $this->assertGreaterThanOrEqual(BootstrapAdminConfiguration::COMPOSITION_WAIVER_LENGTH, strlen($password));
+        $this->assertNotNull(BootstrapAdminConfiguration::fromConfiguration('admin@example.com', $password));
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function waivedCompositionProvider(): iterable
+    {
+        yield 'no digit at exactly the waiver length' => ['Ab'.str_repeat('c', 14)];
+        yield 'all lowercase at exactly the waiver length' => [str_repeat('a', 16)];
+        yield 'generated managed-platform password without a digit' => ['QWZFaxYB-gtYh-AXqFbcde'];
+    }
+
+    /**
+     * The early container check prints these messages verbatim, so a message
+     * that quoted the configured value would leak the secret into the log.
+     */
+    #[DataProvider('rejectedPasswordProvider')]
+    public function testRuleViolationsNeverContainThePassword(string $password): void
+    {
+        try {
+            BootstrapAdminConfiguration::fromConfiguration('admin@example.com', $password);
+            $this->fail(sprintf('Expected the password of %d characters to be rejected.', strlen($password)));
+        } catch (\InvalidArgumentException $violation) {
+            $this->assertStringNotContainsString($password, $violation->getMessage());
+        }
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function rejectedPasswordProvider(): iterable
+    {
+        yield 'too short' => ['Sh0rt'];
+        yield 'too long' => ['Secure1'.str_repeat('x', 58)];
+        yield 'incomplete composition' => ['lowercase-only'];
+    }
+}

--- a/backend/tests/Unit/Service/Admin/BootstrapAdminServiceTest.php
+++ b/backend/tests/Unit/Service/Admin/BootstrapAdminServiceTest.php
@@ -1,0 +1,283 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\Admin;
+
+use App\Entity\User;
+use App\Repository\UserRepository;
+use App\Service\Admin\BootstrapAdminService;
+use App\Service\UserLifecycleService;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Lock\SharedLockInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * The rules themselves belong to BootstrapAdminConfiguration and are covered by
+ * BootstrapAdminConfigurationTest. The validation cases here stay on purpose:
+ * they prove that the service still enforces those rules through that class, so
+ * a second copy cannot creep back in unnoticed.
+ */
+#[AllowMockObjectsWithoutExpectations]
+final class BootstrapAdminServiceTest extends TestCase
+{
+    private UserRepository&MockObject $userRepository;
+    private UserLifecycleService&MockObject $userLifecycleService;
+    private EntityManagerInterface&MockObject $entityManager;
+    private UserPasswordHasherInterface&MockObject $passwordHasher;
+    private LockFactory&MockObject $lockFactory;
+    private SharedLockInterface&MockObject $lock;
+    private LoggerInterface&MockObject $logger;
+    private BootstrapAdminService $service;
+    private bool $lockAcquired = true;
+
+    protected function setUp(): void
+    {
+        $this->userRepository = $this->createMock(UserRepository::class);
+        $this->userLifecycleService = $this->createMock(UserLifecycleService::class);
+        $this->entityManager = $this->createMock(EntityManagerInterface::class);
+        $this->passwordHasher = $this->createMock(UserPasswordHasherInterface::class);
+        $this->lockFactory = $this->createMock(LockFactory::class);
+        $this->lock = $this->createMock(SharedLockInterface::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
+
+        $this->lockFactory->method('createLock')->willReturn($this->lock);
+        $this->lock->method('acquire')->willReturnCallback(fn (): bool => $this->lockAcquired);
+
+        $this->service = new BootstrapAdminService(
+            $this->userRepository,
+            $this->userLifecycleService,
+            $this->entityManager,
+            $this->passwordHasher,
+            $this->lockFactory,
+            $this->logger,
+        );
+    }
+
+    public function testDoesNothingWhenBootstrapIsNotConfigured(): void
+    {
+        $this->lockFactory->expects($this->never())->method('createLock');
+        $this->userRepository->expects($this->never())->method('hasAdmin');
+
+        $result = $this->service->bootstrap('', '');
+
+        $this->assertSame(BootstrapAdminService::RESULT_NOT_CONFIGURED, $result);
+    }
+
+    public function testRejectsEmailWithoutPassword(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('must either both be set or both be empty');
+
+        $this->service->bootstrap('admin@example.com', '');
+    }
+
+    public function testRejectsPasswordWithoutEmail(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('must either both be set or both be empty');
+
+        $this->service->bootstrap('', 'SecurePass123!');
+    }
+
+    public function testRejectsInvalidEmail(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('must be a valid email address');
+
+        $this->service->bootstrap('not-an-email', 'SecurePass123!');
+    }
+
+    public function testRejectsShortPassword(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('must be at least 8 characters');
+
+        $this->service->bootstrap('admin@example.com', 'short');
+    }
+
+    public function testRejectsPasswordOneCharacterBelowTheMinimumLength(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('must be at least 8 characters');
+
+        $this->service->bootstrap('admin@example.com', 'Abcdef1');
+    }
+
+    public function testRejectsOverlongPassword(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('must be at most 64 characters');
+
+        $this->service->bootstrap('admin@example.com', 'Secure1'.str_repeat('x', 58));
+    }
+
+    public function testRejectsWeakPassword(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('uppercase letter, one lowercase letter, and one number, or be at least 16 characters long');
+
+        $this->service->bootstrap('admin@example.com', 'lowercase-only');
+    }
+
+    public function testRejectsIncompleteCompositionJustBelowTheWaiverLength(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('or be at least 16 characters long');
+
+        $this->service->bootstrap('admin@example.com', 'Ab'.str_repeat('c', 13));
+    }
+
+    public function testAcceptsShortPasswordWithCompleteComposition(): void
+    {
+        $this->assertPasswordIsAccepted('Abcdefg1');
+    }
+
+    public function testAcceptsPasswordWithoutDigitAtTheWaiverLength(): void
+    {
+        $this->assertPasswordIsAccepted('Ab'.str_repeat('c', 14));
+    }
+
+    public function testAcceptsAllLowercasePasswordAtTheWaiverLength(): void
+    {
+        $this->assertPasswordIsAccepted(str_repeat('a', 16));
+    }
+
+    public function testAcceptsGeneratedManagedPlatformPasswordWithoutDigit(): void
+    {
+        $this->assertPasswordIsAccepted('QWZFaxYB-gtYh-AXqFbcde');
+    }
+
+    public function testExistingAdminIsNeverChanged(): void
+    {
+        $this->userRepository->expects($this->once())->method('hasAdmin')->willReturn(true);
+        $this->userRepository->expects($this->never())->method('findByEmail');
+        $this->passwordHasher->expects($this->never())->method('hashPassword');
+        $this->userLifecycleService->expects($this->never())->method('createUser');
+        $this->entityManager->expects($this->never())->method('flush');
+        $this->lock->expects($this->once())->method('release');
+
+        $result = $this->service->bootstrap('admin@example.com', 'ChangedPass123!');
+
+        $this->assertSame(BootstrapAdminService::RESULT_ADMIN_EXISTS, $result);
+    }
+
+    public function testPromotesAndVerifiesExactMatchingUser(): void
+    {
+        $user = (new User())
+            ->setMail('admin@example.com')
+            ->setUserLevel('NEW')
+            ->setEmailVerified(false)
+            ->setPw('old-hash');
+
+        $this->userRepository->expects($this->once())->method('hasAdmin')->willReturn(false);
+        $this->userRepository->expects($this->once())
+            ->method('findByEmail')
+            ->with('admin@example.com')
+            ->willReturn($user);
+        $this->passwordHasher->expects($this->once())
+            ->method('hashPassword')
+            ->with($user, 'SecurePass123!')
+            ->willReturn('new-hash');
+        $this->entityManager->expects($this->once())->method('flush');
+        $this->userLifecycleService->expects($this->never())->method('createUser');
+        $this->logger->expects($this->once())
+            ->method('notice')
+            ->with(
+                'Promoted existing user during first-admin bootstrap',
+                $this->logicalNot($this->arrayHasKey('password')),
+            );
+        $this->lock->expects($this->once())->method('release');
+
+        $result = $this->service->bootstrap(' admin@example.com ', 'SecurePass123!');
+
+        $this->assertSame(BootstrapAdminService::RESULT_PROMOTED, $result);
+        $this->assertTrue($user->isAdmin());
+        $this->assertTrue($user->isEmailVerified());
+        $this->assertSame('new-hash', $user->getPw());
+    }
+
+    public function testCreatesVerifiedAdminThroughLifecycleService(): void
+    {
+        $createdUser = (new User())
+            ->setMail('admin@example.com')
+            ->setUserLevel('ADMIN')
+            ->setEmailVerified(true);
+
+        $this->userRepository->expects($this->once())->method('hasAdmin')->willReturn(false);
+        $this->userRepository->expects($this->once())
+            ->method('findByEmail')
+            ->with('admin@example.com')
+            ->willReturn(null);
+        $this->userLifecycleService->expects($this->once())
+            ->method('createUser')
+            ->with(
+                'admin@example.com',
+                'SecurePass123!',
+                'local',
+                'WEB',
+                'ADMIN',
+                true,
+            )
+            ->willReturn($createdUser);
+        $this->passwordHasher->expects($this->never())->method('hashPassword');
+        $this->entityManager->expects($this->never())->method('flush');
+        $this->logger->expects($this->once())
+            ->method('notice')
+            ->with(
+                'Created user during first-admin bootstrap',
+                $this->logicalNot($this->arrayHasKey('password')),
+            );
+        $this->lock->expects($this->once())->method('release');
+
+        $result = $this->service->bootstrap('admin@example.com', 'SecurePass123!');
+
+        $this->assertSame(BootstrapAdminService::RESULT_CREATED, $result);
+    }
+
+    public function testReleasesLockWhenCreationFails(): void
+    {
+        $this->userRepository->method('hasAdmin')->willReturn(false);
+        $this->userRepository->method('findByEmail')->willReturn(null);
+        $this->userLifecycleService->method('createUser')->willThrowException(new \RuntimeException('database unavailable'));
+        $this->lock->expects($this->once())->method('release');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('database unavailable');
+
+        $this->service->bootstrap('admin@example.com', 'SecurePass123!');
+    }
+
+    public function testFailsWhenBootstrapLockCannotBeAcquired(): void
+    {
+        $this->lockAcquired = false;
+        $this->userRepository->expects($this->never())->method('hasAdmin');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Could not acquire');
+
+        $this->service->bootstrap('admin@example.com', 'SecurePass123!');
+    }
+
+    /**
+     * Asserts that validation lets the password through into the bootstrap flow.
+     */
+    private function assertPasswordIsAccepted(string $password): void
+    {
+        $this->userRepository->expects($this->once())->method('hasAdmin')->willReturn(false);
+        $this->userRepository->expects($this->once())->method('findByEmail')->willReturn(null);
+        $this->userLifecycleService->expects($this->once())
+            ->method('createUser')
+            ->with('admin@example.com', $password, 'local', 'WEB', 'ADMIN', true)
+            ->willReturn(new User());
+
+        $result = $this->service->bootstrap('admin@example.com', $password);
+
+        $this->assertSame(BootstrapAdminService::RESULT_CREATED, $result);
+    }
+}

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,193 @@
+# Synaplan production deployment
+
+This directory is the portable, single-node production contract. It uses published
+images only and does not include Vite, MailHog, phpMyAdmin, source bind mounts, or
+other development services.
+
+## Requirements
+
+- Docker Engine with Docker Compose v2
+- Cloud-AI profile: at least 4 vCPU, 8 GB RAM, and 30 GB free disk
+- Optional `local-ai` profile: at least 16 GB RAM and substantially more disk
+- A reverse proxy terminating HTTPS in front of `127.0.0.1:8000`
+
+All database, cache, vector, upload, model, and backup data lives below
+`deploy/data/`. Back up that directory only through the lifecycle hooks so the
+database and vector snapshots are consistent.
+
+## First installation
+
+```bash
+cp deploy/selfhost.env.example deploy/.env
+# Replace every required placeholder, including SYNAPLAN_VERSION.
+deploy/scripts/prepare.sh
+docker compose --env-file deploy/.env -f deploy/compose.yaml pull
+deploy/scripts/validate-release.sh
+docker compose --env-file deploy/.env -f deploy/compose.yaml up -d
+deploy/scripts/smoke-test.sh
+```
+
+`deploy/.env` is intentionally ignored. Keep a secure external copy of it.
+`APP_SECRET`, `TOKEN_SECRET`, both MariaDB passwords, and all `REALTIME_*`
+secrets must remain stable across every redeploy and restore. Keep a configured
+`BOOTSTRAP_ADMIN_PASSWORD` unchanged as well: a later start never rotates the
+administrator account, so a regenerated value would no longer match the password
+that account actually has.
+
+Docker Compose reads `deploy/.env` with its own rules and would change a value
+containing `$`, surrounding quotes, ` #`, or leading and trailing spaces.
+Generate secrets with `openssl rand -hex 32`, or restrict a value you type
+yourself to letters, digits, `-` and `_`. `MAILER_DSN` is the one value you
+cannot simply regenerate, because it carries your SMTP provider's password:
+percent-encode the special characters inside it (`$` as `%24`) as described in
+[Outgoing Email](../docs/EMAIL.md#outgoing-email-smtp). A value that the file
+would alter fails the deployment with a message naming the variable instead of
+being stored in altered form — for the administrator password that would mean
+being locked out of your own instance with no way back. Values that a platform
+passes in as environment variables are used exactly as given.
+
+The bootstrap administrator is created only when no administrator exists. A
+restart must not rotate this account. `BOOTSTRAP_ADMIN_EMAIL` and
+`BOOTSTRAP_ADMIN_PASSWORD` must be set together or left empty together; leaving
+both empty is valid and simply skips the bootstrap, so an administrator can be
+promoted later. The email must be a valid address of at most 128 characters. The
+password must be 8 to 64 characters, and below 16 characters it must also contain
+an uppercase letter, a lowercase letter, and a number; from 16 characters there is
+no character requirement. `validate-release.sh` checks both values before the
+stack starts, so an unusable value fails the deployment once with a fixable
+message instead of crash-looping it. Should only one of the two still reach the
+containers, every application container exits with code `78` before it touches
+the database, and the restart policy retries until the value is corrected. Full
+explanation:
+[Create the First Administrator](../docs/INSTALLATION.md#create-the-first-administrator).
+Configure a cloud AI key after login under Admin > AI Providers, or provide a
+bootstrap provider key in `deploy/.env`.
+
+The checked-in version value is deliberately non-deployable. Replace it only
+after an immutable SemVer image has been published that contains the
+`SYNAPLAN_ROLE=web|worker|scheduler` and `/usr/local/bin/container-healthcheck`
+contracts. `prepare.sh` rejects placeholders and mutable tags;
+`validate-release.sh` checks the pulled image itself. Catalog submissions must
+pin an actually published compatible version, never `latest` or an anticipated
+future tag.
+
+## Local AI profile
+
+Cloud AI is the default. To add Ollama, the embedding model, and Whisper:
+
+```dotenv
+COMPOSE_PROFILES=local-ai
+```
+
+Redeploy after changing the value. This enables Ollama and the Whisper model
+download and points the app roles at Ollama. The large local chat model remains
+off unless `ENABLE_LOCAL_GPT_OSS=true`. To return to Cloud AI, empty
+`COMPOSE_PROFILES`, set the desired cloud provider in the UI, and redeploy. Model
+files remain in `deploy/data/` until deliberately removed.
+
+## Network and persistence
+
+Only the web service binds a host port. MariaDB, Redis, Centrifugo, Tika, Qdrant,
+Ollama, and Whisper remain on the Compose network. The default bind is
+`127.0.0.1:8000`; managed platforms may set `SYNAPLAN_HTTP_BIND=0.0.0.0` while
+restricting exposure with their firewall and HTTPS proxy.
+
+Persistent paths:
+
+- `data/mariadb`: relational data
+- `data/redis`: durable Redis append-only file
+- `data/qdrant`: vector collections
+- `data/uploads`: uploaded and generated files shared by web and worker
+- `data/ollama`, `data/whisper`: optional local models
+- `data/backups`: restricted MariaDB dumps and Qdrant collection snapshots
+
+`deploy/data/` must never be committed.
+
+### Docker Desktop validation
+
+The production bind mounts target Linux servers. MariaDB cannot safely use a
+macOS bind mount because the host filesystem's case behavior differs from the
+Linux database contract. For local Docker Desktop validation, add the supplied
+named-volume override:
+
+```bash
+docker compose --env-file deploy/.env \
+  -f deploy/compose.yaml \
+  -f deploy/compose.docker-desktop.yaml up -d
+```
+
+Pass the same override to lifecycle scripts with an absolute path:
+
+```bash
+SYNAPLAN_COMPOSE_OVERRIDE="$PWD/deploy/compose.docker-desktop.yaml" \
+  deploy/scripts/smoke-test.sh
+```
+
+The override is for local validation only. Elestio and Linux self-hosting use
+the bind-mounted production paths from `deploy/compose.yaml`.
+
+## Backup and restore
+
+The scripts are non-interactive and safe to invoke more than once:
+
+```bash
+deploy/scripts/pre-backup.sh
+# Capture deploy/data with the platform backup system.
+deploy/scripts/post-backup.sh
+```
+
+`pre-backup.sh` first pauses web writers, the worker, and scheduler; while the
+data stores remain online it creates a single-transaction MariaDB dump, one
+snapshot per Qdrant collection, and a checksummed upload archive. It then stops
+every stateful service that was running, including optional Ollama, before the
+platform captures `deploy/data`. If preparation fails, it removes the
+incomplete backup and resumes exactly the services it stopped.
+`post-backup.sh` resumes that recorded service set and keeps seven completed
+portable backups by default (`BACKUP_RETENTION_COUNT` changes this).
+
+For restore:
+
+```bash
+deploy/scripts/pre-restore.sh
+# Restore deploy/data with the platform backup system.
+deploy/scripts/post-restore.sh
+```
+
+By default, the post hook uses the MariaDB and Qdrant data directories restored
+by the platform, repairs upload permissions, lets the web role apply migrations,
+starts background roles, and runs the smoke test. Set
+`RESTORE_PORTABLE_BACKUP=true` only when restoring the generated SQL dump and
+Qdrant snapshots and the uploaded-file archive into fresh, empty storage. The
+archive checksum, paths, link types, and restored file checksums are verified
+before it replaces `data/uploads`. Do not replay portable artifacts on top of
+data directories that the platform already restored. Test restores in a
+separate stack before relying on them.
+
+For the portable import path, invoke the post hook explicitly:
+
+```bash
+RESTORE_PORTABLE_BACKUP=true deploy/scripts/post-restore.sh
+```
+
+## Update
+
+Set a tested, concrete `SYNAPLAN_VERSION`, then run:
+
+```bash
+deploy/scripts/pre-update.sh
+# Redeploy through the platform, or:
+docker compose --env-file deploy/.env -f deploy/compose.yaml up -d
+deploy/scripts/post-update.sh
+```
+
+The pre hook enforces a successful backup and pulls the pin. The post hook waits
+for every role and dependency, then verifies health and reports the running image
+reference and image ID. Roll back by restoring the previous version pin and the
+matching pre-update backup.
+
+## Platform adapters
+
+Platform-specific adapters must call the scripts in this directory rather than
+reimplementing operations. `deploy/elestio/` is the first thin adapter. Future
+Coolify, CapRover, or Railway definitions should preserve the same role,
+persistence, backup, restore, and health contracts.

--- a/deploy/compose.docker-desktop.yaml
+++ b/deploy/compose.docker-desktop.yaml
@@ -1,0 +1,15 @@
+services:
+  db:
+    volumes: !override
+      - desktop_mariadb:/var/lib/mysql
+  redis:
+    volumes: !override
+      - desktop_redis:/data
+  qdrant:
+    volumes: !override
+      - desktop_qdrant:/qdrant/storage
+
+volumes:
+  desktop_mariadb:
+  desktop_redis:
+  desktop_qdrant:

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -1,0 +1,276 @@
+name: "${COMPOSE_PROJECT_NAME:-synaplan}"
+
+x-app-image: &app-image "${SYNAPLAN_IMAGE:-ghcr.io/metadist/synaplan}:${SYNAPLAN_VERSION:?Set SYNAPLAN_VERSION to a published compatible immutable SemVer release}"
+x-app-command: &app-command
+  - |
+    if [[ "$${COMPOSE_PROFILES:-}" == "local-ai" ]]; then
+      export OLLAMA_BASE_URL=http://ollama:11434
+      export AUTO_DOWNLOAD_MODELS=true
+      export WHISPER_ENABLED=true
+    else
+      export OLLAMA_BASE_URL=
+      export AUTO_DOWNLOAD_MODELS=false
+      export WHISPER_ENABLED=false
+    fi
+    exec /usr/local/bin/docker-entrypoint.sh
+x-app-environment: &app-environment
+  APP_ENV: prod
+  APP_DEBUG: "0"
+  APP_URL: "${APP_URL:?Set APP_URL to the public HTTPS URL}"
+  FRONTEND_URL: "${FRONTEND_URL:?Set FRONTEND_URL to the public HTTPS URL}"
+  APP_SECRET: "${APP_SECRET:?Set a stable APP_SECRET}"
+  TOKEN_SECRET: "${TOKEN_SECRET:?Set a stable TOKEN_SECRET}"
+  BOOTSTRAP_ADMIN_EMAIL: "${BOOTSTRAP_ADMIN_EMAIL:-}"
+  BOOTSTRAP_ADMIN_PASSWORD: "${BOOTSTRAP_ADMIN_PASSWORD:-}"
+  DB_HOST: db
+  DB_PORT: "3306"
+  DB_NAME: "${MARIADB_DATABASE:-synaplan}"
+  DB_USER: "${MARIADB_USER:-synaplan}"
+  DB_PASSWORD: "${MARIADB_PASSWORD:?Set a stable MariaDB application password}"
+  DB_SERVER_VERSION: mariadb-12.3.2
+  REDIS_DSN: redis://redis:6379
+  LOCK_DSN: redis://redis:6379
+  REALTIME_ENABLED: "true"
+  REALTIME_API_URL: http://centrifugo:8000/api
+  REALTIME_API_KEY: "${REALTIME_API_KEY:?Set a stable Centrifugo API key}"
+  REALTIME_TOKEN_SECRET: "${REALTIME_TOKEN_SECRET:?Set a stable Centrifugo token secret}"
+  REALTIME_PUBLIC_WS_URL: ""
+  REALTIME_ALLOWED_ORIGINS: "${REALTIME_ALLOWED_ORIGINS:-${APP_URL}}"
+  QDRANT_URL: http://qdrant:6333
+  TIKA_BASE_URL: http://tika:9998
+  COMPOSE_PROFILES: "${COMPOSE_PROFILES:-}"
+  OLLAMA_BASE_URL: ""
+  AUTO_DOWNLOAD_MODELS: "false"
+  ENABLE_LOCAL_GPT_OSS: "${ENABLE_LOCAL_GPT_OSS:-false}"
+  AI_DEFAULT_PROVIDER: "${AI_DEFAULT_PROVIDER:-groq}"
+  WHISPER_BINARY: /usr/local/bin/whisper
+  WHISPER_MODELS_PATH: /var/www/backend/var/whisper
+  WHISPER_DEFAULT_MODEL: "${WHISPER_DEFAULT_MODEL:-tiny}"
+  WHISPER_ENABLED: "false"
+  FFMPEG_BINARY: /usr/bin/ffmpeg
+  MAILER_DSN: "${MAILER_DSN:-null://null}"
+  APP_SENDER_EMAIL: "${APP_SENDER_EMAIL:-}"
+  APP_SENDER_NAME: "${APP_SENDER_NAME:-Synaplan}"
+  PHP_MAX_FILE_UPLOADS: "${PHP_MAX_FILE_UPLOADS:-100}"
+  LOG_FORMAT: "${LOG_FORMAT:-json}"
+  OPENAI_API_KEY: "${OPENAI_API_KEY:-}"
+  ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY:-}"
+  GROQ_API_KEY: "${GROQ_API_KEY:-}"
+  GOOGLE_GEMINI_API_KEY: "${GOOGLE_GEMINI_API_KEY:-}"
+  MISTRAL_API_KEY: "${MISTRAL_API_KEY:-}"
+  XAI_API_KEY: "${XAI_API_KEY:-}"
+
+x-app-volumes: &app-volumes
+  - ./data/uploads:/var/www/backend/var/uploads
+  - ./data/whisper:/var/www/backend/var/whisper:ro
+  - ./data/backups:/var/www/backup
+
+services:
+  backend:
+    image: *app-image
+    pull_policy: "${SYNAPLAN_PULL_POLICY:-always}"
+    entrypoint: ["/bin/bash", "-ec"]
+    command: *app-command
+    environment:
+      <<: *app-environment
+      SYNAPLAN_ROLE: web
+    volumes: *app-volumes
+    ports:
+      - "${SYNAPLAN_HTTP_BIND:-127.0.0.1}:${SYNAPLAN_HTTP_PORT:-8000}:80"
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      centrifugo:
+        condition: service_healthy
+      tika:
+        condition: service_healthy
+      qdrant:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "/usr/local/bin/container-healthcheck"]
+      interval: 15s
+      timeout: 10s
+      retries: 5
+      start_period: 300s
+    restart: unless-stopped
+    networks: [internal]
+
+  worker:
+    image: *app-image
+    pull_policy: "${SYNAPLAN_PULL_POLICY:-always}"
+    entrypoint: ["/bin/bash", "-ec"]
+    command: *app-command
+    environment:
+      <<: *app-environment
+      SYNAPLAN_ROLE: worker
+    volumes: *app-volumes
+    depends_on:
+      backend:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "/usr/local/bin/container-healthcheck"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 120s
+    restart: unless-stopped
+    networks: [internal]
+
+  scheduler:
+    image: *app-image
+    pull_policy: "${SYNAPLAN_PULL_POLICY:-always}"
+    entrypoint: ["/bin/bash", "-ec"]
+    command: *app-command
+    environment:
+      <<: *app-environment
+      SYNAPLAN_ROLE: scheduler
+    volumes: *app-volumes
+    depends_on:
+      backend:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "/usr/local/bin/container-healthcheck"]
+      interval: 60s
+      timeout: 5s
+      retries: 3
+      start_period: 120s
+    restart: unless-stopped
+    networks: [internal]
+
+  db:
+    image: mariadb:12.3.2@sha256:628f228f0fd5913a220438693576b29b6fe4dc1fa0a1298c0e98579fae28635f
+    command: --max-allowed-packet=256M --innodb-buffer-pool-size=512M
+    environment:
+      MARIADB_DATABASE: "${MARIADB_DATABASE:-synaplan}"
+      MARIADB_USER: "${MARIADB_USER:-synaplan}"
+      MARIADB_PASSWORD: "${MARIADB_PASSWORD:?Set a stable MariaDB application password}"
+      MARIADB_ROOT_PASSWORD: "${MARIADB_ROOT_PASSWORD:?Set a stable MariaDB root password}"
+    volumes:
+      - ./data/mariadb:/var/lib/mysql
+    healthcheck:
+      # The password is expanded by the container's shell, so it MUST stay
+      # quoted: an unquoted expansion splits a password containing whitespace
+      # into several arguments, mariadb-admin never authenticates, db never turns
+      # healthy, and backend, worker and scheduler wait on it forever.
+      test: ["CMD-SHELL", "mariadb-admin ping -h 127.0.0.1 -uroot -p\"$$MARIADB_ROOT_PASSWORD\" --silent"]
+      interval: 15s
+      timeout: 10s
+      retries: 10
+      start_period: 60s
+    restart: unless-stopped
+    networks: [internal]
+
+  redis:
+    image: redis:7.4-alpine@sha256:e7723ff73d963f5cc6d9c4643ea3d989527a402a319239054e9472a7fb9219a2
+    command: redis-server --appendonly yes --appendfsync everysec --maxmemory 256mb --maxmemory-policy allkeys-lru
+    volumes:
+      - ./data/redis:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
+    restart: unless-stopped
+    networks: [internal]
+
+  centrifugo:
+    image: centrifugo/centrifugo:v6.9.1@sha256:8ba0c9443dadedc21b20254b3fc76f35c1998b29acc7cdec877ea0c3636c237e
+    command: ["centrifugo", "-c", "/centrifugo/config.json"]
+    environment:
+      CENTRIFUGO_CLIENT_TOKEN_HMAC_SECRET_KEY: "${REALTIME_TOKEN_SECRET:?Set a stable Centrifugo token secret}"
+      CENTRIFUGO_HTTP_API_KEY: "${REALTIME_API_KEY:?Set a stable Centrifugo API key}"
+      CENTRIFUGO_ADMIN_PASSWORD: "${REALTIME_ADMIN_PASSWORD:?Set a stable Centrifugo admin password}"
+      CENTRIFUGO_ADMIN_SECRET: "${REALTIME_ADMIN_SECRET:?Set a stable Centrifugo admin secret}"
+      CENTRIFUGO_CLIENT_ALLOWED_ORIGINS: "${REALTIME_ALLOWED_ORIGINS:-${APP_URL}}"
+      CENTRIFUGO_ENGINE_REDIS_ADDRESS: redis://redis:6379/3
+    volumes:
+      - ../_docker/centrifugo/config.json:/centrifugo/config.json:ro
+    depends_on:
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "centrifugo", "checkconfig", "-c", "/centrifugo/config.json"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+    restart: unless-stopped
+    networks: [internal]
+
+  tika:
+    image: apache/tika:3.3.1.0@sha256:90b7fa1dc018434075fce9e1d9b88b1e3d0ea6979d0cf86e116c79a8073ae973
+    command: -h 0.0.0.0 -p 9998
+    healthcheck:
+      test: ["CMD", "bash", "-c", "exec 3<>/dev/tcp/localhost/9998 && printf 'GET /version HTTP/1.0\\r\\nHost: localhost\\r\\n\\r\\n' >&3 && read -r status <&3 && [[ $$status == *'200 OK'* ]]"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
+    restart: unless-stopped
+    networks: [internal]
+
+  qdrant:
+    image: qdrant/qdrant:v1.18.3@sha256:0bd98fa7977f1e75694779359ca4e212822e5a71334e28421182f72f209d5286
+    volumes:
+      - ./data/qdrant:/qdrant/storage
+    healthcheck:
+      test: ["CMD", "bash", "-c", "exec 3<>/dev/tcp/localhost/6333 && printf 'GET /readyz HTTP/1.0\\r\\nHost: localhost\\r\\n\\r\\n' >&3 && read -r status <&3 && [[ $$status == *'200 OK'* ]]"]
+      interval: 20s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+    restart: unless-stopped
+    networks: [internal]
+
+  ollama:
+    image: ollama/ollama:latest@sha256:4dea9fb511947e24a84237bb636b0203abcb2ff0d3fbc7b4ff865deb91362131
+    profiles: [local-ai]
+    environment:
+      OLLAMA_HOST: 0.0.0.0
+    volumes:
+      - ./data/ollama:/root/.ollama
+    healthcheck:
+      test: ["CMD", "bash", "-c", "exec 3<>/dev/tcp/localhost/11434 && printf 'GET /api/tags HTTP/1.0\\r\\nHost: localhost\\r\\n\\r\\n' >&3 && read -r status <&3 && [[ $$status == *'200 OK'* ]]"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 90s
+    restart: unless-stopped
+    networks: [internal]
+
+  whisper-models:
+    image: alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    profiles: [local-ai]
+    # The model name is passed as an environment variable and expanded by the
+    # container's shell inside quotes, instead of being interpolated by Compose
+    # into the script text. A Compose-interpolated value would become part of the
+    # program: a name containing whitespace would split the arguments of `test`
+    # and `curl`, and a name containing shell metacharacters would run as code.
+    environment:
+      WHISPER_DEFAULT_MODEL: "${WHISPER_DEFAULT_MODEL:-tiny}"
+    command:
+      - /bin/sh
+      - -ec
+      - |
+        apk add --no-cache curl ca-certificates
+        mkdir -p /models
+        model="ggml-$$WHISPER_DEFAULT_MODEL.bin"
+        test -s "/models/$$model" || curl -fL --retry 3 --max-time 900 \
+          -o "/models/$$model" \
+          "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/$$model"
+        chmod 0644 /models/*.bin
+    volumes:
+      - ./data/whisper:/models
+    restart: "no"
+    networks: [internal]
+
+networks:
+  internal:
+    driver: bridge

--- a/deploy/elestio/README.md
+++ b/deploy/elestio/README.md
@@ -1,0 +1,99 @@
+# Elestio adapter
+
+The root `elestio.yml` follows Elestio's documented Docker Compose template
+schema. These files only translate lifecycle events to the portable scripts in
+`deploy/scripts/`.
+
+## Import and first deployment
+
+1. Create a custom Docker Compose CI/CD pipeline from this repository and branch.
+2. Replace `REPLACE_WITH_PUBLISHED_COMPATIBLE_VERSION` with an immutable SemVer
+   tag that already exists in GHCR and passes `deploy/scripts/validate-release.sh`.
+3. Keep `COMPOSE_PROFILES` empty for the initial Cloud-AI installation.
+4. Confirm that HTTPS 443 proxies to host port 8000 without Basic Auth.
+5. Open the Synaplan web UI shortcut and sign in with the generated bootstrap
+   administrator.
+6. Configure an AI provider in Admin > AI Providers and configure SMTP before
+   enabling email-dependent features.
+
+Elestio documents `random_password`, `[EMAIL]`, and `[CI_CD_DOMAIN]`
+substitution. Treat every generated password as a persistent pipeline secret:
+do not regenerate it on redeploy, and include the environment configuration in
+your external disaster-recovery records. The administrator credentials are the
+critical case: see
+[First administrator credentials](#first-administrator-credentials).
+
+The public template documentation does not define a separate schema property
+that marks an environment variable as editable. `COMPOSE_PROFILES` is therefore
+declared as a normal environment value. Change it to `local-ai` in Elestio's
+pipeline environment editor and redeploy. Confirm the exact dashboard editing
+and secret-retention behavior with Elestio before catalog submission.
+
+The documentation also does not publish catalog-only metadata fields or asset
+requirements. No undocumented fields are included. Icon, screenshot, benchmark,
+minimum-size, and marketplace metadata must be added only after Elestio confirms
+their current catalog contract.
+
+## First administrator credentials
+
+Elestio replaces `[EMAIL]` with your Elestio account address and
+`random_password` with a generated value, then shows both as the login for the
+Synaplan shortcut. Store them in a password manager during the first deployment.
+
+> **After a redeploy, the password Elestio displays no longer works.** Elestio
+> generates a new value and shows it, while Synaplan keeps the administrator that
+> was created on the very first start — the bootstrap never resets an existing
+> administrator, deliberately, because otherwise a deployment variable would be a
+> permanent password-reset backdoor. Nothing is broken. Sign in with the
+> **original** credentials from the first deployment, which is why they belong in
+> a password manager. If they are lost, recover as described in
+> [Lost Administrator Password](../../docs/ADMIN.md#lost-administrator-password):
+> a password reset by email once SMTP is configured, otherwise through the
+> database.
+
+If your Elestio account address is not a valid address for Synaplan, the
+deployment stops before the stack starts and names the variable; nothing
+crash-loops. Very few real addresses are affected — the part before the `@` may
+not be longer than 64 characters, and no part of the domain name longer than 63. Set `BOOTSTRAP_ADMIN_EMAIL` to a different valid address in Elestio's
+pipeline environment editor and deploy again, or clear both bootstrap variables,
+sign up in the app, and make that account the administrator afterwards. The rules
+are in
+[Create the First Administrator](../../docs/INSTALLATION.md#create-the-first-administrator).
+
+Generated passwords satisfy those rules with room to spare. In 60 samples from
+Elestio's documented generator endpoint (`/api/auth/passwordgenerator`) every
+value was exactly 21 characters long, and the characters observed across all
+samples were exactly `A-Z`, `a-z`, `0-9` and `-`; Elestio's own Terraform modules
+state the same rule verbatim ("The password can only contain alphanumeric
+characters or hyphens `-`"). Synaplan waives the uppercase/lowercase/digit
+requirement from 16 characters upwards, so a 21-character value is accepted even
+when it contains no digit at all. **Assumption, not verified:** nothing documents
+that the `random_password` placeholder in `elestio.yml` comes from that same
+endpoint. It is the same platform with the same stated policy, which makes it a
+strong inference — but if Elestio ever generated shorter passwords, a generated
+value missing one character class would be refused. Re-check this if a fresh
+deployment is ever rejected because of the password.
+
+## Operations
+
+Elestio lifecycle hooks call the portable backup, restore, update, and smoke
+logic. The platform backup must include the repository's `deploy/data/`
+directory. Run a restore into an isolated pipeline and verify login, uploads,
+Qdrant search, worker processing, scheduler cleanup, and WebSocket delivery.
+
+For upgrades, change `SYNAPLAN_VERSION` to a tested SemVer tag. Never use
+`latest`. The pre-update hook creates a backup gate before the new image is
+started.
+
+The checked-in Elestio value intentionally makes deployment fail before any old
+or incompatible app image can start. Replace it only after the release pipeline
+has published and verified both `linux/amd64` and `linux/arm64` for the chosen
+tag. A catalog submission must contain that published tag, not the placeholder
+or a planned release number.
+
+The optional local-AI profile requires at least 16 GB RAM and additional storage.
+The large local chat model is a separate opt-in through
+`ENABLE_LOCAL_GPT_OSS=true`.
+
+Before a time-limited trial ends, delete pipelines, targets, services, and
+backups, disable auto-refill, and verify that no billable resource remains.

--- a/deploy/elestio/post-backup.sh
+++ b/deploy/elestio/post-backup.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+exec "$(dirname "$0")/../scripts/post-backup.sh"

--- a/deploy/elestio/post-deploy.sh
+++ b/deploy/elestio/post-deploy.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+exec "$(dirname "$0")/../scripts/post-update.sh"

--- a/deploy/elestio/post-install.sh
+++ b/deploy/elestio/post-install.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+exec "$(dirname "$0")/../scripts/post-update.sh"

--- a/deploy/elestio/post-restore.sh
+++ b/deploy/elestio/post-restore.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+exec "$(dirname "$0")/../scripts/post-restore.sh"

--- a/deploy/elestio/post-update.sh
+++ b/deploy/elestio/post-update.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+exec "$(dirname "$0")/../scripts/post-update.sh"

--- a/deploy/elestio/pre-backup.sh
+++ b/deploy/elestio/pre-backup.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+exec "$(dirname "$0")/../scripts/pre-backup.sh"

--- a/deploy/elestio/pre-deploy.sh
+++ b/deploy/elestio/pre-deploy.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+exec "$(dirname "$0")/../scripts/prepare.sh"

--- a/deploy/elestio/pre-install.sh
+++ b/deploy/elestio/pre-install.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+exec "$(dirname "$0")/../scripts/prepare.sh"

--- a/deploy/elestio/pre-restore.sh
+++ b/deploy/elestio/pre-restore.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+exec "$(dirname "$0")/../scripts/pre-restore.sh"

--- a/deploy/elestio/pre-update.sh
+++ b/deploy/elestio/pre-update.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+exec "$(dirname "$0")/../scripts/pre-update.sh"

--- a/deploy/scripts/build.sh
+++ b/deploy/scripts/build.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+# shellcheck source=lib.sh
+source "$(dirname "$0")/lib.sh"
+
+# The platform's build command: prepare the checkout, fetch the pinned image,
+# then verify it.
+#
+# It is a script rather than a `&&` chain in elestio.yml because the pull has to
+# go through compose(). Called as `docker compose -f deploy/compose.yaml pull`,
+# Compose takes deploy/ as the project directory and reads deploy/.env only — so
+# a configuration that arrives as a checkout-root .env is invisible exactly here,
+# every required `${VAR:?}` is unset, and the pull fails while every lifecycle
+# hook, which does go through compose(), works. See resolve_compose_env_file().
+#
+# `set -e` keeps the chain's semantics: the first failing step aborts with its own
+# exit status, so the platform marks the deployment as failed.
+"$DEPLOY_DIR/scripts/prepare.sh"
+compose pull
+"$DEPLOY_DIR/scripts/validate-release.sh"
+echo "Build completed; the pinned application image is present and verified."

--- a/deploy/scripts/lib.sh
+++ b/deploy/scripts/lib.sh
@@ -602,7 +602,12 @@ prepare_data_directories() {
         "$DATA_DIR/uploads" \
         "$DATA_DIR/ollama" \
         "$DATA_DIR/whisper"
-    chmod 0700 "$STATE_DIR" "$BACKUP_DIR"
+    # 0700 on the data root as well, not only on the two directories that hold
+    # dumps and lifecycle state: below it sit the raw MariaDB files, the Redis
+    # append-only file and every uploaded document. post-restore.sh already
+    # tightens it, so a restored instance was stricter than a freshly installed
+    # one — the same deployment, two different permissions.
+    chmod 0700 "$DATA_DIR" "$STATE_DIR" "$BACKUP_DIR"
 }
 
 running_service() {

--- a/deploy/scripts/lib.sh
+++ b/deploy/scripts/lib.sh
@@ -1,0 +1,730 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+DEPLOY_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DATA_DIR="$DEPLOY_DIR/data"
+STATE_DIR="$DEPLOY_DIR/.lifecycle"
+BACKUP_DIR="$DATA_DIR/backups"
+PAUSED_SERVICES_FILE="$STATE_DIR/paused-services"
+
+# The configuration file Compose must read, or nothing at all when the
+# configuration arrives as host environment variables only.
+#
+# Two layouts have to work, and only one of them is Compose's own default:
+#
+#   deploy/.env       the documented self-host location. `-f deploy/compose.yaml`
+#                     makes deploy/ the project directory, so this is also the
+#                     file Compose would read on its own; passing it explicitly
+#                     changes nothing.
+#   <checkout>/.env   where a managed platform materialises the environment it
+#                     was configured with. Elestio's own examples
+#                     (elestio-examples/glpi, elestio-examples/ws-screenshot)
+#                     open their lifecycle hooks with
+#                     `set -o allexport; source .env; set +o allexport`, so the
+#                     file lands at the checkout root — where Compose IGNORES it,
+#                     because the project directory is deploy/. Without this
+#                     fallback every required `${VAR:?}` would abort the very
+#                     first lifecycle script and the deployment would never
+#                     start.
+#
+# Precedence, highest first:
+#   1. a real host environment variable. Compose always prefers it over any
+#      --env-file entry, so exported configuration keeps winning, unchanged.
+#   2. deploy/.env. An operator who created the documented file meant it, and
+#      their behaviour must not change. A checkout can additionally carry a
+#      root .env for the DEVELOPMENT stack (it is gitignored at the repository
+#      root), which must never override the production file.
+#   3. <checkout>/.env, the managed-platform fallback.
+#
+# Exactly one file is ever passed: Compose does not merge env files, so two files
+# with disagreeing values would resolve differently per invocation.
+#
+# The file is handed to Compose instead of being sourced. Sourcing it, as the
+# Elestio examples do, would execute whatever the file contains in the lifecycle
+# shell, and would add a second .env parser that disagrees with the one the
+# containers are configured by. Compose stays the single parser.
+#
+# The candidate files themselves live in one place, so the resolver that PICKS
+# one and the report that names the others as ignored can never disagree about
+# what the candidates are.
+compose_env_file_candidates() {
+    local deploy_dir="${1:-$DEPLOY_DIR}"
+    printf '%s\n' "$deploy_dir/.env" "$(dirname "$deploy_dir")/.env"
+}
+
+resolve_compose_env_file() {
+    local candidate
+    while IFS= read -r candidate; do
+        if [[ -f "$candidate" ]]; then
+            printf '%s\n' "$candidate"
+            return 0
+        fi
+    done < <(compose_env_file_candidates "${1:-$DEPLOY_DIR}")
+}
+
+# Name the file this deployment is configured from, and the two things about it
+# that are silent everywhere else. Called once per platform command, so it stays
+# at one line per fact.
+#
+# BOTH CANDIDATES PRESENT is the dangerous one. Exactly one --env-file is passed
+# and Compose does not merge the other, so every key that only the ignored file
+# assigns falls back to compose.yaml's default. A `${VAR:?}` key fails loudly; a
+# key with a `:-` default degrades in silence — SYNAPLAN_HTTP_BIND returns to
+# 127.0.0.1 and a managed platform's HTTPS proxy can no longer reach the
+# container, BOOTSTRAP_ADMIN_EMAIL and BOOTSTRAP_ADMIN_PASSWORD go empty and no
+# administrator is ever created, provider API keys disappear. The instance is
+# simply offline or half-configured, with nothing in the log to say why. It
+# happens in both directions: a deploy/.env left behind on a managed platform
+# hides the platform's own checkout-root file, and a checkout-root .env written
+# for the DEVELOPMENT stack becomes the production configuration when no
+# deploy/.env exists.
+#
+# CRLF LINE ENDINGS are a note, not a warning: Compose discards the trailing
+# carriage return for every value shape, quoted ones included, and
+# env_file_raw_value() does the same, so a Windows checkout is a valid
+# configuration and must not fail here. It is still named, because
+# core.autocrlf turns the shipped example into a CRLF file silently and an
+# operator who does not know the carriage returns are there cannot reason about
+# the file.
+report_compose_env_file() {
+    local deploy_dir="${1:-$DEPLOY_DIR}"
+    local env_file candidate
+
+    env_file="$(resolve_compose_env_file "$deploy_dir")"
+    if [[ -z "$env_file" ]]; then
+        echo "No deployment configuration file found; using the host environment only."
+        return 0
+    fi
+
+    printf 'Reading deployment configuration from %s.\n' "$env_file"
+
+    while IFS= read -r candidate; do
+        [[ -f "$candidate" && "$candidate" != "$env_file" ]] || continue
+        printf 'Warning: %s also exists and is IGNORED; Compose reads %s only and does not merge the two, so any key set solely in the ignored file falls back to its default.\n' \
+            "$candidate" "$env_file" >&2
+    done < <(compose_env_file_candidates "$deploy_dir")
+
+    if env_file_has_crlf "$env_file"; then
+        printf 'Note: %s uses Windows (CRLF) line endings. Compose discards the carriage returns, so this is supported; convert the file with dos2unix, or with your editor, if you prefer Unix line endings.\n' \
+            "$env_file"
+    fi
+}
+
+# Whether the configuration file uses Windows line endings. One CRLF line is
+# enough: the question is which tool wrote the file, not how consistent it was.
+env_file_has_crlf() {
+    LC_ALL=C awk '/\r$/ { found = 1; exit } END { exit !found }' "$1"
+}
+
+compose() {
+    local args=(docker compose -f "$DEPLOY_DIR/compose.yaml")
+    if [[ -n "${SYNAPLAN_COMPOSE_OVERRIDE:-}" ]]; then
+        args+=(-f "$SYNAPLAN_COMPOSE_OVERRIDE")
+    fi
+    local env_file
+    env_file="$(resolve_compose_env_file)"
+    if [[ -n "$env_file" ]]; then
+        args+=(--env-file "$env_file")
+    fi
+    "${args[@]}" "$@"
+}
+
+resolved_app_image() {
+    compose config |
+        awk '
+            /^  backend:$/ { in_backend = 1; next }
+            in_backend && /^    image: / { print $2; found = 1; exit }
+            in_backend && /^  [^ ]/ { exit 1 }
+            END { if (!found) exit 1 }
+        '
+}
+
+validate_release_pin() {
+    local resolved_image
+    resolved_image="$(resolved_app_image)"
+    if [[ ! "$resolved_image" =~ :[0-9]+\.[0-9]+\.[0-9]+([.-][A-Za-z0-9][A-Za-z0-9.-]*)?$ ]]; then
+        echo "SYNAPLAN_VERSION must resolve to a published immutable SemVer tag; got: $resolved_image" >&2
+        return 1
+    fi
+}
+
+# Read one interpolation variable from `compose config --environment`, which
+# already merges the host environment over deploy/.env using Compose's own
+# precedence — the same resolution the containers will see. The rendered
+# environment is piped in, so no value ever appears in a process list.
+#
+# LC_ALL=C for the same reason env_file_raw_value() uses it: the two results are
+# compared byte for byte, so both sides have to be read with byte semantics.
+compose_environment_value() {
+    printf '%s\n' "$1" | LC_ALL=C awk -v key="$2" '
+        index($0, key "=") == 1 { value = substr($0, length(key) + 2) }
+        END { print value }
+    '
+}
+
+# Keys whose configured value must reach the containers byte for byte, ordered by
+# the consequence of it not doing so:
+#
+#   BOOTSTRAP_ADMIN_EMAIL / BOOTSTRAP_ADMIN_PASSWORD  silent lockout. The first
+#     start stores the hash of the altered password, or creates the administrator
+#     under an altered address; the operator then authenticates with what the
+#     configuration file says and there is no recovery path.
+#   APP_SECRET / TOKEN_SECRET  silent loss of entropy. `ab$cd` becomes `ab`, and
+#     a two-byte application secret signs every token without any symptom.
+#   MARIADB_ROOT_PASSWORD / MARIADB_PASSWORD  used consistently on both sides
+#     today, so an altered value still works — until it is typed by hand during a
+#     recovery, or the file is replayed on a database that already exists.
+#   REALTIME_*  internally consistent for the same reason, and equally weakened.
+#   MAILER_DSN  carries SMTP credentials, and ` #` or `$` in a password is
+#     realistic.
+#   provider API keys  fail loudly at the first request, but the failure names
+#     the provider rather than the configuration file.
+#
+# Deliberately not covered: APP_URL, FRONTEND_URL, REALTIME_ALLOWED_ORIGINS,
+# MARIADB_DATABASE, MARIADB_USER, APP_SENDER_*, AI_DEFAULT_PROVIDER, LOG_FORMAT,
+# PHP_MAX_FILE_UPLOADS, ENABLE_LOCAL_GPT_OSS and WHISPER_DEFAULT_MODEL. None is a
+# secret, an altered value is visible in the running configuration, and it fails
+# where it is used instead of silently succeeding. SYNAPLAN_VERSION and
+# SYNAPLAN_IMAGE are decided by validate_release_pin, and the COMPOSE_* keys
+# configure Compose itself.
+SYNAPLAN_ROUNDTRIP_KEYS=(
+    BOOTSTRAP_ADMIN_EMAIL
+    BOOTSTRAP_ADMIN_PASSWORD
+    APP_SECRET
+    TOKEN_SECRET
+    MARIADB_ROOT_PASSWORD
+    MARIADB_PASSWORD
+    REALTIME_API_KEY
+    REALTIME_TOKEN_SECRET
+    REALTIME_ADMIN_PASSWORD
+    REALTIME_ADMIN_SECRET
+    MAILER_DSN
+    OPENAI_API_KEY
+    ANTHROPIC_API_KEY
+    GROQ_API_KEY
+    GOOGLE_GEMINI_API_KEY
+    MISTRAL_API_KEY
+    XAI_API_KEY
+)
+
+# The value exactly as the FILE spells it: everything after the first "=", with
+# no unquoting, no trimming, no comment stripping and no interpolation.
+#
+# Normalised away, and only this, is the spelling Compose itself discards before
+# it ever looks at a value. Getting that set wrong breaks the guard in both
+# directions: normalising too much hides a real alteration, and normalising too
+# little either reports a file Compose reads perfectly (a blocked installation)
+# or fails to recognise the assignment at all — which skips the key silently,
+# the exact false negative this guard exists to prevent. Every form below was
+# measured against Compose v5.3.1:
+#
+#   a UTF-8 BOM on the first line, which Compose strips before the first key;
+#   a trailing carriage return, which Compose discards for every value shape,
+#     quoted ones included, so a Windows checkout is a valid configuration;
+#   a leading indent and an `export ` prefix;
+#   whitespace between the key and the `=`, which Compose accepts
+#     (`KEY = value` and `KEY<tab>=<tab>value` both assign).
+#
+# Whitespace AFTER the `=` is deliberately NOT normalised. Compose trims it, and
+# reporting that trimming is the whole point — a password written as `  abc  `
+# reaches the containers as `abc`. `KEY = value` therefore reports as altered
+# too, because of the space the file puts in front of the value; that is the
+# same finding, and the message says to remove whitespace around the `=`.
+#
+# The last assignment wins, which is Compose's rule too. Returns non-zero when
+# the file does not assign the key at all.
+#
+# LC_ALL=C keeps every operation on bytes: the BOM is compared as the three
+# bytes it is, and a value that is not valid UTF-8 survives the read unchanged.
+# The BOM is built with sprintf() rather than written as an escape, because a
+# `\xNN` escape is not portable between BSD awk, gawk and mawk. The key is
+# interpolated into a regular expression, which is safe because every covered
+# key is spelled with `[A-Z_]` only.
+env_file_raw_value() {
+    LC_ALL=C awk -v key="$2" '
+        BEGIN { byte_order_mark = sprintf("%c%c%c", 239, 187, 191) }
+        {
+            line = $0
+            if (NR == 1 && substr(line, 1, 3) == byte_order_mark) {
+                line = substr(line, 4)
+            }
+            sub(/\r$/, "", line)
+            sub(/^[[:space:]]*(export[[:space:]]+)?/, "", line)
+        }
+        match(line, "^" key "[[:space:]]*=") {
+            value = substr(line, RLENGTH + 1)
+            found = 1
+        }
+        END { if (!found) exit 1; print value }
+    ' "$1"
+}
+
+# Whether the EXPORTED environment defines the key. Only exported variables reach
+# Compose, and Compose prefers them over every --env-file entry, so a key defined
+# here is not resolved from the file and its file entry must not be compared.
+host_environment_defines() {
+    env | awk -v key="$1" 'index($0, key "=") == 1 { found = 1 } END { exit !found }'
+}
+
+# Reject a configuration file whose secrets Compose does not read back unchanged.
+#
+# validate_bootstrap_admin_config resolves its values through
+# `compose config --environment`, which returns them AFTER Compose's .env
+# parsing. It therefore sees the already-altered value, approves it, and is
+# structurally incapable of noticing the alteration. This check is the missing
+# half: it compares what the file says with what Compose resolved.
+#
+# Compose's .env parser alters a value in five ways — an unescaped `$` starts an
+# interpolation (`ab$cd` becomes `ab`), `$$` collapses to `$`, surrounding
+# quotes are stripped, surrounding whitespace is trimmed, and ` #` starts a
+# comment. A sixth form, `ab${cd`, is already a hard Compose error and fails
+# `compose config` before this runs.
+#
+# One byte-for-byte comparison per key catches all of them, including whatever a
+# future Compose release adds, without reimplementing the dotenv grammar here —
+# a second parser is exactly the kind of divergence this check exists to catch.
+#
+# `$$` is reported as well, even though an operator may have written it as a
+# deliberate escape: the two intentions ("a literal $$" and "an escaped $") are
+# indistinguishable from the file, and guessing wrong on a password means the
+# lockout above. Naming the key and letting the operator choose a value without
+# `$`, or pass it as a host environment variable, is the recoverable outcome.
+#
+# No value is ever printed: these keys are secrets and a deployment log is not.
+#
+# The file is resolved here and cannot be passed in. Both halves of the
+# comparison have to describe the SAME file, and only the internal `compose()`
+# decides which one Compose actually reads; a caller-supplied path is free to
+# name a different one, which would compare a file against an environment
+# rendered from another and report either a phantom alteration or, worse,
+# nothing at all. Nothing needs to compare a file Compose does not read.
+validate_secret_roundtrip() {
+    local environment key raw resolved env_file altered_keys=""
+
+    # A host-environment-only deployment has no file, so Compose parses nothing
+    # and there is nothing to compare.
+    env_file="$(resolve_compose_env_file)"
+    if [[ -z "$env_file" ]]; then
+        return 0
+    fi
+
+    if ! environment="$(compose config --environment)"; then
+        echo "Could not resolve the Compose interpolation environment (see the error above); check $env_file and make sure Docker Compose 2.28 or newer is installed." >&2
+        return 1
+    fi
+
+    for key in "${SYNAPLAN_ROUNDTRIP_KEYS[@]}"; do
+        host_environment_defines "$key" && continue
+        raw="$(env_file_raw_value "$env_file" "$key")" || continue
+        resolved="$(compose_environment_value "$environment" "$key")"
+        if [[ "$raw" != "$resolved" ]]; then
+            altered_keys="${altered_keys}${altered_keys:+ }$key"
+        fi
+    done
+
+    if [[ -n "$altered_keys" ]]; then
+        echo "Docker Compose's .env parsing does not read these values back unchanged from $env_file, so the containers would be configured with something other than what the file says: $altered_keys" >&2
+        echo "Fix: write each listed value without surrounding quotes, without whitespace around the '=' or around the value, without an inline ' #' comment, and without a dollar sign; or pass it as a host environment variable, which Compose never rewrites." >&2
+        echo "For a URL-shaped value such as MAILER_DSN, a dollar sign in a third-party password usually cannot simply be removed: percent-encode it inside the DSN instead, writing '\$' as '%24'." >&2
+        echo "Generating the value with 'openssl rand -hex 32' always satisfies this. No value is printed here, because these keys are secrets." >&2
+        return 1
+    fi
+}
+
+# Reject an unusable first-admin configuration before any container starts.
+#
+# BootstrapAdminService stays the authoritative validator, but it only runs
+# inside the backend container, and compose.yaml restarts that container
+# `unless-stopped` — so a rejected value there crash-loops the deployment
+# instead of reporting the operator error. This host-side preflight runs before
+# `docker compose up -d` and fails the deployment once, with a fixable message.
+#
+# The preflight is deliberately two-tier, because a validator that is looser
+# than the authority reintroduces exactly that crash loop:
+#
+#   Tier 1 — validate_bootstrap_admin_values(): pure shell, no dependencies,
+#     unit-testable without Docker. It runs everywhere, including the update and
+#     restore paths where starting a throwaway container is not appropriate, and
+#     it is the only tier when no image is available. Its email rule mirrors
+#     filter_var(FILTER_VALIDATE_EMAIL) for realistically configurable addresses
+#     (see bootstrap_admin_email_is_valid) and must never reject an address the
+#     authority accepts.
+#   Tier 2 — validate_app_image_contract(): calls the authority itself,
+#     App\Service\Admin\BootstrapAdminConfiguration, inside the resolved
+#     application image, so neither the email nor the password rule can drift
+#     from the PHP implementation. It needs that image, so it only runs where one
+#     is already being probed: validate-release.sh.
+validate_bootstrap_admin_config() {
+    local environment
+    if ! environment="$(compose config --environment)"; then
+        echo "Could not resolve the Compose interpolation environment (see the error above); check deploy/.env and make sure Docker Compose 2.28 or newer is installed." >&2
+        return 1
+    fi
+    validate_bootstrap_admin_values \
+        "$(compose_environment_value "$environment" BOOTSTRAP_ADMIN_EMAIL)" \
+        "$(compose_environment_value "$environment" BOOTSTRAP_ADMIN_PASSWORD)"
+}
+
+# Tier 1's email rule. Mirrors what PHP's
+# filter_var($email, FILTER_VALIDATE_EMAIL) accepts, for the addresses an
+# operator can realistically configure. A plain `local@domain` pattern is not
+# enough: filter_var additionally rejects a leading, trailing or doubled dot in
+# the local part, a domain label that starts or ends with a hyphen, a top-level
+# label that does not start with a letter, a local part longer than 64 bytes and
+# a label longer than 63 bytes. Accepting those here would let the deployment
+# start and then crash-loop the backend.
+#
+# Exotic-but-valid forms that filter_var accepts are intentionally rejected:
+# address literals (admin@[127.0.0.1]) and quoted local parts ("a b"@example.com).
+# Neither is a usable administrator mailbox, and rejecting them costs a clear
+# preflight error instead of a crash loop.
+bootstrap_admin_email_is_valid() {
+    # Byte semantics, matching PHP's strlen().
+    local LC_ALL=C
+    local email="$1"
+    local maximum_local_part_length=64
+    local maximum_label_length=63
+    # Local part: dot-separated, non-empty atoms.
+    local local_part_pattern='^[A-Za-z0-9!#$%&'\''*+/=?^_`{|}~-]+(\.[A-Za-z0-9!#$%&'\''*+/=?^_`{|}~-]+)*$'
+    # Domain: at least two labels; a label may contain hyphens but not at either edge.
+    local domain_pattern='^[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?)+$'
+    local local_part domain label remainder
+
+    [[ "$email" == *@* ]] || return 1
+    # A second "@" stays in the local part, where the pattern rejects it.
+    local_part="${email%@*}"
+    domain="${email##*@}"
+
+    (( ${#local_part} <= maximum_local_part_length )) || return 1
+    [[ "$local_part" =~ $local_part_pattern ]] || return 1
+    [[ "$domain" =~ $domain_pattern ]] || return 1
+
+    remainder="$domain"
+    while :; do
+        label="${remainder%%.*}"
+        (( ${#label} <= maximum_label_length )) || return 1
+        [[ "$remainder" == *.* ]] || break
+        remainder="${remainder#*.}"
+    done
+
+    # $label is now the top-level label. filter_var requires it to start with a
+    # letter, so it rejects admin@example.123 and admin@1.2 while still
+    # accepting digits anywhere else in the domain (admin@1.example.com).
+    [[ "$label" =~ ^[A-Za-z] ]] || return 1
+}
+
+# Mirrors BootstrapAdminService::bootstrap()'s validation. Values are never
+# echoed: the password is a secret and the deployment log is not.
+validate_bootstrap_admin_values() {
+    # Byte semantics, matching PHP's strlen().
+    local LC_ALL=C
+    local email="$1"
+    local password="$2"
+    local maximum_email_length=128
+    local minimum_password_length=8
+    local maximum_password_length=64
+    local composition_waiver_length=16
+    local present missing
+
+    # BootstrapAdminService trims the email, and only the email, before deciding
+    # whether the bootstrap is configured at all.
+    email="${email#"${email%%[![:space:]]*}"}"
+    email="${email%"${email##*[![:space:]]}"}"
+
+    if [[ -z "$email" && -z "$password" ]]; then
+        echo "No first administrator configured; the bootstrap will be skipped."
+        return 0
+    fi
+
+    if [[ -z "$email" || -z "$password" ]]; then
+        present=BOOTSTRAP_ADMIN_EMAIL
+        missing=BOOTSTRAP_ADMIN_PASSWORD
+        if [[ -z "$email" ]]; then
+            present=BOOTSTRAP_ADMIN_PASSWORD
+            missing=BOOTSTRAP_ADMIN_EMAIL
+        fi
+        echo "$present is set but $missing is empty; both must be set together or both left empty." >&2
+        echo "Fix: set $missing, or clear $present to skip the first-admin bootstrap." >&2
+        return 1
+    fi
+
+    if (( ${#email} > maximum_email_length )) || ! bootstrap_admin_email_is_valid "$email"; then
+        echo "BOOTSTRAP_ADMIN_EMAIL must be a valid email address of at most $maximum_email_length characters; the configured value is ${#email} characters long." >&2
+        echo "Fix: set BOOTSTRAP_ADMIN_EMAIL to the administrator's email address, for example admin@example.com." >&2
+        return 1
+    fi
+
+    if (( ${#password} < minimum_password_length )); then
+        echo "BOOTSTRAP_ADMIN_PASSWORD must be at least $minimum_password_length characters." >&2
+        echo "Fix: set BOOTSTRAP_ADMIN_PASSWORD to a longer password." >&2
+        return 1
+    fi
+
+    if (( ${#password} > maximum_password_length )); then
+        echo "BOOTSTRAP_ADMIN_PASSWORD must be at most $maximum_password_length characters." >&2
+        echo "Fix: set BOOTSTRAP_ADMIN_PASSWORD to a shorter password." >&2
+        return 1
+    fi
+
+    # Following NIST SP 800-63B, composition rules only apply to short
+    # passwords: managed platforms such as Elestio inject a high-entropy
+    # generated password that can legitimately contain no digit.
+    if (( ${#password} < composition_waiver_length )) &&
+        { [[ ! "$password" =~ [a-z] ]] || [[ ! "$password" =~ [A-Z] ]] || [[ ! "$password" =~ [0-9] ]]; }; then
+        echo "BOOTSTRAP_ADMIN_PASSWORD must contain at least one uppercase letter, one lowercase letter, and one number, or be at least $composition_waiver_length characters long." >&2
+        echo "Fix: add the missing character types to BOOTSTRAP_ADMIN_PASSWORD, or use a password of at least $composition_waiver_length characters." >&2
+        return 1
+    fi
+}
+
+# The line the authority's program prints when it rejects a value. The host keys
+# on this marker instead of on the exit status alone, so a probe command added
+# later that happens to exit 3 can never be misread as a rejected configuration.
+# Keep it in sync with the printf in bootstrap_admin_authority_command().
+BOOTSTRAP_ADMIN_REJECTION_MARKER=SYNAPLAN_BOOTSTRAP_ADMIN_REJECTED
+
+# The container-side command that asks the authority itself —
+# App\Service\Admin\BootstrapAdminConfiguration, which the application image
+# ships — for a verdict on the WHOLE first-admin configuration.
+#
+# No rule is reimplemented here: this is the same call, through the same
+# SYNAPLAN_AUTOLOAD_PATH knob with the same default, that
+# require_valid_bootstrap_admin_config makes in
+# _docker/backend/lib/container-runtime.sh — a path relative to the application
+# directory the image already works in. It is printed by a function so the
+# contract test in deploy/scripts/tests can run this very command instead of a
+# second copy that would be free to drift.
+#
+# Both values are read from the environment inside PHP and never passed as
+# arguments, so BOOTSTRAP_ADMIN_PASSWORD never reaches a process list, and the
+# only thing ever printed is the validator's own message — which by contract
+# never contains a configured value.
+#
+# Exit status: 0 accepted (including "not configured at all"), 3 plus the marker
+# above rejected; anything else means the program could not run.
+bootstrap_admin_authority_command() {
+    cat <<'COMMAND'
+SYNAPLAN_AUTOLOAD_PATH="${SYNAPLAN_AUTOLOAD_PATH:-vendor/autoload.php}" php -r '
+require getenv("SYNAPLAN_AUTOLOAD_PATH");
+
+try {
+    App\Service\Admin\BootstrapAdminConfiguration::fromConfiguration(
+        (string) getenv("BOOTSTRAP_ADMIN_EMAIL"),
+        (string) getenv("BOOTSTRAP_ADMIN_PASSWORD"),
+    );
+} catch (InvalidArgumentException $violation) {
+    printf("SYNAPLAN_BOOTSTRAP_ADMIN_REJECTED %s\n", $violation->getMessage());
+    exit(3);
+}
+'
+COMMAND
+}
+
+# Tier 2 of the first-admin check, plus the image contract itself.
+#
+# Both checks share ONE throwaway container: starting a second one would add
+# an image start to every managed deployment for no extra coverage. The
+# credentials are read from the container's own environment (compose.yaml passes
+# BOOTSTRAP_ADMIN_EMAIL and BOOTSTRAP_ADMIN_PASSWORD to the backend service), so
+# they are resolved exactly as the real container resolves them, they never reach
+# the host process list, and --rm leaves no container behind to inspect them in.
+#
+# The image already ships the authority, so the probe calls it and covers the
+# email AND the password with it. Repeating a rule here would reintroduce the
+# defect this tier exists to prevent: a copy that drifts from the PHP
+# implementation, accepts a value the bootstrap later rejects, and crash-loops
+# the deployment.
+#
+# Exit-code contract of the probe:
+#   0        the image satisfies the contract and the authority accepted the
+#            configuration;
+#   3 + the rejection marker on stdout: the authority rejected the email or the
+#            password, and its message says which;
+#   64/65/66 an image contract check failed — one explicit code each, so no
+#            other step of the probe can ever produce 3;
+#   anything else, a missing image included: the contract is unverified.
+#
+# If the image cannot be started (for example it was never pulled, because
+# `--pull never` keeps this probe offline), this returns non-zero and the
+# caller fails: the image contract is unverified, so the deployment must not
+# proceed. Validation is never silently skipped — tier 1 has already run by
+# then, so a value that shell can decide on has still been rejected.
+validate_app_image_contract() {
+    local probe output violation status=0
+    probe="$(
+        cat <<'PROBE'
+test -x /usr/local/bin/docker-entrypoint.sh || exit 64
+test -x /usr/local/bin/container-healthcheck || exit 65
+grep -q SYNAPLAN_ROLE /usr/local/bin/docker-entrypoint.sh || exit 66
+PROBE
+        bootstrap_admin_authority_command
+    )"
+
+    output="$(compose run --rm --no-deps --pull never --entrypoint sh backend -ec "$probe")" || status=$?
+    violation="$(
+        printf '%s\n' "$output" |
+            awk -v marker="$BOOTSTRAP_ADMIN_REJECTION_MARKER" '
+                index($0, marker " ") == 1 { print substr($0, length(marker) + 2) }
+            '
+    )"
+
+    if (( status == 3 )) && [[ -n "$violation" ]]; then
+        echo "The first-admin configuration was rejected by the application's own validator, which is stricter than the host-side check:" >&2
+        printf '   %s\n' "$violation" >&2
+        echo "Fix: correct BOOTSTRAP_ADMIN_EMAIL or BOOTSTRAP_ADMIN_PASSWORD in your deployment configuration, then run the deployment again." >&2
+        echo "For the email, use a plain deliverable address, for example admin@example.com; avoid leading, trailing or repeated dots, hyphens at the edge of a domain label, and local parts longer than 64 characters." >&2
+        return 1
+    fi
+
+    if (( status == 0 )) && [[ -z "$violation" ]]; then
+        return 0
+    fi
+
+    # Either a probe step failed, or the probe did not behave as documented (the
+    # marker without status 3, or status 3 without the marker). Both mean the
+    # contract is unverified, so neither may pass as a decided verdict.
+    if [[ -n "$output" ]]; then
+        printf '%s\n' "$output" >&2
+    fi
+    echo "Could not verify the application image contract (see the error above); the image must be present locally, so run 'docker compose -f deploy/compose.yaml pull' first." >&2
+    (( status != 0 )) || status=1
+    return "$status"
+}
+
+prepare_data_directories() {
+    mkdir -p \
+        "$STATE_DIR" \
+        "$BACKUP_DIR" \
+        "$DATA_DIR/mariadb" \
+        "$DATA_DIR/redis" \
+        "$DATA_DIR/qdrant" \
+        "$DATA_DIR/uploads" \
+        "$DATA_DIR/ollama" \
+        "$DATA_DIR/whisper"
+    chmod 0700 "$STATE_DIR" "$BACKUP_DIR"
+}
+
+running_service() {
+    local service="$1"
+    compose ps --services --filter status=running | grep -Fxq "$service"
+}
+
+begin_service_pause() {
+    prepare_data_directories
+    : > "$PAUSED_SERVICES_FILE"
+    chmod 0600 "$PAUSED_SERVICES_FILE"
+}
+
+pause_services() {
+    prepare_data_directories
+    touch "$PAUSED_SERVICES_FILE"
+    chmod 0600 "$PAUSED_SERVICES_FILE"
+
+    local service
+    for service in "$@"; do
+        if running_service "$service" && ! grep -Fxq "$service" "$PAUSED_SERVICES_FILE"; then
+            printf '%s\n' "$service" >> "$PAUSED_SERVICES_FILE"
+        fi
+    done
+
+    for service in "$@"; do
+        if grep -Fxq "$service" "$PAUSED_SERVICES_FILE" && running_service "$service"; then
+            compose stop --timeout 60 "$service"
+        fi
+    done
+}
+
+service_was_paused() {
+    local service="$1"
+    [[ -f "$PAUSED_SERVICES_FILE" ]] && grep -Fxq "$service" "$PAUSED_SERVICES_FILE"
+}
+
+resume_paused_services() {
+    [[ -f "$PAUSED_SERVICES_FILE" ]] || return 0
+
+    local services=()
+    local service
+    while IFS= read -r service; do
+        [[ -n "$service" ]] && services+=("$service")
+    done < "$PAUSED_SERVICES_FILE"
+
+    if ((${#services[@]} > 0)); then
+        compose start "${services[@]}"
+    fi
+    rm -f "$PAUSED_SERVICES_FILE"
+}
+
+sha256_file() {
+    local file="$1"
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$file" | awk '{print $1}'
+    else
+        shasum -a 256 "$file" | awk '{print $1}'
+    fi
+}
+
+verify_sha256_file() {
+    local file="$1"
+    local checksum_file="$2"
+    local expected
+    expected="$(awk 'NR == 1 {print $1}' "$checksum_file")"
+    [[ "$expected" =~ ^[a-fA-F0-9]{64}$ ]] || {
+        echo "Invalid SHA-256 checksum in $checksum_file" >&2
+        return 1
+    }
+    [[ "$(sha256_file "$file")" == "$expected" ]] || {
+        echo "SHA-256 verification failed for $file" >&2
+        return 1
+    }
+}
+
+app_tool() {
+    compose run --rm --no-deps --pull never --entrypoint bash backend -ec "$1"
+}
+
+wait_for_service_health() {
+    local service="$1"
+    local timeout="${2:-300}"
+    local started
+    started="$(date +%s)"
+
+    while true; do
+        local container_id status
+        container_id="$(compose ps -q "$service")"
+        if [[ -n "$container_id" ]]; then
+            status="$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "$container_id")"
+            if [[ "$status" == "healthy" || "$status" == "running" ]]; then
+                return 0
+            fi
+            if [[ "$status" == "unhealthy" || "$status" == "exited" || "$status" == "dead" ]]; then
+                echo "$service entered state: $status" >&2
+                compose logs --tail 80 "$service" >&2 || true
+                return 1
+            fi
+        fi
+
+        if (( $(date +%s) - started >= timeout )); then
+            echo "Timed out waiting for $service health" >&2
+            compose logs --tail 80 "$service" >&2 || true
+            return 1
+        fi
+        sleep 5
+    done
+}
+
+latest_backup_path() {
+    local link="$BACKUP_DIR/latest"
+    local backup_root resolved
+    [[ -L "$link" ]] || {
+        echo "No completed backup is available at $link" >&2
+        return 1
+    }
+    backup_root="$(cd "$BACKUP_DIR" && pwd -P)"
+    resolved="$(cd "$backup_root" && cd "$(readlink latest)" && pwd -P)"
+    [[ "$resolved" == "$backup_root/"* ]] || {
+        echo "Latest backup symlink escapes $backup_root" >&2
+        return 1
+    }
+    printf '%s\n' "$resolved"
+}

--- a/deploy/scripts/post-backup.sh
+++ b/deploy/scripts/post-backup.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+# shellcheck source=lib.sh
+source "$(dirname "$0")/lib.sh"
+
+ACTIVE_BACKUP_FILE="$STATE_DIR/active-backup"
+
+resume_on_exit() {
+    resume_paused_services
+}
+trap resume_on_exit EXIT
+
+if [[ ! -f "$ACTIVE_BACKUP_FILE" ]]; then
+    echo "No active backup marker found; ensuring paused services are released."
+    exit 0
+fi
+
+target="$(<"$ACTIVE_BACKUP_FILE")"
+[[ "$target" == "$BACKUP_DIR/"* && -f "$target/.complete" ]] || {
+    echo "Refusing to finalize an invalid or incomplete backup path: $target" >&2
+    exit 1
+}
+
+ln -sfn "$(basename "$target")" "$BACKUP_DIR/latest"
+rm -f "$ACTIVE_BACKUP_FILE"
+
+keep="${BACKUP_RETENTION_COUNT:-7}"
+[[ "$keep" =~ ^[1-9][0-9]*$ ]] || {
+    echo "BACKUP_RETENTION_COUNT must be a positive integer" >&2
+    exit 1
+}
+
+backups=()
+for candidate in "$BACKUP_DIR"/????????T??????Z; do
+    [[ -d "$candidate" && -f "$candidate/.complete" ]] && backups+=("$candidate")
+done
+
+if ((${#backups[@]} > keep)); then
+    remove_count=$((${#backups[@]} - keep))
+    for ((index = 0; index < remove_count; index++)); do
+        rm -rf "${backups[$index]}"
+    done
+fi
+
+echo "Backup finalized at $target."

--- a/deploy/scripts/post-restore.sh
+++ b/deploy/scripts/post-restore.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+# shellcheck source=lib.sh
+source "$(dirname "$0")/lib.sh"
+
+# Runs before the recovery trap below is installed, on purpose: that trap brings
+# the backend back up, so a failure after it exists would start a container with
+# the rejected configuration — the crash loop this preflight prevents. The
+# configuration is resolvable here because deploy/.env lives outside deploy/data
+# and is therefore untouched by the platform restore.
+#
+# A restore is also the path most likely to run on a hand-written configuration
+# file — recreated on a new host from an external copy of the secrets — so the
+# roundtrip guard runs here too, and before the value rules for the same reason as
+# everywhere else: an altered value must be reported as altered, not as invalid.
+validate_secret_roundtrip
+validate_bootstrap_admin_config
+
+RESTORE_MARKER="$STATE_DIR/restore-ready"
+restore_complete=false
+uploads_staging=""
+ollama_was_running=false
+if service_was_paused ollama; then
+    ollama_was_running=true
+fi
+
+recover_services_on_failure() {
+    local exit_code=$?
+    trap - EXIT INT TERM
+    if [[ "$restore_complete" != true ]]; then
+        ((exit_code != 0)) || exit_code=1
+        echo "Restore finalization failed; attempting to return services to a runnable state." >&2
+        compose up -d db redis qdrant centrifugo tika backend worker scheduler || true
+        if [[ "$ollama_was_running" == true ]]; then
+            compose up -d ollama || true
+        fi
+        [[ -n "$uploads_staging" ]] && rm -rf "$uploads_staging"
+        echo "Restore markers were retained so finalization can be retried safely." >&2
+    fi
+    exit "$exit_code"
+}
+trap recover_services_on_failure EXIT INT TERM
+
+prepare_data_directories
+[[ -f "$RESTORE_MARKER" ]] || echo "Restore marker is absent; running idempotent recovery checks."
+
+backup="$(latest_backup_path)"
+backup_name="$(basename "$backup")"
+restore_portable_backup="${RESTORE_PORTABLE_BACKUP:-false}"
+
+chmod 0700 "$DATA_DIR" "$BACKUP_DIR" "$backup"
+chmod 0600 "$backup/mariadb.sql"
+
+compose up -d db redis qdrant centrifugo tika
+wait_for_service_health db 300
+wait_for_service_health redis 120
+wait_for_service_health qdrant 180
+wait_for_service_health centrifugo 120
+wait_for_service_health tika 180
+
+if [[ "$restore_portable_backup" == "true" ]]; then
+    [[ -f "$backup/uploads.tar.gz" && -f "$backup/uploads.tar.gz.sha256" &&
+        -f "$backup/uploads.manifest.sha256" ]] || {
+        echo "Portable backup is missing uploaded-file artifacts" >&2
+        exit 1
+    }
+    verify_sha256_file "$backup/uploads.tar.gz" "$backup/uploads.tar.gz.sha256"
+
+    while IFS= read -r archive_path; do
+        normalized="${archive_path#./}"
+        [[ -z "$normalized" || "$normalized" == "." ]] && continue
+        [[ "$normalized" != /* && "/$normalized/" != *"/../"* ]] || {
+            echo "Unsafe path in uploads archive: $archive_path" >&2
+            exit 1
+        }
+    done < <(tar -tzf "$backup/uploads.tar.gz")
+    if tar -tvzf "$backup/uploads.tar.gz" | grep -Eq '^[lh]'; then
+        echo "Refusing to restore links from the uploads archive" >&2
+        exit 1
+    fi
+
+    uploads_staging="$(mktemp -d "$DATA_DIR/.uploads-restore.XXXXXX")"
+    tar -xzf "$backup/uploads.tar.gz" \
+        --directory "$uploads_staging" \
+        --no-same-owner \
+        --no-same-permissions
+    if find "$uploads_staging" -type l -print -quit | grep -q .; then
+        echo "Uploads archive extracted an unexpected symlink" >&2
+        exit 1
+    fi
+    if [[ -s "$backup/uploads.manifest.sha256" ]]; then
+        while IFS= read -r checksum_line; do
+            checksum="${checksum_line:0:64}"
+            separator="${checksum_line:64:2}"
+            manifest_path="${checksum_line:66}"
+            normalized="${manifest_path#./}"
+            [[ "$checksum" =~ ^[a-fA-F0-9]{64}$ && "$separator" == "  " &&
+                -n "$normalized" && "$normalized" != /* &&
+                "/$normalized/" != *"/../"* ]] || {
+                echo "Unsafe entry in uploaded-file checksum manifest" >&2
+                exit 1
+            }
+        done < "$backup/uploads.manifest.sha256"
+        (
+            cd "$uploads_staging"
+            if command -v sha256sum >/dev/null 2>&1; then
+                sha256sum -c "$backup/uploads.manifest.sha256"
+            else
+                shasum -a 256 -c "$backup/uploads.manifest.sha256"
+            fi
+        )
+    fi
+
+    echo "Restoring MariaDB from the portable dump..."
+    compose exec -T db sh -ec \
+        'exec mariadb --user=root --password="$MARIADB_ROOT_PASSWORD" "$MARIADB_DATABASE"' \
+        < "$backup/mariadb.sql"
+
+    manifest="$backup/qdrant/manifest.tsv"
+    if [[ -s "$manifest" ]]; then
+        echo "Restoring Qdrant collection snapshots..."
+        while IFS=$'\t' read -r collection snapshot; do
+            [[ "$collection" =~ ^[A-Za-z0-9._-]+$ && "$snapshot" =~ ^[A-Za-z0-9._-]+$ ]] || {
+                echo "Invalid Qdrant snapshot manifest entry" >&2
+                exit 1
+            }
+            app_tool "curl -fsS -X POST \
+                'http://qdrant:6333/collections/$collection/snapshots/upload?priority=snapshot' \
+                -F 'snapshot=@/var/www/backup/$backup_name/qdrant/$snapshot' >/dev/null"
+        done < "$manifest"
+    fi
+
+    echo "Restoring uploaded files from the portable archive..."
+    rm -rf "$DATA_DIR/uploads"
+    mv "$uploads_staging" "$DATA_DIR/uploads"
+    uploads_staging=""
+else
+    echo "Using database and Qdrant state restored by the platform."
+fi
+
+compose run --rm --no-deps --pull never --entrypoint bash backend -ec \
+    'chown -R www-data:www-data /var/www/backend/var/uploads && chmod -R u+rwX,g+rwX /var/www/backend/var/uploads'
+
+compose up -d backend
+wait_for_service_health backend 600
+compose up -d worker scheduler
+wait_for_service_health worker 240
+wait_for_service_health scheduler 240
+if [[ "$ollama_was_running" == true ]]; then
+    compose up -d ollama
+    wait_for_service_health ollama 240
+fi
+
+rm -f "$RESTORE_MARKER" "$PAUSED_SERVICES_FILE" "$STATE_DIR/active-backup"
+"$DEPLOY_DIR/scripts/smoke-test.sh"
+restore_complete=true
+trap - EXIT INT TERM
+echo "Restore completed and verified."

--- a/deploy/scripts/post-update.sh
+++ b/deploy/scripts/post-update.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+# shellcheck source=lib.sh
+source "$(dirname "$0")/lib.sh"
+
+# This script is also the install and deploy hook, so it is the only host-side
+# gate on those paths: validate-release.sh does not run before them. Tier 1 only
+# — the image contract, and with it the authoritative email probe, was already
+# verified by validate-release.sh when the release was pinned.
+#
+# The roundtrip guard comes first, as in prepare.sh and validate-release.sh: it is
+# the only check that compares the configuration FILE with what Compose read back
+# from it, and validate_bootstrap_admin_config resolves its values through
+# Compose, so it sees an altered value as if it were the configured one and
+# approves it.
+validate_secret_roundtrip
+validate_bootstrap_admin_config
+
+compose up -d --remove-orphans
+wait_for_service_health db 300
+wait_for_service_health redis 120
+wait_for_service_health qdrant 180
+wait_for_service_health centrifugo 120
+wait_for_service_health tika 180
+wait_for_service_health backend 600
+wait_for_service_health worker 240
+wait_for_service_health scheduler 240
+
+"$DEPLOY_DIR/scripts/smoke-test.sh"
+
+container_id="$(compose ps -q backend)"
+image_reference="$(docker inspect --format '{{.Config.Image}}' "$container_id")"
+image_id="$(docker inspect --format '{{.Image}}' "$container_id")"
+printf 'Update verified: %s (%s)\n' "$image_reference" "$image_id"

--- a/deploy/scripts/pre-backup.sh
+++ b/deploy/scripts/pre-backup.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+# shellcheck source=lib.sh
+source "$(dirname "$0")/lib.sh"
+
+ACTIVE_BACKUP_FILE="$STATE_DIR/active-backup"
+
+prepare_data_directories
+if [[ -f "$ACTIVE_BACKUP_FILE" && -f "$PAUSED_SERVICES_FILE" ]]; then
+    echo "Backup preparation is already complete: $(<"$ACTIVE_BACKUP_FILE")"
+    exit 0
+fi
+
+timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+target="$BACKUP_DIR/$timestamp"
+mkdir -p "$target/qdrant"
+chmod 0700 "$target"
+backup_complete=false
+
+cleanup_failed_backup() {
+    local exit_code=$?
+    ((exit_code != 0)) || exit_code=1
+    trap - EXIT INT TERM
+    if [[ "$backup_complete" != true ]]; then
+        rm -rf "$target"
+        rm -f "$ACTIVE_BACKUP_FILE"
+        resume_paused_services || true
+    fi
+    exit "$exit_code"
+}
+trap cleanup_failed_backup EXIT INT TERM
+
+begin_service_pause
+pause_services scheduler worker backend
+
+echo "Creating a consistent MariaDB dump..."
+compose exec -T db sh -ec \
+    'exec mariadb-dump --user=root --password="$MARIADB_ROOT_PASSWORD" \
+        --single-transaction --routines --events --triggers --add-drop-table \
+        "$MARIADB_DATABASE"' > "$target/mariadb.sql.tmp"
+chmod 0600 "$target/mariadb.sql.tmp"
+mv "$target/mariadb.sql.tmp" "$target/mariadb.sql"
+
+echo "Creating Qdrant collection snapshots..."
+: > "$target/qdrant/manifest.tsv"
+collections="$(app_tool "curl -fsS http://qdrant:6333/collections | jq -r '.result.collections[].name'")"
+while IFS= read -r collection; do
+    [[ -n "$collection" ]] || continue
+    [[ "$collection" =~ ^[A-Za-z0-9._-]+$ ]] || {
+        echo "Unsafe Qdrant collection name: $collection" >&2
+        exit 1
+    }
+
+    snapshot="$(app_tool "curl -fsS -X POST http://qdrant:6333/collections/$collection/snapshots | jq -er '.result.name'")"
+    [[ "$snapshot" =~ ^[A-Za-z0-9._-]+$ ]] || {
+        echo "Unsafe Qdrant snapshot name returned for $collection" >&2
+        exit 1
+    }
+
+    app_tool "curl -fsS http://qdrant:6333/collections/$collection/snapshots/$snapshot" \
+        > "$target/qdrant/$snapshot.tmp"
+    chmod 0600 "$target/qdrant/$snapshot.tmp"
+    mv "$target/qdrant/$snapshot.tmp" "$target/qdrant/$snapshot"
+    printf '%s\t%s\n' "$collection" "$snapshot" >> "$target/qdrant/manifest.tsv"
+    app_tool "curl -fsS -X DELETE http://qdrant:6333/collections/$collection/snapshots/$snapshot >/dev/null"
+done <<< "$collections"
+chmod 0600 "$target/qdrant/manifest.tsv"
+
+echo "Archiving uploaded files..."
+while IFS= read -r -d '' path; do
+    [[ "$path" != *$'\n'* && "$path" != *\\* ]] || {
+        echo "Upload paths containing newlines or backslashes cannot be backed up safely: $path" >&2
+        exit 1
+    }
+done < <(find "$DATA_DIR/uploads" -mindepth 1 -print0)
+
+if find "$DATA_DIR/uploads" -type l -print -quit | grep -q .; then
+    echo "Refusing to archive symlinks from the uploads directory" >&2
+    exit 1
+fi
+
+(
+    cd "$DATA_DIR/uploads"
+    tar -czf "$target/uploads.tar.gz.tmp" .
+    while IFS= read -r -d '' file; do
+        if command -v sha256sum >/dev/null 2>&1; then
+            sha256sum "$file"
+        else
+            shasum -a 256 "$file"
+        fi
+    done < <(find . -type f -print0)
+) > "$target/uploads.manifest.sha256"
+chmod 0600 "$target/uploads.tar.gz.tmp" "$target/uploads.manifest.sha256"
+mv "$target/uploads.tar.gz.tmp" "$target/uploads.tar.gz"
+printf '%s  uploads.tar.gz\n' "$(sha256_file "$target/uploads.tar.gz")" > "$target/uploads.tar.gz.sha256"
+chmod 0600 "$target/uploads.tar.gz.sha256"
+
+# Portable artifacts must exist before stateful bind mounts are quiesced for the
+# platform's raw filesystem snapshot.
+pause_services ollama qdrant centrifugo redis db
+
+printf '%s\n' "$target" > "$ACTIVE_BACKUP_FILE"
+touch "$target/.complete"
+chmod 0600 "$ACTIVE_BACKUP_FILE" "$target/.complete"
+ln -sfn "$(basename "$target")" "$BACKUP_DIR/latest"
+backup_complete=true
+trap - EXIT INT TERM
+
+echo "Backup artifacts are ready in $target; all previously running stateful services remain paused."

--- a/deploy/scripts/pre-restore.sh
+++ b/deploy/scripts/pre-restore.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+# shellcheck source=lib.sh
+source "$(dirname "$0")/lib.sh"
+
+RESTORE_MARKER="$STATE_DIR/restore-ready"
+
+prepare_data_directories
+if [[ -f "$RESTORE_MARKER" && -f "$PAUSED_SERVICES_FILE" ]]; then
+    echo "Restore preparation is already complete."
+    exit 0
+fi
+
+restore_prepare_complete=false
+cleanup_failed_prepare() {
+    local exit_code=$?
+    ((exit_code != 0)) || exit_code=1
+    trap - EXIT INT TERM
+    if [[ "$restore_prepare_complete" != true ]]; then
+        rm -f "$RESTORE_MARKER"
+        resume_paused_services || true
+    fi
+    exit "$exit_code"
+}
+trap cleanup_failed_prepare EXIT INT TERM
+
+begin_service_pause
+pause_services scheduler worker backend ollama centrifugo redis qdrant db
+touch "$RESTORE_MARKER"
+chmod 0600 "$RESTORE_MARKER"
+restore_prepare_complete=true
+trap - EXIT INT TERM
+
+echo "Application and stateful services are stopped; deploy/data is ready to be restored."

--- a/deploy/scripts/pre-update.sh
+++ b/deploy/scripts/pre-update.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+# shellcheck source=lib.sh
+source "$(dirname "$0")/lib.sh"
+
+"$DEPLOY_DIR/scripts/pre-backup.sh"
+trap '"$DEPLOY_DIR/scripts/post-backup.sh"' EXIT INT TERM
+"$DEPLOY_DIR/scripts/post-backup.sh"
+trap - EXIT INT TERM
+
+echo "Backup gate passed; pulling the pinned application image..."
+compose pull backend worker scheduler
+echo "Pre-update checks completed."

--- a/deploy/scripts/prepare.sh
+++ b/deploy/scripts/prepare.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+# shellcheck source=lib.sh
+source "$(dirname "$0")/lib.sh"
+
+prepare_data_directories
+
+# On a managed platform this is the first place that reveals WHICH configuration
+# file the deployment is running on, that it is running on the host environment
+# alone, or that a second candidate file exists and is being ignored.
+report_compose_env_file
+
+compose config --quiet
+validate_release_pin
+# After `compose config`, which already rejects a value Compose cannot parse at
+# all, and before any rule that inspects a resolved value: a value that Compose
+# altered must be reported as altered, not as invalid.
+validate_secret_roundtrip
+echo "Deployment directories and Compose configuration are ready."

--- a/deploy/scripts/run.sh
+++ b/deploy/scripts/run.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+# shellcheck source=lib.sh
+source "$(dirname "$0")/lib.sh"
+
+# The platform's run command: validate on every start, then start the stack.
+#
+# The validation is deliberately repeated here and not only in build.sh, because
+# a start can follow a configuration change that never ran a build. `compose up`
+# must reach Compose through compose() for the same reason the pull in build.sh
+# does; the post-install, post-deploy and post-update hooks then wait for health.
+#
+# The configuration source is named first, and on this path too: a start can
+# follow a configuration change that never ran build.sh, so this is the only
+# place that reports which file the started containers are configured from.
+report_compose_env_file
+"$DEPLOY_DIR/scripts/validate-release.sh"
+compose up -d
+echo "Services started."

--- a/deploy/scripts/smoke-test.sh
+++ b/deploy/scripts/smoke-test.sh
@@ -29,7 +29,10 @@ assert_healthy backend
 assert_healthy worker
 assert_healthy scheduler
 
-[[ "$(compose exec -T redis redis-cli ping)" == "PONG" ]]
+[[ "$(compose exec -T redis redis-cli ping)" == "PONG" ]] || {
+    echo "redis did not answer PING with PONG" >&2
+    exit 1
+}
 printf 'ok: redis\n'
 
 app_tool "curl -fsS http://qdrant:6333/readyz >/dev/null"

--- a/deploy/scripts/smoke-test.sh
+++ b/deploy/scripts/smoke-test.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+# shellcheck source=lib.sh
+source "$(dirname "$0")/lib.sh"
+
+assert_healthy() {
+    local service="$1"
+    local container_id status
+    container_id="$(compose ps -q "$service")"
+    [[ -n "$container_id" ]] || {
+        echo "$service is not running" >&2
+        return 1
+    }
+    status="$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "$container_id")"
+    [[ "$status" == "healthy" || "$status" == "running" ]] || {
+        echo "$service is $status" >&2
+        return 1
+    }
+    printf 'ok: %s\n' "$service"
+}
+
+compose exec -T backend curl -fsS -o /dev/null http://localhost/api/health
+printf 'ok: api health\n'
+compose exec -T backend curl -fsS -o /dev/null http://localhost/
+printf 'ok: web ui\n'
+
+assert_healthy backend
+assert_healthy worker
+assert_healthy scheduler
+
+[[ "$(compose exec -T redis redis-cli ping)" == "PONG" ]]
+printf 'ok: redis\n'
+
+app_tool "curl -fsS http://qdrant:6333/readyz >/dev/null"
+printf 'ok: qdrant\n'
+app_tool "curl -fsS http://tika:9998/version >/dev/null"
+printf 'ok: tika\n'
+app_tool "curl -fsS http://centrifugo:8000/health >/dev/null"
+printf 'ok: centrifugo\n'
+
+echo "Synaplan smoke test passed."

--- a/deploy/scripts/tests/test-lifecycle.sh
+++ b/deploy/scripts/tests/test-lifecycle.sh
@@ -1,0 +1,1240 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+temporary_dir="$(mktemp -d)"
+trap 'rm -rf "$temporary_dir"' EXIT
+STATE_DIR="$temporary_dir/state"
+BACKUP_DIR="$temporary_dir/backups"
+# Used indirectly by prepare_data_directories() from the sourced library.
+# shellcheck disable=SC2034
+DATA_DIR="$temporary_dir/data"
+PAUSED_SERVICES_FILE="$STATE_DIR/paused-services"
+mkdir -p "$BACKUP_DIR"
+
+COMPOSE_FILE="$SCRIPT_DIR/../compose.yaml"
+
+# A password is expanded by the CONTAINER's shell in a healthcheck, so an
+# unquoted expansion splits a value containing whitespace: mariadb-admin never
+# authenticates, db never turns healthy, and every service that waits on
+# `condition: service_healthy` waits forever. The quoting is asserted on the file
+# itself, because nothing else in this Docker-free suite can observe it.
+grep -Fq -- 'mariadb-admin ping -h 127.0.0.1 -uroot -p\"$$MARIADB_ROOT_PASSWORD\" --silent' "$COMPOSE_FILE" || {
+    echo "The db healthcheck no longer quotes MARIADB_ROOT_PASSWORD" >&2
+    exit 1
+}
+if grep -qE -- '-p\$\$[A-Za-z_]' "$COMPOSE_FILE"; then
+    echo "compose.yaml expands a password into a shell command without quoting it" >&2
+    exit 1
+fi
+
+# The same class of defect one step further: a value Compose interpolates into a
+# command STRING becomes part of the program, so whitespace splits arguments and
+# metacharacters run as code. Operator-configurable values must reach the shell
+# through the environment, quoted.
+if grep -q 'ggml-${WHISPER_DEFAULT_MODEL' "$COMPOSE_FILE"; then
+    echo "compose.yaml interpolates WHISPER_DEFAULT_MODEL into the whisper-models command text" >&2
+    exit 1
+fi
+
+# Where the deployment reads its configuration from, for each layout that has to
+# work. A managed platform may materialise the configured environment as a .env
+# at the CHECKOUT ROOT, which Compose ignores for `-f deploy/compose.yaml`,
+# because deploy/ is the project directory.
+assert_resolved_env_file() {
+    local description="$1"
+    local deploy_dir="$2"
+    local expected="$3"
+    local actual
+    actual="$(resolve_compose_env_file "$deploy_dir")"
+    [[ "$actual" == "$expected" ]] || {
+        printf 'Env file case "%s": expected [%s], got [%s]\n' "$description" "$expected" "$actual" >&2
+        exit 1
+    }
+}
+
+env_tree="$temporary_dir/tree"
+mkdir -p "$env_tree/deploy"
+
+# Today's reality for every self-hoster: no file of either kind, so the whole
+# fallback is a no-op and the configuration comes from the host environment.
+assert_resolved_env_file "no file at all" "$env_tree/deploy" ""
+printf 'SYNAPLAN_VERSION=1.2.3\n' > "$env_tree/.env"
+assert_resolved_env_file "checkout-root file only" "$env_tree/deploy" "$env_tree/.env"
+printf 'SYNAPLAN_VERSION=1.2.3\n' > "$env_tree/deploy/.env"
+assert_resolved_env_file "both files present, the documented one wins" \
+    "$env_tree/deploy" "$env_tree/deploy/.env"
+rm -f "$env_tree/.env"
+assert_resolved_env_file "documented file only" "$env_tree/deploy" "$env_tree/deploy/.env"
+
+# The resolved file must actually reach Compose. `docker` is stubbed instead of
+# `compose`, so this exercises the real argument construction, inside a subshell
+# so neither the stub nor the moved DEPLOY_DIR leaks into the cases below.
+assert_compose_passes_env_file() {
+    local description="$1"
+    local deploy_dir="$2"
+    local expected="$3"
+    local actual
+    actual="$(
+        DEPLOY_DIR="$deploy_dir"
+        docker() { printf '%s\n' "$*"; }
+        compose ps -q backend
+    )"
+    [[ "$actual" == *"$expected"* ]] || {
+        printf 'Compose argument case "%s": expected to contain [%s], got [%s]\n' \
+            "$description" "$expected" "$actual" >&2
+        exit 1
+    }
+}
+
+assert_compose_passes_env_file "documented file" "$env_tree/deploy" \
+    "--env-file $env_tree/deploy/.env"
+rm -f "$env_tree/deploy/.env"
+printf 'SYNAPLAN_VERSION=1.2.3\n' > "$env_tree/.env"
+assert_compose_passes_env_file "checkout-root file" "$env_tree/deploy" \
+    "--env-file $env_tree/.env"
+rm -f "$env_tree/.env"
+assert_compose_passes_env_file "no file" "$env_tree/deploy" \
+    "compose -f $env_tree/deploy/compose.yaml ps -q backend"
+(
+    DEPLOY_DIR="$env_tree/deploy"
+    docker() { printf '%s\n' "$*"; }
+    [[ "$(compose ps)" != *--env-file* ]]
+) || {
+    echo "compose passes --env-file although no configuration file exists" >&2
+    exit 1
+}
+
+# Whether the file uses Windows line endings, which decides one line of the
+# report below. A carriage return that is not a line ending must not count.
+assert_crlf_detection() {
+    local expected_status="$1"
+    local description="$2"
+    local body="$3"
+    local file="$temporary_dir/crlf-probe.env"
+    local status=0
+
+    printf '%s' "$body" > "$file"
+    env_file_has_crlf "$file" || status=$?
+    [[ "$status" == "$expected_status" ]] || {
+        printf 'CRLF detection case "%s": expected status %s, got %s\n' \
+            "$description" "$expected_status" "$status" >&2
+        exit 1
+    }
+}
+
+assert_crlf_detection 0 "a Windows file" $'A=1\r\nB=2\r\n'
+assert_crlf_detection 0 "a Windows file without a final newline" $'A=1\r'
+assert_crlf_detection 0 "only the last line is CRLF" $'A=1\nB=2\r\n'
+assert_crlf_detection 1 "a Unix file" $'A=1\nB=2\n'
+assert_crlf_detection 1 "an empty file" ''
+assert_crlf_detection 1 "a carriage return inside a value is not a line ending" $'A=a\rb\n'
+
+# What the operator is TOLD about the resolution above. The hazard is both
+# candidates existing: Compose is handed exactly one --env-file and does not
+# merge the other, so every key set only in the ignored file falls back to
+# compose.yaml's default. `${VAR:?}` keys fail loudly; keys with a `:-` default
+# do not — SYNAPLAN_HTTP_BIND returns to 127.0.0.1 and a managed platform's
+# HTTPS proxy can no longer reach the container, and BOOTSTRAP_ADMIN_* go empty
+# so no administrator is created. Nothing else in the deployment says a word.
+assert_env_file_report() {
+    local description="$1"
+    local deploy_dir="$2"
+    local expected="$3"
+    local unexpected="${4:-}"
+    local output
+
+    output="$(report_compose_env_file "$deploy_dir" 2>&1)"
+    [[ "$output" == *"$expected"* ]] || {
+        printf 'Env file report case "%s": expected [%s] in:\n%s\n' \
+            "$description" "$expected" "$output" >&2
+        exit 1
+    }
+    [[ -z "$unexpected" || "$output" != *"$unexpected"* ]] || {
+        printf 'Env file report case "%s": did not expect [%s] in:\n%s\n' \
+            "$description" "$unexpected" "$output" >&2
+        exit 1
+    }
+}
+
+assert_env_file_report "no file at all" "$env_tree/deploy" \
+    "using the host environment only" IGNORED
+printf 'SYNAPLAN_VERSION=1.2.3\n' > "$env_tree/deploy/.env"
+assert_env_file_report "the documented file alone" "$env_tree/deploy" \
+    "Reading deployment configuration from $env_tree/deploy/.env" IGNORED
+printf 'SYNAPLAN_VERSION=1.2.3\n' > "$env_tree/.env"
+assert_env_file_report "both files, the used one is named" "$env_tree/deploy" \
+    "Reading deployment configuration from $env_tree/deploy/.env"
+assert_env_file_report "both files, the ignored one is named" "$env_tree/deploy" \
+    "$env_tree/.env also exists and is IGNORED"
+assert_env_file_report "both files, and that they are not merged" "$env_tree/deploy" \
+    "does not merge"
+rm -f "$env_tree/deploy/.env"
+assert_env_file_report "the checkout-root file alone" "$env_tree/deploy" \
+    "Reading deployment configuration from $env_tree/.env" IGNORED
+
+# A Windows configuration file is supported, so it is reported as a note and
+# never as a failure — Compose discards the carriage returns and
+# env_file_raw_value() does the same.
+printf 'SYNAPLAN_VERSION=1.2.3\r\n' > "$env_tree/.env"
+assert_env_file_report "a Windows file is named as such" "$env_tree/deploy" \
+    "Windows (CRLF) line endings"
+report_compose_env_file "$env_tree/deploy" >/dev/null 2>&1 || {
+    echo "The configuration report fails on a Windows configuration file" >&2
+    exit 1
+}
+printf 'SYNAPLAN_VERSION=1.2.3\n' > "$env_tree/.env"
+assert_env_file_report "a Unix file is not" "$env_tree/deploy" \
+    "Reading deployment configuration" CRLF
+rm -f "$env_tree/.env"
+
+# Every Elestio lifecycle entry point reaches Compose through lib.sh's compose(),
+# so the fallback belongs there and nowhere else. A wrapper that called
+# `docker compose` itself would bypass it.
+#
+# Comment lines are exempt, in shell and in YAML alike: these files explain why
+# the command must not be called directly, and naming it in prose is not calling
+# it.
+calls_docker_compose_directly() {
+    awk '
+        { line = $0; sub(/^[[:space:]]*/, "", line) }
+        index(line, "#") == 1 { next }
+        index($0, "docker compose") > 0 { found = 1 }
+        END { exit !found }
+    ' "$1"
+}
+
+assert_no_direct_docker_compose() {
+    calls_docker_compose_directly "$1" || return 0
+    printf '%s calls docker compose directly instead of going through lib.sh\n' \
+        "$(basename "$1")" >&2
+    exit 1
+}
+
+for wrapper in "$SCRIPT_DIR/../elestio"/*.sh; do
+    assert_no_direct_docker_compose "$wrapper"
+done
+
+# The same rule for the scripts, where lib.sh owns the single `docker compose`
+# invocation. Every other script has to reach Compose through compose().
+for script in "$SCRIPT_DIR"/*.sh; do
+    [[ "$script" == */lib.sh ]] && continue
+    assert_no_direct_docker_compose "$script"
+done
+
+# elestio.yml is the remaining entry point: the platform runs its build and run
+# commands itself, outside every lifecycle hook. They used to call
+# `docker compose` directly, which made them the only steps of the deployment that
+# resolved their configuration WITHOUT the fallback above — so a checkout-root
+# .env would have started every hook correctly and failed exactly there.
+ELESTIO_MANIFEST="$(cd "$SCRIPT_DIR/../.." && pwd)/elestio.yml"
+assert_no_direct_docker_compose "$ELESTIO_MANIFEST"
+
+assert_manifest_command() {
+    local field="$1"
+    local script="$2"
+    grep -Eq "^  $field: \"[^\"]*deploy/scripts/$script\.sh" "$ELESTIO_MANIFEST" || {
+        printf 'elestio.yml %s does not run deploy/scripts/%s.sh\n' "$field" "$script" >&2
+        exit 1
+    }
+}
+
+assert_manifest_command buildCommand build
+assert_manifest_command runCommand run
+
+# The two platform commands themselves, executed for real. `docker` and the two
+# sibling scripts are stubbed inside a copied tree, so nothing here needs Docker
+# or a configuration. What it pins: the order of the steps, that the resolved
+# --env-file reaches the pull and the up, that a failing step aborts the whole
+# command non-zero instead of starting the stack anyway, and that both work from
+# the repository root — how the platform invokes them — as well as from deploy/.
+platform_tree="$temporary_dir/platform"
+platform_log="$platform_tree/steps.log"
+mkdir -p "$platform_tree/deploy/scripts" "$platform_tree/bin"
+cp "$SCRIPT_DIR/lib.sh" "$SCRIPT_DIR/build.sh" "$SCRIPT_DIR/run.sh" \
+    "$platform_tree/deploy/scripts/"
+cp "$COMPOSE_FILE" "$platform_tree/deploy/compose.yaml"
+chmod 0755 "$platform_tree/deploy/scripts/build.sh" "$platform_tree/deploy/scripts/run.sh"
+platform_compose="docker compose -f $platform_tree/deploy/compose.yaml"
+
+# The platform invokes ./deploy/scripts/<name>.sh, so the checked-in file has to
+# be executable too, not only the copy above.
+for script in "$SCRIPT_DIR/build.sh" "$SCRIPT_DIR/run.sh"; do
+    [[ -x "$script" ]] || {
+        printf '%s is not executable, so the platform cannot invoke it\n' \
+            "$(basename "$script")" >&2
+        exit 1
+    }
+done
+
+# Records that it ran, and fails when it is the step under test — the sibling
+# scripts do the real work elsewhere, and this suite is about the command around
+# them.
+write_platform_stub() {
+    cat > "$platform_tree/deploy/scripts/$1.sh" <<STUB
+#!/usr/bin/env bash
+printf '%s\n' '$1' >> "\$PLATFORM_LOG"
+[[ "\$PLATFORM_FAILING_STEP" != '$1' ]]
+STUB
+    chmod 0755 "$platform_tree/deploy/scripts/$1.sh"
+}
+
+write_platform_stub prepare
+write_platform_stub validate-release
+
+cat > "$platform_tree/bin/docker" <<'STUB'
+#!/usr/bin/env bash
+printf 'docker %s\n' "$*" >> "$PLATFORM_LOG"
+STUB
+chmod 0755 "$platform_tree/bin/docker"
+
+expected_platform_steps() {
+    printf '%s\n' "$@"
+}
+
+assert_platform_command() {
+    local description="$1"
+    local directory="$2"
+    local command="$3"
+    local failing_step="$4"
+    local expected_status="$5"
+    local expected_steps="$6"
+    local status=0 actual
+
+    : > "$platform_log"
+    (
+        cd "$directory"
+        export PATH="$platform_tree/bin:$PATH"
+        export PLATFORM_LOG="$platform_log"
+        export PLATFORM_FAILING_STEP="$failing_step"
+        "$command"
+    ) >/dev/null 2>&1 || status=$?
+    [[ "$status" == "$expected_status" ]] || {
+        printf 'Platform command case "%s": expected status %s, got %s\n' \
+            "$description" "$expected_status" "$status" >&2
+        exit 1
+    }
+    actual="$(<"$platform_log")"
+    [[ "$actual" == "$expected_steps" ]] || {
+        printf 'Platform command case "%s": expected steps\n[%s]\ngot\n[%s]\n' \
+            "$description" "$expected_steps" "$actual" >&2
+        exit 1
+    }
+}
+
+# Host environment only: no file exists, so no --env-file is passed and Compose
+# uses the exported configuration, exactly as today.
+assert_platform_command "build from the repository root, host environment only" \
+    "$platform_tree" ./deploy/scripts/build.sh "" 0 \
+    "$(expected_platform_steps prepare "$platform_compose pull" validate-release)"
+
+# The managed-platform layout, and the whole reason these scripts exist.
+printf 'SYNAPLAN_VERSION=1.2.3\n' > "$platform_tree/.env"
+assert_platform_command "build from deploy/, checkout-root configuration file" \
+    "$platform_tree/deploy" scripts/build.sh "" 0 \
+    "$(expected_platform_steps prepare \
+        "$platform_compose --env-file $platform_tree/.env pull" validate-release)"
+assert_platform_command "run from the repository root, checkout-root configuration file" \
+    "$platform_tree" ./deploy/scripts/run.sh "" 0 \
+    "$(expected_platform_steps validate-release \
+        "$platform_compose --env-file $platform_tree/.env up -d")"
+
+# The documented self-host file still wins, on the platform commands too.
+printf 'SYNAPLAN_VERSION=1.2.3\n' > "$platform_tree/deploy/.env"
+assert_platform_command "run from deploy/, documented configuration file" \
+    "$platform_tree/deploy" scripts/run.sh "" 0 \
+    "$(expected_platform_steps validate-release \
+        "$platform_compose --env-file $platform_tree/deploy/.env up -d")"
+rm -f "$platform_tree/.env" "$platform_tree/deploy/.env"
+
+# A failing step must abort the command, so the platform reports a failed
+# deployment instead of a started one. The `&&` chain these scripts replaced did
+# this, and losing it would start the stack on a rejected configuration.
+assert_platform_command "the first build step fails" \
+    "$platform_tree" ./deploy/scripts/build.sh prepare 1 \
+    "$(expected_platform_steps prepare)"
+assert_platform_command "validation after the pull fails" \
+    "$platform_tree" ./deploy/scripts/build.sh validate-release 1 \
+    "$(expected_platform_steps prepare "$platform_compose pull" validate-release)"
+assert_platform_command "validation before the start fails" \
+    "$platform_tree" ./deploy/scripts/run.sh validate-release 1 \
+    "$(expected_platform_steps validate-release)"
+
+running=$'backend\ndb\nollama'
+compose_log="$temporary_dir/compose.log"
+
+running_service() {
+    grep -Fxq "$1" <<< "$running"
+}
+
+compose() {
+    local command="$1"
+    shift
+    printf '%s %s\n' "$command" "$*" >> "$compose_log"
+
+    if [[ "$command" == "stop" ]]; then
+        [[ "${1:-}" == "--timeout" ]] && shift 2
+        running="$(grep -Fxv "$1" <<< "$running" || true)"
+    elif [[ "$command" == "start" ]]; then
+        local service
+        for service in "$@"; do
+            running+=$'\n'"$service"
+        done
+    fi
+}
+
+begin_service_pause
+pause_services backend
+pause_services ollama qdrant db
+
+expected=$'backend\nollama\ndb'
+actual="$(<"$PAUSED_SERVICES_FILE")"
+[[ "$actual" == "$expected" ]] || {
+    printf 'Unexpected paused-service record:\n%s\n' "$actual" >&2
+    exit 1
+}
+[[ "$running" != *backend* && "$running" != *db* && "$running" != *ollama* ]]
+
+resume_paused_services
+grep -Fxq "start backend ollama db" "$compose_log"
+[[ ! -e "$PAUSED_SERVICES_FILE" ]]
+
+resolved_app_image() {
+    printf '%s\n' "ghcr.io/metadist/synaplan:5.0.0-rc.1"
+}
+validate_release_pin
+resolved_app_image() {
+    printf '%s\n' "ghcr.io/metadist/synaplan:latest"
+}
+if validate_release_pin 2>/dev/null; then
+    echo "Mutable release tag unexpectedly passed validation" >&2
+    exit 1
+fi
+
+mkdir -p "$BACKUP_DIR/20260804T120000Z"
+ln -s 20260804T120000Z "$BACKUP_DIR/latest"
+expected_backup="$(cd "$BACKUP_DIR/20260804T120000Z" && pwd -P)"
+[[ "$(latest_backup_path)" == "$expected_backup" ]]
+ln -sfn /tmp "$BACKUP_DIR/latest"
+if latest_backup_path >/dev/null 2>&1; then
+    echo "Escaping backup symlink unexpectedly passed validation" >&2
+    exit 1
+fi
+
+assert_bootstrap_values() {
+    local expected_status="$1"
+    local description="$2"
+    local email="$3"
+    local password="$4"
+    local expected_message="${5:-}"
+    local output status=0
+
+    output="$(validate_bootstrap_admin_values "$email" "$password" 2>&1)" || status=$?
+    [[ "$status" == "$expected_status" ]] || {
+        printf 'Bootstrap case "%s": expected status %s, got %s:\n%s\n' \
+            "$description" "$expected_status" "$status" "$output" >&2
+        exit 1
+    }
+    [[ "$output" == *"$expected_message"* ]] || {
+        printf 'Bootstrap case "%s": expected message %s, got:\n%s\n' \
+            "$description" "$expected_message" "$output" >&2
+        exit 1
+    }
+}
+
+# Boundary lengths are built, never hand-counted: a literal with one character
+# too many or too few would silently move the boundary under test.
+repeat_character() {
+    local padding
+    padding="$(printf '%*s' "$2" '')"
+    printf '%s' "${padding// /$1}"
+}
+
+# Assigns a password of exactly $1 bytes to $generated_password, starting with
+# the character classes in $2 so composition can be varied independently of
+# length. The length is asserted here rather than trusted at the call site.
+generated_password=""
+build_password_of_length() {
+    local length="$1"
+    local prefix="$2"
+    generated_password="$prefix$(repeat_character b "$((length - ${#prefix}))")"
+    (( ${#generated_password} == length )) || {
+        printf 'Test helper built a %s byte password, expected %s\n' \
+            "${#generated_password}" "$length" >&2
+        exit 1
+    }
+}
+
+assert_bootstrap_values 0 "both empty" "" "" "bootstrap will be skipped"
+assert_bootstrap_values 1 "email only" "admin@example.com" "" "BOOTSTRAP_ADMIN_PASSWORD is empty"
+assert_bootstrap_values 1 "password only" "" "Str0ngPass" "BOOTSTRAP_ADMIN_EMAIL is empty"
+assert_bootstrap_values 0 "short password with full composition" "admin@example.com" "Str0ngPass"
+assert_bootstrap_values 1 "short password without uppercase" "admin@example.com" "str0ngpass" "one uppercase letter"
+# The motivating Elestio case: a generated high-entropy password without a digit.
+assert_bootstrap_values 0 "long password without a digit" "admin@example.com" "QWZFaxYB-gtYh-AXqFbcde"
+assert_bootstrap_values 1 "password below the minimum" "admin@example.com" "Short1a" "at least 8 characters"
+build_password_of_length 65 Aa1
+assert_bootstrap_values 1 "password above the maximum" "admin@example.com" "$generated_password" "at most 64 characters"
+assert_bootstrap_values 1 "malformed email" "not-an-email" "Str0ngPass" "valid email address"
+assert_bootstrap_values 1 "email above the maximum" "$(printf '%0122d' 0)@example.com" "Str0ngPass" "at most 128 characters"
+assert_bootstrap_values 0 "email with surrounding whitespace" "  admin@example.com  " "Str0ngPass"
+
+# The composition rule is waived from 16 bytes upwards, so both sides of that
+# boundary are pinned: a `<=` instead of `<` in lib.sh would otherwise stay green.
+build_password_of_length 15 Aa
+assert_bootstrap_values 1 "one byte below the composition waiver, no digit" \
+    "admin@example.com" "$generated_password" "one number"
+build_password_of_length 16 Aa
+assert_bootstrap_values 0 "exactly at the composition waiver, no digit" \
+    "admin@example.com" "$generated_password"
+build_password_of_length 8 Aa1
+assert_bootstrap_values 0 "exactly the minimum length with full composition" \
+    "admin@example.com" "$generated_password"
+build_password_of_length 64 Aa1
+assert_bootstrap_values 0 "exactly the maximum length" \
+    "admin@example.com" "$generated_password"
+
+# Addresses that the earlier host-side pattern accepted and filter_var rejects.
+# Each one used to pass the preflight and then crash-loop the backend, because
+# BootstrapAdminService threw on a value this script had already approved.
+assert_bootstrap_values 1 "consecutive dots in the local part" \
+    "a..b@example.com" "Str0ngPass" "valid email address"
+assert_bootstrap_values 1 "leading dot in the local part" \
+    ".admin@example.com" "Str0ngPass" "valid email address"
+assert_bootstrap_values 1 "trailing dot in the local part" \
+    "admin.@example.com" "Str0ngPass" "valid email address"
+assert_bootstrap_values 1 "domain label starting with a hyphen" \
+    "admin@-example.com" "Str0ngPass" "valid email address"
+assert_bootstrap_values 1 "domain label ending with a hyphen" \
+    "admin@example-.com" "Str0ngPass" "valid email address"
+assert_bootstrap_values 1 "local part above 64 bytes" \
+    "$(repeat_character a 65)@example.com" "Str0ngPass" "valid email address"
+assert_bootstrap_values 1 "domain label above 63 bytes" \
+    "admin@$(repeat_character a 64).com" "Str0ngPass" "valid email address"
+
+# The same limits one byte lower stay valid, so the rules above cannot be
+# "fixed" by rejecting every long address.
+assert_bootstrap_values 0 "local part of exactly 64 bytes" \
+    "$(repeat_character a 64)@example.com" "Str0ngPass"
+assert_bootstrap_values 0 "domain label of exactly 63 bytes" \
+    "admin@$(repeat_character a 63).com" "Str0ngPass"
+assert_bootstrap_values 0 "tagged local part" "admin+tag@example.com" "Str0ngPass"
+assert_bootstrap_values 0 "dotted local part" "a.b.c@example.com" "Str0ngPass"
+assert_bootstrap_values 0 "multi-level domain" "admin@sub.example.co.uk" "Str0ngPass"
+assert_bootstrap_values 0 "hyphens inside a domain label" "admin@ex--ample.com" "Str0ngPass"
+assert_bootstrap_values 0 "hyphens at the edge of the local part" "-admin-@example.com" "Str0ngPass"
+
+compose() {
+    [[ "$*" == "config --environment" ]] || return 1
+    printf '%s\n' "PATH=/usr/bin" ${bootstrap_environment[@]+"${bootstrap_environment[@]}"}
+}
+
+bootstrap_environment=()
+validate_bootstrap_admin_config >/dev/null
+bootstrap_environment=(BOOTSTRAP_ADMIN_EMAIL= BOOTSTRAP_ADMIN_PASSWORD=)
+validate_bootstrap_admin_config >/dev/null
+bootstrap_environment=(BOOTSTRAP_ADMIN_EMAIL=admin@example.com "BOOTSTRAP_ADMIN_PASSWORD=Str0ng Pass=word")
+validate_bootstrap_admin_config
+bootstrap_environment=(BOOTSTRAP_ADMIN_EMAIL=admin@example.com BOOTSTRAP_ADMIN_PASSWORD=short)
+if validate_bootstrap_admin_config 2>/dev/null; then
+    echo "Invalid resolved bootstrap password unexpectedly passed validation" >&2
+    exit 1
+fi
+
+# Every path that starts the stack must run the host-side preflight before its
+# first `compose up`; validate-release.sh only guards install-time deploys.
+assert_preflight_precedes_compose_up() {
+    local script="$SCRIPT_DIR/$1"
+    local preflight_line compose_line
+    preflight_line="$(awk '/^validate_bootstrap_admin_config$/ { print NR; exit }' "$script")"
+    compose_line="$(awk '/^compose up/ { print NR; exit }' "$script")"
+
+    [[ -n "$preflight_line" ]] || {
+        printf '%s does not call validate_bootstrap_admin_config\n' "$1" >&2
+        exit 1
+    }
+    [[ -n "$compose_line" ]] || {
+        printf '%s no longer starts services with a "compose up" line; update this test\n' "$1" >&2
+        exit 1
+    }
+    (( preflight_line < compose_line )) || {
+        printf '%s calls validate_bootstrap_admin_config at line %s, after "compose up" at line %s\n' \
+            "$1" "$preflight_line" "$compose_line" >&2
+        exit 1
+    }
+}
+
+assert_preflight_precedes_compose_up post-update.sh
+assert_preflight_precedes_compose_up post-restore.sh
+
+# Tier 2's exit-code contract, without Docker: the probe itself runs inside the
+# application image, so `compose` is stubbed to replay the statuses and the
+# stdout that probe produces. The command line it receives is recorded to a file
+# — a variable would be lost, because the caller reads it in a subshell.
+probe_command_file="$temporary_dir/probe-command"
+probe_status=0
+probe_output=""
+compose() {
+    [[ "$1" == run ]] || return 1
+    printf '%s\n' "$*" > "$probe_command_file"
+    if [[ -n "$probe_output" ]]; then
+        printf '%s\n' "$probe_output"
+    fi
+    return "$probe_status"
+}
+
+assert_image_contract() {
+    local expected_status="$1"
+    local description="$2"
+    local expected_message="${3:-}"
+    local output status=0
+
+    output="$(validate_app_image_contract 2>&1)" || status=$?
+    [[ "$status" == "$expected_status" ]] || {
+        printf 'Image contract case "%s": expected status %s, got %s:\n%s\n' \
+            "$description" "$expected_status" "$status" "$output" >&2
+        exit 1
+    }
+    [[ "$output" == *"$expected_message"* ]] || {
+        printf 'Image contract case "%s": expected message %s, got:\n%s\n' \
+            "$description" "$expected_message" "$output" >&2
+        exit 1
+    }
+}
+
+assert_image_contract 0 "contract satisfied and configuration accepted"
+
+# The reserved status alone is not enough, and neither is the marker alone: only
+# both together mean "the authority decided", so a future probe command that
+# exits 3 for its own reasons cannot be reported as a rejected credential.
+probe_status=3
+probe_output="$BOOTSTRAP_ADMIN_REJECTION_MARKER BOOTSTRAP_ADMIN_PASSWORD must be at least 8 characters."
+assert_image_contract 1 "authority rejected the configuration" "must be at least 8 characters"
+probe_output="a future probe step that happens to exit 3"
+assert_image_contract 3 "reserved status without the rejection marker" \
+    "Could not verify the application image contract"
+probe_status=0
+probe_output="$BOOTSTRAP_ADMIN_REJECTION_MARKER BOOTSTRAP_ADMIN_PASSWORD must be at least 8 characters."
+assert_image_contract 1 "rejection marker without the reserved status" \
+    "Could not verify the application image contract"
+probe_status=64
+probe_output=""
+assert_image_contract 64 "image is missing the entrypoint" \
+    "Could not verify the application image contract"
+probe_status=125
+assert_image_contract 125 "image was never pulled" \
+    "run 'docker compose -f deploy/compose.yaml pull' first"
+probe_status=0
+
+# HARD CONSTRAINT: the probe must reference the password by NAME only. A value on
+# the command line would be visible in the host process list, so a switch to
+# `-e BOOTSTRAP_ADMIN_PASSWORD=$value` has to fail this suite.
+probe_command="$(<"$probe_command_file")"
+[[ "$probe_command" == *'getenv("BOOTSTRAP_ADMIN_PASSWORD")'* ]] || {
+    printf 'The image contract probe no longer reads BOOTSTRAP_ADMIN_PASSWORD from the environment:\n%s\n' \
+        "$probe_command" >&2
+    exit 1
+}
+[[ "$probe_command" != *"BOOTSTRAP_ADMIN_PASSWORD="* ]] || {
+    printf 'The image contract probe puts BOOTSTRAP_ADMIN_PASSWORD on the command line, where the host process list exposes it:\n%s\n' \
+        "$probe_command" >&2
+    exit 1
+}
+
+# The value as the FILE spells it, which is the half `compose config
+# --environment` cannot show: it returns the value AFTER Compose's .env parsing.
+assert_raw_env_value() {
+    local expected_status="$1"
+    local description="$2"
+    local line="$3"
+    local expected="$4"
+    local file="$temporary_dir/raw.env"
+    local actual status=0
+
+    printf '%s' "$line" > "$file"
+    actual="$(env_file_raw_value "$file" PROBE_KEY)" || status=$?
+    [[ "$status" == "$expected_status" ]] || {
+        printf 'Raw value case "%s": expected status %s, got %s\n' \
+            "$description" "$expected_status" "$status" >&2
+        exit 1
+    }
+    [[ "$actual" == "$expected" ]] || {
+        printf 'Raw value case "%s": expected [%s], got [%s]\n' "$description" "$expected" "$actual" >&2
+        exit 1
+    }
+}
+
+assert_raw_env_value 1 "key not assigned at all" $'OTHER_KEY=x\n' ""
+assert_raw_env_value 0 "plain value" $'PROBE_KEY=plainABC123\n' "plainABC123"
+assert_raw_env_value 0 "no trailing newline" 'PROBE_KEY=plainABC123' "plainABC123"
+assert_raw_env_value 0 "quotes are kept" $'PROBE_KEY="abc"\n' '"abc"'
+assert_raw_env_value 0 "surrounding whitespace is kept" $'PROBE_KEY=  abc  \n' "  abc  "
+assert_raw_env_value 0 "an inline comment is kept" $'PROBE_KEY=abc #x\n' "abc #x"
+assert_raw_env_value 0 "only the first = separates" $'PROBE_KEY=a=b=c\n' "a=b=c"
+assert_raw_env_value 0 "empty value" $'PROBE_KEY=\n' ""
+# Forms Compose itself accepts on the KEY side. Reading them as "no assignment"
+# would silently skip the key; reading the indent as part of the value would
+# report a value Compose never altered.
+assert_raw_env_value 0 "an export prefix is normalised away" $'export PROBE_KEY=abc\n' "abc"
+assert_raw_env_value 0 "an indented key is normalised away" $'   PROBE_KEY=abc\n' "abc"
+assert_raw_env_value 0 "the last assignment wins" $'PROBE_KEY=first\nPROBE_KEY=second\n' "second"
+assert_raw_env_value 1 "a longer key is not a prefix match" $'PROBE_KEY_EXTRA=x\n' ""
+
+# Windows line endings. Compose discards the trailing carriage return for every
+# value shape, quoted ones included, so a CRLF file is a VALID configuration —
+# and keeping the carriage return here reported every covered key of such a file
+# as altered at once, with advice naming only causes that did not apply. A
+# Windows checkout (core.autocrlf), Notepad or WinSCP produces exactly this.
+assert_raw_env_value 0 "a CRLF line ending is not part of the value" $'PROBE_KEY=abc\r\n' "abc"
+assert_raw_env_value 0 "a CRLF line ending on a quoted value" $'PROBE_KEY="abc"\r\n' '"abc"'
+assert_raw_env_value 0 "a CRLF line ending without a final newline" $'PROBE_KEY=abc\r' "abc"
+assert_raw_env_value 0 "a CRLF line ending on a later line" \
+    $'OTHER_KEY=x\r\nPROBE_KEY=abc\r\n' "abc"
+assert_raw_env_value 0 "an indented export with a CRLF line ending" \
+    $'  export PROBE_KEY=abc\r\n' "abc"
+# Only the carriage return is discarded. Trimming trailing whitespace as well
+# would hide the alteration the guard exists for: Compose turns `abc  ` into
+# `abc`, and that has to keep reporting as altered.
+assert_raw_env_value 0 "trailing whitespace before a CRLF is kept" $'PROBE_KEY=abc  \r\n' "abc  "
+assert_raw_env_value 0 "a carriage return inside the value is kept" \
+    $'PROBE_KEY=ab\rcd\n' $'ab\rcd'
+
+# Whitespace around the `=`. Compose accepts it and assigns the key; reading the
+# line as "no assignment" skipped the key entirely, so the guard compared
+# nothing and passed a value Compose had truncated to `ab`.
+assert_raw_env_value 0 "whitespace before the = belongs to the key side" $'PROBE_KEY =abc\n' "abc"
+assert_raw_env_value 0 "whitespace after the = stays in the value" $'PROBE_KEY = abc\n' " abc"
+assert_raw_env_value 0 "a tab around the = is accepted as Compose accepts it" \
+    $'PROBE_KEY\t=\tabc\n' $'\tabc'
+assert_raw_env_value 1 "whitespace does not turn a longer key into a match" \
+    $'PROBE_KEY_EXTRA = x\n' ""
+assert_raw_env_value 1 "a key without an = is not an assignment" $'PROBE_KEY\n' ""
+
+# A UTF-8 BOM, which Windows tooling writes and Compose strips before the first
+# key. Keeping it made the first key of the file unrecognisable, so exactly the
+# key an operator writes first was the one never compared.
+assert_raw_env_value 0 "a UTF-8 BOM before the first key is discarded" \
+    $'\xef\xbb\xbfPROBE_KEY=abc\n' "abc"
+assert_raw_env_value 0 "a UTF-8 BOM together with CRLF line endings" \
+    $'\xef\xbb\xbfPROBE_KEY=abc\r\n' "abc"
+assert_raw_env_value 0 "a BOM only affects the first line" \
+    $'\xef\xbb\xbfOTHER_KEY=x\nPROBE_KEY=abc\n' "abc"
+assert_raw_env_value 1 "a BOM does not turn a longer key into a match" \
+    $'\xef\xbb\xbfPROBE_KEY_EXTRA=x\n' ""
+# The BOM is stripped as three bytes, never as "any leading non-ASCII": a value
+# that is not valid UTF-8 has to survive the read byte for byte, or the
+# comparison reports an alteration Compose never made.
+assert_raw_env_value 0 "a non-UTF-8 byte in the value survives" \
+    $'PROBE_KEY=ab\xffcd\n' $'ab\xffcd'
+assert_raw_env_value 0 "a BOM inside the value is not stripped" \
+    $'PROBE_KEY=\xef\xbb\xbfabc\n' $'\xef\xbb\xbfabc'
+
+# The preflight itself. Every "resolved" value below is what Docker Compose
+# v5.3.1 actually returns for the raw value next to it.
+#
+# validate_secret_roundtrip() takes no file argument: it resolves the file it
+# compares with the same resolver compose() uses, so both halves of the
+# comparison are guaranteed to describe the file Compose actually reads. The
+# fixtures therefore live where resolve_compose_env_file() finds them, and
+# DEPLOY_DIR points at that tree for the rest of this section.
+roundtrip_tree="$temporary_dir/roundtrip"
+mkdir -p "$roundtrip_tree/deploy"
+roundtrip_env_file="$roundtrip_tree/deploy/.env"
+DEPLOY_DIR="$roundtrip_tree/deploy"
+roundtrip_resolved=()
+# The cases below decide on the FILE. A covered key that happens to be exported
+# in the caller's shell is skipped by design, which would silently weaken this
+# suite depending on who runs it.
+for roundtrip_key in "${SYNAPLAN_ROUNDTRIP_KEYS[@]}"; do
+    unset "$roundtrip_key"
+done
+compose() {
+    [[ "$*" == "config --environment" ]] || return 1
+    printf '%s\n' "PATH=/usr/bin" ${roundtrip_resolved[@]+"${roundtrip_resolved[@]}"}
+}
+
+assert_secret_roundtrip() {
+    local expected_status="$1"
+    local description="$2"
+    local key="$3"
+    local raw="$4"
+    local resolved="$5"
+    local output status=0
+
+    printf '%s=%s\n' "$key" "$raw" > "$roundtrip_env_file"
+    roundtrip_resolved=("$key=$resolved")
+    output="$(validate_secret_roundtrip 2>&1)" || status=$?
+    [[ "$status" == "$expected_status" ]] || {
+        printf 'Roundtrip case "%s": expected status %s, got %s:\n%s\n' \
+            "$description" "$expected_status" "$status" "$output" >&2
+        exit 1
+    }
+    if (( expected_status != 0 )); then
+        [[ "$output" == *"$key"* ]] || {
+            printf 'Roundtrip case "%s" does not name the affected key:\n%s\n' "$description" "$output" >&2
+            exit 1
+        }
+    fi
+    # HARD CONSTRAINT: these keys are secrets, so neither the configured nor the
+    # resolved value may appear anywhere in the output. Only values long enough
+    # for a match to mean something are asserted: the message legitimately
+    # contains English words, and a two-byte fixture matches "variable" by
+    # accident. The dedicated case below carries a distinctive value.
+    local minimum_distinctive_length=8
+    (( ${#raw} < minimum_distinctive_length )) || [[ "$output" != *"$raw"* ]] || {
+        printf 'Roundtrip case "%s" prints the configured value:\n%s\n' "$description" "$output" >&2
+        exit 1
+    }
+    (( ${#resolved} < minimum_distinctive_length )) || [[ "$output" != *"$resolved"* ]] || {
+        printf 'Roundtrip case "%s" prints the resolved value:\n%s\n' "$description" "$output" >&2
+        exit 1
+    }
+}
+
+# The five ways Compose's .env parser alters a value. Each one silently
+# reconfigures the deployment today; for BOOTSTRAP_ADMIN_PASSWORD it locks the
+# operator out of their own instance with no recovery path.
+assert_secret_roundtrip 1 "an unescaped dollar sign starts an interpolation" \
+    BOOTSTRAP_ADMIN_PASSWORD 'ab$cd' 'ab'
+assert_secret_roundtrip 1 "a doubled dollar sign collapses" \
+    BOOTSTRAP_ADMIN_PASSWORD 'ab$$cd' 'ab$cd'
+assert_secret_roundtrip 1 "surrounding double quotes are stripped" \
+    APP_SECRET '"abc"' 'abc'
+assert_secret_roundtrip 1 "surrounding single quotes are stripped" \
+    APP_SECRET "'abc'" 'abc'
+assert_secret_roundtrip 1 "surrounding whitespace is trimmed" \
+    TOKEN_SECRET '  abc  ' 'abc'
+assert_secret_roundtrip 1 "an inline comment is dropped" \
+    MARIADB_ROOT_PASSWORD 'abc #x' 'abc'
+assert_secret_roundtrip 1 "a backslash escape becomes a real newline" \
+    MAILER_DSN '"ab\ncd"' $'ab\ncd'
+# A generated administrator address that loses a segment is the same silent
+# lockout as a mangled password, so the email is covered too.
+assert_secret_roundtrip 1 "an altered email is caught as well" \
+    BOOTSTRAP_ADMIN_EMAIL 'admin@ex$ample.com' 'admin@ex.com'
+# Distinctive enough that finding it in the output can only mean the guard leaked
+# it. Both halves of the comparison are asserted, before and after Compose.
+assert_secret_roundtrip 1 "neither the configured nor the resolved value is printed" \
+    BOOTSTRAP_ADMIN_PASSWORD 'Zq7NeverPrintThis$suffix' 'Zq7NeverPrintThis'
+
+# Values Compose returns unchanged must not be rejected: a preflight that fails
+# on a legitimate secret is its own outage.
+assert_secret_roundtrip 0 "a generated hexadecimal secret" \
+    APP_SECRET '2f6b8c1d4e9a0b7c' '2f6b8c1d4e9a0b7c'
+assert_secret_roundtrip 0 "a password containing a space" \
+    MARIADB_ROOT_PASSWORD 'has space' 'has space'
+assert_secret_roundtrip 0 "a hash that does not start a comment" \
+    MARIADB_PASSWORD 'a#b' 'a#b'
+assert_secret_roundtrip 0 "an unbalanced trailing quote" \
+    XAI_API_KEY "abc'" "abc'"
+assert_secret_roundtrip 0 "an empty optional key" \
+    GROQ_API_KEY '' ''
+# A Windows configuration file. The helper terminates every line with a newline,
+# so a value ending in a carriage return IS a CRLF line. Compose discards it, so
+# nothing was altered and the deployment must proceed — this used to fail every
+# covered key of such a file at once, with advice naming only causes that did
+# not apply, and no way for the operator to act on it.
+assert_secret_roundtrip 0 "a Windows (CRLF) configuration file is read back unchanged" \
+    APP_SECRET $'2f6b8c1d4e9a0b7c\r' '2f6b8c1d4e9a0b7c'
+assert_secret_roundtrip 0 "a CRLF line ending on a value containing a space" \
+    MARIADB_ROOT_PASSWORD $'has space\r' 'has space'
+# The alteration is still caught in a CRLF file: only the line ending is
+# discarded, never the trailing whitespace Compose trims.
+assert_secret_roundtrip 1 "trailing whitespace is still caught in a CRLF file" \
+    TOKEN_SECRET $'abcdefgh  \r' 'abcdefgh'
+
+# Nothing is printed for an accepted configuration, so the guard cannot leak a
+# secret on the happy path either.
+printf 'APP_SECRET=%s\n' 2f6b8c1d4e9a0b7c > "$roundtrip_env_file"
+roundtrip_resolved=(APP_SECRET=2f6b8c1d4e9a0b7c)
+[[ -z "$(validate_secret_roundtrip 2>&1)" ]] || {
+    echo "The roundtrip guard prints output for an unaltered configuration" >&2
+    exit 1
+}
+
+# Every altered key is named in one message: an operator who has to run the
+# deployment once per broken value gives up on the third one.
+{
+    printf 'APP_SECRET="a"\n'
+    printf 'TOKEN_SECRET=  b  \n'
+    printf 'GROQ_API_KEY=cd\n'
+} > "$roundtrip_env_file"
+roundtrip_resolved=(APP_SECRET=a "TOKEN_SECRET=b" GROQ_API_KEY=cd)
+roundtrip_status=0
+roundtrip_output="$(validate_secret_roundtrip 2>&1)" || roundtrip_status=$?
+(( roundtrip_status != 0 )) || {
+    echo "Two altered values unexpectedly passed the roundtrip guard" >&2
+    exit 1
+}
+[[ "$roundtrip_output" == *APP_SECRET* && "$roundtrip_output" == *TOKEN_SECRET* ]] || {
+    printf 'The roundtrip guard does not name every altered key:\n%s\n' "$roundtrip_output" >&2
+    exit 1
+}
+[[ "$roundtrip_output" != *GROQ_API_KEY* ]] || {
+    printf 'The roundtrip guard names an unaltered key:\n%s\n' "$roundtrip_output" >&2
+    exit 1
+}
+
+# Assignment spellings Compose accepts and the raw reader used to read as "this
+# file does not assign the key". That skipped the comparison entirely, so the
+# guard exited 0 while Compose delivered a truncated `ab` to the containers —
+# the exact silent mangling it exists to prevent. Written out instead of using
+# the helper, which spells every assignment as `KEY=value`.
+assert_altered_value_is_caught() {
+    local description="$1"
+    local status=0
+
+    roundtrip_resolved=(APP_SECRET=ab)
+    validate_secret_roundtrip >/dev/null 2>&1 || status=$?
+    (( status != 0 )) || {
+        printf 'Assignment case "%s": the guard passed a value Compose truncated\n' \
+            "$description" >&2
+        exit 1
+    }
+}
+
+printf 'APP_SECRET = ab$cdefgh\n' > "$roundtrip_env_file"
+assert_altered_value_is_caught "whitespace around the ="
+printf 'APP_SECRET\t=\tab$cdefgh\n' > "$roundtrip_env_file"
+assert_altered_value_is_caught "a tab around the ="
+printf '%s' $'\xef\xbb\xbf' > "$roundtrip_env_file"
+printf 'APP_SECRET=ab$cdefgh\n' >> "$roundtrip_env_file"
+assert_altered_value_is_caught "a UTF-8 BOM before the first key"
+
+# The guard resolves the configuration file itself, with the same resolver
+# compose() uses, so both halves of the comparison always describe the file
+# Compose actually reads. With both candidates present that is deploy/.env: an
+# altered value in the ignored checkout-root file must not fail a deployment
+# that never reads it, and the file that IS in play must still be compared.
+printf 'APP_SECRET=2f6b8c1d4e9a0b7c\n' > "$roundtrip_env_file"
+printf 'APP_SECRET="ignored-entirely"\n' > "$roundtrip_tree/.env"
+roundtrip_resolved=(APP_SECRET=2f6b8c1d4e9a0b7c)
+validate_secret_roundtrip || {
+    echo "The roundtrip guard compared a configuration file Compose does not read" >&2
+    exit 1
+}
+printf 'APP_SECRET="2f6b8c1d4e9a0b7c"\n' > "$roundtrip_env_file"
+if validate_secret_roundtrip >/dev/null 2>&1; then
+    echo "The roundtrip guard did not compare the configuration file Compose reads" >&2
+    exit 1
+fi
+rm -f "$roundtrip_tree/.env"
+
+# An exported host variable wins over every file entry, so Compose resolves it
+# from the environment and the file entry is not the value in play. Comparing it
+# would fail a deployment that is configured correctly.
+printf 'APP_SECRET="abc"\n' > "$roundtrip_env_file"
+roundtrip_resolved=(APP_SECRET=something-else-entirely)
+(
+    export APP_SECRET=something-else-entirely
+    validate_secret_roundtrip
+) || {
+    echo "A host-provided value was compared against a file entry it overrides" >&2
+    exit 1
+}
+
+# Keys the file does not mention at all come from the host environment or from
+# compose.yaml's own default, so there is nothing to compare.
+printf 'UNRELATED_KEY=x\n' > "$roundtrip_env_file"
+roundtrip_resolved=(APP_SECRET=whatever)
+validate_secret_roundtrip || {
+    echo "A key that the configuration file does not assign was compared anyway" >&2
+    exit 1
+}
+
+# A host-environment-only deployment has no file, so Compose parses nothing and
+# the guard must not even resolve an environment: it has to stay a silent no-op.
+# This is the case for every self-hoster who has no configuration file today.
+compose() {
+    echo "the roundtrip guard resolved an environment although no file is in play" >&2
+    return 1
+}
+rm -f "$roundtrip_env_file"
+validate_secret_roundtrip || {
+    echo "The roundtrip guard is not a no-op when no configuration file exists" >&2
+    exit 1
+}
+(
+    # Read indirectly, by resolve_compose_env_file() from the sourced library.
+    # shellcheck disable=SC2034
+    DEPLOY_DIR="$env_tree/deploy"
+    validate_secret_roundtrip
+) || {
+    echo "The roundtrip guard is not a no-op when neither candidate file exists" >&2
+    exit 1
+}
+
+# The guard has to run on the paths that configure a deployment, before any rule
+# that inspects an already-resolved value.
+assert_roundtrip_precedes_value_rules() {
+    local script="$SCRIPT_DIR/$1"
+    local roundtrip_line value_rule_line
+    roundtrip_line="$(awk '/^validate_secret_roundtrip/ { print NR; exit }' "$script")"
+    value_rule_line="$(awk '/^(validate_bootstrap_admin_config|validate_app_image_contract)$/ { print NR; exit }' "$script")"
+
+    [[ -n "$roundtrip_line" ]] || {
+        printf '%s does not call validate_secret_roundtrip\n' "$1" >&2
+        exit 1
+    }
+    [[ -z "$value_rule_line" ]] || (( roundtrip_line < value_rule_line )) || {
+        printf '%s calls validate_secret_roundtrip at line %s, after a value rule at line %s\n' \
+            "$1" "$roundtrip_line" "$value_rule_line" >&2
+        exit 1
+    }
+}
+
+assert_roundtrip_precedes_value_rules prepare.sh
+assert_roundtrip_precedes_value_rules validate-release.sh
+
+# Both platform commands must name the configuration source, before they act on
+# it. run.sh used to start the stack without saying which file configured it, so
+# a checkout-root .env silently ignored in favour of a leftover deploy/.env left
+# no trace anywhere in the deployment log.
+assert_reports_configuration_source() {
+    local script="$SCRIPT_DIR/$1"
+    local report_line action_line
+    report_line="$(awk '/^report_compose_env_file$/ { print NR; exit }' "$script")"
+    action_line="$(awk '/^(compose |"\$DEPLOY_DIR)/ { print NR; exit }' "$script")"
+
+    [[ -n "$report_line" ]] || {
+        printf '%s does not report which configuration file it uses\n' "$1" >&2
+        exit 1
+    }
+    [[ -z "$action_line" ]] || (( report_line < action_line )) || {
+        printf '%s reports the configuration source at line %s, after acting on it at line %s\n' \
+            "$1" "$report_line" "$action_line" >&2
+        exit 1
+    }
+}
+
+assert_reports_configuration_source prepare.sh
+assert_reports_configuration_source run.sh
+# Every path that starts the stack, too: post-update.sh is the install, deploy and
+# update hook, and validate-release.sh does not run before the first two.
+assert_roundtrip_precedes_value_rules post-update.sh
+assert_roundtrip_precedes_value_rules post-restore.sh
+
+# CONTRACT: tier 1 (the pure-shell rules above) must agree with the authority,
+# App\Service\Admin\BootstrapAdminConfiguration, on every case below — the class
+# tier 2 calls inside the application image. The absence of this test is what let
+# the host-side pattern drift looser than the authority.
+#
+# It needs a PHP runtime, which means a container, and this suite runs in CI's
+# Docker-free lint job — so it is opt-in and skipped by default:
+#
+#   SYNAPLAN_CONTRACT_PHP_IMAGE=php:8.3-cli bash deploy/scripts/tests/test-lifecycle.sh
+#
+# Any image providing a `php` binary works: the authority has no dependencies, so
+# its class file is mounted in and reached through the same SYNAPLAN_AUTOLOAD_PATH
+# knob the image uses for vendor/autoload.php. That keeps this case pinned to the
+# rules in THIS checkout instead of the copy baked into some image. Use the
+# release image (ghcr.io/metadist/synaplan:<tag>) to pin the exact runtime
+# production runs.
+AUTHORITY_FILE="$(cd "$SCRIPT_DIR/../.." && pwd)/backend/src/Service/Admin/BootstrapAdminConfiguration.php"
+
+contract_valid_email="admin@example.com"
+contract_valid_password="Str0ngPass"
+contract_emails=(
+    "admin@example.com"
+    "a..b@example.com"
+    ".admin@example.com"
+    "admin.@example.com"
+    "admin@-example.com"
+    "admin@example-.com"
+    "$(repeat_character a 65)@example.com"
+    "$(repeat_character a 64)@example.com"
+    "admin@$(repeat_character a 64).com"
+    "admin@$(repeat_character a 63).com"
+    "admin+tag@example.com"
+    "a.b.c@example.com"
+    "admin@sub.example.co.uk"
+    "admin@ex--ample.com"
+    "-admin-@example.com"
+    "admin@1example.com"
+    "admin@1.example.com"
+    "admin@example.123"
+    "admin@example.1a"
+    "admin@example.a1"
+    "admin@123.45.67.89"
+    "admin@1.2"
+    "admin@example.c"
+    "a@b.c"
+    "admin@example..com"
+    "admin@.example.com"
+    "admin@example.com."
+    "admin@example_x.com"
+    "admin@localhost"
+    "admin@@example.com"
+    "admin @example.com"
+    "ad min@example.com"
+    "admin"
+    "@example.com"
+    "admin@"
+    "!#\$%&'*+-/=?^_\`{|}~@example.com"
+)
+
+# Forms filter_var accepts that the host-side rule rejects on purpose: none of
+# them is a usable administrator mailbox, and rejecting them costs one clear
+# preflight error instead of a crash loop. Listed separately so the intentional
+# asymmetry is visible, and so the strict-agreement list above stays strict.
+contract_stricter_emails=(
+    "admin@[127.0.0.1]"
+    "admin@[IPv6:2001:db8::1]"
+    "\"admin\"@example.com"
+)
+
+# Tier 2 decides the password with the same call, so the password rules belong in
+# the same agreement check. Boundary lengths are built, never hand-counted.
+build_password_of_length 8 Aa1
+contract_password_minimum="$generated_password"
+build_password_of_length 15 Aa
+contract_password_below_waiver="$generated_password"
+build_password_of_length 16 Aa
+contract_password_at_waiver="$generated_password"
+build_password_of_length 64 Aa1
+contract_password_maximum="$generated_password"
+build_password_of_length 65 Aa1
+contract_password_above_maximum="$generated_password"
+contract_passwords=(
+    "$contract_valid_password"
+    "str0ngpass"
+    "STR0NGPASS"
+    "StrongPass"
+    "Short1a"
+    "Str0ng Pass=word"
+    "QWZFaxYB-gtYh-AXqFbcde"
+    "$contract_password_minimum"
+    "$contract_password_below_waiver"
+    "$contract_password_at_waiver"
+    "$contract_password_maximum"
+    "$contract_password_above_maximum"
+)
+
+# One case per line, email and password separated by a tab: no fixture contains
+# one, and any other separator appears inside a realistic address or password.
+contract_tab=$'\t'
+contract_cases=()
+for contract_value in "${contract_emails[@]}"; do
+    contract_cases+=("${contract_value}${contract_tab}${contract_valid_password}")
+done
+for contract_value in "${contract_passwords[@]}"; do
+    contract_cases+=("${contract_valid_email}${contract_tab}${contract_value}")
+done
+contract_stricter_cases=()
+for contract_value in "${contract_stricter_emails[@]}"; do
+    contract_stricter_cases+=("${contract_value}${contract_tab}${contract_valid_password}")
+done
+
+# One container decides every case, and it runs the exact command lib.sh runs
+# inside the application image — so this test can never end up agreeing with a
+# copy of the rules. The cases arrive on stdin and reach PHP through the
+# container's environment, never through a command line.
+authority_statuses() {
+    local image="$1"
+    shift
+    local script
+
+    script="$(
+        printf 'authority_verdict() {\n'
+        bootstrap_admin_authority_command
+        cat <<'LOOP'
+}
+
+tab="$(printf '\t')"
+while IFS="$tab" read -r BOOTSTRAP_ADMIN_EMAIL BOOTSTRAP_ADMIN_PASSWORD; do
+    export BOOTSTRAP_ADMIN_EMAIL BOOTSTRAP_ADMIN_PASSWORD
+    status=0
+    authority_verdict >/dev/null 2>&1 </dev/null || status=$?
+    printf '%s\n' "$status"
+done
+LOOP
+    )"
+
+    printf '%s\n' "$@" |
+        docker run --rm -i \
+            --entrypoint sh \
+            -e SYNAPLAN_AUTOLOAD_PATH=/synaplan-authority.php \
+            -v "$AUTHORITY_FILE:/synaplan-authority.php:ro" \
+            "$image" -ec "$script"
+}
+
+# 0 accepted, 1 rejected — tier 1's own contract. Passwords are never printed by
+# either tier, so a mismatch is reported by case index and length instead.
+host_status() {
+    local status=0
+    validate_bootstrap_admin_values "$1" "$2" >/dev/null 2>&1 || status=$?
+    printf '%s' "$status"
+}
+
+# The authority answers 0 accepted, 3 rejected. Anything else means it could not
+# run at all, which must fail loudly instead of counting as "rejected".
+expected_host_status() {
+    case "$1" in
+        0) printf '0' ;;
+        3) printf '1' ;;
+        *) printf 'undecided' ;;
+    esac
+}
+
+assert_bootstrap_contract() {
+    local image="$1"
+    local statuses status expected email password
+    local index=0
+
+    statuses="$(authority_statuses "$image" "${contract_cases[@]}")"
+    while IFS= read -r status; do
+        email="${contract_cases[$index]%%$contract_tab*}"
+        password="${contract_cases[$index]#*$contract_tab}"
+        expected="$(expected_host_status "$status")"
+        [[ "$expected" != undecided ]] || {
+            printf 'The authority could not decide case %s (email "%s", %s byte password): it exited %s\n' \
+                "$index" "$email" "${#password}" "$status" >&2
+            exit 1
+        }
+        [[ "$(host_status "$email" "$password")" == "$expected" ]] || {
+            printf 'Bootstrap contract drift in case %s (email "%s", %s byte password): the authority says %s, the host says %s\n' \
+                "$index" "$email" "${#password}" \
+                "$(expected_host_status "$status")" "$(host_status "$email" "$password")" >&2
+            exit 1
+        }
+        index=$((index + 1))
+    done <<< "$statuses"
+
+    (( index == ${#contract_cases[@]} )) || {
+        printf 'Expected %s authority verdicts, got %s\n' "${#contract_cases[@]}" "$index" >&2
+        exit 1
+    }
+
+    local stricter_index=0
+    statuses="$(authority_statuses "$image" "${contract_stricter_cases[@]}")"
+    while IFS= read -r status; do
+        email="${contract_stricter_emails[$stricter_index]}"
+        [[ "$status" == 0 && "$(host_status "$email" "$contract_valid_password")" == 1 ]] || {
+            printf 'Expected "%s" to be accepted by the authority and deliberately host-rejected; the authority exited %s, the host says %s\n' \
+                "$email" "$status" "$(host_status "$email" "$contract_valid_password")" >&2
+            exit 1
+        }
+        stricter_index=$((stricter_index + 1))
+    done <<< "$statuses"
+
+    (( stricter_index == ${#contract_stricter_cases[@]} )) || {
+        printf 'Expected %s authority verdicts for the stricter cases, got %s\n' \
+            "${#contract_stricter_cases[@]}" "$stricter_index" >&2
+        exit 1
+    }
+
+    printf 'Bootstrap email contract verified against %s (%s emails + %s passwords matching the authority, %s deliberately stricter).\n' \
+        "$image" "${#contract_emails[@]}" "${#contract_passwords[@]}" "$stricter_index"
+}
+
+if [[ -n "${SYNAPLAN_CONTRACT_PHP_IMAGE:-}" ]]; then
+    assert_bootstrap_contract "$SYNAPLAN_CONTRACT_PHP_IMAGE"
+else
+    echo "Bootstrap email contract test skipped; set SYNAPLAN_CONTRACT_PHP_IMAGE to a PHP-capable image to run it."
+fi
+
+echo "Lifecycle contract tests passed."

--- a/deploy/scripts/validate-release.sh
+++ b/deploy/scripts/validate-release.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+# shellcheck source=lib.sh
+source "$(dirname "$0")/lib.sh"
+
+validate_release_pin
+# elestio.yml runs this script again as its run command, on every start, so the
+# roundtrip guard also covers a configuration file that changed after the
+# install-time prepare.sh. It must precede the value rules below: a value Compose
+# altered has to be reported as altered, not as invalid.
+validate_secret_roundtrip
+# Tier 1: needs no application image, so it decides everything it can before one
+# is started.
+validate_bootstrap_admin_config
+resolved_image="$(resolved_app_image)"
+
+# Tier 2: the image contract probe also asks the application's own validator for a
+# verdict on the COMPLETE first-admin configuration, so no host-side rule can
+# drift from it.
+validate_app_image_contract
+
+echo "Validated compatible Synaplan application image: $resolved_image"

--- a/deploy/selfhost.env.example
+++ b/deploy/selfhost.env.example
@@ -1,0 +1,67 @@
+# Copy to deploy/.env, replace every required placeholder, and keep the file private.
+# Secrets must remain unchanged across restarts, redeploys, backups, and restores.
+
+# Release and public endpoint
+COMPOSE_PROJECT_NAME=synaplan-production
+# Deliberately non-deployable: replace only after the compatible release exists
+# in GHCR and deploy/scripts/validate-release.sh succeeds for that exact tag.
+SYNAPLAN_VERSION=REPLACE_WITH_PUBLISHED_COMPATIBLE_VERSION
+SYNAPLAN_PULL_POLICY=always
+SYNAPLAN_HTTP_BIND=127.0.0.1
+SYNAPLAN_HTTP_PORT=8000
+APP_URL=https://synaplan.example.com
+FRONTEND_URL=https://synaplan.example.com
+
+# Required stable secrets (generate each with: openssl rand -hex 32)
+# Docker Compose reads this file with its own rules and would change a value that
+# contains "$", surrounding quotes, " #", or leading/trailing spaces. Generated
+# hex values avoid that; if you type a value yourself, use only letters, digits,
+# "-" and "_".
+APP_SECRET=replace-with-a-stable-random-value
+TOKEN_SECRET=replace-with-a-different-stable-random-value
+MARIADB_PASSWORD=replace-with-a-stable-random-value
+MARIADB_ROOT_PASSWORD=replace-with-a-different-stable-random-value
+REALTIME_API_KEY=replace-with-a-stable-random-value
+REALTIME_TOKEN_SECRET=replace-with-a-different-stable-random-value
+REALTIME_ADMIN_PASSWORD=replace-with-a-stable-random-value
+REALTIME_ADMIN_SECRET=replace-with-a-different-stable-random-value
+
+# Optional first administrator. Deliberately empty: an unedited copy of this file
+# must never create a working administrator whose password is published in this
+# repository. Leaving both values empty is a valid choice — the bootstrap is
+# skipped and you promote an administrator yourself later.
+# To create one on the first start, set both variables; a stack that receives
+# only one of the two refuses to start. The bootstrap only acts while no
+# administrator exists; later restarts never reset an existing administrator.
+# Password: 8-64 characters; below 16 characters it also needs an uppercase
+# letter, a lowercase letter, and a number. Full rules: docs/INSTALLATION.md.
+# Here the character rule above matters most: if this file changes the password,
+# the value you noted down will not log you in. Generate it: openssl rand -hex 32.
+BOOTSTRAP_ADMIN_EMAIL=
+BOOTSTRAP_ADMIN_PASSWORD=
+
+# Cloud AI is the default. Provider keys can instead be configured after login in
+# Admin > AI Providers, where they are encrypted in MariaDB.
+AI_DEFAULT_PROVIDER=groq
+GROQ_API_KEY=
+OPENAI_API_KEY=
+ANTHROPIC_API_KEY=
+GOOGLE_GEMINI_API_KEY=
+MISTRAL_API_KEY=
+XAI_API_KEY=
+
+# Leave empty for the Cloud-AI stack. Set exactly "local-ai" and redeploy to add
+# Ollama and Whisper. Local chat remains separately opt-in because it is large.
+COMPOSE_PROFILES=
+ENABLE_LOCAL_GPT_OSS=false
+WHISPER_DEFAULT_MODEL=tiny
+
+# Optional production integrations
+# MAILER_DSN is a URL: percent-encode special characters in the SMTP password
+# ("$" as "%24", "@" as "%40", ":" as "%3A"). Details: docs/EMAIL.md
+MAILER_DSN=null://null
+APP_SENDER_EMAIL=
+APP_SENDER_NAME=Synaplan
+REALTIME_ALLOWED_ORIGINS=https://synaplan.example.com
+PHP_MAX_FILE_UPLOADS=100
+LOG_FORMAT=json

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -45,6 +45,7 @@ services:
       AI_DEFAULT_PROVIDER: test
       MAILER_DSN: smtp://mailhog_test:1025
       AUTO_DOWNLOAD_MODELS: "false"
+      RECAPTCHA_ENABLED: "false"
       TOKEN_SECRET: "test_token_secret"
       # OIDC defaults match the Keycloak setup script (_docker/keycloak/setup.sh)
       # These work with --profile oidc; without it, Keycloak is not running but the provider shows as enabled (harmless)

--- a/docs/ADMIN.md
+++ b/docs/ADMIN.md
@@ -6,7 +6,12 @@ Operations reference for self-hosted deployments.
 
 ## Production Setup
 
-### Environment
+Production operations use `deploy/compose.yaml` and the lifecycle scripts under
+`deploy/scripts/`. The root `docker-compose.yml` and
+`docker-compose-minimal.yml` build a development environment and must not be
+treated as the production deployment contract.
+
+### Environment and Secrets
 
 Generate a unique application secret first:
 
@@ -14,9 +19,11 @@ Generate a unique application secret first:
 openssl rand -hex 16
 ```
 
-Then set all production variables in your `.env`:
+Copy `deploy/selfhost.env.example` to `deploy/.env`, restrict access to
+it, and set all required production variables:
 
 ```bash
+SYNAPLAN_VERSION=<released-version>
 APP_ENV=prod
 APP_SECRET=<output from above>
 APP_URL=https://your-domain.com
@@ -24,21 +31,80 @@ FRONTEND_URL=https://your-domain.com
 CORS_ALLOW_ORIGIN=https://your-domain.com
 ```
 
+Set every other password and token marked as required in the template. Secrets
+must remain stable across container recreation, updates, backup, and restore.
+Never commit the populated environment file.
+
 See [Configuration Guide](CONFIGURATION.md) for all environment variables.
 
 ### Starting Services
 
 ```bash
-docker compose up -d
+deploy/scripts/prepare.sh
+docker compose --env-file deploy/.env -f deploy/compose.yaml pull
+deploy/scripts/validate-release.sh
+docker compose --env-file deploy/.env -f deploy/compose.yaml up -d
 ```
 
-Minimal (cloud AI only, no local models):
+The production stack starts in Cloud-AI mode by default. Configure a provider
+after login under **Admin → AI Providers**.
+
+To add Ollama and Whisper on a host with at least 16 GB RAM and sufficient disk,
+enable the optional profile and redeploy:
 
 ```bash
-docker compose -f docker-compose-minimal.yml up -d
+COMPOSE_PROFILES=local-ai \
+  docker compose --env-file deploy/.env -f deploy/compose.yaml up -d
 ```
 
-See [Installation Guide](INSTALLATION.md) for full setup instructions.
+The profile adds local AI services; the local chat model remains a separate
+opt-in. Remove the profile and redeploy to return to the Cloud-AI footprint.
+
+### First Administrator
+
+Provide `BOOTSTRAP_ADMIN_EMAIL` and a strong `BOOTSTRAP_ADMIN_PASSWORD` before
+the first production start, or leave both empty and promote an administrator
+yourself later (see [User Management](#user-management)). Set both variables
+together, or leave both empty: `deploy/scripts/validate-release.sh` refuses to
+pass an unusable pair before the stack starts, and a container that receives only
+one of the two refuses to start and keeps restarting until the configuration is
+corrected. The bootstrap runs only while no administrator exists. It does not
+overwrite an existing administrator on restart. The password must be 8 to 64
+characters long; below 16 characters it must also contain at least one uppercase
+letter, one lowercase letter, and one number.
+
+Sign in immediately, verify access, and move the bootstrap credentials to your
+password manager. Remove both bootstrap variables from platform-visible
+configuration after bootstrap when your deployment platform permits it — always
+both, never only one. Never reuse the development fixture credentials in
+production.
+
+See [Create the First Administrator](INSTALLATION.md#create-the-first-administrator)
+for the password rules and the full bootstrap behavior, and
+[Installation Guide](INSTALLATION.md) for full setup instructions.
+
+### Lost Administrator Password
+
+Changing `BOOTSTRAP_ADMIN_PASSWORD` later does not change the password of an
+administrator that already exists. A new value — including one that a hosting
+platform generates for you on a redeploy and shows in its dashboard — is ignored,
+so the account keeps the password from the very first start. Always sign in with
+the credentials of that first deployment.
+
+If they are lost, there are two ways back in:
+
+1. **Password reset by email.** Use *Forgot password?* on the sign-in page. This
+   only works when the deployment can send mail: `MAILER_DSN` must point at your
+   SMTP server. The production default is `null://null`, which silently discards
+   every message, so configure SMTP first (see [EMAIL.md](EMAIL.md)).
+2. **Through the database.** Sign up in the app with an address you control, then
+   make that account the administrator with the SQL in
+   [User Management](#user-management), which also shows how to open the database
+   prompt. Without working SMTP the sign-up confirmation mail never arrives, so
+   mark the account as verified in the same step — otherwise it cannot sign in.
+
+There is no other recovery path: passwords are stored as hashes and cannot be
+read back out of the database.
 
 ---
 
@@ -72,57 +138,96 @@ See [Health Monitoring](HEALTH_MONITORING.md) for full setup: monitor user creat
 
 ## Backups
 
-### Database
+For production, back up all three state classes together:
 
-MariaDB — use `mariadb-dump` or equivalent:
+- MariaDB data
+- uploaded files
+- Qdrant collections and snapshots
 
-```bash
-docker compose exec db mariadb-dump -u root -p synaplan > backup_$(date +%Y%m%d).sql
-chmod 600 backup_$(date +%Y%m%d).sql
-```
+The portable lifecycle hooks under `deploy/scripts/` coordinate write
+processes and prepare consistent artifacts in the deployment data paths:
 
-Restore (always verify the backup file before restoring):
+1. Run `deploy/scripts/pre-backup.sh`.
+2. After the hook has created SQL, Qdrant, and uploaded-file artifacts and
+   stopped the running stateful services, capture the deployment data paths
+   with the platform backup system.
+3. Run `deploy/scripts/post-backup.sh`, including after a failed snapshot, so
+   exactly the services paused by the pre hook resume.
 
-```bash
-docker compose exec -T db mariadb -u root -p synaplan < backup_20260428.sql
-```
+Elestio maps these hooks through its lifecycle configuration. Trigger the
+backup from Elestio and wait for it to complete before making changes or
+updating.
 
-Schedule daily backups via cron. Keep at least 7 daily and 4 weekly snapshots. Store backups outside the project directory with restricted permissions (`chmod 600`). For sensitive environments, encrypt backups with `gpg` or equivalent before transferring off-server.
+Schedule daily backups and keep at least 7 daily and 4 weekly recovery points.
+Store an encrypted copy outside the host and restrict access to generated dumps
+and snapshots.
 
-### Uploaded Files
+### Restore
 
-Back up the backend storage volume:
+Restore into an isolated deployment before using the procedure on the live
+instance:
 
-```bash
-docker compose cp backend:/var/www/backend/var/uploads ./backup-uploads/
-chmod -R 600 ./backup-uploads/
-```
+1. Verify the backup's timestamp, version, size, and integrity.
+2. Run `deploy/scripts/pre-restore.sh`.
+3. Restore the complete data set through the platform: MariaDB dump/data,
+   uploads, and Qdrant state must come from the same recovery point.
+4. Run `deploy/scripts/post-restore.sh`. It repairs permissions, clears cache,
+   applies required migrations, resumes services, and checks health.
+5. Verify administrator login, representative database records, uploaded files,
+   and a known Qdrant-backed RAG search.
+
+Do not declare a backup strategy operational until this full restore has
+succeeded on a fresh, separate stack.
 
 ---
 
 ## Updates
 
-**Always back up the database before updating:**
+Production images must use a released, pinned `SYNAPLAN_VERSION`; never update
+a production deployment by following `latest`.
+
+Before each update:
+
+1. Read the release notes and [migration guidance](MIGRATIONS.md).
+2. Run `deploy/scripts/pre-update.sh`. Do not continue if its backup gate fails.
+3. Change `SYNAPLAN_VERSION` to the intended release.
+4. Pull and redeploy the production stack.
+5. Run `deploy/scripts/post-update.sh` and verify the reported version and
+   health.
 
 ```bash
-docker compose exec db mariadb-dump -u root -p synaplan > backup_pre_update_$(date +%Y%m%d).sql
+docker compose --env-file deploy/.env -f deploy/compose.yaml pull
+docker compose --env-file deploy/.env -f deploy/compose.yaml up -d
 ```
 
-Then pull and rebuild:
+The web container applies migrations through its production startup contract.
+Do not run `doctrine:schema:update --force`. Keep the pre-update recovery point
+until login, chat, uploads/RAG, worker processing, scheduler execution, and
+realtime connections have been verified.
 
-```bash
-git pull
-docker compose build --no-cache
-docker compose up -d
-```
+On Elestio, use the pipeline update operation; its lifecycle mapping invokes the
+same portable hooks. If verification fails, restore the complete pre-update
+recovery point rather than restoring only the database.
 
-Check `docs/MIGRATIONS.md` before updating — some releases require database migrations:
+---
 
-```bash
-docker compose exec backend php bin/console doctrine:migrations:migrate --no-interaction
-```
+## Elestio Trial Cleanup
 
-Verify the application works after the update. If something breaks, restore from the pre-update backup.
+An imported custom pipeline can incur charges even though the initial
+three-day trial includes credit. Before the recorded trial expiry:
+
+1. Delete the Synaplan pipeline and every target or service created for it.
+2. Delete trial backups and select immediate deletion where offered.
+3. Confirm Auto-Refill is disabled.
+4. Check the Elestio resource and billing views for any remaining billable
+   resource.
+5. Retain only scrubbed test evidence; remove credentials, secret-bearing logs,
+   and private endpoint details.
+
+Custom import support does not imply acceptance into Elestio's Fully Managed
+Catalog. Catalog submission is a separate partnership process and should happen
+only after fresh-install, persistence, restore, update, rollback, and cleanup
+tests pass.
 
 ---
 
@@ -150,7 +255,8 @@ Rotate `APP_SECRET`:
 Auto-generated on first start at `backend/config/jwt/`. To regenerate:
 
 ```bash
-docker compose exec backend php bin/console lexik:jwt:generate-keypair --overwrite
+docker compose --env-file deploy/.env -f deploy/compose.yaml \
+  exec backend php bin/console lexik:jwt:generate-keypair --overwrite
 ```
 
 All active sessions are invalidated on key rotation.
@@ -165,16 +271,50 @@ Always run behind a reverse proxy (nginx, Caddy, Traefik) with TLS termination. 
 
 User levels: `NEW`, `PRO`, `ADMIN`.
 
+### Running These Statements
+
+The production stack publishes no database port, so open a database prompt inside
+the stack:
+
+```bash
+docker compose --env-file deploy/.env -f deploy/compose.yaml \
+  exec db sh -c 'mariadb -u"$MARIADB_USER" -p"$MARIADB_PASSWORD" "$MARIADB_DATABASE"'
+```
+
+On the local development stack (root `docker-compose.yml`) the variable names
+inside the database container are different:
+
+```bash
+docker compose exec db \
+  sh -c 'mariadb -u"$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DATABASE"'
+```
+
+Either command opens a MariaDB prompt — `MariaDB [synaplan]>` with the default
+database name. Keep the single quotes: the user name, password, and database name
+are then read inside the container, so no password appears on your command line
+or in your shell history. Enter the statements below one at a time, end each one
+with `;`, and type `exit` when you are done. Development also offers phpMyAdmin
+at http://localhost:8082.
+
 Verify the user exists before changing their level:
 
 ```sql
-SELECT BID, BMAIL, BUSERLEVEL FROM BUSER WHERE BMAIL = 'user@example.com';
+SELECT BID, BMAIL, BUSERLEVEL, BEMAILVERIFIED FROM BUSER WHERE BMAIL = 'user@example.com';
 ```
 
 Promote to admin only after confirming the correct user:
 
 ```sql
 UPDATE BUSER SET BUSERLEVEL = 'ADMIN' WHERE BID = <id from above>;
+```
+
+An account that never confirmed its sign-up email cannot sign in, whatever its
+level. If the query above returned `BEMAILVERIFIED = 0` — which is what happens
+when the deployment has no working SMTP configuration — mark it as verified in
+the same step:
+
+```sql
+UPDATE BUSER SET BUSERLEVEL = 'ADMIN', BEMAILVERIFIED = 1 WHERE BID = <id from above>;
 ```
 
 List all admin users:
@@ -203,16 +343,17 @@ Always use `BID` (primary key) in UPDATE statements to avoid affecting the wrong
 ### Logs
 
 ```bash
-docker compose logs -f backend
-docker compose logs -f db
-docker compose logs --tail=100 backend
+docker compose --env-file deploy/.env -f deploy/compose.yaml logs -f backend
+docker compose --env-file deploy/.env -f deploy/compose.yaml logs -f db
+docker compose --env-file deploy/.env -f deploy/compose.yaml \
+  logs --tail=100 backend
 ```
 
 ### Restart Services
 
 ```bash
-docker compose restart backend
-docker compose down && docker compose up -d
+docker compose --env-file deploy/.env -f deploy/compose.yaml restart backend
+docker compose --env-file deploy/.env -f deploy/compose.yaml up -d
 ```
 
 ### Full Reset (Development Only — Never in Production)

--- a/docs/ADMIN.md
+++ b/docs/ADMIN.md
@@ -13,10 +13,10 @@ treated as the production deployment contract.
 
 ### Environment and Secrets
 
-Generate a unique application secret first:
+Generate a separate value for every secret, never the same one twice:
 
 ```bash
-openssl rand -hex 16
+openssl rand -hex 32
 ```
 
 Copy `deploy/selfhost.env.example` to `deploy/.env`, restrict access to
@@ -24,12 +24,13 @@ it, and set all required production variables:
 
 ```bash
 SYNAPLAN_VERSION=<released-version>
-APP_ENV=prod
 APP_SECRET=<output from above>
 APP_URL=https://your-domain.com
 FRONTEND_URL=https://your-domain.com
-CORS_ALLOW_ORIGIN=https://your-domain.com
 ```
+
+`deploy/compose.yaml` sets `APP_ENV=prod` itself, so the production stack needs
+no entry for it.
 
 Set every other password and token marked as required in the template. Secrets
 must remain stable across container recreation, updates, backup, and restore.

--- a/docs/ELESTIO_PARTNERSHIP_DRAFT.md
+++ b/docs/ELESTIO_PARTNERSHIP_DRAFT.md
@@ -1,0 +1,39 @@
+# Elestio Partnership Contact Draft
+
+This is a draft for review. Do not send it without project-owner approval.
+
+**To:** contact@elest.io  
+**Subject:** Synaplan integration and Fully Managed Catalog requirements
+
+Hello Elestio team,
+
+We are preparing an Elestio integration for
+[Synaplan](https://github.com/metadist/synaplan), an Apache-2.0 licensed,
+actively released knowledge-management platform. Synaplan provides a web UI and
+API, RAG backed by MariaDB and Qdrant, embeddable chat widgets, and multiple
+cloud and local AI providers.
+
+Our planned integration uses a production Docker Compose contract with pinned
+multi-architecture images, a secure first-administrator bootstrap, health
+checks, and lifecycle hooks for backup, restore, and updates. Cloud AI is the
+resource-efficient default; local Ollama and Whisper services are an optional
+profile.
+
+Before preparing a catalog submission, could you please clarify:
+
+- your current selection and onboarding process for the Fully Managed Catalog;
+- required setup, benchmark, security, backup, restore, update, and maintenance
+  evidence;
+- logo, screenshot, listing-copy, and minimum-resource requirements;
+- release, support, security-fix, and breaking-change responsibilities;
+- current revenue-share terms; and
+- whether you require additional internal scripts or a particular repository
+  layout beyond a public `elestio.yml`.
+
+We plan to validate fresh installation, persistence, restore, version upgrade,
+rollback, and cleanup through a custom-pipeline trial before requesting catalog
+consideration. We understand that a working `elestio.yml` enables import but
+does not guarantee catalog acceptance.
+
+Best regards,  
+The Synaplan team

--- a/docs/EMAIL.md
+++ b/docs/EMAIL.md
@@ -107,6 +107,25 @@ Configure in `backend/.env`:
 MAILER_DSN=smtp://user:pass@smtp.example.com:587
 ```
 
+> **Percent-encode special characters in the user name and password.** The DSN is
+> a URL, so a character that has a meaning in a URL ends the password early or is
+> read as the start of the next part of the address. Replace each one with its
+> percent code and leave the rest of the value untouched: `$` becomes `%24`, `@`
+> becomes `%40`, `:` becomes `%3A`, `/` becomes `%2F`, `#` becomes `%23`, `?`
+> becomes `%3F`, and a literal `%` becomes `%25`. Synaplan decodes them again
+> before it connects, so your SMTP server receives the original password.
+>
+> ```bash
+> # SMTP password: pa$$:word
+> MAILER_DSN=smtp://user:pa%24%24%3Aword@smtp.example.com:587
+> ```
+>
+> Encoding is also what keeps the value intact in a production `deploy/.env`
+> file. Docker Compose reads that file with its own rules and would silently drop
+> everything from the first `$` onwards, and the deployment refuses such a value
+> instead of mailing with a truncated password. An encoded DSN contains no `$` at
+> all and is passed through exactly as written.
+
 > **AWS SES (and other strict SMTP servers):** SES hard-closes connections
 > that are idle for more than ~10 seconds, while Symfony Mailer keeps the
 > connection open between sends and only health-checks it after 100 seconds.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -2,23 +2,207 @@
 
 Complete installation instructions for Synaplan.
 
-## Prerequisites
+## Choose the Right Deployment Path
+
+Synaplan has separate development and production deployment contracts:
+
+- **Local development:** use the root `docker-compose.yml` or
+  `docker-compose-minimal.yml`. These files build from source and include
+  development tooling. They are not the supported production contract.
+- **Production self-hosting:** use `deploy/compose.yaml` with a pinned Synaplan
+  image version and secrets supplied through `deploy/.env`.
+- **Elestio evaluation:** import the repository as a custom Docker Compose
+  CI/CD pipeline. The root `elestio.yml` delegates to the same production
+  contract under `deploy/`.
+
+The Elestio files make a custom import possible; they do **not** mean that
+Synaplan has been accepted into Elestio's Fully Managed Catalog.
+
+## Production Self-Hosting
+
+### Requirements
+
+- Docker Engine and Docker Compose v2
+- A Linux server with at least 4 vCPU, 8 GB RAM, and sufficient persistent disk
+- A DNS name and HTTPS-capable reverse proxy or managed platform
+- A released Synaplan version to pin instead of `latest`
+
+The production stack exposes only the web service. MariaDB, Redis, Centrifugo,
+Tika, and Qdrant remain on its internal network.
+
+### Start the Cloud-AI Stack
+
+Copy the production environment template, then set the required URL, version,
+password, and secret values:
+
+```bash
+cp deploy/selfhost.env.example deploy/.env
+# Edit deploy/.env and replace every required placeholder. The image version
+# must already be published and immutable.
+deploy/scripts/prepare.sh
+docker compose --env-file deploy/.env -f deploy/compose.yaml pull
+deploy/scripts/validate-release.sh
+docker compose --env-file deploy/.env -f deploy/compose.yaml up -d
+```
+
+Keep `deploy/.env` outside version control, restrict its permissions,
+and preserve the same secret values across updates and redeployments.
+
+Cloud AI is the production default. Ollama and Whisper are not started, model
+downloads are disabled, and an AI provider key can be added after login under
+**Admin → AI Providers**.
+
+### Create the First Administrator
+
+Before the first start, set a unique email and strong password in the deployment
+environment:
+
+```dotenv
+BOOTSTRAP_ADMIN_EMAIL=admin@example.com
+BOOTSTRAP_ADMIN_PASSWORD=REPLACE-ME
+```
+
+`REPLACE-ME` is rejected by the checks below on purpose, so a copied example can
+never become a working administrator account.
+
+The email must be a valid address of at most 128 characters. Very long or unusual
+addresses can still be refused: the part before the `@` may not be longer than 64
+characters or contain a dot at the start, at the end, or twice in a row, and each
+part of the domain name may not be longer than 63 characters or start or end with
+a hyphen. If your own address is refused, put a different valid address in
+`BOOTSTRAP_ADMIN_EMAIL`, or leave both bootstrap variables empty, sign up in the
+app afterwards, and make that account the administrator (see
+[User Management](ADMIN.md#user-management)).
+
+The password must be 8 to 64 characters long; below 16 characters it must also
+contain at least one uppercase letter, one lowercase letter, and one number. A
+password of 16 characters or more has no character requirements.
+
+Following [NIST SP 800-63B](https://pages.nist.gov/800-63-3/sp800-63b.html),
+composition rules apply only to short passwords, because length already provides
+the entropy they are meant to enforce. This also means a long generated password
+from a managed platform is accepted as-is: the application never shortens or
+rewrites it.
+
+> **The `deploy/.env` file itself can change a password before the application
+> ever sees it.** Docker Compose reads that file with its own rules: it cuts a
+> value off at the first `$`, removes one matching pair of surrounding quotes,
+> drops everything after a space followed by `#`, and trims leading and trailing
+> spaces. A password containing those characters is therefore stored in a changed
+> form, and the password you typed no longer opens the account. Use only letters,
+> digits, `-` and `_`, or generate the value like the other secrets with
+> `openssl rand -hex 32` — 64 characters, the longest length allowed above, and
+> safe in this file. A deployment that finds such a value in `deploy/.env` stops
+> with a message naming the variable, instead of creating an administrator whose
+> password nobody knows. Values that a hosting platform passes in directly as
+> environment variables are used exactly as given and are not affected. For a
+> value you cannot choose freely — your SMTP provider's password inside
+> `MAILER_DSN` — percent-encode the special characters instead, as described in
+> [Outgoing Email](EMAIL.md#outgoing-email-smtp).
+
+**Set both variables together, or leave both empty.** Leaving both empty is a
+valid choice: no administrator is created automatically, and you can promote one
+later (see [User Management](ADMIN.md#user-management)). Setting only one of the
+two is a configuration error.
+
+> **A half-configured pair stops the container on purpose.** Each application
+> container checks the pair first and, when only one value is set, prints which
+> variable is missing and exits with code `78` before it touches the database.
+> Because the production stack restarts containers automatically, the deployment
+> keeps restarting until you either supply the missing value or clear both. This
+> is intended fail-fast behavior, not a bug — read the container log to see
+> which variable is missing.
+
+The production bootstrap creates or promotes this account only when no
+administrator exists. If an administrator is already present, it changes nothing,
+so it is safe on every start. Later restarts do not reset an existing
+administrator's password or role.
+
+On the deployment path shown above, `deploy/scripts/validate-release.sh` checks
+both values **before the stack starts**. An unusable value fails that command
+once, with a message naming the problem, and nothing is deployed. Only a value
+that reaches the containers anyway — because it was changed after the check, or
+because the check was skipped — is rejected by the application itself, within
+seconds of container start and before it waits for the database, applies
+migrations, or seeds anything; that container then exits with code `1`.
+
+In short: exit code `78` means the pair is half-configured, exit code `1` means
+the email or the password does not meet the rules above.
+
+Remove both bootstrap variables from platform-visible configuration after the
+first login when the platform permits it — always both, never only one — and
+store the credentials in a password manager. Changing the variables later does
+not change the password of the administrator that already exists; if you no
+longer have those credentials, see
+[Lost Administrator Password](ADMIN.md#lost-administrator-password).
+
+### Optional Local AI
+
+The optional `local-ai` Compose profile adds Ollama and Whisper. It requires an
+explicit redeploy, at least 16 GB RAM, and substantially more disk than the
+Cloud-AI stack:
+
+```bash
+COMPOSE_PROFILES=local-ai \
+  docker compose --env-file deploy/.env -f deploy/compose.yaml up -d
+```
+
+Enabling the profile installs the local AI services; a local chat model remains
+an additional opt-in. Leave `COMPOSE_PROFILES` empty to keep the Cloud-AI
+default.
+
+### Evaluate on Elestio
+
+Use Elestio's custom Docker Compose import for evaluation:
+
+1. Start the free three-day trial, note its exact expiry time, disable
+   Auto-Refill immediately, and confirm the current trial terms. Elestio
+   currently requires a payment card.
+2. Create an isolated target with at least 4 vCPU and 8 GB RAM.
+3. Import this repository as a custom CI/CD pipeline. Keep
+   `COMPOSE_PROFILES` empty for the initial Cloud-AI deployment and use the
+   generated HTTPS domain.
+4. Sign in with the generated first-administrator credentials, configure a
+   cloud AI provider, and test chat, file/RAG search, widgets, realtime
+   connections, restart, and redeploy.
+5. Trigger a backup and restore it into a separate pipeline or clone. Confirm
+   database records, uploads, and Qdrant-backed search results.
+6. Before the trial expires, delete every pipeline, target, service, and backup,
+   choose immediate backup deletion, verify Auto-Refill is still disabled, and
+   confirm that no billable resource remains.
+
+Test `local-ai` only when the selected machine and remaining trial credit are
+sufficient. Do not publish credentials, deployment logs containing secrets, or
+private endpoint details.
+
+See [Administration Guide](ADMIN.md) for production updates, backups, restore,
+and cleanup.
+
+---
+
+## Local Development
+
+The remaining instructions are for a source checkout used for development and
+local evaluation. Do not use this root Compose stack as the production
+deployment contract.
+
+### Prerequisites
 
 - **Docker** & **Docker Compose** (v2.0+)
 - **Git**
 - 8GB RAM minimum (16GB recommended for local AI)
 - ~9GB disk space (Standard) or ~5GB (Minimal). Add ~14GB if you enable the local
-  chat model (`ENABLE_LOCAL_GPT_OSS=true`, see [Standard Install](#standard-install-recommended))
+  chat model (`ENABLE_LOCAL_GPT_OSS=true`, see
+  [Standard Development Stack](#standard-development-stack))
 
 > **Apple Silicon (M1–M4) Macs — build the backend image, don't pull it.** The
-> Quick Install below already does: `docker compose up -d` builds the backend and
+> Quick Start below already does: `docker compose up -d` builds the backend and
 > worker locally from a multi-arch base, so PHP runs natively on `arm64` with no
-> emulation tax. That is the fastest setup and needs no extra steps. The pre-built
-> `ghcr.io/metadist/synaplan` production image is `linux/amd64` only — pulling it
-> instead runs the whole backend emulated. See
+> emulation tax. That is the fastest setup and needs no extra steps. Released
+> production images support both `linux/amd64` and `linux/arm64`. See
 > [Troubleshooting](#slow-performance-on-apple-silicon-mac).
 
-## Quick Install
+### Quick Start
 
 ```bash
 git clone <repository-url>
@@ -32,9 +216,9 @@ That's it! Visit http://localhost:5173 after ~2 minutes, log in as
 
 ---
 
-## Installation Modes
+## Local Development Modes
 
-### Standard Install (Recommended)
+### Standard Development Stack
 
 Full-featured installation with local AI models and audio transcription.
 
@@ -72,7 +256,7 @@ Until then — or while the download runs — chat needs a cloud provider key
 - Qdrant vector database (AI memories, RAG, feedback)
 - Dev tools (phpMyAdmin, MailHog)
 
-### Minimal Install (Cloud AI Only)
+### Minimal Development Stack (Cloud AI Only)
 
 Fastest way to start—uses cloud AI providers, skips large local models.
 
@@ -142,9 +326,11 @@ On first start, the system:
 **First startup:** ~1-2 minutes  
 **Subsequent restarts:** ~15-30 seconds
 
-## Default Login Credentials
+## Development Login Credentials
 
-After first startup, the following test accounts are available:
+After the local development stack starts for the first time, the following test
+accounts are available. They are development fixtures and are never the
+production first-administrator mechanism:
 
 | Email | Password | Level |
 |-------|----------|-------|
@@ -212,10 +398,9 @@ If PHP still feels slow, check what you are actually running:
 docker compose exec backend uname -m   # expect: aarch64
 ```
 
-- `x86_64` means you are on an emulated image — most likely you pulled the
-  pre-built `ghcr.io/metadist/synaplan` production image (`linux/amd64` only)
-  instead of building. Rebuild with `docker compose build --pull backend worker`,
-  then `docker compose up -d`.
+- `x86_64` means the local development container is running under emulation.
+  Rebuild with `docker compose build --pull backend worker`, then run
+  `docker compose up -d`.
 - The optional `phpmyadmin` and `mailhog` services use amd64-only upstream images
   and stay emulated. Enable **Docker Desktop → Settings → General → "Use Rosetta
   for x86/amd64 emulation on Apple Silicon"** (macOS 13+) — much faster than the

--- a/elestio.yml
+++ b/elestio.yml
@@ -1,0 +1,92 @@
+config:
+  runTime: "dockerCompose"
+  version: ""
+  framework: ""
+  installCommand: ""
+  # Both commands go through deploy/scripts/, which reaches Compose through
+  # lib.sh's compose(). A `docker compose` call here would read deploy/.env only
+  # and miss a configuration materialised as a checkout-root .env.
+  buildCommand: "./deploy/scripts/build.sh"
+  buildDir: "/"
+  runCommand: "./deploy/scripts/run.sh"
+  isMonoRepoPackageInRoot: false
+
+environments:
+  - key: "COMPOSE_PROJECT_NAME"
+    value: "synaplan"
+  # Deliberately non-deployable: replace only after the compatible release exists
+  # in GHCR. The pre-install hook rejects this placeholder and any mutable tag
+  # before a container starts, so a catalog submission must carry a published
+  # SemVer version, never this value, `latest`, or an anticipated future tag.
+  - key: "SYNAPLAN_VERSION"
+    value: "REPLACE_WITH_PUBLISHED_COMPATIBLE_VERSION"
+  - key: "SYNAPLAN_HTTP_BIND"
+    value: "0.0.0.0"
+  - key: "SYNAPLAN_HTTP_PORT"
+    value: "8000"
+  - key: "APP_URL"
+    value: "https://[CI_CD_DOMAIN]"
+  - key: "FRONTEND_URL"
+    value: "https://[CI_CD_DOMAIN]"
+  - key: "APP_SECRET"
+    value: "random_password"
+  - key: "TOKEN_SECRET"
+    value: "random_password"
+  - key: "MARIADB_DATABASE"
+    value: "synaplan"
+  - key: "MARIADB_USER"
+    value: "synaplan"
+  - key: "MARIADB_PASSWORD"
+    value: "random_password"
+  - key: "MARIADB_ROOT_PASSWORD"
+    value: "random_password"
+  - key: "REALTIME_API_KEY"
+    value: "random_password"
+  - key: "REALTIME_TOKEN_SECRET"
+    value: "random_password"
+  - key: "REALTIME_ADMIN_PASSWORD"
+    value: "random_password"
+  - key: "REALTIME_ADMIN_SECRET"
+    value: "random_password"
+  - key: "REALTIME_ALLOWED_ORIGINS"
+    value: "https://[CI_CD_DOMAIN]"
+  - key: "BOOTSTRAP_ADMIN_EMAIL"
+    value: "[EMAIL]"
+  - key: "BOOTSTRAP_ADMIN_PASSWORD"
+    value: "random_password"
+  - key: "AI_DEFAULT_PROVIDER"
+    value: "groq"
+  - key: "COMPOSE_PROFILES"
+    value: ""
+  - key: "ENABLE_LOCAL_GPT_OSS"
+    value: "false"
+
+ports:
+  - protocol: "HTTPS"
+    targetProtocol: "HTTP"
+    listeningPort: "443"
+    targetPort: "8000"
+    targetIP: "172.17.0.1"
+    public: true
+    path: "/"
+    isAuth: false
+
+lifeCycleConfig:
+  preInstallCommand: "./deploy/elestio/pre-install.sh"
+  postInstallCommand: "./deploy/elestio/post-install.sh"
+  preBackupCommand: "./deploy/elestio/pre-backup.sh"
+  postBackupCommand: "./deploy/elestio/post-backup.sh"
+  preRestoreCommand: "./deploy/elestio/pre-restore.sh"
+  postRestoreCommand: "./deploy/elestio/post-restore.sh"
+  preUpdateCommand: "./deploy/elestio/pre-update.sh"
+  postUpdateCommand: "./deploy/elestio/post-update.sh"
+  preDeployCommand: "./deploy/elestio/pre-deploy.sh"
+  postDeployCommand: "./deploy/elestio/post-deploy.sh"
+
+webUI:
+  - url: "https://[CI_CD_DOMAIN]"
+    label: "Synaplan"
+    login: "[BOOTSTRAP_ADMIN_EMAIL]"
+    password: "[BOOTSTRAP_ADMIN_PASSWORD]"
+
+monoRepoWorkSpaces: []

--- a/frontend/src/stores/history.ts
+++ b/frontend/src/stores/history.ts
@@ -297,6 +297,73 @@ function messageHasRenderableContent(message: Message): boolean {
   )
 }
 
+/** Concatenated text content of a message, used for duplicate detection. */
+function messageTextContent(message: Message): string {
+  return message.parts
+    .filter((part) => part.type === 'text')
+    .map((part) => (part.content ?? '').trim())
+    .join('\n')
+}
+
+/**
+ * Merge a freshly hydrated history snapshot with the live message list when a
+ * foreground load resolves while a streaming exchange is in flight (see
+ * `loadMessages`). The snapshot replaces everything EXCEPT the in-flight
+ * tail: the streaming message(s) plus the locally added user message(s) of
+ * that exchange directly preceding them (added by `addMessage` with a local
+ * uuid and no backend id yet).
+ *
+ * Trailing snapshot rows that duplicate the tail are dropped — the live copy
+ * wins, because ChatView still references it by its local id (error status,
+ * post-stream reconciliation) and it carries the newest streamed content:
+ *  - same local id or same persisted backend id (turn row persisted mid-stream),
+ *  - the synthetic in-progress bubble (the live stream already renders it),
+ *  - a user row with the same text as a not-yet-acknowledged local user
+ *    message (the send was persisted before the response was built).
+ * Only the trailing overlap is scanned, so older history rows with
+ * coincidentally identical text are never dropped.
+ */
+export function mergeHydrationWithStreamingTail(
+  snapshot: Message[],
+  current: Message[]
+): Message[] {
+  const firstStreamingIndex = current.findIndex((message) => message.isStreaming)
+  if (firstStreamingIndex === -1) return snapshot
+
+  let tailStart = firstStreamingIndex
+  while (
+    tailStart > 0 &&
+    current[tailStart - 1].role === 'user' &&
+    current[tailStart - 1].backendMessageId === undefined
+  ) {
+    tailStart--
+  }
+  const tail = current.slice(tailStart)
+
+  const tailIds = new Set(tail.map((message) => message.id))
+  const tailBackendIds = new Set(
+    tail.map((message) => message.backendMessageId).filter((id): id is number => id !== undefined)
+  )
+  const tailUserTexts = new Set(
+    tail
+      .filter((message) => message.role === 'user' && message.backendMessageId === undefined)
+      .map(messageTextContent)
+  )
+
+  const duplicatesTail = (message: Message): boolean =>
+    tailIds.has(message.id) ||
+    message.id === IN_PROGRESS_TURN_ID ||
+    (message.backendMessageId !== undefined && tailBackendIds.has(message.backendMessageId)) ||
+    (message.role === 'user' && tailUserTexts.has(messageTextContent(message)))
+
+  let snapshotEnd = snapshot.length
+  while (snapshotEnd > 0 && duplicatesTail(snapshot[snapshotEnd - 1])) {
+    snapshotEnd--
+  }
+
+  return [...snapshot.slice(0, snapshotEnd), ...tail]
+}
+
 export const useHistoryStore = defineStore('history', () => {
   const messages = ref<Message[]>([])
   const isLoadingMessages = ref(false)
@@ -531,11 +598,15 @@ export const useHistoryStore = defineStore('history', () => {
         if (offset === 0) {
           // A foreground hydration may have started just before the user sent
           // a message. The live stream is newer than that response and must not
-          // be replaced by its stale snapshot.
+          // be replaced by its stale snapshot — but the snapshot still carries
+          // the chat's prior history, so merge it in front of the in-flight
+          // exchange instead of dropping it (and fall through to the pagination
+          // update, which was reset before the fetch).
           if (!silent && messages.value.some((message) => message.isStreaming)) {
-            return
+            messages.value = mergeHydrationWithStreamingTail(loadedMessages, messages.value)
+          } else {
+            messages.value = loadedMessages
           }
-          messages.value = loadedMessages
         } else {
           messages.value = [...loadedMessages, ...messages.value]
         }

--- a/frontend/src/stores/history.ts
+++ b/frontend/src/stores/history.ts
@@ -318,10 +318,12 @@ function messageTextContent(message: Message): string {
  * post-stream reconciliation) and it carries the newest streamed content:
  *  - same local id or same persisted backend id (turn row persisted mid-stream),
  *  - the synthetic in-progress bubble (the live stream already renders it),
- *  - a user row with the same text as a not-yet-acknowledged local user
- *    message (the send was persisted before the response was built).
+ *  - a user row with the same NON-EMPTY text as a not-yet-acknowledged local
+ *    user message (the send was persisted before the response was built).
  * Only the trailing overlap is scanned, so older history rows with
- * coincidentally identical text are never dropped.
+ * coincidentally identical text are never dropped. Empty text is excluded from
+ * that last rule: a file-only send carries no text, and matching on "" would
+ * make every attachment-only prompt look like a duplicate of every other one.
  */
 export function mergeHydrationWithStreamingTail(
   snapshot: Message[],
@@ -348,6 +350,7 @@ export function mergeHydrationWithStreamingTail(
     tail
       .filter((message) => message.role === 'user' && message.backendMessageId === undefined)
       .map(messageTextContent)
+      .filter((text) => text !== '')
   )
 
   const duplicatesTail = (message: Message): boolean =>

--- a/frontend/src/stores/history.ts
+++ b/frontend/src/stores/history.ts
@@ -529,6 +529,12 @@ export const useHistoryStore = defineStore('history', () => {
 
         // If offset is 0, replace messages; otherwise, prepend (for infinite scroll)
         if (offset === 0) {
+          // A foreground hydration may have started just before the user sent
+          // a message. The live stream is newer than that response and must not
+          // be replaced by its stale snapshot.
+          if (!silent && messages.value.some((message) => message.isStreaming)) {
+            return
+          }
           messages.value = loadedMessages
         } else {
           messages.value = [...loadedMessages, ...messages.value]

--- a/frontend/tests/unit/stores/history.spec.ts
+++ b/frontend/tests/unit/stores/history.spec.ts
@@ -102,6 +102,38 @@ describe('History Store', () => {
     expect(store.messages[0].isSuperseded).toBe(true)
   })
 
+  it('does not replace a newer live stream with a stale foreground load', async () => {
+    let resolveLoad!: (value: {
+      success: boolean
+      messages: unknown[]
+      pagination: { hasMore: boolean }
+    }) => void
+    const getChatMessages = vi.fn(
+      () =>
+        new Promise<{
+          success: boolean
+          messages: unknown[]
+          pagination: { hasMore: boolean }
+        }>((resolve) => {
+          resolveLoad = resolve
+        })
+    )
+    vi.doMock('@/services/api', () => ({ chatApi: { getChatMessages } }))
+
+    const store = useHistoryStore()
+    const loading = store.loadMessages(42)
+    await vi.waitFor(() => expect(getChatMessages).toHaveBeenCalledOnce())
+
+    store.addMessage('user', [{ type: 'text', content: 'Hello' }])
+    const assistantId = store.addStreamingMessage('assistant')
+    resolveLoad({ success: true, messages: [], pagination: { hasMore: false } })
+    await loading
+
+    expect(store.messages).toHaveLength(2)
+    expect(store.messages.at(-1)?.id).toBe(assistantId)
+    expect(store.messages.at(-1)?.isStreaming).toBe(true)
+  })
+
   /**
    * Issue #955 regression coverage. The chat API ships uploaded voice
    * notes and TTS audio in two shapes:

--- a/frontend/tests/unit/stores/history.spec.ts
+++ b/frontend/tests/unit/stores/history.spec.ts
@@ -135,6 +135,116 @@ describe('History Store', () => {
   })
 
   /**
+   * PR #1437 review: a foreground hydration that resolves while a live
+   * stream is in flight must MERGE its snapshot in front of the streaming
+   * tail instead of dropping it — otherwise the chat shows no prior history
+   * and the pagination state (reset before the fetch) stays exhausted.
+   */
+  describe('loadMessages — hydration racing a live stream (PR #1437)', () => {
+    const startDeferredLoad = async (extraResponses = false) => {
+      vi.resetModules()
+      let resolveLoad!: (value: unknown) => void
+      const getChatMessages = extraResponses
+        ? vi
+            .fn()
+            .mockImplementationOnce(
+              () =>
+                new Promise<unknown>((resolve) => {
+                  resolveLoad = resolve
+                })
+            )
+            .mockResolvedValue({ success: true, messages: [], pagination: { hasMore: false } })
+        : vi.fn(
+            () =>
+              new Promise<unknown>((resolve) => {
+                resolveLoad = resolve
+              })
+          )
+      vi.doMock('@/services/api', () => ({ chatApi: { getChatMessages } }))
+
+      const { useHistoryStore: useStore } = await import('@/stores/history')
+      const store = useStore()
+      const loading = store.loadMessages(42)
+      await vi.waitFor(() => expect(getChatMessages).toHaveBeenCalledOnce())
+
+      return { store, loading, getChatMessages, resolve: (value: unknown) => resolveLoad(value) }
+    }
+
+    it('prepends the hydrated history in front of the streaming exchange', async () => {
+      const { store, loading, resolve } = await startDeferredLoad()
+
+      store.addMessage('user', [{ type: 'text', content: 'Hello' }])
+      const assistantId = store.addStreamingMessage('assistant')
+      store.updateStreamingMessage(assistantId, 'Partial reply')
+      resolve({
+        success: true,
+        messages: [
+          { id: 1, direction: 'IN', text: 'Old question', timestamp: 1700000000 },
+          { id: 2, direction: 'OUT', text: 'Old answer', timestamp: 1700000001 },
+        ],
+        pagination: { hasMore: false },
+      })
+      await loading
+
+      expect(store.messages.map((m) => m.parts[0].content)).toEqual([
+        'Old question',
+        'Old answer',
+        'Hello',
+        'Partial reply',
+      ])
+      expect(store.messages.at(-1)?.id).toBe(assistantId)
+      expect(store.messages.at(-1)?.isStreaming).toBe(true)
+    })
+
+    it('does not duplicate the just-sent user message already persisted in the snapshot', async () => {
+      const { store, loading, resolve } = await startDeferredLoad()
+
+      store.addMessage('user', [{ type: 'text', content: 'Hello' }])
+      const localUserId = store.messages[0].id
+      const assistantId = store.addStreamingMessage('assistant')
+      resolve({
+        success: true,
+        messages: [
+          // An OLDER prompt with the same text — must never be dropped.
+          { id: 1, direction: 'IN', text: 'Hello', timestamp: 1700000000 },
+          { id: 2, direction: 'OUT', text: 'Hi there', timestamp: 1700000001 },
+          // The just-sent message, persisted before the response was built.
+          { id: 3, direction: 'IN', text: 'Hello', timestamp: 1700000002 },
+        ],
+        pagination: { hasMore: false },
+      })
+      await loading
+
+      expect(store.messages.map((m) => m.id)).toEqual([
+        'backend-1',
+        'backend-2',
+        localUserId,
+        assistantId,
+      ])
+    })
+
+    it('updates pagination in the merge path so older history stays reachable', async () => {
+      const { store, loading, getChatMessages, resolve } = await startDeferredLoad(true)
+
+      store.addMessage('user', [{ type: 'text', content: 'Hello' }])
+      store.addStreamingMessage('assistant')
+      resolve({
+        success: true,
+        messages: [
+          { id: 1, direction: 'IN', text: 'Old question', timestamp: 1700000000 },
+          { id: 2, direction: 'OUT', text: 'Old answer', timestamp: 1700000001 },
+        ],
+        pagination: { hasMore: true },
+      })
+      await loading
+
+      expect(store.hasMoreMessages).toBe(true)
+      await store.loadMoreMessages(42)
+      expect(getChatMessages).toHaveBeenLastCalledWith(42, 2, 50)
+    })
+  })
+
+  /**
    * Issue #955 regression coverage. The chat API ships uploaded voice
    * notes and TTS audio in two shapes:
    *

--- a/frontend/tests/unit/stores/history.spec.ts
+++ b/frontend/tests/unit/stores/history.spec.ts
@@ -135,12 +135,12 @@ describe('History Store', () => {
   })
 
   /**
-   * PR #1437 review: a foreground hydration that resolves while a live
-   * stream is in flight must MERGE its snapshot in front of the streaming
-   * tail instead of dropping it — otherwise the chat shows no prior history
-   * and the pagination state (reset before the fetch) stays exhausted.
+   * A foreground hydration that resolves while a live stream is in flight must
+   * MERGE its snapshot in front of the streaming tail instead of dropping it —
+   * otherwise the chat shows no prior history and the pagination state (reset
+   * before the fetch) stays exhausted.
    */
-  describe('loadMessages — hydration racing a live stream (PR #1437)', () => {
+  describe('loadMessages — hydration racing a live stream', () => {
     const startDeferredLoad = async (extraResponses = false) => {
       vi.resetModules()
       let resolveLoad!: (value: unknown) => void
@@ -219,6 +219,32 @@ describe('History Store', () => {
         'backend-1',
         'backend-2',
         localUserId,
+        assistantId,
+      ])
+    })
+
+    it('keeps older attachment-only prompts when the live send carries no text', async () => {
+      const { store, loading, resolve } = await startDeferredLoad()
+
+      store.addMessage('user', [{ type: 'image', content: 'photo.png' }])
+      const assistantId = store.addStreamingMessage('assistant')
+      resolve({
+        success: true,
+        messages: [
+          { id: 1, direction: 'IN', text: '', timestamp: 1700000000 },
+          { id: 2, direction: 'OUT', text: 'Old answer', timestamp: 1700000001 },
+          // Also text-less, and equally not the message being sent right now.
+          { id: 3, direction: 'IN', text: '', timestamp: 1700000002 },
+        ],
+        pagination: { hasMore: false },
+      })
+      await loading
+
+      expect(store.messages.map((m) => m.id)).toEqual([
+        'backend-1',
+        'backend-2',
+        'backend-3',
+        store.messages[3].id,
         assistantId,
       ])
     })


### PR DESCRIPTION
## Summary
Make Synaplan deployable as a managed one-click offering on Elestio, built on a platform-neutral production stack (`deploy/`) that is reusable for other providers (Coolify, CapRover, PikaPods, Railway) later.

## Changes
- **Portable production stack**: `deploy/compose.yaml` (backend/worker/scheduler roles, MariaDB, Redis, Centrifugo, Tika, Qdrant; cloud-AI default, optional `local-ai` profile with Ollama/Whisper), `deploy/compose.docker-desktop.yaml` override (named volumes for macOS), `deploy/selfhost.env.example`, `deploy/README.md`.
- **Role-based container runtime**: `_docker/backend/lib/container-runtime.sh` + `docker-entrypoint.sh` + `container-healthcheck.sh` — `SYNAPLAN_ROLE` web/worker/scheduler, database/web-init waits with diagnosable timeouts (exit 67 guidance), early fail-fast validation of bootstrap-admin configuration (pairing exit 78; full rules via the authoritative PHP validator), shell test suite `_docker/backend/tests/test-container-runtime.sh`.
- **First-admin bootstrap (backend)**: `app:bootstrap-admin` command, `BootstrapAdminService`, `BootstrapAdminConfiguration` value object (pairing, email ≤128 chars + `filter_var`, password 8–64 chars, NIST-aligned composition waiver at ≥16 chars, `SensitiveParameterValue`), driven by `BOOTSTRAP_ADMIN_EMAIL`/`BOOTSTRAP_ADMIN_PASSWORD`; idempotent, never touches an existing admin; unit + command tests; `backend/scripts/create_admin.php` now wraps the command.
- **Galera-safe migrations**: four production-reachable migrations converted from DBAL `Schema` introspection to idempotent raw SQL / `information_schema` queries; `ProductionMigrationSafetyTest` locks the rule.
- **Lifecycle scripts** (`deploy/scripts/`): prepare, validate-release, build, run, pre/post backup/restore/update, smoke-test, shared `lib.sh` — host-side preflight with two-tier bootstrap-admin validation (incl. containerized contract probe), env-file resolution with host-env > `deploy/.env` > checkout-root `.env` precedence (Elestio materialises config as a root `.env`), `validate_secret_roundtrip` guard detecting Compose dotenv mangling (`$`, quotes, whitespace, trailing ` #`, CRLF/BOM), quoted DB healthcheck password; Docker-free test suite `deploy/scripts/tests/test-lifecycle.sh` wired into CI.
- **Elestio adapter**: `elestio.yml` (dockerCompose runtime, lifecycle hooks, webUI), `deploy/elestio/` wrapper scripts + README (password-generator evidence, redeploy rotation warning, rejected-email guidance), partnership draft `docs/ELESTIO_PARTNERSHIP_DRAFT.md`.
- **CI**: multi-arch image publishing (amd64+arm64, versioned tags, manifest verification); shell suites + bootstrap-admin contract test wired into existing jobs.
- **Docs**: `docs/INSTALLATION.md`, `docs/ADMIN.md` (lost-admin-password recovery incl. verified exec commands, promotion SQL with `BEMAILVERIFIED`), `docs/EMAIL.md` (DSN percent-encoding).
- **Fixes en route**: backend `Makefile` (`max_execution_time=0` for PHPUnit) + `XaiProviderTest` CLI time-limit restore, root `Makefile` (`--wait` for the E2E stack), `docker-compose.test.yml` (`RECAPTCHA_ENABLED: "false"`), `frontend/src/stores/history.ts` (guard against stale history hydration overwriting a streaming assistant message, with unit test).

## Verification
- [ ] Not tested (explain)
- [x] Manual
- [x] Tests added/updated

Full unfiltered quality gate green:
- `make lint` (backend + frontend) — clean
- `make -C backend phpstan` — 978 files, no errors
- `make -C backend test` — 3172 tests, 11508 assertions
- `make -C frontend test` — 988 tests; `vue-tsc` clean
- `test-container-runtime.sh` — 58/58 assertions; migrations-bootstrap suite — 38/38
- `test-lifecycle.sh` — green on BSD awk, mawk and gawk
- Bootstrap-admin containerized contract test verified; all compose/`elestio.yml` YAML parses; fresh-install migration run clean

Manual verifications:
- Container healthcheck with a DB password containing a space
- Env-file precedence (host env > `deploy/.env` > root `.env`) end-to-end
- `validate_secret_roundtrip` detection cases (`$`, quotes, whitespace, trailing ` #`, CRLF/BOM)

## Notes
- The assumption that Elestio delivers configuration as a root `.env` in the checkout is inferred from official Elestio examples; it should be confirmed during the trial deployment on our own Elestio test server before catalog submission.
- Mobile-app classification: backend-only/infrastructure — no SPA behavior change except the history-hydration fix, which is web.

## Screenshots/Logs
```
PHPStan: [OK] No errors (978 files)
PHPUnit: OK (3172 tests, 11508 assertions)
Vitest:  Test Files 65 passed, Tests 988 passed
vue-tsc: clean (no output)
container-runtime: 58/58 assertions passed
migrations-bootstrap: 38/38 assertions passed
lifecycle: all suites green (BSD awk, mawk, gawk)
```