### PR TITLE
feat(gateway): configurable image handling and a full settings UI for AI Agents

### DIFF
--- a/backend/src/AI/Messages/MessagesGateway.php
+++ b/backend/src/AI/Messages/MessagesGateway.php
@@ -8,6 +8,7 @@ use App\AI\Credential\UserProviderKeyResolver;
 use App\AI\Messages\Tools\GatewayToolCatalog;
 use App\AI\Messages\Tools\GatewayToolLoop;
 use App\AI\Messages\Translator\AnthropicPassthroughTranslator;
+use App\AI\Messages\Vision\VisionPolicy;
 use App\Entity\Model;
 use App\Entity\User;
 use App\Message\SummarizeApiSessionCommand;
@@ -27,7 +28,9 @@ use Symfony\Component\Messenger\MessageBusInterface;
  * credential resolve, optional body mutation, translator dispatch, metering.
  *
  * The server-side tool loop (MCP tools plus Synaplan's built-in web search) and
- * context injection are gated by config flags (default off).
+ * context injection are gated by config flags (default off). Image blocks pass
+ * through {@see VisionPolicy} first, which enforces the operator's vision
+ * settings and resolves the image detail the translators forward.
  *
  * @phpstan-type GatewaySuccess array{
  *     ok: true,
@@ -60,7 +63,13 @@ use Symfony\Component\Messenger\MessageBusInterface;
  *     }|null,
  *     replaced_server_tools: list<string>,
  *     web_search: string,
- *     vision: string,
+ *     vision: array{
+ *         handling: string,
+ *         mode: string,
+ *         detail: string,
+ *         images_forwarded: int,
+ *         images_omitted: int
+ *     },
  *     context_hash: string|null,
  *     debug: bool
  * }
@@ -100,6 +109,7 @@ final readonly class MessagesGateway
         private AnthropicPassthroughTranslator $anthropicPassthrough,
         private GatewayToolCatalog $toolCatalog,
         private GatewayToolLoop $toolLoop,
+        private VisionPolicy $visionPolicy,
         private MessagesContextInjector $contextInjector,
         private CacheItemPoolInterface $cache,
         private MessageBusInterface $messageBus,
@@ -165,7 +175,16 @@ final readonly class MessagesGateway
 
         $requestBody = $decoded;
         $bodyMutated = false;
-        $visionRewrite = $this->maybeRewriteForVision($user, $resolved, $decoded);
+
+        // Transport policy first (image cap, detail hint), so the routing
+        // decision below sees the images that actually reach the upstream.
+        $imagePolicy = $this->visionPolicy->apply($requestBody, $user->getId());
+        $requestBody = $imagePolicy['body'];
+        if ($imagePolicy['mutated']) {
+            $bodyMutated = true;
+        }
+
+        $visionRewrite = $this->maybeRewriteForVision($user, $resolved, $requestBody);
         $resolved = $visionRewrite['resolved'];
         $visionHandling = $visionRewrite['vision'];
         if ($visionRewrite['mutated']) {
@@ -283,6 +302,7 @@ final readonly class MessagesGateway
             'anthropic_beta' => $request->headers->get('anthropic-beta'),
             'x_fixture' => $request->headers->get('x-fixture'),
             'raw_body' => $bodyMutated ? null : $rawBody,
+            'image_detail' => $imagePolicy['detail'],
         ];
 
         $headers = array_merge(
@@ -310,7 +330,13 @@ final readonly class MessagesGateway
             'tool_catalog' => $toolCatalog,
             'replaced_server_tools' => $replacedServerTools,
             'web_search' => $webSearch,
-            'vision' => $visionHandling,
+            'vision' => [
+                'handling' => $visionHandling,
+                'mode' => $imagePolicy['mode'],
+                'detail' => $imagePolicy['detail'],
+                'images_forwarded' => $imagePolicy['images_forwarded'],
+                'images_omitted' => $imagePolicy['images_omitted'],
+            ],
             'context_hash' => $contextHash,
             'debug' => '1' === $request->headers->get('x-synaplan-debug'),
         ];

--- a/backend/src/AI/Messages/MessagesTranslatorInterface.php
+++ b/backend/src/AI/Messages/MessagesTranslatorInterface.php
@@ -28,6 +28,7 @@ interface MessagesTranslatorInterface
      *     anthropic_beta?: string|null,
      *     x_fixture?: string|null,
      *     raw_body?: string|null,
+     *     image_detail?: string|null,
      *     parsed_events?: bool
      * } $context
      *
@@ -48,6 +49,7 @@ interface MessagesTranslatorInterface
      *     anthropic_beta?: string|null,
      *     x_fixture?: string|null,
      *     raw_body?: string|null,
+     *     image_detail?: string|null,
      *     parsed_events?: bool
      * } $context
      * @param callable(string|array{event: string, data: array<string, mixed>}): void $emit

--- a/backend/src/AI/Messages/Tools/GatewayToolCatalog.php
+++ b/backend/src/AI/Messages/Tools/GatewayToolCatalog.php
@@ -80,6 +80,32 @@ final readonly class GatewayToolCatalog
     }
 
     /**
+     * The built-in tools this install would run server-side, judged without a
+     * request in hand: current settings plus what is actually configured.
+     *
+     * This answers "what does Synaplan execute on my behalf?" for the settings
+     * page. A concrete request can still drop one of them — the client may ship
+     * a tool of the same name, and web search only runs for a turn that asks for
+     * it — so treat this as the ceiling, not a promise.
+     *
+     * @return list<string>
+     */
+    public function nativeToolNames(int $userId): array
+    {
+        $names = [];
+
+        if ($this->runsSynaplanWebSearch($userId)) {
+            $names[] = WebSearchTool::NAME;
+        }
+
+        if ($this->offersAnalyzeImage($userId)) {
+            $names[] = AnalyzeImageTool::NAME;
+        }
+
+        return $names;
+    }
+
+    /**
      * Client-declared tool entries the gateway must not forward as-is: the
      * Anthropic `web_search_*` server tool, either because Synaplan answers it
      * itself or because it was explicitly turned off.
@@ -193,7 +219,7 @@ final readonly class GatewayToolCatalog
             return;
         }
 
-        if (!$this->webSearchTool->isAvailable()) {
+        if (!$this->runsSynaplanWebSearch($userId)) {
             // No provider to run the search. Leave the Anthropic declaration on
             // the wire so api.anthropic.com can honour it. OpenAI/Gemini
             // translators drop server-tool declarations rather than forwarding
@@ -219,8 +245,7 @@ final readonly class GatewayToolCatalog
      */
     private function appendAnalyzeImage(array &$snapshot, int $userId, array $requestBody): void
     {
-        $mode = $this->config->visionMode($userId);
-        if (MessagesGatewayConfig::VISION_OFF === $mode) {
+        if (!$this->offersAnalyzeImage($userId)) {
             return;
         }
 
@@ -228,11 +253,28 @@ final readonly class GatewayToolCatalog
             return;
         }
 
-        if (!$this->analyzeImageTool->isAvailable($userId)) {
-            return;
-        }
-
         $this->addNativeTool($snapshot, $this->analyzeImageTool->declaration(), AnalyzeImageTool::NAME);
+    }
+
+    /**
+     * Synaplan answers the client's web search declaration itself: any mode that
+     * does not hand the search to the upstream, plus a provider to run it.
+     */
+    private function runsSynaplanWebSearch(int $userId): bool
+    {
+        $mode = $this->config->webSearchMode($userId);
+        $handledUpstream = [
+            MessagesGatewayConfig::WEB_SEARCH_OFF,
+            MessagesGatewayConfig::WEB_SEARCH_PASSTHROUGH,
+        ];
+
+        return !\in_array($mode, $handledUpstream, true) && $this->webSearchTool->isAvailable();
+    }
+
+    private function offersAnalyzeImage(int $userId): bool
+    {
+        return MessagesGatewayConfig::VISION_OFF !== $this->config->visionMode($userId)
+            && $this->analyzeImageTool->isAvailable($userId);
     }
 
     /**

--- a/backend/src/AI/Messages/Translator/OpenAiMessagesTranslator.php
+++ b/backend/src/AI/Messages/Translator/OpenAiMessagesTranslator.php
@@ -47,7 +47,7 @@ final readonly class OpenAiMessagesTranslator implements MessagesTranslatorInter
 
     public function complete(array $requestBody, array $context): array
     {
-        $payload = $this->toOpenAiRequest($requestBody, stream: false);
+        $payload = $this->toOpenAiRequest($requestBody, stream: false, imageDetail: $this->imageDetail($context));
         $response = $this->request($payload, $context, stream: false);
         $status = $response->getStatusCode();
         $headers = $response->getHeaders(false);
@@ -87,7 +87,7 @@ final readonly class OpenAiMessagesTranslator implements MessagesTranslatorInter
 
     public function stream(array $requestBody, array $context, callable $emit): MessagesUsage
     {
-        $payload = $this->toOpenAiRequest($requestBody, stream: true);
+        $payload = $this->toOpenAiRequest($requestBody, stream: true, imageDetail: $this->imageDetail($context));
         $response = $this->request($payload, $context, stream: true);
         $status = $response->getStatusCode();
 
@@ -110,7 +110,7 @@ final readonly class OpenAiMessagesTranslator implements MessagesTranslatorInter
      *
      * @return array<string, mixed>
      */
-    public function toOpenAiRequest(array $requestBody, bool $stream): array
+    public function toOpenAiRequest(array $requestBody, bool $stream, ?string $imageDetail = null): array
     {
         foreach (self::STRIP_KEYS as $key) {
             unset($requestBody[$key]);
@@ -131,7 +131,7 @@ final readonly class OpenAiMessagesTranslator implements MessagesTranslatorInter
             if (!\is_array($msg)) {
                 continue;
             }
-            foreach ($this->mapAnthropicMessage($msg) as $mapped) {
+            foreach ($this->mapAnthropicMessage($msg, $imageDetail) as $mapped) {
                 $messages[] = $mapped;
             }
         }
@@ -254,7 +254,7 @@ final readonly class OpenAiMessagesTranslator implements MessagesTranslatorInter
      *
      * @return list<array<string, mixed>>
      */
-    private function mapAnthropicMessage(array $msg): array
+    private function mapAnthropicMessage(array $msg, ?string $imageDetail = null): array
     {
         $role = (string) ($msg['role'] ?? 'user');
         $content = $msg['content'] ?? '';
@@ -283,7 +283,14 @@ final readonly class OpenAiMessagesTranslator implements MessagesTranslatorInter
             } elseif ('image' === $type) {
                 $url = $this->imageBlockToUrl($block);
                 if (null !== $url) {
-                    $mediaParts[] = ['type' => 'image_url', 'image_url' => ['url' => $url]];
+                    $imageUrl = ['url' => $url];
+                    // `auto` is the provider's own default — leaving the field
+                    // out keeps the payload compatible with the stricter
+                    // OpenAI-compatible upstreams.
+                    if (null !== $imageDetail && 'auto' !== $imageDetail) {
+                        $imageUrl['detail'] = $imageDetail;
+                    }
+                    $mediaParts[] = ['type' => 'image_url', 'image_url' => $imageUrl];
                 }
             } elseif ('tool_use' === $type) {
                 $toolCalls[] = [
@@ -328,6 +335,16 @@ final readonly class OpenAiMessagesTranslator implements MessagesTranslatorInter
         }
 
         return $out;
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    private function imageDetail(array $context): ?string
+    {
+        $detail = $context['image_detail'] ?? null;
+
+        return \is_string($detail) && '' !== $detail ? $detail : null;
     }
 
     /**

--- a/backend/src/AI/Messages/Vision/VisionPolicy.php
+++ b/backend/src/AI/Messages/Vision/VisionPolicy.php
@@ -1,0 +1,208 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\AI\Messages\Vision;
+
+use App\Service\MessagesGateway\MessagesGatewayConfig;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Applies the operator's per-image transport settings to an Anthropic-shaped
+ * request body before it reaches a translator.
+ *
+ * This is the cost side of image handling, and it is deliberately separate from
+ * {@see MessagesGatewayConfig::visionMode()}: the mode decides *which model*
+ * reads an image turn, while the settings here decide *how many* images travel
+ * and *at which resolution* they are read. Screenshot-heavy clients (Claude
+ * Code above all) resend every image of a session on every turn, so a cap is
+ * the difference between an affordable gateway and a surprise bill.
+ *
+ * Omitted images leave a short text block behind instead of disappearing: a
+ * user turn whose only block was an image would otherwise become empty content,
+ * which every provider rejects.
+ *
+ * @phpstan-type VisionOutcome array{
+ *     body: array<string, mixed>,
+ *     mutated: bool,
+ *     mode: string,
+ *     detail: string,
+ *     images_forwarded: int,
+ *     images_omitted: int
+ * }
+ */
+final readonly class VisionPolicy
+{
+    public const PLACEHOLDER_LIMIT = '[Image omitted: this gateway forwards only the %d most recent images.]';
+
+    public function __construct(
+        private MessagesGatewayConfig $config,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $requestBody
+     *
+     * @return VisionOutcome
+     */
+    public function apply(array $requestBody, ?int $userId): array
+    {
+        $mode = $this->config->visionMode($userId);
+        $detail = $this->config->visionImageDetail($userId);
+        $maxImages = $this->config->visionMaxImages($userId);
+
+        $messages = $requestBody['messages'] ?? null;
+        if (!\is_array($messages)) {
+            return $this->outcome($requestBody, false, $mode, $detail, 0, 0);
+        }
+
+        $total = $this->countImages($messages);
+        if (0 === $total) {
+            return $this->outcome($requestBody, false, $mode, $detail, 0, 0);
+        }
+
+        $forwarded = $maxImages > 0 ? min($total, $maxImages) : $total;
+
+        $omitted = $total - $forwarded;
+        if (0 === $omitted) {
+            return $this->outcome($requestBody, false, $mode, $detail, $forwarded, 0);
+        }
+
+        $placeholder = sprintf(self::PLACEHOLDER_LIMIT, $forwarded);
+
+        // The oldest images go first: in an agent loop the newest screenshot is
+        // the one the current turn is actually about.
+        $seen = 0;
+        $decide = static function () use (&$seen, $omitted, $placeholder): ?string {
+            ++$seen;
+
+            return $seen <= $omitted ? $placeholder : null;
+        };
+
+        $requestBody['messages'] = $this->rewriteMessages($messages, $decide);
+
+        $this->logger->info('VisionPolicy: image blocks omitted', [
+            'mode' => $mode,
+            'max_images' => $maxImages,
+            'total' => $total,
+            'omitted' => $omitted,
+        ]);
+
+        return $this->outcome($requestBody, true, $mode, $detail, $forwarded, $omitted);
+    }
+
+    /**
+     * @param array<mixed> $messages
+     */
+    private function countImages(array $messages): int
+    {
+        $count = 0;
+        foreach ($messages as $message) {
+            if (\is_array($message) && \is_array($message['content'] ?? null)) {
+                $count += $this->countImagesInContent($message['content']);
+            }
+        }
+
+        return $count;
+    }
+
+    /**
+     * @param array<mixed> $content
+     */
+    private function countImagesInContent(array $content): int
+    {
+        $count = 0;
+        foreach ($content as $block) {
+            if (!\is_array($block)) {
+                continue;
+            }
+            if ('image' === ($block['type'] ?? null)) {
+                ++$count;
+                continue;
+            }
+            // Tool results carry their own content array — a screenshot tool
+            // returns its image in there.
+            if (\is_array($block['content'] ?? null)) {
+                $count += $this->countImagesInContent($block['content']);
+            }
+        }
+
+        return $count;
+    }
+
+    /**
+     * @param array<mixed>              $messages
+     * @param callable(): (string|null) $decide   returns the placeholder text for an omitted image, or null to forward it
+     *
+     * @return list<mixed>
+     */
+    private function rewriteMessages(array $messages, callable $decide): array
+    {
+        $out = [];
+        foreach ($messages as $message) {
+            if (\is_array($message) && \is_array($message['content'] ?? null)) {
+                $message['content'] = $this->rewriteContent($message['content'], $decide);
+            }
+            $out[] = $message;
+        }
+
+        return $out;
+    }
+
+    /**
+     * @param array<mixed>              $content
+     * @param callable(): (string|null) $decide
+     *
+     * @return list<mixed>
+     */
+    private function rewriteContent(array $content, callable $decide): array
+    {
+        $out = [];
+        foreach ($content as $block) {
+            if (!\is_array($block)) {
+                $out[] = $block;
+                continue;
+            }
+
+            if ('image' === ($block['type'] ?? null)) {
+                $placeholder = $decide();
+                $out[] = null === $placeholder
+                    ? $block
+                    : ['type' => 'text', 'text' => $placeholder];
+                continue;
+            }
+
+            if (\is_array($block['content'] ?? null)) {
+                $block['content'] = $this->rewriteContent($block['content'], $decide);
+            }
+
+            $out[] = $block;
+        }
+
+        return $out;
+    }
+
+    /**
+     * @param array<string, mixed> $body
+     *
+     * @return VisionOutcome
+     */
+    private function outcome(
+        array $body,
+        bool $mutated,
+        string $mode,
+        string $detail,
+        int $forwarded,
+        int $omitted,
+    ): array {
+        return [
+            'body' => $body,
+            'mutated' => $mutated,
+            'mode' => $mode,
+            'detail' => $detail,
+            'images_forwarded' => $forwarded,
+            'images_omitted' => $omitted,
+        ];
+    }
+}

--- a/backend/src/Controller/MessagesApiController.php
+++ b/backend/src/Controller/MessagesApiController.php
@@ -26,6 +26,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  *
  * Distinct from Synaplan's native chat SSE at /api/v1/messages/stream.
  * Errors use Anthropic's envelope: {"type":"error","error":{"type","message"}}.
+ *
+ * @phpstan-import-type GatewaySuccess from MessagesGateway
  */
 #[OA\Tag(name: 'Anthropic Compatible', description: 'Anthropic Messages API-compatible gateway for Claude Code')]
 final class MessagesApiController extends AbstractController
@@ -124,8 +126,7 @@ final class MessagesApiController extends AbstractController
             $response->headers->set($name, $value);
         }
 
-        $this->addWebSearchHeader($response, $prepared);
-        $this->addVisionHeader($response, $prepared);
+        $this->addPolicyHeaders($response, $prepared);
         if (!empty($prepared['debug']) && !empty($prepared['context_hash'])) {
             $response->headers->set('x-synaplan-context-hash', (string) $prepared['context_hash']);
         }
@@ -134,33 +135,51 @@ final class MessagesApiController extends AbstractController
     }
 
     /**
-     * Tell the caller how its `web_search` declaration was handled — `synaplan`
-     * (we ran the search), `passthrough` (forwarded for the upstream to run) or
-     * `off`. Without this, a model answering "I cannot search the web" is
-     * indistinguishable from a misconfigured gateway.
+     * Tell the caller how the gateway's own policies touched this request.
+     *
+     * `x-synaplan-web-search` reports how a `web_search` declaration was handled
+     * — `synaplan` (we ran the search), `passthrough` (forwarded for the upstream
+     * to run) or `off`. Without it, a model answering "I cannot search the web"
+     * is indistinguishable from a misconfigured gateway.
      *
      * @param array<string, mixed> $prepared
      */
-    private function addWebSearchHeader(Response $response, array $prepared): void
+    private function addPolicyHeaders(Response $response, array $prepared): void
     {
         $mode = $prepared['web_search'] ?? null;
         if (\is_string($mode) && '' !== $mode && GatewayToolCatalog::WEB_SEARCH_NONE !== $mode) {
             $response->headers->set('x-synaplan-web-search', $mode);
         }
+
+        $this->addVisionHeader($response, $prepared);
     }
 
     /**
-     * Tell the caller how image turns were handled — `synaplan` (rewrote onto
-     * a Synaplan vision model) or `passthrough` (left on the wire).
+     * Report how the image turn was handled: `synaplan` (rewritten onto a
+     * Synaplan vision model) or `passthrough` (left on the wire), with an
+     * `omitted=N` suffix when the image cap dropped older images. Without it, a
+     * client that sent a screenshot and got a text-only answer cannot tell
+     * gateway policy from model behaviour.
      *
      * @param array<string, mixed> $prepared
      */
     private function addVisionHeader(Response $response, array $prepared): void
     {
-        $mode = $prepared['vision'] ?? null;
-        if (\is_string($mode) && '' !== $mode && GatewayToolCatalog::VISION_NONE !== $mode) {
-            $response->headers->set('x-synaplan-vision', $mode);
+        $vision = $prepared['vision'] ?? null;
+        if (!\is_array($vision)) {
+            return;
         }
+
+        $handling = (string) ($vision['handling'] ?? '');
+        $omitted = (int) ($vision['images_omitted'] ?? 0);
+        if ('' === $handling || GatewayToolCatalog::VISION_NONE === $handling) {
+            return;
+        }
+
+        $response->headers->set(
+            'x-synaplan-vision',
+            $omitted > 0 ? sprintf('%s; omitted=%d', $handling, $omitted) : $handling,
+        );
     }
 
     #[Route('/v1/messages/count_tokens', name: 'anthropic_count_tokens', methods: ['POST'])]
@@ -246,30 +265,7 @@ final class MessagesApiController extends AbstractController
     }
 
     /**
-     * @param array{
-     *     ok: true,
-     *     stream: bool,
-     *     headers: array<string, string>,
-     *     raw_stream: bool,
-     *     key_source: 'user'|'operator',
-     *     resolved: array{provider: string, providerModelId: string, displayModel: string, model_id: int, requested: string, aliased_from: string|null},
-     *     budget: array<string, mixed>,
-     *     session_id: string|null,
-     *     session_key: string,
-     *     body_mutated: bool,
-     *     request_body: array<string, mixed>,
-     *     translator_context: array<string, mixed>,
-     *     status: int,
-     *     body: array<string, mixed>|string|null,
-     *     usage: MessagesUsage,
-     *     tool_loop: bool,
-     *     tool_catalog: array<string, mixed>|null,
-     *     replaced_server_tools: list<string>,
-     *     web_search: string,
-     *     vision: string,
-     *     context_hash: string|null,
-     *     debug: bool
-     * } $prepared
+     * @param GatewaySuccess $prepared
      */
     private function streamResponse(array $prepared, User $user): StreamedResponse
     {
@@ -281,8 +277,7 @@ final class MessagesApiController extends AbstractController
         foreach ($prepared['headers'] as $name => $value) {
             $response->headers->set($name, $value);
         }
-        $this->addWebSearchHeader($response, $prepared);
-        $this->addVisionHeader($response, $prepared);
+        $this->addPolicyHeaders($response, $prepared);
         if (!empty($prepared['debug']) && !empty($prepared['context_hash'])) {
             $response->headers->set('x-synaplan-context-hash', (string) $prepared['context_hash']);
         }

--- a/backend/src/Controller/MessagesGatewayController.php
+++ b/backend/src/Controller/MessagesGatewayController.php
@@ -11,6 +11,7 @@ use App\AI\Messages\Tools\AnalyzeImageTool;
 use App\AI\Messages\Tools\WebSearchTool;
 use App\Entity\User;
 use App\Repository\ConfigRepository;
+use App\Repository\McpServerConfigRepository;
 use App\Service\MessagesGateway\MessagesGatewayConfig;
 use App\Service\RateLimitService;
 use OpenApi\Attributes as OA;
@@ -39,6 +40,7 @@ final class MessagesGatewayController extends AbstractController
         private readonly RateLimitService $rateLimitService,
         private readonly WebSearchTool $webSearchTool,
         private readonly AnalyzeImageTool $analyzeImageTool,
+        private readonly McpServerConfigRepository $mcpServers,
         private readonly LoggerInterface $logger,
     ) {
     }
@@ -59,6 +61,9 @@ final class MessagesGatewayController extends AbstractController
                 new OA\Property(property: 'enabled', type: 'boolean', example: false),
                 new OA\Property(property: 'allow_operator_key', type: 'boolean', example: false),
                 new OA\Property(property: 'mcp_tools_enabled', type: 'boolean', example: false),
+                new OA\Property(property: 'mcp_tools_with_client_tools', type: 'boolean', example: false, description: 'Whether Synaplan MCP tools are also offered when the client already sent its own tools.'),
+                new OA\Property(property: 'mcp_max_iterations', type: 'integer', example: 8, description: 'Maximum server-side tool rounds per request.'),
+                new OA\Property(property: 'mcp_servers_configured', type: 'integer', example: 0, description: 'Number of enabled MCP servers the signed-in user has.'),
                 new OA\Property(
                     property: 'web_search_mode',
                     description: 'How the gateway answers Anthropic web_search declarations: auto (Synaplan search when configured, otherwise passthrough), synaplan, passthrough, or off.',
@@ -75,8 +80,17 @@ final class MessagesGatewayController extends AbstractController
                     example: MessagesGatewayConfig::VISION_AUTO,
                 ),
                 new OA\Property(property: 'vision_available', type: 'boolean', example: true, description: 'Whether a Synaplan PIC2TEXT / catalog vision model is available.'),
+                new OA\Property(
+                    property: 'vision_image_detail',
+                    description: 'Resolution hint forwarded to upstreams that support it (OpenAI-compatible image_url.detail).',
+                    type: 'string',
+                    enum: MessagesGatewayConfig::IMAGE_DETAILS,
+                    example: MessagesGatewayConfig::IMAGE_DETAIL_AUTO,
+                ),
+                new OA\Property(property: 'vision_max_images', type: 'integer', example: 0, description: 'Maximum image blocks forwarded per request; 0 means unlimited.'),
                 new OA\Property(property: 'context_injection_enabled', type: 'boolean', example: false),
                 new OA\Property(property: 'budget_notice_enabled', type: 'boolean', example: true),
+                new OA\Property(property: 'session_summary_enabled', type: 'boolean', example: true),
                 new OA\Property(property: 'upstream_url', type: 'string', example: 'https://api.anthropic.com'),
                 new OA\Property(
                     property: 'model_aliases',
@@ -153,12 +167,18 @@ final class MessagesGatewayController extends AbstractController
             'enabled' => $this->config->isEnabled($userId),
             'allow_operator_key' => $this->config->allowOperatorKey($userId),
             'mcp_tools_enabled' => $this->config->isMcpToolsEnabled($userId),
+            'mcp_tools_with_client_tools' => $this->config->allowMcpToolsWithClientTools($userId),
+            'mcp_max_iterations' => $this->config->mcpMaxIterations($userId),
+            'mcp_servers_configured' => \count($this->mcpServers->findEnabledByUser($userId)),
             'web_search_mode' => $this->config->webSearchMode($userId),
             'web_search_available' => $this->webSearchTool->isAvailable(),
             'vision_mode' => $this->config->visionMode($userId),
             'vision_available' => $this->analyzeImageTool->isAvailable($userId),
+            'vision_image_detail' => $this->config->visionImageDetail($userId),
+            'vision_max_images' => $this->config->visionMaxImages($userId),
             'context_injection_enabled' => $this->config->isContextInjectionEnabled($userId),
             'budget_notice_enabled' => $this->config->isBudgetNoticeEnabled($userId),
+            'session_summary_enabled' => $this->config->isSessionSummaryEnabled($userId),
             'upstream_url' => $this->config->upstreamUrl(),
             'model_aliases' => (object) $this->config->modelAliases(),
             'keys' => $keys,
@@ -432,13 +452,28 @@ final class MessagesGatewayController extends AbstractController
     )]
     #[OA\RequestBody(
         required: true,
+        description: 'Any subset of the gateway settings. Omitted settings keep their current value.',
         content: new OA\JsonContent(
             properties: [
                 new OA\Property(property: 'enabled', type: 'boolean'),
                 new OA\Property(property: 'allow_operator_key', type: 'boolean'),
                 new OA\Property(property: 'mcp_tools_enabled', type: 'boolean'),
+                new OA\Property(property: 'mcp_tools_with_client_tools', type: 'boolean'),
                 new OA\Property(property: 'context_injection_enabled', type: 'boolean'),
                 new OA\Property(property: 'budget_notice_enabled', type: 'boolean'),
+                new OA\Property(property: 'session_summary_enabled', type: 'boolean'),
+                new OA\Property(
+                    property: 'mcp_max_iterations',
+                    type: 'integer',
+                    maximum: MessagesGatewayConfig::MAX_MCP_MAX_ITERATIONS,
+                    minimum: MessagesGatewayConfig::MIN_MCP_MAX_ITERATIONS,
+                ),
+                new OA\Property(
+                    property: 'vision_max_images',
+                    type: 'integer',
+                    maximum: MessagesGatewayConfig::MAX_VISION_MAX_IMAGES,
+                    minimum: MessagesGatewayConfig::MIN_VISION_MAX_IMAGES,
+                ),
                 new OA\Property(
                     property: 'web_search_mode',
                     type: 'string',
@@ -448,32 +483,45 @@ final class MessagesGatewayController extends AbstractController
                     property: 'vision_mode',
                     type: 'string',
                     enum: MessagesGatewayConfig::VISION_MODES,
+                ),
+                new OA\Property(
+                    property: 'vision_image_detail',
+                    type: 'string',
+                    enum: MessagesGatewayConfig::IMAGE_DETAILS,
                 ),
             ],
         ),
     )]
     #[OA\Response(
         response: 200,
-        description: 'Flags updated',
+        description: 'Settings updated',
         content: new OA\JsonContent(
             required: ['success', 'updated'],
             properties: [
                 new OA\Property(property: 'success', type: 'boolean', example: true),
                 new OA\Property(
                     property: 'updated',
+                    description: 'The settings this request actually changed, keyed exactly as sent.',
                     type: 'object',
-                    additionalProperties: new OA\AdditionalProperties(type: 'boolean'),
+                    additionalProperties: new OA\AdditionalProperties(
+                        oneOf: [
+                            new OA\Schema(type: 'boolean'),
+                            new OA\Schema(type: 'integer'),
+                            new OA\Schema(type: 'string'),
+                        ],
+                    ),
+                    example: ['mcp_tools_enabled' => true, 'vision_image_detail' => 'low'],
                 ),
-                new OA\Property(
-                    property: 'web_search_mode',
-                    type: 'string',
-                    enum: MessagesGatewayConfig::WEB_SEARCH_MODES,
-                ),
-                new OA\Property(
-                    property: 'vision_mode',
-                    type: 'string',
-                    enum: MessagesGatewayConfig::VISION_MODES,
-                ),
+            ],
+        ),
+    )]
+    #[OA\Response(
+        response: 400,
+        description: 'A setting carried an invalid value',
+        content: new OA\JsonContent(
+            required: ['error'],
+            properties: [
+                new OA\Property(property: 'error', type: 'string', example: 'vision_image_detail must be one of: auto, low, high'),
             ],
         ),
     )]
@@ -491,106 +539,146 @@ final class MessagesGatewayController extends AbstractController
         } catch (\JsonException) {
             return $this->json(['error' => 'Invalid JSON payload'], Response::HTTP_BAD_REQUEST);
         }
+        if (!\is_array($decoded)) {
+            return $this->json(['error' => 'Invalid JSON payload'], Response::HTTP_BAD_REQUEST);
+        }
 
-        $allowed = [
-            MessagesGatewayConfig::KEY_ENABLED,
-            MessagesGatewayConfig::KEY_ALLOW_OPERATOR_KEY,
-            MessagesGatewayConfig::KEY_MCP_TOOLS_ENABLED,
-            MessagesGatewayConfig::KEY_CONTEXT_INJECTION_ENABLED,
-            MessagesGatewayConfig::KEY_BUDGET_NOTICE_ENABLED,
-        ];
+        try {
+            $updated = $this->collectFlagUpdates($decoded, (int) $user->getId());
+        } catch (\InvalidArgumentException $e) {
+            return $this->json(['error' => $e->getMessage()], Response::HTTP_BAD_REQUEST);
+        }
 
-        $updated = [];
-        foreach ($allowed as $key) {
-            $jsonKey = strtolower($key);
-            if (!\array_key_exists($jsonKey, $decoded) && !\array_key_exists($key, $decoded)) {
-                continue;
-            }
-            $value = $decoded[$jsonKey] ?? $decoded[$key];
-            $bool = filter_var($value, \FILTER_VALIDATE_BOOL, \FILTER_NULL_ON_FAILURE);
-            if (null === $bool) {
-                continue;
-            }
+        $response = [];
+        foreach ($updated as $key => $value) {
             $this->configRepository->setValue(
                 0,
                 MessagesGatewayConfig::CONFIG_GROUP,
                 $key,
-                $bool ? '1' : '0',
+                \is_bool($value) ? ($value ? '1' : '0') : (string) $value,
             );
-            $updated[$jsonKey] = $bool;
+            $response[strtolower($key)] = $value;
         }
 
-        $webSearchMode = $decoded['web_search_mode'] ?? null;
-        if (\is_string($webSearchMode)) {
-            $webSearchMode = strtolower(trim($webSearchMode));
-            if (!\in_array($webSearchMode, MessagesGatewayConfig::WEB_SEARCH_MODES, true)) {
-                return $this->json(
-                    ['error' => 'web_search_mode must be one of: '.implode(', ', MessagesGatewayConfig::WEB_SEARCH_MODES)],
-                    Response::HTTP_BAD_REQUEST,
-                );
-            }
-            if (
-                MessagesGatewayConfig::WEB_SEARCH_SYNAPLAN === $webSearchMode
-                && !$this->webSearchTool->isAvailable()
-            ) {
-                return $this->json(
-                    ['error' => 'web_search_mode=synaplan requires a configured web search provider on this instance'],
-                    Response::HTTP_BAD_REQUEST,
-                );
-            }
-            $this->configRepository->setValue(
-                0,
-                MessagesGatewayConfig::CONFIG_GROUP,
-                MessagesGatewayConfig::KEY_WEB_SEARCH_MODE,
-                $webSearchMode,
-            );
-        } else {
-            $webSearchMode = null;
-        }
-
-        $visionMode = $decoded['vision_mode'] ?? null;
-        if (\is_string($visionMode)) {
-            $visionMode = strtolower(trim($visionMode));
-            if (!\in_array($visionMode, MessagesGatewayConfig::VISION_MODES, true)) {
-                return $this->json(
-                    ['error' => 'vision_mode must be one of: '.implode(', ', MessagesGatewayConfig::VISION_MODES)],
-                    Response::HTTP_BAD_REQUEST,
-                );
-            }
-            if (
-                MessagesGatewayConfig::VISION_SYNAPLAN === $visionMode
-                && !$this->analyzeImageTool->isAvailable((int) $user->getId())
-            ) {
-                return $this->json(
-                    ['error' => 'vision_mode=synaplan requires a configured Synaplan vision (PIC2TEXT) model'],
-                    Response::HTTP_BAD_REQUEST,
-                );
-            }
-            $this->configRepository->setValue(
-                0,
-                MessagesGatewayConfig::CONFIG_GROUP,
-                MessagesGatewayConfig::KEY_VISION_MODE,
-                $visionMode,
-            );
-        } else {
-            $visionMode = null;
-        }
-
-        $this->logger->warning('MessagesGateway: flags updated (audit)', [
+        $this->logger->warning('MessagesGateway: settings updated (audit)', [
             'acting_user_id' => $user->getId(),
-            'updated' => $updated,
-            'web_search_mode' => $webSearchMode,
-            'vision_mode' => $visionMode,
+            'updated' => $response,
         ]);
 
-        $response = ['success' => true, 'updated' => $updated];
-        if (null !== $webSearchMode) {
-            $response['web_search_mode'] = $webSearchMode;
-        }
-        if (null !== $visionMode) {
-            $response['vision_mode'] = $visionMode;
+        return $this->json(['success' => true, 'updated' => $response]);
+    }
+
+    /**
+     * Validate the submitted subset of settings. Clients address a setting by
+     * its BCONFIG name in lower case, so one map per value kind is enough.
+     *
+     * @param array<mixed> $decoded
+     *
+     * @return array<string, bool|int|string> keyed by BCONFIG setting name
+     *
+     * @throws \InvalidArgumentException when a submitted value is out of range
+     */
+    private function collectFlagUpdates(array $decoded, int $userId): array
+    {
+        $booleans = [
+            MessagesGatewayConfig::KEY_ENABLED,
+            MessagesGatewayConfig::KEY_ALLOW_OPERATOR_KEY,
+            MessagesGatewayConfig::KEY_MCP_TOOLS_ENABLED,
+            MessagesGatewayConfig::KEY_MCP_TOOLS_WITH_CLIENT_TOOLS,
+            MessagesGatewayConfig::KEY_CONTEXT_INJECTION_ENABLED,
+            MessagesGatewayConfig::KEY_BUDGET_NOTICE_ENABLED,
+            MessagesGatewayConfig::KEY_SESSION_SUMMARY_ENABLED,
+        ];
+
+        $enums = [
+            MessagesGatewayConfig::KEY_WEB_SEARCH_MODE => MessagesGatewayConfig::WEB_SEARCH_MODES,
+            MessagesGatewayConfig::KEY_VISION_MODE => MessagesGatewayConfig::VISION_MODES,
+            MessagesGatewayConfig::KEY_VISION_IMAGE_DETAIL => MessagesGatewayConfig::IMAGE_DETAILS,
+        ];
+
+        $integers = [
+            MessagesGatewayConfig::KEY_MCP_MAX_ITERATIONS => [
+                MessagesGatewayConfig::MIN_MCP_MAX_ITERATIONS,
+                MessagesGatewayConfig::MAX_MCP_MAX_ITERATIONS,
+            ],
+            MessagesGatewayConfig::KEY_VISION_MAX_IMAGES => [
+                MessagesGatewayConfig::MIN_VISION_MAX_IMAGES,
+                MessagesGatewayConfig::MAX_VISION_MAX_IMAGES,
+            ],
+        ];
+
+        $updated = [];
+
+        foreach ($booleans as $key) {
+            $value = $this->submittedValue($decoded, $key);
+            if (null === $value) {
+                continue;
+            }
+            $bool = filter_var($value, \FILTER_VALIDATE_BOOL, \FILTER_NULL_ON_FAILURE);
+            if (null === $bool) {
+                throw new \InvalidArgumentException(strtolower($key).' must be a boolean.');
+            }
+            $updated[$key] = $bool;
         }
 
-        return $this->json($response);
+        foreach ($enums as $key => $allowed) {
+            $value = $this->submittedValue($decoded, $key);
+            if (null === $value) {
+                continue;
+            }
+            $normalized = \is_string($value) ? strtolower(trim($value)) : '';
+            if (!\in_array($normalized, $allowed, true)) {
+                throw new \InvalidArgumentException(strtolower($key).' must be one of: '.implode(', ', $allowed));
+            }
+            $this->assertModeIsUsable($key, $normalized, $userId);
+            $updated[$key] = $normalized;
+        }
+
+        foreach ($integers as $key => [$min, $max]) {
+            $value = $this->submittedValue($decoded, $key);
+            if (null === $value) {
+                continue;
+            }
+            $int = filter_var($value, \FILTER_VALIDATE_INT);
+            if (false === $int || $int < $min || $int > $max) {
+                throw new \InvalidArgumentException(sprintf('%s must be an integer between %d and %d.', strtolower($key), $min, $max));
+            }
+            $updated[$key] = $int;
+        }
+
+        return $updated;
+    }
+
+    /**
+     * Reject a `synaplan` mode the install cannot honour — silently accepting it
+     * would leave the admin page showing a capability that never runs.
+     *
+     * @throws \InvalidArgumentException
+     */
+    private function assertModeIsUsable(string $key, string $mode, int $userId): void
+    {
+        if (
+            MessagesGatewayConfig::KEY_WEB_SEARCH_MODE === $key
+            && MessagesGatewayConfig::WEB_SEARCH_SYNAPLAN === $mode
+            && !$this->webSearchTool->isAvailable()
+        ) {
+            throw new \InvalidArgumentException('web_search_mode=synaplan requires a configured web search provider on this instance');
+        }
+
+        if (
+            MessagesGatewayConfig::KEY_VISION_MODE === $key
+            && MessagesGatewayConfig::VISION_SYNAPLAN === $mode
+            && !$this->analyzeImageTool->isAvailable($userId)
+        ) {
+            throw new \InvalidArgumentException('vision_mode=synaplan requires a configured Synaplan vision (PIC2TEXT) model');
+        }
+    }
+
+    /**
+     * @param array<mixed> $decoded
+     */
+    private function submittedValue(array $decoded, string $key): mixed
+    {
+        return $decoded[strtolower($key)] ?? $decoded[$key] ?? null;
     }
 }

--- a/backend/src/Controller/MessagesGatewayController.php
+++ b/backend/src/Controller/MessagesGatewayController.php
@@ -8,6 +8,7 @@ use App\AI\Credential\ProviderKeyStore;
 use App\AI\Credential\UserProviderKeyResolver;
 use App\AI\Messages\MessagesGateway;
 use App\AI\Messages\Tools\AnalyzeImageTool;
+use App\AI\Messages\Tools\GatewayToolCatalog;
 use App\AI\Messages\Tools\WebSearchTool;
 use App\Entity\User;
 use App\Repository\ConfigRepository;
@@ -40,6 +41,7 @@ final class MessagesGatewayController extends AbstractController
         private readonly RateLimitService $rateLimitService,
         private readonly WebSearchTool $webSearchTool,
         private readonly AnalyzeImageTool $analyzeImageTool,
+        private readonly GatewayToolCatalog $toolCatalog,
         private readonly McpServerConfigRepository $mcpServers,
         private readonly LoggerInterface $logger,
     ) {
@@ -64,6 +66,13 @@ final class MessagesGatewayController extends AbstractController
                 new OA\Property(property: 'mcp_tools_with_client_tools', type: 'boolean', example: false, description: 'Whether Synaplan MCP tools are also offered when the client already sent its own tools.'),
                 new OA\Property(property: 'mcp_max_iterations', type: 'integer', example: 8, description: 'Maximum server-side tool rounds per request.'),
                 new OA\Property(property: 'mcp_servers_configured', type: 'integer', example: 0, description: 'Number of enabled MCP servers the signed-in user has.'),
+                new OA\Property(
+                    property: 'server_tools',
+                    description: 'Built-in tools the gateway would run server-side under the current settings. A single request can still drop one of them.',
+                    type: 'array',
+                    items: new OA\Items(type: 'string'),
+                    example: ['web_search', 'analyze_image'],
+                ),
                 new OA\Property(
                     property: 'web_search_mode',
                     description: 'How the gateway answers Anthropic web_search declarations: auto (Synaplan search when configured, otherwise passthrough), synaplan, passthrough, or off.',
@@ -170,6 +179,7 @@ final class MessagesGatewayController extends AbstractController
             'mcp_tools_with_client_tools' => $this->config->allowMcpToolsWithClientTools($userId),
             'mcp_max_iterations' => $this->config->mcpMaxIterations($userId),
             'mcp_servers_configured' => \count($this->mcpServers->findEnabledByUser($userId)),
+            'server_tools' => $this->toolCatalog->nativeToolNames($userId),
             'web_search_mode' => $this->config->webSearchMode($userId),
             'web_search_available' => $this->webSearchTool->isAvailable(),
             'vision_mode' => $this->config->visionMode($userId),

--- a/backend/src/Seed/MessagesGatewayConfigSeeder.php
+++ b/backend/src/Seed/MessagesGatewayConfigSeeder.php
@@ -31,6 +31,8 @@ final readonly class MessagesGatewayConfigSeeder
             ['ownerId' => 0, 'group' => MessagesGatewayConfig::CONFIG_GROUP, 'setting' => MessagesGatewayConfig::KEY_MCP_MAX_ITERATIONS, 'value' => '8'],
             ['ownerId' => 0, 'group' => MessagesGatewayConfig::CONFIG_GROUP, 'setting' => MessagesGatewayConfig::KEY_WEB_SEARCH_MODE, 'value' => MessagesGatewayConfig::WEB_SEARCH_AUTO],
             ['ownerId' => 0, 'group' => MessagesGatewayConfig::CONFIG_GROUP, 'setting' => MessagesGatewayConfig::KEY_VISION_MODE, 'value' => MessagesGatewayConfig::VISION_AUTO],
+            ['ownerId' => 0, 'group' => MessagesGatewayConfig::CONFIG_GROUP, 'setting' => MessagesGatewayConfig::KEY_VISION_IMAGE_DETAIL, 'value' => MessagesGatewayConfig::IMAGE_DETAIL_AUTO],
+            ['ownerId' => 0, 'group' => MessagesGatewayConfig::CONFIG_GROUP, 'setting' => MessagesGatewayConfig::KEY_VISION_MAX_IMAGES, 'value' => '0'],
             ['ownerId' => 0, 'group' => MessagesGatewayConfig::CONFIG_GROUP, 'setting' => MessagesGatewayConfig::KEY_CONTEXT_INJECTION_ENABLED, 'value' => '0'],
             ['ownerId' => 0, 'group' => MessagesGatewayConfig::CONFIG_GROUP, 'setting' => MessagesGatewayConfig::KEY_BUDGET_NOTICE_ENABLED, 'value' => '1'],
             ['ownerId' => 0, 'group' => MessagesGatewayConfig::CONFIG_GROUP, 'setting' => MessagesGatewayConfig::KEY_SESSION_SUMMARY_ENABLED, 'value' => '1'],

--- a/backend/src/Service/MessagesGateway/MessagesGatewayConfig.php
+++ b/backend/src/Service/MessagesGateway/MessagesGatewayConfig.php
@@ -27,6 +27,8 @@ final readonly class MessagesGatewayConfig
     public const KEY_MCP_MAX_ITERATIONS = 'MCP_MAX_ITERATIONS';
     public const KEY_WEB_SEARCH_MODE = 'WEB_SEARCH_MODE';
     public const KEY_VISION_MODE = 'VISION_MODE';
+    public const KEY_VISION_IMAGE_DETAIL = 'VISION_IMAGE_DETAIL';
+    public const KEY_VISION_MAX_IMAGES = 'VISION_MAX_IMAGES';
     public const KEY_CONTEXT_INJECTION_ENABLED = 'CONTEXT_INJECTION_ENABLED';
     public const KEY_BUDGET_NOTICE_ENABLED = 'BUDGET_NOTICE_ENABLED';
     public const KEY_SESSION_SUMMARY_ENABLED = 'SESSION_SUMMARY_ENABLED';
@@ -67,6 +69,24 @@ final readonly class MessagesGatewayConfig
         self::VISION_OFF,
     ];
 
+    /** Let the provider pick the resolution it reads the image at. */
+    public const IMAGE_DETAIL_AUTO = 'auto';
+    /** Cheap fixed-resolution read (fewest image tokens). */
+    public const IMAGE_DETAIL_LOW = 'low';
+    /** Full tiled read (most image tokens). */
+    public const IMAGE_DETAIL_HIGH = 'high';
+
+    public const IMAGE_DETAILS = [
+        self::IMAGE_DETAIL_AUTO,
+        self::IMAGE_DETAIL_LOW,
+        self::IMAGE_DETAIL_HIGH,
+    ];
+
+    public const MIN_MCP_MAX_ITERATIONS = 1;
+    public const MAX_MCP_MAX_ITERATIONS = 32;
+    public const MIN_VISION_MAX_IMAGES = 0;
+    public const MAX_VISION_MAX_IMAGES = 100;
+
     private const DEFAULT_ENABLED = false;
     private const DEFAULT_ALLOW_OPERATOR_KEY = false;
     private const DEFAULT_MCP_TOOLS_ENABLED = false;
@@ -74,6 +94,8 @@ final readonly class MessagesGatewayConfig
     private const DEFAULT_MCP_MAX_ITERATIONS = 8;
     private const DEFAULT_WEB_SEARCH_MODE = self::WEB_SEARCH_AUTO;
     private const DEFAULT_VISION_MODE = self::VISION_AUTO;
+    private const DEFAULT_VISION_IMAGE_DETAIL = self::IMAGE_DETAIL_AUTO;
+    private const DEFAULT_VISION_MAX_IMAGES = 0;
     private const DEFAULT_CONTEXT_INJECTION_ENABLED = false;
     private const DEFAULT_BUDGET_NOTICE_ENABLED = true;
     private const DEFAULT_SESSION_SUMMARY_ENABLED = true;
@@ -119,7 +141,10 @@ final readonly class MessagesGatewayConfig
         $raw = $this->resolveString(self::KEY_MCP_MAX_ITERATIONS, $userId, (string) self::DEFAULT_MCP_MAX_ITERATIONS);
         $n = (int) $raw;
 
-        return max(1, min(32, $n > 0 ? $n : self::DEFAULT_MCP_MAX_ITERATIONS));
+        return max(
+            self::MIN_MCP_MAX_ITERATIONS,
+            min(self::MAX_MCP_MAX_ITERATIONS, $n > 0 ? $n : self::DEFAULT_MCP_MAX_ITERATIONS),
+        );
     }
 
     /**
@@ -136,17 +161,9 @@ final readonly class MessagesGatewayConfig
      */
     public function webSearchMode(?int $userId): string
     {
-        $raw = strtolower(trim((string) $this->resolveString(
-            self::KEY_WEB_SEARCH_MODE,
-            $userId,
-            self::DEFAULT_WEB_SEARCH_MODE,
-        )));
+        $raw = $this->resolveToken(self::KEY_WEB_SEARCH_MODE, $userId, self::DEFAULT_WEB_SEARCH_MODE);
 
-        if (!\in_array($raw, self::WEB_SEARCH_MODES, true)) {
-            return self::DEFAULT_WEB_SEARCH_MODE;
-        }
-
-        return $raw;
+        return \in_array($raw, self::WEB_SEARCH_MODES, true) ? $raw : self::DEFAULT_WEB_SEARCH_MODE;
     }
 
     /**
@@ -161,17 +178,37 @@ final readonly class MessagesGatewayConfig
      */
     public function visionMode(?int $userId): string
     {
-        $raw = strtolower(trim((string) $this->resolveString(
-            self::KEY_VISION_MODE,
-            $userId,
-            self::DEFAULT_VISION_MODE,
-        )));
+        $raw = $this->resolveToken(self::KEY_VISION_MODE, $userId, self::DEFAULT_VISION_MODE);
 
-        if (!\in_array($raw, self::VISION_MODES, true)) {
-            return self::DEFAULT_VISION_MODE;
+        return \in_array($raw, self::VISION_MODES, true) ? $raw : self::DEFAULT_VISION_MODE;
+    }
+
+    /**
+     * Resolution the provider should read forwarded images at.
+     *
+     * Only routes that expose the knob apply it (OpenAI-compatible upstreams
+     * via `image_url.detail`); `auto` leaves the choice to the provider.
+     *
+     * @return self::IMAGE_DETAIL_AUTO|self::IMAGE_DETAIL_LOW|self::IMAGE_DETAIL_HIGH
+     */
+    public function visionImageDetail(?int $userId): string
+    {
+        $raw = $this->resolveToken(self::KEY_VISION_IMAGE_DETAIL, $userId, self::DEFAULT_VISION_IMAGE_DETAIL);
+
+        return \in_array($raw, self::IMAGE_DETAILS, true) ? $raw : self::DEFAULT_VISION_IMAGE_DETAIL;
+    }
+
+    /**
+     * Maximum image blocks forwarded per request; 0 means unlimited.
+     */
+    public function visionMaxImages(?int $userId): int
+    {
+        $raw = $this->resolveString(self::KEY_VISION_MAX_IMAGES, $userId, null);
+        if (null === $raw || '' === trim($raw) || !is_numeric(trim($raw))) {
+            return self::DEFAULT_VISION_MAX_IMAGES;
         }
 
-        return $raw;
+        return max(self::MIN_VISION_MAX_IMAGES, min(self::MAX_VISION_MAX_IMAGES, (int) trim($raw)));
     }
 
     public function isContextInjectionEnabled(?int $userId): bool
@@ -348,6 +385,16 @@ final readonly class MessagesGatewayConfig
         }
 
         return filter_var($raw, \FILTER_VALIDATE_BOOL, \FILTER_NULL_ON_FAILURE) ?? $default;
+    }
+
+    /**
+     * Stored enum value, lowercased and trimmed. Callers match it against their
+     * own allow-list so an unknown value falls back to the code default — a typo
+     * in BCONFIG must never break a working install.
+     */
+    private function resolveToken(string $setting, ?int $userId, string $default): string
+    {
+        return strtolower(trim((string) $this->resolveString($setting, $userId, $default)));
     }
 
     private function resolveString(string $setting, ?int $userId, ?string $default): ?string

--- a/backend/tests/Unit/AI/Messages/GatewayToolCatalogTest.php
+++ b/backend/tests/Unit/AI/Messages/GatewayToolCatalogTest.php
@@ -138,6 +138,47 @@ final class GatewayToolCatalogTest extends TestCase
         self::assertSame([], $snapshot['tools']);
     }
 
+    /**
+     * The settings page reads the same rules without a request in hand, so the
+     * operator is told what the gateway runs rather than what it was asked to.
+     */
+    public function testNativeToolNamesReportWhatTheInstallCanRun(): void
+    {
+        $both = $this->catalog(
+            MessagesGatewayConfig::WEB_SEARCH_AUTO,
+            searchConfigured: true,
+            visionMode: MessagesGatewayConfig::VISION_AUTO,
+            visionConfigured: true,
+        );
+
+        self::assertSame([WebSearchTool::NAME, AnalyzeImageTool::NAME], $both->nativeToolNames(5));
+    }
+
+    public function testNativeToolNamesDropWhatCannotRun(): void
+    {
+        // Passthrough hands the search to the upstream, and vision has no model.
+        $neither = $this->catalog(
+            MessagesGatewayConfig::WEB_SEARCH_PASSTHROUGH,
+            searchConfigured: true,
+            visionMode: MessagesGatewayConfig::VISION_AUTO,
+            visionConfigured: false,
+        );
+
+        self::assertSame([], $neither->nativeToolNames(5));
+    }
+
+    public function testNativeToolNamesDropSearchWithoutAProvider(): void
+    {
+        $catalog = $this->catalog(
+            MessagesGatewayConfig::WEB_SEARCH_AUTO,
+            searchConfigured: false,
+            visionMode: MessagesGatewayConfig::VISION_SYNAPLAN,
+            visionConfigured: true,
+        );
+
+        self::assertSame([AnalyzeImageTool::NAME], $catalog->nativeToolNames(5));
+    }
+
     private function catalog(
         string $mode,
         bool $searchConfigured,

--- a/backend/tests/Unit/AI/Messages/MessagesGatewayByoPlanTest.php
+++ b/backend/tests/Unit/AI/Messages/MessagesGatewayByoPlanTest.php
@@ -11,6 +11,7 @@ use App\AI\Messages\MessagesModelResolver;
 use App\AI\Messages\Tools\GatewayToolCatalog;
 use App\AI\Messages\Tools\GatewayToolLoop;
 use App\AI\Messages\Translator\AnthropicPassthroughTranslator;
+use App\AI\Messages\Vision\VisionPolicy;
 use App\Entity\User;
 use App\Repository\ModelRepository;
 use App\Service\MessagesGateway\MessagesGatewayConfig;
@@ -77,6 +78,18 @@ class MessagesGatewayByoPlanTest extends TestCase
         ]);
         $toolCatalog->method('replacedServerTools')->willReturn([]);
 
+        $visionPolicy = $this->createMock(VisionPolicy::class);
+        $visionPolicy->method('apply')->willReturnCallback(
+            static fn (array $body): array => [
+                'body' => $body,
+                'mutated' => false,
+                'mode' => MessagesGatewayConfig::VISION_AUTO,
+                'detail' => MessagesGatewayConfig::IMAGE_DETAIL_AUTO,
+                'images_forwarded' => 0,
+                'images_omitted' => 0,
+            ],
+        );
+
         $this->gateway = new MessagesGateway(
             $this->config,
             $modelResolver,
@@ -87,6 +100,7 @@ class MessagesGatewayByoPlanTest extends TestCase
             $passthrough,
             $toolCatalog,
             $this->createMock(GatewayToolLoop::class),
+            $visionPolicy,
             $this->createMock(MessagesContextInjector::class),
             $this->createMock(CacheItemPoolInterface::class),
             $this->createMock(MessageBusInterface::class),

--- a/backend/tests/Unit/AI/Messages/MessagesGatewayVisionTest.php
+++ b/backend/tests/Unit/AI/Messages/MessagesGatewayVisionTest.php
@@ -11,6 +11,7 @@ use App\AI\Messages\MessagesModelResolver;
 use App\AI\Messages\Tools\GatewayToolCatalog;
 use App\AI\Messages\Tools\GatewayToolLoop;
 use App\AI\Messages\Translator\AnthropicPassthroughTranslator;
+use App\AI\Messages\Vision\VisionPolicy;
 use App\Entity\Model;
 use App\Entity\User;
 use App\Repository\ModelRepository;
@@ -44,7 +45,7 @@ final class MessagesGatewayVisionTest extends TestCase
         $result = $gateway->prepare($this->imageRequest('text-only'), $this->user());
 
         self::assertTrue($result['ok']);
-        self::assertSame(GatewayToolCatalog::VISION_SYNAPLAN, $result['vision']);
+        self::assertSame(GatewayToolCatalog::VISION_SYNAPLAN, $result['vision']['handling']);
         self::assertSame(99, $result['resolved']['model_id']);
         self::assertSame('gpt-4o', $result['request_body']['model']);
     }
@@ -67,7 +68,7 @@ final class MessagesGatewayVisionTest extends TestCase
         $result = $gateway->prepare($this->imageRequest('claude-sonnet-4-5'), $this->user());
 
         self::assertTrue($result['ok']);
-        self::assertSame(GatewayToolCatalog::VISION_PASSTHROUGH, $result['vision']);
+        self::assertSame(GatewayToolCatalog::VISION_PASSTHROUGH, $result['vision']['handling']);
         self::assertSame(42, $result['resolved']['model_id']);
     }
 
@@ -89,7 +90,7 @@ final class MessagesGatewayVisionTest extends TestCase
         $result = $gateway->prepare($this->imageRequest('text-only'), $this->user());
 
         self::assertTrue($result['ok']);
-        self::assertSame(GatewayToolCatalog::VISION_PASSTHROUGH, $result['vision']);
+        self::assertSame(GatewayToolCatalog::VISION_PASSTHROUGH, $result['vision']['handling']);
         self::assertSame(42, $result['resolved']['model_id']);
     }
 
@@ -110,7 +111,7 @@ final class MessagesGatewayVisionTest extends TestCase
         ])), $this->user());
 
         self::assertTrue($result['ok']);
-        self::assertSame(GatewayToolCatalog::VISION_NONE, $result['vision']);
+        self::assertSame(GatewayToolCatalog::VISION_NONE, $result['vision']['handling']);
     }
 
     private function gateway(
@@ -126,6 +127,8 @@ final class MessagesGatewayVisionTest extends TestCase
         $config->method('isMcpToolsEnabled')->willReturn(false);
         $config->method('isContextInjectionEnabled')->willReturn(false);
         $config->method('visionMode')->willReturn($visionMode);
+        $config->method('visionImageDetail')->willReturn(MessagesGatewayConfig::IMAGE_DETAIL_AUTO);
+        $config->method('visionMaxImages')->willReturn(0);
         $config->method('upstreamUrl')->willReturn('https://api.anthropic.com');
 
         $modelResolver = $this->createMock(MessagesModelResolver::class);
@@ -188,6 +191,7 @@ final class MessagesGatewayVisionTest extends TestCase
             $passthrough,
             $toolCatalog,
             $this->createMock(GatewayToolLoop::class),
+            new VisionPolicy($config, new NullLogger()),
             $this->createMock(MessagesContextInjector::class),
             $this->createMock(CacheItemPoolInterface::class),
             $this->createMock(MessageBusInterface::class),

--- a/backend/tests/Unit/AI/Messages/OpenAiMessagesTranslatorTest.php
+++ b/backend/tests/Unit/AI/Messages/OpenAiMessagesTranslatorTest.php
@@ -72,6 +72,37 @@ final class OpenAiMessagesTranslatorTest extends TestCase
         $this->assertSame('What is on this page?', $content[0]['text']);
         $this->assertSame('data:image/png;base64,iVBORw0KGgo=', $content[1]['image_url']['url']);
         $this->assertSame('https://example.test/page.png', $content[2]['image_url']['url']);
+        $this->assertArrayNotHasKey('detail', $content[1]['image_url']);
+    }
+
+    public function testConfiguredImageDetailReachesTheUpstream(): void
+    {
+        $t = new OpenAiMessagesTranslator(new MockHttpClient());
+
+        $payload = $t->toOpenAiRequest([
+            'model' => 'gpt-4o',
+            'max_tokens' => 64,
+            'messages' => [['role' => 'user', 'content' => [
+                ['type' => 'image', 'source' => ['type' => 'url', 'url' => 'https://example.test/page.png']],
+            ]]],
+        ], stream: false, imageDetail: 'low');
+
+        $this->assertSame('low', $payload['messages'][0]['content'][0]['image_url']['detail']);
+    }
+
+    public function testAutoImageDetailIsLeftToTheProvider(): void
+    {
+        $t = new OpenAiMessagesTranslator(new MockHttpClient());
+
+        $payload = $t->toOpenAiRequest([
+            'model' => 'gpt-4o',
+            'max_tokens' => 64,
+            'messages' => [['role' => 'user', 'content' => [
+                ['type' => 'image', 'source' => ['type' => 'url', 'url' => 'https://example.test/page.png']],
+            ]]],
+        ], stream: false, imageDetail: 'auto');
+
+        $this->assertArrayNotHasKey('detail', $payload['messages'][0]['content'][0]['image_url']);
     }
 
     public function testTextOnlyTurnsStayPlainStrings(): void

--- a/backend/tests/Unit/AI/Messages/VisionPolicyTest.php
+++ b/backend/tests/Unit/AI/Messages/VisionPolicyTest.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\AI\Messages;
+
+use App\AI\Messages\Vision\VisionPolicy;
+use App\Service\MessagesGateway\MessagesGatewayConfig;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+final class VisionPolicyTest extends TestCase
+{
+    private MessagesGatewayConfig&MockObject $config;
+    private VisionPolicy $policy;
+
+    protected function setUp(): void
+    {
+        $this->config = $this->createMock(MessagesGatewayConfig::class);
+        $this->policy = new VisionPolicy($this->config, new NullLogger());
+    }
+
+    public function testAnUncappedRequestIsLeftUntouched(): void
+    {
+        $this->configure(MessagesGatewayConfig::VISION_AUTO, MessagesGatewayConfig::IMAGE_DETAIL_AUTO, 0);
+        $body = $this->bodyWithImages(3);
+
+        $result = $this->policy->apply($body, 1);
+
+        $this->assertFalse($result['mutated']);
+        $this->assertSame($body, $result['body']);
+        $this->assertSame(3, $result['images_forwarded']);
+        $this->assertSame(0, $result['images_omitted']);
+    }
+
+    public function testDetailIsReportedForTranslators(): void
+    {
+        $this->configure(MessagesGatewayConfig::VISION_AUTO, MessagesGatewayConfig::IMAGE_DETAIL_LOW, 0);
+
+        $result = $this->policy->apply($this->bodyWithImages(1), 1);
+
+        $this->assertSame(MessagesGatewayConfig::IMAGE_DETAIL_LOW, $result['detail']);
+    }
+
+    public function testTheLimitKeepsTheMostRecentImages(): void
+    {
+        $this->configure(MessagesGatewayConfig::VISION_AUTO, MessagesGatewayConfig::IMAGE_DETAIL_AUTO, 2);
+
+        $result = $this->policy->apply($this->bodyWithImages(5), 1);
+
+        $this->assertTrue($result['mutated']);
+        $this->assertSame(2, $result['images_forwarded']);
+        $this->assertSame(3, $result['images_omitted']);
+        $this->assertSame(['img-3', 'img-4'], $this->imageIdsOf($result['body']));
+        $this->assertSame(
+            array_fill(0, 3, sprintf(VisionPolicy::PLACEHOLDER_LIMIT, 2)),
+            $this->placeholdersOf($result['body']),
+        );
+    }
+
+    public function testTurnsWithOnlyAnImageKeepNonEmptyContent(): void
+    {
+        $this->configure(MessagesGatewayConfig::VISION_AUTO, MessagesGatewayConfig::IMAGE_DETAIL_AUTO, 1);
+        $body = ['messages' => [
+            ['role' => 'user', 'content' => [$this->imageBlock('old')]],
+            ['role' => 'user', 'content' => [$this->imageBlock('new')]],
+        ]];
+
+        $result = $this->policy->apply($body, 1);
+
+        $this->assertSame(
+            [['type' => 'text', 'text' => sprintf(VisionPolicy::PLACEHOLDER_LIMIT, 1)]],
+            $result['body']['messages'][0]['content'],
+        );
+        $this->assertSame(['new'], $this->imageIdsOf($result['body']));
+    }
+
+    public function testTheLimitIsANoOpBelowTheThreshold(): void
+    {
+        $this->configure(MessagesGatewayConfig::VISION_AUTO, MessagesGatewayConfig::IMAGE_DETAIL_AUTO, 10);
+        $body = $this->bodyWithImages(2);
+
+        $result = $this->policy->apply($body, 1);
+
+        $this->assertFalse($result['mutated']);
+        $this->assertSame($body, $result['body']);
+    }
+
+    public function testImagesInsideToolResultsCount(): void
+    {
+        $this->configure(MessagesGatewayConfig::VISION_AUTO, MessagesGatewayConfig::IMAGE_DETAIL_AUTO, 1);
+        $body = ['messages' => [
+            [
+                'role' => 'user',
+                'content' => [[
+                    'type' => 'tool_result',
+                    'tool_use_id' => 'call_1',
+                    'content' => [
+                        ['type' => 'text', 'text' => 'screenshot taken'],
+                        $this->imageBlock('shot'),
+                    ],
+                ]],
+            ],
+            ['role' => 'user', 'content' => [$this->imageBlock('newer')]],
+        ]];
+
+        $result = $this->policy->apply($body, 1);
+
+        $this->assertSame(1, $result['images_omitted']);
+        $this->assertSame(
+            ['type' => 'text', 'text' => sprintf(VisionPolicy::PLACEHOLDER_LIMIT, 1)],
+            $result['body']['messages'][0]['content'][0]['content'][1],
+        );
+    }
+
+    public function testTextOnlyRequestsAreNeverRewritten(): void
+    {
+        $this->configure(MessagesGatewayConfig::VISION_AUTO, MessagesGatewayConfig::IMAGE_DETAIL_AUTO, 1);
+        $body = ['messages' => [['role' => 'user', 'content' => 'hello']]];
+
+        $result = $this->policy->apply($body, 1);
+
+        $this->assertFalse($result['mutated']);
+        $this->assertSame($body, $result['body']);
+    }
+
+    private function configure(string $mode, string $detail, int $maxImages): void
+    {
+        $this->config->method('visionMode')->willReturn($mode);
+        $this->config->method('visionImageDetail')->willReturn($detail);
+        $this->config->method('visionMaxImages')->willReturn($maxImages);
+    }
+
+    /**
+     * One image per user turn, ids `img-0` … `img-{n-1}` in send order.
+     *
+     * @return array<string, mixed>
+     */
+    private function bodyWithImages(int $count): array
+    {
+        $messages = [];
+        for ($i = 0; $i < $count; ++$i) {
+            $messages[] = [
+                'role' => 'user',
+                'content' => [
+                    ['type' => 'text', 'text' => 'look at this'],
+                    $this->imageBlock('img-'.$i),
+                ],
+            ];
+        }
+
+        return ['model' => 'claude-sonnet-4-5', 'messages' => $messages];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function imageBlock(string $id): array
+    {
+        return [
+            'type' => 'image',
+            'source' => ['type' => 'base64', 'media_type' => 'image/png', 'data' => $id],
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $body
+     *
+     * @return list<string>
+     */
+    private function imageIdsOf(array $body): array
+    {
+        $ids = [];
+        foreach ($this->blocksOf($body) as $block) {
+            if ('image' === ($block['type'] ?? null)) {
+                $ids[] = (string) $block['source']['data'];
+            }
+        }
+
+        return $ids;
+    }
+
+    /**
+     * @param array<string, mixed> $body
+     *
+     * @return list<string>
+     */
+    private function placeholdersOf(array $body): array
+    {
+        $texts = [];
+        foreach ($this->blocksOf($body) as $block) {
+            $text = $block['text'] ?? null;
+            if (\is_string($text) && str_starts_with($text, '[Image omitted')) {
+                $texts[] = $text;
+            }
+        }
+
+        return $texts;
+    }
+
+    /**
+     * @param array<string, mixed> $body
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function blocksOf(array $body): array
+    {
+        $blocks = [];
+        foreach ($body['messages'] as $message) {
+            foreach ($message['content'] as $block) {
+                $blocks[] = $block;
+            }
+        }
+
+        return $blocks;
+    }
+}

--- a/backend/tests/Unit/Controller/MessagesGatewayControllerFlagsTest.php
+++ b/backend/tests/Unit/Controller/MessagesGatewayControllerFlagsTest.php
@@ -1,0 +1,223 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Controller;
+
+use App\AI\Credential\ProviderKeyStore;
+use App\AI\Credential\UserProviderKeyResolver;
+use App\AI\Messages\Tools\AnalyzeImageTool;
+use App\AI\Messages\Tools\WebSearchTool;
+use App\Controller\MessagesGatewayController;
+use App\Entity\Config;
+use App\Entity\User;
+use App\Repository\ConfigRepository;
+use App\Repository\McpServerConfigRepository;
+use App\Service\MessagesGateway\MessagesGatewayConfig;
+use App\Service\RateLimitService;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+
+/**
+ * The settings endpoint behind Channels → AI Agents. It writes one BCONFIG row
+ * per submitted setting, so an unnoticed type slip would silently persist
+ * garbage that only surfaces on the next gateway request.
+ */
+final class MessagesGatewayControllerFlagsTest extends TestCase
+{
+    private ConfigRepository&MockObject $configRepository;
+    private WebSearchTool&MockObject $webSearchTool;
+    private AnalyzeImageTool&MockObject $analyzeImageTool;
+    private MessagesGatewayController $controller;
+
+    protected function setUp(): void
+    {
+        $this->configRepository = $this->createMock(ConfigRepository::class);
+        $this->webSearchTool = $this->createMock(WebSearchTool::class);
+        $this->analyzeImageTool = $this->createMock(AnalyzeImageTool::class);
+
+        $this->controller = new MessagesGatewayController(
+            $this->createStub(MessagesGatewayConfig::class),
+            $this->createStub(UserProviderKeyResolver::class),
+            $this->createStub(ProviderKeyStore::class),
+            $this->configRepository,
+            $this->createStub(RateLimitService::class),
+            $this->webSearchTool,
+            $this->analyzeImageTool,
+            $this->createStub(McpServerConfigRepository::class),
+            new NullLogger(),
+        );
+
+        $this->grantAdmin(true);
+    }
+
+    public function testRejectsNonAdmin(): void
+    {
+        $this->grantAdmin(false);
+
+        $response = $this->controller->putFlags($this->request(['enabled' => true]), $this->makeUser());
+
+        $this->assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
+    }
+
+    public function testWritesEveryValueKind(): void
+    {
+        $this->webSearchTool->method('isAvailable')->willReturn(true);
+        $written = [];
+        $this->configRepository->method('setValue')
+            ->willReturnCallback(function (int $ownerId, string $group, string $setting, string $value) use (&$written): Config {
+                $this->assertSame(0, $ownerId);
+                $this->assertSame(MessagesGatewayConfig::CONFIG_GROUP, $group);
+                $written[$setting] = $value;
+
+                return new Config();
+            });
+
+        $response = $this->controller->putFlags($this->request([
+            'mcp_tools_enabled' => true,
+            'session_summary_enabled' => false,
+            'mcp_max_iterations' => 12,
+            'vision_max_images' => 4,
+            'vision_mode' => 'OFF',
+            'vision_image_detail' => 'low',
+            'web_search_mode' => 'synaplan',
+        ]), $this->makeUser());
+
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertSame([
+            'MCP_TOOLS_ENABLED' => '1',
+            'SESSION_SUMMARY_ENABLED' => '0',
+            'WEB_SEARCH_MODE' => 'synaplan',
+            'VISION_MODE' => 'off',
+            'VISION_IMAGE_DETAIL' => 'low',
+            'MCP_MAX_ITERATIONS' => '12',
+            'VISION_MAX_IMAGES' => '4',
+        ], $written);
+
+        $payload = $this->decode($response);
+        $this->assertTrue($payload['success']);
+        $this->assertSame(12, $payload['updated']['mcp_max_iterations']);
+        $this->assertSame('off', $payload['updated']['vision_mode']);
+        $this->assertFalse($payload['updated']['session_summary_enabled']);
+    }
+
+    public function testOmittedSettingsAreLeftAlone(): void
+    {
+        $this->configRepository->expects($this->once())->method('setValue');
+
+        $response = $this->controller->putFlags($this->request(['enabled' => true]), $this->makeUser());
+
+        $this->assertSame(['enabled' => true], $this->decode($response)['updated']);
+    }
+
+    /**
+     * @return iterable<string, array{array<string, mixed>, string}>
+     */
+    public static function invalidValues(): iterable
+    {
+        yield 'unknown vision mode' => [['vision_mode' => 'sometimes'], 'vision_mode must be one of'];
+        yield 'unknown image detail' => [['vision_image_detail' => 'ultra'], 'vision_image_detail must be one of'];
+        yield 'unknown web search mode' => [['web_search_mode' => 'maybe'], 'web_search_mode must be one of'];
+        yield 'iterations out of range' => [['mcp_max_iterations' => 999], 'mcp_max_iterations must be an integer'];
+        yield 'negative image cap' => [['vision_max_images' => -1], 'vision_max_images must be an integer'];
+        yield 'non-numeric image cap' => [['vision_max_images' => 'lots'], 'vision_max_images must be an integer'];
+        yield 'non-boolean flag' => [['enabled' => 'perhaps'], 'enabled must be a boolean'];
+    }
+
+    /**
+     * @param array<string, mixed> $body
+     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('invalidValues')]
+    public function testInvalidValuesAreRejectedWithoutWriting(array $body, string $expectedError): void
+    {
+        $this->configRepository->expects($this->never())->method('setValue');
+
+        $response = $this->controller->putFlags($this->request($body), $this->makeUser());
+
+        $this->assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+        $this->assertStringContainsString($expectedError, $this->decode($response)['error']);
+    }
+
+    public function testSynaplanModesNeedTheCapabilityToBeConfigured(): void
+    {
+        $this->webSearchTool->method('isAvailable')->willReturn(false);
+        $this->analyzeImageTool->method('isAvailable')->willReturn(false);
+        $this->configRepository->expects($this->never())->method('setValue');
+
+        $search = $this->controller->putFlags(
+            $this->request(['web_search_mode' => 'synaplan']),
+            $this->makeUser(),
+        );
+        $vision = $this->controller->putFlags(
+            $this->request(['vision_mode' => 'synaplan']),
+            $this->makeUser(),
+        );
+
+        $this->assertSame(Response::HTTP_BAD_REQUEST, $search->getStatusCode());
+        $this->assertStringContainsString(
+            'requires a configured web search provider',
+            $this->decode($search)['error'],
+        );
+        $this->assertSame(Response::HTTP_BAD_REQUEST, $vision->getStatusCode());
+        $this->assertStringContainsString(
+            'requires a configured Synaplan vision',
+            $this->decode($vision)['error'],
+        );
+    }
+
+    public function testInvalidJsonIsRejected(): void
+    {
+        $response = $this->controller->putFlags(
+            new Request(server: ['CONTENT_TYPE' => 'application/json'], content: 'not json'),
+            $this->makeUser(),
+        );
+
+        $this->assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+    }
+
+    private function grantAdmin(bool $granted): void
+    {
+        $checker = $this->createStub(AuthorizationCheckerInterface::class);
+        $checker->method('isGranted')->willReturn($granted);
+
+        $container = new Container();
+        $container->set('security.authorization_checker', $checker);
+        $this->controller->setContainer($container);
+    }
+
+    /**
+     * @param array<string, mixed> $body
+     */
+    private function request(array $body): Request
+    {
+        return new Request(
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: json_encode($body, \JSON_THROW_ON_ERROR),
+        );
+    }
+
+    private function makeUser(): User&MockObject
+    {
+        $user = $this->createMock(User::class);
+        $user->method('getId')->willReturn(7);
+
+        return $user;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decode(JsonResponse $response): array
+    {
+        /** @var array<string, mixed> $decoded */
+        $decoded = json_decode((string) $response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+
+        return $decoded;
+    }
+}

--- a/backend/tests/Unit/Controller/MessagesGatewayControllerFlagsTest.php
+++ b/backend/tests/Unit/Controller/MessagesGatewayControllerFlagsTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Unit\Controller;
 use App\AI\Credential\ProviderKeyStore;
 use App\AI\Credential\UserProviderKeyResolver;
 use App\AI\Messages\Tools\AnalyzeImageTool;
+use App\AI\Messages\Tools\GatewayToolCatalog;
 use App\AI\Messages\Tools\WebSearchTool;
 use App\Controller\MessagesGatewayController;
 use App\Entity\Config;
@@ -50,6 +51,7 @@ final class MessagesGatewayControllerFlagsTest extends TestCase
             $this->createStub(RateLimitService::class),
             $this->webSearchTool,
             $this->analyzeImageTool,
+            $this->createStub(GatewayToolCatalog::class),
             $this->createStub(McpServerConfigRepository::class),
             new NullLogger(),
         );

--- a/backend/tests/Unit/Service/MessagesGateway/MessagesGatewayConfigTest.php
+++ b/backend/tests/Unit/Service/MessagesGateway/MessagesGatewayConfigTest.php
@@ -120,4 +120,63 @@ final class MessagesGatewayConfigTest extends TestCase
         $this->assertTrue($this->config->isEnabled(5));
         $this->assertFalse($this->config->isEnabled(99));
     }
+
+    public function testVisionDefaultsForwardEverything(): void
+    {
+        $this->configRepository->method('getValue')->willReturn(null);
+
+        $this->assertSame(MessagesGatewayConfig::VISION_AUTO, $this->config->visionMode(1));
+        $this->assertSame(MessagesGatewayConfig::IMAGE_DETAIL_AUTO, $this->config->visionImageDetail(1));
+        $this->assertSame(0, $this->config->visionMaxImages(1));
+    }
+
+    public function testVisionSettingsAreReadFromConfig(): void
+    {
+        $this->stubGlobalRows([
+            'VISION_MODE' => 'OFF',
+            'VISION_IMAGE_DETAIL' => ' Low ',
+            'VISION_MAX_IMAGES' => '4',
+        ]);
+
+        $this->assertSame(MessagesGatewayConfig::VISION_OFF, $this->config->visionMode(1));
+        $this->assertSame(MessagesGatewayConfig::IMAGE_DETAIL_LOW, $this->config->visionImageDetail(1));
+        $this->assertSame(4, $this->config->visionMaxImages(1));
+    }
+
+    public function testUnknownVisionValuesFallBackToDefaults(): void
+    {
+        $this->stubGlobalRows([
+            'VISION_MODE' => 'sometimes',
+            'VISION_IMAGE_DETAIL' => 'ultra',
+            'VISION_MAX_IMAGES' => 'many',
+        ]);
+
+        $this->assertSame(MessagesGatewayConfig::VISION_AUTO, $this->config->visionMode(1));
+        $this->assertSame(MessagesGatewayConfig::IMAGE_DETAIL_AUTO, $this->config->visionImageDetail(1));
+        $this->assertSame(0, $this->config->visionMaxImages(1));
+    }
+
+    public function testNumericSettingsAreClampedToTheirRange(): void
+    {
+        $this->stubGlobalRows([
+            'VISION_MAX_IMAGES' => '5000',
+            'MCP_MAX_ITERATIONS' => '999',
+        ]);
+
+        $this->assertSame(MessagesGatewayConfig::MAX_VISION_MAX_IMAGES, $this->config->visionMaxImages(1));
+        $this->assertSame(MessagesGatewayConfig::MAX_MCP_MAX_ITERATIONS, $this->config->mcpMaxIterations(1));
+    }
+
+    /**
+     * @param array<string, string> $rows setting name → stored global value
+     */
+    private function stubGlobalRows(array $rows): void
+    {
+        $this->configRepository->method('getValue')
+            ->willReturnCallback(
+                static fn (int $ownerId, string $group, string $setting): ?string => 0 === $ownerId
+                    ? ($rows[$setting] ?? null)
+                    : null,
+            );
+    }
 }

--- a/docs/ANTHROPIC_COMPATIBLE_API.md
+++ b/docs/ANTHROPIC_COMPATIBLE_API.md
@@ -63,7 +63,10 @@ search or vision:
 
 Every one of these is editable in the UI under **Channels → AI Agents** (admins
 only), grouped by what it controls: access, tool calling, images, context and
-session, connection.
+session, connection. Because several of them read `auto`, the tool calling
+section also lists what the gateway actually runs server-side right now
+(`server_tools` in the status response) — a mode is policy, that list is the
+outcome.
 
 Env fallback for local smoke tests: `MESSAGES_GATEWAY_UPSTREAM_URL` (DB value wins in production).
 

--- a/docs/ANTHROPIC_COMPATIBLE_API.md
+++ b/docs/ANTHROPIC_COMPATIBLE_API.md
@@ -56,8 +56,14 @@ search or vision:
 | `MCP_TOOLS_WITH_CLIENT_TOOLS` | `0` | Also inject when the client already sent `tools` (off — Claude Code brings its own) |
 | `MCP_MAX_ITERATIONS` | `8` | Max LLM↔tool rounds per request (applies to every server-side tool) |
 | `WEB_SEARCH_MODE` | `auto` | How to answer Anthropic’s `web_search_*` server tool — `auto`, `synaplan`, `passthrough` or `off` (see [Web search](#web-search)) |
-| `VISION_MODE` | `auto` | How to handle image turns: `auto` (Synaplan PIC2TEXT when the resolved model lacks vision, otherwise passthrough), `synaplan`, `passthrough`, or `off` |
+| `VISION_MODE` | `auto` | Which model reads an image turn: `auto` (Synaplan PIC2TEXT when the resolved model lacks vision, otherwise passthrough), `synaplan`, `passthrough`, or `off` (see [Vision](#vision)) |
+| `VISION_IMAGE_DETAIL` | `auto` | Resolution hint for upstreams that expose one — `auto`, `low` or `high` |
+| `VISION_MAX_IMAGES` | `0` | Max image blocks forwarded per request, newest kept; `0` means unlimited |
 | `CONTEXT_INJECTION_ENABLED` | `0` | Append session-stable RAG/memory system block |
+
+Every one of these is editable in the UI under **Channels → AI Agents** (admins
+only), grouped by what it controls: access, tool calling, images, context and
+session, connection.
 
 Env fallback for local smoke tests: `MESSAGES_GATEWAY_UPSTREAM_URL` (DB value wins in production).
 
@@ -103,14 +109,25 @@ Every response to a request that declared web search carries `x-synaplan-web-sea
 
 Image blocks are forwarded on every route: unchanged on the Anthropic passthrough, as `image_url` (data URI or URL) for OpenAI, and as `inlineData` / `fileData` for Gemini.
 
-Default `VISION_MODE=auto` also mixes in Synaplan’s own vision models:
+Two independent layers decide what an image turn costs and who reads it.
+
+**`VISION_MODE` — which model reads the images.** Default `auto` mixes in Synaplan’s own vision models:
 
 - If the resolved chat model already has `vision`, images stay on the wire (Anthropic keeps its eyes).
 - If it does not, Synaplan rewrites the turn onto the user’s PIC2TEXT / catalog vision model when that model’s provider is Anthropic, OpenAI, or Google — same fallback order as normal chat.
 - If Synaplan has no usable vision model, images are still forwarded upstream (`x-synaplan-vision: passthrough`).
 - When Synaplan vision is available, the gateway also offers an `analyze_image` tool (OCR/describe via PIC2TEXT) in the same server-side tool loop as `web_search`. Explicit `off` skips both the rewrite and the tool.
 
-Applied handling is reported in the `x-synaplan-vision` response header (`synaplan` / `passthrough`).
+**`VisionPolicy` — how many images travel and at which resolution.** It runs before the mode is applied, so the routing decision sees the images that actually reach the upstream. Agent clients resend every image of a session on every turn, so this is the cost side:
+
+| Setting | Effect |
+| ------- | ------ |
+| `VISION_MAX_IMAGES=n` | Only the newest `n` images are forwarded; older ones are replaced with a short text placeholder. A turn whose only block was an image keeps non-empty content, so the request still succeeds. `0` means unlimited. |
+| `VISION_IMAGE_DETAIL` | Forwarded as `image_url.detail` on OpenAI-compatible routes. `auto` omits the field and leaves the choice to the provider; Anthropic and Gemini have no equivalent and ignore the setting. |
+
+Images inside `tool_result` blocks (screenshot tools) count and are rewritten the same way.
+
+Applied handling is reported in the `x-synaplan-vision` response header: `synaplan` or `passthrough`, with an `; omitted=<n>` suffix when the cap dropped images. A text-only answer to a screenshot can therefore be traced to policy rather than to the model.
 
 ## Errors
 

--- a/docs/CLAUDE_CODE_COMPATIBILITY_PLAN.md
+++ b/docs/CLAUDE_CODE_COMPATIBILITY_PLAN.md
@@ -204,6 +204,39 @@ what was missing was anything proving it. Both are now covered end-to-end
 (`05-tools-and-vision.sh`), so a regression shows up as a failing test rather
 than as another screenshot.
 
+### Phase 2c — every setting reachable, and image cost under control (done)
+
+Six settings that changed real gateway behaviour existed only as `BCONFIG` rows:
+MCP tools, MCP tools alongside client tools, the tool-round cap, context
+injection, budget notices and session summaries. An operator had to edit the
+database to reach any of them, so in practice the tool loop shipped off. All of
+them are now on the **Channels → AI Agents** page, grouped by what they control
+and each with an explanation of the consequence — plus the state that makes a
+setting inert (no tool server connected, no search provider, a parent switch
+off) shown next to the control rather than discovered afterwards.
+
+Image handling is now two independent layers, and the admin page presents them
+as such. `VISION_MODE` (Phase 1b) decides *which model reads* an image turn;
+`VisionPolicy` runs before it and decides *how much travels*:
+
+- `VISION_MAX_IMAGES=n` forwards only the newest `n` images and leaves a short
+  text placeholder behind for the rest, so a turn whose only block was an image
+  keeps non-empty content. Agent clients resend the whole image history on every
+  turn, so this is the difference between a bounded and an unbounded bill on a
+  long session.
+- `VISION_IMAGE_DETAIL` reaches OpenAI-compatible upstreams as
+  `image_url.detail`; `auto` omits the field entirely, which the stricter
+  OpenAI-compatible servers need.
+
+Both apply in every mode, because the cost of an image is the same whoever ends
+up reading it. The routing select refuses `synaplan` when no PIC2TEXT model is
+configured — the same guard the API enforces — and a stored mode whose provider
+has since disappeared falls back to `auto` instead of advertising a capability
+that never runs.
+
+`x-synaplan-vision: <handling>; omitted=<n>` reports both layers at once, so a
+text-only answer to a screenshot can be traced to policy rather than the model.
+
 ### Phase 3 — not built yet
 
 Ordered by value, with the reason each one is not in this branch.
@@ -233,7 +266,11 @@ Ordered by value, with the reason each one is not in this branch.
 
 Unit coverage: `WebSearchToolTest`, `GatewayToolCatalogTest`,
 `GatewayToolLoopTest`, `OpenAiMessagesTranslatorTest`,
-`GeminiMessagesTranslatorTest`, `OpenAICompatibleControllerMultimodalTest`.
+`GeminiMessagesTranslatorTest`, `OpenAICompatibleControllerMultimodalTest`,
+`AnalyzeImageToolTest`, `VisionModelResolverTest`, `MessagesGatewayVisionTest`,
+`VisionPolicyTest`, `MessagesGatewayConfigTest`,
+`MessagesGatewayControllerFlagsTest`, and the frontend
+`MessagesGatewayAdminSettings.spec.ts`.
 
 End-to-end against the running stack:
 
@@ -258,13 +295,16 @@ their status.
 
 ## 5. Rollout
 
-Everything is backend-only plus one admin setting, and nothing has to be
-switched on. Web search works out of the box for Anthropic-backed Claude Code
-sessions: default `auto` either runs Synaplan’s search or forwards the
-declaration upstream. To use Synaplan’s own search results (and to serve search
-on aliased OpenAI/Gemini routes), configure a search provider
-(`BRAVE_SEARCH_API_KEY` in `backend/.env`). Admins can force `synaplan`,
-`passthrough` or `off` under **Channels → AI Agents**.
+Nothing has to be switched on. Web search works out of the box for
+Anthropic-backed Claude Code sessions: default `auto` either runs Synaplan’s
+search or forwards the declaration upstream. To use Synaplan’s own search
+results (and to serve search on aliased OpenAI/Gemini routes), configure a
+search provider (`BRAVE_SEARCH_API_KEY` in `backend/.env`). Admins can force
+`synaplan`, `passthrough` or `off` under **Channels → AI Agents**.
+
+The image cost settings default to today’s behaviour — no cap, provider picks
+the detail — so an existing install sees no change until an admin decides
+otherwise. `VISION_MODE` keeps its own `auto` default from Phase 1b.
 
 The metering, vision and error-relay fixes are unconditional, because all three
 are bug fixes with no configurable behaviour.

--- a/frontend/scripts/generate-schemas.js
+++ b/frontend/scripts/generate-schemas.js
@@ -33,6 +33,8 @@ console.log('🔧 Fixing Zod v4 compatibility...')
 content = content.replace(/z\.record\(\s*\n/g, 'z.record(z.string(), \n')
 content = content.replace(/z\.record\(z\.object/g, 'z.record(z.string(), z.object')
 content = content.replace(/z\.record\((z\.[a-zA-Z]+\(\))\)/g, 'z.record(z.string(), $1)')
+// A value schema built from an OpenAPI oneOf, e.g. z.record(z.union([...]))
+content = content.replace(/z\.record\(z\.union\(/g, 'z.record(z.string(), z.union(')
 
 // Step 4: Add readable aliases
 console.log('✨ Creating readable aliases...')

--- a/frontend/src/components/config/MessagesGatewayConfiguration.vue
+++ b/frontend/src/components/config/MessagesGatewayConfiguration.vue
@@ -142,140 +142,7 @@
         </div>
       </div>
 
-      <!-- Admin: enable + upstream -->
-      <div
-        v-if="status.is_admin"
-        class="surface-card p-6 space-y-5"
-        data-testid="section-agents-admin"
-      >
-        <h3 class="text-lg font-semibold txt-primary">
-          {{ $t('messagesGateway.adminTitle') }}
-        </h3>
-
-        <label class="flex items-center gap-3 text-sm txt-primary">
-          <input
-            v-model="enabledFlag"
-            type="checkbox"
-            class="rounded border-light-border"
-            data-testid="checkbox-agents-enabled"
-            @change="onToggleEnabled"
-          />
-          {{ $t('messagesGateway.enableLabel') }}
-        </label>
-
-        <label class="flex items-center gap-3 text-sm txt-primary">
-          <input
-            v-model="allowOperatorFlag"
-            type="checkbox"
-            class="rounded border-light-border"
-            data-testid="checkbox-agents-operator-key"
-            @change="onToggleOperatorKey"
-          />
-          {{ $t('messagesGateway.allowOperatorKeyLabel') }}
-        </label>
-
-        <div>
-          <label class="block text-sm font-medium txt-primary mb-1">
-            {{ $t('messagesGateway.webSearchLabel') }}
-          </label>
-          <select
-            v-model="webSearchMode"
-            class="w-full px-3 py-2 rounded-lg surface-card border border-light-border/30 dark:border-dark-border/20 txt-primary text-sm focus:outline-none focus:ring-2 focus:ring-[var(--brand)]"
-            data-testid="select-agents-web-search"
-            @change="onChangeWebSearchMode"
-          >
-            <option value="auto">{{ $t('messagesGateway.webSearchModeAuto') }}</option>
-            <option value="synaplan" :disabled="!status.web_search_available">
-              {{ $t('messagesGateway.webSearchModeSynaplan') }}
-            </option>
-            <option value="passthrough">
-              {{ $t('messagesGateway.webSearchModePassthrough') }}
-            </option>
-            <option value="off">{{ $t('messagesGateway.webSearchModeOff') }}</option>
-          </select>
-          <p class="txt-secondary text-xs mt-1">
-            {{
-              status.web_search_available
-                ? $t('messagesGateway.webSearchHint')
-                : $t('messagesGateway.webSearchUnavailable')
-            }}
-          </p>
-        </div>
-
-        <div>
-          <label class="block text-sm font-medium txt-primary mb-1">
-            {{ $t('messagesGateway.visionLabel') }}
-          </label>
-          <select
-            v-model="visionMode"
-            class="w-full px-3 py-2 rounded-lg surface-card border border-light-border/30 dark:border-dark-border/20 txt-primary text-sm focus:outline-none focus:ring-2 focus:ring-[var(--brand)]"
-            data-testid="select-agents-vision"
-            @change="onChangeVisionMode"
-          >
-            <option value="auto">{{ $t('messagesGateway.visionModeAuto') }}</option>
-            <option value="synaplan" :disabled="!status.vision_available">
-              {{ $t('messagesGateway.visionModeSynaplan') }}
-            </option>
-            <option value="passthrough">
-              {{ $t('messagesGateway.visionModePassthrough') }}
-            </option>
-            <option value="off">{{ $t('messagesGateway.visionModeOff') }}</option>
-          </select>
-          <p class="txt-secondary text-xs mt-1">
-            {{
-              status.vision_available
-                ? $t('messagesGateway.visionHint')
-                : $t('messagesGateway.visionUnavailable')
-            }}
-          </p>
-        </div>
-
-        <div>
-          <label class="block text-sm font-medium txt-primary mb-1">
-            {{ $t('messagesGateway.upstreamLabel') }}
-          </label>
-          <p class="txt-secondary text-xs mb-2">{{ $t('messagesGateway.upstreamWarning') }}</p>
-          <div class="flex flex-wrap gap-2">
-            <input
-              v-model="upstreamUrl"
-              type="url"
-              class="flex-1 min-w-[16rem] px-3 py-2 rounded surface-card border border-light-border/30 dark:border-dark-border/20 txt-primary text-sm font-mono"
-              data-testid="input-agents-upstream"
-            />
-            <button
-              type="button"
-              class="btn-primary px-4 py-2 rounded-lg text-sm font-medium"
-              :disabled="savingUpstream"
-              data-testid="btn-agents-save-upstream"
-              @click="onSaveUpstream"
-            >
-              {{ $t('messagesGateway.saveUpstream') }}
-            </button>
-          </div>
-        </div>
-
-        <div>
-          <label class="block text-sm font-medium txt-primary mb-1">
-            {{ $t('messagesGateway.aliasesLabel') }}
-          </label>
-          <p class="txt-secondary text-xs mb-2">{{ $t('messagesGateway.aliasesHint') }}</p>
-          <textarea
-            v-model="aliasesJson"
-            rows="4"
-            class="w-full px-3 py-2 rounded surface-card border border-light-border/30 dark:border-dark-border/20 txt-primary text-xs font-mono"
-            data-testid="input-agents-aliases"
-          />
-          <button
-            type="button"
-            class="btn-primary mt-2 px-4 py-2 rounded-lg text-sm font-medium"
-            :disabled="savingAliases"
-            data-testid="btn-agents-save-aliases"
-            @click="onSaveAliases"
-          >
-            {{ $t('messagesGateway.saveAliases') }}
-          </button>
-        </div>
-      </div>
+      <MessagesGatewayAdminSettings v-if="status.is_admin" :status="status" @saved="load(true)" />
     </template>
   </div>
 </template>
@@ -289,14 +156,10 @@ import { useNotification } from '@/composables/useNotification'
 import {
   clearMessagesGatewayKey,
   getMessagesGatewayStatus,
-  saveMessagesGatewayAliases,
-  saveMessagesGatewayFlags,
   saveMessagesGatewayKey,
-  saveMessagesGatewayUpstream,
   type MessagesGatewayStatus,
-  type VisionMode,
-  type WebSearchMode,
 } from '@/services/api/messagesGatewayApi'
+import MessagesGatewayAdminSettings from './messagesGateway/MessagesGatewayAdminSettings.vue'
 
 const { t } = useI18n()
 const { confirm } = useDialog()
@@ -307,14 +170,6 @@ const status = ref<MessagesGatewayStatus | null>(null)
 const apiKey = ref('')
 const savingKey = ref(false)
 const clearingKey = ref(false)
-const savingUpstream = ref(false)
-const savingAliases = ref(false)
-const enabledFlag = ref(false)
-const allowOperatorFlag = ref(false)
-const webSearchMode = ref<WebSearchMode>('auto')
-const visionMode = ref<VisionMode>('auto')
-const upstreamUrl = ref('')
-const aliasesJson = ref('{}')
 
 // A budget of 0 means "no monthly budget configured" (unlimited), not "exhausted".
 const budgetUnlimited = computed(() => Number(status.value?.budget?.budget ?? 0) <= 0)
@@ -335,71 +190,21 @@ const setupSnippet = computed(() => {
   ].join('\n')
 })
 
-async function load() {
-  loading.value = true
+/**
+ * `silent` keeps the rendered page in place while a settings change is written
+ * back — swapping the whole panel for a spinner after every toggle would make
+ * the settings feel like they reload rather than save.
+ */
+async function load(silent = false) {
+  if (!silent) {
+    loading.value = true
+  }
   try {
     status.value = await getMessagesGatewayStatus()
-    enabledFlag.value = status.value.enabled
-    allowOperatorFlag.value = status.value.allow_operator_key ?? false
-    webSearchMode.value = resolveWebSearchMode(
-      (status.value.web_search_mode as WebSearchMode | undefined) ?? 'auto',
-      Boolean(status.value.web_search_available)
-    )
-    visionMode.value = resolveVisionMode(
-      (status.value.vision_mode as VisionMode | undefined) ?? 'auto',
-      Boolean(status.value.vision_available)
-    )
-    upstreamUrl.value = status.value.upstream_url
-    aliasesJson.value = JSON.stringify(status.value.model_aliases ?? {}, null, 2)
-    await persistUnavailableModeFallbacks()
   } catch (err) {
     error((err as Error).message || t('messagesGateway.loadError'))
   } finally {
     loading.value = false
-  }
-}
-
-/**
- * `synaplan` needs a configured provider. If the DB still has that mode after
- * the provider disappeared, show (and persist) `auto` so the control cannot
- * leave the instance in a state that silently does nothing useful.
- */
-function resolveWebSearchMode(mode: WebSearchMode, available: boolean): WebSearchMode {
-  return !available && mode === 'synaplan' ? 'auto' : mode
-}
-
-function resolveVisionMode(mode: VisionMode, available: boolean): VisionMode {
-  return !available && mode === 'synaplan' ? 'auto' : mode
-}
-
-async function persistUnavailableModeFallbacks(): Promise<void> {
-  if (!status.value) return
-
-  const patch: Partial<{ web_search_mode: WebSearchMode; vision_mode: VisionMode }> = {}
-  if (
-    status.value.web_search_mode === 'synaplan' &&
-    !status.value.web_search_available &&
-    webSearchMode.value === 'auto'
-  ) {
-    patch.web_search_mode = 'auto'
-  }
-  if (
-    status.value.vision_mode === 'synaplan' &&
-    !status.value.vision_available &&
-    visionMode.value === 'auto'
-  ) {
-    patch.vision_mode = 'auto'
-  }
-  if (Object.keys(patch).length === 0) return
-
-  try {
-    await saveMessagesGatewayFlags(patch)
-    status.value = {
-      ...status.value,
-      ...patch,
-    }
-  } catch {
-    // Leave the coerced UI value; the next successful save will catch up.
   }
 }
 
@@ -419,7 +224,7 @@ async function onSaveKey() {
     await saveMessagesGatewayKey('anthropic', apiKey.value.trim())
     apiKey.value = ''
     success(t('messagesGateway.saveKeySuccess'))
-    await load()
+    await load(true)
   } catch (err) {
     error((err as Error).message || t('messagesGateway.saveKeyError'))
   } finally {
@@ -439,88 +244,11 @@ async function onClearKey() {
   try {
     await clearMessagesGatewayKey('anthropic')
     success(t('messagesGateway.clearKeySuccess'))
-    await load()
+    await load(true)
   } catch (err) {
     error((err as Error).message || t('messagesGateway.clearKeyError'))
   } finally {
     clearingKey.value = false
-  }
-}
-
-async function onToggleEnabled() {
-  try {
-    await saveMessagesGatewayFlags({ enabled: enabledFlag.value })
-    success(t('messagesGateway.flagsSaved'))
-    await load()
-  } catch (err) {
-    error((err as Error).message || t('messagesGateway.flagsError'))
-    enabledFlag.value = status.value?.enabled ?? false
-  }
-}
-
-async function onToggleOperatorKey() {
-  try {
-    await saveMessagesGatewayFlags({ allow_operator_key: allowOperatorFlag.value })
-    success(t('messagesGateway.flagsSaved'))
-    await load()
-  } catch (err) {
-    error((err as Error).message || t('messagesGateway.flagsError'))
-    allowOperatorFlag.value = status.value?.allow_operator_key ?? false
-  }
-}
-
-async function onChangeWebSearchMode() {
-  try {
-    await saveMessagesGatewayFlags({ web_search_mode: webSearchMode.value })
-    success(t('messagesGateway.flagsSaved'))
-    await load()
-  } catch (err) {
-    error((err as Error).message || t('messagesGateway.flagsError'))
-    webSearchMode.value = resolveWebSearchMode(
-      (status.value?.web_search_mode as WebSearchMode | undefined) ?? 'auto',
-      Boolean(status.value?.web_search_available)
-    )
-  }
-}
-
-async function onChangeVisionMode() {
-  try {
-    await saveMessagesGatewayFlags({ vision_mode: visionMode.value })
-    success(t('messagesGateway.flagsSaved'))
-    await load()
-  } catch (err) {
-    error((err as Error).message || t('messagesGateway.flagsError'))
-    visionMode.value = resolveVisionMode(
-      (status.value?.vision_mode as VisionMode | undefined) ?? 'auto',
-      Boolean(status.value?.vision_available)
-    )
-  }
-}
-
-async function onSaveUpstream() {
-  savingUpstream.value = true
-  try {
-    await saveMessagesGatewayUpstream(upstreamUrl.value.trim())
-    success(t('messagesGateway.upstreamSaved'))
-    await load()
-  } catch (err) {
-    error((err as Error).message || t('messagesGateway.upstreamError'))
-  } finally {
-    savingUpstream.value = false
-  }
-}
-
-async function onSaveAliases() {
-  savingAliases.value = true
-  try {
-    const parsed = JSON.parse(aliasesJson.value) as Record<string, string>
-    await saveMessagesGatewayAliases(parsed)
-    success(t('messagesGateway.aliasesSaved'))
-    await load()
-  } catch (err) {
-    error((err as Error).message || t('messagesGateway.aliasesError'))
-  } finally {
-    savingAliases.value = false
   }
 }
 

--- a/frontend/src/components/config/messagesGateway/GatewayAccessSection.vue
+++ b/frontend/src/components/config/messagesGateway/GatewayAccessSection.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+/** Who may reach the gateway, and with whose provider key. */
+import type { MessagesGatewaySettings } from '@/services/api/messagesGatewayApi'
+import type { GatewayForm } from './types'
+import GatewaySettingRow from './GatewaySettingRow.vue'
+import GatewaySettingSection from './GatewaySettingSection.vue'
+import GatewaySettingToggle from './GatewaySettingToggle.vue'
+
+defineProps<{
+  form: GatewayForm
+}>()
+
+const emit = defineEmits<{
+  change: [patch: MessagesGatewaySettings]
+}>()
+</script>
+
+<template>
+  <GatewaySettingSection
+    :title="$t('messagesGateway.settings.sections.access.title')"
+    :description="$t('messagesGateway.settings.sections.access.description')"
+  >
+    <div class="divide-y divide-light-border/20 dark:divide-dark-border/10">
+      <GatewaySettingRow
+        :label="$t('messagesGateway.settings.enabled.label')"
+        :description="$t('messagesGateway.settings.enabled.description')"
+      >
+        <GatewaySettingToggle
+          :model-value="form.enabled"
+          :label="$t('messagesGateway.settings.enabled.label')"
+          data-testid="toggle-agents-enabled"
+          @update:model-value="emit('change', { enabled: $event })"
+        />
+      </GatewaySettingRow>
+
+      <GatewaySettingRow
+        :label="$t('messagesGateway.settings.operatorKey.label')"
+        :description="$t('messagesGateway.settings.operatorKey.description')"
+      >
+        <GatewaySettingToggle
+          :model-value="form.allow_operator_key"
+          :label="$t('messagesGateway.settings.operatorKey.label')"
+          data-testid="toggle-agents-operator-key"
+          @update:model-value="emit('change', { allow_operator_key: $event })"
+        />
+      </GatewaySettingRow>
+    </div>
+  </GatewaySettingSection>
+</template>

--- a/frontend/src/components/config/messagesGateway/GatewayActiveTools.vue
+++ b/frontend/src/components/config/messagesGateway/GatewayActiveTools.vue
@@ -57,7 +57,7 @@ const isEmpty = computed(() => 0 === labelled.value.length && '' === mcpSummary.
         :data-testid="`agents-active-tool-${tool.name}`"
       >
         {{ tool.label }}
-        <code class="text-[0.65rem] txt-secondary">{{ tool.name }}</code>
+        <code class="text-[0.7rem] txt-secondary">{{ tool.name }}</code>
       </span>
       <span v-if="mcpSummary" class="text-xs txt-secondary">{{ mcpSummary }}</span>
     </div>

--- a/frontend/src/components/config/messagesGateway/GatewayActiveTools.vue
+++ b/frontend/src/components/config/messagesGateway/GatewayActiveTools.vue
@@ -1,0 +1,69 @@
+<script setup lang="ts">
+/**
+ * What the gateway actually runs server-side under the settings above.
+ *
+ * The mode dropdowns say "automatic" a lot, and automatic resolves against
+ * things the operator cannot see from here (is a search provider configured? is
+ * there a vision model?). This turns those switches into an answer.
+ */
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { Icon } from '@iconify/vue'
+
+const props = defineProps<{
+  tools: string[]
+  mcpServers: number
+  mcpEnabled: boolean
+}>()
+
+const { t, te } = useI18n()
+
+const labelled = computed(() =>
+  props.tools.map((name) => ({
+    name,
+    // A tool added to the backend before this page learns its name still shows
+    // up, just under its raw identifier.
+    label: te(`messagesGateway.settings.activeTools.tools.${name}`)
+      ? t(`messagesGateway.settings.activeTools.tools.${name}`)
+      : name,
+  }))
+)
+
+const mcpSummary = computed(() =>
+  props.mcpEnabled && props.mcpServers > 0
+    ? t('messagesGateway.settings.activeTools.mcpServers', props.mcpServers)
+    : ''
+)
+
+const isEmpty = computed(() => 0 === labelled.value.length && '' === mcpSummary.value)
+</script>
+
+<template>
+  <div class="mt-4 rounded-lg surface-chip px-4 py-3" data-testid="agents-active-tools">
+    <p class="flex items-center gap-1.5 text-xs font-medium txt-primary">
+      <Icon icon="heroicons:bolt" class="w-4 h-4 text-[var(--brand)]" />
+      {{ $t('messagesGateway.settings.activeTools.title') }}
+    </p>
+
+    <p v-if="isEmpty" class="text-xs txt-secondary mt-2">
+      {{ $t('messagesGateway.settings.activeTools.empty') }}
+    </p>
+
+    <div v-else class="flex flex-wrap items-center gap-2 mt-2">
+      <span
+        v-for="tool in labelled"
+        :key="tool.name"
+        class="inline-flex items-center gap-1.5 rounded-md surface-card px-2 py-1 text-xs txt-primary"
+        :data-testid="`agents-active-tool-${tool.name}`"
+      >
+        {{ tool.label }}
+        <code class="text-[0.65rem] txt-secondary">{{ tool.name }}</code>
+      </span>
+      <span v-if="mcpSummary" class="text-xs txt-secondary">{{ mcpSummary }}</span>
+    </div>
+
+    <p v-if="!isEmpty" class="text-xs txt-secondary mt-2 leading-relaxed">
+      {{ $t('messagesGateway.settings.activeTools.hint') }}
+    </p>
+  </div>
+</template>

--- a/frontend/src/components/config/messagesGateway/GatewayActiveTools.vue
+++ b/frontend/src/components/config/messagesGateway/GatewayActiveTools.vue
@@ -31,7 +31,11 @@ const labelled = computed(() =>
 
 const mcpSummary = computed(() =>
   props.mcpEnabled && props.mcpServers > 0
-    ? t('messagesGateway.settings.activeTools.mcpServers', props.mcpServers)
+    ? t(
+        'messagesGateway.settings.activeTools.mcpServers',
+        { count: props.mcpServers },
+        props.mcpServers
+      )
     : ''
 )
 

--- a/frontend/src/components/config/messagesGateway/GatewayConnectionSection.vue
+++ b/frontend/src/components/config/messagesGateway/GatewayConnectionSection.vue
@@ -1,0 +1,125 @@
+<script setup lang="ts">
+/**
+ * Where the gateway forwards to, and under which model names.
+ *
+ * Unlike every other setting on this page, these two are free text: they are
+ * submitted on demand rather than on change, so a half-typed URL is never
+ * persisted.
+ */
+import { ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useNotification } from '@/composables/useNotification'
+import {
+  saveMessagesGatewayAliases,
+  saveMessagesGatewayUpstream,
+  type MessagesGatewayStatus,
+} from '@/services/api/messagesGatewayApi'
+import GatewaySettingSection from './GatewaySettingSection.vue'
+
+const props = defineProps<{
+  status: MessagesGatewayStatus
+}>()
+
+const emit = defineEmits<{
+  saved: []
+}>()
+
+const { t } = useI18n()
+const { success, error } = useNotification()
+
+const upstreamUrl = ref('')
+const aliasesJson = ref('{}')
+const savingUpstream = ref(false)
+const savingAliases = ref(false)
+
+watch(
+  () => props.status,
+  (status) => {
+    upstreamUrl.value = status.upstream_url
+    aliasesJson.value = JSON.stringify(status.model_aliases ?? {}, null, 2)
+  },
+  { immediate: true, deep: true }
+)
+
+async function onSaveUpstream() {
+  savingUpstream.value = true
+  try {
+    await saveMessagesGatewayUpstream(upstreamUrl.value.trim())
+    success(t('messagesGateway.upstreamSaved'))
+    emit('saved')
+  } catch (err) {
+    error((err as Error).message || t('messagesGateway.upstreamError'))
+  } finally {
+    savingUpstream.value = false
+  }
+}
+
+async function onSaveAliases() {
+  savingAliases.value = true
+  try {
+    const parsed = JSON.parse(aliasesJson.value) as Record<string, string>
+    await saveMessagesGatewayAliases(parsed)
+    success(t('messagesGateway.aliasesSaved'))
+    emit('saved')
+  } catch (err) {
+    error((err as Error).message || t('messagesGateway.aliasesError'))
+  } finally {
+    savingAliases.value = false
+  }
+}
+</script>
+
+<template>
+  <GatewaySettingSection
+    :title="$t('messagesGateway.settings.sections.connection.title')"
+    :description="$t('messagesGateway.settings.sections.connection.description')"
+  >
+    <div class="mt-4">
+      <label class="block text-sm font-medium txt-primary mb-1" for="agents-upstream">
+        {{ $t('messagesGateway.upstreamLabel') }}
+      </label>
+      <p class="txt-secondary text-xs mb-2">{{ $t('messagesGateway.upstreamWarning') }}</p>
+      <div class="flex flex-wrap gap-2">
+        <input
+          id="agents-upstream"
+          v-model="upstreamUrl"
+          type="url"
+          class="flex-1 min-w-[16rem] px-3 py-2 rounded surface-card border border-light-border/30 dark:border-dark-border/20 txt-primary text-sm font-mono"
+          data-testid="input-agents-upstream"
+        />
+        <button
+          type="button"
+          class="btn-primary px-4 py-2 rounded-lg text-sm font-medium disabled:opacity-50"
+          :disabled="savingUpstream"
+          data-testid="btn-agents-save-upstream"
+          @click="onSaveUpstream"
+        >
+          {{ $t('messagesGateway.saveUpstream') }}
+        </button>
+      </div>
+    </div>
+
+    <div class="mt-5">
+      <label class="block text-sm font-medium txt-primary mb-1" for="agents-aliases">
+        {{ $t('messagesGateway.aliasesLabel') }}
+      </label>
+      <p class="txt-secondary text-xs mb-2">{{ $t('messagesGateway.aliasesHint') }}</p>
+      <textarea
+        id="agents-aliases"
+        v-model="aliasesJson"
+        rows="4"
+        class="w-full px-3 py-2 rounded surface-card border border-light-border/30 dark:border-dark-border/20 txt-primary text-xs font-mono"
+        data-testid="input-agents-aliases"
+      />
+      <button
+        type="button"
+        class="btn-primary mt-2 px-4 py-2 rounded-lg text-sm font-medium disabled:opacity-50"
+        :disabled="savingAliases"
+        data-testid="btn-agents-save-aliases"
+        @click="onSaveAliases"
+      >
+        {{ $t('messagesGateway.saveAliases') }}
+      </button>
+    </div>
+  </GatewaySettingSection>
+</template>

--- a/frontend/src/components/config/messagesGateway/GatewayImagesSection.vue
+++ b/frontend/src/components/config/messagesGateway/GatewayImagesSection.vue
@@ -1,0 +1,114 @@
+<script setup lang="ts">
+/**
+ * Image handling, in two independent layers.
+ *
+ * The mode decides *who reads* an image turn (Synaplan's vision model or the
+ * upstream). Detail and the per-request cap decide *what goes on the wire* and
+ * apply in every mode — an agent loop that resends its whole screenshot history
+ * is expensive no matter which model ends up reading it.
+ */
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import type {
+  ImageDetail,
+  MessagesGatewaySettings,
+  MessagesGatewayStatus,
+  VisionMode,
+} from '@/services/api/messagesGatewayApi'
+import type { GatewayForm } from './types'
+import GatewaySettingNumber from './GatewaySettingNumber.vue'
+import GatewaySettingRow from './GatewaySettingRow.vue'
+import GatewaySettingSection from './GatewaySettingSection.vue'
+import GatewaySettingSelect from './GatewaySettingSelect.vue'
+
+const MIN_MAX_IMAGES = 0
+const MAX_MAX_IMAGES = 100
+
+const props = defineProps<{
+  form: GatewayForm
+  status: MessagesGatewayStatus
+}>()
+
+const emit = defineEmits<{
+  change: [patch: MessagesGatewaySettings]
+}>()
+
+const { t } = useI18n()
+
+const visionNote = computed(() =>
+  props.status.vision_available ? undefined : t('messagesGateway.visionUnavailable')
+)
+
+const visionOptions = computed(() => [
+  { value: 'auto', label: t('messagesGateway.visionModeAuto') },
+  {
+    value: 'synaplan',
+    label: t('messagesGateway.visionModeSynaplan'),
+    disabled: !props.status.vision_available,
+  },
+  { value: 'passthrough', label: t('messagesGateway.visionModePassthrough') },
+  { value: 'off', label: t('messagesGateway.visionModeOff') },
+])
+
+const detailOptions = computed(() => [
+  { value: 'auto', label: t('messagesGateway.settings.imageDetail.optionAuto') },
+  { value: 'low', label: t('messagesGateway.settings.imageDetail.optionLow') },
+  { value: 'high', label: t('messagesGateway.settings.imageDetail.optionHigh') },
+])
+
+const maxImagesHint = computed(() =>
+  0 === props.form.vision_max_images
+    ? t('messagesGateway.settings.maxImages.unlimited')
+    : t('messagesGateway.settings.maxImages.limited', { count: props.form.vision_max_images })
+)
+</script>
+
+<template>
+  <GatewaySettingSection
+    :title="$t('messagesGateway.settings.sections.vision.title')"
+    :description="$t('messagesGateway.settings.sections.vision.description')"
+  >
+    <div class="divide-y divide-light-border/20 dark:divide-dark-border/10">
+      <GatewaySettingRow
+        :label="$t('messagesGateway.visionLabel')"
+        :description="$t('messagesGateway.visionHint')"
+        :note="visionNote"
+      >
+        <GatewaySettingSelect
+          :model-value="form.vision_mode"
+          :options="visionOptions"
+          data-testid="select-agents-vision-mode"
+          @update:model-value="emit('change', { vision_mode: $event as VisionMode })"
+        />
+      </GatewaySettingRow>
+
+      <GatewaySettingRow
+        :label="$t('messagesGateway.settings.imageDetail.label')"
+        :description="$t('messagesGateway.settings.imageDetail.description')"
+      >
+        <GatewaySettingSelect
+          :model-value="form.vision_image_detail"
+          :options="detailOptions"
+          data-testid="select-agents-image-detail"
+          @update:model-value="emit('change', { vision_image_detail: $event as ImageDetail })"
+        />
+      </GatewaySettingRow>
+
+      <GatewaySettingRow
+        :label="$t('messagesGateway.settings.maxImages.label')"
+        :description="$t('messagesGateway.settings.maxImages.description')"
+      >
+        <div class="flex items-center gap-3 sm:justify-end">
+          <GatewaySettingNumber
+            :model-value="form.vision_max_images"
+            :min="MIN_MAX_IMAGES"
+            :max="MAX_MAX_IMAGES"
+            data-testid="input-agents-max-images"
+            @change="emit('change', { vision_max_images: $event })"
+          />
+          <span class="text-xs txt-secondary w-24 text-left">{{ maxImagesHint }}</span>
+        </div>
+      </GatewaySettingRow>
+    </div>
+  </GatewaySettingSection>
+</template>

--- a/frontend/src/components/config/messagesGateway/GatewaySessionSection.vue
+++ b/frontend/src/components/config/messagesGateway/GatewaySessionSection.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts">
+/** What Synaplan adds around the conversation itself. */
+import type { MessagesGatewaySettings } from '@/services/api/messagesGatewayApi'
+import type { GatewayForm } from './types'
+import GatewaySettingRow from './GatewaySettingRow.vue'
+import GatewaySettingSection from './GatewaySettingSection.vue'
+import GatewaySettingToggle from './GatewaySettingToggle.vue'
+
+defineProps<{
+  form: GatewayForm
+}>()
+
+const emit = defineEmits<{
+  change: [patch: MessagesGatewaySettings]
+}>()
+</script>
+
+<template>
+  <GatewaySettingSection
+    :title="$t('messagesGateway.settings.sections.session.title')"
+    :description="$t('messagesGateway.settings.sections.session.description')"
+  >
+    <div class="divide-y divide-light-border/20 dark:divide-dark-border/10">
+      <GatewaySettingRow
+        :label="$t('messagesGateway.settings.contextInjection.label')"
+        :description="$t('messagesGateway.settings.contextInjection.description')"
+      >
+        <GatewaySettingToggle
+          :model-value="form.context_injection_enabled"
+          :label="$t('messagesGateway.settings.contextInjection.label')"
+          data-testid="toggle-agents-context-injection"
+          @update:model-value="emit('change', { context_injection_enabled: $event })"
+        />
+      </GatewaySettingRow>
+
+      <GatewaySettingRow
+        :label="$t('messagesGateway.settings.budgetNotice.label')"
+        :description="$t('messagesGateway.settings.budgetNotice.description')"
+      >
+        <GatewaySettingToggle
+          :model-value="form.budget_notice_enabled"
+          :label="$t('messagesGateway.settings.budgetNotice.label')"
+          data-testid="toggle-agents-budget-notice"
+          @update:model-value="emit('change', { budget_notice_enabled: $event })"
+        />
+      </GatewaySettingRow>
+
+      <GatewaySettingRow
+        :label="$t('messagesGateway.settings.sessionSummary.label')"
+        :description="$t('messagesGateway.settings.sessionSummary.description')"
+      >
+        <GatewaySettingToggle
+          :model-value="form.session_summary_enabled"
+          :label="$t('messagesGateway.settings.sessionSummary.label')"
+          data-testid="toggle-agents-session-summary"
+          @update:model-value="emit('change', { session_summary_enabled: $event })"
+        />
+      </GatewaySettingRow>
+    </div>
+  </GatewaySettingSection>
+</template>

--- a/frontend/src/components/config/messagesGateway/GatewaySettingNumber.vue
+++ b/frontend/src/components/config/messagesGateway/GatewaySettingNumber.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+/**
+ * A bounded numeric gateway setting.
+ *
+ * The value is clamped on commit rather than rejected: the backend enforces the
+ * same range, and silently correcting a typo is friendlier than an error toast
+ * for a number nobody meant to type. Nothing is emitted when the committed
+ * value already matches, so tabbing through the field saves nothing.
+ */
+import { ref, watch } from 'vue'
+
+const props = defineProps<{
+  modelValue: number
+  min: number
+  max: number
+  disabled?: boolean
+}>()
+
+const emit = defineEmits<{
+  change: [value: number]
+}>()
+
+const draft = ref(props.modelValue)
+
+watch(
+  () => props.modelValue,
+  (value) => {
+    draft.value = value
+  }
+)
+
+function commit() {
+  const raw = Number(draft.value)
+  const value = Number.isFinite(raw)
+    ? Math.min(props.max, Math.max(props.min, Math.round(raw)))
+    : props.min
+
+  draft.value = value
+  if (value === props.modelValue) return
+
+  emit('change', value)
+}
+</script>
+
+<template>
+  <input
+    v-model.number="draft"
+    type="number"
+    :min="min"
+    :max="max"
+    :disabled="disabled"
+    class="w-24 px-3 py-2 rounded-lg surface-card border border-light-border/30 dark:border-dark-border/20 txt-primary text-sm text-right focus:outline-none focus:ring-2 focus:ring-[var(--brand)] disabled:cursor-not-allowed"
+    @change="commit"
+  />
+</template>

--- a/frontend/src/components/config/messagesGateway/GatewaySettingRow.vue
+++ b/frontend/src/components/config/messagesGateway/GatewaySettingRow.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+/**
+ * One labelled gateway setting: explanation on the left, control on the right.
+ *
+ * `note` is for the state that makes a setting inert right now (no search
+ * provider, no MCP server, a parent switch turned off) — the operator sees why
+ * before they change something that cannot take effect.
+ */
+import { Icon } from '@iconify/vue'
+
+defineProps<{
+  label: string
+  description: string
+  note?: string
+  disabled?: boolean
+}>()
+</script>
+
+<template>
+  <div
+    class="flex flex-col gap-3 py-4 sm:flex-row sm:items-start sm:justify-between sm:gap-8"
+    :class="disabled && 'opacity-60'"
+  >
+    <div class="min-w-0 sm:max-w-lg">
+      <p class="text-sm font-medium txt-primary">{{ label }}</p>
+      <p class="text-xs txt-secondary mt-1 leading-relaxed">{{ description }}</p>
+      <p
+        v-if="note"
+        class="text-xs mt-1.5 flex items-start gap-1.5 text-amber-600 dark:text-amber-400"
+      >
+        <Icon icon="heroicons:information-circle" class="w-4 h-4 flex-shrink-0" />
+        <span>{{ note }}</span>
+      </p>
+    </div>
+    <div class="flex-shrink-0 sm:min-w-[13rem] sm:text-right">
+      <slot />
+    </div>
+  </div>
+</template>

--- a/frontend/src/components/config/messagesGateway/GatewaySettingSection.vue
+++ b/frontend/src/components/config/messagesGateway/GatewaySettingSection.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+/**
+ * A titled group of gateway settings. The heading carries the operator's
+ * vocabulary ("Tool calling", "Images") rather than the BCONFIG key names.
+ */
+defineProps<{
+  title: string
+  description: string
+}>()
+</script>
+
+<template>
+  <section class="mt-8">
+    <h4 class="text-sm font-semibold txt-primary uppercase tracking-wide">{{ title }}</h4>
+    <p class="txt-secondary text-xs mt-1">{{ description }}</p>
+    <slot />
+  </section>
+</template>

--- a/frontend/src/components/config/messagesGateway/GatewaySettingSelect.vue
+++ b/frontend/src/components/config/messagesGateway/GatewaySettingSelect.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+/**
+ * The dropdown shape shared by every gateway mode setting. An option the
+ * install cannot honour stays visible but disabled, so the operator learns the
+ * capability exists instead of wondering where it went.
+ */
+defineProps<{
+  modelValue: string
+  options: { value: string; label: string; disabled?: boolean }[]
+}>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: string]
+}>()
+</script>
+
+<template>
+  <select
+    :value="modelValue"
+    class="w-full sm:w-56 px-3 py-2 rounded-lg surface-card border border-light-border/30 dark:border-dark-border/20 txt-primary text-sm focus:outline-none focus:ring-2 focus:ring-[var(--brand)]"
+    @change="emit('update:modelValue', ($event.target as HTMLSelectElement).value)"
+  >
+    <option
+      v-for="option in options"
+      :key="option.value"
+      :value="option.value"
+      :disabled="option.disabled"
+    >
+      {{ option.label }}
+    </option>
+  </select>
+</template>

--- a/frontend/src/components/config/messagesGateway/GatewaySettingToggle.vue
+++ b/frontend/src/components/config/messagesGateway/GatewaySettingToggle.vue
@@ -1,0 +1,57 @@
+<script setup lang="ts">
+/**
+ * On/off control for a single gateway setting.
+ */
+defineProps<{
+  modelValue: boolean
+  label: string
+  disabled?: boolean
+}>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: boolean]
+}>()
+
+function toggle(current: boolean, disabled: boolean | undefined) {
+  if (disabled) return
+  emit('update:modelValue', !current)
+}
+</script>
+
+<template>
+  <div class="inline-flex items-center gap-3">
+    <!--
+      The track colour lives on an inner element on purpose: the V2 design sets
+      a flat background on every `[role="switch"]`, which would beat a utility
+      class on the button itself and make on and off look identical.
+    -->
+    <button
+      type="button"
+      role="switch"
+      :aria-checked="modelValue"
+      :aria-label="label"
+      :disabled="disabled"
+      :class="[
+        'relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full bg-transparent focus:outline-none focus:ring-2 focus:ring-[var(--brand)] focus:ring-offset-2',
+        disabled ? 'cursor-not-allowed' : 'cursor-pointer',
+      ]"
+      @click="toggle(modelValue, disabled)"
+    >
+      <span
+        :class="[
+          'pointer-events-none absolute inset-0 rounded-full transition-colors duration-200 ease-in-out',
+          modelValue ? 'bg-[var(--brand)]' : 'bg-[var(--status-neutral)]',
+        ]"
+      />
+      <span
+        :class="[
+          'pointer-events-none relative inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out',
+          modelValue ? 'translate-x-5' : 'translate-x-0.5',
+        ]"
+      />
+    </button>
+    <span class="text-sm txt-secondary w-16 text-left">
+      {{ modelValue ? $t('common.enabled') : $t('common.disabled') }}
+    </span>
+  </div>
+</template>

--- a/frontend/src/components/config/messagesGateway/GatewayToolsSection.vue
+++ b/frontend/src/components/config/messagesGateway/GatewayToolsSection.vue
@@ -1,0 +1,134 @@
+<script setup lang="ts">
+/**
+ * Which tools the AI assistant can call, and who executes them.
+ *
+ * The section leads with what is running right now, because the settings below
+ * are policy ("automatic") while the readout is outcome.
+ */
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import type {
+  MessagesGatewaySettings,
+  MessagesGatewayStatus,
+  WebSearchMode,
+} from '@/services/api/messagesGatewayApi'
+import type { GatewayForm } from './types'
+import GatewayActiveTools from './GatewayActiveTools.vue'
+import GatewaySettingNumber from './GatewaySettingNumber.vue'
+import GatewaySettingRow from './GatewaySettingRow.vue'
+import GatewaySettingSection from './GatewaySettingSection.vue'
+import GatewaySettingSelect from './GatewaySettingSelect.vue'
+import GatewaySettingToggle from './GatewaySettingToggle.vue'
+
+const MIN_TOOL_ROUNDS = 1
+const MAX_TOOL_ROUNDS = 32
+
+const props = defineProps<{
+  form: GatewayForm
+  status: MessagesGatewayStatus
+}>()
+
+const emit = defineEmits<{
+  change: [patch: MessagesGatewaySettings]
+}>()
+
+const { t } = useI18n()
+
+const mcpNote = computed(() =>
+  (props.status.mcp_servers_configured ?? 0) > 0
+    ? undefined
+    : t('messagesGateway.settings.mcpTools.noneConfigured')
+)
+
+/** Everything below the MCP switch is dead weight while the switch is off. */
+const mcpDependentNote = computed(() =>
+  props.form.mcp_tools_enabled ? undefined : t('messagesGateway.settings.requiresMcpTools')
+)
+
+const webSearchNote = computed(() =>
+  props.status.web_search_available ? undefined : t('messagesGateway.webSearchUnavailable')
+)
+
+const webSearchOptions = computed(() => [
+  { value: 'auto', label: t('messagesGateway.webSearchModeAuto') },
+  {
+    value: 'synaplan',
+    label: t('messagesGateway.webSearchModeSynaplan'),
+    disabled: !props.status.web_search_available,
+  },
+  { value: 'passthrough', label: t('messagesGateway.webSearchModePassthrough') },
+  { value: 'off', label: t('messagesGateway.webSearchModeOff') },
+])
+</script>
+
+<template>
+  <GatewaySettingSection
+    :title="$t('messagesGateway.settings.sections.tools.title')"
+    :description="$t('messagesGateway.settings.sections.tools.description')"
+  >
+    <GatewayActiveTools
+      :tools="status.server_tools ?? []"
+      :mcp-servers="status.mcp_servers_configured ?? 0"
+      :mcp-enabled="form.mcp_tools_enabled"
+    />
+
+    <div class="divide-y divide-light-border/20 dark:divide-dark-border/10">
+      <GatewaySettingRow
+        :label="$t('messagesGateway.settings.mcpTools.label')"
+        :description="$t('messagesGateway.settings.mcpTools.description')"
+        :note="mcpNote"
+      >
+        <GatewaySettingToggle
+          :model-value="form.mcp_tools_enabled"
+          :label="$t('messagesGateway.settings.mcpTools.label')"
+          data-testid="toggle-agents-mcp-tools"
+          @update:model-value="emit('change', { mcp_tools_enabled: $event })"
+        />
+      </GatewaySettingRow>
+
+      <GatewaySettingRow
+        :label="$t('messagesGateway.settings.mcpWithClientTools.label')"
+        :description="$t('messagesGateway.settings.mcpWithClientTools.description')"
+        :note="mcpDependentNote"
+        :disabled="!form.mcp_tools_enabled"
+      >
+        <GatewaySettingToggle
+          :model-value="form.mcp_tools_with_client_tools"
+          :label="$t('messagesGateway.settings.mcpWithClientTools.label')"
+          :disabled="!form.mcp_tools_enabled"
+          data-testid="toggle-agents-mcp-with-client-tools"
+          @update:model-value="emit('change', { mcp_tools_with_client_tools: $event })"
+        />
+      </GatewaySettingRow>
+
+      <GatewaySettingRow
+        :label="$t('messagesGateway.settings.toolRounds.label')"
+        :description="$t('messagesGateway.settings.toolRounds.description')"
+        :note="mcpDependentNote"
+        :disabled="!form.mcp_tools_enabled"
+      >
+        <GatewaySettingNumber
+          :model-value="form.mcp_max_iterations"
+          :min="MIN_TOOL_ROUNDS"
+          :max="MAX_TOOL_ROUNDS"
+          :disabled="!form.mcp_tools_enabled"
+          data-testid="input-agents-tool-rounds"
+          @change="emit('change', { mcp_max_iterations: $event })"
+        />
+      </GatewaySettingRow>
+
+      <GatewaySettingRow
+        :label="$t('messagesGateway.webSearchLabel')"
+        :description="$t('messagesGateway.webSearchHint')"
+        :note="webSearchNote"
+      >
+        <GatewaySettingSelect
+          :model-value="form.web_search_mode"
+          :options="webSearchOptions"
+          data-testid="select-agents-web-search"
+          @update:model-value="emit('change', { web_search_mode: $event as WebSearchMode })"
+        />
+      </GatewaySettingRow>
+    </div>
+  </GatewaySettingSection>
+</template>

--- a/frontend/src/components/config/messagesGateway/MessagesGatewayAdminSettings.vue
+++ b/frontend/src/components/config/messagesGateway/MessagesGatewayAdminSettings.vue
@@ -2,31 +2,29 @@
 /**
  * Instance-wide settings for the Anthropic-compatible gateway (admins only).
  *
- * Every control writes one setting and reports the outcome immediately —
- * there is no "Save all" button to forget. The upstream URL and the model
- * aliases are the exception: free text is only submitted on demand.
+ * This component owns the working copy and the writes; the sections below are
+ * presentational and hand back a patch. Every control saves on change and
+ * reports the outcome immediately — there is no "Save all" button to forget.
+ * The upstream URL and the model aliases are the exception (see
+ * GatewayConnectionSection).
  */
-import { computed, ref, watch } from 'vue'
+import { ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { Icon } from '@iconify/vue'
 import { useNotification } from '@/composables/useNotification'
 import {
-  saveMessagesGatewayAliases,
   saveMessagesGatewayFlags,
-  saveMessagesGatewayUpstream,
-  type ImageDetail,
   type MessagesGatewaySettings,
   type MessagesGatewayStatus,
   type VisionMode,
   type WebSearchMode,
 } from '@/services/api/messagesGatewayApi'
-import GatewaySettingRow from './GatewaySettingRow.vue'
-import GatewaySettingToggle from './GatewaySettingToggle.vue'
-
-const MIN_TOOL_ROUNDS = 1
-const MAX_TOOL_ROUNDS = 32
-const MIN_MAX_IMAGES = 0
-const MAX_MAX_IMAGES = 100
+import type { GatewayForm } from './types'
+import GatewayAccessSection from './GatewayAccessSection.vue'
+import GatewayConnectionSection from './GatewayConnectionSection.vue'
+import GatewayImagesSection from './GatewayImagesSection.vue'
+import GatewaySessionSection from './GatewaySessionSection.vue'
+import GatewayToolsSection from './GatewayToolsSection.vue'
 
 const props = defineProps<{
   status: MessagesGatewayStatus
@@ -40,46 +38,21 @@ const { t } = useI18n()
 const { success, error } = useNotification()
 
 const saving = ref(false)
-const savingUpstream = ref(false)
-const savingAliases = ref(false)
 
-const form = ref({
+const form = ref<GatewayForm>({
   enabled: false,
   allow_operator_key: false,
   mcp_tools_enabled: false,
   mcp_tools_with_client_tools: false,
   mcp_max_iterations: 8,
-  web_search_mode: 'auto' as WebSearchMode,
-  vision_mode: 'auto' as VisionMode,
-  vision_image_detail: 'auto' as ImageDetail,
+  web_search_mode: 'auto',
+  vision_mode: 'auto',
+  vision_image_detail: 'auto',
   vision_max_images: 0,
   context_injection_enabled: false,
   budget_notice_enabled: true,
   session_summary_enabled: true,
 })
-
-const upstreamUrl = ref('')
-const aliasesJson = ref('{}')
-
-const mcpServerCount = computed(() => props.status.mcp_servers_configured ?? 0)
-
-const mcpNote = computed(() =>
-  mcpServerCount.value > 0 ? undefined : t('messagesGateway.settings.mcpTools.noneConfigured')
-)
-const mcpDependentNote = computed(() =>
-  form.value.mcp_tools_enabled ? undefined : t('messagesGateway.settings.requiresMcpTools')
-)
-const webSearchNote = computed(() =>
-  props.status.web_search_available ? undefined : t('messagesGateway.webSearchUnavailable')
-)
-const visionNote = computed(() =>
-  props.status.vision_available ? undefined : t('messagesGateway.visionUnavailable')
-)
-const maxImagesHint = computed(() =>
-  0 === form.value.vision_max_images
-    ? t('messagesGateway.settings.maxImages.unlimited')
-    : t('messagesGateway.settings.maxImages.limited', { count: form.value.vision_max_images })
-)
 
 watch(() => props.status, syncFromStatus, { immediate: true, deep: true })
 
@@ -111,8 +84,6 @@ function syncFromStatus() {
     budget_notice_enabled: status.budget_notice_enabled ?? true,
     session_summary_enabled: status.session_summary_enabled ?? true,
   }
-  upstreamUrl.value = status.upstream_url
-  aliasesJson.value = JSON.stringify(status.model_aliases ?? {}, null, 2)
   void persistUnusableModes()
 }
 
@@ -133,9 +104,14 @@ async function persistUnusableModes(): Promise<void> {
   }
 }
 
+/**
+ * One patch carries exactly the setting that changed: the endpoint leaves
+ * omitted settings alone, so a wider patch could reset a neighbour.
+ */
 async function apply(patch: MessagesGatewaySettings) {
   if (saving.value) return
   saving.value = true
+  Object.assign(form.value, patch)
   try {
     await saveMessagesGatewayFlags(patch)
     success(t('messagesGateway.flagsSaved'))
@@ -145,52 +121,6 @@ async function apply(patch: MessagesGatewaySettings) {
     syncFromStatus()
   } finally {
     saving.value = false
-  }
-}
-
-function clamp(value: number, min: number, max: number): number {
-  if (!Number.isFinite(value)) return min
-  return Math.min(max, Math.max(min, Math.round(value)))
-}
-
-async function onToolRoundsChange() {
-  const value = clamp(Number(form.value.mcp_max_iterations), MIN_TOOL_ROUNDS, MAX_TOOL_ROUNDS)
-  form.value.mcp_max_iterations = value
-  if (value === props.status.mcp_max_iterations) return
-  await apply({ mcp_max_iterations: value })
-}
-
-async function onMaxImagesChange() {
-  const value = clamp(Number(form.value.vision_max_images), MIN_MAX_IMAGES, MAX_MAX_IMAGES)
-  form.value.vision_max_images = value
-  if (value === props.status.vision_max_images) return
-  await apply({ vision_max_images: value })
-}
-
-async function onSaveUpstream() {
-  savingUpstream.value = true
-  try {
-    await saveMessagesGatewayUpstream(upstreamUrl.value.trim())
-    success(t('messagesGateway.upstreamSaved'))
-    emit('saved')
-  } catch (err) {
-    error((err as Error).message || t('messagesGateway.upstreamError'))
-  } finally {
-    savingUpstream.value = false
-  }
-}
-
-async function onSaveAliases() {
-  savingAliases.value = true
-  try {
-    const parsed = JSON.parse(aliasesJson.value) as Record<string, string>
-    await saveMessagesGatewayAliases(parsed)
-    success(t('messagesGateway.aliasesSaved'))
-    emit('saved')
-  } catch (err) {
-    error((err as Error).message || t('messagesGateway.aliasesError'))
-  } finally {
-    savingAliases.value = false
   }
 }
 </script>
@@ -218,347 +148,10 @@ async function onSaveAliases() {
       <span>{{ $t('messagesGateway.settings.disabledNotice') }}</span>
     </p>
 
-    <!-- Access -->
-    <section class="mt-6">
-      <h4 class="text-sm font-semibold txt-primary uppercase tracking-wide">
-        {{ $t('messagesGateway.settings.sections.access.title') }}
-      </h4>
-      <p class="txt-secondary text-xs mt-1">
-        {{ $t('messagesGateway.settings.sections.access.description') }}
-      </p>
-      <div class="divide-y divide-light-border/20 dark:divide-dark-border/10">
-        <GatewaySettingRow
-          :label="$t('messagesGateway.settings.enabled.label')"
-          :description="$t('messagesGateway.settings.enabled.description')"
-        >
-          <GatewaySettingToggle
-            :model-value="form.enabled"
-            :label="$t('messagesGateway.settings.enabled.label')"
-            data-testid="toggle-agents-enabled"
-            @update:model-value="
-              (value) => {
-                form.enabled = value
-                apply({ enabled: value })
-              }
-            "
-          />
-        </GatewaySettingRow>
-
-        <GatewaySettingRow
-          :label="$t('messagesGateway.settings.operatorKey.label')"
-          :description="$t('messagesGateway.settings.operatorKey.description')"
-        >
-          <GatewaySettingToggle
-            :model-value="form.allow_operator_key"
-            :label="$t('messagesGateway.settings.operatorKey.label')"
-            data-testid="toggle-agents-operator-key"
-            @update:model-value="
-              (value) => {
-                form.allow_operator_key = value
-                apply({ allow_operator_key: value })
-              }
-            "
-          />
-        </GatewaySettingRow>
-      </div>
-    </section>
-
-    <!-- Tool calling -->
-    <section class="mt-8">
-      <h4 class="text-sm font-semibold txt-primary uppercase tracking-wide">
-        {{ $t('messagesGateway.settings.sections.tools.title') }}
-      </h4>
-      <p class="txt-secondary text-xs mt-1">
-        {{ $t('messagesGateway.settings.sections.tools.description') }}
-      </p>
-      <div class="divide-y divide-light-border/20 dark:divide-dark-border/10">
-        <GatewaySettingRow
-          :label="$t('messagesGateway.settings.mcpTools.label')"
-          :description="$t('messagesGateway.settings.mcpTools.description')"
-          :note="mcpNote"
-        >
-          <GatewaySettingToggle
-            :model-value="form.mcp_tools_enabled"
-            :label="$t('messagesGateway.settings.mcpTools.label')"
-            data-testid="toggle-agents-mcp-tools"
-            @update:model-value="
-              (value) => {
-                form.mcp_tools_enabled = value
-                apply({ mcp_tools_enabled: value })
-              }
-            "
-          />
-        </GatewaySettingRow>
-
-        <GatewaySettingRow
-          :label="$t('messagesGateway.settings.mcpWithClientTools.label')"
-          :description="$t('messagesGateway.settings.mcpWithClientTools.description')"
-          :note="mcpDependentNote"
-          :disabled="!form.mcp_tools_enabled"
-        >
-          <GatewaySettingToggle
-            :model-value="form.mcp_tools_with_client_tools"
-            :label="$t('messagesGateway.settings.mcpWithClientTools.label')"
-            :disabled="!form.mcp_tools_enabled"
-            data-testid="toggle-agents-mcp-with-client-tools"
-            @update:model-value="
-              (value) => {
-                form.mcp_tools_with_client_tools = value
-                apply({ mcp_tools_with_client_tools: value })
-              }
-            "
-          />
-        </GatewaySettingRow>
-
-        <GatewaySettingRow
-          :label="$t('messagesGateway.settings.toolRounds.label')"
-          :description="$t('messagesGateway.settings.toolRounds.description')"
-          :note="mcpDependentNote"
-          :disabled="!form.mcp_tools_enabled"
-        >
-          <input
-            v-model.number="form.mcp_max_iterations"
-            type="number"
-            :min="MIN_TOOL_ROUNDS"
-            :max="MAX_TOOL_ROUNDS"
-            :disabled="!form.mcp_tools_enabled"
-            class="w-24 px-3 py-2 rounded-lg surface-card border border-light-border/30 dark:border-dark-border/20 txt-primary text-sm text-right focus:outline-none focus:ring-2 focus:ring-[var(--brand)] disabled:cursor-not-allowed"
-            data-testid="input-agents-tool-rounds"
-            @change="onToolRoundsChange"
-          />
-        </GatewaySettingRow>
-
-        <GatewaySettingRow
-          :label="$t('messagesGateway.webSearchLabel')"
-          :description="$t('messagesGateway.webSearchHint')"
-          :note="webSearchNote"
-        >
-          <select
-            :value="form.web_search_mode"
-            class="w-full sm:w-56 px-3 py-2 rounded-lg surface-card border border-light-border/30 dark:border-dark-border/20 txt-primary text-sm focus:outline-none focus:ring-2 focus:ring-[var(--brand)]"
-            data-testid="select-agents-web-search"
-            @change="
-              (event) => {
-                const value = (event.target as HTMLSelectElement).value as WebSearchMode
-                form.web_search_mode = value
-                apply({ web_search_mode: value })
-              }
-            "
-          >
-            <option value="auto">{{ $t('messagesGateway.webSearchModeAuto') }}</option>
-            <option value="synaplan" :disabled="!status.web_search_available">
-              {{ $t('messagesGateway.webSearchModeSynaplan') }}
-            </option>
-            <option value="passthrough">
-              {{ $t('messagesGateway.webSearchModePassthrough') }}
-            </option>
-            <option value="off">{{ $t('messagesGateway.webSearchModeOff') }}</option>
-          </select>
-        </GatewaySettingRow>
-      </div>
-    </section>
-
-    <!-- Images -->
-    <section class="mt-8">
-      <h4 class="text-sm font-semibold txt-primary uppercase tracking-wide">
-        {{ $t('messagesGateway.settings.sections.vision.title') }}
-      </h4>
-      <p class="txt-secondary text-xs mt-1">
-        {{ $t('messagesGateway.settings.sections.vision.description') }}
-      </p>
-      <div class="divide-y divide-light-border/20 dark:divide-dark-border/10">
-        <GatewaySettingRow
-          :label="$t('messagesGateway.visionLabel')"
-          :description="$t('messagesGateway.visionHint')"
-          :note="visionNote"
-        >
-          <select
-            :value="form.vision_mode"
-            class="w-full sm:w-56 px-3 py-2 rounded-lg surface-card border border-light-border/30 dark:border-dark-border/20 txt-primary text-sm focus:outline-none focus:ring-2 focus:ring-[var(--brand)]"
-            data-testid="select-agents-vision-mode"
-            @change="
-              (event) => {
-                const value = (event.target as HTMLSelectElement).value as VisionMode
-                form.vision_mode = value
-                apply({ vision_mode: value })
-              }
-            "
-          >
-            <option value="auto">{{ $t('messagesGateway.visionModeAuto') }}</option>
-            <option value="synaplan" :disabled="!status.vision_available">
-              {{ $t('messagesGateway.visionModeSynaplan') }}
-            </option>
-            <option value="passthrough">
-              {{ $t('messagesGateway.visionModePassthrough') }}
-            </option>
-            <option value="off">{{ $t('messagesGateway.visionModeOff') }}</option>
-          </select>
-        </GatewaySettingRow>
-
-        <GatewaySettingRow
-          :label="$t('messagesGateway.settings.imageDetail.label')"
-          :description="$t('messagesGateway.settings.imageDetail.description')"
-        >
-          <select
-            :value="form.vision_image_detail"
-            class="w-full sm:w-56 px-3 py-2 rounded-lg surface-card border border-light-border/30 dark:border-dark-border/20 txt-primary text-sm focus:outline-none focus:ring-2 focus:ring-[var(--brand)]"
-            data-testid="select-agents-image-detail"
-            @change="
-              (event) => {
-                const value = (event.target as HTMLSelectElement).value as ImageDetail
-                form.vision_image_detail = value
-                apply({ vision_image_detail: value })
-              }
-            "
-          >
-            <option value="auto">
-              {{ $t('messagesGateway.settings.imageDetail.optionAuto') }}
-            </option>
-            <option value="low">{{ $t('messagesGateway.settings.imageDetail.optionLow') }}</option>
-            <option value="high">
-              {{ $t('messagesGateway.settings.imageDetail.optionHigh') }}
-            </option>
-          </select>
-        </GatewaySettingRow>
-
-        <GatewaySettingRow
-          :label="$t('messagesGateway.settings.maxImages.label')"
-          :description="$t('messagesGateway.settings.maxImages.description')"
-        >
-          <div class="flex items-center gap-3 sm:justify-end">
-            <input
-              v-model.number="form.vision_max_images"
-              type="number"
-              :min="MIN_MAX_IMAGES"
-              :max="MAX_MAX_IMAGES"
-              class="w-24 px-3 py-2 rounded-lg surface-card border border-light-border/30 dark:border-dark-border/20 txt-primary text-sm text-right focus:outline-none focus:ring-2 focus:ring-[var(--brand)]"
-              data-testid="input-agents-max-images"
-              @change="onMaxImagesChange"
-            />
-            <span class="text-xs txt-secondary w-24 text-left">{{ maxImagesHint }}</span>
-          </div>
-        </GatewaySettingRow>
-      </div>
-    </section>
-
-    <!-- Context & session -->
-    <section class="mt-8">
-      <h4 class="text-sm font-semibold txt-primary uppercase tracking-wide">
-        {{ $t('messagesGateway.settings.sections.session.title') }}
-      </h4>
-      <p class="txt-secondary text-xs mt-1">
-        {{ $t('messagesGateway.settings.sections.session.description') }}
-      </p>
-      <div class="divide-y divide-light-border/20 dark:divide-dark-border/10">
-        <GatewaySettingRow
-          :label="$t('messagesGateway.settings.contextInjection.label')"
-          :description="$t('messagesGateway.settings.contextInjection.description')"
-        >
-          <GatewaySettingToggle
-            :model-value="form.context_injection_enabled"
-            :label="$t('messagesGateway.settings.contextInjection.label')"
-            data-testid="toggle-agents-context-injection"
-            @update:model-value="
-              (value) => {
-                form.context_injection_enabled = value
-                apply({ context_injection_enabled: value })
-              }
-            "
-          />
-        </GatewaySettingRow>
-
-        <GatewaySettingRow
-          :label="$t('messagesGateway.settings.budgetNotice.label')"
-          :description="$t('messagesGateway.settings.budgetNotice.description')"
-        >
-          <GatewaySettingToggle
-            :model-value="form.budget_notice_enabled"
-            :label="$t('messagesGateway.settings.budgetNotice.label')"
-            data-testid="toggle-agents-budget-notice"
-            @update:model-value="
-              (value) => {
-                form.budget_notice_enabled = value
-                apply({ budget_notice_enabled: value })
-              }
-            "
-          />
-        </GatewaySettingRow>
-
-        <GatewaySettingRow
-          :label="$t('messagesGateway.settings.sessionSummary.label')"
-          :description="$t('messagesGateway.settings.sessionSummary.description')"
-        >
-          <GatewaySettingToggle
-            :model-value="form.session_summary_enabled"
-            :label="$t('messagesGateway.settings.sessionSummary.label')"
-            data-testid="toggle-agents-session-summary"
-            @update:model-value="
-              (value) => {
-                form.session_summary_enabled = value
-                apply({ session_summary_enabled: value })
-              }
-            "
-          />
-        </GatewaySettingRow>
-      </div>
-    </section>
-
-    <!-- Connection -->
-    <section class="mt-8">
-      <h4 class="text-sm font-semibold txt-primary uppercase tracking-wide">
-        {{ $t('messagesGateway.settings.sections.connection.title') }}
-      </h4>
-      <p class="txt-secondary text-xs mt-1">
-        {{ $t('messagesGateway.settings.sections.connection.description') }}
-      </p>
-
-      <div class="mt-4">
-        <label class="block text-sm font-medium txt-primary mb-1" for="agents-upstream">
-          {{ $t('messagesGateway.upstreamLabel') }}
-        </label>
-        <p class="txt-secondary text-xs mb-2">{{ $t('messagesGateway.upstreamWarning') }}</p>
-        <div class="flex flex-wrap gap-2">
-          <input
-            id="agents-upstream"
-            v-model="upstreamUrl"
-            type="url"
-            class="flex-1 min-w-[16rem] px-3 py-2 rounded surface-card border border-light-border/30 dark:border-dark-border/20 txt-primary text-sm font-mono"
-            data-testid="input-agents-upstream"
-          />
-          <button
-            type="button"
-            class="btn-primary px-4 py-2 rounded-lg text-sm font-medium disabled:opacity-50"
-            :disabled="savingUpstream"
-            data-testid="btn-agents-save-upstream"
-            @click="onSaveUpstream"
-          >
-            {{ $t('messagesGateway.saveUpstream') }}
-          </button>
-        </div>
-      </div>
-
-      <div class="mt-5">
-        <label class="block text-sm font-medium txt-primary mb-1" for="agents-aliases">
-          {{ $t('messagesGateway.aliasesLabel') }}
-        </label>
-        <p class="txt-secondary text-xs mb-2">{{ $t('messagesGateway.aliasesHint') }}</p>
-        <textarea
-          id="agents-aliases"
-          v-model="aliasesJson"
-          rows="4"
-          class="w-full px-3 py-2 rounded surface-card border border-light-border/30 dark:border-dark-border/20 txt-primary text-xs font-mono"
-          data-testid="input-agents-aliases"
-        />
-        <button
-          type="button"
-          class="btn-primary mt-2 px-4 py-2 rounded-lg text-sm font-medium disabled:opacity-50"
-          :disabled="savingAliases"
-          data-testid="btn-agents-save-aliases"
-          @click="onSaveAliases"
-        >
-          {{ $t('messagesGateway.saveAliases') }}
-        </button>
-      </div>
-    </section>
+    <GatewayAccessSection :form="form" @change="apply" />
+    <GatewayToolsSection :form="form" :status="status" @change="apply" />
+    <GatewayImagesSection :form="form" :status="status" @change="apply" />
+    <GatewaySessionSection :form="form" @change="apply" />
+    <GatewayConnectionSection :status="status" @saved="emit('saved')" />
   </div>
 </template>

--- a/frontend/src/components/config/messagesGateway/MessagesGatewayAdminSettings.vue
+++ b/frontend/src/components/config/messagesGateway/MessagesGatewayAdminSettings.vue
@@ -1,0 +1,564 @@
+<script setup lang="ts">
+/**
+ * Instance-wide settings for the Anthropic-compatible gateway (admins only).
+ *
+ * Every control writes one setting and reports the outcome immediately —
+ * there is no "Save all" button to forget. The upstream URL and the model
+ * aliases are the exception: free text is only submitted on demand.
+ */
+import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { Icon } from '@iconify/vue'
+import { useNotification } from '@/composables/useNotification'
+import {
+  saveMessagesGatewayAliases,
+  saveMessagesGatewayFlags,
+  saveMessagesGatewayUpstream,
+  type ImageDetail,
+  type MessagesGatewaySettings,
+  type MessagesGatewayStatus,
+  type VisionMode,
+  type WebSearchMode,
+} from '@/services/api/messagesGatewayApi'
+import GatewaySettingRow from './GatewaySettingRow.vue'
+import GatewaySettingToggle from './GatewaySettingToggle.vue'
+
+const MIN_TOOL_ROUNDS = 1
+const MAX_TOOL_ROUNDS = 32
+const MIN_MAX_IMAGES = 0
+const MAX_MAX_IMAGES = 100
+
+const props = defineProps<{
+  status: MessagesGatewayStatus
+}>()
+
+const emit = defineEmits<{
+  saved: []
+}>()
+
+const { t } = useI18n()
+const { success, error } = useNotification()
+
+const saving = ref(false)
+const savingUpstream = ref(false)
+const savingAliases = ref(false)
+
+const form = ref({
+  enabled: false,
+  allow_operator_key: false,
+  mcp_tools_enabled: false,
+  mcp_tools_with_client_tools: false,
+  mcp_max_iterations: 8,
+  web_search_mode: 'auto' as WebSearchMode,
+  vision_mode: 'auto' as VisionMode,
+  vision_image_detail: 'auto' as ImageDetail,
+  vision_max_images: 0,
+  context_injection_enabled: false,
+  budget_notice_enabled: true,
+  session_summary_enabled: true,
+})
+
+const upstreamUrl = ref('')
+const aliasesJson = ref('{}')
+
+const mcpServerCount = computed(() => props.status.mcp_servers_configured ?? 0)
+
+const mcpNote = computed(() =>
+  mcpServerCount.value > 0 ? undefined : t('messagesGateway.settings.mcpTools.noneConfigured')
+)
+const mcpDependentNote = computed(() =>
+  form.value.mcp_tools_enabled ? undefined : t('messagesGateway.settings.requiresMcpTools')
+)
+const webSearchNote = computed(() =>
+  props.status.web_search_available ? undefined : t('messagesGateway.webSearchUnavailable')
+)
+const visionNote = computed(() =>
+  props.status.vision_available ? undefined : t('messagesGateway.visionUnavailable')
+)
+const maxImagesHint = computed(() =>
+  0 === form.value.vision_max_images
+    ? t('messagesGateway.settings.maxImages.unlimited')
+    : t('messagesGateway.settings.maxImages.limited', { count: form.value.vision_max_images })
+)
+
+watch(() => props.status, syncFromStatus, { immediate: true, deep: true })
+
+/**
+ * `synaplan` needs a configured provider. A stored mode whose provider has
+ * since disappeared would leave the page advertising a capability that never
+ * runs, so fall back to `auto` for display and write that back once.
+ */
+function usableMode<T extends WebSearchMode | VisionMode>(mode: T, available: boolean): T {
+  return !available && 'synaplan' === mode ? ('auto' as T) : mode
+}
+
+function syncFromStatus() {
+  const status = props.status
+  form.value = {
+    enabled: status.enabled,
+    allow_operator_key: status.allow_operator_key ?? false,
+    mcp_tools_enabled: status.mcp_tools_enabled ?? false,
+    mcp_tools_with_client_tools: status.mcp_tools_with_client_tools ?? false,
+    mcp_max_iterations: status.mcp_max_iterations ?? 8,
+    web_search_mode: usableMode(
+      status.web_search_mode ?? 'auto',
+      Boolean(status.web_search_available)
+    ),
+    vision_mode: usableMode(status.vision_mode ?? 'auto', Boolean(status.vision_available)),
+    vision_image_detail: status.vision_image_detail ?? 'auto',
+    vision_max_images: status.vision_max_images ?? 0,
+    context_injection_enabled: status.context_injection_enabled ?? false,
+    budget_notice_enabled: status.budget_notice_enabled ?? true,
+    session_summary_enabled: status.session_summary_enabled ?? true,
+  }
+  upstreamUrl.value = status.upstream_url
+  aliasesJson.value = JSON.stringify(status.model_aliases ?? {}, null, 2)
+  void persistUnusableModes()
+}
+
+async function persistUnusableModes(): Promise<void> {
+  const patch: MessagesGatewaySettings = {}
+  if (form.value.web_search_mode !== props.status.web_search_mode) {
+    patch.web_search_mode = form.value.web_search_mode
+  }
+  if (form.value.vision_mode !== props.status.vision_mode) {
+    patch.vision_mode = form.value.vision_mode
+  }
+  if (0 === Object.keys(patch).length) return
+
+  try {
+    await saveMessagesGatewayFlags(patch)
+  } catch {
+    // Keep the coerced value on screen; the next explicit save catches up.
+  }
+}
+
+async function apply(patch: MessagesGatewaySettings) {
+  if (saving.value) return
+  saving.value = true
+  try {
+    await saveMessagesGatewayFlags(patch)
+    success(t('messagesGateway.flagsSaved'))
+    emit('saved')
+  } catch (err) {
+    error((err as Error).message || t('messagesGateway.flagsError'))
+    syncFromStatus()
+  } finally {
+    saving.value = false
+  }
+}
+
+function clamp(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return min
+  return Math.min(max, Math.max(min, Math.round(value)))
+}
+
+async function onToolRoundsChange() {
+  const value = clamp(Number(form.value.mcp_max_iterations), MIN_TOOL_ROUNDS, MAX_TOOL_ROUNDS)
+  form.value.mcp_max_iterations = value
+  if (value === props.status.mcp_max_iterations) return
+  await apply({ mcp_max_iterations: value })
+}
+
+async function onMaxImagesChange() {
+  const value = clamp(Number(form.value.vision_max_images), MIN_MAX_IMAGES, MAX_MAX_IMAGES)
+  form.value.vision_max_images = value
+  if (value === props.status.vision_max_images) return
+  await apply({ vision_max_images: value })
+}
+
+async function onSaveUpstream() {
+  savingUpstream.value = true
+  try {
+    await saveMessagesGatewayUpstream(upstreamUrl.value.trim())
+    success(t('messagesGateway.upstreamSaved'))
+    emit('saved')
+  } catch (err) {
+    error((err as Error).message || t('messagesGateway.upstreamError'))
+  } finally {
+    savingUpstream.value = false
+  }
+}
+
+async function onSaveAliases() {
+  savingAliases.value = true
+  try {
+    const parsed = JSON.parse(aliasesJson.value) as Record<string, string>
+    await saveMessagesGatewayAliases(parsed)
+    success(t('messagesGateway.aliasesSaved'))
+    emit('saved')
+  } catch (err) {
+    error((err as Error).message || t('messagesGateway.aliasesError'))
+  } finally {
+    savingAliases.value = false
+  }
+}
+</script>
+
+<template>
+  <div class="surface-card p-6" data-testid="section-agents-admin">
+    <div class="flex items-start gap-3 mb-2">
+      <div class="p-2 rounded-lg bg-[var(--brand)]/10">
+        <Icon icon="heroicons:adjustments-horizontal" class="w-5 h-5 text-[var(--brand)]" />
+      </div>
+      <div class="min-w-0">
+        <h3 class="text-lg font-semibold txt-primary">
+          {{ $t('messagesGateway.settings.title') }}
+        </h3>
+        <p class="txt-secondary text-sm mt-0.5">{{ $t('messagesGateway.settings.subtitle') }}</p>
+      </div>
+    </div>
+
+    <p
+      v-if="!form.enabled"
+      class="mt-4 flex items-start gap-2 rounded-lg px-3 py-2 text-xs bg-amber-500/10 text-amber-700 dark:text-amber-300"
+      data-testid="notice-agents-disabled"
+    >
+      <Icon icon="heroicons:pause-circle" class="w-4 h-4 flex-shrink-0 mt-0.5" />
+      <span>{{ $t('messagesGateway.settings.disabledNotice') }}</span>
+    </p>
+
+    <!-- Access -->
+    <section class="mt-6">
+      <h4 class="text-sm font-semibold txt-primary uppercase tracking-wide">
+        {{ $t('messagesGateway.settings.sections.access.title') }}
+      </h4>
+      <p class="txt-secondary text-xs mt-1">
+        {{ $t('messagesGateway.settings.sections.access.description') }}
+      </p>
+      <div class="divide-y divide-light-border/20 dark:divide-dark-border/10">
+        <GatewaySettingRow
+          :label="$t('messagesGateway.settings.enabled.label')"
+          :description="$t('messagesGateway.settings.enabled.description')"
+        >
+          <GatewaySettingToggle
+            :model-value="form.enabled"
+            :label="$t('messagesGateway.settings.enabled.label')"
+            data-testid="toggle-agents-enabled"
+            @update:model-value="
+              (value) => {
+                form.enabled = value
+                apply({ enabled: value })
+              }
+            "
+          />
+        </GatewaySettingRow>
+
+        <GatewaySettingRow
+          :label="$t('messagesGateway.settings.operatorKey.label')"
+          :description="$t('messagesGateway.settings.operatorKey.description')"
+        >
+          <GatewaySettingToggle
+            :model-value="form.allow_operator_key"
+            :label="$t('messagesGateway.settings.operatorKey.label')"
+            data-testid="toggle-agents-operator-key"
+            @update:model-value="
+              (value) => {
+                form.allow_operator_key = value
+                apply({ allow_operator_key: value })
+              }
+            "
+          />
+        </GatewaySettingRow>
+      </div>
+    </section>
+
+    <!-- Tool calling -->
+    <section class="mt-8">
+      <h4 class="text-sm font-semibold txt-primary uppercase tracking-wide">
+        {{ $t('messagesGateway.settings.sections.tools.title') }}
+      </h4>
+      <p class="txt-secondary text-xs mt-1">
+        {{ $t('messagesGateway.settings.sections.tools.description') }}
+      </p>
+      <div class="divide-y divide-light-border/20 dark:divide-dark-border/10">
+        <GatewaySettingRow
+          :label="$t('messagesGateway.settings.mcpTools.label')"
+          :description="$t('messagesGateway.settings.mcpTools.description')"
+          :note="mcpNote"
+        >
+          <GatewaySettingToggle
+            :model-value="form.mcp_tools_enabled"
+            :label="$t('messagesGateway.settings.mcpTools.label')"
+            data-testid="toggle-agents-mcp-tools"
+            @update:model-value="
+              (value) => {
+                form.mcp_tools_enabled = value
+                apply({ mcp_tools_enabled: value })
+              }
+            "
+          />
+        </GatewaySettingRow>
+
+        <GatewaySettingRow
+          :label="$t('messagesGateway.settings.mcpWithClientTools.label')"
+          :description="$t('messagesGateway.settings.mcpWithClientTools.description')"
+          :note="mcpDependentNote"
+          :disabled="!form.mcp_tools_enabled"
+        >
+          <GatewaySettingToggle
+            :model-value="form.mcp_tools_with_client_tools"
+            :label="$t('messagesGateway.settings.mcpWithClientTools.label')"
+            :disabled="!form.mcp_tools_enabled"
+            data-testid="toggle-agents-mcp-with-client-tools"
+            @update:model-value="
+              (value) => {
+                form.mcp_tools_with_client_tools = value
+                apply({ mcp_tools_with_client_tools: value })
+              }
+            "
+          />
+        </GatewaySettingRow>
+
+        <GatewaySettingRow
+          :label="$t('messagesGateway.settings.toolRounds.label')"
+          :description="$t('messagesGateway.settings.toolRounds.description')"
+          :note="mcpDependentNote"
+          :disabled="!form.mcp_tools_enabled"
+        >
+          <input
+            v-model.number="form.mcp_max_iterations"
+            type="number"
+            :min="MIN_TOOL_ROUNDS"
+            :max="MAX_TOOL_ROUNDS"
+            :disabled="!form.mcp_tools_enabled"
+            class="w-24 px-3 py-2 rounded-lg surface-card border border-light-border/30 dark:border-dark-border/20 txt-primary text-sm text-right focus:outline-none focus:ring-2 focus:ring-[var(--brand)] disabled:cursor-not-allowed"
+            data-testid="input-agents-tool-rounds"
+            @change="onToolRoundsChange"
+          />
+        </GatewaySettingRow>
+
+        <GatewaySettingRow
+          :label="$t('messagesGateway.webSearchLabel')"
+          :description="$t('messagesGateway.webSearchHint')"
+          :note="webSearchNote"
+        >
+          <select
+            :value="form.web_search_mode"
+            class="w-full sm:w-56 px-3 py-2 rounded-lg surface-card border border-light-border/30 dark:border-dark-border/20 txt-primary text-sm focus:outline-none focus:ring-2 focus:ring-[var(--brand)]"
+            data-testid="select-agents-web-search"
+            @change="
+              (event) => {
+                const value = (event.target as HTMLSelectElement).value as WebSearchMode
+                form.web_search_mode = value
+                apply({ web_search_mode: value })
+              }
+            "
+          >
+            <option value="auto">{{ $t('messagesGateway.webSearchModeAuto') }}</option>
+            <option value="synaplan" :disabled="!status.web_search_available">
+              {{ $t('messagesGateway.webSearchModeSynaplan') }}
+            </option>
+            <option value="passthrough">
+              {{ $t('messagesGateway.webSearchModePassthrough') }}
+            </option>
+            <option value="off">{{ $t('messagesGateway.webSearchModeOff') }}</option>
+          </select>
+        </GatewaySettingRow>
+      </div>
+    </section>
+
+    <!-- Images -->
+    <section class="mt-8">
+      <h4 class="text-sm font-semibold txt-primary uppercase tracking-wide">
+        {{ $t('messagesGateway.settings.sections.vision.title') }}
+      </h4>
+      <p class="txt-secondary text-xs mt-1">
+        {{ $t('messagesGateway.settings.sections.vision.description') }}
+      </p>
+      <div class="divide-y divide-light-border/20 dark:divide-dark-border/10">
+        <GatewaySettingRow
+          :label="$t('messagesGateway.visionLabel')"
+          :description="$t('messagesGateway.visionHint')"
+          :note="visionNote"
+        >
+          <select
+            :value="form.vision_mode"
+            class="w-full sm:w-56 px-3 py-2 rounded-lg surface-card border border-light-border/30 dark:border-dark-border/20 txt-primary text-sm focus:outline-none focus:ring-2 focus:ring-[var(--brand)]"
+            data-testid="select-agents-vision-mode"
+            @change="
+              (event) => {
+                const value = (event.target as HTMLSelectElement).value as VisionMode
+                form.vision_mode = value
+                apply({ vision_mode: value })
+              }
+            "
+          >
+            <option value="auto">{{ $t('messagesGateway.visionModeAuto') }}</option>
+            <option value="synaplan" :disabled="!status.vision_available">
+              {{ $t('messagesGateway.visionModeSynaplan') }}
+            </option>
+            <option value="passthrough">
+              {{ $t('messagesGateway.visionModePassthrough') }}
+            </option>
+            <option value="off">{{ $t('messagesGateway.visionModeOff') }}</option>
+          </select>
+        </GatewaySettingRow>
+
+        <GatewaySettingRow
+          :label="$t('messagesGateway.settings.imageDetail.label')"
+          :description="$t('messagesGateway.settings.imageDetail.description')"
+        >
+          <select
+            :value="form.vision_image_detail"
+            class="w-full sm:w-56 px-3 py-2 rounded-lg surface-card border border-light-border/30 dark:border-dark-border/20 txt-primary text-sm focus:outline-none focus:ring-2 focus:ring-[var(--brand)]"
+            data-testid="select-agents-image-detail"
+            @change="
+              (event) => {
+                const value = (event.target as HTMLSelectElement).value as ImageDetail
+                form.vision_image_detail = value
+                apply({ vision_image_detail: value })
+              }
+            "
+          >
+            <option value="auto">
+              {{ $t('messagesGateway.settings.imageDetail.optionAuto') }}
+            </option>
+            <option value="low">{{ $t('messagesGateway.settings.imageDetail.optionLow') }}</option>
+            <option value="high">
+              {{ $t('messagesGateway.settings.imageDetail.optionHigh') }}
+            </option>
+          </select>
+        </GatewaySettingRow>
+
+        <GatewaySettingRow
+          :label="$t('messagesGateway.settings.maxImages.label')"
+          :description="$t('messagesGateway.settings.maxImages.description')"
+        >
+          <div class="flex items-center gap-3 sm:justify-end">
+            <input
+              v-model.number="form.vision_max_images"
+              type="number"
+              :min="MIN_MAX_IMAGES"
+              :max="MAX_MAX_IMAGES"
+              class="w-24 px-3 py-2 rounded-lg surface-card border border-light-border/30 dark:border-dark-border/20 txt-primary text-sm text-right focus:outline-none focus:ring-2 focus:ring-[var(--brand)]"
+              data-testid="input-agents-max-images"
+              @change="onMaxImagesChange"
+            />
+            <span class="text-xs txt-secondary w-24 text-left">{{ maxImagesHint }}</span>
+          </div>
+        </GatewaySettingRow>
+      </div>
+    </section>
+
+    <!-- Context & session -->
+    <section class="mt-8">
+      <h4 class="text-sm font-semibold txt-primary uppercase tracking-wide">
+        {{ $t('messagesGateway.settings.sections.session.title') }}
+      </h4>
+      <p class="txt-secondary text-xs mt-1">
+        {{ $t('messagesGateway.settings.sections.session.description') }}
+      </p>
+      <div class="divide-y divide-light-border/20 dark:divide-dark-border/10">
+        <GatewaySettingRow
+          :label="$t('messagesGateway.settings.contextInjection.label')"
+          :description="$t('messagesGateway.settings.contextInjection.description')"
+        >
+          <GatewaySettingToggle
+            :model-value="form.context_injection_enabled"
+            :label="$t('messagesGateway.settings.contextInjection.label')"
+            data-testid="toggle-agents-context-injection"
+            @update:model-value="
+              (value) => {
+                form.context_injection_enabled = value
+                apply({ context_injection_enabled: value })
+              }
+            "
+          />
+        </GatewaySettingRow>
+
+        <GatewaySettingRow
+          :label="$t('messagesGateway.settings.budgetNotice.label')"
+          :description="$t('messagesGateway.settings.budgetNotice.description')"
+        >
+          <GatewaySettingToggle
+            :model-value="form.budget_notice_enabled"
+            :label="$t('messagesGateway.settings.budgetNotice.label')"
+            data-testid="toggle-agents-budget-notice"
+            @update:model-value="
+              (value) => {
+                form.budget_notice_enabled = value
+                apply({ budget_notice_enabled: value })
+              }
+            "
+          />
+        </GatewaySettingRow>
+
+        <GatewaySettingRow
+          :label="$t('messagesGateway.settings.sessionSummary.label')"
+          :description="$t('messagesGateway.settings.sessionSummary.description')"
+        >
+          <GatewaySettingToggle
+            :model-value="form.session_summary_enabled"
+            :label="$t('messagesGateway.settings.sessionSummary.label')"
+            data-testid="toggle-agents-session-summary"
+            @update:model-value="
+              (value) => {
+                form.session_summary_enabled = value
+                apply({ session_summary_enabled: value })
+              }
+            "
+          />
+        </GatewaySettingRow>
+      </div>
+    </section>
+
+    <!-- Connection -->
+    <section class="mt-8">
+      <h4 class="text-sm font-semibold txt-primary uppercase tracking-wide">
+        {{ $t('messagesGateway.settings.sections.connection.title') }}
+      </h4>
+      <p class="txt-secondary text-xs mt-1">
+        {{ $t('messagesGateway.settings.sections.connection.description') }}
+      </p>
+
+      <div class="mt-4">
+        <label class="block text-sm font-medium txt-primary mb-1" for="agents-upstream">
+          {{ $t('messagesGateway.upstreamLabel') }}
+        </label>
+        <p class="txt-secondary text-xs mb-2">{{ $t('messagesGateway.upstreamWarning') }}</p>
+        <div class="flex flex-wrap gap-2">
+          <input
+            id="agents-upstream"
+            v-model="upstreamUrl"
+            type="url"
+            class="flex-1 min-w-[16rem] px-3 py-2 rounded surface-card border border-light-border/30 dark:border-dark-border/20 txt-primary text-sm font-mono"
+            data-testid="input-agents-upstream"
+          />
+          <button
+            type="button"
+            class="btn-primary px-4 py-2 rounded-lg text-sm font-medium disabled:opacity-50"
+            :disabled="savingUpstream"
+            data-testid="btn-agents-save-upstream"
+            @click="onSaveUpstream"
+          >
+            {{ $t('messagesGateway.saveUpstream') }}
+          </button>
+        </div>
+      </div>
+
+      <div class="mt-5">
+        <label class="block text-sm font-medium txt-primary mb-1" for="agents-aliases">
+          {{ $t('messagesGateway.aliasesLabel') }}
+        </label>
+        <p class="txt-secondary text-xs mb-2">{{ $t('messagesGateway.aliasesHint') }}</p>
+        <textarea
+          id="agents-aliases"
+          v-model="aliasesJson"
+          rows="4"
+          class="w-full px-3 py-2 rounded surface-card border border-light-border/30 dark:border-dark-border/20 txt-primary text-xs font-mono"
+          data-testid="input-agents-aliases"
+        />
+        <button
+          type="button"
+          class="btn-primary mt-2 px-4 py-2 rounded-lg text-sm font-medium disabled:opacity-50"
+          :disabled="savingAliases"
+          data-testid="btn-agents-save-aliases"
+          @click="onSaveAliases"
+        >
+          {{ $t('messagesGateway.saveAliases') }}
+        </button>
+      </div>
+    </section>
+  </div>
+</template>

--- a/frontend/src/components/config/messagesGateway/types.ts
+++ b/frontend/src/components/config/messagesGateway/types.ts
@@ -1,0 +1,11 @@
+import type { MessagesGatewaySettings } from '@/services/api/messagesGatewayApi'
+
+/**
+ * The settings panel's working copy: the same settings the flags endpoint
+ * accepts, but with every one resolved to a concrete value for the controls to
+ * bind to. Derived from the generated request schema so a new backend setting
+ * cannot be forgotten here.
+ */
+export type GatewayForm = {
+  [K in keyof Required<MessagesGatewaySettings>]-?: NonNullable<MessagesGatewaySettings[K]>
+}

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -4427,9 +4427,6 @@
     "saveKeyError": "API-Schlüssel konnte nicht gespeichert werden",
     "clearKeySuccess": "API-Schlüssel entfernt",
     "clearKeyError": "API-Schlüssel konnte nicht entfernt werden",
-    "adminTitle": "Admin-Einstellungen",
-    "enableLabel": "Messages-Gateway für diese Instanz aktivieren",
-    "allowOperatorKeyLabel": "Operator-Anthropic-Schlüssel als Fallback erlauben (mit Vorsicht nutzen)",
     "webSearchLabel": "Websuche für verbundene KI-Assistenten",
     "webSearchModeAuto": "Automatisch (empfohlen)",
     "webSearchModeSynaplan": "Immer die Websuche von Synaplan verwenden",
@@ -4450,12 +4447,86 @@
     "upstreamSaved": "Upstream-URL gespeichert",
     "upstreamError": "Upstream-URL konnte nicht gespeichert werden",
     "aliasesLabel": "Modell-Aliase (JSON)",
-    "aliasesHint": "Mappt Claude-Code-Modell-IDs auf Synaplan-Katalog-IDs, z. B. {\"claude-sonnet-4-6\": \"claude-sonnet-4-5-20250929\"}.",
+    "aliasesHint": "Ordnet die von Claude Code angefragten Modellnamen Modellen in Ihrem Synaplan-Katalog zu, zum Beispiel claude-sonnet-4-6 → claude-sonnet-4-5-20250929.",
     "saveAliases": "Aliase speichern",
     "aliasesSaved": "Aliase gespeichert",
     "aliasesError": "Aliase konnten nicht gespeichert werden (JSON prüfen)",
     "flagsSaved": "Einstellungen gespeichert",
     "flagsError": "Einstellungen konnten nicht gespeichert werden",
+    "settings": {
+      "title": "Gateway-Einstellungen",
+      "subtitle": "Diese Einstellungen gelten für jedes Agenten-Tool, das mit dieser Instanz verbunden ist.",
+      "disabledNotice": "Das Gateway ist derzeit aus. Die Einstellungen werden gespeichert und greifen, sobald Sie es einschalten.",
+      "sections": {
+        "access": {
+          "title": "Zugang",
+          "description": "Wer das Gateway nutzen darf und welcher API-Schlüssel die Anfragen bezahlt."
+        },
+        "tools": {
+          "title": "Werkzeugaufrufe",
+          "description": "Was verbundene KI-Assistenten außer Antworten noch dürfen: die Werkzeuge Ihres Arbeitsbereichs nutzen und im Web suchen."
+        },
+        "vision": {
+          "title": "Bilder",
+          "description": "Wie Screenshots und andere Bilder an den KI-Anbieter weitergegeben werden. Agenten-Tools schicken bei jeder Nachricht alle Bilder einer Sitzung erneut mit, deshalb wirken sich diese Einstellungen stark auf die Kosten aus."
+        },
+        "session": {
+          "title": "Kontext und Sitzung",
+          "description": "Was Synaplan einer Anfrage hinzufügt und was danach festgehalten wird."
+        },
+        "connection": {
+          "title": "Verbindung",
+          "description": "Wohin Anfragen gehen und wie Modellnamen übersetzt werden."
+        }
+      },
+      "enabled": {
+        "label": "Gateway aktivieren",
+        "description": "Solange dies aus ist, erhalten verbundene Tools eine klare Fehlermeldung statt einer Antwort."
+      },
+      "operatorKey": {
+        "label": "Instanz-Schlüssel als Rückfallebene erlauben",
+        "description": "Nutzerinnen und Nutzer ohne eigenen Anthropic-Schlüssel verwenden dann den Schlüssel dieser Instanz; die Kosten laufen gegen ihr Synaplan-Budget."
+      },
+      "mcpTools": {
+        "label": "KI-Assistenten Ihre Werkzeuge nutzen lassen",
+        "description": "Synaplan führt die Werkzeuge Ihrer verbundenen Werkzeug-Server selbst aus und gibt das Ergebnis an den Assistenten zurück.",
+        "noneConfigured": "Es ist noch kein Werkzeug-Server verbunden. Sie können einen unter Kanäle → MCP-Server hinzufügen."
+      },
+      "mcpWithClientTools": {
+        "label": "Eigene Werkzeuge auch anbieten, wenn das Agenten-Tool eigene mitbringt",
+        "description": "Claude Code bringt bereits einen vollständigen Satz Werkzeuge mit. Schalten Sie dies nur ein, wenn Ihre Werkzeuge zusätzlich angeboten werden sollen — eine sehr lange Werkzeugliste macht einen Assistenten ungenauer."
+      },
+      "toolRounds": {
+        "label": "Maximale Werkzeugrunden pro Nachricht",
+        "description": "Wie oft ein KI-Assistent ein Werkzeug nutzen und erneut nachdenken darf, bevor er antworten muss. Höhere Werte erlauben gründlicheres Arbeiten und kosten mehr."
+      },
+      "imageDetail": {
+        "label": "Bildqualität",
+        "description": "Wie genau das KI-Modell ein Bild ansehen soll. Niedrige Qualität kostet deutlich weniger und reicht meist aus, um Text von einem Screenshot zu lesen. Anbieter ohne diese Wahlmöglichkeit ignorieren die Einstellung.",
+        "optionAuto": "Anbieter entscheiden lassen (empfohlen)",
+        "optionLow": "Niedrig — am günstigsten",
+        "optionHigh": "Hoch — meiste Details"
+      },
+      "maxImages": {
+        "label": "Maximale Bilder pro Nachricht",
+        "description": "Es werden nur die neuesten Bilder gesendet, ältere durch einen Hinweis ersetzt. Das begrenzt die Kosten langer Sitzungen voller Screenshots.",
+        "unlimited": "Ohne Limit",
+        "limited": "Neueste {count}"
+      },
+      "contextInjection": {
+        "label": "Wissen aus Ihrem Arbeitsbereich ergänzen",
+        "description": "Synaplan fügt jeder Anfrage passende Informationen aus Ihrem Arbeitsbereich hinzu, damit der KI-Assistent Ihren Kontext kennt."
+      },
+      "budgetNotice": {
+        "label": "Warnen, wenn das Budget knapp wird",
+        "description": "Der KI-Assistent erhält einen kurzen Hinweis in seiner Antwort, sobald Ihr Synaplan-Budget fast aufgebraucht ist."
+      },
+      "sessionSummary": {
+        "label": "Zusammenfassung jeder Sitzung behalten",
+        "description": "Synaplan schreibt zu jeder Agenten-Sitzung eine kurze Zusammenfassung in Ihren Chat-Verlauf, damit Sie später sehen, woran gearbeitet wurde."
+      },
+      "requiresMcpTools": "Verfügbar, sobald Ihre Werkzeuge oben eingeschaltet sind."
+    },
     "loadError": "KI-Agenten-Einstellungen konnten nicht geladen werden",
     "source": {
       "user": "Ihr Schlüssel",

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -4479,6 +4479,16 @@
           "description": "Wohin Anfragen gehen und wie Modellnamen übersetzt werden."
         }
       },
+      "activeTools": {
+        "title": "Läuft gerade in Ihrem Auftrag",
+        "empty": "Synaplan führt keine eigenen Tools aus. Verbundene KI-Assistenten erhalten nur die Tools, die ihr eigenes Programm mitbringt.",
+        "hint": "Eine einzelne Nachricht kann eines davon trotzdem auslassen: Bringt ein Programm ein eigenes Tool mit demselben Namen mit, behält es dieses, und die Websuche läuft nur, wenn der Assistent danach fragt.",
+        "mcpServers": "dazu die Tools von 1 verbundenen Tool-Server | dazu die Tools von {count} verbundenen Tool-Servern",
+        "tools": {
+          "web_search": "Websuche",
+          "analyze_image": "Bildanalyse"
+        }
+      },
       "enabled": {
         "label": "Gateway aktivieren",
         "description": "Solange dies aus ist, erhalten verbundene Tools eine klare Fehlermeldung statt einer Antwort."

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -4545,6 +4545,16 @@
           "description": "Where requests are sent and how model names are translated."
         }
       },
+      "activeTools": {
+        "title": "Running on your behalf right now",
+        "empty": "Synaplan runs no tools of its own. Connected AI assistants only get the tools their own program brings along.",
+        "hint": "A single message can still skip one of these: a program that brings its own tool of the same name keeps it, and web search only runs when the assistant asks for it.",
+        "mcpServers": "plus the tools of 1 connected tool server | plus the tools of {count} connected tool servers",
+        "tools": {
+          "web_search": "Web search",
+          "analyze_image": "Image analysis"
+        }
+      },
       "enabled": {
         "label": "Enable the gateway",
         "description": "While this is off, connected tools get a clear error instead of an answer."

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -4493,9 +4493,6 @@
     "saveKeyError": "Could not save API key",
     "clearKeySuccess": "API key removed",
     "clearKeyError": "Could not remove API key",
-    "adminTitle": "Admin settings",
-    "enableLabel": "Enable Messages gateway for this instance",
-    "allowOperatorKeyLabel": "Allow operator Anthropic key as fallback (use with care)",
     "webSearchLabel": "Web search for connected AI assistants",
     "webSearchModeAuto": "Automatic (recommended)",
     "webSearchModeSynaplan": "Always use Synaplan's web search",
@@ -4516,12 +4513,86 @@
     "upstreamSaved": "Upstream URL saved",
     "upstreamError": "Could not save upstream URL",
     "aliasesLabel": "Model aliases (JSON)",
-    "aliasesHint": "Map Claude Code model IDs to Synaplan catalog IDs, e.g. {\"claude-sonnet-4-6\": \"claude-sonnet-4-5-20250929\"}.",
+    "aliasesHint": "Map the model names Claude Code asks for to models in your Synaplan catalog, for example claude-sonnet-4-6 → claude-sonnet-4-5-20250929.",
     "saveAliases": "Save aliases",
     "aliasesSaved": "Aliases saved",
     "aliasesError": "Could not save aliases (check JSON)",
     "flagsSaved": "Settings saved",
     "flagsError": "Could not save settings",
+    "settings": {
+      "title": "Gateway settings",
+      "subtitle": "These settings apply to every agent tool connected to this instance.",
+      "disabledNotice": "The gateway is off right now. Settings are saved and take effect as soon as you turn it on.",
+      "sections": {
+        "access": {
+          "title": "Access",
+          "description": "Who can use the gateway, and which API key pays for the requests."
+        },
+        "tools": {
+          "title": "Tool calling",
+          "description": "What connected AI assistants may do besides answering: use the tools of your workspace and search the web."
+        },
+        "vision": {
+          "title": "Images",
+          "description": "How screenshots and other images are passed on to the AI provider. Agent tools resend every image of a session with each message, so these settings have a large effect on cost."
+        },
+        "session": {
+          "title": "Context and session",
+          "description": "What Synaplan adds to a request, and what it keeps afterwards."
+        },
+        "connection": {
+          "title": "Connection",
+          "description": "Where requests are sent and how model names are translated."
+        }
+      },
+      "enabled": {
+        "label": "Enable the gateway",
+        "description": "While this is off, connected tools get a clear error instead of an answer."
+      },
+      "operatorKey": {
+        "label": "Allow the instance key as fallback",
+        "description": "Users without their own Anthropic key then use the key of this instance, and the cost counts against their Synaplan budget."
+      },
+      "mcpTools": {
+        "label": "Let AI assistants use your tools",
+        "description": "Synaplan runs the tools of your connected tool servers itself and passes the result back to the assistant.",
+        "noneConfigured": "No tool server is connected yet. You can add one under Channels → MCP servers."
+      },
+      "mcpWithClientTools": {
+        "label": "Offer your tools even when the agent tool brings its own",
+        "description": "Claude Code already ships a full set of tools. Turn this on only if your own tools should be offered on top — a very long tool list makes an assistant less precise."
+      },
+      "toolRounds": {
+        "label": "Maximum tool rounds per message",
+        "description": "How often an AI assistant may use a tool and think again before it has to answer. Higher values allow more thorough work and cost more."
+      },
+      "imageDetail": {
+        "label": "Image quality",
+        "description": "How closely the AI model should look at an image. Low quality costs noticeably less and is usually enough to read text off a screenshot. Providers that do not offer this choice ignore it.",
+        "optionAuto": "Let the provider decide (recommended)",
+        "optionLow": "Low — cheapest",
+        "optionHigh": "High — most detail"
+      },
+      "maxImages": {
+        "label": "Maximum images per message",
+        "description": "Only the newest images are sent; older ones are replaced with a note. This caps the cost of long sessions full of screenshots.",
+        "unlimited": "No limit",
+        "limited": "Newest {count}"
+      },
+      "contextInjection": {
+        "label": "Add knowledge from your workspace",
+        "description": "Synaplan adds matching information from your workspace to each request, so the AI assistant knows your context."
+      },
+      "budgetNotice": {
+        "label": "Warn when the budget runs low",
+        "description": "The AI assistant receives a short note in its answer once your Synaplan budget is nearly used up."
+      },
+      "sessionSummary": {
+        "label": "Keep a summary of each session",
+        "description": "Synaplan writes a short summary of every agent session to your chat history, so you can see later what was worked on."
+      },
+      "requiresMcpTools": "Available once your tools are switched on above."
+    },
     "loadError": "Could not load AI Agents settings",
     "source": {
       "user": "Your key",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -3445,9 +3445,6 @@
     "saveKeyError": "No se pudo guardar la clave API",
     "clearKeySuccess": "Clave API eliminada",
     "clearKeyError": "No se pudo eliminar la clave API",
-    "adminTitle": "Ajustes de administrador",
-    "enableLabel": "Activar la puerta de enlace Messages en esta instancia",
-    "allowOperatorKeyLabel": "Permitir la clave Anthropic del operador como respaldo (úselo con cuidado)",
     "webSearchLabel": "Búsqueda web para los asistentes de IA conectados",
     "webSearchModeAuto": "Automático (recomendado)",
     "webSearchModeSynaplan": "Usar siempre la búsqueda web de Synaplan",
@@ -3468,12 +3465,86 @@
     "upstreamSaved": "URL upstream guardada",
     "upstreamError": "No se pudo guardar la URL upstream",
     "aliasesLabel": "Alias de modelo (JSON)",
-    "aliasesHint": "Asigna IDs de modelo de Claude Code a IDs del catálogo Synaplan, p. ej. {\"claude-sonnet-4-6\": \"claude-sonnet-4-5-20250929\"}.",
+    "aliasesHint": "Asigna los nombres de modelo que pide Claude Code a modelos de su catálogo de Synaplan, por ejemplo claude-sonnet-4-6 → claude-sonnet-4-5-20250929.",
     "saveAliases": "Guardar alias",
     "aliasesSaved": "Alias guardados",
     "aliasesError": "No se pudieron guardar los alias (revise el JSON)",
     "flagsSaved": "Ajustes guardados",
     "flagsError": "No se pudieron guardar los ajustes",
+    "settings": {
+      "title": "Ajustes de la puerta de enlace",
+      "subtitle": "Estos ajustes se aplican a todas las herramientas de agente conectadas a esta instancia.",
+      "disabledNotice": "La puerta de enlace está desactivada. Los ajustes se guardan y se aplican en cuanto la active.",
+      "sections": {
+        "access": {
+          "title": "Acceso",
+          "description": "Quién puede usar la puerta de enlace y qué clave de API paga las peticiones."
+        },
+        "tools": {
+          "title": "Llamadas a herramientas",
+          "description": "Qué pueden hacer los asistentes de IA conectados además de responder: usar las herramientas de su espacio de trabajo y buscar en la web."
+        },
+        "vision": {
+          "title": "Imágenes",
+          "description": "Cómo se envían las capturas de pantalla y otras imágenes al proveedor de IA. Las herramientas de agente reenvían todas las imágenes de una sesión con cada mensaje, así que estos ajustes influyen mucho en el coste."
+        },
+        "session": {
+          "title": "Contexto y sesión",
+          "description": "Qué añade Synaplan a una petición y qué conserva después."
+        },
+        "connection": {
+          "title": "Conexión",
+          "description": "A dónde se envían las peticiones y cómo se traducen los nombres de modelo."
+        }
+      },
+      "enabled": {
+        "label": "Activar la puerta de enlace",
+        "description": "Mientras esté desactivada, las herramientas conectadas reciben un error claro en lugar de una respuesta."
+      },
+      "operatorKey": {
+        "label": "Permitir la clave de la instancia como respaldo",
+        "description": "Quienes no tengan su propia clave de Anthropic usarán la clave de esta instancia, y el coste se descuenta de su presupuesto de Synaplan."
+      },
+      "mcpTools": {
+        "label": "Permitir que los asistentes de IA usen sus herramientas",
+        "description": "Synaplan ejecuta las herramientas de sus servidores conectados y devuelve el resultado al asistente.",
+        "noneConfigured": "Aún no hay ningún servidor de herramientas conectado. Puede añadir uno en Canales → Servidores MCP."
+      },
+      "mcpWithClientTools": {
+        "label": "Ofrecer sus herramientas aunque la herramienta de agente traiga las suyas",
+        "description": "Claude Code ya incluye un conjunto completo de herramientas. Active esto solo si sus herramientas deben ofrecerse además — una lista muy larga hace que el asistente sea menos preciso."
+      },
+      "toolRounds": {
+        "label": "Máximo de rondas de herramientas por mensaje",
+        "description": "Cuántas veces puede un asistente de IA usar una herramienta y volver a pensar antes de tener que responder. Valores más altos permiten un trabajo más minucioso y cuestan más."
+      },
+      "imageDetail": {
+        "label": "Calidad de imagen",
+        "description": "Con cuánto detalle debe mirar el modelo de IA una imagen. La calidad baja cuesta bastante menos y suele bastar para leer texto de una captura. Los proveedores que no ofrecen esta opción la ignoran.",
+        "optionAuto": "Que decida el proveedor (recomendado)",
+        "optionLow": "Baja — la más económica",
+        "optionHigh": "Alta — máximo detalle"
+      },
+      "maxImages": {
+        "label": "Máximo de imágenes por mensaje",
+        "description": "Solo se envían las imágenes más recientes; las anteriores se sustituyen por una nota. Así se limita el coste de sesiones largas llenas de capturas.",
+        "unlimited": "Sin límite",
+        "limited": "Las {count} más recientes"
+      },
+      "contextInjection": {
+        "label": "Añadir conocimiento de su espacio de trabajo",
+        "description": "Synaplan añade a cada petición la información pertinente de su espacio de trabajo para que el asistente de IA conozca su contexto."
+      },
+      "budgetNotice": {
+        "label": "Avisar cuando el presupuesto se agote",
+        "description": "El asistente de IA recibe una nota breve en su respuesta cuando su presupuesto de Synaplan está casi agotado."
+      },
+      "sessionSummary": {
+        "label": "Conservar un resumen de cada sesión",
+        "description": "Synaplan escribe un resumen breve de cada sesión de agente en su historial de chat para que después pueda ver en qué se trabajó."
+      },
+      "requiresMcpTools": "Disponible cuando active sus herramientas arriba."
+    },
     "loadError": "No se pudieron cargar los ajustes de Agentes de IA",
     "source": {
       "user": "Su clave",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -3497,6 +3497,16 @@
           "description": "A dónde se envían las peticiones y cómo se traducen los nombres de modelo."
         }
       },
+      "activeTools": {
+        "title": "Ejecutándose en su nombre ahora mismo",
+        "empty": "Synaplan no ejecuta ninguna herramienta propia. Los asistentes de IA conectados solo reciben las herramientas que aporta su propio programa.",
+        "hint": "Un mensaje concreto puede omitir alguna de ellas: si un programa aporta su propia herramienta con el mismo nombre, se queda con la suya, y la búsqueda web solo se ejecuta cuando el asistente la pide.",
+        "mcpServers": "más las herramientas de 1 servidor de herramientas conectado | más las herramientas de {count} servidores de herramientas conectados",
+        "tools": {
+          "web_search": "Búsqueda web",
+          "analyze_image": "Análisis de imágenes"
+        }
+      },
       "enabled": {
         "label": "Activar la puerta de enlace",
         "description": "Mientras esté desactivada, las herramientas conectadas reciben un error claro en lugar de una respuesta."

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -3446,9 +3446,6 @@
     "saveKeyError": "API anahtarı kaydedilemedi",
     "clearKeySuccess": "API anahtarı kaldırıldı",
     "clearKeyError": "API anahtarı kaldırılamadı",
-    "adminTitle": "Yönetici ayarları",
-    "enableLabel": "Bu örnekte Messages ağ geçidini etkinleştir",
-    "allowOperatorKeyLabel": "Operatör Anthropic anahtarına yedek olarak izin ver (dikkatli kullanın)",
     "webSearchLabel": "Bağlı AI asistanları için web araması",
     "webSearchModeAuto": "Otomatik (önerilen)",
     "webSearchModeSynaplan": "Her zaman Synaplan'ın web aramasını kullan",
@@ -3469,12 +3466,86 @@
     "upstreamSaved": "Upstream URL'si kaydedildi",
     "upstreamError": "Upstream URL'si kaydedilemedi",
     "aliasesLabel": "Model takma adları (JSON)",
-    "aliasesHint": "Claude Code model kimliklerini Synaplan katalog kimliklerine eşler, örn. {\"claude-sonnet-4-6\": \"claude-sonnet-4-5-20250929\"}.",
+    "aliasesHint": "Claude Code'un istediği model adlarını Synaplan kataloğunuzdaki modellere eşler, örneğin claude-sonnet-4-6 → claude-sonnet-4-5-20250929.",
     "saveAliases": "Takma adları kaydet",
     "aliasesSaved": "Takma adlar kaydedildi",
     "aliasesError": "Takma adlar kaydedilemedi (JSON'u kontrol edin)",
     "flagsSaved": "Ayarlar kaydedildi",
     "flagsError": "Ayarlar kaydedilemedi",
+    "settings": {
+      "title": "Ağ geçidi ayarları",
+      "subtitle": "Bu ayarlar, bu örneğe bağlı her aracı aracı için geçerlidir.",
+      "disabledNotice": "Ağ geçidi şu anda kapalı. Ayarlar kaydedilir ve açtığınız anda geçerli olur.",
+      "sections": {
+        "access": {
+          "title": "Erişim",
+          "description": "Ağ geçidini kimler kullanabilir ve istekleri hangi API anahtarı öder."
+        },
+        "tools": {
+          "title": "Araç çağrıları",
+          "description": "Bağlı AI asistanlarının yanıt vermenin dışında neler yapabileceği: çalışma alanınızın araçlarını kullanmak ve web'de arama yapmak."
+        },
+        "vision": {
+          "title": "Görseller",
+          "description": "Ekran görüntülerinin ve diğer görsellerin AI sağlayıcısına nasıl iletileceği. Aracı araçları her mesajda oturumdaki tüm görselleri yeniden gönderir, bu yüzden bu ayarlar maliyeti belirgin biçimde etkiler."
+        },
+        "session": {
+          "title": "Bağlam ve oturum",
+          "description": "Synaplan'ın bir isteğe ne eklediği ve sonrasında neyi sakladığı."
+        },
+        "connection": {
+          "title": "Bağlantı",
+          "description": "İsteklerin nereye gönderildiği ve model adlarının nasıl çevrildiği."
+        }
+      },
+      "enabled": {
+        "label": "Ağ geçidini etkinleştir",
+        "description": "Bu kapalıyken bağlı araçlar yanıt yerine açık bir hata alır."
+      },
+      "operatorKey": {
+        "label": "Yedek olarak örnek anahtarına izin ver",
+        "description": "Kendi Anthropic anahtarı olmayan kullanıcılar bu örneğin anahtarını kullanır ve maliyet Synaplan bütçelerinden düşülür."
+      },
+      "mcpTools": {
+        "label": "AI asistanlarının araçlarınızı kullanmasına izin ver",
+        "description": "Synaplan, bağlı araç sunucularınızın araçlarını kendisi çalıştırır ve sonucu asistana geri verir.",
+        "noneConfigured": "Henüz bağlı bir araç sunucusu yok. Kanallar → MCP sunucuları bölümünden ekleyebilirsiniz."
+      },
+      "mcpWithClientTools": {
+        "label": "Aracı aracının kendi araçları olsa da sizinkileri sun",
+        "description": "Claude Code zaten eksiksiz bir araç seti getirir. Bunu yalnızca kendi araçlarınız da sunulacaksa açın — çok uzun bir araç listesi asistanı daha az isabetli yapar."
+      },
+      "toolRounds": {
+        "label": "Mesaj başına en fazla araç turu",
+        "description": "Bir AI asistanının yanıt vermek zorunda kalmadan önce kaç kez araç kullanıp yeniden düşünebileceği. Yüksek değerler daha titiz çalışmaya izin verir ve daha pahalıdır."
+      },
+      "imageDetail": {
+        "label": "Görsel kalitesi",
+        "description": "AI modelinin bir görsele ne kadar ayrıntılı bakacağı. Düşük kalite belirgin biçimde daha ucuzdur ve ekran görüntüsündeki metni okumak için çoğunlukla yeterlidir. Bu seçeneği sunmayan sağlayıcılar ayarı yok sayar.",
+        "optionAuto": "Sağlayıcı karar versin (önerilir)",
+        "optionLow": "Düşük — en ucuz",
+        "optionHigh": "Yüksek — en fazla ayrıntı"
+      },
+      "maxImages": {
+        "label": "Mesaj başına en fazla görsel",
+        "description": "Yalnızca en yeni görseller gönderilir; eskiler bir notla değiştirilir. Bu, ekran görüntüsüyle dolu uzun oturumların maliyetini sınırlar.",
+        "unlimited": "Sınırsız",
+        "limited": "En yeni {count}"
+      },
+      "contextInjection": {
+        "label": "Çalışma alanınızdan bilgi ekle",
+        "description": "Synaplan her isteğe çalışma alanınızdan ilgili bilgileri ekler, böylece AI asistanı bağlamınızı bilir."
+      },
+      "budgetNotice": {
+        "label": "Bütçe azaldığında uyar",
+        "description": "Synaplan bütçeniz neredeyse tükendiğinde AI asistanı yanıtında kısa bir not alır."
+      },
+      "sessionSummary": {
+        "label": "Her oturumun özetini sakla",
+        "description": "Synaplan her aracı oturumunun kısa bir özetini sohbet geçmişinize yazar, böylece sonradan neyin üzerinde çalışıldığını görebilirsiniz."
+      },
+      "requiresMcpTools": "Yukarıda araçlarınızı açtığınızda kullanılabilir."
+    },
     "loadError": "Yapay zeka ajanları ayarları yüklenemedi",
     "source": {
       "user": "Sizin anahtarınız",

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -3498,6 +3498,16 @@
           "description": "İsteklerin nereye gönderildiği ve model adlarının nasıl çevrildiği."
         }
       },
+      "activeTools": {
+        "title": "Şu anda sizin adınıza çalışıyor",
+        "empty": "Synaplan kendi araçlarından hiçbirini çalıştırmıyor. Bağlı AI asistanları yalnızca kendi programlarının sunduğu araçları alır.",
+        "hint": "Tek bir mesaj bunlardan birini yine de atlayabilir: kendi programı aynı adda bir araç getiriyorsa onu kullanır ve web araması yalnızca asistan istediğinde çalışır.",
+        "mcpServers": "ayrıca 1 bağlı araç sunucusunun araçları | ayrıca {count} bağlı araç sunucusunun araçları",
+        "tools": {
+          "web_search": "Web araması",
+          "analyze_image": "Görüntü analizi"
+        }
+      },
       "enabled": {
         "label": "Ağ geçidini etkinleştir",
         "description": "Bu kapalıyken bağlı araçlar yanıt yerine açık bir hata alır."

--- a/frontend/src/services/api/messagesGatewayApi.ts
+++ b/frontend/src/services/api/messagesGatewayApi.ts
@@ -12,6 +12,7 @@ import {
   PutApiMessagesGatewayPutFlagsResponseSchema,
   PutApiMessagesGatewayPutKeyResponseSchema,
   PutApiMessagesGatewayPutUpstreamResponseSchema,
+  put_api_messages_gateway_put_flags_Body,
 } from '@/generated/api-schemas'
 import { httpClient } from './httpClient'
 
@@ -67,22 +68,18 @@ export async function saveMessagesGatewayAliases(
   })
 }
 
-/** How the gateway answers a client's Anthropic `web_search` declaration. */
-export type WebSearchMode = 'auto' | 'synaplan' | 'passthrough' | 'off'
+/** Any subset of the gateway settings; omitted ones keep their current value. */
+export type MessagesGatewaySettings = z.infer<typeof put_api_messages_gateway_put_flags_Body>
 
-/** How the gateway handles image turns for Claude Code. */
-export type VisionMode = 'auto' | 'synaplan' | 'passthrough' | 'off'
+/** How the gateway answers a client's Anthropic `web_search` declaration. */
+export type WebSearchMode = NonNullable<MessagesGatewaySettings['web_search_mode']>
+/** Which model reads an image turn that reaches the gateway. */
+export type VisionMode = NonNullable<MessagesGatewaySettings['vision_mode']>
+/** Resolution hint forwarded to upstreams that support it. */
+export type ImageDetail = NonNullable<MessagesGatewaySettings['vision_image_detail']>
 
 export async function saveMessagesGatewayFlags(
-  flags: Partial<{
-    enabled: boolean
-    allow_operator_key: boolean
-    mcp_tools_enabled: boolean
-    context_injection_enabled: boolean
-    budget_notice_enabled: boolean
-    web_search_mode: WebSearchMode
-    vision_mode: VisionMode
-  }>
+  flags: MessagesGatewaySettings
 ): Promise<z.infer<typeof PutApiMessagesGatewayPutFlagsResponseSchema>> {
   return httpClient(`${BASE}/flags`, {
     method: 'PUT',

--- a/frontend/tests/unit/components/MessagesGatewayAdminSettings.spec.ts
+++ b/frontend/tests/unit/components/MessagesGatewayAdminSettings.spec.ts
@@ -32,6 +32,7 @@ const baseStatus = (overrides: Partial<MessagesGatewayStatus> = {}): MessagesGat
     mcp_tools_with_client_tools: false,
     mcp_max_iterations: 8,
     mcp_servers_configured: 0,
+    server_tools: [],
     web_search_mode: 'auto',
     web_search_available: true,
     vision_mode: 'auto',
@@ -158,5 +159,38 @@ describe('MessagesGatewayAdminSettings', () => {
     const wrapper = mountPanel(baseStatus({ enabled: false }))
 
     expect(wrapper.find('[data-testid="notice-agents-disabled"]').exists()).toBe(true)
+  })
+
+  it('names the tools the gateway runs server-side', () => {
+    const wrapper = mountPanel(baseStatus({ server_tools: ['web_search', 'analyze_image'] }))
+    const readout = wrapper.find('[data-testid="agents-active-tools"]')
+
+    expect(readout.text()).toContain('Web search')
+    expect(readout.text()).toContain('Image analysis')
+  })
+
+  it('falls back to the raw name for a tool this page does not know', () => {
+    const wrapper = mountPanel(baseStatus({ server_tools: ['some_future_tool'] }))
+
+    expect(wrapper.find('[data-testid="agents-active-tool-some_future_tool"]').text()).toContain(
+      'some_future_tool'
+    )
+  })
+
+  it('says so when the gateway runs nothing of its own', () => {
+    const wrapper = mountPanel(baseStatus({ mcp_servers_configured: 2 }))
+
+    // MCP servers exist but the switch is off, so they are not running either.
+    expect(wrapper.find('[data-testid="agents-active-tools"]').text()).toContain(
+      'runs no tools of its own'
+    )
+  })
+
+  it('counts the connected tool servers once MCP tools are on', () => {
+    const wrapper = mountPanel(baseStatus({ mcp_tools_enabled: true, mcp_servers_configured: 2 }))
+
+    expect(wrapper.find('[data-testid="agents-active-tools"]').text()).toContain(
+      '2 connected tool servers'
+    )
   })
 })

--- a/frontend/tests/unit/components/MessagesGatewayAdminSettings.spec.ts
+++ b/frontend/tests/unit/components/MessagesGatewayAdminSettings.spec.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import MessagesGatewayAdminSettings from '@/components/config/messagesGateway/MessagesGatewayAdminSettings.vue'
+import type { MessagesGatewayStatus } from '@/services/api/messagesGatewayApi'
+
+/**
+ * The AI Agents settings panel writes one setting per control, so a patch that
+ * carries more than the changed key would silently reset a neighbouring
+ * setting. It also has to make a setting that cannot take effect obviously
+ * inert instead of letting an admin toggle something with no consequence.
+ */
+
+const { mockSaveFlags } = vi.hoisted(() => ({
+  mockSaveFlags: vi.fn(),
+}))
+
+vi.mock('@/services/api/messagesGatewayApi', () => ({
+  saveMessagesGatewayFlags: mockSaveFlags,
+  saveMessagesGatewayAliases: vi.fn(),
+  saveMessagesGatewayUpstream: vi.fn(),
+}))
+
+vi.mock('@/composables/useNotification', () => ({
+  useNotification: () => ({ success: vi.fn(), error: vi.fn() }),
+}))
+
+const baseStatus = (overrides: Partial<MessagesGatewayStatus> = {}): MessagesGatewayStatus =>
+  ({
+    enabled: true,
+    allow_operator_key: false,
+    mcp_tools_enabled: false,
+    mcp_tools_with_client_tools: false,
+    mcp_max_iterations: 8,
+    mcp_servers_configured: 0,
+    web_search_mode: 'auto',
+    web_search_available: true,
+    vision_mode: 'auto',
+    vision_available: true,
+    vision_image_detail: 'auto',
+    vision_max_images: 0,
+    context_injection_enabled: false,
+    budget_notice_enabled: true,
+    session_summary_enabled: true,
+    upstream_url: 'https://api.anthropic.com',
+    model_aliases: {},
+    keys: {},
+    budget: {},
+    is_admin: true,
+    setup: {},
+    ...overrides,
+  }) as MessagesGatewayStatus
+
+const mountPanel = (status: MessagesGatewayStatus = baseStatus()) =>
+  mount(MessagesGatewayAdminSettings, {
+    props: { status },
+    global: { stubs: { Icon: true } },
+  })
+
+describe('MessagesGatewayAdminSettings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSaveFlags.mockResolvedValue({ success: true, updated: {} })
+  })
+
+  it('sends only the setting that changed', async () => {
+    const wrapper = mountPanel()
+
+    await wrapper.find('[data-testid="toggle-agents-mcp-tools"] button').trigger('click')
+    await flushPromises()
+
+    expect(mockSaveFlags).toHaveBeenCalledWith({ mcp_tools_enabled: true })
+  })
+
+  it('disables the MCP follow-up settings until MCP tools are on', async () => {
+    const wrapper = mountPanel()
+
+    expect(
+      wrapper
+        .find('[data-testid="toggle-agents-mcp-with-client-tools"] button')
+        .attributes('disabled')
+    ).toBeDefined()
+    expect(
+      wrapper.find('[data-testid="input-agents-tool-rounds"]').attributes('disabled')
+    ).toBeDefined()
+
+    const enabled = mountPanel(baseStatus({ mcp_tools_enabled: true }))
+    expect(
+      enabled.find('[data-testid="input-agents-tool-rounds"]').attributes('disabled')
+    ).toBeUndefined()
+  })
+
+  it('offers Synaplan vision only when a vision model is configured', () => {
+    const unavailable = mountPanel(baseStatus({ vision_available: false }))
+    const option = unavailable.find(
+      '[data-testid="select-agents-vision-mode"] option[value=synaplan]'
+    )
+    expect(option.attributes('disabled')).toBeDefined()
+
+    const available = mountPanel()
+    expect(
+      available
+        .find('[data-testid="select-agents-vision-mode"] option[value=synaplan]')
+        .attributes('disabled')
+    ).toBeUndefined()
+  })
+
+  it('falls back to automatic when the stored mode lost its provider', async () => {
+    const wrapper = mountPanel(baseStatus({ vision_mode: 'synaplan', vision_available: false }))
+    await flushPromises()
+
+    expect(mockSaveFlags).toHaveBeenCalledWith({ vision_mode: 'auto' })
+    expect(
+      (wrapper.find('[data-testid="select-agents-vision-mode"]').element as HTMLSelectElement).value
+    ).toBe('auto')
+  })
+
+  it('keeps the image cost controls usable in every vision mode', () => {
+    const wrapper = mountPanel(baseStatus({ vision_mode: 'off' }))
+
+    expect(
+      wrapper.find('[data-testid="select-agents-image-detail"]').attributes('disabled')
+    ).toBeUndefined()
+    expect(
+      wrapper.find('[data-testid="input-agents-max-images"]').attributes('disabled')
+    ).toBeUndefined()
+  })
+
+  it('clamps an out-of-range image cap before saving it', async () => {
+    const wrapper = mountPanel()
+    const input = wrapper.find('[data-testid="input-agents-max-images"]')
+
+    await input.setValue('4000')
+    await input.trigger('change')
+    await flushPromises()
+
+    expect(mockSaveFlags).toHaveBeenCalledWith({ vision_max_images: 100 })
+    expect((input.element as HTMLInputElement).value).toBe('100')
+  })
+
+  it('does not save a number that did not change', async () => {
+    const wrapper = mountPanel(baseStatus({ mcp_tools_enabled: true }))
+    const input = wrapper.find('[data-testid="input-agents-tool-rounds"]')
+
+    await input.setValue('8')
+    await input.trigger('change')
+    await flushPromises()
+
+    expect(mockSaveFlags).not.toHaveBeenCalled()
+  })
+
+  it('points out that no tool server is connected yet', () => {
+    const wrapper = mountPanel()
+
+    expect(wrapper.text()).toContain('No tool server is connected yet')
+  })
+
+  it('warns that settings do nothing while the gateway is off', () => {
+    const wrapper = mountPanel(baseStatus({ enabled: false }))
+
+    expect(wrapper.find('[data-testid="notice-agents-disabled"]').exists()).toBe(true)
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Gives the AI Agents admin page real depth for tool calling, vision and image detail handling: every gateway setting is now configurable from the UI instead of only in `BCONFIG`, image handling gains its own transport controls, and the page now states what the gateway actually runs rather than only what it was configured to prefer.

The first commit is the follow-up work to #1475 that missed the merge window — it landed on that branch about two minutes after the squash-merge, so it never reached `main`. It is replayed here unchanged on top of current `main`.

## Changes

**New image controls** — `VISION_IMAGE_DETAIL` (`auto`/`low`/`high`, forwarded as OpenAI `image_url.detail`) and `VISION_MAX_IMAGES` (cap forwarded image blocks, oldest replaced by a placeholder). A new `VisionPolicy` applies them to the request body *before* the vision routing decision, so the router sees the images that actually reach the upstream. The two layers are independent: the mode decides who reads an image turn, detail and the cap decide what goes on the wire in every mode.

**Generalized settings endpoint** — `PUT /api/v1/messages-gateway/flags` accepts any subset of the gateway settings across three value kinds (boolean, enum, integer) with per-kind validation, and rejects a `synaplan` mode the install cannot honour (no search provider / no PIC2TEXT model) instead of silently storing it.

**A settings page that answers, not just asks** — the mode dropdowns read "automatic" a lot, and automatic resolves against things an operator cannot see from that page. `GatewayToolCatalog` now also reports the built-in tools it would run without a request in hand, reusing the same availability predicates as the request path so the two cannot drift, and the status endpoint exposes it as `server_tools`. The Tool calling section leads with that readout.

**Sectioned, modular panel** — the settings block moves out of `MessagesGatewayConfiguration.vue` into Access / Tool calling / Images / Context and session / Connection, each its own presentational component that emits the patch it changed. The repeated select and number controls become `GatewaySettingSelect` and `GatewaySettingNumber`, so clamping and the "nothing changed, save nothing" rule live in one place. Each control saves on change and reports the outcome; unavailable options stay visible but disabled with an inline reason, and a stored mode whose provider disappeared falls back to `auto`.

i18n for all four locales, and the gateway docs describe both image layers and the readout.

## Verification
- [x] Manual
- [x] Tests added/updated

Full gate green: `make -C backend lint`, `make -C backend phpstan` (0 errors), `make -C backend test` (3410 tests), `make -C frontend lint`, `vue-tsc`, `make -C frontend test` (1041 tests).

End-to-end, the status endpoint reports the readout as real data:

```
server_tools           = ["web_search", "analyze_image"]
web_search_available   = true
vision_available       = true
```

The demo changes each mode and watches the readout follow: switching web search to passthrough drops the `web_search` chip, switching it back restores it, and turning vision off drops `analyze_image`.

[ai_agents_settings_tool_and_image_controls.mp4](https://cursor.com/agents/bc-019fe7e2-36fa-7d59-831f-c5ebc52c3e1a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fai_agents_settings_tool_and_image_controls.mp4)

Contrast was measured rather than eyeballed, since the readout is a new surface. Light 4.89:1 and dark 6.66:1 for the smallest text (the tool identifiers), everything else 4.68:1 or better — all above the 4.5:1 AA threshold. Checked in light, dark, V2 (the default) and V1.

[Tool calling readout, light theme](https://cursor.com/agents/bc-019fe7e2-36fa-7d59-831f-c5ebc52c3e1a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fai_agents_tool_calling_readout_light.webp)

[Tool calling readout, dark theme](https://cursor.com/agents/bc-019fe7e2-36fa-7d59-831f-c5ebc52c3e1a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fai_agents_tool_calling_readout_dark.webp)

## Notes
Supersedes the orphaned tail of #1475. Mobile impact classifies as `ota-candidate` (`node scripts/mobile-impact.mjs`), so no policy allow-list change was needed.

One unrelated observation while testing: `useDesignVariant()` is never called anywhere, and `design-v2` is hardcoded on `<html>` in `frontend/index.html`, so the V1/V2 switch in that composable has no effect. Left alone here.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe7e2-36fa-7d59-831f-c5ebc52c3e1a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe7e2-36fa-7d59-831f-c5ebc52c3e1a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

