### PR TITLE
fix(deploy): pin a real release instead of a placeholder version

### DIFF
--- a/deploy/elestio/README.md
+++ b/deploy/elestio/README.md
@@ -7,8 +7,10 @@ schema. These files only translate lifecycle events to the portable scripts in
 ## Import and first deployment
 
 1. Create a custom Docker Compose CI/CD pipeline from this repository and branch.
-2. Replace `REPLACE_WITH_PUBLISHED_COMPATIBLE_VERSION` with an immutable SemVer
-   tag that already exists in GHCR and passes `deploy/scripts/validate-release.sh`.
+2. Leave `SYNAPLAN_VERSION` as it is to install the release this branch ships.
+   Any other value must be an immutable SemVer version that already exists in
+   GHCR; `deploy/scripts/validate-release.sh` rejects everything else before a
+   container starts. Later version changes follow [docs/UPDATE_ELESTIO.md](../../docs/UPDATE_ELESTIO.md).
 3. Keep `COMPOSE_PROFILES` empty for the initial Cloud-AI installation.
 4. Confirm that HTTPS 443 proxies to host port 8000 without Basic Auth.
 5. Open the Synaplan web UI shortcut and sign in with the generated bootstrap

--- a/deploy/selfhost.env.example
+++ b/deploy/selfhost.env.example
@@ -3,9 +3,11 @@
 
 # Release and public endpoint
 COMPOSE_PROJECT_NAME=synaplan-production
-# Deliberately non-deployable: replace only after the compatible release exists
-# in GHCR and deploy/scripts/validate-release.sh succeeds for that exact tag.
-SYNAPLAN_VERSION=REPLACE_WITH_PUBLISHED_COMPATIBLE_VERSION
+# The release to install. Only an immutable SemVer version is accepted; `latest`
+# and any mutable tag are rejected before a container starts, so a redeploy can
+# never pull a different version behind your back. Newer releases are listed at
+# https://github.com/metadist/synaplan/releases — see docs/UPDATE_SELFHOST.md.
+SYNAPLAN_VERSION=4.0.13
 SYNAPLAN_PULL_POLICY=always
 SYNAPLAN_HTTP_BIND=127.0.0.1
 SYNAPLAN_HTTP_PORT=8000

--- a/elestio.yml
+++ b/elestio.yml
@@ -14,12 +14,16 @@ config:
 environments:
   - key: "COMPOSE_PROJECT_NAME"
     value: "synaplan"
-  # Deliberately non-deployable: replace only after the compatible release exists
-  # in GHCR. The pre-install hook rejects this placeholder and any mutable tag
-  # before a container starts, so a catalog submission must carry a published
-  # SemVer version, never this value, `latest`, or an anticipated future tag.
+  # Elestio materialises these values into the deployment's .env automatically,
+  # so this has to name a release that already exists in GHCR — there is no step
+  # in which an operator could substitute a placeholder before the first deploy.
+  # Only an immutable SemVer release is accepted here: the pre-install hook
+  # rejects `latest`, any mutable tag and any version that is not published yet,
+  # before a container starts. Raising this value is what ships a new release to
+  # new deployments; existing ones stay on their pinned version until their
+  # operator changes it, as described in docs/UPDATE_ELESTIO.md.
   - key: "SYNAPLAN_VERSION"
-    value: "REPLACE_WITH_PUBLISHED_COMPATIBLE_VERSION"
+    value: "4.0.13"
   # Deployment hint for the release notice, so the admin UI links to the Elestio
   # update guide instead of the self-hosted one. Display only: Synaplan never
   # updates itself.


### PR DESCRIPTION
## Summary

Every Elestio deployment aborted before starting a container. `elestio.yml` shipped `SYNAPLAN_VERSION=REPLACE_WITH_PUBLISHED_COMPATIBLE_VERSION`, and Elestio writes that value into the deployment's `.env` verbatim, so the release-pin guard rejected it:

```
Reading deployment configuration from /opt/app/synaplan/.env.
SYNAPLAN_VERSION must resolve to a published immutable SemVer tag; got: ghcr.io/metadist/synaplan:REPLACE_WITH_PUBLISHED_COMPATIBLE_VERSION
```

The guard behaved correctly. The mistake was assuming an operator gets a chance to replace the placeholder first — Elestio materialises the manifest's environment values automatically, so there is no such step. A one-click deployment has to name a release that already exists.

## Changes

- `elestio.yml` pins `4.0.13`, published from `main` at `25ee3bee9`. Raising this value is what ships a new release to *new* deployments; existing ones stay on their pinned version until their operator changes it, per `docs/UPDATE_ELESTIO.md`.
- `deploy/selfhost.env.example` pins the same release instead of a placeholder, so a fresh self-hosting copy starts rather than failing on the first run. It links to the releases page and the update guide.
- `deploy/elestio/README.md` step 2 no longer instructs replacing a placeholder.

The guard itself is untouched: `latest`, mutable tags, bare `4` / `4.0` and unpublished versions are still rejected before a container starts.

## Verification

- [x] Manual
- [x] Tests added/updated

No placeholder remains anywhere in the repository. `elestio.yml` parses and yields `SYNAPLAN_VERSION=4.0.13`. `deploy/scripts/tests/test-lifecycle.sh` passes, including the pin assertions that reject mutable and partial tags. The pinned value was checked against `validate_release_pin`'s exact expression: `4.0.13` accepted, the placeholder, `latest` and `4.0` rejected.

## Notes

Merge order matters: the tag `v4.0.13` was cut first so the image exists in GHCR before `main` points at it. Do not merge until the multi-arch publish for that tag has finished, otherwise a deployment started in between would fail on a missing image.