### PR TITLE
ci: enforce production dependency audit gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,13 @@ jobs:
 
       - name: Security audit
         working-directory: backend
-        run: composer audit || true
+        # Blocking gate: fail the PR on high/critical advisories in production
+        # (require) dependencies. Dev-only tools (--no-dev) and lower severities
+        # are excluded to avoid blocking on issues that never ship to prod or
+        # have no fix yet. Abandoned packages are reported, not failed.
+        run: >-
+          composer audit --no-dev --abandoned=report
+          --ignore-severity=low --ignore-severity=medium --ignore-severity=moderate
 
       - name: Run PHPStan
         working-directory: backend
@@ -384,6 +390,13 @@ jobs:
       - name: Install dependencies
         working-directory: frontend
         run: npm ci
+
+      - name: Security audit
+        working-directory: frontend
+        # Blocking gate: fail on high/critical advisories in production
+        # dependencies only (--omit=dev). Dev tooling and lower severities do
+        # not ship to users and would otherwise block PRs without fixes.
+        run: npm audit --omit=dev --audit-level=high
 
       - name: Download OpenAPI spec artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8

--- a/backend/composer.lock
+++ b/backend/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2056cbbf3ad92e02632ea5295e2a4e5b",
+    "content-hash": "67036699757d3345b1452c42efa2fd6d",
     "packages": [
         {
             "name": "api-platform/doctrine-common",
@@ -3783,21 +3783,21 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.15.1",
+            "version": "7.15.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "61443dfb33c62f308ee8add20f45b4d6e4bf8d2f"
+                "reference": "ae311b8f045ea93ce7b1c9cdb7cec06c53f944bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/61443dfb33c62f308ee8add20f45b4d6e4bf8d2f",
-                "reference": "61443dfb33c62f308ee8add20f45b4d6e4bf8d2f",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/ae311b8f045ea93ce7b1c9cdb7cec06c53f944bc",
+                "reference": "ae311b8f045ea93ce7b1c9cdb7cec06c53f944bc",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^2.5.1",
+                "guzzlehttp/promises": "^2.5.2",
                 "guzzlehttp/psr7": "^2.13",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
@@ -3891,7 +3891,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.15.1"
+                "source": "https://github.com/guzzle/guzzle/tree/7.15.3"
             },
             "funding": [
                 {
@@ -3907,20 +3907,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-18T11:23:11+00:00"
+            "time": "2026-08-05T19:48:21+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.5.1",
+            "version": "2.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "9ad1e4fc607446a055b95870c7f668e93b5cff29"
+                "reference": "2823687acff28b2dbe67b2508a6b300e2c3fa4ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/9ad1e4fc607446a055b95870c7f668e93b5cff29",
-                "reference": "9ad1e4fc607446a055b95870c7f668e93b5cff29",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/2823687acff28b2dbe67b2508a6b300e2c3fa4ce",
+                "reference": "2823687acff28b2dbe67b2508a6b300e2c3fa4ce",
                 "shasum": ""
             },
             "require": {
@@ -3975,7 +3975,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.5.1"
+                "source": "https://github.com/guzzle/promises/tree/2.5.2"
             },
             "funding": [
                 {
@@ -3991,7 +3991,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-08T15:48:39+00:00"
+            "time": "2026-08-05T19:30:54+00:00"
         },
         {
             "name": "guzzlehttp/psr7",


### PR DESCRIPTION
## Summary

Makes dependency vulnerability auditing a **blocking** part of CI so a green `All Checks Passed` guarantees that shipped (production) dependencies carry no known high/critical advisories. This is groundwork for merging Renovate updates with less manual checking.

- **Frontend** (`frontend-checks`): add `npm audit --omit=dev --audit-level=high`.
- **Backend** (`backend`): `composer audit` is now blocking (was `|| true`), scoped to production deps (`--no-dev`), high/critical only (`--ignore-severity=low/medium/moderate`), abandoned packages reported not failed.
- **Fix required to make the composer gate green:** bump `guzzlehttp/guzzle` 7.15.1 → 7.15.3 (+ `guzzlehttp/promises` 2.5.1 → 2.5.2), which clears the existing high advisory.

### Why high/critical + prod-only (not everything)

Lower severities and dev-only tooling do not ship to users and often have no fix available yet — gating on them would block unrelated PRs. A stricter ratchet can be added later if we want. Tradeoff noted explicitly.

## Test plan

Verified locally in the dev containers before pushing:

- `composer audit --no-dev --abandoned=report --ignore-severity=low --ignore-severity=medium --ignore-severity=moderate` → *No security vulnerability advisories found.*
- `npm audit --omit=dev --audit-level=high` → *found 0 vulnerabilities* (exit 0).
- `actionlint` on `ci.yml`: no new findings (only pre-existing shellcheck/`ubuntu-latest-m` warnings remain).

Rely on CI to run both gates on this PR.