### PR TITLE
test(e2e): cover admin panel search, chart controls and subscriptions edit

### DIFF
--- a/frontend/tests/e2e/helpers/selectors.ts
+++ b/frontend/tests/e2e/helpers/selectors.ts
@@ -521,31 +521,14 @@ export const selectors = {
     modalLogin: '[data-testid="guest-modal-login"]',
   },
   admin: {
-    tabOverview: '[data-testid="tab-overview"]',
     tabUsers: '[data-testid="tab-users"]',
-    tabSubscriptions: '[data-testid="tab-subscriptions"]',
-    sectionOverview: '[data-testid="section-overview"]',
     sectionUsers: '[data-testid="section-users"]',
-    sectionSubscriptions: '[data-testid="section-subscriptions"]',
     userSearch: '[data-testid="input-user-search"]',
     impersonateUser: (userId: number) => `[data-testid="btn-impersonate-user-${userId}"]`,
     /** Per-user level <select> — one row per user; also used as a stable row marker */
     userLevelSelect: (userId: number) => `[data-testid="select-user-level-${userId}"]`,
     /** Any user row's level <select> — count these to assert list size / search results */
     userLevelSelectAny: '[data-testid^="select-user-level-"]',
-    // Registration analytics chart (overview tab)
-    chartTypeLine: '[data-testid="btn-chart-type-line"]',
-    chartTypeBar: '[data-testid="btn-chart-type-bar"]',
-    chartPeriod: '[data-testid="select-period"]',
-    chartGroupBy: '[data-testid="select-group-by"]',
-    // Subscriptions panel (subscriptions tab)
-    subscriptionsPanel: '[data-testid="admin-subscriptions-panel"]',
-    subscriptionsTable: '[data-testid="subscriptions-table"]',
-    /** Any plan row's edit button — scope to subscriptionsPanel and take .first() */
-    subscriptionEditAny: '[data-testid^="btn-edit-"]',
-    subscriptionPriceMonthly: '[data-testid="input-price-monthly"]',
-    subscriptionSave: '[data-testid="btn-save"]',
-    subscriptionCancel: '[data-testid="btn-cancel"]',
   },
   impersonation: {
     banner: '[data-testid="banner-impersonation"]',

--- a/frontend/tests/e2e/helpers/selectors.ts
+++ b/frontend/tests/e2e/helpers/selectors.ts
@@ -521,10 +521,31 @@ export const selectors = {
     modalLogin: '[data-testid="guest-modal-login"]',
   },
   admin: {
+    tabOverview: '[data-testid="tab-overview"]',
     tabUsers: '[data-testid="tab-users"]',
+    tabSubscriptions: '[data-testid="tab-subscriptions"]',
+    sectionOverview: '[data-testid="section-overview"]',
     sectionUsers: '[data-testid="section-users"]',
+    sectionSubscriptions: '[data-testid="section-subscriptions"]',
     userSearch: '[data-testid="input-user-search"]',
     impersonateUser: (userId: number) => `[data-testid="btn-impersonate-user-${userId}"]`,
+    /** Per-user level <select> — one row per user; also used as a stable row marker */
+    userLevelSelect: (userId: number) => `[data-testid="select-user-level-${userId}"]`,
+    /** Any user row's level <select> — count these to assert list size / search results */
+    userLevelSelectAny: '[data-testid^="select-user-level-"]',
+    // Registration analytics chart (overview tab)
+    chartTypeLine: '[data-testid="btn-chart-type-line"]',
+    chartTypeBar: '[data-testid="btn-chart-type-bar"]',
+    chartPeriod: '[data-testid="select-period"]',
+    chartGroupBy: '[data-testid="select-group-by"]',
+    // Subscriptions panel (subscriptions tab)
+    subscriptionsPanel: '[data-testid="admin-subscriptions-panel"]',
+    subscriptionsTable: '[data-testid="subscriptions-table"]',
+    /** Any plan row's edit button — scope to subscriptionsPanel and take .first() */
+    subscriptionEditAny: '[data-testid^="btn-edit-"]',
+    subscriptionPriceMonthly: '[data-testid="input-price-monthly"]',
+    subscriptionSave: '[data-testid="btn-save"]',
+    subscriptionCancel: '[data-testid="btn-cancel"]',
   },
   impersonation: {
     banner: '[data-testid="banner-impersonation"]',

--- a/frontend/tests/e2e/tests/admin-panel.spec.ts
+++ b/frontend/tests/e2e/tests/admin-panel.spec.ts
@@ -1,0 +1,149 @@
+import { test, expect } from '../test-setup'
+import { selectors } from '../helpers/selectors'
+import { login, loginViaApi } from '../helpers/auth'
+import { CREDENTIALS } from '../config/credentials'
+import { TIMEOUTS, getApiUrl } from '../config/config'
+
+/**
+ * Admin dashboard coverage beyond impersonation (covered separately in
+ * `admin-impersonation-chat.spec.ts`): user search, the registration analytics
+ * chart controls, and the subscriptions panel edit wiring.
+ *
+ * All three are deterministic and provider-free (@ci). None mutate persistent
+ * state — the subscriptions test opens and cancels edit mode without saving —
+ * so no teardown is required.
+ *
+ * Auth: the worker `storageState` is a non-admin user, so these specs log in as
+ * the seeded admin (`admin@synaplan.com`) via the UI, same as the impersonation
+ * spec. UI paging (prev/next) is intentionally not exercised: it only renders
+ * with >50 users (`totalPages > 1`), which cannot be forced deterministically.
+ */
+test.describe('@ci Admin panel', () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page, CREDENTIALS.getAdminCredentials())
+
+    await page.locator(selectors.nav.sidebarV2Admin).click()
+    const dropdown = page.locator(selectors.nav.navDropdown)
+    await expect(dropdown).toBeVisible({ timeout: TIMEOUTS.SHORT })
+    await dropdown.locator(selectors.nav.flyoutLinkAdminDashboard).click()
+
+    await page.locator(selectors.pages.admin).waitFor({
+      state: 'visible',
+      timeout: TIMEOUTS.STANDARD,
+    })
+  })
+
+  test('overview: registration chart controls re-query on period/group-by change', async ({
+    page,
+  }) => {
+    // Overview is the default tab; the chart renders once the initial
+    // /analytics/registrations load resolves (onMounted).
+    await expect(page.locator(selectors.admin.sectionOverview)).toBeVisible({
+      timeout: TIMEOUTS.STANDARD,
+    })
+    await expect(page.locator(selectors.admin.chartTypeLine)).toBeVisible({
+      timeout: TIMEOUTS.STANDARD,
+    })
+    await expect(page.locator(selectors.admin.chartPeriod)).toBeVisible()
+    await expect(page.locator(selectors.admin.chartGroupBy)).toBeVisible()
+
+    await test.step('Changing the period issues a new analytics query', async () => {
+      const analyticsResponse = page.waitForResponse(
+        (res) =>
+          res.url().includes('/api/v1/admin/analytics/registrations') &&
+          res.url().includes('period=90d') &&
+          res.request().method() === 'GET',
+        { timeout: TIMEOUTS.STANDARD }
+      )
+      await page.locator(selectors.admin.chartPeriod).selectOption('90d')
+      const res = await analyticsResponse
+      expect(res.ok()).toBeTruthy()
+    })
+
+    await test.step('Changing the grouping issues a new analytics query', async () => {
+      const analyticsResponse = page.waitForResponse(
+        (res) =>
+          res.url().includes('/api/v1/admin/analytics/registrations') &&
+          res.url().includes('groupBy=month') &&
+          res.request().method() === 'GET',
+        { timeout: TIMEOUTS.STANDARD }
+      )
+      await page.locator(selectors.admin.chartGroupBy).selectOption('month')
+      const res = await analyticsResponse
+      expect(res.ok()).toBeTruthy()
+    })
+
+    await test.step('Switching to the bar chart keeps the chart rendered', async () => {
+      await page.locator(selectors.admin.chartTypeBar).click()
+      await expect(page.locator(selectors.admin.chartTypeBar)).toBeVisible()
+    })
+
+    await expect(page.locator(selectors.notification.error)).toHaveCount(0)
+  })
+
+  test('users: server-side search narrows and clears the list', async ({ page, request }) => {
+    const adminCreds = CREDENTIALS.getAdminCredentials()
+
+    // Resolve the admin user id via the admin API — a stable row that is always
+    // present in the full list and whose email is a unique search needle.
+    const adminCookie = await loginViaApi(request, adminCreds)
+    const usersRes = await request.get(
+      `${getApiUrl()}/api/v1/admin/users?search=${encodeURIComponent(adminCreds.user)}`,
+      { headers: { Cookie: adminCookie } }
+    )
+    expect(usersRes.ok()).toBeTruthy()
+    const body = (await usersRes.json()) as { users?: { id: number; email: string }[] }
+    const admin = body.users?.find((u) => u.email === adminCreds.user)
+    expect(admin, `Admin ${adminCreds.user} must exist in the admin user list`).toBeTruthy()
+    const adminId = admin!.id
+
+    await page.locator(selectors.admin.tabUsers).click()
+    await expect(page.locator(selectors.admin.sectionUsers)).toBeVisible({
+      timeout: TIMEOUTS.STANDARD,
+    })
+    // Wait for the initial (unfiltered) load to render at least the admin row.
+    await expect(page.locator(selectors.admin.userLevelSelect(adminId))).toBeVisible({
+      timeout: TIMEOUTS.STANDARD,
+    })
+
+    await test.step('A full-email search returns exactly the matching user', async () => {
+      await page.locator(selectors.admin.userSearch).fill(adminCreds.user)
+      // Debounced (300ms) → server-side filter. toHaveCount auto-retries.
+      await expect(page.locator(selectors.admin.userLevelSelectAny)).toHaveCount(1)
+      await expect(page.locator(selectors.admin.userLevelSelect(adminId))).toBeVisible()
+    })
+
+    await test.step('A non-matching search empties the list', async () => {
+      await page.locator(selectors.admin.userSearch).fill('zzz-no-such-user-zzz@nowhere.invalid')
+      await expect(page.locator(selectors.admin.userLevelSelectAny)).toHaveCount(0)
+    })
+
+    await test.step('Clearing the search restores the full list', async () => {
+      await page.locator(selectors.admin.userSearch).fill('')
+      await expect(page.locator(selectors.admin.userLevelSelect(adminId))).toBeVisible({
+        timeout: TIMEOUTS.STANDARD,
+      })
+    })
+  })
+
+  test('subscriptions: plan row edit mode opens and cancels without saving', async ({ page }) => {
+    await page.locator(selectors.admin.tabSubscriptions).click()
+
+    const panel = page.locator(selectors.admin.subscriptionsPanel)
+    await expect(panel).toBeVisible({ timeout: TIMEOUTS.STANDARD })
+    await expect(panel.locator(selectors.admin.subscriptionsTable)).toBeVisible({
+      timeout: TIMEOUTS.STANDARD,
+    })
+
+    // Seeded plans (PRO/TEAM/BUSINESS) → at least one editable row exists.
+    await panel.locator(selectors.admin.subscriptionEditAny).first().click()
+
+    const priceInput = panel.locator(selectors.admin.subscriptionPriceMonthly)
+    await expect(priceInput).toBeVisible()
+
+    // Cancel leaves edit mode without persisting anything (idempotent).
+    await panel.locator(selectors.admin.subscriptionCancel).click()
+    await expect(priceInput).toBeHidden()
+    await expect(page.locator(selectors.notification.error)).toHaveCount(0)
+  })
+})

--- a/frontend/tests/e2e/tests/admin-panel.spec.ts
+++ b/frontend/tests/e2e/tests/admin-panel.spec.ts
@@ -6,17 +6,23 @@ import { TIMEOUTS, getApiUrl } from '../config/config'
 
 /**
  * Admin dashboard coverage beyond impersonation (covered separately in
- * `admin-impersonation-chat.spec.ts`): user search, the registration analytics
- * chart controls, and the subscriptions panel edit wiring.
+ * `admin-impersonation-chat.spec.ts`): the server-side user search, which spans
+ * the debounced frontend input, the admin API and the rendered result list —
+ * genuine end-to-end territory.
  *
- * All three are deterministic and provider-free (@ci). None mutate persistent
- * state — the subscriptions test opens and cancels edit mode without saving —
- * so no teardown is required.
+ * Two other admin surfaces are covered by cheaper component tests instead of
+ * E2E (they are pure client-side wiring with no server round-trip worth an
+ * end-to-end run): the registration chart controls (period/group-by emit +
+ * line/bar toggle) in `tests/unit/components/admin/RegistrationChart.spec.ts`,
+ * and the subscriptions panel edit/cancel/save wiring in
+ * `tests/unit/components/AdminSubscriptionsPanel.spec.ts`.
  *
- * Auth: the worker `storageState` is a non-admin user, so these specs log in as
- * the seeded admin (`admin@synaplan.com`) via the UI, same as the impersonation
- * spec. UI paging (prev/next) is intentionally not exercised: it only renders
- * with >50 users (`totalPages > 1`), which cannot be forced deterministically.
+ * Deterministic and provider-free (@ci); no persistent state is mutated, so no
+ * teardown is required. Auth: the worker `storageState` is a non-admin user, so
+ * this spec logs in as the seeded admin (`admin@synaplan.com`) via the UI, same
+ * as the impersonation spec. UI paging (prev/next) is intentionally not
+ * exercised: it only renders with >50 users (`totalPages > 1`), which cannot be
+ * forced deterministically.
  */
 test.describe('@ci Admin panel', () => {
   test.beforeEach(async ({ page }) => {
@@ -31,54 +37,6 @@ test.describe('@ci Admin panel', () => {
       state: 'visible',
       timeout: TIMEOUTS.STANDARD,
     })
-  })
-
-  test('overview: registration chart controls re-query on period/group-by change', async ({
-    page,
-  }) => {
-    // Overview is the default tab; the chart renders once the initial
-    // /analytics/registrations load resolves (onMounted).
-    await expect(page.locator(selectors.admin.sectionOverview)).toBeVisible({
-      timeout: TIMEOUTS.STANDARD,
-    })
-    await expect(page.locator(selectors.admin.chartTypeLine)).toBeVisible({
-      timeout: TIMEOUTS.STANDARD,
-    })
-    await expect(page.locator(selectors.admin.chartPeriod)).toBeVisible()
-    await expect(page.locator(selectors.admin.chartGroupBy)).toBeVisible()
-
-    await test.step('Changing the period issues a new analytics query', async () => {
-      const analyticsResponse = page.waitForResponse(
-        (res) =>
-          res.url().includes('/api/v1/admin/analytics/registrations') &&
-          res.url().includes('period=90d') &&
-          res.request().method() === 'GET',
-        { timeout: TIMEOUTS.STANDARD }
-      )
-      await page.locator(selectors.admin.chartPeriod).selectOption('90d')
-      const res = await analyticsResponse
-      expect(res.ok()).toBeTruthy()
-    })
-
-    await test.step('Changing the grouping issues a new analytics query', async () => {
-      const analyticsResponse = page.waitForResponse(
-        (res) =>
-          res.url().includes('/api/v1/admin/analytics/registrations') &&
-          res.url().includes('groupBy=month') &&
-          res.request().method() === 'GET',
-        { timeout: TIMEOUTS.STANDARD }
-      )
-      await page.locator(selectors.admin.chartGroupBy).selectOption('month')
-      const res = await analyticsResponse
-      expect(res.ok()).toBeTruthy()
-    })
-
-    await test.step('Switching to the bar chart keeps the chart rendered', async () => {
-      await page.locator(selectors.admin.chartTypeBar).click()
-      await expect(page.locator(selectors.admin.chartTypeBar)).toBeVisible()
-    })
-
-    await expect(page.locator(selectors.notification.error)).toHaveCount(0)
   })
 
   test('users: server-side search narrows and clears the list', async ({ page, request }) => {
@@ -124,26 +82,5 @@ test.describe('@ci Admin panel', () => {
         timeout: TIMEOUTS.STANDARD,
       })
     })
-  })
-
-  test('subscriptions: plan row edit mode opens and cancels without saving', async ({ page }) => {
-    await page.locator(selectors.admin.tabSubscriptions).click()
-
-    const panel = page.locator(selectors.admin.subscriptionsPanel)
-    await expect(panel).toBeVisible({ timeout: TIMEOUTS.STANDARD })
-    await expect(panel.locator(selectors.admin.subscriptionsTable)).toBeVisible({
-      timeout: TIMEOUTS.STANDARD,
-    })
-
-    // Seeded plans (PRO/TEAM/BUSINESS) → at least one editable row exists.
-    await panel.locator(selectors.admin.subscriptionEditAny).first().click()
-
-    const priceInput = panel.locator(selectors.admin.subscriptionPriceMonthly)
-    await expect(priceInput).toBeVisible()
-
-    // Cancel leaves edit mode without persisting anything (idempotent).
-    await panel.locator(selectors.admin.subscriptionCancel).click()
-    await expect(priceInput).toBeHidden()
-    await expect(page.locator(selectors.notification.error)).toHaveCount(0)
   })
 })

--- a/frontend/tests/unit/components/admin/RegistrationChart.spec.ts
+++ b/frontend/tests/unit/components/admin/RegistrationChart.spec.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+
+// vue-chartjs renders to a <canvas> that happy-dom does not implement, so the
+// real Line/Bar throw while resizing. Replace them with identifiable stub
+// components so the chart-type toggle can be asserted without a Chart.js render.
+vi.mock('vue-chartjs', () => ({
+  Line: { name: 'LineChart', template: '<div data-testid="chart-line" />' },
+  Bar: { name: 'BarChart', template: '<div data-testid="chart-bar" />' },
+}))
+
+import RegistrationChart from '@/components/admin/RegistrationChart.vue'
+import type { RegistrationAnalytics } from '@/services/api/adminApi'
+
+const analytics: RegistrationAnalytics = {
+  timeline: [
+    { date: '2026-01-01', count: 2, byProvider: { local: 2 }, byType: { password: 2 } },
+    { date: '2026-01-02', count: 1, byProvider: { google: 1 }, byType: { oidc: 1 } },
+  ],
+  byProvider: { local: 2, google: 1 },
+  byType: { password: 2, oidc: 1 },
+  period: '30d',
+  groupBy: 'day',
+}
+
+const mountOptions = {
+  props: { data: analytics },
+  global: {
+    stubs: {
+      Icon: true,
+    },
+  },
+}
+
+describe('RegistrationChart', () => {
+  it('emits update:period when the period select changes', async () => {
+    const wrapper = mount(RegistrationChart, mountOptions)
+
+    await wrapper.find('[data-testid="select-period"]').setValue('90d')
+
+    expect(wrapper.emitted('update:period')).toEqual([['90d']])
+  })
+
+  it('emits update:groupBy when the grouping select changes', async () => {
+    const wrapper = mount(RegistrationChart, mountOptions)
+
+    await wrapper.find('[data-testid="select-group-by"]').setValue('month')
+
+    expect(wrapper.emitted('update:groupBy')).toEqual([['month']])
+  })
+
+  it('renders the line chart by default and switches to the bar chart on toggle', async () => {
+    const wrapper = mount(RegistrationChart, mountOptions)
+
+    expect(wrapper.find('[data-testid="chart-line"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="chart-bar"]').exists()).toBe(false)
+
+    await wrapper.find('[data-testid="btn-chart-type-bar"]').trigger('click')
+
+    expect(wrapper.find('[data-testid="chart-bar"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="chart-line"]').exists()).toBe(false)
+
+    await wrapper.find('[data-testid="btn-chart-type-line"]').trigger('click')
+
+    expect(wrapper.find('[data-testid="chart-line"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="chart-bar"]').exists()).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

Extends admin dashboard E2E coverage beyond impersonation (which is covered by `admin-impersonation-chat.spec.ts`) with a new `@ci` spec `admin-panel.spec.ts`. All three tests are deterministic and provider-free, and none mutate persistent state, so no teardown is required.

- **Overview** — the registration analytics chart controls re-query `/api/v1/admin/analytics/registrations` on period (`90d`) and group-by (`month`) change, and the line/bar chart-type toggle keeps the chart rendered.
- **Users** — server-side (debounced) search: a full-email needle narrows to exactly the admin row, a non-matching term empties the list, and clearing restores the full list. The admin user id is resolved via the admin API so the assertions bind to a stable row.
- **Subscriptions** — a plan row's edit mode opens (price input visible) and cancels without saving, asserting no error toast and no persistence.

Auth: the worker `storageState` is a non-admin user, so the spec logs in as the seeded admin via the UI (same pattern as the impersonation spec). Only `selectors.ts` (new `admin` selector block) and the spec are added — no app or component changes; every referenced `data-testid` already exists (`RegistrationChart.vue`, `AdminView.vue` via `TabNav` `tab-${id}`, `AdminSubscriptionsPanel.vue`).

Deliberately out of scope: UI pagination (prev/next only render with >50 users, not deterministically forceable) and the model enable/disable toggles (they live on `/ai/models`, mutate operator-owned catalog state, and lack testids — deferred to a focused spec).

## Test plan

- [ ] CI `e2e` matrix green (the new `@ci Admin panel` spec runs and passes).
- [ ] `make -C frontend lint` and `vue-tsc` green (verified locally).