### PR TITLE
fix(ci): keep a verified release green when its version proposal cannot open

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1370,12 +1370,30 @@ jobs:
           and verified.
           EOF
 
-          url="$(gh pr create \
+          # The branch above already carries the change, so the release itself is
+          # complete and verified at this point. Opening the proposal needs
+          # `Pull requests: write` on top of that, which the token does not
+          # necessarily carry: the release App is scoped to Contents, and
+          # GITHUB_TOKEN cannot open pull requests while the organization
+          # forbids it. Report the branch instead of marking a published release
+          # as failed — this step proposes a convenience, it does not gate.
+          error_file="$(mktemp)"
+          if url="$(gh pr create \
             --base "$BASE" \
             --head "$BRANCH" \
             --title "chore(release): install ${VERSION} in new deployments" \
-            --body-file "$body_file")"
-          echo "Opened ${url}" | tee -a "$GITHUB_STEP_SUMMARY"
+            --body-file "$body_file" 2>"$error_file")"; then
+            echo "Opened ${url}" | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          echo "::warning::Could not open the default-version pull request: $(tr '\n' ' ' < "$error_file")"
+          {
+            echo "Branch \`${BRANCH}\` was updated to \`${VERSION}\`, but its pull request could not be opened automatically."
+            echo ""
+            echo "Open it from [this comparison](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/compare/${BASE}...${BRANCH}?expand=1)," \
+              "or grant the release App \`Pull requests: write\` so the proposal opens by itself."
+          } >> "$GITHUB_STEP_SUMMARY"
 
   cloudflare-deploy:
     name: Deploy Cloudflare Worker


### PR DESCRIPTION
## What broke

The CI run on tag `v4.0.16` failed in **Update the Default Release Version**, which took `All Checks Passed` down with it. Because the tag sits on the current `main` commit, that commit shows red in `main`'s history — `main`'s own CI run was green.

The failing call:

```
pull request create failed: GraphQL: Resource not accessible by integration (createPullRequest)
```

## Why now, and not before

`release-version-pin` pushes `automation/default-release-version` and then opens a pull request for it. The push only needs `Contents: write`; opening a pull request additionally needs `Pull requests: write`, which the release App (`synaplan-release-tagger`, scoped to Contents) does not carry.

Earlier releases never reached the failing call: a proposal from the previous release was still open, so the job took the `existing` update path and exited early. `v4.0.15` did exactly that against [#1464](https://github.com/metadist/synaplan/pull/1464). Once #1464 merged, `v4.0.16` was the first release with no open proposal — and hit `gh pr create`.

So this is a latent, pre-existing gap, not a regression from the release-chain rework.

## The change

By the time this call runs, the branch already carries the pin and the release is published and verified. A convenience proposal that cannot be opened must not mark that release as failed. The failure now emits a warning plus a step summary with the comparison link, and the job exits successfully.

The durable fix is a permission, not code: granting the release App `Pull requests: write` makes the proposal open by itself again. The step summary says so explicitly.

## Verification

- `ci.yml` parses; the extracted `run` script passes `bash -n`.
- Both paths exercised against a stubbed `gh`: success prints `Opened <url>` and exits 0; failure prints the warning, writes the comparison link to the summary, and exits 0.
- Classification of this PR: `no-app-impact` (`.github/workflows/**`), so it reaches no app.

## Test plan

- [ ] Merge, then re-run the failed jobs of the `v4.0.16` CI run to confirm green.