### PR TITLE
chore(renovate): add stability gate and explicit concurrency limit

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -8,11 +8,28 @@
   "enabled": true,
   "timezone": "Europe/Berlin",
   "prHourlyLimit": 2,
+  // Make the implicit Renovate default (10) explicit. Grouping already collapses
+  // minor/patch into ~6 buckets, so this is a backlog cap, not a per-dependency knob.
+  "prConcurrentLimit": 10,
   "prCreation": "immediate",
   "dependencyDashboard": true,
   "labels": ["dependencies"],
   "ignorePaths": ["_devextras/mail-handler-test/**"],
+  // Security fixes (GitHub advisories) bypass the stability gate below and are
+  // labelled so they stand out from routine updates.
+  "vulnerabilityAlerts": {
+    "labels": ["dependencies", "security"]
+  },
   "packageRules": [
+    {
+      "description": "Stability gate: let fresh releases prove themselves before we open a PR (supply-chain + broken-release protection). Security fixes bypass this.",
+      "matchDatasources": ["*"],
+      "minimumReleaseAge": "3 days",
+      // Docker/registry sources without a reliable publish timestamp would otherwise
+      // hang forever; treat missing timestamps as "passed" for them.
+      "minimumReleaseAgeBehaviour": "timestamp-optional",
+      "internalChecksFilter": "strict"
+    },
     {
       "description": "Catch-all composer patch/minor FIRST — later rules override groupName for Framework/QA",
       "groupName": "Backend Dependencies",
@@ -66,5 +83,16 @@
       "automerge": false,
       "labels": ["dependencies", "breaking"]
     }
+    // PLANNED (not enabled yet): auto-merge dev/QA tooling once we trust the
+    // stability gate. Dev-only deps are fully covered by CI; runtime deps, the
+    // PHP Framework and all majors would stay manual. Requires branch protection
+    // (required status checks) + platformAutomerge before switching on. Enable by
+    // uncommenting and adding a comma after the "Major updates" rule above:
+    // {
+    //   "description": "Auto-merge dev/QA tooling once the stability gate and CI both pass",
+    //   "matchDepTypes": ["devDependencies", "require-dev"],
+    //   "matchUpdateTypes": ["minor", "patch"],
+    //   "automerge": true
+    // }
   ]
 }


### PR DESCRIPTION
## Summary

Makes dependency updates safer and lays the groundwork for future auto-merge, based on a discussion about freshly published (possibly broken/malicious) releases and Renovate's PR limits.

- **Global stability gate** — `minimumReleaseAge: "3 days"` for `matchDatasources: ["*"]` with `internalChecksFilter: "strict"`. Renovate opens **no branch/PR** until a release is 3 days old, so day-0 broken releases get superseded by their fix before they ever reach us. Previously only npm was gated (via `security:minimumReleaseAgeNpm` from `config:best-practices`); this extends the same protection to Composer, Docker and GitHub Actions.
  - `minimumReleaseAgeBehaviour: "timestamp-optional"` so Docker/registry sources without a reliable publish timestamp don't hang.
- **Security fixes are not delayed** — GitHub advisory updates bypass the gate and now carry a `security` label so they stand out.
- **Explicit `prConcurrentLimit: 10`** — makes the implicit Renovate default visible. Grouping already collapses minor/patch into ~6 buckets, so this is a backlog cap, not a per-dependency knob.
- **Auto-merge: planned, not enabled** — a commented-out rule documents the intended first step (dev/QA tooling, minor/patch only; runtime deps, PHP Framework and all majors stay manual). It is intentionally left off for now.

The `major` rule still forces `automerge: false` + individual review, unchanged.

## Notes / follow-up (before enabling auto-merge later)

- Requires branch protection with **required status checks** + `platformAutomerge` (GitHub native auto-merge) so nothing merges on red CI.
- Known Renovate edge case: if a security-fix version is itself younger than the gate, `internalChecksFilter: strict` can drop it as "pending" and the security PR may temporarily target an older version (Renovate discussions #44065 / #42720). Low impact for us (no 48–72h compliance requirement); worst case a fresh security fix arrives a few days later.

## Test plan

- [x] `renovate-config-validator` passes ("Config validated successfully").
- [ ] Confirm the Dependency Dashboard shows updates moving to a `pending` state until they clear the 3-day gate.
- [ ] Confirm existing grouped PRs (Backend/Frontend/QA/Docker) still group as before.