### PR TITLE
fix(devextras): patch nanoid and postcss security advisories

### DIFF
--- a/_devextras/test/package-lock.json
+++ b/_devextras/test/package-lock.json
@@ -1097,9 +1097,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -1134,9 +1134,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.20",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
-      "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -1153,7 +1153,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.16",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
## Summary

Clears the two open Dependabot alerts in `_devextras/test/` (test-only tooling). **Lockfile-only** — all bumps within existing semver ranges.

| Package | From | To | Advisory | Severity |
| ------- | ---- | -- | -------- | -------- |
| nanoid | 3.3.16 | 3.3.18 | GHSA-2v37-7h3g-55p8 | high |
| postcss | 8.5.20 | 8.5.26 | GHSA-fxqj-rqcc-2cmp | moderate |

Lowest-risk of the batch: this directory is a local test harness that never runs in production. `npm audit` reports **0 vulnerabilities** afterwards.

## Test plan

- [x] `npm audit` → 0 vulnerabilities