### PR TITLE
ci: validate Cloudflare Worker on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1397,7 +1397,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
-          node-version: "24"
+          node-version-file: .nvmrc
           cache: "npm"
           cache-dependency-path: cloudflare/package-lock.json
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1380,11 +1380,40 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: npx wrangler deploy --env production
 
+  # cloudflare-deploy only runs on push to main/tags, so dependency bumps in
+  # cloudflare/ (wrangler, workers-types and their transitive miniflare) are
+  # never exercised on a PR. This job bundles the Worker via `wrangler --dry-run`
+  # (esbuild build, no upload, no secrets required) so those updates are
+  # validated before merge instead of failing at deploy time.
+  cloudflare-check:
+    name: Cloudflare Worker Check
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: "24"
+          cache: "npm"
+          cache-dependency-path: cloudflare/package-lock.json
+
+      - name: Install dependencies
+        working-directory: cloudflare
+        run: npm ci
+
+      - name: Validate Worker build (dry-run)
+        working-directory: cloudflare
+        run: npx wrangler deploy --env production --dry-run --outdir dist
+
   # Gate job that depends on all checks - only this needs to be required in branch protection
   all-checks-passed:
     name: All Checks Passed
     runs-on: ubuntu-latest
-    needs: [lint, mobile-tooling, backend, frontend-build, frontend-checks, docker-build, e2e, e2e-visual, docker-push, release-manifest, release-version-pin, cloudflare-deploy]
+    needs: [lint, mobile-tooling, backend, frontend-build, frontend-checks, docker-build, e2e, e2e-visual, docker-push, release-manifest, release-version-pin, cloudflare-deploy, cloudflare-check]
     if: always()
     steps:
       - name: Check for failures
@@ -1401,7 +1430,8 @@ jobs:
             (needs.docker-push.result != 'success' && needs.docker-push.result != 'skipped') ||
             (needs.release-manifest.result != 'success' && needs.release-manifest.result != 'skipped') ||
             (needs.release-version-pin.result != 'success' && needs.release-version-pin.result != 'skipped') ||
-            (needs.cloudflare-deploy.result != 'success' && needs.cloudflare-deploy.result != 'skipped')
+            (needs.cloudflare-deploy.result != 'success' && needs.cloudflare-deploy.result != 'skipped') ||
+            (needs.cloudflare-check.result != 'success' && needs.cloudflare-check.result != 'skipped')
           )
         run: |
           echo "One or more checks failed, were cancelled, or were skipped"


### PR DESCRIPTION
## Summary

Add a PR-only `cloudflare-check` job. `cloudflare-deploy` only runs on `push` to `main`/tags, so dependency bumps in `cloudflare/` (`wrangler`, `@cloudflare/workers-types` and their transitive `miniflare`) are never exercised on a PR — a broken Worker build only surfaces at deploy time after merge, blocking the `main` deploy. The new job runs on PRs, does `npm ci` in `cloudflare/`, and bundles the Worker via `wrangler deploy --env production --dry-run` (esbuild build, no upload, **no secrets required**). It is wired into the `all-checks-passed` gate as skip-aware, so `push` runs (where it is skipped) stay green.

## Why

Concrete gap found while triaging Renovate PRs: the frontend-dependencies group bump (`wrangler` 4.116→4.118, pulling transitive `miniflare@5.x-alpha`) had no CI coverage for the `cloudflare/` Worker at all.

## Scope notes

- Runs on **every** PR (no `paths` filter) — consistent with the rest of this workflow and avoids a blind spot if Worker behavior is ever affected by changes outside `cloudflare/`. The job is cheap (~30s, parallel, off the E2E-dominated critical path).
- No `tsc` type-check step: `typescript` is not a dependency of `cloudflare/`; the dry-run validates the esbuild build, not types.

## Validation

`wrangler deploy --env production --dry-run` runs locally in a `node` container against `cloudflare/` with no secrets — builds cleanly (Total Upload ~2.56 KiB, exit 0). Workflow YAML parses; `actionlint` reports only pre-existing findings, none in the added job.

## Test plan

- [ ] `cloudflare-check` runs on this PR and passes (Worker dry-run build succeeds).
- [ ] `All Checks Passed` gate depends on `cloudflare-check` and goes green.