### PR TITLE
feat: show the installed version and notify admins about new releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -892,6 +892,12 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      # The version release-manifest advertises. Taken from the metadata step
+      # that produced the pushed image tags, so the manifest can only ever name
+      # a version this job actually published — never one re-derived from the
+      # ref by a second, possibly diverging, expression.
+      version: ${{ steps.meta.outputs.version }}
 
     steps:
       - name: Checkout
@@ -1078,6 +1084,110 @@ jobs:
           docker buildx imagetools inspect \
             "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${IMAGE_DIGEST}"
 
+  release-manifest:
+    name: Publish Release Manifest
+    runs-on: ubuntu-latest
+    # An instance learns that a newer release exists from versions.json, so the
+    # manifest must never exist before the image it names. docker-push completes
+    # only after the multi-arch manifest was created AND verified to expose both
+    # platforms at the tested digests, which makes it the earliest point where
+    # advertising the version is honest.
+    needs: [docker-push]
+    # Release tags only. A main push publishes `latest`, which is not a release,
+    # and a pull request publishes nothing at all.
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      # The only write privilege in this workflow, and only for the push below.
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          # Nothing but scripts/release-manifest.mjs is used from this checkout,
+          # and the push below authenticates through its own remote URL, so no
+          # writable token belongs in .git/config.
+          persist-credentials: false
+
+      - name: Publish versions.json
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.docker-push.outputs.version }}
+          # NOT main, and this is the reason the branch exists: Elestio pipelines
+          # track main and redeploy on every commit, so a manifest commit there
+          # would restart every managed instance on every release. The branch
+          # holds versions.json on an orphan history and nothing else, which also
+          # keeps it out of diffs, release archives and CI runs on main.
+          BRANCH: release-manifest
+        run: |
+          set -euo pipefail
+
+          # docker/metadata-action derives {{version}} from the tag. Cross-check
+          # it against the ref so a change in that derivation cannot shift the
+          # advertised version away from the tag that was actually published.
+          if [ "$VERSION" != "${GITHUB_REF_NAME#v}" ]; then
+            echo "::error::Published version ${VERSION} does not match tag ${GITHUB_REF_NAME}"
+            exit 1
+          fi
+
+          # A pre-release (v5.0.0-rc.1) is a legitimate deployment pin, but it
+          # must never become `stable` — so it publishes nothing instead of
+          # failing the release run. The generator refuses one as a backstop.
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Tag ${GITHUB_REF_NAME} is not a plain release; no manifest is published." |
+              tee -a "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          work_dir="$(mktemp -d)"
+          branch_dir="$work_dir/branch"
+          mkdir -p "$branch_dir"
+          git -C "$branch_dir" init -q -b "$BRANCH"
+          git -C "$branch_dir" config user.name 'github-actions[bot]'
+          git -C "$branch_dir" config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git -C "$branch_dir" remote add origin \
+            "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+          manifest=(--version "$VERSION" --repository "$GITHUB_REPOSITORY")
+          if git -C "$branch_dir" fetch -q --depth 1 origin "refs/heads/${BRANCH}"; then
+            git -C "$branch_dir" reset -q --hard FETCH_HEAD
+            # The current manifest is read from OUTSIDE the work tree: the
+            # generator's stdout is redirected onto versions.json, which
+            # truncates the file before it could be read in place — and its
+            # `yanked` list has to survive this release.
+            if [ -f "$branch_dir/versions.json" ]; then
+              cp "$branch_dir/versions.json" "$work_dir/existing.json"
+              manifest+=(--existing "$work_dir/existing.json")
+            fi
+          else
+            echo "Branch ${BRANCH} does not exist yet; this push creates it."
+          fi
+
+          node scripts/release-manifest.mjs "${manifest[@]}" > "$branch_dir/versions.json"
+
+          git -C "$branch_dir" add versions.json
+          # Re-running the same tag produces the same manifest, so there is
+          # nothing to commit — the job is idempotent and safe to re-run.
+          if git -C "$branch_dir" diff --quiet --cached; then
+            echo "versions.json is already up to date; nothing was published." |
+              tee -a "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          git -C "$branch_dir" commit -q -m "chore(release): publish versions.json for ${VERSION}"
+          git -C "$branch_dir" push -q origin "HEAD:refs/heads/${BRANCH}"
+
+          {
+            echo "Published \`versions.json\` on \`${BRANCH}\`:"
+            echo ''
+            echo '```json'
+            cat "$branch_dir/versions.json"
+            echo '```'
+            echo ''
+            echo "A security release is marked by editing \`severity\` to" \
+              "\`security\` on \`${BRANCH}\`; the next release resets it, which is" \
+              "correct — the field describes that release."
+          } >> "$GITHUB_STEP_SUMMARY"
+
   cloudflare-deploy:
     name: Deploy Cloudflare Worker
     runs-on: ubuntu-latest
@@ -1109,7 +1219,7 @@ jobs:
   all-checks-passed:
     name: All Checks Passed
     runs-on: ubuntu-latest
-    needs: [lint, mobile-tooling, backend, frontend-build, frontend-checks, docker-build, e2e, e2e-visual, docker-push, cloudflare-deploy]
+    needs: [lint, mobile-tooling, backend, frontend-build, frontend-checks, docker-build, e2e, e2e-visual, docker-push, release-manifest, cloudflare-deploy]
     if: always()
     steps:
       - name: Check for failures
@@ -1124,6 +1234,7 @@ jobs:
             needs.e2e.result != 'success' ||
             needs.e2e-visual.result != 'success' ||
             (needs.docker-push.result != 'success' && needs.docker-push.result != 'skipped') ||
+            (needs.release-manifest.result != 'success' && needs.release-manifest.result != 'skipped') ||
             (needs.cloudflare-deploy.result != 'success' && needs.cloudflare-deploy.result != 'skipped')
           )
         run: |

--- a/_docker/backend/lib/container-runtime.sh
+++ b/_docker/backend/lib/container-runtime.sh
@@ -339,8 +339,10 @@ run_scheduler_role() {
     local env="${APP_ENV:-prod}"
     local tick_seconds="${SYNAPLAN_SCHEDULER_TICK_SECONDS:-60}"
     local hourly_seconds="${SYNAPLAN_SCHEDULER_HOURLY_SECONDS:-3600}"
+    local daily_seconds="${SYNAPLAN_SCHEDULER_DAILY_SECONDS:-86400}"
     local now
     local next_hourly=0
+    local next_daily=0
     local cycles=0
     local max_cycles="${SYNAPLAN_SCHEDULER_MAX_CYCLES:-0}"
 
@@ -350,7 +352,7 @@ run_scheduler_role() {
     mkdir -p "$SYNAPLAN_RUNTIME_DIR"
     trap stop_scheduler TERM INT
 
-    runtime_log "Starting scheduler (media reaper every ${tick_seconds}s, ephemeral-file reaper every ${hourly_seconds}s)."
+    runtime_log "Starting scheduler (media reaper every ${tick_seconds}s, ephemeral-file reaper every ${hourly_seconds}s, update check every ${daily_seconds}s)."
     while [ "$_scheduler_stopping" -eq 0 ]; do
         now="$(date +%s)"
         printf '%s\n' "$now" > "${SYNAPLAN_RUNTIME_DIR}/scheduler.heartbeat"
@@ -364,6 +366,17 @@ run_scheduler_role() {
                 runtime_log "Ephemeral-file reaper failed; it will be retried next hour." >&2
             fi
             next_hourly=$((now + hourly_seconds))
+        fi
+
+        # Release-notice detection. Detection only: it stores the published
+        # version in BCONFIG and never touches the installation, so a failure
+        # (offline instance, unreachable manifest) is expected and is simply
+        # retried on the next interval.
+        if [ "$now" -ge "$next_daily" ]; then
+            if ! run_scheduler_command bin/console --env="$env" app:updates:check --no-interaction; then
+                runtime_log "Update check failed; it will be retried on the next daily interval." >&2
+            fi
+            next_daily=$((now + daily_seconds))
         fi
 
         cycles=$((cycles + 1))

--- a/_docker/backend/tests/test-container-runtime.sh
+++ b/_docker/backend/tests/test-container-runtime.sh
@@ -84,7 +84,7 @@ echo "Case 1: worker waits for initialization and preserves Messenger defaults"
 assert_contains "doctrine:migrations:up-to-date --no-interaction" "$COMMAND_LOG" "worker waits until migrations are current"
 assert_contains "messenger:consume async_ai_high async_extract async_index --time-limit=3600 --memory-limit=512M -v" "$COMMAND_LOG" "worker consumes all current transports with current limits"
 
-echo "Case 2: scheduler runs both commands initially and writes a heartbeat"
+echo "Case 2: scheduler runs every slot's command initially and writes a heartbeat"
 : > "$COMMAND_LOG"
 (
     cd "$TMP_DIR/app" || exit
@@ -104,6 +104,7 @@ echo "Case 2: scheduler runs both commands initially and writes a heartbeat"
 )
 assert_contains "app:media:reap-jobs --no-interaction" "$COMMAND_LOG" "scheduler runs media reaper"
 assert_contains "app:files:reap-ephemeral --no-interaction" "$COMMAND_LOG" "scheduler runs ephemeral-file reaper"
+assert_contains "app:updates:check --no-interaction" "$COMMAND_LOG" "scheduler runs the daily update check"
 if [ -s "$TMP_DIR/runtime/scheduler.heartbeat" ]; then
     assert_eq 1 1 "scheduler writes liveness heartbeat"
 else

--- a/backend/config/services.yaml
+++ b/backend/config/services.yaml
@@ -15,6 +15,12 @@ parameters:
     # nothing hard-codes a release number that inevitably drifts.
     app_version_default: 'dev'
 
+    # Deployment platform hint for the release-notice guide link. Optional and
+    # additive: an unset (or unknown) value means the self-hosted guide, so
+    # nothing breaks when a deployment does not set it. deploy/compose.yaml
+    # passes it through; elestio.yml sets it to 'elestio'.
+    env(SYNAPLAN_PLATFORM): 'selfhost'
+
     # OIDC admin role claim values (comma-separated, case-insensitive)
     env(OIDC_ADMIN_ROLES): 'admin,realm-admin,synaplan-admin,administrator'
 
@@ -948,6 +954,19 @@ services:
     # Alias for injection
     App\Service\RAG\VectorStorage\VectorStorageInterface:
         alias: App\Service\RAG\VectorStorage\VectorStorageFacade
+
+    # Release-notice detection (app:updates:check + /api/v1/admin/updates).
+    # Never changes the installation: the scheduler stores the published
+    # manifest's stable version in BCONFIG and the admin API only reads it.
+    # The running version comes from APP_VERSION, exactly like the runtime
+    # config's build.version, and falls back to 'dev' in a source checkout.
+    App\Service\Update\UpdateStatusService:
+        arguments:
+            $appVersion: '%env(default:app_version_default:APP_VERSION)%'
+
+    App\Service\Update\UpdatePlatformGuide:
+        arguments:
+            $platform: '%env(string:SYNAPLAN_PLATFORM)%'
 
     # Widget real-time event store (SSE backing).
     # DB-backed (Galera-replicated) so events are visible cluster-wide; swap this

--- a/backend/src/Command/CheckUpdatesCommand.php
+++ b/backend/src/Command/CheckUpdatesCommand.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Service\Update\UpdateStatusService;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Refreshes the stored release-notice status (detection only — this command
+ * never changes the installation).
+ *
+ * Run once per day by the scheduler container. A network failure or an
+ * unreadable manifest is an EXPECTED outcome, recorded in BCONFIG and reported
+ * as success: the scheduler log must not fill up with stack traces because
+ * GitHub was briefly unreachable. Only a genuinely unexpected error exits
+ * non-zero.
+ */
+#[AsCommand(
+    name: 'app:updates:check',
+    description: 'Check whether a newer Synaplan release exists and store the result (no installation change)'
+)]
+final class CheckUpdatesCommand extends Command
+{
+    public function __construct(
+        private readonly UpdateStatusService $updateStatusService,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addOption(
+            'force',
+            null,
+            InputOption::VALUE_NONE,
+            'Bypass the cached manifest and fetch it again'
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        try {
+            $status = $this->updateStatusService->refresh(force: (bool) $input->getOption('force'));
+        } catch (\Throwable $e) {
+            $output->writeln(sprintf('<error>Update check failed unexpectedly: %s</error>', $e->getMessage()));
+
+            return Command::FAILURE;
+        }
+
+        $output->writeln($this->summarize($status));
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @param array{currentVersion: string, latestVersion: string|null, updateAvailable: bool, severity: string, lastError: string|null, checkEnabled: bool} $status
+     */
+    private function summarize(array $status): string
+    {
+        if (!$status['checkEnabled']) {
+            return 'Update check is disabled; nothing was fetched.';
+        }
+
+        if (null !== $status['lastError']) {
+            return sprintf('Update check could not complete: %s', $status['lastError']);
+        }
+
+        if ($status['updateAvailable']) {
+            return sprintf(
+                'Update available: %s (current %s, severity %s).',
+                (string) $status['latestVersion'],
+                $status['currentVersion'],
+                $status['severity'],
+            );
+        }
+
+        return sprintf(
+            'No update available (current %s, latest known %s).',
+            $status['currentVersion'],
+            $status['latestVersion'] ?? 'unknown',
+        );
+    }
+}

--- a/backend/src/Command/SeedAllCommand.php
+++ b/backend/src/Command/SeedAllCommand.php
@@ -17,6 +17,7 @@ use App\Seed\PromptSeeder;
 use App\Seed\RateLimitConfigSeeder;
 use App\Seed\SeedResult;
 use App\Seed\SubscriptionPlanSeeder;
+use App\Seed\UpdateConfigSeeder;
 use App\Seed\UsageTaximeterConfigSeeder;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -40,7 +41,8 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  *  10. mobile        (BCONFIG: MOBILE forced-update gate defaults, ownerId=0)
  *  11. marketing-news (BCONFIG: MARKETING_NEWS guest-landing flags, master switch OFF)
  *  12. usage-taximeter (BCONFIG: USAGE_TAXIMETER display switch, ownerId=0 — default ON)
- *  13. demo-widget   (BCONFIG: example widget for ownerId=2 — dev/test only, no-op in prod)
+ *  13. updates       (BCONFIG: UPDATES release-notice switch + manifest URL, ownerId=0 — default ON)
+ *  14. demo-widget   (BCONFIG: example widget for ownerId=2 — dev/test only, no-op in prod)
  *
  * Wired into the Docker entrypoint after `doctrine:migrations:migrate`, so it runs
  * on every container startup in dev AND prod.
@@ -65,6 +67,7 @@ final class SeedAllCommand extends Command
         private readonly MobileConfigSeeder $mobileConfigSeeder,
         private readonly MarketingNewsConfigSeeder $marketingNewsConfigSeeder,
         private readonly UsageTaximeterConfigSeeder $usageTaximeterConfigSeeder,
+        private readonly UpdateConfigSeeder $updateConfigSeeder,
     ) {
         parent::__construct();
     }
@@ -85,7 +88,8 @@ final class SeedAllCommand extends Command
             "  10. mobile gate defaults       (BCONFIG, group=MOBILE, ownerId=0)\n".
             "  11. marketing news flags       (BCONFIG, group=MARKETING_NEWS, ownerId=0 — master switch OFF)\n".
             "  12. usage taximeter switch      (BCONFIG, group=USAGE_TAXIMETER, ownerId=0 — default ON)\n".
-            "  13. demo widget config         (BCONFIG, group=widget_1, ownerId=2 — dev/test only)\n\n".
+            "  13. update notice config       (BCONFIG, group=UPDATES, ownerId=0 — default ON)\n".
+            "  14. demo widget config         (BCONFIG, group=widget_1, ownerId=2 — dev/test only)\n\n".
             'All steps are idempotent and safe to run on every deploy. The demo-widget step is a no-op in prod.'
         );
     }
@@ -108,6 +112,7 @@ final class SeedAllCommand extends Command
             ['mobile',      fn (): SeedResult => $this->mobileConfigSeeder->seed()],
             ['marketing-news', fn (): SeedResult => $this->marketingNewsConfigSeeder->seed()],
             ['usage-taximeter', fn (): SeedResult => $this->usageTaximeterConfigSeeder->seed()],
+            ['updates',      fn (): SeedResult => $this->updateConfigSeeder->seed()],
             ['demo-widget', fn (): SeedResult => $this->demoWidgetConfigSeeder->seed()],
         ];
 

--- a/backend/src/Controller/AdminUpdatesController.php
+++ b/backend/src/Controller/AdminUpdatesController.php
@@ -1,0 +1,332 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\DTO\AdminUpdateDismissRequest;
+use App\DTO\AdminUpdateSettingsRequest;
+use App\Service\Update\ReleaseManifest;
+use App\Service\Update\UpdatePlatformGuide;
+use App\Service\Update\UpdateStatusService;
+use OpenApi\Attributes as OA;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Attribute\MapRequestPayload;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/**
+ * Release-notice endpoints for admins.
+ *
+ * Detection and display ONLY: nothing here downloads, installs or selects a
+ * version. `GET /status` reads values the daily scheduler check stored in
+ * BCONFIG, so it works offline; `POST /check` is the manual "check now" button
+ * and is the only endpoint that may perform an outbound request.
+ *
+ * SECURITY: all endpoints require ROLE_ADMIN (class-level IsGranted).
+ */
+#[Route('/api/v1/admin/updates')]
+#[IsGranted('ROLE_ADMIN', message: 'Admin access required')]
+#[OA\Tag(name: 'Admin Updates')]
+final class AdminUpdatesController extends AbstractController
+{
+    public function __construct(
+        private readonly UpdateStatusService $updateStatusService,
+        private readonly UpdatePlatformGuide $platformGuide,
+    ) {
+    }
+
+    /**
+     * Stored update status (no outbound request).
+     */
+    #[Route('/status', name: 'admin_updates_status', methods: ['GET'])]
+    #[OA\Get(
+        path: '/api/v1/admin/updates/status',
+        summary: 'Get the stored update status',
+        description: 'Returns the result of the last daily update check. Reads stored values only — no outbound HTTP, so it also works without internet access (admin only).',
+        security: [['Bearer' => []]],
+        tags: ['Admin Updates']
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'Stored update status',
+        content: new OA\JsonContent(
+            required: [
+                'currentVersion',
+                'latestVersion',
+                'updateAvailable',
+                'notesUrl',
+                'severity',
+                'releasedAt',
+                'lastCheckedAt',
+                'lastError',
+                'checkEnabled',
+                'dismissedVersion',
+                'platform',
+                'guideUrl',
+            ],
+            properties: [
+                new OA\Property(
+                    property: 'currentVersion',
+                    type: 'string',
+                    description: "Running release (APP_VERSION); 'dev' for a source checkout, which cannot be compared",
+                    example: '4.0.12'
+                ),
+                new OA\Property(
+                    property: 'latestVersion',
+                    type: 'string',
+                    nullable: true,
+                    description: 'Latest known stable release, or null when no check has succeeded yet',
+                    example: '4.0.13'
+                ),
+                new OA\Property(
+                    property: 'updateAvailable',
+                    type: 'boolean',
+                    description: 'True only when the latest known release is strictly newer than the running one',
+                    example: true
+                ),
+                new OA\Property(
+                    property: 'notesUrl',
+                    type: 'string',
+                    nullable: true,
+                    description: 'Release notes of the latest known release',
+                    example: 'https://github.com/metadist/synaplan/releases/tag/v4.0.13'
+                ),
+                new OA\Property(
+                    property: 'severity',
+                    type: 'string',
+                    enum: [ReleaseManifest::SEVERITY_NORMAL, ReleaseManifest::SEVERITY_SECURITY],
+                    description: 'Importance of the latest known release',
+                    example: ReleaseManifest::SEVERITY_NORMAL
+                ),
+                new OA\Property(
+                    property: 'releasedAt',
+                    type: 'string',
+                    nullable: true,
+                    description: 'Publication timestamp of the latest known release (ISO-8601)',
+                    example: '2026-08-10T09:00:00Z'
+                ),
+                new OA\Property(
+                    property: 'lastCheckedAt',
+                    type: 'string',
+                    nullable: true,
+                    description: 'When the check last ran (ISO-8601, UTC), or null when it never ran',
+                    example: '2026-08-10T09:05:00+00:00'
+                ),
+                new OA\Property(
+                    property: 'lastError',
+                    type: 'string',
+                    nullable: true,
+                    description: 'Why the last check could not complete; null after a successful check',
+                    example: null
+                ),
+                new OA\Property(
+                    property: 'checkEnabled',
+                    type: 'boolean',
+                    description: 'Master switch: while false no outbound request is ever made',
+                    example: true
+                ),
+                new OA\Property(
+                    property: 'dismissedVersion',
+                    type: 'string',
+                    nullable: true,
+                    description: 'Version the admin acknowledged, so the notice can stay hidden',
+                    example: null
+                ),
+                new OA\Property(
+                    property: 'platform',
+                    type: 'string',
+                    enum: [UpdatePlatformGuide::PLATFORM_SELFHOST, UpdatePlatformGuide::PLATFORM_ELESTIO],
+                    description: 'Deployment hint (SYNAPLAN_PLATFORM), used to pick the update guide',
+                    example: UpdatePlatformGuide::PLATFORM_SELFHOST
+                ),
+                new OA\Property(
+                    property: 'guideUrl',
+                    type: 'string',
+                    description: 'Manual-update guide for this platform — the link the update button opens',
+                    example: UpdatePlatformGuide::GUIDE_URL_SELFHOST
+                ),
+            ]
+        )
+    )]
+    #[OA\Response(response: 401, description: 'Authentication required')]
+    #[OA\Response(response: 403, description: 'Admin access required')]
+    public function getStatus(): JsonResponse
+    {
+        return $this->json($this->payload());
+    }
+
+    /**
+     * Run the check now and return the refreshed status.
+     */
+    #[Route('/check', name: 'admin_updates_check', methods: ['POST'])]
+    #[OA\Post(
+        path: '/api/v1/admin/updates/check',
+        summary: 'Check for a newer release now',
+        description: 'Fetches the release manifest, stores the outcome and returns the refreshed status. A network failure is reported through lastError, not as an HTTP error. Does nothing when the master switch is off (admin only).',
+        security: [['Bearer' => []]],
+        tags: ['Admin Updates']
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'Refreshed update status — same payload as GET /api/v1/admin/updates/status',
+        content: new OA\JsonContent(
+            required: [
+                'currentVersion',
+                'latestVersion',
+                'updateAvailable',
+                'notesUrl',
+                'severity',
+                'releasedAt',
+                'lastCheckedAt',
+                'lastError',
+                'checkEnabled',
+                'dismissedVersion',
+                'platform',
+                'guideUrl',
+            ],
+            properties: [
+                new OA\Property(property: 'currentVersion', type: 'string', example: '4.0.12'),
+                new OA\Property(property: 'latestVersion', type: 'string', nullable: true, example: '4.0.13'),
+                new OA\Property(property: 'updateAvailable', type: 'boolean', example: true),
+                new OA\Property(
+                    property: 'notesUrl',
+                    type: 'string',
+                    nullable: true,
+                    example: 'https://github.com/metadist/synaplan/releases/tag/v4.0.13'
+                ),
+                new OA\Property(
+                    property: 'severity',
+                    type: 'string',
+                    enum: [ReleaseManifest::SEVERITY_NORMAL, ReleaseManifest::SEVERITY_SECURITY],
+                    example: ReleaseManifest::SEVERITY_NORMAL
+                ),
+                new OA\Property(property: 'releasedAt', type: 'string', nullable: true, example: '2026-08-10T09:00:00Z'),
+                new OA\Property(property: 'lastCheckedAt', type: 'string', nullable: true, example: '2026-08-10T09:05:00+00:00'),
+                new OA\Property(property: 'lastError', type: 'string', nullable: true, example: null),
+                new OA\Property(property: 'checkEnabled', type: 'boolean', example: true),
+                new OA\Property(property: 'dismissedVersion', type: 'string', nullable: true, example: null),
+                new OA\Property(
+                    property: 'platform',
+                    type: 'string',
+                    enum: [UpdatePlatformGuide::PLATFORM_SELFHOST, UpdatePlatformGuide::PLATFORM_ELESTIO],
+                    example: UpdatePlatformGuide::PLATFORM_SELFHOST
+                ),
+                new OA\Property(property: 'guideUrl', type: 'string', example: UpdatePlatformGuide::GUIDE_URL_SELFHOST),
+            ]
+        )
+    )]
+    #[OA\Response(response: 401, description: 'Authentication required')]
+    #[OA\Response(response: 403, description: 'Admin access required')]
+    public function check(): JsonResponse
+    {
+        $status = $this->updateStatusService->refresh();
+
+        return $this->json($this->payload($status));
+    }
+
+    /**
+     * Acknowledge a version so the notice can stay hidden.
+     */
+    #[Route('/dismiss', name: 'admin_updates_dismiss', methods: ['POST'])]
+    #[OA\Post(
+        path: '/api/v1/admin/updates/dismiss',
+        summary: 'Acknowledge an available release',
+        description: 'Stores the acknowledged version so the update notice can stay hidden until a newer release appears (admin only).',
+        security: [['Bearer' => []]],
+        tags: ['Admin Updates']
+    )]
+    #[OA\RequestBody(
+        required: true,
+        content: new OA\JsonContent(
+            required: ['version'],
+            properties: [
+                new OA\Property(property: 'version', type: 'string', example: '4.0.13'),
+            ]
+        )
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'Version acknowledged',
+        content: new OA\JsonContent(
+            required: ['success', 'dismissedVersion'],
+            properties: [
+                new OA\Property(property: 'success', type: 'boolean', example: true),
+                new OA\Property(property: 'dismissedVersion', type: 'string', nullable: true, example: '4.0.13'),
+            ]
+        )
+    )]
+    #[OA\Response(response: 401, description: 'Authentication required')]
+    #[OA\Response(response: 403, description: 'Admin access required')]
+    #[OA\Response(response: 422, description: 'Validation error')]
+    public function dismiss(#[MapRequestPayload] AdminUpdateDismissRequest $dto): JsonResponse
+    {
+        $this->updateStatusService->dismiss($dto->version);
+
+        return $this->json([
+            'success' => true,
+            'dismissedVersion' => $this->updateStatusService->getStatus()['dismissedVersion'],
+        ]);
+    }
+
+    /**
+     * Toggle the master switch.
+     */
+    #[Route('/settings', name: 'admin_updates_settings', methods: ['PUT'])]
+    #[OA\Put(
+        path: '/api/v1/admin/updates/settings',
+        summary: 'Toggle the update check',
+        description: 'Enables or disables the daily update check. While disabled, no outbound request is ever made (admin only).',
+        security: [['Bearer' => []]],
+        tags: ['Admin Updates']
+    )]
+    #[OA\RequestBody(
+        required: true,
+        content: new OA\JsonContent(
+            required: ['checkEnabled'],
+            properties: [
+                new OA\Property(property: 'checkEnabled', type: 'boolean', example: true),
+            ]
+        )
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'Master switch updated',
+        content: new OA\JsonContent(
+            required: ['success', 'checkEnabled'],
+            properties: [
+                new OA\Property(property: 'success', type: 'boolean', example: true),
+                new OA\Property(property: 'checkEnabled', type: 'boolean', example: true),
+            ]
+        )
+    )]
+    #[OA\Response(response: 401, description: 'Authentication required')]
+    #[OA\Response(response: 403, description: 'Admin access required')]
+    #[OA\Response(response: 422, description: 'Validation error')]
+    public function updateSettings(#[MapRequestPayload] AdminUpdateSettingsRequest $dto): JsonResponse
+    {
+        $this->updateStatusService->setCheckEnabled((bool) $dto->checkEnabled);
+
+        return $this->json([
+            'success' => true,
+            'checkEnabled' => $this->updateStatusService->getStatus()['checkEnabled'],
+        ]);
+    }
+
+    /**
+     * The status payload: the stored comparison plus the platform-specific
+     * documentation link the update button opens.
+     *
+     * @param array{currentVersion: string, latestVersion: string|null, updateAvailable: bool, notesUrl: string|null, severity: string, releasedAt: string|null, lastCheckedAt: string|null, lastError: string|null, dismissedVersion: string|null, checkEnabled: bool}|null $status
+     *
+     * @return array<string, bool|string|null>
+     */
+    private function payload(?array $status = null): array
+    {
+        return ($status ?? $this->updateStatusService->getStatus()) + [
+            'platform' => $this->platformGuide->platform(),
+            'guideUrl' => $this->platformGuide->guideUrl(),
+        ];
+    }
+}

--- a/backend/src/DTO/AdminUpdateDismissRequest.php
+++ b/backend/src/DTO/AdminUpdateDismissRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO;
+
+use OpenApi\Attributes as OA;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * Request DTO for acknowledging an available release.
+ */
+#[OA\Schema(
+    schema: 'AdminUpdateDismissRequest',
+    required: ['version'],
+)]
+final class AdminUpdateDismissRequest
+{
+    #[Assert\NotBlank(normalizer: 'trim', message: 'Version is required')]
+    #[Assert\Length(max: 64, maxMessage: 'Version cannot exceed 64 characters')]
+    #[Assert\Regex(
+        pattern: '/^\d+(\.\d+){0,3}([-+][0-9A-Za-z.\-]+)?$/',
+        message: 'Version must look like 4.0.13 or 4.1.0-rc.1'
+    )]
+    #[OA\Property(description: 'The release version the admin acknowledged', example: '4.0.13')]
+    public string $version = '';
+}

--- a/backend/src/DTO/AdminUpdateSettingsRequest.php
+++ b/backend/src/DTO/AdminUpdateSettingsRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO;
+
+use OpenApi\Attributes as OA;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * Request DTO for the update-notice master switch.
+ *
+ * Nullable with a NotNull constraint on purpose: an omitted field must be a
+ * validation error, not a silent "false" that turns the check off.
+ */
+#[OA\Schema(
+    schema: 'AdminUpdateSettingsRequest',
+    required: ['checkEnabled'],
+)]
+final class AdminUpdateSettingsRequest
+{
+    #[Assert\NotNull(message: 'checkEnabled is required')]
+    #[Assert\Type(type: 'bool', message: 'checkEnabled must be a boolean')]
+    #[OA\Property(description: 'Whether the daily update check may run', example: true)]
+    public ?bool $checkEnabled = null;
+}

--- a/backend/src/Seed/UpdateConfigSeeder.php
+++ b/backend/src/Seed/UpdateConfigSeeder.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Seed;
+
+use App\Service\Update\UpdateConfig;
+use Doctrine\DBAL\Connection;
+
+/**
+ * Idempotent seeder for the update-notice config (BCONFIG, ownerId=0).
+ *
+ * Seeds the two operator-owned settings (master switch ON, manifest URL) plus
+ * the result fields the daily check writes — the latter as empty strings, so the
+ * rows are visible and editable before the first check has ever run.
+ * Insert-if-missing only; operator overrides are never touched.
+ *
+ * NOTE: BCONFIG defaults are bootstrap-only. Nothing here propagates to an
+ * existing install until `app:seed` runs, which is why every read in
+ * {@see UpdateConfig} falls back to the same built-in default when its row is
+ * missing. Changing a default later would need an explicit UPDATE migration
+ * (see docs/MIGRATIONS.md).
+ */
+final readonly class UpdateConfigSeeder
+{
+    public function __construct(
+        private Connection $connection,
+    ) {
+    }
+
+    public function seed(): SeedResult
+    {
+        $group = UpdateConfig::CONFIG_GROUP;
+
+        $rows = [
+            [
+                'ownerId' => UpdateConfig::OWNER_ID,
+                'group' => $group,
+                'setting' => UpdateConfig::KEY_CHECK_ENABLED,
+                // Master switch ON: detection never changes the installation,
+                // and UpdateConfig applies the same default when the row is
+                // missing entirely.
+                'value' => '1',
+            ],
+            [
+                'ownerId' => UpdateConfig::OWNER_ID,
+                'group' => $group,
+                'setting' => UpdateConfig::KEY_MANIFEST_URL,
+                'value' => UpdateConfig::DEFAULT_MANIFEST_URL,
+            ],
+        ];
+
+        $resultKeys = [
+            UpdateConfig::KEY_LATEST_VERSION,
+            UpdateConfig::KEY_LATEST_NOTES_URL,
+            UpdateConfig::KEY_LATEST_SEVERITY,
+            UpdateConfig::KEY_LATEST_RELEASED_AT,
+            UpdateConfig::KEY_LAST_CHECKED_AT,
+            UpdateConfig::KEY_LAST_ERROR,
+            UpdateConfig::KEY_DISMISSED_VERSION,
+        ];
+
+        foreach ($resultKeys as $setting) {
+            $rows[] = [
+                'ownerId' => UpdateConfig::OWNER_ID,
+                'group' => $group,
+                'setting' => $setting,
+                'value' => '',
+            ];
+        }
+
+        return BConfigSeeder::insertIfMissing($this->connection, 'update_config', $rows);
+    }
+}

--- a/backend/src/Service/Update/ReleaseManifest.php
+++ b/backend/src/Service/Update/ReleaseManifest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Update;
+
+/**
+ * Immutable, already-validated view of the published release manifest.
+ *
+ * Only {@see UpdateManifestClient} creates instances, and it only does so for a
+ * payload that passed every structural check — so every consumer can rely on
+ * `version` being a comparable version string, `notesUrl` being an http(s) URL
+ * or null, and `severity` being one of the two known values.
+ */
+final readonly class ReleaseManifest
+{
+    public const SEVERITY_NORMAL = 'normal';
+    public const SEVERITY_SECURITY = 'security';
+
+    /**
+     * @param list<string> $yankedVersions versions that must never be recommended
+     */
+    public function __construct(
+        public string $version,
+        public ?string $notesUrl,
+        public string $severity,
+        public ?string $releasedAt,
+        public array $yankedVersions,
+    ) {
+    }
+
+    /**
+     * Whether the given version was withdrawn by the publisher.
+     *
+     * Compared with version_compare() rather than string equality, so a
+     * withdrawn release cannot slip through because the publisher spelled its
+     * separators differently ('4.1.0-rc.1' / '4.1.0.rc.1').
+     */
+    public function isYanked(string $version): bool
+    {
+        foreach ($this->yankedVersions as $yanked) {
+            if (version_compare($version, $yanked, '==')) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/backend/src/Service/Update/UpdateConfig.php
+++ b/backend/src/Service/Update/UpdateConfig.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Update;
+
+use App\Repository\ConfigRepository;
+
+/**
+ * Update-notice configuration and stored check result (BCONFIG group UPDATES,
+ * ownerId 0).
+ *
+ * Two operator-owned settings — the master switch and the manifest URL (so
+ * forks and air-gapped installs can repoint or disable the check) — plus the
+ * result fields the daily check writes. The admin API only ever READS the
+ * result fields, so no request path performs outbound HTTP.
+ *
+ * Every read has a built-in fallback for a MISSING row (and treats a
+ * whitespace-only value as missing), because BCONFIG seeder defaults are
+ * bootstrap-only: an install that upgraded into this feature has no UPDATES
+ * rows at all until the next `app:seed`, and must still behave exactly like a
+ * freshly seeded one.
+ */
+final readonly class UpdateConfig
+{
+    public const CONFIG_GROUP = 'UPDATES';
+    public const OWNER_ID = 0;
+
+    public const KEY_CHECK_ENABLED = 'CHECK_ENABLED';
+    public const KEY_MANIFEST_URL = 'MANIFEST_URL';
+    public const KEY_LATEST_VERSION = 'LATEST_VERSION';
+    public const KEY_LATEST_NOTES_URL = 'LATEST_NOTES_URL';
+    public const KEY_LATEST_SEVERITY = 'LATEST_SEVERITY';
+    public const KEY_LATEST_RELEASED_AT = 'LATEST_RELEASED_AT';
+    public const KEY_LAST_CHECKED_AT = 'LAST_CHECKED_AT';
+    public const KEY_LAST_ERROR = 'LAST_ERROR';
+    public const KEY_DISMISSED_VERSION = 'DISMISSED_VERSION';
+
+    /**
+     * Published manifest of the upstream project. A plain static file: the check
+     * is a bare GET with no instance identifier, no telemetry and no query
+     * parameters.
+     */
+    public const DEFAULT_MANIFEST_URL = 'https://raw.githubusercontent.com/metadist/synaplan/release-manifest/versions.json';
+
+    /**
+     * Detection is a display-only feature that never changes the installation,
+     * so it defaults ON — an operator who does not want any outbound request
+     * turns it off (or empties MANIFEST_URL).
+     */
+    private const DEFAULT_CHECK_ENABLED = true;
+
+    /**
+     * A recorded error is operator-facing context, not a log sink: cap it so a
+     * server answering with a whole HTML page never lands in BCONFIG.
+     */
+    private const MAX_ERROR_LENGTH = 500;
+
+    public function __construct(
+        private ConfigRepository $configRepository,
+    ) {
+    }
+
+    /**
+     * Master switch. Defaults ON when no row exists; accepts both the seeder
+     * convention ('1'/'0') and the admin UI convention ('true'/'false'), and
+     * falls back to the built-in default for a garbage value.
+     */
+    public function isCheckEnabled(): bool
+    {
+        $value = $this->read(self::KEY_CHECK_ENABLED);
+        if (null === $value) {
+            return self::DEFAULT_CHECK_ENABLED;
+        }
+
+        return filter_var($value, \FILTER_VALIDATE_BOOL, \FILTER_NULL_ON_FAILURE) ?? self::DEFAULT_CHECK_ENABLED;
+    }
+
+    /**
+     * The manifest URL to fetch, or null when the configured value is not a
+     * usable http(s) URL (an operator can empty it to stop the check without
+     * flipping the switch).
+     */
+    public function manifestUrl(): ?string
+    {
+        $configured = $this->read(self::KEY_MANIFEST_URL);
+        if (null === $configured) {
+            return self::DEFAULT_MANIFEST_URL;
+        }
+
+        return $this->isUsableUrl($configured) ? $configured : null;
+    }
+
+    public function latestVersion(): ?string
+    {
+        return $this->read(self::KEY_LATEST_VERSION);
+    }
+
+    public function latestNotesUrl(): ?string
+    {
+        $stored = $this->read(self::KEY_LATEST_NOTES_URL);
+
+        return null !== $stored && $this->isUsableUrl($stored) ? $stored : null;
+    }
+
+    /**
+     * Stored severity, normalised to one of the two known values so an unknown
+     * or missing value can never be rendered as a security warning.
+     */
+    public function latestSeverity(): string
+    {
+        return ReleaseManifest::SEVERITY_SECURITY === $this->read(self::KEY_LATEST_SEVERITY)
+            ? ReleaseManifest::SEVERITY_SECURITY
+            : ReleaseManifest::SEVERITY_NORMAL;
+    }
+
+    public function latestReleasedAt(): ?string
+    {
+        return $this->read(self::KEY_LATEST_RELEASED_AT);
+    }
+
+    public function lastCheckedAt(): ?string
+    {
+        return $this->read(self::KEY_LAST_CHECKED_AT);
+    }
+
+    public function lastError(): ?string
+    {
+        return $this->read(self::KEY_LAST_ERROR);
+    }
+
+    public function dismissedVersion(): ?string
+    {
+        return $this->read(self::KEY_DISMISSED_VERSION);
+    }
+
+    public function setCheckEnabled(bool $enabled): void
+    {
+        $this->write(self::KEY_CHECK_ENABLED, $enabled ? '1' : '0');
+    }
+
+    public function setDismissedVersion(string $version): void
+    {
+        $this->write(self::KEY_DISMISSED_VERSION, $version);
+    }
+
+    /**
+     * Persist the outcome of a completed check.
+     *
+     * A null $recommended clears the result fields: that is how a manifest
+     * whose stable release was withdrawn, or one that turned out to be
+     * unusable, stops being offered. Success always clears LAST_ERROR.
+     */
+    public function recordSuccessfulCheck(?ReleaseManifest $recommended, string $checkedAt): void
+    {
+        $this->write(self::KEY_LATEST_VERSION, $recommended->version ?? '');
+        $this->write(self::KEY_LATEST_NOTES_URL, $recommended->notesUrl ?? '');
+        $this->write(self::KEY_LATEST_SEVERITY, $recommended->severity ?? '');
+        $this->write(self::KEY_LATEST_RELEASED_AT, $recommended->releasedAt ?? '');
+        $this->write(self::KEY_LAST_ERROR, '');
+        $this->write(self::KEY_LAST_CHECKED_AT, $checkedAt);
+    }
+
+    /**
+     * Record that a check ran but produced nothing usable. The previously known
+     * release is deliberately KEPT so a transient outage does not hide a notice
+     * that was already correct.
+     */
+    public function recordFailedCheck(string $error, string $checkedAt): void
+    {
+        $this->write(self::KEY_LAST_ERROR, mb_substr($error, 0, self::MAX_ERROR_LENGTH));
+        $this->write(self::KEY_LAST_CHECKED_AT, $checkedAt);
+    }
+
+    /**
+     * A missing row and a blank value are the same thing: "not configured".
+     */
+    private function read(string $setting): ?string
+    {
+        $raw = $this->configRepository->getValue(self::OWNER_ID, self::CONFIG_GROUP, $setting);
+        if (null === $raw) {
+            return null;
+        }
+
+        $trimmed = trim($raw);
+
+        return '' === $trimmed ? null : $trimmed;
+    }
+
+    private function write(string $setting, string $value): void
+    {
+        $this->configRepository->setValue(self::OWNER_ID, self::CONFIG_GROUP, $setting, $value);
+    }
+
+    private function isUsableUrl(string $url): bool
+    {
+        if (false === filter_var($url, \FILTER_VALIDATE_URL)) {
+            return false;
+        }
+
+        return \in_array(parse_url($url, \PHP_URL_SCHEME), ['http', 'https'], true);
+    }
+}

--- a/backend/src/Service/Update/UpdateManifestClient.php
+++ b/backend/src/Service/Update/UpdateManifestClient.php
@@ -1,0 +1,249 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Update;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * Fetches, validates and caches the published release manifest.
+ *
+ * Mirrors {@see \App\Service\MarketingNews\MarketingNewsFeedService}: a plain GET
+ * with a short timeout, graceful degradation on every failure, and a cache in
+ * front of it. The request carries no instance identifier, no telemetry and no
+ * query parameters — it is a static file download.
+ *
+ * Every failure mode (transport error, HTTP error status, invalid JSON, unknown
+ * schema version, missing or malformed fields) resolves to null. The caller
+ * turns that into a recorded error; nothing ever throws out of here.
+ */
+final readonly class UpdateManifestClient
+{
+    public const SUPPORTED_SCHEMA = 1;
+
+    private const CACHE_TTL_SECONDS = 21600; // 6 h
+    private const FAILURE_CACHE_TTL_SECONDS = 300;
+    private const FETCH_TIMEOUT_SECONDS = 5;
+    private const MAX_RESPONSE_BYTES = 65536;
+
+    /**
+     * A release version as the manifest may spell it: up to four numeric
+     * segments plus an optional pre-release/build suffix ('4.1.0-rc.1').
+     */
+    private const VERSION_PATTERN = '/^\d+(\.\d+){0,3}([-+][0-9A-Za-z.\-]+)?$/';
+
+    public function __construct(
+        private HttpClientInterface $httpClient,
+        private CacheInterface $cache,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * The manifest behind $manifestUrl, or null when nothing usable was
+     * obtained. Pass $force to bypass the cache (used by `--force`).
+     */
+    public function fetch(string $manifestUrl, bool $force = false): ?ReleaseManifest
+    {
+        $cacheKey = 'update_manifest_'.hash('sha256', $manifestUrl);
+
+        try {
+            if ($force) {
+                $this->cache->delete($cacheKey);
+            }
+
+            /** @var array{version: string, notesUrl: string|null, severity: string, releasedAt: string|null, yanked: list<string>}|null $payload */
+            $payload = $this->cache->get($cacheKey, function (ItemInterface $item) use ($manifestUrl): ?array {
+                $payload = $this->download($manifestUrl);
+                // A failed fetch is cached only briefly: a transient outage must
+                // not suppress the next daily check for six hours.
+                $item->expiresAfter(null === $payload ? self::FAILURE_CACHE_TTL_SECONDS : self::CACHE_TTL_SECONDS);
+
+                return $payload;
+            });
+        } catch (\Throwable $e) {
+            $this->logger->warning('Update manifest cache/fetch failed', [
+                'manifestUrl' => $manifestUrl,
+                'error' => $e->getMessage(),
+            ]);
+
+            return null;
+        }
+
+        if (null === $payload) {
+            return null;
+        }
+
+        return new ReleaseManifest(
+            version: $payload['version'],
+            notesUrl: $payload['notesUrl'],
+            severity: $payload['severity'],
+            releasedAt: $payload['releasedAt'],
+            yankedVersions: $payload['yanked'],
+        );
+    }
+
+    /**
+     * The validated manifest as a plain array, or null on any failure.
+     *
+     * Plain arrays (not the value object) are what goes into the cache, so the
+     * cached shape stays independent of the class layout.
+     *
+     * @return array{version: string, notesUrl: string|null, severity: string, releasedAt: string|null, yanked: list<string>}|null
+     */
+    private function download(string $manifestUrl): ?array
+    {
+        try {
+            $response = $this->httpClient->request('GET', $manifestUrl, [
+                'headers' => [
+                    'Accept' => 'application/json',
+                    'User-Agent' => 'Synaplan/1.0 (+https://www.synaplan.com)',
+                ],
+                'timeout' => self::FETCH_TIMEOUT_SECONDS,
+            ]);
+
+            if ($response->getStatusCode() >= 400) {
+                $this->logger->warning('Update manifest returned an error status', [
+                    'manifestUrl' => $manifestUrl,
+                    'status' => $response->getStatusCode(),
+                ]);
+
+                return null;
+            }
+
+            $body = $response->getContent();
+        } catch (\Throwable $e) {
+            $this->logger->warning('Update manifest fetch failed', [
+                'manifestUrl' => $manifestUrl,
+                'error' => $e->getMessage(),
+            ]);
+
+            return null;
+        }
+
+        if (\strlen($body) > self::MAX_RESPONSE_BYTES) {
+            $this->logger->warning('Update manifest is larger than the accepted maximum', [
+                'manifestUrl' => $manifestUrl,
+                'bytes' => \strlen($body),
+            ]);
+
+            return null;
+        }
+
+        return $this->parse($body, $manifestUrl);
+    }
+
+    /**
+     * @return array{version: string, notesUrl: string|null, severity: string, releasedAt: string|null, yanked: list<string>}|null
+     */
+    private function parse(string $body, string $manifestUrl): ?array
+    {
+        try {
+            $decoded = json_decode($body, true, 16, \JSON_THROW_ON_ERROR);
+        } catch (\JsonException $e) {
+            $this->logger->warning('Update manifest is not valid JSON', [
+                'manifestUrl' => $manifestUrl,
+                'error' => $e->getMessage(),
+            ]);
+
+            return null;
+        }
+
+        if (!\is_array($decoded)) {
+            return null;
+        }
+
+        // An unknown schema version means a newer publisher format we cannot
+        // interpret: treat it as "no usable manifest" instead of guessing.
+        $schema = $decoded['schema'] ?? null;
+        if (!\is_int($schema) || self::SUPPORTED_SCHEMA !== $schema) {
+            $this->logger->warning('Update manifest uses an unsupported schema version', [
+                'manifestUrl' => $manifestUrl,
+                'schema' => \is_scalar($schema) ? $schema : null,
+            ]);
+
+            return null;
+        }
+
+        $stable = $decoded['stable'] ?? null;
+        if (!\is_array($stable)) {
+            return null;
+        }
+
+        $version = $stable['version'] ?? null;
+        if (!\is_string($version) || !$this->isValidVersion(trim($version))) {
+            $this->logger->warning('Update manifest has no usable stable version', [
+                'manifestUrl' => $manifestUrl,
+            ]);
+
+            return null;
+        }
+
+        return [
+            'version' => trim($version),
+            'notesUrl' => $this->readUrl($stable['notesUrl'] ?? null),
+            'severity' => ReleaseManifest::SEVERITY_SECURITY === ($stable['severity'] ?? null)
+                ? ReleaseManifest::SEVERITY_SECURITY
+                : ReleaseManifest::SEVERITY_NORMAL,
+            'releasedAt' => $this->readTimestamp($stable['releasedAt'] ?? null),
+            'yanked' => $this->readVersionList($decoded['yanked'] ?? null),
+        ];
+    }
+
+    private function isValidVersion(string $version): bool
+    {
+        return '' !== $version && 1 === preg_match(self::VERSION_PATTERN, $version);
+    }
+
+    private function readUrl(mixed $value): ?string
+    {
+        if (!\is_string($value)) {
+            return null;
+        }
+
+        $url = trim($value);
+        if (false === filter_var($url, \FILTER_VALIDATE_URL)) {
+            return null;
+        }
+
+        return \in_array(parse_url($url, \PHP_URL_SCHEME), ['http', 'https'], true) ? $url : null;
+    }
+
+    private function readTimestamp(mixed $value): ?string
+    {
+        if (!\is_string($value) || '' === trim($value)) {
+            return null;
+        }
+
+        try {
+            new \DateTimeImmutable(trim($value));
+        } catch (\Exception) {
+            return null;
+        }
+
+        return trim($value);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function readVersionList(mixed $value): array
+    {
+        if (!\is_array($value)) {
+            return [];
+        }
+
+        $versions = [];
+        foreach ($value as $candidate) {
+            if (\is_string($candidate) && $this->isValidVersion(trim($candidate))) {
+                $versions[] = trim($candidate);
+            }
+        }
+
+        return array_values(array_unique($versions));
+    }
+}

--- a/backend/src/Service/Update/UpdatePlatformGuide.php
+++ b/backend/src/Service/Update/UpdatePlatformGuide.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Update;
+
+/**
+ * Resolves the deployment platform hint (SYNAPLAN_PLATFORM) to the manual-update
+ * guide an admin should follow.
+ *
+ * Synaplan never updates itself: the notice only links to documentation, and the
+ * operator performs the update. Which document that is depends on how the
+ * instance was deployed, which only the deployment can know — hence the
+ * optional environment hint, defaulting to the self-hosted guide so an unset or
+ * unknown value can never produce a broken link.
+ */
+final readonly class UpdatePlatformGuide
+{
+    public const PLATFORM_SELFHOST = 'selfhost';
+    public const PLATFORM_ELESTIO = 'elestio';
+
+    public const GUIDE_URL_SELFHOST = 'https://github.com/metadist/synaplan/blob/main/docs/UPDATE_SELFHOST.md';
+    public const GUIDE_URL_ELESTIO = 'https://github.com/metadist/synaplan/blob/main/docs/UPDATE_ELESTIO.md';
+
+    public function __construct(
+        private string $platform,
+    ) {
+    }
+
+    /**
+     * The configured platform, normalised to a known value.
+     */
+    public function platform(): string
+    {
+        return self::PLATFORM_ELESTIO === strtolower(trim($this->platform))
+            ? self::PLATFORM_ELESTIO
+            : self::PLATFORM_SELFHOST;
+    }
+
+    public function guideUrl(): string
+    {
+        return match ($this->platform()) {
+            self::PLATFORM_ELESTIO => self::GUIDE_URL_ELESTIO,
+            default => self::GUIDE_URL_SELFHOST,
+        };
+    }
+}

--- a/backend/src/Service/Update/UpdateStatusService.php
+++ b/backend/src/Service/Update/UpdateStatusService.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Update;
+
+use Psr\Log\LoggerInterface;
+
+/**
+ * Detects — and only detects — that a newer release of Synaplan exists.
+ *
+ * This never changes the running installation: no download, no version
+ * selection, no state file. {@see refresh()} is called once per day by the
+ * scheduler container and stores its outcome in BCONFIG; {@see getStatus()}
+ * reads those stored values only, so the admin API performs no outbound HTTP
+ * and keeps working without internet access.
+ *
+ * Comparison rules:
+ *   - PHP's built-in version_compare() (no extra dependency), which also orders
+ *     pre-releases sanely ('4.1.0-rc.1' < '4.1.0').
+ *   - An unparseable current version — 'dev' being the normal case for a
+ *     source checkout — means "cannot compare": no update is reported rather
+ *     than a wrong one.
+ *   - A version listed as `yanked` in the manifest is never recommended: it is
+ *     not even stored, so it cannot resurface from BCONFIG later.
+ */
+final readonly class UpdateStatusService
+{
+    /**
+     * Mirrors {@see UpdateManifestClient} so a stored version is held to the
+     * same shape as a fetched one.
+     */
+    private const VERSION_PATTERN = '/^\d+(\.\d+){0,3}([-+][0-9A-Za-z.\-]+)?$/';
+
+    public function __construct(
+        private UpdateConfig $config,
+        private UpdateManifestClient $manifestClient,
+        private LoggerInterface $logger,
+        private string $appVersion,
+    ) {
+    }
+
+    /**
+     * The stored update status. Pure read: no HTTP, no writes.
+     *
+     * @return array{currentVersion: string, latestVersion: string|null, updateAvailable: bool, notesUrl: string|null, severity: string, releasedAt: string|null, lastCheckedAt: string|null, lastError: string|null, dismissedVersion: string|null, checkEnabled: bool}
+     */
+    public function getStatus(): array
+    {
+        $currentVersion = $this->currentVersion();
+        $latestVersion = $this->config->latestVersion();
+
+        return [
+            'currentVersion' => $currentVersion,
+            'latestVersion' => $latestVersion,
+            'updateAvailable' => $this->isNewer($currentVersion, $latestVersion),
+            'notesUrl' => $this->config->latestNotesUrl(),
+            'severity' => $this->config->latestSeverity(),
+            'releasedAt' => $this->config->latestReleasedAt(),
+            'lastCheckedAt' => $this->config->lastCheckedAt(),
+            'lastError' => $this->config->lastError(),
+            'dismissedVersion' => $this->config->dismissedVersion(),
+            'checkEnabled' => $this->config->isCheckEnabled(),
+        ];
+    }
+
+    /**
+     * Run the check now and store its outcome, then return the fresh status.
+     *
+     * A disabled master switch (or an unusable manifest URL) short-circuits
+     * BEFORE the client is consulted, so no outbound request is made at all.
+     * A network or parsing failure is a normal outcome: it is recorded in
+     * LAST_ERROR and never raised.
+     *
+     * @return array{currentVersion: string, latestVersion: string|null, updateAvailable: bool, notesUrl: string|null, severity: string, releasedAt: string|null, lastCheckedAt: string|null, lastError: string|null, dismissedVersion: string|null, checkEnabled: bool}
+     */
+    public function refresh(bool $force = false): array
+    {
+        if (!$this->config->isCheckEnabled()) {
+            return $this->getStatus();
+        }
+
+        $manifestUrl = $this->config->manifestUrl();
+        $checkedAt = $this->now();
+
+        if (null === $manifestUrl) {
+            $this->config->recordFailedCheck('No valid manifest URL is configured.', $checkedAt);
+
+            return $this->getStatus();
+        }
+
+        $manifest = $this->manifestClient->fetch($manifestUrl, $force);
+
+        if (null === $manifest) {
+            $this->config->recordFailedCheck(
+                sprintf('Could not read a usable release manifest from %s.', $manifestUrl),
+                $checkedAt,
+            );
+
+            return $this->getStatus();
+        }
+
+        // A withdrawn stable release is not an error, it just must never be
+        // recommended — so the stored result is cleared instead of updated.
+        if ($manifest->isYanked($manifest->version)) {
+            $this->logger->warning('Published stable release is listed as yanked; not offering it', [
+                'manifestUrl' => $manifestUrl,
+                'version' => $manifest->version,
+            ]);
+            $this->config->recordSuccessfulCheck(null, $checkedAt);
+
+            return $this->getStatus();
+        }
+
+        $this->config->recordSuccessfulCheck($manifest, $checkedAt);
+
+        return $this->getStatus();
+    }
+
+    /**
+     * Remember that the admin acknowledged this version, so the UI can stop
+     * nagging about it. Display state only — nothing else reads it.
+     */
+    public function dismiss(string $version): void
+    {
+        $this->config->setDismissedVersion(trim($version));
+    }
+
+    public function setCheckEnabled(bool $enabled): void
+    {
+        $this->config->setCheckEnabled($enabled);
+    }
+
+    /**
+     * Whether a version string can take part in a comparison at all.
+     */
+    public function isComparableVersion(string $version): bool
+    {
+        return 1 === preg_match(self::VERSION_PATTERN, $version);
+    }
+
+    /**
+     * Same source and same fallback as the runtime config's build info: the
+     * release pipeline sets APP_VERSION, and a plain checkout reports 'dev'.
+     */
+    private function currentVersion(): string
+    {
+        $version = trim($this->appVersion);
+
+        return '' === $version ? 'dev' : $version;
+    }
+
+    private function isNewer(string $currentVersion, ?string $latestVersion): bool
+    {
+        if (null === $latestVersion || !$this->isComparableVersion($latestVersion)) {
+            return false;
+        }
+
+        if (!$this->isComparableVersion($currentVersion)) {
+            return false;
+        }
+
+        return version_compare($latestVersion, $currentVersion, '>');
+    }
+
+    private function now(): string
+    {
+        return (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format(\DateTimeInterface::ATOM);
+    }
+}

--- a/backend/tests/Command/CheckUpdatesCommandTest.php
+++ b/backend/tests/Command/CheckUpdatesCommandTest.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Command;
+
+use App\Command\CheckUpdatesCommand;
+use App\Entity\Config;
+use App\Repository\ConfigRepository;
+use App\Service\Update\UpdateConfig;
+use App\Service\Update\UpdateManifestClient;
+use App\Service\Update\UpdateStatusService;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+/**
+ * The scheduler runs this once a day, unattended. An unreachable manifest is an
+ * EXPECTED outcome and must stay a quiet success — only a genuinely unexpected
+ * error may exit non-zero.
+ */
+final class CheckUpdatesCommandTest extends TestCase
+{
+    /** @var array<string, string> */
+    private array $rows = [];
+
+    private ConfigRepository&MockObject $configRepository;
+
+    protected function setUp(): void
+    {
+        $this->rows = [];
+        $this->configRepository = $this->createMock(ConfigRepository::class);
+    }
+
+    public function testReportsAnAvailableUpdate(): void
+    {
+        $this->stubConfigRepository();
+        $tester = $this->testerFor('4.0.12', new MockResponse((string) json_encode([
+            'schema' => 1,
+            'stable' => ['version' => '4.0.13', 'severity' => 'security'],
+        ])));
+
+        $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $tester->getStatusCode());
+        self::assertStringContainsString('Update available: 4.0.13', $tester->getDisplay());
+        self::assertStringContainsString('severity security', $tester->getDisplay());
+        self::assertSame('4.0.13', $this->rows[UpdateConfig::KEY_LATEST_VERSION]);
+    }
+
+    public function testReportsThatNoUpdateIsAvailable(): void
+    {
+        $this->stubConfigRepository();
+        $tester = $this->testerFor('4.0.13', new MockResponse((string) json_encode([
+            'schema' => 1,
+            'stable' => ['version' => '4.0.13'],
+        ])));
+
+        $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $tester->getStatusCode());
+        self::assertStringContainsString('No update available', $tester->getDisplay());
+    }
+
+    public function testANetworkFailureIsAQuietSuccess(): void
+    {
+        $this->stubConfigRepository();
+        $tester = $this->testerFor('4.0.12', new MockResponse('', ['error' => 'Connection refused']));
+
+        $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $tester->getStatusCode());
+        self::assertStringContainsString('could not complete', $tester->getDisplay());
+        self::assertStringNotContainsString('Fatal', $tester->getDisplay());
+        self::assertArrayHasKey(UpdateConfig::KEY_LAST_ERROR, $this->rows);
+    }
+
+    public function testADisabledCheckSaysSoAndFetchesNothing(): void
+    {
+        $this->stubConfigRepository();
+        $this->rows[UpdateConfig::KEY_CHECK_ENABLED] = '0';
+        $httpClient = new MockHttpClient(new MockResponse('{"schema": 1, "stable": {"version": "4.0.13"}}'));
+        $tester = $this->testerWith('4.0.12', $httpClient);
+
+        $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $tester->getStatusCode());
+        self::assertStringContainsString('disabled', $tester->getDisplay());
+        self::assertSame(0, $httpClient->getRequestsCount());
+    }
+
+    public function testForceBypassesTheCachedManifest(): void
+    {
+        $this->stubConfigRepository();
+        $httpClient = new MockHttpClient([
+            new MockResponse('{"schema": 1, "stable": {"version": "4.0.13"}}'),
+            new MockResponse('{"schema": 1, "stable": {"version": "4.0.14"}}'),
+        ]);
+        $tester = $this->testerWith('4.0.12', $httpClient);
+
+        $tester->execute([]);
+        $tester->execute([]);
+        self::assertSame(1, $httpClient->getRequestsCount());
+
+        $tester->execute(['--force' => true]);
+
+        self::assertSame(2, $httpClient->getRequestsCount());
+        self::assertSame('4.0.14', $this->rows[UpdateConfig::KEY_LATEST_VERSION]);
+    }
+
+    public function testAnUnexpectedErrorExitsNonZero(): void
+    {
+        $this->configRepository
+            ->method('getValue')
+            ->willThrowException(new \RuntimeException('MySQL server has gone away'));
+
+        $tester = $this->testerFor('4.0.12', new MockResponse('{"schema": 1, "stable": {"version": "4.0.13"}}'));
+
+        $tester->execute([]);
+
+        self::assertSame(Command::FAILURE, $tester->getStatusCode());
+        self::assertStringContainsString('MySQL server has gone away', $tester->getDisplay());
+    }
+
+    private function stubConfigRepository(): void
+    {
+        $this->configRepository
+            ->method('getValue')
+            ->willReturnCallback(fn (int $ownerId, string $group, string $setting): ?string => $this->rows[$setting] ?? null);
+
+        $this->configRepository
+            ->method('setValue')
+            ->willReturnCallback(function (int $ownerId, string $group, string $setting, string $value): Config {
+                $this->rows[$setting] = $value;
+
+                return new Config();
+            });
+    }
+
+    private function testerFor(string $currentVersion, MockResponse $response): CommandTester
+    {
+        return $this->testerWith($currentVersion, new MockHttpClient($response));
+    }
+
+    private function testerWith(string $currentVersion, MockHttpClient $httpClient): CommandTester
+    {
+        $service = new UpdateStatusService(
+            new UpdateConfig($this->configRepository),
+            new UpdateManifestClient($httpClient, new ArrayAdapter(), new NullLogger()),
+            new NullLogger(),
+            $currentVersion,
+        );
+
+        $application = new Application();
+        $application->addCommand(new CheckUpdatesCommand($service));
+
+        return new CommandTester($application->find('app:updates:check'));
+    }
+}

--- a/backend/tests/Unit/Controller/AdminUpdatesControllerTest.php
+++ b/backend/tests/Unit/Controller/AdminUpdatesControllerTest.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Controller;
+
+use App\Controller\AdminUpdatesController;
+use App\DTO\AdminUpdateDismissRequest;
+use App\DTO\AdminUpdateSettingsRequest;
+use App\Entity\Config;
+use App\Repository\ConfigRepository;
+use App\Service\Update\ReleaseManifest;
+use App\Service\Update\UpdateConfig;
+use App\Service\Update\UpdateManifestClient;
+use App\Service\Update\UpdatePlatformGuide;
+use App\Service\Update\UpdateStatusService;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+/**
+ * The /status payload is a published contract the admin UI is built against, so
+ * its exact key set is asserted here rather than described in a comment.
+ */
+final class AdminUpdatesControllerTest extends TestCase
+{
+    /** @var array<string, string> */
+    private array $rows = [];
+
+    private ConfigRepository&MockObject $configRepository;
+
+    protected function setUp(): void
+    {
+        $this->rows = [];
+        $this->configRepository = $this->createMock(ConfigRepository::class);
+        $this->configRepository
+            ->method('getValue')
+            ->willReturnCallback(function (int $ownerId, string $group, string $setting): ?string {
+                return $this->rows[$setting] ?? null;
+            });
+        $this->configRepository
+            ->method('setValue')
+            ->willReturnCallback(function (int $ownerId, string $group, string $setting, string $value): Config {
+                $this->rows[$setting] = $value;
+
+                return new Config();
+            });
+    }
+
+    public function testStatusReturnsTheStoredValuesAndTheSelfHostGuide(): void
+    {
+        $this->rows = [
+            UpdateConfig::KEY_LATEST_VERSION => '4.0.13',
+            UpdateConfig::KEY_LATEST_NOTES_URL => 'https://github.com/metadist/synaplan/releases/tag/v4.0.13',
+            UpdateConfig::KEY_LATEST_SEVERITY => ReleaseManifest::SEVERITY_SECURITY,
+            UpdateConfig::KEY_LATEST_RELEASED_AT => '2026-08-10T09:00:00Z',
+            UpdateConfig::KEY_LAST_CHECKED_AT => '2026-08-10T09:05:00+00:00',
+        ];
+
+        $payload = $this->decode($this->controller()->getStatus()->getContent());
+
+        self::assertSame([
+            'currentVersion' => '4.0.12',
+            'latestVersion' => '4.0.13',
+            'updateAvailable' => true,
+            'notesUrl' => 'https://github.com/metadist/synaplan/releases/tag/v4.0.13',
+            'severity' => ReleaseManifest::SEVERITY_SECURITY,
+            'releasedAt' => '2026-08-10T09:00:00Z',
+            'lastCheckedAt' => '2026-08-10T09:05:00+00:00',
+            'lastError' => null,
+            'dismissedVersion' => null,
+            'checkEnabled' => true,
+            'platform' => UpdatePlatformGuide::PLATFORM_SELFHOST,
+            'guideUrl' => UpdatePlatformGuide::GUIDE_URL_SELFHOST,
+        ], $payload);
+    }
+
+    public function testStatusOnAFreshInstallReportsNoUpdate(): void
+    {
+        $payload = $this->decode($this->controller()->getStatus()->getContent());
+
+        self::assertFalse($payload['updateAvailable']);
+        self::assertNull($payload['latestVersion']);
+        self::assertNull($payload['lastCheckedAt']);
+        self::assertTrue($payload['checkEnabled']);
+    }
+
+    public function testStatusLinksTheElestioGuideOnElestio(): void
+    {
+        $payload = $this->decode($this->controller(platform: 'elestio')->getStatus()->getContent());
+
+        self::assertSame(UpdatePlatformGuide::PLATFORM_ELESTIO, $payload['platform']);
+        self::assertSame(UpdatePlatformGuide::GUIDE_URL_ELESTIO, $payload['guideUrl']);
+    }
+
+    public function testCheckRefreshesAndReturnsTheSamePayloadShape(): void
+    {
+        $controller = $this->controller(new MockResponse((string) json_encode([
+            'schema' => 1,
+            'stable' => ['version' => '4.0.13', 'notesUrl' => 'https://example.com/notes'],
+        ])));
+
+        $payload = $this->decode($controller->check()->getContent());
+
+        self::assertSame('4.0.13', $payload['latestVersion']);
+        self::assertTrue($payload['updateAvailable']);
+        self::assertNotNull($payload['lastCheckedAt']);
+        self::assertSame(UpdatePlatformGuide::GUIDE_URL_SELFHOST, $payload['guideUrl']);
+        self::assertSame('4.0.13', $this->rows[UpdateConfig::KEY_LATEST_VERSION]);
+    }
+
+    public function testDismissStoresTheAcknowledgedVersion(): void
+    {
+        $dto = new AdminUpdateDismissRequest();
+        $dto->version = '4.0.13';
+
+        $payload = $this->decode($this->controller()->dismiss($dto)->getContent());
+
+        self::assertTrue($payload['success']);
+        self::assertSame('4.0.13', $payload['dismissedVersion']);
+        self::assertSame('4.0.13', $this->rows[UpdateConfig::KEY_DISMISSED_VERSION]);
+    }
+
+    public function testSettingsTogglesTheMasterSwitch(): void
+    {
+        $dto = new AdminUpdateSettingsRequest();
+        $dto->checkEnabled = false;
+
+        $payload = $this->decode($this->controller()->updateSettings($dto)->getContent());
+
+        self::assertTrue($payload['success']);
+        self::assertFalse($payload['checkEnabled']);
+        self::assertSame('0', $this->rows[UpdateConfig::KEY_CHECK_ENABLED]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decode(string|false $json): array
+    {
+        self::assertIsString($json);
+
+        /** @var array<string, mixed> $decoded */
+        $decoded = json_decode($json, true, 512, \JSON_THROW_ON_ERROR);
+
+        return $decoded;
+    }
+
+    private function controller(?MockResponse $response = null, string $platform = 'selfhost'): AdminUpdatesController
+    {
+        $httpClient = null === $response ? new MockHttpClient() : new MockHttpClient($response);
+
+        $controller = new AdminUpdatesController(
+            new UpdateStatusService(
+                new UpdateConfig($this->configRepository),
+                new UpdateManifestClient($httpClient, new ArrayAdapter(), new NullLogger()),
+                new NullLogger(),
+                '4.0.12',
+            ),
+            new UpdatePlatformGuide($platform),
+        );
+
+        $container = new Container();
+        $container->set('serializer', new class {
+            public function serialize(mixed $data, string $format): string
+            {
+                return json_encode($data, \JSON_THROW_ON_ERROR);
+            }
+        });
+        $controller->setContainer($container);
+
+        return $controller;
+    }
+}

--- a/backend/tests/Unit/Service/Update/UpdateConfigTest.php
+++ b/backend/tests/Unit/Service/Update/UpdateConfigTest.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\Update;
+
+use App\Entity\Config;
+use App\Repository\ConfigRepository;
+use App\Service\Update\ReleaseManifest;
+use App\Service\Update\UpdateConfig;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * BCONFIG seeder defaults are bootstrap-only: an install that upgraded into this
+ * feature has NO rows in the UPDATES group until `app:seed` runs again. Every
+ * read must therefore be safe with a missing row — and with a blank one, which
+ * is how the seeder ships the result fields.
+ */
+final class UpdateConfigTest extends TestCase
+{
+    public function testEveryReadHasASafeFallbackWhenNoRowExists(): void
+    {
+        $config = $this->configWith([]);
+
+        self::assertTrue($config->isCheckEnabled());
+        self::assertSame(UpdateConfig::DEFAULT_MANIFEST_URL, $config->manifestUrl());
+        self::assertNull($config->latestVersion());
+        self::assertNull($config->latestNotesUrl());
+        self::assertSame(ReleaseManifest::SEVERITY_NORMAL, $config->latestSeverity());
+        self::assertNull($config->latestReleasedAt());
+        self::assertNull($config->lastCheckedAt());
+        self::assertNull($config->lastError());
+        self::assertNull($config->dismissedVersion());
+    }
+
+    /**
+     * The seeder writes the result fields as empty strings, so "present but
+     * blank" has to behave exactly like "missing".
+     */
+    public function testBlankRowsBehaveLikeMissingRows(): void
+    {
+        $config = $this->configWith([
+            UpdateConfig::KEY_LATEST_VERSION => '',
+            UpdateConfig::KEY_LATEST_NOTES_URL => '   ',
+            UpdateConfig::KEY_LATEST_SEVERITY => '',
+            UpdateConfig::KEY_LATEST_RELEASED_AT => '',
+            UpdateConfig::KEY_LAST_CHECKED_AT => '',
+            UpdateConfig::KEY_LAST_ERROR => '',
+            UpdateConfig::KEY_DISMISSED_VERSION => '',
+            UpdateConfig::KEY_CHECK_ENABLED => '',
+            UpdateConfig::KEY_MANIFEST_URL => '',
+        ]);
+
+        self::assertTrue($config->isCheckEnabled());
+        self::assertSame(UpdateConfig::DEFAULT_MANIFEST_URL, $config->manifestUrl());
+        self::assertNull($config->latestVersion());
+        self::assertNull($config->latestNotesUrl());
+        self::assertSame(ReleaseManifest::SEVERITY_NORMAL, $config->latestSeverity());
+        self::assertNull($config->latestReleasedAt());
+        self::assertNull($config->lastCheckedAt());
+        self::assertNull($config->lastError());
+        self::assertNull($config->dismissedVersion());
+    }
+
+    /**
+     * @return iterable<string, array{0: string, 1: bool}>
+     */
+    public static function checkEnabledProvider(): iterable
+    {
+        yield 'seeder 1' => ['1', true];
+        yield 'seeder 0' => ['0', false];
+        yield 'admin true' => ['true', true];
+        yield 'admin false' => ['false', false];
+        yield 'garbage falls back to the default' => ['nonsense', true];
+    }
+
+    #[DataProvider('checkEnabledProvider')]
+    public function testCheckEnabledAcceptsBothConventions(string $stored, bool $expected): void
+    {
+        $config = $this->configWith([UpdateConfig::KEY_CHECK_ENABLED => $stored]);
+
+        self::assertSame($expected, $config->isCheckEnabled());
+    }
+
+    /**
+     * @return iterable<string, array{0: string, 1: string|null}>
+     */
+    public static function manifestUrlProvider(): iterable
+    {
+        yield 'a fork repoints the check' => [
+            'https://fork.example.com/versions.json',
+            'https://fork.example.com/versions.json',
+        ];
+        yield 'plain http is allowed for an internal mirror' => [
+            'http://mirror.internal/versions.json',
+            'http://mirror.internal/versions.json',
+        ];
+        yield 'file scheme is rejected' => ['file:///etc/passwd', null];
+        yield 'not a url at all' => ['definitely not a url', null];
+    }
+
+    #[DataProvider('manifestUrlProvider')]
+    public function testManifestUrlOnlyAcceptsHttpUrls(string $stored, ?string $expected): void
+    {
+        $config = $this->configWith([UpdateConfig::KEY_MANIFEST_URL => $stored]);
+
+        self::assertSame($expected, $config->manifestUrl());
+    }
+
+    public function testAnUnusableStoredNotesUrlIsNotHandedToTheUi(): void
+    {
+        $config = $this->configWith([UpdateConfig::KEY_LATEST_NOTES_URL => 'javascript:alert(1)']);
+
+        self::assertNull($config->latestNotesUrl());
+    }
+
+    /**
+     * @return iterable<string, array{0: string, 1: string}>
+     */
+    public static function severityProvider(): iterable
+    {
+        yield 'unknown severity' => ['catastrophic', ReleaseManifest::SEVERITY_NORMAL];
+        yield 'normal' => [ReleaseManifest::SEVERITY_NORMAL, ReleaseManifest::SEVERITY_NORMAL];
+        yield 'security' => [ReleaseManifest::SEVERITY_SECURITY, ReleaseManifest::SEVERITY_SECURITY];
+    }
+
+    #[DataProvider('severityProvider')]
+    public function testStoredSeverityIsNormalisedToAKnownValue(string $stored, string $expected): void
+    {
+        $config = $this->configWith([UpdateConfig::KEY_LATEST_SEVERITY => $stored]);
+
+        self::assertSame($expected, $config->latestSeverity());
+    }
+
+    public function testRecordedErrorsAreCapped(): void
+    {
+        $written = [];
+        $configRepository = $this->createMock(ConfigRepository::class);
+        $configRepository->method('getValue')->willReturn(null);
+        $configRepository
+            ->method('setValue')
+            ->willReturnCallback(function (int $ownerId, string $group, string $setting, string $value) use (&$written): Config {
+                $written[$setting] = $value;
+
+                return new Config();
+            });
+
+        (new UpdateConfig($configRepository))->recordFailedCheck(str_repeat('x', 5000), '2026-08-10T09:00:00+00:00');
+
+        self::assertArrayHasKey(UpdateConfig::KEY_LAST_ERROR, $written);
+        self::assertSame(500, mb_strlen($written[UpdateConfig::KEY_LAST_ERROR]));
+        self::assertSame('2026-08-10T09:00:00+00:00', $written[UpdateConfig::KEY_LAST_CHECKED_AT]);
+    }
+
+    /**
+     * @param array<string, string> $rows
+     */
+    private function configWith(array $rows): UpdateConfig
+    {
+        $configRepository = $this->createMock(ConfigRepository::class);
+        $configRepository
+            ->method('getValue')
+            ->willReturnCallback(static function (int $ownerId, string $group, string $setting) use ($rows): ?string {
+                self::assertSame(UpdateConfig::OWNER_ID, $ownerId);
+                self::assertSame(UpdateConfig::CONFIG_GROUP, $group);
+
+                return $rows[$setting] ?? null;
+            });
+
+        return new UpdateConfig($configRepository);
+    }
+}

--- a/backend/tests/Unit/Service/Update/UpdateManifestClientTest.php
+++ b/backend/tests/Unit/Service/Update/UpdateManifestClientTest.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\Update;
+
+use App\Service\Update\ReleaseManifest;
+use App\Service\Update\UpdateManifestClient;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+/**
+ * The manifest is a file on someone else's server: every shape it can arrive in
+ * — including "not at all" — must degrade to "no usable manifest" instead of an
+ * exception in the caller.
+ */
+final class UpdateManifestClientTest extends TestCase
+{
+    private const URL = 'https://example.com/versions.json';
+
+    public function testParsesAWellFormedManifest(): void
+    {
+        $client = $this->clientFor(new MockResponse((string) json_encode([
+            'schema' => 1,
+            'stable' => [
+                'version' => '4.0.13',
+                'releasedAt' => '2026-08-10T09:00:00Z',
+                'notesUrl' => 'https://github.com/metadist/synaplan/releases/tag/v4.0.13',
+                'severity' => 'security',
+            ],
+            'yanked' => ['4.0.11'],
+        ])));
+
+        $manifest = $client->fetch(self::URL);
+
+        self::assertInstanceOf(ReleaseManifest::class, $manifest);
+        self::assertSame('4.0.13', $manifest->version);
+        self::assertSame('2026-08-10T09:00:00Z', $manifest->releasedAt);
+        self::assertSame('https://github.com/metadist/synaplan/releases/tag/v4.0.13', $manifest->notesUrl);
+        self::assertSame(ReleaseManifest::SEVERITY_SECURITY, $manifest->severity);
+        self::assertSame(['4.0.11'], $manifest->yankedVersions);
+        self::assertTrue($manifest->isYanked('4.0.11'));
+        self::assertFalse($manifest->isYanked('4.0.13'));
+    }
+
+    /**
+     * @return iterable<string, array{0: string}>
+     */
+    public static function unusableBodyProvider(): iterable
+    {
+        yield 'empty body' => [''];
+        yield 'whitespace only' => ["  \n"];
+        yield 'malformed json' => ['{"schema": 1, "stable":'];
+        yield 'json scalar' => ['"just a string"'];
+        yield 'json list' => ['[1, 2, 3]'];
+        yield 'newer schema' => ['{"schema": 2, "stable": {"version": "9.0.0"}}'];
+        yield 'schema as string' => ['{"schema": "1", "stable": {"version": "4.0.13"}}'];
+        yield 'schema missing' => ['{"stable": {"version": "4.0.13"}}'];
+        yield 'stable missing' => ['{"schema": 1}'];
+        yield 'stable not an object' => ['{"schema": 1, "stable": "4.0.13"}'];
+        yield 'version missing' => ['{"schema": 1, "stable": {"severity": "normal"}}'];
+        yield 'version empty' => ['{"schema": 1, "stable": {"version": "   "}}'];
+        yield 'version not a string' => ['{"schema": 1, "stable": {"version": 4}}'];
+        yield 'version malformed' => ['{"schema": 1, "stable": {"version": "not-a-version"}}'];
+        yield 'version with injection' => ['{"schema": 1, "stable": {"version": "4.0.13; rm -rf /"}}'];
+    }
+
+    #[DataProvider('unusableBodyProvider')]
+    public function testUnusableBodyYieldsNoManifest(string $body): void
+    {
+        self::assertNull($this->clientFor(new MockResponse($body))->fetch(self::URL));
+    }
+
+    public function testHttpErrorStatusYieldsNoManifest(): void
+    {
+        $response = new MockResponse('Not Found', ['http_code' => 404]);
+
+        self::assertNull($this->clientFor($response)->fetch(self::URL));
+    }
+
+    public function testTransportFailureYieldsNoManifest(): void
+    {
+        $client = $this->clientFor(new MockResponse('', [
+            'error' => 'Could not resolve host: example.com',
+        ]));
+
+        self::assertNull($client->fetch(self::URL));
+    }
+
+    public function testOversizedResponseYieldsNoManifest(): void
+    {
+        $client = $this->clientFor(new MockResponse(str_repeat('a', 70000)));
+
+        self::assertNull($client->fetch(self::URL));
+    }
+
+    public function testUnknownSeverityFallsBackToNormal(): void
+    {
+        $client = $this->clientFor(new MockResponse((string) json_encode([
+            'schema' => 1,
+            'stable' => ['version' => '4.0.13', 'severity' => 'catastrophic'],
+        ])));
+
+        $manifest = $client->fetch(self::URL);
+
+        self::assertInstanceOf(ReleaseManifest::class, $manifest);
+        self::assertSame(ReleaseManifest::SEVERITY_NORMAL, $manifest->severity);
+    }
+
+    public function testUnusableOptionalFieldsBecomeNull(): void
+    {
+        $client = $this->clientFor(new MockResponse((string) json_encode([
+            'schema' => 1,
+            'stable' => [
+                'version' => '4.1.0-rc.1',
+                'notesUrl' => 'javascript:alert(1)',
+                'releasedAt' => 'the day before yesterday',
+            ],
+            'yanked' => ['4.0.11', 'nonsense', 42, '4.0.11'],
+        ])));
+
+        $manifest = $client->fetch(self::URL);
+
+        self::assertInstanceOf(ReleaseManifest::class, $manifest);
+        self::assertSame('4.1.0-rc.1', $manifest->version);
+        self::assertNull($manifest->notesUrl);
+        self::assertNull($manifest->releasedAt);
+        self::assertSame(['4.0.11'], $manifest->yankedVersions);
+    }
+
+    public function testSuccessfulFetchIsCachedAndForceBypassesIt(): void
+    {
+        $httpClient = new MockHttpClient([
+            new MockResponse('{"schema": 1, "stable": {"version": "4.0.13"}}'),
+            new MockResponse('{"schema": 1, "stable": {"version": "4.0.14"}}'),
+        ]);
+        $client = new UpdateManifestClient($httpClient, new ArrayAdapter(), new NullLogger());
+
+        $first = $client->fetch(self::URL);
+        $cached = $client->fetch(self::URL);
+        $forced = $client->fetch(self::URL, force: true);
+
+        self::assertInstanceOf(ReleaseManifest::class, $first);
+        self::assertInstanceOf(ReleaseManifest::class, $cached);
+        self::assertInstanceOf(ReleaseManifest::class, $forced);
+        self::assertSame('4.0.13', $first->version);
+        self::assertSame('4.0.13', $cached->version);
+        self::assertSame('4.0.14', $forced->version);
+        self::assertSame(2, $httpClient->getRequestsCount());
+    }
+
+    /**
+     * A bare GET: no query parameters, no instance identifier, no telemetry.
+     */
+    public function testRequestCarriesNoIdentifyingData(): void
+    {
+        $seen = null;
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options) use (&$seen): MockResponse {
+            $seen = ['method' => $method, 'url' => $url, 'options' => $options];
+
+            return new MockResponse('{"schema": 1, "stable": {"version": "4.0.13"}}');
+        });
+
+        (new UpdateManifestClient($httpClient, new ArrayAdapter(), new NullLogger()))->fetch(self::URL);
+
+        self::assertIsArray($seen);
+        self::assertSame('GET', $seen['method']);
+        self::assertSame(self::URL, $seen['url']);
+        self::assertStringNotContainsString('?', $seen['url']);
+        self::assertSame([], $seen['options']['query'] ?? []);
+        self::assertSame('', (string) ($seen['options']['body'] ?? ''));
+    }
+
+    private function clientFor(MockResponse $response): UpdateManifestClient
+    {
+        return new UpdateManifestClient(
+            new MockHttpClient($response),
+            new ArrayAdapter(),
+            new NullLogger(),
+        );
+    }
+}

--- a/backend/tests/Unit/Service/Update/UpdatePlatformGuideTest.php
+++ b/backend/tests/Unit/Service/Update/UpdatePlatformGuideTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\Update;
+
+use App\Service\Update\UpdatePlatformGuide;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * SYNAPLAN_PLATFORM is an optional deployment hint, so an unset, empty or
+ * unknown value must resolve to the self-hosted guide rather than to a broken
+ * link.
+ */
+final class UpdatePlatformGuideTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{0: string, 1: string, 2: string}>
+     */
+    public static function platformProvider(): iterable
+    {
+        yield 'elestio' => [
+            'elestio',
+            UpdatePlatformGuide::PLATFORM_ELESTIO,
+            UpdatePlatformGuide::GUIDE_URL_ELESTIO,
+        ];
+        yield 'elestio with stray whitespace and case' => [
+            '  Elestio ',
+            UpdatePlatformGuide::PLATFORM_ELESTIO,
+            UpdatePlatformGuide::GUIDE_URL_ELESTIO,
+        ];
+        yield 'selfhost' => [
+            'selfhost',
+            UpdatePlatformGuide::PLATFORM_SELFHOST,
+            UpdatePlatformGuide::GUIDE_URL_SELFHOST,
+        ];
+        yield 'unset' => [
+            '',
+            UpdatePlatformGuide::PLATFORM_SELFHOST,
+            UpdatePlatformGuide::GUIDE_URL_SELFHOST,
+        ];
+        yield 'unknown platform' => [
+            'some-future-marketplace',
+            UpdatePlatformGuide::PLATFORM_SELFHOST,
+            UpdatePlatformGuide::GUIDE_URL_SELFHOST,
+        ];
+    }
+
+    #[DataProvider('platformProvider')]
+    public function testPlatformHintResolvesToTheMatchingGuide(
+        string $configured,
+        string $expectedPlatform,
+        string $expectedGuideUrl,
+    ): void {
+        $guide = new UpdatePlatformGuide($configured);
+
+        self::assertSame($expectedPlatform, $guide->platform());
+        self::assertSame($expectedGuideUrl, $guide->guideUrl());
+    }
+}

--- a/backend/tests/Unit/Service/Update/UpdateStatusServiceTest.php
+++ b/backend/tests/Unit/Service/Update/UpdateStatusServiceTest.php
@@ -1,0 +1,302 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\Update;
+
+use App\Entity\Config;
+use App\Repository\ConfigRepository;
+use App\Service\Update\ReleaseManifest;
+use App\Service\Update\UpdateConfig;
+use App\Service\Update\UpdateManifestClient;
+use App\Service\Update\UpdateStatusService;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+/**
+ * Detection must be conservative: it may only claim an update when the
+ * comparison is unambiguous, and it may never change anything but the stored
+ * result fields.
+ *
+ * The BCONFIG rows are backed by an in-memory store so a test can start from a
+ * completely EMPTY group — which is exactly the state of an install that
+ * upgraded into this feature before `app:seed` ran again.
+ */
+final class UpdateStatusServiceTest extends TestCase
+{
+    /** @var array<string, string> */
+    private array $rows = [];
+
+    private ConfigRepository&MockObject $configRepository;
+
+    protected function setUp(): void
+    {
+        $this->rows = [];
+        $this->configRepository = $this->createMock(ConfigRepository::class);
+
+        $this->configRepository
+            ->method('getValue')
+            ->willReturnCallback(function (int $ownerId, string $group, string $setting): ?string {
+                self::assertSame(UpdateConfig::OWNER_ID, $ownerId);
+                self::assertSame(UpdateConfig::CONFIG_GROUP, $group);
+
+                return $this->rows[$setting] ?? null;
+            });
+
+        $this->configRepository
+            ->method('setValue')
+            ->willReturnCallback(function (int $ownerId, string $group, string $setting, string $value): Config {
+                $this->rows[$setting] = $value;
+
+                return new Config();
+            });
+    }
+
+    /**
+     * @return iterable<string, array{0: string, 1: string, 2: bool}>
+     */
+    public static function comparisonProvider(): iterable
+    {
+        yield 'newer patch' => ['4.0.12', '4.0.13', true];
+        yield 'newer minor' => ['4.0.13', '4.1.0', true];
+        yield 'equal' => ['4.0.13', '4.0.13', false];
+        yield 'older published' => ['4.0.14', '4.0.13', false];
+        yield 'dev checkout' => ['dev', '4.0.13', false];
+        yield 'unparseable current' => ['nightly-2026-08-05', '4.0.13', false];
+        yield 'release beats own rc' => ['4.1.0-rc.1', '4.1.0', true];
+        yield 'rc does not beat release' => ['4.1.0', '4.1.0-rc.1', false];
+        yield 'later rc beats earlier rc' => ['4.1.0-rc.1', '4.1.0-rc.2', true];
+    }
+
+    #[DataProvider('comparisonProvider')]
+    public function testUpdateAvailabilityFollowsVersionOrder(string $current, string $published, bool $expected): void
+    {
+        $service = $this->service($current, $this->manifest($published));
+
+        $status = $service->refresh();
+
+        self::assertSame($expected, $status['updateAvailable']);
+        self::assertSame($current, $status['currentVersion']);
+        self::assertSame($published, $status['latestVersion']);
+        self::assertNull($status['lastError']);
+    }
+
+    public function testYankedVersionIsNeverOffered(): void
+    {
+        $service = $this->service('4.0.12', $this->manifest('4.0.13', yanked: ['4.0.13']));
+
+        $status = $service->refresh();
+
+        self::assertFalse($status['updateAvailable']);
+        self::assertNull($status['latestVersion']);
+        // A withdrawn release is a normal outcome, not a failure.
+        self::assertNull($status['lastError']);
+        self::assertNotNull($status['lastCheckedAt']);
+    }
+
+    public function testYankedVersionIsNotEvenStored(): void
+    {
+        $this->rows[UpdateConfig::KEY_LATEST_VERSION] = '4.0.13';
+
+        $this->service('4.0.12', $this->manifest('4.0.13', yanked: ['4.0.13']))->refresh();
+
+        self::assertSame('', $this->rows[UpdateConfig::KEY_LATEST_VERSION]);
+    }
+
+    /**
+     * @return iterable<string, array{0: MockResponse}>
+     */
+    public static function unusableManifestProvider(): iterable
+    {
+        yield 'empty' => [new MockResponse('')];
+        yield 'malformed' => [new MockResponse('{"schema": 1, "stable":')];
+        yield 'wrong schema' => [new MockResponse('{"schema": 99, "stable": {"version": "9.9.9"}}')];
+        yield 'server error' => [new MockResponse('boom', ['http_code' => 500])];
+        yield 'transport failure' => [new MockResponse('', ['error' => 'Connection refused'])];
+    }
+
+    #[DataProvider('unusableManifestProvider')]
+    public function testUnusableManifestDegradesToNoUpdateAndRecordsTheError(MockResponse $response): void
+    {
+        $service = $this->service('4.0.12', $response);
+
+        $status = $service->refresh();
+
+        self::assertFalse($status['updateAvailable']);
+        self::assertNull($status['latestVersion']);
+        self::assertNotNull($status['lastError']);
+        self::assertNotNull($status['lastCheckedAt']);
+    }
+
+    /**
+     * A transient outage must not retract a notice that was already correct.
+     */
+    public function testAFailedCheckKeepsThePreviouslyKnownRelease(): void
+    {
+        $this->rows[UpdateConfig::KEY_LATEST_VERSION] = '4.0.13';
+
+        $status = $this->service('4.0.12', new MockResponse('', ['error' => 'Connection refused']))->refresh();
+
+        self::assertSame('4.0.13', $status['latestVersion']);
+        self::assertTrue($status['updateAvailable']);
+        self::assertNotNull($status['lastError']);
+    }
+
+    public function testASuccessfulCheckClearsAPreviousError(): void
+    {
+        $this->rows[UpdateConfig::KEY_LAST_ERROR] = 'Connection refused';
+
+        $status = $this->service('4.0.12', $this->manifest('4.0.13'))->refresh();
+
+        self::assertNull($status['lastError']);
+    }
+
+    /**
+     * The master switch is the operator's guarantee that the installation makes
+     * no outbound request at all — asserted on the HTTP client itself, not on a
+     * stubbed manifest client.
+     */
+    public function testDisabledCheckMakesNoOutboundRequest(): void
+    {
+        $this->rows[UpdateConfig::KEY_CHECK_ENABLED] = '0';
+        $httpClient = new MockHttpClient($this->manifest('4.0.13'));
+        $service = $this->serviceWith('4.0.12', $httpClient);
+
+        $status = $service->refresh(force: true);
+
+        self::assertSame(0, $httpClient->getRequestsCount());
+        self::assertFalse($status['checkEnabled']);
+        self::assertFalse($status['updateAvailable']);
+        self::assertNull($status['lastCheckedAt']);
+        self::assertArrayNotHasKey(UpdateConfig::KEY_LAST_CHECKED_AT, $this->rows);
+    }
+
+    public function testAnUnusableManifestUrlMakesNoOutboundRequest(): void
+    {
+        $this->rows[UpdateConfig::KEY_MANIFEST_URL] = 'file:///etc/passwd';
+        $httpClient = new MockHttpClient($this->manifest('4.0.13'));
+
+        $status = $this->serviceWith('4.0.12', $httpClient)->refresh();
+
+        self::assertSame(0, $httpClient->getRequestsCount());
+        self::assertNotNull($status['lastError']);
+    }
+
+    /**
+     * Reading must never trigger a check: the admin UI has to work offline.
+     */
+    public function testReadingTheStatusMakesNoOutboundRequest(): void
+    {
+        $httpClient = new MockHttpClient($this->manifest('4.0.13'));
+
+        $status = $this->serviceWith('4.0.12', $httpClient)->getStatus();
+
+        self::assertSame(0, $httpClient->getRequestsCount());
+        self::assertNull($status['latestVersion']);
+        self::assertFalse($status['updateAvailable']);
+    }
+
+    /**
+     * Every field falls back safely when the UPDATES group has no rows at all.
+     */
+    public function testEmptyConfigGroupYieldsSafeDefaults(): void
+    {
+        $status = $this->serviceWith('4.0.12', new MockHttpClient())->getStatus();
+
+        self::assertSame([], $this->rows);
+        self::assertSame('4.0.12', $status['currentVersion']);
+        self::assertNull($status['latestVersion']);
+        self::assertFalse($status['updateAvailable']);
+        self::assertNull($status['notesUrl']);
+        self::assertSame(ReleaseManifest::SEVERITY_NORMAL, $status['severity']);
+        self::assertNull($status['releasedAt']);
+        self::assertNull($status['lastCheckedAt']);
+        self::assertNull($status['lastError']);
+        self::assertNull($status['dismissedVersion']);
+        self::assertTrue($status['checkEnabled']);
+    }
+
+    public function testMissingAppVersionReportsDev(): void
+    {
+        $service = new UpdateStatusService(
+            new UpdateConfig($this->configRepository),
+            new UpdateManifestClient(new MockHttpClient(), new ArrayAdapter(), new NullLogger()),
+            new NullLogger(),
+            '',
+        );
+
+        self::assertSame('dev', $service->getStatus()['currentVersion']);
+    }
+
+    public function testDismissStoresTheAcknowledgedVersion(): void
+    {
+        $service = $this->serviceWith('4.0.12', new MockHttpClient());
+
+        $service->dismiss('  4.0.13  ');
+
+        self::assertSame('4.0.13', $this->rows[UpdateConfig::KEY_DISMISSED_VERSION]);
+        self::assertSame('4.0.13', $service->getStatus()['dismissedVersion']);
+    }
+
+    public function testTheMasterSwitchIsPersistedInTheSeederConvention(): void
+    {
+        $service = $this->serviceWith('4.0.12', new MockHttpClient());
+
+        $service->setCheckEnabled(false);
+        self::assertSame('0', $this->rows[UpdateConfig::KEY_CHECK_ENABLED]);
+        self::assertFalse($service->getStatus()['checkEnabled']);
+
+        $service->setCheckEnabled(true);
+        self::assertSame('1', $this->rows[UpdateConfig::KEY_CHECK_ENABLED]);
+        self::assertTrue($service->getStatus()['checkEnabled']);
+    }
+
+    public function testSecuritySeverityIsCarriedThroughToTheStatus(): void
+    {
+        $status = $this->service('4.0.12', $this->manifest('4.0.13', severity: 'security'))->refresh();
+
+        self::assertSame(ReleaseManifest::SEVERITY_SECURITY, $status['severity']);
+        self::assertSame('https://example.com/notes', $status['notesUrl']);
+        self::assertSame('2026-08-10T09:00:00Z', $status['releasedAt']);
+    }
+
+    /**
+     * @param list<string> $yanked
+     */
+    private function manifest(string $version, string $severity = 'normal', array $yanked = []): MockResponse
+    {
+        return new MockResponse((string) json_encode([
+            'schema' => 1,
+            'stable' => [
+                'version' => $version,
+                'releasedAt' => '2026-08-10T09:00:00Z',
+                'notesUrl' => 'https://example.com/notes',
+                'severity' => $severity,
+            ],
+            'yanked' => $yanked,
+        ]));
+    }
+
+    private function service(string $currentVersion, MockResponse $response): UpdateStatusService
+    {
+        return $this->serviceWith($currentVersion, new MockHttpClient($response));
+    }
+
+    private function serviceWith(string $currentVersion, MockHttpClient $httpClient): UpdateStatusService
+    {
+        // No MANIFEST_URL row on purpose: the missing-row fallback to the
+        // built-in default URL is part of what these tests cover, and
+        // MockHttpClient answers whatever URL it is given.
+        return new UpdateStatusService(
+            new UpdateConfig($this->configRepository),
+            new UpdateManifestClient($httpClient, new ArrayAdapter(), new NullLogger()),
+            new NullLogger(),
+            $currentVersion,
+        );
+    }
+}

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -89,8 +89,13 @@ files remain in `deploy/data/` until deliberately removed.
 
 Only the web service binds a host port. MariaDB, Redis, Centrifugo, Tika, Qdrant,
 Ollama, and Whisper remain on the Compose network. The default bind is
-`127.0.0.1:8000`; managed platforms may set `SYNAPLAN_HTTP_BIND=0.0.0.0` while
-restricting exposure with their firewall and HTTPS proxy.
+`127.0.0.1:8000`. A managed platform whose HTTPS proxy runs in its own container
+cannot reach that address and needs `SYNAPLAN_HTTP_BIND` set to the host
+interface the proxy connects to — the Docker bridge gateway, usually
+`172.17.0.1`, which is what `elestio.yml` uses. Do not use `0.0.0.0`: Docker
+publishes ports through its own iptables rules, which a host firewall such as
+ufw does not close, so the app would be reachable as plain HTTP from the
+internet and the HTTPS proxy could be bypassed.
 
 Persistent paths:
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -171,14 +171,10 @@ RESTORE_PORTABLE_BACKUP=true deploy/scripts/post-restore.sh
 
 ## Update
 
-Set a tested, concrete `SYNAPLAN_VERSION`, then run:
-
-```bash
-deploy/scripts/pre-update.sh
-# Redeploy through the platform, or:
-docker compose --env-file deploy/.env -f deploy/compose.yaml up -d
-deploy/scripts/post-update.sh
-```
+Step-by-step instructions:
+[Update a Self-Hosted Deployment](../docs/UPDATE_SELFHOST.md), or
+[Update on Elestio](../docs/UPDATE_ELESTIO.md) for a pipeline on that platform.
+Only a tested, concrete `SYNAPLAN_VERSION` may be deployed.
 
 The pre hook enforces a successful backup and pulls the pin. The post hook waits
 for every role and dependency, then verifies health and reports the running image

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -16,6 +16,10 @@ x-app-command: &app-command
 x-app-environment: &app-environment
   APP_ENV: prod
   APP_DEBUG: "0"
+  # Deployment hint for the release notice: it decides which manual-update guide
+  # the admin UI links to. Optional — an unset or unknown value means the
+  # self-hosted guide, so nothing breaks when a deployment never sets it.
+  SYNAPLAN_PLATFORM: "${SYNAPLAN_PLATFORM:-selfhost}"
   APP_URL: "${APP_URL:?Set APP_URL to the public HTTPS URL}"
   FRONTEND_URL: "${FRONTEND_URL:?Set FRONTEND_URL to the public HTTPS URL}"
   APP_SECRET: "${APP_SECRET:?Set a stable APP_SECRET}"

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -3,15 +3,23 @@ name: "${COMPOSE_PROJECT_NAME:-synaplan}"
 x-app-image: &app-image "${SYNAPLAN_IMAGE:-ghcr.io/metadist/synaplan}:${SYNAPLAN_VERSION:?Set SYNAPLAN_VERSION to a published compatible immutable SemVer release}"
 x-app-command: &app-command
   - |
-    if [[ "$${COMPOSE_PROFILES:-}" == "local-ai" ]]; then
-      export OLLAMA_BASE_URL=http://ollama:11434
-      export AUTO_DOWNLOAD_MODELS=true
-      export WHISPER_ENABLED=true
-    else
-      export OLLAMA_BASE_URL=
-      export AUTO_DOWNLOAD_MODELS=false
-      export WHISPER_ENABLED=false
-    fi
+    # COMPOSE_PROFILES is a comma-separated list, so the profile is matched as a
+    # list ELEMENT. An equality test against the whole value made
+    # "local-ai,anything" start Ollama — Compose does read the list — while
+    # leaving the app roles pointed at no local AI at all: a stack that looks
+    # enabled and silently answers from the cloud provider instead.
+    case ",$${COMPOSE_PROFILES:-}," in
+      *,local-ai,*)
+        export OLLAMA_BASE_URL=http://ollama:11434
+        export AUTO_DOWNLOAD_MODELS=true
+        export WHISPER_ENABLED=true
+        ;;
+      *)
+        export OLLAMA_BASE_URL=
+        export AUTO_DOWNLOAD_MODELS=false
+        export WHISPER_ENABLED=false
+        ;;
+    esac
     exec /usr/local/bin/docker-entrypoint.sh
 x-app-environment: &app-environment
   APP_ENV: prod
@@ -67,7 +75,14 @@ x-app-environment: &app-environment
 x-app-volumes: &app-volumes
   - ./data/uploads:/var/www/backend/var/uploads
   - ./data/whisper:/var/www/backend/var/whisper:ro
-  - ./data/backups:/var/www/backup
+  # Read-only: this directory holds every MariaDB dump and Qdrant snapshot, so
+  # it carries all user data, password hashes and encrypted provider keys. The
+  # backup artifacts are written by the HOST (pre-backup.sh redirects the dump
+  # and each snapshot into it), and the only container-side access is
+  # post-restore.sh reading one snapshot file back for upload. Mounting it
+  # writable gave the internet-facing PHP container the ability to read, alter
+  # or destroy the entire backup history for no functional gain.
+  - ./data/backups:/var/www/backup:ro
 
 services:
   backend:

--- a/deploy/elestio/README.md
+++ b/deploy/elestio/README.md
@@ -81,9 +81,13 @@ logic. The platform backup must include the repository's `deploy/data/`
 directory. Run a restore into an isolated pipeline and verify login, uploads,
 Qdrant search, worker processing, scheduler cleanup, and WebSocket delivery.
 
-For upgrades, change `SYNAPLAN_VERSION` to a tested SemVer tag. Never use
-`latest`. The pre-update hook creates a backup gate before the new image is
-started.
+For upgrades, follow [Update on Elestio](../../docs/UPDATE_ELESTIO.md). Never use
+`latest`: `validate_release_pin` accepts immutable SemVer tags only.
+`preUpdateCommand` maps to `deploy/scripts/pre-update.sh`, which creates a backup
+gate before the new image is started — but Elestio runs that hook only for its
+own update operation. A redeploy after an environment change takes the deploy
+path (`prepare.sh`, `build.sh`, `run.sh`, then `post-update.sh`) and has no
+backup gate, so a version change must be preceded by a manual backup.
 
 The checked-in Elestio value intentionally makes deployment fail before any old
 or incompatible app image can start. Replace it only after the release pipeline

--- a/deploy/scripts/tests/test-lifecycle.sh
+++ b/deploy/scripts/tests/test-lifecycle.sh
@@ -403,15 +403,61 @@ resume_paused_services
 grep -Fxq "start backend ollama db" "$compose_log"
 [[ ! -e "$PAUSED_SERVICES_FILE" ]]
 
-resolved_app_image() {
-    printf '%s\n' "ghcr.io/metadist/synaplan:5.0.0-rc.1"
+# The guarantee that a redeploy never silently upgrades: compose.yaml sets
+# `pull_policy: always`, so every start re-pulls the configured tag. On an
+# IMMUTABLE tag that returns the identical digest and the operator gets the
+# release they pinned; on a MUTABLE one the same restart — a reboot, a platform
+# redeploy, an unrelated `docker compose up` — quietly installs a different
+# application. validate_release_pin is the only thing standing between the two,
+# so every mutable form the registry actually publishes is pinned here, not just
+# `latest`: metadata-action also moves `4` and `4.0` on every release, which is
+# the realistic floating-tag mistake.
+assert_release_pin() {
+    local expected_status="$1"
+    local description="$2"
+    local image="$3"
+    local output status=0
+
+    resolved_app_image() { printf '%s\n' "$image"; }
+    output="$(validate_release_pin 2>&1)" || status=$?
+    [[ "$status" == "$expected_status" ]] || {
+        printf 'Release pin case "%s": expected status %s, got %s:\n%s\n' \
+            "$description" "$expected_status" "$status" "$output" >&2
+        exit 1
+    }
 }
-validate_release_pin
+
+assert_release_pin 0 "the immutable release tag every pin must be" \
+    "ghcr.io/metadist/synaplan:4.0.13"
+assert_release_pin 0 "a pre-release, which is immutable too" \
+    "ghcr.io/metadist/synaplan:5.0.0-rc.1"
+# A registry port contains the only other colon an image reference can carry, so
+# a rule anchored on the wrong one would reject a mirrored deployment.
+assert_release_pin 0 "the same pin behind a private registry mirror" \
+    "registry.example.com:5000/metadist/synaplan:4.0.13"
+assert_release_pin 1 "latest, which moves on every release" \
+    "ghcr.io/metadist/synaplan:latest"
+assert_release_pin 1 "a branch tag, which moves on every merge" \
+    "ghcr.io/metadist/synaplan:main"
+assert_release_pin 1 "a channel name that is not published at all" \
+    "ghcr.io/metadist/synaplan:stable"
+assert_release_pin 1 "the floating major alias" "ghcr.io/metadist/synaplan:4"
+assert_release_pin 1 "the floating major.minor alias" "ghcr.io/metadist/synaplan:4.0"
+# The git tag is `v4.0.13`, the published image tag is `4.0.13`. Copying the
+# former must fail the preflight rather than the image pull.
+assert_release_pin 1 "the v-prefixed git tag" "ghcr.io/metadist/synaplan:v4.0.13"
+assert_release_pin 1 "an empty version" "ghcr.io/metadist/synaplan:"
+assert_release_pin 1 "no tag at all, which docker reads as latest" \
+    "ghcr.io/metadist/synaplan"
+
+# Unset, compose.yaml's `${SYNAPLAN_VERSION:?}` makes `compose config` itself
+# fail, so validate_release_pin never sees an image reference. That has to be a
+# rejection as well, instead of an empty value falling through the pattern.
 resolved_app_image() {
-    printf '%s\n' "ghcr.io/metadist/synaplan:latest"
+    return 1
 }
 if validate_release_pin 2>/dev/null; then
-    echo "Mutable release tag unexpectedly passed validation" >&2
+    echo "A deployment whose image cannot be resolved unexpectedly passed validation" >&2
     exit 1
 fi
 

--- a/docs/ADMIN.md
+++ b/docs/ADMIN.md
@@ -259,7 +259,7 @@ Always run behind a reverse proxy (nginx, Caddy, Traefik) with TLS termination. 
 
 ## User Management
 
-User levels: `NEW`, `PRO`, `ADMIN`.
+User levels: `NEW`, `PRO`, `TEAM`, `BUSINESS`, `ADMIN`.
 
 ### Running These Statements
 

--- a/docs/ADMIN.md
+++ b/docs/ADMIN.md
@@ -184,31 +184,20 @@ succeeded on a fresh, separate stack.
 
 ## Updates
 
+Follow the step-by-step guide for your platform:
+
+- [Update a Self-Hosted Deployment](UPDATE_SELFHOST.md)
+- [Update on Elestio](UPDATE_ELESTIO.md)
+
 Production images must use a released, pinned `SYNAPLAN_VERSION`; never update
-a production deployment by following `latest`.
-
-Before each update:
-
-1. Read the release notes and [migration guidance](MIGRATIONS.md).
-2. Run `deploy/scripts/pre-update.sh`. Do not continue if its backup gate fails.
-3. Change `SYNAPLAN_VERSION` to the intended release.
-4. Pull and redeploy the production stack.
-5. Run `deploy/scripts/post-update.sh` and verify the reported version and
-   health.
-
-```bash
-docker compose --env-file deploy/.env -f deploy/compose.yaml pull
-docker compose --env-file deploy/.env -f deploy/compose.yaml up -d
-```
+a production deployment by following `latest`. Read the release notes and the
+[migration guidance](MIGRATIONS.md) before you start.
 
 The web container applies migrations through its production startup contract.
 Do not run `doctrine:schema:update --force`. Keep the pre-update recovery point
 until login, chat, uploads/RAG, worker processing, scheduler execution, and
-realtime connections have been verified.
-
-On Elestio, use the pipeline update operation; its lifecycle mapping invokes the
-same portable hooks. If verification fails, restore the complete pre-update
-recovery point rather than restoring only the database.
+realtime connections have been verified. If verification fails, restore the
+complete pre-update recovery point rather than restoring only the database.
 
 ---
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -175,8 +175,9 @@ Test `local-ai` only when the selected machine and remaining trial credit are
 sufficient. Do not publish credentials, deployment logs containing secrets, or
 private endpoint details.
 
-See [Administration Guide](ADMIN.md) for production updates, backups, restore,
-and cleanup.
+See [Administration Guide](ADMIN.md) for backups, restore, and cleanup, and
+[Update a Self-Hosted Deployment](UPDATE_SELFHOST.md) or
+[Update on Elestio](UPDATE_ELESTIO.md) for version upgrades.
 
 ---
 

--- a/docs/UPDATE_ELESTIO.md
+++ b/docs/UPDATE_ELESTIO.md
@@ -1,0 +1,38 @@
+# Update on Elestio
+
+Synaplan never updates itself. Nothing changes until you run the steps below.
+
+## Which version to install
+
+Synaplan shows its current version in the sidebar. When a newer release exists,
+the admin area shows that new version number next to the current one, together
+with a link to its release notes. Read the release notes, then use that version
+number in step 2.
+
+## Update
+
+1. **Create a backup.** In Elestio, open your service, go to **Backups**, and
+   start a manual backup. Wait until it has finished.
+2. **Set the new version.** Open your CI/CD pipeline's environment variables and
+   change `SYNAPLAN_VERSION` to the version shown in Synaplan, without a leading
+   `v` — for example `1.4.0`, not `v1.4.0`.
+3. **Trigger a redeploy** of the pipeline.
+4. **Done.** Elestio downloads and checks the new image, the database migrations
+   run automatically when the app starts, and every service is health-checked.
+   The app is back within a few minutes.
+
+> **Step 1 is not optional.** A redeploy caused by an environment change runs
+> Elestio's deploy path, which does **not** include the automatic backup that
+> Elestio's own update operation creates. Your manual backup is the only
+> recovery point.
+
+## Roll back
+
+Set `SYNAPLAN_VERSION` back to the previous version and redeploy. If the new
+version already changed the database, also restore the backup from step 1.
+
+## Good to know
+
+A redeploy on its own never installs a newer version — the version only changes
+when you change it. Always use a released version number; `latest` is rejected
+before anything starts.

--- a/docs/UPDATE_SELFHOST.md
+++ b/docs/UPDATE_SELFHOST.md
@@ -1,0 +1,54 @@
+# Update a Self-Hosted Deployment
+
+Synaplan never updates itself. Nothing changes until you run the steps below.
+
+## Which version to install
+
+Synaplan shows its current version in the sidebar. When a newer release exists,
+the admin area shows that new version number next to the current one, together
+with a link to its release notes. Read the release notes, then use that version
+number in step 2.
+
+## Update
+
+Run every command from the repository root.
+
+1. **Create a backup.** Do not continue if this command fails. The app is
+   briefly unavailable while the backup is taken.
+
+```bash
+deploy/scripts/pre-update.sh
+```
+
+2. **Set the new version** in `deploy/.env`, without a leading `v`:
+
+```dotenv
+# Example format only — use the version shown in Synaplan.
+SYNAPLAN_VERSION=1.4.0
+```
+
+3. **Start the new version.** The new image is downloaded, and the database
+   migrations run automatically when the app starts.
+
+```bash
+docker compose --env-file deploy/.env -f deploy/compose.yaml up -d
+```
+
+4. **Verify.** This waits for every service, checks health, and prints the
+   running version.
+
+```bash
+deploy/scripts/post-update.sh
+```
+
+## Roll back
+
+Put the previous version back in `deploy/.env` and repeat steps 3 and 4. If the
+new version already changed the database, also restore the backup from step 1 as
+described in [Backup and restore](../deploy/README.md#backup-and-restore).
+
+## Good to know
+
+A redeploy on its own never installs a newer version — the version only changes
+when you change it. Always use a released version number; `latest` is rejected
+before anything starts.

--- a/elestio.yml
+++ b/elestio.yml
@@ -20,6 +20,11 @@ environments:
   # SemVer version, never this value, `latest`, or an anticipated future tag.
   - key: "SYNAPLAN_VERSION"
     value: "REPLACE_WITH_PUBLISHED_COMPATIBLE_VERSION"
+  # Deployment hint for the release notice, so the admin UI links to the Elestio
+  # update guide instead of the self-hosted one. Display only: Synaplan never
+  # updates itself.
+  - key: "SYNAPLAN_PLATFORM"
+    value: "elestio"
   - key: "SYNAPLAN_HTTP_BIND"
     value: "0.0.0.0"
   - key: "SYNAPLAN_HTTP_PORT"

--- a/elestio.yml
+++ b/elestio.yml
@@ -25,8 +25,13 @@ environments:
   # updates itself.
   - key: "SYNAPLAN_PLATFORM"
     value: "elestio"
+  # The Docker bridge gateway, which is exactly the `targetIP` the reverse-proxy
+  # route below connects to — and the binding Elestio's own compose examples
+  # use. Binding 0.0.0.0 instead published the app as plain HTTP on every host
+  # interface: Docker writes its own iptables rules, so a host firewall does not
+  # close that port, and the HTTPS proxy in front of it could simply be bypassed.
   - key: "SYNAPLAN_HTTP_BIND"
-    value: "0.0.0.0"
+    value: "172.17.0.1"
   - key: "SYNAPLAN_HTTP_PORT"
     value: "8000"
   - key: "APP_URL"

--- a/frontend/src/components/SidebarV2.vue
+++ b/frontend/src/components/SidebarV2.vue
@@ -87,26 +87,6 @@
       </button>
     </div>
 
-    <!-- User Avatar -->
-    <div class="flex items-center justify-center py-4 flex-shrink-0">
-      <button
-        ref="userBtnRef"
-        class="v2-rail-icon w-[72px] min-h-[48px] flex flex-col items-center justify-center gap-0.5 py-1.5"
-        :title="authStore.user?.email || $t('nav.accountDescription')"
-        data-testid="btn-sidebar-v2-user"
-        @click="toggleUserMenu"
-      >
-        <div
-          class="w-8 h-8 rounded-full surface-chip flex items-center justify-center text-xs font-semibold"
-        >
-          {{ initials }}
-        </div>
-        <span class="v2-rail-label text-[10px] font-medium leading-tight">
-          {{ $t('nav.account') }}
-        </span>
-      </button>
-    </div>
-
     <!--
       Running release, for every user. Admins with a pending release get a link
       to the manual-update guide instead — Synaplan never updates itself, the
@@ -114,7 +94,7 @@
     -->
     <div
       v-if="versionLabel"
-      class="flex items-center justify-center pb-3 flex-shrink-0"
+      class="flex items-center justify-center pt-2 flex-shrink-0"
       data-testid="section-sidebar-v2-version"
     >
       <a
@@ -143,6 +123,26 @@
       >
         {{ versionLabel }}
       </span>
+    </div>
+
+    <!-- User Avatar -->
+    <div class="flex items-center justify-center py-4 flex-shrink-0">
+      <button
+        ref="userBtnRef"
+        class="v2-rail-icon w-[72px] min-h-[48px] flex flex-col items-center justify-center gap-0.5 py-1.5"
+        :title="authStore.user?.email || $t('nav.accountDescription')"
+        data-testid="btn-sidebar-v2-user"
+        @click="toggleUserMenu"
+      >
+        <div
+          class="w-8 h-8 rounded-full surface-chip flex items-center justify-center text-xs font-semibold"
+        >
+          {{ initials }}
+        </div>
+        <span class="v2-rail-label text-[10px] font-medium leading-tight">
+          {{ $t('nav.account') }}
+        </span>
+      </button>
     </div>
   </aside>
 

--- a/frontend/src/components/SidebarV2.vue
+++ b/frontend/src/components/SidebarV2.vue
@@ -106,6 +106,44 @@
         </span>
       </button>
     </div>
+
+    <!--
+      Running release, for every user. Admins with a pending release get a link
+      to the manual-update guide instead — Synaplan never updates itself, the
+      operator does, so this is a pointer to documentation and nothing else.
+    -->
+    <div
+      v-if="versionLabel"
+      class="flex items-center justify-center pb-3 flex-shrink-0"
+      data-testid="section-sidebar-v2-version"
+    >
+      <a
+        v-if="showUpdateLink"
+        :href="updatesStore.guideUrl ?? undefined"
+        target="_blank"
+        rel="noopener noreferrer"
+        :class="[
+          'inline-flex items-center gap-1 max-w-[72px] px-2 py-0.5 rounded-full text-[10px] font-semibold transition-opacity hover:opacity-80',
+          isSecurityUpdate
+            ? 'bg-[var(--status-error-muted)] text-[var(--status-error-text)]'
+            : 'bg-[var(--status-warning-muted)] text-[var(--status-warning-text)]',
+        ]"
+        :title="updateHint"
+        :aria-label="updateHint"
+        data-testid="link-sidebar-v2-update"
+      >
+        <ArrowUpCircleIcon class="w-3.5 h-3.5 flex-shrink-0" aria-hidden="true" />
+        <span class="truncate">{{ updatesStore.latestVersion }}</span>
+      </a>
+      <span
+        v-else
+        class="text-[10px] txt-secondary"
+        :title="$t('updates.runningVersion', { version: versionLabel })"
+        data-testid="text-sidebar-v2-version"
+      >
+        {{ versionLabel }}
+      </span>
+    </div>
   </aside>
 
   <!-- User Dropdown (teleported to #app to escape local stacking context) -->
@@ -610,6 +648,7 @@
 import { ref, computed, watch, onMounted, onBeforeUnmount } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import {
+  ArrowUpCircleIcon,
   ChatBubbleLeftRightIcon,
   CreditCardIcon,
   PlusIcon,
@@ -629,6 +668,7 @@ import { useAuth } from '../composables/useAuth'
 import { useNavItems, type NavChild, type NavItem } from '../composables/useNavItems'
 import { useTheme } from '../composables/useTheme'
 import { useChatsStore, isDefaultChatTitle, type Chat as StoreChat } from '../stores/chats'
+import { useUpdatesStore } from '../stores/updates'
 import { useDialog } from '../composables/useDialog'
 import { useI18n } from 'vue-i18n'
 import { useDateFormat } from '@/composables/useDateFormat'
@@ -645,6 +685,7 @@ const configStore = useConfigStore()
 // No purchase path on a custom server in the native app (store IAP only).
 const purchaseAllowed = isPurchaseAllowed()
 const chatsStore = useChatsStore()
+const updatesStore = useUpdatesStore()
 const dialog = useDialog()
 const { logout, isImpersonating } = useAuth()
 const { navItems, isItemActive, isGuestMode, loadFeatureStatus } = useNavItems()
@@ -754,6 +795,37 @@ const initials = computed(() => {
   const email = authStore.user?.email || 'G'
   return email.charAt(0).toUpperCase()
 })
+
+/**
+ * Running release from the public runtime config, so every user sees it. Empty
+ * while the config is still loading (or unavailable), which hides the footer
+ * rather than showing a placeholder.
+ */
+const versionLabel = computed(() => {
+  const version = configStore.build.version
+  if (!version || version === 'unknown') return ''
+
+  return /^\d/.test(version) ? `v${version}` : version
+})
+
+const showUpdateLink = computed(() => updatesStore.showBadge && !!updatesStore.guideUrl)
+const isSecurityUpdate = computed(() => updatesStore.severity === 'security')
+const updateHint = computed(() =>
+  t(isSecurityUpdate.value ? 'updates.badge.securityHint' : 'updates.badge.availableHint', {
+    version: updatesStore.latestVersion ?? '',
+  })
+)
+
+// Admins only, once per session (the store caches, so navigating never refetches).
+// Watched rather than read on mount because `isAdmin` only becomes true once
+// /auth/me has resolved, which can be after the rail is already rendered.
+watch(
+  () => updatesStore.canRead,
+  (canRead) => {
+    if (canRead) updatesStore.ensureLoaded()
+  },
+  { immediate: true }
+)
 
 const groupedChildren = computed(() => {
   if (!activeFlyoutItem.value?.children) return []

--- a/frontend/src/components/admin/UpdateCheckToggle.vue
+++ b/frontend/src/components/admin/UpdateCheckToggle.vue
@@ -1,0 +1,77 @@
+<script setup lang="ts">
+/**
+ * Master switch for the periodic version check. While it is off, the backend
+ * never makes an outbound request.
+ */
+import { ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useNotification } from '@/composables/useNotification'
+import { useUpdatesStore } from '@/stores/updates'
+
+const { t } = useI18n()
+const { success, error: showError } = useNotification()
+const updatesStore = useUpdatesStore()
+
+const saving = ref(false)
+
+async function handleToggle() {
+  if (saving.value) return
+
+  saving.value = true
+  try {
+    await updatesStore.setCheckEnabled(!updatesStore.checkEnabled)
+    success(t('updates.panel.saved'))
+  } catch {
+    showError(t('updates.panel.saveError'))
+  } finally {
+    saving.value = false
+  }
+}
+</script>
+
+<template>
+  <div
+    class="flex items-center justify-between gap-4 pt-4 border-t border-light-border/20 dark:border-dark-border/10"
+  >
+    <div class="min-w-0">
+      <p class="text-sm font-medium txt-primary">{{ $t('updates.panel.autoCheck') }}</p>
+      <p class="text-xs txt-secondary mt-0.5">{{ $t('updates.panel.autoCheckHint') }}</p>
+    </div>
+    <div class="flex items-center gap-3 flex-shrink-0">
+      <!--
+        The track colour lives on an inner element on purpose: the V2 design
+        sets a flat background on every `[role="switch"]`, which would beat a
+        utility class on the button itself and make on and off look identical.
+      -->
+      <button
+        type="button"
+        role="switch"
+        :aria-checked="updatesStore.checkEnabled"
+        :aria-label="$t('updates.panel.autoCheck')"
+        :disabled="saving"
+        :class="[
+          'relative inline-flex h-6 w-11 flex-shrink-0 items-center cursor-pointer rounded-full bg-transparent focus:outline-none focus:ring-2 focus:ring-[var(--brand)] focus:ring-offset-2',
+          saving && 'opacity-50 cursor-not-allowed',
+        ]"
+        data-testid="toggle-admin-updates-check"
+        @click="handleToggle"
+      >
+        <span
+          :class="[
+            'pointer-events-none absolute inset-0 rounded-full transition-colors duration-200 ease-in-out',
+            updatesStore.checkEnabled ? 'bg-[var(--brand)]' : 'bg-[var(--status-neutral)]',
+          ]"
+        />
+        <span
+          :class="[
+            'pointer-events-none relative inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out',
+            updatesStore.checkEnabled ? 'translate-x-5' : 'translate-x-0.5',
+          ]"
+        />
+      </button>
+      <span class="text-sm txt-secondary">
+        {{ updatesStore.checkEnabled ? $t('common.enabled') : $t('common.disabled') }}
+      </span>
+    </div>
+  </div>
+</template>

--- a/frontend/src/components/admin/UpdatePanel.vue
+++ b/frontend/src/components/admin/UpdatePanel.vue
@@ -159,9 +159,28 @@ onMounted(() => {
       </button>
     </div>
 
-    <div v-if="!status" class="flex justify-center py-8" data-testid="state-admin-updates-loading">
+    <div
+      v-if="updatesStore.loading"
+      class="flex justify-center py-8"
+      data-testid="state-admin-updates-loading"
+    >
       <Icon icon="mdi:loading" class="w-6 h-6 animate-spin txt-secondary" aria-hidden="true" />
     </div>
+
+    <!-- Reading the stored status failed. "Check now" fetches it again, so the
+         card stays usable instead of looking like it is still loading. -->
+    <p
+      v-else-if="!status"
+      class="text-sm txt-secondary flex items-start gap-1.5 py-4"
+      data-testid="state-admin-updates-unavailable"
+    >
+      <Icon
+        icon="mdi:information-outline"
+        class="w-4 h-4 flex-shrink-0 mt-0.5"
+        aria-hidden="true"
+      />
+      {{ $t('updates.panel.statusUnavailable') }}
+    </p>
 
     <div v-else class="space-y-5">
       <!-- Version tiles -->

--- a/frontend/src/components/admin/UpdatePanel.vue
+++ b/frontend/src/components/admin/UpdatePanel.vue
@@ -1,0 +1,265 @@
+<script setup lang="ts">
+/**
+ * Release notice for admins: which version runs here, whether a newer one
+ * exists, and where the instructions are.
+ *
+ * Deliberately has NO button that changes the installation — Synaplan never
+ * updates itself. Everything here either reads the stored check result or
+ * records a display preference (acknowledged version, automatic check).
+ */
+import { computed, onMounted, ref } from 'vue'
+import { Icon } from '@iconify/vue'
+import { useI18n } from 'vue-i18n'
+import { useDateFormat } from '@/composables/useDateFormat'
+import { useNotification } from '@/composables/useNotification'
+import { useUpdatesStore } from '@/stores/updates'
+import UpdateCheckToggle from '@/components/admin/UpdateCheckToggle.vue'
+
+const { t } = useI18n()
+const { formatDate, formatRelativeTime } = useDateFormat()
+const { success, error: showError } = useNotification()
+const updatesStore = useUpdatesStore()
+
+const checking = ref(false)
+const dismissing = ref(false)
+
+const status = computed(() => updatesStore.status)
+const isSecurity = computed(() => updatesStore.severity === 'security')
+
+/**
+ * A newer release exists. Unlike the sidebar badge this ignores the
+ * acknowledged version: this card is the detail view, so it always states the
+ * facts — acknowledging only silences the badge.
+ */
+const hasUpdate = computed(
+  () => status.value?.updateAvailable === true && status.value.latestVersion !== null
+)
+
+/** The newer release is known, but the admin already acknowledged it. */
+const isDismissed = computed(
+  () => hasUpdate.value && status.value?.dismissedVersion === status.value?.latestVersion
+)
+
+/** A check succeeded and the release it found is not newer than the installed one. */
+const isUpToDate = computed(
+  () =>
+    status.value !== null &&
+    !status.value.updateAvailable &&
+    status.value.latestVersion !== null &&
+    status.value.lastCheckedAt !== null
+)
+
+const latestVersionLabel = computed(
+  () => updatesStore.latestVersion ?? t('updates.panel.unknownVersion')
+)
+
+const releasedAtLabel = computed(() => {
+  const releasedAt = status.value?.releasedAt
+  if (!releasedAt) return ''
+
+  const date = new Date(releasedAt)
+
+  return Number.isNaN(date.getTime()) ? '' : formatDate(date)
+})
+
+const lastCheckedLabel = computed(() => {
+  const lastCheckedAt = status.value?.lastCheckedAt
+  if (!lastCheckedAt) return t('updates.panel.neverChecked')
+
+  const date = new Date(lastCheckedAt)
+
+  return Number.isNaN(date.getTime())
+    ? t('updates.panel.neverChecked')
+    : t('updates.panel.lastChecked', { time: formatRelativeTime(date) })
+})
+
+const statusToneClass = computed(() => {
+  if (hasUpdate.value) {
+    return isSecurity.value
+      ? 'bg-[var(--status-error-muted)] text-[var(--status-error-text)]'
+      : 'bg-[var(--status-warning-muted)] text-[var(--status-warning-text)]'
+  }
+  if (isUpToDate.value) {
+    return 'bg-[var(--status-success-muted)] text-[var(--status-success-text)]'
+  }
+
+  return 'bg-[var(--status-neutral-muted)] text-[var(--status-neutral-text)]'
+})
+
+const statusLabel = computed(() => {
+  if (hasUpdate.value) {
+    return isSecurity.value ? t('updates.panel.securityUpdate') : t('updates.panel.updateAvailable')
+  }
+  if (isUpToDate.value) return t('updates.panel.upToDate')
+
+  return t('updates.panel.unknownState')
+})
+
+async function handleCheckNow() {
+  if (checking.value) return
+
+  checking.value = true
+  try {
+    await updatesStore.checkNow()
+    success(t('updates.panel.checkDone'))
+  } catch {
+    showError(t('updates.panel.checkError'))
+  } finally {
+    checking.value = false
+  }
+}
+
+async function handleDismiss() {
+  if (dismissing.value) return
+
+  dismissing.value = true
+  try {
+    await updatesStore.dismissLatest()
+    success(t('updates.panel.dismissDone'))
+  } catch {
+    showError(t('updates.panel.saveError'))
+  } finally {
+    dismissing.value = false
+  }
+}
+
+onMounted(() => {
+  updatesStore.ensureLoaded()
+})
+</script>
+
+<template>
+  <div class="surface-card rounded-xl p-6" data-testid="panel-admin-updates">
+    <div class="flex items-start justify-between gap-3 mb-4">
+      <div class="min-w-0">
+        <h3 class="text-lg font-semibold txt-primary flex items-center gap-2">
+          <Icon icon="mdi:package-variant" class="w-5 h-5 txt-secondary" aria-hidden="true" />
+          {{ $t('updates.panel.title') }}
+        </h3>
+        <p class="text-xs txt-secondary mt-1">{{ $t('updates.panel.description') }}</p>
+      </div>
+      <button
+        type="button"
+        class="btn-secondary px-3 py-2 rounded-lg flex items-center gap-2 flex-shrink-0"
+        :disabled="checking || !updatesStore.checkEnabled"
+        :title="
+          updatesStore.checkEnabled
+            ? $t('updates.panel.checkNow')
+            : $t('updates.panel.autoCheckOffHint')
+        "
+        data-testid="btn-admin-updates-check"
+        @click="handleCheckNow"
+      >
+        <Icon
+          :icon="checking ? 'mdi:loading' : 'mdi:refresh'"
+          :class="['w-5 h-5', checking && 'animate-spin']"
+          aria-hidden="true"
+        />
+        <span class="hidden sm:inline">{{ $t('updates.panel.checkNow') }}</span>
+      </button>
+    </div>
+
+    <div v-if="!status" class="flex justify-center py-8" data-testid="state-admin-updates-loading">
+      <Icon icon="mdi:loading" class="w-6 h-6 animate-spin txt-secondary" aria-hidden="true" />
+    </div>
+
+    <div v-else class="space-y-5">
+      <!-- Version tiles -->
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div class="surface-elevated rounded-lg p-4">
+          <span class="text-sm txt-secondary">{{ $t('updates.panel.currentVersion') }}</span>
+          <div class="text-2xl font-bold txt-primary" data-testid="text-admin-updates-current">
+            {{ status.currentVersion }}
+          </div>
+        </div>
+        <div class="surface-elevated rounded-lg p-4">
+          <span class="text-sm txt-secondary">{{ $t('updates.panel.latestVersion') }}</span>
+          <div class="text-2xl font-bold txt-primary" data-testid="text-admin-updates-latest">
+            {{ latestVersionLabel }}
+          </div>
+          <div v-if="releasedAtLabel" class="text-xs txt-secondary mt-1">
+            {{ $t('updates.panel.releasedOn', { date: releasedAtLabel }) }}
+          </div>
+        </div>
+      </div>
+
+      <!-- Status + actions -->
+      <div class="flex flex-wrap items-center gap-3">
+        <span
+          :class="[
+            'inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium',
+            statusToneClass,
+          ]"
+          data-testid="badge-admin-updates-status"
+        >
+          <Icon
+            :icon="hasUpdate ? 'mdi:arrow-up-circle' : 'mdi:check-circle'"
+            class="w-3.5 h-3.5"
+            aria-hidden="true"
+          />
+          {{ statusLabel }}
+        </span>
+        <span class="text-xs txt-secondary" data-testid="text-admin-updates-last-checked">
+          {{ lastCheckedLabel }}
+        </span>
+      </div>
+
+      <div v-if="hasUpdate" class="flex flex-wrap items-center gap-3">
+        <a
+          v-if="status.guideUrl"
+          :href="status.guideUrl"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="btn-primary px-4 py-2 rounded-lg inline-flex items-center gap-2 text-sm font-medium"
+          data-testid="link-admin-updates-guide"
+        >
+          <Icon icon="mdi:book-open-variant" class="w-4 h-4" aria-hidden="true" />
+          {{ $t('updates.panel.openGuide') }}
+        </a>
+        <a
+          v-if="status.notesUrl"
+          :href="status.notesUrl"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="text-sm txt-brand hover:underline inline-flex items-center gap-1"
+          data-testid="link-admin-updates-notes"
+        >
+          <Icon icon="mdi:open-in-new" class="w-4 h-4" aria-hidden="true" />
+          {{ $t('updates.panel.releaseNotes') }}
+        </a>
+        <button
+          v-if="!isDismissed"
+          type="button"
+          class="text-sm txt-secondary hover:txt-primary disabled:opacity-50"
+          :disabled="dismissing"
+          data-testid="btn-admin-updates-dismiss"
+          @click="handleDismiss"
+        >
+          {{ $t('updates.panel.dismiss') }}
+        </button>
+        <span
+          v-else
+          class="text-sm txt-secondary inline-flex items-center gap-1.5"
+          data-testid="text-admin-updates-dismissed"
+        >
+          <Icon icon="mdi:bell-off-outline" class="w-4 h-4" aria-hidden="true" />
+          {{ $t('updates.panel.noticeHidden') }}
+        </span>
+      </div>
+
+      <!-- A failed check is usually just a missing internet connection: keep it
+           a hint, never a warning surface. -->
+      <p
+        v-if="status.lastError"
+        class="text-xs txt-secondary flex items-start gap-1.5"
+        :title="status.lastError"
+        data-testid="hint-admin-updates-error"
+      >
+        <Icon icon="mdi:information-outline" class="w-4 h-4 flex-shrink-0" aria-hidden="true" />
+        {{ $t('updates.panel.checkFailedHint') }}
+      </p>
+
+      <UpdateCheckToggle />
+    </div>
+  </div>
+</template>

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -16,6 +16,7 @@
       "updateAvailable": "Eine neuere Version ist verfügbar",
       "securityUpdate": "Ein Sicherheitsupdate ist verfügbar",
       "unknownState": "Es wurde noch nicht nach Versionen gesucht",
+      "statusUnavailable": "Die Versionsinformationen konnten nicht geladen werden. Wählen Sie „Jetzt prüfen“, um es erneut zu versuchen.",
       "openGuide": "So aktualisieren Sie",
       "releaseNotes": "Was ist neu",
       "dismiss": "Hinweis ausblenden",

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -1,4 +1,39 @@
 {
+  "updates": {
+    "runningVersion": "Version {version}",
+    "badge": {
+      "availableHint": "Version {version} ist verfügbar — öffnet die Update-Anleitung in einem neuen Tab",
+      "securityHint": "Sicherheitsupdate {version} ist verfügbar — öffnet die Update-Anleitung in einem neuen Tab"
+    },
+    "panel": {
+      "title": "Software-Version",
+      "description": "Synaplan sagt Ihnen, wenn eine neuere Version verfügbar ist. Es installiert nie etwas von selbst — Sie entscheiden, wann und wie Sie aktualisieren.",
+      "currentVersion": "Installierte Version",
+      "latestVersion": "Neueste Version",
+      "unknownVersion": "Noch nicht bekannt",
+      "releasedOn": "Veröffentlicht am {date}",
+      "upToDate": "Sie haben die neueste Version",
+      "updateAvailable": "Eine neuere Version ist verfügbar",
+      "securityUpdate": "Ein Sicherheitsupdate ist verfügbar",
+      "unknownState": "Es wurde noch nicht nach Versionen gesucht",
+      "openGuide": "So aktualisieren Sie",
+      "releaseNotes": "Was ist neu",
+      "dismiss": "Hinweis ausblenden",
+      "dismissDone": "Hinweis ausgeblendet, bis eine neuere Version erscheint.",
+      "noticeHidden": "Hinweis ausgeblendet",
+      "checkNow": "Jetzt prüfen",
+      "checkDone": "Versionsprüfung abgeschlossen.",
+      "checkError": "Die Versionsprüfung konnte gerade nicht gestartet werden.",
+      "checkFailedHint": "Die letzte Prüfung kam nicht durch — meist fehlt einfach die Internetverbindung.",
+      "lastChecked": "Zuletzt geprüft {time}",
+      "neverChecked": "Noch nie geprüft",
+      "autoCheck": "Automatisch nach neuen Versionen suchen",
+      "autoCheckHint": "Einmal täglich fragt Synaplan, ob eine neuere Version veröffentlicht wurde. Es werden keine Daten über Sie übertragen.",
+      "autoCheckOffHint": "Die automatische Prüfung ist ausgeschaltet.",
+      "saved": "Einstellung gespeichert.",
+      "saveError": "Die Einstellung konnte nicht gespeichert werden."
+    }
+  },
   "incognito": {
     "toggleStart": "Inkognito-Chat starten",
     "toggleEnd": "Inkognito-Chat beenden",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -1,4 +1,39 @@
 {
+  "updates": {
+    "runningVersion": "Version {version}",
+    "badge": {
+      "availableHint": "Version {version} is available — opens the update guide in a new tab",
+      "securityHint": "Security update {version} is available — opens the update guide in a new tab"
+    },
+    "panel": {
+      "title": "Software version",
+      "description": "Synaplan tells you when a newer version is available. It never installs anything on its own — you decide when and how to update.",
+      "currentVersion": "Installed version",
+      "latestVersion": "Newest version",
+      "unknownVersion": "Not known yet",
+      "releasedOn": "Released {date}",
+      "upToDate": "You have the newest version",
+      "updateAvailable": "A newer version is available",
+      "securityUpdate": "A security update is available",
+      "unknownState": "No version check has run yet",
+      "openGuide": "How to update",
+      "releaseNotes": "What's new",
+      "dismiss": "Hide this notice",
+      "dismissDone": "Notice hidden until a newer version appears.",
+      "noticeHidden": "Notice hidden",
+      "checkNow": "Check now",
+      "checkDone": "Version check finished.",
+      "checkError": "The version check could not be started right now.",
+      "checkFailedHint": "The last check did not get through — usually there is simply no internet connection.",
+      "lastChecked": "Last checked {time}",
+      "neverChecked": "Never checked",
+      "autoCheck": "Check for new versions automatically",
+      "autoCheckHint": "Once a day Synaplan asks whether a newer version has been published. Nothing about your data is sent.",
+      "autoCheckOffHint": "Automatic checking is switched off.",
+      "saved": "Setting saved.",
+      "saveError": "The setting could not be saved."
+    }
+  },
   "incognito": {
     "toggleStart": "Start incognito chat",
     "toggleEnd": "End incognito chat",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -16,6 +16,7 @@
       "updateAvailable": "A newer version is available",
       "securityUpdate": "A security update is available",
       "unknownState": "No version check has run yet",
+      "statusUnavailable": "The version information could not be loaded. Select \"Check now\" to try again.",
       "openGuide": "How to update",
       "releaseNotes": "What's new",
       "dismiss": "Hide this notice",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -1,4 +1,39 @@
 {
+  "updates": {
+    "runningVersion": "Versión {version}",
+    "badge": {
+      "availableHint": "La versión {version} está disponible: abre la guía de actualización en una pestaña nueva",
+      "securityHint": "La actualización de seguridad {version} está disponible: abre la guía de actualización en una pestaña nueva"
+    },
+    "panel": {
+      "title": "Versión del software",
+      "description": "Synaplan te avisa cuando hay una versión más reciente. Nunca instala nada por su cuenta: tú decides cuándo y cómo actualizar.",
+      "currentVersion": "Versión instalada",
+      "latestVersion": "Versión más reciente",
+      "unknownVersion": "Aún no se sabe",
+      "releasedOn": "Publicada el {date}",
+      "upToDate": "Tienes la versión más reciente",
+      "updateAvailable": "Hay una versión más reciente disponible",
+      "securityUpdate": "Hay una actualización de seguridad disponible",
+      "unknownState": "Todavía no se ha buscado ninguna versión",
+      "openGuide": "Cómo actualizar",
+      "releaseNotes": "Novedades",
+      "dismiss": "Ocultar este aviso",
+      "dismissDone": "Aviso oculto hasta que aparezca una versión más reciente.",
+      "noticeHidden": "Aviso oculto",
+      "checkNow": "Buscar ahora",
+      "checkDone": "Comprobación de versión finalizada.",
+      "checkError": "No se ha podido iniciar la comprobación de versión en este momento.",
+      "checkFailedHint": "La última comprobación no llegó a completarse: normalmente solo falta la conexión a internet.",
+      "lastChecked": "Última comprobación {time}",
+      "neverChecked": "Nunca se ha comprobado",
+      "autoCheck": "Buscar nuevas versiones automáticamente",
+      "autoCheckHint": "Una vez al día Synaplan consulta si se ha publicado una versión más reciente. No se envía ningún dato tuyo.",
+      "autoCheckOffHint": "La comprobación automática está desactivada.",
+      "saved": "Ajuste guardado.",
+      "saveError": "No se ha podido guardar el ajuste."
+    }
+  },
   "incognito": {
     "toggleStart": "Iniciar chat de incógnito",
     "toggleEnd": "Finalizar chat de incógnito",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -16,6 +16,7 @@
       "updateAvailable": "Hay una versión más reciente disponible",
       "securityUpdate": "Hay una actualización de seguridad disponible",
       "unknownState": "Todavía no se ha buscado ninguna versión",
+      "statusUnavailable": "No se ha podido cargar la información de versión. Seleccione «Buscar ahora» para volver a intentarlo.",
       "openGuide": "Cómo actualizar",
       "releaseNotes": "Novedades",
       "dismiss": "Ocultar este aviso",

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -1,4 +1,39 @@
 {
+  "updates": {
+    "runningVersion": "Sürüm {version}",
+    "badge": {
+      "availableHint": "{version} sürümü mevcut — güncelleme kılavuzunu yeni sekmede açar",
+      "securityHint": "{version} güvenlik güncellemesi mevcut — güncelleme kılavuzunu yeni sekmede açar"
+    },
+    "panel": {
+      "title": "Yazılım sürümü",
+      "description": "Daha yeni bir sürüm çıktığında Synaplan sizi bilgilendirir. Kendi kendine hiçbir şey kurmaz — ne zaman ve nasıl güncelleyeceğinize siz karar verirsiniz.",
+      "currentVersion": "Kurulu sürüm",
+      "latestVersion": "En yeni sürüm",
+      "unknownVersion": "Henüz bilinmiyor",
+      "releasedOn": "{date} tarihinde yayınlandı",
+      "upToDate": "En yeni sürümü kullanıyorsunuz",
+      "updateAvailable": "Daha yeni bir sürüm mevcut",
+      "securityUpdate": "Bir güvenlik güncellemesi mevcut",
+      "unknownState": "Henüz sürüm kontrolü yapılmadı",
+      "openGuide": "Nasıl güncellenir",
+      "releaseNotes": "Yenilikler",
+      "dismiss": "Bu bildirimi gizle",
+      "dismissDone": "Daha yeni bir sürüm çıkana kadar bildirim gizlendi.",
+      "noticeHidden": "Bildirim gizlendi",
+      "checkNow": "Şimdi kontrol et",
+      "checkDone": "Sürüm kontrolü tamamlandı.",
+      "checkError": "Sürüm kontrolü şu anda başlatılamadı.",
+      "checkFailedHint": "Son kontrol tamamlanamadı — genellikle sadece internet bağlantısı yoktur.",
+      "lastChecked": "Son kontrol {time}",
+      "neverChecked": "Hiç kontrol edilmedi",
+      "autoCheck": "Yeni sürümleri otomatik olarak kontrol et",
+      "autoCheckHint": "Synaplan günde bir kez daha yeni bir sürüm yayınlanıp yayınlanmadığını sorar. Verilerinizle ilgili hiçbir bilgi gönderilmez.",
+      "autoCheckOffHint": "Otomatik kontrol kapalı.",
+      "saved": "Ayar kaydedildi.",
+      "saveError": "Ayar kaydedilemedi."
+    }
+  },
   "incognito": {
     "toggleStart": "Gizli sohbeti başlat",
     "toggleEnd": "Gizli sohbeti bitir",

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -16,6 +16,7 @@
       "updateAvailable": "Daha yeni bir sürüm mevcut",
       "securityUpdate": "Bir güvenlik güncellemesi mevcut",
       "unknownState": "Henüz sürüm kontrolü yapılmadı",
+      "statusUnavailable": "Sürüm bilgileri yüklenemedi. Yeniden denemek için \"Şimdi kontrol et\" seçeneğini kullanın.",
       "openGuide": "Nasıl güncellenir",
       "releaseNotes": "Yenilikler",
       "dismiss": "Bu bildirimi gizle",

--- a/frontend/src/services/api/updates.ts
+++ b/frontend/src/services/api/updates.ts
@@ -1,0 +1,68 @@
+import type { z } from 'zod'
+import {
+  GetAdminUpdatesStatusResponseSchema,
+  PostAdminUpdatesCheckResponseSchema,
+  PostAdminUpdatesDismissResponseSchema,
+  PutAdminUpdatesSettingsResponseSchema,
+} from '@/generated/api-schemas'
+import { httpClient } from './httpClient'
+
+// Types are inferred from the generated Zod schemas (per AGENTS.md: never
+// hand-write interfaces for API responses).
+export type UpdateStatus = z.infer<typeof GetAdminUpdatesStatusResponseSchema>
+
+/** Importance of the latest known release. */
+export type UpdateSeverity = UpdateStatus['severity']
+
+/** Deployment flavour the backend detected; decides which guide `guideUrl` points at. */
+export type UpdatePlatform = UpdateStatus['platform']
+
+const BASE_PATH = '/api/v1/admin/updates'
+
+/**
+ * Release-notice API (ROLE_ADMIN on the backend — never call this for a
+ * non-admin, it would just 403).
+ *
+ * Detection and display only: nothing here changes the installation. The
+ * update itself is always performed manually by the operator, following the
+ * guide at `status.guideUrl`.
+ */
+export const updatesApi = {
+  /** Stored result of the last check — no outbound request, works offline. */
+  getStatus: async (): Promise<UpdateStatus> => {
+    return httpClient(`${BASE_PATH}/status`, { schema: GetAdminUpdatesStatusResponseSchema })
+  },
+
+  /**
+   * Run the check now. A network failure is a normal outcome and surfaces in
+   * `lastError` rather than as a rejected promise.
+   */
+  check: async (): Promise<UpdateStatus> => {
+    return httpClient(`${BASE_PATH}/check`, {
+      method: 'POST',
+      schema: PostAdminUpdatesCheckResponseSchema,
+    })
+  },
+
+  /** Acknowledge a version so the notice stays hidden until a newer one appears. */
+  dismiss: async (
+    version: string
+  ): Promise<z.infer<typeof PostAdminUpdatesDismissResponseSchema>> => {
+    return httpClient(`${BASE_PATH}/dismiss`, {
+      method: 'POST',
+      body: JSON.stringify({ version }),
+      schema: PostAdminUpdatesDismissResponseSchema,
+    })
+  },
+
+  /** Master switch: while off, no outbound request is ever made. */
+  setCheckEnabled: async (
+    checkEnabled: boolean
+  ): Promise<z.infer<typeof PutAdminUpdatesSettingsResponseSchema>> => {
+    return httpClient(`${BASE_PATH}/settings`, {
+      method: 'PUT',
+      body: JSON.stringify({ checkEnabled }),
+      schema: PutAdminUpdatesSettingsResponseSchema,
+    })
+  },
+}

--- a/frontend/src/stores/history.ts
+++ b/frontend/src/stores/history.ts
@@ -297,6 +297,18 @@ function messageHasRenderableContent(message: Message): boolean {
   )
 }
 
+/**
+ * Whether a message is a live, client-owned stream.
+ *
+ * The synthetic in-progress bubble carries `isStreaming` too, but it is not
+ * live state the client owns — it is re-rendered from the server on every
+ * in-progress poll. Treating it as a stream to preserve would keep the stale
+ * copy and drop the fresh one, freezing the task cards it exists to update.
+ */
+function isLiveStream(message: Message): boolean {
+  return true === message.isStreaming && message.id !== IN_PROGRESS_TURN_ID
+}
+
 /** Concatenated text content of a message, used for duplicate detection. */
 function messageTextContent(message: Message): string {
   return message.parts
@@ -307,11 +319,11 @@ function messageTextContent(message: Message): string {
 
 /**
  * Merge a freshly hydrated history snapshot with the live message list when a
- * foreground load resolves while a streaming exchange is in flight (see
- * `loadMessages`). The snapshot replaces everything EXCEPT the in-flight
- * tail: the streaming message(s) plus the locally added user message(s) of
- * that exchange directly preceding them (added by `addMessage` with a local
- * uuid and no backend id yet).
+ * load resolves while a streaming exchange is in flight (see `loadMessages`).
+ * The snapshot replaces everything EXCEPT the in-flight tail: the streaming
+ * message(s) plus the locally added user message(s) of that exchange directly
+ * preceding them (added by `addMessage` with a local uuid and no backend id
+ * yet).
  *
  * Trailing snapshot rows that duplicate the tail are dropped — the live copy
  * wins, because ChatView still references it by its local id (error status,
@@ -329,7 +341,7 @@ export function mergeHydrationWithStreamingTail(
   snapshot: Message[],
   current: Message[]
 ): Message[] {
-  const firstStreamingIndex = current.findIndex((message) => message.isStreaming)
+  const firstStreamingIndex = current.findIndex(isLiveStream)
   if (firstStreamingIndex === -1) return snapshot
 
   let tailStart = firstStreamingIndex
@@ -599,13 +611,21 @@ export const useHistoryStore = defineStore('history', () => {
 
         // If offset is 0, replace messages; otherwise, prepend (for infinite scroll)
         if (offset === 0) {
-          // A foreground hydration may have started just before the user sent
-          // a message. The live stream is newer than that response and must not
-          // be replaced by its stale snapshot — but the snapshot still carries
-          // the chat's prior history, so merge it in front of the in-flight
-          // exchange instead of dropping it (and fall through to the pagination
-          // update, which was reset before the fetch).
-          if (!silent && messages.value.some((message) => message.isStreaming)) {
+          // A hydration may have started just before the user sent a message.
+          // The live stream is newer than that response and must not be replaced
+          // by its stale snapshot — but the snapshot still carries the chat's
+          // prior history, so merge it in front of the in-flight exchange
+          // instead of dropping it (and fall through to the pagination update,
+          // which was reset before the fetch).
+          //
+          // Silent loads need the same protection: the very response that
+          // triggers the merge also schedules the 2s in-progress poll above, and
+          // that poll is silent — guarding only the foreground path let it
+          // replace the streaming bubble two seconds later, so a multitask turn
+          // visibly stopped streaming mid-answer. Drop recovery is unaffected:
+          // ChatView calls finishStreamingMessage() before recoverInterruptedTurn(),
+          // so its silent reloads never see an active stream to preserve.
+          if (messages.value.some(isLiveStream)) {
             messages.value = mergeHydrationWithStreamingTail(loadedMessages, messages.value)
           } else {
             messages.value = loadedMessages

--- a/frontend/src/stores/updates.ts
+++ b/frontend/src/stores/updates.ts
@@ -1,0 +1,140 @@
+import { defineStore } from 'pinia'
+import { computed, ref } from 'vue'
+import { updatesApi, type UpdateSeverity, type UpdateStatus } from '@/services/api/updates'
+import { isNativeApp } from '@/services/api/nativeRuntime'
+import { useAuthStore } from '@/stores/auth'
+
+/**
+ * Release notice: "a newer Synaplan exists".
+ *
+ * Display only — Synaplan never updates itself. Everything here either reads
+ * the stored result of the daily check or records a display preference
+ * (acknowledged version, master switch); the update itself is performed
+ * manually by the operator following `guideUrl`.
+ *
+ * Two invariants the whole UI depends on:
+ *   - The endpoints are ROLE_ADMIN, so a non-admin must never trigger a
+ *     request. Every action is gated on {@link canRead}.
+ *   - The status is fetched ONCE per session and cached, because the sidebar
+ *     reads it on every route: {@link ensureLoaded} is idempotent and
+ *     de-duplicates concurrent callers.
+ *
+ * The running version shown to ALL users does NOT come from here — it is the
+ * public runtime config's `build.version` (useConfigStore).
+ */
+export const useUpdatesStore = defineStore('updates', () => {
+  const authStore = useAuthStore()
+
+  const status = ref<UpdateStatus | null>(null)
+  const loading = ref(false)
+
+  /**
+   * True once an attempt finished, successfully or not. A failed check must not
+   * make the sidebar retry on every navigation, so failure also counts as
+   * "asked".
+   */
+  const loaded = ref(false)
+
+  /** De-duplicates concurrent ensureLoaded() calls (sidebar + admin card). */
+  let inFlight: Promise<void> | null = null
+
+  /**
+   * Only an admin may talk to the release-notice endpoints.
+   *
+   * MOBILE-APP SEAM: the native app is excluded. Updating means changing a
+   * version on the server and redeploying it, which nobody can do from a phone,
+   * so the notice would only ever be a dead end there.
+   */
+  const canRead = computed(() => authStore.isAdmin && !isNativeApp())
+
+  const latestVersion = computed(() => status.value?.latestVersion ?? null)
+  const severity = computed<UpdateSeverity>(() => status.value?.severity ?? 'normal')
+  const guideUrl = computed(() => status.value?.guideUrl ?? null)
+  const checkEnabled = computed(() => status.value?.checkEnabled ?? true)
+
+  /** A newer release is known and it is not the one the admin acknowledged. */
+  const showBadge = computed(() => {
+    const current = status.value
+    if (!current || !canRead.value) return false
+    if (!current.updateAvailable || current.latestVersion === null) return false
+
+    return current.latestVersion !== current.dismissedVersion
+  })
+
+  /**
+   * Load the stored status once. Safe to call from anywhere: a non-admin, an
+   * already-loaded store and a request in flight all return without a second
+   * network call.
+   */
+  async function ensureLoaded(): Promise<void> {
+    if (!canRead.value || loaded.value) return
+    if (inFlight) return inFlight
+
+    inFlight = (async () => {
+      loading.value = true
+      try {
+        status.value = await updatesApi.getStatus()
+      } catch {
+        // A release notice is never important enough to break a page: without a
+        // status the sidebar simply shows the plain version number.
+        status.value = null
+      } finally {
+        loaded.value = true
+        loading.value = false
+        inFlight = null
+      }
+    })()
+
+    return inFlight
+  }
+
+  /**
+   * Manual "check now". Unlike {@link ensureLoaded} this performs an outbound
+   * request on the backend, so failures are the caller's to report — a
+   * transport error rejects, while an unreachable manifest comes back as a
+   * normal payload carrying `lastError`.
+   */
+  async function checkNow(): Promise<void> {
+    if (!canRead.value) return
+
+    loading.value = true
+    try {
+      status.value = await updatesApi.check()
+      loaded.value = true
+    } finally {
+      loading.value = false
+    }
+  }
+
+  /** Acknowledge the currently offered release so the badge disappears. */
+  async function dismissLatest(): Promise<void> {
+    const version = latestVersion.value
+    if (!canRead.value || version === null || status.value === null) return
+
+    const response = await updatesApi.dismiss(version)
+    status.value = { ...status.value, dismissedVersion: response.dismissedVersion ?? version }
+  }
+
+  /** Turn the periodic check on or off. */
+  async function setCheckEnabled(enabled: boolean): Promise<void> {
+    if (!canRead.value || status.value === null) return
+
+    const response = await updatesApi.setCheckEnabled(enabled)
+    status.value = { ...status.value, checkEnabled: response.checkEnabled }
+  }
+
+  return {
+    status,
+    loading,
+    canRead,
+    latestVersion,
+    severity,
+    guideUrl,
+    checkEnabled,
+    showBadge,
+    ensureLoaded,
+    checkNow,
+    dismissLatest,
+    setCheckEnabled,
+  }
+})

--- a/frontend/src/views/AdminConfigView.vue
+++ b/frontend/src/views/AdminConfigView.vue
@@ -5,7 +5,9 @@ import { Icon } from '@iconify/vue'
 import { useI18n } from 'vue-i18n'
 import MainLayout from '@/components/MainLayout.vue'
 import ConfigField from '@/components/admin/ConfigField.vue'
+import UpdatePanel from '@/components/admin/UpdatePanel.vue'
 import { useAuthStore } from '@/stores/auth'
+import { useUpdatesStore } from '@/stores/updates'
 import { useNotification } from '@/composables/useNotification'
 import { triggerHapticImpact } from '@/services/api/nativeHaptics'
 import { useTheme } from '@/composables/useTheme'
@@ -21,6 +23,7 @@ import {
 const { t } = useI18n()
 const router = useRouter()
 const authStore = useAuthStore()
+const updatesStore = useUpdatesStore()
 const { success, error: showError } = useNotification()
 const { isDark } = useTheme()
 
@@ -363,6 +366,9 @@ onBeforeUnmount(() => {
           </div>
           <p class="txt-secondary">{{ $t('admin.config.description') }}</p>
         </div>
+
+        <!-- Release notice: informs and links to the guide, never updates anything -->
+        <UpdatePanel v-if="updatesStore.canRead" class="mb-6" />
 
         <!-- Loading State -->
         <div v-if="loading" class="flex items-center justify-center py-20">

--- a/frontend/tests/unit/components/admin/UpdatePanel.spec.ts
+++ b/frontend/tests/unit/components/admin/UpdatePanel.spec.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+import UpdatePanel from '@/components/admin/UpdatePanel.vue'
+import type { UpdateStatus } from '@/services/api/updates'
+
+const storeState = vi.hoisted(() => ({
+  status: null as UpdateStatus | null,
+  loading: false,
+  checkEnabled: true,
+  latestVersion: null as string | null,
+  severity: 'normal' as UpdateStatus['severity'],
+  ensureLoaded: vi.fn(),
+  checkNow: vi.fn(),
+  dismissLatest: vi.fn(),
+}))
+
+vi.mock('@/stores/updates', () => ({
+  useUpdatesStore: () => storeState,
+}))
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock('@/composables/useDateFormat', () => ({
+  useDateFormat: () => ({
+    formatDate: (date: Date) => date.toISOString().slice(0, 10),
+    formatRelativeTime: () => 'just now',
+  }),
+}))
+
+vi.mock('@/composables/useNotification', () => ({
+  useNotification: () => ({ success: vi.fn(), error: vi.fn() }),
+}))
+
+const mountOptions = {
+  global: {
+    stubs: { Icon: true, UpdateCheckToggle: true },
+    mocks: { $t: (key: string) => key },
+  },
+}
+
+function statusPayload(overrides: Partial<UpdateStatus> = {}): UpdateStatus {
+  return {
+    currentVersion: '4.0.12',
+    latestVersion: '4.0.13',
+    updateAvailable: true,
+    notesUrl: 'https://example.test/releases/tag/v4.0.13',
+    severity: 'normal',
+    releasedAt: '2026-08-10T09:00:00Z',
+    lastCheckedAt: '2026-08-05T10:24:22+00:00',
+    lastError: null,
+    dismissedVersion: null,
+    checkEnabled: true,
+    platform: 'selfhost',
+    guideUrl: 'https://example.test/docs/UPDATE_SELFHOST.md',
+    ...overrides,
+  }
+}
+
+describe('UpdatePanel', () => {
+  beforeEach(() => {
+    storeState.status = null
+    storeState.loading = false
+    storeState.checkEnabled = true
+    storeState.latestVersion = null
+    storeState.severity = 'normal'
+    storeState.ensureLoaded.mockReset()
+    storeState.checkNow.mockReset()
+    storeState.dismissLatest.mockReset()
+  })
+
+  it('spins only while the status is actually being fetched', async () => {
+    storeState.loading = true
+    const wrapper = mount(UpdatePanel, mountOptions)
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="state-admin-updates-loading"]').exists()).toBe(true)
+  })
+
+  // A failed read used to leave the spinner running forever, which hid the whole
+  // card — including the switch — behind something that looked like progress.
+  it('explains an unreadable status instead of spinning forever', async () => {
+    storeState.loading = false
+    storeState.status = null
+    const wrapper = mount(UpdatePanel, mountOptions)
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="state-admin-updates-loading"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="state-admin-updates-unavailable"]').exists()).toBe(true)
+    expect(wrapper.text()).toContain('updates.panel.statusUnavailable')
+  })
+
+  it('keeps "check now" usable so the admin can recover', async () => {
+    storeState.loading = false
+    storeState.status = null
+    const wrapper = mount(UpdatePanel, mountOptions)
+    await flushPromises()
+
+    const button = wrapper.get('[data-testid="btn-admin-updates-check"]')
+    expect(button.attributes('disabled')).toBeUndefined()
+
+    await button.trigger('click')
+    expect(storeState.checkNow).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows the versions once the status is available', async () => {
+    storeState.status = statusPayload()
+    storeState.latestVersion = '4.0.13'
+    const wrapper = mount(UpdatePanel, mountOptions)
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="state-admin-updates-loading"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="state-admin-updates-unavailable"]').exists()).toBe(false)
+    expect(wrapper.get('[data-testid="text-admin-updates-current"]').text()).toBe('4.0.12')
+    expect(wrapper.get('[data-testid="text-admin-updates-latest"]').text()).toBe('4.0.13')
+  })
+})

--- a/frontend/tests/unit/stores/history.spec.ts
+++ b/frontend/tests/unit/stores/history.spec.ts
@@ -268,6 +268,79 @@ describe('History Store', () => {
       await store.loadMoreMessages(42)
       expect(getChatMessages).toHaveBeenLastCalledWith(42, 2, 50)
     })
+
+    /**
+     * The response that triggers the merge also schedules the 2s in-progress
+     * poll (#1142), and that poll loads silently. Guarding only the foreground
+     * path let the poll replace the whole list two seconds later, so a
+     * multitask turn visibly stopped streaming mid-answer.
+     */
+    it('keeps the live stream when the in-progress poll reloads the chat', async () => {
+      vi.useFakeTimers()
+      try {
+        const { store, loading, getChatMessages, resolve } = await startDeferredLoad(true)
+
+        store.addMessage('user', [{ type: 'text', content: 'Hello' }])
+        const assistantId = store.addStreamingMessage('assistant')
+        store.updateStreamingMessage(assistantId, 'Partial reply')
+        resolve({
+          success: true,
+          messages: [{ id: 1, direction: 'IN', text: 'Hello', timestamp: 1700000000 }],
+          pagination: { hasMore: false },
+          inProgressTurn: { reply_node: 'reply', cards: [] },
+        })
+        await loading
+
+        // The poll scheduled by the response above fires and reloads silently.
+        await vi.advanceTimersByTimeAsync(2000)
+
+        expect(getChatMessages).toHaveBeenCalledTimes(2)
+        expect(store.messages.at(-1)?.id).toBe(assistantId)
+        expect(store.messages.at(-1)?.parts[0].content).toBe('Partial reply')
+        store.clear()
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    /**
+     * The in-progress bubble carries `isStreaming` itself. Treating it as a
+     * live stream would preserve the stale copy and drop the freshly loaded
+     * one, freezing the task cards the reload exists to refresh.
+     */
+    it('replaces the in-progress bubble instead of preserving the stale one', async () => {
+      vi.useFakeTimers()
+      try {
+        vi.resetModules()
+        const turnResponse = (state: string) => ({
+          success: true,
+          messages: [{ id: 1, direction: 'IN', text: 'Render a video', timestamp: 1700000000 }],
+          pagination: { hasMore: false },
+          inProgressTurn: {
+            reply_node: 'reply',
+            cards: [{ nodeId: 'n1', capability: 'video', kind: 'video', state }],
+          },
+        })
+        const getChatMessages = vi
+          .fn()
+          .mockResolvedValueOnce(turnResponse('running'))
+          .mockResolvedValue(turnResponse('done'))
+        vi.doMock('@/services/api', () => ({ chatApi: { getChatMessages } }))
+
+        const { useHistoryStore: useStore } = await import('@/stores/history')
+        const store = useStore()
+
+        await store.loadMessages(42)
+        expect(store.messages.at(-1)?.taskPlan?.cards[0].state).toBe('running')
+
+        await store.loadMessages(42)
+
+        expect(store.messages.at(-1)?.taskPlan?.cards[0].state).toBe('done')
+        store.clear()
+      } finally {
+        vi.useRealTimers()
+      }
+    })
   })
 
   /**

--- a/frontend/tests/unit/stores/updates.spec.ts
+++ b/frontend/tests/unit/stores/updates.spec.ts
@@ -1,0 +1,303 @@
+import { setActivePinia, createPinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Control the admin gate deterministically (no real auth store / no runtime
+// config) so the store logic can be exercised in isolation.
+let mockIsAdmin = true
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => ({
+    get isAdmin() {
+      return mockIsAdmin
+    },
+  }),
+}))
+
+let mockIsNativeApp = false
+
+vi.mock('@/services/api/nativeRuntime', () => ({
+  isNativeApp: () => mockIsNativeApp,
+}))
+
+const getStatus = vi.fn()
+const check = vi.fn()
+const dismiss = vi.fn()
+const setCheckEnabled = vi.fn()
+
+vi.mock('@/services/api/updates', () => ({
+  updatesApi: {
+    getStatus: () => getStatus(),
+    check: () => check(),
+    dismiss: (version: string) => dismiss(version),
+    setCheckEnabled: (enabled: boolean) => setCheckEnabled(enabled),
+  },
+}))
+
+import type { UpdateStatus } from '@/services/api/updates'
+import { useUpdatesStore } from '@/stores/updates'
+
+/** A pending, non-dismissed, normal-severity update. */
+function statusPayload(overrides: Partial<UpdateStatus> = {}): UpdateStatus {
+  return {
+    currentVersion: '4.0.12',
+    latestVersion: '4.0.13',
+    updateAvailable: true,
+    notesUrl: 'https://example.test/releases/tag/v4.0.13',
+    severity: 'normal',
+    releasedAt: '2026-08-10T09:00:00Z',
+    lastCheckedAt: '2026-08-05T10:24:22+00:00',
+    lastError: null,
+    dismissedVersion: null,
+    checkEnabled: true,
+    platform: 'selfhost',
+    guideUrl: 'https://example.test/docs/UPDATE_SELFHOST.md',
+    ...overrides,
+  }
+}
+
+describe('updates store', () => {
+  beforeEach(() => {
+    mockIsAdmin = true
+    mockIsNativeApp = false
+    getStatus.mockReset()
+    check.mockReset()
+    dismiss.mockReset()
+    setCheckEnabled.mockReset()
+    setActivePinia(createPinia())
+  })
+
+  describe('admin gate', () => {
+    it('never touches the admin endpoints for a non-admin', async () => {
+      mockIsAdmin = false
+      const store = useUpdatesStore()
+
+      await store.ensureLoaded()
+      await store.checkNow()
+      await store.dismissLatest()
+      await store.setCheckEnabled(false)
+
+      expect(getStatus).not.toHaveBeenCalled()
+      expect(check).not.toHaveBeenCalled()
+      expect(dismiss).not.toHaveBeenCalled()
+      expect(setCheckEnabled).not.toHaveBeenCalled()
+      expect(store.status).toBeNull()
+      expect(store.showBadge).toBe(false)
+    })
+
+    // MOBILE-APP SEAM: an update means changing a version on the server and
+    // redeploying it, which cannot be done from the app, so the notice must not
+    // appear there at all.
+    it('never touches the admin endpoints inside the native app', async () => {
+      mockIsNativeApp = true
+      const store = useUpdatesStore()
+
+      await store.ensureLoaded()
+      await store.checkNow()
+      await store.dismissLatest()
+      await store.setCheckEnabled(false)
+
+      expect(getStatus).not.toHaveBeenCalled()
+      expect(check).not.toHaveBeenCalled()
+      expect(dismiss).not.toHaveBeenCalled()
+      expect(setCheckEnabled).not.toHaveBeenCalled()
+      expect(store.canRead).toBe(false)
+      expect(store.showBadge).toBe(false)
+    })
+  })
+
+  describe('caching', () => {
+    it('fetches once, so the sidebar does not refetch on every navigation', async () => {
+      getStatus.mockResolvedValue(statusPayload())
+      const store = useUpdatesStore()
+
+      await store.ensureLoaded()
+      await store.ensureLoaded()
+      await store.ensureLoaded()
+
+      expect(getStatus).toHaveBeenCalledTimes(1)
+    })
+
+    it('de-duplicates concurrent callers', async () => {
+      getStatus.mockResolvedValue(statusPayload())
+      const store = useUpdatesStore()
+
+      await Promise.all([store.ensureLoaded(), store.ensureLoaded(), store.ensureLoaded()])
+
+      expect(getStatus).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('badge visibility', () => {
+    it('shows for a pending update and exposes the guide link', async () => {
+      getStatus.mockResolvedValue(statusPayload())
+      const store = useUpdatesStore()
+
+      await store.ensureLoaded()
+
+      expect(store.showBadge).toBe(true)
+      expect(store.latestVersion).toBe('4.0.13')
+      expect(store.guideUrl).toBe('https://example.test/docs/UPDATE_SELFHOST.md')
+      expect(store.severity).toBe('normal')
+    })
+
+    it('stays hidden for the version the admin dismissed', async () => {
+      getStatus.mockResolvedValue(statusPayload({ dismissedVersion: '4.0.13' }))
+      const store = useUpdatesStore()
+
+      await store.ensureLoaded()
+
+      expect(store.showBadge).toBe(false)
+      // The version itself is still known — only the badge is suppressed.
+      expect(store.latestVersion).toBe('4.0.13')
+    })
+
+    it('reappears once a release newer than the dismissed one is published', async () => {
+      getStatus.mockResolvedValue(
+        statusPayload({ latestVersion: '4.0.14', dismissedVersion: '4.0.13' })
+      )
+      const store = useUpdatesStore()
+
+      await store.ensureLoaded()
+
+      expect(store.showBadge).toBe(true)
+    })
+
+    it('stays hidden when no release is known yet', async () => {
+      getStatus.mockResolvedValue(
+        statusPayload({
+          latestVersion: null,
+          updateAvailable: false,
+          notesUrl: null,
+          releasedAt: null,
+          lastCheckedAt: null,
+        })
+      )
+      const store = useUpdatesStore()
+
+      await store.ensureLoaded()
+
+      expect(store.showBadge).toBe(false)
+      expect(store.latestVersion).toBeNull()
+    })
+
+    it('needs a version to link to, even if the backend claims an update', async () => {
+      getStatus.mockResolvedValue(statusPayload({ latestVersion: null, updateAvailable: true }))
+      const store = useUpdatesStore()
+
+      await store.ensureLoaded()
+
+      expect(store.showBadge).toBe(false)
+    })
+
+    it('marks a security release as more important', async () => {
+      getStatus.mockResolvedValue(statusPayload({ severity: 'security' }))
+      const store = useUpdatesStore()
+
+      await store.ensureLoaded()
+
+      expect(store.showBadge).toBe(true)
+      expect(store.severity).toBe('security')
+    })
+  })
+
+  describe('master switch', () => {
+    it('reads as on until the real value is known', () => {
+      expect(useUpdatesStore().checkEnabled).toBe(true)
+    })
+
+    it('exposes a switched-off check and still reports the known release', async () => {
+      getStatus.mockResolvedValue(statusPayload({ checkEnabled: false }))
+      const store = useUpdatesStore()
+
+      await store.ensureLoaded()
+
+      expect(store.checkEnabled).toBe(false)
+      // Detection being off does not retroactively hide what was already found.
+      expect(store.showBadge).toBe(true)
+    })
+
+    it('stores the value the backend confirmed, not the requested one', async () => {
+      getStatus.mockResolvedValue(statusPayload())
+      setCheckEnabled.mockResolvedValue({ success: true, checkEnabled: false })
+      const store = useUpdatesStore()
+      await store.ensureLoaded()
+
+      await store.setCheckEnabled(false)
+
+      expect(setCheckEnabled).toHaveBeenCalledWith(false)
+      expect(store.checkEnabled).toBe(false)
+    })
+  })
+
+  describe('dismissing', () => {
+    it('acknowledges the offered version and hides the badge', async () => {
+      getStatus.mockResolvedValue(statusPayload())
+      dismiss.mockResolvedValue({ success: true, dismissedVersion: '4.0.13' })
+      const store = useUpdatesStore()
+      await store.ensureLoaded()
+
+      await store.dismissLatest()
+
+      expect(dismiss).toHaveBeenCalledWith('4.0.13')
+      expect(store.showBadge).toBe(false)
+    })
+
+    it('does nothing when there is no release to acknowledge', async () => {
+      getStatus.mockResolvedValue(statusPayload({ latestVersion: null, updateAvailable: false }))
+      const store = useUpdatesStore()
+      await store.ensureLoaded()
+
+      await store.dismissLatest()
+
+      expect(dismiss).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('failing requests', () => {
+    it('degrades quietly when the stored status cannot be read', async () => {
+      getStatus.mockRejectedValue(new Error('network unreachable'))
+      const store = useUpdatesStore()
+
+      await expect(store.ensureLoaded()).resolves.toBeUndefined()
+
+      expect(store.status).toBeNull()
+      expect(store.showBadge).toBe(false)
+      expect(store.loading).toBe(false)
+    })
+
+    it('does not retry a failed read on every navigation', async () => {
+      getStatus.mockRejectedValue(new Error('network unreachable'))
+      const store = useUpdatesStore()
+
+      await store.ensureLoaded()
+      await store.ensureLoaded()
+
+      expect(getStatus).toHaveBeenCalledTimes(1)
+    })
+
+    it('reports a failed manual check to the caller', async () => {
+      getStatus.mockResolvedValue(statusPayload())
+      check.mockRejectedValue(new Error('gateway timeout'))
+      const store = useUpdatesStore()
+      await store.ensureLoaded()
+
+      await expect(store.checkNow()).rejects.toThrow('gateway timeout')
+
+      expect(store.loading).toBe(false)
+    })
+
+    it('keeps the known release and surfaces lastError when a check found nothing', async () => {
+      getStatus.mockResolvedValue(statusPayload())
+      check.mockResolvedValue(
+        statusPayload({ lastError: 'Could not reach the release list.', lastCheckedAt: 'now' })
+      )
+      const store = useUpdatesStore()
+      await store.ensureLoaded()
+
+      await store.checkNow()
+
+      expect(store.status?.lastError).toBe('Could not reach the release list.')
+      expect(store.showBadge).toBe(true)
+    })
+  })
+})

--- a/scripts/release-manifest.mjs
+++ b/scripts/release-manifest.mjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+
+// Builds the release manifest a running instance polls to learn that a newer
+// release exists. CI publishes the result to the dedicated `release-manifest`
+// branch after the image for the tag is pushed and verified — see the
+// `release-manifest` job in .github/workflows/ci.yml for why that branch.
+//
+// Everything a human may have edited on that branch is carried over: the
+// `yanked` list always, and `releasedAt`/`severity` when the same version is
+// republished (a re-run of the same tag must not overwrite a `security` mark).
+
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+export const SCHEMA = 1
+
+// Only plain releases are advertised. A pre-release (v5.0.0-rc.1) is a valid
+// deployment pin but must never become `stable`, and next-release-tag.mjs keeps
+// them out of the release series for the same reason.
+const RELEASE_VERSION = /^(\d+)\.(\d+)\.(\d+)$/
+const REPOSITORY = /^[^/\s]+\/[^/\s]+$/
+const SEVERITIES = ['normal', 'security']
+
+export const parseReleaseVersion = (version) => {
+  const match = RELEASE_VERSION.exec(String(version).trim())
+  if (!match) return null
+  return { major: Number(match[1]), minor: Number(match[2]), patch: Number(match[3]) }
+}
+
+const compareVersions = (left, right) =>
+  left.major - right.major || left.minor - right.minor || left.patch - right.patch
+
+// The yanked list is maintained by hand on the branch, so it is carried over
+// verbatim — entries may be a bare version or an object with a reason next to
+// it. A list that cannot be read is an error rather than an empty list: losing a
+// yank would re-advertise a release that was withdrawn on purpose.
+export const yankedEntries = (existing) => {
+  const yanked = existing?.yanked
+  if (yanked === undefined || yanked === null) return []
+  if (!Array.isArray(yanked)) {
+    throw new Error('The existing manifest has a non-array `yanked` list; refusing to drop it.')
+  }
+  return yanked
+}
+
+const yankedVersion = (entry) => (typeof entry === 'string' ? entry : entry?.version)
+
+export const buildManifest = ({
+  version,
+  repository,
+  releasedAt,
+  severity = 'normal',
+  existing = null
+}) => {
+  const released = parseReleaseVersion(version)
+  if (released === null) {
+    throw new Error(
+      `Not a plain release version: "${version}". Pre-releases and mutable tags are never advertised as stable.`
+    )
+  }
+  if (!SEVERITIES.includes(severity)) {
+    throw new Error(`Unknown severity "${severity}"; expected one of ${SEVERITIES.join(', ')}.`)
+  }
+  if (!REPOSITORY.test(String(repository))) {
+    throw new Error(`Not an owner/name repository: "${repository}".`)
+  }
+  if (!releasedAt) {
+    throw new Error('A release date is required.')
+  }
+
+  const yanked = yankedEntries(existing)
+  if (yanked.some((entry) => yankedVersion(entry) === version)) {
+    throw new Error(`${version} is on the yanked list; refusing to advertise it as stable.`)
+  }
+
+  const previous = existing?.stable ?? null
+  const previousVersion = parseReleaseVersion(previous?.version ?? '')
+  // An older maintenance tag must not move `stable` backwards: every instance
+  // would then be told that a release older than the one it runs is the newest.
+  if (previousVersion !== null && compareVersions(previousVersion, released) > 0) return existing
+  const republished = previousVersion !== null && compareVersions(previousVersion, released) === 0
+
+  return {
+    schema: SCHEMA,
+    stable: {
+      version,
+      releasedAt: (republished && previous.releasedAt) || releasedAt,
+      notesUrl: `https://github.com/${repository}/releases/tag/v${version}`,
+      severity: (republished && previous.severity) || severity
+    },
+    yanked
+  }
+}
+
+const readOption = (arguments_, name) => {
+  const index = arguments_.indexOf(`--${name}`)
+  return index >= 0 ? arguments_[index + 1] : undefined
+}
+
+// Seconds, no milliseconds: the manifest is read by humans as often as by
+// clients, and `2026-08-10T09:00:00Z` is still a valid RFC 3339 instant.
+const utcSecond = (date) => `${date.toISOString().slice(0, 19)}Z`
+
+// A manifest that is absent is the first release; a manifest that exists but
+// cannot be read stops the publication, because writing over it would drop the
+// yanked list.
+const readExisting = (path) => {
+  if (path === undefined) return null
+  const file = resolve(path)
+  let raw
+  try {
+    raw = readFileSync(file, 'utf8')
+  } catch (error) {
+    if (error.code === 'ENOENT') return null
+    throw error
+  }
+  try {
+    return JSON.parse(raw)
+  } catch (error) {
+    throw new Error(`${file} is not a readable manifest: ${error.message}`)
+  }
+}
+
+export const runCli = (arguments_) => {
+  const version = readOption(arguments_, 'version')
+  const existing = readExisting(readOption(arguments_, 'existing'))
+  const manifest = buildManifest({
+    version,
+    repository: readOption(arguments_, 'repository'),
+    releasedAt: readOption(arguments_, 'released-at') ?? utcSecond(new Date()),
+    severity: readOption(arguments_, 'severity') ?? 'normal',
+    existing
+  })
+  if (manifest === existing) {
+    process.stderr.write(
+      `Keeping ${existing.stable.version} as stable: ${version} is an older release.\n`
+    )
+  }
+  process.stdout.write(`${JSON.stringify(manifest, null, 2)}\n`)
+}
+
+if (process.argv[1] && pathToFileURL(resolve(process.argv[1])).href === import.meta.url) {
+  try {
+    runCli(process.argv.slice(2))
+  } catch (error) {
+    process.stderr.write(`${error.message}\n`)
+    process.exitCode = 1
+  }
+}


### PR DESCRIPTION
## Summary

Synaplan now shows which version is installed and tells an admin when a newer release exists, linking to a short update guide for their platform. It never updates itself — the version only changes when the operator changes it.

## Changes

- **Sidebar** shows the installed version for every user. For an admin with a pending release it becomes a badge that opens the matching guide in a new tab; a security release is highlighted more strongly.
- **Admin card** in the config area: installed and available version, release notes, when it was last checked, a "check now" button, dismiss, and a switch to turn the check off. There is deliberately no button that changes the installation.
- **Detection** runs once a day in the `scheduler` container (`app:updates:check`) and stores its result in `BCONFIG`. The admin API only reads stored values, so no request path does outbound HTTP and the UI keeps working without internet access. A plain GET, no instance identifier, no telemetry.
- **`GET|POST /api/v1/admin/updates/*`** (`ROLE_ADMIN`) with full OpenAPI annotations; the frontend uses the generated Zod schemas.
- **CI** publishes `versions.json` after the multi-arch image is published and verified, so a manifest can never advertise a version whose image does not exist. It goes to a dedicated `release-manifest` branch, **not** `main`, because Elestio pipelines redeploy on every `main` commit.
- **New guides** `docs/UPDATE_ELESTIO.md` (38 lines) and `docs/UPDATE_SELFHOST.md` (54 lines). The same procedure previously existed in three places; `docs/ADMIN.md`, `deploy/README.md` and `deploy/elestio/README.md` now point at the guides instead of repeating them.
- **`SYNAPLAN_PLATFORM`** (default `selfhost`, `elestio` in `elestio.yml`) decides which guide the button opens.

Two documentation errors surfaced and were fixed: `deploy/elestio/README.md` claimed the pre-update backup gate applies to every upgrade — it only runs on Elestio's own update operation, not on a redeploy after an environment change, which is exactly why the guide puts a manual backup first. `docs/ADMIN.md` pointed at the pipeline update operation instead of the environment-variable path.

## Verification

- [x] Manual
- [x] Tests added/updated

Full gate green: `make lint`, `make -C backend phpstan`, `make test` (3254 backend / 1011 frontend), `vue-tsc`, `make -C frontend build`. Shell suites: `test-container-runtime.sh` 62/62, `test-lifecycle.sh` passed, `node --test tests/*.test.mjs` 19/19.

Exercised for real against the running stack: higher, equal, yanked, malformed and unparseable-current-version manifests, plus proof that `CHECK_ENABLED=0` performs zero outbound requests and that a non-admin makes no admin request (0 of 368 captured requests). Contrast measured against the actually composed background in light, dark and V2 — every element between 4.76 and 12.25, all above WCAG AA.

`test-lifecycle.sh` gained 10 assertions pinning the guarantee that a redeploy never silently upgrades: `latest`, `main`, `stable`, a bare major and a bare major.minor are all rejected. Each new assertion was mutation-tested.

## Notes

**Mobile:** backend-only plus a web-asset change, no native effect. The notice is hidden inside the app — an update means changing a version on the server and redeploying it, which cannot be done from a phone. The runtime config gains no required fields.

**No database migration.** `UPDATES` is a new `BCONFIG` group and every read falls back safely when the row is missing, so an install that upgrades without re-seeding behaves exactly like a freshly seeded one.

**Before the first release after merge:** the `release-manifest` branch is created by the first tag run, which needs `contents: write` for `GITHUB_TOKEN` — worth confirming no org ruleset blocks it. A release is marked as a security release by editing `severity` on that branch.