### PR TITLE
fix(gateway): keep empty JSON Schema objects when re-encoding Claude Code tools

### DIFF
--- a/backend/src/AI/Messages/AnthropicJsonSchemaNormalizer.php
+++ b/backend/src/AI/Messages/AnthropicJsonSchemaNormalizer.php
@@ -11,7 +11,8 @@ namespace App\AI\Messages;
  * `['properties' => []]`. A later {@see json_encode} then emits
  * `"properties":[]`, which Anthropic rejects (`input_schema.properties: Input
  * should be an object`). The same corruption hits empty schema objects used as
- * `additionalProperties: {}` (Claude Code's TaskCreate `metadata` field).
+ * `additionalProperties: {}` (Claude Code's TaskCreate `metadata` field) and
+ * empty child schemas such as a property defined as `{}` or `items: {}`.
  *
  * Claude Code ships several tools with these empty objects; the moment the
  * gateway mutates the body (tool injection, vision rewrite, …) and re-encodes,
@@ -54,10 +55,15 @@ final class AnthropicJsonSchemaNormalizer
     /**
      * @param array<string, mixed> $schema
      *
-     * @return array<string, mixed>
+     * @return array<string, mixed>|\stdClass
      */
-    public function normalizeSchema(array $schema): array
+    public function normalizeSchema(array $schema): array|\stdClass
     {
+        // A wholly empty schema object (`{}`) becomes [] after json_decode(true).
+        if ([] === $schema) {
+            return new \stdClass();
+        }
+
         if (\array_key_exists('properties', $schema)) {
             $schema['properties'] = $this->objectOrWalk($schema['properties']);
         }
@@ -70,20 +76,20 @@ final class AnthropicJsonSchemaNormalizer
             // `additionalProperties: {}` is a valid empty schema object; after
             // json_decode(true) it is []. Re-encoding that as a JSON array makes
             // Anthropic reject the whole tool schema as invalid draft 2020-12.
-            $schema['additionalProperties'] = [] === $schema['additionalProperties']
-                ? new \stdClass()
-                : $this->normalizeSchema($schema['additionalProperties']);
+            $schema['additionalProperties'] = $this->normalizeSchema($schema['additionalProperties']);
         }
 
         if (\array_key_exists('propertyNames', $schema) && \is_array($schema['propertyNames'])) {
-            $schema['propertyNames'] = [] === $schema['propertyNames']
-                ? new \stdClass()
-                : $this->normalizeSchema($schema['propertyNames']);
+            $schema['propertyNames'] = $this->normalizeSchema($schema['propertyNames']);
         }
 
         if (\array_key_exists('items', $schema) && \is_array($schema['items'])) {
-            // Tuple form (list of schemas) vs single schema object.
-            if ($this->isList($schema['items'])) {
+            // Empty [] here is ambiguous (tuple of zero vs empty schema object).
+            // Prefer the schema-object reading — `items: {}` is the form that
+            // actually appears in tool schemas; `items: []` is useless.
+            if ([] === $schema['items']) {
+                $schema['items'] = new \stdClass();
+            } elseif ($this->isList($schema['items'])) {
                 foreach ($schema['items'] as $i => $item) {
                     if (\is_array($item)) {
                         $schema['items'][$i] = $this->normalizeSchema($item);
@@ -134,6 +140,7 @@ final class AnthropicJsonSchemaNormalizer
 
         foreach ($value as $key => $child) {
             if (\is_array($child)) {
+                // Nested property schemas may themselves be empty objects.
                 $value[$key] = $this->normalizeSchema($child);
             }
         }

--- a/backend/src/AI/Messages/AnthropicJsonSchemaNormalizer.php
+++ b/backend/src/AI/Messages/AnthropicJsonSchemaNormalizer.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\AI\Messages;
+
+/**
+ * Keeps JSON Schema object fields as JSON objects across PHP's array decode.
+ *
+ * {@see json_decode} with associative arrays turns `{"properties":{}}` into
+ * `['properties' => []]`. A later {@see json_encode} then emits
+ * `"properties":[]`, which Anthropic rejects (`input_schema.properties: Input
+ * should be an object`). The same corruption hits empty schema objects used as
+ * `additionalProperties: {}` (Claude Code's TaskCreate `metadata` field).
+ *
+ * Claude Code ships several tools with these empty objects; the moment the
+ * gateway mutates the body (tool injection, vision rewrite, …) and re-encodes,
+ * those tools break.
+ */
+final class AnthropicJsonSchemaNormalizer
+{
+    /**
+     * @param array<string, mixed> $requestBody
+     *
+     * @return array<string, mixed>
+     */
+    public function normalizeRequestBody(array $requestBody): array
+    {
+        if (!isset($requestBody['tools']) || !\is_array($requestBody['tools'])) {
+            return $requestBody;
+        }
+
+        foreach ($requestBody['tools'] as $index => $tool) {
+            if (!\is_array($tool)) {
+                continue;
+            }
+
+            if (isset($tool['input_schema']) && \is_array($tool['input_schema'])) {
+                $requestBody['tools'][$index]['input_schema'] = $this->normalizeSchema($tool['input_schema']);
+            }
+
+            if (isset($tool['custom']) && \is_array($tool['custom'])
+                && isset($tool['custom']['input_schema']) && \is_array($tool['custom']['input_schema'])
+            ) {
+                $requestBody['tools'][$index]['custom']['input_schema'] = $this->normalizeSchema(
+                    $tool['custom']['input_schema'],
+                );
+            }
+        }
+
+        return $requestBody;
+    }
+
+    /**
+     * @param array<string, mixed> $schema
+     *
+     * @return array<string, mixed>
+     */
+    public function normalizeSchema(array $schema): array
+    {
+        if (\array_key_exists('properties', $schema)) {
+            $schema['properties'] = $this->objectOrWalk($schema['properties']);
+        }
+
+        if (\array_key_exists('patternProperties', $schema)) {
+            $schema['patternProperties'] = $this->objectOrWalk($schema['patternProperties']);
+        }
+
+        if (\array_key_exists('additionalProperties', $schema) && \is_array($schema['additionalProperties'])) {
+            // `additionalProperties: {}` is a valid empty schema object; after
+            // json_decode(true) it is []. Re-encoding that as a JSON array makes
+            // Anthropic reject the whole tool schema as invalid draft 2020-12.
+            $schema['additionalProperties'] = [] === $schema['additionalProperties']
+                ? new \stdClass()
+                : $this->normalizeSchema($schema['additionalProperties']);
+        }
+
+        if (\array_key_exists('propertyNames', $schema) && \is_array($schema['propertyNames'])) {
+            $schema['propertyNames'] = [] === $schema['propertyNames']
+                ? new \stdClass()
+                : $this->normalizeSchema($schema['propertyNames']);
+        }
+
+        if (\array_key_exists('items', $schema) && \is_array($schema['items'])) {
+            // Tuple form (list of schemas) vs single schema object.
+            if ($this->isList($schema['items'])) {
+                foreach ($schema['items'] as $i => $item) {
+                    if (\is_array($item)) {
+                        $schema['items'][$i] = $this->normalizeSchema($item);
+                    }
+                }
+            } else {
+                $schema['items'] = $this->normalizeSchema($schema['items']);
+            }
+        }
+
+        foreach (['anyOf', 'oneOf', 'allOf', 'prefixItems'] as $combiner) {
+            if (!isset($schema[$combiner]) || !\is_array($schema[$combiner])) {
+                continue;
+            }
+            foreach ($schema[$combiner] as $i => $sub) {
+                if (\is_array($sub)) {
+                    $schema[$combiner][$i] = $this->normalizeSchema($sub);
+                }
+            }
+        }
+
+        if (isset($schema['$defs']) && \is_array($schema['$defs'])) {
+            $schema['$defs'] = $this->objectOrWalk($schema['$defs']);
+        }
+
+        if (isset($schema['definitions']) && \is_array($schema['definitions'])) {
+            $schema['definitions'] = $this->objectOrWalk($schema['definitions']);
+        }
+
+        return $schema;
+    }
+
+    private function objectOrWalk(mixed $value): mixed
+    {
+        if (!\is_array($value)) {
+            return $value;
+        }
+
+        if ([] === $value) {
+            return new \stdClass();
+        }
+
+        if ($this->isList($value)) {
+            // A JSON Schema "properties" / "$defs" value must be a map, never a
+            // list. Leave unexpected lists alone rather than inventing keys.
+            return $value;
+        }
+
+        foreach ($value as $key => $child) {
+            if (\is_array($child)) {
+                $value[$key] = $this->normalizeSchema($child);
+            }
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param array<mixed> $value
+     */
+    private function isList(array $value): bool
+    {
+        return array_is_list($value);
+    }
+}

--- a/backend/src/AI/Messages/Translator/AnthropicPassthroughTranslator.php
+++ b/backend/src/AI/Messages/Translator/AnthropicPassthroughTranslator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\AI\Messages\Translator;
 
+use App\AI\Messages\AnthropicJsonSchemaNormalizer;
 use App\AI\Messages\MessagesTranslatorInterface;
 use App\AI\Messages\MessagesUsage;
 use Psr\Log\LoggerInterface;
@@ -16,7 +17,9 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  * Raw-body fast path: when context['raw_body'] is set and the body was not
  * mutated, the exact request bytes are forwarded (beta fields, attribution
  * block, cache_control markers stay byte-identical). Otherwise the decoded
- * $requestBody is re-encoded with JSON_THROW_ON_ERROR.
+ * $requestBody is re-encoded with JSON_THROW_ON_ERROR after
+ * {@see AnthropicJsonSchemaNormalizer} restores empty schema objects that PHP
+ * would otherwise emit as JSON arrays.
  *
  * Streaming emits raw SSE byte chunks via $emit(string) while teeing them
  * to extract usage from message_start / message_delta events.
@@ -29,6 +32,7 @@ final readonly class AnthropicPassthroughTranslator implements MessagesTranslato
     public function __construct(
         private HttpClientInterface $httpClient,
         private LoggerInterface $logger,
+        private AnthropicJsonSchemaNormalizer $schemaNormalizer,
     ) {
     }
 
@@ -130,7 +134,7 @@ final readonly class AnthropicPassthroughTranslator implements MessagesTranslato
 
         $body = $context['raw_body'] ?? null;
         if (null === $body || '' === $body) {
-            $payload = $requestBody;
+            $payload = $this->schemaNormalizer->normalizeRequestBody($requestBody);
             $payload['stream'] = $stream;
             $body = json_encode($payload, \JSON_THROW_ON_ERROR | \JSON_INVALID_UTF8_SUBSTITUTE);
         } elseif ($stream) {
@@ -140,6 +144,7 @@ final readonly class AnthropicPassthroughTranslator implements MessagesTranslato
             $decoded = json_decode($body, true);
             if (\is_array($decoded) && true !== ($decoded['stream'] ?? false)) {
                 $decoded['stream'] = true;
+                $decoded = $this->schemaNormalizer->normalizeRequestBody($decoded);
                 $body = json_encode($decoded, \JSON_THROW_ON_ERROR | \JSON_INVALID_UTF8_SUBSTITUTE);
             }
         }

--- a/backend/tests/Unit/AI/Messages/AnthropicJsonSchemaNormalizerTest.php
+++ b/backend/tests/Unit/AI/Messages/AnthropicJsonSchemaNormalizerTest.php
@@ -113,4 +113,40 @@ final class AnthropicJsonSchemaNormalizerTest extends TestCase
 
         self::assertStringContainsString('"properties":{}', $encoded);
     }
+
+    public function testEmptyChildPropertySchemaBecomesObject(): void
+    {
+        // {"properties":{"extra":{}}} → property "extra" decodes as [].
+        $schema = [
+            'type' => 'object',
+            'properties' => [
+                'extra' => [],
+            ],
+        ];
+
+        $encoded = json_encode($this->normalizer->normalizeSchema($schema), \JSON_THROW_ON_ERROR);
+
+        self::assertStringContainsString('"extra":{}', $encoded);
+        self::assertStringNotContainsString('"extra":[]', $encoded);
+    }
+
+    public function testEmptyItemsSchemaBecomesObject(): void
+    {
+        $schema = [
+            'type' => 'array',
+            'items' => [],
+        ];
+
+        $encoded = json_encode($this->normalizer->normalizeSchema($schema), \JSON_THROW_ON_ERROR);
+
+        self::assertStringContainsString('"items":{}', $encoded);
+        self::assertStringNotContainsString('"items":[]', $encoded);
+    }
+
+    public function testEmptyRootSchemaBecomesObject(): void
+    {
+        $encoded = json_encode($this->normalizer->normalizeSchema([]), \JSON_THROW_ON_ERROR);
+
+        self::assertSame('{}', $encoded);
+    }
 }

--- a/backend/tests/Unit/AI/Messages/AnthropicJsonSchemaNormalizerTest.php
+++ b/backend/tests/Unit/AI/Messages/AnthropicJsonSchemaNormalizerTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\AI\Messages;
+
+use App\AI\Messages\AnthropicJsonSchemaNormalizer;
+use PHPUnit\Framework\TestCase;
+
+final class AnthropicJsonSchemaNormalizerTest extends TestCase
+{
+    private AnthropicJsonSchemaNormalizer $normalizer;
+
+    protected function setUp(): void
+    {
+        $this->normalizer = new AnthropicJsonSchemaNormalizer();
+    }
+
+    public function testEmptyPropertiesSurviveJsonRoundTripAsObject(): void
+    {
+        // Mimic what json_decode(..., true) does to Claude Code's CronList /
+        // TaskList tools: {"properties":{}} becomes an empty PHP array.
+        /** @var array{tools: list<array{input_schema: array{properties: array<mixed>}}>} $decoded */
+        $decoded = json_decode(
+            '{"tools":[{"name":"CronList","input_schema":{"type":"object","properties":{},"additionalProperties":false}}]}',
+            true,
+            512,
+            \JSON_THROW_ON_ERROR,
+        );
+        self::assertSame([], $decoded['tools'][0]['input_schema']['properties']);
+
+        $normalized = $this->normalizer->normalizeRequestBody($decoded);
+        $encoded = json_encode($normalized, \JSON_THROW_ON_ERROR);
+
+        self::assertStringContainsString('"properties":{}', $encoded);
+        self::assertStringNotContainsString('"properties":[]', $encoded);
+    }
+
+    public function testNestedEmptyPropertiesAlsoBecomeObjects(): void
+    {
+        $schema = [
+            'type' => 'object',
+            'properties' => [
+                'files' => [
+                    'type' => 'array',
+                    'items' => [
+                        'type' => 'object',
+                        'properties' => [],
+                        'additionalProperties' => false,
+                    ],
+                ],
+            ],
+        ];
+
+        $encoded = json_encode($this->normalizer->normalizeSchema($schema), \JSON_THROW_ON_ERROR);
+
+        self::assertStringContainsString('"properties":{}', $encoded);
+        self::assertStringNotContainsString('"properties":[]', $encoded);
+    }
+
+    public function testEmptyRequiredArrayStaysAJsonArray(): void
+    {
+        $schema = [
+            'type' => 'object',
+            'properties' => ['q' => ['type' => 'string']],
+            'required' => [],
+        ];
+
+        $encoded = json_encode($this->normalizer->normalizeSchema($schema), \JSON_THROW_ON_ERROR);
+
+        self::assertStringContainsString('"required":[]', $encoded);
+    }
+
+    public function testEmptyAdditionalPropertiesSurviveAsObject(): void
+    {
+        // TaskCreate's metadata field: additionalProperties: {}
+        $schema = [
+            'type' => 'object',
+            'properties' => [
+                'metadata' => [
+                    'type' => 'object',
+                    'propertyNames' => ['type' => 'string'],
+                    'additionalProperties' => [],
+                ],
+            ],
+            'required' => ['subject'],
+            'additionalProperties' => false,
+        ];
+
+        $encoded = json_encode($this->normalizer->normalizeSchema($schema), \JSON_THROW_ON_ERROR);
+
+        self::assertStringContainsString('"additionalProperties":{}', $encoded);
+        self::assertStringNotContainsString('"additionalProperties":[]', $encoded);
+        self::assertStringContainsString('"additionalProperties":false', $encoded);
+    }
+
+    public function testCustomWrappedToolSchemasAreNormalized(): void
+    {
+        $body = [
+            'tools' => [[
+                'type' => 'custom',
+                'name' => 'CronList',
+                'custom' => [
+                    'input_schema' => [
+                        'type' => 'object',
+                        'properties' => [],
+                    ],
+                ],
+            ]],
+        ];
+
+        $encoded = json_encode($this->normalizer->normalizeRequestBody($body), \JSON_THROW_ON_ERROR);
+
+        self::assertStringContainsString('"properties":{}', $encoded);
+    }
+}

--- a/backend/tests/Unit/AI/Messages/AnthropicPassthroughEmptyPropertiesTest.php
+++ b/backend/tests/Unit/AI/Messages/AnthropicPassthroughEmptyPropertiesTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\AI\Messages;
+
+use App\AI\Messages\AnthropicJsonSchemaNormalizer;
+use App\AI\Messages\Translator\AnthropicPassthroughTranslator;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+final class AnthropicPassthroughEmptyPropertiesTest extends TestCase
+{
+    public function testReencodedBodyKeepsEmptyToolPropertiesAsObject(): void
+    {
+        $captured = null;
+        $client = new MockHttpClient(static function (string $method, string $url, array $options) use (&$captured): MockResponse {
+            $captured = $options['body'] ?? '';
+
+            return new MockResponse(json_encode([
+                'id' => 'msg_test',
+                'type' => 'message',
+                'role' => 'assistant',
+                'content' => [['type' => 'text', 'text' => 'ok']],
+                'stop_reason' => 'end_turn',
+                'usage' => ['input_tokens' => 1, 'output_tokens' => 1],
+            ], \JSON_THROW_ON_ERROR));
+        });
+
+        $translator = new AnthropicPassthroughTranslator(
+            $client,
+            new NullLogger(),
+            new AnthropicJsonSchemaNormalizer(),
+        );
+
+        // Empty properties array = what json_decode(true) produces for {}.
+        $requestBody = [
+            'model' => 'claude-sonnet-5',
+            'max_tokens' => 16,
+            'messages' => [['role' => 'user', 'content' => 'hi']],
+            'tools' => [[
+                'name' => 'CronList',
+                'description' => 'List cron jobs',
+                'input_schema' => [
+                    'type' => 'object',
+                    'properties' => [],
+                    'additionalProperties' => false,
+                ],
+            ]],
+        ];
+
+        $translator->complete($requestBody, [
+            'api_key' => 'test-key',
+            'upstream_url' => 'https://api.anthropic.com',
+            'anthropic_version' => '2023-06-01',
+            // Force the re-encode path used after tool injection.
+            'raw_body' => null,
+        ]);
+
+        self::assertIsString($captured);
+        self::assertStringContainsString('"properties":{}', $captured);
+        self::assertStringNotContainsString('"properties":[]', $captured);
+    }
+}


### PR DESCRIPTION
## Summary
- Claude Code was failing against Synaplan with `400 tools.5.custom.input_schema.properties: Input should be an object` (and a follow-on invalid draft 2020-12 error on TaskCreate).
- Root cause: when the gateway mutates the request (injects `analyze_image` / web search) it drops `raw_body` and re-encodes. PHP turns empty JSON objects `{}` into `[]`, which Anthropic rejects.
- Fix: normalize tool `input_schema` object fields (`properties`, `additionalProperties`, …) back to empty objects before encoding on the Anthropic passthrough path.

## Test plan
- [x] Unit tests for empty `properties` and empty `additionalProperties`
- [x] Passthrough translator re-encode test
- [x] `make -C backend lint` / `phpstan` / full `make -C backend test`
- [x] Live Claude Code CLI against local Synaplan returns `synaplan-claude-ok`
- [ ] After merge + deploy: Claude Code against web.synaplan.com


Made with [Cursor](https://cursor.com)