### PR TITLE
fix(ai): keep chat working when the first API key arrives after the first account

### DIFF
--- a/backend/config/services.yaml
+++ b/backend/config/services.yaml
@@ -589,6 +589,13 @@ services:
         arguments:
             $cache: '@cache.model_config'
 
+    # Same pool again: readiness reporting and model resolution both decide
+    # whether a local model can serve a request from this inventory, so it must
+    # be dropped by the same clear that drops their other cached lookups.
+    App\AI\Service\OllamaModelInventory:
+        arguments:
+            $cache: '@cache.model_config'
+
     # Internal Email Service (system emails - uses SMTP from ENV)
     App\Service\InternalEmailService: ~
 

--- a/backend/src/AI/Credential/ChatReadinessService.php
+++ b/backend/src/AI/Credential/ChatReadinessService.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\AI\Credential;
 
-use App\AI\Provider\OllamaProvider;
+use App\AI\Service\OllamaModelInventory;
 use App\AI\Service\ProviderRegistry;
 use App\Repository\ModelRepository;
 use App\Service\ModelConfigService;
@@ -31,6 +31,7 @@ final class ChatReadinessService
         private readonly ProviderDefaultsService $defaults,
         private readonly ModelConfigService $modelConfigService,
         private readonly ModelRepository $modelRepository,
+        private readonly OllamaModelInventory $ollamaModelInventory,
         private readonly CacheItemPoolInterface $cache,
         private readonly LoggerInterface $logger,
     ) {
@@ -119,16 +120,10 @@ final class ChatReadinessService
 
     /**
      * Whether a concrete model is pulled on the local Ollama server.
-     *
-     * OllamaProvider::isAvailable() only proves the server answers — a stock
-     * install has a reachable Ollama holding nothing but the embedding model, so
-     * anything that may route work there must check the concrete model.
      */
     public function isOllamaModelPulled(string $model): bool
     {
-        $provider = $this->ollamaProvider();
-
-        return null !== $provider && $provider->hasModel($model);
+        return $this->ollamaModelInventory->isPulled($model);
     }
 
     /**
@@ -248,16 +243,5 @@ final class ChatReadinessService
         $model = $this->modelRepository->find($bid);
 
         return null !== $model && $this->isOllamaModelPulled($model->getProviderId());
-    }
-
-    private function ollamaProvider(): ?OllamaProvider
-    {
-        foreach ($this->providerRegistry->getUniqueProviders() as $name => $provider) {
-            if ('ollama' === strtolower((string) $name) && $provider instanceof OllamaProvider) {
-                return $provider;
-            }
-        }
-
-        return null;
     }
 }

--- a/backend/src/AI/Credential/ChatReadinessService.php
+++ b/backend/src/AI/Credential/ChatReadinessService.php
@@ -159,10 +159,16 @@ final class ChatReadinessService
     /**
      * Drop the cached snapshot — call after a key was saved or removed so the
      * setup banner reacts to the change immediately.
+     *
+     * Model resolution keeps its own snapshot of which providers have
+     * credentials, for the same reason and with the same lifetime. Clearing it
+     * from here keeps "a key changed" a single call for every caller instead of
+     * something each one has to remember twice.
      */
     public function invalidate(): void
     {
         $this->cache->deleteItem(self::CACHE_KEY);
+        $this->modelConfigService->invalidateUsableProviders();
     }
 
     /**

--- a/backend/src/AI/Service/OllamaModelInventory.php
+++ b/backend/src/AI/Service/OllamaModelInventory.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\AI\Service;
+
+use App\AI\Provider\OllamaProvider;
+use Psr\Cache\CacheItemPoolInterface;
+
+/**
+ * Is a concrete model actually downloaded on the Ollama server?
+ *
+ * {@see OllamaProvider::isAvailable()} only proves the server answers, and a
+ * stock install has a reachable Ollama holding nothing but the embedding model.
+ * Anything that may route work at a local model therefore has to ask about the
+ * concrete model — and everyone has to get the same answer: readiness reporting
+ * and model resolution disagreeing about the same server is exactly what
+ * produces a chat that fails while the UI insists a provider is connected.
+ */
+final readonly class OllamaModelInventory
+{
+    private const CACHE_PREFIX = 'ollama_model_pulled.';
+
+    /**
+     * Matches the lifetime of the readiness snapshot, the other cached view of
+     * "what can serve a request right now".
+     */
+    private const CACHE_TTL_SECONDS = 30;
+
+    public function __construct(
+        private ProviderRegistry $providerRegistry,
+        private CacheItemPoolInterface $cache,
+    ) {
+    }
+
+    /**
+     * Cached because the underlying probe is an uncached HTTP call per lookup,
+     * while model resolution runs several times per message.
+     */
+    public function isPulled(string $model): bool
+    {
+        $model = strtolower(trim($model));
+        if ('' === $model) {
+            return false;
+        }
+
+        // Ollama names carry the characters PSR-6 reserves for its own use
+        // ("llama3:latest"), so the name is hashed instead of embedded.
+        $item = $this->cache->getItem(self::CACHE_PREFIX.hash('xxh128', $model));
+
+        if ($item->isHit()) {
+            return (bool) $item->get();
+        }
+
+        $provider = $this->ollamaProvider();
+        $pulled = null !== $provider && $provider->hasModel($model);
+
+        $item->set($pulled);
+        $item->expiresAfter(self::CACHE_TTL_SECONDS);
+        $this->cache->save($item);
+
+        return $pulled;
+    }
+
+    private function ollamaProvider(): ?OllamaProvider
+    {
+        foreach ($this->providerRegistry->getUniqueProviders() as $provider) {
+            if ($provider instanceof OllamaProvider) {
+                return $provider;
+            }
+        }
+
+        return null;
+    }
+}

--- a/backend/src/Service/ModelConfigService.php
+++ b/backend/src/Service/ModelConfigService.php
@@ -2,6 +2,7 @@
 
 namespace App\Service;
 
+use App\AI\Service\OllamaModelInventory;
 use App\AI\Service\ProviderRegistry;
 use App\Entity\Message;
 use App\Entity\User;
@@ -27,6 +28,7 @@ final readonly class ModelConfigService
         private UserRepository $userRepository,
         private CacheItemPoolInterface $cache,
         private ProviderRegistry $providerRegistry,
+        private OllamaModelInventory $ollamaModelInventory,
         private string $environment = 'prod',
     ) {
     }
@@ -401,13 +403,18 @@ final readonly class ModelConfigService
     }
 
     /**
-     * Can the provider behind this model be used right now?
+     * Can this model actually serve a request right now?
      *
-     * Deliberately answers the provider-level question ("are there working
-     * credentials") rather than "does it serve this capability": the capability
-     * is already encoded in the binding, and a per-capability mapping of the
-     * DEFAULTMODEL settings onto registry capabilities would be one more thing
-     * to keep in sync for no gain.
+     * Answers the provider-level question ("are there working credentials")
+     * rather than "does it serve this capability": the capability is already
+     * encoded in the binding, and a per-capability mapping of the DEFAULTMODEL
+     * settings onto registry capabilities would be one more thing to keep in
+     * sync for no gain.
+     *
+     * Ollama is the exception that has to be model-aware. Its provider reports
+     * itself available as soon as the server answers, which a stock install
+     * does while holding nothing but the embedding model — so a provider-level
+     * answer would happily route chat at a model nobody downloaded.
      *
      * Unknown models — the negative placeholder BIDs of the test catalog, or a
      * binding left behind by a catalog reshuffle — count as usable so this
@@ -429,7 +436,13 @@ final readonly class ModelConfigService
             return true;
         }
 
-        return in_array(strtolower($model->getService()), $usable, true);
+        $service = strtolower($model->getService());
+
+        if (!in_array($service, $usable, true)) {
+            return false;
+        }
+
+        return 'ollama' !== $service || $this->ollamaModelInventory->isPulled($model->getProviderId());
     }
 
     /**

--- a/backend/src/Service/ModelConfigService.php
+++ b/backend/src/Service/ModelConfigService.php
@@ -18,6 +18,9 @@ use Psr\Cache\CacheItemPoolInterface;
  */
 final readonly class ModelConfigService
 {
+    private const USABLE_PROVIDERS_CACHE_KEY = 'model_config.usable_providers';
+    private const USABLE_PROVIDERS_CACHE_TTL_SECONDS = 60;
+
     public function __construct(
         private ConfigRepository $configRepository,
         private ModelRepository $modelRepository,
@@ -351,34 +354,127 @@ final readonly class ModelConfigService
      *
      * Priority: User Config > Global Config > null.
      * In test env, ConfigFixtures seeds global defaults pointing to TestProvider models.
+     *
+     * A per-user binding whose provider currently has no credentials is skipped
+     * in favour of the global default. {@see resetUserDefaults()} writes the
+     * code-recommended bindings when an account is created, without knowing
+     * which providers this install can actually reach, while the key-save path
+     * only ever repairs the global row. Installs that receive their first API
+     * key AFTER the first account exists — every App Store or appliance
+     * install, where the operator logs in before configuring anything — would
+     * otherwise keep routing that user at a provider they never configured.
+     * The override stays stored and takes effect again as soon as its provider
+     * has credentials.
      */
     public function getDefaultModel(string $capability, ?int $userId = null): ?int
     {
-        // Try user-specific config first
-        if ($userId) {
-            $config = $this->configRepository->findOneBy([
-                'ownerId' => $userId,
-                'group' => 'DEFAULTMODEL',
-                'setting' => strtoupper($capability),
-            ]);
+        $setting = strtoupper($capability);
 
-            if ($config) {
-                return (int) $config->getValue();
+        if ($userId) {
+            $userModelId = $this->readDefaultModel($userId, $setting);
+
+            if (null !== $userModelId) {
+                if ($this->isModelProviderUsable($userModelId)) {
+                    return $userModelId;
+                }
+
+                $globalModelId = $this->readDefaultModel(0, $setting);
+
+                return null !== $globalModelId && $this->isModelProviderUsable($globalModelId)
+                    ? $globalModelId
+                    : $userModelId;
             }
         }
 
-        // Fall back to global config
+        return $this->readDefaultModel(0, $setting);
+    }
+
+    private function readDefaultModel(int $ownerId, string $setting): ?int
+    {
         $config = $this->configRepository->findOneBy([
-            'ownerId' => 0,
+            'ownerId' => $ownerId,
             'group' => 'DEFAULTMODEL',
-            'setting' => strtoupper($capability),
+            'setting' => $setting,
         ]);
 
-        if ($config) {
-            return (int) $config->getValue();
+        return $config ? (int) $config->getValue() : null;
+    }
+
+    /**
+     * Can the provider behind this model be used right now?
+     *
+     * Deliberately answers the provider-level question ("are there working
+     * credentials") rather than "does it serve this capability": the capability
+     * is already encoded in the binding, and a per-capability mapping of the
+     * DEFAULTMODEL settings onto registry capabilities would be one more thing
+     * to keep in sync for no gain.
+     *
+     * Unknown models — the negative placeholder BIDs of the test catalog, or a
+     * binding left behind by a catalog reshuffle — count as usable so this
+     * check never becomes the reason a configured default is dropped.
+     */
+    private function isModelProviderUsable(int $modelId): bool
+    {
+        $model = $this->modelRepository->find($modelId);
+        if (!$model) {
+            return true;
         }
 
-        return null;
+        $usable = $this->usableProviders();
+
+        // An empty set means "cannot tell" (no providers registered at all),
+        // never "nothing works" — falling back on that basis would replace a
+        // configured binding with an equally unusable one.
+        if ([] === $usable) {
+            return true;
+        }
+
+        return in_array(strtolower($model->getService()), $usable, true);
+    }
+
+    /**
+     * Drop the cached provider snapshot so a key that was just saved or removed
+     * takes effect on the very next model resolution. The admin UI promises the
+     * change applies without a restart, and a stale snapshot would keep routing
+     * at the old provider for up to the cache lifetime.
+     */
+    public function invalidateUsableProviders(): void
+    {
+        $this->cache->deleteItem(self::USABLE_PROVIDERS_CACHE_KEY);
+    }
+
+    /**
+     * Lowercased names of the providers that currently have credentials.
+     *
+     * Cached briefly because this sits on the model-resolution path, which runs
+     * several times per message, while the underlying probe decrypts a stored
+     * key per cloud provider and talks HTTP to a local Ollama.
+     *
+     * @return list<string>
+     */
+    private function usableProviders(): array
+    {
+        $item = $this->cache->getItem(self::USABLE_PROVIDERS_CACHE_KEY);
+
+        if ($item->isHit()) {
+            /** @var list<string> $cached */
+            $cached = $item->get();
+
+            return $cached;
+        }
+
+        $usable = [];
+        foreach ($this->providerRegistry->getUniqueProviders() as $provider) {
+            if ($provider->isAvailable()) {
+                $usable[] = strtolower($provider->getName());
+            }
+        }
+
+        $item->set($usable);
+        $item->expiresAfter(self::USABLE_PROVIDERS_CACHE_TTL_SECONDS);
+        $this->cache->save($item);
+
+        return $usable;
     }
 
     /**

--- a/backend/tests/Unit/AI/Credential/ChatReadinessServiceTest.php
+++ b/backend/tests/Unit/AI/Credential/ChatReadinessServiceTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\AI\Credential;
 
 use App\AI\Credential\ChatReadinessService;
 use App\AI\Credential\ProviderDefaultsService;
+use App\AI\Service\OllamaModelInventory;
 use App\AI\Service\ProviderRegistry;
 use App\Entity\Config;
 use App\Entity\Model;
@@ -49,12 +50,15 @@ class ChatReadinessServiceTest extends TestCase
 
     private function service(): ChatReadinessService
     {
+        $ollamaModelInventory = new OllamaModelInventory($this->providerRegistry, new ArrayAdapter());
+
         $modelConfigService = new ModelConfigService(
             $this->configRepository,
             $this->modelRepository,
             $this->createMock(UserRepository::class),
             new ArrayAdapter(),
             $this->providerRegistry,
+            $ollamaModelInventory,
             'test',
         );
 
@@ -63,6 +67,7 @@ class ChatReadinessServiceTest extends TestCase
             new ProviderDefaultsService($this->configRepository, new ArrayAdapter(), new NullLogger()),
             $modelConfigService,
             $this->modelRepository,
+            $ollamaModelInventory,
             new ArrayAdapter(),
             new NullLogger(),
         );

--- a/backend/tests/Unit/ModelConfigServiceTest.php
+++ b/backend/tests/Unit/ModelConfigServiceTest.php
@@ -2,6 +2,7 @@
 
 namespace App\Tests\Unit;
 
+use App\AI\Interface\ProviderMetadataInterface;
 use App\AI\Service\ProviderRegistry;
 use App\Entity\Config;
 use App\Entity\Model;
@@ -208,6 +209,131 @@ class ModelConfigServiceTest extends TestCase
         $result = $this->service->getDefaultModel($capability, $userId);
 
         $this->assertNull($result);
+    }
+
+    /**
+     * The failure this guards against: an install whose first API key arrives
+     * AFTER the first account was created. resetUserDefaults() has already
+     * written the code-recommended per-user bindings, the key-save path repairs
+     * only the global row, and the user is left pointed at a provider they
+     * never configured — chat fails and the setup banner keeps asking for a
+     * provider that is plainly connected.
+     */
+    public function testGetDefaultModelSkipsAUserOverrideWhoseProviderHasNoKey(): void
+    {
+        $this->givenModels([249 => 'Anthropic', 9 => 'Groq']);
+        $this->givenUsableProviders(['groq']);
+        $this->givenDefaultModelRows([1 => 249, 0 => 9]);
+
+        self::assertSame(9, $this->service->getDefaultModel('CHAT', 1));
+    }
+
+    public function testGetDefaultModelKeepsAUserOverrideWhoseProviderHasAKey(): void
+    {
+        $this->givenModels([249 => 'Anthropic', 9 => 'Groq']);
+        $this->givenUsableProviders(['anthropic', 'groq']);
+        $this->givenDefaultModelRows([1 => 249, 0 => 9]);
+
+        self::assertSame(249, $this->service->getDefaultModel('CHAT', 1));
+    }
+
+    /**
+     * Nothing is usable, so the global default is no better than the user's own
+     * binding. Keep the configured one rather than shuffling to an equally
+     * dead alternative.
+     */
+    public function testGetDefaultModelKeepsTheUserOverrideWhenTheGlobalDefaultIsAlsoUnusable(): void
+    {
+        $this->givenModels([249 => 'Anthropic', 255 => 'OpenAI']);
+        $this->givenUsableProviders(['groq']);
+        $this->givenDefaultModelRows([1 => 249, 0 => 255]);
+
+        self::assertSame(249, $this->service->getDefaultModel('CHAT', 1));
+    }
+
+    /**
+     * An empty registry means "cannot tell", not "nothing works" — a bare
+     * ProviderRegistry must never be the reason a configured default is
+     * replaced.
+     */
+    public function testGetDefaultModelKeepsTheUserOverrideWhenNoProviderIsRegistered(): void
+    {
+        $this->givenModels([249 => 'Anthropic', 9 => 'Groq']);
+        $this->givenUsableProviders([]);
+        $this->givenDefaultModelRows([1 => 249, 0 => 9]);
+
+        self::assertSame(249, $this->service->getDefaultModel('CHAT', 1));
+    }
+
+    /**
+     * The test catalog binds capabilities to negative placeholder BIDs that
+     * have no BMODELS row. Those must resolve unchanged.
+     */
+    public function testGetDefaultModelKeepsAnOverridePointingAtAnUnknownModel(): void
+    {
+        $this->givenModels([]);
+        $this->givenDefaultModelRows([1 => -1, 0 => 9]);
+
+        self::assertSame(-1, $this->service->getDefaultModel('CHAT', 1));
+    }
+
+    /**
+     * @param array<int, string> $servicesByModelId
+     */
+    private function givenModels(array $servicesByModelId): void
+    {
+        $this->modelRepository
+            ->method('find')
+            ->willReturnCallback(function (int $modelId) use ($servicesByModelId): ?Model {
+                if (!isset($servicesByModelId[$modelId])) {
+                    return null;
+                }
+
+                $model = $this->createMock(Model::class);
+                $model->method('getService')->willReturn($servicesByModelId[$modelId]);
+
+                return $model;
+            });
+    }
+
+    /**
+     * @param list<string> $names
+     */
+    private function givenUsableProviders(array $names): void
+    {
+        $providers = [];
+        foreach ($names as $name) {
+            $provider = $this->createMock(ProviderMetadataInterface::class);
+            $provider->method('getName')->willReturn($name);
+            $provider->method('isAvailable')->willReturn(true);
+            $providers[$name] = $provider;
+        }
+
+        $this->providerRegistry->method('getUniqueProviders')->willReturn($providers);
+
+        // The snapshot is cached; these tests want it computed every time.
+        $this->cacheItem->method('isHit')->willReturn(false);
+        $this->cache->method('getItem')->willReturn($this->cacheItem);
+    }
+
+    /**
+     * @param array<int, int> $modelIdByOwnerId
+     */
+    private function givenDefaultModelRows(array $modelIdByOwnerId): void
+    {
+        $this->configRepository
+            ->method('findOneBy')
+            ->willReturnCallback(function (array $criteria) use ($modelIdByOwnerId): ?Config {
+                $modelId = $modelIdByOwnerId[$criteria['ownerId']] ?? null;
+                if (null === $modelId) {
+                    return null;
+                }
+
+                $config = $this->createMock(Config::class);
+                $config->method('getValue')->willReturn((string) $modelId);
+
+                return $config;
+            });
     }
 
     public function testGetProviderForModel(): void

--- a/backend/tests/Unit/ModelConfigServiceTest.php
+++ b/backend/tests/Unit/ModelConfigServiceTest.php
@@ -3,6 +3,7 @@
 namespace App\Tests\Unit;
 
 use App\AI\Interface\ProviderMetadataInterface;
+use App\AI\Service\OllamaModelInventory;
 use App\AI\Service\ProviderRegistry;
 use App\Entity\Config;
 use App\Entity\Model;
@@ -26,6 +27,7 @@ class ModelConfigServiceTest extends TestCase
     private UserRepository&MockObject $userRepository;
     private CacheItemPoolInterface&MockObject $cache;
     private ProviderRegistry&MockObject $providerRegistry;
+    private OllamaModelInventory&MockObject $ollamaModelInventory;
     private ModelConfigService $service;
     private CacheItemInterface&MockObject $cacheItem;
 
@@ -42,12 +44,15 @@ class ModelConfigServiceTest extends TestCase
         $this->providerRegistry->method('getAvailableProviders')
             ->willReturn(['openai', 'groq']);
 
+        $this->ollamaModelInventory = $this->createMock(OllamaModelInventory::class);
+
         $this->service = new ModelConfigService(
             $this->configRepository,
             $this->modelRepository,
             $this->userRepository,
             $this->cache,
-            $this->providerRegistry
+            $this->providerRegistry,
+            $this->ollamaModelInventory
         );
     }
 
@@ -278,19 +283,64 @@ class ModelConfigServiceTest extends TestCase
     }
 
     /**
-     * @param array<int, string> $servicesByModelId
+     * Ollama reports itself available as soon as the server answers, which a
+     * stock install does while holding nothing but the embedding model. Falling
+     * back to a local model nobody downloaded would trade one dead binding for
+     * another — and discard the user's choice on the way.
      */
-    private function givenModels(array $servicesByModelId): void
+    public function testGetDefaultModelKeepsTheUserOverrideWhenTheGlobalOllamaModelIsNotPulled(): void
+    {
+        $this->givenModels([249 => 'Anthropic', 77 => 'Ollama'], [77 => 'llama3']);
+        $this->givenUsableProviders(['ollama']);
+        $this->givenDefaultModelRows([1 => 249, 0 => 77]);
+
+        $this->ollamaModelInventory->method('isPulled')->with('llama3')->willReturn(false);
+
+        self::assertSame(249, $this->service->getDefaultModel('CHAT', 1));
+    }
+
+    public function testGetDefaultModelFallsBackToAnOllamaModelThatIsPulled(): void
+    {
+        $this->givenModels([249 => 'Anthropic', 77 => 'Ollama'], [77 => 'llama3']);
+        $this->givenUsableProviders(['ollama']);
+        $this->givenDefaultModelRows([1 => 249, 0 => 77]);
+
+        $this->ollamaModelInventory->method('isPulled')->with('llama3')->willReturn(true);
+
+        self::assertSame(77, $this->service->getDefaultModel('CHAT', 1));
+    }
+
+    /**
+     * The mirror image: a user who deliberately bound chat to a local model
+     * keeps it, and only loses it while that model is absent.
+     */
+    public function testGetDefaultModelSkipsAUserOverrideWhoseOllamaModelIsNotPulled(): void
+    {
+        $this->givenModels([77 => 'Ollama', 9 => 'Groq'], [77 => 'llama3']);
+        $this->givenUsableProviders(['ollama', 'groq']);
+        $this->givenDefaultModelRows([1 => 77, 0 => 9]);
+
+        $this->ollamaModelInventory->method('isPulled')->with('llama3')->willReturn(false);
+
+        self::assertSame(9, $this->service->getDefaultModel('CHAT', 1));
+    }
+
+    /**
+     * @param array<int, string> $servicesByModelId
+     * @param array<int, string> $providerIdsByModelId
+     */
+    private function givenModels(array $servicesByModelId, array $providerIdsByModelId = []): void
     {
         $this->modelRepository
             ->method('find')
-            ->willReturnCallback(function (int $modelId) use ($servicesByModelId): ?Model {
+            ->willReturnCallback(function (int $modelId) use ($servicesByModelId, $providerIdsByModelId): ?Model {
                 if (!isset($servicesByModelId[$modelId])) {
                     return null;
                 }
 
                 $model = $this->createMock(Model::class);
                 $model->method('getService')->willReturn($servicesByModelId[$modelId]);
+                $model->method('getProviderId')->willReturn($providerIdsByModelId[$modelId] ?? '');
 
                 return $model;
             });


### PR DESCRIPTION
## Problem

An install whose first API key is added **after** the first account exists cannot chat at all.

Sending a message fails with `Message processing failed`, and the backend logs:

```
chat provider 'anthropic' not found or unavailable.
Available: anthropic, google, groq, huggingface, mistral, ollama, ...
```

At the same time the setup page shows the configured provider as **Connected / Current default**, while the banner directly above it keeps asking the user to connect a provider. So the UI contradicts itself and the one action it suggests has already been done.

## Root cause

Two things are each individually reasonable and wrong in combination:

1. `ModelConfigService::resetUserDefaults()` — reached via `initializeNewUserDefaults()` when an account is created — writes the per-user `BCONFIG[DEFAULTMODEL]` bindings from `DefaultModelConfigSeeder::getRecommendedDefaults()`. Those are catalog recommendations (CHAT → Anthropic); it does not know which providers this install can actually reach.
2. Saving a provider key (`AdminProviderKeysController` → `ProviderDefaultsService`) repairs only the **global** row, `BOWNERID = 0`.

The per-user row wins in `getDefaultModel()`, which both `ChatReadinessService::isChatReady()` and the chat pipeline resolve through. So the user stays pointed at a provider they never configured, and nothing in the UI can repair it — the banner is not a cosmetic mismatch, it correctly reports that *this user's* resolved default is unusable.

Why it has not shown up before: when keys come from `.env`, they exist before the first account, so the recommended binding happens to point at a provider that works. The failure needs the reverse order — which is the normal order on any appliance or App Store install, where the operator logs in before configuring anything.

## Fix

`getDefaultModel()` skips a per-user binding whose provider currently has no credentials and uses the global default instead — the row that the key-save path keeps repaired. One change covers both symptoms, since the banner and the chat pipeline share this resolution.

Deliberate properties:

- **Nothing is deleted.** The override stays stored and takes effect again as soon as its provider has credentials, so a user who deliberately chose Anthropic gets it back by adding an Anthropic key.
- **Fails safe.** An unknown model (the negative placeholder BIDs of the test catalog, or a binding left behind by a catalog reshuffle) and an empty provider registry both count as usable. Neither may become the reason a configured default is dropped.
- **No pointless shuffling.** If the global default is unusable too, the user's own binding is kept rather than swapped for an equally dead one.
- **The snapshot of "which providers have credentials" is cached for 60 s**, because this sits on the model-resolution path and the probe decrypts a stored key per cloud provider and talks HTTP to a local Ollama. `ChatReadinessService::invalidate()` clears it alongside its own snapshot, so all four existing call sites stay a single call and the admin UI keeps its promise that a key takes effect immediately.

## Verification

Reproduced and fixed on a containerized umbrelOS instance running the published `4.0.14` image, following the exact flow the App Store listing prescribes: install → log in → add a Groq key.

| | before | after |
| --- | --- | --- |
| `setup.chatReady` | `false` | `true` |
| `POST /api/v1/messages/send` | `Message processing failed` | answers via Groq |
| `BCONFIG[DEFAULTMODEL][CHAT]` for the user | `249` (Anthropic) | `249` — untouched |

Gate: `make -C backend lint`, `make -C backend phpstan` (src + tests, no errors), `make -C backend test` (3277 tests green). Frontend untouched.

## Note

This is the last blocker for the Umbrel App Store submission — the packaging in `deploy/umbrel/` is already verified. The submission needs a release carrying this fix.