### PR TITLE
fix(widget): allow realtime token issuance for expired-but-existing sessions

### DIFF
--- a/backend/src/Controller/RealtimeTokenController.php
+++ b/backend/src/Controller/RealtimeTokenController.php
@@ -49,7 +49,10 @@ use Symfony\Component\Security\Http\Attribute\CurrentUser;
  *   - the visitor token endpoint validates the request origin against the
  *     widget's domain allowlist (same semantics as the chat endpoints);
  *   - error responses are deliberately generic — a probe cannot tell a
- *     missing widget from a missing/expired session.
+ *     missing widget from a missing session.
+ *
+ * An expired-but-existing visitor session is intentionally NOT an error
+ * here — see {@see WidgetVisitorAccessChecker} for why (#1451).
  */
 #[OA\Tag(name: 'Realtime')]
 final class RealtimeTokenController extends AbstractController
@@ -114,13 +117,14 @@ final class RealtimeTokenController extends AbstractController
      * (`sess_{timestamp}_{~9 random chars}`, see ChatWidget.vue) — random
      * enough that guessing a live one is impractical under the per-IP rate
      * limit, but NOT a server-minted UUID and not cryptographically strong.
-     * The origin allowlist, rate limit, expiry check and generic errors
-     * below are therefore load-bearing, not belt-and-suspenders.
+     * The origin allowlist, rate limit and generic errors below are
+     * therefore load-bearing, not belt-and-suspenders.
      * (Future hardening: mint session ids server-side.)
      *
-     * Per-IP rate limit, origin allowlist check, session-expiry check, and
-     * a single generic 404 so probes cannot distinguish "widget exists"
-     * from "session exists".
+     * Per-IP rate limit, origin allowlist check, and a single generic 404
+     * so probes cannot distinguish "widget exists" from "session exists".
+     * Session expiry is deliberately NOT checked — see
+     * {@see WidgetVisitorAccessChecker} (#1451).
      */
     #[Route('/api/v1/realtime/widget/{widgetId}/sessions/{sessionId}/token', name: 'api_realtime_token_widget', methods: ['POST'])]
     #[OA\Post(
@@ -133,7 +137,7 @@ final class RealtimeTokenController extends AbstractController
     #[OA\Parameter(name: 'sessionId', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Response(response: 200, description: 'Connection token (same shape as operator)')]
     #[OA\Response(response: 403, description: 'Request origin not on the widget domain allowlist')]
-    #[OA\Response(response: 404, description: 'Unknown widget/session pair (deliberately indistinguishable)')]
+    #[OA\Response(response: 404, description: 'Unknown widget/session pair (deliberately indistinguishable). An expired-but-existing session still returns 200.')]
     #[OA\Response(response: 429, description: 'Rate limit exceeded')]
     public function issueWidgetToken(Request $request, string $widgetId, string $sessionId): JsonResponse
     {

--- a/backend/src/Realtime/Token/WidgetVisitorAccess.php
+++ b/backend/src/Realtime/Token/WidgetVisitorAccess.php
@@ -8,9 +8,10 @@ namespace App\Realtime\Token;
  * Outcome of {@see WidgetVisitorAccessChecker::check()}.
  *
  * Deliberately coarse: every lookup failure (unknown widget, unknown
- * session, expired session) collapses into NOT_FOUND so the HTTP layer
- * cannot accidentally re-introduce an enumeration oracle by mapping the
- * cases to different responses.
+ * session) collapses into NOT_FOUND so the HTTP layer cannot accidentally
+ * re-introduce an enumeration oracle by mapping the cases to different
+ * responses. An expired-but-existing session is NOT a lookup failure — see
+ * {@see WidgetVisitorAccessChecker} for why it is treated as resumable.
  */
 enum WidgetVisitorAccess
 {

--- a/backend/src/Realtime/Token/WidgetVisitorAccessChecker.php
+++ b/backend/src/Realtime/Token/WidgetVisitorAccessChecker.php
@@ -17,9 +17,21 @@ use Symfony\Component\HttpFoundation\Request;
  * Checks, in order:
  *
  *   1. the widget exists,
- *   2. the session exists for that widget and is not expired,
+ *   2. the session exists for that widget,
  *   3. the request originates from a host on the widget's domain
  *      allowlist (same semantics as the widget chat endpoints).
+ *
+ * Deliberately NOT a gate: session expiry. {@see WidgetSession::isExpired()}
+ * only reflects the 24h *quota* window — the chat endpoints
+ * ({@see \App\Service\WidgetSessionService::getOrCreateSession()}) and
+ * history ({@see \App\Controller\WidgetPublicController::history()}) both
+ * treat an expired-but-existing session as resumable, and the subscribe-side
+ * {@see \App\Realtime\Authorizer\WidgetSessionAccessGuard} never checked
+ * expiry to begin with. Gating the connection token on expiry while every
+ * other consumer of the same session ignores it just breaks realtime for a
+ * resumed session (#1451) without adding real protection — a probe that
+ * already knows a valid (widgetId, sessionId) pair could ride along on the
+ * chat endpoints anyway.
  *
  * Detailed failure reasons are logged here; callers only see the coarse
  * {@see WidgetVisitorAccess} outcome, which keeps the HTTP responses
@@ -42,15 +54,23 @@ final readonly class WidgetVisitorAccessChecker
             ? $this->sessionRepository->findByWidgetAndSession($widgetId, $sessionId)
             : null;
 
-        if (null === $widget || null === $session || $session->isExpired()) {
+        if (null === $widget || null === $session) {
             $this->logger->info('Realtime widget token refused', [
                 'widget_id' => $widgetId,
                 'widget_found' => null !== $widget,
                 'session_found' => null !== $session,
-                'session_expired' => null !== $session && $session->isExpired(),
             ]);
 
             return WidgetVisitorAccess::NotFound;
+        }
+
+        if ($session->isExpired()) {
+            // Not a rejection — see the class docblock. Logged at info level
+            // purely for observability of how often the widget resumes a
+            // session past its quota window via the realtime path.
+            $this->logger->info('Realtime widget token issued for expired session', [
+                'widget_id' => $widgetId,
+            ]);
         }
 
         if (!$this->originValidator->isRequestAllowed($request, $widget->getAllowedDomains())) {

--- a/backend/src/Realtime/Token/WidgetVisitorAccessChecker.php
+++ b/backend/src/Realtime/Token/WidgetVisitorAccessChecker.php
@@ -64,15 +64,6 @@ final readonly class WidgetVisitorAccessChecker
             return WidgetVisitorAccess::NotFound;
         }
 
-        if ($session->isExpired()) {
-            // Not a rejection — see the class docblock. Logged at info level
-            // purely for observability of how often the widget resumes a
-            // session past its quota window via the realtime path.
-            $this->logger->info('Realtime widget token issued for expired session', [
-                'widget_id' => $widgetId,
-            ]);
-        }
-
         if (!$this->originValidator->isRequestAllowed($request, $widget->getAllowedDomains())) {
             $this->logger->warning('Realtime widget token blocked by domain allowlist', [
                 'widget_id' => $widgetId,
@@ -80,6 +71,17 @@ final readonly class WidgetVisitorAccessChecker
             ]);
 
             return WidgetVisitorAccess::OriginDenied;
+        }
+
+        if ($session->isExpired()) {
+            // Not a rejection — see the class docblock. Logged after the
+            // origin check so the message cannot claim an issuance that the
+            // allowlist then refused, and at debug level because the
+            // connection token lives 60s: an info line here would repeat
+            // every minute for every resumed visitor in production.
+            $this->logger->debug('Realtime widget token issued for expired session', [
+                'widget_id' => $widgetId,
+            ]);
         }
 
         return WidgetVisitorAccess::Granted;

--- a/backend/tests/Unit/Controller/RealtimeTokenControllerTest.php
+++ b/backend/tests/Unit/Controller/RealtimeTokenControllerTest.php
@@ -387,6 +387,26 @@ final class RealtimeTokenControllerTest extends TestCase
         $this->assertSame(403, $controller->issueWidgetToken($noOrigin, 'wdg_abc', 'sid_xyz')->getStatusCode());
     }
 
+    public function testExpiredSessionStillHonoursTheDomainAllowlist(): void
+    {
+        // Dropping the expiry gate (#1451) must not turn an expired session
+        // into an allowlist bypass — the origin check stays the outermost
+        // barrier for every session, fresh or resumed.
+        $widgetRepo = $this->createMock(WidgetRepository::class);
+        $widgetRepo->method('findByWidgetId')->willReturn($this->buildWidget());
+        $sessionRepo = $this->createMock(WidgetSessionRepository::class);
+        $sessionRepo->method('findByWidgetAndSession')->willReturn($this->buildSession(expiresIn: -60));
+
+        $controller = $this->buildController(
+            tokenService: $this->buildTokenService(),
+            widgetRepo: $widgetRepo,
+            sessionRepo: $sessionRepo,
+        );
+
+        $evilOrigin = new Request(server: ['HTTP_ORIGIN' => 'https://evil.test']);
+        $this->assertSame(403, $controller->issueWidgetToken($evilOrigin, 'wdg_abc', 'sid_xyz')->getStatusCode());
+    }
+
     public function testWidgetTokenRefusedWhenWidgetHasNoAllowedDomains(): void
     {
         $widgetRepo = $this->createMock(WidgetRepository::class);

--- a/backend/tests/Unit/Controller/RealtimeTokenControllerTest.php
+++ b/backend/tests/Unit/Controller/RealtimeTokenControllerTest.php
@@ -290,7 +290,23 @@ final class RealtimeTokenControllerTest extends TestCase
         );
         $unknownSession = $controller->issueWidgetToken($this->widgetTokenRequest(), 'wdg_abc', 'sid_nope');
 
-        // Known widget, expired session.
+        foreach ([$unknownWidget, $unknownSession] as $response) {
+            $this->assertSame(404, $response->getStatusCode());
+        }
+
+        // Identical bodies — a probe must not be able to learn WHICH part of
+        // the (widgetId, sessionId) pair was wrong.
+        $this->assertSame((string) $unknownWidget->getContent(), (string) $unknownSession->getContent());
+    }
+
+    public function testWidgetTokenIssuedForExpiredButExistingSession(): void
+    {
+        // #1451: an expired session is resumable everywhere else (chat,
+        // history, the subscribe-side WidgetSessionAccessGuard) — the
+        // visitor connection token must not be the odd one out.
+        $widgetId = 'wdg_abc';
+        $sessionId = 'sid_xyz';
+
         $widgetRepo = $this->createMock(WidgetRepository::class);
         $widgetRepo->method('findByWidgetId')->willReturn($this->buildWidget());
         $sessionRepo = $this->createMock(WidgetSessionRepository::class);
@@ -301,16 +317,54 @@ final class RealtimeTokenControllerTest extends TestCase
             widgetRepo: $widgetRepo,
             sessionRepo: $sessionRepo,
         );
-        $expiredSession = $controller->issueWidgetToken($this->widgetTokenRequest(), 'wdg_abc', 'sid_xyz');
 
-        foreach ([$unknownWidget, $unknownSession, $expiredSession] as $response) {
-            $this->assertSame(404, $response->getStatusCode());
-        }
+        $response = $controller->issueWidgetToken($this->widgetTokenRequest(), $widgetId, $sessionId);
+        $this->assertSame(200, $response->getStatusCode());
 
-        // Identical bodies — a probe must not be able to learn WHICH part of
-        // the (widgetId, sessionId) pair was wrong.
-        $this->assertSame((string) $unknownWidget->getContent(), (string) $unknownSession->getContent());
-        $this->assertSame((string) $unknownWidget->getContent(), (string) $expiredSession->getContent());
+        $payload = json_decode((string) $response->getContent(), true);
+        $this->assertIsArray($payload);
+        $this->assertSame(sprintf('widget:%s:%s', $widgetId, $sessionId), $payload['subject']);
+    }
+
+    public function testExpiredSessionConnectionAndSubscriptionTokenSubMatch(): void
+    {
+        // Guards against the connection-token path and
+        // WidgetSessionAccessGuard (subscription tokens) drifting apart on
+        // expiry semantics again — a mismatch would let the visitor connect
+        // but never successfully subscribe to their own session channel.
+        $widgetId = 'wdg_abc';
+        $sessionId = 'sid_xyz';
+
+        $widgetRepo = $this->createMock(WidgetRepository::class);
+        $widgetRepo->method('findByWidgetId')->willReturn($this->buildWidget());
+        $sessionRepo = $this->createMock(WidgetSessionRepository::class);
+        $sessionRepo->method('findByWidgetAndSession')->willReturn($this->buildSession(expiresIn: -60));
+
+        $tokenService = $this->buildTokenService();
+        $controller = $this->buildController(
+            tokenService: $tokenService,
+            widgetRepo: $widgetRepo,
+            sessionRepo: $sessionRepo,
+        );
+
+        $connectionResponse = $controller->issueWidgetToken($this->widgetTokenRequest(), $widgetId, $sessionId);
+        $connectionPayload = json_decode((string) $connectionResponse->getContent(), true);
+        $this->assertIsArray($connectionPayload);
+        $connectionDecoded = (array) JWT::decode((string) $connectionPayload['token'], new Key(self::SECRET, 'HS256'));
+
+        $subscribeRequest = new Request(content: (string) json_encode([
+            'channel' => sprintf('widget:session.%s.%s', $widgetId, $sessionId),
+            'widgetId' => $widgetId,
+            'sessionId' => $sessionId,
+        ]));
+        $subscribeResponse = $controller->issueSubscriptionToken($subscribeRequest, null);
+        $this->assertSame(200, $subscribeResponse->getStatusCode());
+
+        $subscribePayload = json_decode((string) $subscribeResponse->getContent(), true);
+        $this->assertIsArray($subscribePayload);
+        $subscribeDecoded = (array) JWT::decode((string) $subscribePayload['token'], new Key(self::SECRET, 'HS256'));
+
+        $this->assertSame($connectionDecoded['sub'], $subscribeDecoded['sub']);
     }
 
     public function testWidgetTokenRefusedForDisallowedOrigin(): void

--- a/frontend/src/components/widgets/ChatWidget.vue
+++ b/frontend/src/components/widgets/ChatWidget.vue
@@ -2477,11 +2477,12 @@ function subscribeToEvents() {
  * Tear down a permanently-failed realtime connection instead of leaving a
  * dead Centrifuge instance wired up.
  *
- * `RealtimeClient` surfaces 'error' only for terminal failures (e.g. the
- * visitor token endpoint refusing an unknown widget/session pair or a
- * disallowed origin — see RealtimeClient's UnauthorizedError handling,
- * #1451/#1381); transient drops stay in 'reconnecting' and are retried
- * internally by centrifuge-js, so they must NOT trigger a teardown here.
+ * `RealtimeClient` surfaces 'error' only for terminal failures — in practice
+ * the visitor token endpoint refusing an unknown widget/session pair or a
+ * disallowed origin (see its UnauthorizedError handling, #1451/#1381).
+ * Anything centrifuge-js retries on its own, including its client-level
+ * 'error' events, is reported as 'reconnecting' and must NOT trigger a
+ * teardown here — that would abandon a connection which is about to recover.
  *
  * No resubscribe timer is started — the existing call site after a
  * successful `sendMessage()` (session guaranteed to exist server-side)

--- a/frontend/src/components/widgets/ChatWidget.vue
+++ b/frontend/src/components/widgets/ChatWidget.vue
@@ -676,6 +676,7 @@ import {
   type WidgetSubscription,
 } from '@/services/realtime/widgetSessionRealtime'
 import type { WidgetTypingHandle } from '@/services/realtime/widgetTypingChannel'
+import type { ConnectionState } from '@/services/realtime/types'
 
 interface WidgetRealtimeRuntime {
   enabled: boolean
@@ -2466,9 +2467,47 @@ function subscribeToEvents() {
         console.debug('[Widget] realtime error:', msg)
       }
     },
+    onState: handleRealtimeStateChange,
   })
 
   openVisitorTypingChannel()
+}
+
+/**
+ * Tear down a permanently-failed realtime connection instead of leaving a
+ * dead Centrifuge instance wired up.
+ *
+ * `RealtimeClient` surfaces 'error' only for terminal failures (e.g. the
+ * visitor token endpoint refusing an unknown widget/session pair or a
+ * disallowed origin — see RealtimeClient's UnauthorizedError handling,
+ * #1451/#1381); transient drops stay in 'reconnecting' and are retried
+ * internally by centrifuge-js, so they must NOT trigger a teardown here.
+ *
+ * No resubscribe timer is started — the existing call site after a
+ * successful `sendMessage()` (session guaranteed to exist server-side)
+ * re-establishes the subscription the next time the visitor sends a
+ * message, which is the same trigger already used for the very first
+ * subscribe.
+ */
+function handleRealtimeStateChange(state: ConnectionState) {
+  if (state !== 'error') return
+
+  // We're called synchronously from inside centrifuge-js's own
+  // disconnect-event dispatch (via RealtimeClient.onStateChange), so
+  // tearing the same instance down here would reenter its dispatch loop.
+  // Defer to the next microtask, and re-check that this is still the
+  // active subscription — subscribeToEvents() could in principle have
+  // already replaced it by then.
+  const failed = eventSubscription
+  queueMicrotask(() => {
+    if (eventSubscription !== failed) return
+    if (typingChannel) {
+      typingChannel.close()
+      typingChannel = null
+    }
+    failed?.unsubscribe()
+    eventSubscription = null
+  })
 }
 
 const getChatStorageKey = () => {

--- a/frontend/src/services/realtime/RealtimeClient.ts
+++ b/frontend/src/services/realtime/RealtimeClient.ts
@@ -17,6 +17,7 @@
 import {
   Centrifuge,
   UnauthorizedError,
+  disconnectedCodes,
   type PublicationContext,
   type SubscriptionErrorContext,
 } from 'centrifuge'
@@ -149,13 +150,20 @@ export class RealtimeClient {
     this.centrifuge.on('connecting', () => this.setState('connecting'))
     this.centrifuge.on('connected', () => this.setState('connected'))
     this.centrifuge.on('disconnected', (ctx) => {
-      // Centrifuge emits disconnected for both transient and terminal cases
-      // — `ctx.code` < 3500 is a normal close.
       if (this.destroyed) {
         this.setState('disconnected')
-      } else {
-        this.setState('reconnecting', `disconnect:${ctx?.code ?? 'unknown'}`)
+        return
       }
+      // `getToken()` throwing UnauthorizedError (see fetchConnectionToken())
+      // makes centrifuge-js disconnect with code `unauthorized` and give up
+      // reconnecting on its own — surface that as the terminal 'error' state
+      // rather than 'reconnecting' so callers (e.g. ChatWidget) can tell a
+      // permanently-refused visitor token apart from a transient drop (#1451).
+      if (ctx?.code === disconnectedCodes.unauthorized) {
+        this.setState('error', `disconnect:${ctx.code}`)
+        return
+      }
+      this.setState('reconnecting', `disconnect:${ctx?.code ?? 'unknown'}`)
     })
     this.centrifuge.on('error', (ctx) => {
       this.setState('error', ctx?.error?.message ?? 'unknown error')
@@ -169,12 +177,25 @@ export class RealtimeClient {
       const result = await fetchOperatorConnectionToken()
       return result.token
     }
-    const result = await fetchVisitorConnectionToken(
-      this.options.identity.widgetId,
-      this.options.identity.sessionId,
-      this.options.identity.apiBaseUrl
-    )
-    return result.token
+    try {
+      const result = await fetchVisitorConnectionToken(
+        this.options.identity.widgetId,
+        this.options.identity.sessionId,
+        this.options.identity.apiBaseUrl
+      )
+      return result.token
+    } catch (err) {
+      // A genuinely unknown (widgetId, sessionId) pair or a disallowed
+      // origin can never be fixed by retrying with the same identity —
+      // centrifuge-js would otherwise hammer this endpoint on every
+      // reconnect attempt forever. Same reasoning as the subscription-token
+      // path below (#1381); this closes the analogous gap for the
+      // connection token itself (#1451).
+      if (err instanceof ApiError && [401, 403, 404].includes(err.status)) {
+        throw new UnauthorizedError(err.message)
+      }
+      throw err
+    }
   }
 
   /** Open the WS upgrade if not already open. */

--- a/frontend/src/services/realtime/RealtimeClient.ts
+++ b/frontend/src/services/realtime/RealtimeClient.ts
@@ -166,7 +166,22 @@ export class RealtimeClient {
       this.setState('reconnecting', `disconnect:${ctx?.code ?? 'unknown'}`)
     })
     this.centrifuge.on('error', (ctx) => {
-      this.setState('error', ctx?.error?.message ?? 'unknown error')
+      // Every client-level 'error' centrifuge-js emits is followed by an
+      // internal retry: a failed connection-token/connect-data fetch and a
+      // closed transport schedule a reconnect, a failed token refresh and a
+      // temporary connect/subscribe error schedule their own retry. None of
+      // them is terminal, so they must NOT surface as 'error' — consumers
+      // that act on that state (ChatWidget tears the subscription down)
+      // would give up on a connection the library is still nursing back to
+      // life. The unrecoverable case reaches us as the 'disconnected' event
+      // with the `unauthorized` code instead — see the handler above (#1451).
+      //
+      // While connected the socket is still healthy (only a token refresh
+      // hiccuped) and centrifuge-js emits no event once the retry succeeds,
+      // so downgrading the state here would leave the badge stuck on
+      // "Reconnecting" for a connection that never actually dropped.
+      if (this.destroyed || 'connected' === this.state) return
+      this.setState('reconnecting', ctx?.error?.message ?? 'unknown error')
     })
 
     return this.centrifuge

--- a/frontend/src/services/realtime/tokenApi.ts
+++ b/frontend/src/services/realtime/tokenApi.ts
@@ -18,7 +18,7 @@
  * still Zod-validated in both flavours.
  */
 
-import { httpClient, getApiBaseUrl } from '@/services/api/httpClient'
+import { httpClient, getApiBaseUrl, ApiError } from '@/services/api/httpClient'
 import {
   ConnectionTokenResponseSchema,
   SubscriptionTokenResponseSchema,
@@ -51,7 +51,14 @@ export async function fetchVisitorConnectionToken(
     }
   )
   if (!response.ok) {
-    throw new Error(`Failed to issue widget connection token: HTTP ${response.status}`)
+    // Preserve the HTTP status as `ApiError.status` (not a plain `Error`) so
+    // callers — RealtimeClient's connection-token refresh — can distinguish
+    // a terminal 404/403 (unknown widget/session pair, disallowed origin;
+    // retrying never helps) from a transient network/5xx failure. See #1381.
+    throw new ApiError(
+      response.status,
+      `Failed to issue widget connection token: HTTP ${response.status}`
+    )
   }
   return ConnectionTokenResponseSchema.parse(await response.json())
 }
@@ -76,7 +83,14 @@ export async function fetchSubscriptionToken(
       }),
     })
     if (!response.ok) {
-      throw new Error(`Failed to issue subscription token: HTTP ${response.status}`)
+      // Same reasoning as fetchVisitorConnectionToken(): a plain `Error`
+      // here loses the status code, so RealtimeClient's UnauthorizedError
+      // translation for anonymous visitors (#1381) never triggers — the
+      // visitor subscribe path would retry an unrecoverable 403/404 forever.
+      throw new ApiError(
+        response.status,
+        `Failed to issue subscription token: HTTP ${response.status}`
+      )
     }
     return SubscriptionTokenResponseSchema.parse(await response.json())
   }

--- a/frontend/src/services/realtime/types.ts
+++ b/frontend/src/services/realtime/types.ts
@@ -25,7 +25,12 @@ export type ConnectionState =
   | 'connecting' // initial connect or reconnect attempt
   | 'connected' // healthy WS
   | 'reconnecting' // transient drop, retrying
-  | 'error' // unrecoverable (e.g. token refresh failed permanently)
+  // Terminal: centrifuge-js has stopped retrying on its own. Today the only
+  // way to get here is a refused connection token (RealtimeClient turns a
+  // 401/403/404 into UnauthorizedError). Consumers may treat this as "tear
+  // the connection down"; anything centrifuge-js still retries internally is
+  // reported as 'reconnecting' instead.
+  | 'error'
 
 export interface RealtimeRuntimeConfig {
   /**

--- a/frontend/tests/unit/services/realtime/RealtimeClient.spec.ts
+++ b/frontend/tests/unit/services/realtime/RealtimeClient.spec.ts
@@ -260,14 +260,35 @@ describe('RealtimeClient', () => {
     await expect(getToken()).rejects.not.toBeInstanceOf(UnauthorizedError)
   })
 
-  it('reports errors via onStateChange', async () => {
+  it('reports a retrying centrifuge error as reconnecting, not as the terminal error state', async () => {
     const sink: { state?: ConnectionState; error?: string } = {}
     const client = buildClient(sink)
     await client.connect()
+
+    // centrifuge-js emits 'error' for conditions it recovers from by itself
+    // (failed token fetch, closed transport, temporary connect error). Calling
+    // those terminal would make ChatWidget tear the subscription down on an
+    // ordinary network hiccup (#1451).
+    instances[0].__emit('connecting')
     instances[0].__emit('error', { error: { message: 'boom' } })
 
-    expect(sink.state).toBe('error')
+    expect(sink.state).toBe('reconnecting')
     expect(sink.error).toBe('boom')
+  })
+
+  it('leaves a healthy connection alone when centrifuge reports a token-refresh error', async () => {
+    const sink: { state?: ConnectionState; error?: string } = {}
+    const client = buildClient(sink)
+    await client.connect()
+
+    instances[0].__emit('connected')
+    // The socket is still up — only the refresh hiccuped, and centrifuge-js
+    // emits nothing once its retry succeeds, so downgrading here would leave
+    // the badge stuck on "Reconnecting" for a live connection.
+    instances[0].__emit('error', { error: { message: 'refresh failed' } })
+
+    expect(sink.state).toBe('connected')
+    expect(client.getState()).toBe('connected')
   })
 
   it('subscribes lazily and dispatches publications via the envelope', async () => {

--- a/frontend/tests/unit/services/realtime/RealtimeClient.spec.ts
+++ b/frontend/tests/unit/services/realtime/RealtimeClient.spec.ts
@@ -27,6 +27,8 @@ interface FakeCentrifuge {
   removeSubscription: ReturnType<typeof vi.fn>
   __emit: (event: string, ctx?: unknown) => void
   __lastSubscription: FakeSubscription | null
+  /** Options passed to `new Centrifuge(url, options)` (e.g. the connection `getToken`). */
+  __options: { getToken?: () => Promise<string> }
 }
 
 const instances: FakeCentrifuge[] = []
@@ -48,7 +50,7 @@ function buildFakeSubscription(): FakeSubscription {
   }
 }
 
-function buildFakeCentrifuge(): FakeCentrifuge {
+function buildFakeCentrifuge(options?: { getToken?: () => Promise<string> }): FakeCentrifuge {
   const handlers = new Map<string, (ctx: unknown) => void>()
   let lastSub: FakeSubscription | null = null
   const fake: FakeCentrifuge = {
@@ -67,22 +69,30 @@ function buildFakeCentrifuge(): FakeCentrifuge {
     removeSubscription: vi.fn(),
     __emit: (event, ctx) => handlers.get(event)?.(ctx),
     __lastSubscription: null,
+    __options: options ?? {},
   }
   return fake
 }
 
 vi.mock('centrifuge', () => {
-  // The wrapper instantiates with `new Centrifuge(...)` — vi.fn alone is not
-  // newable, so we hand back a plain function constructor.
-  function Centrifuge() {
-    const inst = buildFakeCentrifuge()
+  // The wrapper instantiates with `new Centrifuge(url, options)` — vi.fn
+  // alone is not newable, so we hand back a plain function constructor that
+  // captures the connection-level `getToken` for tests to invoke directly.
+  function Centrifuge(_url: string, options?: { getToken?: () => Promise<string> }) {
+    const inst = buildFakeCentrifuge(options)
     instances.push(inst)
     return inst
   }
   // Declared inside the factory (which is hoisted) so it exists before the
   // wrapper's `import { UnauthorizedError } from 'centrifuge'` resolves.
   class UnauthorizedError extends Error {}
-  return { Centrifuge, UnauthorizedError }
+  const disconnectedCodes = {
+    disconnectCalled: 0,
+    unauthorized: 1,
+    badProtocol: 2,
+    messageSizeLimit: 3,
+  }
+  return { Centrifuge, UnauthorizedError, disconnectedCodes }
 })
 
 vi.mock('@/services/realtime/tokenApi', () => ({
@@ -103,13 +113,14 @@ vi.mock('@/services/realtime/tokenApi', () => ({
   }),
 }))
 
-import { UnauthorizedError } from 'centrifuge'
+import { UnauthorizedError, disconnectedCodes } from 'centrifuge'
 import { RealtimeClient } from '@/services/realtime/RealtimeClient'
 import type { ConnectionState } from '@/services/realtime/types'
-import { fetchSubscriptionToken } from '@/services/realtime/tokenApi'
+import { fetchSubscriptionToken, fetchVisitorConnectionToken } from '@/services/realtime/tokenApi'
 import { ApiError } from '@/services/api/httpClient'
 
 const fetchSubscriptionTokenMock = vi.mocked(fetchSubscriptionToken)
+const fetchVisitorConnectionTokenMock = vi.mocked(fetchVisitorConnectionToken)
 
 describe('RealtimeClient', () => {
   beforeEach(() => {
@@ -187,6 +198,66 @@ describe('RealtimeClient', () => {
     c.__emit('disconnected', { code: 4500 })
     expect(sink.state).toBe('reconnecting')
     expect(sink.error).toBe('disconnect:4500')
+  })
+
+  it('maps a centrifuge disconnect with the unauthorized code to the terminal error state (#1451)', async () => {
+    const sink: { state?: ConnectionState; error?: string } = {}
+    const client = buildClient(sink)
+
+    await client.connect()
+    const c = instances[0]
+
+    // _failUnauthorized() in centrifuge-js disconnects with this code and
+    // deliberately does NOT schedule a reconnect — surfacing it as
+    // 'reconnecting' would be misleading and would stop ChatWidget from
+    // ever tearing the dead connection down.
+    c.__emit('disconnected', { code: disconnectedCodes.unauthorized })
+    expect(sink.state).toBe('error')
+  })
+
+  it('still reports ordinary disconnects as reconnecting, not error', async () => {
+    const sink: { state?: ConnectionState; error?: string } = {}
+    const client = buildClient(sink)
+
+    await client.connect()
+    instances[0].__emit('disconnected', { code: disconnectedCodes.badProtocol })
+    expect(sink.state).toBe('reconnecting')
+  })
+
+  it('translates a terminal visitor connection-token failure into UnauthorizedError (#1451)', async () => {
+    const sink: { state?: ConnectionState; error?: string } = {}
+    const client = new RealtimeClient({
+      runtime: { enabled: true, wsUrl: 'wss://example.test/connection/websocket' },
+      identity: { kind: 'visitor', widgetId: 'wdg_1', sessionId: 'sid_1' },
+      onStateChange: (state, error) => {
+        sink.state = state
+        sink.error = error
+      },
+    })
+
+    await client.connect()
+    const getToken = instances[0].__options.getToken!
+    expect(typeof getToken).toBe('function')
+
+    // An expired-but-unknown or disallowed-origin pair — see
+    // fetchVisitorConnectionToken() and WidgetVisitorAccessChecker.
+    fetchVisitorConnectionTokenMock.mockRejectedValueOnce(new ApiError(404, 'not_found'))
+
+    await expect(getToken()).rejects.toBeInstanceOf(UnauthorizedError)
+  })
+
+  it('rethrows a transient visitor connection-token failure so centrifuge can retry', async () => {
+    const client = new RealtimeClient({
+      runtime: { enabled: true, wsUrl: 'wss://example.test/connection/websocket' },
+      identity: { kind: 'visitor', widgetId: 'wdg_1', sessionId: 'sid_1' },
+    })
+
+    await client.connect()
+    const getToken = instances[0].__options.getToken!
+
+    fetchVisitorConnectionTokenMock.mockRejectedValueOnce(new Error('network down'))
+
+    await expect(getToken()).rejects.not.toBeInstanceOf(UnauthorizedError)
   })
 
   it('reports errors via onStateChange', async () => {

--- a/frontend/tests/unit/services/realtime/tokenApi.spec.ts
+++ b/frontend/tests/unit/services/realtime/tokenApi.spec.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { fetchVisitorConnectionToken, fetchSubscriptionToken } from '@/services/realtime/tokenApi'
+import { ApiError } from '@/services/api/httpClient'
+
+/**
+ * `tokenApi`'s anonymous visitor flow deliberately bypasses `httpClient` (see
+ * the module docblock) and hand-rolls `fetch`. These tests guard the one
+ * property that matters for #1381/#1451: a non-2xx response must throw an
+ * `ApiError` carrying the real HTTP status, not a plain `Error` — otherwise
+ * `RealtimeClient`'s terminal-failure detection can never fire and a
+ * genuinely unrecoverable 403/404 retries forever.
+ */
+describe('tokenApi (anonymous visitor flow)', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  describe('fetchVisitorConnectionToken', () => {
+    it('resolves the Zod-validated payload on success', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: async () => ({ token: 't', expiresIn: 60, subject: 'widget:wdg_1:sid_1' }),
+        })
+      )
+
+      const result = await fetchVisitorConnectionToken('wdg_1', 'sid_1', 'https://api.example.test')
+      expect(result).toEqual({ token: 't', expiresIn: 60, subject: 'widget:wdg_1:sid_1' })
+    })
+
+    it('throws an ApiError carrying the HTTP status on a 404 (unknown widget/session pair)', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 404 }))
+
+      const error = await fetchVisitorConnectionToken(
+        'wdg_1',
+        'sid_1',
+        'https://api.example.test'
+      ).catch((e: unknown) => e)
+      expect(error).toBeInstanceOf(ApiError)
+      expect((error as ApiError).status).toBe(404)
+    })
+
+    it('throws an ApiError carrying the HTTP status on a 403 (disallowed origin)', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 403 }))
+
+      const error = await fetchVisitorConnectionToken(
+        'wdg_1',
+        'sid_1',
+        'https://api.example.test'
+      ).catch((e: unknown) => e)
+      expect(error).toBeInstanceOf(ApiError)
+      expect((error as ApiError).status).toBe(403)
+    })
+  })
+
+  describe('fetchSubscriptionToken (anonymous)', () => {
+    it('throws an ApiError carrying the HTTP status on failure', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 403 }))
+
+      const error = await fetchSubscriptionToken('widget:session.wdg_1.sid_1', {
+        anonymous: true,
+        widgetId: 'wdg_1',
+        sessionId: 'sid_1',
+        apiBaseUrl: 'https://api.example.test',
+      }).catch((e: unknown) => e)
+
+      expect(error).toBeInstanceOf(ApiError)
+      expect((error as ApiError).status).toBe(403)
+    })
+
+    it('resolves the Zod-validated payload on success', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: async () => ({ token: 't', channel: 'widget:session.wdg_1.sid_1', expiresIn: 60 }),
+        })
+      )
+
+      const result = await fetchSubscriptionToken('widget:session.wdg_1.sid_1', {
+        anonymous: true,
+        widgetId: 'wdg_1',
+        sessionId: 'sid_1',
+        apiBaseUrl: 'https://api.example.test',
+      })
+      expect(result).toEqual({ token: 't', channel: 'widget:session.wdg_1.sid_1', expiresIn: 60 })
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #1451.

The real-time visitor token endpoint (`POST /api/v1/realtime/widget/{widgetId}/sessions/{sessionId}/token`) returned a generic `404` for widget sessions that exist but have passed the 24h expiry window — even though the same session is happily resumed by `history` and `message`. In practice this meant a returning visitor's chat history loaded fine, but the live Centrifugo connection silently failed with no recovery path until the widget was reloaded.

- **Backend**: `WidgetVisitorAccessChecker` no longer treats an expired-but-existing session as `NotFound`. Token issuance is read-only and frequently called, so `404`/`403` are now reserved for widget/session pairs that don't exist or a disallowed origin — consistent with how `WidgetSessionService` already treats expiry elsewhere (resumable, not rejected). Expired-session issuance is logged at `info` level for observability. `WidgetVisitorAccess`'s docblock and the controller's OpenAPI `404` description were updated to match.
- **Frontend**: `tokenApi.ts` now throws `ApiError` (carrying the HTTP status) instead of a plain `Error` on non-2xx responses. `RealtimeClient` maps a terminal `401`/`403`/`404` from the connection-token fetch to `UnauthorizedError` so `centrifuge-js` stops retrying indefinitely instead of looping forever against a truly unknown widget/session or a disallowed origin. `ChatWidget.vue` tears down its stale realtime subscription when the connection reaches this terminal `error` state, so a fresh subscription is established automatically after the next successful message send.

## Test plan

- [x] `make lint` (backend + frontend)
- [x] `make -C backend phpstan`
- [x] `make test` (backend PHPUnit: 3384 tests; frontend Vitest: 1037 tests)
- [x] `docker compose exec -T frontend npm run check:types` (pre-existing, unrelated `messagesGatewayApi.ts` schema-name mismatch on `main`, not touched by this change)
- [x] New/updated backend unit tests: expired session → `200` with a valid token, `sub` claim matches between connection and subscription tokens, unknown widget/session/origin stay generically indistinguishable
- [x] New/updated frontend unit tests: `RealtimeClient` transitions to `error` state on `disconnectedCodes.unauthorized` and on a `404` from the connection-token endpoint, still retries on transient errors; new `tokenApi.spec.ts` covering `ApiError` status propagation
- [x] Manually verified against the running dev stack: fresh session → `200`, DB-forced expired session → `200` (previously `404`), unknown session → `404`, unknown widget → `404`, wrong `Origin` → `403`, `history` on the expired session still works unchanged