### PR TITLE
chore(release): install 4.0.15 in new deployments

### DIFF
--- a/deploy/selfhost.env.example
+++ b/deploy/selfhost.env.example
@@ -9,7 +9,7 @@ COMPOSE_PROJECT_NAME=synaplan-production
 # and any mutable tag are rejected before a container starts, so a redeploy can
 # never pull a different version behind your back. Newer releases are listed at
 # https://github.com/metadist/synaplan/releases — see docs/UPDATE_SELFHOST.md.
-SYNAPLAN_VERSION=4.0.14
+SYNAPLAN_VERSION=4.0.15
 SYNAPLAN_PULL_POLICY=always
 SYNAPLAN_HTTP_BIND=127.0.0.1
 SYNAPLAN_HTTP_PORT=8000

--- a/deploy/umbrel/synaplan/docker-compose.yml
+++ b/deploy/umbrel/synaplan/docker-compose.yml
@@ -19,7 +19,7 @@ x-app-environment: &app-environment
   # (together with the image pin below and umbrel-app.yml) to the version whose
   # image was just published. Do not edit by hand —
   # scripts/set-release-version.mjs owns these three lines.
-  APP_VERSION: "4.0.14"
+  APP_VERSION: "4.0.15"
 
   # umbrelOS serves apps over plain HTTP on the device's .local domain. Synaplan
   # derives the auth cookies' Secure flag from this scheme, so the session
@@ -85,7 +85,7 @@ x-app-environment: &app-environment
 # then hands over to Caddy/FrankenPHP, which binds port 80 inside the container.
 # Tag and digest are maintained by CI together with APP_VERSION above —
 # scripts/set-release-version.mjs owns this line.
-x-app-image: &app-image ghcr.io/metadist/synaplan:4.0.14@sha256:40489bf5db1a3f34727b715045b6d7c157bc86e5a85c85f4c31a2c26b32a7423
+x-app-image: &app-image ghcr.io/metadist/synaplan:4.0.15@sha256:0aa4123d5e74d683a2f26e904e8f1421629575030f62ab2335fcf4ec93230d7b
 
 # Uploaded and generated files. The web role writes them, the worker reads them
 # back while processing a job, so all three app roles share the directory.

--- a/deploy/umbrel/synaplan/umbrel-app.yml
+++ b/deploy/umbrel/synaplan/umbrel-app.yml
@@ -4,7 +4,7 @@ category: ai
 name: Synaplan
 # Maintained by CI together with APP_VERSION and the image pin in
 # docker-compose.yml — scripts/set-release-version.mjs owns this field.
-version: "4.0.14"
+version: "4.0.15"
 tagline: Private AI workspace with chat, document search and embeddable widgets
 description: >-
   Synaplan is a self-hosted AI workspace. Chat with the model of your choice,

--- a/elestio.yml
+++ b/elestio.yml
@@ -27,7 +27,7 @@ environments:
   # new deployments; existing ones stay on their pinned version until their
   # operator changes it, as described in docs/UPDATE_ELESTIO.md.
   - key: "SYNAPLAN_VERSION"
-    value: "4.0.14"
+    value: "4.0.15"
   # Deployment hint for the release notice, so the admin UI links to the Elestio
   # update guide instead of the self-hosted one. Display only: Synaplan never
   # updates itself.


### PR DESCRIPTION
Raises the pinned release version to `4.0.15` for the deployment adapters, so a fresh install gets the version that was just built and published.

- `deploy/selfhost.env.example` — `SYNAPLAN_VERSION`
- `elestio.yml` — `SYNAPLAN_VERSION`
- `deploy/umbrel/synaplan/umbrel-app.yml` — `version`
- `deploy/umbrel/synaplan/docker-compose.yml` — `APP_VERSION` and the image pin, now `4.0.15@sha256:0aa4123d5e74d683a2f26e904e8f1421629575030f62ab2335fcf4ec93230d7b`

Generated by the `release-version-pin` job of the `v4.0.15` tag build. Opened by hand because that job cannot create pull requests: it fails with `Resource not accessible by integration (createPullRequest)`, the same way it did for `v4.0.14`. The branch it pushed is used unchanged.

Why 4.0.15 matters for the Umbrel package specifically: it is the first release in which a fresh App Store install can actually chat. `4.0.14` fixed login over plain HTTP, but an install that receives its first API key after the first account exists — the order the store listing prescribes — was still left routed at a provider that was never configured (#1463).