### PR TITLE
Automatic release version and one secret per purpose on Elestio

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -459,6 +459,20 @@ jobs:
             # For PRs, tag with PR number
             type=ref,event=pr
 
+      # metadata-action's version follows the first image tag. On main that is
+      # `latest`, which must never become APP_VERSION — the sidebar would show
+      # that word to every user. Resolve a SemVer (or `dev`) instead.
+      - name: Resolve application version
+        id: app-version
+        env:
+          META_VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          set -euo pipefail
+          git fetch --tags --force 2>/dev/null || true
+          version="$(node scripts/resolve-app-version.mjs --meta "$META_VERSION" --ref "$GITHUB_REF_NAME")"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "Application version for this image: ${version} (metadata was ${META_VERSION:-empty})"
+
       - name: Build Docker image
         id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
@@ -469,7 +483,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            APP_VERSION=${{ steps.meta.outputs.version }}
+            APP_VERSION=${{ steps.app-version.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           # Export to tar file for sharing between jobs
@@ -893,11 +907,10 @@ jobs:
       contents: read
       packages: write
     outputs:
-      # The version release-manifest advertises. Taken from the metadata step
-      # that produced the pushed image tags, so the manifest can only ever name
-      # a version this job actually published — never one re-derived from the
-      # ref by a second, possibly diverging, expression.
-      version: ${{ steps.meta.outputs.version }}
+      # The version release-manifest advertises. Taken from the same resolver that
+      # bakes APP_VERSION into the image, so the manifest can only ever name a
+      # SemVer this job actually published — never the mutable `latest` tag.
+      version: ${{ steps.app-version.outputs.version }}
 
     steps:
       - name: Checkout
@@ -942,6 +955,20 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
 
+      # Same resolution as docker-build: the registry may still move the `latest`
+      # tag, but APP_VERSION inside that image must stay a SemVer so the UI never
+      # shows the word "latest" as the running release.
+      - name: Resolve application version
+        id: app-version
+        env:
+          META_VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          set -euo pipefail
+          git fetch --tags --force 2>/dev/null || true
+          version="$(node scripts/resolve-app-version.mjs --meta "$META_VERSION" --ref "$GITHUB_REF_NAME")"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "Application version for this image: ${version} (metadata was ${META_VERSION:-empty})"
+
       - name: Log in to the Container registry
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
@@ -985,7 +1012,7 @@ jobs:
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:ci-${{ github.sha }}-arm64
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            APP_VERSION=${{ steps.meta.outputs.version }}
+            APP_VERSION=${{ steps.app-version.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1188,6 +1188,131 @@ jobs:
               "correct — the field describes that release."
           } >> "$GITHUB_STEP_SUMMARY"
 
+  release-version-pin:
+    name: Update the Default Release Version
+    runs-on: ubuntu-latest
+    # elestio.yml and deploy/selfhost.env.example decide which version a NEW
+    # deployment installs, so they may only ever name a release whose image is
+    # published and verified — which is what docker-push guarantees.
+    needs: [docker-push]
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      # A pull request, deliberately, rather than a push to main. Elestio
+      # pipelines redeploy on every commit to the branch they track, so pushing
+      # here would restart every managed instance at an unpredictable moment.
+      # Merging is the maintainer's choice of when that happens.
+      - name: Checkout the default branch
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      # The secrets context is not available in an `if` expression, so their
+      # presence is carried through an output — the same workaround release-tag.yml
+      # uses.
+      - name: Check pull request credentials
+        id: config
+        env:
+          APP_ID: ${{ secrets.MOBILE_TAG_APP_ID }}
+          APP_PRIVATE_KEY: ${{ secrets.MOBILE_TAG_APP_PRIVATE_KEY }}
+        run: |
+          if test -n "$APP_ID" && test -n "$APP_PRIVATE_KEY"; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Refs created with the default GITHUB_TOKEN do not start workflow runs,
+      # so a pull request opened with it would carry no checks at all. The same
+      # app that creates release tags is used here for the same reason; without
+      # it the proposal is still opened, just unchecked.
+      - name: Create pull request token
+        id: app-token
+        if: steps.config.outputs.configured == 'true'
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ secrets.MOBILE_TAG_APP_ID }}
+          private-key: ${{ secrets.MOBILE_TAG_APP_PRIVATE_KEY }}
+
+      - name: Propose the new default version
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.docker-push.outputs.version }}
+          BRANCH: automation/default-release-version
+          BASE: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+
+          # Same cross-check as the manifest job: the advertised default must be
+          # the tag that was actually published, whatever metadata-action does.
+          if [ "$VERSION" != "${GITHUB_REF_NAME#v}" ]; then
+            echo "::error::Published version ${VERSION} does not match tag ${GITHUB_REF_NAME}"
+            exit 1
+          fi
+
+          # A pre-release is a valid pin for someone who types it in, but never
+          # the default a new deployment installs.
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Tag ${GITHUB_REF_NAME} is not a plain release; the default version is unchanged." |
+              tee -a "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          node scripts/set-release-version.mjs --version "$VERSION"
+
+          if git diff --quiet; then
+            echo "The default version is already \`${VERSION}\`; nothing to propose." |
+              tee -a "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git checkout -q -B "$BRANCH"
+          git commit -qam "chore(release): install ${VERSION} in new deployments"
+
+          # Force-push the fixed branch: if an earlier release's proposal is
+          # still open, it is carried forward to the newest release rather than
+          # leaving two competing pull requests behind.
+          git push -q --force \
+            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+            "HEAD:refs/heads/${BRANCH}"
+
+          existing="$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // ""')"
+          if [ -n "$existing" ]; then
+            echo "Updated [pull request #${existing}](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/pull/${existing}) to \`${VERSION}\`." |
+              tee -a "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          body_file="$(mktemp)"
+          cat > "$body_file" <<EOF
+          Installs \`${VERSION}\` in **new** deployments: \`elestio.yml\` for the one-click
+          path and \`deploy/selfhost.env.example\` for self-hosting.
+
+          Existing deployments are unaffected. They keep the version their operator
+          pinned and change it only by following the update guide, so a redeploy never
+          moves a running installation to a different version.
+
+          Merging this restarts every Elestio instance that tracks \`${BASE}\`, because
+          Elestio redeploys on each commit to the branch it tracks. Merge when that is
+          convenient.
+
+          Opened automatically after the image for \`${GITHUB_REF_NAME}\` was published
+          and verified.
+          EOF
+
+          url="$(gh pr create \
+            --base "$BASE" \
+            --head "$BRANCH" \
+            --title "chore(release): install ${VERSION} in new deployments" \
+            --body-file "$body_file")"
+          echo "Opened ${url}" | tee -a "$GITHUB_STEP_SUMMARY"
+
   cloudflare-deploy:
     name: Deploy Cloudflare Worker
     runs-on: ubuntu-latest
@@ -1219,7 +1344,7 @@ jobs:
   all-checks-passed:
     name: All Checks Passed
     runs-on: ubuntu-latest
-    needs: [lint, mobile-tooling, backend, frontend-build, frontend-checks, docker-build, e2e, e2e-visual, docker-push, release-manifest, cloudflare-deploy]
+    needs: [lint, mobile-tooling, backend, frontend-build, frontend-checks, docker-build, e2e, e2e-visual, docker-push, release-manifest, release-version-pin, cloudflare-deploy]
     if: always()
     steps:
       - name: Check for failures
@@ -1235,6 +1360,7 @@ jobs:
             needs.e2e-visual.result != 'success' ||
             (needs.docker-push.result != 'success' && needs.docker-push.result != 'skipped') ||
             (needs.release-manifest.result != 'success' && needs.release-manifest.result != 'skipped') ||
+            (needs.release-version-pin.result != 'success' && needs.release-version-pin.result != 'skipped') ||
             (needs.cloudflare-deploy.result != 'success' && needs.cloudflare-deploy.result != 'skipped')
           )
         run: |

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -34,6 +34,48 @@ secrets must remain stable across every redeploy and restore. Keep a configured
 administrator account, so a regenerated value would no longer match the password
 that account actually has.
 
+### Generated secrets: `deploy/data/secrets.env`
+
+Those eight secrets do not have to be configured at all. Every lifecycle script
+calls `ensure_deployment_secrets`, which resolves each of them once:
+
+- A value you configured — in `deploy/.env` or as an environment variable — is
+  adopted unchanged, so an installation that already runs keeps exactly the
+  credentials it has.
+- A secret with no value is generated with 32 bytes of randomness, independently
+  of every other secret, but only while the stack has never been initialised.
+- The resolved set is written to `deploy/data/secrets.env` with mode `0600`. From
+  then on that file is authoritative and is never rewritten, so a value once in
+  use stays in use, and exported before Compose runs, because Compose prefers a
+  real environment variable over any `--env-file` entry.
+- If a secret has no value and `deploy/data/mariadb` already holds a database,
+  the deployment stops and names the variable. Generating a new one is not an
+  option: the MariaDB user still authenticates with the old password, so a new
+  `MARIADB_PASSWORD` would lock the application out of its own data permanently.
+  Restore the variable in your configuration, or write the known value into
+  `deploy/data/secrets.env`.
+
+Because the file is authoritative and is exported before Compose runs, editing
+one of these eight variables in `deploy/.env` no longer changes the running
+deployment. To rotate one deliberately, change it in
+`deploy/data/secrets.env` — and only together with the state it belongs to:
+`MARIADB_PASSWORD` and `MARIADB_ROOT_PASSWORD` must be changed in MariaDB itself
+in the same step, and a new `APP_SECRET` makes the provider API keys stored in the
+database undecryptable (see
+[AI Providers](../docs/CONFIGURATION.md#ai-providers)).
+
+**`deploy/data/secrets.env` is part of this deployment's secret material and MUST
+be included in every backup and disaster-recovery record.** A database restored
+without it is a database nobody can open again — the password exists nowhere
+else. Keep it private, never commit it (`deploy/data/` is gitignored), and change
+a value in it only in the deliberate way described above.
+
+This is also why a managed platform's generated values are not used directly:
+Elestio's `random_password` placeholder is a single draw per deployment,
+substituted into every variable that names it, so the database password, the
+secret that signs every application token and the Centrifugo admin password were
+all the same string. See [`elestio/README.md`](elestio/README.md).
+
 Docker Compose reads `deploy/.env` with its own rules and would change a value
 containing `$`, surrounding quotes, ` #`, or leading and trailing spaces.
 Generate secrets with `openssl rand -hex 32`, or restrict a value you type
@@ -105,6 +147,8 @@ Persistent paths:
 - `data/uploads`: uploaded and generated files shared by web and worker
 - `data/ollama`, `data/whisper`: optional local models
 - `data/backups`: restricted MariaDB dumps and Qdrant collection snapshots
+- `data/secrets.env`: the deployment's generated secrets, mode `0600` — required
+  to open the restored database, so it must be in every backup
 
 `deploy/data/` must never be committed.
 
@@ -140,6 +184,10 @@ deploy/scripts/pre-backup.sh
 # Capture deploy/data with the platform backup system.
 deploy/scripts/post-backup.sh
 ```
+
+Whatever captures `deploy/data` must include `deploy/data/secrets.env`. It holds
+the database, realtime and application secrets, and without it the restored
+database cannot be authenticated against.
 
 `pre-backup.sh` first pauses web writers, the worker, and scheduler; while the
 data stores remain online it creates a single-transaction MariaDB dump, one

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -28,6 +28,11 @@ x-app-environment: &app-environment
   # the admin UI links to. Optional — an unset or unknown value means the
   # self-hosted guide, so nothing breaks when a deployment never sets it.
   SYNAPLAN_PLATFORM: "${SYNAPLAN_PLATFORM:-selfhost}"
+  # The version the operator pinned. Overrides the value baked into the image so
+  # the sidebar and the update check always show the release that is actually
+  # configured — never a mutable registry tag such as `latest` that an older
+  # image build may have recorded as APP_VERSION.
+  APP_VERSION: "${SYNAPLAN_VERSION}"
   APP_URL: "${APP_URL:?Set APP_URL to the public HTTPS URL}"
   FRONTEND_URL: "${FRONTEND_URL:?Set FRONTEND_URL to the public HTTPS URL}"
   APP_SECRET: "${APP_SECRET:?Set a stable APP_SECRET}"

--- a/deploy/elestio/README.md
+++ b/deploy/elestio/README.md
@@ -25,6 +25,38 @@ your external disaster-recovery records. The administrator credentials are the
 critical case: see
 [First administrator credentials](#first-administrator-credentials).
 
+## Application secrets are generated per deployment
+
+`random_password` is a single draw per deployment: Elestio substitutes the same
+generated value into every variable that names it. A real installation therefore
+came up with `APP_SECRET`, `TOKEN_SECRET`, `MARIADB_PASSWORD`,
+`MARIADB_ROOT_PASSWORD` and all four `REALTIME_*` values set to one identical
+string — the database password was also the secret that signs every application
+token and the Centrifugo admin password, so a single leak was every credential
+the deployment had. Elestio has no second generator, and their own catalog
+templates share the defect.
+
+Those eight variables are therefore no longer declared in `elestio.yml`. The
+lifecycle scripts resolve them instead, on every start:
+
+- a value that is already in use — from the pipeline environment of an existing
+  deployment — is adopted unchanged, so an upgrade changes nothing;
+- anything still missing on a stack that was never initialised is generated with
+  32 bytes of randomness, independently per secret;
+- the resolved set is recorded once in `deploy/data/secrets.env`, mode `0600`.
+  Elestio rewrites the deployment's `.env` on every deploy, so the bind-mounted
+  data directory is the only location a generated value can survive in.
+
+`BOOTSTRAP_ADMIN_PASSWORD` is not part of this. Elestio displays it as the login
+for the Synaplan shortcut, so it stays exactly the value the platform generated.
+
+> **`deploy/data/secrets.env` must be in your backups.** It is created on the
+> first start and is the only copy of the database password. A backup that
+> restores `deploy/data/mariadb` without it produces a database the application
+> cannot authenticate against; the deployment then stops with a message naming the
+> missing variable instead of starting into that state. Do not commit the file,
+> and do not edit a value the running stack was built with.
+
 The public template documentation does not define a separate schema property
 that marks an environment variable as editable. `COMPOSE_PROFILES` is therefore
 declared as a normal environment value. Change it to `local-ai` in Elestio's
@@ -80,7 +112,9 @@ deployment is ever rejected because of the password.
 
 Elestio lifecycle hooks call the portable backup, restore, update, and smoke
 logic. The platform backup must include the repository's `deploy/data/`
-directory. Run a restore into an isolated pipeline and verify login, uploads,
+directory, `deploy/data/secrets.env` included — that file carries the database,
+realtime and application secrets. Run a restore into an isolated pipeline and
+verify login, uploads,
 Qdrant search, worker processing, scheduler cleanup, and WebSocket delivery.
 
 For upgrades, follow [Update on Elestio](../../docs/UPDATE_ELESTIO.md). Never use

--- a/deploy/scripts/build.sh
+++ b/deploy/scripts/build.sh
@@ -4,6 +4,11 @@ set -Eeuo pipefail
 # shellcheck source=lib.sh
 source "$(dirname "$0")/lib.sh"
 
+# Also here, and not only in prepare.sh below: that runs as a child process, so
+# the variables it exports never reach this shell, and the `compose pull` further
+# down resolves compose.yaml's `${VAR:?}` keys itself.
+ensure_deployment_secrets
+
 # The platform's build command: prepare the checkout, fetch the pinned image,
 # then verify it.
 #

--- a/deploy/scripts/lib.sh
+++ b/deploy/scripts/lib.sh
@@ -592,6 +592,309 @@ PROBE
     return "$status"
 }
 
+# The secrets this deployment gives its own, independent value to.
+#
+# Why the deployment has to do this at all: a managed platform's password
+# generator is ONE draw per deployment. Elestio substitutes its `random_password`
+# placeholder into every variable that names it, so a real installation came up
+# with APP_SECRET, TOKEN_SECRET, both MariaDB passwords and all four REALTIME_*
+# values set to the same string — the password of the database was also the
+# secret that signs every application token, and the Centrifugo admin password.
+# One leaked value is then every credential the deployment has. Elestio offers no
+# second generator (their own catalog templates, elestio-examples/glpi among
+# them, carry the same defect), so the split has to happen on this side.
+#
+# BOOTSTRAP_ADMIN_PASSWORD is deliberately NOT managed here. The platform DISPLAYS
+# that value as the login for the web UI shortcut, and the bootstrap never resets
+# an existing administrator, so it has to stay exactly the value the platform
+# generated — rotating it would leave the operator with a password that does not
+# open their own instance.
+SYNAPLAN_MANAGED_SECRET_KEYS=(
+    APP_SECRET
+    TOKEN_SECRET
+    MARIADB_PASSWORD
+    MARIADB_ROOT_PASSWORD
+    REALTIME_API_KEY
+    REALTIME_TOKEN_SECRET
+    REALTIME_ADMIN_PASSWORD
+    REALTIME_ADMIN_SECRET
+)
+
+# Give every managed secret its own value, once, and export all of them.
+#
+# The values are recorded in $DATA_DIR/secrets.env, which is the only place they
+# CAN live: Elestio rewrites the deployment's .env from the pipeline's configured
+# environment on every deploy, so a value written back into that file is gone on
+# the next one. The bind-mounted data directory is the one part of the deployment
+# that survives a redeploy — and it is what the platform backup captures, which is
+# why that file is backup-critical: a database restored without it is a database
+# nobody can open again.
+#
+# Resolution per key, in this order:
+#
+#   1. secrets.env, when it exists. It is authoritative and is never rewritten,
+#      because it records what the running stack was BUILT with.
+#   2. the value the deployment already resolves to — an exported host
+#      environment variable, or the configuration file Compose reads. Adopted
+#      verbatim, which is what guarantees that an installation which already runs
+#      keeps exactly the credentials it has: a self-hosted deploy/.env, or a
+#      platform deployment whose one shared value is already in use everywhere.
+#   3. a fresh, independent draw, but only while the stack has never been
+#      initialised and no secrets.env exists yet.
+#   4. otherwise the deployment is refused, see the two messages below.
+#
+# Exporting is not cosmetic. Compose prefers a real host environment variable
+# over every --env-file entry, so exporting is the only way these values reliably
+# win however the platform delivered the originals — and the only way a generated
+# value reaches a `compose` call at all, because it appears in no configuration
+# file the platform would pass with --env-file.
+ensure_deployment_secrets() {
+    local secrets_file="$DATA_DIR/secrets.env"
+    local env_file secrets_file_existed=false
+    local index key value
+    local values=() assignments=()
+    local generated_count=0 adopted_count=0
+    # Collected instead of reported one at a time: an operator who has to run the
+    # deployment once per missing variable gives up on the third one. This is the
+    # same reason validate_secret_roundtrip() names every altered key at once.
+    local unresolved_keys="" unadoptable_keys=""
+
+    # The data root has to exist before the file can be written, and this runs on
+    # paths that have not called prepare_data_directories() yet. 0700 for the same
+    # reason it applies there: everything below this directory is either data or,
+    # now, credentials.
+    mkdir -p "$DATA_DIR"
+    chmod 0700 "$DATA_DIR"
+
+    [[ -f "$secrets_file" ]] && secrets_file_existed=true
+    env_file="$(resolve_compose_env_file)"
+
+    for ((index = 0; index < ${#SYNAPLAN_MANAGED_SECRET_KEYS[@]}; index++)); do
+        key="${SYNAPLAN_MANAGED_SECRET_KEYS[$index]}"
+        value=""
+        values[$index]=""
+        assignments[$index]="$key="
+
+        if [[ "$secrets_file_existed" == true ]]; then
+            value="$(env_file_raw_value "$secrets_file" "$key")" || value=""
+        fi
+
+        # Compose's precedence, so the value adopted here is the value the
+        # containers are running with: an exported host variable beats every
+        # --env-file entry, and the file only decides what the environment does
+        # not. An exported variable that is EMPTY is not a value — compose.yaml's
+        # `${VAR:?}` rejects it exactly like an unset one — so the file still
+        # decides in that case.
+        if [[ -z "$value" ]]; then
+            if host_environment_defines "$key" && [[ -n "${!key-}" ]]; then
+                value="${!key-}"
+            elif [[ -n "$env_file" ]]; then
+                value="$(env_file_raw_value "$env_file" "$key")" || value=""
+                if [[ -n "$value" ]] && ! deployment_secret_is_adoptable "$value"; then
+                    unadoptable_keys="${unadoptable_keys}${unadoptable_keys:+ }$key"
+                    continue
+                fi
+            fi
+            [[ -z "$value" ]] || adopted_count=$((adopted_count + 1))
+        fi
+
+        if [[ -z "$value" ]]; then
+            # Nothing may be generated for a key that cannot be recorded, and
+            # nothing may be generated for a stack that already exists:
+            #
+            #   an EXISTING secrets.env is never rewritten, so a value generated
+            #     here would be a different one on every single start — APP_SECRET
+            #     alone would invalidate every session on each deploy;
+            #   an INITIALISED stack keeps credentials that cannot be
+            #     reconstructed from its data. MariaDB created its user with the
+            #     old password, so a new MARIADB_PASSWORD locks the application
+            #     out of its own database permanently.
+            if [[ "$secrets_file_existed" == true ]] || deployment_stack_is_initialised; then
+                unresolved_keys="${unresolved_keys}${unresolved_keys:+ }$key"
+                continue
+            fi
+            value="$(generate_deployment_secret)" || return 1
+            generated_count=$((generated_count + 1))
+        fi
+
+        values[$index]="$value"
+        assignments[$index]="$key=$value"
+    done
+
+    if [[ -n "$unadoptable_keys" ]]; then
+        echo "Docker Compose does not read these values back unchanged from $env_file, so they cannot be adopted as the deployment's secrets: $unadoptable_keys" >&2
+        echo "This deployment exports the value it adopts, and Compose never rewrites a host environment variable — so adopting one of these as written would change the credential the containers have been using until now, and a changed MARIADB_PASSWORD locks the application out of its own database." >&2
+        echo "Fix: write each listed value without surrounding quotes, without whitespace around the '=' or around the value, without an inline ' #' comment and without a dollar sign; or pass it as a host environment variable, which Compose never rewrites. 'openssl rand -hex 32' always satisfies this. No value is printed here, because these keys are secrets." >&2
+        return 1
+    fi
+
+    if [[ -n "$unresolved_keys" ]]; then
+        if [[ "$secrets_file_existed" == true ]]; then
+            echo "$secrets_file exists but does not assign these secrets, and neither the host environment nor the deployment configuration provides them: $unresolved_keys" >&2
+            echo "That file is authoritative and is never rewritten, because it records the values this stack was built with; generating new ones here would produce a different set on every start." >&2
+            echo "Fix: add a '<VARIABLE>=<the value this deployment was installed with>' line per listed secret to $secrets_file, or set them in the platform's environment editor, then run the deployment again." >&2
+        else
+            echo "These secrets have no value, and this deployment is already initialised — $DATA_DIR/mariadb holds a database that was created with the previous ones: $unresolved_keys" >&2
+            echo "Refusing to generate replacements: a generated credential cannot match an initialised stack. A new MARIADB_PASSWORD locks the application out of its own database permanently, because the MariaDB user still authenticates with the old one, and no secret can be reconstructed from the stored data." >&2
+            echo "Fix: restore the listed variables in the platform's environment editor or in the deployment configuration file, or write their known values into $secrets_file as '<VARIABLE>=<value>' lines, then run the deployment again." >&2
+        fi
+        return 1
+    fi
+
+    if [[ "$secrets_file_existed" == false ]]; then
+        write_deployment_secrets_file "$secrets_file" "${assignments[@]}" || return 1
+        printf 'Recorded %s deployment secrets in %s (%s generated independently, %s adopted from the existing configuration). This file is secret material and belongs in every backup.\n' \
+            "${#SYNAPLAN_MANAGED_SECRET_KEYS[@]}" "$secrets_file" "$generated_count" "$adopted_count"
+    else
+        printf 'Using the %s deployment secrets recorded in %s.\n' \
+            "${#SYNAPLAN_MANAGED_SECRET_KEYS[@]}" "$secrets_file"
+    fi
+
+    for ((index = 0; index < ${#SYNAPLAN_MANAGED_SECRET_KEYS[@]}; index++)); do
+        export "${SYNAPLAN_MANAGED_SECRET_KEYS[$index]}=${values[$index]}"
+    done
+}
+
+# Whether the stack has already been initialised, which decides whether a missing
+# credential may be generated or has to be refused.
+#
+# The mere EXISTENCE of data/mariadb is not the signal: prepare_data_directories()
+# creates that directory empty on the very first start, and every lifecycle script
+# calls it, so an existence check would report a brand-new deployment as
+# initialised and refuse it with advice about a credential that never existed.
+# MariaDB populating the directory is what makes the old password unrecoverable.
+deployment_stack_is_initialised() {
+    [[ -d "$DATA_DIR/mariadb" ]] || return 1
+    find "$DATA_DIR/mariadb" -mindepth 1 -print -quit 2>/dev/null | grep -q .
+}
+
+# Whether Compose's .env parser returns this raw spelling unchanged, and only
+# relevant for a value read from the configuration FILE.
+#
+# The adopted value is EXPORTED afterwards, and Compose never rewrites a host
+# environment variable — so adopting a spelling Compose alters would change the
+# credential the containers have used until now: `MARIADB_PASSWORD="abc"` reaches
+# the database as `abc` today and would reach it as `"abc"` from here on, which is
+# the single outcome the adoption rule exists to prevent.
+#
+# validate_secret_roundtrip() rejects exactly these spellings, for these keys,
+# with the same advice — but it resolves its comparison through
+# `compose config --environment`, which cannot run before these variables have a
+# value at all (compose.yaml declares them as `${VAR:?}`). So the alterations that
+# parser performs are named here instead, and a value carrying one is refused
+# rather than adopted: an unescaped `$` starts an interpolation, `$$` collapses to
+# `$`, surrounding quotes are stripped (with backslash escapes inside them
+# expanded), surrounding whitespace is trimmed, and ` #` starts a comment.
+# Anything else is returned byte for byte, which is why every value is also read
+# back from the file after it is written.
+deployment_secret_is_adoptable() {
+    local value="$1"
+
+    [[ "$value" != *'$'* ]] || return 1
+    [[ "$value" != *' #'* && "$value" != *$'\t#'* ]] || return 1
+    [[ "$value" == "${value#[[:space:]]}" && "$value" == "${value%[[:space:]]}" ]] || return 1
+    case "$value" in
+        '"'*'"' | "'"*"'") return 1 ;;
+    esac
+}
+
+# 32 bytes of randomness rendered as 64 hexadecimal characters.
+#
+# Hexadecimal only, deliberately: Compose interpolation, a .env parser and the
+# container shell that expands MARIADB_ROOT_PASSWORD inside the db healthcheck
+# each rewrite or split a value containing `$`, quotes, whitespace or ` #`.
+# validate_secret_roundtrip() guards that class of bug for a CONFIGURED value; a
+# generated one must not be able to cause it in the first place.
+#
+# openssl is present in every image this deployment runs, but not guaranteed on a
+# minimal host, so /dev/urandom is read directly as a fallback. Either way the
+# result is length-checked: a short read would silently weaken every secret it
+# produced, and nothing downstream would notice.
+generate_deployment_secret() {
+    local value=""
+
+    if command -v openssl >/dev/null 2>&1; then
+        value="$(openssl rand -hex 32)"
+    else
+        value="$(LC_ALL=C od -vAn -N 32 -tx1 < /dev/urandom | LC_ALL=C tr -d ' \n')"
+    fi
+
+    [[ "$value" =~ ^[0-9a-f]{64}$ ]] || {
+        echo "Could not generate a 32-byte random secret; install openssl, or make /dev/urandom readable for this deployment." >&2
+        return 1
+    }
+    printf '%s' "$value"
+}
+
+# Create the secrets file, as a whole set, verified — and only ever create it.
+#
+# umask 077 rather than a chmod after the fact: between creating a world-readable
+# file and tightening it there is a window in which every credential of the
+# deployment is readable by any local account. The previous umask is restored,
+# because this library is sourced by scripts that write other files afterwards.
+#
+# Every value is read back with env_file_raw_value(), the same reader
+# ensure_deployment_secrets() and validate_secret_roundtrip() use, and compared
+# byte for byte. A value adopted from the host environment can contain anything —
+# a newline, a carriage return — and this file format cannot represent all of it.
+# Refusing to install a file that does not read back is what keeps "adopted
+# verbatim" true; the alternative is a deployment configured with a silently
+# truncated credential.
+#
+# The write goes to a temporary file next to the target and is moved into place,
+# so an interrupted or rejected run never leaves a half-written authoritative
+# file behind. Values are passed as function arguments, which stay inside this
+# shell: no external command receives them, so none appears in a process list.
+write_deployment_secrets_file() {
+    local secrets_file="$1"
+    shift
+    local assignment key value temporary_file previous_umask status=0
+
+    previous_umask="$(umask)"
+    umask 077
+    temporary_file="$(mktemp "$(dirname "$secrets_file")/.secrets.env.XXXXXX")" || status=$?
+    if ((status == 0)); then
+        {
+            printf '# Synaplan deployment secrets, generated once on the first start.\n'
+            printf '#\n'
+            printf '# Each value is an independent random draw, or the value this deployment was\n'
+            printf '# already configured with. Together they are the credentials of the database,\n'
+            printf '# of the realtime service and of the application token signing, so this file is\n'
+            printf '# secret material:\n'
+            printf '#\n'
+            printf '#   - it MUST be part of every backup. A database restored without it cannot be\n'
+            printf '#     opened again, because the MariaDB user still expects the password recorded\n'
+            printf '#     here and it exists nowhere else.\n'
+            printf '#   - it must never be committed, and never be readable by anyone else.\n'
+            printf '#   - a value in use must not be edited. The deployment reads this file as\n'
+            printf '#     authoritative and never rewrites it.\n'
+            printf '\n'
+            for assignment in "$@"; do
+                printf '%s\n' "$assignment"
+            done
+        } > "$temporary_file" || status=$?
+    fi
+    umask "$previous_umask"
+    ((status == 0)) || {
+        echo "Could not write the deployment secrets next to $secrets_file; check that the deployment data directory is writable." >&2
+        return 1
+    }
+
+    for assignment in "$@"; do
+        key="${assignment%%=*}"
+        value="${assignment#*=}"
+        [[ "$(env_file_raw_value "$temporary_file" "$key")" == "$value" ]] || {
+            rm -f "$temporary_file"
+            echo "The value configured for $key cannot be recorded in $secrets_file unchanged, so this deployment refuses to store an altered credential for it." >&2
+            echo "Fix: give $key a value without line breaks or carriage returns — 'openssl rand -hex 32' always works — or clear it and let the deployment generate one. No value is printed here, because this key is a secret." >&2
+            return 1
+        }
+    done
+
+    chmod 0600 "$temporary_file"
+    mv "$temporary_file" "$secrets_file"
+}
+
 prepare_data_directories() {
     mkdir -p \
         "$STATE_DIR" \

--- a/deploy/scripts/post-backup.sh
+++ b/deploy/scripts/post-backup.sh
@@ -4,6 +4,11 @@ set -Eeuo pipefail
 # shellcheck source=lib.sh
 source "$(dirname "$0")/lib.sh"
 
+# Resuming the paused services goes through Compose, so this path needs the
+# stack's credentials too — a backup that ends without its services back up is
+# an outage.
+ensure_deployment_secrets
+
 ACTIVE_BACKUP_FILE="$STATE_DIR/active-backup"
 
 resume_on_exit() {

--- a/deploy/scripts/post-restore.sh
+++ b/deploy/scripts/post-restore.sh
@@ -4,6 +4,12 @@ set -Eeuo pipefail
 # shellcheck source=lib.sh
 source "$(dirname "$0")/lib.sh"
 
+# The restored deploy/data carries the deployment's secrets.env, so this is also
+# the point at which a restore that did NOT include that file fails — with a
+# message naming the variable, instead of a database nobody can authenticate
+# against.
+ensure_deployment_secrets
+
 # Runs before the recovery trap below is installed, on purpose: that trap brings
 # the backend back up, so a failure after it exists would start a container with
 # the rejected configuration — the crash loop this preflight prevents. The

--- a/deploy/scripts/post-update.sh
+++ b/deploy/scripts/post-update.sh
@@ -4,6 +4,10 @@ set -Eeuo pipefail
 # shellcheck source=lib.sh
 source "$(dirname "$0")/lib.sh"
 
+# First, because everything below reaches Compose and the roundtrip guard resolves
+# the interpolation environment, which the managed secrets are part of.
+ensure_deployment_secrets
+
 # This script is also the install and deploy hook, so it is the only host-side
 # gate on those paths: validate-release.sh does not run before them. Tier 1 only
 # — the image contract, and with it the authoritative email probe, was already

--- a/deploy/scripts/pre-backup.sh
+++ b/deploy/scripts/pre-backup.sh
@@ -4,6 +4,11 @@ set -Eeuo pipefail
 # shellcheck source=lib.sh
 source "$(dirname "$0")/lib.sh"
 
+# The dump below authenticates against MariaDB with MARIADB_ROOT_PASSWORD, which
+# this deployment keeps in deploy/data/secrets.env rather than in the platform's
+# environment.
+ensure_deployment_secrets
+
 ACTIVE_BACKUP_FILE="$STATE_DIR/active-backup"
 
 prepare_data_directories

--- a/deploy/scripts/pre-restore.sh
+++ b/deploy/scripts/pre-restore.sh
@@ -4,6 +4,11 @@ set -Eeuo pipefail
 # shellcheck source=lib.sh
 source "$(dirname "$0")/lib.sh"
 
+# Stopping the stack is a Compose call as well, and it happens before the platform
+# replaces deploy/data — so this reads the secrets file that is still the current
+# deployment's.
+ensure_deployment_secrets
+
 RESTORE_MARKER="$STATE_DIR/restore-ready"
 
 prepare_data_directories

--- a/deploy/scripts/pre-update.sh
+++ b/deploy/scripts/pre-update.sh
@@ -4,6 +4,10 @@ set -Eeuo pipefail
 # shellcheck source=lib.sh
 source "$(dirname "$0")/lib.sh"
 
+# For the `compose pull` at the end of this script: the backup scripts it calls
+# are child processes and export nothing back into this shell.
+ensure_deployment_secrets
+
 "$DEPLOY_DIR/scripts/pre-backup.sh"
 trap '"$DEPLOY_DIR/scripts/post-backup.sh"' EXIT INT TERM
 "$DEPLOY_DIR/scripts/post-backup.sh"

--- a/deploy/scripts/prepare.sh
+++ b/deploy/scripts/prepare.sh
@@ -4,6 +4,13 @@ set -Eeuo pipefail
 # shellcheck source=lib.sh
 source "$(dirname "$0")/lib.sh"
 
+# Before anything reaches Compose. compose.yaml declares the managed secrets as
+# `${VAR:?}`, so on a deployment whose platform no longer supplies them — which is
+# every new Elestio deployment, because one shared generated value for all of them
+# was worse than none — `compose config --quiet` below would abort here first, and
+# the deployment would never start.
+ensure_deployment_secrets
+
 prepare_data_directories
 
 # On a managed platform this is the first place that reveals WHICH configuration

--- a/deploy/scripts/run.sh
+++ b/deploy/scripts/run.sh
@@ -4,6 +4,11 @@ set -Eeuo pipefail
 # shellcheck source=lib.sh
 source "$(dirname "$0")/lib.sh"
 
+# Every start needs the stack's own credentials, and they are exported here rather
+# than read from a configuration file: the platform rewrites that file on every
+# deploy, and Compose prefers an exported variable over any --env-file entry.
+ensure_deployment_secrets
+
 # The platform's run command: validate on every start, then start the stack.
 #
 # The validation is deliberately repeated here and not only in build.sh, because

--- a/deploy/scripts/smoke-test.sh
+++ b/deploy/scripts/smoke-test.sh
@@ -4,6 +4,9 @@ set -Eeuo pipefail
 # shellcheck source=lib.sh
 source "$(dirname "$0")/lib.sh"
 
+# Documented as directly runnable, and every probe below is a Compose call.
+ensure_deployment_secrets
+
 assert_healthy() {
     local service="$1"
     local container_id status

--- a/deploy/scripts/tests/test-lifecycle.sh
+++ b/deploy/scripts/tests/test-lifecycle.sh
@@ -1064,6 +1064,416 @@ assert_reports_configuration_source run.sh
 assert_roundtrip_precedes_value_rules post-update.sh
 assert_roundtrip_precedes_value_rules post-restore.sh
 
+# One independent value per secret, recorded where a redeploy cannot erase it.
+#
+# The defect these cases exist for: a managed platform's password generator is ONE
+# draw per deployment. Elestio substitutes its `random_password` placeholder into
+# every variable that names it, so a real installation came up with APP_SECRET,
+# TOKEN_SECRET, both MariaDB passwords and all four REALTIME_* values set to the
+# same string — the database password was also the secret signing every
+# application token. Nothing in the stack noticed, because every side used the
+# same wrong value consistently.
+#
+# Every case runs in a subshell. ensure_deployment_secrets EXPORTS its result, and
+# a leaked export would silently decide the next case — and would make the
+# roundtrip section above skip the very keys it covers.
+secrets_tree="$temporary_dir/secrets"
+secrets_case_index=0
+secrets_deploy_dir=""
+secrets_data_dir=""
+secrets_file=""
+secrets_messages=""
+
+# A deployment tree per case: resolve_compose_env_file() looks for deploy/.env and
+# <checkout>/.env, and the secrets file lives in deploy/data, so no two cases may
+# share a root.
+new_secrets_case() {
+    secrets_case_index=$((secrets_case_index + 1))
+    secrets_deploy_dir="$secrets_tree/case-$secrets_case_index/deploy"
+    secrets_data_dir="$secrets_deploy_dir/data"
+    secrets_file="$secrets_data_dir/secrets.env"
+    secrets_messages="$secrets_tree/case-$secrets_case_index/messages.log"
+    mkdir -p "$secrets_deploy_dir"
+}
+
+# Runs ensure_deployment_secrets for the current case and prints the RESOLVED
+# environment it exported, one `KEY=value` line per managed secret, so a case can
+# assert on values that only exist inside that subshell. Arguments are `KEY=value`
+# assignments exported before the call, which is how the "already configured"
+# cases are set up. The function's own messages go to a file instead of stdout, so
+# they can be asserted separately — several cases require that no value appears in
+# them.
+run_ensure_secrets() {
+    local status=0
+    (
+        # Both are read indirectly, by the sourced library.
+        # shellcheck disable=SC2030,SC2034
+        DEPLOY_DIR="$secrets_deploy_dir"
+        # shellcheck disable=SC2030,SC2034
+        DATA_DIR="$secrets_data_dir"
+        if (($# > 0)); then
+            export "$@"
+        fi
+        ensure_deployment_secrets > "$secrets_messages" 2>&1 || exit $?
+        for secrets_key in "${SYNAPLAN_MANAGED_SECRET_KEYS[@]}"; do
+            printf '%s=%s\n' "$secrets_key" "${!secrets_key-}"
+        done
+    ) || status=$?
+    return "$status"
+}
+
+# The permission bits, spelled differently by GNU and BSD stat. The mode is a
+# guarantee of this file, not a detail: it holds every credential of the
+# deployment.
+#
+# GNU is asked first, and its output is captured rather than tested in place:
+# `stat -f` means --file-system there, so it reads "%Lp" as a FILE NAME, prints a
+# filesystem report for the real argument on STDOUT and exits non-zero. A
+# BSD-first probe would therefore pass that report on as the mode on every Linux
+# host, CI included. BSD rejects `-c` as an illegal option with nothing on stdout,
+# so this order is unambiguous on both.
+file_mode() {
+    local mode
+    mode="$(stat -c '%a' "$1" 2>/dev/null)" || mode="$(stat -f '%Lp' "$1")"
+    printf '%s\n' "$mode"
+}
+
+assert_secret_value() {
+    local description="$1"
+    local resolved="$2"
+    local key="$3"
+    local expected="$4"
+    local actual
+    actual="$(compose_environment_value "$resolved" "$key")"
+    [[ "$actual" == "$expected" ]] || {
+        printf 'Secret case "%s": %s resolved to %s bytes, expected the configured %s bytes\n' \
+            "$description" "$key" "${#actual}" "${#expected}" >&2
+        exit 1
+    }
+}
+
+# A fresh deployment: nothing configured, nothing initialised. Every secret must
+# get its OWN 32-byte draw — the whole point — and the generated shape must be one
+# that no later parser can rewrite.
+new_secrets_case
+secrets_resolved="$(run_ensure_secrets)"
+for secrets_key in "${SYNAPLAN_MANAGED_SECRET_KEYS[@]}"; do
+    secrets_generated="$(compose_environment_value "$secrets_resolved" "$secrets_key")"
+    [[ "$secrets_generated" =~ ^[0-9a-f]{64}$ ]] || {
+        printf 'A fresh deployment did not generate 64 hexadecimal characters for %s; it produced %s bytes\n' \
+            "$secrets_key" "${#secrets_generated}" >&2
+        exit 1
+    }
+done
+
+# THE defect. Eight identical values is exactly what the platform produced, and a
+# suite that only checked the shape above would have passed on it.
+secrets_distinct="$(printf '%s\n' "$secrets_resolved" | awk -F= '{ print $2 }' | sort -u | wc -l | tr -d ' ')"
+[[ "$secrets_distinct" == "${#SYNAPLAN_MANAGED_SECRET_KEYS[@]}" ]] || {
+    printf 'A fresh deployment produced %s distinct values for %s secrets; each one must be an independent draw\n' \
+        "$secrets_distinct" "${#SYNAPLAN_MANAGED_SECRET_KEYS[@]}" >&2
+    exit 1
+}
+
+# HARD CONSTRAINT: a deployment log is not a place for credentials, and these
+# lines are printed on every start.
+while IFS= read -r secrets_line; do
+    secrets_generated="${secrets_line#*=}"
+    [[ "$(<"$secrets_messages")" != *"$secrets_generated"* ]] || {
+        printf 'ensure_deployment_secrets prints the value it generated for %s\n' \
+            "${secrets_line%%=*}" >&2
+        exit 1
+    }
+done <<< "$secrets_resolved"
+
+# The file the values live in. deploy/data is the only part of the deployment that
+# survives an Elestio redeploy, because the platform rewrites the deployment's
+# .env from its own configuration every time.
+[[ -f "$secrets_file" ]] || {
+    printf 'A fresh deployment did not record its secrets in %s\n' "$secrets_file" >&2
+    exit 1
+}
+[[ "$(file_mode "$secrets_file")" == "600" ]] || {
+    printf 'The deployment secrets file has mode %s, expected 600\n' \
+        "$(file_mode "$secrets_file")" >&2
+    exit 1
+}
+secrets_assignment_count="$(LC_ALL=C awk '/^[A-Z]/ { count++ } END { print count + 0 }' "$secrets_file")"
+[[ "$secrets_assignment_count" == "${#SYNAPLAN_MANAGED_SECRET_KEYS[@]}" ]] || {
+    printf 'The deployment secrets file assigns %s keys, expected %s\n' \
+        "$secrets_assignment_count" "${#SYNAPLAN_MANAGED_SECRET_KEYS[@]}" >&2
+    exit 1
+}
+# The file itself has to say that losing it loses the database: whoever finds it
+# during a disaster recovery has nothing else to go by.
+grep -Fq 'backup' "$secrets_file" || {
+    printf '%s does not tell the reader that it belongs in a backup\n' "$secrets_file" >&2
+    exit 1
+}
+
+# A host without openssl. The portable /dev/urandom fallback has to produce the
+# same shape, because nothing downstream would notice a short or empty draw — it
+# would simply become the deployment's permanent database password.
+(
+    command() { return 1; }
+    secrets_fallback="$(generate_deployment_secret)"
+    [[ "$secrets_fallback" =~ ^[0-9a-f]{64}$ ]]
+) || {
+    echo "The /dev/urandom fallback does not produce 64 hexadecimal characters on a host without openssl" >&2
+    exit 1
+}
+
+# An installation that already runs must not change at all. Its credentials come
+# from the host environment or from the configuration file Compose reads, and both
+# are adopted BYTE FOR BYTE — a "normalised" MariaDB password would be a database
+# the application can no longer open.
+new_secrets_case
+printf 'APP_SECRET=configured-in-the-deployment-file\n' > "$secrets_deploy_dir/.env"
+printf 'UNRELATED_KEY=x\n' > "$(dirname "$secrets_deploy_dir")/.env"
+secrets_adopted_password='already in use #7'
+secrets_resolved="$(run_ensure_secrets "MARIADB_PASSWORD=$secrets_adopted_password")"
+assert_secret_value "adoption" "$secrets_resolved" MARIADB_PASSWORD "$secrets_adopted_password"
+assert_secret_value "adoption" "$secrets_resolved" APP_SECRET configured-in-the-deployment-file
+[[ "$(compose_environment_value "$secrets_resolved" TOKEN_SECRET)" =~ ^[0-9a-f]{64}$ ]] || {
+    echo "A secret that nothing configured was not generated alongside the adopted ones" >&2
+    exit 1
+}
+[[ "$(<"$secrets_messages")" != *"$secrets_adopted_password"* ]] || {
+    echo "ensure_deployment_secrets prints an adopted secret" >&2
+    exit 1
+}
+# Adopted values are recorded too, so the next start no longer depends on a
+# platform that may not deliver them again.
+[[ "$(env_file_raw_value "$secrets_file" MARIADB_PASSWORD)" == "$secrets_adopted_password" ]] || {
+    echo "The adopted MariaDB password was not recorded verbatim in the secrets file" >&2
+    exit 1
+}
+
+# Idempotence, and the reason the file exists: once a value is in use it is fixed.
+# A second start must resolve the recorded set even when the environment now says
+# something else — a platform that rotates its generated value on every deploy is
+# exactly the situation this deployment is protecting itself from.
+secrets_recorded="$(<"$secrets_file")"
+secrets_resolved_again="$(run_ensure_secrets MARIADB_PASSWORD=a-rotated-value APP_SECRET=another-rotated-value)"
+[[ "$(<"$secrets_file")" == "$secrets_recorded" ]] || {
+    echo "A second run rewrote the deployment secrets file" >&2
+    exit 1
+}
+[[ "$secrets_resolved_again" == "$secrets_resolved" ]] || {
+    echo "A second run resolved different secrets than the recorded ones" >&2
+    exit 1
+}
+[[ "$(<"$secrets_messages")" != *a-rotated-value* ]] || {
+    echo "ensure_deployment_secrets prints a value from the environment" >&2
+    exit 1
+}
+
+# The abort. An initialised stack whose credential is unknown must NOT be given a
+# new one: MariaDB created its user with the old password, so a generated
+# MARIADB_PASSWORD locks the application out of its own data permanently, with no
+# way back. The message has to name the variable, because that is the only thing
+# the operator can act on.
+new_secrets_case
+mkdir -p "$secrets_data_dir/mariadb"
+# What "initialised" means here: a POPULATED data directory. The directory itself
+# exists on every deployment from the first start onwards, because
+# prepare_data_directories() creates it empty — treating that as initialised would
+# abort every fresh installation with advice about a credential that never was.
+printf 'x' > "$secrets_data_dir/mariadb/ibdata1"
+secrets_status=0
+run_ensure_secrets \
+    APP_SECRET=known TOKEN_SECRET=known MARIADB_ROOT_PASSWORD=known \
+    REALTIME_API_KEY=known REALTIME_TOKEN_SECRET=known \
+    REALTIME_ADMIN_PASSWORD=known REALTIME_ADMIN_SECRET=known \
+    > /dev/null || secrets_status=$?
+((secrets_status != 0)) || {
+    echo "An initialised deployment with an unknown MariaDB password was allowed to generate a new one" >&2
+    exit 1
+}
+grep -Fq MARIADB_PASSWORD "$secrets_messages" || {
+    printf 'The refusal does not name the missing variable:\n%s\n' "$(<"$secrets_messages")" >&2
+    exit 1
+}
+[[ ! -f "$secrets_file" ]] || {
+    echo "A refused deployment left a secrets file behind" >&2
+    exit 1
+}
+
+# And every missing variable in ONE message: an operator who has to run the
+# deployment once per missing value gives up on the third one.
+new_secrets_case
+mkdir -p "$secrets_data_dir/mariadb"
+printf 'x' > "$secrets_data_dir/mariadb/ibdata1"
+secrets_status=0
+run_ensure_secrets \
+    APP_SECRET=known TOKEN_SECRET=known MARIADB_ROOT_PASSWORD=known \
+    REALTIME_TOKEN_SECRET=known REALTIME_ADMIN_PASSWORD=known \
+    REALTIME_ADMIN_SECRET=known \
+    > /dev/null || secrets_status=$?
+((secrets_status != 0)) || {
+    echo "An initialised deployment with two unknown secrets was allowed to generate them" >&2
+    exit 1
+}
+grep -Fq MARIADB_PASSWORD "$secrets_messages" && grep -Fq REALTIME_API_KEY "$secrets_messages" || {
+    printf 'The refusal does not name every missing variable:\n%s\n' "$(<"$secrets_messages")" >&2
+    exit 1
+}
+
+# The same directory, empty, is a fresh deployment and must generate. This is the
+# state prepare_data_directories() leaves behind on every single start.
+new_secrets_case
+mkdir -p "$secrets_data_dir/mariadb"
+secrets_resolved="$(run_ensure_secrets)"
+[[ "$(compose_environment_value "$secrets_resolved" MARIADB_PASSWORD)" =~ ^[0-9a-f]{64}$ ]] || {
+    echo "An empty data/mariadb directory was mistaken for an initialised deployment" >&2
+    exit 1
+}
+
+# A spelling Compose does not read back unchanged must not be adopted from the
+# configuration FILE. The adopted value is exported afterwards, and Compose never
+# rewrites a host environment variable — so `MARIADB_PASSWORD="abc"`, which
+# reaches the database as `abc` today, would reach it as `"abc"` from then on and
+# break exactly the installation this rule protects. validate_secret_roundtrip()
+# rejects the same spellings, but it cannot run this early: it resolves its
+# comparison through `compose config --environment`, which fails while these
+# `${VAR:?}` keys have no value at all.
+assert_secret_not_adoptable() {
+    local description="$1"
+    local raw="$2"
+    local status=0
+
+    new_secrets_case
+    printf 'APP_SECRET=%s\n' "$raw" > "$secrets_deploy_dir/.env"
+    run_ensure_secrets > /dev/null || status=$?
+    ((status != 0)) || {
+        printf 'Adoption case "%s": a value Compose rewrites was adopted and exported as written\n' \
+            "$description" >&2
+        exit 1
+    }
+    grep -Fq APP_SECRET "$secrets_messages" || {
+        printf 'Adoption case "%s" does not name the affected key:\n%s\n' \
+            "$description" "$(<"$secrets_messages")" >&2
+        exit 1
+    }
+}
+
+assert_secret_not_adoptable "surrounding double quotes" '"abcdefgh"'
+assert_secret_not_adoptable "surrounding single quotes" "'abcdefgh'"
+assert_secret_not_adoptable "an unescaped dollar sign" 'ab$cdefgh'
+assert_secret_not_adoptable "surrounding whitespace" '  abcdefgh  '
+assert_secret_not_adoptable "an inline comment" 'abcdefgh #x'
+
+# Spellings Compose returns unchanged stay adoptable: refusing them would fail a
+# deployment that is configured perfectly well.
+assert_secret_adoptable() {
+    local description="$1"
+    local raw="$2"
+
+    new_secrets_case
+    printf 'APP_SECRET=%s\n' "$raw" > "$secrets_deploy_dir/.env"
+    assert_secret_value "$description" "$(run_ensure_secrets)" APP_SECRET "$raw"
+}
+
+assert_secret_adoptable "a generated hexadecimal secret" 2f6b8c1d4e9a0b7c
+assert_secret_adoptable "an interior space" 'has space'
+assert_secret_adoptable "a hash that does not start a comment" 'a#b'
+assert_secret_adoptable "an unbalanced trailing quote" "abcdefgh'"
+
+# CONTRACT with the roundtrip guard: a generated value must be one Docker Compose
+# reads back byte for byte, or the deployment would reject its own secrets on the
+# next start.
+#
+# The property is asserted directly — none of the five spellings Compose's .env
+# parser rewrites can occur in 64 hexadecimal characters — and then fed through
+# validate_secret_roundtrip() itself. Its `compose config --environment` is
+# stubbed to return the value unchanged, which is what Compose does for a value
+# with no dollar sign, no quotes, no surrounding whitespace and no ` #`; the shape
+# assertion above is what makes that stub legitimate in a suite that must run
+# without Docker.
+new_secrets_case
+secrets_resolved="$(run_ensure_secrets)"
+(
+    roundtrip_tree="$secrets_tree/roundtrip"
+    mkdir -p "$roundtrip_tree/deploy"
+    # Read indirectly, by resolve_compose_env_file() from the sourced library.
+    # shellcheck disable=SC2030,SC2034
+    DEPLOY_DIR="$roundtrip_tree/deploy"
+    : > "$roundtrip_tree/deploy/.env"
+    while IFS= read -r secrets_line; do
+        secrets_key="${secrets_line%%=*}"
+        secrets_generated="${secrets_line#*=}"
+        [[ "$secrets_generated" != *'$'* && "$secrets_generated" != *'"'* &&
+            "$secrets_generated" != *"'"* && "$secrets_generated" != *' '* &&
+            "$secrets_generated" != *'#'* ]] || {
+            printf 'The value generated for %s contains a character Compose rewrites in a .env file\n' \
+                "$secrets_key" >&2
+            exit 1
+        }
+        printf '%s\n' "$secrets_line" >> "$roundtrip_tree/deploy/.env"
+    done <<< "$secrets_resolved"
+
+    compose() {
+        [[ "$*" == "config --environment" ]] || return 1
+        printf '%s\n' "PATH=/usr/bin" "$secrets_resolved"
+    }
+
+    validate_secret_roundtrip
+) || {
+    echo "Generated secrets do not survive the roundtrip guard" >&2
+    exit 1
+}
+
+# Every lifecycle script has to resolve the secrets before it touches the stack.
+# compose.yaml declares them as `${VAR:?}`, so a script that reaches Compose
+# without them aborts on the first interpolation — and one that reaches it with
+# only SOME of them configured would start a container against the wrong
+# credentials. build.sh and pre-update.sh are the subtle ones: they call sibling
+# scripts as CHILD processes, whose exports never come back to them, and then run
+# a `compose pull` of their own.
+assert_resolves_secrets_before_compose() {
+    local script="$SCRIPT_DIR/$1"
+    local ensure_line stack_line
+    ensure_line="$(awk '/^ensure_deployment_secrets$/ { print NR; exit }' "$script")"
+    stack_line="$(awk '/^(compose |app_tool |begin_service_pause|pause_services|resume_paused_services|wait_for_service_health|validate_|"\$DEPLOY_DIR)/ { print NR; exit }' "$script")"
+
+    [[ -n "$ensure_line" ]] || {
+        printf '%s reaches the stack without resolving the deployment secrets first\n' "$1" >&2
+        exit 1
+    }
+    [[ -z "$stack_line" ]] || ((ensure_line < stack_line)) || {
+        printf '%s calls ensure_deployment_secrets at line %s, after reaching the stack at line %s\n' \
+            "$1" "$ensure_line" "$stack_line" >&2
+        exit 1
+    }
+}
+
+for script in "$SCRIPT_DIR"/*.sh; do
+    [[ "$script" == */lib.sh ]] && continue
+    assert_resolves_secrets_before_compose "$(basename "$script")"
+done
+
+# The platform manifest must no longer declare the managed secrets. Elestio would
+# generate ONE value for all of them and display it, which is the defect; leaving
+# a single key in place would silently reintroduce a shared credential for it.
+for secrets_key in "${SYNAPLAN_MANAGED_SECRET_KEYS[@]}"; do
+    grep -Eq "^  - key: \"$secrets_key\"" "$ELESTIO_MANIFEST" && {
+        printf 'elestio.yml still declares %s, so the platform generates one shared value for it again\n' \
+            "$secrets_key" >&2
+        exit 1
+    }
+done
+# BOOTSTRAP_ADMIN_PASSWORD is deliberately NOT managed: the platform displays it as
+# the login for the web UI shortcut, so it has to stay exactly what the platform
+# generated.
+grep -Eq '^  - key: "BOOTSTRAP_ADMIN_PASSWORD"' "$ELESTIO_MANIFEST" || {
+    echo "elestio.yml no longer declares BOOTSTRAP_ADMIN_PASSWORD, which the platform displays as the administrator login" >&2
+    exit 1
+}
+[[ " ${SYNAPLAN_MANAGED_SECRET_KEYS[*]} " != *" BOOTSTRAP_ADMIN_PASSWORD "* ]] || {
+    echo "BOOTSTRAP_ADMIN_PASSWORD must not be a managed secret; the platform displays it as the administrator login" >&2
+    exit 1
+}
+
 # CONTRACT: tier 1 (the pure-shell rules above) must agree with the authority,
 # App\Service\Admin\BootstrapAdminConfiguration, on every case below — the class
 # tier 2 calls inside the application image. The absence of this test is what let

--- a/deploy/scripts/validate-release.sh
+++ b/deploy/scripts/validate-release.sh
@@ -4,6 +4,11 @@ set -Eeuo pipefail
 # shellcheck source=lib.sh
 source "$(dirname "$0")/lib.sh"
 
+# Every check below resolves the Compose configuration, and the managed secrets are
+# `${VAR:?}` keys in it. This script is also documented as directly runnable, so it
+# cannot rely on a caller having exported them.
+ensure_deployment_secrets
+
 validate_release_pin
 # elestio.yml runs this script again as its run command, on every start, so the
 # roundtrip guard also covers a configuration file that changed after the

--- a/deploy/selfhost.env.example
+++ b/deploy/selfhost.env.example
@@ -1,5 +1,7 @@
 # Copy to deploy/.env, replace every required placeholder, and keep the file private.
 # Secrets must remain unchanged across restarts, redeploys, backups, and restores.
+# Any secret you leave unset is generated once on the first start and recorded in
+# deploy/data/secrets.env — see the section below.
 
 # Release and public endpoint
 COMPOSE_PROJECT_NAME=synaplan-production
@@ -14,11 +16,20 @@ SYNAPLAN_HTTP_PORT=8000
 APP_URL=https://synaplan.example.com
 FRONTEND_URL=https://synaplan.example.com
 
-# Required stable secrets (generate each with: openssl rand -hex 32)
-# Docker Compose reads this file with its own rules and would change a value that
-# contains "$", surrounding quotes, " #", or leading/trailing spaces. Generated
-# hex values avoid that; if you type a value yourself, use only letters, digits,
-# "-" and "_".
+# Stable secrets. Setting them here is fully supported: the deployment adopts the
+# value you configure, unchanged, on every start.
+# You can also delete these eight lines. Left unset, the first start generates an
+# independent value for each of them and records the whole set in
+# deploy/data/secrets.env, which is then authoritative and never rewritten — so a
+# value once in use stays in use. That file is secret material: include it in every
+# backup (a database restored without it can no longer be opened), keep it private,
+# and never commit it.
+# If you do set values here, generate each one separately with
+# "openssl rand -hex 32". Docker Compose reads this file with its own rules and
+# would change a value that contains "$", surrounding quotes, " #", or
+# leading/trailing spaces; the deployment refuses such a value instead of storing a
+# mangled credential. Generated hex values avoid that; if you type a value
+# yourself, use only letters, digits, "-" and "_".
 APP_SECRET=replace-with-a-stable-random-value
 TOKEN_SECRET=replace-with-a-different-stable-random-value
 MARIADB_PASSWORD=replace-with-a-stable-random-value

--- a/docs/ADMIN.md
+++ b/docs/ADMIN.md
@@ -36,6 +36,13 @@ Set every other password and token marked as required in the template. Secrets
 must remain stable across container recreation, updates, backup, and restore.
 Never commit the populated environment file.
 
+`APP_SECRET`, `TOKEN_SECRET`, both MariaDB passwords and the four `REALTIME_*`
+secrets may also be left unset. The lifecycle scripts then generate an
+independent value for each on the first start and record the set in
+`deploy/data/secrets.env` (mode `0600`), which is authoritative from then on and
+never rewritten. A value you configure yourself is adopted unchanged. Details:
+[deploy/README.md](../deploy/README.md#generated-secrets-deploydatasecretsenv).
+
 See [Configuration Guide](CONFIGURATION.md) for all environment variables.
 
 ### Starting Services
@@ -139,11 +146,16 @@ See [Health Monitoring](HEALTH_MONITORING.md) for full setup: monitor user creat
 
 ## Backups
 
-For production, back up all three state classes together:
+For production, back up all four state classes together:
 
 - MariaDB data
 - uploaded files
 - Qdrant collections and snapshots
+- `deploy/data/secrets.env`, the deployment's generated secrets
+
+The secrets file is as critical as the data itself: it holds the MariaDB
+password the restored database expects, and it exists nowhere else. A recovery
+point without it yields a database the application cannot open.
 
 The portable lifecycle hooks under `deploy/scripts/` coordinate write
 processes and prepare consistent artifacts in the deployment data paths:

--- a/elestio.yml
+++ b/elestio.yml
@@ -14,6 +14,10 @@ config:
 environments:
   - key: "COMPOSE_PROJECT_NAME"
     value: "synaplan"
+  # Maintained by CI: publishing a release opens a pull request that raises this
+  # to the version whose image was just published and verified. Do not edit it by
+  # hand — scripts/set-release-version.mjs owns this line.
+  #
   # Elestio materialises these values into the deployment's .env automatically,
   # so this has to name a release that already exists in GHCR — there is no step
   # in which an operator could substitute a placeholder before the first deploy.

--- a/elestio.yml
+++ b/elestio.yml
@@ -46,26 +46,21 @@ environments:
     value: "https://[CI_CD_DOMAIN]"
   - key: "FRONTEND_URL"
     value: "https://[CI_CD_DOMAIN]"
-  - key: "APP_SECRET"
-    value: "random_password"
-  - key: "TOKEN_SECRET"
-    value: "random_password"
   - key: "MARIADB_DATABASE"
     value: "synaplan"
   - key: "MARIADB_USER"
     value: "synaplan"
-  - key: "MARIADB_PASSWORD"
-    value: "random_password"
-  - key: "MARIADB_ROOT_PASSWORD"
-    value: "random_password"
-  - key: "REALTIME_API_KEY"
-    value: "random_password"
-  - key: "REALTIME_TOKEN_SECRET"
-    value: "random_password"
-  - key: "REALTIME_ADMIN_PASSWORD"
-    value: "random_password"
-  - key: "REALTIME_ADMIN_SECRET"
-    value: "random_password"
+  # APP_SECRET, TOKEN_SECRET, MARIADB_PASSWORD, MARIADB_ROOT_PASSWORD and the four
+  # REALTIME_* secrets are deliberately absent here. The `random_password`
+  # placeholder is ONE draw per deployment and the same value is substituted into
+  # every variable that names it, so declaring them produced an installation in
+  # which the database password, the secret that signs every application token and
+  # the Centrifugo admin password were all one string. The lifecycle scripts in
+  # deploy/scripts/ generate them instead — one independent value each, recorded
+  # once in deploy/data/secrets.env, which is the only location that survives a
+  # redeploy because Elestio rewrites this deployment's .env every time. An
+  # existing deployment keeps the values it already runs with: they are adopted
+  # from the environment on the first start after this change.
   - key: "REALTIME_ALLOWED_ORIGINS"
     value: "https://[CI_CD_DOMAIN]"
   - key: "BOOTSTRAP_ADMIN_EMAIL"

--- a/frontend/src/components/SidebarV2.vue
+++ b/frontend/src/components/SidebarV2.vue
@@ -113,7 +113,7 @@
         data-testid="link-sidebar-v2-update"
       >
         <ArrowUpCircleIcon class="w-3.5 h-3.5 flex-shrink-0" aria-hidden="true" />
-        <span class="truncate">{{ updatesStore.latestVersion }}</span>
+        <span class="truncate">{{ versionLabel }}</span>
       </a>
       <span
         v-else
@@ -669,6 +669,7 @@ import { useNavItems, type NavChild, type NavItem } from '../composables/useNavI
 import { useTheme } from '../composables/useTheme'
 import { useChatsStore, isDefaultChatTitle, type Chat as StoreChat } from '../stores/chats'
 import { useUpdatesStore } from '../stores/updates'
+import { formatRunningVersion } from '@/utils/formatRunningVersion'
 import { useDialog } from '../composables/useDialog'
 import { useI18n } from 'vue-i18n'
 import { useDateFormat } from '@/composables/useDateFormat'
@@ -798,15 +799,10 @@ const initials = computed(() => {
 
 /**
  * Running release from the public runtime config, so every user sees it. Empty
- * while the config is still loading (or unavailable), which hides the footer
- * rather than showing a placeholder.
+ * while the config is still loading (or unavailable), and when the image only
+ * knows a mutable tag such as `latest` — that word must never appear here.
  */
-const versionLabel = computed(() => {
-  const version = configStore.build.version
-  if (!version || version === 'unknown') return ''
-
-  return /^\d/.test(version) ? `v${version}` : version
-})
+const versionLabel = computed(() => formatRunningVersion(configStore.build.version))
 
 const showUpdateLink = computed(() => updatesStore.showBadge && !!updatesStore.guideUrl)
 const isSecurityUpdate = computed(() => updatesStore.severity === 'security')

--- a/frontend/src/utils/formatRunningVersion.ts
+++ b/frontend/src/utils/formatRunningVersion.ts
@@ -1,0 +1,15 @@
+/**
+ * Formats the running Synaplan release for user-facing surfaces (sidebar, titles).
+ *
+ * Mutable image tags such as `latest` must never appear as the version label —
+ * they are registry pointers, not releases. A missing or unknown value hides the
+ * label rather than showing a placeholder.
+ */
+export const formatRunningVersion = (version: string | null | undefined): string => {
+  if (!version) return ''
+
+  const trimmed = version.trim()
+  if (!trimmed || trimmed === 'unknown' || trimmed === 'latest') return ''
+
+  return /^\d/.test(trimmed) ? `v${trimmed}` : trimmed
+}

--- a/frontend/tests/unit/utils/formatRunningVersion.spec.ts
+++ b/frontend/tests/unit/utils/formatRunningVersion.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatRunningVersion } from '@/utils/formatRunningVersion'
+
+describe('formatRunningVersion', () => {
+  it('prefixes a SemVer with v', () => {
+    expect(formatRunningVersion('4.0.13')).toBe('v4.0.13')
+  })
+
+  it('keeps an already-prefixed or named release as-is', () => {
+    expect(formatRunningVersion('v4.0.13')).toBe('v4.0.13')
+    expect(formatRunningVersion('dev')).toBe('dev')
+  })
+
+  it('never shows the mutable latest tag', () => {
+    expect(formatRunningVersion('latest')).toBe('')
+    expect(formatRunningVersion(' latest ')).toBe('')
+  })
+
+  it('hides empty and unknown values', () => {
+    expect(formatRunningVersion('')).toBe('')
+    expect(formatRunningVersion('unknown')).toBe('')
+    expect(formatRunningVersion(null)).toBe('')
+    expect(formatRunningVersion(undefined)).toBe('')
+  })
+})

--- a/scripts/resolve-app-version.mjs
+++ b/scripts/resolve-app-version.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+
+// Resolves the version string baked into the application image as APP_VERSION.
+//
+// docker/metadata-action's `version` output follows the first image tag. On the
+// default branch that tag is deliberately `latest`, so using the metadata value
+// verbatim made every user-facing surface — the sidebar above the profile, the
+// admin update panel, the OpenAPI info block — display the word "latest"
+// instead of a release number.
+//
+// Rules, in order:
+//   1. A plain MAJOR.MINOR.PATCH from metadata (a release-tag build) wins.
+//   2. A release git ref (vX.Y.Z) wins when metadata is missing or mutable.
+//   3. Otherwise the newest release tag in the checkout — never the word
+//      "latest", never a branch name, never a PR ref.
+
+import { execFileSync } from 'node:child_process'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+import { latestReleaseTag } from './next-release-tag.mjs'
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url))
+const DEFAULT_ROOT = resolve(SCRIPT_DIR, '..')
+
+const PLAIN_RELEASE = /^\d+\.\d+\.\d+$/
+const TAGGED_RELEASE = /^v(\d+\.\d+\.\d+)$/
+
+export const resolveAppVersion = ({ metaVersion, refName, releaseTags }) => {
+  const meta = String(metaVersion ?? '').trim()
+  if (PLAIN_RELEASE.test(meta)) {
+    return meta
+  }
+
+  const ref = String(refName ?? '').trim()
+  const fromRef = TAGGED_RELEASE.exec(ref)
+  if (fromRef) {
+    return fromRef[1]
+  }
+
+  const latest = latestReleaseTag(releaseTags ?? [])
+  if (latest) {
+    return latest.tag.replace(/^v/, '')
+  }
+
+  return 'dev'
+}
+
+const readTags = (root) =>
+  execFileSync('git', ['tag', '--list', 'v*'], { cwd: root, encoding: 'utf8' })
+    .split(/\r?\n/)
+    .filter(Boolean)
+
+export const runCli = (arguments_) => {
+  const readOption = (name) => {
+    const index = arguments_.indexOf(name)
+    return index >= 0 ? arguments_[index + 1] : undefined
+  }
+
+  const rootOption = readOption('--root')
+  const root = rootOption ? resolve(rootOption) : DEFAULT_ROOT
+  const version = resolveAppVersion({
+    metaVersion: readOption('--meta'),
+    refName: readOption('--ref'),
+    releaseTags: readTags(root),
+  })
+
+  process.stdout.write(`${version}\n`)
+}
+
+if (process.argv[1] && pathToFileURL(resolve(process.argv[1])).href === import.meta.url) {
+  try {
+    runCli(process.argv.slice(2))
+  } catch (error) {
+    process.stderr.write(`${error.message}\n`)
+    process.exitCode = 1
+  }
+}

--- a/scripts/set-release-version.mjs
+++ b/scripts/set-release-version.mjs
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+
+// Writes a published release version into the two files that decide which
+// version a NEW deployment installs: the Elestio manifest and the self-hosting
+// example configuration.
+//
+// Existing deployments are untouched by design. They keep the version their
+// operator pinned, and change it only by following docs/UPDATE_ELESTIO.md or
+// docs/UPDATE_SELFHOST.md — a redeploy never moves a running installation to a
+// different version.
+//
+// Every replacement is anchored on the exact line it owns and fails loudly when
+// that anchor is missing. A silent no-op would be the worst outcome here: the
+// release would look bumped while new deployments kept installing the old
+// version, which is precisely the failure this automation exists to prevent.
+
+import { readFileSync, writeFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url))
+const DEFAULT_ROOT = resolve(SCRIPT_DIR, '..')
+
+// Deliberately the plain patch series only. A pre-release is a legitimate pin
+// for someone who types it in, but it must never become the default a new
+// deployment silently installs.
+const RELEASE_VERSION = /^\d+\.\d+\.\d+$/
+
+export const parseReleaseVersion = (value) => {
+  const version = String(value ?? '').trim().replace(/^v/, '')
+  return RELEASE_VERSION.test(version) ? version : null
+}
+
+// The manifest lists environment variables as `- key:` / `value:` pairs, so the
+// value belongs to the key that was seen last. Matching `value:` alone would
+// rewrite whichever variable happens to come first in the file.
+export const applyElestioVersion = (text, version) => {
+  const lines = text.split('\n')
+  let keySeen = false
+  let replaced = false
+
+  const result = lines.map((line) => {
+    if (/^\s*-\s*key:\s*"?SYNAPLAN_VERSION"?\s*$/.test(line)) {
+      keySeen = true
+      return line
+    }
+
+    if (!keySeen) return line
+
+    const match = /^(\s*)value:\s*.*$/.exec(line)
+    if (!match) {
+      throw new Error(
+        'elestio.yml: the line after the SYNAPLAN_VERSION key is not a value line'
+      )
+    }
+
+    keySeen = false
+    replaced = true
+    return `${match[1]}value: "${version}"`
+  })
+
+  if (!replaced) {
+    throw new Error('elestio.yml: no SYNAPLAN_VERSION entry found')
+  }
+
+  return result.join('\n')
+}
+
+export const readElestioVersion = (text) => {
+  const match = /^[ \t]*-[ \t]*key:[ \t]*"?SYNAPLAN_VERSION"?[ \t]*$\n[ \t]*value:[ \t]*"?([^"\n]*)"?[ \t]*$/m.exec(
+    text
+  )
+  return match ? match[1].trim() : null
+}
+
+export const readEnvExampleVersion = (text) => {
+  const match = /^SYNAPLAN_VERSION=(.*)$/m.exec(text)
+  return match ? match[1].trim() : null
+}
+
+export const applyEnvExampleVersion = (text, version) => {
+  let replaced = 0
+  const result = text
+    .split('\n')
+    .map((line) => {
+      if (!/^SYNAPLAN_VERSION=/.test(line)) return line
+      replaced += 1
+      return `SYNAPLAN_VERSION=${version}`
+    })
+    .join('\n')
+
+  if (replaced !== 1) {
+    throw new Error(
+      `deploy/selfhost.env.example: expected exactly one SYNAPLAN_VERSION assignment, found ${replaced}`
+    )
+  }
+
+  return result
+}
+
+const TARGETS = [
+  { path: 'elestio.yml', apply: applyElestioVersion },
+  { path: join('deploy', 'selfhost.env.example'), apply: applyEnvExampleVersion },
+]
+
+export const runCli = (arguments_) => {
+  const readOption = (name) => {
+    const index = arguments_.indexOf(name)
+    return index >= 0 ? arguments_[index + 1] : undefined
+  }
+
+  const version = parseReleaseVersion(readOption('--version'))
+  if (!version) {
+    throw new Error('--version must be a released MAJOR.MINOR.PATCH version')
+  }
+
+  const rootOption = readOption('--root')
+  const root = rootOption ? resolve(rootOption) : DEFAULT_ROOT
+
+  const changed = []
+  for (const target of TARGETS) {
+    const file = join(root, target.path)
+    const before = readFileSync(file, 'utf8')
+    const after = target.apply(before, version)
+    if (after !== before) {
+      writeFileSync(file, after)
+      changed.push(target.path)
+    }
+  }
+
+  process.stdout.write(
+    changed.length > 0
+      ? `Set ${version} in ${changed.join(', ')}\n`
+      : `Already at ${version}\n`
+  )
+}
+
+if (process.argv[1] && pathToFileURL(resolve(process.argv[1])).href === import.meta.url) {
+  try {
+    runCli(process.argv.slice(2))
+  } catch (error) {
+    process.stderr.write(`${error.message}\n`)
+    process.exitCode = 1
+  }
+}

--- a/scripts/set-release-version.mjs
+++ b/scripts/set-release-version.mjs
@@ -37,7 +37,7 @@ export const parseReleaseVersion = (value) => {
 export const applyElestioVersion = (text, version) => {
   const lines = text.split('\n')
   let keySeen = false
-  let replaced = false
+  let replaced = 0
 
   const result = lines.map((line) => {
     if (/^\s*-\s*key:\s*"?SYNAPLAN_VERSION"?\s*$/.test(line)) {
@@ -55,12 +55,18 @@ export const applyElestioVersion = (text, version) => {
     }
 
     keySeen = false
-    replaced = true
+    replaced += 1
     return `${match[1]}value: "${version}"`
   })
 
-  if (!replaced) {
-    throw new Error('elestio.yml: no SYNAPLAN_VERSION entry found')
+  // Exactly one, like the example configuration below. A second entry is a
+  // mistake worth reporting rather than rewriting: Elestio keeps the last value
+  // for a duplicated key, so the deployment would install whichever entry came
+  // last while both looked correct here.
+  if (replaced !== 1) {
+    throw new Error(
+      `elestio.yml: expected exactly one SYNAPLAN_VERSION entry, found ${replaced}`
+    )
   }
 
   return result.join('\n')

--- a/tests/resolve-app-version.test.mjs
+++ b/tests/resolve-app-version.test.mjs
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { resolveAppVersion } from '../scripts/resolve-app-version.mjs'
+
+test('keeps a plain SemVer from image metadata', () => {
+  assert.equal(
+    resolveAppVersion({ metaVersion: '4.0.13', refName: 'main', releaseTags: ['v4.0.12'] }),
+    '4.0.13'
+  )
+})
+
+test('never returns the mutable latest tag as the application version', () => {
+  assert.equal(
+    resolveAppVersion({
+      metaVersion: 'latest',
+      refName: 'main',
+      releaseTags: ['v4.0.10', 'v4.0.13', 'v4.0.2'],
+    }),
+    '4.0.13'
+  )
+})
+
+test('falls back to the release ref when metadata is missing', () => {
+  assert.equal(
+    resolveAppVersion({ metaVersion: '', refName: 'v4.1.0', releaseTags: [] }),
+    '4.1.0'
+  )
+})
+
+test('ignores branch names and PR refs', () => {
+  assert.equal(
+    resolveAppVersion({
+      metaVersion: 'pr-1441',
+      refName: 'ci/automatic-release-version',
+      releaseTags: ['v4.0.13'],
+    }),
+    '4.0.13'
+  )
+})
+
+test('reports dev when no release exists yet', () => {
+  assert.equal(
+    resolveAppVersion({ metaVersion: 'latest', refName: 'main', releaseTags: ['nightly'] }),
+    'dev'
+  )
+})

--- a/tests/set-release-version.test.mjs
+++ b/tests/set-release-version.test.mjs
@@ -1,0 +1,130 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+import {
+  applyElestioVersion,
+  applyEnvExampleVersion,
+  parseReleaseVersion,
+  readElestioVersion,
+  readEnvExampleVersion,
+} from '../scripts/set-release-version.mjs'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
+
+const ELESTIO_SAMPLE = [
+  'environments:',
+  '  - key: "COMPOSE_PROJECT_NAME"',
+  '    value: "synaplan"',
+  '  # A comment about the release pin.',
+  '  - key: "SYNAPLAN_VERSION"',
+  '    value: "4.0.12"',
+  '  - key: "SYNAPLAN_PLATFORM"',
+  '    value: "elestio"',
+].join('\n')
+
+test('accepts a released version and rejects anything mutable', () => {
+  assert.equal(parseReleaseVersion('4.0.13'), '4.0.13')
+  assert.equal(parseReleaseVersion('v4.0.13'), '4.0.13')
+  assert.equal(parseReleaseVersion(' 4.0.13 '), '4.0.13')
+
+  // A default that new deployments install must never be one of these.
+  assert.equal(parseReleaseVersion('latest'), null)
+  assert.equal(parseReleaseVersion('main'), null)
+  assert.equal(parseReleaseVersion('4.0'), null)
+  assert.equal(parseReleaseVersion('4'), null)
+  assert.equal(parseReleaseVersion('5.0.0-rc.1'), null)
+  assert.equal(parseReleaseVersion('REPLACE_WITH_PUBLISHED_COMPATIBLE_VERSION'), null)
+  assert.equal(parseReleaseVersion(''), null)
+  assert.equal(parseReleaseVersion(undefined), null)
+})
+
+test('rewrites only the release pin, not a neighbouring variable', () => {
+  const result = applyElestioVersion(ELESTIO_SAMPLE, '4.0.13')
+
+  assert.match(result, /- key: "SYNAPLAN_VERSION"\n {4}value: "4\.0\.13"/)
+  assert.match(result, /- key: "COMPOSE_PROJECT_NAME"\n {4}value: "synaplan"/)
+  assert.match(result, /- key: "SYNAPLAN_PLATFORM"\n {4}value: "elestio"/)
+  assert.equal(result.split('\n').length, ELESTIO_SAMPLE.split('\n').length)
+})
+
+test('keeps the surrounding comments and indentation of the manifest', () => {
+  const result = applyElestioVersion(ELESTIO_SAMPLE, '5.1.0')
+
+  assert.ok(result.includes('  # A comment about the release pin.'))
+  assert.ok(result.includes('    value: "5.1.0"'))
+})
+
+// A bump that quietly changes nothing would advertise a release while new
+// deployments keep installing the previous version.
+test('fails loudly when the manifest anchor is gone', () => {
+  assert.throws(
+    () => applyElestioVersion('environments:\n  - key: "OTHER"\n    value: "x"', '4.0.13'),
+    /no SYNAPLAN_VERSION entry found/
+  )
+
+  assert.throws(
+    () => applyElestioVersion('  - key: "SYNAPLAN_VERSION"\n  - key: "NEXT"', '4.0.13'),
+    /not a value line/
+  )
+})
+
+test('rewrites the single assignment in the example configuration', () => {
+  const before = [
+    '# Release and public endpoint',
+    'COMPOSE_PROJECT_NAME=synaplan-production',
+    'SYNAPLAN_VERSION=4.0.12',
+    'SYNAPLAN_PULL_POLICY=always',
+  ].join('\n')
+
+  const result = applyEnvExampleVersion(before, '4.0.13')
+
+  assert.ok(result.includes('SYNAPLAN_VERSION=4.0.13'))
+  assert.ok(result.includes('SYNAPLAN_PULL_POLICY=always'))
+  assert.ok(!result.includes('4.0.12'))
+})
+
+test('fails when the example configuration has no or several assignments', () => {
+  assert.throws(
+    () => applyEnvExampleVersion('APP_URL=https://example.test', '4.0.13'),
+    /found 0/
+  )
+
+  assert.throws(
+    () => applyEnvExampleVersion('SYNAPLAN_VERSION=1.0.0\nSYNAPLAN_VERSION=2.0.0', '4.0.13'),
+    /found 2/
+  )
+})
+
+// The guard against the failure that prompted this automation: a deployment
+// once aborted because the shipped manifest still carried a placeholder instead
+// of a published version.
+test('the shipped files name one and the same released version', () => {
+  const elestio = readElestioVersion(readFileSync(join(ROOT, 'elestio.yml'), 'utf8'))
+  const example = readEnvExampleVersion(
+    readFileSync(join(ROOT, 'deploy', 'selfhost.env.example'), 'utf8')
+  )
+
+  assert.equal(
+    parseReleaseVersion(elestio),
+    elestio,
+    `elestio.yml must pin a released version, found ${JSON.stringify(elestio)}`
+  )
+  assert.equal(
+    parseReleaseVersion(example),
+    example,
+    `deploy/selfhost.env.example must pin a released version, found ${JSON.stringify(example)}`
+  )
+  assert.equal(elestio, example, 'both files must install the same version')
+})
+
+test('a comment mentioning the variable is not treated as an assignment', () => {
+  const before = ['# SYNAPLAN_VERSION picks the release', 'SYNAPLAN_VERSION=4.0.12'].join('\n')
+
+  const result = applyEnvExampleVersion(before, '4.0.13')
+
+  assert.ok(result.includes('# SYNAPLAN_VERSION picks the release'))
+  assert.ok(result.includes('SYNAPLAN_VERSION=4.0.13'))
+})

--- a/tests/set-release-version.test.mjs
+++ b/tests/set-release-version.test.mjs
@@ -62,12 +62,28 @@ test('keeps the surrounding comments and indentation of the manifest', () => {
 test('fails loudly when the manifest anchor is gone', () => {
   assert.throws(
     () => applyElestioVersion('environments:\n  - key: "OTHER"\n    value: "x"', '4.0.13'),
-    /no SYNAPLAN_VERSION entry found/
+    /expected exactly one SYNAPLAN_VERSION entry, found 0/
   )
 
   assert.throws(
     () => applyElestioVersion('  - key: "SYNAPLAN_VERSION"\n  - key: "NEXT"', '4.0.13'),
     /not a value line/
+  )
+})
+
+// Elestio keeps the last value for a duplicated key, so a second entry would
+// decide the installed version while both lines looked correct here.
+test('fails when the manifest carries the release pin twice', () => {
+  const duplicated = [
+    '  - key: "SYNAPLAN_VERSION"',
+    '    value: "4.0.12"',
+    '  - key: "SYNAPLAN_VERSION"',
+    '    value: "4.0.11"',
+  ].join('\n')
+
+  assert.throws(
+    () => applyElestioVersion(duplicated, '4.0.13'),
+    /expected exactly one SYNAPLAN_VERSION entry, found 2/
   )
 })
 


### PR DESCRIPTION
## Summary
Two Elestio findings from the first real deployment: the default release version had to be edited by hand for every release, and the platform gave every generated secret the same value.

## Changes
- **Release version is maintained by CI.** After the image for a tag is published and verified, a new `release-version-pin` job proposes the new default as a pull request, updating `elestio.yml` and `deploy/selfhost.env.example` via `scripts/set-release-version.mjs`. A missing anchor is a hard error, because a silent no-op would advertise a release while new deployments kept installing the old version. A test asserts both files name one and the same released version.
- **Every deployment secret gets its own value.** Elestio's `random_password` yields one value per deployment and substitutes it everywhere, so the database password, `APP_SECRET`, `TOKEN_SECRET`, all four Centrifugo secrets and the administrator password were one string. The eight infrastructure secrets are no longer declared in the manifest; `ensure_deployment_secrets()` draws each independently and records them in `deploy/data/secrets.env`, the only directory that survives a redeploy.

## Verification
- [x] Tests added/updated
- [x] Manual

`bash deploy/scripts/tests/test-lifecycle.sh` and `node --test "tests/*.test.mjs"` pass. Backend and frontend are untouched, so those gates do not apply.

The CI job was simulated end to end against a throwaway clone with `git push` and `gh` stubbed: first proposal, re-run when already current, an earlier proposal still open, a pre-release tag, and a published version disagreeing with its tag. The version guard was mutation-tested by planting a placeholder, which fails the suite as intended.

The secret handling was verified independently of its own tests: a fresh deployment produces eight distinct 32-byte values at mode `0600`, a second run leaves the file byte-identical, an initialised deployment carrying one shared value adopts all eight verbatim, two deployments share no value, and an initialised stack with an unknown credential exits non-zero naming the variable without leaving a partial file behind.

## Notes
**A running deployment is never changed.** A secret that is already in effect is adopted verbatim. When a credential is unknown but the stack is already initialised, the deployment stops and names the variable instead of inventing one — a new `MARIADB_PASSWORD` would lock the application out of its own database permanently. `BOOTSTRAP_ADMIN_PASSWORD` stays exactly as the platform generates it, because that is the login it displays.

`deploy/data/secrets.env` is secret material: it belongs in every backup, and losing it while keeping the database means losing database access. It is covered by `.gitignore`.

The version job opens a pull request rather than pushing to `main`, deliberately. Elestio redeploys on every commit to the branch a pipeline tracks, so merging decides when managed instances restart.

Follows up on #1440. Mobile classification: **backend-only**.