### PR TITLE
chore(umbrel): record the App Store submission PR link

### DIFF
--- a/deploy/umbrel/synaplan/umbrel-app.yml
+++ b/deploy/umbrel/synaplan/umbrel-app.yml
@@ -50,4 +50,4 @@ defaultUsername: "admin@umbrel.local"
 defaultPassword: ""
 deterministicPassword: true
 submitter: Metadist
-submission: https://github.com/getumbrel/umbrel-apps/pull/PENDING
+submission: https://github.com/getumbrel/umbrel-apps/pull/5962


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The Umbrel App Store package was submitted at [getumbrel/umbrel-apps#5962](https://github.com/getumbrel/umbrel-apps/pull/5962). This replaces the `.../pull/PENDING` placeholder in `umbrel-app.yml` with that link, as noted in `deploy/umbrel/README.md`.

No functional change — manifest metadata only.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-486e2bab-bde7-4578-8bc1-4763f6f89b29?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-486e2bab-bde7-4578-8bc1-4763f6f89b29&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

