### PR TITLE
feat(models): detect AI model outages and show them on a status page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,10 @@ plugins/synafastbill/
 
 #local development stuff
 _devextras/local-ignore/
+
+# Local output of scripts/mobile-impact.mjs. Anchored to the repo root on
+# purpose: every workflow passes an explicit --output elsewhere
+# (mobile-impact/manifest.json, mobile-release/mobile-release-manifest.json),
+# and those must stay visible to git. Only a run without --output lands here.
+/mobile-release-manifest.json
+/mobile-impact-manifest.json

--- a/_docker/backend/lib/container-runtime.sh
+++ b/_docker/backend/lib/container-runtime.sh
@@ -340,9 +340,12 @@ run_scheduler_role() {
     local tick_seconds="${SYNAPLAN_SCHEDULER_TICK_SECONDS:-60}"
     local hourly_seconds="${SYNAPLAN_SCHEDULER_HOURLY_SECONDS:-3600}"
     local daily_seconds="${SYNAPLAN_SCHEDULER_DAILY_SECONDS:-86400}"
+    local health_seconds="${SYNAPLAN_SCHEDULER_MODEL_HEALTH_SECONDS:-900}"
+    local health_jitter="${SYNAPLAN_SCHEDULER_MODEL_HEALTH_JITTER:-120}"
     local now
     local next_hourly=0
     local next_daily=0
+    local next_health=0
     local cycles=0
     local max_cycles="${SYNAPLAN_SCHEDULER_MAX_CYCLES:-0}"
 
@@ -352,7 +355,7 @@ run_scheduler_role() {
     mkdir -p "$SYNAPLAN_RUNTIME_DIR"
     trap stop_scheduler TERM INT
 
-    runtime_log "Starting scheduler (media reaper every ${tick_seconds}s, ephemeral-file reaper every ${hourly_seconds}s, update + model-availability check every ${daily_seconds}s)."
+    runtime_log "Starting scheduler (media reaper every ${tick_seconds}s, ephemeral-file reaper every ${hourly_seconds}s, model health check every ${health_seconds}s, update + model-availability check every ${daily_seconds}s)."
     while [ "$_scheduler_stopping" -eq 0 ]; do
         now="$(date +%s)"
         printf '%s\n' "$now" > "${SYNAPLAN_RUNTIME_DIR}/scheduler.heartbeat"
@@ -390,6 +393,22 @@ run_scheduler_role() {
             fi
 
             next_daily=$((now + daily_seconds))
+        fi
+
+        # Runtime health of the models this install actually uses. Distinct from
+        # the daily availability check above: that one reports catalog drift for
+        # a human to act on, this one reacts within minutes to a provider that
+        # started failing, which is why it runs on a much shorter interval.
+        # Every provider is asked once through its free "list your models"
+        # endpoint — no inference, so this costs nothing to run on a schedule.
+        # The jitter keeps a fleet of installs from hitting the same provider
+        # APIs on the same minute. A failure just means one provider was
+        # unreachable and is retried on the next interval.
+        if [ "$now" -ge "$next_health" ]; then
+            if ! run_scheduler_command bin/console --env="$env" app:model:health-check --jitter="$health_jitter" --no-interaction; then
+                runtime_log "Model health check failed; it will be retried on the next interval." >&2
+            fi
+            next_health=$((now + health_seconds))
         fi
 
         cycles=$((cycles + 1))

--- a/_docker/backend/tests/test-container-runtime.sh
+++ b/_docker/backend/tests/test-container-runtime.sh
@@ -106,6 +106,7 @@ assert_contains "app:media:reap-jobs --no-interaction" "$COMMAND_LOG" "scheduler
 assert_contains "app:files:reap-ephemeral --no-interaction" "$COMMAND_LOG" "scheduler runs ephemeral-file reaper"
 assert_contains "app:updates:check --no-interaction" "$COMMAND_LOG" "scheduler runs the daily update check"
 assert_contains "app:models:check-availability --notify --no-interaction" "$COMMAND_LOG" "scheduler runs the daily model availability check"
+assert_contains "app:model:health-check --jitter=" "$COMMAND_LOG" "scheduler runs the model health check with request jitter"
 if [ -s "$TMP_DIR/runtime/scheduler.heartbeat" ]; then
     assert_eq 1 1 "scheduler writes liveness heartbeat"
 else

--- a/backend/config/services.yaml
+++ b/backend/config/services.yaml
@@ -174,6 +174,10 @@ services:
             tags: ['app.oauth.provider_source']
         App\Service\Connection\ConnectionTester:
             tags: ['app.connection.tester']
+        # Free provider catalog lookups for model outage detection — collected
+        # by ModelListProbeRegistry. Never inference, always metadata.
+        App\AI\Health\Probe\ModelListProbeInterface:
+            tags: ['app.model_list_probe']
 
     App\:
         resource: '../src/'
@@ -402,6 +406,17 @@ services:
             $apiToken: '%env(CLOUDFLARE_API_TOKEN)%'
         tags:
             - { name: 'app.ai.embedding' }
+
+    # Model health: the account-scoped Cloudflare catalog needs the same
+    # credentials as the provider itself.
+    App\AI\Health\Probe\CloudflareModelListProbe:
+        arguments:
+            $accountId: '%env(CLOUDFLARE_ACCOUNT_ID)%'
+            $apiToken: '%env(CLOUDFLARE_API_TOKEN)%'
+
+    App\AI\Health\Probe\ModelListProbeRegistry:
+        arguments:
+            $probes: !tagged_iterator app.model_list_probe
 
     # Generic "OpenAI Compatible" provider (LocalAI, vLLM, LiteLLM, Ollama /v1,
     # …). Endpoints are configured at runtime and stored encrypted in BCONFIG

--- a/backend/migrations/Version20260819120000.php
+++ b/backend/migrations/Version20260819120000.php
@@ -66,7 +66,7 @@ final class Version20260819120000 extends AbstractMigration
                 BSTATE VARCHAR(16) NOT NULL DEFAULT 'unknown',
                 BSOURCE VARCHAR(16) NOT NULL DEFAULT 'probe',
                 BKIND VARCHAR(16) DEFAULT NULL,
-                BMESSAGE TEXT DEFAULT NULL,
+                BMESSAGE LONGTEXT DEFAULT NULL,
                 BLASTCHECK BIGINT NOT NULL DEFAULT 0,
                 BLASTSUCCESS BIGINT NOT NULL DEFAULT 0,
                 BLASTFAILURE BIGINT NOT NULL DEFAULT 0,

--- a/backend/migrations/Version20260819120000.php
+++ b/backend/migrations/Version20260819120000.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Model health monitoring: the BMODELHEALTH state table plus the MODELHEALTH
+ * configuration defaults.
+ *
+ * Rolling success/failure counters stay in Redis (written on every AI call).
+ * This table holds only what has to survive a cache flush, above all the
+ * auto-disable provenance — without it nobody can tell a model an operator
+ * switched off from one the automation retired.
+ *
+ * Written with raw idempotent SQL and no Schema API calls on purpose: the DBAL
+ * comparator throws "There is no table with name ..." on the production Galera
+ * cluster, so `$schema->hasTable()` / `createTable()` are off limits here.
+ *
+ * BCONFIG rows are inserted rather than left to the seeder because seeder
+ * values are bootstrap-only and never reach installs that already exist.
+ * AUTO_DISABLE_ENABLED ships as '0': alerting is safe from day one, retiring a
+ * model on a heuristic is not, and it gets switched on by its own migration
+ * once the thresholds have proven themselves against real traffic.
+ */
+final class Version20260819120000 extends AbstractMigration
+{
+    /**
+     * Global (ownerId 0) defaults for the MODELHEALTH group.
+     *
+     * @var array<string, string>
+     */
+    private const DEFAULTS = [
+        // Master switch for probing and traffic evaluation.
+        'ENABLED' => '1',
+        // Share of failing calls (percent) above which a model counts as degraded.
+        'ERROR_RATE_PERCENT' => '50',
+        // Below this many recorded calls the rate is noise and is ignored.
+        'MIN_SAMPLE_SIZE' => '5',
+        // Rolling window for the traffic counters, in minutes.
+        'WINDOW_MINUTES' => '30',
+        // How often the scheduler runs the free catalog probe, in minutes.
+        'PROBE_INTERVAL_MINUTES' => '15',
+        // At most one alert per model (and per provider) in this many minutes.
+        'ALERT_THROTTLE_MINUTES' => '60',
+        // Retiring a model automatically. Off until the thresholds are proven.
+        'AUTO_DISABLE_ENABLED' => '0',
+        // After a manual re-enable the automation only reports for this long.
+        'SUPPRESSION_DAYS' => '7',
+    ];
+
+    public function getDescription(): string
+    {
+        return 'Add BMODELHEALTH state table and MODELHEALTH configuration defaults for AI model outage detection.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE IF NOT EXISTS BMODELHEALTH (
+                BID BIGINT AUTO_INCREMENT NOT NULL,
+                BMODELID BIGINT NOT NULL,
+                BSTATE VARCHAR(16) NOT NULL DEFAULT 'unknown',
+                BSOURCE VARCHAR(16) NOT NULL DEFAULT 'probe',
+                BKIND VARCHAR(16) DEFAULT NULL,
+                BMESSAGE TEXT DEFAULT NULL,
+                BLASTCHECK BIGINT NOT NULL DEFAULT 0,
+                BLASTSUCCESS BIGINT NOT NULL DEFAULT 0,
+                BLASTFAILURE BIGINT NOT NULL DEFAULT 0,
+                BAUTODISABLED INT NOT NULL DEFAULT 0,
+                BAUTODISABLEDAT BIGINT NOT NULL DEFAULT 0,
+                BSUPPRESSUNTIL BIGINT NOT NULL DEFAULT 0,
+                BUPDATED BIGINT NOT NULL DEFAULT 0,
+                UNIQUE INDEX uniq_modelhealth_model (BMODELID),
+                INDEX idx_modelhealth_state (BSTATE),
+                PRIMARY KEY (BID)
+            ) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB
+        SQL);
+
+        foreach (self::DEFAULTS as $setting => $value) {
+            // INSERT ... SELECT ... WHERE NOT EXISTS keeps an operator's own
+            // value intact on re-run, which ON DUPLICATE KEY UPDATE would not.
+            $this->addSql(<<<'SQL'
+                INSERT INTO BCONFIG (BOWNERID, BGROUP, BSETTING, BVALUE)
+                SELECT 0, 'MODELHEALTH', :setting, :value
+                  FROM DUAL
+                 WHERE NOT EXISTS (
+                     SELECT 1 FROM BCONFIG
+                      WHERE BOWNERID = 0 AND BGROUP = 'MODELHEALTH' AND BSETTING = :settingCheck
+                 )
+            SQL, [
+                'setting' => $setting,
+                'value' => $value,
+                'settingCheck' => $setting,
+            ]);
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql("DELETE FROM BCONFIG WHERE BOWNERID = 0 AND BGROUP = 'MODELHEALTH'");
+        $this->addSql('DROP TABLE IF EXISTS BMODELHEALTH');
+    }
+}

--- a/backend/src/AI/Health/FailureClassifier.php
+++ b/backend/src/AI/Health/FailureClassifier.php
@@ -41,10 +41,19 @@ final readonly class FailureClassifier
         'no longer supported',
         'has been retired',
         'is retired',
-        'deprecated',
+        // "deprecated" alone matches "parameter X is deprecated" on a 400, which
+        // is a request problem, not a retired model. Keep the phrasing that
+        // providers use when the model itself is going away.
+        'model is deprecated',
+        'has been deprecated',
+        'was deprecated',
+        'deprecated and will be removed',
+        'deprecated model',
         'decommissioned',
         'discontinued',
-        'sunset',
+        'has been sunset',
+        'is sunset',
+        'sunsetting',
         'not_found_error',
     ];
 
@@ -77,14 +86,18 @@ final readonly class FailureClassifier
         'content blocked',
         'content_filter',
         'content_policy',
-        'safety',
+        'safety filter',
+        'safety system',
+        'safety settings',
+        'safety ratings',
+        'content safety',
+        'blocked by safety',
         'context length',
         'context_length_exceeded',
         'maximum context',
         'too many tokens',
         'prompt is too long',
         'string too long',
-        'invalid_request_error',
     ];
 
     /** Recoverable on its own — never a reason to switch a model off. */

--- a/backend/src/AI/Health/FailureClassifier.php
+++ b/backend/src/AI/Health/FailureClassifier.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\AI\Health;
+
+use App\AI\Exception\ProviderCancelledException;
+use App\AI\Exception\ProviderException;
+use App\Service\Exception\StreamCancelledException;
+
+/**
+ * Sorts a failed AI call into a {@see FailureKind}.
+ *
+ * Order matters. The upstream HTTP status is the most reliable signal, but it
+ * is only present when the provider actually answered — SDK wrappers, cURL
+ * errors and our own guard clauses all arrive with code 0. Message matching
+ * therefore runs first for the cases that are unambiguous in text, then the
+ * status decides, and only what is left over falls back to transient.
+ *
+ * Defaulting to transient is deliberate: an unknown failure must never be able
+ * to retire a model on its own.
+ */
+final readonly class FailureClassifier
+{
+    /**
+     * Provider wording for "this model does not exist (any more)". Matched
+     * case-insensitively against the exception message.
+     */
+    private const PERMANENT_PATTERNS = [
+        'model_not_found',
+        'model not found',
+        // ProviderException::noModelAvailable() puts the rejected model name
+        // between the words: "Model 'gpt-5' not found for provider 'openai'".
+        'not found for provider',
+        'model available for provider',
+        'unknown model',
+        'invalid model',
+        'model does not exist',
+        'does not exist or you do not have access',
+        'no longer available',
+        'no longer supported',
+        'has been retired',
+        'is retired',
+        'deprecated',
+        'decommissioned',
+        'discontinued',
+        'sunset',
+        'not_found_error',
+    ];
+
+    /** Credential, entitlement and billing problems — every model of the provider is affected. */
+    private const CREDENTIAL_PATTERNS = [
+        'api key',
+        'api_key',
+        'apikey',
+        'invalid_api_key',
+        'authentication_error',
+        'authentication failed',
+        'unauthorized',
+        'unauthenticated',
+        'permission_error',
+        'permission denied',
+        'invalid authentication',
+        'incorrect api key',
+        'out of credits',
+        'insufficient_quota',
+        'insufficient credits',
+        'insufficient balance',
+        'billing',
+        'payment required',
+        'quota exceeded',
+        'exceeded your current quota',
+    ];
+
+    /** The request was at fault, not the model. */
+    private const USER_ERROR_PATTERNS = [
+        'content blocked',
+        'content_filter',
+        'content_policy',
+        'safety',
+        'context length',
+        'context_length_exceeded',
+        'maximum context',
+        'too many tokens',
+        'prompt is too long',
+        'string too long',
+        'invalid_request_error',
+    ];
+
+    /** Recoverable on its own — never a reason to switch a model off. */
+    private const TRANSIENT_PATTERNS = [
+        'rate limit',
+        'rate_limit',
+        'too many requests',
+        'overloaded',
+        'capacity',
+        'timeout',
+        'timed out',
+        'temporarily unavailable',
+        'service unavailable',
+        'circuit breaker',
+        'connection refused',
+        'could not resolve host',
+        'network',
+        'try again',
+    ];
+
+    public function classify(\Throwable $error): FailureKind
+    {
+        if ($error instanceof ProviderCancelledException || $error instanceof StreamCancelledException) {
+            return FailureKind::Cancelled;
+        }
+
+        // ProviderException::contentBlocked() carries the provider's own block
+        // reason. Trust that over any text matching — a blocked prompt is a
+        // property of the request, never of the model.
+        if ($error instanceof ProviderException) {
+            $context = $error->getContext() ?? [];
+            if (isset($context['block_reason'])) {
+                return FailureKind::UserError;
+            }
+            // missingApiKey() documents the env var it wants set.
+            if (isset($context['env_var'])) {
+                return FailureKind::Credential;
+            }
+            // noModelAvailable() names the model the provider rejected.
+            if (isset($context['requested_model']) || isset($context['suggested_models'])) {
+                return FailureKind::Permanent;
+            }
+        }
+
+        $message = strtolower($error->getMessage());
+
+        // Text first: a provider that answers "model X was deprecated" with a
+        // generic 400 would otherwise be filed as a user error.
+        if (self::matchesAny($message, self::PERMANENT_PATTERNS)) {
+            return FailureKind::Permanent;
+        }
+        if (self::matchesAny($message, self::CREDENTIAL_PATTERNS)) {
+            return FailureKind::Credential;
+        }
+        if (self::matchesAny($message, self::TRANSIENT_PATTERNS)) {
+            return FailureKind::Transient;
+        }
+        if (self::matchesAny($message, self::USER_ERROR_PATTERNS)) {
+            return FailureKind::UserError;
+        }
+
+        $status = $error instanceof ProviderException ? $error->getUpstreamStatus() : null;
+        if (null !== $status) {
+            return self::fromStatus($status);
+        }
+
+        return FailureKind::Transient;
+    }
+
+    /**
+     * Map an upstream HTTP status onto a failure kind.
+     *
+     * 429 is transient by definition — treating a rate limit as a model defect
+     * is exactly how an automation switches off the busiest model during a
+     * traffic spike. {@see \App\AI\Credential\ProviderKeyValidator} already
+     * encodes the same rule for key validation.
+     */
+    private static function fromStatus(int $status): FailureKind
+    {
+        return match (true) {
+            401 === $status, 403 === $status, 402 === $status => FailureKind::Credential,
+            404 === $status, 410 === $status => FailureKind::Permanent,
+            429 === $status, 408 === $status, 409 === $status, 425 === $status => FailureKind::Transient,
+            $status >= 500 => FailureKind::Transient,
+            $status >= 400 => FailureKind::UserError,
+            default => FailureKind::Transient,
+        };
+    }
+
+    /**
+     * @param list<string> $patterns
+     */
+    private static function matchesAny(string $haystack, array $patterns): bool
+    {
+        foreach ($patterns as $pattern) {
+            if (str_contains($haystack, $pattern)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/backend/src/AI/Health/FailureKind.php
+++ b/backend/src/AI/Health/FailureKind.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\AI\Health;
+
+/**
+ * How a failed AI call should be counted by the health monitor.
+ *
+ * The distinction is what keeps self-healing from doing damage: a rate limit
+ * and a retired model both surface as "the call failed", but reacting to them
+ * the same way would switch off the busiest model during a traffic spike.
+ */
+enum FailureKind: string
+{
+    /** Provider hiccup: rate limit, timeout, 5xx, open circuit. Recovers on its own. */
+    case Transient = 'transient';
+
+    /** The model itself is gone or permanently rejected: retired, renamed, unknown to the provider. */
+    case Permanent = 'permanent';
+
+    /** Credentials or billing: bad key, revoked key, exhausted credits. Hits every model of that provider. */
+    case Credential = 'credential';
+
+    /** Caused by the request, not the model: content filter, context length exceeded. */
+    case UserError = 'user_error';
+
+    /** The user pressed stop. The provider was healthy. */
+    case Cancelled = 'cancelled';
+
+    /**
+     * Does this count towards the model's own error rate?
+     *
+     * User errors and cancellations say nothing about model health, and a
+     * credential problem belongs to the provider — attributing it to whichever
+     * model happened to be called first would disable an innocent model.
+     */
+    public function countsAgainstModel(): bool
+    {
+        return self::Transient === $this || self::Permanent === $this;
+    }
+
+    /**
+     * May the automation switch the model off for this?
+     *
+     * Only for failures that will still be there after a retry. Everything
+     * else has to heal on its own or be fixed by an operator.
+     */
+    public function justifiesAutoDisable(): bool
+    {
+        return self::Permanent === $this;
+    }
+
+    /** Does this affect every model of the provider rather than a single one? */
+    public function isProviderWide(): bool
+    {
+        return self::Credential === $this;
+    }
+
+    /** Operator-facing label; the UI translates on top of this. */
+    public function label(): string
+    {
+        return match ($this) {
+            self::Transient => 'Temporarily unavailable',
+            self::Permanent => 'No longer offered by the provider',
+            self::Credential => 'Credentials or credit problem',
+            self::UserError => 'Rejected because of the request',
+            self::Cancelled => 'Cancelled by the user',
+        };
+    }
+}

--- a/backend/src/AI/Health/ModelAutoDisabler.php
+++ b/backend/src/AI/Health/ModelAutoDisabler.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\AI\Health;
+
+use App\Entity\Model;
+use App\Entity\ModelHealth;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Switches a model off when the provider clearly retired it, and back on when
+ * it returns.
+ *
+ * The whole design is about provenance. Automation that cannot tell its own
+ * changes from an operator's will eventually undo a deliberate decision, and
+ * an operator who has had a setting silently reverted stops trusting the
+ * feature. So:
+ *
+ *   - only rows this automation switched off are ever switched back on
+ *     ({@see ModelHealth::isAutoDisabled()}),
+ *   - a model an operator disabled by hand is never touched,
+ *   - an operator re-enabling one of our rows wins, and buys a grace period in
+ *     which we report but do not act.
+ *
+ * Off by default (MODELHEALTH.AUTO_DISABLE_ENABLED). Alerting is safe from day
+ * one; retiring a model on a heuristic has to earn its trust first.
+ */
+final readonly class ModelAutoDisabler
+{
+    public function __construct(
+        private ModelHealthConfig $config,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * Reconcile BMODELS.BACTIVE with the verdict.
+     *
+     * @return array{disabled: bool, reEnabled: bool}
+     */
+    public function apply(ModelHealthVerdict $verdict, Model $model, ModelHealth $health, int $now): array
+    {
+        $isActive = 1 === $model->getActive();
+
+        // An operator switched our row back on. Their call wins, and the grace
+        // period stops us from immediately switching it off again — a fight the
+        // human would always lose and always notice.
+        if ($health->isAutoDisabled() && $isActive) {
+            $health->setAutoDisabled(false)
+                ->setAutoDisabledAt(0)
+                ->setSuppressUntil($now + $this->config->suppressionSeconds());
+
+            $this->logger->info('Model re-enabled by an operator, pausing automatic disabling', [
+                'model_id' => $verdict->modelId,
+                'model' => $verdict->modelName,
+                'until' => $health->getSuppressUntil(),
+            ]);
+
+            return ['disabled' => false, 'reEnabled' => false];
+        }
+
+        if ($health->isAutoDisabled() && !$isActive && ModelHealthState::Online === $verdict->state) {
+            $model->setActive(1);
+            $health->setAutoDisabled(false)->setAutoDisabledAt(0);
+
+            $this->logger->info('Model automatically re-enabled: provider offers it again', [
+                'model_id' => $verdict->modelId,
+                'model' => $verdict->modelName,
+            ]);
+
+            return ['disabled' => false, 'reEnabled' => true];
+        }
+
+        if (!$this->config->isAutoDisableEnabled()) {
+            return ['disabled' => false, 'reEnabled' => false];
+        }
+
+        if (!$isActive || $health->isSuppressed($now)) {
+            return ['disabled' => false, 'reEnabled' => false];
+        }
+
+        // Only a permanent verdict qualifies. A rate limit or a provider
+        // hiccup must never be able to retire a model — that is how automation
+        // switches off the busiest model during a traffic spike.
+        if (ModelHealthState::Offline !== $verdict->state || true !== $verdict->kind?->justifiesAutoDisable()) {
+            return ['disabled' => false, 'reEnabled' => false];
+        }
+
+        // A verdict built on a catalog listing that only partly covers this
+        // capability is worth reporting but not worth acting on.
+        if (!$verdict->safeToDisable) {
+            return ['disabled' => false, 'reEnabled' => false];
+        }
+
+        $model->setActive(0);
+        $health->setAutoDisabled(true)->setAutoDisabledAt($now);
+
+        $this->logger->warning('Model automatically disabled: no longer offered by the provider', [
+            'model_id' => $verdict->modelId,
+            'model' => $verdict->modelName,
+            'service' => $verdict->service,
+            'reason' => $verdict->message,
+        ]);
+
+        return ['disabled' => true, 'reEnabled' => false];
+    }
+}

--- a/backend/src/AI/Health/ModelHealthAlert.php
+++ b/backend/src/AI/Health/ModelHealthAlert.php
@@ -18,14 +18,26 @@ final readonly class ModelHealthAlert
     public const KIND_CREDENTIAL = 'credential';
 
     /**
-     * @param list<string> $modelNames names of the affected models, for the alert body
+     * @param string       $provider    internal service key; also the throttle key, so it
+     *                                  must stay stable and must not be a display string
+     * @param list<string> $modelNames  names of the affected models, for the alert body
+     * @param string|null  $displayName the provider's branded name, for the alert text
      */
     public function __construct(
         public string $kind,
         public string $provider,
         public array $modelNames,
         public string $reason,
+        public ?string $displayName = null,
     ) {
+    }
+
+    /** The provider as it should appear in the alert, never the raw service key. */
+    public function name(): string
+    {
+        return null === $this->displayName || '' === $this->displayName
+            ? $this->provider
+            : $this->displayName;
     }
 
     public function modelCount(): int
@@ -39,18 +51,18 @@ final readonly class ModelHealthAlert
         return match ($this->kind) {
             self::KIND_CREDENTIAL => sprintf(
                 '%s credentials rejected — %d model(s) unavailable',
-                $this->provider,
+                $this->name(),
                 $this->modelCount()
             ),
             self::KIND_OFFLINE => sprintf(
                 '%d %s model(s) no longer available',
                 $this->modelCount(),
-                $this->provider
+                $this->name()
             ),
             default => sprintf(
                 '%d %s model(s) failing',
                 $this->modelCount(),
-                $this->provider
+                $this->name()
             ),
         };
     }

--- a/backend/src/AI/Health/ModelHealthAlert.php
+++ b/backend/src/AI/Health/ModelHealthAlert.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\AI\Health;
+
+/**
+ * One thing worth waking an operator for, already aggregated per provider.
+ *
+ * Aggregation is the point: a revoked OpenAI key breaks every OpenAI model at
+ * once, and forty separate emails about the same key would train the operator
+ * to ignore the alert channel.
+ */
+final readonly class ModelHealthAlert
+{
+    public const KIND_OFFLINE = 'offline';
+    public const KIND_DEGRADED = 'degraded';
+    public const KIND_CREDENTIAL = 'credential';
+
+    /**
+     * @param list<string> $modelNames names of the affected models, for the alert body
+     */
+    public function __construct(
+        public string $kind,
+        public string $provider,
+        public array $modelNames,
+        public string $reason,
+    ) {
+    }
+
+    public function modelCount(): int
+    {
+        return count($this->modelNames);
+    }
+
+    /** Short one-liner used as the email subject and the Discord title. */
+    public function headline(): string
+    {
+        return match ($this->kind) {
+            self::KIND_CREDENTIAL => sprintf(
+                '%s credentials rejected — %d model(s) unavailable',
+                $this->provider,
+                $this->modelCount()
+            ),
+            self::KIND_OFFLINE => sprintf(
+                '%d %s model(s) no longer available',
+                $this->modelCount(),
+                $this->provider
+            ),
+            default => sprintf(
+                '%d %s model(s) failing',
+                $this->modelCount(),
+                $this->provider
+            ),
+        };
+    }
+
+    /** What the operator is expected to do about it. */
+    public function actionRequired(): string
+    {
+        return match ($this->kind) {
+            self::KIND_CREDENTIAL => 'Check the API key and the account balance for this provider. Every model behind it is affected.',
+            self::KIND_OFFLINE => 'The provider no longer offers these models. Pick replacements in the model settings.',
+            default => 'The provider is answering but failing often. If this does not clear up on its own, switch to another model.',
+        };
+    }
+
+    /** At most this many model names go into an alert body; the rest are summarised. */
+    public function previewNames(int $limit = 10): string
+    {
+        if ($this->modelCount() <= $limit) {
+            return implode(', ', $this->modelNames);
+        }
+
+        return implode(', ', array_slice($this->modelNames, 0, $limit))
+            .sprintf(' and %d more', $this->modelCount() - $limit);
+    }
+}

--- a/backend/src/AI/Health/ModelHealthAlerter.php
+++ b/backend/src/AI/Health/ModelHealthAlerter.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\AI\Health;
+
+use App\Service\DiscordNotificationService;
+use App\Service\InternalEmailService;
+use Psr\Cache\CacheItemPoolInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Decides whether an operator hears about a health event, and on which channel.
+ *
+ * Two pieces of state per (provider, kind), both in the shared Redis pool so
+ * three web nodes do not send three copies of the same alert:
+ *
+ *   - a THROTTLE key that suppresses repeats of an alert already sent,
+ *   - an OPEN key that remembers an incident is running.
+ *
+ * The second one is what makes the all-clear trustworthy. Without it, a restart
+ * or an expired throttle would produce "resolved" for an incident nobody was
+ * ever told about — and an all-clear for an alert you never saw is worse than
+ * no all-clear at all.
+ */
+final readonly class ModelHealthAlerter
+{
+    private const THROTTLE_PREFIX = 'model_health.alert.';
+    private const OPEN_PREFIX = 'model_health.open.';
+
+    /** An incident stays open far longer than the throttle window. */
+    private const OPEN_TTL_SECONDS = 604800;
+
+    public function __construct(
+        private CacheItemPoolInterface $cache,
+        private ModelHealthConfig $config,
+        private InternalEmailService $email,
+        private DiscordNotificationService $discord,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * Raise an alert unless an identical one went out recently.
+     *
+     * @return bool true when something was actually sent
+     */
+    public function raise(ModelHealthAlert $alert): bool
+    {
+        $key = $this->key($alert);
+
+        if ($this->has(self::THROTTLE_PREFIX.$key)) {
+            $this->logger->debug('Model health alert throttled', [
+                'provider' => $alert->provider,
+                'kind' => $alert->kind,
+            ]);
+
+            return false;
+        }
+
+        $this->email->sendModelHealthAlert($alert);
+        $this->discord->notifyModelHealth($alert);
+
+        $this->remember(self::THROTTLE_PREFIX.$key, $this->config->alertThrottleSeconds());
+        $this->remember(self::OPEN_PREFIX.$key, self::OPEN_TTL_SECONDS);
+
+        $this->logger->warning('Model health alert raised', [
+            'provider' => $alert->provider,
+            'kind' => $alert->kind,
+            'models' => $alert->modelCount(),
+            'reason' => $alert->reason,
+        ]);
+
+        return true;
+    }
+
+    /**
+     * Send the all-clear — but only for an incident the operator was told about.
+     *
+     * @return bool true when an all-clear was actually sent
+     */
+    public function resolve(ModelHealthAlert $alert): bool
+    {
+        $key = $this->key($alert);
+
+        if (!$this->has(self::OPEN_PREFIX.$key)) {
+            return false;
+        }
+
+        $this->email->sendModelHealthAlert($alert, resolved: true);
+        $this->discord->notifyModelHealth($alert, resolved: true);
+
+        $this->forget(self::OPEN_PREFIX.$key);
+        // Drop the throttle too: the next incident on this provider deserves an
+        // immediate alert instead of inheriting the old one's silence window.
+        $this->forget(self::THROTTLE_PREFIX.$key);
+
+        $this->logger->info('Model health alert resolved', [
+            'provider' => $alert->provider,
+            'kind' => $alert->kind,
+            'models' => $alert->modelCount(),
+        ]);
+
+        return true;
+    }
+
+    /** Is an incident of this kind currently open for this provider? */
+    public function isOpen(string $provider, string $kind): bool
+    {
+        return $this->has(self::OPEN_PREFIX.self::normalize($provider).'.'.$kind);
+    }
+
+    private function key(ModelHealthAlert $alert): string
+    {
+        return self::normalize($alert->provider).'.'.$alert->kind;
+    }
+
+    /**
+     * Cache keys may not contain the PSR-6 reserved characters, and provider
+     * names reach us straight from BSERVICE.
+     */
+    private static function normalize(string $provider): string
+    {
+        return preg_replace('/[^a-z0-9_]/', '_', mb_strtolower($provider)) ?? 'unknown';
+    }
+
+    private function has(string $key): bool
+    {
+        try {
+            return $this->cache->getItem($key)->isHit();
+        } catch (\Throwable $e) {
+            // A cache outage must not silence alerting. Reporting "not sent
+            // yet" errs towards a duplicate alert, which beats silence.
+            $this->logger->debug('Model health alert state read failed', ['error' => $e->getMessage()]);
+
+            return false;
+        }
+    }
+
+    private function remember(string $key, int $ttl): void
+    {
+        try {
+            $item = $this->cache->getItem($key);
+            $item->set(time());
+            $item->expiresAfter($ttl);
+            $this->cache->save($item);
+        } catch (\Throwable $e) {
+            $this->logger->debug('Model health alert state write failed', ['error' => $e->getMessage()]);
+        }
+    }
+
+    private function forget(string $key): void
+    {
+        try {
+            $this->cache->deleteItem($key);
+        } catch (\Throwable $e) {
+            $this->logger->debug('Model health alert state delete failed', ['error' => $e->getMessage()]);
+        }
+    }
+}

--- a/backend/src/AI/Health/ModelHealthConfig.php
+++ b/backend/src/AI/Health/ModelHealthConfig.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\AI\Health;
+
+use App\Repository\ConfigRepository;
+
+/**
+ * Operator settings for the health monitor, from BCONFIG group MODELHEALTH.
+ *
+ * Defaults here mirror Version20260819120000. They only apply when a row is
+ * missing entirely — the migration is what puts the values in front of installs
+ * that already exist, because seeded defaults never reach them.
+ *
+ * Values are memoized per process: the health check reads them once per model
+ * and this must not turn into one query per model.
+ */
+final class ModelHealthConfig
+{
+    public const GROUP = 'MODELHEALTH';
+
+    private const DEFAULTS = [
+        'ENABLED' => '1',
+        'ERROR_RATE_PERCENT' => '50',
+        'MIN_SAMPLE_SIZE' => '5',
+        'WINDOW_MINUTES' => '30',
+        'PROBE_INTERVAL_MINUTES' => '15',
+        'ALERT_THROTTLE_MINUTES' => '60',
+        'AUTO_DISABLE_ENABLED' => '0',
+        'SUPPRESSION_DAYS' => '7',
+    ];
+
+    private const MEMO_TTL_SECONDS = 30;
+
+    /** @var array<string, string> */
+    private array $memo = [];
+
+    private int $memoAt = 0;
+
+    public function __construct(private readonly ConfigRepository $configRepository)
+    {
+    }
+
+    public function isEnabled(): bool
+    {
+        return '1' === $this->get('ENABLED');
+    }
+
+    public function isAutoDisableEnabled(): bool
+    {
+        return '1' === $this->get('AUTO_DISABLE_ENABLED');
+    }
+
+    /** Failure share (0..100) at which a model is reported as degraded. */
+    public function errorRatePercent(): int
+    {
+        return max(1, min(100, (int) $this->get('ERROR_RATE_PERCENT')));
+    }
+
+    /** Below this many samples the rate is noise and no verdict is formed. */
+    public function minSampleSize(): int
+    {
+        return max(1, (int) $this->get('MIN_SAMPLE_SIZE'));
+    }
+
+    public function windowSeconds(): int
+    {
+        return max(60, (int) $this->get('WINDOW_MINUTES') * 60);
+    }
+
+    public function probeIntervalSeconds(): int
+    {
+        return max(60, (int) $this->get('PROBE_INTERVAL_MINUTES') * 60);
+    }
+
+    public function alertThrottleSeconds(): int
+    {
+        return max(60, (int) $this->get('ALERT_THROTTLE_MINUTES') * 60);
+    }
+
+    /** How long the automation stays hands-off after a manual re-enable. */
+    public function suppressionSeconds(): int
+    {
+        return max(0, (int) $this->get('SUPPRESSION_DAYS') * 86400);
+    }
+
+    private function get(string $setting): string
+    {
+        $now = time();
+        if ($now - $this->memoAt >= self::MEMO_TTL_SECONDS) {
+            $this->memo = [];
+            $this->memoAt = $now;
+        }
+
+        if (isset($this->memo[$setting])) {
+            return $this->memo[$setting];
+        }
+
+        $value = null;
+
+        try {
+            $value = $this->configRepository->getValue(0, self::GROUP, $setting);
+        } catch (\Throwable) {
+            // Health monitoring must never take a request down with it — an
+            // unavailable BCONFIG (early boot, migration in flight) falls back
+            // to the shipped defaults.
+            $value = null;
+        }
+
+        if (null === $value || '' === trim($value)) {
+            $value = self::DEFAULTS[$setting] ?? '';
+        }
+
+        return $this->memo[$setting] = $value;
+    }
+}

--- a/backend/src/AI/Health/ModelHealthCounters.php
+++ b/backend/src/AI/Health/ModelHealthCounters.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\AI\Health;
+
+/**
+ * Outcome counts for one model inside the current rolling window.
+ */
+final readonly class ModelHealthCounters
+{
+    public function __construct(
+        public int $successes = 0,
+        public int $failures = 0,
+        public ?FailureKind $lastKind = null,
+        public ?string $lastMessage = null,
+        public int $lastFailureAt = 0,
+        public int $lastSuccessAt = 0,
+    ) {
+    }
+
+    public function total(): int
+    {
+        return $this->successes + $this->failures;
+    }
+
+    /** Failure share in percent, 0 when nothing was recorded. */
+    public function errorRatePercent(): int
+    {
+        $total = $this->total();
+
+        return 0 === $total ? 0 : (int) round($this->failures * 100 / $total);
+    }
+
+    public function isEmpty(): bool
+    {
+        return 0 === $this->total();
+    }
+}

--- a/backend/src/AI/Health/ModelHealthEvaluator.php
+++ b/backend/src/AI/Health/ModelHealthEvaluator.php
@@ -1,0 +1,425 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\AI\Health;
+
+use App\AI\Health\Probe\ModelListProbeInterface;
+use App\AI\Health\Probe\ModelListProbeRegistry;
+use App\AI\Health\Probe\ProbeResult;
+use App\AI\Service\ModelProbeResult;
+use App\Entity\Model;
+use App\Entity\ModelHealth;
+use App\Repository\ModelHealthRepository;
+use App\Repository\ModelRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Cache\CacheItemPoolInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Turns free catalog lookups and passive traffic counters into one verdict per
+ * model, persists it, and alerts on the changes.
+ *
+ * Two evidence sources, in this order:
+ *
+ *   1. The provider's own catalog. Authoritative for "does this model still
+ *      exist" and free, but blind to problems that only affect this account.
+ *   2. The rolling traffic counters. They see the account-specific failures
+ *      (exhausted quota, blocked region) that a catalog lookup never will.
+ *
+ * The catalog wins where it speaks, because a model the provider no longer
+ * lists is gone no matter what the counters say.
+ */
+final readonly class ModelHealthEvaluator
+{
+    /**
+     * Ceiling on per-model confirmations per provider per run. Reached only
+     * when a listing parses but is wildly incomplete; without it, one malformed
+     * response would turn into one request per catalogued model.
+     */
+    private const MAX_CONFIRMATIONS_PER_SERVICE = 25;
+
+    /**
+     * How long a conclusive per-model answer is reused. An hour keeps a retired
+     * model from being re-probed on every run while still noticing a model that
+     * comes back well before anyone would act on the status page.
+     */
+    private const PRESENCE_CACHE_TTL_SECONDS = 3600;
+
+    public function __construct(
+        private ModelRepository $models,
+        private ModelHealthRepository $healthRepository,
+        private ModelListProbeRegistry $probes,
+        private ModelHealthRecorder $recorder,
+        private ModelHealthConfig $config,
+        private ModelHealthAlerter $alerter,
+        private ModelAutoDisabler $autoDisabler,
+        private EntityManagerInterface $em,
+        private CacheItemPoolInterface $cache,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * Run one full check.
+     *
+     * @param list<string> $onlyServices restrict the run to these services (case-insensitive)
+     */
+    public function run(bool $dryRun = false, array $onlyServices = []): ModelHealthRun
+    {
+        $verdicts = [];
+        $skipped = [];
+        $raised = [];
+        $resolved = [];
+        $budget = [];
+        $now = time();
+
+        $wanted = array_map(mb_strtolower(...), $onlyServices);
+
+        foreach ($this->models->findAllServices() as $service) {
+            if ([] !== $wanted && !in_array(mb_strtolower($service), $wanted, true)) {
+                continue;
+            }
+
+            $catalogModels = $this->models->findByServiceIndexedByProviderId($service);
+            if ([] === $catalogModels) {
+                continue;
+            }
+
+            $probe = $this->probes->find($service);
+            $result = null === $probe
+                ? ProbeResult::skipped('No free catalog endpoint exists for this provider.')
+                : $this->probeSafely($service, $probe);
+
+            if ($result->isSkipped()) {
+                $skipped[$service] = $result->message;
+            }
+
+            $serviceVerdicts = [];
+            foreach ($catalogModels as $providerId => $rows) {
+                // One confirmation per provider model id, not per BMODELS row:
+                // the same id appears once per capability it is bound to.
+                $presence = $this->presence($service, $probe, $result, (string) $providerId, $budget);
+
+                foreach ($rows as $model) {
+                    $verdict = $this->judge($service, $model, (string) $providerId, $result, $presence, $now);
+                    if (!$dryRun) {
+                        $verdict = $this->commit($verdict, $model, $now);
+                    }
+                    $serviceVerdicts[] = $verdict;
+                }
+            }
+
+            $outcome = $this->reconcileAlerts($service, $serviceVerdicts, $result, $dryRun);
+            $raised = array_merge($raised, $outcome['raised']);
+            $resolved = array_merge($resolved, $outcome['resolved']);
+
+            $verdicts = array_merge($verdicts, $serviceVerdicts);
+        }
+
+        if (!$dryRun) {
+            $this->em->flush();
+            $this->healthRepository->pruneOrphans();
+        }
+
+        return new ModelHealthRun($verdicts, $skipped, $raised, $resolved, $dryRun);
+    }
+
+    /**
+     * A probe that throws must not abort the whole run — one broken provider
+     * would otherwise hide the state of every other one.
+     */
+    private function probeSafely(string $service, ModelListProbeInterface $probe): ProbeResult
+    {
+        try {
+            return $probe->probe($service);
+        } catch (\Throwable $e) {
+            $this->logger->warning('Model catalog probe threw', [
+                'service' => $service,
+                'error' => $e->getMessage(),
+            ]);
+
+            return ProbeResult::failed(FailureKind::Transient, 'Probe failed: '.$e->getMessage());
+        }
+    }
+
+    /**
+     * Settle whether a model missing from the listing is actually gone.
+     *
+     * An earlier version answered this with a heuristic: a listing was allowed
+     * to retire models of a capability once it recognised any other model of
+     * that capability. Measured against the live APIs, that was wrong in both
+     * directions on our own catalog — it reported the three Imagen models as
+     * retired (Google omits them from models.list but serves them, and
+     * `GET /v1beta/models/imagen-4.0-generate-001` answers 200) while excusing
+     * `grok-tts`, which xAI really had removed (404). The heuristic tracked how
+     * our catalog is grouped, not what the provider serves, so it is gone and
+     * the provider itself is asked instead.
+     *
+     * @param array<string, int> $budget per-service confirmation counter, by reference
+     */
+    private function presence(
+        string $service,
+        ?ModelListProbeInterface $probe,
+        ProbeResult $result,
+        string $providerId,
+        array &$budget,
+    ): ModelProbeResult {
+        if (!$result->listingComplete) {
+            return ModelProbeResult::Inconclusive;
+        }
+        if ($result->offers($providerId)) {
+            return ModelProbeResult::Alive;
+        }
+        // Ollama and Cloudflare enumerate their whole surface in one call, so
+        // absence there is already the answer and costs no extra request.
+        if ($result->listingAuthoritative) {
+            return ModelProbeResult::Gone;
+        }
+        if (null === $probe) {
+            return ModelProbeResult::Inconclusive;
+        }
+
+        // This check runs every few minutes, but a model does not come back
+        // from the dead that fast. Re-asking about a settled model on every run
+        // would mean hundreds of pointless requests a day per retired model, so
+        // a conclusive answer is remembered for a while. Recovery is still
+        // noticed, just one cache period later instead of one run later.
+        $cacheKey = 'model_health.presence.'.mb_strtolower($service).'.'.md5($providerId);
+        $item = $this->cache->getItem($cacheKey);
+        if ($item->isHit()) {
+            $cached = $item->get();
+            if ($cached instanceof ModelProbeResult) {
+                return $cached;
+            }
+        }
+
+        // A listing that is technically valid but wildly incomplete would
+        // otherwise fan out into one request per catalogued model. Past the
+        // ceiling we report "unknown", which is honest and harmless.
+        $spent = $budget[$service] ?? 0;
+        if ($spent >= self::MAX_CONFIRMATIONS_PER_SERVICE) {
+            return ModelProbeResult::Inconclusive;
+        }
+        $budget[$service] = $spent + 1;
+
+        try {
+            $presence = $probe->confirm($service, $providerId);
+        } catch (\Throwable $e) {
+            $this->logger->warning('Model confirmation probe threw', [
+                'service' => $service,
+                'model' => $providerId,
+                'error' => $e->getMessage(),
+            ]);
+
+            return ModelProbeResult::Inconclusive;
+        }
+
+        // Only conclusive answers are worth remembering. Caching "inconclusive"
+        // would extend a rate limit into a blind spot.
+        if (ModelProbeResult::Inconclusive !== $presence) {
+            $item->set($presence);
+            $item->expiresAfter(self::PRESENCE_CACHE_TTL_SECONDS);
+            $this->cache->save($item);
+        }
+
+        return $presence;
+    }
+
+    /**
+     * Decide the state of a single model.
+     */
+    private function judge(string $service, Model $model, string $providerId, ProbeResult $probe, ModelProbeResult $presence, int $now): ModelHealthVerdict
+    {
+        $modelId = (int) $model->getId();
+        $counters = $this->recorder->snapshot($modelId);
+
+        $make = fn (ModelHealthState $state, ?FailureKind $kind, string $message, string $source, bool $safeToDisable = false): ModelHealthVerdict => new ModelHealthVerdict(
+            modelId: $modelId,
+            service: $service,
+            modelName: $model->getName(),
+            providerId: $providerId,
+            tag: $model->getTag(),
+            state: $state,
+            kind: $kind,
+            message: $message,
+            source: $source,
+            safeToDisable: $safeToDisable,
+        );
+
+        // A provider nobody configured is not broken. Saying otherwise would
+        // paint a self-hosted install red for the fifteen providers it never
+        // set up, and an operator who learns to ignore red stops reading it.
+        if ($probe->isSkipped()) {
+            return $make(ModelHealthState::Unconfigured, null, $probe->message, ModelHealth::SOURCE_PROBE);
+        }
+
+        if ($probe->isFailed()) {
+            $state = FailureKind::Credential === $probe->kind
+                ? ModelHealthState::Offline
+                : ModelHealthState::Degraded;
+
+            return $make($state, $probe->kind, $probe->message, ModelHealth::SOURCE_PROBE);
+        }
+
+        // Only the provider's own rejection retires a model. This is the single
+        // place allowed to emit Offline+Permanent from catalog evidence, and
+        // ModelConfigService routes traffic away from exactly that combination,
+        // so anything weaker than a confirmed Gone must not reach it.
+        if (ModelProbeResult::Gone === $presence) {
+            return $make(
+                ModelHealthState::Offline,
+                FailureKind::Permanent,
+                sprintf('%s no longer serves this model.', $service),
+                ModelHealth::SOURCE_PROBE,
+                safeToDisable: true,
+            );
+        }
+
+        // Missing from the listing, and the provider would not say either way.
+        // Fall through to the traffic counters and, failing those, report
+        // honestly that we do not know rather than guessing in either direction.
+        if (ModelProbeResult::Inconclusive === $presence && $probe->listingComplete && !$probe->offers($providerId) && $counters->isEmpty()) {
+            return $make(
+                ModelHealthState::Unknown,
+                null,
+                sprintf('%s does not list this model and did not confirm whether it still exists.', $service),
+                ModelHealth::SOURCE_PROBE,
+            );
+        }
+
+        // The provider still offers it. Now ask real traffic whether it works
+        // for THIS account — the part a catalog lookup can never answer.
+        if ($counters->total() >= $this->config->minSampleSize()
+            && $counters->errorRatePercent() >= $this->config->errorRatePercent()) {
+            $state = FailureKind::Permanent === $counters->lastKind
+                ? ModelHealthState::Offline
+                : ModelHealthState::Degraded;
+
+            return $make(
+                $state,
+                $counters->lastKind,
+                trim(sprintf(
+                    '%d%% of the last %d calls failed. %s',
+                    $counters->errorRatePercent(),
+                    $counters->total(),
+                    $counters->lastMessage ?? ''
+                )),
+                ModelHealth::SOURCE_TRAFFIC,
+                // Real calls failing permanently is the strongest evidence
+                // there is — that is a model the provider actually rejects.
+                safeToDisable: FailureKind::Permanent === $counters->lastKind,
+            );
+        }
+
+        if (!$probe->listingComplete && $counters->isEmpty()) {
+            // Nothing to go on: no catalog listing and no traffic. Reporting
+            // "online" here would be a guess dressed up as a fact.
+            return $make(ModelHealthState::Unknown, null, $probe->message, ModelHealth::SOURCE_PROBE);
+        }
+
+        return $make(
+            ModelHealthState::Online,
+            null,
+            '',
+            $counters->isEmpty() ? ModelHealth::SOURCE_PROBE : ModelHealth::SOURCE_TRAFFIC,
+        );
+    }
+
+    /**
+     * Aggregate this provider's verdicts into at most one alert per kind, and
+     * send the all-clear for the kinds that recovered.
+     *
+     * @param list<ModelHealthVerdict> $verdicts
+     *
+     * @return array{raised: list<ModelHealthAlert>, resolved: list<ModelHealthAlert>}
+     */
+    private function reconcileAlerts(string $service, array $verdicts, ProbeResult $probe, bool $dryRun): array
+    {
+        $raised = [];
+        $resolved = [];
+
+        $credentialProblem = $probe->isFailed() && FailureKind::Credential === $probe->kind;
+
+        $offline = array_values(array_filter(
+            $verdicts,
+            static fn (ModelHealthVerdict $v): bool => ModelHealthState::Offline === $v->state
+        ));
+        $degraded = array_values(array_filter(
+            $verdicts,
+            static fn (ModelHealthVerdict $v): bool => ModelHealthState::Degraded === $v->state
+        ));
+
+        $buckets = [
+            ModelHealthAlert::KIND_CREDENTIAL => $credentialProblem ? $offline : [],
+            // A credential failure already reports every model of the provider;
+            // a second "models offline" alert about the same cause would just
+            // double the noise.
+            ModelHealthAlert::KIND_OFFLINE => $credentialProblem ? [] : $offline,
+            ModelHealthAlert::KIND_DEGRADED => $degraded,
+        ];
+
+        foreach ($buckets as $kind => $affected) {
+            if ([] !== $affected) {
+                $alert = new ModelHealthAlert(
+                    $kind,
+                    $service,
+                    array_map(static fn (ModelHealthVerdict $v): string => $v->modelName, $affected),
+                    $affected[0]->message,
+                );
+
+                if ($dryRun || $this->alerter->raise($alert)) {
+                    $raised[] = $alert;
+                }
+                continue;
+            }
+
+            if ($this->alerter->isOpen($service, $kind)) {
+                $alert = new ModelHealthAlert($kind, $service, [], 'All models are answering again.');
+                if ($dryRun || $this->alerter->resolve($alert)) {
+                    $resolved[] = $alert;
+                }
+            }
+        }
+
+        return ['raised' => $raised, 'resolved' => $resolved];
+    }
+
+    /**
+     * Write the verdict to BMODELHEALTH and let the auto-disabler act on it.
+     * Returns the verdict enriched with what actually happened to BACTIVE.
+     */
+    private function commit(ModelHealthVerdict $verdict, Model $model, int $now): ModelHealthVerdict
+    {
+        $health = $this->healthRepository->findOrCreate($verdict->modelId);
+        $health->setState($verdict->state)
+            ->setSource($verdict->source)
+            ->setKind($verdict->kind?->value)
+            ->setMessage('' === $verdict->message ? null : $verdict->message)
+            ->setLastCheck($now)
+            ->setUpdated($now);
+
+        if (ModelHealthState::Online === $verdict->state) {
+            $health->setLastSuccess($now);
+        } elseif ($verdict->state->needsAttention()) {
+            $health->setLastFailure($now);
+        }
+
+        $applied = $this->autoDisabler->apply($verdict, $model, $health, $now);
+
+        return new ModelHealthVerdict(
+            modelId: $verdict->modelId,
+            service: $verdict->service,
+            modelName: $verdict->modelName,
+            providerId: $verdict->providerId,
+            tag: $verdict->tag,
+            state: $verdict->state,
+            kind: $verdict->kind,
+            message: $verdict->message,
+            source: $verdict->source,
+            safeToDisable: $verdict->safeToDisable,
+            autoDisabled: $applied['disabled'],
+            reEnabled: $applied['reEnabled'],
+        );
+    }
+}

--- a/backend/src/AI/Health/ModelHealthEvaluator.php
+++ b/backend/src/AI/Health/ModelHealthEvaluator.php
@@ -8,6 +8,7 @@ use App\AI\Health\Probe\ModelListProbeInterface;
 use App\AI\Health\Probe\ModelListProbeRegistry;
 use App\AI\Health\Probe\ProbeResult;
 use App\AI\Service\ModelProbeResult;
+use App\AI\Service\ProviderDisplayNames;
 use App\Entity\Model;
 use App\Entity\ModelHealth;
 use App\Repository\ModelHealthRepository;
@@ -56,6 +57,7 @@ final readonly class ModelHealthEvaluator
         private ModelAutoDisabler $autoDisabler,
         private EntityManagerInterface $em,
         private CacheItemPoolInterface $cache,
+        private ProviderDisplayNames $displayNames,
         private LoggerInterface $logger,
     ) {
     }
@@ -270,7 +272,7 @@ final readonly class ModelHealthEvaluator
             return $make(
                 ModelHealthState::Offline,
                 FailureKind::Permanent,
-                sprintf('%s no longer serves this model.', $service),
+                sprintf('%s no longer serves this model.', $this->displayNames->forService($service)),
                 ModelHealth::SOURCE_PROBE,
                 safeToDisable: true,
             );
@@ -283,7 +285,7 @@ final readonly class ModelHealthEvaluator
             return $make(
                 ModelHealthState::Unknown,
                 null,
-                sprintf('%s does not list this model and did not confirm whether it still exists.', $service),
+                sprintf('%s does not list this model and did not confirm whether it still exists.', $this->displayNames->forService($service)),
                 ModelHealth::SOURCE_PROBE,
             );
         }
@@ -366,6 +368,7 @@ final readonly class ModelHealthEvaluator
                     $service,
                     array_map(static fn (ModelHealthVerdict $v): string => $v->modelName, $affected),
                     $affected[0]->message,
+                    $this->displayNames->forService($service),
                 );
 
                 if ($dryRun || $this->alerter->raise($alert)) {
@@ -375,7 +378,7 @@ final readonly class ModelHealthEvaluator
             }
 
             if ($this->alerter->isOpen($service, $kind)) {
-                $alert = new ModelHealthAlert($kind, $service, [], 'All models are answering again.');
+                $alert = new ModelHealthAlert($kind, $service, [], 'All models are answering again.', $this->displayNames->forService($service));
                 if ($dryRun || $this->alerter->resolve($alert)) {
                     $resolved[] = $alert;
                 }

--- a/backend/src/AI/Health/ModelHealthOverview.php
+++ b/backend/src/AI/Health/ModelHealthOverview.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\AI\Health;
+
+use App\Entity\Model;
+use App\Entity\ModelHealth;
+use App\Repository\ModelHealthRepository;
+use App\Repository\ModelRepository;
+
+/**
+ * Builds the payload behind the admin model status page.
+ *
+ * Reads only: the persisted verdict from BMODELHEALTH plus the live traffic
+ * counters from Redis. Opening the page never triggers a provider call — a
+ * status page that probes on render turns a browser refresh into API traffic,
+ * and an operator watching an incident refreshes a lot.
+ */
+final readonly class ModelHealthOverview
+{
+    public function __construct(
+        private ModelRepository $models,
+        private ModelHealthRepository $healthRepository,
+        private ModelHealthRecorder $recorder,
+        private ModelHealthConfig $config,
+    ) {
+    }
+
+    /**
+     * @return array{
+     *     summary: array{total: int, online: int, degraded: int, offline: int, unconfigured: int, unknown: int, needsAttention: int, lastCheck: int, autoDisableEnabled: bool, monitoringEnabled: bool},
+     *     providers: list<array{name: string, needsAttention: int, models: list<array<string, mixed>>}>
+     * }
+     */
+    public function build(): array
+    {
+        /** @var list<Model> $models */
+        $models = $this->models->findBy([], ['service' => 'ASC', 'tag' => 'ASC', 'name' => 'ASC']);
+        $healthByModel = $this->healthRepository->findIndexedByModelId();
+
+        $counts = array_fill_keys(array_map(static fn (ModelHealthState $s): string => $s->value, ModelHealthState::cases()), 0);
+        $lastCheck = 0;
+        $byProvider = [];
+        $now = time();
+
+        foreach ($models as $model) {
+            $modelId = (int) $model->getId();
+            $health = $healthByModel[$modelId] ?? null;
+            $counters = $this->recorder->snapshot($modelId);
+
+            $state = $health?->getState() ?? ModelHealthState::Unknown;
+            ++$counts[$state->value];
+            $lastCheck = max($lastCheck, $health?->getLastCheck() ?? 0);
+
+            $service = $model->getService();
+            $byProvider[$service] ??= ['name' => $service, 'needsAttention' => 0, 'models' => []];
+            if ($state->needsAttention()) {
+                ++$byProvider[$service]['needsAttention'];
+            }
+
+            $byProvider[$service]['models'][] = [
+                'id' => $modelId,
+                'name' => $model->getName(),
+                'providerId' => $model->getProviderId(),
+                'capability' => $model->getTag(),
+                'state' => $state->value,
+                'reason' => $health?->getMessage() ?? '',
+                'source' => $health?->getSource() ?? ModelHealth::SOURCE_PROBE,
+                'lastCheck' => $health?->getLastCheck() ?? 0,
+                'lastSuccess' => max($health?->getLastSuccess() ?? 0, $counters->lastSuccessAt),
+                'lastFailure' => max($health?->getLastFailure() ?? 0, $counters->lastFailureAt),
+                'successes' => $counters->successes,
+                'failures' => $counters->failures,
+                'errorRatePercent' => $counters->errorRatePercent(),
+                'active' => 1 === $model->getActive(),
+                'selectable' => 1 === $model->getSelectable(),
+                'autoDisabled' => $health?->isAutoDisabled() ?? false,
+                'exemptUntil' => null !== $health && $health->isSuppressed($now) ? $health->getSuppressUntil() : 0,
+            ];
+        }
+
+        $providers = array_values($byProvider);
+        // Providers with something wrong float to the top: an operator opening
+        // this page is looking for the problem, not for an alphabet.
+        usort($providers, static function (array $a, array $b): int {
+            return [$b['needsAttention'], $a['name']] <=> [$a['needsAttention'], $b['name']];
+        });
+
+        return [
+            'summary' => [
+                'total' => count($models),
+                'online' => $counts[ModelHealthState::Online->value],
+                'degraded' => $counts[ModelHealthState::Degraded->value],
+                'offline' => $counts[ModelHealthState::Offline->value],
+                'unconfigured' => $counts[ModelHealthState::Unconfigured->value],
+                'unknown' => $counts[ModelHealthState::Unknown->value],
+                'needsAttention' => $counts[ModelHealthState::Degraded->value] + $counts[ModelHealthState::Offline->value],
+                'lastCheck' => $lastCheck,
+                'autoDisableEnabled' => $this->config->isAutoDisableEnabled(),
+                'monitoringEnabled' => $this->config->isEnabled(),
+            ],
+            'providers' => $providers,
+        ];
+    }
+}

--- a/backend/src/AI/Health/ModelHealthOverview.php
+++ b/backend/src/AI/Health/ModelHealthOverview.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace App\AI\Health;
 
+use App\AI\Service\ProviderDisplayNames;
 use App\Entity\Model;
 use App\Entity\ModelHealth;
+use App\Model\ModelCatalog;
 use App\Repository\ModelHealthRepository;
 use App\Repository\ModelRepository;
 
@@ -24,13 +26,14 @@ final readonly class ModelHealthOverview
         private ModelHealthRepository $healthRepository,
         private ModelHealthRecorder $recorder,
         private ModelHealthConfig $config,
+        private ProviderDisplayNames $displayNames,
     ) {
     }
 
     /**
      * @return array{
      *     summary: array{total: int, online: int, degraded: int, offline: int, unconfigured: int, unknown: int, needsAttention: int, lastCheck: int, autoDisableEnabled: bool, monitoringEnabled: bool},
-     *     providers: list<array{name: string, needsAttention: int, models: list<array<string, mixed>>}>
+     *     providers: list<array{name: string, displayName: string, needsAttention: int, models: list<array<string, mixed>>}>
      * }
      */
     public function build(): array
@@ -38,6 +41,7 @@ final readonly class ModelHealthOverview
         /** @var list<Model> $models */
         $models = $this->models->findBy([], ['service' => 'ASC', 'tag' => 'ASC', 'name' => 'ASC']);
         $healthByModel = $this->healthRepository->findIndexedByModelId();
+        $displayNames = $this->displayNames->all();
 
         $counts = array_fill_keys(array_map(static fn (ModelHealthState $s): string => $s->value, ModelHealthState::cases()), 0);
         $lastCheck = 0;
@@ -53,8 +57,20 @@ final readonly class ModelHealthOverview
             ++$counts[$state->value];
             $lastCheck = max($lastCheck, $health?->getLastCheck() ?? 0);
 
-            $service = $model->getService();
-            $byProvider[$service] ??= ['name' => $service, 'needsAttention' => 0, 'models' => []];
+            // Grouped by the normalised key, not by BSERVICE itself: the
+            // catalog holds both "Ollama" and "ollama", which would otherwise
+            // render as two sections under the same heading. A re-check scoped
+            // to this key still covers both, because the run matches services
+            // case-insensitively.
+            $service = ModelCatalog::normalizeProvider($model->getService());
+            $byProvider[$service] ??= [
+                'name' => $service,
+                // A catalog entry for a provider this build does not register
+                // still has to show something, so the raw service is the fallback.
+                'displayName' => $displayNames[$service] ?? $model->getService(),
+                'needsAttention' => 0,
+                'models' => [],
+            ];
             if ($state->needsAttention()) {
                 ++$byProvider[$service]['needsAttention'];
             }
@@ -82,9 +98,10 @@ final readonly class ModelHealthOverview
 
         $providers = array_values($byProvider);
         // Providers with something wrong float to the top: an operator opening
-        // this page is looking for the problem, not for an alphabet.
+        // this page is looking for the problem, not for an alphabet. Ties are
+        // ordered by the label actually on screen, not by the internal key.
         usort($providers, static function (array $a, array $b): int {
-            return [$b['needsAttention'], $a['name']] <=> [$a['needsAttention'], $b['name']];
+            return [$b['needsAttention'], $a['displayName']] <=> [$a['needsAttention'], $b['displayName']];
         });
 
         return [

--- a/backend/src/AI/Health/ModelHealthRecorder.php
+++ b/backend/src/AI/Health/ModelHealthRecorder.php
@@ -1,0 +1,281 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\AI\Health;
+
+use App\Repository\ModelRepository;
+use App\Service\Usage\UsageFailureLogger;
+use Psr\Cache\CacheItemPoolInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Counts how AI calls end, per model, inside a rolling window.
+ *
+ * This is the free half of the detection: it only looks at calls that happen
+ * anyway, so it costs nothing and — unlike a catalog lookup — it also sees the
+ * failures that only show up for THIS account (exhausted quota, blocked
+ * region).
+ *
+ * Counters live in the shared Redis pool so all web nodes agree, and expire on
+ * their own: an unused window simply lapses instead of having to be swept.
+ * Increments are read-modify-write rather than atomic, so a burst can lose the
+ * odd count. That is fine for a threshold heuristic and not worth a Redis-only
+ * dependency for.
+ *
+ * Nothing in here may throw: a broken health counter must never take down the
+ * AI call it is observing.
+ */
+final class ModelHealthRecorder
+{
+    private const KEY_PREFIX = 'model_health.window.';
+
+    /**
+     * AiFacade capability => BMODELS.BTAG. Needed because one provider model id
+     * can back several catalog rows (Groq's Qwen backs both the chat and the
+     * vision row), and attributing a vision failure to the chat row would
+     * report the wrong model as broken.
+     */
+    private const CAPABILITY_TAGS = [
+        'chat' => 'chat',
+        'vision' => 'pic2text',
+        'embedding' => 'vectorize',
+        'image_generation' => 'text2pic',
+        'video_generation' => 'text2vid',
+        'speech_to_text' => 'sound2text',
+        'text_to_speech' => 'text2sound',
+    ];
+
+    /** @return list<string> */
+    public static function capabilities(): array
+    {
+        return array_keys(self::CAPABILITY_TAGS);
+    }
+
+    /** BMODELS.BTAG for an AiFacade capability, or null when unmapped. */
+    public static function tagForCapability(string $capability): ?string
+    {
+        return self::CAPABILITY_TAGS[$capability] ?? null;
+    }
+
+    /** @var array<string, int|null> */
+    private array $resolveMemo = [];
+
+    public function __construct(
+        private readonly CacheItemPoolInterface $cache,
+        private readonly ModelHealthConfig $config,
+        private readonly FailureClassifier $classifier,
+        private readonly ModelRepository $modelRepository,
+        private readonly UsageFailureLogger $failureLogger,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * Record a call that came back cleanly.
+     */
+    public function recordSuccess(string $capability, string $providerName, ?string $providerModelId): void
+    {
+        $modelId = $this->resolveModelId($capability, $providerName, $providerModelId);
+        if (null === $modelId) {
+            return;
+        }
+
+        $this->mutate($modelId, function (array $window): array {
+            ++$window['ok'];
+            $window['last_success_at'] = time();
+            // A success clears the stored error so the status page never shows
+            // a stale message next to a model that is working again.
+            $window['last_kind'] = null;
+            $window['last_message'] = null;
+
+            return $window;
+        });
+    }
+
+    /**
+     * Record a failed call. Returns how it was classified so the caller can act
+     * on it without classifying a second time.
+     */
+    public function recordFailure(
+        string $capability,
+        string $providerName,
+        ?string $providerModelId,
+        \Throwable $error,
+        ?int $userId = null,
+    ): FailureKind {
+        $kind = $this->classifier->classify($error);
+        if (!$kind->countsAgainstModel()) {
+            return $kind;
+        }
+
+        $modelId = $this->resolveModelId($capability, $providerName, $providerModelId);
+
+        // The BUSELOG row is written even when the model is not in the catalog:
+        // an operator debugging a direct provider call still wants the trail.
+        if (null !== $userId && $userId > 0) {
+            $this->failureLogger->record(
+                userId: $userId,
+                action: $capability,
+                provider: $providerName,
+                model: $providerModelId ?? 'unknown',
+                modelId: $modelId,
+                failureKind: $kind->value,
+                errorMessage: $error->getMessage(),
+            );
+        }
+
+        if (null === $modelId) {
+            return $kind;
+        }
+
+        $message = $error->getMessage();
+        $this->mutate($modelId, static function (array $window) use ($kind, $message): array {
+            ++$window['fail'];
+            $window['last_failure_at'] = time();
+            $window['last_kind'] = $kind->value;
+            $window['last_message'] = mb_substr($message, 0, 500);
+
+            return $window;
+        });
+
+        return $kind;
+    }
+
+    public function snapshot(int $modelId): ModelHealthCounters
+    {
+        $window = $this->readWindow($modelId);
+
+        return new ModelHealthCounters(
+            successes: (int) $window['ok'],
+            failures: (int) $window['fail'],
+            lastKind: is_string($window['last_kind'] ?? null) ? FailureKind::tryFrom($window['last_kind']) : null,
+            lastMessage: is_string($window['last_message'] ?? null) ? $window['last_message'] : null,
+            lastFailureAt: (int) ($window['last_failure_at'] ?? 0),
+            lastSuccessAt: (int) ($window['last_success_at'] ?? 0),
+        );
+    }
+
+    /**
+     * @param list<int> $modelIds
+     *
+     * @return array<int, ModelHealthCounters>
+     */
+    public function snapshotMany(array $modelIds): array
+    {
+        $snapshots = [];
+        foreach ($modelIds as $modelId) {
+            $snapshots[$modelId] = $this->snapshot($modelId);
+        }
+
+        return $snapshots;
+    }
+
+    /**
+     * Forget the window for a model. Used after an operator acts on it, so the
+     * next verdict is formed from fresh evidence instead of the old backlog.
+     */
+    public function reset(int $modelId): void
+    {
+        try {
+            $this->cache->deleteItem(self::KEY_PREFIX.$modelId);
+        } catch (\Throwable $e) {
+            $this->logger->debug('Model health counter reset failed', [
+                'model_id' => $modelId,
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+
+    /**
+     * Find the catalog row a provider call belongs to.
+     *
+     * Returns null when the model is not in BMODELS — direct provider calls
+     * with an ad-hoc model id exist, and they simply have nothing to report on.
+     */
+    public function resolveModelId(string $capability, string $providerName, ?string $providerModelId): ?int
+    {
+        if (null === $providerModelId || '' === trim($providerModelId)) {
+            return null;
+        }
+
+        $tag = self::CAPABILITY_TAGS[$capability] ?? null;
+        if (null === $tag) {
+            return null;
+        }
+
+        $memoKey = $tag.'|'.strtolower($providerName).'|'.strtolower($providerModelId);
+        if (array_key_exists($memoKey, $this->resolveMemo)) {
+            return $this->resolveMemo[$memoKey];
+        }
+
+        try {
+            $modelId = $this->modelRepository->findIdByServiceProviderIdAndTag($providerName, $providerModelId, $tag);
+        } catch (\Throwable $e) {
+            $this->logger->debug('Model health lookup failed', [
+                'provider' => $providerName,
+                'model' => $providerModelId,
+                'error' => $e->getMessage(),
+            ]);
+            $modelId = null;
+        }
+
+        return $this->resolveMemo[$memoKey] = $modelId;
+    }
+
+    /**
+     * @param callable(array<string, mixed>): array<string, mixed> $mutator
+     */
+    private function mutate(int $modelId, callable $mutator): void
+    {
+        try {
+            $item = $this->cache->getItem(self::KEY_PREFIX.$modelId);
+            $window = $item->isHit() && is_array($item->get()) ? $item->get() : self::emptyWindow();
+            $item->set($mutator($window + self::emptyWindow()));
+            // Tumbling window: when nothing is recorded for a full window the
+            // key lapses and the model starts from a clean slate.
+            $item->expiresAfter($this->config->windowSeconds());
+            $this->cache->save($item);
+        } catch (\Throwable $e) {
+            $this->logger->debug('Model health counter update failed', [
+                'model_id' => $modelId,
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readWindow(int $modelId): array
+    {
+        try {
+            $item = $this->cache->getItem(self::KEY_PREFIX.$modelId);
+            if ($item->isHit() && is_array($item->get())) {
+                return $item->get() + self::emptyWindow();
+            }
+        } catch (\Throwable $e) {
+            $this->logger->debug('Model health counter read failed', [
+                'model_id' => $modelId,
+                'error' => $e->getMessage(),
+            ]);
+        }
+
+        return self::emptyWindow();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function emptyWindow(): array
+    {
+        return [
+            'ok' => 0,
+            'fail' => 0,
+            'last_kind' => null,
+            'last_message' => null,
+            'last_failure_at' => 0,
+            'last_success_at' => 0,
+        ];
+    }
+}

--- a/backend/src/AI/Health/ModelHealthRun.php
+++ b/backend/src/AI/Health/ModelHealthRun.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\AI\Health;
+
+/**
+ * Everything one health-check run produced, for the console output and the
+ * admin endpoint.
+ */
+final readonly class ModelHealthRun
+{
+    /**
+     * @param list<ModelHealthVerdict> $verdicts
+     * @param array<string, string>    $skippedProviders provider => why it was skipped
+     * @param list<ModelHealthAlert>   $alertsRaised
+     * @param list<ModelHealthAlert>   $alertsResolved
+     */
+    public function __construct(
+        public array $verdicts,
+        public array $skippedProviders,
+        public array $alertsRaised,
+        public array $alertsResolved,
+        public bool $dryRun,
+    ) {
+    }
+
+    /**
+     * @return list<ModelHealthVerdict>
+     */
+    public function withState(ModelHealthState $state): array
+    {
+        return array_values(array_filter($this->verdicts, static fn (ModelHealthVerdict $v): bool => $v->state === $state));
+    }
+
+    public function countWithState(ModelHealthState $state): int
+    {
+        return count($this->withState($state));
+    }
+
+    /**
+     * @return list<ModelHealthVerdict>
+     */
+    public function autoDisabled(): array
+    {
+        return array_values(array_filter($this->verdicts, static fn (ModelHealthVerdict $v): bool => $v->autoDisabled));
+    }
+
+    /**
+     * @return list<ModelHealthVerdict>
+     */
+    public function reEnabled(): array
+    {
+        return array_values(array_filter($this->verdicts, static fn (ModelHealthVerdict $v): bool => $v->reEnabled));
+    }
+}

--- a/backend/src/AI/Health/ModelHealthState.php
+++ b/backend/src/AI/Health/ModelHealthState.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\AI\Health;
+
+/**
+ * What the operator sees for a single model on the status page.
+ *
+ * {@see self::Unconfigured} is the load-bearing one: a self-hosted install
+ * typically has a single provider key, so without it the status page would
+ * paint over a hundred models red and look like a broken product.
+ */
+enum ModelHealthState: string
+{
+    /** Offered by the provider and no recent failures. */
+    case Online = 'online';
+
+    /** Reachable but failing more often than the threshold allows. */
+    case Degraded = 'degraded';
+
+    /** Gone from the provider's catalog, or failing permanently. */
+    case Offline = 'offline';
+
+    /** The provider has no credentials on this install — not a fault. */
+    case Unconfigured = 'unconfigured';
+
+    /** Never probed and never used, so there is nothing to report yet. */
+    case Unknown = 'unknown';
+
+    /** Should this state draw the operator's attention? */
+    public function needsAttention(): bool
+    {
+        return self::Degraded === $this || self::Offline === $this;
+    }
+}

--- a/backend/src/AI/Health/ModelHealthVerdict.php
+++ b/backend/src/AI/Health/ModelHealthVerdict.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\AI\Health;
+
+use App\Entity\ModelHealth;
+
+/**
+ * The health monitor's conclusion about one model in one run.
+ */
+final readonly class ModelHealthVerdict
+{
+    public function __construct(
+        public int $modelId,
+        public string $service,
+        public string $modelName,
+        public string $providerId,
+        public string $tag,
+        public ModelHealthState $state,
+        public ?FailureKind $kind,
+        public string $message,
+        public string $source = ModelHealth::SOURCE_PROBE,
+        /**
+         * May the automation act on this verdict, not just report it?
+         *
+         * True only where the provider itself gave a verdict about this exact
+         * model: it rejected the id, or real calls to it failed permanently.
+         * Absence from a published model list never qualifies — Google leaves
+         * Imagen out of /v1beta/models and serves it regardless, so "absent
+         * from the list" and "retired" are not the same claim.
+         */
+        public bool $safeToDisable = false,
+        public bool $autoDisabled = false,
+        public bool $reEnabled = false,
+    ) {
+    }
+
+    public function needsAttention(): bool
+    {
+        return $this->state->needsAttention();
+    }
+}

--- a/backend/src/AI/Health/Probe/CloudflareModelListProbe.php
+++ b/backend/src/AI/Health/Probe/CloudflareModelListProbe.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\AI\Health\Probe;
+
+use App\AI\Health\FailureKind;
+use App\AI\Service\ModelProbeResult;
+use Psr\Log\LoggerInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * Cloudflare Workers AI catalog.
+ *
+ * Account-scoped and therefore not covered by {@see PlatformKeyModelListProbe},
+ * whose endpoints all come from {@see \App\AI\Credential\ProviderKeyCatalog}.
+ * The search endpoint is free and returns the models this account may use.
+ */
+final readonly class CloudflareModelListProbe implements ModelListProbeInterface
+{
+    private const TIMEOUT_SECONDS = 12;
+
+    public function __construct(
+        private HttpClientInterface $httpClient,
+        private LoggerInterface $logger,
+        private ?string $accountId = null,
+        private ?string $apiToken = null,
+    ) {
+    }
+
+    public function supports(string $service): bool
+    {
+        return 'cloudflare' === mb_strtolower($service);
+    }
+
+    public function probe(string $service): ProbeResult
+    {
+        if (null === $this->accountId || '' === trim($this->accountId)
+            || null === $this->apiToken || '' === trim($this->apiToken)) {
+            return ProbeResult::skipped('CLOUDFLARE_ACCOUNT_ID / CLOUDFLARE_API_TOKEN are not configured.');
+        }
+
+        $url = sprintf(
+            'https://api.cloudflare.com/client/v4/accounts/%s/ai/models/search',
+            rawurlencode($this->accountId)
+        );
+
+        try {
+            $response = $this->httpClient->request('GET', $url, [
+                'headers' => ['Authorization' => 'Bearer '.$this->apiToken],
+                'timeout' => self::TIMEOUT_SECONDS,
+            ]);
+            $status = $response->getStatusCode();
+            $body = $status >= 200 && $status < 300 ? $response->toArray(false) : [];
+        } catch (\Throwable $e) {
+            $this->logger->info('Cloudflare catalog probe failed', ['error' => $e->getMessage()]);
+
+            return ProbeResult::failed(FailureKind::Transient, 'Could not reach the Cloudflare API: '.$e->getMessage());
+        }
+
+        if ($status < 200 || $status >= 300) {
+            return ProbeResult::failed(
+                match (true) {
+                    401 === $status, 403 === $status => FailureKind::Credential,
+                    429 === $status, $status >= 500 => FailureKind::Transient,
+                    default => FailureKind::Permanent,
+                },
+                sprintf('Cloudflare catalog returned HTTP %d.', $status)
+            );
+        }
+
+        $ids = [];
+        $rows = is_array($body['result'] ?? null) ? $body['result'] : [];
+        foreach ($rows as $row) {
+            if (is_array($row) && isset($row['name']) && is_string($row['name']) && '' !== $row['name']) {
+                $ids[] = mb_strtolower($row['name']);
+            }
+        }
+
+        if ([] === $ids) {
+            return ProbeResult::reachable('Cloudflare answered but returned no model list.');
+        }
+
+        // The search endpoint spans every Workers AI task type, so absence from
+        // it is a real verdict for any capability.
+        return ProbeResult::ok($ids, listingAuthoritative: true);
+    }
+
+    /** Never reached: the search listing above is authoritative on its own. */
+    public function confirm(string $service, string $providerModelId): ModelProbeResult
+    {
+        return ModelProbeResult::Inconclusive;
+    }
+}

--- a/backend/src/AI/Health/Probe/LocalProviderAvailabilityProbe.php
+++ b/backend/src/AI/Health/Probe/LocalProviderAvailabilityProbe.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\AI\Health\Probe;
+
+use App\AI\Health\FailureKind;
+use App\AI\Service\ModelProbeResult;
+use App\AI\Service\ProviderRegistry;
+
+/**
+ * Reachability check for self-hosted providers that have no catalog endpoint
+ * (Triton over gRPC, Piper TTS).
+ *
+ * Their own `isAvailable()` is the free check they already ship, so this probe
+ * can say "the service is up" without ever running inference. It cannot say
+ * anything about individual models, hence {@see ProbeResult::reachable()} — a
+ * reachable service must never be used as grounds for retiring a model.
+ */
+final readonly class LocalProviderAvailabilityProbe implements ModelListProbeInterface
+{
+    private const SERVICES = ['triton', 'piper'];
+
+    public function __construct(private ProviderRegistry $registry)
+    {
+    }
+
+    public function supports(string $service): bool
+    {
+        return in_array(mb_strtolower($service), self::SERVICES, true);
+    }
+
+    public function probe(string $service): ProbeResult
+    {
+        $name = mb_strtolower($service);
+
+        foreach ($this->registry->getUniqueProviders() as $provider) {
+            if (mb_strtolower($provider->getName()) !== $name) {
+                continue;
+            }
+
+            try {
+                return $provider->isAvailable()
+                    ? ProbeResult::reachable(sprintf('%s is reachable.', $provider->getDisplayName()))
+                    : ProbeResult::failed(FailureKind::Transient, sprintf('%s is not reachable.', $provider->getDisplayName()));
+            } catch (\Throwable $e) {
+                return ProbeResult::failed(FailureKind::Transient, sprintf('%s check failed: %s', $service, $e->getMessage()));
+            }
+        }
+
+        return ProbeResult::skipped(sprintf('"%s" is not registered in this installation.', $service));
+    }
+
+    /**
+     * A reachability check never produces a listing, so no model is ever
+     * missing from one and nothing here can be confirmed retired.
+     */
+    public function confirm(string $service, string $providerModelId): ModelProbeResult
+    {
+        return ModelProbeResult::Inconclusive;
+    }
+}

--- a/backend/src/AI/Health/Probe/ModelListProbeInterface.php
+++ b/backend/src/AI/Health/Probe/ModelListProbeInterface.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\AI\Health\Probe;
+
+use App\AI\Service\ModelProbeResult;
+
+/**
+ * Asks a provider which models it currently offers.
+ *
+ * Every implementation MUST use a free metadata endpoint. Inference calls are
+ * out of bounds here — pinging text-to-video models on a schedule would cost
+ * more per month than the rest of the platform put together, and the whole
+ * point of this layer is that outage detection is free.
+ *
+ * Implementations are collected by {@see ModelListProbeRegistry} via the
+ * `app.model_list_probe` tag.
+ */
+interface ModelListProbeInterface
+{
+    /** Service name as stored in BMODELS.BSERVICE, compared case-insensitively. */
+    public function supports(string $service): bool;
+
+    public function probe(string $service): ProbeResult;
+
+    /**
+     * Ask the provider about one specific model id.
+     *
+     * Called only for models missing from a listing that is not authoritative,
+     * and it is what turns "absent from a list" into "the provider says this is
+     * gone". Implementations MUST return {@see ModelProbeResult::Inconclusive}
+     * for anything they cannot answer conclusively; a wrong Gone retires a
+     * working model for every user of the install.
+     */
+    public function confirm(string $service, string $providerModelId): ModelProbeResult;
+}

--- a/backend/src/AI/Health/Probe/ModelListProbeRegistry.php
+++ b/backend/src/AI/Health/Probe/ModelListProbeRegistry.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\AI\Health\Probe;
+
+/**
+ * Finds the probe responsible for a BMODELS service name.
+ *
+ * Providers with no probe at all (Higgsfield, TheHive, the `test` fixtures)
+ * are not a gap: they have no free catalog endpoint, and inventing one out of
+ * paid inference calls is exactly what this design refuses to do. They are
+ * covered by the passive traffic counters instead.
+ */
+final readonly class ModelListProbeRegistry
+{
+    /**
+     * @param iterable<ModelListProbeInterface> $probes injected via the `app.model_list_probe` tag
+     */
+    public function __construct(private iterable $probes)
+    {
+    }
+
+    public function find(string $service): ?ModelListProbeInterface
+    {
+        foreach ($this->probes as $probe) {
+            if ($probe->supports($service)) {
+                return $probe;
+            }
+        }
+
+        return null;
+    }
+
+    public function has(string $service): bool
+    {
+        return null !== $this->find($service);
+    }
+}

--- a/backend/src/AI/Health/Probe/OllamaModelListProbe.php
+++ b/backend/src/AI/Health/Probe/OllamaModelListProbe.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\AI\Health\Probe;
+
+use App\AI\Health\FailureKind;
+use App\AI\Provider\OllamaProvider;
+use App\AI\Service\ModelProbeResult;
+use App\AI\Service\ProviderRegistry;
+
+/**
+ * Which models are actually pulled on the local Ollama server.
+ *
+ * The most useful probe of the lot for a self-hosted install: a reachable
+ * Ollama with nothing pulled is the single most common reason chat "does not
+ * work", and it is invisible to every other check because the server itself
+ * answers perfectly well.
+ */
+final readonly class OllamaModelListProbe implements ModelListProbeInterface
+{
+    public function __construct(private ProviderRegistry $registry)
+    {
+    }
+
+    public function supports(string $service): bool
+    {
+        return 'ollama' === mb_strtolower($service);
+    }
+
+    public function probe(string $service): ProbeResult
+    {
+        $provider = $this->ollamaProvider();
+        if (null === $provider) {
+            return ProbeResult::skipped('Ollama is not registered in this installation.');
+        }
+
+        try {
+            // getAvailableModels() returns [] both for "server down" and for
+            // "nothing pulled", which are very different verdicts — so the
+            // reachability question is asked separately.
+            if (!$provider->isAvailable()) {
+                return ProbeResult::failed(FailureKind::Transient, 'Ollama server is not reachable.');
+            }
+
+            $models = $provider->getAvailableModels();
+        } catch (\Throwable $e) {
+            return ProbeResult::failed(FailureKind::Transient, 'Ollama server not reachable: '.$e->getMessage());
+        }
+
+        $ids = [];
+        foreach ($models as $model) {
+            if (is_string($model) && '' !== trim($model)) {
+                $ids[] = mb_strtolower(trim($model));
+            }
+        }
+
+        // Authoritative: Ollama keeps every pulled model in one namespace, so
+        // "not in this list" means "not on the server" for chat, embedding and
+        // everything else alike. An empty list is therefore a real verdict — a
+        // reachable Ollama with nothing pulled is exactly what the user hits.
+        return ProbeResult::ok($ids, listingAuthoritative: true);
+    }
+
+    /**
+     * Never reached: the listing above already settles every model, so the
+     * evaluator has no missing model left to confirm.
+     */
+    public function confirm(string $service, string $providerModelId): ModelProbeResult
+    {
+        return ModelProbeResult::Inconclusive;
+    }
+
+    private function ollamaProvider(): ?OllamaProvider
+    {
+        foreach ($this->registry->getUniqueProviders() as $provider) {
+            if ($provider instanceof OllamaProvider) {
+                return $provider;
+            }
+        }
+
+        return null;
+    }
+}

--- a/backend/src/AI/Health/Probe/PlatformKeyModelListProbe.php
+++ b/backend/src/AI/Health/Probe/PlatformKeyModelListProbe.php
@@ -1,0 +1,205 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\AI\Health\Probe;
+
+use App\AI\Credential\ProviderKeyCatalog;
+use App\AI\Credential\ProviderKeyStore;
+use App\AI\Health\FailureKind;
+use App\AI\Service\ModelProbeResult;
+use App\AI\Service\ProviderModelInventoryInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * Catalog lookup for every cloud provider whose key lives in the
+ * {@see ProviderKeyStore}: Groq, OpenAI, Anthropic, Google, Mistral,
+ * TrustedTokens, HuggingFace and xAI.
+ *
+ * It reuses the endpoints {@see ProviderKeyCatalog} already declares for key
+ * validation — all of them are free "list your models" calls, which is exactly
+ * what outage detection needs. One class instead of one per provider: the
+ * providers differ only in the JSON key their list hides behind, and eight
+ * near-identical classes would drift apart the first time one of them changed.
+ */
+final readonly class PlatformKeyModelListProbe implements ModelListProbeInterface
+{
+    private const TIMEOUT_SECONDS = 12;
+
+    /** Safety stop for paginated catalogs, so a broken cursor cannot loop forever. */
+    private const MAX_PAGES = 10;
+
+    /**
+     * Providers whose validation endpoint confirms the credentials but does not
+     * enumerate models. HuggingFace's whoami-v2 answers "this token is valid"
+     * and nothing else — good enough to tell a key problem from an outage, not
+     * good enough to declare a model retired.
+     */
+    private const NO_LISTING = ['huggingface'];
+
+    public function __construct(
+        private HttpClientInterface $httpClient,
+        private ProviderKeyStore $keyStore,
+        private ProviderModelInventoryInterface $inventory,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function supports(string $service): bool
+    {
+        return ProviderKeyCatalog::has(mb_strtolower($service));
+    }
+
+    public function probe(string $service): ProbeResult
+    {
+        $provider = mb_strtolower($service);
+        if (!ProviderKeyCatalog::has($provider)) {
+            return ProbeResult::skipped(sprintf('No catalog endpoint known for "%s".', $service));
+        }
+
+        $key = $this->keyStore->getKey($provider);
+        if (null === $key || '' === $key) {
+            // Not an outage: this install simply never configured the provider.
+            return ProbeResult::skipped('No API key configured for this provider.');
+        }
+
+        $check = ProviderKeyCatalog::get($provider)['validation'];
+        $headers = [];
+        foreach ($check['headers'] as $name => $value) {
+            $headers[$name] = str_replace('{key}', $key, $value);
+        }
+
+        $modelIds = [];
+        $url = $check['url'];
+        $pagesLeft = self::MAX_PAGES;
+
+        // Google's model list is paginated and defaults to a page size well
+        // below its catalog, so a single request silently omits whole model
+        // families — and an omitted model looks exactly like a retired one.
+        do {
+            try {
+                $response = $this->httpClient->request($check['method'], $url, [
+                    'headers' => $headers,
+                    'timeout' => self::TIMEOUT_SECONDS,
+                ]);
+                $status = $response->getStatusCode();
+                $body = $status >= 200 && $status < 300 ? $response->toArray(false) : [];
+            } catch (\Throwable $e) {
+                $this->logger->info('Model catalog probe could not reach provider', [
+                    'provider' => $provider,
+                    'error' => $e->getMessage(),
+                ]);
+
+                return ProbeResult::failed(FailureKind::Transient, 'Could not reach the provider API: '.$e->getMessage());
+            }
+
+            if ($status < 200 || $status >= 300) {
+                return ProbeResult::failed(self::kindForStatus($status), sprintf('Provider catalog returned HTTP %d.', $status));
+            }
+
+            if (in_array($provider, self::NO_LISTING, true)) {
+                return ProbeResult::reachable('Credentials accepted; this provider does not publish a model list.');
+            }
+
+            $modelIds = array_merge($modelIds, self::extractModelIds($body));
+
+            $nextPage = is_string($body['nextPageToken'] ?? null) && '' !== $body['nextPageToken']
+                ? $body['nextPageToken']
+                : null;
+            $url = null === $nextPage
+                ? null
+                : $check['url'].(str_contains($check['url'], '?') ? '&' : '?').'pageToken='.rawurlencode($nextPage);
+        } while (null !== $url && --$pagesLeft > 0);
+
+        $modelIds = array_values(array_unique($modelIds));
+
+        if ([] === $modelIds) {
+            // A 200 with an unparseable body means the provider is up but we
+            // learned nothing. Reporting every model as retired on that basis
+            // would be a catastrophic false positive.
+            $this->logger->warning('Model catalog probe returned no recognisable model list', [
+                'provider' => $provider,
+            ]);
+
+            return ProbeResult::reachable('Provider answered but returned no recognisable model list.');
+        }
+
+        // Never authoritative: these catalogs are partial. xAI's /v1/models
+        // lists chat models only, and Google omits Imagen from models.list
+        // while still serving it. Absence here is a hint, and confirm() decides.
+        return ProbeResult::ok($modelIds, listingAuthoritative: false);
+    }
+
+    /**
+     * Delegated to {@see ProviderModelInventoryInterface}, which the
+     * availability check already uses for exactly this question. Keeping a
+     * second implementation would mean two places encoding which status codes a
+     * given provider returns for an unknown model — and the day one of them
+     * learns that a provider answers 400 instead of 404, the other would keep
+     * reporting that model as alive.
+     */
+    public function confirm(string $service, string $providerModelId): ModelProbeResult
+    {
+        $provider = mb_strtolower($service);
+        if ('' === trim($providerModelId) || in_array($provider, self::NO_LISTING, true)) {
+            return ModelProbeResult::Inconclusive;
+        }
+
+        return $this->inventory->probe($provider, $providerModelId);
+    }
+
+    /**
+     * A rate-limited probe proves the credentials were accepted far enough to
+     * be throttled. Treating it as a failure would report a healthy provider as
+     * down every time the catalog endpoint is busy.
+     */
+    private static function kindForStatus(int $status): FailureKind
+    {
+        return match (true) {
+            401 === $status, 403 === $status, 402 === $status => FailureKind::Credential,
+            429 === $status => FailureKind::Transient,
+            $status >= 500 => FailureKind::Transient,
+            default => FailureKind::Permanent,
+        };
+    }
+
+    /**
+     * Pull model ids out of the two shapes these providers use: OpenAI-style
+     * `{"data":[{"id":...}]}` (Groq, OpenAI, Anthropic, Mistral, xAI,
+     * TrustedTokens) and Google's `{"models":[{"name":"models/..."}]}`.
+     *
+     * @param array<mixed> $body
+     *
+     * @return list<string>
+     */
+    private static function extractModelIds(array $body): array
+    {
+        $rows = [];
+        foreach (['data', 'models', 'result'] as $key) {
+            if (isset($body[$key]) && is_array($body[$key])) {
+                $rows = $body[$key];
+                break;
+            }
+        }
+
+        $ids = [];
+        foreach ($rows as $row) {
+            if (is_string($row)) {
+                $ids[] = mb_strtolower($row);
+                continue;
+            }
+            if (!is_array($row)) {
+                continue;
+            }
+            foreach (['id', 'name', 'model'] as $field) {
+                if (isset($row[$field]) && is_string($row[$field]) && '' !== $row[$field]) {
+                    $ids[] = mb_strtolower($row[$field]);
+                    break;
+                }
+            }
+        }
+
+        return array_values(array_unique($ids));
+    }
+}

--- a/backend/src/AI/Health/Probe/ProbeResult.php
+++ b/backend/src/AI/Health/Probe/ProbeResult.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\AI\Health\Probe;
+
+use App\AI\Health\FailureKind;
+
+/**
+ * What a free catalog lookup found for one provider.
+ *
+ * {@see self::skipped()} exists so a self-hosted install with a single API key
+ * does not light up red for the fifteen providers it never configured. A
+ * provider nobody set up is not broken, and saying so is the difference between
+ * a status page an operator trusts and one they learn to ignore.
+ */
+final readonly class ProbeResult
+{
+    public const STATUS_OK = 'ok';
+    public const STATUS_SKIPPED = 'skipped';
+    public const STATUS_FAILED = 'failed';
+
+    /**
+     * @param list<string> $modelIds             provider model ids the provider currently offers,
+     *                                           lowercased; empty when the provider has no listing
+     *                                           endpoint but did confirm the credentials
+     * @param bool         $listingComplete      whether $modelIds is a real listing rather than a
+     *                                           bare reachability check
+     * @param bool         $listingAuthoritative whether absence from this listing is by itself
+     *                                           conclusive. True only where one endpoint enumerates
+     *                                           the provider's entire surface (Ollama's pulled
+     *                                           models, Cloudflare's model search). False for every
+     *                                           cloud catalog: those publish partial lists, so a
+     *                                           missing model has to be confirmed one by one via
+     *                                           {@see ModelListProbeInterface::confirm()}
+     */
+    private function __construct(
+        public string $status,
+        public array $modelIds,
+        public bool $listingComplete,
+        public bool $listingAuthoritative,
+        public ?FailureKind $kind,
+        public string $message,
+    ) {
+    }
+
+    /**
+     * @param list<string> $modelIds
+     */
+    public static function ok(array $modelIds, bool $listingAuthoritative = false): self
+    {
+        return new self(self::STATUS_OK, array_values(array_unique($modelIds)), true, $listingAuthoritative, null, '');
+    }
+
+    /**
+     * The provider answered, but cannot enumerate its catalog. Proves the
+     * credentials work; says nothing about individual models.
+     */
+    public static function reachable(string $message = 'Provider reachable, catalog listing not supported'): self
+    {
+        return new self(self::STATUS_OK, [], false, false, null, $message);
+    }
+
+    public static function skipped(string $reason): self
+    {
+        return new self(self::STATUS_SKIPPED, [], false, false, null, $reason);
+    }
+
+    public static function failed(FailureKind $kind, string $message): self
+    {
+        return new self(self::STATUS_FAILED, [], false, false, $kind, $message);
+    }
+
+    public function isOk(): bool
+    {
+        return self::STATUS_OK === $this->status;
+    }
+
+    public function isSkipped(): bool
+    {
+        return self::STATUS_SKIPPED === $this->status;
+    }
+
+    public function isFailed(): bool
+    {
+        return self::STATUS_FAILED === $this->status;
+    }
+
+    /**
+     * Does the provider still offer this model id?
+     *
+     * Comparison ignores case and the Ollama/Google style suffixes and prefixes
+     * that differ between a catalog entry and the listing response.
+     */
+    public function offers(string $providerModelId): bool
+    {
+        $wanted = mb_strtolower(trim($providerModelId));
+        if ('' === $wanted) {
+            return false;
+        }
+
+        foreach ($this->modelIds as $offered) {
+            if ($offered === $wanted) {
+                return true;
+            }
+            // Ollama reports "llama3:latest" for a catalog entry of "llama3";
+            // Google reports "models/gemini-3-pro" for "gemini-3-pro".
+            if ($offered === $wanted.':latest' || $wanted === $offered.':latest') {
+                return true;
+            }
+            if (str_ends_with($offered, '/'.$wanted)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/backend/src/AI/Provider/OllamaProvider.php
+++ b/backend/src/AI/Provider/OllamaProvider.php
@@ -428,8 +428,14 @@ class OllamaProvider implements ChatProviderInterface, EmbeddingProviderInterfac
 
     /**
      * Get list of available models from Ollama.
+     *
+     * Public because the health monitor reports which models are actually
+     * pulled: a reachable Ollama holding nothing is the most common reason a
+     * self-hosted chat fails, and it is invisible to isAvailable().
+     * Returns an empty array both when nothing is pulled and when the call
+     * fails, so callers that need to tell those apart check isAvailable() too.
      */
-    protected function getAvailableModels(): array
+    public function getAvailableModels(): array
     {
         try {
             $models = $this->client->models()->list();

--- a/backend/src/AI/Service/AiFacade.php
+++ b/backend/src/AI/Service/AiFacade.php
@@ -4,6 +4,7 @@ namespace App\AI\Service;
 
 use App\AI\Credential\HiggsfieldCredentialResolver;
 use App\AI\Exception\ProviderException;
+use App\AI\Health\ModelHealthRecorder;
 use App\AI\Interface\EmbeddingProviderInterface;
 use App\AI\Interface\ProviderMetadataInterface;
 use App\AI\Interface\SupportsAsyncVideo;
@@ -56,6 +57,7 @@ class AiFacade
         private CacheItemPoolInterface $cachePool,
         private HiggsfieldCredentialResolver $higgsfieldCredentials,
         private TranscriptionUsageRecorder $transcriptionUsageRecorder,
+        private ModelHealthRecorder $health,
         private string $uploadDir = '/var/www/backend/var/uploads',
         private string $embeddingFallbackProvider = '',
     ) {
@@ -169,9 +171,13 @@ class AiFacade
 
         // Execute with Circuit Breaker protection
         try {
-            $response = $this->circuitBreaker->execute(
+            $response = $this->executeWithHealth(
                 callback: fn () => $provider->chat($messages, $options),
                 serviceName: 'ai_provider_'.$provider->getName(),
+                capability: 'chat',
+                provider: $provider,
+                options: $options,
+                userId: $userId,
                 fallback: null // NO FALLBACK - let ProviderException bubble up
             );
         } catch (ProviderException $e) {
@@ -231,7 +237,7 @@ class AiFacade
         // Execute streaming with Circuit Breaker protection
         $streamResult = null;
         try {
-            $this->circuitBreaker->execute(
+            $this->executeWithHealth(
                 callback: function () use ($provider, $messages, $streamCallback, $options, &$streamResult) {
                     $this->logger->info('🟢 AiFacade: Calling provider chatStream');
                     $streamResult = $provider->chatStream($messages, $streamCallback, $options);
@@ -240,6 +246,9 @@ class AiFacade
                     return null;
                 },
                 serviceName: 'ai_provider_'.$provider->getName(),
+                capability: 'chat',
+                provider: $provider,
+                options: $options,
                 fallback: null // NO FALLBACK - let ProviderException bubble up
             );
         } catch (ProviderException|StreamCancelledException $e) {
@@ -320,7 +329,13 @@ class AiFacade
                         'text_length' => strlen($text),
                     ]);
 
-                    return $provider->embed($text, $options);
+                    return $this->observing(
+                        'embedding',
+                        $provider->getName(),
+                        $resolvedModel,
+                        $userId,
+                        fn () => $provider->embed($text, $options),
+                    );
                 }
             );
         } catch (ProviderException $primaryError) {
@@ -505,7 +520,13 @@ class AiFacade
         $missingIndexes = array_keys($missingByIndex);
 
         try {
-            $batch = $provider->embedBatch($missingTexts, $options);
+            $batch = $this->observing(
+                'embedding',
+                $provider->getName(),
+                $resolvedModel,
+                $userId,
+                fn () => $provider->embedBatch($missingTexts, $options),
+            );
         } catch (\Throwable $primaryError) {
             // The fallback covers the FULL original text list (not just the
             // misses). Mixing cached primary vectors with fallback vectors
@@ -802,9 +823,13 @@ class AiFacade
             ]);
 
             try {
-                $response = $this->circuitBreaker->execute(
+                $response = $this->executeWithHealth(
                     callback: fn () => $provider->explainImage($imagePath, $prompt, $candidateOptions),
                     serviceName: 'ai_provider_vision_'.$provider->getName(),
+                    capability: 'vision',
+                    provider: $provider,
+                    options: $candidateOptions,
+                    userId: $userId,
                     fallback: null // NO FALLBACK
                 );
 
@@ -876,9 +901,13 @@ class AiFacade
         ]);
 
         try {
-            $images = $this->circuitBreaker->execute(
+            $images = $this->executeWithHealth(
                 callback: fn () => $provider->generateImage($prompt, $options),
                 serviceName: 'ai_provider_image_'.$provider->getName(),
+                capability: 'image_generation',
+                provider: $provider,
+                options: $options,
+                userId: $userId,
                 fallback: null // NO FALLBACK
             );
         } catch (ProviderException $e) {
@@ -926,9 +955,13 @@ class AiFacade
         ]);
 
         try {
-            $videos = $this->circuitBreaker->execute(
+            $videos = $this->executeWithHealth(
                 callback: fn () => $provider->generateVideo($prompt, $options),
                 serviceName: 'ai_provider_video_'.$provider->getName(),
+                capability: 'video_generation',
+                provider: $provider,
+                options: $options,
+                userId: $userId,
                 fallback: null // NO FALLBACK
             );
         } catch (ProviderException $e) {
@@ -1152,6 +1185,57 @@ class AiFacade
         return 'unknown';
     }
 
+    /**
+     * Run a provider call through the circuit breaker and tell the health
+     * monitor how it ended.
+     *
+     * This is the single choke point for passive detection: every capability
+     * already goes through the circuit breaker, so wrapping it here observes
+     * real traffic without adding a single extra provider request. Recording
+     * never throws — {@see ModelHealthRecorder} swallows its own errors — so a
+     * broken counter cannot take down the call it is watching.
+     *
+     * @param array<string, mixed> $options
+     */
+    private function executeWithHealth(
+        callable $callback,
+        string $serviceName,
+        string $capability,
+        ProviderMetadataInterface $provider,
+        array $options,
+        ?int $userId = null,
+        ?callable $fallback = null,
+    ): mixed {
+        return $this->observing(
+            $capability,
+            $provider->getName(),
+            $this->reportedModel($provider, $options, $capability),
+            $userId,
+            fn () => $this->circuitBreaker->execute($callback, $serviceName, $fallback),
+        );
+    }
+
+    /**
+     * Report how a provider call ended to the health monitor and pass the
+     * result (or the exception) straight through.
+     *
+     * Used directly by the embedding path, which caches and falls back instead
+     * of going through the circuit breaker.
+     */
+    private function observing(string $capability, string $providerName, ?string $model, ?int $userId, callable $callback): mixed
+    {
+        try {
+            $result = $callback();
+        } catch (\Throwable $e) {
+            $this->health->recordFailure($capability, $providerName, $model, $e, $userId);
+            throw $e;
+        }
+
+        $this->health->recordSuccess($capability, $providerName, $model);
+
+        return $result;
+    }
+
     public function transcribe(string $audioPath, ?int $userId = null, array $options = []): array
     {
         $providerName = $options['provider'] ?? null;
@@ -1190,9 +1274,13 @@ class AiFacade
         ]);
 
         try {
-            $result = $this->circuitBreaker->execute(
+            $result = $this->executeWithHealth(
                 callback: fn () => $provider->transcribe($audioPath, $options),
                 serviceName: 'ai_provider_stt_'.$provider->getName(),
+                capability: 'speech_to_text',
+                provider: $provider,
+                options: $options,
+                userId: $userId,
                 fallback: null // NO FALLBACK
             );
         } catch (ProviderException $e) {
@@ -1291,9 +1379,13 @@ class AiFacade
         ]);
 
         try {
-            $filename = $this->circuitBreaker->execute(
+            $filename = $this->executeWithHealth(
                 callback: fn () => $provider->synthesize($text, $options),
                 serviceName: 'ai_provider_tts_'.$provider->getName(),
+                capability: 'text_to_speech',
+                provider: $provider,
+                options: $options,
+                userId: $userId,
                 fallback: null // NO FALLBACK
             );
         } catch (ProviderException $e) {

--- a/backend/src/AI/Service/ProviderDisplayNames.php
+++ b/backend/src/AI/Service/ProviderDisplayNames.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\AI\Service;
+
+use App\Model\ModelCatalog;
+
+/**
+ * Turns an internal service key into the provider's branded name.
+ *
+ * BMODELS.BSERVICE is an identifier, not a label: it is inconsistently cased
+ * ("ollama", "xAI", "triton") and cannot be put on screen as-is. CSS cannot
+ * repair it either — `text-transform: capitalize` renders xAI as "XAI". The
+ * provider registry already carries the correct spelling for every provider,
+ * so this reads it rather than introducing a second list to keep in sync.
+ *
+ * Deliberately built on getUniqueProviders(): it returns the registered
+ * instances without asking any of them whether they are reachable, unlike
+ * getProvidersMetadata(). Callers here include the status page, which must
+ * never trigger a provider call.
+ */
+final class ProviderDisplayNames
+{
+    /** @var array<string, string>|null */
+    private ?array $names = null;
+
+    public function __construct(private readonly ProviderRegistry $registry)
+    {
+    }
+
+    /**
+     * The branded name for a service key, or the key itself when this build
+     * registers no provider for it — a catalog row still has to show something.
+     */
+    public function forService(string $service): string
+    {
+        return $this->all()[ModelCatalog::normalizeProvider($service)] ?? $service;
+    }
+
+    /**
+     * @return array<string, string> branded name, keyed by normalised service
+     */
+    public function all(): array
+    {
+        if (null !== $this->names) {
+            return $this->names;
+        }
+
+        $names = [];
+        foreach ($this->registry->getUniqueProviders() as $key => $provider) {
+            $names[ModelCatalog::normalizeProvider($key)] = $provider->getDisplayName();
+        }
+
+        return $this->names = $names;
+    }
+}

--- a/backend/src/Command/ModelHealthCheckCommand.php
+++ b/backend/src/Command/ModelHealthCheckCommand.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\AI\Health\ModelHealthConfig;
+use App\AI\Health\ModelHealthEvaluator;
+use App\AI\Health\ModelHealthState;
+use App\AI\Health\ModelHealthVerdict;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Checks which AI models the configured providers still offer, and reports the
+ * ones that stopped working.
+ *
+ * Costs nothing to run: every provider is asked exactly once, through its free
+ * "list your models" endpoint. No inference happens here — pinging the video
+ * models alone would run into five figures a month.
+ */
+#[AsCommand(
+    name: 'app:model:health-check',
+    description: 'Check AI model availability via free provider catalog endpoints and alert on outages',
+)]
+final class ModelHealthCheckCommand extends Command
+{
+    /** Longest random start delay the scheduler may ask for, in seconds. */
+    private const MAX_JITTER_SECONDS = 300;
+
+    public function __construct(
+        private readonly ModelHealthEvaluator $evaluator,
+        private readonly ModelHealthConfig $config,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Probe and report without writing state, disabling models or sending alerts')
+            ->addOption('provider', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Only check this provider (repeatable)')
+            ->addOption('jitter', null, InputOption::VALUE_REQUIRED, 'Wait a random 0..N seconds before starting, so scheduled runs do not all hit the providers at once')
+            ->addOption('force', null, InputOption::VALUE_NONE, 'Run even when MODELHEALTH.ENABLED is off');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $dryRun = (bool) $input->getOption('dry-run');
+
+        if (!$this->config->isEnabled() && !$input->getOption('force')) {
+            $io->note('Model health monitoring is switched off (MODELHEALTH.ENABLED). Use --force to run anyway.');
+
+            return Command::SUCCESS;
+        }
+
+        $this->sleepForJitter($input, $io);
+
+        /** @var list<string> $providers */
+        $providers = array_values(array_filter(
+            (array) $input->getOption('provider'),
+            static fn (mixed $value): bool => is_string($value) && '' !== trim($value)
+        ));
+
+        $io->title($dryRun ? 'Model health check (dry run)' : 'Model health check');
+
+        $run = $this->evaluator->run($dryRun, $providers);
+
+        if ([] === $run->verdicts) {
+            $io->warning('No models found to check.');
+
+            return Command::SUCCESS;
+        }
+
+        $this->renderSummary($io, $run->verdicts);
+        $this->renderProblems($io, $run->verdicts);
+
+        foreach ($run->skippedProviders as $provider => $reason) {
+            $io->writeln(sprintf('  <comment>skipped</comment> %s — %s', $provider, $reason));
+        }
+
+        foreach ($run->autoDisabled() as $verdict) {
+            $io->writeln(sprintf('  <error>disabled</error> %s (%s)', $verdict->modelName, $verdict->service));
+        }
+        foreach ($run->reEnabled() as $verdict) {
+            $io->writeln(sprintf('  <info>re-enabled</info> %s (%s)', $verdict->modelName, $verdict->service));
+        }
+
+        $io->newLine();
+        if ($dryRun) {
+            $io->note(sprintf(
+                'Dry run: nothing was written. Would have raised %d alert(s) and resolved %d.',
+                count($run->alertsRaised),
+                count($run->alertsResolved),
+            ));
+
+            return Command::SUCCESS;
+        }
+
+        $io->success(sprintf(
+            'Checked %d model(s). Raised %d alert(s), resolved %d.',
+            count($run->verdicts),
+            count($run->alertsRaised),
+            count($run->alertsResolved),
+        ));
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Spread scheduled runs out in time. Every install polls the same handful of
+     * provider APIs, and a fleet that all wakes up on the same cron minute is a
+     * good way to get rate-limited by them.
+     */
+    private function sleepForJitter(InputInterface $input, SymfonyStyle $io): void
+    {
+        $jitter = $input->getOption('jitter');
+        if (!is_string($jitter) && !is_int($jitter)) {
+            return;
+        }
+
+        $max = min(self::MAX_JITTER_SECONDS, max(0, (int) $jitter));
+        if ($max <= 0) {
+            return;
+        }
+
+        $delay = random_int(0, $max);
+        if ($delay > 0) {
+            $io->writeln(sprintf('<comment>Waiting %ds before probing providers.</comment>', $delay));
+            sleep($delay);
+        }
+    }
+
+    /**
+     * @param list<ModelHealthVerdict> $verdicts
+     */
+    private function renderSummary(SymfonyStyle $io, array $verdicts): void
+    {
+        $rows = [];
+        foreach (ModelHealthState::cases() as $state) {
+            $count = count(array_filter($verdicts, static fn (ModelHealthVerdict $v): bool => $v->state === $state));
+            if ($count > 0) {
+                $rows[] = [$state->value, $count];
+            }
+        }
+
+        $io->table(['State', 'Models'], $rows);
+    }
+
+    /**
+     * @param list<ModelHealthVerdict> $verdicts
+     */
+    private function renderProblems(SymfonyStyle $io, array $verdicts): void
+    {
+        $problems = array_filter($verdicts, static fn (ModelHealthVerdict $v): bool => $v->needsAttention());
+        if ([] === $problems) {
+            return;
+        }
+
+        $io->section('Models needing attention');
+        $io->table(
+            ['Provider', 'Model', 'Capability', 'State', 'Reason'],
+            array_map(
+                static fn (ModelHealthVerdict $v): array => [
+                    $v->service,
+                    $v->modelName,
+                    $v->tag,
+                    $v->state->value,
+                    mb_substr($v->message, 0, 80),
+                ],
+                array_values($problems)
+            )
+        );
+    }
+}

--- a/backend/src/Controller/AdminModelHealthController.php
+++ b/backend/src/Controller/AdminModelHealthController.php
@@ -86,9 +86,10 @@ final class AdminModelHealthController extends AbstractController
                     property: 'providers',
                     type: 'array',
                     items: new OA\Items(
-                        required: ['name', 'needsAttention', 'models'],
+                        required: ['name', 'displayName', 'needsAttention', 'models'],
                         properties: [
-                            new OA\Property(property: 'name', type: 'string', example: 'groq'),
+                            new OA\Property(property: 'name', type: 'string', description: 'Internal service key, used to scope a re-check', example: 'xAI'),
+                            new OA\Property(property: 'displayName', type: 'string', description: 'Branded provider name for display', example: 'xAI'),
                             new OA\Property(property: 'needsAttention', type: 'integer', example: 2),
                             new OA\Property(
                                 property: 'models',
@@ -190,9 +191,12 @@ final class AdminModelHealthController extends AbstractController
         ]);
     }
 
-    // Negative ids are the catalog's "let the provider registry decide"
-    // placeholders and are real, routable BMODELS rows, so the pattern has to
-    // allow the sign — a \d+ requirement would 404 on nine of them.
+    // ModelSeeder gives the dev/test mock models negative BIDs so they cannot
+    // collide with the auto-increment range. They are ordinary BMODELS rows and
+    // the status page lists them like any other, so a `\d+` requirement would
+    // make the buttons next to them 404 in the dev and E2E stacks. An id with
+    // no BMODELS row is still a 404 below, sign or not — there is nothing to
+    // exempt for a model that is not in the catalog.
     #[Route('/models/{id}/exempt', name: 'admin_model_health_exempt', requirements: ['id' => '-?\d+'], methods: ['POST'])]
     #[OA\Post(
         path: '/api/v1/admin/model-health/models/{id}/exempt',
@@ -258,6 +262,7 @@ final class AdminModelHealthController extends AbstractController
         ]);
     }
 
+    // Negative ids are the seeded mock models — see the note on exempt() above.
     #[Route('/models/{id}/reset', name: 'admin_model_health_reset', requirements: ['id' => '-?\d+'], methods: ['POST'])]
     #[OA\Post(
         path: '/api/v1/admin/model-health/models/{id}/reset',

--- a/backend/src/Controller/AdminModelHealthController.php
+++ b/backend/src/Controller/AdminModelHealthController.php
@@ -8,6 +8,8 @@ use App\AI\Health\ModelHealthConfig;
 use App\AI\Health\ModelHealthEvaluator;
 use App\AI\Health\ModelHealthOverview;
 use App\AI\Health\ModelHealthRecorder;
+use App\AI\Health\ModelHealthState;
+use App\Entity\ModelHealth;
 use App\Repository\ModelHealthRepository;
 use App\Repository\ModelRepository;
 use App\Service\ModelConfigService;
@@ -165,8 +167,7 @@ final class AdminModelHealthController extends AbstractController
     #[OA\Response(response: 503, description: 'The check could not be completed')]
     public function refresh(Request $request): JsonResponse
     {
-        /** @var array<string, mixed> $payload */
-        $payload = json_decode((string) $request->getContent(), true) ?: [];
+        $payload = $this->jsonObject($request);
         $provider = isset($payload['provider']) && is_string($payload['provider']) && '' !== trim($payload['provider'])
             ? [trim($payload['provider'])]
             : [];
@@ -177,7 +178,7 @@ final class AdminModelHealthController extends AbstractController
             $this->logger->error('Manual model health check failed', ['error' => $e->getMessage()]);
 
             return $this->json([
-                'error' => 'The availability check could not be completed: '.$e->getMessage(),
+                'error' => 'The availability check could not be completed.',
             ], Response::HTTP_SERVICE_UNAVAILABLE);
         }
 
@@ -233,8 +234,7 @@ final class AdminModelHealthController extends AbstractController
     #[OA\Response(response: 404, description: 'Model not found')]
     public function exempt(int $id, Request $request): JsonResponse
     {
-        /** @var array<string, mixed> $payload */
-        $payload = json_decode((string) $request->getContent(), true) ?: [];
+        $payload = $this->jsonObject($request);
         if (!isset($payload['exempt']) || !is_bool($payload['exempt'])) {
             return $this->json(['error' => 'Field "exempt" must be a boolean'], Response::HTTP_BAD_REQUEST);
         }
@@ -293,6 +293,32 @@ final class AdminModelHealthController extends AbstractController
 
         $this->recorder->reset($id);
 
+        // Traffic counters and the persisted traffic verdict must move together.
+        // Clearing only Redis left the page showing "offline because 50% failed"
+        // next to a 0% error rate, and routing kept avoiding a model the
+        // operator had just asked to judge on fresh calls.
+        $health = $this->healthRepository->findByModelId($id);
+        if (null !== $health && ModelHealth::SOURCE_TRAFFIC === $health->getSource()) {
+            $health
+                ->setState(ModelHealthState::Unknown)
+                ->setKind(null)
+                ->setMessage(null)
+                ->setUpdated(time());
+            $this->entityManager->flush();
+        }
+
+        $this->modelConfigService->invalidateModelHealth();
+
         return $this->json(['success' => true, 'modelId' => $id]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function jsonObject(Request $request): array
+    {
+        $decoded = json_decode((string) $request->getContent(), true);
+
+        return is_array($decoded) ? $decoded : [];
     }
 }

--- a/backend/src/Controller/AdminModelHealthController.php
+++ b/backend/src/Controller/AdminModelHealthController.php
@@ -1,0 +1,293 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\AI\Health\ModelHealthConfig;
+use App\AI\Health\ModelHealthEvaluator;
+use App\AI\Health\ModelHealthOverview;
+use App\AI\Health\ModelHealthRecorder;
+use App\Repository\ModelHealthRepository;
+use App\Repository\ModelRepository;
+use App\Service\ModelConfigService;
+use Doctrine\ORM\EntityManagerInterface;
+use OpenApi\Attributes as OA;
+use Psr\Log\LoggerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/**
+ * Admin endpoints behind the model status page.
+ *
+ * Endpoints:
+ *   GET  /api/v1/admin/model-health                       ─ current status of every catalogued model
+ *   POST /api/v1/admin/model-health/refresh               ─ re-probe now, optionally one provider
+ *   POST /api/v1/admin/model-health/models/{id}/exempt    ─ pause automatic disabling for one model
+ *
+ * SECURITY: all endpoints require ROLE_ADMIN. The read endpoint never talks to
+ * a provider; only the explicit refresh does.
+ */
+#[Route('/api/v1/admin/model-health')]
+#[IsGranted('ROLE_ADMIN', message: 'Admin access required')]
+#[OA\Tag(name: 'Admin Model Health')]
+final class AdminModelHealthController extends AbstractController
+{
+    public function __construct(
+        private readonly ModelHealthOverview $overview,
+        private readonly ModelHealthEvaluator $evaluator,
+        private readonly ModelHealthRecorder $recorder,
+        private readonly ModelHealthRepository $healthRepository,
+        private readonly ModelHealthConfig $config,
+        private readonly ModelRepository $modelRepository,
+        private readonly ModelConfigService $modelConfigService,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    #[Route('', name: 'admin_model_health_status', methods: ['GET'])]
+    #[OA\Get(
+        path: '/api/v1/admin/model-health',
+        summary: 'Availability of every catalogued AI model (admin only)',
+        description: 'Returns the last stored verdict per model together with the rolling success/failure counters from live traffic. Reads stored state only and never calls a provider.',
+        security: [['Bearer' => []]],
+        tags: ['Admin Model Health']
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'Model availability snapshot',
+        content: new OA\JsonContent(
+            required: ['success', 'summary', 'providers'],
+            properties: [
+                new OA\Property(property: 'success', type: 'boolean', example: true),
+                new OA\Property(
+                    property: 'summary',
+                    required: ['total', 'online', 'degraded', 'offline', 'unconfigured', 'unknown', 'needsAttention', 'lastCheck', 'autoDisableEnabled', 'monitoringEnabled'],
+                    properties: [
+                        new OA\Property(property: 'total', type: 'integer', example: 84),
+                        new OA\Property(property: 'online', type: 'integer', example: 71),
+                        new OA\Property(property: 'degraded', type: 'integer', example: 2),
+                        new OA\Property(property: 'offline', type: 'integer', example: 3),
+                        new OA\Property(property: 'unconfigured', type: 'integer', example: 8),
+                        new OA\Property(property: 'unknown', type: 'integer', example: 0),
+                        new OA\Property(property: 'needsAttention', type: 'integer', example: 5),
+                        new OA\Property(property: 'lastCheck', type: 'integer', description: 'Unix timestamp of the most recent check, 0 when none ran yet', example: 1755600000),
+                        new OA\Property(property: 'autoDisableEnabled', type: 'boolean', example: false),
+                        new OA\Property(property: 'monitoringEnabled', type: 'boolean', example: true),
+                    ],
+                    type: 'object'
+                ),
+                new OA\Property(
+                    property: 'providers',
+                    type: 'array',
+                    items: new OA\Items(
+                        required: ['name', 'needsAttention', 'models'],
+                        properties: [
+                            new OA\Property(property: 'name', type: 'string', example: 'groq'),
+                            new OA\Property(property: 'needsAttention', type: 'integer', example: 2),
+                            new OA\Property(
+                                property: 'models',
+                                type: 'array',
+                                items: new OA\Items(
+                                    required: ['id', 'name', 'providerId', 'capability', 'state', 'reason', 'source', 'lastCheck', 'lastSuccess', 'lastFailure', 'successes', 'failures', 'errorRatePercent', 'active', 'selectable', 'autoDisabled', 'exemptUntil'],
+                                    properties: [
+                                        new OA\Property(property: 'id', type: 'integer', example: 42),
+                                        new OA\Property(property: 'name', type: 'string', example: 'Llama 3.3 70B'),
+                                        new OA\Property(property: 'providerId', type: 'string', example: 'llama-3.3-70b-versatile'),
+                                        new OA\Property(property: 'capability', type: 'string', example: 'chat'),
+                                        new OA\Property(property: 'state', type: 'string', enum: ['online', 'degraded', 'offline', 'unconfigured', 'unknown'], example: 'online'),
+                                        new OA\Property(property: 'reason', type: 'string', description: 'Human-readable explanation, empty when healthy', example: ''),
+                                        new OA\Property(property: 'source', type: 'string', enum: ['probe', 'traffic'], example: 'probe'),
+                                        new OA\Property(property: 'lastCheck', type: 'integer', example: 1755600000),
+                                        new OA\Property(property: 'lastSuccess', type: 'integer', example: 1755600000),
+                                        new OA\Property(property: 'lastFailure', type: 'integer', example: 0),
+                                        new OA\Property(property: 'successes', type: 'integer', description: 'Successful calls in the rolling window', example: 12),
+                                        new OA\Property(property: 'failures', type: 'integer', description: 'Failed calls in the rolling window', example: 0),
+                                        new OA\Property(property: 'errorRatePercent', type: 'integer', example: 0),
+                                        new OA\Property(property: 'active', type: 'boolean', example: true),
+                                        new OA\Property(property: 'selectable', type: 'boolean', example: true),
+                                        new OA\Property(property: 'autoDisabled', type: 'boolean', description: 'Switched off by the monitor rather than by an operator', example: false),
+                                        new OA\Property(property: 'exemptUntil', type: 'integer', description: 'Unix timestamp until which automatic disabling is paused, 0 when not paused', example: 0),
+                                    ],
+                                    type: 'object'
+                                )
+                            ),
+                        ],
+                        type: 'object'
+                    )
+                ),
+            ]
+        )
+    )]
+    #[OA\Response(response: 403, description: 'Admin access required')]
+    public function status(): JsonResponse
+    {
+        return $this->json(['success' => true] + $this->overview->build());
+    }
+
+    #[Route('/refresh', name: 'admin_model_health_refresh', methods: ['POST'])]
+    #[OA\Post(
+        path: '/api/v1/admin/model-health/refresh',
+        summary: 'Re-check model availability now (admin only)',
+        description: 'Asks every provider for its published model list and re-evaluates the traffic counters. Uses free catalog endpoints only, so it never runs inference and never costs anything. Pass a provider to check just one.',
+        security: [['Bearer' => []]],
+        tags: ['Admin Model Health'],
+        requestBody: new OA\RequestBody(
+            required: false,
+            content: new OA\JsonContent(
+                properties: [
+                    new OA\Property(property: 'provider', type: 'string', description: 'Restrict the check to this provider', example: 'groq', nullable: true),
+                ],
+                type: 'object'
+            )
+        )
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'What the check did. Fetch GET /api/v1/admin/model-health afterwards for the new snapshot.',
+        content: new OA\JsonContent(
+            required: ['success', 'checked', 'alertsRaised', 'alertsResolved'],
+            properties: [
+                new OA\Property(property: 'success', type: 'boolean', example: true),
+                new OA\Property(property: 'checked', type: 'integer', description: 'Number of models re-evaluated', example: 84),
+                new OA\Property(property: 'alertsRaised', type: 'integer', example: 1),
+                new OA\Property(property: 'alertsResolved', type: 'integer', example: 0),
+            ]
+        )
+    )]
+    #[OA\Response(response: 403, description: 'Admin access required')]
+    #[OA\Response(response: 503, description: 'The check could not be completed')]
+    public function refresh(Request $request): JsonResponse
+    {
+        /** @var array<string, mixed> $payload */
+        $payload = json_decode((string) $request->getContent(), true) ?: [];
+        $provider = isset($payload['provider']) && is_string($payload['provider']) && '' !== trim($payload['provider'])
+            ? [trim($payload['provider'])]
+            : [];
+
+        try {
+            $run = $this->evaluator->run(dryRun: false, onlyServices: $provider);
+        } catch (\Throwable $e) {
+            $this->logger->error('Manual model health check failed', ['error' => $e->getMessage()]);
+
+            return $this->json([
+                'error' => 'The availability check could not be completed: '.$e->getMessage(),
+            ], Response::HTTP_SERVICE_UNAVAILABLE);
+        }
+
+        $this->modelConfigService->invalidateModelHealth();
+
+        return $this->json([
+            'success' => true,
+            'checked' => count($run->verdicts),
+            'alertsRaised' => count($run->alertsRaised),
+            'alertsResolved' => count($run->alertsResolved),
+        ]);
+    }
+
+    // Negative ids are the catalog's "let the provider registry decide"
+    // placeholders and are real, routable BMODELS rows, so the pattern has to
+    // allow the sign — a \d+ requirement would 404 on nine of them.
+    #[Route('/models/{id}/exempt', name: 'admin_model_health_exempt', requirements: ['id' => '-?\d+'], methods: ['POST'])]
+    #[OA\Post(
+        path: '/api/v1/admin/model-health/models/{id}/exempt',
+        summary: 'Pause or resume automatic disabling for one model (admin only)',
+        description: 'While a model is exempt, the monitor keeps reporting its state but never switches it off. Use this for a model an operator knows is fine even though the provider does not publish it.',
+        security: [['Bearer' => []]],
+        tags: ['Admin Model Health'],
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                required: ['exempt'],
+                properties: [
+                    new OA\Property(property: 'exempt', type: 'boolean', description: 'true pauses automatic disabling, false resumes it', example: true),
+                ],
+                type: 'object'
+            )
+        )
+    )]
+    #[OA\Parameter(name: 'id', in: 'path', required: true, schema: new OA\Schema(type: 'integer'))]
+    #[OA\Response(
+        response: 200,
+        description: 'New exemption state',
+        content: new OA\JsonContent(
+            required: ['success', 'modelId', 'exemptUntil'],
+            properties: [
+                new OA\Property(property: 'success', type: 'boolean', example: true),
+                new OA\Property(property: 'modelId', type: 'integer', example: 42),
+                new OA\Property(property: 'exemptUntil', type: 'integer', description: 'Unix timestamp until which automatic disabling is paused, 0 when not paused', example: 1756204800),
+            ]
+        )
+    )]
+    #[OA\Response(response: 400, description: 'Missing or invalid "exempt" flag')]
+    #[OA\Response(response: 403, description: 'Admin access required')]
+    #[OA\Response(response: 404, description: 'Model not found')]
+    public function exempt(int $id, Request $request): JsonResponse
+    {
+        /** @var array<string, mixed> $payload */
+        $payload = json_decode((string) $request->getContent(), true) ?: [];
+        if (!isset($payload['exempt']) || !is_bool($payload['exempt'])) {
+            return $this->json(['error' => 'Field "exempt" must be a boolean'], Response::HTTP_BAD_REQUEST);
+        }
+
+        if (null === $this->modelRepository->find($id)) {
+            return $this->json(['error' => 'Model not found'], Response::HTTP_NOT_FOUND);
+        }
+
+        $health = $this->healthRepository->findOrCreate($id);
+        $until = $payload['exempt'] ? time() + $this->config->suppressionSeconds() : 0;
+        $health->setSuppressUntil($until)->setUpdated(time());
+
+        $this->entityManager->flush();
+        $this->modelConfigService->invalidateModelHealth();
+
+        $this->logger->info('Automatic disabling exemption changed', [
+            'model_id' => $id,
+            'exempt_until' => $until,
+        ]);
+
+        return $this->json([
+            'success' => true,
+            'modelId' => $id,
+            'exemptUntil' => $until,
+        ]);
+    }
+
+    #[Route('/models/{id}/reset', name: 'admin_model_health_reset', requirements: ['id' => '-?\d+'], methods: ['POST'])]
+    #[OA\Post(
+        path: '/api/v1/admin/model-health/models/{id}/reset',
+        summary: 'Clear the rolling error counters for one model (admin only)',
+        description: 'Forgets the recorded successes and failures of the current window. Use after fixing the cause so the model is judged on fresh traffic instead of waiting out the window.',
+        security: [['Bearer' => []]],
+        tags: ['Admin Model Health']
+    )]
+    #[OA\Parameter(name: 'id', in: 'path', required: true, schema: new OA\Schema(type: 'integer'))]
+    #[OA\Response(
+        response: 200,
+        description: 'Counters cleared',
+        content: new OA\JsonContent(
+            required: ['success', 'modelId'],
+            properties: [
+                new OA\Property(property: 'success', type: 'boolean', example: true),
+                new OA\Property(property: 'modelId', type: 'integer', example: 42),
+            ]
+        )
+    )]
+    #[OA\Response(response: 403, description: 'Admin access required')]
+    #[OA\Response(response: 404, description: 'Model not found')]
+    public function reset(int $id): JsonResponse
+    {
+        if (null === $this->modelRepository->find($id)) {
+            return $this->json(['error' => 'Model not found'], Response::HTTP_NOT_FOUND);
+        }
+
+        $this->recorder->reset($id);
+
+        return $this->json(['success' => true, 'modelId' => $id]);
+    }
+}

--- a/backend/src/Entity/ModelHealth.php
+++ b/backend/src/Entity/ModelHealth.php
@@ -1,0 +1,238 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use App\AI\Health\ModelHealthState;
+use App\Repository\ModelHealthRepository;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Persisted health of one BMODELS row.
+ *
+ * Rolling success/failure counters live in Redis because they are written on
+ * every AI call; this table holds what must survive a cache flush — above all
+ * {@see self::$autoDisabled}. Without that provenance nobody could tell a model
+ * an operator switched off from one the automation retired, and the automation
+ * could never safely switch it back on.
+ *
+ * Deliberately no foreign key to BMODELS: several FKs in this schema have no
+ * ON DELETE CASCADE and force delete-ordering gymnastics in migrations on the
+ * Galera cluster. An orphaned row here is harmless and gets pruned by the
+ * health check.
+ */
+#[ORM\Entity(repositoryClass: ModelHealthRepository::class)]
+#[ORM\Table(name: 'BMODELHEALTH')]
+#[ORM\UniqueConstraint(name: 'uniq_modelhealth_model', columns: ['BMODELID'])]
+#[ORM\Index(columns: ['BSTATE'], name: 'idx_modelhealth_state')]
+class ModelHealth
+{
+    /** Recorded from a free provider catalog lookup. */
+    public const SOURCE_PROBE = 'probe';
+
+    /** Recorded from a real user request that happened anyway. */
+    public const SOURCE_TRAFFIC = 'traffic';
+
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(name: 'BID', type: 'bigint')]
+    private ?int $id = null;
+
+    #[ORM\Column(name: 'BMODELID', type: 'bigint')]
+    private int $modelId = 0;
+
+    #[ORM\Column(name: 'BSTATE', length: 16)]
+    private string $state = ModelHealthState::Unknown->value;
+
+    #[ORM\Column(name: 'BSOURCE', length: 16)]
+    private string $source = self::SOURCE_PROBE;
+
+    /** {@see \App\AI\Health\FailureKind} value, or null while healthy. */
+    #[ORM\Column(name: 'BKIND', length: 16, nullable: true)]
+    private ?string $kind = null;
+
+    #[ORM\Column(name: 'BMESSAGE', type: 'text', nullable: true)]
+    private ?string $message = null;
+
+    #[ORM\Column(name: 'BLASTCHECK', type: 'bigint', options: ['default' => 0])]
+    private int $lastCheck = 0;
+
+    #[ORM\Column(name: 'BLASTSUCCESS', type: 'bigint', options: ['default' => 0])]
+    private int $lastSuccess = 0;
+
+    #[ORM\Column(name: 'BLASTFAILURE', type: 'bigint', options: ['default' => 0])]
+    private int $lastFailure = 0;
+
+    /** True only when THIS automation set BACTIVE = 0. */
+    #[ORM\Column(name: 'BAUTODISABLED', type: 'integer', options: ['default' => 0])]
+    private int $autoDisabled = 0;
+
+    #[ORM\Column(name: 'BAUTODISABLEDAT', type: 'bigint', options: ['default' => 0])]
+    private int $autoDisabledAt = 0;
+
+    /**
+     * Until this timestamp the automation may report but must not switch this
+     * model off. Set when an operator re-enables a model by hand, so human and
+     * automation stop fighting over the same row.
+     */
+    #[ORM\Column(name: 'BSUPPRESSUNTIL', type: 'bigint', options: ['default' => 0])]
+    private int $suppressUntil = 0;
+
+    #[ORM\Column(name: 'BUPDATED', type: 'bigint', options: ['default' => 0])]
+    private int $updated = 0;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getModelId(): int
+    {
+        return $this->modelId;
+    }
+
+    public function setModelId(int $modelId): self
+    {
+        $this->modelId = $modelId;
+
+        return $this;
+    }
+
+    public function getState(): ModelHealthState
+    {
+        return ModelHealthState::tryFrom($this->state) ?? ModelHealthState::Unknown;
+    }
+
+    public function setState(ModelHealthState $state): self
+    {
+        $this->state = $state->value;
+
+        return $this;
+    }
+
+    public function getSource(): string
+    {
+        return $this->source;
+    }
+
+    public function setSource(string $source): self
+    {
+        $this->source = $source;
+
+        return $this;
+    }
+
+    public function getKind(): ?string
+    {
+        return $this->kind;
+    }
+
+    public function setKind(?string $kind): self
+    {
+        $this->kind = $kind;
+
+        return $this;
+    }
+
+    public function getMessage(): ?string
+    {
+        return $this->message;
+    }
+
+    public function setMessage(?string $message): self
+    {
+        $this->message = null === $message ? null : mb_substr($message, 0, 2000);
+
+        return $this;
+    }
+
+    public function getLastCheck(): int
+    {
+        return $this->lastCheck;
+    }
+
+    public function setLastCheck(int $lastCheck): self
+    {
+        $this->lastCheck = $lastCheck;
+
+        return $this;
+    }
+
+    public function getLastSuccess(): int
+    {
+        return $this->lastSuccess;
+    }
+
+    public function setLastSuccess(int $lastSuccess): self
+    {
+        $this->lastSuccess = $lastSuccess;
+
+        return $this;
+    }
+
+    public function getLastFailure(): int
+    {
+        return $this->lastFailure;
+    }
+
+    public function setLastFailure(int $lastFailure): self
+    {
+        $this->lastFailure = $lastFailure;
+
+        return $this;
+    }
+
+    public function isAutoDisabled(): bool
+    {
+        return 1 === $this->autoDisabled;
+    }
+
+    public function setAutoDisabled(bool $autoDisabled): self
+    {
+        $this->autoDisabled = $autoDisabled ? 1 : 0;
+
+        return $this;
+    }
+
+    public function getAutoDisabledAt(): int
+    {
+        return $this->autoDisabledAt;
+    }
+
+    public function setAutoDisabledAt(int $autoDisabledAt): self
+    {
+        $this->autoDisabledAt = $autoDisabledAt;
+
+        return $this;
+    }
+
+    public function getSuppressUntil(): int
+    {
+        return $this->suppressUntil;
+    }
+
+    public function setSuppressUntil(int $suppressUntil): self
+    {
+        $this->suppressUntil = $suppressUntil;
+
+        return $this;
+    }
+
+    public function isSuppressed(?int $now = null): bool
+    {
+        return $this->suppressUntil > ($now ?? time());
+    }
+
+    public function getUpdated(): int
+    {
+        return $this->updated;
+    }
+
+    public function setUpdated(int $updated): self
+    {
+        $this->updated = $updated;
+
+        return $this;
+    }
+}

--- a/backend/src/Entity/ModelHealth.php
+++ b/backend/src/Entity/ModelHealth.php
@@ -42,10 +42,13 @@ class ModelHealth
     #[ORM\Column(name: 'BMODELID', type: 'bigint')]
     private int $modelId = 0;
 
-    #[ORM\Column(name: 'BSTATE', length: 16)]
+    // Spelled out rather than read from the enum because an attribute argument
+    // must be a constant expression. Must stay equal to the migration's DEFAULT
+    // and to ModelHealthState::Unknown->value, or doctrine:schema:validate fails.
+    #[ORM\Column(name: 'BSTATE', length: 16, options: ['default' => 'unknown'])]
     private string $state = ModelHealthState::Unknown->value;
 
-    #[ORM\Column(name: 'BSOURCE', length: 16)]
+    #[ORM\Column(name: 'BSOURCE', length: 16, options: ['default' => self::SOURCE_PROBE])]
     private string $source = self::SOURCE_PROBE;
 
     /** {@see \App\AI\Health\FailureKind} value, or null while healthy. */

--- a/backend/src/Repository/ModelHealthRepository.php
+++ b/backend/src/Repository/ModelHealthRepository.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\AI\Health\FailureKind;
+use App\AI\Health\ModelHealthState;
+use App\Entity\ModelHealth;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<ModelHealth>
+ */
+class ModelHealthRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, ModelHealth::class);
+    }
+
+    public function findByModelId(int $modelId): ?ModelHealth
+    {
+        return $this->findOneBy(['modelId' => $modelId]);
+    }
+
+    /**
+     * Existing rows keyed by model id, for callers that need many at once
+     * (status page, health check) without an N+1 query.
+     *
+     * @param list<int> $modelIds
+     *
+     * @return array<int, ModelHealth>
+     */
+    public function findIndexedByModelId(array $modelIds = []): array
+    {
+        $qb = $this->createQueryBuilder('h');
+        if ([] !== $modelIds) {
+            $qb->where('h.modelId IN (:ids)')->setParameter('ids', $modelIds, ArrayParameterType::INTEGER);
+        }
+
+        $indexed = [];
+        foreach ($qb->getQuery()->getResult() as $row) {
+            /* @var ModelHealth $row */
+            $indexed[$row->getModelId()] = $row;
+        }
+
+        return $indexed;
+    }
+
+    /**
+     * Get the row for a model, creating an unsaved one when it does not exist
+     * yet. The caller decides when to persist and flush.
+     */
+    public function findOrCreate(int $modelId): ModelHealth
+    {
+        $health = $this->findByModelId($modelId);
+        if (null !== $health) {
+            return $health;
+        }
+
+        $health = (new ModelHealth())->setModelId($modelId);
+        $this->getEntityManager()->persist($health);
+
+        return $health;
+    }
+
+    /**
+     * Ids of models the monitor currently considers dead.
+     *
+     * Restricted to a permanent verdict on purpose: a degraded model is flaky,
+     * not gone, and routing away from every model that had a bad minute would
+     * turn a provider hiccup into a platform-wide reshuffle. A credential
+     * outage is excluded too — that is already handled provider-wide by the
+     * usable-provider check, one layer up.
+     *
+     * INVARIANT: only confirmed evidence may reach this query, because routing
+     * users away from a working model is as damaging as leaving a dead one in
+     * place. Offline+Permanent is written in exactly two situations, both of
+     * which the provider itself decided: it rejected the model id outright, or
+     * real calls to it failed permanently. Absence from a published model list
+     * is deliberately NOT one of them — those lists are partial, and an earlier
+     * version that trusted them condemned three working Imagen models.
+     *
+     * @return list<int>
+     */
+    public function findOfflineModelIds(): array
+    {
+        $rows = $this->createQueryBuilder('h')
+            ->select('h.modelId')
+            ->where('h.state = :state')
+            ->andWhere('h.kind = :kind')
+            ->setParameter('state', ModelHealthState::Offline->value)
+            ->setParameter('kind', FailureKind::Permanent->value)
+            ->getQuery()
+            ->getScalarResult();
+
+        return array_map(static fn (array $row): int => (int) $row['modelId'], $rows);
+    }
+
+    /**
+     * Models this automation switched off and may switch back on.
+     *
+     * @return list<ModelHealth>
+     */
+    public function findAutoDisabled(): array
+    {
+        return $this->createQueryBuilder('h')
+            ->where('h.autoDisabled = 1')
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
+     * Drop rows whose model no longer exists, so a deleted model does not keep
+     * a stale entry on the status page forever.
+     */
+    public function pruneOrphans(): int
+    {
+        return (int) $this->getEntityManager()->getConnection()->executeStatement(
+            'DELETE h FROM BMODELHEALTH h LEFT JOIN BMODELS m ON m.BID = h.BMODELID WHERE m.BID IS NULL'
+        );
+    }
+}

--- a/backend/src/Repository/ModelRepository.php
+++ b/backend/src/Repository/ModelRepository.php
@@ -194,4 +194,71 @@ class ModelRepository extends ServiceEntityRepository
 
         return array_filter($models, fn (Model $model) => $model->hasFeature($feature));
     }
+
+    /**
+     * Resolve the catalog row behind a live provider call.
+     *
+     * Service names are compared case-insensitively: BSERVICE stores them in
+     * CamelCase ('OpenAI', 'Groq') while providers report themselves lowercase
+     * from getName(). The tag is part of the lookup because one provider model
+     * id can back several rows — Groq's Qwen backs both the chat and the vision
+     * entry, and a vision outage must not be charged to the chat row.
+     */
+    public function findIdByServiceProviderIdAndTag(string $service, string $providerId, string $tag): ?int
+    {
+        $result = $this->createQueryBuilder('m')
+            ->select('m.id')
+            ->where('LOWER(m.service) = :service')
+            ->andWhere('LOWER(m.providerId) = :providerId')
+            ->andWhere('m.tag = :tag')
+            ->setParameter('service', mb_strtolower($service))
+            ->setParameter('providerId', mb_strtolower($providerId))
+            ->setParameter('tag', $tag)
+            ->orderBy('m.id', 'ASC')
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        return null === $result ? null : (int) $result['id'];
+    }
+
+    /**
+     * Every model of one service, keyed by the lowercased provider model id.
+     *
+     * Feeds the catalog diff: one query per provider instead of one per model.
+     *
+     * @return array<string, list<Model>>
+     */
+    public function findByServiceIndexedByProviderId(string $service): array
+    {
+        $models = $this->createQueryBuilder('m')
+            ->where('LOWER(m.service) = :service')
+            ->setParameter('service', mb_strtolower($service))
+            ->getQuery()
+            ->getResult();
+
+        $indexed = [];
+        foreach ($models as $model) {
+            /* @var Model $model */
+            $indexed[mb_strtolower($model->getProviderId())][] = $model;
+        }
+
+        return $indexed;
+    }
+
+    /**
+     * All distinct service names present in the catalog, as stored.
+     *
+     * @return list<string>
+     */
+    public function findAllServices(): array
+    {
+        $results = $this->createQueryBuilder('m')
+            ->select('DISTINCT m.service')
+            ->orderBy('m.service', 'ASC')
+            ->getQuery()
+            ->getScalarResult();
+
+        return array_map(static fn (array $row): string => (string) $row['service'], $results);
+    }
 }

--- a/backend/src/Service/DiscordNotificationService.php
+++ b/backend/src/Service/DiscordNotificationService.php
@@ -786,7 +786,7 @@ final readonly class DiscordNotificationService
         $fields = [
             [
                 'name' => '🏢 Provider',
-                'value' => $alert->provider,
+                'value' => $alert->name(),
                 'inline' => true,
             ],
             [
@@ -816,7 +816,7 @@ final readonly class DiscordNotificationService
 
         $this->sendEmbed(
             title: $resolved
-                ? '✅ [RESOLVED] '.$alert->provider.' models available again'
+                ? '✅ [RESOLVED] '.$alert->name().' models available again'
                 : '🚨 [INCIDENT] '.$alert->headline(),
             color: $resolved ? self::COLOR_SUCCESS : self::COLOR_ERROR,
             fields: $fields,

--- a/backend/src/Service/DiscordNotificationService.php
+++ b/backend/src/Service/DiscordNotificationService.php
@@ -2,6 +2,7 @@
 
 namespace App\Service;
 
+use App\AI\Health\ModelHealthAlert;
 use App\Entity\User;
 use App\Repository\UserRepository;
 use Psr\Log\LoggerInterface;
@@ -759,6 +760,68 @@ final readonly class DiscordNotificationService
             color: self::COLOR_WARNING,
             fields: $fields,
             footer: 'Synaplan model availability check · daily',
+        );
+    }
+
+    /**
+     * Report AI models that stopped working, or that started working again.
+     *
+     * Distinct from {@see self::notifyModelAvailabilityDrift()} on purpose: that
+     * one is a maintenance reminder that our catalog drifted from the provider's,
+     * this one is an incident about models failing right now — including the
+     * account-specific failures a catalog comparison cannot see.
+     *
+     * One message per provider rather than per model — see
+     * {@see ModelHealthAlert}. `@everyone` is reserved for the
+     * credential case: a rejected key or an empty balance takes out every model
+     * behind that provider and only an operator can fix it, whereas a provider
+     * retiring a single model can wait for office hours.
+     */
+    public function notifyModelHealth(ModelHealthAlert $alert, bool $resolved = false): void
+    {
+        if (!$this->isEnabled()) {
+            return;
+        }
+
+        $fields = [
+            [
+                'name' => '🏢 Provider',
+                'value' => $alert->provider,
+                'inline' => true,
+            ],
+            [
+                'name' => '🔢 Models',
+                'value' => (string) $alert->modelCount(),
+                'inline' => true,
+            ],
+            [
+                'name' => '🧠 Affected',
+                'value' => $this->truncate($alert->previewNames(), self::MAX_RESPONSE),
+                'inline' => false,
+            ],
+            [
+                'name' => $resolved ? 'Recovered after' : '⚠️ Reason',
+                'value' => '```'.$this->truncate($alert->reason, self::MAX_ERROR).'```',
+                'inline' => false,
+            ],
+        ];
+
+        if (!$resolved) {
+            $fields[] = [
+                'name' => 'Action required',
+                'value' => $alert->actionRequired(),
+                'inline' => false,
+            ];
+        }
+
+        $this->sendEmbed(
+            title: $resolved
+                ? '✅ [RESOLVED] '.$alert->provider.' models available again'
+                : '🚨 [INCIDENT] '.$alert->headline(),
+            color: $resolved ? self::COLOR_SUCCESS : self::COLOR_ERROR,
+            fields: $fields,
+            footer: 'Synaplan Model Health · one alert per provider',
+            mentionEveryone: !$resolved && ModelHealthAlert::KIND_CREDENTIAL === $alert->kind,
         );
     }
 

--- a/backend/src/Service/InternalEmailService.php
+++ b/backend/src/Service/InternalEmailService.php
@@ -493,7 +493,7 @@ final readonly class InternalEmailService
         $fromName = $_ENV['APP_SENDER_NAME'] ?? 'Synaplan';
         $timestamp = (new \DateTimeImmutable())->format('Y-m-d H:i:s T');
 
-        $provider = htmlspecialchars($alert->provider, ENT_QUOTES);
+        $provider = htmlspecialchars($alert->name(), ENT_QUOTES);
         $models = htmlspecialchars($alert->previewNames(), ENT_QUOTES);
         $reason = htmlspecialchars($alert->reason, ENT_QUOTES);
         $count = $alert->modelCount();
@@ -503,7 +503,7 @@ final readonly class InternalEmailService
             $title = '✅ RESOLVED — AI models available again';
             $lead = "<p><strong>{$count}</strong> model(s) from <strong>{$provider}</strong> are working again. No action needed.</p>";
             $action = '';
-            $subject = '[RESOLVED][Synaplan] '.$alert->provider.' models available again';
+            $subject = '[RESOLVED][Synaplan] '.$alert->name().' models available again';
         } else {
             $banner = '#c62828';
             $title = '🚨 INCIDENT — AI models unavailable';

--- a/backend/src/Service/InternalEmailService.php
+++ b/backend/src/Service/InternalEmailService.php
@@ -2,6 +2,7 @@
 
 namespace App\Service;
 
+use App\AI\Health\ModelHealthAlert;
 use Parsedown;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
@@ -465,6 +466,91 @@ final readonly class InternalEmailService
             $this->logger->info('Embedding fallback warning email sent', ['to' => $adminEmail]);
         } catch (\Exception $e) {
             $this->logger->warning('Failed to send embedding fallback warning email', [
+                'to' => $adminEmail,
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+
+    /**
+     * Report AI models that stopped working, or that started working again.
+     *
+     * One email per provider, never one per model: a revoked key takes out
+     * every model behind it at once, and forty separate emails about the same
+     * key is how an alert channel gets muted. Throttling lives in
+     * {@see \App\AI\Health\ModelHealthAlerter}, alongside the Discord path.
+     */
+    public function sendModelHealthAlert(ModelHealthAlert $alert, bool $resolved = false): void
+    {
+        $adminEmail = $this->operatorInbox();
+        if (null === $adminEmail) {
+            $this->logger->debug('No admin email configured, skipping model health alert');
+
+            return;
+        }
+
+        $fromEmail = $this->configuredAddress('APP_SENDER_EMAIL') ?? 'noreply@synaplan.com';
+        $fromName = $_ENV['APP_SENDER_NAME'] ?? 'Synaplan';
+        $timestamp = (new \DateTimeImmutable())->format('Y-m-d H:i:s T');
+
+        $provider = htmlspecialchars($alert->provider, ENT_QUOTES);
+        $models = htmlspecialchars($alert->previewNames(), ENT_QUOTES);
+        $reason = htmlspecialchars($alert->reason, ENT_QUOTES);
+        $count = $alert->modelCount();
+
+        if ($resolved) {
+            $banner = '#2e7d32';
+            $title = '✅ RESOLVED — AI models available again';
+            $lead = "<p><strong>{$count}</strong> model(s) from <strong>{$provider}</strong> are working again. No action needed.</p>";
+            $action = '';
+            $subject = '[RESOLVED][Synaplan] '.$alert->provider.' models available again';
+        } else {
+            $banner = '#c62828';
+            $title = '🚨 INCIDENT — AI models unavailable';
+            $lead = "<p><strong>{$count}</strong> model(s) from <strong>{$provider}</strong> are currently not usable.</p>";
+            $action = '<p><strong>Action required:</strong> '.htmlspecialchars($alert->actionRequired(), ENT_QUOTES).'</p>';
+            $subject = '[INCIDENT][Synaplan] '.$alert->headline();
+        }
+
+        $html = <<<HTML
+            <div style="font-family: -apple-system, sans-serif; max-width: 600px; margin: 0 auto;">
+                <div style="background: {$banner}; color: #fff; padding: 12px 16px; border-radius: 6px; margin-bottom: 16px;">
+                    <strong style="font-size: 18px;">{$title}</strong>
+                </div>
+                {$lead}
+                {$action}
+                <table style="width: 100%; border-collapse: collapse; margin: 16px 0;">
+                    <tr><td style="padding: 8px; border: 1px solid #ddd; font-weight: bold;">Provider</td>
+                        <td style="padding: 8px; border: 1px solid #ddd;">{$provider}</td></tr>
+                    <tr><td style="padding: 8px; border: 1px solid #ddd; font-weight: bold;">Models</td>
+                        <td style="padding: 8px; border: 1px solid #ddd;">{$models}</td></tr>
+                    <tr><td style="padding: 8px; border: 1px solid #ddd; font-weight: bold;">Reason</td>
+                        <td style="padding: 8px; border: 1px solid #ddd; font-family: monospace;">{$reason}</td></tr>
+                    <tr><td style="padding: 8px; border: 1px solid #ddd; font-weight: bold;">Time</td>
+                        <td style="padding: 8px; border: 1px solid #ddd;">{$timestamp}</td></tr>
+                </table>
+                <p style="color: #666; font-size: 13px;">Full status per model: Admin → Model status.</p>
+            </div>
+            HTML;
+
+        try {
+            $email = (new Email())
+                ->from(sprintf('%s <%s>', $fromName, $fromEmail))
+                ->to($adminEmail)
+                // Prefix stays machine-matchable so inbox rules and pagers can
+                // route on it without parsing the body.
+                ->subject($subject)
+                ->priority($resolved ? Email::PRIORITY_NORMAL : Email::PRIORITY_HIGH)
+                ->html($html);
+
+            $this->sendWithRetry($email);
+            $this->logger->info('Model health alert email sent', [
+                'to' => $adminEmail,
+                'provider' => $alert->provider,
+                'resolved' => $resolved,
+            ]);
+        } catch (\Exception $e) {
+            $this->logger->warning('Failed to send model health alert email', [
                 'to' => $adminEmail,
                 'error' => $e->getMessage(),
             ]);

--- a/backend/src/Service/ModelConfigService.php
+++ b/backend/src/Service/ModelConfigService.php
@@ -16,9 +16,9 @@ use Psr\Cache\CacheItemPoolInterface;
 use Psr\Log\LoggerInterface;
 
 /**
- * Service für dynamische AI-Modell-Konfiguration basierend auf User-Einstellungen.
+ * Resolves which AI model a user should get, from their settings.
  *
- * Ermöglicht User-spezifische Default-Modelle aus BCONFIG + BMODELS Tabellen
+ * User-specific defaults live in BCONFIG; the catalog of available models is BMODELS.
  */
 final readonly class ModelConfigService
 {
@@ -72,12 +72,12 @@ final readonly class ModelConfigService
     }
 
     /**
-     * Holt Default-Provider für einen User und Capability.
+     * Default provider for a user and capability.
      *
-     * Reihenfolge:
-     * 1. User-spezifische Config (BCONFIG: BOWNERID=userId, BGROUP='ai', BSETTING='default_chat_provider')
-     * 2. Global Default Config (BOWNERID=0)
-     * 3. Smart Fallback from DB
+     * Order:
+     * 1. User-specific config (BCONFIG: BOWNERID=userId, BGROUP='ai', BSETTING='default_chat_provider')
+     * 2. Global default config (BOWNERID=0)
+     * 3. Smart fallback from the database
      */
     public function getDefaultProvider(?int $userId, string $capability = 'chat'): string
     {
@@ -88,7 +88,7 @@ final readonly class ModelConfigService
             return $item->get();
         }
 
-        // 1. User-spezifische Config
+        // 1. User-specific config
         if ($userId) {
             $config = $this->configRepository->findByOwnerGroupAndSetting(
                 $userId,
@@ -99,7 +99,7 @@ final readonly class ModelConfigService
             if ($config) {
                 $provider = $config->getValue();
                 $item->set($provider);
-                $item->expiresAfter(300); // 5 Min Cache
+                $item->expiresAfter(300); // 5 minute cache
                 $this->cache->save($item);
 
                 return $provider;
@@ -180,12 +180,12 @@ final readonly class ModelConfigService
     }
 
     /**
-     * Holt Default-Modell für einen User, Provider und Capability (OLD METHOD - DEPRECATED).
+     * Default model for a user, provider and capability (OLD METHOD - DEPRECATED).
      *
-     * Reihenfolge:
-     * 1. User-spezifische Config (BCONFIG: 'default_chat_model')
-     * 2. BMODELS Tabelle (BPROVIDER, BCAPABILITY, BISDEFAULT=1)
-     * 3. ENV Variable (fallback)
+     * Order:
+     * 1. User-specific config (BCONFIG: 'default_chat_model')
+     * 2. BMODELS table (BPROVIDER, BCAPABILITY, BISDEFAULT=1)
+     * 3. ENV variable (fallback)
      */
     public function getDefaultModelOld(?int $userId, string $provider, string $capability = 'chat'): ?string
     {
@@ -196,7 +196,7 @@ final readonly class ModelConfigService
             return $item->get();
         }
 
-        // 1. User-spezifische Config
+        // 1. User-specific config
         if ($userId) {
             $config = $this->configRepository->findByOwnerGroupAndSetting(
                 $userId,
@@ -214,7 +214,7 @@ final readonly class ModelConfigService
             }
         }
 
-        // 2. BMODELS Tabelle
+        // 2. BMODELS table
         $model = $this->modelRepository->findDefaultByProviderAndCapability($provider, $capability);
 
         if ($model) {
@@ -226,7 +226,7 @@ final readonly class ModelConfigService
             return $modelName;
         }
 
-        // 3. null zurückgeben - Provider nutzt dann seinen eigenen Default
+        // 3. Return null — the provider then uses its own default
         $item->set(null);
         $item->expiresAfter(60);
         $this->cache->save($item);
@@ -235,7 +235,7 @@ final readonly class ModelConfigService
     }
 
     /**
-     * Setzt User-spezifischen Default-Provider.
+     * Set a user-specific default provider.
      */
     public function setDefaultProvider(int $userId, string $capability, string $provider): void
     {
@@ -260,7 +260,7 @@ final readonly class ModelConfigService
     }
 
     /**
-     * Setzt User-spezifisches Default-Modell.
+     * Set a user-specific default model.
      */
     public function setDefaultModel(int $userId, string $capability, string $model): void
     {
@@ -290,7 +290,7 @@ final readonly class ModelConfigService
     }
 
     /**
-     * Holt komplette AI-Config für einen User.
+     * Full AI config for a user.
      */
     public function getUserAiConfig(?int $userId): array
     {

--- a/backend/src/Service/ModelConfigService.php
+++ b/backend/src/Service/ModelConfigService.php
@@ -8,10 +8,12 @@ use App\Entity\Message;
 use App\Entity\Model;
 use App\Entity\User;
 use App\Repository\ConfigRepository;
+use App\Repository\ModelHealthRepository;
 use App\Repository\ModelRepository;
 use App\Repository\UserRepository;
 use App\Seed\DefaultModelConfigSeeder;
 use Psr\Cache\CacheItemPoolInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * Service für dynamische AI-Modell-Konfiguration basierend auf User-Einstellungen.
@@ -22,6 +24,9 @@ final readonly class ModelConfigService
 {
     private const USABLE_PROVIDERS_CACHE_KEY = 'model_config.usable_providers';
     private const USABLE_PROVIDERS_CACHE_TTL_SECONDS = 60;
+
+    private const OFFLINE_MODELS_CACHE_KEY = 'model_config.offline_models';
+    private const OFFLINE_MODELS_CACHE_TTL_SECONDS = 60;
 
     /**
      * DEFAULTMODEL capability => BMODELS.BTAG, for the last-resort pick in
@@ -60,6 +65,8 @@ final readonly class ModelConfigService
         private CacheItemPoolInterface $cache,
         private ProviderRegistry $providerRegistry,
         private OllamaModelInventory $ollamaModelInventory,
+        private ModelHealthRepository $modelHealthRepository,
+        private LoggerInterface $logger,
         private string $environment = 'prod',
     ) {
     }
@@ -450,16 +457,67 @@ final readonly class ModelConfigService
             return null;
         }
 
-        foreach ([true, false] as $selectableOnly) {
-            // findByTag() orders by quality DESC, id ASC.
-            foreach ($this->modelRepository->findByTag($tag, $selectableOnly) as $model) {
-                if ($this->isModelUsable($model)) {
+        // Health is a preference, not a veto. Pass one skips the models the
+        // monitor considers dead; pass two accepts them anyway. A wrong health
+        // verdict must never be able to leave a capability with no model at
+        // all — routing at a suspect model beats routing nowhere, and the
+        // status page is there to tell the operator what happened.
+        foreach ([true, false] as $healthyOnly) {
+            foreach ([true, false] as $selectableOnly) {
+                // findByTag() orders by quality DESC, id ASC.
+                foreach ($this->modelRepository->findByTag($tag, $selectableOnly) as $model) {
+                    if (!$this->isModelUsable($model)) {
+                        continue;
+                    }
+                    if ($healthyOnly && $this->isModelOffline((int) $model->getId())) {
+                        continue;
+                    }
+
                     return $model->getId();
                 }
             }
         }
 
         return null;
+    }
+
+    /**
+     * Has the health monitor seen this model fail permanently?
+     *
+     * Cached like the usable-provider snapshot and for the same reason: this
+     * sits on the model-resolution path, which runs several times per message.
+     */
+    private function isModelOffline(int $modelId): bool
+    {
+        return in_array($modelId, $this->offlineModelIds(), true);
+    }
+
+    /**
+     * @return list<int>
+     */
+    private function offlineModelIds(): array
+    {
+        $item = $this->cache->getItem(self::OFFLINE_MODELS_CACHE_KEY);
+        if ($item->isHit()) {
+            /** @var list<int> $cached */
+            $cached = $item->get();
+
+            return $cached;
+        }
+
+        try {
+            $ids = $this->modelHealthRepository->findOfflineModelIds();
+        } catch (\Throwable) {
+            // Before the health table exists (fresh install mid-migration) the
+            // answer is simply "nothing is known to be offline".
+            $ids = [];
+        }
+
+        $item->set($ids);
+        $item->expiresAfter(self::OFFLINE_MODELS_CACHE_TTL_SECONDS);
+        $this->cache->save($item);
+
+        return $ids;
     }
 
     /**
@@ -475,8 +533,29 @@ final readonly class ModelConfigService
      */
     public function resolveUsableModelId(?int $modelId, string $capability, ?int $userId = null): ?int
     {
-        if (null !== $modelId && $modelId > 0 && !$this->isModelProviderUsable($modelId)) {
+        if (null === $modelId || $modelId <= 0) {
+            return $modelId;
+        }
+
+        if (!$this->isModelProviderUsable($modelId)) {
             return $this->getDefaultModel($capability, $userId);
+        }
+
+        // The binding still resolves, but the health monitor saw this model
+        // fail permanently. Move to the capability default only when that
+        // default is not itself under suspicion — swapping one broken model for
+        // another just makes the failure harder to explain.
+        if ($this->isModelOffline($modelId)) {
+            $fallback = $this->getDefaultModel($capability, $userId);
+            if (null !== $fallback && $fallback !== $modelId && !$this->isModelOffline($fallback)) {
+                $this->logger->info('Routing away from a model reported as unavailable', [
+                    'model_id' => $modelId,
+                    'fallback_model_id' => $fallback,
+                    'capability' => $capability,
+                ]);
+
+                return $fallback;
+            }
         }
 
         return $modelId;
@@ -567,6 +646,15 @@ final readonly class ModelConfigService
     public function invalidateUsableProviders(): void
     {
         $this->cache->deleteItem(self::USABLE_PROVIDERS_CACHE_KEY);
+    }
+
+    /**
+     * Drop the cached health snapshot so a re-check or an operator's override
+     * takes effect on the next model resolution instead of after the TTL.
+     */
+    public function invalidateModelHealth(): void
+    {
+        $this->cache->deleteItem(self::OFFLINE_MODELS_CACHE_KEY);
     }
 
     /**

--- a/backend/src/Service/Usage/UsageFailureLogger.php
+++ b/backend/src/Service/Usage/UsageFailureLogger.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Usage;
+
+use Doctrine\DBAL\Connection;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Writes a BUSELOG row for an AI call that failed.
+ *
+ * BUSELOG has carried BSTATUS and BERROR columns from the start, but every
+ * writer so far hard-coded 'success' — so the table recorded what a model cost
+ * and never what it broke. Failures land here with BTOKENS = 0 and BCOST = 0
+ * so nothing is billed, which keeps the statistics untouched while giving the
+ * status page a history that survives a Redis flush.
+ *
+ * Deliberately narrow (a DBAL connection and nothing else) so it can be called
+ * from inside a failing AI call without dragging the pricing stack along.
+ */
+final readonly class UsageFailureLogger
+{
+    private const MAX_ERROR_LENGTH = 1000;
+
+    public function __construct(
+        private Connection $connection,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $metadata
+     */
+    public function record(
+        int $userId,
+        string $action,
+        string $provider,
+        string $model,
+        ?int $modelId,
+        string $failureKind,
+        string $errorMessage,
+        array $metadata = [],
+    ): void {
+        if ($userId <= 0) {
+            return;
+        }
+
+        try {
+            $this->connection->executeStatement(
+                'INSERT INTO BUSELOG (BUSERID, BUNIXTIMES, BACTION, BPROVIDER, BMODEL, BTOKENS,
+                 BPROMPT_TOKENS, BCOMPLETION_TOKENS, BCACHED_TOKENS, BCACHE_CREATION_TOKENS,
+                 BESTIMATED, BMODEL_ID, BPRICE_SNAPSHOT, BCOST, BLATENCY, BSTATUS, BERROR, BMETADATA)
+                 VALUES (:user_id, :timestamp, :action, :provider, :model, 0,
+                 0, 0, 0, 0,
+                 0, :model_id, NULL, :cost, 0, :status, :error, :metadata)',
+                [
+                    'user_id' => $userId,
+                    'timestamp' => time(),
+                    'action' => $action,
+                    'provider' => $provider,
+                    'model' => mb_substr($model, 0, 128),
+                    'model_id' => $modelId,
+                    'cost' => '0.000000',
+                    'status' => 'error',
+                    'error' => mb_substr($errorMessage, 0, self::MAX_ERROR_LENGTH),
+                    'metadata' => json_encode(
+                        $metadata + ['failure_kind' => $failureKind],
+                        \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE
+                    ),
+                ]
+            );
+        } catch (\Throwable $e) {
+            // The call this describes has already failed; failing to write the
+            // audit row must not replace the real error with a database one.
+            $this->logger->warning('Failed to record AI usage failure', [
+                'action' => $action,
+                'provider' => $provider,
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+}

--- a/backend/tests/AI/Provider/OllamaProviderHasModelTest.php
+++ b/backend/tests/AI/Provider/OllamaProviderHasModelTest.php
@@ -34,7 +34,7 @@ final class OllamaProviderHasModelTest extends TestCase
                 parent::__construct($logger, $baseUrl, $httpClient);
             }
 
-            protected function getAvailableModels(): array
+            public function getAvailableModels(): array
             {
                 return $this->models;
             }

--- a/backend/tests/Integration/Controller/AdminModelHealthControllerTest.php
+++ b/backend/tests/Integration/Controller/AdminModelHealthControllerTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Controller;
+
+use App\AI\Health\ModelHealthState;
+use App\Entity\Model;
+use App\Entity\ModelHealth;
+use App\Entity\User;
+use App\Tests\Trait\AuthenticatedTestTrait;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Contract of the admin model status page: the read endpoint reports every
+ * catalogued model without ever calling a provider, and the exemption toggle
+ * is what an operator uses to overrule the automation.
+ */
+class AdminModelHealthControllerTest extends WebTestCase
+{
+    use AuthenticatedTestTrait;
+
+    private KernelBrowser $client;
+    private string $token;
+
+    /** @var list<int> */
+    private array $createdHealthIds = [];
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+
+        $user = $this->client->getContainer()->get('doctrine')
+            ->getRepository(User::class)
+            ->findOneBy(['mail' => 'admin@synaplan.com']);
+
+        if (!$user) {
+            self::markTestSkipped('Test user admin@synaplan.com not found. Run fixtures first.');
+        }
+
+        $this->token = $this->authenticateClient($this->client, $user);
+    }
+
+    protected function tearDown(): void
+    {
+        $em = $this->client->getContainer()->get('doctrine')->getManager();
+        foreach ($this->createdHealthIds as $id) {
+            $entity = $em->find(ModelHealth::class, $id);
+            if ($entity) {
+                $em->remove($entity);
+            }
+        }
+        $em->flush();
+
+        parent::tearDown();
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     *
+     * @return array<string, mixed>
+     */
+    private function request(string $method, string $uri, array $payload = []): array
+    {
+        $this->client->request($method, $uri, [], [], [
+            'CONTENT_TYPE' => 'application/json',
+            'HTTP_AUTHORIZATION' => 'Bearer '.$this->token,
+        ], [] === $payload ? null : (string) json_encode($payload));
+
+        $decoded = json_decode((string) $this->client->getResponse()->getContent(), true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    public function testStatusReportsEveryModelGroupedByProvider(): void
+    {
+        $data = $this->request('GET', '/api/v1/admin/model-health');
+
+        self::assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        self::assertTrue($data['success']);
+
+        foreach (['total', 'online', 'degraded', 'offline', 'unconfigured', 'unknown', 'needsAttention', 'lastCheck', 'autoDisableEnabled', 'monitoringEnabled'] as $key) {
+            self::assertArrayHasKey($key, $data['summary'], $key);
+        }
+
+        $em = $this->client->getContainer()->get('doctrine')->getManager();
+        $catalogued = (int) $em->getRepository(Model::class)->count([]);
+        self::assertSame($catalogued, $data['summary']['total']);
+
+        // Every model has to appear exactly once, whatever its state — a status
+        // page that silently drops rows is worse than no status page.
+        $listed = 0;
+        foreach ($data['providers'] as $provider) {
+            self::assertArrayHasKey('name', $provider);
+            self::assertArrayHasKey('needsAttention', $provider);
+            $listed += count($provider['models']);
+
+            foreach ($provider['models'] as $model) {
+                self::assertContains(
+                    $model['state'],
+                    array_map(static fn (ModelHealthState $s): string => $s->value, ModelHealthState::cases()),
+                    $model['name']
+                );
+                self::assertIsInt($model['errorRatePercent']);
+                self::assertIsBool($model['active']);
+            }
+        }
+        self::assertSame($catalogued, $listed);
+    }
+
+    public function testExemptingAModelPausesAndResumesTheAutomation(): void
+    {
+        $em = $this->client->getContainer()->get('doctrine')->getManager();
+        $model = $em->getRepository(Model::class)->findOneBy([]);
+        self::assertNotNull($model, 'The model catalog must not be empty');
+        $modelId = (int) $model->getId();
+
+        $granted = $this->request('POST', "/api/v1/admin/model-health/models/{$modelId}/exempt", ['exempt' => true]);
+        self::assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        self::assertTrue($granted['success']);
+        self::assertGreaterThan(time(), $granted['exemptUntil']);
+
+        $health = $em->getRepository(ModelHealth::class)->findOneBy(['modelId' => $modelId]);
+        self::assertNotNull($health);
+        $this->createdHealthIds[] = (int) $health->getId();
+        self::assertTrue($health->isSuppressed());
+
+        $revoked = $this->request('POST', "/api/v1/admin/model-health/models/{$modelId}/exempt", ['exempt' => false]);
+        self::assertSame(0, $revoked['exemptUntil']);
+    }
+
+    public function testExemptRejectsAMissingFlagAndAnUnknownModel(): void
+    {
+        $em = $this->client->getContainer()->get('doctrine')->getManager();
+        $model = $em->getRepository(Model::class)->findOneBy([]);
+        self::assertNotNull($model);
+
+        $this->request('POST', '/api/v1/admin/model-health/models/'.$model->getId().'/exempt', ['exempt' => 'yes']);
+        self::assertSame(Response::HTTP_BAD_REQUEST, $this->client->getResponse()->getStatusCode());
+
+        $this->request('POST', '/api/v1/admin/model-health/models/99999999/exempt', ['exempt' => true]);
+        self::assertSame(Response::HTTP_NOT_FOUND, $this->client->getResponse()->getStatusCode());
+    }
+}

--- a/backend/tests/Integration/Controller/AdminModelHealthControllerTest.php
+++ b/backend/tests/Integration/Controller/AdminModelHealthControllerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Integration\Controller;
 
+use App\AI\Health\FailureKind;
 use App\AI\Health\ModelHealthState;
 use App\AI\Service\ProviderRegistry;
 use App\Entity\Model;
@@ -177,5 +178,67 @@ class AdminModelHealthControllerTest extends WebTestCase
 
         $this->request('POST', '/api/v1/admin/model-health/models/99999999/exempt', ['exempt' => true]);
         self::assertSame(Response::HTTP_NOT_FOUND, $this->client->getResponse()->getStatusCode());
+    }
+
+    public function testResetClearsATrafficVerdictButLeavesAProbeRetirement(): void
+    {
+        $em = $this->client->getContainer()->get('doctrine')->getManager();
+        $model = $em->getRepository(Model::class)->findOneBy([]);
+        self::assertNotNull($model);
+        $modelId = (int) $model->getId();
+
+        $health = $em->getRepository(ModelHealth::class)->findOneBy(['modelId' => $modelId]);
+        if (null === $health) {
+            $health = (new ModelHealth())->setModelId($modelId);
+            $em->persist($health);
+        }
+        $health
+            ->setState(ModelHealthState::Offline)
+            ->setSource(ModelHealth::SOURCE_TRAFFIC)
+            ->setKind(FailureKind::Permanent->value)
+            ->setMessage('80% of recent calls failed')
+            ->setUpdated(time());
+        $em->flush();
+        $this->createdHealthIds[] = (int) $health->getId();
+
+        $this->request('POST', "/api/v1/admin/model-health/models/{$modelId}/reset");
+        self::assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+
+        $em->clear();
+        $reloaded = $em->getRepository(ModelHealth::class)->findOneBy(['modelId' => $modelId]);
+        self::assertNotNull($reloaded);
+        self::assertSame(ModelHealthState::Unknown, $reloaded->getState());
+        self::assertNull($reloaded->getMessage());
+        self::assertNull($reloaded->getKind());
+
+        $reloaded
+            ->setState(ModelHealthState::Offline)
+            ->setSource(ModelHealth::SOURCE_PROBE)
+            ->setKind(FailureKind::Permanent->value)
+            ->setMessage('Provider no longer serves this model.')
+            ->setUpdated(time());
+        $em->flush();
+
+        $this->request('POST', "/api/v1/admin/model-health/models/{$modelId}/reset");
+        $em->clear();
+        $stillRetired = $em->getRepository(ModelHealth::class)->findOneBy(['modelId' => $modelId]);
+        self::assertNotNull($stillRetired);
+        self::assertSame(ModelHealthState::Offline, $stillRetired->getState());
+        self::assertSame(ModelHealth::SOURCE_PROBE, $stillRetired->getSource());
+        self::assertSame('Provider no longer serves this model.', $stillRetired->getMessage());
+    }
+
+    public function testExemptRejectsANonObjectJsonBody(): void
+    {
+        $em = $this->client->getContainer()->get('doctrine')->getManager();
+        $model = $em->getRepository(Model::class)->findOneBy([]);
+        self::assertNotNull($model);
+
+        $this->client->request('POST', '/api/v1/admin/model-health/models/'.$model->getId().'/exempt', [], [], [
+            'CONTENT_TYPE' => 'application/json',
+            'HTTP_AUTHORIZATION' => 'Bearer '.$this->token,
+        ], '"not-an-object"');
+
+        self::assertSame(Response::HTTP_BAD_REQUEST, $this->client->getResponse()->getStatusCode());
     }
 }

--- a/backend/tests/Integration/Controller/AdminModelHealthControllerTest.php
+++ b/backend/tests/Integration/Controller/AdminModelHealthControllerTest.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace App\Tests\Integration\Controller;
 
 use App\AI\Health\ModelHealthState;
+use App\AI\Service\ProviderRegistry;
 use App\Entity\Model;
 use App\Entity\ModelHealth;
 use App\Entity\User;
+use App\Model\ModelCatalog;
 use App\Tests\Trait\AuthenticatedTestTrait;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
@@ -95,6 +97,9 @@ class AdminModelHealthControllerTest extends WebTestCase
         foreach ($data['providers'] as $provider) {
             self::assertArrayHasKey('name', $provider);
             self::assertArrayHasKey('needsAttention', $provider);
+            // The heading has to carry the provider's own spelling. Deriving
+            // it in CSS was tried and turns "xAI" into "XAI".
+            self::assertNotSame('', $provider['displayName'], $provider['name']);
             $listed += count($provider['models']);
 
             foreach ($provider['models'] as $model) {
@@ -108,6 +113,36 @@ class AdminModelHealthControllerTest extends WebTestCase
             }
         }
         self::assertSame($catalogued, $listed);
+    }
+
+    /**
+     * The provider registry, not the BSERVICE column, owns how a provider is
+     * spelled on screen. xAI is the case that catches a regression: the column
+     * says "xAI", any CSS or PHP casing helper would render "XAI", and only
+     * reading the registry gives the brand back.
+     */
+    public function testProviderHeadingsUseTheBrandedName(): void
+    {
+        $data = $this->request('GET', '/api/v1/admin/model-health');
+
+        $byKey = [];
+        foreach ($data['providers'] as $provider) {
+            $byKey[$provider['name']] = $provider['displayName'];
+        }
+
+        $registry = $this->client->getContainer()->get(ProviderRegistry::class);
+        foreach ($byKey as $service => $displayName) {
+            $key = ModelCatalog::normalizeProvider($service);
+            $provider = $registry->getUniqueProviders()[$key] ?? null;
+            if (null === $provider) {
+                // Not every catalogued service is a registered provider; those
+                // fall back to the raw key rather than showing nothing.
+                self::assertSame($service, $displayName);
+                continue;
+            }
+
+            self::assertSame($provider->getDisplayName(), $displayName, $service);
+        }
     }
 
     public function testExemptingAModelPausesAndResumesTheAutomation(): void

--- a/backend/tests/Unit/AI/Credential/ChatReadinessServiceTest.php
+++ b/backend/tests/Unit/AI/Credential/ChatReadinessServiceTest.php
@@ -11,6 +11,7 @@ use App\AI\Service\ProviderRegistry;
 use App\Entity\Config;
 use App\Entity\Model;
 use App\Repository\ConfigRepository;
+use App\Repository\ModelHealthRepository;
 use App\Repository\ModelRepository;
 use App\Repository\UserRepository;
 use App\Service\ModelConfigService;
@@ -59,6 +60,8 @@ class ChatReadinessServiceTest extends TestCase
             new ArrayAdapter(),
             $this->providerRegistry,
             $ollamaModelInventory,
+            $this->createMock(ModelHealthRepository::class),
+            new NullLogger(),
             'test',
         );
 

--- a/backend/tests/Unit/AI/Health/FailureClassifierTest.php
+++ b/backend/tests/Unit/AI/Health/FailureClassifierTest.php
@@ -158,11 +158,29 @@ final class FailureClassifierTest extends TestCase
         yield 'groq decommissioned' => ['The model `llama-3.3-70b-versatile` has been decommissioned', FailureKind::Permanent];
         yield 'anthropic not_found_error' => ['not_found_error: model: claude-3-opus', FailureKind::Permanent];
         yield 'deprecated wording' => ['This model is deprecated and will be removed', FailureKind::Permanent];
+        yield 'deprecated parameter is not a retired model' => ['The `functions` parameter is deprecated. Use `tools` instead.', FailureKind::Transient];
+        yield 'invalid_request_error alone is not a user error' => ['invalid_request_error', FailureKind::Transient];
         yield 'invalid key' => ['Incorrect API key provided', FailureKind::Credential];
         yield 'exhausted quota' => ['You exceeded your current quota, please check your plan and billing details', FailureKind::Credential];
         yield 'overloaded' => ['Overloaded, please retry', FailureKind::Transient];
         yield 'timeout' => ['Request timed out after 60s', FailureKind::Transient];
         yield 'context length' => ['This model maximum context length is 8192 tokens', FailureKind::UserError];
+        yield 'safety ratings' => ['The response was blocked by the safety ratings filter', FailureKind::UserError];
+        yield 'unrelated safety outage stays transient' => ['Could not reach the safety endpoint', FailureKind::Transient];
+    }
+
+    /**
+     * OpenAI wraps almost every 4xx as type=invalid_request_error, including
+     * a bad key. That string must not hide a 401, or a credential outage is
+     * filed as a user error and never pages anyone.
+     */
+    public function testUnauthorizedStatusWinsOverGenericInvalidRequestType(): void
+    {
+        $kind = $this->classifier->classify(
+            new ProviderException('invalid_request_error', 'openai', null, 401)
+        );
+
+        self::assertSame(FailureKind::Credential, $kind);
     }
 
     /**

--- a/backend/tests/Unit/AI/Health/FailureClassifierTest.php
+++ b/backend/tests/Unit/AI/Health/FailureClassifierTest.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\AI\Health;
+
+use App\AI\Exception\ProviderCancelledException;
+use App\AI\Exception\ProviderException;
+use App\AI\Health\FailureClassifier;
+use App\AI\Health\FailureKind;
+use App\Service\Exception\StreamCancelledException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class FailureClassifierTest extends TestCase
+{
+    private FailureClassifier $classifier;
+
+    protected function setUp(): void
+    {
+        $this->classifier = new FailureClassifier();
+    }
+
+    /**
+     * A rate limit must never be able to retire a model. This is the single
+     * most important rule in the whole health monitor: without it, the first
+     * traffic spike switches off the busiest model.
+     */
+    public function testRateLimitIsTransientAndNeverJustifiesAutoDisable(): void
+    {
+        $kind = $this->classifier->classify(
+            new ProviderException('Rate limit reached for gpt-5', 'openai', null, 429)
+        );
+
+        self::assertSame(FailureKind::Transient, $kind);
+        self::assertFalse($kind->justifiesAutoDisable());
+        self::assertTrue($kind->countsAgainstModel());
+    }
+
+    public function testRateLimitWithoutStatusCodeIsStillTransient(): void
+    {
+        // Several SDKs wrap the upstream response and lose the status.
+        $kind = $this->classifier->classify(
+            new ProviderException('Groq chat error: Too Many Requests', 'groq')
+        );
+
+        self::assertSame(FailureKind::Transient, $kind);
+    }
+
+    public function testMissingApiKeyIsCredential(): void
+    {
+        $kind = $this->classifier->classify(
+            ProviderException::missingApiKey('anthropic', 'ANTHROPIC_API_KEY')
+        );
+
+        self::assertSame(FailureKind::Credential, $kind);
+        self::assertTrue($kind->isProviderWide());
+        self::assertFalse($kind->countsAgainstModel());
+    }
+
+    public function testBlockedContentIsAUserErrorNotAModelDefect(): void
+    {
+        $kind = $this->classifier->classify(
+            ProviderException::contentBlocked('google', 'SAFETY')
+        );
+
+        self::assertSame(FailureKind::UserError, $kind);
+        self::assertFalse($kind->countsAgainstModel());
+    }
+
+    /**
+     * The message puts the model name between the words ("Model 'x' not found
+     * for provider 'y'"), which a naive "model not found" match would miss.
+     */
+    public function testRejectedModelNameIsPermanent(): void
+    {
+        $kind = $this->classifier->classify(
+            ProviderException::noModelAvailable('chat', 'openai', 'gpt-4-vision-preview')
+        );
+
+        self::assertSame(FailureKind::Permanent, $kind);
+        self::assertTrue($kind->justifiesAutoDisable());
+    }
+
+    public function testOllamaMissingModelIsPermanent(): void
+    {
+        $kind = $this->classifier->classify(
+            ProviderException::noModelAvailable('chat', 'ollama', 'qwen2.5:3b')
+        );
+
+        self::assertSame(FailureKind::Permanent, $kind);
+    }
+
+    public function testUserCancelIsNeverCountedAsAFailure(): void
+    {
+        foreach ([new ProviderCancelledException('stopped'), new StreamCancelledException('stopped')] as $error) {
+            $kind = $this->classifier->classify($error);
+
+            self::assertSame(FailureKind::Cancelled, $kind);
+            self::assertFalse($kind->countsAgainstModel());
+        }
+    }
+
+    /**
+     * An open circuit is an echo of earlier failures, not new evidence. It stays
+     * transient so a provider hiccup can never escalate into a retirement.
+     */
+    public function testOpenCircuitBreakerIsTransient(): void
+    {
+        $kind = $this->classifier->classify(
+            new ProviderException('Service temporarily unavailable (circuit breaker is OPEN)', 'openai')
+        );
+
+        self::assertSame(FailureKind::Transient, $kind);
+        self::assertFalse($kind->justifiesAutoDisable());
+    }
+
+    #[DataProvider('statusProvider')]
+    public function testUpstreamStatusDecidesWhenTheMessageSaysNothing(int $status, FailureKind $expected): void
+    {
+        self::assertSame(
+            $expected,
+            $this->classifier->classify(new ProviderException('upstream rejected the call', 'openai', null, $status))
+        );
+    }
+
+    /**
+     * @return iterable<string, array{int, FailureKind}>
+     */
+    public static function statusProvider(): iterable
+    {
+        yield '400 bad request' => [400, FailureKind::UserError];
+        yield '401 unauthorized' => [401, FailureKind::Credential];
+        yield '402 payment required' => [402, FailureKind::Credential];
+        yield '403 forbidden' => [403, FailureKind::Credential];
+        yield '404 not found' => [404, FailureKind::Permanent];
+        yield '410 gone' => [410, FailureKind::Permanent];
+        yield '429 rate limited' => [429, FailureKind::Transient];
+        yield '500 server error' => [500, FailureKind::Transient];
+        yield '503 unavailable' => [503, FailureKind::Transient];
+    }
+
+    #[DataProvider('messageProvider')]
+    public function testProviderWordingIsRecognised(string $message, FailureKind $expected): void
+    {
+        self::assertSame(
+            $expected,
+            $this->classifier->classify(new ProviderException($message, 'openai'))
+        );
+    }
+
+    /**
+     * @return iterable<string, array{string, FailureKind}>
+     */
+    public static function messageProvider(): iterable
+    {
+        yield 'openai model_not_found' => ['The model `gpt-4-vision-preview` does not exist or you do not have access to it', FailureKind::Permanent];
+        yield 'groq decommissioned' => ['The model `llama-3.3-70b-versatile` has been decommissioned', FailureKind::Permanent];
+        yield 'anthropic not_found_error' => ['not_found_error: model: claude-3-opus', FailureKind::Permanent];
+        yield 'deprecated wording' => ['This model is deprecated and will be removed', FailureKind::Permanent];
+        yield 'invalid key' => ['Incorrect API key provided', FailureKind::Credential];
+        yield 'exhausted quota' => ['You exceeded your current quota, please check your plan and billing details', FailureKind::Credential];
+        yield 'overloaded' => ['Overloaded, please retry', FailureKind::Transient];
+        yield 'timeout' => ['Request timed out after 60s', FailureKind::Transient];
+        yield 'context length' => ['This model maximum context length is 8192 tokens', FailureKind::UserError];
+    }
+
+    /**
+     * An unrecognised failure must land somewhere harmless. Transient is the
+     * only default that cannot retire a model on its own.
+     */
+    public function testUnknownFailureDefaultsToTransient(): void
+    {
+        self::assertSame(
+            FailureKind::Transient,
+            $this->classifier->classify(new \RuntimeException('something went sideways'))
+        );
+    }
+}

--- a/backend/tests/Unit/AI/Health/ModelHealthAlerterTest.php
+++ b/backend/tests/Unit/AI/Health/ModelHealthAlerterTest.php
@@ -139,4 +139,32 @@ final class ModelHealthAlerterTest extends TestCase
         self::assertStringContainsString('Groq credentials rejected', $alert->headline());
         self::assertStringContainsString('and 15 more', $alert->previewNames());
     }
+
+    /**
+     * The alert carries two different things under similar names: `provider` is
+     * the BSERVICE key that the throttle is keyed on, and `name()` is what the
+     * operator reads. Rendering the key would put "ollama" and "xAI" in the
+     * subject line; keying on the label would silently split the throttle the
+     * day a display name changes.
+     */
+    #[AllowMockObjectsWithoutExpectations]
+    public function testTheAlertRendersTheBrandedNameButThrottlesOnTheKey(): void
+    {
+        $alert = new ModelHealthAlert(ModelHealthAlert::KIND_OFFLINE, 'ollama', ['x'], 'gone', 'Ollama');
+
+        self::assertSame('Ollama', $alert->name());
+        self::assertStringContainsString('Ollama model(s)', $alert->headline());
+        self::assertSame('ollama', $alert->provider);
+
+        self::assertTrue($this->alerter->raise($alert));
+        self::assertTrue($this->alerter->isOpen('ollama', ModelHealthAlert::KIND_OFFLINE));
+    }
+
+    /** Without a display name the key is still better than printing nothing. */
+    public function testTheAlertFallsBackToTheKeyWhenNoNameIsGiven(): void
+    {
+        $alert = new ModelHealthAlert(ModelHealthAlert::KIND_OFFLINE, 'ollama', ['x'], 'gone');
+
+        self::assertSame('ollama', $alert->name());
+    }
 }

--- a/backend/tests/Unit/AI/Health/ModelHealthAlerterTest.php
+++ b/backend/tests/Unit/AI/Health/ModelHealthAlerterTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\AI\Health;
+
+use App\AI\Health\ModelHealthAlert;
+use App\AI\Health\ModelHealthAlerter;
+use App\AI\Health\ModelHealthConfig;
+use App\Repository\ConfigRepository;
+use App\Service\DiscordNotificationService;
+use App\Service\InternalEmailService;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+final class ModelHealthAlerterTest extends TestCase
+{
+    private ArrayAdapter $cache;
+    private InternalEmailService&MockObject $email;
+    private DiscordNotificationService&MockObject $discord;
+    private ModelHealthAlerter $alerter;
+
+    protected function setUp(): void
+    {
+        $this->cache = new ArrayAdapter();
+        $this->email = $this->createMock(InternalEmailService::class);
+        $this->discord = $this->createMock(DiscordNotificationService::class);
+
+        $configRepository = $this->createStub(ConfigRepository::class);
+        $configRepository->method('getValue')->willReturn(null);
+
+        $this->alerter = new ModelHealthAlerter(
+            $this->cache,
+            new ModelHealthConfig($configRepository),
+            $this->email,
+            $this->discord,
+            new NullLogger(),
+        );
+    }
+
+    private static function alert(string $kind = ModelHealthAlert::KIND_OFFLINE): ModelHealthAlert
+    {
+        return new ModelHealthAlert($kind, 'OpenAI', ['GPT-5', 'GPT-5 Vision'], 'retired upstream');
+    }
+
+    public function testFirstAlertReachesBothChannels(): void
+    {
+        $this->email->expects(self::once())->method('sendModelHealthAlert');
+        $this->discord->expects(self::once())->method('notifyModelHealth');
+
+        self::assertTrue($this->alerter->raise(self::alert()));
+    }
+
+    /**
+     * A flapping provider must not turn into a stream of identical emails —
+     * that is how an alert channel gets muted and the next real outage is
+     * missed.
+     */
+    public function testRepeatedAlertsAreThrottled(): void
+    {
+        $this->email->expects(self::once())->method('sendModelHealthAlert');
+        $this->discord->expects(self::once())->method('notifyModelHealth');
+
+        self::assertTrue($this->alerter->raise(self::alert()));
+        self::assertFalse($this->alerter->raise(self::alert()));
+        self::assertFalse($this->alerter->raise(self::alert()));
+    }
+
+    #[AllowMockObjectsWithoutExpectations]
+    public function testDifferentKindsForTheSameProviderAlertSeparately(): void
+    {
+        $this->email->expects(self::exactly(2))->method('sendModelHealthAlert');
+
+        self::assertTrue($this->alerter->raise(self::alert(ModelHealthAlert::KIND_OFFLINE)));
+        self::assertTrue($this->alerter->raise(self::alert(ModelHealthAlert::KIND_CREDENTIAL)));
+    }
+
+    /**
+     * An all-clear for an incident nobody was told about is worse than none:
+     * it reports a recovery the operator cannot place.
+     */
+    public function testNoAllClearWithoutAnOpenIncident(): void
+    {
+        $this->email->expects(self::never())->method('sendModelHealthAlert');
+        $this->discord->expects(self::never())->method('notifyModelHealth');
+
+        self::assertFalse($this->alerter->resolve(self::alert()));
+    }
+
+    #[AllowMockObjectsWithoutExpectations]
+    public function testAllClearFollowsAnOpenIncidentAndClosesIt(): void
+    {
+        $this->alerter->raise(self::alert());
+        self::assertTrue($this->alerter->isOpen('OpenAI', ModelHealthAlert::KIND_OFFLINE));
+
+        self::assertTrue($this->alerter->resolve(self::alert()));
+        self::assertFalse($this->alerter->isOpen('OpenAI', ModelHealthAlert::KIND_OFFLINE));
+
+        // Second all-clear is a no-op — the incident is already closed.
+        self::assertFalse($this->alerter->resolve(self::alert()));
+    }
+
+    /**
+     * The all-clear also clears the throttle, so a fresh outage right after a
+     * recovery is reported immediately instead of inheriting the old silence.
+     */
+    #[AllowMockObjectsWithoutExpectations]
+    public function testRecoveryClearsTheThrottleWindow(): void
+    {
+        $this->alerter->raise(self::alert());
+        $this->alerter->resolve(self::alert());
+
+        self::assertTrue($this->alerter->raise(self::alert()));
+    }
+
+    /**
+     * Provider names come straight from BSERVICE and can carry characters PSR-6
+     * reserves for cache keys.
+     */
+    #[AllowMockObjectsWithoutExpectations]
+    public function testProviderNamesWithReservedCharactersDoNotBreakTheCacheKey(): void
+    {
+        $alert = new ModelHealthAlert(ModelHealthAlert::KIND_OFFLINE, 'Open{AI}:test', ['x'], 'gone');
+
+        self::assertTrue($this->alerter->raise($alert));
+        self::assertFalse($this->alerter->raise($alert));
+    }
+
+    #[AllowMockObjectsWithoutExpectations]
+    public function testHeadlineAndPreviewSummariseLargeOutages(): void
+    {
+        $names = array_map(static fn (int $i): string => 'model-'.$i, range(1, 25));
+        $alert = new ModelHealthAlert(ModelHealthAlert::KIND_CREDENTIAL, 'Groq', $names, 'key rejected');
+
+        self::assertSame(25, $alert->modelCount());
+        self::assertStringContainsString('Groq credentials rejected', $alert->headline());
+        self::assertStringContainsString('and 15 more', $alert->previewNames());
+    }
+}

--- a/backend/tests/Unit/AI/Health/ModelHealthEvaluatorRetirementTest.php
+++ b/backend/tests/Unit/AI/Health/ModelHealthEvaluatorRetirementTest.php
@@ -16,6 +16,8 @@ use App\AI\Health\Probe\ModelListProbeInterface;
 use App\AI\Health\Probe\ModelListProbeRegistry;
 use App\AI\Health\Probe\ProbeResult;
 use App\AI\Service\ModelProbeResult;
+use App\AI\Service\ProviderDisplayNames;
+use App\AI\Service\ProviderRegistry;
 use App\Entity\Model;
 use App\Repository\ConfigRepository;
 use App\Repository\ModelHealthRepository;
@@ -124,6 +126,7 @@ final class ModelHealthEvaluatorRetirementTest extends TestCase
             new ModelAutoDisabler($config, new NullLogger()),
             $this->createMock(EntityManagerInterface::class),
             new ArrayAdapter(),
+            new ProviderDisplayNames($this->createStub(ProviderRegistry::class)),
             new NullLogger(),
         );
     }

--- a/backend/tests/Unit/AI/Health/ModelHealthEvaluatorRetirementTest.php
+++ b/backend/tests/Unit/AI/Health/ModelHealthEvaluatorRetirementTest.php
@@ -1,0 +1,251 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\AI\Health;
+
+use App\AI\Health\FailureClassifier;
+use App\AI\Health\FailureKind;
+use App\AI\Health\ModelAutoDisabler;
+use App\AI\Health\ModelHealthAlerter;
+use App\AI\Health\ModelHealthConfig;
+use App\AI\Health\ModelHealthEvaluator;
+use App\AI\Health\ModelHealthRecorder;
+use App\AI\Health\ModelHealthState;
+use App\AI\Health\Probe\ModelListProbeInterface;
+use App\AI\Health\Probe\ModelListProbeRegistry;
+use App\AI\Health\Probe\ProbeResult;
+use App\AI\Service\ModelProbeResult;
+use App\Entity\Model;
+use App\Repository\ConfigRepository;
+use App\Repository\ModelHealthRepository;
+use App\Repository\ModelRepository;
+use App\Service\DiscordNotificationService;
+use App\Service\InternalEmailService;
+use App\Service\Usage\UsageFailureLogger;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+/**
+ * Locks the rule that decides whether a model is declared retired.
+ *
+ * Both scenarios below are real, and both were verified against the live APIs
+ * with this installation's own keys:
+ *
+ *   - Google omits `imagen-4.0-generate-001` from `models.list` while
+ *     `GET /v1beta/models/imagen-4.0-generate-001` answers 200. It is alive.
+ *   - xAI omits `grok-tts` from `/v1/models` and answers 404 for it. It is gone.
+ *
+ * A listing-only verdict cannot tell these apart, and an earlier capability
+ * heuristic got both wrong: it condemned the three working Imagen models and
+ * excused the dead xAI one. Only the provider's answer about the exact model id
+ * decides now.
+ */
+final class ModelHealthEvaluatorRetirementTest extends TestCase
+{
+    /** The probe handed to the most recent evaluator, for counting requests. */
+    private object $lastProbe;
+
+    /**
+     * @param array<string, ModelProbeResult> $confirmations provider model id => what the provider says
+     * @param list<string>                    $listed        model ids the bulk listing returns
+     */
+    private function evaluatorFor(Model $model, array $listed, array $confirmations, bool $authoritative = false): ModelHealthEvaluator
+    {
+        $probe = new class($listed, $confirmations, $authoritative) implements ModelListProbeInterface {
+            public int $confirmCalls = 0;
+
+            /**
+             * @param list<string>                    $listed
+             * @param array<string, ModelProbeResult> $confirmations
+             */
+            public function __construct(
+                private readonly array $listed,
+                private readonly array $confirmations,
+                private readonly bool $authoritative,
+            ) {
+            }
+
+            public function supports(string $service): bool
+            {
+                return true;
+            }
+
+            public function probe(string $service): ProbeResult
+            {
+                return ProbeResult::ok($this->listed, listingAuthoritative: $this->authoritative);
+            }
+
+            public function confirm(string $service, string $providerModelId): ModelProbeResult
+            {
+                ++$this->confirmCalls;
+
+                return $this->confirmations[$providerModelId] ?? ModelProbeResult::Inconclusive;
+            }
+        };
+
+        $this->lastProbe = $probe;
+
+        $configRepository = $this->createStub(ConfigRepository::class);
+        $configRepository->method('getValue')->willReturn(null);
+        $config = new ModelHealthConfig($configRepository);
+
+        $models = $this->createMock(ModelRepository::class);
+        $models->method('findAllServices')->willReturn([$model->getService()]);
+        $models->method('findByServiceIndexedByProviderId')
+            ->willReturn([$model->getProviderId() => [$model]]);
+
+        $recorder = new ModelHealthRecorder(
+            new ArrayAdapter(),
+            $config,
+            new FailureClassifier(),
+            $models,
+            $this->createMock(UsageFailureLogger::class),
+            new NullLogger(),
+        );
+
+        $alerter = new ModelHealthAlerter(
+            new ArrayAdapter(),
+            $config,
+            $this->createMock(InternalEmailService::class),
+            $this->createMock(DiscordNotificationService::class),
+            new NullLogger(),
+        );
+
+        return new ModelHealthEvaluator(
+            $models,
+            $this->createMock(ModelHealthRepository::class),
+            new ModelListProbeRegistry([$probe]),
+            $recorder,
+            $config,
+            $alerter,
+            new ModelAutoDisabler($config, new NullLogger()),
+            $this->createMock(EntityManagerInterface::class),
+            new ArrayAdapter(),
+            new NullLogger(),
+        );
+    }
+
+    private static function model(int $id, string $service, string $providerId, string $tag): Model
+    {
+        $model = new Model();
+        $model->setService($service)
+            ->setProviderId($providerId)
+            ->setName($providerId)
+            ->setTag($tag);
+
+        $reflection = new \ReflectionProperty(Model::class, 'id');
+        $reflection->setValue($model, $id);
+
+        return $model;
+    }
+
+    public function testAModelTheProviderStillServesSurvivesBeingMissingFromTheListing(): void
+    {
+        // Google's models.list carries gemini-2.5-flash-image but not Imagen.
+        $imagen = self::model(115, 'Google', 'imagen-4.0-generate-001', 'text2pic');
+
+        $run = $this->evaluatorFor(
+            $imagen,
+            ['gemini-2.5-flash-image', 'gemini-2.5-pro'],
+            ['imagen-4.0-generate-001' => ModelProbeResult::Alive],
+        )->run(dryRun: true);
+
+        $verdict = $run->verdicts[0];
+        self::assertSame(ModelHealthState::Online, $verdict->state, 'A model the provider answers 200 for must never be reported as retired');
+        self::assertFalse($verdict->safeToDisable);
+        self::assertSame([], $run->alertsRaised);
+    }
+
+    public function testAModelTheProviderRejectsIsRetiredAndActionable(): void
+    {
+        // xAI's /v1/models is chat-only, so grok-tts is absent either way —
+        // the 404 is what separates it from the Imagen case above.
+        $tts = self::model(320, 'xAI', 'grok-tts', 'text2sound');
+
+        $run = $this->evaluatorFor(
+            $tts,
+            ['grok-4.5'],
+            ['grok-tts' => ModelProbeResult::Gone],
+        )->run(dryRun: true);
+
+        $verdict = $run->verdicts[0];
+        self::assertSame(ModelHealthState::Offline, $verdict->state);
+        self::assertSame(FailureKind::Permanent, $verdict->kind);
+        self::assertTrue($verdict->safeToDisable);
+        self::assertCount(1, $run->alertsRaised);
+    }
+
+    /**
+     * The dangerous middle ground. A rate-limited or unauthorised confirmation
+     * says nothing about the model, and reporting it as retired would route
+     * users away from something that very likely works.
+     */
+    public function testAnInconclusiveConfirmationNeverRetiresAModel(): void
+    {
+        $model = self::model(320, 'xAI', 'grok-tts', 'text2sound');
+
+        $run = $this->evaluatorFor(
+            $model,
+            ['grok-4.5'],
+            ['grok-tts' => ModelProbeResult::Inconclusive],
+        )->run(dryRun: true);
+
+        $verdict = $run->verdicts[0];
+        self::assertSame(ModelHealthState::Unknown, $verdict->state);
+        self::assertNull($verdict->kind);
+        self::assertFalse($verdict->safeToDisable);
+        self::assertSame([], $run->alertsRaised);
+    }
+
+    /**
+     * The check runs every few minutes; a model that the provider already
+     * rejected must not be re-asked on every single run. Without this, six
+     * retired models cost several hundred pointless requests a day.
+     */
+    public function testASettledAnswerIsReusedInsteadOfReprobed(): void
+    {
+        $model = self::model(320, 'xAI', 'grok-tts', 'text2sound');
+
+        $evaluator = $this->evaluatorFor($model, ['grok-4.5'], ['grok-tts' => ModelProbeResult::Gone]);
+        $evaluator->run(dryRun: true);
+        $evaluator->run(dryRun: true);
+        $third = $evaluator->run(dryRun: true);
+
+        self::assertSame(1, $this->lastProbe->confirmCalls);
+        self::assertSame(ModelHealthState::Offline, $third->verdicts[0]->state, 'The remembered verdict must survive, not decay into unknown');
+    }
+
+    /**
+     * An inconclusive answer is the one thing that must NOT be remembered:
+     * caching a rate limit would turn a five-minute hiccup into an hour-long
+     * blind spot on the status page.
+     */
+    public function testAnInconclusiveAnswerIsNotRemembered(): void
+    {
+        $model = self::model(320, 'xAI', 'grok-tts', 'text2sound');
+
+        $evaluator = $this->evaluatorFor($model, ['grok-4.5'], ['grok-tts' => ModelProbeResult::Inconclusive]);
+        $evaluator->run(dryRun: true);
+        $evaluator->run(dryRun: true);
+
+        self::assertSame(2, $this->lastProbe->confirmCalls);
+    }
+
+    /**
+     * Ollama lists every pulled model in one namespace, so absence is already
+     * the answer and must not cost an extra request per model.
+     */
+    public function testAnAuthoritativeListingRetiresWithoutAskingAgain(): void
+    {
+        $model = self::model(7, 'Ollama', 'llama3', 'chat');
+
+        $evaluator = $this->evaluatorFor($model, ['mistral'], [], authoritative: true);
+        $run = $evaluator->run(dryRun: true);
+
+        self::assertSame(ModelHealthState::Offline, $run->verdicts[0]->state);
+        self::assertTrue($run->verdicts[0]->safeToDisable);
+    }
+}

--- a/backend/tests/Unit/AI/Health/ModelHealthRecorderTest.php
+++ b/backend/tests/Unit/AI/Health/ModelHealthRecorderTest.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\AI\Health;
+
+use App\AI\Exception\ProviderException;
+use App\AI\Health\FailureClassifier;
+use App\AI\Health\FailureKind;
+use App\AI\Health\ModelHealthConfig;
+use App\AI\Health\ModelHealthRecorder;
+use App\Repository\ConfigRepository;
+use App\Repository\ModelRepository;
+use App\Service\Exception\StreamCancelledException;
+use App\Service\Usage\UsageFailureLogger;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+final class ModelHealthRecorderTest extends TestCase
+{
+    private const MODEL_ID = 42;
+
+    private ModelHealthRecorder $recorder;
+
+    protected function setUp(): void
+    {
+        $this->recorder = $this->makeRecorder($this->createStub(UsageFailureLogger::class));
+    }
+
+    private function makeRecorder(UsageFailureLogger $failureLogger): ModelHealthRecorder
+    {
+        $configRepository = $this->createStub(ConfigRepository::class);
+        $configRepository->method('getValue')->willReturn(null);
+
+        $models = $this->createStub(ModelRepository::class);
+        $models->method('findIdByServiceProviderIdAndTag')->willReturn(self::MODEL_ID);
+
+        return new ModelHealthRecorder(
+            new ArrayAdapter(),
+            new ModelHealthConfig($configRepository),
+            new FailureClassifier(),
+            $models,
+            $failureLogger,
+            new NullLogger(),
+        );
+    }
+
+    public function testCountsSuccessesAndFailuresInTheSameWindow(): void
+    {
+        $this->recorder->recordSuccess('chat', 'openai', 'gpt-5');
+        $this->recorder->recordSuccess('chat', 'openai', 'gpt-5');
+        $this->recorder->recordFailure('chat', 'openai', 'gpt-5', new ProviderException('boom', 'openai', null, 500));
+
+        $snapshot = $this->recorder->snapshot(self::MODEL_ID);
+
+        self::assertSame(2, $snapshot->successes);
+        self::assertSame(1, $snapshot->failures);
+        self::assertSame(3, $snapshot->total());
+        self::assertSame(33, $snapshot->errorRatePercent());
+        self::assertSame(FailureKind::Transient, $snapshot->lastKind);
+    }
+
+    /**
+     * A cancelled stream is the user pressing stop. Counting it would make a
+     * perfectly healthy model look broken on a page full of impatient users.
+     */
+    public function testCancelledCallsAreNotCounted(): void
+    {
+        $kind = $this->recorder->recordFailure('chat', 'openai', 'gpt-5', new StreamCancelledException('stopped'));
+
+        self::assertSame(FailureKind::Cancelled, $kind);
+        self::assertTrue($this->recorder->snapshot(self::MODEL_ID)->isEmpty());
+    }
+
+    public function testUserErrorsAreNotCountedAgainstTheModel(): void
+    {
+        $this->recorder->recordFailure('chat', 'google', 'gemini-3-pro', ProviderException::contentBlocked('google', 'SAFETY'));
+
+        self::assertTrue($this->recorder->snapshot(self::MODEL_ID)->isEmpty());
+    }
+
+    /**
+     * A credential problem belongs to the provider. Charging it to whichever
+     * model happened to be called first would frame an innocent model.
+     */
+    public function testCredentialFailuresAreNotCountedAgainstTheModel(): void
+    {
+        $kind = $this->recorder->recordFailure(
+            'chat',
+            'anthropic',
+            'claude-4',
+            ProviderException::missingApiKey('anthropic', 'ANTHROPIC_API_KEY')
+        );
+
+        self::assertSame(FailureKind::Credential, $kind);
+        self::assertTrue($this->recorder->snapshot(self::MODEL_ID)->isEmpty());
+    }
+
+    public function testASuccessClearsTheStoredErrorMessage(): void
+    {
+        $this->recorder->recordFailure('chat', 'openai', 'gpt-5', new ProviderException('upstream exploded', 'openai', null, 500));
+        self::assertNotNull($this->recorder->snapshot(self::MODEL_ID)->lastKind);
+
+        $this->recorder->recordSuccess('chat', 'openai', 'gpt-5');
+
+        $snapshot = $this->recorder->snapshot(self::MODEL_ID);
+        self::assertNull($snapshot->lastKind);
+        self::assertNull($snapshot->lastMessage);
+        self::assertSame(1, $snapshot->failures);
+    }
+
+    public function testFailuresAreWrittenToTheUsageLogWhenAUserIsKnown(): void
+    {
+        $failureLogger = $this->createMock(UsageFailureLogger::class);
+        $failureLogger->expects(self::once())
+            ->method('record')
+            ->with(
+                7,
+                'chat',
+                'openai',
+                'gpt-5',
+                self::MODEL_ID,
+                FailureKind::Transient->value,
+                self::stringContains('upstream exploded'),
+            );
+
+        $this->makeRecorder($failureLogger)->recordFailure(
+            'chat',
+            'openai',
+            'gpt-5',
+            new ProviderException('upstream exploded', 'openai', null, 500),
+            7,
+        );
+    }
+
+    public function testAnonymousFailuresSkipTheUsageLog(): void
+    {
+        $failureLogger = $this->createMock(UsageFailureLogger::class);
+        $failureLogger->expects(self::never())->method('record');
+
+        $this->makeRecorder($failureLogger)
+            ->recordFailure('chat', 'openai', 'gpt-5', new ProviderException('boom', 'openai', null, 500));
+    }
+
+    public function testUnknownCapabilityIsIgnored(): void
+    {
+        $this->recorder->recordSuccess('telepathy', 'openai', 'gpt-5');
+
+        self::assertNull($this->recorder->resolveModelId('telepathy', 'openai', 'gpt-5'));
+        self::assertTrue($this->recorder->snapshot(self::MODEL_ID)->isEmpty());
+    }
+
+    public function testResetClearsTheWindow(): void
+    {
+        $this->recorder->recordSuccess('chat', 'openai', 'gpt-5');
+        $this->recorder->reset(self::MODEL_ID);
+
+        self::assertTrue($this->recorder->snapshot(self::MODEL_ID)->isEmpty());
+    }
+}

--- a/backend/tests/Unit/AI/Service/AiFacadeAnalyzeImageTest.php
+++ b/backend/tests/Unit/AI/Service/AiFacadeAnalyzeImageTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\AI\Service;
 
 use App\AI\Credential\HiggsfieldCredentialResolver;
 use App\AI\Exception\ProviderException;
+use App\AI\Health\ModelHealthRecorder;
 use App\AI\Interface\VisionProviderInterface;
 use App\AI\Service\AiFacade;
 use App\AI\Service\ProviderRegistry;
@@ -59,6 +60,7 @@ class AiFacadeAnalyzeImageTest extends TestCase
             $this->createMock(CacheItemPoolInterface::class),
             $this->createMock(HiggsfieldCredentialResolver::class),
             $this->createMock(TranscriptionUsageRecorder::class),
+            $this->createMock(ModelHealthRecorder::class),
             '/tmp'
         );
     }

--- a/backend/tests/Unit/AI/Service/AiFacadeAsyncVideoTest.php
+++ b/backend/tests/Unit/AI/Service/AiFacadeAsyncVideoTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Unit\AI\Service;
 
 use App\AI\Credential\HiggsfieldCredentialResolver;
+use App\AI\Health\ModelHealthRecorder;
 use App\AI\Provider\GoogleProvider;
 use App\AI\Provider\XaiProvider;
 use App\AI\Service\AiFacade;
@@ -48,6 +49,7 @@ class AiFacadeAsyncVideoTest extends TestCase
             $this->createMock(CacheItemPoolInterface::class),
             $this->createMock(HiggsfieldCredentialResolver::class),
             $this->createMock(TranscriptionUsageRecorder::class),
+            $this->createMock(ModelHealthRecorder::class),
             '/tmp'
         );
     }

--- a/backend/tests/Unit/AI/Service/AiFacadeStreamCancellationTest.php
+++ b/backend/tests/Unit/AI/Service/AiFacadeStreamCancellationTest.php
@@ -6,6 +6,8 @@ namespace App\Tests\Unit\AI\Service;
 
 use App\AI\Credential\HiggsfieldCredentialResolver;
 use App\AI\Exception\ProviderException;
+use App\AI\Health\FailureKind;
+use App\AI\Health\ModelHealthRecorder;
 use App\AI\Interface\ChatProviderInterface;
 use App\AI\Service\AiFacade;
 use App\AI\Service\ProviderRegistry;
@@ -43,6 +45,11 @@ class AiFacadeStreamCancellationTest extends TestCase
         $circuitBreaker = $this->createMock(CircuitBreaker::class);
         $circuitBreaker->method('execute')->willReturnCallback(static fn (callable $callback) => $callback());
 
+        // recordFailure() returns an enum, which PHPUnit cannot invent a
+        // default for, so the stub has to name one explicitly.
+        $health = $this->createMock(ModelHealthRecorder::class);
+        $health->method('recordFailure')->willReturn(FailureKind::Cancelled);
+
         $facade = new AiFacade(
             $registry,
             $this->createMock(ModelConfigService::class),
@@ -55,6 +62,7 @@ class AiFacadeStreamCancellationTest extends TestCase
             $this->createMock(CacheItemPoolInterface::class),
             $this->createMock(HiggsfieldCredentialResolver::class),
             $this->createMock(TranscriptionUsageRecorder::class),
+            $health,
             '/tmp'
         );
 

--- a/backend/tests/Unit/AI/Service/AiFacadeTranscribeTest.php
+++ b/backend/tests/Unit/AI/Service/AiFacadeTranscribeTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Unit\AI\Service;
 
 use App\AI\Credential\HiggsfieldCredentialResolver;
+use App\AI\Health\ModelHealthRecorder;
 use App\AI\Interface\SpeechToTextProviderInterface;
 use App\AI\Service\AiFacade;
 use App\AI\Service\ProviderRegistry;
@@ -67,6 +68,7 @@ class AiFacadeTranscribeTest extends TestCase
             $this->createMock(CacheItemPoolInterface::class),
             $this->createMock(HiggsfieldCredentialResolver::class),
             $this->transcriptionUsageRecorder,
+            $this->createMock(ModelHealthRecorder::class),
             '/tmp'
         );
     }

--- a/backend/tests/Unit/AiFacadeEmbeddingFallbackTest.php
+++ b/backend/tests/Unit/AiFacadeEmbeddingFallbackTest.php
@@ -6,6 +6,8 @@ namespace App\Tests\Unit;
 
 use App\AI\Credential\HiggsfieldCredentialResolver;
 use App\AI\Exception\ProviderException;
+use App\AI\Health\FailureKind;
+use App\AI\Health\ModelHealthRecorder;
 use App\AI\Interface\EmbeddingProviderInterface;
 use App\AI\Service\AiFacade;
 use App\AI\Service\ProviderRegistry;
@@ -451,6 +453,11 @@ class AiFacadeEmbeddingFallbackTest extends TestCase
 
     private function createFacade(string $fallbackProvider): AiFacade
     {
+        // recordFailure() returns an enum, which PHPUnit cannot invent a
+        // default for, so the stub has to name one explicitly.
+        $health = $this->createMock(ModelHealthRecorder::class);
+        $health->method('recordFailure')->willReturn(FailureKind::Transient);
+
         return new AiFacade(
             registry: $this->registry,
             modelConfig: $this->modelConfig,
@@ -463,6 +470,7 @@ class AiFacadeEmbeddingFallbackTest extends TestCase
             cachePool: $this->cachePool,
             higgsfieldCredentials: $this->createMock(HiggsfieldCredentialResolver::class),
             transcriptionUsageRecorder: $this->createMock(TranscriptionUsageRecorder::class),
+            health: $health,
             embeddingFallbackProvider: $fallbackProvider,
         );
     }

--- a/backend/tests/Unit/ModelConfigServiceTest.php
+++ b/backend/tests/Unit/ModelConfigServiceTest.php
@@ -8,6 +8,7 @@ use App\AI\Service\ProviderRegistry;
 use App\Entity\Config;
 use App\Entity\Model;
 use App\Repository\ConfigRepository;
+use App\Repository\ModelHealthRepository;
 use App\Repository\ModelRepository;
 use App\Repository\UserRepository;
 use App\Service\ModelConfigService;
@@ -15,6 +16,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
+use Psr\Log\NullLogger;
 
 class ModelConfigServiceTest extends TestCase
 {
@@ -28,6 +30,7 @@ class ModelConfigServiceTest extends TestCase
     private CacheItemPoolInterface&MockObject $cache;
     private ProviderRegistry&MockObject $providerRegistry;
     private OllamaModelInventory&MockObject $ollamaModelInventory;
+    private ModelHealthRepository&MockObject $modelHealthRepository;
     private ModelConfigService $service;
     private CacheItemInterface&MockObject $cacheItem;
 
@@ -46,13 +49,18 @@ class ModelConfigServiceTest extends TestCase
 
         $this->ollamaModelInventory = $this->createMock(OllamaModelInventory::class);
 
+        $this->modelHealthRepository = $this->createMock(ModelHealthRepository::class);
+        $this->modelHealthRepository->method('findOfflineModelIds')->willReturn([]);
+
         $this->service = new ModelConfigService(
             $this->configRepository,
             $this->modelRepository,
             $this->userRepository,
             $this->cache,
             $this->providerRegistry,
-            $this->ollamaModelInventory
+            $this->ollamaModelInventory,
+            $this->modelHealthRepository,
+            new NullLogger(),
         );
     }
 

--- a/frontend/src/composables/useNavItems.ts
+++ b/frontend/src/composables/useNavItems.ts
@@ -79,7 +79,7 @@ export function useNavItems() {
     // mean two entry points for callers to remember.
     try {
       const status = await modelStatusApi.getStatus()
-      offlineModelsCount.value = status.summary.offline
+      offlineModelsCount.value = status.summary.needsAttention
     } catch {
       offlineModelsCount.value = 0
     }

--- a/frontend/src/composables/useNavItems.ts
+++ b/frontend/src/composables/useNavItems.ts
@@ -12,6 +12,7 @@ import { useI18n } from 'vue-i18n'
 import { useAuthStore } from '../stores/auth'
 import { useConfigStore } from '../stores/config'
 import { getFeaturesStatus } from '../services/featuresService'
+import { modelStatusApi } from '../services/api/adminModelStatusApi'
 import { isSavedTasksEnabled } from './useSavedTasksFeature'
 
 export interface NavChild {
@@ -39,6 +40,7 @@ export interface NavItem {
 
 // Module-scoped so the desktop rail and the mobile nav share one fetch.
 const disabledFeaturesCount = ref(0)
+const offlineModelsCount = ref(0)
 let featureStatusRequested = false
 
 /**
@@ -70,6 +72,16 @@ export function useNavItems() {
       }
     } catch {
       disabledFeaturesCount.value = 0
+    }
+
+    // Both admin badges load together: they share the same trigger, the same
+    // admin guard and the same once-per-session flag, and splitting them would
+    // mean two entry points for callers to remember.
+    try {
+      const status = await modelStatusApi.getStatus()
+      offlineModelsCount.value = status.summary.offline
+    } catch {
+      offlineModelsCount.value = 0
     }
   }
 
@@ -177,6 +189,17 @@ export function useNavItems() {
         featureStatusItem.badge = String(disabledFeaturesCount.value)
       }
       adminChildren.push(featureStatusItem)
+
+      const modelStatusItem: NavChild = {
+        key: 'admin-model-status',
+        path: '/admin/model-status',
+        label: t('nav.adminModelStatus'),
+      }
+      if (offlineModelsCount.value > 0) {
+        modelStatusItem.badge = String(offlineModelsCount.value)
+      }
+      adminChildren.push(modelStatusItem)
+
       adminChildren.push({
         key: 'admin-setup',
         path: '/admin/setup',

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -178,6 +178,7 @@
     "actions": {
       "refresh": "Jetzt prüfen",
       "refreshProvider": "Diesen Anbieter prüfen",
+      "refreshProviderAria": "{provider} jetzt prüfen",
       "resetCounters": "Fehlerverlauf löschen",
       "exempt": "Von Automatik ausnehmen",
       "unexempt": "Automatik wieder erlauben"

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -114,6 +114,7 @@
     "profile": "Profil",
     "admin": "Admin-Panel",
     "adminFeatures": "Feature-Status",
+    "adminModelStatus": "Modell-Status",
     "adminConfig": "Systemkonfiguration",
     "adminSetup": "KI-Anbieter einrichten",
     "subscription": "Abonnement",
@@ -132,6 +133,64 @@
     "aiAgents": "KI-Agenten",
     "connections": "Verbindungen",
     "savedTasks": "Gespeicherte Aufgaben"
+  },
+  "adminModelStatus": {
+    "title": "Modell-Status",
+    "subtitle": "Welche KI-Modelle gerade funktionieren und welche nicht.",
+    "loading": "Modell-Status wird geladen…",
+    "loadFailed": "Der Modell-Status konnte nicht geladen werden.",
+    "never": "nie",
+    "noMatches": "Keine Modelle passen zu den gewählten Filtern.",
+    "freeHint": "Die Prüfung ist kostenlos: Es wird nur abgefragt, welche Modelle ein Anbieter veröffentlicht. Dafür wird nie ein KI-Modell ausgeführt.",
+    "states": {
+      "online": "Online",
+      "degraded": "Gestört",
+      "offline": "Offline",
+      "unconfigured": "Nicht eingerichtet",
+      "unknown": "Unbekannt"
+    },
+    "sources": {
+      "probe": "Modell-Liste des Anbieters",
+      "traffic": "echte Nutzung"
+    },
+    "summary": {
+      "allGood": "Alle Modelle antworten",
+      "problems": "{count} Modell(e) brauchen Aufmerksamkeit",
+      "lastCheck": "Zuletzt geprüft",
+      "monitoringOff": "Die automatische Prüfung ist ausgeschaltet, diese Seite zeigt daher nur den zuletzt bekannten Stand."
+    },
+    "filters": {
+      "onlyProblems": "Nur Probleme anzeigen",
+      "capability": "Aufgabe",
+      "allCapabilities": "Alle Aufgaben"
+    },
+    "provider": {
+      "affected": "{count} betroffen"
+    },
+    "model": {
+      "lastSuccess": "Zuletzt funktioniert",
+      "errorRate": "{percent} % der letzten {total} Aufrufe sind fehlgeschlagen",
+      "source": "Grundlage",
+      "autoDisabled": "Automatisch abgeschaltet",
+      "switchedOff": "Abgeschaltet",
+      "exempt": "Von automatischer Abschaltung ausgenommen"
+    },
+    "actions": {
+      "refresh": "Jetzt prüfen",
+      "refreshProvider": "Diesen Anbieter prüfen",
+      "resetCounters": "Fehlerverlauf löschen",
+      "exempt": "Von Automatik ausnehmen",
+      "unexempt": "Automatik wieder erlauben"
+    },
+    "messages": {
+      "refreshed": "{count} Modell(e) geprüft.",
+      "refreshFailed": "Die Prüfung konnte nicht abgeschlossen werden.",
+      "exempted": "Dieses Modell ist jetzt von der automatischen Abschaltung ausgenommen.",
+      "unexempted": "Die automatische Abschaltung gilt für dieses Modell wieder.",
+      "exemptFailed": "Die Ausnahme konnte nicht geändert werden.",
+      "countersReset": "Fehlerverlauf gelöscht.",
+      "countersResetFailed": "Der Fehlerverlauf konnte nicht gelöscht werden."
+    }
   },
   "addinConnect": {
     "title": "Mit Synaplan verbinden",
@@ -594,6 +653,7 @@
     "admin": "Admin",
     "adminDashboard": "Dashboard",
     "adminFeatureStatus": "Feature-Status",
+    "adminModelStatus": "Modell-Status",
     "adminSystemConfig": "Systemkonfiguration",
     "adminProviderSetup": "KI-Anbieter",
     "more": "Mehr",

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -183,6 +183,8 @@
       "exempt": "Von Automatik ausnehmen",
       "unexempt": "Automatik wieder erlauben"
     },
+    "confirmResetTitle": "Fehlerverlauf löschen?",
+    "confirmResetMessage": "„{name}“ wird danach nur noch nach neuer Nutzung bewertet. Eine Prüfung, die das Modell bereits als eingestellt erkannt hat, bleibt bestehen.",
     "messages": {
       "refreshed": "{count} Modell(e) geprüft.",
       "refreshFailed": "Die Prüfung konnte nicht abgeschlossen werden.",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -178,6 +178,7 @@
     "actions": {
       "refresh": "Check now",
       "refreshProvider": "Check this provider",
+      "refreshProviderAria": "Check {provider} now",
       "resetCounters": "Clear error history",
       "exempt": "Exempt from automation",
       "unexempt": "Allow automation again"

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -183,6 +183,8 @@
       "exempt": "Exempt from automation",
       "unexempt": "Allow automation again"
     },
+    "confirmResetTitle": "Clear error history?",
+    "confirmResetMessage": "\"{name}\" will then be judged on new usage only. A check that already found this model retired is not undone.",
     "messages": {
       "refreshed": "Checked {count} model(s).",
       "refreshFailed": "The check could not be completed.",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -114,6 +114,7 @@
     "profile": "Profile",
     "admin": "Admin Panel",
     "adminFeatures": "Feature Status",
+    "adminModelStatus": "Model Status",
     "adminConfig": "System Configuration",
     "adminSetup": "AI Provider Setup",
     "subscription": "Subscription",
@@ -132,6 +133,64 @@
     "aiAgents": "AI Agents",
     "connections": "Connections",
     "savedTasks": "Saved Tasks"
+  },
+  "adminModelStatus": {
+    "title": "Model Status",
+    "subtitle": "Which AI models are currently working, and which are not.",
+    "loading": "Loading model status…",
+    "loadFailed": "The model status could not be loaded.",
+    "never": "never",
+    "noMatches": "No models match the current filters.",
+    "freeHint": "Checking is free: providers are only asked which models they publish. No AI model is ever run for this.",
+    "states": {
+      "online": "Online",
+      "degraded": "Impaired",
+      "offline": "Offline",
+      "unconfigured": "Not set up",
+      "unknown": "Unknown"
+    },
+    "sources": {
+      "probe": "provider model list",
+      "traffic": "real usage"
+    },
+    "summary": {
+      "allGood": "All models are answering",
+      "problems": "{count} model(s) need attention",
+      "lastCheck": "Last checked",
+      "monitoringOff": "Automatic checking is switched off, so this page only shows the last known state."
+    },
+    "filters": {
+      "onlyProblems": "Only show problems",
+      "capability": "Task",
+      "allCapabilities": "All tasks"
+    },
+    "provider": {
+      "affected": "{count} affected"
+    },
+    "model": {
+      "lastSuccess": "Last worked",
+      "errorRate": "{percent}% of the last {total} calls failed",
+      "source": "Based on",
+      "autoDisabled": "Switched off automatically",
+      "switchedOff": "Switched off",
+      "exempt": "Exempt from automatic switch-off"
+    },
+    "actions": {
+      "refresh": "Check now",
+      "refreshProvider": "Check this provider",
+      "resetCounters": "Clear error history",
+      "exempt": "Exempt from automation",
+      "unexempt": "Allow automation again"
+    },
+    "messages": {
+      "refreshed": "Checked {count} model(s).",
+      "refreshFailed": "The check could not be completed.",
+      "exempted": "This model is now exempt from automatic switch-off.",
+      "unexempted": "Automatic switch-off applies to this model again.",
+      "exemptFailed": "The exemption could not be changed.",
+      "countersReset": "Error history cleared.",
+      "countersResetFailed": "The error history could not be cleared."
+    }
   },
   "addinConnect": {
     "title": "Connect to Synaplan",
@@ -598,6 +657,7 @@
     "admin": "Admin",
     "adminDashboard": "Dashboard",
     "adminFeatureStatus": "Feature Status",
+    "adminModelStatus": "Model Status",
     "adminSystemConfig": "System Config",
     "adminProviderSetup": "AI Providers",
     "more": "More",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -182,6 +182,8 @@
       "exempt": "Eximir de la automatización",
       "unexempt": "Permitir la automatización de nuevo"
     },
+    "confirmResetTitle": "¿Borrar el historial de errores?",
+    "confirmResetMessage": "Después, \"{name}\" se evaluará solo con el uso nuevo. Una comprobación que ya haya detectado que el modelo está retirado no se deshace.",
     "messages": {
       "refreshed": "Se comprobaron {count} modelo(s).",
       "refreshFailed": "No se pudo completar la comprobación.",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -177,6 +177,7 @@
     "actions": {
       "refresh": "Comprobar ahora",
       "refreshProvider": "Comprobar este proveedor",
+      "refreshProviderAria": "Comprobar {provider} ahora",
       "resetCounters": "Borrar historial de errores",
       "exempt": "Eximir de la automatización",
       "unexempt": "Permitir la automatización de nuevo"

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -112,6 +112,7 @@
     "profile": "Perfil",
     "admin": "Panel de administración",
     "adminFeatures": "Estado de funciones",
+    "adminModelStatus": "Estado de modelos",
     "adminConfig": "Configuración del Sistema",
     "adminSetup": "Configuración de Proveedores de IA",
     "subscription": "Suscripción",
@@ -131,6 +132,64 @@
     "aiAgents": "Agentes de IA",
     "connections": "Conexiones",
     "savedTasks": "Tareas guardadas"
+  },
+  "adminModelStatus": {
+    "title": "Estado de modelos",
+    "subtitle": "Qué modelos de IA funcionan ahora mismo y cuáles no.",
+    "loading": "Cargando el estado de los modelos…",
+    "loadFailed": "No se pudo cargar el estado de los modelos.",
+    "never": "nunca",
+    "noMatches": "Ningún modelo coincide con los filtros seleccionados.",
+    "freeHint": "La comprobación es gratuita: solo se pregunta qué modelos publica cada proveedor. Nunca se ejecuta un modelo de IA para esto.",
+    "states": {
+      "online": "En línea",
+      "degraded": "Con fallos",
+      "offline": "Fuera de servicio",
+      "unconfigured": "Sin configurar",
+      "unknown": "Desconocido"
+    },
+    "sources": {
+      "probe": "lista de modelos del proveedor",
+      "traffic": "uso real"
+    },
+    "summary": {
+      "allGood": "Todos los modelos responden",
+      "problems": "{count} modelo(s) requieren atención",
+      "lastCheck": "Última comprobación",
+      "monitoringOff": "La comprobación automática está desactivada, por lo que esta página solo muestra el último estado conocido."
+    },
+    "filters": {
+      "onlyProblems": "Mostrar solo problemas",
+      "capability": "Tarea",
+      "allCapabilities": "Todas las tareas"
+    },
+    "provider": {
+      "affected": "{count} afectados"
+    },
+    "model": {
+      "lastSuccess": "Última vez que funcionó",
+      "errorRate": "Falló el {percent} % de las últimas {total} llamadas",
+      "source": "Basado en",
+      "autoDisabled": "Desactivado automáticamente",
+      "switchedOff": "Desactivado",
+      "exempt": "Exento de la desactivación automática"
+    },
+    "actions": {
+      "refresh": "Comprobar ahora",
+      "refreshProvider": "Comprobar este proveedor",
+      "resetCounters": "Borrar historial de errores",
+      "exempt": "Eximir de la automatización",
+      "unexempt": "Permitir la automatización de nuevo"
+    },
+    "messages": {
+      "refreshed": "Se comprobaron {count} modelo(s).",
+      "refreshFailed": "No se pudo completar la comprobación.",
+      "exempted": "Este modelo queda exento de la desactivación automática.",
+      "unexempted": "La desactivación automática vuelve a aplicarse a este modelo.",
+      "exemptFailed": "No se pudo cambiar la exención.",
+      "countersReset": "Historial de errores borrado.",
+      "countersResetFailed": "No se pudo borrar el historial de errores."
+    }
   },
   "addinConnect": {
     "title": "Conectar a Synaplan",
@@ -586,6 +645,7 @@
     "admin": "Admin",
     "adminDashboard": "Panel",
     "adminFeatureStatus": "Estado de Funciones",
+    "adminModelStatus": "Estado de Modelos",
     "adminSystemConfig": "Configuración del Sistema",
     "adminProviderSetup": "Proveedores de IA",
     "profile": "Perfil",

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -177,6 +177,7 @@
     "actions": {
       "refresh": "Şimdi kontrol et",
       "refreshProvider": "Bu sağlayıcıyı kontrol et",
+      "refreshProviderAria": "{provider} sağlayıcısını şimdi kontrol et",
       "resetCounters": "Hata geçmişini temizle",
       "exempt": "Otomasyondan muaf tut",
       "unexempt": "Otomasyona tekrar izin ver"

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -182,6 +182,8 @@
       "exempt": "Otomasyondan muaf tut",
       "unexempt": "Otomasyona tekrar izin ver"
     },
+    "confirmResetTitle": "Hata geçmişi temizlensin mi?",
+    "confirmResetMessage": "Bundan sonra \"{name}\" yalnızca yeni kullanıma göre değerlendirilir. Modelin kaldırıldığını zaten tespit eden bir kontrol geri alınmaz.",
     "messages": {
       "refreshed": "{count} model kontrol edildi.",
       "refreshFailed": "Kontrol tamamlanamadı.",

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -112,6 +112,7 @@
     "profile": "Profil",
     "admin": "Yönetici Paneli",
     "adminFeatures": "Özellik Durumu",
+    "adminModelStatus": "Model Durumu",
     "adminConfig": "Sistem Yapılandırması",
     "adminSetup": "AI Sağlayıcı Kurulumu",
     "subscription": "Abonelik",
@@ -131,6 +132,64 @@
     "aiAgents": "Yapay zeka ajanları",
     "connections": "Bağlantılar",
     "savedTasks": "Kayıtlı görevler"
+  },
+  "adminModelStatus": {
+    "title": "Model Durumu",
+    "subtitle": "Hangi AI modelleri şu anda çalışıyor, hangileri çalışmıyor.",
+    "loading": "Model durumu yükleniyor…",
+    "loadFailed": "Model durumu yüklenemedi.",
+    "never": "hiç",
+    "noMatches": "Seçili filtrelere uyan model yok.",
+    "freeHint": "Kontrol ücretsizdir: sağlayıcılara yalnızca hangi modelleri yayınladıkları sorulur. Bunun için hiçbir zaman bir AI modeli çalıştırılmaz.",
+    "states": {
+      "online": "Çevrimiçi",
+      "degraded": "Sorunlu",
+      "offline": "Çevrimdışı",
+      "unconfigured": "Kurulmamış",
+      "unknown": "Bilinmiyor"
+    },
+    "sources": {
+      "probe": "sağlayıcının model listesi",
+      "traffic": "gerçek kullanım"
+    },
+    "summary": {
+      "allGood": "Tüm modeller yanıt veriyor",
+      "problems": "{count} model ilgi bekliyor",
+      "lastCheck": "Son kontrol",
+      "monitoringOff": "Otomatik kontrol kapalı, bu nedenle bu sayfa yalnızca bilinen son durumu gösterir."
+    },
+    "filters": {
+      "onlyProblems": "Yalnızca sorunları göster",
+      "capability": "Görev",
+      "allCapabilities": "Tüm görevler"
+    },
+    "provider": {
+      "affected": "{count} etkilendi"
+    },
+    "model": {
+      "lastSuccess": "Son çalıştığı zaman",
+      "errorRate": "Son {total} çağrının %{percent} kadarı başarısız oldu",
+      "source": "Dayanak",
+      "autoDisabled": "Otomatik olarak kapatıldı",
+      "switchedOff": "Kapalı",
+      "exempt": "Otomatik kapatmadan muaf"
+    },
+    "actions": {
+      "refresh": "Şimdi kontrol et",
+      "refreshProvider": "Bu sağlayıcıyı kontrol et",
+      "resetCounters": "Hata geçmişini temizle",
+      "exempt": "Otomasyondan muaf tut",
+      "unexempt": "Otomasyona tekrar izin ver"
+    },
+    "messages": {
+      "refreshed": "{count} model kontrol edildi.",
+      "refreshFailed": "Kontrol tamamlanamadı.",
+      "exempted": "Bu model artık otomatik kapatmadan muaf.",
+      "unexempted": "Otomatik kapatma bu model için tekrar geçerli.",
+      "exemptFailed": "Muafiyet değiştirilemedi.",
+      "countersReset": "Hata geçmişi temizlendi.",
+      "countersResetFailed": "Hata geçmişi temizlenemedi."
+    }
   },
   "addinConnect": {
     "title": "Synaplan'a bağlan",
@@ -586,6 +645,7 @@
     "admin": "Yönetici",
     "adminDashboard": "Kontrol Paneli",
     "adminFeatureStatus": "Özellik Durumu",
+    "adminModelStatus": "Model Durumu",
     "adminSystemConfig": "Sistem Yapılandırması",
     "adminProviderSetup": "AI Sağlayıcıları",
     "profile": "Profil",

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -441,6 +441,12 @@ const router = createRouter({
       meta: { requiresAuth: true, requiresAdmin: true, titleKey: 'pageTitles.adminFeatures' },
     },
     {
+      path: '/admin/model-status',
+      name: 'admin-model-status',
+      component: () => import('@/views/ModelStatusView.vue'),
+      meta: { requiresAuth: true, requiresAdmin: true, titleKey: 'pageTitles.adminModelStatus' },
+    },
+    {
       path: '/admin/config',
       name: 'admin-config',
       component: () => import('@/views/AdminConfigView.vue'),

--- a/frontend/src/services/api/adminModelStatusApi.ts
+++ b/frontend/src/services/api/adminModelStatusApi.ts
@@ -1,0 +1,64 @@
+import type { z } from 'zod'
+import {
+  GetAdminModelHealthStatusResponseSchema,
+  PostAdminModelHealthExemptResponseSchema,
+  PostAdminModelHealthRefreshResponseSchema,
+  PostAdminModelHealthResetResponseSchema,
+} from '@/generated/api-schemas'
+import { httpClient } from './httpClient'
+
+const BASE_PATH = '/api/v1/admin/model-health'
+
+export type ModelStatusSnapshot = z.infer<typeof GetAdminModelHealthStatusResponseSchema>
+export type ModelStatusProvider = ModelStatusSnapshot['providers'][number]
+export type ModelStatusEntry = ModelStatusProvider['models'][number]
+export type ModelStatusState = ModelStatusEntry['state']
+export type ModelStatusRefreshResult = z.infer<typeof PostAdminModelHealthRefreshResponseSchema>
+
+/**
+ * Model availability API (ROLE_ADMIN on the backend).
+ *
+ * Every call here is free: the backend asks providers for their published
+ * model list and reads counters from traffic that happened anyway. Nothing in
+ * here ever runs inference.
+ */
+export const modelStatusApi = {
+  /** Stored verdicts and traffic counters — no provider is contacted. */
+  getStatus: async (): Promise<ModelStatusSnapshot> => {
+    return httpClient(BASE_PATH, { schema: GetAdminModelHealthStatusResponseSchema })
+  },
+
+  /**
+   * Re-check now, optionally for a single provider. Fetch the status again
+   * afterwards for the new snapshot.
+   */
+  refresh: async (provider?: string): Promise<ModelStatusRefreshResult> => {
+    return httpClient(`${BASE_PATH}/refresh`, {
+      method: 'POST',
+      body: JSON.stringify(provider ? { provider } : {}),
+      schema: PostAdminModelHealthRefreshResponseSchema,
+    })
+  },
+
+  /** Pause or resume automatic disabling for one model. */
+  setExempt: async (
+    modelId: number,
+    exempt: boolean
+  ): Promise<z.infer<typeof PostAdminModelHealthExemptResponseSchema>> => {
+    return httpClient(`${BASE_PATH}/models/${modelId}/exempt`, {
+      method: 'POST',
+      body: JSON.stringify({ exempt }),
+      schema: PostAdminModelHealthExemptResponseSchema,
+    })
+  },
+
+  /** Forget the recorded successes and failures of the current window. */
+  resetCounters: async (
+    modelId: number
+  ): Promise<z.infer<typeof PostAdminModelHealthResetResponseSchema>> => {
+    return httpClient(`${BASE_PATH}/models/${modelId}/reset`, {
+      method: 'POST',
+      schema: PostAdminModelHealthResetResponseSchema,
+    })
+  },
+}

--- a/frontend/src/views/ModelStatusView.vue
+++ b/frontend/src/views/ModelStatusView.vue
@@ -1,0 +1,371 @@
+<template>
+  <MainLayout>
+    <div
+      class="min-h-screen bg-chat p-4 md:p-8 overflow-y-auto scroll-thin"
+      data-testid="page-model-status"
+    >
+      <div class="max-w-6xl mx-auto space-y-6">
+        <div class="surface-card p-6" data-testid="section-header">
+          <div class="flex items-center gap-3 mb-2">
+            <Icon icon="mdi:heart-pulse" class="w-8 h-8 text-[var(--brand)]" />
+            <h1 class="text-3xl font-bold txt-primary">{{ $t('adminModelStatus.title') }}</h1>
+          </div>
+          <p class="txt-secondary">{{ $t('adminModelStatus.subtitle') }}</p>
+        </div>
+
+        <div v-if="isLoading" class="surface-card p-8 text-center" data-testid="state-loading">
+          <Icon icon="mdi:loading" class="w-8 h-8 animate-spin mx-auto mb-4 txt-secondary" />
+          <div class="txt-secondary">{{ $t('adminModelStatus.loading') }}</div>
+        </div>
+
+        <div
+          v-else-if="!snapshot"
+          class="surface-card p-8 text-center"
+          data-testid="state-load-error"
+        >
+          <div class="txt-secondary mb-4">{{ $t('adminModelStatus.loadFailed') }}</div>
+          <button class="btn-primary px-6 py-2.5 rounded-lg" data-testid="btn-retry" @click="load">
+            {{ $t('common.retry') }}
+          </button>
+        </div>
+
+        <template v-else>
+          <div
+            class="surface-card p-6 border-l-4"
+            :class="
+              snapshot.summary.needsAttention > 0
+                ? 'border-[var(--status-error)]'
+                : 'border-[var(--status-success)]'
+            "
+            data-testid="section-summary"
+          >
+            <div class="flex flex-wrap items-start justify-between gap-4">
+              <div>
+                <h2 class="text-xl font-bold txt-primary mb-1">
+                  {{
+                    snapshot.summary.needsAttention > 0
+                      ? $t('adminModelStatus.summary.problems', {
+                          count: snapshot.summary.needsAttention,
+                        })
+                      : $t('adminModelStatus.summary.allGood')
+                  }}
+                </h2>
+                <p class="txt-secondary text-sm">
+                  {{ $t('adminModelStatus.summary.lastCheck') }}:
+                  {{ formatTime(snapshot.summary.lastCheck) }}
+                </p>
+                <p v-if="!snapshot.summary.monitoringEnabled" class="txt-secondary text-sm mt-1">
+                  {{ $t('adminModelStatus.summary.monitoringOff') }}
+                </p>
+              </div>
+
+              <button
+                class="btn-primary px-5 py-2.5 rounded-lg flex items-center gap-2 disabled:opacity-60"
+                :disabled="isRefreshing"
+                data-testid="btn-refresh"
+                @click="refresh()"
+              >
+                <Icon
+                  :icon="isRefreshing ? 'mdi:loading' : 'mdi:refresh'"
+                  class="w-5 h-5"
+                  :class="{ 'animate-spin': isRefreshing }"
+                />
+                {{ $t('adminModelStatus.actions.refresh') }}
+              </button>
+            </div>
+
+            <p class="txt-secondary text-xs mt-3">{{ $t('adminModelStatus.freeHint') }}</p>
+
+            <div class="flex flex-wrap gap-2 mt-4" data-testid="summary-counts">
+              <span
+                v-for="tile in summaryTiles"
+                :key="tile.state"
+                class="px-3 py-1.5 rounded-lg text-xs font-semibold"
+                :class="badgeClass(tile.state)"
+              >
+                {{ tile.count }} {{ $t(`adminModelStatus.states.${tile.state}`) }}
+              </span>
+            </div>
+          </div>
+
+          <div
+            class="surface-card p-4 flex flex-wrap items-center gap-4"
+            data-testid="section-filters"
+          >
+            <label class="flex items-center gap-2 text-sm txt-primary cursor-pointer">
+              <input v-model="onlyProblems" type="checkbox" data-testid="filter-only-problems" />
+              {{ $t('adminModelStatus.filters.onlyProblems') }}
+            </label>
+
+            <label class="flex items-center gap-2 text-sm txt-primary">
+              <span>{{ $t('adminModelStatus.filters.capability') }}</span>
+              <select
+                v-model="capabilityFilter"
+                class="px-3 py-1.5 rounded-lg surface-chip txt-primary text-sm focus:outline-none focus:ring-2 focus:ring-[var(--brand)]"
+                data-testid="filter-capability"
+              >
+                <option value="">{{ $t('adminModelStatus.filters.allCapabilities') }}</option>
+                <option v-for="cap in capabilities" :key="cap" :value="cap">{{ cap }}</option>
+              </select>
+            </label>
+          </div>
+
+          <div
+            v-if="visibleProviders.length === 0"
+            class="surface-card p-8 text-center txt-secondary"
+            data-testid="state-empty"
+          >
+            {{ $t('adminModelStatus.noMatches') }}
+          </div>
+
+          <div
+            v-for="provider in visibleProviders"
+            :key="provider.name"
+            class="space-y-3"
+            data-testid="section-provider"
+          >
+            <div class="flex items-center gap-3 px-2">
+              <h2 class="text-xl font-semibold txt-primary capitalize">{{ provider.name }}</h2>
+              <span
+                v-if="provider.needsAttention > 0"
+                class="px-2.5 py-1 rounded-md text-xs font-semibold"
+                :class="badgeClass('offline')"
+              >
+                {{ $t('adminModelStatus.provider.affected', { count: provider.needsAttention }) }}
+              </span>
+              <div class="h-px flex-1 bg-[var(--divider)]"></div>
+              <button
+                class="btn-secondary px-3 py-1.5 rounded-lg text-xs disabled:opacity-60"
+                :disabled="isRefreshing"
+                data-testid="btn-refresh-provider"
+                @click="refresh(provider.name)"
+              >
+                {{ $t('adminModelStatus.actions.refreshProvider') }}
+              </button>
+            </div>
+
+            <div
+              v-for="model in provider.models"
+              :key="model.id"
+              class="surface-card p-5"
+              data-testid="item-model"
+            >
+              <div class="flex items-start justify-between gap-4">
+                <div class="flex-1 min-w-0">
+                  <div class="flex items-center gap-2 flex-wrap mb-1">
+                    <h3 class="text-base font-semibold txt-primary">{{ model.name }}</h3>
+                    <span class="pill text-xs">{{ model.capability }}</span>
+                    <span v-if="model.autoDisabled" class="pill text-xs">
+                      {{ $t('adminModelStatus.model.autoDisabled') }}
+                    </span>
+                    <span v-else-if="!model.active" class="pill text-xs">
+                      {{ $t('adminModelStatus.model.switchedOff') }}
+                    </span>
+                    <span v-if="model.exemptUntil > 0" class="pill text-xs">
+                      {{ $t('adminModelStatus.model.exempt') }}
+                    </span>
+                  </div>
+
+                  <code class="text-xs txt-secondary font-mono opacity-70">{{
+                    model.providerId
+                  }}</code>
+
+                  <p v-if="model.reason" class="txt-secondary text-sm mt-2">{{ model.reason }}</p>
+
+                  <div class="flex flex-wrap gap-x-5 gap-y-1 mt-2 text-xs txt-secondary">
+                    <span>
+                      {{ $t('adminModelStatus.model.lastSuccess') }}:
+                      {{ formatTime(model.lastSuccess) }}
+                    </span>
+                    <span v-if="model.failures > 0">
+                      {{
+                        $t('adminModelStatus.model.errorRate', {
+                          percent: model.errorRatePercent,
+                          total: model.successes + model.failures,
+                        })
+                      }}
+                    </span>
+                    <span>
+                      {{ $t('adminModelStatus.model.source') }}:
+                      {{ $t(`adminModelStatus.sources.${model.source}`) }}
+                    </span>
+                  </div>
+                </div>
+
+                <div class="flex flex-col items-end gap-2 flex-shrink-0">
+                  <span
+                    class="px-4 py-2 rounded-lg text-xs font-bold uppercase tracking-wide whitespace-nowrap"
+                    :class="badgeClass(model.state)"
+                    data-testid="badge-model-state"
+                  >
+                    {{ $t(`adminModelStatus.states.${model.state}`) }}
+                  </span>
+
+                  <div class="flex gap-2">
+                    <button
+                      class="btn-secondary px-3 py-1.5 rounded-lg text-xs"
+                      data-testid="btn-reset-counters"
+                      @click="resetCounters(model)"
+                    >
+                      {{ $t('adminModelStatus.actions.resetCounters') }}
+                    </button>
+                    <button
+                      class="btn-secondary px-3 py-1.5 rounded-lg text-xs"
+                      data-testid="btn-toggle-exempt"
+                      @click="toggleExempt(model)"
+                    >
+                      {{
+                        model.exemptUntil > 0
+                          ? $t('adminModelStatus.actions.unexempt')
+                          : $t('adminModelStatus.actions.exempt')
+                      }}
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </template>
+      </div>
+    </div>
+  </MainLayout>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import { Icon } from '@iconify/vue'
+import { useI18n } from 'vue-i18n'
+import MainLayout from '@/components/MainLayout.vue'
+import { useNotification } from '@/composables/useNotification'
+import {
+  modelStatusApi,
+  type ModelStatusEntry,
+  type ModelStatusSnapshot,
+  type ModelStatusState,
+} from '@/services/api/adminModelStatusApi'
+
+const { t, locale } = useI18n()
+const { success, error } = useNotification()
+
+const snapshot = ref<ModelStatusSnapshot | null>(null)
+const isLoading = ref(false)
+const isRefreshing = ref(false)
+const onlyProblems = ref(false)
+const capabilityFilter = ref('')
+
+const ORDERED_STATES: ModelStatusState[] = [
+  'offline',
+  'degraded',
+  'online',
+  'unconfigured',
+  'unknown',
+]
+
+const summaryTiles = computed(() => {
+  const summary = snapshot.value?.summary
+  if (!summary) return []
+
+  return ORDERED_STATES.map((state) => ({ state, count: summary[state] })).filter(
+    (tile) => tile.count > 0
+  )
+})
+
+const capabilities = computed(() => {
+  const seen = new Set<string>()
+  for (const provider of snapshot.value?.providers ?? []) {
+    for (const model of provider.models) {
+      seen.add(model.capability)
+    }
+  }
+  return [...seen].sort()
+})
+
+const visibleProviders = computed(() => {
+  return (snapshot.value?.providers ?? [])
+    .map((provider) => ({
+      ...provider,
+      models: provider.models.filter((model) => {
+        if (capabilityFilter.value && model.capability !== capabilityFilter.value) return false
+        if (onlyProblems.value && model.state !== 'offline' && model.state !== 'degraded')
+          return false
+        return true
+      }),
+    }))
+    .filter((provider) => provider.models.length > 0)
+})
+
+/**
+ * Muted background plus the matching ink token, never white on a filled
+ * status colour. The filled variants are tuned for light backgrounds: white
+ * text on `--status-warning` measures 2.9:1 in light theme and 1.5:1 in dark,
+ * both far below the 4.5:1 these badges need. The muted pairs stay between
+ * 6.4:1 and 8.9:1 in both themes and are defined for both, so they also
+ * survive the V2 glass surfaces.
+ */
+const badgeClass = (state: ModelStatusState): string => {
+  switch (state) {
+    case 'online':
+      return 'bg-[var(--status-success-muted)] text-[var(--status-success-text)]'
+    case 'degraded':
+      return 'bg-[var(--status-warning-muted)] text-[var(--status-warning-text)]'
+    case 'offline':
+      return 'bg-[var(--status-error-muted)] text-[var(--status-error-text)]'
+    default:
+      return 'bg-[var(--status-neutral-muted)] text-[var(--status-neutral-text)]'
+  }
+}
+
+const formatTime = (unix: number): string => {
+  if (!unix) return t('adminModelStatus.never')
+  return new Date(unix * 1000).toLocaleString(locale.value)
+}
+
+const load = async () => {
+  isLoading.value = true
+  try {
+    snapshot.value = await modelStatusApi.getStatus()
+  } catch {
+    snapshot.value = null
+  } finally {
+    isLoading.value = false
+  }
+}
+
+const refresh = async (provider?: string) => {
+  isRefreshing.value = true
+  try {
+    const result = await modelStatusApi.refresh(provider)
+    snapshot.value = await modelStatusApi.getStatus()
+    success(t('adminModelStatus.messages.refreshed', { count: result.checked }))
+  } catch {
+    error(t('adminModelStatus.messages.refreshFailed'))
+  } finally {
+    isRefreshing.value = false
+  }
+}
+
+const toggleExempt = async (model: ModelStatusEntry) => {
+  const exempt = model.exemptUntil === 0
+  try {
+    await modelStatusApi.setExempt(model.id, exempt)
+    snapshot.value = await modelStatusApi.getStatus()
+    success(
+      exempt ? t('adminModelStatus.messages.exempted') : t('adminModelStatus.messages.unexempted')
+    )
+  } catch {
+    error(t('adminModelStatus.messages.exemptFailed'))
+  }
+}
+
+const resetCounters = async (model: ModelStatusEntry) => {
+  try {
+    await modelStatusApi.resetCounters(model.id)
+    snapshot.value = await modelStatusApi.getStatus()
+    success(t('adminModelStatus.messages.countersReset'))
+  } catch {
+    error(t('adminModelStatus.messages.countersResetFailed'))
+  }
+}
+
+onMounted(load)
+</script>

--- a/frontend/src/views/ModelStatusView.vue
+++ b/frontend/src/views/ModelStatusView.vue
@@ -105,7 +105,9 @@
                 data-testid="filter-capability"
               >
                 <option value="">{{ $t('adminModelStatus.filters.allCapabilities') }}</option>
-                <option v-for="cap in capabilities" :key="cap" :value="cap">{{ cap }}</option>
+                <option v-for="cap in capabilities" :key="cap" :value="cap">
+                  {{ capabilityLabel(cap) }}
+                </option>
               </select>
             </label>
           </div>
@@ -159,7 +161,7 @@
                 <div class="flex-1 min-w-0">
                   <div class="flex items-center gap-2 flex-wrap mb-1">
                     <h3 class="text-base font-semibold txt-primary">{{ model.name }}</h3>
-                    <span class="pill text-xs">{{ model.capability }}</span>
+                    <span class="pill text-xs">{{ capabilityLabel(model.capability) }}</span>
                     <span v-if="model.autoDisabled" class="pill text-xs">
                       {{ $t('adminModelStatus.model.autoDisabled') }}
                     </span>
@@ -210,6 +212,7 @@
                     <button
                       class="btn-secondary px-3 py-1.5 rounded-lg text-xs"
                       data-testid="btn-reset-counters"
+                      :disabled="busyModelId === model.id"
                       @click="resetCounters(model)"
                     >
                       {{ $t('adminModelStatus.actions.resetCounters') }}
@@ -217,6 +220,7 @@
                     <button
                       class="btn-secondary px-3 py-1.5 rounded-lg text-xs"
                       data-testid="btn-toggle-exempt"
+                      :disabled="busyModelId === model.id"
                       @click="toggleExempt(model)"
                     >
                       {{
@@ -242,6 +246,7 @@ import { Icon } from '@iconify/vue'
 import { useI18n } from 'vue-i18n'
 import MainLayout from '@/components/MainLayout.vue'
 import { useNotification } from '@/composables/useNotification'
+import { useDialog } from '@/composables/useDialog'
 import {
   modelStatusApi,
   type ModelStatusEntry,
@@ -251,12 +256,14 @@ import {
 
 const { t, locale } = useI18n()
 const { success, error } = useNotification()
+const { confirm } = useDialog()
 
 const snapshot = ref<ModelStatusSnapshot | null>(null)
 const isLoading = ref(false)
 const isRefreshing = ref(false)
 const onlyProblems = ref(false)
 const capabilityFilter = ref('')
+const busyModelId = ref<number | null>(null)
 
 const ORDERED_STATES: ModelStatusState[] = [
   'offline',
@@ -325,6 +332,12 @@ const formatTime = (unix: number): string => {
   return new Date(unix * 1000).toLocaleString(locale.value)
 }
 
+const capabilityLabel = (tag: string): string => {
+  const key = `config.aiModels.capabilities.${tag}`
+  const label = t(key)
+  return label === key ? tag : label
+}
+
 const load = async () => {
   isLoading.value = true
   try {
@@ -351,6 +364,7 @@ const refresh = async (provider?: string) => {
 
 const toggleExempt = async (model: ModelStatusEntry) => {
   const exempt = model.exemptUntil === 0
+  busyModelId.value = model.id
   try {
     await modelStatusApi.setExempt(model.id, exempt)
     snapshot.value = await modelStatusApi.getStatus()
@@ -359,16 +373,29 @@ const toggleExempt = async (model: ModelStatusEntry) => {
     )
   } catch {
     error(t('adminModelStatus.messages.exemptFailed'))
+  } finally {
+    busyModelId.value = null
   }
 }
 
 const resetCounters = async (model: ModelStatusEntry) => {
+  const confirmed = await confirm({
+    title: t('adminModelStatus.confirmResetTitle'),
+    message: t('adminModelStatus.confirmResetMessage', { name: model.name }),
+    confirmText: t('adminModelStatus.actions.resetCounters'),
+    cancelText: t('common.cancel'),
+  })
+  if (!confirmed) return
+
+  busyModelId.value = model.id
   try {
     await modelStatusApi.resetCounters(model.id)
     snapshot.value = await modelStatusApi.getStatus()
     success(t('adminModelStatus.messages.countersReset'))
   } catch {
     error(t('adminModelStatus.messages.countersResetFailed'))
+  } finally {
+    busyModelId.value = null
   }
 }
 

--- a/frontend/src/views/ModelStatusView.vue
+++ b/frontend/src/views/ModelStatusView.vue
@@ -125,7 +125,7 @@
             data-testid="section-provider"
           >
             <div class="flex items-center gap-3 px-2">
-              <h2 class="text-xl font-semibold txt-primary capitalize">{{ provider.name }}</h2>
+              <h2 class="text-xl font-semibold txt-primary">{{ provider.displayName }}</h2>
               <span
                 v-if="provider.needsAttention > 0"
                 class="px-2.5 py-1 rounded-md text-xs font-semibold"
@@ -137,6 +137,11 @@
               <button
                 class="btn-secondary px-3 py-1.5 rounded-lg text-xs disabled:opacity-60"
                 :disabled="isRefreshing"
+                :aria-label="
+                  $t('adminModelStatus.actions.refreshProviderAria', {
+                    provider: provider.displayName,
+                  })
+                "
                 data-testid="btn-refresh-provider"
                 @click="refresh(provider.name)"
               >

--- a/frontend/tests/unit/views/ModelStatusView.spec.ts
+++ b/frontend/tests/unit/views/ModelStatusView.spec.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+
+const mockGetStatus = vi.fn()
+const mockResetCounters = vi.fn()
+const mockConfirm = vi.fn()
+
+vi.mock('@/services/api/adminModelStatusApi', () => ({
+  modelStatusApi: {
+    getStatus: (...args: unknown[]) => mockGetStatus(...args),
+    refresh: vi.fn(),
+    setExempt: vi.fn(),
+    resetCounters: (...args: unknown[]) => mockResetCounters(...args),
+  },
+}))
+
+vi.mock('@/composables/useNotification', () => ({
+  useNotification: () => ({ success: vi.fn(), error: vi.fn() }),
+}))
+
+vi.mock('@/composables/useDialog', () => ({
+  useDialog: () => ({ confirm: (...args: unknown[]) => mockConfirm(...args) }),
+}))
+
+vi.mock('@iconify/vue', () => ({
+  Icon: { template: '<i />' },
+}))
+
+import ModelStatusView from '@/views/ModelStatusView.vue'
+
+const snapshot = {
+  success: true,
+  summary: {
+    total: 1,
+    online: 1,
+    degraded: 0,
+    offline: 0,
+    unconfigured: 0,
+    unknown: 0,
+    needsAttention: 0,
+    lastCheck: 1_700_000_000,
+    autoDisableEnabled: false,
+    monitoringEnabled: true,
+  },
+  providers: [
+    {
+      name: 'openai',
+      displayName: 'OpenAI',
+      needsAttention: 0,
+      models: [
+        {
+          id: 42,
+          name: 'GPT-4o',
+          providerId: 'gpt-4o',
+          capability: 'chat',
+          state: 'online',
+          reason: '',
+          source: 'probe',
+          lastCheck: 1_700_000_000,
+          lastSuccess: 1_700_000_000,
+          lastFailure: 0,
+          successes: 4,
+          failures: 0,
+          errorRatePercent: 0,
+          active: true,
+          selectable: true,
+          autoDisabled: false,
+          exemptUntil: 0,
+        },
+      ],
+    },
+  ],
+}
+
+function mountView() {
+  return mount(ModelStatusView, {
+    global: {
+      stubs: { MainLayout: { template: '<div><slot /></div>' } },
+    },
+  })
+}
+
+describe('ModelStatusView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetStatus.mockResolvedValue(snapshot)
+    mockConfirm.mockResolvedValue(true)
+    mockResetCounters.mockResolvedValue({ success: true, modelId: 42 })
+  })
+
+  it('shows a human task name instead of the raw catalog tag', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    expect(wrapper.get('[data-testid="item-model"]').text()).toContain('Chat / General AI')
+    expect(wrapper.get('[data-testid="item-model"]').text()).not.toMatch(/\bchat\b/)
+    wrapper.unmount()
+  })
+
+  it('asks before clearing the error history', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    await wrapper.get('[data-testid="btn-reset-counters"]').trigger('click')
+    await flushPromises()
+
+    expect(mockConfirm).toHaveBeenCalledOnce()
+    expect(mockResetCounters).toHaveBeenCalledWith(42)
+    wrapper.unmount()
+  })
+})

--- a/tests/mobile-impact.test.mjs
+++ b/tests/mobile-impact.test.mjs
@@ -184,6 +184,39 @@ test('classifies all server-side code and server-delivered plugins as backend-on
   }
 })
 
+test('classifies the model status surfaces as backend-only plus ota-candidate', () => {
+  const backendPaths = [
+    'backend/src/AI/Health/ModelHealthEvaluator.php',
+    'backend/src/AI/Health/Probe/PlatformKeyModelListProbe.php',
+    'backend/src/Command/ModelHealthCheckCommand.php',
+    'backend/src/Controller/AdminModelHealthController.php',
+    'backend/src/Entity/ModelHealth.php',
+    'backend/src/Repository/ModelHealthRepository.php'
+  ]
+
+  for (const path of backendPaths) {
+    assert.equal(classifyFiles([entry(path, 'A')], policy).classification, 'backend-only', path)
+  }
+
+  // The status page is ordinary web-layer code and must stay shippable over
+  // the air. A store review for a monitoring screen would be pure friction.
+  const webPaths = [
+    'frontend/src/views/ModelStatusView.vue',
+    'frontend/src/services/api/adminModelStatusApi.ts'
+  ]
+
+  for (const path of webPaths) {
+    assert.equal(classifyFiles([entry(path, 'A')], policy).classification, 'ota-candidate', path)
+  }
+
+  // The scheduler slot that runs the check lives in container tooling and is
+  // never delivered to an installed app.
+  assert.equal(
+    classifyFiles([entry('_docker/backend/lib/container-runtime.sh', 'M')], policy).classification,
+    'no-app-impact'
+  )
+})
+
 test('uses the highest classification for mixed changes', () => {
   assert.equal(classifyFiles([
     entry('README.md'),


### PR DESCRIPTION
## Summary
Providers retire models, keys expire and balances run out — today all three surface as a user-facing error mid-conversation, and this adds the detection, alerting and operator surface so we find out first.

## Changes
- **Two evidence sources, both free.** The provider's own catalog answers "does this model still exist" through the listing endpoints already used for key validation — no inference, so it costs nothing to run on a schedule. Rolling success/failure counters from real traffic answer "does it work for THIS account", which a catalog lookup can never see (exhausted quota, blocked region).
- **Absence from a listing is deliberately not a verdict.** Cloud catalogs are partial, so every missing model is confirmed individually through `ProviderModelInventory` from #1512, and only a model the provider itself rejects is reported as retired. This replaces an earlier per-capability heuristic — see Notes, it was wrong in both directions on our own catalog.
- **Failure classification.** `FailureClassifier` sorts `ProviderException` into transient / permanent / credential / user-error / cancelled; 429 is always transient, and a cancelled stream is never counted as a failure. Failed calls are written to `BUSELOG` with `BSTATUS = error`, which they were not before.
- **Persisted verdicts.** New `BMODELHEALTH` table (idempotent migration, raw `addSql`, no `Schema` API — Galera). Records state, reason, source, last success/failure and whether the automation or an operator switched a model off.
- **Alerting** over mail and Discord following the `sendEmbeddingFallbackWarning` pattern: aggregated per provider rather than per model, Redis-throttled, with an all-clear when a provider recovers. `@everyone` is reserved for credential failures, which take out every model behind a provider.
- **Model resolution prefers models that are not known-dead** — as a preference, never a veto. If every candidate is suspect the request still gets a model; routing at a suspect model beats routing nowhere.
- **Auto-disable** exists but is off by default, acts only on confirmed evidence, re-enables automatically on recovery, and records that it was the automation rather than an operator.
- **Admin status page** at `/admin/model-status`: every catalogued model grouped by provider with reason, rolling error rate and last success. Reading the page never contacts a provider; re-checking is an explicit button, optionally scoped to one provider. Operators can pause automatic disabling per model and clear the counters after fixing a cause.
- **Scheduler** runs `app:model:health-check` on its own short interval with jitter, alongside — not instead of — the daily availability check from #1512. They answer different questions: that one reports catalog drift for a human, this one reacts within minutes to a provider that started failing.

## Verification
- [ ] Not tested (explain)
- [x] Manual
- [x] Tests added/updated

Full gate green on this branch: `make lint`, `make -C backend phpstan` (no errors over `src/` **and** `tests/`), `make -C backend test` (3723 tests), `make -C frontend test` (1208 tests), `vue-tsc`, and `bash _docker/backend/tests/test-container-runtime.sh` (64/64, including both scheduler assertions).

Verified against the live provider APIs with this install's keys. The monitor independently reproduces all six retirements confirmed in #1512 — the four Groq models and both xAI ones — from a separate code path:

| Provider | Model | Direct probe | Reported |
| --- | --- | --- | --- |
| xAI | `grok-tts` | 404 | offline |
| xAI | `grok-stt` | 404 | offline |
| Google | `imagen-4.0-generate-001` | 200 | online |
| Google | `imagen-4.0-fast-generate-001` | 200 | online |
| Google | `imagen-4.0-ultra-generate-001` | 200 | online |

New tests: six evaluator cases locking the retirement rule (both live scenarios above, the inconclusive middle ground, the authoritative-listing path, and that a settled answer is reused rather than re-probed while an inconclusive one is not), plus recorder, classifier and alerter unit tests and an integration test for the admin endpoints.

## Notes
Builds on #1512 and #1513, both merged. The consolidation asked for in my review of #1512 is done here: `PlatformKeyModelListProbe::confirm()` delegates to `ProviderModelInventoryInterface` instead of keeping a second implementation of "ask a provider about one model id", and the duplicate enum is gone in favour of `ModelProbeResult`.

The heuristic this replaces is worth recording, because it looks reasonable and is not. It allowed a listing to retire models of a capability once it recognised any other model of that capability. On our catalog that condemned three working Imagen models — Google lists `gemini-2.5-flash-image` under the same capability, so the Imagen rows lost their excuse — while permanently excusing the genuinely dead `grok-tts`, the only `text2sound` row xAI has. It tracked how our catalog is grouped, not what the provider serves.

Because of that, `Offline` + `Permanent` is now written in exactly two situations, both decided by the provider: it rejected the model id, or real calls failed permanently. That invariant matters beyond reporting — `ModelHealthRepository::findOfflineModelIds()` feeds model resolution, so anything weaker reaching it would route users away from working models. It is documented at the query.

Mobile impact classifies as `ota-candidate`; nothing falls through to `store-required`, so no allow-list changes were needed. `frontend/src/generated/api-schemas.ts` is gitignored by design and regenerated from the OpenAPI annotations.

Not merging this myself — @FExB17 may want to look at the consolidation against his code.

## Screenshots/Logs
Dry run against the live APIs after the change:

```
 --------- --------
  State     Models
 --------- --------
  online    31
  offline   2
 --------- --------

  Provider   Model      Capability   State     Reason
  xAI        Grok TTS   text2sound   offline   xAI no longer serves this model.
  xAI        Grok STT   sound2text   offline   xAI no longer serves this model.
```