### PR TITLE
chore(release): install 4.0.14 in new deployments

### DIFF
--- a/deploy/selfhost.env.example
+++ b/deploy/selfhost.env.example
@@ -9,7 +9,7 @@ COMPOSE_PROJECT_NAME=synaplan-production
 # and any mutable tag are rejected before a container starts, so a redeploy can
 # never pull a different version behind your back. Newer releases are listed at
 # https://github.com/metadist/synaplan/releases — see docs/UPDATE_SELFHOST.md.
-SYNAPLAN_VERSION=4.0.13
+SYNAPLAN_VERSION=4.0.14
 SYNAPLAN_PULL_POLICY=always
 SYNAPLAN_HTTP_BIND=127.0.0.1
 SYNAPLAN_HTTP_PORT=8000

--- a/elestio.yml
+++ b/elestio.yml
@@ -27,7 +27,7 @@ environments:
   # new deployments; existing ones stay on their pinned version until their
   # operator changes it, as described in docs/UPDATE_ELESTIO.md.
   - key: "SYNAPLAN_VERSION"
-    value: "4.0.13"
+    value: "4.0.14"
   # Deployment hint for the release notice, so the admin UI links to the Elestio
   # update guide instead of the self-hosted one. Display only: Synaplan never
   # updates itself.


### PR DESCRIPTION
Installs `4.0.14` in **new** deployments: `elestio.yml` for the one-click
path and `deploy/selfhost.env.example` for self-hosting.

Existing deployments are unaffected. They keep the version their operator
pinned and change it only by following the update guide, so a redeploy never
moves a running installation to a different version.

Merging this restarts every Elestio instance that tracks `main`, because
Elestio redeploys on each commit to the branch it tracks. Merge when that is
convenient.

Opened manually after the automated step failed with
`Resource not accessible by integration (createPullRequest)` on the tag CI
for `v4.0.14`. The image itself is already published and verified:
`ghcr.io/metadist/synaplan:4.0.14@sha256:40489bf5db1a3f34727b715045b6d7c157bc86e5a85c85f4c31a2c26b32a7423`