### PR TITLE
fix(files): NFS-aware path lookup in FileProcessor

### DIFF
--- a/backend/src/Service/File/FileProcessor.php
+++ b/backend/src/Service/File/FileProcessor.php
@@ -431,7 +431,9 @@ final readonly class FileProcessor
         ];
 
         foreach ($candidates as $path) {
-            if (is_file($path)) {
+            // NFS-aware: plain is_file() misses files just written on another
+            // web node until the attribute cache expires (actimeo≈1s).
+            if (FileHelper::fileExistsNfs($path)) {
                 return $path;
             }
         }


### PR DESCRIPTION
## Summary
- Restores the leftover one-line fix that landed on the deleted `fix/gateway-empty-tool-schema-properties` branch after #1479 merged (wrong commit message; actual change was FileProcessor only).
- Uses `FileHelper::fileExistsNfs()` instead of `is_file()` when resolving upload paths, matching the other file services on multi-node NFS.

## Test plan
- [x] `make -C backend lint`
- [x] `make -C backend phpstan`
- [x] `make -C backend test`
- [ ] Spot-check file processing after upload on a multi-web-node / NFS setup if available


Made with [Cursor](https://cursor.com)