### PR TITLE
feat(branding): enhance logo and icon handling across components

### DIFF
--- a/frontend/src/components/SidebarV2.vue
+++ b/frontend/src/components/SidebarV2.vue
@@ -12,7 +12,12 @@
     <div
       class="flex flex-col items-center justify-center flex-shrink-0 border-b border-white/[0.04] h-[76px]"
     >
-      <img :src="logoIconSrc" alt="synaplan" class="h-7 w-auto" />
+      <img
+        :src="iconSrc"
+        :alt="configStore.branding.name"
+        class="h-7 w-auto"
+        data-testid="img-sidebar-brand"
+      />
     </div>
 
     <!-- New Chat Button -->
@@ -667,6 +672,7 @@ import { useConfigStore } from '../stores/config'
 import { useAuth } from '../composables/useAuth'
 import { useNavItems, type NavChild, type NavItem } from '../composables/useNavItems'
 import { useTheme } from '../composables/useTheme'
+import { useBrandLogo } from '../composables/useBrandLogo'
 import { useChatsStore, isDefaultChatTitle, type Chat as StoreChat } from '../stores/chats'
 import { useUpdatesStore } from '../stores/updates'
 import { formatRunningVersion } from '@/utils/formatRunningVersion'
@@ -690,7 +696,8 @@ const updatesStore = useUpdatesStore()
 const dialog = useDialog()
 const { logout, isImpersonating } = useAuth()
 const { navItems, isItemActive, isGuestMode, loadFeatureStatus } = useNavItems()
-const { theme } = useTheme()
+const { isDark } = useTheme()
+const { iconSrc } = useBrandLogo(isDark)
 const route = useRoute()
 const router = useRouter()
 const isMemoriesDialogOpen = ref(false)
@@ -780,17 +787,6 @@ const handleEscape = (event: KeyboardEvent) => {
     closeFlyout()
   }
 }
-
-const isDark = computed(() => {
-  if (theme.value === 'dark') return true
-  if (theme.value === 'light') return false
-  return matchMedia('(prefers-color-scheme: dark)').matches
-})
-
-const logoIconSrc = computed(
-  () =>
-    `${import.meta.env.BASE_URL}${isDark.value ? 'single_bird-light.svg' : 'single_bird-dark.svg'}`
-)
 
 const initials = computed(() => {
   const email = authStore.user?.email || 'G'

--- a/frontend/src/composables/useBrandLogo.ts
+++ b/frontend/src/composables/useBrandLogo.ts
@@ -1,22 +1,50 @@
 import { computed, type Ref } from 'vue'
 import { useConfigStore } from '@/stores/config'
 
+function bundledAsset(file: string): string {
+  return `${import.meta.env.BASE_URL}${file}`
+}
+
 /**
- * Resolve the brand wordmark logo, config-addressable with a safe fallback
- * (Epic 4.4). A white-label hoster can point `branding.logoUrl` /
- * `branding.logoDarkUrl` at their own asset; when empty we fall back to the
- * bundled Synaplan SVGs so the default look is unchanged.
+ * Resolve the brand wordmark and compact icon from runtime config (Epic 4.4).
+ *
+ * A white-label hoster points `branding.logoUrl` / `logoDarkUrl` / `iconUrl`
+ * at their own assets. Empty values keep the bundled Synaplan look.
+ *
+ * Dark-mode wordmark falls back to the light logo before the bundled SVG, so
+ * setting only `logoUrl` still brands both themes.
  */
 export function useBrandLogo(isDark: Ref<boolean>) {
   const config = useConfigStore()
 
-  const logoSrc = computed(() => {
-    const configured = isDark.value ? config.branding.logoDarkUrl : config.branding.logoUrl
-    if (configured) {
-      return configured
+  const configuredWordmark = computed(() => {
+    if (isDark.value) {
+      return config.branding.logoDarkUrl || config.branding.logoUrl
     }
-    return `${import.meta.env.BASE_URL}${isDark.value ? 'synaplan-light.svg' : 'synaplan-dark.svg'}`
+    return config.branding.logoUrl
   })
 
-  return { logoSrc }
+  const logoSrc = computed(() => {
+    if (configuredWordmark.value) {
+      return configuredWordmark.value
+    }
+    return bundledAsset(isDark.value ? 'synaplan-light.svg' : 'synaplan-dark.svg')
+  })
+
+  /**
+   * Compact mark for the sidebar rail, favicon, and decorative watermarks.
+   * Prefer the dedicated icon; otherwise reuse the wordmark so a logo-only
+   * branding config still replaces the bird.
+   */
+  const iconSrc = computed(() => {
+    if (config.branding.iconUrl) {
+      return config.branding.iconUrl
+    }
+    if (configuredWordmark.value) {
+      return configuredWordmark.value
+    }
+    return bundledAsset(isDark.value ? 'single_bird-light.svg' : 'single_bird-dark.svg')
+  })
+
+  return { logoSrc, iconSrc }
 }

--- a/frontend/src/utils/brandingTheme.ts
+++ b/frontend/src/utils/brandingTheme.ts
@@ -152,6 +152,11 @@ function applyFonts(): void {
 /**
  * Point the document favicon at `branding.iconUrl` when configured.
  * Empty keeps the bundled Synaplan bird from index.html.
+ *
+ * index.html ships both an SVG icon and a PNG fallback. Overwriting every
+ * href with one URL while leaving the original `type` would mismatch (e.g.
+ * type="image/png" pointing at an .svg), which some browsers then ignore.
+ * Collapse to a single correctly-typed <link rel="icon"> instead.
  */
 function applyIcon(): void {
   const iconUrl = config.branding.iconUrl
@@ -159,13 +164,59 @@ function applyIcon(): void {
     return
   }
 
-  document.querySelectorAll<HTMLLinkElement>('link[rel="icon"]').forEach((link) => {
+  const type = iconMimeType(iconUrl)
+  const icons = Array.from(document.querySelectorAll<HTMLLinkElement>('link[rel="icon"]'))
+  const [primary, ...extras] = icons
+
+  if (primary) {
+    primary.href = iconUrl
+    primary.removeAttribute('sizes')
+    if (type) {
+      primary.type = type
+    } else {
+      primary.removeAttribute('type')
+    }
+    extras.forEach((link) => link.remove())
+  } else {
+    const link = document.createElement('link')
+    link.rel = 'icon'
     link.href = iconUrl
-  })
+    if (type) {
+      link.type = type
+    }
+    document.head.appendChild(link)
+  }
 
   const apple = document.querySelector<HTMLLinkElement>('link[rel="apple-touch-icon"]')
   if (apple) {
     apple.href = iconUrl
+  }
+}
+
+function iconMimeType(url: string): string | undefined {
+  let pathname: string
+  try {
+    pathname = new URL(url, 'https://placeholder.local').pathname
+  } catch {
+    pathname = url.split(/[?#]/)[0] ?? url
+  }
+
+  switch (pathname.split('.').pop()?.toLowerCase()) {
+    case 'svg':
+      return 'image/svg+xml'
+    case 'png':
+      return 'image/png'
+    case 'ico':
+      return 'image/x-icon'
+    case 'webp':
+      return 'image/webp'
+    case 'gif':
+      return 'image/gif'
+    case 'jpg':
+    case 'jpeg':
+      return 'image/jpeg'
+    default:
+      return undefined
   }
 }
 

--- a/frontend/src/utils/brandingTheme.ts
+++ b/frontend/src/utils/brandingTheme.ts
@@ -23,6 +23,7 @@ const BRAND_COLOR_STYLE_ID = 'brand-color-vars'
 export function applyBrandingTheme(): void {
   applyColors()
   applyFonts()
+  applyIcon()
 }
 
 /**
@@ -145,6 +146,26 @@ function applyFonts(): void {
       document.head.appendChild(styleEl)
     }
     styleEl.textContent = `h1,h2,h3,h4,h5,h6{font-family:${heading};}`
+  }
+}
+
+/**
+ * Point the document favicon at `branding.iconUrl` when configured.
+ * Empty keeps the bundled Synaplan bird from index.html.
+ */
+function applyIcon(): void {
+  const iconUrl = config.branding.iconUrl
+  if (!iconUrl) {
+    return
+  }
+
+  document.querySelectorAll<HTMLLinkElement>('link[rel="icon"]').forEach((link) => {
+    link.href = iconUrl
+  })
+
+  const apple = document.querySelector<HTMLLinkElement>('link[rel="apple-touch-icon"]')
+  if (apple) {
+    apple.href = iconUrl
   }
 }
 

--- a/frontend/src/views/EmailVerifiedView.vue
+++ b/frontend/src/views/EmailVerifiedView.vue
@@ -30,7 +30,7 @@
     <div class="w-full max-w-md" data-testid="section-card">
       <div class="text-center mb-8" data-testid="section-header">
         <router-link to="/login" class="inline-block">
-          <img :src="logoSrc" alt="synaplan" class="h-12 mx-auto mb-6" />
+          <img :src="logoSrc" :alt="config.branding.name" class="h-12 mx-auto mb-6" />
         </router-link>
       </div>
 
@@ -77,21 +77,15 @@ import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { SunIcon, MoonIcon, CheckCircleIcon } from '@heroicons/vue/24/outline'
 import { useTheme } from '../composables/useTheme'
+import { useBrandLogo } from '@/composables/useBrandLogo'
+import { useConfigStore } from '@/stores/config'
 import Button from '../components/Button.vue'
 
 const router = useRouter()
 const { locale } = useI18n()
 const themeStore = useTheme()
-
-const isDark = computed(() => {
-  if (themeStore.theme.value === 'dark') return true
-  if (themeStore.theme.value === 'light') return false
-  return matchMedia('(prefers-color-scheme: dark)').matches
-})
-
-const logoSrc = computed(
-  () => `${import.meta.env.BASE_URL}${isDark.value ? 'synaplan-light.svg' : 'synaplan-dark.svg'}`
-)
+const config = useConfigStore()
+const { logoSrc } = useBrandLogo(themeStore.isDark)
 
 const countdown = ref(5)
 let countdownInterval: number | null = null

--- a/frontend/src/views/ForgotPasswordView.vue
+++ b/frontend/src/views/ForgotPasswordView.vue
@@ -30,7 +30,7 @@
     <div class="w-full max-w-md" data-testid="section-card">
       <div class="text-center mb-8" data-testid="section-header">
         <router-link to="/login" class="inline-block">
-          <img :src="logoSrc" alt="synaplan" class="h-12 mx-auto mb-6" />
+          <img :src="logoSrc" :alt="config.branding.name" class="h-12 mx-auto mb-6" />
         </router-link>
         <h1 class="text-3xl font-bold txt-primary mb-2">{{ $t('auth.forgotPassword') }}</h1>
         <p class="txt-secondary">{{ $t('auth.forgotPasswordDesc') }}</p>
@@ -154,22 +154,15 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { SunIcon, MoonIcon, ArrowLeftIcon } from '@heroicons/vue/24/outline'
 import { useTheme } from '@/composables/useTheme'
+import { useBrandLogo } from '@/composables/useBrandLogo'
+import { useConfigStore } from '@/stores/config'
 import { authApi } from '@/services/api'
 import Button from '@/components/Button.vue'
 
 const { locale, t } = useI18n()
 const themeStore = useTheme()
-
-const isDark = computed(() => {
-  if (themeStore.theme.value === 'dark') return true
-  if (themeStore.theme.value === 'light') return false
-  return matchMedia('(prefers-color-scheme: dark)').matches
-})
-
-const logoSrc = computed(() => {
-  const baseUrl = import.meta.env.BASE_URL || '/'
-  return `${baseUrl}${isDark.value ? 'synaplan-light.svg' : 'synaplan-dark.svg'}`
-})
+const config = useConfigStore()
+const { logoSrc } = useBrandLogo(themeStore.isDark)
 
 const emailPlaceholder = computed(() => {
   // Combine prefix and suffix with @ to avoid vue-i18n interpreting @ as linked message syntax

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -15,7 +15,7 @@
         class="absolute -bottom-24 right-1/4 w-[28rem] h-[28rem] bg-brand/4 dark:bg-brand/8 rounded-full blur-3xl animate-float-delayed"
       ></div>
       <img
-        :src="birdSrc"
+        :src="iconSrc"
         alt=""
         class="absolute top-[8%] right-[5%] w-[280px] opacity-[0.035] dark:opacity-[0.06] rotate-12 pointer-events-none select-none"
       />
@@ -449,11 +449,7 @@ const isDark = computed(() => {
   return matchMedia('(prefers-color-scheme: dark)').matches
 })
 
-const { logoSrc } = useBrandLogo(isDark)
-const birdSrc = computed(
-  () =>
-    `${import.meta.env.BASE_URL}${isDark.value ? 'single_bird-light.svg' : 'single_bird-dark.svg'}`
-)
+const { logoSrc, iconSrc } = useBrandLogo(isDark)
 
 const email = ref('')
 const password = ref('')

--- a/frontend/src/views/RegisterView.vue
+++ b/frontend/src/views/RegisterView.vue
@@ -15,7 +15,7 @@
         class="absolute -bottom-24 right-1/4 w-[28rem] h-[28rem] bg-brand/4 dark:bg-brand/8 rounded-full blur-3xl animate-float-delayed"
       ></div>
       <img
-        :src="birdSrc"
+        :src="iconSrc"
         alt=""
         class="absolute top-[8%] right-[5%] w-[280px] opacity-[0.035] dark:opacity-[0.06] rotate-12 pointer-events-none select-none"
       />
@@ -454,11 +454,7 @@ const isDark = computed(() => {
   return matchMedia('(prefers-color-scheme: dark)').matches
 })
 
-const { logoSrc } = useBrandLogo(isDark)
-const birdSrc = computed(
-  () =>
-    `${import.meta.env.BASE_URL}${isDark.value ? 'single_bird-light.svg' : 'single_bird-dark.svg'}`
-)
+const { logoSrc, iconSrc } = useBrandLogo(isDark)
 
 const fullName = ref('')
 const email = ref('')

--- a/frontend/src/views/ResetPasswordView.vue
+++ b/frontend/src/views/ResetPasswordView.vue
@@ -5,7 +5,7 @@
   >
     <div class="w-full max-w-md">
       <div class="text-center mb-8">
-        <img :src="logoSrc" alt="synaplan" class="h-12 mx-auto mb-6" />
+        <img :src="logoSrc" :alt="config.branding.name" class="h-12 mx-auto mb-6" />
         <h1 class="text-3xl font-bold txt-primary mb-2">Reset Password</h1>
         <p class="txt-secondary">Enter your new password</p>
       </div>
@@ -110,9 +110,11 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
+import { ref, onMounted } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import { useTheme } from '../composables/useTheme'
+import { useBrandLogo } from '@/composables/useBrandLogo'
+import { useConfigStore } from '@/stores/config'
 import { usePasswordValidation } from '../composables/usePasswordValidation'
 import { authApi } from '@/services/api'
 import { getApiErrorMessage } from '@/utils/errorMessage'
@@ -121,16 +123,8 @@ import Button from '../components/Button.vue'
 const router = useRouter()
 const route = useRoute()
 const themeStore = useTheme()
-
-const isDark = computed(() => {
-  if (themeStore.theme.value === 'dark') return true
-  if (themeStore.theme.value === 'light') return false
-  return matchMedia('(prefers-color-scheme: dark)').matches
-})
-
-const logoSrc = computed(
-  () => `${import.meta.env.BASE_URL}${isDark.value ? 'synaplan-light.svg' : 'synaplan-dark.svg'}`
-)
+const config = useConfigStore()
+const { logoSrc } = useBrandLogo(themeStore.isDark)
 
 const password = ref('')
 const confirmPassword = ref('')

--- a/frontend/src/views/VerifyEmailCallbackView.vue
+++ b/frontend/src/views/VerifyEmailCallbackView.vue
@@ -5,7 +5,7 @@
   >
     <div class="w-full max-w-md">
       <div class="text-center mb-8">
-        <img :src="logoSrc" alt="synaplan" class="h-12 mx-auto mb-6" />
+        <img :src="logoSrc" :alt="config.branding.name" class="h-12 mx-auto mb-6" />
       </div>
 
       <div class="surface-card p-8 text-center" data-testid="section-verify-card">
@@ -97,23 +97,17 @@
 
 <script setup lang="ts">
 import { getErrorMessage } from '@/utils/errorMessage'
-import { ref, computed, onMounted } from 'vue'
+import { ref, onMounted } from 'vue'
 import { useRoute } from 'vue-router'
 import { useTheme } from '../composables/useTheme'
+import { useBrandLogo } from '@/composables/useBrandLogo'
+import { useConfigStore } from '@/stores/config'
 import { authApi } from '@/services/api'
 
 const route = useRoute()
 const themeStore = useTheme()
-
-const isDark = computed(() => {
-  if (themeStore.theme.value === 'dark') return true
-  if (themeStore.theme.value === 'light') return false
-  return matchMedia('(prefers-color-scheme: dark)').matches
-})
-
-const logoSrc = computed(
-  () => `${import.meta.env.BASE_URL}${isDark.value ? 'synaplan-light.svg' : 'synaplan-dark.svg'}`
-)
+const config = useConfigStore()
+const { logoSrc } = useBrandLogo(themeStore.isDark)
 
 const loading = ref(true)
 const verified = ref(false)

--- a/frontend/src/views/VerifyEmailView.vue
+++ b/frontend/src/views/VerifyEmailView.vue
@@ -35,7 +35,7 @@
     <div class="w-full max-w-md">
       <div class="text-center mb-8">
         <router-link to="/login" class="inline-block" data-testid="link-back-login">
-          <img :src="logoSrc" alt="synaplan" class="h-12 mx-auto mb-6" />
+          <img :src="logoSrc" :alt="config.branding.name" class="h-12 mx-auto mb-6" />
         </router-link>
       </div>
 
@@ -191,6 +191,8 @@ import {
   InformationCircleIcon,
 } from '@heroicons/vue/24/outline'
 import { useTheme } from '../composables/useTheme'
+import { useBrandLogo } from '@/composables/useBrandLogo'
+import { useConfigStore } from '@/stores/config'
 import { authApi } from '@/services/api'
 import { getApiErrorMessage } from '@/utils/errorMessage'
 import Button from '../components/Button.vue'
@@ -199,16 +201,8 @@ const route = useRoute()
 const router = useRouter()
 const { locale } = useI18n()
 const themeStore = useTheme()
-
-const isDark = computed(() => {
-  if (themeStore.theme.value === 'dark') return true
-  if (themeStore.theme.value === 'light') return false
-  return matchMedia('(prefers-color-scheme: dark)').matches
-})
-
-const logoSrc = computed(
-  () => `${import.meta.env.BASE_URL}${isDark.value ? 'synaplan-light.svg' : 'synaplan-dark.svg'}`
-)
+const config = useConfigStore()
+const { logoSrc } = useBrandLogo(themeStore.isDark)
 
 const userEmail = ref((route.query.email as string) || 'your@email.com')
 const isResending = ref(false)

--- a/frontend/tests/unit/composables/useBrandLogo.spec.ts
+++ b/frontend/tests/unit/composables/useBrandLogo.spec.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ref } from 'vue'
+
+const branding = {
+  logoUrl: '',
+  logoDarkUrl: '',
+  iconUrl: '',
+}
+
+vi.mock('@/stores/config', () => ({
+  useConfigStore: () => ({ branding }),
+}))
+
+import { useBrandLogo } from '@/composables/useBrandLogo'
+
+describe('useBrandLogo', () => {
+  const isDark = ref(false)
+
+  beforeEach(() => {
+    branding.logoUrl = ''
+    branding.logoDarkUrl = ''
+    branding.iconUrl = ''
+    isDark.value = false
+  })
+
+  it('falls back to the bundled wordmark and bird when branding is empty', () => {
+    const { logoSrc, iconSrc } = useBrandLogo(isDark)
+
+    expect(logoSrc.value).toMatch(/synaplan-dark\.svg$/)
+    expect(iconSrc.value).toMatch(/single_bird-dark\.svg$/)
+
+    isDark.value = true
+    expect(logoSrc.value).toMatch(/synaplan-light\.svg$/)
+    expect(iconSrc.value).toMatch(/single_bird-light\.svg$/)
+  })
+
+  it('uses the configured wordmark in both themes when only logoUrl is set', () => {
+    branding.logoUrl = 'https://brand.test/logo.svg'
+    const { logoSrc, iconSrc } = useBrandLogo(isDark)
+
+    expect(logoSrc.value).toBe('https://brand.test/logo.svg')
+    expect(iconSrc.value).toBe('https://brand.test/logo.svg')
+
+    isDark.value = true
+    expect(logoSrc.value).toBe('https://brand.test/logo.svg')
+    expect(iconSrc.value).toBe('https://brand.test/logo.svg')
+  })
+
+  it('prefers the dark wordmark in dark mode when both logos are set', () => {
+    branding.logoUrl = 'https://brand.test/logo.svg'
+    branding.logoDarkUrl = 'https://brand.test/logo-dark.svg'
+    isDark.value = true
+    const { logoSrc } = useBrandLogo(isDark)
+
+    expect(logoSrc.value).toBe('https://brand.test/logo-dark.svg')
+  })
+
+  it('prefers iconUrl for the compact mark over the wordmark', () => {
+    branding.logoUrl = 'https://brand.test/logo.svg'
+    branding.iconUrl = 'https://brand.test/icon.svg'
+    const { logoSrc, iconSrc } = useBrandLogo(isDark)
+
+    expect(logoSrc.value).toBe('https://brand.test/logo.svg')
+    expect(iconSrc.value).toBe('https://brand.test/icon.svg')
+  })
+})

--- a/frontend/tests/unit/utils/brandingTheme.spec.ts
+++ b/frontend/tests/unit/utils/brandingTheme.spec.ts
@@ -20,11 +20,16 @@ vi.mock('@/stores/config', () => ({
 
 import { applyBrandingTheme } from '@/utils/brandingTheme'
 
+function iconLinks(): HTMLLinkElement[] {
+  return Array.from(document.querySelectorAll<HTMLLinkElement>('link[rel="icon"]'))
+}
+
 describe('applyBrandingTheme — icon', () => {
   beforeEach(() => {
     branding.iconUrl = ''
     document.head.innerHTML = `
       <link rel="icon" type="image/svg+xml" href="/single_bird.svg" />
+      <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png" />
       <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     `
   })
@@ -32,19 +37,37 @@ describe('applyBrandingTheme — icon', () => {
   it('leaves bundled favicons when iconUrl is empty', () => {
     applyBrandingTheme()
 
-    expect(document.querySelector('link[rel="icon"]')?.href).toContain('/single_bird.svg')
+    const icons = iconLinks()
+    expect(icons).toHaveLength(2)
+    expect(icons[0]?.href).toContain('/single_bird.svg')
+    expect(icons[0]?.type).toBe('image/svg+xml')
+    expect(icons[1]?.href).toContain('/favicon-32.png')
+    expect(icons[1]?.type).toBe('image/png')
     expect(document.querySelector('link[rel="apple-touch-icon"]')?.href).toContain(
       '/apple-touch-icon.png'
     )
   })
 
-  it('points favicon links at branding.iconUrl when configured', () => {
+  it('replaces bundled favicons with a single correctly-typed branding icon', () => {
     branding.iconUrl = 'https://brand.test/icon.svg'
     applyBrandingTheme()
 
-    expect(document.querySelector('link[rel="icon"]')?.href).toContain('https://brand.test/icon.svg')
+    const icons = iconLinks()
+    expect(icons).toHaveLength(1)
+    expect(icons[0]?.href).toContain('https://brand.test/icon.svg')
+    expect(icons[0]?.type).toBe('image/svg+xml')
     expect(document.querySelector('link[rel="apple-touch-icon"]')?.href).toContain(
       'https://brand.test/icon.svg'
     )
+  })
+
+  it('sets image/png type when the branding icon is a PNG', () => {
+    branding.iconUrl = 'https://brand.test/icon.png'
+    applyBrandingTheme()
+
+    const icons = iconLinks()
+    expect(icons).toHaveLength(1)
+    expect(icons[0]?.href).toContain('https://brand.test/icon.png')
+    expect(icons[0]?.type).toBe('image/png')
   })
 })

--- a/frontend/tests/unit/utils/brandingTheme.spec.ts
+++ b/frontend/tests/unit/utils/brandingTheme.spec.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const branding = vi.hoisted(() => ({
+  primaryColor: '#003fc7',
+  secondaryColor: '',
+  accentColor: '',
+  primaryColorDark: '',
+  secondaryColorDark: '',
+  accentColorDark: '',
+  fontFamily: '',
+  headingFontFamily: '',
+  fontUrl: '',
+  iconUrl: '',
+}))
+
+vi.mock('@/stores/config', () => ({
+  default: { branding },
+  useConfigStore: () => ({ branding }),
+}))
+
+import { applyBrandingTheme } from '@/utils/brandingTheme'
+
+describe('applyBrandingTheme — icon', () => {
+  beforeEach(() => {
+    branding.iconUrl = ''
+    document.head.innerHTML = `
+      <link rel="icon" type="image/svg+xml" href="/single_bird.svg" />
+      <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+    `
+  })
+
+  it('leaves bundled favicons when iconUrl is empty', () => {
+    applyBrandingTheme()
+
+    expect(document.querySelector('link[rel="icon"]')?.href).toContain('/single_bird.svg')
+    expect(document.querySelector('link[rel="apple-touch-icon"]')?.href).toContain(
+      '/apple-touch-icon.png'
+    )
+  })
+
+  it('points favicon links at branding.iconUrl when configured', () => {
+    branding.iconUrl = 'https://brand.test/icon.svg'
+    applyBrandingTheme()
+
+    expect(document.querySelector('link[rel="icon"]')?.href).toContain('https://brand.test/icon.svg')
+    expect(document.querySelector('link[rel="apple-touch-icon"]')?.href).toContain(
+      'https://brand.test/icon.svg'
+    )
+  })
+})

--- a/frontend/tests/unit/utils/brandingTheme.spec.ts
+++ b/frontend/tests/unit/utils/brandingTheme.spec.ts
@@ -24,6 +24,10 @@ function iconLinks(): HTMLLinkElement[] {
   return Array.from(document.querySelectorAll<HTMLLinkElement>('link[rel="icon"]'))
 }
 
+function appleTouchIcon(): HTMLLinkElement | null {
+  return document.querySelector<HTMLLinkElement>('link[rel="apple-touch-icon"]')
+}
+
 describe('applyBrandingTheme — icon', () => {
   beforeEach(() => {
     branding.iconUrl = ''
@@ -43,9 +47,7 @@ describe('applyBrandingTheme — icon', () => {
     expect(icons[0]?.type).toBe('image/svg+xml')
     expect(icons[1]?.href).toContain('/favicon-32.png')
     expect(icons[1]?.type).toBe('image/png')
-    expect(document.querySelector('link[rel="apple-touch-icon"]')?.href).toContain(
-      '/apple-touch-icon.png'
-    )
+    expect(appleTouchIcon()?.href).toContain('/apple-touch-icon.png')
   })
 
   it('replaces bundled favicons with a single correctly-typed branding icon', () => {
@@ -56,9 +58,7 @@ describe('applyBrandingTheme — icon', () => {
     expect(icons).toHaveLength(1)
     expect(icons[0]?.href).toContain('https://brand.test/icon.svg')
     expect(icons[0]?.type).toBe('image/svg+xml')
-    expect(document.querySelector('link[rel="apple-touch-icon"]')?.href).toContain(
-      'https://brand.test/icon.svg'
-    )
+    expect(appleTouchIcon()?.href).toContain('https://brand.test/icon.svg')
   })
 
   it('sets image/png type when the branding icon is a PNG', () => {


### PR DESCRIPTION
## Summary
Missing logo links for the branding fixed

## Changes
This commit refactors the logo and icon management in the application by introducing the `useBrandLogo` composable. It centralizes the logic for determining the appropriate logo and icon based on the branding configuration and the current theme (dark/light). The changes include:

- Updated `SidebarV2.vue`, `EmailVerifiedView.vue`, `ForgotPasswordView.vue`, `LoginView.vue`, `RegisterView.vue`, `ResetPasswordView.vue`, `VerifyEmailCallbackView.vue`, and `VerifyEmailView.vue` to utilize the new `useBrandLogo` composable for logo and icon sources.
- Added `applyIcon` function in `brandingTheme.ts` to dynamically set the document favicon based on the branding configuration.
- Removed redundant computed properties for logo sources in various views, streamlining the codebase.

These updates improve maintainability and ensure consistent branding across the application.

## Verification
- [ ] Not tested (explain)
- [X] Manual
- [ ] Tests added/updated

## Notes
<!-- Related issues/links/threads. -->

## Screenshots/Logs
