### PR TITLE
chore(umbrel): pin the App Store package to 4.0.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -924,6 +924,11 @@ jobs:
       # bakes APP_VERSION into the image, so the manifest can only ever name a
       # SemVer this job actually published — never the mutable `latest` tag.
       version: ${{ steps.app-version.outputs.version }}
+      # Multi-arch manifest digest of the tags that were just published and
+      # verified. The Umbrel package pins tag@digest; the release-version-pin
+      # job writes this value into deploy/umbrel/ so a new store submission
+      # never invents a digest of its own.
+      digest: ${{ steps.release.outputs.digest }}
 
     steps:
       - name: Checkout
@@ -1231,9 +1236,10 @@ jobs:
   release-version-pin:
     name: Update the Default Release Version
     runs-on: ubuntu-latest
-    # elestio.yml and deploy/selfhost.env.example decide which version a NEW
-    # deployment installs, so they may only ever name a release whose image is
-    # published and verified — which is what docker-push guarantees.
+    # elestio.yml, deploy/selfhost.env.example and deploy/umbrel/synaplan/
+    # decide which version a NEW deployment installs, so they may only ever
+    # name a release whose image is published and verified — which is what
+    # docker-push guarantees. Umbrel also needs the digest of that image.
     needs: [docker-push]
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     permissions:
@@ -1244,7 +1250,10 @@ jobs:
       # A pull request, deliberately, rather than a push to main. Elestio
       # pipelines redeploy on every commit to the branch they track, so pushing
       # here would restart every managed instance at an unpredictable moment.
-      # Merging is the maintainer's choice of when that happens.
+      # Merging is the maintainer's choice of when that happens. The Umbrel
+      # package lives in this same PR so a release bumps every catalog pin
+      # together; the getumbrel/umbrel-apps store submission stays a separate,
+      # manual step because it targets a foreign repository.
       - name: Checkout the default branch
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -1282,6 +1291,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
           VERSION: ${{ needs.docker-push.outputs.version }}
+          DIGEST: ${{ needs.docker-push.outputs.digest }}
           BRANCH: automation/default-release-version
           BASE: ${{ github.event.repository.default_branch }}
         run: |
@@ -1302,7 +1312,12 @@ jobs:
             exit 0
           fi
 
-          node scripts/set-release-version.mjs --version "$VERSION"
+          if [ -z "$DIGEST" ]; then
+            echo "::error::docker-push did not provide the multi-arch manifest digest; Umbrel cannot be pinned without it"
+            exit 1
+          fi
+
+          node scripts/set-release-version.mjs --version "$VERSION" --digest "$DIGEST"
 
           if git diff --quiet; then
             echo "The default version is already \`${VERSION}\`; nothing to propose." |
@@ -1331,8 +1346,13 @@ jobs:
 
           body_file="$(mktemp)"
           cat > "$body_file" <<EOF
-          Installs \`${VERSION}\` in **new** deployments: \`elestio.yml\` for the one-click
-          path and \`deploy/selfhost.env.example\` for self-hosting.
+          Installs \`${VERSION}\` in **new** deployments:
+
+          - \`elestio.yml\` for the one-click path
+          - \`deploy/selfhost.env.example\` for self-hosting
+          - \`deploy/umbrel/synaplan/\` for the Umbrel App Store package
+            (version, \`APP_VERSION\`, and the published image digest
+            \`${DIGEST}\`)
 
           Existing deployments are unaffected. They keep the version their operator
           pinned and change it only by following the update guide, so a redeploy never
@@ -1341,6 +1361,10 @@ jobs:
           Merging this restarts every Elestio instance that tracks \`${BASE}\`, because
           Elestio redeploys on each commit to the branch it tracks. Merge when that is
           convenient.
+
+          The Umbrel pin lives in this repository only. Submitting the raised package
+          to [getumbrel/umbrel-apps](https://github.com/getumbrel/umbrel-apps) remains
+          a separate, manual pull request.
 
           Opened automatically after the image for \`${GITHUB_REF_NAME}\` was published
           and verified.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -249,3 +249,9 @@ the app's data directory for the same reason this deployment does — a database
 restored without its password cannot be opened. Its deviations, including the
 absent local-AI services and the missing consistent-backup hook, are listed in
 [`umbrel/README.md`](umbrel/README.md).
+
+The release pin for that package (store `version`, `APP_VERSION`, and the
+`tag@sha256:…` image) is raised automatically together with `elestio.yml` and
+`deploy/selfhost.env.example` by `scripts/set-release-version.mjs` after every
+published release. Submitting the raised package to the Umbrel App Store remains
+a separate, manual pull request against `getumbrel/umbrel-apps`.

--- a/deploy/umbrel/README.md
+++ b/deploy/umbrel/README.md
@@ -17,10 +17,11 @@ over plain `http://<device>.local:<port>`, and up to and including 4.0.13
 Synaplan marks its auth cookies `Secure` whenever `APP_ENV=prod`. A browser
 never sends those back over HTTP, so the user logs in successfully and is
 anonymous again on the next request. `AuthCookieFactory` derives the flag from
-the `APP_URL` scheme instead; the first release containing it is the first
-release that can be offered here.
+the `APP_URL` scheme instead; **4.0.14 is the first release that can be offered
+here**, and the package is pinned to it.
 
-The release number appears in three places that have to move together:
+The release number appears in three places that have to move together on every
+later bump:
 
 - `docker-compose.yml` — the `x-app-image` tag **and** its `@sha256:` digest.
 - `docker-compose.yml` — `APP_VERSION`, which is what the admin UI displays.
@@ -36,8 +37,8 @@ release workflow runs on every tag, only knows `elestio.yml` and
 go through a `getumbrel/umbrel-apps` pull request anyway. Assume the numbers below
 are stale and check them against the latest release before every submission.
 
-Re-run the login check from *Testing* below against the raised pin: it is the
-one thing that cannot be verified on 4.0.13.
+Re-run the login check from *Testing* below against every raised pin: cookies
+must be issued without `Secure` over plain HTTP.
 
 ## What umbrelOS changes
 

--- a/deploy/umbrel/README.md
+++ b/deploy/umbrel/README.md
@@ -20,22 +20,26 @@ anonymous again on the next request. `AuthCookieFactory` derives the flag from
 the `APP_URL` scheme instead; **4.0.14 is the first release that can be offered
 here**, and the package is pinned to it.
 
-The release number appears in three places that have to move together on every
-later bump:
+### How the pin is raised
 
-- `docker-compose.yml` — the `x-app-image` tag **and** its `@sha256:` digest.
-- `docker-compose.yml` — `APP_VERSION`, which is what the admin UI displays.
-- `umbrel-app.yml` — `version`.
+Publishing a release tag opens one pull request
+(`automation/default-release-version`) that bumps every catalog pin together:
 
-Three manifest fields are still placeholders and have to be filled in as well:
-`releaseNotes`, `gallery` (the store expects screenshots) and `submission`, which
-currently reads `.../pull/PENDING`.
+- `elestio.yml` and `deploy/selfhost.env.example`
+- this package: `umbrel-app.yml` (`version`), `docker-compose.yml`
+  (`APP_VERSION` and the `tag@sha256:…` image pin)
 
-Nothing raises these for you. `scripts/set-release-version.mjs`, which the
-release workflow runs on every tag, only knows `elestio.yml` and
-`deploy/selfhost.env.example` — it cannot pin a digest, and the store copy has to
-go through a `getumbrel/umbrel-apps` pull request anyway. Assume the numbers below
-are stale and check them against the latest release before every submission.
+`scripts/set-release-version.mjs` owns those lines. The digest comes from the
+multi-arch manifest the release workflow just published, so the PR never invents
+one. Do not edit them by hand.
+
+Merging that PR updates **this** repository only. Submitting the raised package
+to [getumbrel/umbrel-apps](https://github.com/getumbrel/umbrel-apps) remains a
+separate, manual pull request — Umbrel cannot pull from our repo on its own.
+
+Three other manifest fields are still placeholders and have to be filled in for
+a store submission: `releaseNotes`, `gallery` (the store expects screenshots)
+and `submission`, which currently reads `.../pull/PENDING`.
 
 Re-run the login check from *Testing* below against every raised pin: cookies
 must be issued without `Secure` over plain HTTP.

--- a/deploy/umbrel/synaplan/docker-compose.yml
+++ b/deploy/umbrel/synaplan/docker-compose.yml
@@ -15,6 +15,10 @@ x-app-environment: &app-environment
   # self-hosted guide, which is close enough: Umbrel updates arrive through the
   # App Store, not through a manual pull.
   SYNAPLAN_PLATFORM: umbrel
+  # Maintained by CI: publishing a release opens a pull request that raises this
+  # (together with the image pin below and umbrel-app.yml) to the version whose
+  # image was just published. Do not edit by hand —
+  # scripts/set-release-version.mjs owns these three lines.
   APP_VERSION: "4.0.14"
 
   # umbrelOS serves apps over plain HTTP on the device's .local domain. Synaplan
@@ -79,6 +83,8 @@ x-app-environment: &app-environment
 # The three app roles share one image and differ only by SYNAPLAN_ROLE. It runs
 # as root because its entrypoint repairs ownership of the upload directory and
 # then hands over to Caddy/FrankenPHP, which binds port 80 inside the container.
+# Tag and digest are maintained by CI together with APP_VERSION above —
+# scripts/set-release-version.mjs owns this line.
 x-app-image: &app-image ghcr.io/metadist/synaplan:4.0.14@sha256:40489bf5db1a3f34727b715045b6d7c157bc86e5a85c85f4c31a2c26b32a7423
 
 # Uploaded and generated files. The web role writes them, the worker reads them

--- a/deploy/umbrel/synaplan/docker-compose.yml
+++ b/deploy/umbrel/synaplan/docker-compose.yml
@@ -15,7 +15,7 @@ x-app-environment: &app-environment
   # self-hosted guide, which is close enough: Umbrel updates arrive through the
   # App Store, not through a manual pull.
   SYNAPLAN_PLATFORM: umbrel
-  APP_VERSION: "4.0.13"
+  APP_VERSION: "4.0.14"
 
   # umbrelOS serves apps over plain HTTP on the device's .local domain. Synaplan
   # derives the auth cookies' Secure flag from this scheme, so the session
@@ -79,7 +79,7 @@ x-app-environment: &app-environment
 # The three app roles share one image and differ only by SYNAPLAN_ROLE. It runs
 # as root because its entrypoint repairs ownership of the upload directory and
 # then hands over to Caddy/FrankenPHP, which binds port 80 inside the container.
-x-app-image: &app-image ghcr.io/metadist/synaplan:4.0.13@sha256:0f8037576f93ab7458c344b1023973046501fa473d9a1b2ff58c2854e2e0d0f2
+x-app-image: &app-image ghcr.io/metadist/synaplan:4.0.14@sha256:40489bf5db1a3f34727b715045b6d7c157bc86e5a85c85f4c31a2c26b32a7423
 
 # Uploaded and generated files. The web role writes them, the worker reads them
 # back while processing a job, so all three app roles share the directory.

--- a/deploy/umbrel/synaplan/umbrel-app.yml
+++ b/deploy/umbrel/synaplan/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: synaplan
 category: ai
 name: Synaplan
-version: "4.0.13"
+version: "4.0.14"
 tagline: Private AI workspace with chat, document search and embeddable widgets
 description: >-
   Synaplan is a self-hosted AI workspace. Chat with the model of your choice,

--- a/deploy/umbrel/synaplan/umbrel-app.yml
+++ b/deploy/umbrel/synaplan/umbrel-app.yml
@@ -2,6 +2,8 @@ manifestVersion: 1
 id: synaplan
 category: ai
 name: Synaplan
+# Maintained by CI together with APP_VERSION and the image pin in
+# docker-compose.yml — scripts/set-release-version.mjs owns this field.
 version: "4.0.14"
 tagline: Private AI workspace with chat, document search and embeddable widgets
 description: >-

--- a/scripts/set-release-version.mjs
+++ b/scripts/set-release-version.mjs
@@ -38,6 +38,11 @@ const IMAGE_DIGEST = /^sha256:[a-f0-9]{64}$/
 
 const UMBREL_IMAGE_REPOSITORY = 'ghcr.io/metadist/synaplan'
 
+// Full regex-metacharacter escape, not just the dots this one constant happens
+// to contain today — a partial escape would silently stop being safe the day
+// the repository name changes to include any other special character.
+const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
 export const parseReleaseVersion = (value) => {
   const version = String(value ?? '').trim().replace(/^v/, '')
   return RELEASE_VERSION.test(version) ? version : null
@@ -206,7 +211,7 @@ export const readUmbrelComposePin = (text) => {
   }
 
   const match = new RegExp(
-    `^${UMBREL_IMAGE_REPOSITORY.replace(/\./g, '\\.')}:([^@]+)@(sha256:[a-f0-9]{64})$`
+    `^${escapeRegExp(UMBREL_IMAGE_REPOSITORY)}:([^@]+)@(sha256:[a-f0-9]{64})$`
   ).exec(image)
 
   return {

--- a/scripts/set-release-version.mjs
+++ b/scripts/set-release-version.mjs
@@ -1,13 +1,19 @@
 #!/usr/bin/env node
 
-// Writes a published release version into the two files that decide which
-// version a NEW deployment installs: the Elestio manifest and the self-hosting
-// example configuration.
+// Writes a published release version into the files that decide which version a
+// NEW deployment installs: the Elestio manifest, the self-hosting example
+// configuration, and the Umbrel App Store package.
 //
 // Existing deployments are untouched by design. They keep the version their
-// operator pinned, and change it only by following docs/UPDATE_ELESTIO.md or
-// docs/UPDATE_SELFHOST.md — a redeploy never moves a running installation to a
-// different version.
+// operator pinned, and change it only by following docs/UPDATE_ELESTIO.md,
+// docs/UPDATE_SELFHOST.md, or the Umbrel App Store update flow — a redeploy never
+// moves a running installation to a different version.
+//
+// Umbrel also pins the image digest. Umbrel's linter and store policy require
+// `tag@sha256:…`, so the digest has to move with the version. The release
+// workflow passes the digest of the multi-arch manifest it just published and
+// verified; inventing or guessing one here would pin a digest that does not
+// exist, or the wrong one.
 //
 // Every replacement is anchored on the exact line it owns and fails loudly when
 // that anchor is missing. A silent no-op would be the worst outcome here: the
@@ -26,9 +32,29 @@ const DEFAULT_ROOT = resolve(SCRIPT_DIR, '..')
 // deployment silently installs.
 const RELEASE_VERSION = /^\d+\.\d+\.\d+$/
 
+// Manifest-list digests as published by docker-push. Anything shorter, longer,
+// or without the sha256: prefix is not a digest this script may pin.
+const IMAGE_DIGEST = /^sha256:[a-f0-9]{64}$/
+
+const UMBREL_IMAGE_REPOSITORY = 'ghcr.io/metadist/synaplan'
+
 export const parseReleaseVersion = (value) => {
   const version = String(value ?? '').trim().replace(/^v/, '')
   return RELEASE_VERSION.test(version) ? version : null
+}
+
+export const parseImageDigest = (value) => {
+  const digest = String(value ?? '').trim()
+  if (IMAGE_DIGEST.test(digest)) {
+    return digest
+  }
+
+  // Allow callers to pass the bare hex; normalize to the form Compose pins use.
+  if (/^[a-f0-9]{64}$/.test(digest)) {
+    return `sha256:${digest}`
+  }
+
+  return null
 }
 
 // The manifest lists environment variables as `- key:` / `value:` pairs, so the
@@ -104,9 +130,108 @@ export const applyEnvExampleVersion = (text, version) => {
   return result
 }
 
+// Only the top-level `version:` field. `manifestVersion:` must stay untouched —
+// Umbrel's store rejects an unexpected manifestVersion.
+export const applyUmbrelAppVersion = (text, version) => {
+  let replaced = 0
+  const result = text
+    .split('\n')
+    .map((line) => {
+      if (!/^version:\s*.*$/.test(line)) return line
+      replaced += 1
+      return `version: "${version}"`
+    })
+    .join('\n')
+
+  if (replaced !== 1) {
+    throw new Error(
+      `deploy/umbrel/synaplan/umbrel-app.yml: expected exactly one top-level version field, found ${replaced}`
+    )
+  }
+
+  return result
+}
+
+export const readUmbrelAppVersion = (text) => {
+  const match = /^version:\s*"?([^"\n]*)"?\s*$/m.exec(text)
+  return match ? match[1].trim() : null
+}
+
+export const applyUmbrelComposeVersion = (text, version, digest) => {
+  let appVersionReplaced = 0
+  let imageReplaced = 0
+  const imageLine = `x-app-image: &app-image ${UMBREL_IMAGE_REPOSITORY}:${version}@${digest}`
+
+  const result = text
+    .split('\n')
+    .map((line) => {
+      if (/^(\s*)APP_VERSION:\s*.*$/.test(line)) {
+        appVersionReplaced += 1
+        const indent = /^(\s*)/.exec(line)[1]
+        return `${indent}APP_VERSION: "${version}"`
+      }
+
+      if (/^x-app-image:\s*&app-image\s+ghcr\.io\/metadist\/synaplan:.+$/.test(line)) {
+        imageReplaced += 1
+        return imageLine
+      }
+
+      return line
+    })
+    .join('\n')
+
+  if (appVersionReplaced !== 1) {
+    throw new Error(
+      `deploy/umbrel/synaplan/docker-compose.yml: expected exactly one APP_VERSION assignment, found ${appVersionReplaced}`
+    )
+  }
+
+  if (imageReplaced !== 1) {
+    throw new Error(
+      `deploy/umbrel/synaplan/docker-compose.yml: expected exactly one x-app-image pin, found ${imageReplaced}`
+    )
+  }
+
+  return result
+}
+
+export const readUmbrelComposePin = (text) => {
+  const appVersion = /^\s*APP_VERSION:\s*"?([^"\n]*)"?\s*$/m.exec(text)?.[1]?.trim() ?? null
+  const image = /^x-app-image:\s*&app-image\s+(ghcr\.io\/metadist\/synaplan:[^\s]+)\s*$/m.exec(
+    text
+  )?.[1] ?? null
+
+  if (!image) {
+    return { appVersion, version: null, digest: null, image: null }
+  }
+
+  const match = new RegExp(
+    `^${UMBREL_IMAGE_REPOSITORY.replace(/\./g, '\\.')}:([^@]+)@(sha256:[a-f0-9]{64})$`
+  ).exec(image)
+
+  return {
+    appVersion,
+    image,
+    version: match?.[1] ?? null,
+    digest: match?.[2] ?? null,
+  }
+}
+
 const TARGETS = [
-  { path: 'elestio.yml', apply: applyElestioVersion },
-  { path: join('deploy', 'selfhost.env.example'), apply: applyEnvExampleVersion },
+  { path: 'elestio.yml', apply: (text, version) => applyElestioVersion(text, version) },
+  {
+    path: join('deploy', 'selfhost.env.example'),
+    apply: (text, version) => applyEnvExampleVersion(text, version),
+  },
+  {
+    path: join('deploy', 'umbrel', 'synaplan', 'umbrel-app.yml'),
+    apply: (text, version) => applyUmbrelAppVersion(text, version),
+  },
+  {
+    path: join('deploy', 'umbrel', 'synaplan', 'docker-compose.yml'),
+    apply: (text, version, digest) => applyUmbrelComposeVersion(text, version, digest),
+    needsDigest: true,
+  },
 ]
 
 export const runCli = (arguments_) => {
@@ -120,6 +245,13 @@ export const runCli = (arguments_) => {
     throw new Error('--version must be a released MAJOR.MINOR.PATCH version')
   }
 
+  const digest = parseImageDigest(readOption('--digest'))
+  if (!digest) {
+    throw new Error(
+      '--digest must be the published multi-arch manifest digest (sha256:…); Umbrel pins tag@digest'
+    )
+  }
+
   const rootOption = readOption('--root')
   const root = rootOption ? resolve(rootOption) : DEFAULT_ROOT
 
@@ -127,7 +259,9 @@ export const runCli = (arguments_) => {
   for (const target of TARGETS) {
     const file = join(root, target.path)
     const before = readFileSync(file, 'utf8')
-    const after = target.apply(before, version)
+    const after = target.needsDigest
+      ? target.apply(before, version, digest)
+      : target.apply(before, version)
     if (after !== before) {
       writeFileSync(file, after)
       changed.push(target.path)
@@ -136,8 +270,8 @@ export const runCli = (arguments_) => {
 
   process.stdout.write(
     changed.length > 0
-      ? `Set ${version} in ${changed.join(', ')}\n`
-      : `Already at ${version}\n`
+      ? `Set ${version} (${digest}) in ${changed.join(', ')}\n`
+      : `Already at ${version} (${digest})\n`
   )
 }
 

--- a/tests/set-release-version.test.mjs
+++ b/tests/set-release-version.test.mjs
@@ -7,9 +7,14 @@ import { fileURLToPath } from 'node:url'
 import {
   applyElestioVersion,
   applyEnvExampleVersion,
+  applyUmbrelAppVersion,
+  applyUmbrelComposeVersion,
+  parseImageDigest,
   parseReleaseVersion,
   readElestioVersion,
   readEnvExampleVersion,
+  readUmbrelAppVersion,
+  readUmbrelComposePin,
 } from '../scripts/set-release-version.mjs'
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
@@ -25,6 +30,22 @@ const ELESTIO_SAMPLE = [
   '    value: "elestio"',
 ].join('\n')
 
+const UMBREL_COMPOSE_SAMPLE = [
+  'x-app-environment: &app-environment',
+  '  SYNAPLAN_PLATFORM: umbrel',
+  '  APP_VERSION: "4.0.12"',
+  '  APP_URL: "http://example.local:8300"',
+  '',
+  'x-app-image: &app-image ghcr.io/metadist/synaplan:4.0.12@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  '',
+  'services:',
+  '  web:',
+  '    image: *app-image',
+].join('\n')
+
+const DIGEST_A = 'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+const DIGEST_B = 'sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+
 test('accepts a released version and rejects anything mutable', () => {
   assert.equal(parseReleaseVersion('4.0.13'), '4.0.13')
   assert.equal(parseReleaseVersion('v4.0.13'), '4.0.13')
@@ -39,6 +60,19 @@ test('accepts a released version and rejects anything mutable', () => {
   assert.equal(parseReleaseVersion('REPLACE_WITH_PUBLISHED_COMPATIBLE_VERSION'), null)
   assert.equal(parseReleaseVersion(''), null)
   assert.equal(parseReleaseVersion(undefined), null)
+})
+
+test('accepts a published digest and rejects anything that is not one', () => {
+  assert.equal(parseImageDigest(DIGEST_A), DIGEST_A)
+  assert.equal(
+    parseImageDigest('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
+    DIGEST_A
+  )
+
+  assert.equal(parseImageDigest('sha256:short'), null)
+  assert.equal(parseImageDigest('latest'), null)
+  assert.equal(parseImageDigest(''), null)
+  assert.equal(parseImageDigest(undefined), null)
 })
 
 test('rewrites only the release pin, not a neighbouring variable', () => {
@@ -114,6 +148,63 @@ test('fails when the example configuration has no or several assignments', () =>
   )
 })
 
+test('rewrites the Umbrel store version without touching manifestVersion', () => {
+  const before = [
+    'manifestVersion: 1',
+    'id: synaplan',
+    'version: "4.0.12"',
+    'name: Synaplan',
+  ].join('\n')
+
+  const result = applyUmbrelAppVersion(before, '4.0.14')
+
+  assert.ok(result.includes('manifestVersion: 1'))
+  assert.ok(result.includes('version: "4.0.14"'))
+  assert.ok(!result.includes('version: "4.0.12"'))
+})
+
+test('fails when the Umbrel store version field is missing or duplicated', () => {
+  assert.throws(
+    () => applyUmbrelAppVersion('manifestVersion: 1\nid: synaplan\n', '4.0.14'),
+    /found 0/
+  )
+
+  assert.throws(
+    () => applyUmbrelAppVersion('version: "1"\nversion: "2"\n', '4.0.14'),
+    /found 2/
+  )
+})
+
+test('rewrites Umbrel APP_VERSION and the image pin together', () => {
+  const result = applyUmbrelComposeVersion(UMBREL_COMPOSE_SAMPLE, '4.0.14', DIGEST_B)
+
+  assert.ok(result.includes('  APP_VERSION: "4.0.14"'))
+  assert.ok(
+    result.includes(
+      `x-app-image: &app-image ghcr.io/metadist/synaplan:4.0.14@${DIGEST_B}`
+    )
+  )
+  assert.ok(result.includes('SYNAPLAN_PLATFORM: umbrel'))
+  assert.ok(!result.includes('4.0.12'))
+})
+
+test('fails when either Umbrel compose anchor is missing', () => {
+  assert.throws(
+    () =>
+      applyUmbrelComposeVersion(
+        'x-app-image: &app-image ghcr.io/metadist/synaplan:4.0.12@' + DIGEST_A,
+        '4.0.14',
+        DIGEST_B
+      ),
+    /APP_VERSION/
+  )
+
+  assert.throws(
+    () => applyUmbrelComposeVersion('  APP_VERSION: "4.0.12"\n', '4.0.14', DIGEST_B),
+    /x-app-image/
+  )
+})
+
 // The guard against the failure that prompted this automation: a deployment
 // once aborted because the shipped manifest still carried a placeholder instead
 // of a published version.
@@ -121,6 +212,12 @@ test('the shipped files name one and the same released version', () => {
   const elestio = readElestioVersion(readFileSync(join(ROOT, 'elestio.yml'), 'utf8'))
   const example = readEnvExampleVersion(
     readFileSync(join(ROOT, 'deploy', 'selfhost.env.example'), 'utf8')
+  )
+  const umbrelApp = readUmbrelAppVersion(
+    readFileSync(join(ROOT, 'deploy', 'umbrel', 'synaplan', 'umbrel-app.yml'), 'utf8')
+  )
+  const umbrelCompose = readUmbrelComposePin(
+    readFileSync(join(ROOT, 'deploy', 'umbrel', 'synaplan', 'docker-compose.yml'), 'utf8')
   )
 
   assert.equal(
@@ -133,7 +230,31 @@ test('the shipped files name one and the same released version', () => {
     example,
     `deploy/selfhost.env.example must pin a released version, found ${JSON.stringify(example)}`
   )
-  assert.equal(elestio, example, 'both files must install the same version')
+  assert.equal(
+    parseReleaseVersion(umbrelApp),
+    umbrelApp,
+    `umbrel-app.yml must pin a released version, found ${JSON.stringify(umbrelApp)}`
+  )
+  assert.equal(
+    parseReleaseVersion(umbrelCompose.appVersion),
+    umbrelCompose.appVersion,
+    `umbrel docker-compose APP_VERSION must be a released version, found ${JSON.stringify(umbrelCompose.appVersion)}`
+  )
+  assert.equal(
+    parseReleaseVersion(umbrelCompose.version),
+    umbrelCompose.version,
+    `umbrel docker-compose image tag must be a released version, found ${JSON.stringify(umbrelCompose.version)}`
+  )
+  assert.equal(
+    parseImageDigest(umbrelCompose.digest),
+    umbrelCompose.digest,
+    `umbrel docker-compose image must pin a digest, found ${JSON.stringify(umbrelCompose.digest)}`
+  )
+
+  assert.equal(elestio, example, 'Elestio and self-host must install the same version')
+  assert.equal(elestio, umbrelApp, 'Umbrel store version must match Elestio')
+  assert.equal(elestio, umbrelCompose.appVersion, 'Umbrel APP_VERSION must match Elestio')
+  assert.equal(elestio, umbrelCompose.version, 'Umbrel image tag must match Elestio')
 })
 
 test('a comment mentioning the variable is not treated as an assignment', () => {

--- a/tests/set-release-version.test.mjs
+++ b/tests/set-release-version.test.mjs
@@ -205,6 +205,22 @@ test('fails when either Umbrel compose anchor is missing', () => {
   )
 })
 
+// readUmbrelComposePin builds a regex from the repository name. A partial
+// escape (dots only) would still work for `ghcr.io/metadist/synaplan` today,
+// but would misparse — or throw on — a line whose image differs by even one
+// regex metacharacter, silently or loudly breaking the release automation.
+test('the image-pin regex is not confused by a similar but different repository', () => {
+  const before = UMBREL_COMPOSE_SAMPLE.replace(
+    'ghcr.io/metadist/synaplan',
+    'ghcr.io/metadistXsynaplan'
+  )
+
+  const result = readUmbrelComposePin(before)
+
+  assert.equal(result.version, null)
+  assert.equal(result.digest, null)
+})
+
 // The guard against the failure that prompted this automation: a deployment
 // once aborted because the shipped manifest still carried a placeholder instead
 // of a published version.


### PR DESCRIPTION
## Summary

Pins the Umbrel App Store package to `4.0.14` (first release with `AuthCookieFactory`) **and** wires Umbrel into the existing release-version automation, so future releases bump it the same way as Elestio.

### Pin to 4.0.14
- `umbrel-app.yml` → `version: "4.0.14"`
- `docker-compose.yml` → `APP_VERSION: "4.0.14"`
- `docker-compose.yml` → `ghcr.io/metadist/synaplan:4.0.14@sha256:40489bf5db1a3f34727b715045b6d7c157bc86e5a85c85f4c31a2c26b32a7423` (manifest list, amd64 + arm64)

### Automation (like Elestio)
- `scripts/set-release-version.mjs` now also rewrites the three Umbrel pin sites and requires `--digest`
- `docker-push` exports the multi-arch digest; `release-version-pin` passes it in
- One PR (`automation/default-release-version`) continues to cover Elestio + self-host + Umbrel
- Submitting to `getumbrel/umbrel-apps` stays a separate, manual step (foreign repo)
- Ownership comments on the pinned lines; README updated

## Test plan

- [x] `node --test tests/set-release-version.test.mjs` (14 pass)
- [x] CLI no-op on current 4.0.14 pin; CLI rewrite round-trip restored
- [x] Umbrel app linter previously green on the 4.0.14 pin
- [ ] After merge: next release tag should open a version PR that includes `deploy/umbrel/`
- [ ] After merge: fresh umbrelOS install, login cookies without `Secure`