### PR TITLE
docs(elestio): record the measured pipeline behaviour

### DIFF
--- a/deploy/elestio/README.md
+++ b/deploy/elestio/README.md
@@ -19,10 +19,9 @@ schema. These files only translate lifecycle events to the portable scripts in
    enabling email-dependent features.
 
 Elestio documents `random_password`, `[EMAIL]`, and `[CI_CD_DOMAIN]`
-substitution. Treat every generated password as a persistent pipeline secret:
-do not regenerate it on redeploy, and include the environment configuration in
-your external disaster-recovery records. The administrator credentials are the
-critical case: see
+substitution. Every generated password is a persistent pipeline secret: it is
+drawn once, at creation, and belongs in your external disaster-recovery records.
+The administrator credentials are the critical case: see
 [First administrator credentials](#first-administrator-credentials).
 
 ## Application secrets are generated per deployment
@@ -60,8 +59,31 @@ for the Synaplan shortcut, so it stays exactly the value the platform generated.
 The public template documentation does not define a separate schema property
 that marks an environment variable as editable. `COMPOSE_PROFILES` is therefore
 declared as a normal environment value. Change it to `local-ai` in Elestio's
-pipeline environment editor and redeploy. Confirm the exact dashboard editing
-and secret-retention behavior with Elestio before catalog submission.
+pipeline environment editor and redeploy.
+
+## How this manifest reaches a pipeline
+
+Measured on a live pipeline, because the published documentation does not state
+it and the behaviour decides whether a release can move a running deployment:
+
+- **A pipeline's environment is materialised once, when the pipeline is
+  created.** Afterwards it belongs to the pipeline, not to this file.
+- **Changing a value here does not reach a pipeline that already exists.** A
+  probe key was deployed as `probe-1`, changed to `probe-2` in this manifest, and
+  the pipeline still reported `probe-1` after the redeploy that commit triggered.
+  Raising `SYNAPLAN_VERSION` therefore only decides what a NEW deployment
+  installs; a running one stays on the release its operator deployed until that
+  operator changes it. That is the guarantee
+  [docs/UPDATE_ELESTIO.md](../../docs/UPDATE_ELESTIO.md) makes, and it holds.
+- **`random_password` is drawn once, at creation**, not on every deploy. The
+  generated administrator password stays valid for the life of the pipeline.
+- **A commit on the tracked branch deploys automatically.** Merging anything into
+  the default branch restarts every pipeline that tracks it — with its own stored
+  configuration, so nothing is upgraded, but the restart itself is not optional.
+  This is why the release automation opens a pull request instead of pushing.
+
+Deleting and recreating a pipeline is a new pipeline: it re-reads this file and
+draws fresh passwords. Do not mistake that for a redeploy.
 
 The documentation also does not publish catalog-only metadata fields or asset
 requirements. No undocumented fields are included. Icon, screenshot, benchmark,
@@ -74,13 +96,17 @@ Elestio replaces `[EMAIL]` with your Elestio account address and
 `random_password` with a generated value, then shows both as the login for the
 Synaplan shortcut. Store them in a password manager during the first deployment.
 
-> **After a redeploy, the password Elestio displays no longer works.** Elestio
-> generates a new value and shows it, while Synaplan keeps the administrator that
-> was created on the very first start — the bootstrap never resets an existing
-> administrator, deliberately, because otherwise a deployment variable would be a
-> permanent password-reset backdoor. Nothing is broken. Sign in with the
-> **original** credentials from the first deployment, which is why they belong in
-> a password manager. If they are lost, recover as described in
+A redeploy keeps that password: the value is drawn once, when the pipeline is
+created, and the pipeline's stored environment is authoritative from then on.
+
+> **Recreating the pipeline is the case to watch.** A new pipeline draws a new
+> password and displays it, while Synaplan keeps the administrator created on the
+> very first start — the bootstrap never resets an existing administrator,
+> deliberately, because otherwise a deployment variable would be a permanent
+> password-reset backdoor. Nothing is broken, but the newly displayed password
+> does not work if the data directory survived. Sign in with the **original**
+> credentials, which is why they belong in a password manager. If they are lost,
+> recover as described in
 > [Lost Administrator Password](../../docs/ADMIN.md#lost-administrator-password):
 > a password reset by email once SMTP is configured, otherwise through the
 > database.

--- a/docs/UPDATE_ELESTIO.md
+++ b/docs/UPDATE_ELESTIO.md
@@ -36,3 +36,7 @@ version already changed the database, also restore the backup from step 1.
 A redeploy on its own never installs a newer version — the version only changes
 when you change it. Always use a released version number; `latest` is rejected
 before anything starts.
+
+Your pipeline may restart by itself when the Synaplan repository receives a new
+commit. That is a restart, not an update: it reuses the version and the settings
+your pipeline already has.


### PR DESCRIPTION
## Summary
Three Elestio properties this repository had to assume are now measured on a live pipeline, and one of them turned out to be documented incorrectly.

## Changes
- `deploy/elestio/README.md`: new section stating how the manifest reaches a pipeline, replacing the note that told a reader to confirm the behaviour with Elestio.
- Corrected the administrator-password warning. `random_password` is drawn once at pipeline creation, not on every deploy, so a redeploy keeps the displayed password valid. Recreating the pipeline is the case that matters, and the section now says so.
- `docs/UPDATE_ELESTIO.md`: one sentence explaining that a pipeline may restart on its own when the repository receives a commit, and that this is a restart rather than an update.

## Verification
- [x] Manual

Measured with a probe key that nothing reads (`deploy/compose.yaml` never references it, and every validation in `deploy/scripts/lib.sh` iterates a fixed key list):

1. A pipeline was created on a branch carrying `SYNAPLAN_MANIFEST_PROBE=probe-1`; the deployed environment reported `probe-1`.
2. The manifest was changed to `probe-2` and pushed. The commit started a deployment automatically.
3. The same pipeline still reported `probe-1`, and `BOOTSTRAP_ADMIN_PASSWORD` was byte-identical to the value from step 1.

Docs only — no code, no gate applies.

## Notes
The first finding confirms the guarantee `docs/UPDATE_ELESTIO.md` already made: raising `SYNAPLAN_VERSION` in the manifest decides only what a **new** deployment installs, and a running deployment stays on its version until its operator changes it. The release automation added in #1441 is therefore safe as built.

The third finding is why that automation opens a pull request instead of pushing to the default branch: every merge restarts each pipeline that tracks it.

Earlier observations that suggested the opposite came from a pipeline that had been deleted and recreated between deployments, which re-reads the manifest and draws fresh passwords.

Mobile classification: **backend-only** — documentation only.