### PR TITLE
feat(models): detect discontinued provider models before users hit them

### DIFF
--- a/_docker/backend/lib/container-runtime.sh
+++ b/_docker/backend/lib/container-runtime.sh
@@ -352,7 +352,7 @@ run_scheduler_role() {
     mkdir -p "$SYNAPLAN_RUNTIME_DIR"
     trap stop_scheduler TERM INT
 
-    runtime_log "Starting scheduler (media reaper every ${tick_seconds}s, ephemeral-file reaper every ${hourly_seconds}s, update check every ${daily_seconds}s)."
+    runtime_log "Starting scheduler (media reaper every ${tick_seconds}s, ephemeral-file reaper every ${hourly_seconds}s, update + model-availability check every ${daily_seconds}s)."
     while [ "$_scheduler_stopping" -eq 0 ]; do
         now="$(date +%s)"
         printf '%s\n' "$now" > "${SYNAPLAN_RUNTIME_DIR}/scheduler.heartbeat"
@@ -380,6 +380,15 @@ run_scheduler_role() {
             if ! run_scheduler_command bin/console --env="$env" app:updates:check --no-interaction; then
                 runtime_log "Update check failed; it will be retried on the next daily interval." >&2
             fi
+
+            # Discontinued-model detection. Read-only and reports only: it asks
+            # the providers the operator already configured a key for which
+            # models they still serve, and never changes a row. Installs without
+            # cloud keys make no outbound request at all.
+            if ! run_scheduler_command bin/console --env="$env" app:models:check-availability --notify --no-interaction; then
+                runtime_log "Model availability check failed; it will be retried on the next daily interval." >&2
+            fi
+
             next_daily=$((now + daily_seconds))
         fi
 

--- a/_docker/backend/tests/test-container-runtime.sh
+++ b/_docker/backend/tests/test-container-runtime.sh
@@ -105,6 +105,7 @@ echo "Case 2: scheduler runs every slot's command initially and writes a heartbe
 assert_contains "app:media:reap-jobs --no-interaction" "$COMMAND_LOG" "scheduler runs media reaper"
 assert_contains "app:files:reap-ephemeral --no-interaction" "$COMMAND_LOG" "scheduler runs ephemeral-file reaper"
 assert_contains "app:updates:check --no-interaction" "$COMMAND_LOG" "scheduler runs the daily update check"
+assert_contains "app:models:check-availability --notify --no-interaction" "$COMMAND_LOG" "scheduler runs the daily model availability check"
 if [ -s "$TMP_DIR/runtime/scheduler.heartbeat" ]; then
     assert_eq 1 1 "scheduler writes liveness heartbeat"
 else

--- a/backend/config/services.yaml
+++ b/backend/config/services.yaml
@@ -582,6 +582,11 @@ services:
     App\Service\MediaGenerationServiceInterface:
         alias: App\Service\MediaGenerationService
 
+    # Model availability detection talks to provider listing endpoints; the
+    # interface keeps the diff logic testable without credentials or network.
+    App\AI\Service\ProviderModelInventoryInterface:
+        alias: App\AI\Service\ProviderModelInventory
+
     App\Service\Media\GeneratedFileRegistrar:
         arguments:
             $uploadDir: '%kernel.project_dir%/var/uploads'

--- a/backend/src/AI/Service/ModelAvailabilityChecker.php
+++ b/backend/src/AI/Service/ModelAvailabilityChecker.php
@@ -1,0 +1,225 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\AI\Service;
+
+use App\AI\Credential\ProviderDefaultsService;
+use App\Model\ModelCatalog;
+use App\Repository\ModelRepository;
+
+/**
+ * Compares the models we offer against the models providers actually serve.
+ *
+ * Two scopes are reported independently, and they are genuinely different:
+ *
+ *   - {@see SCOPE_DATABASE} — what does THIS install still offer? Answered
+ *     against active `BMODELS` rows, because `ModelSeeder` never deactivates
+ *     anything: a row the catalog dropped long ago can still be selectable
+ *     here, and only the database knows that.
+ *   - {@see SCOPE_CATALOG} — what do we still ship to NEW installs? Answered
+ *     against {@see ModelCatalog}. An operator who already cleaned up their own
+ *     database would see nothing wrong while every fresh install keeps getting
+ *     the dead model.
+ *
+ * Detection runs in two stages. The provider's bulk listing is a cheap
+ * pre-filter, then every model missing from it is confirmed individually via
+ * {@see ProviderModelInventoryInterface::probe()}. The second stage is what makes the
+ * result trustworthy — listings omit live models (Gemini keeps Imagen out of
+ * `models.list`) and a listing-only verdict produces both false alarms and
+ * blind spots. Only a model the provider itself reports as unknown is confirmed.
+ *
+ * Findings stay advisory and are never applied automatically: retirement
+ * touches every user of an install and remains a reviewed migration.
+ */
+final readonly class ModelAvailabilityChecker
+{
+    public const SCOPE_DATABASE = 'database';
+    public const SCOPE_CATALOG = 'catalog';
+
+    /**
+     * Ceiling on per-model probes per provider. Reached only when a listing is
+     * technically valid but wildly incomplete; without the cap, one malformed
+     * response would turn into hundreds of requests. Models past the ceiling
+     * are reported unconfirmed rather than silently dropped.
+     */
+    private const MAX_PROBES_PER_PROVIDER = 25;
+
+    public function __construct(
+        private ProviderModelInventoryInterface $inventory,
+        private ModelRepository $modelRepository,
+        private ProviderDefaultsService $providerDefaults,
+    ) {
+    }
+
+    /**
+     * @return array{
+     *     providers: array<string, array{status: string, detail: string|null, servedCount: int, matchedCount: int, offeredCount: int}>,
+     *     findings: list<array{
+     *         provider: string,
+     *         providerId: string,
+     *         name: string,
+     *         tag: string,
+     *         bids: list<int>,
+     *         scopes: list<string>,
+     *         recommended: bool,
+     *         confirmed: bool,
+     *     }>,
+     * }
+     */
+    public function run(): array
+    {
+        $offered = $this->offeredModels();
+        $listings = [];
+        foreach (array_keys($offered) as $provider) {
+            $listings[$provider] = $this->inventory->fetch($provider);
+        }
+
+        $recommendedBids = $this->recommendedBids();
+        $findings = [];
+        $providers = [];
+
+        foreach ($offered as $provider => $models) {
+            $listing = $listings[$provider];
+            $matched = 0;
+            $probes = 0;
+
+            foreach ($models as $model) {
+                if (!$listing->isConclusive()) {
+                    continue;
+                }
+                if ($listing->serves($model['providerId'])) {
+                    ++$matched;
+                    continue;
+                }
+
+                $verdict = $probes < self::MAX_PROBES_PER_PROVIDER
+                    ? $this->inventory->probe($provider, $model['providerId'])
+                    : ModelProbeResult::Inconclusive;
+                ++$probes;
+
+                if (ModelProbeResult::Alive === $verdict) {
+                    ++$matched;
+                    continue;
+                }
+
+                $key = $provider.'|'.strtolower($model['providerId']);
+                $findings[$key] ??= [
+                    'provider' => $provider,
+                    'providerId' => $model['providerId'],
+                    'name' => $model['name'],
+                    'tag' => $model['tag'],
+                    'bids' => [],
+                    'scopes' => [],
+                    'recommended' => false,
+                    'confirmed' => ModelProbeResult::Gone === $verdict,
+                ];
+                foreach ($model['bids'] as $bid) {
+                    if (!in_array($bid, $findings[$key]['bids'], true)) {
+                        $findings[$key]['bids'][] = $bid;
+                    }
+                    $findings[$key]['recommended'] = $findings[$key]['recommended'] || ($recommendedBids[$bid] ?? false);
+                }
+                foreach ($model['scopes'] as $scope) {
+                    if (!in_array($scope, $findings[$key]['scopes'], true)) {
+                        $findings[$key]['scopes'][] = $scope;
+                    }
+                }
+            }
+
+            $providers[$provider] = [
+                'status' => $listing->status,
+                'detail' => $listing->detail,
+                'servedCount' => count($listing->modelIds),
+                'matchedCount' => $matched,
+                'offeredCount' => count($models),
+            ];
+        }
+
+        ksort($providers);
+        $findings = array_values($findings);
+        usort($findings, static function (array $a, array $b): int {
+            return [$b['confirmed'], $b['recommended'], $a['provider']]
+                <=> [$a['confirmed'], $a['recommended'], $b['provider']];
+        });
+
+        return ['providers' => $providers, 'findings' => $findings];
+    }
+
+    /**
+     * Everything we offer, per provider, merged across both scopes.
+     *
+     * @return array<string, array<string, array{providerId: string, name: string, tag: string, bids: list<int>, scopes: list<string>}>>
+     */
+    private function offeredModels(): array
+    {
+        $offered = [];
+
+        foreach ($this->modelRepository->findAllActive() as $model) {
+            $this->addOffered($offered, $model->getService(), $model->getProviderId(), $model->getName(), $model->getTag(), $model->getId(), self::SCOPE_DATABASE);
+        }
+
+        foreach (ModelCatalog::all() as $row) {
+            if (1 !== (int) ($row['active'] ?? 0)) {
+                continue;
+            }
+            $this->addOffered($offered, (string) $row['service'], (string) $row['providerId'], (string) $row['name'], (string) $row['tag'], (int) $row['id'], self::SCOPE_CATALOG);
+        }
+
+        return $offered;
+    }
+
+    /**
+     * @param array<string, array<string, array{providerId: string, name: string, tag: string, bids: list<int>, scopes: list<string>}>> $offered
+     */
+    private function addOffered(array &$offered, string $service, string $providerId, string $name, string $tag, ?int $bid, string $scope): void
+    {
+        $provider = ModelCatalog::normalizeProvider($service);
+        $key = strtolower($providerId).'|'.strtolower($tag);
+
+        $offered[$provider][$key] ??= [
+            'providerId' => $providerId,
+            'name' => $name,
+            'tag' => strtolower($tag),
+            'bids' => [],
+            'scopes' => [],
+        ];
+
+        if (null !== $bid && !in_array($bid, $offered[$provider][$key]['bids'], true)) {
+            $offered[$provider][$key]['bids'][] = $bid;
+        }
+        if (!in_array($scope, $offered[$provider][$key]['scopes'], true)) {
+            $offered[$provider][$key]['scopes'][] = $scope;
+        }
+    }
+
+    /**
+     * BIDs a provider recommends as a default binding. A dead model here is the
+     * urgent case: `app:provider:apply-defaults --auto` writes these unattended
+     * at container start, so nobody has to choose the model to be hit by it.
+     *
+     * @return array<int, bool>
+     */
+    private function recommendedBids(): array
+    {
+        $bids = [];
+        foreach (ProviderDefaultsService::PREFERENCE_ORDER as $provider) {
+            if (!ProviderDefaultsService::supports($provider)) {
+                continue;
+            }
+
+            try {
+                foreach ($this->providerDefaults->getRecommendedDefaults($provider) as $bid) {
+                    $bids[$bid] = true;
+                }
+            } catch (\Throwable) {
+                // A mapping that no longer resolves is a build inconsistency
+                // locked by ProviderDefaultsServiceTest; it must not break the
+                // report.
+                continue;
+            }
+        }
+
+        return $bids;
+    }
+}

--- a/backend/src/AI/Service/ModelProbeResult.php
+++ b/backend/src/AI/Service/ModelProbeResult.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\AI\Service;
+
+/**
+ * Verdict of asking a provider about one specific model id.
+ */
+enum ModelProbeResult
+{
+    /** The provider still knows this model. */
+    case Alive;
+
+    /** The provider answered that this model does not exist. */
+    case Gone;
+
+    /** No usable answer — rate limit, auth problem, outage, network error. */
+    case Inconclusive;
+}

--- a/backend/src/AI/Service/ProviderModelInventory.php
+++ b/backend/src/AI/Service/ProviderModelInventory.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\AI\Service;
+
+use App\AI\Credential\ProviderKeyCatalog;
+use App\AI\Credential\ProviderKeyStore;
+use App\Model\ModelCatalog;
+use Psr\Log\LoggerInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * Asks a cloud provider which models it currently serves.
+ *
+ * Reuses the listing endpoints already declared in {@see ProviderKeyCatalog}
+ * for API-key validation — those requests hit `/models` (or the provider's
+ * equivalent) and throw the response body away. This service keeps the body.
+ *
+ * Two provider shapes cover all supported APIs: OpenAI-compatible payloads
+ * expose `data[].id`, Google exposes `models[].name` prefixed with `models/`.
+ * Both are read on every response rather than switched per provider, so a
+ * provider that changes shape degrades to "unreachable" instead of silently
+ * reporting an empty catalog.
+ */
+final readonly class ProviderModelInventory implements ProviderModelInventoryInterface
+{
+    private const TIMEOUT_SECONDS = 20;
+    private const PROBE_TIMEOUT_SECONDS = 10;
+
+    /**
+     * Providers whose key-validation endpoint is not a model listing.
+     * HuggingFace validates against `whoami-v2`, which says nothing about
+     * served models, so it can never contribute an availability verdict.
+     *
+     * @var list<string>
+     */
+    private const NO_LISTING_ENDPOINT = ['huggingface'];
+
+    public function __construct(
+        private HttpClientInterface $httpClient,
+        private ProviderKeyStore $keyStore,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function fetch(string $provider): ProviderModelListing
+    {
+        $provider = ModelCatalog::normalizeProvider($provider);
+
+        if (!ProviderKeyCatalog::has($provider)) {
+            return ProviderModelListing::noListingEndpoint('Provider is not key-managed (self-hosted or per-install endpoint).');
+        }
+
+        if (in_array($provider, self::NO_LISTING_ENDPOINT, true)) {
+            return ProviderModelListing::noListingEndpoint('Provider exposes no model-listing endpoint.');
+        }
+
+        $key = $this->keyStore->getKey($provider);
+        if (null === $key) {
+            return ProviderModelListing::notConfigured();
+        }
+
+        $listing = ProviderKeyCatalog::get($provider)['validation'];
+        $headers = [];
+        foreach ($listing['headers'] as $name => $value) {
+            $headers[$name] = str_replace('{key}', $key, $value);
+        }
+
+        try {
+            $response = $this->httpClient->request($listing['method'], $listing['url'], [
+                'headers' => $headers,
+                'timeout' => self::TIMEOUT_SECONDS,
+            ]);
+            $status = $response->getStatusCode();
+            if ($status < 200 || $status >= 300) {
+                return ProviderModelListing::unreachable(sprintf('The provider API returned HTTP %d.', $status));
+            }
+
+            $modelIds = $this->extractModelIds($response->toArray(false));
+        } catch (\Throwable $e) {
+            $this->logger->warning('Model availability listing failed', [
+                'provider' => $provider,
+                'error' => $e->getMessage(),
+            ]);
+
+            return ProviderModelListing::unreachable('Could not read the provider model list: '.$e->getMessage());
+        }
+
+        if ([] === $modelIds) {
+            return ProviderModelListing::unreachable('The provider returned no recognisable model list.');
+        }
+
+        return ProviderModelListing::ok($modelIds);
+    }
+
+    /**
+     * Ask the provider about one specific model id.
+     *
+     * This is the reliable oracle, and the bulk listing is only a cheap
+     * pre-filter for it. A listing can omit a model that is very much alive:
+     * Gemini serves `imagen-4.0-generate-001` through `:predict` and leaves it
+     * out of `models.list`, while `GET /v1beta/models/imagen-4.0-generate-001`
+     * answers 200. Judging by listing membership alone reports such models as
+     * discontinued, and hides the opposite case just as easily.
+     *
+     * Every supported provider addresses a single model as `{listUrl}/{id}`.
+     */
+    public function probe(string $provider, string $providerModelId): ModelProbeResult
+    {
+        $provider = ModelCatalog::normalizeProvider($provider);
+        if (!ProviderKeyCatalog::has($provider)) {
+            return ModelProbeResult::Inconclusive;
+        }
+
+        $key = $this->keyStore->getKey($provider);
+        if (null === $key) {
+            return ModelProbeResult::Inconclusive;
+        }
+
+        $listing = ProviderKeyCatalog::get($provider)['validation'];
+        $headers = [];
+        foreach ($listing['headers'] as $name => $value) {
+            $headers[$name] = str_replace('{key}', $key, $value);
+        }
+
+        try {
+            $status = $this->httpClient->request('GET', rtrim($listing['url'], '/').'/'.ltrim($providerModelId, '/'), [
+                'headers' => $headers,
+                'timeout' => self::PROBE_TIMEOUT_SECONDS,
+            ])->getStatusCode();
+        } catch (\Throwable $e) {
+            $this->logger->warning('Model availability probe failed', [
+                'provider' => $provider,
+                'model' => $providerModelId,
+                'error' => $e->getMessage(),
+            ]);
+
+            return ModelProbeResult::Inconclusive;
+        }
+
+        // 400 is included because OpenAI-compatible providers answer an unknown
+        // model with "model_not_found" under either status. 401/403/429/5xx say
+        // nothing about the model and must stay inconclusive.
+        return match (true) {
+            $status >= 200 && $status < 300 => ModelProbeResult::Alive,
+            404 === $status, 400 === $status => ModelProbeResult::Gone,
+            default => ModelProbeResult::Inconclusive,
+        };
+    }
+
+    /**
+     * @param array<mixed> $payload
+     *
+     * @return list<string>
+     */
+    private function extractModelIds(array $payload): array
+    {
+        $ids = [];
+
+        foreach ($this->entries($payload, 'data') as $entry) {
+            $id = $entry['id'] ?? null;
+            if (is_string($id) && '' !== $id) {
+                $ids[] = $id;
+            }
+        }
+
+        foreach ($this->entries($payload, 'models') as $entry) {
+            $name = $entry['name'] ?? null;
+            if (is_string($name) && '' !== $name) {
+                $ids[] = preg_replace('#^models/#', '', $name) ?? $name;
+            }
+        }
+
+        return $ids;
+    }
+
+    /**
+     * @param array<mixed> $payload
+     *
+     * @return list<array<mixed>>
+     */
+    private function entries(array $payload, string $key): array
+    {
+        $list = $payload[$key] ?? null;
+        if (!is_array($list)) {
+            return [];
+        }
+
+        $entries = [];
+        foreach ($list as $entry) {
+            if (is_array($entry)) {
+                $entries[] = $entry;
+            }
+        }
+
+        return $entries;
+    }
+}

--- a/backend/src/AI/Service/ProviderModelInventoryInterface.php
+++ b/backend/src/AI/Service/ProviderModelInventoryInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\AI\Service;
+
+/**
+ * Reads which models a provider currently serves.
+ *
+ * Exists so availability logic can be exercised without provider credentials or
+ * network access — see `ModelAvailabilityCheckerTest`.
+ */
+interface ProviderModelInventoryInterface
+{
+    /**
+     * The provider's full model list, or why it could not be obtained.
+     */
+    public function fetch(string $provider): ProviderModelListing;
+
+    /**
+     * Whether the provider still knows one specific model id.
+     */
+    public function probe(string $provider, string $providerModelId): ModelProbeResult;
+}

--- a/backend/src/AI/Service/ProviderModelListing.php
+++ b/backend/src/AI/Service/ProviderModelListing.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\AI\Service;
+
+/**
+ * The result of asking one provider which models it currently serves.
+ *
+ * The distinction between {@see STATUS_OK} and every other status is the whole
+ * point of this class. A caller may only conclude "this model is gone" when the
+ * status is OK; an unreachable API, a missing key or a provider without a
+ * listing endpoint must never be read as an empty catalog, because that would
+ * report every model of that provider as discontinued at once.
+ */
+final readonly class ProviderModelListing
+{
+    public const STATUS_OK = 'ok';
+
+    /** The provider exposes no endpoint that enumerates served models. */
+    public const STATUS_NO_LISTING_ENDPOINT = 'no_listing_endpoint';
+
+    /** No API key is configured for this provider on this install. */
+    public const STATUS_NOT_CONFIGURED = 'not_configured';
+
+    /** The API could not be reached, rejected us, or returned nothing usable. */
+    public const STATUS_UNREACHABLE = 'unreachable';
+
+    /**
+     * @param list<string> $modelIds lowercased provider-side model ids
+     */
+    private function __construct(
+        public string $status,
+        public array $modelIds,
+        public ?string $detail,
+    ) {
+    }
+
+    /**
+     * @param list<string> $modelIds
+     */
+    public static function ok(array $modelIds): self
+    {
+        $normalised = [];
+        foreach ($modelIds as $id) {
+            $id = strtolower(trim($id));
+            if ('' !== $id) {
+                $normalised[$id] = true;
+            }
+        }
+
+        return new self(self::STATUS_OK, array_keys($normalised), null);
+    }
+
+    public static function noListingEndpoint(string $detail): self
+    {
+        return new self(self::STATUS_NO_LISTING_ENDPOINT, [], $detail);
+    }
+
+    public static function notConfigured(): self
+    {
+        return new self(self::STATUS_NOT_CONFIGURED, [], 'No API key configured.');
+    }
+
+    public static function unreachable(string $detail): self
+    {
+        return new self(self::STATUS_UNREACHABLE, [], $detail);
+    }
+
+    /**
+     * True only when the returned list can be trusted as complete enough to
+     * conclude that an absent model is really absent.
+     */
+    public function isConclusive(): bool
+    {
+        return self::STATUS_OK === $this->status;
+    }
+
+    public function serves(string $providerModelId): bool
+    {
+        return in_array(strtolower(trim($providerModelId)), $this->modelIds, true);
+    }
+}

--- a/backend/src/Command/CheckModelAvailabilityCommand.php
+++ b/backend/src/Command/CheckModelAvailabilityCommand.php
@@ -1,0 +1,229 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\AI\Service\ModelAvailabilityChecker;
+use App\AI\Service\ProviderModelListing;
+use App\Service\DiscordNotificationService;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Detects models a provider no longer serves, before users hit the error.
+ *
+ * Read-only by design: it never deactivates a row. A model can vanish from a
+ * listing for reasons other than discontinuation (rename, region gate, account
+ * tier), and an unattended `BACTIVE = 0` on a false positive would take a
+ * working model away from every user of the install. Retirement stays a
+ * reviewed migration — see `docs/PRICING_MAINTENANCE.md`.
+ */
+#[AsCommand(
+    name: 'app:models:check-availability',
+    description: 'Check whether providers still serve the models we offer (discontinuation detection)',
+)]
+final class CheckModelAvailabilityCommand extends Command
+{
+    /**
+     * Exit code for "we offer models the provider no longer serves". Distinct
+     * from Command::FAILURE (1, the command itself broke) so a scheduled run
+     * can tell the two apart.
+     */
+    private const EXIT_DRIFT_DETECTED = 2;
+
+    public function __construct(
+        private readonly ModelAvailabilityChecker $checker,
+        private readonly DiscordNotificationService $discord,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('fail-on-drift', null, InputOption::VALUE_NONE, 'Exit with code 2 if any offered model is missing from its provider listing')
+            ->addOption('notify', null, InputOption::VALUE_NONE, 'Send a Discord alert when models are missing (no-op without DISCORD_WEBHOOK_URL)')
+            ->setHelp(<<<'HELP'
+            Queries every key-configured provider for its current model list, then asks the
+            provider directly about each model that is missing from that list. Only models
+            the provider itself reports as unknown are treated as discontinued — listings
+            legitimately omit live models, so list membership alone is not evidence.
+
+            Two scopes are reported independently:
+              <info>database</info>  this install still offers the model (active BMODELS row)
+              <info>catalog</info>   we still ship the model to new installs (ModelCatalog)
+
+            Providers without an API key, without a listing endpoint, or that could not be
+            reached are reported as unchecked and never produce findings — an unreachable
+            API must not look like an empty catalog.
+
+            Nothing is changed. Retire a confirmed dead model with a reviewed migration.
+            HELP)
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        try {
+            $report = $this->checker->run();
+        } catch (\Throwable $e) {
+            $io->error('Model availability check failed: '.$e->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        $this->renderProviders($io, $report['providers']);
+
+        $checked = array_filter(
+            $report['providers'],
+            static fn (array $p): bool => ProviderModelListing::STATUS_OK === $p['status'],
+        );
+
+        if ([] === $checked) {
+            $io->warning('No provider could be checked. Availability is unknown, not confirmed — configure at least one API key.');
+
+            return Command::SUCCESS;
+        }
+
+        $confirmed = array_values(array_filter($report['findings'], static fn (array $f): bool => $f['confirmed']));
+        $unverified = array_values(array_filter($report['findings'], static fn (array $f): bool => !$f['confirmed']));
+
+        if ([] !== $unverified) {
+            $this->renderUnverified($io, $unverified);
+        }
+
+        if ([] === $confirmed) {
+            $io->success(sprintf('All models offered by the %d checked provider(s) are still served upstream.', count($checked)));
+
+            return Command::SUCCESS;
+        }
+
+        $this->renderConfirmed($io, $confirmed);
+
+        if ($input->getOption('notify')) {
+            $this->notify($io, $confirmed, $report['providers']);
+        }
+
+        return $input->getOption('fail-on-drift') ? self::EXIT_DRIFT_DETECTED : Command::SUCCESS;
+    }
+
+    /**
+     * @param array<string, array{status: string, detail: string|null, servedCount: int, matchedCount: int, offeredCount: int}> $providers
+     */
+    private function renderProviders(SymfonyStyle $io, array $providers): void
+    {
+        $rows = [];
+        foreach ($providers as $provider => $state) {
+            $rows[] = [
+                $provider,
+                match ($state['status']) {
+                    ProviderModelListing::STATUS_OK => sprintf(
+                        'checked — %d served, %d/%d of ours matched',
+                        $state['servedCount'],
+                        $state['matchedCount'],
+                        $state['offeredCount'],
+                    ),
+                    ProviderModelListing::STATUS_NOT_CONFIGURED => 'skipped — no API key',
+                    ProviderModelListing::STATUS_NO_LISTING_ENDPOINT => 'unchecked — no listing endpoint',
+                    default => 'unchecked — '.($state['detail'] ?? 'unreachable'),
+                },
+            ];
+        }
+
+        $io->table(['Provider', 'Status'], $rows);
+    }
+
+    /**
+     * @param list<array{provider: string, providerId: string, name: string, tag: string, bids: list<int>, scopes: list<string>, recommended: bool, confirmed: bool}> $findings
+     */
+    private function renderConfirmed(SymfonyStyle $io, array $findings): void
+    {
+        $io->table(
+            ['Provider', 'Provider model id', 'Name', 'Tag', 'BID', 'Scope', 'Provider default'],
+            array_map(static fn (array $f): array => [
+                $f['provider'],
+                $f['providerId'],
+                $f['name'],
+                $f['tag'],
+                implode(', ', array_map('strval', $f['bids'])),
+                implode(' + ', $f['scopes']),
+                $f['recommended'] ? 'yes' : '',
+            ], $findings),
+        );
+
+        $io->warning(sprintf('%d model(s) are offered but no longer served by their provider.', count($findings)));
+        $io->writeln([
+            'Verify each one against the provider\'s deprecation page, then retire it with a',
+            'migration — deactivate, never delete: see <info>docs/PRICING_MAINTENANCE.md</info>.',
+            '',
+            'Rows marked as a provider default are urgent: <info>app:provider:apply-defaults --auto</info>',
+            'assigns them unattended at container start.',
+            '',
+        ]);
+    }
+
+    /**
+     * @param list<array{provider: string, providerId: string, name: string, tag: string, bids: list<int>, scopes: list<string>, recommended: bool, confirmed: bool}> $findings
+     */
+    private function renderUnverified(SymfonyStyle $io, array $findings): void
+    {
+        $io->table(
+            ['Provider', 'Provider model id', 'Tag', 'BID'],
+            array_map(static fn (array $f): array => [
+                $f['provider'],
+                $f['providerId'],
+                $f['tag'],
+                implode(', ', array_map('strval', $f['bids'])),
+            ], $findings),
+        );
+
+        $io->note([
+            sprintf('%d model(s) are absent from their provider listing, but asking the provider', count($findings)),
+            'about them directly gave no usable answer (rate limit, auth or outage).',
+            'Their availability is unknown, not disproven, so they are NOT reported as',
+            'discontinued. Re-run later if they keep appearing here.',
+        ]);
+    }
+
+    /**
+     * @param list<array{provider: string, providerId: string, name: string, tag: string, bids: list<int>, scopes: list<string>, recommended: bool, confirmed: bool}> $findings
+     * @param array<string, array{status: string, detail: string|null, servedCount: int, matchedCount: int, offeredCount: int}>                                       $providers
+     */
+    private function notify(SymfonyStyle $io, array $findings, array $providers): void
+    {
+        if (!$this->discord->isEnabled()) {
+            $io->note('Discord notifications are disabled (no DISCORD_WEBHOOK_URL); reported to the console only.');
+
+            return;
+        }
+
+        $missing = [];
+        foreach ($findings as $finding) {
+            $missing[] = sprintf(
+                '%s `%s`%s — BID %s (%s)',
+                $finding['provider'],
+                $finding['providerId'],
+                $finding['recommended'] ? ' **[provider default]**' : '',
+                implode('/', array_map('strval', $finding['bids'])),
+                implode(' + ', $finding['scopes']),
+            );
+        }
+
+        $unchecked = [];
+        foreach ($providers as $provider => $state) {
+            if (ProviderModelListing::STATUS_OK !== $state['status']) {
+                $unchecked[] = $provider;
+            }
+        }
+
+        $this->discord->notifyModelAvailabilityDrift($missing, $unchecked);
+        $io->note('Discord alert sent.');
+    }
+}

--- a/backend/src/Repository/ModelRepository.php
+++ b/backend/src/Repository/ModelRepository.php
@@ -46,6 +46,25 @@ class ModelRepository extends ServiceEntityRepository
     }
 
     /**
+     * Every row this install currently offers, regardless of capability.
+     *
+     * Used by the model-availability check, which must judge what the running
+     * database serves rather than what the catalog declares — an install can
+     * hold active rows the catalog dropped long ago.
+     *
+     * @return Model[] Array of active models sorted by service, then id
+     */
+    public function findAllActive(): array
+    {
+        return $this->createQueryBuilder('m')
+            ->where('m.active = 1')
+            ->orderBy('m.service', 'ASC')
+            ->addOrderBy('m.id', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
      * Get model by service and provider ID.
      *
      * @param string $service    Service name (e.g., 'Ollama', 'OpenAI')

--- a/backend/src/Service/DiscordNotificationService.php
+++ b/backend/src/Service/DiscordNotificationService.php
@@ -18,12 +18,15 @@ final readonly class DiscordNotificationService
     // Discord embed colors
     private const COLOR_SUCCESS = 0x00FF00; // Green
     private const COLOR_ERROR = 0xFF0000;   // Red
+    private const COLOR_WARNING = 0xFFA500; // Orange
 
     // Truncation limits (Discord API: field value max 1024, total embed max 6000)
     // @see https://discord.com/developers/docs/resources/channel#embed-object-embed-limits
     private const MAX_USER_MESSAGE = 200;  // Truncate user message preview
     private const MAX_RESPONSE = 300;      // Truncate response preview
     private const MAX_ERROR = 450;         // Truncate error (leaves room for code block formatting)
+    private const MAX_FIELD_VALUE = 1024;  // Hard Discord limit for a single field value
+    private const MAX_DRIFT_ENTRIES = 15;  // Model-availability findings listed before "… and N more"
 
     public function __construct(
         private HttpClientInterface $httpClient,
@@ -711,6 +714,80 @@ final readonly class DiscordNotificationService
             footer: 'Synaplan Embedding · throttled to 1/hour per provider pair',
             mentionEveryone: true,
         );
+    }
+
+    /**
+     * Notify that we still offer models a provider no longer lists.
+     *
+     * Deliberately not an `@everyone` incident: the finding is advisory and the
+     * models are still installed and selectable, so there is nothing to ack at
+     * 3am. It is a standing reminder that a retirement migration is due before
+     * users start seeing provider errors.
+     *
+     * @param list<string> $missingModels      human-readable lines, most urgent first
+     * @param list<string> $uncheckedProviders providers that could not be verified
+     */
+    public function notifyModelAvailabilityDrift(array $missingModels, array $uncheckedProviders): void
+    {
+        if (!$this->isEnabled() || [] === $missingModels) {
+            return;
+        }
+
+        $fields = [
+            [
+                'name' => sprintf('Missing upstream (%d)', count($missingModels)),
+                'value' => $this->bulletList($missingModels, self::MAX_DRIFT_ENTRIES),
+                'inline' => false,
+            ],
+            [
+                'name' => 'Action required',
+                'value' => 'Confirm on the provider deprecation page, then retire via migration (deactivate, never delete) — docs/PRICING_MAINTENANCE.md.',
+                'inline' => false,
+            ],
+        ];
+
+        if ([] !== $uncheckedProviders) {
+            $fields[] = [
+                'name' => 'Not verified',
+                'value' => $this->truncate(implode(', ', $uncheckedProviders), self::MAX_ERROR),
+                'inline' => false,
+            ];
+        }
+
+        $this->sendEmbed(
+            title: '⚠️ Discontinued AI models detected',
+            color: self::COLOR_WARNING,
+            fields: $fields,
+            footer: 'Synaplan model availability check · daily',
+        );
+    }
+
+    /**
+     * Render lines as a Discord field value, capped at both the entry count and
+     * the API's 1024-character field limit.
+     *
+     * @param list<string> $lines
+     */
+    private function bulletList(array $lines, int $maxEntries): string
+    {
+        $shown = array_slice($lines, 0, $maxEntries);
+        $value = '';
+        $rendered = 0;
+        foreach ($shown as $line) {
+            $candidate = $value.'• '.$line."\n";
+            if (mb_strlen($candidate) > self::MAX_FIELD_VALUE - 40) {
+                break;
+            }
+            $value = $candidate;
+            ++$rendered;
+        }
+
+        $omitted = count($lines) - $rendered;
+        if ($omitted > 0) {
+            $value .= sprintf('… and %d more', $omitted);
+        }
+
+        return '' === $value ? '(none)' : $value;
     }
 
     /**

--- a/backend/tests/Command/CheckModelAvailabilityCommandTest.php
+++ b/backend/tests/Command/CheckModelAvailabilityCommandTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Command;
+
+use App\AI\Credential\ProviderDefaultsService;
+use App\AI\Service\ModelAvailabilityChecker;
+use App\AI\Service\ModelProbeResult;
+use App\AI\Service\ProviderModelInventoryInterface;
+use App\AI\Service\ProviderModelListing;
+use App\Command\CheckModelAvailabilityCommand;
+use App\Entity\Model;
+use App\Repository\ConfigRepository;
+use App\Repository\ModelRepository;
+use App\Repository\UserRepository;
+use App\Service\DiscordNotificationService;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+final class CheckModelAvailabilityCommandTest extends TestCase
+{
+    /** @var list<string> */
+    private array $webhookCalls = [];
+
+    public function testReportsSuccessWhenEverythingIsStillServed(): void
+    {
+        $tester = $this->tester(ProviderModelListing::notConfigured(), ModelProbeResult::Alive);
+        $tester->execute(['--fail-on-drift' => true]);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $this->assertStringContainsString('No provider could be checked', $tester->getDisplay());
+    }
+
+    public function testConfirmedFindingFailsOnlyWhenAskedTo(): void
+    {
+        $tester = $this->tester(ProviderModelListing::ok(['unrelated']), ModelProbeResult::Gone);
+        $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode(), 'Without --fail-on-drift the command only reports.');
+        $this->assertStringContainsString('no longer served by their provider', $tester->getDisplay());
+    }
+
+    public function testConfirmedFindingExitsWithTheDriftCode(): void
+    {
+        $tester = $this->tester(ProviderModelListing::ok(['unrelated']), ModelProbeResult::Gone);
+        $tester->execute(['--fail-on-drift' => true]);
+
+        $this->assertSame(2, $tester->getStatusCode());
+    }
+
+    /**
+     * An unconfirmed finding is an unanswered question, not a retirement, so it
+     * must neither fail the run nor raise an alert.
+     */
+    public function testUnconfirmedFindingsNeitherFailNorNotify(): void
+    {
+        $tester = $this->tester(ProviderModelListing::ok(['unrelated']), ModelProbeResult::Inconclusive);
+        $tester->execute(['--fail-on-drift' => true, '--notify' => true]);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $this->assertStringContainsString('no usable answer', $tester->getDisplay());
+        $this->assertSame([], $this->webhookCalls, 'Unconfirmed findings must not reach Discord.');
+    }
+
+    public function testNotifyIsOptIn(): void
+    {
+        $tester = $this->tester(ProviderModelListing::ok(['unrelated']), ModelProbeResult::Gone);
+        $tester->execute([]);
+        $this->assertSame([], $this->webhookCalls);
+
+        $tester = $this->tester(ProviderModelListing::ok(['unrelated']), ModelProbeResult::Gone);
+        $tester->execute(['--notify' => true]);
+        $this->assertCount(1, $this->webhookCalls);
+    }
+
+    public function testFindingNamesTheModelAndItsScopes(): void
+    {
+        $tester = $this->tester(ProviderModelListing::ok(['unrelated']), ModelProbeResult::Gone);
+        $tester->execute([]);
+
+        $display = $tester->getDisplay();
+        $this->assertStringContainsString('retired-test-model', $display);
+        $this->assertStringContainsString(ModelAvailabilityChecker::SCOPE_DATABASE, $display);
+        $this->assertStringContainsString('docs/PRICING_MAINTENANCE.md', $display, 'The report must point at the retirement procedure.');
+    }
+
+    private function tester(ProviderModelListing $listing, ModelProbeResult $verdict): CommandTester
+    {
+        $this->webhookCalls = [];
+
+        $inventory = $this->createStub(ProviderModelInventoryInterface::class);
+        $inventory->method('fetch')->willReturnCallback(
+            static fn (string $provider): ProviderModelListing => 'groq' === $provider
+                ? $listing
+                : ProviderModelListing::notConfigured(),
+        );
+        $inventory->method('probe')->willReturnCallback(
+            static fn (string $provider, string $modelId): ModelProbeResult => 'retired-test-model' === $modelId
+                ? $verdict
+                : ModelProbeResult::Alive,
+        );
+
+        $modelRepository = $this->createStub(ModelRepository::class);
+        $modelRepository->method('findAllActive')->willReturn([$this->model()]);
+
+        $checker = new ModelAvailabilityChecker(
+            $inventory,
+            $modelRepository,
+            new ProviderDefaultsService($this->createStub(ConfigRepository::class), new ArrayAdapter(), new NullLogger()),
+        );
+
+        $webhookClient = new MockHttpClient(function (string $method, string $url): MockResponse {
+            $this->webhookCalls[] = $url;
+
+            return new MockResponse('', ['http_code' => 204]);
+        });
+
+        $command = new CheckModelAvailabilityCommand(
+            $checker,
+            new DiscordNotificationService(
+                $webhookClient,
+                new NullLogger(),
+                $this->createStub(UserRepository::class),
+                'https://discord.test/webhook',
+            ),
+        );
+
+        $application = new Application();
+        $application->addCommand($command);
+
+        return new CommandTester($application->find('app:models:check-availability'));
+    }
+
+    private function model(): Model
+    {
+        $model = new Model();
+        $model->setService('Groq');
+        $model->setProviderId('retired-test-model');
+        $model->setName('Retired Test Model');
+        $model->setTag('chat');
+        $model->setActive(1);
+
+        return $model;
+    }
+}

--- a/backend/tests/Unit/AI/Service/ModelAvailabilityCheckerTest.php
+++ b/backend/tests/Unit/AI/Service/ModelAvailabilityCheckerTest.php
@@ -1,0 +1,286 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\AI\Service;
+
+use App\AI\Credential\ProviderDefaultsService;
+use App\AI\Service\ModelAvailabilityChecker;
+use App\AI\Service\ModelProbeResult;
+use App\AI\Service\ProviderModelInventoryInterface;
+use App\AI\Service\ProviderModelListing;
+use App\Entity\Model;
+use App\Model\ModelCatalog;
+use App\Repository\ConfigRepository;
+use App\Repository\ModelRepository;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+/**
+ * The rules that make this detector trustworthy rather than noisy.
+ *
+ * Every case here mirrors a real provider behaviour observed while building the
+ * check: listings that omit live models, listings that cannot be obtained, and
+ * capabilities a provider serves through a separate product surface.
+ *
+ * The checker always reads the real {@see ModelCatalog}, so assertions target
+ * individual models instead of counting findings — a catalog edit must not be
+ * able to break an unrelated test.
+ */
+final class ModelAvailabilityCheckerTest extends TestCase
+{
+    private const TEST_PROVIDER = 'groq';
+
+    /**
+     * The false alarm a listing-only check produces. Gemini serves
+     * `imagen-4.0-generate-001` but omits it from `models.list` and answers 200
+     * when asked directly, so absence from a listing is not evidence by itself.
+     */
+    public function testModelMissingFromListingButAliveOnProbeIsNotReported(): void
+    {
+        $report = $this->report(
+            activeModels: [$this->model('Groq', 'served-elsewhere', 'text2pic')],
+            listing: ProviderModelListing::ok(['unrelated-model']),
+            verdicts: ['served-elsewhere' => ModelProbeResult::Alive],
+        );
+
+        $this->assertNull($this->finding($report, 'served-elsewhere'));
+    }
+
+    public function testModelTheProviderReportsAsUnknownIsConfirmed(): void
+    {
+        $report = $this->report(
+            activeModels: [$this->model('Groq', 'retired-chat-model', 'chat')],
+            listing: ProviderModelListing::ok(['unrelated-model']),
+            verdicts: ['retired-chat-model' => ModelProbeResult::Gone],
+        );
+
+        $finding = $this->finding($report, 'retired-chat-model');
+        $this->assertNotNull($finding);
+        $this->assertTrue($finding['confirmed']);
+        $this->assertSame([ModelAvailabilityChecker::SCOPE_DATABASE], $finding['scopes']);
+    }
+
+    /**
+     * A rate limit or outage says nothing about the model, so it stays visible
+     * to a human without counting as a confirmed retirement.
+     */
+    public function testInconclusiveProbeIsReportedButNotConfirmed(): void
+    {
+        $report = $this->report(
+            activeModels: [$this->model('Groq', 'rate-limited-model', 'chat')],
+            listing: ProviderModelListing::ok(['unrelated-model']),
+            verdicts: ['rate-limited-model' => ModelProbeResult::Inconclusive],
+        );
+
+        $finding = $this->finding($report, 'rate-limited-model');
+        $this->assertNotNull($finding);
+        $this->assertFalse($finding['confirmed']);
+    }
+
+    /**
+     * The most damaging possible bug: reading "we could not ask" as "the
+     * provider serves nothing" would report every model of that provider as
+     * discontinued in a single run.
+     */
+    public function testUnreachableProviderNeverProducesFindings(): void
+    {
+        $inventory = $this->createMock(ProviderModelInventoryInterface::class);
+        $inventory->method('fetch')->willReturn(ProviderModelListing::unreachable('HTTP 500'));
+        $inventory->expects($this->never())->method('probe');
+
+        $report = $this->reportWith($inventory, [
+            $this->model('Groq', 'retired-chat-model', 'chat'),
+            $this->model('Groq', 'another-retired-model', 'chat'),
+        ]);
+
+        $this->assertSame([], $report['findings']);
+        $this->assertSame(ProviderModelListing::STATUS_UNREACHABLE, $report['providers'][self::TEST_PROVIDER]['status']);
+    }
+
+    public function testProviderWithoutConfiguredKeyProducesNoFindings(): void
+    {
+        $inventory = $this->createMock(ProviderModelInventoryInterface::class);
+        $inventory->method('fetch')->willReturn(ProviderModelListing::notConfigured());
+        $inventory->expects($this->never())->method('probe');
+
+        $report = $this->reportWith($inventory, [$this->model('Groq', 'retired-chat-model', 'chat')]);
+
+        $this->assertSame([], $report['findings']);
+    }
+
+    /**
+     * A dead model that `app:provider:apply-defaults --auto` assigns unattended
+     * is the urgent case, so it must be marked and sorted ahead of the rest.
+     */
+    public function testRecommendedProviderDefaultIsFlaggedAndRankedFirst(): void
+    {
+        $chatBid = $this->providerDefaults()->getRecommendedDefaults(self::TEST_PROVIDER)['CHAT'];
+        $recommendedProviderId = $this->catalogProviderId($chatBid);
+
+        $report = $this->report(
+            activeModels: [$this->model('Groq', 'ordinary-retired-model', 'chat')],
+            listing: ProviderModelListing::ok(['unrelated-model']),
+            verdicts: [
+                'ordinary-retired-model' => ModelProbeResult::Gone,
+                $recommendedProviderId => ModelProbeResult::Gone,
+            ],
+        );
+
+        $finding = $this->finding($report, $recommendedProviderId);
+        $this->assertNotNull($finding);
+        $this->assertTrue($finding['recommended']);
+        $this->assertContains($chatBid, $finding['bids']);
+        $this->assertSame($recommendedProviderId, $report['findings'][0]['providerId'], 'A provider default must be reported first.');
+    }
+
+    /**
+     * The database and the catalog answer different questions: an operator who
+     * already deactivated a row locally must still learn that new installs keep
+     * getting it.
+     */
+    public function testCatalogEntryIsCheckedEvenWhenTheDatabaseHasNoSuchRow(): void
+    {
+        $catalogProviderId = $this->firstCatalogProviderId();
+
+        $report = $this->report(
+            activeModels: [],
+            listing: ProviderModelListing::ok(['unrelated-model']),
+            verdicts: [$catalogProviderId => ModelProbeResult::Gone],
+        );
+
+        $finding = $this->finding($report, $catalogProviderId);
+        $this->assertNotNull($finding);
+        $this->assertSame([ModelAvailabilityChecker::SCOPE_CATALOG], $finding['scopes']);
+    }
+
+    /**
+     * A listing that parses but is wildly incomplete must not turn into hundreds
+     * of probe requests. Models past the ceiling stay visible as unconfirmed
+     * rather than being dropped.
+     */
+    public function testProbesAreCappedPerProvider(): void
+    {
+        $activeModels = [];
+        for ($i = 0; $i < 40; ++$i) {
+            $activeModels[] = $this->model('Groq', sprintf('bulk-model-%02d', $i), 'chat');
+        }
+
+        $probed = 0;
+        $inventory = $this->createStub(ProviderModelInventoryInterface::class);
+        $inventory->method('fetch')->willReturnCallback(
+            static fn (string $provider): ProviderModelListing => self::TEST_PROVIDER === $provider
+                ? ProviderModelListing::ok(['unrelated-model'])
+                : ProviderModelListing::notConfigured(),
+        );
+        $inventory->method('probe')->willReturnCallback(
+            static function () use (&$probed): ModelProbeResult {
+                ++$probed;
+
+                return ModelProbeResult::Gone;
+            },
+        );
+
+        $report = $this->reportWith($inventory, $activeModels);
+
+        $this->assertLessThanOrEqual(25, $probed, 'The per-provider probe ceiling must hold.');
+        $unconfirmed = array_filter($report['findings'], static fn (array $f): bool => !$f['confirmed']);
+        $this->assertNotSame([], $unconfirmed, 'Models beyond the ceiling stay reported, just unconfirmed.');
+    }
+
+    /**
+     * @param list<Model>                     $activeModels
+     * @param array<string, ModelProbeResult> $verdicts
+     *
+     * @return array{providers: array<string, array{status: string, detail: string|null, servedCount: int, matchedCount: int, offeredCount: int}>, findings: list<array{provider: string, providerId: string, name: string, tag: string, bids: list<int>, scopes: list<string>, recommended: bool, confirmed: bool}>}
+     */
+    private function report(array $activeModels, ProviderModelListing $listing, array $verdicts): array
+    {
+        $inventory = $this->createStub(ProviderModelInventoryInterface::class);
+        $inventory->method('fetch')->willReturnCallback(
+            static fn (string $provider): ProviderModelListing => self::TEST_PROVIDER === $provider
+                ? $listing
+                : ProviderModelListing::notConfigured(),
+        );
+        // Everything not named by the test is alive, so unrelated catalog rows of
+        // the same provider cannot leak into the assertions.
+        $inventory->method('probe')->willReturnCallback(
+            static fn (string $provider, string $modelId): ModelProbeResult => $verdicts[$modelId] ?? ModelProbeResult::Alive,
+        );
+
+        return $this->reportWith($inventory, $activeModels);
+    }
+
+    /**
+     * @param list<Model> $activeModels
+     *
+     * @return array{providers: array<string, array{status: string, detail: string|null, servedCount: int, matchedCount: int, offeredCount: int}>, findings: list<array{provider: string, providerId: string, name: string, tag: string, bids: list<int>, scopes: list<string>, recommended: bool, confirmed: bool}>}
+     */
+    private function reportWith(ProviderModelInventoryInterface $inventory, array $activeModels): array
+    {
+        $modelRepository = $this->createStub(ModelRepository::class);
+        $modelRepository->method('findAllActive')->willReturn($activeModels);
+
+        return (new ModelAvailabilityChecker($inventory, $modelRepository, $this->providerDefaults()))->run();
+    }
+
+    /**
+     * @param array{providers: array<string, array{status: string, detail: string|null, servedCount: int, matchedCount: int, offeredCount: int}>, findings: list<array{provider: string, providerId: string, name: string, tag: string, bids: list<int>, scopes: list<string>, recommended: bool, confirmed: bool}>} $report
+     *
+     * @return array{provider: string, providerId: string, name: string, tag: string, bids: list<int>, scopes: list<string>, recommended: bool, confirmed: bool}|null
+     */
+    private function finding(array $report, string $providerId): ?array
+    {
+        foreach ($report['findings'] as $finding) {
+            if ($finding['providerId'] === $providerId) {
+                return $finding;
+            }
+        }
+
+        return null;
+    }
+
+    private function providerDefaults(): ProviderDefaultsService
+    {
+        return new ProviderDefaultsService(
+            $this->createStub(ConfigRepository::class),
+            new ArrayAdapter(),
+            new NullLogger(),
+        );
+    }
+
+    private function catalogProviderId(int $bid): string
+    {
+        foreach (ModelCatalog::all() as $row) {
+            if ((int) $row['id'] === $bid) {
+                return (string) $row['providerId'];
+            }
+        }
+
+        self::fail(sprintf('ModelCatalog has no entry with BID %d.', $bid));
+    }
+
+    private function firstCatalogProviderId(): string
+    {
+        foreach (ModelCatalog::all() as $row) {
+            if (self::TEST_PROVIDER === ModelCatalog::normalizeProvider((string) $row['service']) && 1 === (int) $row['active']) {
+                return (string) $row['providerId'];
+            }
+        }
+
+        self::fail(sprintf('ModelCatalog has no active %s entry.', self::TEST_PROVIDER));
+    }
+
+    private function model(string $service, string $providerId, string $tag): Model
+    {
+        $model = new Model();
+        $model->setService($service);
+        $model->setProviderId($providerId);
+        $model->setName($providerId);
+        $model->setTag($tag);
+        $model->setActive(1);
+
+        return $model;
+    }
+}

--- a/backend/tests/Unit/AI/Service/ProviderModelInventoryTest.php
+++ b/backend/tests/Unit/AI/Service/ProviderModelInventoryTest.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\AI\Service;
+
+use App\AI\Credential\ProviderKeyStore;
+use App\AI\Service\ModelProbeResult;
+use App\AI\Service\ProviderModelInventory;
+use App\AI\Service\ProviderModelListing;
+use App\Repository\ConfigRepository;
+use App\Service\EncryptionService;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+final class ProviderModelInventoryTest extends TestCase
+{
+    public function testParsesOpenAiCompatibleListing(): void
+    {
+        $listing = $this->inventory(new MockResponse('{"data":[{"id":"openai/gpt-oss-120b"},{"id":"Whisper-Large-V3"}]}'))
+            ->fetch('groq');
+
+        $this->assertTrue($listing->isConclusive());
+        $this->assertTrue($listing->serves('openai/gpt-oss-120b'));
+        $this->assertTrue($listing->serves('whisper-large-v3'), 'Model ids must match case-insensitively.');
+        $this->assertFalse($listing->serves('llama-3.3-70b-versatile'));
+    }
+
+    public function testParsesGeminiListingAndStripsTheModelsPrefix(): void
+    {
+        $listing = $this->inventory(new MockResponse('{"models":[{"name":"models/gemini-2.5-flash"}]}'), 'google')
+            ->fetch('google');
+
+        $this->assertTrue($listing->isConclusive());
+        $this->assertTrue($listing->serves('gemini-2.5-flash'));
+    }
+
+    /**
+     * An empty or unrecognised payload must never become a conclusive empty
+     * catalog — that would report every model of the provider as discontinued.
+     */
+    public function testEmptyPayloadIsInconclusiveRatherThanAnEmptyCatalog(): void
+    {
+        $listing = $this->inventory(new MockResponse('{"data":[]}'))->fetch('groq');
+
+        $this->assertFalse($listing->isConclusive());
+        $this->assertSame(ProviderModelListing::STATUS_UNREACHABLE, $listing->status);
+    }
+
+    public function testHttpErrorIsInconclusive(): void
+    {
+        $listing = $this->inventory(new MockResponse('{"error":"nope"}', ['http_code' => 500]))->fetch('groq');
+
+        $this->assertFalse($listing->isConclusive());
+        $this->assertSame(ProviderModelListing::STATUS_UNREACHABLE, $listing->status);
+    }
+
+    public function testTransportFailureIsInconclusive(): void
+    {
+        $client = new MockHttpClient(static function (): MockResponse {
+            throw new \RuntimeException('DNS failure');
+        });
+
+        $listing = $this->inventoryWithClient($client)->fetch('groq');
+
+        $this->assertFalse($listing->isConclusive());
+        $this->assertSame(ProviderModelListing::STATUS_UNREACHABLE, $listing->status);
+    }
+
+    public function testProviderWithoutKeyIsReportedAsNotConfigured(): void
+    {
+        $listing = $this->inventory(new MockResponse('{"data":[{"id":"x"}]}'), 'google')->fetch('mistral');
+
+        $this->assertSame(ProviderModelListing::STATUS_NOT_CONFIGURED, $listing->status);
+        $this->assertFalse($listing->isConclusive());
+    }
+
+    /**
+     * HuggingFace validates keys against `whoami-v2`, which lists no models, so
+     * it can never contribute an availability verdict.
+     */
+    public function testHuggingFaceHasNoListingEndpoint(): void
+    {
+        $listing = $this->inventory(new MockResponse('{}'), 'huggingface')->fetch('huggingface');
+
+        $this->assertSame(ProviderModelListing::STATUS_NO_LISTING_ENDPOINT, $listing->status);
+    }
+
+    public function testSelfHostedProviderHasNoListingEndpoint(): void
+    {
+        $listing = $this->inventory(new MockResponse('{}'))->fetch('ollama');
+
+        $this->assertSame(ProviderModelListing::STATUS_NO_LISTING_ENDPOINT, $listing->status);
+    }
+
+    public function testProbeVerdicts(): void
+    {
+        $expected = [
+            200 => ModelProbeResult::Alive,
+            404 => ModelProbeResult::Gone,
+            400 => ModelProbeResult::Gone,
+            401 => ModelProbeResult::Inconclusive,
+            429 => ModelProbeResult::Inconclusive,
+            500 => ModelProbeResult::Inconclusive,
+        ];
+
+        foreach ($expected as $status => $verdict) {
+            $actual = $this->inventory(new MockResponse('{}', ['http_code' => $status]))
+                ->probe('groq', 'some-model');
+
+            $this->assertSame($verdict, $actual, sprintf('HTTP %d must map to %s.', $status, $verdict->name));
+        }
+    }
+
+    public function testProbeAddressesTheModelUnderTheListingUrl(): void
+    {
+        $requested = [];
+        $client = new MockHttpClient(static function (string $method, string $url) use (&$requested): MockResponse {
+            $requested[] = $url;
+
+            return new MockResponse('{}', ['http_code' => 404]);
+        });
+
+        $this->inventoryWithClient($client)->probe('groq', 'meta-llama/llama-4-scout-17b-16e-instruct');
+
+        $this->assertSame(
+            ['https://api.groq.com/openai/v1/models/meta-llama/llama-4-scout-17b-16e-instruct'],
+            $requested,
+            'A slash inside a model id is part of the path and must survive unescaped.',
+        );
+    }
+
+    private function inventory(MockResponse $response, string $provider = 'groq'): ProviderModelInventory
+    {
+        return $this->inventoryWithClient(new MockHttpClient($response), $provider);
+    }
+
+    private function inventoryWithClient(MockHttpClient $client, string $provider = 'groq'): ProviderModelInventory
+    {
+        $keyStore = new ProviderKeyStore(
+            $this->createStub(ConfigRepository::class),
+            new EncryptionService('unit-test-secret', new NullLogger()),
+            new NullLogger(),
+            [$provider => 'unit-test-provider-key-0123456789'],
+        );
+
+        return new ProviderModelInventory($client, $keyStore, new NullLogger());
+    }
+}

--- a/docs/PRICING_MAINTENANCE.md
+++ b/docs/PRICING_MAINTENANCE.md
@@ -119,7 +119,9 @@ Exit codes match `app:sync-model-prices`: `0` clean, `1` the command broke, `2` 
 
 ### First run against live APIs (2026-08-19)
 
-Six confirmed retirements, each re-verified by hand: Groq dropped `llama-3.3-70b-versatile` (BID 9), `llama-3.1-8b-instant` (236), `qwen/qwen3-32b` (53) and `meta-llama/llama-4-scout-17b-16e-instruct` (17 — the Groq `PIC2TEXT` default), xAI dropped `grok-stt` (321 — the xAI `SOUND2TEXT` default) and `grok-tts` (320). Groq's current list is 13 models; `whisper-large-v3` and `openai/gpt-oss-*` are unaffected. Retirement migrations are tracked separately per provider.
+Six confirmed retirements, each re-verified by hand: Groq dropped `llama-3.3-70b-versatile` (BID 9), `llama-3.1-8b-instant` (236), `qwen/qwen3-32b` (53) and `meta-llama/llama-4-scout-17b-16e-instruct` (17 — the Groq `PIC2TEXT` default), xAI dropped `grok-stt` (321 — the xAI `SOUND2TEXT` default) and `grok-tts` (320). Groq's current list is 13 models; `whisper-large-v3` and `openai/gpt-oss-*` are unaffected.
+
+The four Groq rows were retired in `Version20260819080000` (#1513), which also added Groq Qwen 3.6 27B (324/325) as their successor. Re-running the check after that migration reports Groq at `7/7 matched`: the retired rows are out of the active set and the freshly added successor BIDs produce no false positive. The two xAI rows stay open (#1514) — the catalog has no xAI replacement for either capability, so the `SOUND2TEXT` recommendation has to move to another provider or be dropped rather than repointed within xAI.
 
 ## Maintenance links
 

--- a/docs/PRICING_MAINTENANCE.md
+++ b/docs/PRICING_MAINTENANCE.md
@@ -93,6 +93,34 @@ Provider billing-mechanics cheat-sheet (verified 2026-07-13):
 
 Catalog now set to DeepInfra rates. Note K2.7 was previously $0.95/$4.00 (ABOVE DeepInfra) → we had been overcharging customers; K2.5/K2.6 were below → we had been losing money.
 
+## Discontinuation detection — `app:models:check-availability`
+
+Providers retire models without telling us, and until now we found out when a user hit a provider error. This command finds it first.
+
+```bash
+docker compose exec -T backend php bin/console app:models:check-availability --fail-on-drift; echo $?
+```
+
+It runs in **two stages, and the second one is the point**: the provider's model list is only a cheap pre-filter, then every model missing from that list is confirmed individually via `GET {listUrl}/{modelId}`. Only a model the provider itself answers `404`/`400` for is reported. Judging by list membership alone is wrong in both directions, verified against the live APIs on 2026-08-19:
+
+- **False alarm** — Gemini serves `imagen-4.0-generate-001` through `:predict` and leaves it out of `models.list`, but answers `200` when asked directly. A list-only check reports all three Imagen rows as dead.
+- **Blind spot** — xAI's `grok-tts` is also absent from `/v1/models`, and there it really is gone (`404`). Any heuristic that excused the Imagen case (per-capability coverage, tag families) hid this one.
+
+What it deliberately does **not** do: change anything. No `BACTIVE=0`, no default repointing. A model also disappears from a listing through a rename, a region gate or an account tier, and an unattended deactivation on a false positive takes a working model away from every user of the install. Retirement stays a reviewed migration (see the retirement policy below).
+
+Reporting rules that keep it trustworthy:
+
+- Providers with no key, no listing endpoint (HuggingFace validates via `whoami-v2`; Ollama et al. are per-install) or an unreachable API are **unchecked** — never read as "serves nothing".
+- A probe that answers `401`/`429`/`5xx` leaves the model **unconfirmed**: shown in the console, excluded from the alert and the exit code.
+- Findings carry both scopes independently: `database` (this install's active `BMODELS` rows) and `catalog` (what new installs still get). An operator who cleaned up locally must still learn that fresh installs keep receiving the dead model.
+- A finding on a `ProviderDefaultsService` recommendation is marked and sorted first — `app:provider:apply-defaults --auto` assigns those unattended at container start.
+
+Exit codes match `app:sync-model-prices`: `0` clean, `1` the command broke, `2` confirmed findings (only with `--fail-on-drift`). The scheduler role runs it daily with `--notify`, which posts to Discord when `DISCORD_WEBHOOK_URL` is set. Installs without cloud keys make no outbound request at all.
+
+### First run against live APIs (2026-08-19)
+
+Six confirmed retirements, each re-verified by hand: Groq dropped `llama-3.3-70b-versatile` (BID 9), `llama-3.1-8b-instant` (236), `qwen/qwen3-32b` (53) and `meta-llama/llama-4-scout-17b-16e-instruct` (17 — the Groq `PIC2TEXT` default), xAI dropped `grok-stt` (321 — the xAI `SOUND2TEXT` default) and `grok-tts` (320). Groq's current list is 13 models; `whisper-large-v3` and `openai/gpt-oss-*` are unaffected. Retirement migrations are tracked separately per provider.
+
 ## Maintenance links
 
 **Official provider price pages** (use these first — step 2 of the playbook):


### PR DESCRIPTION
## Why

Providers retire models without telling us, and so far we learned about it from a user-facing provider error. #1511 retires one such model by hand — this PR is the part that finds the next one first.

## What it does

`app:models:check-availability` compares what we offer against what providers actually serve, in two independent scopes:

- **`database`** — the active `BMODELS` rows of *this* install. `ModelSeeder` never deactivates anything, so a row the catalog dropped long ago can still be selectable here, and only the database knows that.
- **`catalog`** — what `ModelCatalog` still ships to *new* installs. An operator who cleaned up locally would otherwise never learn that every fresh install keeps getting the dead model.

## The part that makes it trustworthy

Detection is two-stage: the provider's model list is only a cheap pre-filter, and every model missing from that list is then confirmed individually via `GET {listUrl}/{modelId}`. Only a model the provider itself answers `404`/`400` for is reported.

A listing-only verdict is wrong in **both** directions — verified against the live APIs while building this:

| Case | Listing | Direct probe | A list-only check would… |
| --- | --- | --- | --- |
| `google imagen-4.0-generate-001` | absent | **200 — alive** (served via `:predict`) | raise a false alarm on all three Imagen rows |
| `xai grok-tts` | absent | **404 — gone** | look identical to the case above |

I first tried to separate the two with a per-capability coverage heuristic. It excused Imagen correctly and hid `grok-tts` — which is why the heuristic is gone and the probe decides.

## Deliberately read-only

No `BACTIVE = 0`, no default repointing. A model also vanishes from a listing through a rename, a region gate or an account tier, and an unattended deactivation on a false positive takes a working model away from every user of an install. Retirement stays a reviewed migration.

Nothing is ever read as evidence when it isn't:

- No key, no listing endpoint (HuggingFace validates via `whoami-v2`; Ollama et al. are per-install) or an unreachable API → **unchecked**, never "serves nothing". A conclusive-looking empty list is rejected too.
- A probe answering `401`/`429`/`5xx` → **unconfirmed**: visible in the console, excluded from the alert and the exit code.
- Probes are capped per provider so a malformed listing cannot fan out into hundreds of requests.

Findings on a `ProviderDefaultsService` recommendation are marked and sorted first, because `app:provider:apply-defaults --auto` assigns those unattended at container start.

## First run against the live APIs

Six confirmed retirements, each re-verified by hand with `curl` plus a known-good control:

| Provider | Model | BID | Note |
| --- | --- | --- | --- |
| groq | `meta-llama/llama-4-scout-17b-16e-instruct` | 17 | Groq `PIC2TEXT` default |
| groq | `llama-3.3-70b-versatile` | 9 | already handled by #1511 |
| groq | `qwen/qwen3-32b` | 53 | |
| groq | `llama-3.1-8b-instant` | 236 | |
| xai | `grok-stt` | 321 | xAI `SOUND2TEXT` default |
| xai | `grok-tts` | 320 | |

Two of them are provider defaults, which is exactly the class of breakage nobody chooses to run into. Retirement migrations are follow-ups, one per provider — this PR intentionally changes no model row.

## How it runs

Daily in the scheduler role with `--notify` (Discord, no-op without `DISCORD_WEBHOOK_URL`). Exit codes match `app:sync-model-prices`: `0` clean, `1` broke, `2` confirmed findings with `--fail-on-drift`. Installs without cloud provider keys make no outbound request at all.

## Test plan

- [x] `make -C backend lint` — clean
- [x] `make -C backend phpstan` — no errors
- [x] `make -C backend test` — 3627 tests green
- [x] `bash _docker/backend/tests/test-container-runtime.sh` — 65/65, incl. the new scheduler assertion
- [x] Ran against live Groq/OpenAI/Anthropic/Google/Mistral/xAI APIs; every finding and every suppression re-verified by hand
- [x] `scripts/mobile-impact.mjs` → `backend-only`
- [ ] Reviewer: confirm the read-only stance is the wanted default rather than auto-deactivation