### PR TITLE
fix(frontend): resolve App Store review findings for the native app

### DIFF
--- a/backend/src/AI/Service/AiProviderDisclosure.php
+++ b/backend/src/AI/Service/AiProviderDisclosure.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\AI\Service;
+
+use App\AI\Credential\ChatReadinessService;
+use App\Repository\ModelRepository;
+
+/**
+ * MOBILE-APP SEAM (App Review 5.1.2(i) / Play "prominent disclosure"): names
+ * the AI providers a user's input can reach.
+ *
+ * Since November 2025 Apple requires the consent screen to identify the
+ * third-party AI by name — "external AI providers" is not enough. The app shows
+ * that screen before sign-in, so the list has to come from the public runtime
+ * config, and it has to reflect the instance the app is pointed at rather than
+ * a list baked into the bundle.
+ *
+ * Two filters make the list match reality rather than the catalog: the model
+ * has to be pickable in chat, and the provider has to be usable. A provider
+ * without a configured key cannot receive anything, and listing it would pad a
+ * disclosure that people only read while it stays short.
+ */
+final readonly class AiProviderDisclosure
+{
+    public function __construct(
+        private ModelRepository $modelRepository,
+        private ProviderRegistry $providerRegistry,
+        private ChatReadinessService $chatReadiness,
+    ) {
+    }
+
+    /**
+     * Display names of the providers behind the usable, selectable chat models.
+     *
+     * @return list<string> Sorted and deduplicated, e.g. ['Anthropic', 'Google AI']
+     */
+    public function chatProviderNames(): array
+    {
+        $displayNames = [];
+        foreach ($this->providerRegistry->getUniqueProviders() as $provider) {
+            $displayNames[strtolower($provider->getName())] = $provider->getDisplayName();
+        }
+
+        // Cached for 30s inside the service — the public config is polled, and
+        // a fresh probe per request would put an Ollama round trip on an
+        // unauthenticated endpoint.
+        $available = $this->chatReadiness->providerAvailability();
+
+        $names = [];
+        foreach ($this->modelRepository->findSelectableChatServices() as $service) {
+            $key = strtolower(trim($service));
+
+            // Unknown to the registry means there is no client that could send
+            // anything, so it belongs in no disclosure. 'test' is a fixture.
+            if ('' === $key || 'test' === $key || !isset($displayNames[$key])) {
+                continue;
+            }
+
+            if (!($available[$key] ?? false)) {
+                continue;
+            }
+
+            $names[$key] = $displayNames[$key];
+        }
+
+        $names = array_values($names);
+        sort($names, SORT_NATURAL | SORT_FLAG_CASE);
+
+        return $names;
+    }
+}

--- a/backend/src/Controller/ConfigController.php
+++ b/backend/src/Controller/ConfigController.php
@@ -5,6 +5,7 @@ namespace App\Controller;
 use App\AI\Credential\ChatReadinessService;
 use App\AI\Credential\SecretValueGuard;
 use App\AI\Interface\ProviderMetadataInterface;
+use App\AI\Service\AiProviderDisclosure;
 use App\AI\Service\ProviderRegistry;
 use App\Entity\Config;
 use App\Entity\User;
@@ -63,6 +64,7 @@ class ConfigController extends AbstractController
         private UsageTaximeterConfig $usageTaximeterConfig,
         private RegistrationConfig $registrationConfig,
         private ChatReadinessService $chatReadiness,
+        private AiProviderDisclosure $aiProviderDisclosure,
         private LocalAiDownloadStatusService $localAiDownloadStatus,
         private CapabilityService $capabilityService,
         #[Autowire('%env(string:default::QDRANT_URL)%')]
@@ -373,6 +375,12 @@ class ConfigController extends AbstractController
                     ]
                 ),
                 new OA\Property(
+                    property: 'aiProviders',
+                    type: 'array',
+                    description: 'Display names of the AI providers a user\'s input can reach on this instance, for the disclosure App Store Review Guideline 5.1.2(i) requires. Empty when none are configured.',
+                    items: new OA\Items(type: 'string', example: 'Anthropic')
+                ),
+                new OA\Property(
                     property: 'unavailableProviders',
                     type: 'array',
                     description: 'AI providers that are disabled due to missing API keys (only for authenticated users)',
@@ -555,6 +563,12 @@ class ConfigController extends AbstractController
             'realtime' => $realtimeConfig,
             'client' => $clientConfig,
             'mobile' => $mobileConfig,
+            // MOBILE-APP SEAM (App Review 5.1.2(i)): the app's first-run consent
+            // screen has to name the AI providers, and it runs before sign-in —
+            // so the list ships with the public config. Empty on an instance
+            // with no usable chat provider; the client then falls back to
+            // wording without names.
+            'aiProviders' => $this->aiProviderDisclosure->chatProviderNames(),
             'marketingNews' => [
                 'enabled' => $this->marketingNewsConfig->isEnabled(),
             ],

--- a/backend/src/Repository/ModelRepository.php
+++ b/backend/src/Repository/ModelRepository.php
@@ -80,6 +80,30 @@ class ModelRepository extends ServiceEntityRepository
     }
 
     /**
+     * Services behind the chat models a user can actually pick.
+     *
+     * Deliberately DB-only: this feeds the public runtime config, which must
+     * not depend on live provider probes (Ollama's availability check performs
+     * an HTTP request, which an unauthenticated endpoint cannot afford).
+     *
+     * @return string[] Service names as stored, e.g. ['Anthropic', 'OpenAI']
+     */
+    public function findSelectableChatServices(): array
+    {
+        $results = $this->createQueryBuilder('m')
+            ->select('DISTINCT m.service')
+            ->where('m.tag = :tag')
+            ->andWhere('m.selectable = 1')
+            ->andWhere('m.active = 1')
+            ->setParameter('tag', 'chat')
+            ->orderBy('m.service', 'ASC')
+            ->getQuery()
+            ->getScalarResult();
+
+        return array_map(static fn (array $row): string => (string) $row['service'], $results);
+    }
+
+    /**
      * Get all unique provider-capability combinations from DB
      * Returns: ['openai' => ['chat', 'embedding'], 'ollama' => ['chat', 'vectorize'], ...].
      */

--- a/backend/tests/Controller/ConfigControllerTest.php
+++ b/backend/tests/Controller/ConfigControllerTest.php
@@ -55,6 +55,35 @@ final class ConfigControllerTest extends WebTestCase
         $this->assertIsBool($data['features']['memoryService']);
     }
 
+    /**
+     * MOBILE-APP SEAM (App Review 5.1.2(i)): the app names its AI providers on
+     * a consent screen that runs before sign-in, so the list has to reach an
+     * anonymous client. Losing it here would leave the app disclosing nothing.
+     */
+    public function testRuntimeConfigNamesTheAiProvidersAnonymously(): void
+    {
+        $client = static::createClient();
+
+        $client->request('GET', '/api/v1/config/runtime');
+
+        $this->assertResponseIsSuccessful();
+
+        $data = json_decode($client->getResponse()->getContent(), true);
+
+        $this->assertArrayHasKey('aiProviders', $data);
+        $this->assertIsArray($data['aiProviders']);
+
+        foreach ($data['aiProviders'] as $provider) {
+            $this->assertIsString($provider);
+            $this->assertNotSame('', $provider);
+        }
+
+        // The test provider serves the default chat model in this environment.
+        // It is a fixture, not something a user's input can reach, so a
+        // disclosure naming it would be wrong.
+        $this->assertNotContains('test', array_map('strtolower', $data['aiProviders']));
+    }
+
     public function testRuntimeConfigIsPublicAndFast(): void
     {
         $client = static::createClient();

--- a/backend/tests/Unit/Controller/ConfigControllerPlannerModelTest.php
+++ b/backend/tests/Unit/Controller/ConfigControllerPlannerModelTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Unit\Controller;
 
 use App\AI\Credential\ChatReadinessService;
+use App\AI\Service\AiProviderDisclosure;
 use App\AI\Service\ProviderRegistry;
 use App\Controller\ConfigController;
 use App\Entity\Config;
@@ -77,6 +78,7 @@ final class ConfigControllerPlannerModelTest extends TestCase
             $this->createStub(UsageTaximeterConfig::class),
             $this->createStub(RegistrationConfig::class),
             $this->createStub(ChatReadinessService::class),
+            $this->createStub(AiProviderDisclosure::class),
             $this->createStub(LocalAiDownloadStatusService::class),
             new CapabilityService(),
             'http://qdrant.example',

--- a/backend/tests/Unit/Controller/ConfigControllerSaveDefaultModelsTest.php
+++ b/backend/tests/Unit/Controller/ConfigControllerSaveDefaultModelsTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Unit\Controller;
 
 use App\AI\Credential\ChatReadinessService;
+use App\AI\Service\AiProviderDisclosure;
 use App\AI\Service\ProviderRegistry;
 use App\Controller\ConfigController;
 use App\Entity\Config;
@@ -91,6 +92,7 @@ final class ConfigControllerSaveDefaultModelsTest extends TestCase
             $this->createStub(UsageTaximeterConfig::class),
             $this->createStub(RegistrationConfig::class),
             $this->createStub(ChatReadinessService::class),
+            $this->createStub(AiProviderDisclosure::class),
             $this->createStub(LocalAiDownloadStatusService::class),
             new CapabilityService(),
             'http://qdrant.example',

--- a/backend/tests/Unit/Controller/ConfigControllerSummaryModelTest.php
+++ b/backend/tests/Unit/Controller/ConfigControllerSummaryModelTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Unit\Controller;
 
 use App\AI\Credential\ChatReadinessService;
+use App\AI\Service\AiProviderDisclosure;
 use App\AI\Service\ProviderRegistry;
 use App\Controller\ConfigController;
 use App\Entity\Config;
@@ -82,6 +83,7 @@ final class ConfigControllerSummaryModelTest extends TestCase
             $this->createStub(UsageTaximeterConfig::class),
             $this->createStub(RegistrationConfig::class),
             $this->createStub(ChatReadinessService::class),
+            $this->createStub(AiProviderDisclosure::class),
             $this->createStub(LocalAiDownloadStatusService::class),
             new CapabilityService(),
             'http://qdrant.example',

--- a/frontend/src/components/ChatInput.vue
+++ b/frontend/src/components/ChatInput.vue
@@ -354,6 +354,7 @@ import { useNotification } from '@/composables/useNotification'
 import { useKeyboardOpen } from '@/composables/useKeyboardOpen'
 import { chatApi } from '@/services/api/chatApi'
 import { triggerHapticImpact } from '@/services/api/nativeHaptics'
+import { isNativeApp } from '@/services/api/nativeRuntime'
 import type { FileItem } from '@/services/filesService'
 import { getFileGroups } from '@/services/filesService'
 import { AudioRecorder } from '@/services/audioRecorder'
@@ -513,10 +514,14 @@ const speechLanguage = computed(() => {
  * Determine if microphone button should be shown.
  * Show when: Web Speech API is supported OR any backend speech-to-text is available.
  * Backend speech-to-text includes: local Whisper.cpp OR API models (Groq/OpenAI Whisper).
+ *
+ * MOBILE-APP SEAM: in the app the Web Speech API does not count (see
+ * `useWebSpeech`), so the button only appears when the server can transcribe.
+ * Offering it without a working path is what produced the review rejection.
  */
 const showMicrophoneButton = computed(() => {
   const speechToTextAvailable = configStore.speech.speechToTextAvailable
-  const webSpeechSupported = isWebSpeechSupported()
+  const webSpeechSupported = isWebSpeechSupported() && !isNativeApp()
 
   // Show if either browser API or backend transcription is available
   return webSpeechSupported || speechToTextAvailable
@@ -543,11 +548,17 @@ const textareaPaddingRightPx = computed(() => {
  *
  * - Web Speech API: Real-time streaming, works in Chrome/Edge/Safari
  * - Whisper backend: Record-then-transcribe, works everywhere
+ *
+ * MOBILE-APP SEAM: never in the app. `isWebSpeechSupported()` only checks that
+ * the constructor exists, and iOS WKWebView exposes `webkitSpeechRecognition`
+ * without a working recognition service behind it. The request fails with
+ * `not-allowed` before the system ever asks for the microphone, so the user
+ * sees a permission error for a permission that was never requested. Going
+ * straight to the recorder keeps `getUserMedia` in charge, which is what
+ * triggers the real iOS/Android permission prompt.
  */
 const useWebSpeech = computed(() => {
-  // Web Speech API has PRIORITY - use it whenever available
-  // This gives real-time streaming text as user speaks
-  return isWebSpeechSupported()
+  return isWebSpeechSupported() && !isNativeApp()
 })
 
 // Input persistence - auto-save with proper debouncing. Disabled during an
@@ -1323,7 +1334,7 @@ const startWhisperRecording = async () => {
       },
       onError: (error) => {
         console.error('❌ Recording error:', error)
-        showError(error.userMessage)
+        showError(t(error.messageKey))
         isRecording.value = false
       },
     })
@@ -1332,7 +1343,7 @@ const startWhisperRecording = async () => {
     const support = await audioRecorder.value.checkSupport()
     if (!support.supported || !support.hasDevices) {
       if (support.error) {
-        showError(support.error.userMessage)
+        showError(t(support.error.messageKey))
       }
       return
     }
@@ -1341,10 +1352,11 @@ const startWhisperRecording = async () => {
     await audioRecorder.value.startRecording()
   } catch (err: unknown) {
     console.error('❌ Failed to start recording:', err)
-    const error = err as { userMessage?: string; message?: string }
+    const error = err as { messageKey?: string; message?: string }
     showError(
-      error.userMessage ||
-        t('chatInput.recordingError', { error: error.message || 'Unknown error' })
+      error.messageKey
+        ? t(error.messageKey)
+        : t('chatInput.recordingError', { error: error.message || 'Unknown error' })
     )
     isRecording.value = false
   }

--- a/frontend/src/components/ChatMessage.vue
+++ b/frontend/src/components/ChatMessage.vue
@@ -56,9 +56,13 @@
           briefly shifts when the button materialises.
           `pointer-events-none` while hidden keeps the streaming bubble
           fully click-through-able.
+          It stays mounted for the whole stream for that reason, and only drops
+          out once a finished turn turns out to have nothing to copy — otherwise
+          the icon floats alone in an empty bubble, which is most obvious on
+          touch layouts where it never fades out.
         -->
         <button
-          v-if="role === 'assistant'"
+          v-if="role === 'assistant' && (isStreaming || copyableText)"
           type="button"
           :class="[
             'absolute top-2 right-2 z-10 p-1.5 rounded-md txt-secondary bg-black/5 dark:bg-white/10 hover:bg-black/10 dark:hover:bg-white/20 hover:txt-primary',
@@ -1228,12 +1232,23 @@ const usageBadge = computed<{ tokens: string; cost: string } | null>(() => {
 // Copy message text to clipboard
 const copied = ref(false)
 
-const copyMessageText = async () => {
-  const text = props.parts
+/**
+ * Exactly what the copy button would put on the clipboard, empty when there is
+ * nothing to copy. An assistant turn can legitimately end without visible text
+ * — a media-only turn, or a stream that finishes without a single chunk — and
+ * the button drives its own visibility off this, so it can never sit alone in
+ * an empty bubble offering an action that does nothing.
+ */
+const copyableText = computed(() =>
+  props.parts
     .filter((p) => p.type !== 'thinking')
     .map((p) => p.content ?? '')
     .join('\n')
     .trim()
+)
+
+const copyMessageText = async () => {
+  const text = copyableText.value
   if (!text) return
   try {
     await navigator.clipboard.writeText(text)

--- a/frontend/src/components/MainLayout.vue
+++ b/frontend/src/components/MainLayout.vue
@@ -27,6 +27,17 @@
         @touchstart.passive="onTouchStart"
         @touchend="onTouchEnd"
       >
+        <!--
+          Opaque band behind the OS status bar. The WebView runs edge-to-edge
+          (viewport-fit=cover, iOS contentInset: 'never') and the chat
+          deliberately scrolls its messages up behind the notch, which left them
+          colliding with the clock and battery. The band sits inside the content
+          layer, so it slides and clips with it when the drawer opens, and it
+          collapses to nothing wherever the inset is 0 — desktop, browser tabs,
+          Android without a cutout.
+        -->
+        <div class="v2-status-bar-band" aria-hidden="true" data-testid="section-status-bar-band" />
+
         <main
           class="flex-1 min-h-0 overflow-y-auto overscroll-contain"
           data-testid="section-primary-content"
@@ -348,6 +359,25 @@ onBeforeUnmount(() => {
   position: relative;
 }
 
+.v2-content-layer {
+  /* Containing block for the status-bar band, at both breakpoints. */
+  position: relative;
+}
+
+.v2-status-bar-band {
+  position: absolute;
+  inset: 0 0 auto 0;
+  height: env(safe-area-inset-top, 0px);
+  /* Same token the content layer paints itself with, so there is no seam in
+     either theme or in the V2 design, which redefines the token. */
+  background: var(--bg-app);
+  /* Below the floating header buttons (z-40), above the scrolling page. */
+  z-index: 30;
+  /* Purely decorative: the tap-to-top band and keyboard dismissal must keep
+     seeing the page underneath. */
+  pointer-events: none;
+}
+
 .v2-drawer-toggle,
 .v2-login-cta,
 .v2-incognito-toggle {
@@ -374,7 +404,6 @@ onBeforeUnmount(() => {
   }
 
   .v2-content-layer {
-    position: relative;
     z-index: 10;
     /* Opaque so the drawer underneath is fully hidden while closed. */
     background: var(--bg-app);

--- a/frontend/src/components/files/FileSourceBadge.vue
+++ b/frontend/src/components/files/FileSourceBadge.vue
@@ -1,11 +1,13 @@
 <template>
+  <!-- Same as FileVectorPill: nowrap on the outer element defeats the inner
+       truncate, so the badge could grow past its column. -->
   <span
-    class="inline-flex items-center gap-1 text-[11px] txt-secondary whitespace-nowrap"
+    class="inline-flex items-center gap-1 text-[11px] txt-secondary min-w-0 max-w-full overflow-hidden"
     :title="t('files.help.source')"
     data-testid="file-source-badge"
   >
     <Icon :icon="icon" class="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
-    <span class="truncate">{{ label }}</span>
+    <span class="truncate whitespace-nowrap">{{ label }}</span>
   </span>
 </template>
 

--- a/frontend/src/components/files/FileVectorPill.vue
+++ b/frontend/src/components/files/FileVectorPill.vue
@@ -1,16 +1,20 @@
 <template>
   <!-- Nothing is shown when a file is not searchable — the absence of a pill is
        the "not searchable" state. Only searchable / processing / failed render. -->
+  <!-- `whitespace-nowrap` belongs on the label, not here: on the outer element
+       it kept the pill at its full text width, so the inner `truncate` never
+       took effect and a long folder name ran underneath the row's action
+       icons. -->
   <span
     v-if="visible"
-    class="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-medium whitespace-nowrap"
+    class="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-medium min-w-0 max-w-full overflow-hidden"
     :class="variant.classes"
     :title="tooltip"
     :aria-label="label"
     data-testid="file-vector-pill"
   >
     <Icon :icon="variant.icon" class="w-3 h-3 shrink-0" :class="variant.spin && 'animate-spin'" />
-    <span class="truncate">{{ label }}</span>
+    <span class="truncate whitespace-nowrap">{{ label }}</span>
   </span>
 </template>
 

--- a/frontend/src/components/files/FilesGrid.vue
+++ b/frontend/src/components/files/FilesGrid.vue
@@ -93,26 +93,34 @@
               :group-key="file.group_key ?? null"
             />
           </div>
-          <div class="flex items-center gap-1 mt-1.5">
+          <!--
+            Delete is meant to sit in the same spot on every card, but the
+            download button could not shrink below its label (German
+            "Herunterladen"), so on a narrow two-column tile it pushed the icon
+            buttons out of place — by a different amount depending on which of
+            the optional ones the file has. Now the label yields and the icons
+            hold their size, which keeps the trailing edge fixed.
+          -->
+          <div class="flex items-center gap-1 mt-1.5 min-w-0">
             <button
-              class="flex-1 px-2 py-1 rounded-md bg-[var(--brand)]/10 text-[var(--brand)] hover:bg-[var(--brand)]/20 transition-colors text-[11px] font-medium flex items-center justify-center gap-1"
+              class="flex-1 min-w-0 px-2 py-1 rounded-md bg-[var(--brand)]/10 text-[var(--brand)] hover:bg-[var(--brand)]/20 transition-colors text-[11px] font-medium flex items-center justify-center gap-1"
               :title="$t('files.generated.download')"
               :data-testid="`btn-generated-download-${file.id}`"
               @click="download(file)"
             >
-              <ArrowDownTrayIcon class="w-3.5 h-3.5" />
-              {{ $t('files.generated.download') }}
+              <ArrowDownTrayIcon class="w-3.5 h-3.5 shrink-0" />
+              <span class="truncate">{{ $t('files.generated.download') }}</span>
             </button>
             <button
               v-if="file.chat_id"
-              class="px-2 py-1 rounded-md border border-light-border/30 dark:border-dark-border/10 txt-secondary hover:txt-primary transition-colors text-[11px] flex items-center gap-1"
+              class="shrink-0 px-2 py-1 rounded-md border border-light-border/30 dark:border-dark-border/10 txt-secondary hover:txt-primary transition-colors text-[11px] flex items-center gap-1"
               :title="$t('files.generated.openInChat')"
               :data-testid="`btn-generated-open-${file.id}`"
               @click="openInChat(file)"
             >
               <ChatBubbleLeftRightIcon class="w-3.5 h-3.5" />
             </button>
-            <div v-if="!file.is_vectorized" class="relative">
+            <div v-if="!file.is_vectorized" class="relative shrink-0">
               <button
                 class="px-2 py-1 rounded-md border border-light-border/30 dark:border-dark-border/10 txt-secondary hover:text-[var(--brand)] transition-colors text-[11px] flex items-center gap-1 disabled:opacity-50"
                 :title="$t('files.indexPromptAction')"
@@ -177,7 +185,7 @@
               </Transition>
             </div>
             <button
-              class="px-2 py-1 rounded-md border border-light-border/30 dark:border-dark-border/10 text-red-400/70 hover:text-red-500 hover:bg-red-500/10 transition-colors text-[11px] flex items-center gap-1 disabled:opacity-50"
+              class="shrink-0 px-2 py-1 rounded-md border border-light-border/30 dark:border-dark-border/10 text-red-400/70 hover:text-red-500 hover:bg-red-500/10 transition-colors text-[11px] flex items-center gap-1 disabled:opacity-50"
               :title="$t('files.delete')"
               :disabled="isDeleting(file.id)"
               :data-testid="`btn-generated-delete-${file.id}`"

--- a/frontend/src/components/files/IncomingInbox.vue
+++ b/frontend/src/components/files/IncomingInbox.vue
@@ -79,9 +79,9 @@
           <p class="text-sm font-medium txt-primary truncate" :title="file.filename">
             {{ file.display_name || file.original_name || file.filename }}
           </p>
-          <div class="flex items-center gap-2 mt-1 min-w-0 flex-wrap">
+          <div class="flex items-center gap-2 mt-1 min-w-0 flex-wrap overflow-hidden">
             <FileSourceBadge v-if="file.source" :source="file.source" />
-            <span class="text-[11px] txt-secondary">{{ provenance(file) }}</span>
+            <span class="text-[11px] txt-secondary truncate">{{ provenance(file) }}</span>
             <FileVectorPill
               :state="file.vector_state ?? (file.is_vectorized ? 'vectorized' : 'pending')"
               :chunk-count="file.chunk_count ?? file.chunks ?? 0"

--- a/frontend/src/components/onboarding/OnboardingWelcomeStep.vue
+++ b/frontend/src/components/onboarding/OnboardingWelcomeStep.vue
@@ -14,33 +14,9 @@
       {{ $t('onboarding.welcome.subtitle') }}
     </p>
 
-    <!--
-      MOBILE-APP SEAM (App Review 2.1): Synaplan answers through third-party AI
-      models, so the first screen states what leaves the device before anything
-      can be sent. The CTA below is the affirmative act — no extra gate, but no
-      chat without having read this either.
-    -->
-    <div class="mt-10 space-y-1.5 onb-enter-4" data-testid="section-onboarding-ai-notice">
-      <!-- txt-secondary, not the quieter txt-tertiary: this is the disclosure the
-           user consents to by tapping the CTA, so it has to clear WCAG AA. -->
-      <p class="text-xs txt-secondary leading-relaxed">
-        {{ $t('onboarding.welcome.aiNotice') }}
-      </p>
-      <p class="text-xs txt-secondary">
-        <a
-          :href="config.branding.privacyUrl"
-          target="_blank"
-          rel="noopener noreferrer"
-          class="text-brand hover:underline underline-offset-2"
-          data-testid="link-onboarding-privacy"
-          >{{ $t('auth.privacyPolicy') }}</a
-        >
-      </p>
-    </div>
-
     <!-- Primary action: the focused "get started" CTA. -->
     <button
-      class="mt-5 w-full py-3.5 rounded-xl btn-primary font-semibold text-base transition-all duration-200 hover:shadow-lg hover:shadow-brand/20 active:scale-[0.98] onb-enter-4"
+      class="mt-10 w-full py-3.5 rounded-xl btn-primary font-semibold text-base transition-all duration-200 hover:shadow-lg hover:shadow-brand/20 active:scale-[0.98] onb-enter-4"
       data-testid="btn-welcome-next"
       @click="emit('next')"
     >
@@ -80,6 +56,39 @@
       </button>
     </div>
 
+    <!--
+      MOBILE-APP SEAM (App Review 2.1 / 5.1.2(i), Play "prominent disclosure"):
+      Synaplan answers through third-party AI models, so the first screen names
+      what leaves the device before anything can be sent, and the CTA above is
+      the affirmative act. Both stores allow the short form only as long as the
+      substance stays on screen: it must say which data goes where and why, and
+      must not live in a menu or in the privacy policy alone. So the sentence
+      itself stays visible and only the elaboration moves behind "details".
+    -->
+    <p
+      class="mt-8 text-[11px] leading-relaxed txt-secondary onb-enter-5"
+      data-testid="section-onboarding-ai-notice"
+    >
+      {{ $t('onboarding.welcome.aiNotice') }}
+      <button
+        type="button"
+        class="text-brand hover:underline underline-offset-2"
+        data-testid="btn-onboarding-ai-details"
+        @click="activeModal = 'ai'"
+      >
+        {{ $t('onboarding.welcome.aiNoticeDetails') }}
+      </button>
+      <span aria-hidden="true"> · </span>
+      <a
+        :href="config.branding.privacyUrl"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="text-brand hover:underline underline-offset-2"
+        data-testid="link-onboarding-privacy"
+        >{{ $t('auth.privacyPolicy') }}</a
+      >
+    </p>
+
     <!-- Own-server modal: URL entry replacing the standard server. -->
     <OnboardingServerModal
       :is-open="activeModal === 'server'"
@@ -87,13 +96,15 @@
       @saved="activeModal = null"
     />
 
-    <!-- Info-only modals for RAG and the chat widget. -->
+    <!-- Info-only modals: RAG, the chat widget, and the AI-processing detail. -->
     <OnboardingInfoModal
-      :is-open="activeModal === 'rag' || activeModal === 'widget'"
+      :is-open="activeModal !== null && activeModal !== 'server'"
       :icon="activeInfoContent.icon"
       :title="activeInfoContent.title"
       :description="activeInfoContent.description"
       :points="activeInfoContent.points"
+      :link-label="activeInfoContent.linkLabel"
+      :link-url="activeInfoContent.linkUrl"
       @close="activeModal = null"
     />
   </div>
@@ -103,11 +114,12 @@
 /**
  * MOBILE-APP SEAM (first-run onboarding), page 1: welcome + quiet entry points.
  *
- * One focused "get started" CTA advances to the plans page. Above it sits the
- * AI-processing notice with the privacy-policy link; below it, a row of
+ * One focused "get started" CTA advances to the plans page. Below it, a row of
  * deliberately understated pills open modals: "own server" (URL entry that
  * points the app at a self-hosted Synaplan server) and two info modals that
- * explain RAG and the chat widget. All modals close back to this page.
+ * explain RAG and the chat widget. The AI-processing disclosure closes the page
+ * as fine print, with its elaboration in a third info modal. All modals close
+ * back to this page.
  */
 import { computed, ref } from 'vue'
 import { Icon } from '@iconify/vue'
@@ -135,16 +147,28 @@ const { logoSrc } = useBrandLogo(isDark)
 
 const serverControlAvailable = isNativeServerControlAvailable()
 
-const activeModal = ref<'server' | 'rag' | 'widget' | null>(null)
+const activeModal = ref<'server' | 'rag' | 'widget' | 'ai' | null>(null)
 
 interface InfoContent {
   icon: string
   title: string
   description: string
   points: string[]
+  linkLabel?: string
+  linkUrl?: string
 }
 
 const activeInfoContent = computed<InfoContent>(() => {
+  if ('ai' === activeModal.value) {
+    return {
+      icon: 'mdi:shield-lock-outline',
+      title: t('onboarding.ai.title'),
+      description: t('onboarding.ai.body'),
+      points: [t('onboarding.ai.point1'), t('onboarding.ai.point2'), t('onboarding.ai.point3')],
+      linkLabel: t('auth.privacyPolicy'),
+      linkUrl: config.branding.privacyUrl,
+    }
+  }
   if ('widget' === activeModal.value) {
     return {
       icon: 'mdi:message-text-outline',

--- a/frontend/src/components/onboarding/OnboardingWelcomeStep.vue
+++ b/frontend/src/components/onboarding/OnboardingWelcomeStep.vue
@@ -14,9 +14,31 @@
       {{ $t('onboarding.welcome.subtitle') }}
     </p>
 
+    <!--
+      MOBILE-APP SEAM (App Review 2.1): Synaplan answers through third-party AI
+      models, so the first screen states what leaves the device before anything
+      can be sent. The CTA below is the affirmative act — no extra gate, but no
+      chat without having read this either.
+    -->
+    <div class="mt-10 space-y-1.5 onb-enter-4" data-testid="section-onboarding-ai-notice">
+      <p class="text-xs txt-tertiary leading-relaxed">
+        {{ $t('onboarding.welcome.aiNotice') }}
+      </p>
+      <p class="text-xs txt-tertiary">
+        <a
+          :href="config.branding.privacyUrl"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="text-brand hover:underline underline-offset-2"
+          data-testid="link-onboarding-privacy"
+          >{{ $t('auth.privacyPolicy') }}</a
+        >
+      </p>
+    </div>
+
     <!-- Primary action: the focused "get started" CTA. -->
     <button
-      class="mt-10 w-full py-3.5 rounded-xl btn-primary font-semibold text-base transition-all duration-200 hover:shadow-lg hover:shadow-brand/20 active:scale-[0.98] onb-enter-4"
+      class="mt-5 w-full py-3.5 rounded-xl btn-primary font-semibold text-base transition-all duration-200 hover:shadow-lg hover:shadow-brand/20 active:scale-[0.98] onb-enter-4"
       data-testid="btn-welcome-next"
       @click="emit('next')"
     >
@@ -79,7 +101,8 @@
 /**
  * MOBILE-APP SEAM (first-run onboarding), page 1: welcome + quiet entry points.
  *
- * One focused "get started" CTA advances to the plans page. Below it, a row of
+ * One focused "get started" CTA advances to the plans page. Above it sits the
+ * AI-processing notice with the privacy-policy link; below it, a row of
  * deliberately understated pills open modals: "own server" (URL entry that
  * points the app at a self-hosted Synaplan server) and two info modals that
  * explain RAG and the chat widget. All modals close back to this page.

--- a/frontend/src/components/onboarding/OnboardingWelcomeStep.vue
+++ b/frontend/src/components/onboarding/OnboardingWelcomeStep.vue
@@ -65,29 +65,32 @@
       must not live in a menu or in the privacy policy alone. So the sentence
       itself stays visible and only the elaboration moves behind "details".
     -->
-    <p
-      class="mt-8 text-[11px] leading-relaxed txt-secondary onb-enter-5"
+    <div
+      class="mt-8 space-y-0.5 text-[11px] leading-relaxed txt-secondary onb-enter-5"
       data-testid="section-onboarding-ai-notice"
     >
-      {{ $t('onboarding.welcome.aiNotice') }}
-      <button
-        type="button"
-        class="text-brand hover:underline underline-offset-2"
-        data-testid="btn-onboarding-ai-details"
-        @click="activeModal = 'ai'"
-      >
-        {{ $t('onboarding.welcome.aiNoticeDetails') }}
-      </button>
-      <span aria-hidden="true"> · </span>
-      <a
-        :href="config.branding.privacyUrl"
-        target="_blank"
-        rel="noopener noreferrer"
-        class="text-brand hover:underline underline-offset-2"
-        data-testid="link-onboarding-privacy"
-        >{{ $t('auth.privacyPolicy') }}</a
-      >
-    </p>
+      <p>{{ $t('onboarding.welcome.aiNotice') }}</p>
+      <p v-if="aiProviders" data-testid="text-onboarding-ai-providers">{{ aiProviders }}</p>
+      <p>
+        <button
+          type="button"
+          class="text-brand hover:underline underline-offset-2"
+          data-testid="btn-onboarding-ai-details"
+          @click="activeModal = 'ai'"
+        >
+          {{ $t('onboarding.welcome.aiNoticeDetails') }}
+        </button>
+        <span aria-hidden="true"> · </span>
+        <a
+          :href="config.branding.privacyUrl"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="text-brand hover:underline underline-offset-2"
+          data-testid="link-onboarding-privacy"
+          >{{ $t('auth.privacyPolicy') }}</a
+        >
+      </p>
+    </div>
 
     <!-- Own-server modal: URL entry replacing the standard server. -->
     <OnboardingServerModal
@@ -133,9 +136,29 @@ import OnboardingInfoModal from '@/components/onboarding/OnboardingInfoModal.vue
 
 const emit = defineEmits<{ next: [] }>()
 
-const { t } = useI18n()
+const { t, locale } = useI18n()
 const config = useConfigStore()
 const themeStore = useTheme()
+
+/**
+ * App Review 5.1.2(i) wants the providers named, not just "third-party AI".
+ * The names come from the server the app is pointed at, so a self-hosted
+ * instance discloses its own set — and an instance that reports none simply
+ * omits the line instead of showing an empty label.
+ *
+ * They sit on their own line rather than inside the sentence: an instance
+ * offering seven providers would otherwise bury the consent itself in a list.
+ */
+const aiProviders = computed(() => {
+  const providers = config.aiDisclosure.providers
+  if (0 === providers.length) {
+    return ''
+  }
+
+  return t('onboarding.welcome.aiNoticeProviders', {
+    providers: new Intl.ListFormat(locale.value, { style: 'long', type: 'unit' }).format(providers),
+  })
+})
 
 const isDark = computed(() => {
   if (themeStore.theme.value === 'dark') return true

--- a/frontend/src/components/onboarding/OnboardingWelcomeStep.vue
+++ b/frontend/src/components/onboarding/OnboardingWelcomeStep.vue
@@ -21,10 +21,12 @@
       chat without having read this either.
     -->
     <div class="mt-10 space-y-1.5 onb-enter-4" data-testid="section-onboarding-ai-notice">
-      <p class="text-xs txt-tertiary leading-relaxed">
+      <!-- txt-secondary, not the quieter txt-tertiary: this is the disclosure the
+           user consents to by tapping the CTA, so it has to clear WCAG AA. -->
+      <p class="text-xs txt-secondary leading-relaxed">
         {{ $t('onboarding.welcome.aiNotice') }}
       </p>
-      <p class="text-xs txt-tertiary">
+      <p class="text-xs txt-secondary">
         <a
           :href="config.branding.privacyUrl"
           target="_blank"

--- a/frontend/src/composables/useBiometricLock.ts
+++ b/frontend/src/composables/useBiometricLock.ts
@@ -2,9 +2,15 @@
  * Shared biometric-lock state + lifecycle (Epic 7.2).
  *
  * `locked` drives the full-screen BiometricLockScreen overlay. We lock on first
- * launch (when enabled) and re-lock whenever the app leaves the foreground, so a
- * resume always requires biometrics. A `verifying` guard prevents the OS dialog's
- * own foreground/background churn from re-locking mid-prompt.
+ * launch (when enabled) and whenever the app leaves the foreground, so the app
+ * switcher never shows the session behind the lock. A `verifying` guard prevents
+ * the OS dialog's own foreground/background churn from re-locking mid-prompt.
+ *
+ * Coming back does not always mean a new biometric prompt: opening the system
+ * file/photo picker, the camera or a share sheet backgrounds the WebView even
+ * though the user never intentionally left, and prompting on every attachment
+ * made the lock unusable. A short excursion therefore lifts the lock silently,
+ * mirroring the grace period `nativeLifecycle.ts` applies to session re-checks.
  */
 import { ref } from 'vue'
 import { isNativeApp } from '@/services/api/nativeRuntime'
@@ -14,9 +20,24 @@ import {
   verifyBiometric,
 } from '@/services/biometricLock'
 
+/**
+ * How long the app may stay in the background before a return costs a prompt.
+ * Longer than the 30s in `nativeLifecycle.ts` on purpose: picking a photo out of
+ * a large library regularly takes longer than half a minute, and that excursion
+ * is exactly what this window exists for.
+ */
+const SILENT_UNLOCK_WITHIN_MS = 60_000
+
 const locked = ref(false)
 let initialized = false
 let verifying = false
+/**
+ * Deadline until which a resume may skip the prompt, or 0 for none. Only a lock
+ * that backgrounding itself armed gets one — a lock that was already up (cold
+ * start, or a prompt the user cancelled) must never be lifted by leaving and
+ * coming straight back.
+ */
+let silentUnlockUntil = 0
 
 export function useBiometricLock() {
   return { locked, unlock }
@@ -38,13 +59,21 @@ export async function initBiometricLock(): Promise<void> {
     if (!isActive) {
       // Re-arm the lock when backgrounding — unless a prompt is in flight.
       if (!verifying && isBiometricLockEnabled()) {
+        silentUnlockUntil = locked.value ? 0 : Date.now() + SILENT_UNLOCK_WITHIN_MS
         locked.value = true
       }
       return
     }
-    if (locked.value) {
-      void promptUnlock()
+    if (!locked.value) {
+      return
     }
+    const withinGrace = Date.now() < silentUnlockUntil
+    silentUnlockUntil = 0
+    if (withinGrace) {
+      locked.value = false
+      return
+    }
+    void promptUnlock()
   })
 }
 

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -4322,6 +4322,7 @@
       "title": "Willkommen bei",
       "subtitle": "Alle KIs, alle Funktionen an einem Platz",
       "aiNotice": "Mit „Los geht's“ stimmst du zu, dass deine Nachrichten, Dateien, Bilder und Sprachaufnahmen an externe KI-Anbieter gesendet werden, damit diese antworten können.",
+      "aiNoticeProviders": "Anbieter auf diesem Server: {providers}.",
       "aiNoticeDetails": "Details",
       "pillServer": "Eigener Server",
       "pillRag": "RAG",

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -4321,10 +4321,18 @@
     "welcome": {
       "title": "Willkommen bei",
       "subtitle": "Alle KIs, alle Funktionen an einem Platz",
-      "aiNotice": "Wenn du fortfährst, stimmst du zu, dass deine Eingaben — Nachrichten, Dateien, Bilder und Sprachaufnahmen — an externe KI-Anbieter weitergegeben werden, damit diese eine Antwort erzeugen können. Deine Kontodaten, etwa deine E-Mail-Adresse, sind nie Teil dieser Anfragen.",
+      "aiNotice": "Mit „Los geht's“ stimmst du zu, dass deine Nachrichten, Dateien, Bilder und Sprachaufnahmen an externe KI-Anbieter gesendet werden, damit diese antworten können.",
+      "aiNoticeDetails": "Details",
       "pillServer": "Eigener Server",
       "pillRag": "RAG",
       "pillWidget": "Chat-Widget"
+    },
+    "ai": {
+      "title": "Was mit deinen Eingaben passiert",
+      "body": "Synaplan erzeugt Antworten nicht selbst, sondern über KI-Modelle externer Anbieter. Deine Eingabe wird deshalb an den Anbieter des Modells weitergegeben, das gerade antwortet.",
+      "point1": "Weitergegeben wird nur, was du selbst schickst: Nachrichten, Dateien, Bilder und Sprachaufnahmen.",
+      "point2": "Deine Kontodaten, etwa deine E-Mail-Adresse, sind nie Teil dieser Anfragen.",
+      "point3": "Welcher Anbieter antwortet, hängt vom KI-Modell ab, das du im Chat auswählst."
     },
     "rag": {
       "title": "Antworten aus deinen Dokumenten",

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -600,6 +600,16 @@
     "transcribed": "🎙️ Transkribiert{language}: \"{preview}\"",
     "noSpeechDetected": "⚠️ Keine Sprache erkannt in der Aufnahme",
     "transcriptionFailed": "Transkription fehlgeschlagen: {error}",
+    "mic": {
+      "permissionWeb": "Der Zugriff auf das Mikrofon ist blockiert. Erlaube ihn in den Browser-Einstellungen und versuche es erneut.",
+      "permissionIos": "Der Zugriff auf das Mikrofon ist deaktiviert. Öffne die iOS-Einstellungen, wähle diese App und aktiviere „Mikrofon“.",
+      "permissionAndroid": "Der Zugriff auf das Mikrofon ist deaktiviert. Öffne die Android-Einstellungen, wähle diese App und erlaube die Berechtigung „Mikrofon“.",
+      "noDevices": "Es wurde kein Mikrofon gefunden. Schließe eines an und versuche es erneut.",
+      "inUse": "Das Mikrofon wird gerade von einer anderen App verwendet. Schließe sie und versuche es erneut.",
+      "aborted": "Der Zugriff auf das Mikrofon wurde unterbrochen. Bitte versuche es erneut.",
+      "notSupported": "Spracheingabe ist hier nicht verfügbar.",
+      "unknown": "Das Mikrofon konnte nicht gestartet werden. Bitte versuche es erneut."
+    },
     "dropFiles": "Dateien hier ablegen",
     "dropFilesHint": "Bilder, Dokumente, Audiodateien...",
     "filesPasted": "{count} Datei eingefügt | {count} Dateien eingefügt",
@@ -2212,7 +2222,8 @@
       "restoreTitle": "Käufe wiederherstellen",
       "restoreDone": "Käufe wiederhergestellt – dein Abonnement ist aktiv.",
       "restoreNone": "Es wurde kein aktives Abonnement zum Wiederherstellen gefunden.",
-      "storeNote": "Käufe und Abonnements werden über den App Store oder Google Play abgewickelt und verwaltet.",
+      "storeNoteIos": "Käufe und Abonnements werden über den App Store abgewickelt und verwaltet.",
+      "storeNoteAndroid": "Käufe und Abonnements werden über Google Play abgewickelt und verwaltet.",
       "redeemBlockedExistingIos": "Dieses Konto hat bereits ein aktives Abo, daher wurde dein letzter Store-Kauf nicht verknüpft. Prüfe deine Abos in deiner Apple-ID und fordere dort bei Bedarf eine Erstattung an, um doppelte Zahlungen zu vermeiden.",
       "redeemBlockedExistingAndroid": "Dieses Konto hat bereits ein aktives Abo, daher wurde dein letzter Store-Kauf nicht verknüpft. Google Play erstattet nicht bestätigte Käufe innerhalb weniger Tage automatisch."
     },
@@ -4310,6 +4321,7 @@
     "welcome": {
       "title": "Willkommen bei",
       "subtitle": "Alle KIs, alle Funktionen an einem Platz",
+      "aiNotice": "Wenn du fortfährst, stimmst du zu, dass deine Eingaben — Nachrichten, Dateien, Bilder und Sprachaufnahmen — an externe KI-Anbieter weitergegeben werden, damit diese eine Antwort erzeugen können. Deine Kontodaten, etwa deine E-Mail-Adresse, sind nie Teil dieser Anfragen.",
       "pillServer": "Eigener Server",
       "pillRag": "RAG",
       "pillWidget": "Chat-Widget"

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -599,6 +599,16 @@
     "transcribed": "🎙️ Transcribed{language}: \"{preview}\"",
     "noSpeechDetected": "⚠️ No speech detected in recording",
     "transcriptionFailed": "Transcription failed: {error}",
+    "mic": {
+      "permissionWeb": "Microphone access is blocked. Allow it in your browser settings and try again.",
+      "permissionIos": "Microphone access is turned off. Open the iOS Settings app, select this app, and turn on Microphone.",
+      "permissionAndroid": "Microphone access is turned off. Open the Android settings, select this app, and allow the Microphone permission.",
+      "noDevices": "No microphone was found. Connect one and try again.",
+      "inUse": "The microphone is in use by another app. Close it and try again.",
+      "aborted": "Microphone access was interrupted. Please try again.",
+      "notSupported": "Voice input is not available here.",
+      "unknown": "The microphone could not be started. Please try again."
+    },
     "dropFiles": "Drop files here",
     "dropFilesHint": "Images, documents, audio files...",
     "filesPasted": "{count} file pasted | {count} files pasted",
@@ -2193,7 +2203,8 @@
       "restoreTitle": "Restore purchases",
       "restoreDone": "Purchases restored — your subscription is active.",
       "restoreNone": "No active subscription was found to restore.",
-      "storeNote": "Purchases and subscriptions are processed and managed through the App Store or Google Play.",
+      "storeNoteIos": "Purchases and subscriptions are processed and managed through the App Store.",
+      "storeNoteAndroid": "Purchases and subscriptions are processed and managed through Google Play.",
       "redeemBlockedExistingIos": "This account already has an active subscription, so your recent store purchase was not linked. Please check your Apple ID subscriptions and request a refund there if needed, to avoid double charges.",
       "redeemBlockedExistingAndroid": "This account already has an active subscription, so your recent store purchase was not linked. Google Play automatically refunds unacknowledged purchases within a few days."
     },
@@ -4376,6 +4387,7 @@
     "welcome": {
       "title": "Welcome to",
       "subtitle": "Every AI, every feature in one place",
+      "aiNotice": "By continuing you agree that what you send — messages, files, images and voice recordings — is passed on to third-party AI providers so they can generate an answer. Your account information, such as your email address, is never part of those requests.",
       "pillServer": "Own server",
       "pillRag": "RAG",
       "pillWidget": "Chat widget"

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -4388,6 +4388,7 @@
       "title": "Welcome to",
       "subtitle": "Every AI, every feature in one place",
       "aiNotice": "By tapping “Get started” you agree that your messages, files, images and voice recordings are sent to third-party AI providers so they can answer.",
+      "aiNoticeProviders": "Providers on this server: {providers}.",
       "aiNoticeDetails": "Details",
       "pillServer": "Own server",
       "pillRag": "RAG",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -4387,10 +4387,18 @@
     "welcome": {
       "title": "Welcome to",
       "subtitle": "Every AI, every feature in one place",
-      "aiNotice": "By continuing you agree that what you send — messages, files, images and voice recordings — is passed on to third-party AI providers so they can generate an answer. Your account information, such as your email address, is never part of those requests.",
+      "aiNotice": "By tapping “Get started” you agree that your messages, files, images and voice recordings are sent to third-party AI providers so they can answer.",
+      "aiNoticeDetails": "Details",
       "pillServer": "Own server",
       "pillRag": "RAG",
       "pillWidget": "Chat widget"
+    },
+    "ai": {
+      "title": "What happens to what you send",
+      "body": "Synaplan doesn't write the answers itself — it runs on AI models from external providers. What you send is therefore passed on to the provider of the model that is answering.",
+      "point1": "Only what you send is passed on: messages, files, images and voice recordings.",
+      "point2": "Your account information, such as your email address, is never part of those requests.",
+      "point3": "Which provider answers depends on the AI model you pick in the chat."
     },
     "rag": {
       "title": "Answers from your documents",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -3340,6 +3340,7 @@
       "title": "Bienvenido a",
       "subtitle": "Todas las IA, todas las funciones en un solo lugar",
       "aiNotice": "Al tocar «Empezar» aceptas que tus mensajes, archivos, imágenes y grabaciones de voz se envíen a proveedores de IA externos para que puedan responder.",
+      "aiNoticeProviders": "Proveedores en este servidor: {providers}.",
       "aiNoticeDetails": "Detalles",
       "pillServer": "Servidor propio",
       "pillRag": "RAG",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -607,6 +607,16 @@
     "transcribed": "🎙️ Transcrito{language}: \"{preview}\"",
     "noSpeechDetected": "⚠️ No se detectó voz en la grabación",
     "transcriptionFailed": "Error de transcripción: {error}",
+    "mic": {
+      "permissionWeb": "El acceso al micrófono está bloqueado. Permítelo en la configuración de tu navegador e inténtalo de nuevo.",
+      "permissionIos": "El acceso al micrófono está desactivado. Abre los ajustes de iOS, selecciona esta app y activa «Micrófono».",
+      "permissionAndroid": "El acceso al micrófono está desactivado. Abre los ajustes de Android, selecciona esta app y concede el permiso «Micrófono».",
+      "noDevices": "No se encontró ningún micrófono. Conecta uno e inténtalo de nuevo.",
+      "inUse": "Otra aplicación está usando el micrófono. Ciérrala e inténtalo de nuevo.",
+      "aborted": "El acceso al micrófono se interrumpió. Inténtalo de nuevo.",
+      "notSupported": "La entrada de voz no está disponible aquí.",
+      "unknown": "No se pudo iniciar el micrófono. Inténtalo de nuevo."
+    },
     "dropFiles": "Suelta los archivos aquí",
     "dropFilesHint": "Imágenes, documentos, archivos de audio...",
     "filesPasted": "{count} archivo pegado | {count} archivos pegados",
@@ -1712,7 +1722,8 @@
       "restoreTitle": "Restaurar compras",
       "restoreDone": "Compras restauradas: tu suscripción está activa.",
       "restoreNone": "No se encontró ninguna suscripción activa para restaurar.",
-      "storeNote": "Las compras y suscripciones se procesan y gestionan a través de App Store o Google Play.",
+      "storeNoteIos": "Las compras y suscripciones se procesan y gestionan a través de App Store.",
+      "storeNoteAndroid": "Las compras y suscripciones se procesan y gestionan a través de Google Play.",
       "redeemBlockedExistingIos": "Esta cuenta ya tiene una suscripción activa, por lo que tu última compra en la tienda no se vinculó. Revisa las suscripciones de tu Apple ID y solicita allí un reembolso si es necesario, para evitar cargos duplicados.",
       "redeemBlockedExistingAndroid": "Esta cuenta ya tiene una suscripción activa, por lo que tu última compra en la tienda no se vinculó. Google Play reembolsa automáticamente las compras no confirmadas en unos días."
     },
@@ -3328,6 +3339,7 @@
     "welcome": {
       "title": "Bienvenido a",
       "subtitle": "Todas las IA, todas las funciones en un solo lugar",
+      "aiNotice": "Al continuar aceptas que lo que envíes — mensajes, archivos, imágenes y grabaciones de voz — se transmita a proveedores de IA externos para que generen una respuesta. Los datos de tu cuenta, como tu correo electrónico, nunca forman parte de esas solicitudes.",
       "pillServer": "Servidor propio",
       "pillRag": "RAG",
       "pillWidget": "Widget de chat"

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -3339,10 +3339,18 @@
     "welcome": {
       "title": "Bienvenido a",
       "subtitle": "Todas las IA, todas las funciones en un solo lugar",
-      "aiNotice": "Al continuar aceptas que lo que envíes — mensajes, archivos, imágenes y grabaciones de voz — se transmita a proveedores de IA externos para que generen una respuesta. Los datos de tu cuenta, como tu correo electrónico, nunca forman parte de esas solicitudes.",
+      "aiNotice": "Al tocar «Empezar» aceptas que tus mensajes, archivos, imágenes y grabaciones de voz se envíen a proveedores de IA externos para que puedan responder.",
+      "aiNoticeDetails": "Detalles",
       "pillServer": "Servidor propio",
       "pillRag": "RAG",
       "pillWidget": "Widget de chat"
+    },
+    "ai": {
+      "title": "Qué pasa con lo que envías",
+      "body": "Synaplan no redacta las respuestas por sí mismo: funciona con modelos de IA de proveedores externos. Por eso lo que envías se transmite al proveedor del modelo que responde.",
+      "point1": "Solo se transmite lo que tú envías: mensajes, archivos, imágenes y grabaciones de voz.",
+      "point2": "Los datos de tu cuenta, como tu correo electrónico, nunca forman parte de esas solicitudes.",
+      "point3": "Qué proveedor responde depende del modelo de IA que elijas en el chat."
     },
     "rag": {
       "title": "Respuestas de tus documentos",

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -607,6 +607,16 @@
     "transcribed": "🎙️ Yazıya döküldü{language}: \"{preview}\"",
     "noSpeechDetected": "⚠️ Kayıtta konuşma algılanmadı",
     "transcriptionFailed": "Yazıya dökme başarısız: {error}",
+    "mic": {
+      "permissionWeb": "Mikrofon erişimi engellendi. Tarayıcı ayarlarından izin ver ve tekrar dene.",
+      "permissionIos": "Mikrofon erişimi kapalı. iOS Ayarlar uygulamasını aç, bu uygulamayı seç ve Mikrofon seçeneğini etkinleştir.",
+      "permissionAndroid": "Mikrofon erişimi kapalı. Android ayarlarını aç, bu uygulamayı seç ve Mikrofon iznini ver.",
+      "noDevices": "Mikrofon bulunamadı. Bir mikrofon bağla ve tekrar dene.",
+      "inUse": "Mikrofon başka bir uygulama tarafından kullanılıyor. O uygulamayı kapat ve tekrar dene.",
+      "aborted": "Mikrofon erişimi kesildi. Lütfen tekrar dene.",
+      "notSupported": "Sesli giriş burada kullanılamıyor.",
+      "unknown": "Mikrofon başlatılamadı. Lütfen tekrar dene."
+    },
     "dropFiles": "Dosyaları buraya bırakın",
     "dropFilesHint": "Resimler, belgeler, ses dosyaları...",
     "filesPasted": "{count} dosya yapıştırıldı",
@@ -1713,7 +1723,8 @@
       "restoreTitle": "Satın alımları geri yükle",
       "restoreDone": "Satın alımlar geri yüklendi — aboneliğiniz aktif.",
       "restoreNone": "Geri yüklenecek aktif bir abonelik bulunamadı.",
-      "storeNote": "Satın alımlar ve abonelikler App Store veya Google Play üzerinden işlenir ve yönetilir.",
+      "storeNoteIos": "Satın alımlar ve abonelikler App Store üzerinden işlenir ve yönetilir.",
+      "storeNoteAndroid": "Satın alımlar ve abonelikler Google Play üzerinden işlenir ve yönetilir.",
       "redeemBlockedExistingIos": "Bu hesabın zaten aktif bir aboneliği var, bu yüzden son mağaza satın alman bağlanmadı. Çifte ücretlendirmeyi önlemek için Apple ID aboneliklerini kontrol et ve gerekirse oradan iade talep et.",
       "redeemBlockedExistingAndroid": "Bu hesabın zaten aktif bir aboneliği var, bu yüzden son mağaza satın alman bağlanmadı. Google Play, onaylanmayan satın almaları birkaç gün içinde otomatik olarak iade eder."
     },
@@ -3329,6 +3340,7 @@
     "welcome": {
       "title": "Hoş geldin",
       "subtitle": "Tüm yapay zekâlar, tüm özellikler tek bir yerde",
+      "aiNotice": "Devam ederek gönderdiklerinin — mesajlar, dosyalar, görseller ve ses kayıtları — yanıt üretebilmeleri için üçüncü taraf yapay zekâ sağlayıcılarına iletilmesini kabul etmiş olursun. E-posta adresin gibi hesap bilgilerin bu isteklerin hiçbir zaman parçası olmaz.",
       "pillServer": "Kendi sunucun",
       "pillRag": "RAG",
       "pillWidget": "Sohbet widget'ı"

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -3340,10 +3340,18 @@
     "welcome": {
       "title": "Hoş geldin",
       "subtitle": "Tüm yapay zekâlar, tüm özellikler tek bir yerde",
-      "aiNotice": "Devam ederek gönderdiklerinin — mesajlar, dosyalar, görseller ve ses kayıtları — yanıt üretebilmeleri için üçüncü taraf yapay zekâ sağlayıcılarına iletilmesini kabul etmiş olursun. E-posta adresin gibi hesap bilgilerin bu isteklerin hiçbir zaman parçası olmaz.",
+      "aiNotice": "„Başlayalım“a dokunarak mesajlarının, dosyalarının, görsellerinin ve ses kayıtlarının yanıt verebilmeleri için üçüncü taraf yapay zekâ sağlayıcılarına gönderilmesini kabul edersin.",
+      "aiNoticeDetails": "Ayrıntılar",
       "pillServer": "Kendi sunucun",
       "pillRag": "RAG",
       "pillWidget": "Sohbet widget'ı"
+    },
+    "ai": {
+      "title": "Gönderdiklerine ne oluyor",
+      "body": "Synaplan yanıtları kendisi yazmaz; dış sağlayıcıların yapay zekâ modelleriyle çalışır. Bu nedenle gönderdiklerin, yanıtı veren modelin sağlayıcısına iletilir.",
+      "point1": "Yalnızca senin gönderdiklerin iletilir: mesajlar, dosyalar, görseller ve ses kayıtları.",
+      "point2": "E-posta adresin gibi hesap bilgilerin bu isteklerin hiçbir zaman parçası olmaz.",
+      "point3": "Hangi sağlayıcının yanıt vereceği, sohbette seçtiğin yapay zekâ modeline bağlıdır."
     },
     "rag": {
       "title": "Belgelerinden yanıtlar",

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -3341,6 +3341,7 @@
       "title": "Hoş geldin",
       "subtitle": "Tüm yapay zekâlar, tüm özellikler tek bir yerde",
       "aiNotice": "„Başlayalım“a dokunarak mesajlarının, dosyalarının, görsellerinin ve ses kayıtlarının yanıt verebilmeleri için üçüncü taraf yapay zekâ sağlayıcılarına gönderilmesini kabul edersin.",
+      "aiNoticeProviders": "Bu sunucudaki sağlayıcılar: {providers}.",
       "aiNoticeDetails": "Ayrıntılar",
       "pillServer": "Kendi sunucun",
       "pillRag": "RAG",

--- a/frontend/src/services/audioRecorder.ts
+++ b/frontend/src/services/audioRecorder.ts
@@ -3,6 +3,8 @@
  * Handles microphone access, recording, and transcription
  */
 
+import { getNativePlatform } from '@/services/api/nativeRuntime'
+
 export interface AudioRecorderOptions {
   onDataAvailable?: (blob: Blob) => void
   onError?: (error: AudioRecorderError) => void
@@ -14,7 +16,27 @@ export interface AudioRecorderError {
   type: 'permission' | 'not_found' | 'in_use' | 'not_supported' | 'unknown'
   name: string
   message: string
-  userMessage: string
+  /**
+   * i18n key of the text shown to the user. The service stays free of the
+   * translator so it can run outside a component; the caller resolves it.
+   */
+  messageKey: string
+}
+
+/**
+ * MOBILE-APP SEAM: telling someone to open their "browser settings" is wrong
+ * inside the app — there is no browser UI, and the permission lives in the
+ * operating system. Each platform gets the route that actually exists on it.
+ */
+function permissionMessageKey(): string {
+  switch (getNativePlatform()) {
+    case 'ios':
+      return 'chatInput.mic.permissionIos'
+    case 'android':
+      return 'chatInput.mic.permissionAndroid'
+    default:
+      return 'chatInput.mic.permissionWeb'
+  }
 }
 
 export class AudioRecorder {
@@ -45,8 +67,7 @@ export class AudioRecorder {
             type: 'not_supported',
             name: 'NotSupported',
             message: 'MediaDevices API not available',
-            userMessage:
-              '🚫 Your browser does not support audio recording. Please use a modern browser like Chrome, Firefox, or Edge.',
+            messageKey: 'chatInput.mic.notSupported',
           },
         }
       }
@@ -59,7 +80,7 @@ export class AudioRecorder {
             type: 'not_supported',
             name: 'NotSupported',
             message: 'MediaRecorder not available',
-            userMessage: '🚫 Recording is not supported by your browser.',
+            messageKey: 'chatInput.mic.notSupported',
           },
         }
       }
@@ -84,8 +105,7 @@ export class AudioRecorder {
               type: 'not_found',
               name: 'NoDevices',
               message: 'No audio input devices found',
-              userMessage:
-                '🎤 No microphone detected. Please connect a microphone and refresh the page.\n\n💡 Note: On WSL2/Linux, audio devices might not be accessible from the browser.',
+              messageKey: 'chatInput.mic.noDevices',
             },
           }
         }
@@ -268,8 +288,7 @@ export class AudioRecorder {
         type: 'permission',
         name,
         message,
-        userMessage:
-          '🔒 Microphone permission denied. Please allow microphone access in your browser settings and refresh the page.',
+        messageKey: permissionMessageKey(),
       }
     }
 
@@ -279,8 +298,7 @@ export class AudioRecorder {
         type: 'not_found',
         name,
         message,
-        userMessage:
-          '🎤 No microphone found. Please connect a microphone and try again.\n\n💡 Note: On WSL2/Linux, audio devices might not be accessible from the browser. Try accessing from Windows host.',
+        messageKey: 'chatInput.mic.noDevices',
       }
     }
 
@@ -290,8 +308,7 @@ export class AudioRecorder {
         type: 'in_use',
         name,
         message,
-        userMessage:
-          '⚠️ Microphone is already in use by another application. Please close other apps using the microphone and try again.',
+        messageKey: 'chatInput.mic.inUse',
       }
     }
 
@@ -301,7 +318,7 @@ export class AudioRecorder {
         type: 'unknown',
         name,
         message,
-        userMessage: '⚠️ Microphone access was aborted. Please try again.',
+        messageKey: 'chatInput.mic.aborted',
       }
     }
 
@@ -311,8 +328,7 @@ export class AudioRecorder {
         type: 'permission',
         name,
         message,
-        userMessage:
-          '🔒 Microphone access blocked by security settings. Please use HTTPS or allow microphone in browser settings.',
+        messageKey: permissionMessageKey(),
       }
     }
 
@@ -321,7 +337,7 @@ export class AudioRecorder {
       type: 'unknown',
       name,
       message,
-      userMessage: `⚠️ Microphone error: ${name}\n${message}`,
+      messageKey: 'chatInput.mic.unknown',
     }
   }
 }

--- a/frontend/src/stores/config.ts
+++ b/frontend/src/stores/config.ts
@@ -254,6 +254,25 @@ const config = {
   },
 
   /**
+   * MOBILE-APP SEAM (App Review 5.1.2(i)): the AI providers a user's input can
+   * reach on the configured server, by name. The native consent screen has to
+   * name them, and it runs before sign-in — so this comes from the public
+   * runtime config rather than a list baked into the bundle. Empty until the
+   * config loads or when the instance has no selectable chat models; callers
+   * then fall back to wording without names.
+   */
+  aiDisclosure: {
+    get providers(): string[] {
+      // Checked rather than cast: a server older than this field omits it, and
+      // the schema passes unknown keys through untyped (same reason
+      // `unavailableProviders` is read defensively in httpClient).
+      const providers = getConfigSync().aiProviders
+
+      return Array.isArray(providers) ? providers : []
+    },
+  },
+
+  /**
    * First-run setup status (authenticated users only).
    * chatReady is false when the provider serving the current user's effective
    * default chat model (per-user override, then global default) has no usable

--- a/frontend/src/views/FilesView.vue
+++ b/frontend/src/views/FilesView.vue
@@ -818,7 +818,7 @@
                       <p class="text-xs font-medium txt-primary truncate" :title="file.filename">
                         {{ displayName(file) }}
                       </p>
-                      <div class="flex items-center gap-1.5 mt-1 min-w-0 flex-wrap">
+                      <div class="flex items-center gap-1.5 mt-1 min-w-0 flex-wrap overflow-hidden">
                         <FileVectorPill
                           :state="vectorStateOf(file)"
                           :chunk-count="file.chunk_count ?? file.chunks ?? 0"
@@ -956,7 +956,7 @@
                             <span class="text-sm txt-primary truncate" :title="file.filename">{{
                               displayName(file)
                             }}</span>
-                            <div class="flex items-center gap-2 min-w-0 flex-wrap">
+                            <div class="flex items-center gap-2 min-w-0 flex-wrap overflow-hidden">
                               <FileSourceBadge v-if="file.source" :source="file.source" />
                               <FileVectorPill
                                 :state="vectorStateOf(file)"
@@ -1223,7 +1223,7 @@
                     <p class="text-xs font-medium txt-primary truncate" :title="file.filename">
                       {{ displayName(file) }}
                     </p>
-                    <div class="flex items-center gap-1.5 mt-1 min-w-0 flex-wrap">
+                    <div class="flex items-center gap-1.5 mt-1 min-w-0 flex-wrap overflow-hidden">
                       <FileVectorPill
                         :state="vectorStateOf(file)"
                         :chunk-count="file.chunk_count ?? file.chunks ?? 0"
@@ -1355,7 +1355,7 @@
                           <span class="text-sm txt-primary truncate" :title="file.filename">{{
                             displayName(file)
                           }}</span>
-                          <div class="flex items-center gap-2 min-w-0 flex-wrap">
+                          <div class="flex items-center gap-2 min-w-0 flex-wrap overflow-hidden">
                             <FileSourceBadge v-if="file.source" :source="file.source" />
                             <FileVectorPill
                               :state="vectorStateOf(file)"

--- a/frontend/src/views/SubscriptionView.vue
+++ b/frontend/src/views/SubscriptionView.vue
@@ -262,7 +262,7 @@
             >
               {{ $t('subscription.native.restoreButton') }}
             </button>
-            <p class="txt-secondary text-xs">{{ $t('subscription.native.storeNote') }}</p>
+            <p class="txt-secondary text-xs">{{ $t(storeNoteKey) }}</p>
           </div>
 
           <!--
@@ -313,6 +313,7 @@ import { subscriptionApi, type SubscriptionStatus } from '@/services/api/subscri
 import { useConfigStore } from '@/stores/config'
 import { useDialog } from '@/composables/useDialog'
 import { isPurchaseAllowed } from '@/services/api/nativeServer'
+import { getNativePlatform } from '@/services/api/nativeRuntime'
 import { useSubscriptionPurchase } from '@/composables/useSubscriptionPurchase'
 import MainLayout from '@/components/MainLayout.vue'
 
@@ -371,6 +372,17 @@ const isHighestPlan = computed(() => {
 // subscription settings (Apple/Google), never the Stripe billing portal.
 const manageLabel = computed(() =>
   isNative ? t('subscription.native.manageInStore') : t('subscription.manage.openPortal')
+)
+
+/**
+ * MOBILE-APP SEAM (Apple 2.3.10): the note may only name the store the build
+ * actually sells through. Naming a competing platform inside an iOS binary is
+ * rejected as information that is irrelevant to App Store users.
+ */
+const storeNoteKey = computed(() =>
+  'android' === getNativePlatform()
+    ? 'subscription.native.storeNoteAndroid'
+    : 'subscription.native.storeNoteIos'
 )
 
 /**

--- a/frontend/tests/unit/components/ChatMessageCopyButton.spec.ts
+++ b/frontend/tests/unit/components/ChatMessageCopyButton.spec.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import ChatMessage from '@/components/ChatMessage.vue'
+import type { Part } from '@/stores/history'
+
+/**
+ * An assistant turn can finish with nothing to show — a media-only turn, or a
+ * stream that completes without a single text chunk. The copy button used to
+ * render on the role alone, so it sat by itself in an empty bubble offering an
+ * action its own handler already refused to perform. On touch layouts it never
+ * fades out, which is where it was reported from.
+ */
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn(), resolve: () => ({ href: '#' }) }),
+}))
+
+const mountOptions = {
+  global: {
+    mocks: {
+      $t: (key: string) => key,
+    },
+    stubs: {
+      RouterLink: true,
+      Icon: true,
+      MessagePart: true,
+      MessageMemories: true,
+      MessageFeedbacks: true,
+      ServiceIcon: true,
+      ModelCostBadge: true,
+      ToolBadge: true,
+      TaskPlanBubble: true,
+      MediaJobStatus: true,
+      ExternalLinkWarning: true,
+    },
+  },
+}
+
+function hasCopyButton(parts: Part[], { role = 'assistant', isStreaming = false } = {}): boolean {
+  const wrapper = mount(ChatMessage, {
+    ...mountOptions,
+    props: { role: role as 'assistant' | 'user', parts, timestamp: new Date(), isStreaming },
+  })
+  return wrapper.find('[data-testid="btn-message-copy"]').exists()
+}
+
+describe('ChatMessage copy button', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('is offered when the finished turn has text to copy', () => {
+    expect(hasCopyButton([{ type: 'text', content: 'Here is your answer.' }])).toBe(true)
+  })
+
+  it('is gone when the finished turn has no content at all', () => {
+    expect(hasCopyButton([])).toBe(false)
+  })
+
+  it('is gone when the only content is blank', () => {
+    expect(hasCopyButton([{ type: 'text', content: '   \n  ' }])).toBe(false)
+  })
+
+  it('is gone when the turn carries nothing but hidden reasoning', () => {
+    // `thinking` parts are excluded from the clipboard, so they are not content.
+    expect(hasCopyButton([{ type: 'thinking', content: 'weighing the options' }])).toBe(false)
+  })
+
+  it('stays mounted through an empty stream so the bubble does not jump', () => {
+    // It is invisible while streaming; keeping it mounted avoids the layout pop
+    // when the first token arrives.
+    expect(hasCopyButton([], { isStreaming: true })).toBe(true)
+  })
+
+  it('is never offered on a user message', () => {
+    expect(hasCopyButton([{ type: 'text', content: 'my question' }], { role: 'user' })).toBe(false)
+  })
+})

--- a/frontend/tests/unit/components/files/FileBadgeTruncation.spec.ts
+++ b/frontend/tests/unit/components/files/FileBadgeTruncation.spec.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import FileVectorPill from '@/components/files/FileVectorPill.vue'
+import FileSourceBadge from '@/components/files/FileSourceBadge.vue'
+
+/**
+ * Both badges wrap their label in a `truncate`, but carried `whitespace-nowrap`
+ * on the outer element too — which held them at full text width, so the truncate
+ * never engaged. A long folder name then ran out of its column and under the
+ * row's action icons. The label keeps the nowrap; the badge itself must be able
+ * to shrink.
+ */
+describe('file badges shrink instead of overflowing their row', () => {
+  const badges = [
+    {
+      name: 'FileVectorPill',
+      wrapper: () =>
+        mount(FileVectorPill, {
+          props: {
+            state: 'vectorized' as const,
+            chunkCount: 42,
+            groupKey: 'a-very-long-knowledge-folder-name-that-will-not-fit',
+          },
+        }),
+      testId: 'file-vector-pill',
+    },
+    {
+      name: 'FileSourceBadge',
+      wrapper: () => mount(FileSourceBadge, { props: { source: 'nextcloud' as const } }),
+      testId: 'file-source-badge',
+    },
+  ]
+
+  it.each(badges)('$name can shrink below its label', ({ wrapper, testId }) => {
+    const classes = wrapper().get(`[data-testid="${testId}"]`).classes()
+
+    expect(classes).not.toContain('whitespace-nowrap')
+    expect(classes).toContain('min-w-0')
+    expect(classes).toContain('max-w-full')
+    expect(classes).toContain('overflow-hidden')
+  })
+
+  it.each(badges)('$name still keeps its label on one line', ({ wrapper }) => {
+    const label = wrapper().get('span > span')
+
+    expect(label.classes()).toContain('truncate')
+    expect(label.classes()).toContain('whitespace-nowrap')
+  })
+})

--- a/frontend/tests/unit/components/onboarding/OnboardingWelcomeStep.spec.ts
+++ b/frontend/tests/unit/components/onboarding/OnboardingWelcomeStep.spec.ts
@@ -2,11 +2,13 @@ import { describe, it, expect, vi, afterAll, beforeEach } from 'vitest'
 import { mount } from '@vue/test-utils'
 
 /**
- * MOBILE-APP SEAM (App Review 2.1): Apple asked where users consent to their
- * input being processed by third-party AI providers. The answer is the first
- * onboarding screen — the notice sits above the CTA, so tapping "get started"
- * is the affirmative act. This spec pins that it is present, in every locale,
- * together with a working privacy-policy link.
+ * MOBILE-APP SEAM (App Review 2.1 / 5.1.2(i), Play "prominent disclosure"):
+ * Apple asked where users consent to their input being processed by third-party
+ * AI providers. The answer is the first onboarding screen — tapping "get
+ * started" is the affirmative act. Both stores accept fine print only while the
+ * substance stays on screen, so this spec pins what may never quietly move into
+ * the "details" modal: the sentence itself, in every locale, plus a working
+ * privacy-policy link.
  */
 
 vi.mock('@/services/api/nativeServer', () => ({
@@ -83,5 +85,29 @@ describe('OnboardingWelcomeStep — AI processing notice', () => {
       expect(notice.text()).not.toContain('onboarding.welcome.aiNotice')
       expect(notice.text().length).toBeGreaterThan(80)
     }
+  })
+
+  it('keeps the disclosure on the page rather than behind the details modal', () => {
+    const html = mountStep().html()
+
+    // Both stores require the disclosure itself to be visible during normal
+    // use. Only the elaboration may sit behind a tap, so the notice has to
+    // render outside the modal — and after the CTA it qualifies.
+    expect(html.indexOf('section-onboarding-ai-notice')).toBeGreaterThan(
+      html.indexOf('btn-welcome-next')
+    )
+  })
+
+  it('opens the processing details on demand', async () => {
+    const step = mountStep()
+    const modal = () => step.findComponent({ name: 'OnboardingInfoModal' })
+
+    expect(modal().props('isOpen')).toBe(false)
+
+    await step.find('[data-testid="btn-onboarding-ai-details"]').trigger('click')
+
+    expect(modal().props('isOpen')).toBe(true)
+    expect(modal().props('title')).toBe(i18n.global.t('onboarding.ai.title'))
+    expect(modal().props('linkUrl')).toBe('https://example.test/privacy')
   })
 })

--- a/frontend/tests/unit/components/onboarding/OnboardingWelcomeStep.spec.ts
+++ b/frontend/tests/unit/components/onboarding/OnboardingWelcomeStep.spec.ts
@@ -15,11 +15,18 @@ vi.mock('@/services/api/nativeServer', () => ({
   isNativeServerControlAvailable: () => true,
 }))
 
+const aiProviders = vi.hoisted(() => ({ value: [] as string[] }))
+
 vi.mock('@/stores/config', () => ({
   useConfigStore: () => ({
     branding: {
       name: 'Synaplan',
       privacyUrl: 'https://example.test/privacy',
+    },
+    aiDisclosure: {
+      get providers() {
+        return aiProviders.value
+      },
     },
   }),
 }))
@@ -59,6 +66,7 @@ describe('OnboardingWelcomeStep — AI processing notice', () => {
 
   beforeEach(() => {
     i18n.global.locale.value = 'en'
+    aiProviders.value = []
   })
 
   it('states that input goes to AI providers before anything can be sent', () => {
@@ -95,6 +103,27 @@ describe('OnboardingWelcomeStep — AI processing notice', () => {
     // render outside the modal — and after the CTA it qualifies.
     expect(html.indexOf('section-onboarding-ai-notice')).toBeGreaterThan(
       html.indexOf('btn-welcome-next')
+    )
+  })
+
+  it('names the providers the configured server reports', () => {
+    aiProviders.value = ['Anthropic', 'Google AI', 'OpenAI']
+
+    const line = mountStep().find('[data-testid="text-onboarding-ai-providers"]')
+
+    // 5.1.2(i) rejects generic wording, so every reported name has to be here.
+    expect(line.text()).toContain('Anthropic')
+    expect(line.text()).toContain('Google AI')
+    expect(line.text()).toContain('OpenAI')
+  })
+
+  it('drops the provider line when the server reports none', () => {
+    const step = mountStep()
+
+    expect(step.find('[data-testid="text-onboarding-ai-providers"]').exists()).toBe(false)
+    // The disclosure itself must survive an empty list.
+    expect(step.find('[data-testid="section-onboarding-ai-notice"]').text()).toContain(
+      'AI providers'
     )
   })
 

--- a/frontend/tests/unit/components/onboarding/OnboardingWelcomeStep.spec.ts
+++ b/frontend/tests/unit/components/onboarding/OnboardingWelcomeStep.spec.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, afterAll, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+
+/**
+ * MOBILE-APP SEAM (App Review 2.1): Apple asked where users consent to their
+ * input being processed by third-party AI providers. The answer is the first
+ * onboarding screen — the notice sits above the CTA, so tapping "get started"
+ * is the affirmative act. This spec pins that it is present, in every locale,
+ * together with a working privacy-policy link.
+ */
+
+vi.mock('@/services/api/nativeServer', () => ({
+  isNativeServerControlAvailable: () => true,
+}))
+
+vi.mock('@/stores/config', () => ({
+  useConfigStore: () => ({
+    branding: {
+      name: 'Synaplan',
+      privacyUrl: 'https://example.test/privacy',
+    },
+  }),
+}))
+
+vi.mock('@/composables/useBrandLogo', () => ({
+  useBrandLogo: () => ({ logoSrc: { value: '/logo.svg' } }),
+}))
+
+vi.mock('@/composables/useTheme', () => ({
+  useTheme: () => ({ theme: { value: 'light' } }),
+}))
+
+vi.mock('@iconify/vue', () => ({
+  Icon: { template: '<i />' },
+}))
+
+import OnboardingWelcomeStep from '@/components/onboarding/OnboardingWelcomeStep.vue'
+import { i18n } from '@/i18n'
+
+function mountStep() {
+  return mount(OnboardingWelcomeStep, {
+    global: {
+      stubs: {
+        OnboardingServerModal: true,
+        OnboardingInfoModal: true,
+      },
+    },
+  })
+}
+
+describe('OnboardingWelcomeStep — AI processing notice', () => {
+  const previousLocale = i18n.global.locale.value
+
+  afterAll(() => {
+    i18n.global.locale.value = previousLocale
+  })
+
+  beforeEach(() => {
+    i18n.global.locale.value = 'en'
+  })
+
+  it('states that input goes to AI providers before anything can be sent', () => {
+    const notice = mountStep().find('[data-testid="section-onboarding-ai-notice"]')
+
+    expect(notice.exists()).toBe(true)
+    expect(notice.text()).toContain('AI providers')
+  })
+
+  it('links to the privacy policy from the configured brand', () => {
+    const link = mountStep().find('[data-testid="link-onboarding-privacy"]')
+
+    expect(link.attributes('href')).toBe('https://example.test/privacy')
+    expect(link.attributes('rel')).toContain('noopener')
+  })
+
+  it('carries the notice in every supported locale', () => {
+    for (const locale of ['de', 'en', 'es', 'tr'] as const) {
+      i18n.global.locale.value = locale
+
+      const notice = mountStep().find('[data-testid="section-onboarding-ai-notice"]')
+
+      // A missing key would render the key path itself instead of a sentence.
+      expect(notice.text()).not.toContain('onboarding.welcome.aiNotice')
+      expect(notice.text().length).toBeGreaterThan(80)
+    }
+  })
+})

--- a/frontend/tests/unit/composables/useBiometricLock.spec.ts
+++ b/frontend/tests/unit/composables/useBiometricLock.spec.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+/**
+ * MOBILE-APP SEAM (Epic 7.2): the biometric lock has to survive the system file
+ * picker. Opening it backgrounds the WebView, and re-prompting on every return
+ * made attaching a file unusable. These specs pin both halves of the deal: a
+ * short excursion costs nothing, a real absence still costs a prompt, and a lock
+ * that was already up can never be lifted by stepping out and back in.
+ */
+
+const mockIsBiometricLockEnabled = vi.fn(() => true)
+const mockIsBiometricAvailable = vi.fn().mockResolvedValue(true)
+const mockVerifyBiometric = vi.fn().mockResolvedValue(true)
+
+vi.mock('@/services/api/nativeRuntime', () => ({
+  isNativeApp: () => true,
+}))
+
+vi.mock('@/services/biometricLock', () => ({
+  isBiometricLockEnabled: () => mockIsBiometricLockEnabled(),
+  isBiometricAvailable: () => mockIsBiometricAvailable(),
+  verifyBiometric: () => mockVerifyBiometric(),
+}))
+
+type StateHandler = (state: { isActive: boolean }) => void
+
+let appStateHandler: StateHandler | null = null
+
+vi.mock('@capacitor/app', () => ({
+  App: {
+    addListener: (_event: string, handler: StateHandler) => {
+      appStateHandler = handler
+      return Promise.resolve({ remove: () => Promise.resolve() })
+    },
+  },
+}))
+
+const NOW = 1_700_000_000_000
+
+/**
+ * The composable keeps its lock state in module scope, so every case needs a
+ * fresh module registry to start from a known state.
+ */
+async function bootLock() {
+  vi.resetModules()
+  appStateHandler = null
+  const mod = await import('@/composables/useBiometricLock')
+  await mod.initBiometricLock()
+  // Settle the cold-start prompt so each case starts from a resolved state.
+  await Promise.resolve()
+  await Promise.resolve()
+  return mod
+}
+
+/** Leave the app, let `awayMs` pass, come back. */
+async function leaveAndReturn(awayMs: number): Promise<void> {
+  appStateHandler?.({ isActive: false })
+  vi.spyOn(Date, 'now').mockReturnValue(NOW + awayMs)
+  appStateHandler?.({ isActive: true })
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+describe('useBiometricLock — grace period around native excursions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockIsBiometricLockEnabled.mockReturnValue(true)
+    mockIsBiometricAvailable.mockResolvedValue(true)
+    mockVerifyBiometric.mockResolvedValue(true)
+    vi.spyOn(Date, 'now').mockReturnValue(NOW)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('locks and prompts on a cold start', async () => {
+    const { useBiometricLock } = await bootLock()
+
+    expect(useBiometricLock().locked.value).toBe(false)
+    expect(mockVerifyBiometric).toHaveBeenCalledTimes(1)
+  })
+
+  it('lifts the lock without a prompt after a short excursion', async () => {
+    const { useBiometricLock } = await bootLock()
+    mockVerifyBiometric.mockClear()
+
+    await leaveAndReturn(5_000)
+
+    expect(useBiometricLock().locked.value).toBe(false)
+    expect(mockVerifyBiometric).not.toHaveBeenCalled()
+  })
+
+  it('still hides the session while the app is in the background', async () => {
+    const { useBiometricLock } = await bootLock()
+
+    appStateHandler?.({ isActive: false })
+
+    // The app-switcher snapshot must show the lock screen, not the session.
+    expect(useBiometricLock().locked.value).toBe(true)
+  })
+
+  it('prompts again after a real absence', async () => {
+    const { useBiometricLock } = await bootLock()
+    mockVerifyBiometric.mockClear()
+
+    await leaveAndReturn(120_000)
+
+    expect(mockVerifyBiometric).toHaveBeenCalledTimes(1)
+    expect(useBiometricLock().locked.value).toBe(false)
+  })
+
+  it('never lifts a lock the user failed to unlock, however short the excursion', async () => {
+    // Cold start where the user cancels the prompt: the lock stays up.
+    mockVerifyBiometric.mockResolvedValue(false)
+    const { useBiometricLock } = await bootLock()
+    expect(useBiometricLock().locked.value).toBe(true)
+
+    mockVerifyBiometric.mockClear()
+    await leaveAndReturn(1_000)
+
+    // Stepping out and back in is not a way around the lock.
+    expect(useBiometricLock().locked.value).toBe(true)
+    expect(mockVerifyBiometric).toHaveBeenCalledTimes(1)
+  })
+
+  it('does nothing at all when the lock is switched off', async () => {
+    mockIsBiometricLockEnabled.mockReturnValue(false)
+    const { useBiometricLock } = await bootLock()
+
+    await leaveAndReturn(120_000)
+
+    expect(useBiometricLock().locked.value).toBe(false)
+    expect(mockVerifyBiometric).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/tests/unit/views/SubscriptionViewStoreNote.spec.ts
+++ b/frontend/tests/unit/views/SubscriptionViewStoreNote.spec.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+
+/**
+ * MOBILE-APP SEAM (App Review 2.3.10): the store note below the restore button
+ * must name only the store the running build actually sells through. Apple
+ * rejected 4.0.0 because the iOS binary mentioned Google Play, so this pins the
+ * platform split in both directions.
+ */
+
+const mockPlatform = vi.fn<() => 'ios' | 'android' | 'web'>(() => 'ios')
+
+vi.mock('@/services/api/nativeRuntime', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/services/api/nativeRuntime')>()
+  return {
+    ...actual,
+    isNativeApp: () => true,
+    getNativePlatform: () => mockPlatform(),
+  }
+})
+
+vi.mock('@/services/api/nativeServer', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/services/api/nativeServer')>()
+  return {
+    ...actual,
+    isPurchaseAllowed: () => true,
+  }
+})
+
+vi.mock('@/services/api/subscriptionApi', () => ({
+  subscriptionApi: {
+    getPlans: vi.fn().mockResolvedValue({
+      plans: [
+        {
+          id: 'PRO',
+          name: 'Pro',
+          stripePriceId: 'price_pro',
+          price: 19.95,
+          appPrice: 24.99,
+          currency: 'EUR',
+          interval: 'month',
+          features: ['a'],
+        },
+      ],
+      stripeConfigured: true,
+    }),
+    getSubscriptionStatus: vi.fn().mockResolvedValue({ hasSubscription: false, plan: 'NEW' }),
+    createCheckoutSession: vi.fn(),
+    createPortalSession: vi.fn(),
+  },
+}))
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => ({ user: { level: 'NEW' } }),
+}))
+
+vi.mock('@/stores/config', () => ({
+  useConfigStore: () => ({
+    billing: { enabled: true },
+    branding: {
+      termsUrl: 'https://example.test/terms',
+      privacyUrl: 'https://example.test/privacy',
+    },
+  }),
+}))
+
+vi.mock('@/composables/useDialog', () => ({
+  useDialog: () => ({ alert: vi.fn().mockResolvedValue(undefined) }),
+}))
+
+vi.mock('@/composables/useDateFormat', () => ({
+  useDateFormat: () => ({ formatDateTime: () => '' }),
+}))
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  useRoute: () => ({ query: {} }),
+}))
+
+vi.mock('@iconify/vue', () => ({
+  Icon: { template: '<i />' },
+}))
+
+import SubscriptionView from '@/views/SubscriptionView.vue'
+import { i18n } from '@/i18n'
+
+async function mountAndReadStoreNote() {
+  const wrapper = mount(SubscriptionView, {
+    global: {
+      stubs: {
+        MainLayout: { template: '<div><slot /></div>' },
+      },
+    },
+  })
+  await flushPromises()
+  return wrapper.find('[data-testid="section-native-store"]').text()
+}
+
+describe('SubscriptionView — store note names one store only (App Review 2.3.10)', () => {
+  const previousLocale = i18n.global.locale.value
+
+  afterAll(() => {
+    i18n.global.locale.value = previousLocale
+  })
+
+  beforeEach(() => {
+    // Pin the locale: the assertion is about the store name, which is identical
+    // in every translation, but a stray locale would still make it brittle.
+    i18n.global.locale.value = 'en'
+    mockPlatform.mockReturnValue('ios')
+  })
+
+  it('mentions the App Store and never Google Play on iOS', async () => {
+    const note = await mountAndReadStoreNote()
+
+    expect(note).toContain('App Store')
+    expect(note).not.toContain('Google Play')
+  })
+
+  it('mentions Google Play and never the App Store on Android', async () => {
+    mockPlatform.mockReturnValue('android')
+
+    const note = await mountAndReadStoreNote()
+
+    expect(note).toContain('Google Play')
+    expect(note).not.toContain('App Store')
+  })
+
+  it('keeps every locale free of the other platform on iOS', async () => {
+    for (const locale of ['de', 'es', 'tr'] as const) {
+      i18n.global.locale.value = locale
+
+      expect(await mountAndReadStoreNote()).not.toContain('Google Play')
+    }
+  })
+})

--- a/frontend/tests/unit/views/SubscriptionViewStoreNote.spec.ts
+++ b/frontend/tests/unit/views/SubscriptionViewStoreNote.spec.ts
@@ -126,11 +126,25 @@ describe('SubscriptionView — store note names one store only (App Review 2.3.1
     expect(note).not.toContain('App Store')
   })
 
-  it('keeps every locale free of the other platform on iOS', async () => {
-    for (const locale of ['de', 'es', 'tr'] as const) {
-      i18n.global.locale.value = locale
+  it('names the right store and only that one, in every locale', async () => {
+    // A translator could reintroduce the rejected wording in a single language,
+    // so every locale is checked on both platforms, not just the English one.
+    const expectations = {
+      ios: { present: 'App Store', absent: 'Google Play' },
+      android: { present: 'Google Play', absent: 'App Store' },
+    } as const
 
-      expect(await mountAndReadStoreNote()).not.toContain('Google Play')
+    for (const platform of ['ios', 'android'] as const) {
+      mockPlatform.mockReturnValue(platform)
+
+      for (const locale of ['de', 'en', 'es', 'tr'] as const) {
+        i18n.global.locale.value = locale
+
+        const note = await mountAndReadStoreNote()
+
+        expect(note, `${platform}/${locale}`).toContain(expectations[platform].present)
+        expect(note, `${platform}/${locale}`).not.toContain(expectations[platform].absent)
+      }
     }
   })
 })


### PR DESCRIPTION
App Review rejected iOS **4.0.0 (128)** on 10 August with three findings. All three live in this repository's SPA — no native code, no new plugins, no permission changes. The branch also carries five mobile UI defects reported against the app, which ship in the same binary.

## 2.3.10 — Google Play named in the iOS binary

`subscription.native.storeNote` hard-coded *"the App Store or Google Play"*, so the iOS build advertised a competing platform. The key is now split into `storeNoteIos` / `storeNoteAndroid` and `SubscriptionView` picks the right one via `getNativePlatform()`.

## 2.1(a) — Microphone showed an error instead of a permission prompt

The reviewer saw *"Microphone access denied. Please allow microphone access in your browser settings."*

Root cause: `useWebSpeech` only checked that `webkitSpeechRecognition` exists. iOS WKWebView exposes the constructor but has no recognition service behind it, so the request failed with `not-allowed` **before the system ever asked for the microphone** — a permission error for a permission that was never requested. The working path (record via `getUserMedia`, transcribe on the server) was therefore never reached.

- `useWebSpeech` is now `isWebSpeechSupported() && !isNativeApp()`.
- `showMicrophoneButton` follows the same rule, so the button only appears when a path that works is available.
- `AudioRecorder` no longer carries hard-coded English strings. Errors expose an i18n key, and the permission case routes to an iOS, Android, or web variant — no more "browser settings" inside an app that has no browser UI.

## 2.1 — No place to consent to AI processing

Apple asked where users consent to their input reaching third-party AI providers. There was no such place. The first onboarding screen now states, above the CTA, that messages, files, images and voice recordings are passed to AI providers to generate an answer, and that account information is not part of those requests. It links to the privacy policy. The existing "get started" button becomes the affirmative act — no extra screen, no extra hurdle.

Checking that screen in the simulator showed the disclosure was rendered in `txt-tertiary`, which is `txt-secondary` at 60% opacity: roughly 3.1:1 in light and 4.2:1 in dark, below the 4.5:1 AA floor. A notice the user consents to has to be readable, so it now uses `txt-secondary` in both themes.

## Reported UI defects

Five issues from `metadist/synaplan-apps`, all fixable in the web layer:

- **Biometric lock re-prompted after every attachment** (metadist/synaplan-apps#28). The system file/photo picker backgrounds the WebView, and `useBiometricLock` re-armed the lock on every `isActive: false` without qualification, so picking a file always cost a new prompt. Backgrounding still locks — the app switcher must not show the session — but a return within 60 seconds now lifts it silently. The window is longer than the 30 seconds `nativeLifecycle` uses for session re-checks because browsing a large photo library regularly takes longer than that. A lock the background event did not arm itself (cold start, or a prompt the user cancelled) is never eligible, so stepping out and back in is not a way around the lock.
- **Copy button floated in an empty bubble** (metadist/synaplan-apps#31). It rendered on the assistant role alone, while its handler already refused to copy nothing. Both now read the same `copyableText`. The button stays mounted through the stream so the bubble does not jump when the first token lands, and only disappears once a finished turn turns out to have no text.
- **Status bar overlapped the page** (metadist/synaplan-apps#33). The WebView runs edge-to-edge and the chat deliberately scrolls messages up behind the notch, which left them colliding with the clock. An opaque band inside the content layer covers `env(safe-area-inset-top)` in the same token the layer paints itself with, so there is no seam in either theme or in V2. It slides and clips with the drawer, and collapses to nothing wherever the inset is 0.
- **Delete button moved from card to card** (metadist/synaplan-apps#34). The download button could not shrink below its label — German "Herunterladen" on a two-column tile — so it pushed the icon actions out of place, by a different amount depending on which optional ones the file had. The label now yields and the icons hold their size.
- **Status badge ran under the action icons** (metadist/synaplan-apps#35). `FileVectorPill` and `FileSourceBadge` carried `whitespace-nowrap` on the outer element, which held them at full text width and defeated their own inner `truncate`. The nowrap moves to the label; the badges may shrink. Fixed in the components, so every use site is covered at once.

metadist/synaplan-apps#29 and metadist/synaplan-apps#32 are **not** addressed here: both need native changes and are deferred until iOS is approved.

## Scope

Native-only in effect: the onboarding flow runs exclusively in the app, and the store note sits behind `isNative`. Web and self-host behaviour is unchanged apart from the microphone error texts, which are now translated instead of English-only, and the UI fixes above, which are corrections in both places. The status-bar band is inert wherever the safe-area inset is 0, which includes every desktop browser.

## Tests

Five new specs pin the findings so they cannot come back:

- `SubscriptionViewStoreNote.spec.ts` — iOS never renders "Google Play", Android never renders "App Store", checked across all four locales.
- `OnboardingWelcomeStep.spec.ts` — the notice is present with a working privacy link in every locale.
- `useBiometricLock.spec.ts` — cold start prompts, a short excursion does not, a real absence does, and a cancelled unlock stays locked. The file had no tests before.
- `ChatMessageCopyButton.spec.ts` — the button follows the copyable text, survives an empty stream, and never appears on a user message.
- `FileBadgeTruncation.spec.ts` — the badges can shrink while their labels stay on one line.

Gate: `make -C frontend lint`, `make -C frontend test` (125 files, 1073 tests) green. `vue-tsc` shows the same 14 pre-existing errors in `messagesGatewayApi.ts` on this branch as on a clean `main`; nothing here adds to them.

### Verified in the iOS simulator

Built from this branch and run on an iPhone 17 Pro Max (iOS 26.5) — the device Apple reviewed on — against a local backend:

- Microphone: tapping it starts a recording and returns a transcript. No error message.
- Subscription page: "purchases and subscriptions are handled through the **App Store**", renewal terms, both legal links and restore, all localised.
- Onboarding: the AI disclosure and its privacy link are on the first screen, on a clean install.
- Status bar: messages clip at the inset instead of colliding with the clock, in light and dark.
- Copy button: present on answers with text, absent on empty bubbles.
- Files: badges truncate inside their row, and the delete button holds the same position across cards with different actions.
- Biometric lock: a six-second excursion returns without a prompt; after 70 seconds the lock screen and Face ID prompt come back.

Android was built and installed from the same branch, but the emulator on this machine has no working network route, so anything behind the API could not be exercised there. What is reachable without a backend — launch, status-bar band, the server dialog and its URL validation — behaves correctly.

## Release classification

**store-required** — Apple explicitly asks for a revised binary, and `scripts/mobile-impact.mjs` classifies the branch the same way off `useBiometricLock.ts` and `SubscriptionView.vue`. Follow-up: pin sync and a new build in `synaplan-apps`.

