### PR TITLE
fix(models): retire decommissioned Groq llama-3.3-70b-versatile

### DIFF
--- a/backend/migrations/Version20260819090000.php
+++ b/backend/migrations/Version20260819090000.php
@@ -33,9 +33,19 @@ use Doctrine\Migrations\AbstractMigration;
  * idempotent, and DEFAULTMODEL bindings are repointed for every owner behind an
  * EXISTS subquery so an install without the successor is left untouched.
  *
- * Successor: Groq gpt-oss-120b (BID 76) — already the SORT/PLAN/SUMMARIZE/MEM
- * binding for Groq and ranked above the retired row on every catalog axis
- * (quality 10 vs 9, rating 4 vs 1, and cheaper at 0.15/0.60 vs 0.59/0.79).
+ * Successor: Groq gpt-oss-120b (BID 76). Note what this costs, because the
+ * retired row was deliberately the MAIN tier while 76 was the cheap FAST tier
+ * (see #1392 and _devextras/planning/archive/20260606_multitask-routing.md):
+ * Groq's remaining catalog no longer holds a chat model above its router, so
+ * MAIN and FAST collapse onto one model, and the per-answer output budget drops
+ * from 32768 to 16384 tokens because that is 76's catalog max_tokens. No Groq
+ * chat row combines the higher budget with a comparable tier.
+ *
+ * Unlike the earlier retirements this one refuses to touch VECTORIZE: swapping
+ * an embedding binding without re-vectorising corrupts every stored vector
+ * (issue #948), and docs/PRICING_MAINTENANCE.md forbids it. The retired row is
+ * chat-tagged, so a VECTORIZE binding on it can only come from operator error —
+ * which is exactly when a silent repoint would do the most damage.
  */
 final class Version20260819090000 extends AbstractMigration
 {
@@ -54,8 +64,11 @@ final class Version20260819090000 extends AbstractMigration
             UPDATE BCONFIG
                SET BVALUE = :successor
              WHERE BGROUP = 'DEFAULTMODEL'
+               AND BSETTING <> 'VECTORIZE'
                AND BVALUE = :retiredValue
-               AND EXISTS (SELECT 1 FROM BMODELS WHERE BID = :successor)
+               AND EXISTS (
+                   SELECT 1 FROM BMODELS WHERE BID = :successor AND BACTIVE = 1
+               )
         SQL, [
             'retiredValue' => (string) self::RETIRED_BID,
             'successor' => (string) self::SUCCESSOR_BID,

--- a/backend/migrations/Version20260819090000.php
+++ b/backend/migrations/Version20260819090000.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Retire Groq `llama-3.3-70b-versatile` (BID 9), decommissioned upstream: the
+ * provider now answers every request for it with "The model ... does not exist
+ * or you do not have access to it".
+ *
+ * The row is removed from {@see \App\Model\ModelCatalog} in the same change, so
+ * this migration is what stops it from reaching users:
+ *
+ *   - `ModelSeeder` never deactivates rows, so without the UPDATE below the
+ *     model stays BACTIVE=1/BSELECTABLE=1 — and therefore user-pickable — in
+ *     every install that already has it.
+ *   - Deleting the row instead would not be durable: `ModelCatalog::upsert()`
+ *     writes an explicit BID, so as long as the catalog entry existed the next
+ *     `app:seed` (run on every container start) restored BID 9 verbatim.
+ *
+ * The BID was also the recommended CHAT/TOOLS/ANALYZE binding for Groq in
+ * `ProviderDefaultsService`, which `app:provider:apply-defaults --auto` applies
+ * unattended at container start. Installs that were auto-pointed at Groq
+ * therefore hold a dead default and are repaired by the repoint below.
+ *
+ * Same contract as {@see Version20260728120000}: rows are deactivated rather
+ * than deleted (BUSELOG and BMODEL_PRICE_HISTORY reference BID with ON DELETE
+ * RESTRICT, and BIDs must never be reused), the BPROVID guard keeps a re-run
+ * idempotent, and DEFAULTMODEL bindings are repointed for every owner behind an
+ * EXISTS subquery so an install without the successor is left untouched.
+ *
+ * Successor: Groq gpt-oss-120b (BID 76) — already the SORT/PLAN/SUMMARIZE/MEM
+ * binding for Groq and ranked above the retired row on every catalog axis
+ * (quality 10 vs 9, rating 4 vs 1, and cheaper at 0.15/0.60 vs 0.59/0.79).
+ */
+final class Version20260819090000 extends AbstractMigration
+{
+    private const RETIRED_BID = 9;
+    private const RETIRED_PROVID = 'llama-3.3-70b-versatile';
+    private const SUCCESSOR_BID = 76;
+
+    public function getDescription(): string
+    {
+        return 'Retire Groq llama-3.3-70b-versatile (BID 9), decommissioned upstream, and repoint its DEFAULTMODEL bindings to Groq gpt-oss-120b (BID 76).';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            UPDATE BCONFIG
+               SET BVALUE = :successor
+             WHERE BGROUP = 'DEFAULTMODEL'
+               AND BVALUE = :retiredValue
+               AND EXISTS (SELECT 1 FROM BMODELS WHERE BID = :successor)
+        SQL, [
+            'retiredValue' => (string) self::RETIRED_BID,
+            'successor' => (string) self::SUCCESSOR_BID,
+        ]);
+
+        $this->addSql(<<<'SQL'
+            UPDATE BMODELS
+               SET BACTIVE = 0,
+                   BSELECTABLE = 0,
+                   BISDEFAULT = 0
+             WHERE BID = :retired
+               AND BPROVID = :providerId
+        SQL, [
+            'retired' => self::RETIRED_BID,
+            'providerId' => self::RETIRED_PROVID,
+        ]);
+    }
+
+    public function down(Schema $schema): void
+    {
+        // Reactivate the row so it reappears in the admin UI. The BCONFIG
+        // repoint is intentionally not undone: an auto-migrated binding cannot
+        // be told apart from one an operator set deliberately afterwards. Same
+        // contract as Version20260728120000::down().
+        $this->addSql(<<<'SQL'
+            UPDATE BMODELS
+               SET BACTIVE = 1,
+                   BSELECTABLE = 1
+             WHERE BID = :retired
+               AND BPROVID = :providerId
+        SQL, [
+            'retired' => self::RETIRED_BID,
+            'providerId' => self::RETIRED_PROVID,
+        ]);
+    }
+}

--- a/backend/src/AI/Credential/ProviderDefaultsService.php
+++ b/backend/src/AI/Credential/ProviderDefaultsService.php
@@ -36,9 +36,9 @@ final readonly class ProviderDefaultsService
      */
     private const PROVIDER_DEFAULTS = [
         'groq' => [
-            'CHAT' => 'groq:llama-3.3-70b-versatile:chat',
-            'TOOLS' => 'groq:llama-3.3-70b-versatile:chat',
-            'ANALYZE' => 'groq:llama-3.3-70b-versatile:chat',
+            'CHAT' => 'groq:openai/gpt-oss-120b:chat',
+            'TOOLS' => 'groq:openai/gpt-oss-120b:chat',
+            'ANALYZE' => 'groq:openai/gpt-oss-120b:chat',
             'SORT' => 'groq:openai/gpt-oss-120b:chat',
             'PLAN' => 'groq:openai/gpt-oss-120b:chat',
             'SUMMARIZE' => 'groq:openai/gpt-oss-120b:chat',

--- a/backend/src/Command/ModelDisableCommand.php
+++ b/backend/src/Command/ModelDisableCommand.php
@@ -29,7 +29,7 @@ class ModelDisableCommand extends Command
     {
         $this
             ->addArgument('models', InputArgument::IS_ARRAY | InputArgument::REQUIRED,
-                'Model keys to disable (e.g. groq:llama-3.3-70b-versatile ollama:bge-m3)')
+                'Model keys to disable (e.g. groq:llama-3.1-8b-instant ollama:bge-m3)')
             ->setHelp(
                 "Remove one or more AI models from the database.\n\n".
                 "Key format: service:providerId (or service:providerId:tag to target a specific variant)\n\n".

--- a/backend/src/Command/ModelEnableCommand.php
+++ b/backend/src/Command/ModelEnableCommand.php
@@ -30,7 +30,7 @@ class ModelEnableCommand extends Command
     {
         $this
             ->addArgument('models', InputArgument::IS_ARRAY | InputArgument::REQUIRED,
-                'Model keys to enable (e.g. groq:llama-3.3-70b-versatile ollama:bge-m3)')
+                'Model keys to enable (e.g. groq:llama-3.1-8b-instant ollama:bge-m3)')
             ->addOption('system', null, InputOption::VALUE_NONE,
                 'Mark enabled models as system models (locked, users cannot change)')
             ->setHelp(

--- a/backend/src/Command/ModelSetDefaultCommand.php
+++ b/backend/src/Command/ModelSetDefaultCommand.php
@@ -29,7 +29,7 @@ class ModelSetDefaultCommand extends Command
     {
         $this
             ->addArgument('model', InputArgument::REQUIRED,
-                'Model key (e.g. groq:llama-3.3-70b-versatile, ollama:bge-m3)')
+                'Model key (e.g. groq:llama-3.1-8b-instant, ollama:bge-m3)')
             ->addArgument('capabilities', InputArgument::IS_ARRAY | InputArgument::REQUIRED,
                 'Capabilities to set this model as default for (e.g. chat vectorize)')
             ->setHelp(

--- a/backend/src/Model/ModelCatalog.php
+++ b/backend/src/Model/ModelCatalog.php
@@ -16,7 +16,7 @@ use Doctrine\DBAL\Connection;
  * To target a specific variant, append the tag: "service:providerId:tag"
  *
  * Usage:
- *   ModelCatalog::find('groq:llama-3.3-70b-versatile')  → [model]
+ *   ModelCatalog::find('groq:llama-3.1-8b-instant')      → [model]
  *   ModelCatalog::find('openai:gpt-4o')                  → [chat, pic2text]
  *   ModelCatalog::find('openai:gpt-4o:chat')             → [chat only]
  */
@@ -419,31 +419,8 @@ class ModelCatalog
             ],
         ],
         // ==================== GROQ MODELS ====================
-        [
-            'id' => 9,
-            'service' => 'Groq',
-            'name' => 'Llama 3.3 70b versatile',
-            'tag' => 'chat',
-            'selectable' => 1,
-            'active' => 1,
-            'providerId' => 'llama-3.3-70b-versatile',
-            'priceIn' => 0.59,
-            'inUnit' => 'per1M',
-            'priceOut' => 0.79,
-            'outUnit' => 'per1M',
-            'quality' => 9,
-            'rating' => 1,
-            'json' => [
-                'description' => 'Fast API service via groq',
-                'max_tokens' => 32768,
-                'params' => [
-                    'model' => 'llama-3.3-70b-versatile',
-                    'reasoning_format' => 'hidden',
-                    'messages' => [],
-                ],
-                'meta' => ['context_window' => '131072', 'max_output' => '32768'],
-            ],
-        ],
+        // BID 9 (llama-3.3-70b-versatile) was decommissioned by Groq and is
+        // retired by Version20260819090000.
         [
             'id' => 17,
             'service' => 'Groq',

--- a/backend/tests/AI/Credential/ProviderDefaultsServiceTest.php
+++ b/backend/tests/AI/Credential/ProviderDefaultsServiceTest.php
@@ -231,37 +231,29 @@ final class ProviderDefaultsServiceTest extends TestCase
     }
 
     /**
-     * PROVIDER_DEFAULTS splits each provider into a MAIN tier (CHAT, TOOLS,
-     * ANALYZE) and a cheaper FAST tier (SORT, PLAN, SUMMARIZE). Nothing used to
-     * enforce that ordering, so the map could keep recommending a former
-     * flagship long after the catalog ranked a FAST-tier model above it — the
-     * shape a stale binding takes before anyone notices it is also dead.
+     * A CHAT recommendation is what a user actually talks to, so it must be a
+     * model the provider can answer with rather than a media or embedding row.
+     * Cheap structural check; it cannot tell whether the model still exists
+     * upstream — only a live provider query can.
      */
-    public function testFlagshipTierIsNotRankedBelowTheFastTier(): void
+    public function testRecommendedChatDefaultsAreChatCapable(): void
     {
         $byId = $this->catalogById();
 
         foreach ([...ProviderKeyStore::SUPPORTED_PROVIDERS, 'ollama'] as $provider) {
             $defaults = $this->service->getRecommendedDefaults($provider);
-            if (!isset($defaults['CHAT'], $defaults['SORT'])) {
-                continue;
+
+            foreach (['CHAT', 'TOOLS', 'ANALYZE', 'SORT', 'PLAN', 'SUMMARIZE'] as $capability) {
+                if (!isset($defaults[$capability])) {
+                    continue;
+                }
+
+                self::assertSame(
+                    'chat',
+                    $byId[$defaults[$capability]]['tag'],
+                    sprintf('%s/%s must recommend a chat-tagged model', $provider, $capability)
+                );
             }
-
-            $main = $byId[$defaults['CHAT']];
-            $fast = $byId[$defaults['SORT']];
-
-            self::assertGreaterThanOrEqual(
-                (float) $fast['quality'],
-                (float) $main['quality'],
-                sprintf(
-                    'Provider "%s" recommends %s (quality %s) as its flagship CHAT model while using %s (quality %s) for the cheap SORT tier',
-                    $provider,
-                    $main['providerId'],
-                    $main['quality'],
-                    $fast['providerId'],
-                    $fast['quality']
-                )
-            );
         }
     }
 

--- a/backend/tests/AI/Credential/ProviderDefaultsServiceTest.php
+++ b/backend/tests/AI/Credential/ProviderDefaultsServiceTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\AI\Credential;
 use App\AI\Credential\ProviderDefaultsService;
 use App\AI\Credential\ProviderKeyStore;
 use App\Entity\Config;
+use App\Model\ModelCatalog;
 use App\Repository\ConfigRepository;
 use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
@@ -206,5 +207,74 @@ final class ProviderDefaultsServiceTest extends TestCase
         $this->service->applyGlobalDefaults('groq');
 
         self::assertArrayNotHasKey('0|DEFAULTMODEL|VECTORIZE', $this->written, 'VECTORIZE (local embeddings) must keep its current value');
+    }
+
+    /**
+     * A recommended default is applied unattended by
+     * `app:provider:apply-defaults --auto` at container start, so a binding that
+     * points at a deactivated catalog row hands a fresh install a model its own
+     * UI refuses to offer. Resolving to a unique BID is not enough.
+     */
+    public function testEveryRecommendedDefaultPointsAtAnActiveCatalogEntry(): void
+    {
+        $byId = $this->catalogById();
+
+        foreach ([...ProviderKeyStore::SUPPORTED_PROVIDERS, 'ollama'] as $provider) {
+            foreach ($this->service->getRecommendedDefaults($provider) as $capability => $bid) {
+                self::assertSame(
+                    1,
+                    $byId[$bid]['active'],
+                    sprintf('%s/%s recommends BID %d, which is not active in the catalog', $provider, $capability, $bid)
+                );
+            }
+        }
+    }
+
+    /**
+     * PROVIDER_DEFAULTS splits each provider into a MAIN tier (CHAT, TOOLS,
+     * ANALYZE) and a cheaper FAST tier (SORT, PLAN, SUMMARIZE). Nothing used to
+     * enforce that ordering, so the map could keep recommending a former
+     * flagship long after the catalog ranked a FAST-tier model above it — the
+     * shape a stale binding takes before anyone notices it is also dead.
+     */
+    public function testFlagshipTierIsNotRankedBelowTheFastTier(): void
+    {
+        $byId = $this->catalogById();
+
+        foreach ([...ProviderKeyStore::SUPPORTED_PROVIDERS, 'ollama'] as $provider) {
+            $defaults = $this->service->getRecommendedDefaults($provider);
+            if (!isset($defaults['CHAT'], $defaults['SORT'])) {
+                continue;
+            }
+
+            $main = $byId[$defaults['CHAT']];
+            $fast = $byId[$defaults['SORT']];
+
+            self::assertGreaterThanOrEqual(
+                (float) $fast['quality'],
+                (float) $main['quality'],
+                sprintf(
+                    'Provider "%s" recommends %s (quality %s) as its flagship CHAT model while using %s (quality %s) for the cheap SORT tier',
+                    $provider,
+                    $main['providerId'],
+                    $main['quality'],
+                    $fast['providerId'],
+                    $fast['quality']
+                )
+            );
+        }
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function catalogById(): array
+    {
+        $byId = [];
+        foreach (ModelCatalog::all() as $model) {
+            $byId[(int) $model['id']] = $model;
+        }
+
+        return $byId;
     }
 }

--- a/backend/tests/Command/ModelDisableCommandTest.php
+++ b/backend/tests/Command/ModelDisableCommandTest.php
@@ -35,7 +35,7 @@ class ModelDisableCommandTest extends TestCase
         $this->connection->expects($this->once())->method('executeStatement')
             ->with('DELETE FROM BMODELS WHERE BID = ?', new IsType(NativeType::Array));
 
-        $this->commandTester->execute(['models' => ['groq:llama-3.3-70b-versatile']]);
+        $this->commandTester->execute(['models' => ['groq:llama-3.1-8b-instant']]);
 
         $this->assertSame(Command::SUCCESS, $this->commandTester->getStatusCode());
         $this->assertStringContainsString('Disabled 1 model(s)', $this->commandTester->getDisplay());
@@ -68,7 +68,7 @@ class ModelDisableCommandTest extends TestCase
         // @phpstan-ignore-next-line
         $this->connection->expects($this->once())->method('executeStatement');
 
-        $this->commandTester->execute(['models' => ['groq:llama-3.3-70b-versatile', 'fake:nope']]);
+        $this->commandTester->execute(['models' => ['groq:llama-3.1-8b-instant', 'fake:nope']]);
 
         $this->assertSame(Command::FAILURE, $this->commandTester->getStatusCode());
         $output = $this->commandTester->getDisplay();

--- a/backend/tests/Command/ModelEnableCommandTest.php
+++ b/backend/tests/Command/ModelEnableCommandTest.php
@@ -32,7 +32,7 @@ class ModelEnableCommandTest extends TestCase
         // @phpstan-ignore-next-line
         $this->connection->expects($this->once())->method('executeStatement');
 
-        $this->commandTester->execute(['models' => ['groq:llama-3.3-70b-versatile']]);
+        $this->commandTester->execute(['models' => ['groq:llama-3.1-8b-instant']]);
 
         $this->assertSame(Command::SUCCESS, $this->commandTester->getStatusCode());
         $this->assertStringContainsString('Enabled 1 model(s)', $this->commandTester->getDisplay());
@@ -43,7 +43,7 @@ class ModelEnableCommandTest extends TestCase
         // @phpstan-ignore-next-line
         $this->connection->expects($this->exactly(2))->method('executeStatement');
 
-        $this->commandTester->execute(['models' => ['groq:llama-3.3-70b-versatile', 'ollama:bge-m3']]);
+        $this->commandTester->execute(['models' => ['groq:llama-3.1-8b-instant', 'ollama:bge-m3']]);
 
         $this->assertSame(Command::SUCCESS, $this->commandTester->getStatusCode());
         $this->assertStringContainsString('Enabled 2 model(s)', $this->commandTester->getDisplay());
@@ -77,7 +77,7 @@ class ModelEnableCommandTest extends TestCase
         // @phpstan-ignore-next-line
         $this->connection->expects($this->once())->method('executeStatement');
 
-        $this->commandTester->execute(['models' => ['groq:llama-3.3-70b-versatile', 'fake:nope']]);
+        $this->commandTester->execute(['models' => ['groq:llama-3.1-8b-instant', 'fake:nope']]);
 
         $this->assertSame(Command::FAILURE, $this->commandTester->getStatusCode());
         $output = $this->commandTester->getDisplay();

--- a/backend/tests/Command/ModelListCommandTest.php
+++ b/backend/tests/Command/ModelListCommandTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Command;
 
 use App\Command\ModelListCommand;
+use App\Model\ModelCatalog;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
@@ -43,9 +44,12 @@ class ModelListCommandTest extends TestCase
 
     public function testListShowsEnabledModelAsYes(): void
     {
-        // Enable the groq llama model (BID=9)
+        // Any catalog BID will do; reading it from the catalog keeps the test
+        // alive when that model is later retired.
+        $enabledBid = (string) ModelCatalog::all()[0]['id'];
+
         // @phpstan-ignore-next-line
-        $this->connection->method('fetchFirstColumn')->willReturn(['9']);
+        $this->connection->method('fetchFirstColumn')->willReturn([$enabledBid]);
 
         $this->commandTester->execute([]);
 

--- a/backend/tests/Command/ModelSetDefaultCommandTest.php
+++ b/backend/tests/Command/ModelSetDefaultCommandTest.php
@@ -45,7 +45,7 @@ class ModelSetDefaultCommandTest extends TestCase
         // @phpstan-ignore-next-line
         $this->connection->expects($this->exactly(4))->method('executeStatement');
 
-        $this->commandTester->execute(['model' => 'groq:llama-3.3-70b-versatile', 'capabilities' => ['chat', 'sort']]);
+        $this->commandTester->execute(['model' => 'groq:llama-3.1-8b-instant', 'capabilities' => ['chat', 'sort']]);
 
         $this->assertSame(Command::SUCCESS, $this->commandTester->getStatusCode());
         $output = $this->commandTester->getDisplay();

--- a/backend/tests/Command/SyncModelPricesCommandTest.php
+++ b/backend/tests/Command/SyncModelPricesCommandTest.php
@@ -220,10 +220,10 @@ class SyncModelPricesCommandTest extends TestCase
 
     public function testMatchesPrefixedModelKey(): void
     {
-        $model = $this->createModelMock('groq', 'llama-3.3-70b-versatile', 0.5, 0.8);
+        $model = $this->createModelMock('groq', 'llama-3.1-8b-instant', 0.5, 0.8);
 
         $this->mockLiteLLMResponse([
-            'groq/llama-3.3-70b-versatile' => [
+            'groq/llama-3.1-8b-instant' => [
                 'input_cost_per_token' => 0.0000006,
                 'output_cost_per_token' => 0.0000008,
                 'mode' => 'chat',
@@ -297,10 +297,10 @@ class SyncModelPricesCommandTest extends TestCase
 
     public function testMatchesCaseInsensitiveServicePrefix(): void
     {
-        $model = $this->createModelMock('Groq', 'llama-3.3-70b-versatile', 0.5, 0.8);
+        $model = $this->createModelMock('Groq', 'llama-3.1-8b-instant', 0.5, 0.8);
 
         $this->mockLiteLLMResponse([
-            'groq/llama-3.3-70b-versatile' => [
+            'groq/llama-3.1-8b-instant' => [
                 'input_cost_per_token' => 0.0000006,
                 'output_cost_per_token' => 0.0000008,
                 'mode' => 'chat',

--- a/backend/tests/Unit/Model/ModelCatalogTest.php
+++ b/backend/tests/Unit/Model/ModelCatalogTest.php
@@ -13,11 +13,11 @@ class ModelCatalogTest extends TestCase
 {
     public function testFindByServiceAndProviderId(): void
     {
-        $results = ModelCatalog::find('groq:llama-3.3-70b-versatile');
+        $results = ModelCatalog::find('groq:llama-3.1-8b-instant');
 
         $this->assertNotEmpty($results);
         $this->assertSame('Groq', $results[0]['service']);
-        $this->assertSame('llama-3.3-70b-versatile', $results[0]['providerId']);
+        $this->assertSame('llama-3.1-8b-instant', $results[0]['providerId']);
     }
 
     /**
@@ -35,9 +35,9 @@ class ModelCatalogTest extends TestCase
 
     public function testFindIsCaseInsensitive(): void
     {
-        $lower = ModelCatalog::find('groq:llama-3.3-70b-versatile');
-        $upper = ModelCatalog::find('GROQ:LLAMA-3.3-70B-VERSATILE');
-        $mixed = ModelCatalog::find('Groq:Llama-3.3-70b-Versatile');
+        $lower = ModelCatalog::find('groq:llama-3.1-8b-instant');
+        $upper = ModelCatalog::find('GROQ:LLAMA-3.1-8B-INSTANT');
+        $mixed = ModelCatalog::find('Groq:Llama-3.1-8b-Instant');
 
         $this->assertSame($lower, $upper);
         $this->assertSame($lower, $mixed);
@@ -111,7 +111,7 @@ class ModelCatalogTest extends TestCase
     public function testUpsertCallsExecuteStatement(): void
     {
         $connection = $this->createMock(Connection::class);
-        $model = ModelCatalog::find('groq:llama-3.3-70b-versatile')[0];
+        $model = ModelCatalog::find('groq:llama-3.1-8b-instant')[0];
 
         // @phpstan-ignore-next-line
         $connection
@@ -128,7 +128,7 @@ class ModelCatalogTest extends TestCase
     public function testRemoveCallsDeleteById(): void
     {
         $connection = $this->createMock(Connection::class);
-        $model = ModelCatalog::find('groq:llama-3.3-70b-versatile')[0];
+        $model = ModelCatalog::find('groq:llama-3.1-8b-instant')[0];
 
         // @phpstan-ignore-next-line
         $connection
@@ -142,7 +142,7 @@ class ModelCatalogTest extends TestCase
     public function testUpsertSqlDoesNotOverwriteOperatorOwnedFields(): void
     {
         $connection = $this->createMock(Connection::class);
-        $model = ModelCatalog::find('groq:llama-3.3-70b-versatile')[0];
+        $model = ModelCatalog::find('groq:llama-3.1-8b-instant')[0];
 
         // @phpstan-ignore-next-line
         $connection
@@ -425,14 +425,14 @@ class ModelCatalogTest extends TestCase
 
     public function testFingerprintIsDeterministic(): void
     {
-        $model = ModelCatalog::find('groq:llama-3.3-70b-versatile')[0];
+        $model = ModelCatalog::find('groq:llama-3.1-8b-instant')[0];
 
         $this->assertSame(ModelCatalog::fingerprint($model), ModelCatalog::fingerprint($model));
     }
 
     public function testFingerprintIgnoresOperatorOwnedFields(): void
     {
-        $model = ModelCatalog::find('groq:llama-3.3-70b-versatile')[0];
+        $model = ModelCatalog::find('groq:llama-3.1-8b-instant')[0];
         $expected = ModelCatalog::fingerprint($model);
 
         $toggled = array_merge($model, [
@@ -446,7 +446,7 @@ class ModelCatalogTest extends TestCase
 
     public function testFingerprintIgnoresEmbeddedFingerprintKey(): void
     {
-        $model = ModelCatalog::find('groq:llama-3.3-70b-versatile')[0];
+        $model = ModelCatalog::find('groq:llama-3.1-8b-instant')[0];
         $expected = ModelCatalog::fingerprint($model);
 
         $stamped = $model;
@@ -457,7 +457,7 @@ class ModelCatalogTest extends TestCase
 
     public function testFingerprintChangesWhenCatalogValueChanges(): void
     {
-        $model = ModelCatalog::find('groq:llama-3.3-70b-versatile')[0];
+        $model = ModelCatalog::find('groq:llama-3.1-8b-instant')[0];
         $original = ModelCatalog::fingerprint($model);
 
         $model['priceIn'] = 0.99;
@@ -537,7 +537,7 @@ class ModelCatalogTest extends TestCase
         // Doctrine DBAL hands floats back as native floats; the identity should
         // survive a string round-trip equivalent to what (float) $row['BPRICEIN']
         // produces after JSON encode/decode in the actual seed flow.
-        $model = ModelCatalog::find('groq:llama-3.3-70b-versatile')[0];
+        $model = ModelCatalog::find('groq:llama-3.1-8b-instant')[0];
         $original = ModelCatalog::fingerprint($model);
 
         $roundTripped = $model;
@@ -552,7 +552,7 @@ class ModelCatalogTest extends TestCase
     public function testUpsertEmbedsFingerprintInJsonPayload(): void
     {
         $connection = $this->createMock(Connection::class);
-        $model = ModelCatalog::find('groq:llama-3.3-70b-versatile')[0];
+        $model = ModelCatalog::find('groq:llama-3.1-8b-instant')[0];
         $expectedFingerprint = ModelCatalog::fingerprint($model);
 
         // @phpstan-ignore-next-line

--- a/docs/PRICING_MAINTENANCE.md
+++ b/docs/PRICING_MAINTENANCE.md
@@ -313,7 +313,11 @@ Groq decommissioned `llama-3.3-70b-versatile` (BID 9) — every request now come
 
 What made this one worse than a stale catalog row: BID 9 was also the recommended `CHAT`/`TOOLS`/`ANALYZE` binding for Groq in `ProviderDefaultsService`, and Groq is **first** in `PREFERENCE_ORDER`. `app:provider:apply-defaults --auto` runs on every container start and `ChatReadinessService` calls the same path at runtime, so any install holding a Groq key while its current default provider had none was repointed at a dead model **without anyone choosing it**. The migration repairs existing bindings for every owner; the catalog and map changes stop it recurring.
 
-The catalog already ranked the successor above the retired row on every axis (quality 10 vs 9, rating 4 vs 1, price 0.15/0.60 vs 0.59/0.79) — the map had simply drifted. `ProviderDefaultsServiceTest::testFlagshipTierIsNotRankedBelowTheFastTier()` now fails the build when a provider's MAIN tier ranks below its FAST tier, and `testEveryRecommendedDefaultPointsAtAnActiveCatalogEntry()` fails when a recommendation points at a deactivated row.
+**What the retirement costs.** BID 9 was deliberately Groq's MAIN tier while BID 76 was the cheap FAST tier used for routing (#1392, `_devextras/planning/archive/20260606_multitask-routing.md`). Groq's remaining chat rows hold nothing above the router, so MAIN and FAST now collapse onto one model, and the per-answer output budget drops from 32768 to 16384 tokens (BID 76's `max_tokens`). The only Groq chat rows that keep the 32768 budget are Qwen3 32B (53) and Llama 3.1 8B Instant (236); neither is an obvious drop-in, so the collapse is the deliberate choice and worth revisiting when Groq ships a new top-tier model.
+
+**Do not use `BQUALITY`/`BRATING` to justify a successor.** They are hand-authored and currently unmaintained; a comparison between two rows says nothing reliable. Pick successors from verifiable facts — upstream availability, price, output budget, declared features — and state which one you used.
+
+`ProviderDefaultsServiceTest::testEveryRecommendedDefaultPointsAtAnActiveCatalogEntry()` now fails the build when a recommendation points at a deactivated row, and `testRecommendedChatDefaultsAreChatCapable()` when it points at a non-chat row. Neither can detect an upstream removal — only a live provider query can.
 
 ### A non-zero price under a "free" unit is silently free
 

--- a/docs/PRICING_MAINTENANCE.md
+++ b/docs/PRICING_MAINTENANCE.md
@@ -288,7 +288,7 @@ Source: https://platform.claude.com/docs/en/about-claude/models/overview
 | Claude Opus 4.8 | 238 / 239 | $5 / $25 |
 | Claude Haiku 4.5 | 162 / 235 | $1 / $5 |
 
-Retired on 2026-07-27 by `Version20260727120000` (rows deactivated, never deleted — `BMESSAGES` FKs; BIDs must never be reused): Claude Sonnet 4.5 (112/109), Claude Opus 4.6 (160/164), Claude Sonnet 4.6 (161/163), Claude Opus 4.7 (165/166), plus the catalog-orphans Claude Opus 4.1 (69/93, deprecated upstream and retired by Anthropic on 2026-08-05) and Claude Opus 4.5 (121).
+Retired on 2026-07-27 by `Version20260727120000` (rows deactivated, never deleted — see "Why retirement means deactivation" below; BIDs must never be reused): Claude Sonnet 4.5 (112/109), Claude Opus 4.6 (160/164), Claude Sonnet 4.6 (161/163), Claude Opus 4.7 (165/166), plus the catalog-orphans Claude Opus 4.1 (69/93, deprecated upstream and retired by Anthropic on 2026-08-05) and Claude Opus 4.5 (121).
 
 The same orphan cleanup continues in `Version20260727180000` for two non-Anthropic rows: **OpenAI `gpt-4.1` (BID 30)** → GPT-5.6 Terra (253) and **Groq `llama-4-maverick-17b-128e-instruct` (BID 49)** → Groq `gpt-oss-120b` (76).
 
@@ -307,6 +307,14 @@ Comparing the production catalog (`GET /api/v1/admin/models`) against `ModelCata
 
 > **Never repoint `DEFAULTMODEL.VECTORIZE` from a migration.** Embedding models are not interchangeable: swapping the binding without re-vectorizing leaves every stored vector in the wrong space, which is exactly the failure mode of issue #948 (Qdrant HTTP 400, memory lost). The admin path pairs the switch with a re-vectorize run via `VectorizeBindingService`; a migration cannot. BID 129 is therefore deactivated only where nothing binds to it, guarded by a `NOT EXISTS` on `BCONFIG` — an install still using it keeps working search and switches through the UI.
 
+### Groq flagship retirement 2026-08-19 (`Version20260819090000`)
+
+Groq decommissioned `llama-3.3-70b-versatile` (BID 9) — every request now comes back as "The model ... does not exist or you do not have access to it". Successor: Groq `gpt-oss-120b` (76), the same successor `Version20260727180000` used for the previous Groq retirement.
+
+What made this one worse than a stale catalog row: BID 9 was also the recommended `CHAT`/`TOOLS`/`ANALYZE` binding for Groq in `ProviderDefaultsService`, and Groq is **first** in `PREFERENCE_ORDER`. `app:provider:apply-defaults --auto` runs on every container start and `ChatReadinessService` calls the same path at runtime, so any install holding a Groq key while its current default provider had none was repointed at a dead model **without anyone choosing it**. The migration repairs existing bindings for every owner; the catalog and map changes stop it recurring.
+
+The catalog already ranked the successor above the retired row on every axis (quality 10 vs 9, rating 4 vs 1, price 0.15/0.60 vs 0.59/0.79) — the map had simply drifted. `ProviderDefaultsServiceTest::testFlagshipTierIsNotRankedBelowTheFastTier()` now fails the build when a provider's MAIN tier ranks below its FAST tier, and `testEveryRecommendedDefaultPointsAtAnActiveCatalogEntry()` fails when a recommendation points at a deactivated row.
+
 ### A non-zero price under a "free" unit is silently free
 
 `normaliseToPerUnit()` maps `-`, `` and `free` to **0**, so a price stored under one of those units is displayed but never billed. Two Ollama rows shipped exactly that — BID 3 (`deepseek-r1:32b`, out 0.91) and BID 6 (`mistral:7b`, out 0.475) had `BOUTUNIT = '-'` while their input side was `per1M`, so their output tokens were free while input was charged. `Version20260727190000` corrects the unit only; the price values stay as they were, since Ollama rows are an operator-hosted synthetic resale basis and re-pricing them is a decision, not a fix.
@@ -314,6 +322,16 @@ Comparing the production catalog (`GET /api/v1/admin/models`) against `ModelCata
 `ModelCatalogTest::testNoCatalogPriceIsAuthoredUnderAUnitThatNormalisesToZero()` now fails the build if a catalog row is ever authored this way again. Note that `per_generation` (Higgsfield video, BIDs 302–308) is *not* this bug — unknown units fall through as per-1, which is what a flat per-clip fee needs.
 
 > **Removing a model from the catalog is only half a retirement.** `ModelSeeder` never deletes or deactivates rows, so a model dropped from `ModelCatalog.php` without a companion migration stays `BACTIVE=1, BSELECTABLE=1` in every existing database — still pickable in the UI and still billed at whatever price the stale row holds. That is how Opus 4.1/4.5 survived several releases. Always pair a catalog removal with a deactivation migration.
+
+### Why retirement means deactivation, not deletion
+
+Earlier notes here justified this with a foreign key from `BMESSAGES` to `BMODELS`. **That FK does not exist** — `BMESSAGES` has no model column at all; messages keep their model as denormalised `BMESSAGEMETA` strings (`ai_chat_model`, `ai_chat_provider`), which is why historical messages still render correctly after a retirement. Only two tables reference `BMODELS.BID`: `BUSELOG` and `BMODEL_PRICE_HISTORY`. The real reasons to deactivate are:
+
+1. **`DELETE` fails on any model that was ever used.** Both FKs are `ON DELETE RESTRICT`, so as soon as usage or a price change was recorded, the delete is rejected by the database — precisely for the long-lived models one actually wants to retire.
+2. **`DELETE` is not durable.** `ModelCatalog::upsert()` writes an explicit `BID`, and `app:seed` runs on every container start (`_docker/backend/docker-entrypoint.sh`). A deleted row whose catalog entry still exists is restored verbatim, with the same BID, on the next deploy. Deactivation survives instead, because `BACTIVE`/`BSELECTABLE`/`BISDEFAULT` are operator-owned and excluded from the `ON DUPLICATE KEY UPDATE` clause.
+3. **BIDs must never be reused**, since `BUSELOG` rows and cost history are keyed by them.
+
+Note that `app:model:disable` does **not** follow this policy — despite its name it issues `DELETE FROM BMODELS`, so it inherits both problems above. Retire models through a migration.
 
 ## Related issues
 


### PR DESCRIPTION
## Why

Groq no longer serves `llama-3.3-70b-versatile` (BID 9) — every request comes back as *"The model `llama-3.3-70b-versatile` does not exist or you do not have access to it"*. We found out because a user posted a screenshot in the team chat.

The row was not just a stale catalog entry. It was also the recommended `CHAT`/`TOOLS`/`ANALYZE` binding for Groq in `ProviderDefaultsService`, and Groq is **first** in `PREFERENCE_ORDER`. Since `app:provider:apply-defaults --auto` runs on every container start (`_docker/backend/docker-entrypoint.sh`) and `ChatReadinessService` calls the same path at runtime, any install holding a Groq key while its default provider had none was repointed at the dead model **unattended** — self-hosters included.

## What changed

- Catalog row BID 9 removed from `ModelCatalog.php`.
- Groq `CHAT`/`TOOLS`/`ANALYZE` → `groq:openai/gpt-oss-120b:chat` (BID 76), the successor the previous Groq retirement (`Version20260727180000`) already used.
- `Version20260819090000`: deactivates BID 9 and repoints `DEFAULTMODEL` bindings for every owner. Deactivation, not deletion — see below.
- Guard tests: a recommended default must resolve to an **active**, **chat-tagged** catalog row.
- The dead model removed as an example/fixture from 3 command help strings and 6 test files; `ModelListCommandTest` now reads a BID from the catalog instead of hardcoding one.
- `docs/PRICING_MAINTENANCE.md`: retirement logged, plus a correction — the file justified "deactivate, never delete" with a `BMESSAGES` → `BMODELS` foreign key **that does not exist**.

## Why deactivate instead of delete

Both real reasons differ from what the docs claimed:

1. `ModelCatalog::upsert()` writes an **explicit BID** and `app:seed` runs on every container start. A deleted row whose catalog entry still existed was restored verbatim on the next deploy. Deactivation survives because `BACTIVE`/`BSELECTABLE`/`BISDEFAULT` are operator-owned and excluded from `ON DUPLICATE KEY UPDATE`.
2. The only two FKs into `BMODELS` (`BUSELOG`, `BMODEL_PRICE_HISTORY`) are `ON DELETE RESTRICT`, so deleting a model that was ever used fails outright.

Note that `app:model:disable` does **not** follow this policy despite its name — it issues `DELETE FROM BMODELS`. Documented here, not fixed; that belongs in its own PR.

## Tradeoffs reviewers should weigh

These are deliberate, not oversights:

- **MAIN and FAST collapse onto one model.** #1392 and `_devextras/planning/archive/20260606_multitask-routing.md` deliberately made llama-3.3 the MAIN tier and gpt-oss-120b the cheap FAST router. Groq's remaining chat rows hold nothing above the router, so both tiers now point at BID 76. Alternatives that keep a split are Qwen3 32B (53) or Llama 3.1 8B Instant (236); neither is an obvious drop-in.
- **Output budget drops from 32768 to 16384 tokens**, because that is BID 76's catalog `max_tokens` and `ChatHandler` clamps to it. Rows 53 and 236 keep 32768 but change the tier more.
- **BID 76 is a reasoning model that our catalog does not declare as one.** The identical model on TrustedTokens carries `features: ['reasoning', 'tool_use', ...]`; the Groq row carries none, so the frontend thinking toggle stays hidden while `GroqProvider` does stream `reasoning_content`. Pre-existing (76 already serves SORT/PLAN/MEM) but more visible now that it answers users. Left for a follow-up rather than widened here.
- **Widget and prompt pins are not repaired.** `BWIDGETS.config.aiModelId` and `BPROMPTMETA.aiModel` can hold BID 9 and take precedence over `DEFAULTMODEL` in `ChatHandler`. Those were already broken before this PR and the earlier retirement migrations left the same gap. Widgets set to automated/`-1` fall through to `DEFAULTMODEL` and **are** repaired.
- **`BQUALITY`/`BRATING` were not used to pick the successor.** They are hand-authored and unmaintained; an earlier revision of this branch had a test comparing them and it has been removed.

## Migration safety

- Never touches `Schema $schema` — no comparator, Galera-safe.
- Raw, idempotent SQL. The `BPROVID` guard makes the `BMODELS` update a no-op on re-run, on an install where the row was already deleted, or where the BID means something else.
- Repoints all owners (global and per-user), but only when the successor exists **and is active**.
- Explicitly excludes `VECTORIZE`: swapping an embedding binding without re-vectorising corrupts every stored vector (issue #948). The retired row is chat-tagged, so a `VECTORIZE` binding on it can only come from operator error — precisely when a silent repoint does the most damage. The earlier retirement migrations did not have this guard.
- `down()` reactivates the rows and deliberately does not undo the repoints, matching `Version20260728120000`.

## What this PR does not do

The reason we learned about this from a screenshot is still unaddressed: there is no availability signal anywhere. Prices have a weekly LiteLLM drift check; models have nothing. Follow-up plan is a scheduled command diffing each provider's `/models` endpoint twice — against the running install's active rows, and against the catalog plus provider recommendations — reporting to Discord, plus classifying `model_not_found` provider errors so the providers without a listing API are covered too.

## Test plan

- [x] `make -C backend lint` — clean
- [x] `make -C backend phpstan` — no errors
- [x] `make -C backend test` — 3605 tests, no failures or errors
- [x] Migration applied locally: BID 9 → `BACTIVE=0, BSELECTABLE=0, BISDEFAULT=0`
- [x] Planted `DEFAULTMODEL` bindings on BID 9 for a synthetic owner: `CHAT` repointed to 76, `VECTORIZE` deliberately left untouched
- [x] `down()` / `up()` round-trip verified
- [x] `app:seed` re-run afterwards (simulating a container start): 101 models skipped, BID 9 stays deactivated — the row does not come back
- [ ] Verify on prod which state BID 9 is in: `SELECT BID, BACTIVE, BSELECTABLE FROM BMODELS WHERE BPROVID='llama-3.3-70b-versatile';` — the migration is a no-op if the row is gone or already deactivated
- [ ] After deploy, confirm a Groq-default install answers chat instead of erroring

Backend-only; no API or OpenAPI change, so no schema regeneration and no frontend checks needed.