### PR TITLE
ci(e2e): run firefox as a focused @crossbrowser smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -513,8 +513,9 @@ jobs:
     name: E2E Tests (${{ matrix.browser }}${{ matrix.variant && format(' {0}', matrix.variant) || '' }}${{ matrix.auth_method == 'oidc' && ' OIDC' || matrix.auth_method == 'oidc-redirect' && ' OIDC Redirect' || '' }}${{ matrix.shard && format(' [{0}]', matrix.shard) || '' }})
     # E2E jobs run on free ubuntu-latest runners (unlimited capacity for public
     # repos) to avoid queue contention from the limited ubuntu-latest-m pool.
-    # Chromium and Firefox are sharded (--shard=N/M) so each half finishes in
-    # ~50% of the time; the free runner pool ensures all shards start instantly.
+    # Chromium runs the full @ci suite sharded (--shard=N/M) so each half
+    # finishes in ~50% of the time; the free runner pool ensures all shards
+    # start instantly. Firefox is a single unsharded @crossbrowser smoke.
     runs-on: ubuntu-latest
     needs: [docker-build]
     strategy:
@@ -536,21 +537,17 @@ jobs:
             npm_script: "test:e2e"
             grep_filter: "@ci"
             shard: "2/2"
-          # Standard password auth — firefox sharded into 2 parallel jobs
+          # Firefox cross-browser SMOKE — a single unsharded job. The firefox
+          # project only runs @crossbrowser-tagged tests (engine-divergent flows:
+          # SSE, widget Shadow DOM, upload), so the lean set needs no sharding.
+          # See frontend/tests/e2e/playwright.config.ts and docs/E2E_TESTING.md §0.
           - browser: firefox
             variant: ""
             auth_method: password
             compose_profiles: ""
             npm_script: "test:e2e:firefox"
             grep_filter: "@ci"
-            shard: "1/2"
-          - browser: firefox
-            variant: ""
-            auth_method: password
-            compose_profiles: ""
-            npm_script: "test:e2e:firefox"
-            grep_filter: "@ci"
-            shard: "2/2"
+            shard: ""
           # Mobile viewport layout guard (chromium device emulation; runs the
           # @layout suite only — see frontend/tests/e2e/playwright.config.ts)
           - browser: chromium

--- a/docs/E2E_TESTING.md
+++ b/docs/E2E_TESTING.md
@@ -59,19 +59,42 @@ backend reaches it container-to-container either way.
 ## 0. Tags & CI Matrix
 
 **`@ci` is the only authoritative tag.** The CI workflow runs `--grep "@ci"`
-(chromium 2 shards, firefox 2 shards, chromium-mobile) — a test without
-`@ci` in its title chain does not run in CI, period. Other tags:
+(chromium 2 shards, one firefox cross-browser smoke, chromium-mobile) — a test
+without `@ci` in its title chain does not run in CI, period. Other tags:
 
 | Tag | Meaning |
 |-----|---------|
 | `@noci` | Excluded via project `grepInvert` even when the surrounding describe is `@ci`. Local/nightly only. |
-| `@layout` | Layout guard — runs in chromium desktop + chromium-mobile, excluded from firefox. |
+| `@crossbrowser` | Also runs in the **firefox** project. Firefox only runs `@crossbrowser` tests (AND-ed with `@ci` in CI) — see convention below. |
+| `@layout` | Layout guard — runs in chromium desktop + chromium-mobile only. |
 | `@visual` | Snapshot tests — separate CI-only project (baselines from the ubuntu runner). |
 | `@oidc`, `@oidc-redirect` | OIDC jobs only (dedicated matrix entries with Keycloak). |
 | `@smoke`, `@auth`, `@api`, … | Informational grouping — no CI effect, historically inconsistent. Don't rely on them for filtering. |
 
 When adding a test, decide explicitly: `@ci` (stable, deterministic, runs on
 every PR) or `@noci` (needs real providers/keys or is nightly-grade).
+
+### Cross-browser (firefox) — opt-in via `@crossbrowser`
+
+Firefox is a **focused cross-browser smoke, not a second full suite.** The
+firefox project (`playwright.config.ts`) runs `grep: /@crossbrowser/`; in CI
+that is AND-ed with `--grep "@ci"`, so **only stable `@crossbrowser` tests run
+in firefox.** Everything else is browser-agnostic app logic already covered by
+chromium — running it twice only adds flake and couples every merge to a
+firefox-only flake, without new signal.
+
+**Tag a test `@crossbrowser` only when it exercises a genuine engine
+(Gecko-vs-Blink) divergence**, e.g.:
+
+- **SSE streaming** (`EventSource`) — the core chat/stream path.
+- **Embeddable widget** — Shadow DOM mount + cross-origin behavior (runs on
+  unknown customer browsers).
+- **Upload / clipboard / WebSpeech** and other browser-API-heavy flows.
+- **Auth / session cookies** — the gate to everything, with real cookie edges.
+
+Do NOT tag browser-agnostic logic (chat rename/delete, memories, task prompts,
+profile, settings CRUD, …) — chromium already covers it. Keep the
+`@crossbrowser` set small and high-value; it is a required gate.
 
 ---
 

--- a/frontend/tests/e2e/playwright.config.ts
+++ b/frontend/tests/e2e/playwright.config.ts
@@ -57,9 +57,14 @@ export default defineConfig({
         ...devices['Desktop Firefox'],
         ...(process.env.CI ? {} : { launchOptions: { args: ['--start-maximized'] } }),
       },
-      // Layout guard runs in chromium (desktop) + chromium-mobile only —
-      // geometry contracts are browser-agnostic, firefox stays functional.
-      grepInvert: /@oidc-redirect|@noci|@visual|@layout/,
+      // Firefox is a focused cross-browser SMOKE, not a second full suite.
+      // Only tests tagged @crossbrowser run here — the engine-divergent flows
+      // (SSE streaming, widget Shadow DOM, upload/clipboard APIs). Everything
+      // else is browser-agnostic app logic already covered by chromium, so
+      // running it twice adds flake + gate coupling without real signal.
+      // In CI this is further AND-ed with --grep @ci, so only stable
+      // @crossbrowser tests execute. See docs/E2E_TESTING.md §0.
+      grep: /@crossbrowser/,
     },
     {
       name: 'chromium-oidc-redirect',

--- a/frontend/tests/e2e/tests/admin-impersonation-chat.spec.ts
+++ b/frontend/tests/e2e/tests/admin-impersonation-chat.spec.ts
@@ -55,16 +55,25 @@ test.describe('@ci @smoke Admin impersonation + chat', () => {
     await test.step('Act: search for the worker user and impersonate', async () => {
       await page.locator(selectors.admin.userSearch).fill(credentials.user)
 
-      await page
-        .locator(selectors.admin.impersonateUser(targetUserId))
-        .waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
+      const impersonateBtn = page.locator(selectors.admin.impersonateUser(targetUserId))
+      const confirmBtn = page.locator(selectors.dialog.confirmBtn)
 
-      await page.locator(selectors.admin.impersonateUser(targetUserId)).click()
+      await impersonateBtn.waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
 
-      await page
-        .locator(selectors.dialog.confirmBtn)
-        .waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
-      await page.locator(selectors.dialog.confirmBtn).click()
+      // The email search is debounced and re-renders the users table. A click
+      // that lands during that re-render hits a detaching row button, so
+      // confirmImpersonate() never fires and the dialog never opens (observed
+      // CI flake: btn-dialog-confirm absent after 10s). Retry the click until
+      // the dialog actually appears; skip re-clicking once it is open so we
+      // never click behind the modal overlay.
+      await expect(async () => {
+        if (!(await confirmBtn.isVisible())) {
+          await impersonateBtn.click()
+        }
+        await expect(confirmBtn).toBeVisible({ timeout: TIMEOUTS.SHORT })
+      }).toPass({ timeout: TIMEOUTS.STANDARD })
+
+      await confirmBtn.click()
     })
 
     await test.step('Assert: impersonation banner is visible', async () => {

--- a/frontend/tests/e2e/tests/auth.spec.ts
+++ b/frontend/tests/e2e/tests/auth.spec.ts
@@ -8,7 +8,9 @@ import { TIMEOUTS } from '../config/config'
 test.use(LOGGED_OUT)
 
 test.describe('@ci @auth Authentication', () => {
-  test('@smoke should successfully login', async ({ page, credentials }) => {
+  // @crossbrowser: form submit + session cookie handling has real
+  // Gecko-vs-Blink cookie/security edges; login is the gate to everything.
+  test('@crossbrowser @smoke should successfully login', async ({ page, credentials }) => {
     await test.step('Act: login with credentials', async () => {
       await login(page, credentials)
     })

--- a/frontend/tests/e2e/tests/chat.spec.ts
+++ b/frontend/tests/e2e/tests/chat.spec.ts
@@ -13,7 +13,10 @@ const e2eDir = path.join(__dirname, '..')
 const VISION_FIXTURE = readFileSync(path.join(e2eDir, FIXTURE_PATHS.VISION_PATTERN_64))
 
 test.describe('@ci @smoke Chat', () => {
-  test('standard model generates answer', async ({ page }) => {
+  // @crossbrowser: SSE streaming (EventSource) is the core chat mechanism and
+  // Gecko has its own implementation — a firefox-only stream regression here
+  // would otherwise only surface in production.
+  test('@crossbrowser standard model generates answer', async ({ page }) => {
     await openApp(page)
     const chat = new ChatHelper(page)
 

--- a/frontend/tests/e2e/tests/file-manage.spec.ts
+++ b/frontend/tests/e2e/tests/file-manage.spec.ts
@@ -58,19 +58,36 @@ test.describe('@ci File Management', () => {
     })
 
     await test.step('Assert: the folder contains the uploaded file', async () => {
+      // A freshly created folder is a client-only "pending" card; it becomes a
+      // real folder only once the upload+vectorize round-trip finishes and
+      // loadFileGroups() refreshes it — at which point its "Use in chat"
+      // affordance renders (v-if="!folder.pending"). Wait for that BEFORE
+      // entering, otherwise the async post-upload refresh races enterFolder()
+      // and bounces the view back to root, so btn-back-to-root never appears.
+      await expect(page.locator(FILES.btnUseInChat(folderName))).toBeVisible({
+        timeout: TIMEOUTS.VERY_LONG,
+      })
+
       await page.locator(FILES.folderCard(folderName)).click()
-      await page.locator(FILES.table).waitFor({ state: 'visible', timeout: TIMEOUTS.VERY_LONG })
+      // Confirm we actually entered the folder view — btn-back-to-root exists
+      // only inside a folder. The file is also listed at root, so asserting the
+      // row alone would pass even if navigation silently stayed at root.
+      await page
+        .locator(FILES.btnBackToRoot)
+        .waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
+      await page.locator(FILES.table).waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
       // Each file renders twice (mobile card + desktop table row, one hidden
-      // via CSS) — count only the visible representation. VERY_LONG because the
-      // row only appears once the upload+vectorize round-trip finishes, which
-      // can lag well past STANDARD under CI load.
+      // via CSS) — count only the visible representation.
       await expect(
         page.locator(FILES.fileRow).filter({ hasText: fixtureName }).filter({ visible: true })
-      ).toHaveCount(1, { timeout: TIMEOUTS.VERY_LONG })
+      ).toHaveCount(1, { timeout: TIMEOUTS.STANDARD })
     })
 
     await test.step('Act: "Use in chat" opens a chat scoped to the folder', async () => {
-      await page.locator(FILES.btnBackToRoot).click()
+      // Return to the root grid deterministically instead of depending on the
+      // in-folder back button (which is absent if a refresh bounced us to root).
+      await page.goto('/files')
+      await page.locator(FILES.page).waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
       const card = page.locator(FILES.folderCard(folderName))
       await card.waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
       await card.hover()

--- a/frontend/tests/e2e/tests/file-manage.spec.ts
+++ b/frontend/tests/e2e/tests/file-manage.spec.ts
@@ -21,7 +21,9 @@ const CHAT = selectors.chat
  * management actions.
  */
 test.describe('@ci File Management', () => {
-  test('user can create a folder, upload into it, use it in chat and delete the file', async ({
+  // @crossbrowser: file input / upload handling is a classic browser-API
+  // divergence (setInputFiles, multipart, drag targets) worth a Gecko check.
+  test('@crossbrowser user can create a folder, upload into it, use it in chat and delete the file', async ({
     page,
   }) => {
     // Upload + vectorization plus create/open/use-in-chat/delete navigations

--- a/frontend/tests/e2e/tests/widget.spec.ts
+++ b/frontend/tests/e2e/tests/widget.spec.ts
@@ -152,7 +152,10 @@ test.describe('@ci @smoke Widget', () => {
     })
   })
 
-  test('embedded chat receives response', async ({ page, request, credentials }) => {
+  // @crossbrowser: the embeddable widget runs on unknown customer sites in
+  // whatever browser their visitors use. This exercises Shadow DOM mount +
+  // cross-origin SSE response — the highest-value Gecko path in the product.
+  test('@crossbrowser embedded chat receives response', async ({ page, request, credentials }) => {
     const widgetName = WIDGET_NAMES.unique('Embedded Widget Flow')
     const widgetInfo = await createWidgetViaApi(request, credentials, widgetName, {
       websiteUrl: URLS.TEST_PAGE_URL,


### PR DESCRIPTION
## Summary

Firefox in CI previously re-ran the **entire functional `@ci` suite** (2 shards), the bulk of which is browser-agnostic app logic already covered by chromium. That gave little cross-browser signal while **doubling the `playwright install-deps` flake surface** and coupling every merge to a firefox-only flake in the required gate.

This turns firefox into a **focused cross-browser smoke** via an opt-in `@crossbrowser` tag, covering only the genuinely engine-divergent (Gecko-vs-Blink) flows.

- **`playwright.config.ts`** — firefox project: `grepInvert: /@oidc-redirect|@noci|@visual|@layout/` → `grep: /@crossbrowser/`. In CI this is AND-ed with `--grep "@ci"`, so only stable `@crossbrowser` tests run.
- **`ci.yml`** — the two firefox shards collapse into **one unsharded** firefox job (halves firefox jobs in the required gate + the `install-deps` flake surface). Chromium is unchanged (still full `@ci`, 2 shards).
- **Tagged `@crossbrowser`** (with rationale comments): login/session cookies (`auth.spec.ts`), chat SSE streaming (`chat.spec.ts`), embeddable widget Shadow DOM + cross-origin SSE (`widget.spec.ts`), file upload (`file-manage.spec.ts`).
- **`docs/E2E_TESTING.md`** — documents the tag and the convention for *when* to apply it (guards against opt-in rot).

## Flaky-test root-cause fixes (firefox)

The earlier "fix" for these two only bumped timeouts, which merely masked them — the flakes persisted (Aug 4–7). Analysis of the CI failure DOM snapshots showed the real causes are **state races**, not slow rendering:

- **`admin-impersonation-chat.spec.ts`** — the debounced email search re-renders the users table; a click landing during that re-render hits a detaching row button, so `confirmImpersonate()` never fires and the confirm dialog never opens (`btn-dialog-confirm` absent after 10s). Fix: retry the impersonate click until the dialog actually appears, skipping the re-click once it is open (never clicks behind the modal overlay).
- **`file-manage.spec.ts`** — a freshly created folder is a client-only "pending" card; the async post-upload refresh (`loadFileGroups` + `loadFiles`) races `enterFolder()` and bounces the view back to root. Because the uploaded file is *also* listed at root, the "file in folder" assert still passed, and the next step then timed out clicking a non-existent `btn-back-to-root` (90s). Fix: wait for the folder to leave the pending state before entering, confirm entry via `btn-back-to-root`, and return to root via `goto` instead of the in-folder back button.

No timeout increases; both fixes remove the underlying race.

## Verification

| Check | Result |
|---|---|
| Firefox listing (as CI filters) | **4 tests** (was ~86) |
| Chromium listing (as CI filters) | **90 tests** unchanged, incl. the 4 crossbrowser tests |
| `make -C frontend lint` | pass |
| `npm run check:types` (vue-tsc) | pass |
| `make -C frontend test` (Vitest) | 1028 pass |
| `ci.yml` YAML | valid |

## Test plan

- [ ] CI green on this PR, incl. the single `E2E Tests (firefox)` job running only the 4 `@crossbrowser` specs
- [ ] Chromium E2E matrix still runs the full `@ci` suite (2 shards)
- [ ] Confirm the firefox job is no longer sharded in the Actions run
- [ ] `admin-impersonation-chat` + `file-manage` pass on firefox without retries across repeated runs