### PR TITLE
fix(frontend): improve code block contrast in light mode

### DIFF
--- a/frontend/src/assets/highlight-theme.css
+++ b/frontend/src/assets/highlight-theme.css
@@ -1,0 +1,196 @@
+/*
+ * Theme-aware highlight.js colors for chat code blocks.
+ *
+ * Light mode uses a WCAG-AA-oriented One Light variant (dark ink on pale
+ * surfaces). Dark mode keeps Atom One Dark. Backgrounds stay transparent so
+ * MessageCode / markdown containers own the surface.
+ *
+ * User bubbles keep a dark translucent code surface, so they always use the
+ * dark token palette (same as `.dark`).
+ *
+ * Contrast targets on white / near-white: ≥ 4.5:1 for normal text tokens.
+ */
+
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+
+code.hljs {
+  padding: 3px 5px;
+}
+
+/* ——— Light mode (default) ——— */
+.hljs {
+  color: #383a42;
+  background: transparent;
+}
+
+.hljs-comment,
+.hljs-quote {
+  color: #5c6370;
+  font-style: italic;
+}
+
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula {
+  color: #a626a4;
+}
+
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-deletion,
+.hljs-subst {
+  color: #c73d32;
+}
+
+.hljs-literal {
+  color: #0070a8;
+}
+
+.hljs-string,
+.hljs-regexp,
+.hljs-addition,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #2f6f2f;
+}
+
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #8a5b00;
+}
+
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #275dc5;
+}
+
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #9a6700;
+}
+
+.hljs-emphasis {
+  font-style: italic;
+}
+
+.hljs-strong {
+  font-weight: 700;
+}
+
+.hljs-link {
+  text-decoration: underline;
+}
+
+/* ——— Dark mode + user-bubble code (dark translucent surface) ——— */
+.dark .hljs,
+.bubble-user .hljs {
+  color: #abb2bf;
+  background: transparent;
+}
+
+.dark .hljs-comment,
+.dark .hljs-quote,
+.bubble-user .hljs-comment,
+.bubble-user .hljs-quote {
+  color: #7d8491;
+  font-style: italic;
+}
+
+.dark .hljs-doctag,
+.dark .hljs-keyword,
+.dark .hljs-formula,
+.bubble-user .hljs-doctag,
+.bubble-user .hljs-keyword,
+.bubble-user .hljs-formula {
+  color: #c678dd;
+}
+
+.dark .hljs-section,
+.dark .hljs-name,
+.dark .hljs-selector-tag,
+.dark .hljs-deletion,
+.dark .hljs-subst,
+.bubble-user .hljs-section,
+.bubble-user .hljs-name,
+.bubble-user .hljs-selector-tag,
+.bubble-user .hljs-deletion,
+.bubble-user .hljs-subst {
+  color: #e06c75;
+}
+
+.dark .hljs-literal,
+.bubble-user .hljs-literal {
+  color: #56b6c2;
+}
+
+.dark .hljs-string,
+.dark .hljs-regexp,
+.dark .hljs-addition,
+.dark .hljs-attribute,
+.dark .hljs-meta .hljs-string,
+.bubble-user .hljs-string,
+.bubble-user .hljs-regexp,
+.bubble-user .hljs-addition,
+.bubble-user .hljs-attribute,
+.bubble-user .hljs-meta .hljs-string {
+  color: #98c379;
+}
+
+.dark .hljs-attr,
+.dark .hljs-variable,
+.dark .hljs-template-variable,
+.dark .hljs-type,
+.dark .hljs-selector-class,
+.dark .hljs-selector-attr,
+.dark .hljs-selector-pseudo,
+.dark .hljs-number,
+.bubble-user .hljs-attr,
+.bubble-user .hljs-variable,
+.bubble-user .hljs-template-variable,
+.bubble-user .hljs-type,
+.bubble-user .hljs-selector-class,
+.bubble-user .hljs-selector-attr,
+.bubble-user .hljs-selector-pseudo,
+.bubble-user .hljs-number {
+  color: #d19a66;
+}
+
+.dark .hljs-symbol,
+.dark .hljs-bullet,
+.dark .hljs-link,
+.dark .hljs-meta,
+.dark .hljs-selector-id,
+.dark .hljs-title,
+.bubble-user .hljs-symbol,
+.bubble-user .hljs-bullet,
+.bubble-user .hljs-link,
+.bubble-user .hljs-meta,
+.bubble-user .hljs-selector-id,
+.bubble-user .hljs-title {
+  color: #61aeee;
+}
+
+.dark .hljs-built_in,
+.dark .hljs-title.class_,
+.dark .hljs-class .hljs-title,
+.bubble-user .hljs-built_in,
+.bubble-user .hljs-title.class_,
+.bubble-user .hljs-class .hljs-title {
+  color: #e6c07b;
+}

--- a/frontend/src/assets/highlight-theme.css
+++ b/frontend/src/assets/highlight-theme.css
@@ -97,9 +97,13 @@ code.hljs {
   text-decoration: underline;
 }
 
-/* ——— Dark mode + user-bubble code (dark translucent surface) ——— */
+/* ——— Dark mode + user-bubble code (dark translucent surface) ———
+   `.bubble-user .markdown-content code.hljs` matches the bubble code
+   specificity so non-token text keeps the dark palette. Token spans inherit
+   via the rules below; style.css leaves `.hljs` out of the forced-white rule. */
 .dark .hljs,
-.bubble-user .hljs {
+.bubble-user .hljs,
+.bubble-user .markdown-content code.hljs {
   color: #abb2bf;
   background: transparent;
 }

--- a/frontend/src/assets/widget-markdown.css
+++ b/frontend/src/assets/widget-markdown.css
@@ -304,7 +304,9 @@
 }
 
 /* ========================================
-   Highlight.js Theme (One Dark)
+   Highlight.js Theme (light + dark)
+   Mirrored from assets/highlight-theme.css — widget CSS is inlined
+   separately and cannot share the app bundle import.
    ======================================== */
 
 pre code.hljs {
@@ -318,8 +320,8 @@ code.hljs {
 }
 
 .hljs {
-  color: #abb2bf;
-  background: #282c34;
+  color: #383a42;
+  background: transparent;
 }
 
 .hljs-comment,
@@ -331,7 +333,7 @@ code.hljs {
 .hljs-doctag,
 .hljs-keyword,
 .hljs-formula {
-  color: #c678dd;
+  color: #a626a4;
 }
 
 .hljs-section,
@@ -339,11 +341,11 @@ code.hljs {
 .hljs-selector-tag,
 .hljs-deletion,
 .hljs-subst {
-  color: #e06c75;
+  color: #c73d32;
 }
 
 .hljs-literal {
-  color: #56b6c2;
+  color: #0070a8;
 }
 
 .hljs-string,
@@ -351,7 +353,7 @@ code.hljs {
 .hljs-addition,
 .hljs-attribute,
 .hljs-meta .hljs-string {
-  color: #98c379;
+  color: #2f6f2f;
 }
 
 .hljs-attr,
@@ -362,7 +364,7 @@ code.hljs {
 .hljs-selector-attr,
 .hljs-selector-pseudo,
 .hljs-number {
-  color: #d19a66;
+  color: #8a5b00;
 }
 
 .hljs-symbol,
@@ -371,13 +373,13 @@ code.hljs {
 .hljs-meta,
 .hljs-selector-id,
 .hljs-title {
-  color: #61aeee;
+  color: #275dc5;
 }
 
 .hljs-built_in,
 .hljs-title.class_,
 .hljs-class .hljs-title {
-  color: #e6c07b;
+  color: #9a6700;
 }
 
 .hljs-emphasis {
@@ -390,4 +392,67 @@ code.hljs {
 
 .hljs-link {
   text-decoration: underline;
+}
+
+.dark .hljs {
+  color: #abb2bf;
+  background: transparent;
+}
+
+.dark .hljs-comment,
+.dark .hljs-quote {
+  color: #7d8491;
+  font-style: italic;
+}
+
+.dark .hljs-doctag,
+.dark .hljs-keyword,
+.dark .hljs-formula {
+  color: #c678dd;
+}
+
+.dark .hljs-section,
+.dark .hljs-name,
+.dark .hljs-selector-tag,
+.dark .hljs-deletion,
+.dark .hljs-subst {
+  color: #e06c75;
+}
+
+.dark .hljs-literal {
+  color: #56b6c2;
+}
+
+.dark .hljs-string,
+.dark .hljs-regexp,
+.dark .hljs-addition,
+.dark .hljs-attribute,
+.dark .hljs-meta .hljs-string {
+  color: #98c379;
+}
+
+.dark .hljs-attr,
+.dark .hljs-variable,
+.dark .hljs-template-variable,
+.dark .hljs-type,
+.dark .hljs-selector-class,
+.dark .hljs-selector-attr,
+.dark .hljs-selector-pseudo,
+.dark .hljs-number {
+  color: #d19a66;
+}
+
+.dark .hljs-symbol,
+.dark .hljs-bullet,
+.dark .hljs-link,
+.dark .hljs-meta,
+.dark .hljs-selector-id,
+.dark .hljs-title {
+  color: #61aeee;
+}
+
+.dark .hljs-built_in,
+.dark .hljs-title.class_,
+.dark .hljs-class .hljs-title {
+  color: #e6c07b;
 }

--- a/frontend/src/composables/useHighlight.ts
+++ b/frontend/src/composables/useHighlight.ts
@@ -21,11 +21,12 @@
 
 import type { HLJSApi } from 'highlight.js'
 // Static import so Rolldown (Vite 8) emits it as a plain CSS asset.
-// A dynamic import() causes Rolldown to generate an undeclared
-// `atom_one_dark_exports` binding that crashes at runtime.
-// This file is only imported by lazy-loaded components, so the CSS
-// still stays out of the initial bundle.
-import 'highlight.js/styles/atom-one-dark.css'
+// A dynamic import() of highlight.js theme CSS caused Rolldown to generate an
+// undeclared binding that crashed at runtime. Our dual light/dark theme lives
+// in assets/ so light-mode code blocks stay readable on pale surfaces.
+// This file is only imported by lazy-loaded components, so the CSS still stays
+// out of the initial bundle.
+import '@/assets/highlight-theme.css'
 
 let hljsInstance: HLJSApi | null = null
 let loadPromise: Promise<HLJSApi> | null = null

--- a/frontend/src/composables/useHighlight.ts
+++ b/frontend/src/composables/useHighlight.ts
@@ -20,12 +20,11 @@
  */
 
 import type { HLJSApi } from 'highlight.js'
-// Static import so Rolldown (Vite 8) emits it as a plain CSS asset.
+// Static import so Rolldown (Vite 8) emits the theme as a plain CSS asset.
 // A dynamic import() of highlight.js theme CSS caused Rolldown to generate an
-// undeclared binding that crashed at runtime. Our dual light/dark theme lives
-// in assets/ so light-mode code blocks stay readable on pale surfaces.
-// This file is only imported by lazy-loaded components, so the CSS still stays
-// out of the initial bundle.
+// undeclared binding that crashed at runtime. highlight.js JS is still loaded
+// on demand via doLoad(); this CSS ships with any chunk that imports
+// useHighlight (e.g. chat MessageCode / useMarkdown).
 import '@/assets/highlight-theme.css'
 
 let hljsInstance: HLJSApi | null = null

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -442,8 +442,10 @@
     box-shadow: none;
   }
 
-  .bubble-user .markdown-content .code-block code,
-  .bubble-user .markdown-content pre code {
+  /* Plain (non-highlighted) code stays white on the dark bubble surface.
+     Syntax-highlighted blocks (.hljs) are owned by highlight-theme.css. */
+  .bubble-user .markdown-content .code-block code:not(.hljs),
+  .bubble-user .markdown-content pre code:not(.hljs) {
     color: #ffffff !important;
   }
 
@@ -1212,16 +1214,12 @@
     animation: fadeSlideIn 0.3s ease-out;
   }
 
-  /* Code Block — theme-aware surface; syntax colors live in highlight-theme.css */
+  /* Code Block — theme-aware surface; syntax colors live in highlight-theme.css.
+     Markup is <pre class="code-block"><code class="hljs">…</code></pre>. */
   .code-block {
     background: var(--bg-chip, rgba(0, 0, 0, 0.05)) !important;
     color: #383a42 !important;
     border-radius: 0.5rem;
-  }
-  .code-block pre {
-    margin: 0;
-    color: inherit !important;
-    background: transparent !important;
   }
   .dark .code-block {
     background: rgba(0, 0, 0, 0.5) !important;

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1212,19 +1212,20 @@
     animation: fadeSlideIn 0.3s ease-out;
   }
 
-  /* Code Block - Always dark background for better readability */
+  /* Code Block — theme-aware surface; syntax colors live in highlight-theme.css */
   .code-block {
-    background: #000000 !important;
-    color: #4ade80 !important; /* green-400 */
+    background: var(--bg-chip, rgba(0, 0, 0, 0.05)) !important;
+    color: #383a42 !important;
     border-radius: 0.5rem;
   }
   .code-block pre {
     margin: 0;
-    color: #4ade80 !important; /* green-400 */
+    color: inherit !important;
     background: transparent !important;
   }
   .dark .code-block {
     background: rgba(0, 0, 0, 0.5) !important;
+    color: #abb2bf !important;
   }
 
   /* Info Boxes - High contrast for light mode */


### PR DESCRIPTION
## Summary
Improve syntax highlighting contrast in light mode so chat code blocks remain readable on pale surfaces.

## Changes
- Add a dual light/dark highlight.js theme with WCAG-oriented light-mode token colors
- Switch `useHighlight` from atom-one-dark-only CSS to the theme-aware stylesheet
- Make `.code-block` backgrounds theme-aware instead of always forcing a black surface
- Mirror the same light/dark token palette in widget markdown styles
- Keep dark token colors for dark mode and user-bubble code surfaces

## Verification
- [ ] Not tested (explain)
- [x] Manual
- [ ] Tests added/updated

Frontend gate (lint, `vue-tsc`, Vitest) passed locally. Existing MessageCode / markdown unit tests cover highlighting behavior; no new tests added for CSS-only contrast changes.

## Notes
ota-candidate (frontend styling only). Please do not merge until CI is green and review is complete.

## Screenshots/Logs
Before: light-grey / pale syntax tokens on white code blocks in light mode (poor contrast).
After: darker One-Light-style tokens on pale surfaces; Atom One Dark retained for dark mode.