### PR TITLE
feat: GUEST_CHAT_ENABLED switch for the anonymous guest trial

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -532,8 +532,15 @@ DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/1234567890/abcdefghijklmnop
 
 # =============================================================================
 # --- Guest Trial Chat (optional) ---
+# Master switch for the anonymous guest trial. Defaults to true when unset.
+# Set to false on SSO-/OIDC-only instances (typically together with
+# REGISTRATION_ENABLED=false): unauthenticated visitors are sent to the login
+# page instead of getting a trial session, and every /api/v1/guest endpoint
+# is refused server-side (issue #1517).
+# =============================================================================
+GUEST_CHAT_ENABLED=true
+
 # Anti-abuse cap on concurrent active guest sessions per client IP.
 # Defaults to 5 when unset. Raise only in test environments where many
 # sessions legitimately share one IP.
-# =============================================================================
 GUEST_MAX_SESSIONS_PER_IP=5

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -532,15 +532,15 @@ DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/1234567890/abcdefghijklmnop
 
 # =============================================================================
 # --- Guest Trial Chat (optional) ---
-# Master switch for the anonymous guest trial. Defaults to true when unset.
-# Set to false on SSO-/OIDC-only instances (typically together with
-# REGISTRATION_ENABLED=false): unauthenticated visitors are sent to the login
-# page instead of getting a trial session, and every /api/v1/guest endpoint
-# is refused server-side (issue #1517).
+# GUEST_CHAT_ENABLED: master switch for the anonymous guest trial. Defaults to
+# true when unset. Set to false on SSO-/OIDC-only instances (typically together
+# with REGISTRATION_ENABLED=false): unauthenticated visitors are sent to the
+# login page instead of getting a trial session, and every /api/v1/guest
+# endpoint is refused server-side (issue #1517).
+#
+# GUEST_MAX_SESSIONS_PER_IP: anti-abuse cap on concurrent active guest sessions
+# per client IP. Defaults to 5 when unset. Raise only in test environments
+# where many sessions legitimately share one IP.
 # =============================================================================
 GUEST_CHAT_ENABLED=true
-
-# Anti-abuse cap on concurrent active guest sessions per client IP.
-# Defaults to 5 when unset. Raise only in test environments where many
-# sessions legitimately share one IP.
 GUEST_MAX_SESSIONS_PER_IP=5

--- a/backend/src/Controller/ConfigController.php
+++ b/backend/src/Controller/ConfigController.php
@@ -19,6 +19,7 @@ use App\Service\Client\MobileVersionService;
 use App\Service\Embedding\EmbeddingMetadataService;
 use App\Service\Embedding\EmbeddingModelChangeGuard;
 use App\Service\Embedding\Exception\PremiumRequiredException;
+use App\Service\GuestChatConfig;
 use App\Service\Infrastructure\RedisService;
 use App\Service\LocalAi\LocalAiDownloadStatusService;
 use App\Service\MarketingNews\MarketingNewsConfig;
@@ -64,6 +65,7 @@ class ConfigController extends AbstractController
         private MarketingNewsConfig $marketingNewsConfig,
         private UsageTaximeterConfig $usageTaximeterConfig,
         private RegistrationConfig $registrationConfig,
+        private GuestChatConfig $guestChatConfig,
         private SavedTaskConfig $savedTaskConfig,
         private ChatReadinessService $chatReadiness,
         private AiProviderDisclosure $aiProviderDisclosure,
@@ -136,6 +138,7 @@ class ConfigController extends AbstractController
                     description: 'Authentication surface flags. Lets the frontend hide sign-up affordances when the operator runs an SSO-/OIDC-only instance.',
                     properties: [
                         new OA\Property(property: 'registrationEnabled', type: 'boolean', example: true, description: 'When false, local email/password self-registration is disabled (set REGISTRATION_ENABLED=false, e.g. for OIDC-only deployments). The /register endpoint is also refused server-side.'),
+                        new OA\Property(property: 'guestChatEnabled', type: 'boolean', example: true, description: 'When false, the anonymous guest trial chat is disabled (set GUEST_CHAT_ENABLED=false, e.g. for OIDC-only deployments): the frontend sends unauthenticated visitors to /login and every /api/v1/guest endpoint is refused server-side.'),
                     ]
                 ),
                 new OA\Property(
@@ -556,6 +559,10 @@ class ConfigController extends AbstractController
                 // Default ON; operators set REGISTRATION_ENABLED=false for
                 // SSO-/OIDC-only instances so no local sign-up is offered.
                 'registrationEnabled' => $this->registrationConfig->isEnabled(),
+                // Default ON; operators set GUEST_CHAT_ENABLED=false so
+                // unauthenticated visitors are sent to /login instead of the
+                // anonymous guest trial (issue #1517).
+                'guestChatEnabled' => $this->guestChatConfig->isEnabled(),
             ],
             'recaptcha' => $recaptchaConfig,
             'branding' => $this->brandingService->getBranding(),

--- a/backend/src/Controller/GuestChatController.php
+++ b/backend/src/Controller/GuestChatController.php
@@ -487,10 +487,9 @@ class GuestChatController extends AbstractController
     #[OA\Parameter(name: 'sessionId', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Parameter(name: 'fileId', in: 'path', required: true, schema: new OA\Schema(type: 'integer'))]
     #[OA\Response(response: 200, description: 'File content')]
-    #[OA\Response(response: 403, description: 'File not associated with this session')]
+    #[OA\Response(response: 403, description: 'Guest chat is disabled on this instance (GUEST_CHAT_ENABLED=false), or file not associated with this session')]
     #[OA\Response(response: 404, description: 'Session or file not found')]
     #[OA\Response(response: 410, description: 'Session expired')]
-    #[OA\Response(response: 403, description: 'Guest chat is disabled on this instance (GUEST_CHAT_ENABLED=false)')]
     public function downloadFile(string $sessionId, int $fileId): Response
     {
         if ($denied = $this->denyWhenDisabled()) {

--- a/backend/src/Controller/GuestChatController.php
+++ b/backend/src/Controller/GuestChatController.php
@@ -93,6 +93,7 @@ class GuestChatController extends AbstractController
             ]
         )
     )]
+    #[OA\Response(response: 403, description: 'Guest chat is disabled on this instance (GUEST_CHAT_ENABLED=false)')]
     public function createSession(Request $request): JsonResponse
     {
         if ($denied = $this->denyWhenDisabled()) {
@@ -166,6 +167,7 @@ class GuestChatController extends AbstractController
         )
     )]
     #[OA\Response(response: 404, description: 'Session not found or expired')]
+    #[OA\Response(response: 403, description: 'Guest chat is disabled on this instance (GUEST_CHAT_ENABLED=false)')]
     public function getSessionStatus(string $sessionId): JsonResponse
     {
         if ($denied = $this->denyWhenDisabled()) {
@@ -221,6 +223,7 @@ class GuestChatController extends AbstractController
             ]
         )
     )]
+    #[OA\Response(response: 403, description: 'Guest chat is disabled on this instance (GUEST_CHAT_ENABLED=false)')]
     public function createChat(Request $request): JsonResponse
     {
         if ($denied = $this->denyWhenDisabled()) {
@@ -337,6 +340,7 @@ class GuestChatController extends AbstractController
     #[OA\Response(response: 400, description: 'Missing or invalid sessionId/trackId')]
     #[OA\Response(response: 404, description: 'Session not found, or no turn with this trackId in this session')]
     #[OA\Response(response: 410, description: 'Session expired')]
+    #[OA\Response(response: 403, description: 'Guest chat is disabled on this instance (GUEST_CHAT_ENABLED=false)')]
     public function stopStream(Request $request): JsonResponse
     {
         if ($denied = $this->denyWhenDisabled()) {
@@ -415,6 +419,7 @@ class GuestChatController extends AbstractController
         )
     )]
     #[OA\Response(response: 404, description: 'Session not found or has no chat')]
+    #[OA\Response(response: 403, description: 'Guest chat is disabled on this instance (GUEST_CHAT_ENABLED=false)')]
     public function getMessages(string $sessionId): JsonResponse
     {
         if ($denied = $this->denyWhenDisabled()) {
@@ -485,6 +490,7 @@ class GuestChatController extends AbstractController
     #[OA\Response(response: 403, description: 'File not associated with this session')]
     #[OA\Response(response: 404, description: 'Session or file not found')]
     #[OA\Response(response: 410, description: 'Session expired')]
+    #[OA\Response(response: 403, description: 'Guest chat is disabled on this instance (GUEST_CHAT_ENABLED=false)')]
     public function downloadFile(string $sessionId, int $fileId): Response
     {
         if ($denied = $this->denyWhenDisabled()) {

--- a/backend/src/Controller/GuestChatController.php
+++ b/backend/src/Controller/GuestChatController.php
@@ -59,7 +59,7 @@ class GuestChatController extends AbstractController
 
         return $this->json([
             'error' => 'Guest chat is disabled on this instance.',
-            'code' => 'GUEST_CHAT_DISABLED',
+            'code' => GuestChatConfig::DISABLED_CODE,
         ], Response::HTTP_FORBIDDEN);
     }
 

--- a/backend/src/Controller/GuestChatController.php
+++ b/backend/src/Controller/GuestChatController.php
@@ -57,7 +57,10 @@ class GuestChatController extends AbstractController
             return null;
         }
 
-        return $this->json(['error' => 'Guest chat is disabled on this instance'], Response::HTTP_FORBIDDEN);
+        return $this->json([
+            'error' => 'Guest chat is disabled on this instance.',
+            'code' => 'GUEST_CHAT_DISABLED',
+        ], Response::HTTP_FORBIDDEN);
     }
 
     /**
@@ -166,8 +169,8 @@ class GuestChatController extends AbstractController
             ]
         )
     )]
-    #[OA\Response(response: 404, description: 'Session not found or expired')]
     #[OA\Response(response: 403, description: 'Guest chat is disabled on this instance (GUEST_CHAT_ENABLED=false)')]
+    #[OA\Response(response: 404, description: 'Session not found or expired')]
     public function getSessionStatus(string $sessionId): JsonResponse
     {
         if ($denied = $this->denyWhenDisabled()) {
@@ -338,9 +341,9 @@ class GuestChatController extends AbstractController
         )
     )]
     #[OA\Response(response: 400, description: 'Missing or invalid sessionId/trackId')]
+    #[OA\Response(response: 403, description: 'Guest chat is disabled on this instance (GUEST_CHAT_ENABLED=false)')]
     #[OA\Response(response: 404, description: 'Session not found, or no turn with this trackId in this session')]
     #[OA\Response(response: 410, description: 'Session expired')]
-    #[OA\Response(response: 403, description: 'Guest chat is disabled on this instance (GUEST_CHAT_ENABLED=false)')]
     public function stopStream(Request $request): JsonResponse
     {
         if ($denied = $this->denyWhenDisabled()) {
@@ -418,8 +421,8 @@ class GuestChatController extends AbstractController
             ]
         )
     )]
-    #[OA\Response(response: 404, description: 'Session not found or has no chat')]
     #[OA\Response(response: 403, description: 'Guest chat is disabled on this instance (GUEST_CHAT_ENABLED=false)')]
+    #[OA\Response(response: 404, description: 'Session not found or has no chat')]
     public function getMessages(string $sessionId): JsonResponse
     {
         if ($denied = $this->denyWhenDisabled()) {

--- a/backend/src/Controller/GuestChatController.php
+++ b/backend/src/Controller/GuestChatController.php
@@ -7,6 +7,7 @@ namespace App\Controller;
 use App\Entity\Chat;
 use App\Repository\FileRepository;
 use App\Repository\MessageRepository;
+use App\Service\GuestChatConfig;
 use App\Service\GuestSessionService;
 use App\Service\Media\MediaCancellationStore;
 use App\Service\Message\MessageApiFormatter;
@@ -33,6 +34,7 @@ class GuestChatController extends AbstractController
 {
     public function __construct(
         private GuestSessionService $guestSessionService,
+        private GuestChatConfig $guestChatConfig,
         private EntityManagerInterface $em,
         private MessageRepository $messageRepository,
         private FileRepository $fileRepository,
@@ -41,6 +43,21 @@ class GuestChatController extends AbstractController
         private LoggerInterface $logger,
         private string $uploadDir,
     ) {
+    }
+
+    /**
+     * Server-side gate for GUEST_CHAT_ENABLED=false (issue #1517): every guest
+     * endpoint refuses so disabling the trial is not merely cosmetic. Applied
+     * uniformly (not just to session creation) so a stale client with a stored
+     * session cannot keep using it after the operator turns the trial off.
+     */
+    private function denyWhenDisabled(): ?JsonResponse
+    {
+        if ($this->guestChatConfig->isEnabled()) {
+            return null;
+        }
+
+        return $this->json(['error' => 'Guest chat is disabled on this instance'], Response::HTTP_FORBIDDEN);
     }
 
     /**
@@ -78,6 +95,10 @@ class GuestChatController extends AbstractController
     )]
     public function createSession(Request $request): JsonResponse
     {
+        if ($denied = $this->denyWhenDisabled()) {
+            return $denied;
+        }
+
         $data = json_decode($request->getContent(), true) ?? [];
         $clientSessionId = $data['sessionId'] ?? null;
 
@@ -147,6 +168,10 @@ class GuestChatController extends AbstractController
     #[OA\Response(response: 404, description: 'Session not found or expired')]
     public function getSessionStatus(string $sessionId): JsonResponse
     {
+        if ($denied = $this->denyWhenDisabled()) {
+            return $denied;
+        }
+
         if (!Uuid::isValid($sessionId)) {
             return $this->json(['error' => 'Invalid session ID'], Response::HTTP_BAD_REQUEST);
         }
@@ -198,6 +223,10 @@ class GuestChatController extends AbstractController
     )]
     public function createChat(Request $request): JsonResponse
     {
+        if ($denied = $this->denyWhenDisabled()) {
+            return $denied;
+        }
+
         $data = json_decode($request->getContent(), true) ?? [];
         $sessionId = $data['sessionId'] ?? null;
 
@@ -310,6 +339,10 @@ class GuestChatController extends AbstractController
     #[OA\Response(response: 410, description: 'Session expired')]
     public function stopStream(Request $request): JsonResponse
     {
+        if ($denied = $this->denyWhenDisabled()) {
+            return $denied;
+        }
+
         $data = json_decode($request->getContent(), true) ?? [];
         $sessionId = $data['sessionId'] ?? null;
         $trackId = isset($data['trackId']) && is_scalar($data['trackId']) ? trim((string) $data['trackId']) : '';
@@ -384,6 +417,10 @@ class GuestChatController extends AbstractController
     #[OA\Response(response: 404, description: 'Session not found or has no chat')]
     public function getMessages(string $sessionId): JsonResponse
     {
+        if ($denied = $this->denyWhenDisabled()) {
+            return $denied;
+        }
+
         if (!Uuid::isValid($sessionId)) {
             return $this->json(['error' => 'Invalid session ID'], Response::HTTP_BAD_REQUEST);
         }
@@ -450,6 +487,10 @@ class GuestChatController extends AbstractController
     #[OA\Response(response: 410, description: 'Session expired')]
     public function downloadFile(string $sessionId, int $fileId): Response
     {
+        if ($denied = $this->denyWhenDisabled()) {
+            return $denied;
+        }
+
         if (!Uuid::isValid($sessionId)) {
             return $this->json(['error' => 'Invalid session ID'], Response::HTTP_BAD_REQUEST);
         }

--- a/backend/src/Controller/StreamController.php
+++ b/backend/src/Controller/StreamController.php
@@ -16,6 +16,7 @@ use App\Service\File\DocumentImageReferenceResolver;
 use App\Service\File\FileGenerationEnvelope;
 use App\Service\File\Presentation\PptxRequestDirectiveResolver;
 use App\Service\File\UserUploadPathBuilder;
+use App\Service\GuestChatConfig;
 use App\Service\GuestSessionService;
 use App\Service\Media\GeneratedFileRegistrar;
 use App\Service\Media\MediaCancellationStore;
@@ -80,6 +81,7 @@ class StreamController extends AbstractController
         private WidgetService $widgetService,
         private WidgetSessionService $widgetSessionService,
         private GuestSessionService $guestSessionService,
+        private GuestChatConfig $guestChatConfig,
         private RateLimitService $rateLimitService,
         private string $uploadDir,
         private UserUploadPathBuilder $userUploadPathBuilder,
@@ -465,6 +467,16 @@ class StreamController extends AbstractController
                 // Guest Mode: Check for guest session parameter (query or POST body)
                 $guestSessionId = $params->get('guestSession');
                 if ($guestSessionId) {
+                    if (!$this->guestChatConfig->isEnabled()) {
+                        // Distinguish "trial disabled" from "session expired" so
+                        // clients do not offer a new-trial/sign-up flow that the
+                        // instance cannot serve (issue #1517).
+                        return $this->json([
+                            'error' => 'Guest chat is disabled on this instance.',
+                            'code' => 'GUEST_CHAT_DISABLED',
+                        ], Response::HTTP_FORBIDDEN);
+                    }
+
                     $guestSession = $this->guestSessionService->getSession($guestSessionId);
                     if ($guestSession && !$guestSession->isExpired()) {
                         if (!$this->guestSessionService->checkLimit($guestSession)) {

--- a/backend/src/Controller/StreamController.php
+++ b/backend/src/Controller/StreamController.php
@@ -473,7 +473,7 @@ class StreamController extends AbstractController
                         // instance cannot serve (issue #1517).
                         return $this->json([
                             'error' => 'Guest chat is disabled on this instance.',
-                            'code' => 'GUEST_CHAT_DISABLED',
+                            'code' => GuestChatConfig::DISABLED_CODE,
                         ], Response::HTTP_FORBIDDEN);
                     }
 

--- a/backend/src/Service/GuestChatConfig.php
+++ b/backend/src/Service/GuestChatConfig.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+/**
+ * Deployment-level switch for the anonymous guest trial chat.
+ *
+ * Like {@see RegistrationConfig}, this is an environment flag because it is an
+ * install-shape decision, not a runtime admin preference: an operator running
+ * an SSO-/OIDC-only instance sets `GUEST_CHAT_ENABLED=false` so anonymous
+ * visitors cannot consume AI (or upload files) without signing in, and the
+ * trial's sign-up funnel — which such instances cannot serve — never shows
+ * (issue #1517).
+ *
+ * Read at two seams:
+ *   - the public runtime-config response (frontend sends unauthenticated
+ *     visitors to /login instead of starting a guest session), and
+ *   - {@see \App\Controller\GuestChatController} (server-side refusal of every
+ *     guest endpoint, so disabling it is not merely cosmetic).
+ *
+ * Defaults ON when unset so existing self-host and cloud installs are unchanged.
+ */
+final readonly class GuestChatConfig
+{
+    public function isEnabled(): bool
+    {
+        $raw = trim((string) ($_ENV['GUEST_CHAT_ENABLED'] ?? ''));
+
+        // Unset or empty keeps the safe default (enabled), so existing installs
+        // that never set the flag are unaffected.
+        if ('' === $raw) {
+            return true;
+        }
+
+        // Only an explicit falsey value ('false'/'0'/'off'/'no') disables it;
+        // an unrecognized value also falls back to the safe default.
+        return filter_var($raw, \FILTER_VALIDATE_BOOL, \FILTER_NULL_ON_FAILURE) ?? true;
+    }
+}

--- a/backend/src/Service/GuestChatConfig.php
+++ b/backend/src/Service/GuestChatConfig.php
@@ -11,7 +11,7 @@ namespace App\Service;
  * install-shape decision, not a runtime admin preference: an operator running
  * an SSO-/OIDC-only instance sets `GUEST_CHAT_ENABLED=false` so anonymous
  * visitors cannot consume AI (or upload files) without signing in, and the
- * trial's sign-up funnel — which such instances cannot serve — never shows
+ * trial's sign-up funnel (which such instances cannot serve) never shows
  * (issue #1517).
  *
  * Read at two seams:

--- a/backend/src/Service/GuestChatConfig.php
+++ b/backend/src/Service/GuestChatConfig.php
@@ -24,6 +24,13 @@ namespace App\Service;
  */
 final readonly class GuestChatConfig
 {
+    /**
+     * Machine-readable code carried by every 403 the disabled trial produces
+     * (guest endpoints and the stream endpoint's guest path alike), mirroring
+     * REGISTRATION_DISABLED from issue #462.
+     */
+    public const DISABLED_CODE = 'GUEST_CHAT_DISABLED';
+
     public function isEnabled(): bool
     {
         $raw = trim((string) ($_ENV['GUEST_CHAT_ENABLED'] ?? ''));

--- a/backend/src/Service/GuestSessionService.php
+++ b/backend/src/Service/GuestSessionService.php
@@ -44,6 +44,7 @@ final class GuestSessionService
         private GuestSessionRepository $sessionRepository,
         private UserRepository $userRepository,
         private LoggerInterface $logger,
+        private GuestChatConfig $guestChatConfig,
         private int $maxSessionsPerIp = self::MAX_SESSIONS_PER_IP,
     ) {
     }
@@ -121,6 +122,15 @@ final class GuestSessionService
 
     public function getSession(string $sessionId): ?GuestSession
     {
+        // GUEST_CHAT_ENABLED=false (issue #1517): resolve no session for ANY
+        // consumer - guest turns also flow through StreamController's
+        // guestSession parameter, not only through GuestChatController's own
+        // (separately gated) endpoints. A stale stored session must not keep
+        // consuming AI after the operator turns the trial off.
+        if (!$this->guestChatConfig->isEnabled()) {
+            return null;
+        }
+
         return $this->sessionRepository->findBySessionId($sessionId);
     }
 

--- a/backend/tests/Controller/GuestChatControllerTest.php
+++ b/backend/tests/Controller/GuestChatControllerTest.php
@@ -8,6 +8,7 @@ use App\Entity\Chat;
 use App\Entity\File;
 use App\Entity\GuestSession;
 use App\Entity\Message;
+use App\Service\GuestChatConfig;
 use App\Service\Media\MediaCancellationStore;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Response;
@@ -121,7 +122,7 @@ class GuestChatControllerTest extends WebTestCase
 
                 $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN, "$method $url");
                 $data = json_decode($this->client->getResponse()->getContent(), true);
-                $this->assertSame('GUEST_CHAT_DISABLED', $data['code'] ?? null, "$method $url");
+                $this->assertSame(GuestChatConfig::DISABLED_CODE, $data['code'] ?? null, "$method $url");
             }
         } finally {
             unset($_ENV['GUEST_CHAT_ENABLED']);

--- a/backend/tests/Controller/GuestChatControllerTest.php
+++ b/backend/tests/Controller/GuestChatControllerTest.php
@@ -94,6 +94,40 @@ class GuestChatControllerTest extends WebTestCase
         return json_decode($this->client->getResponse()->getContent(), true);
     }
 
+    public function testEveryEndpointReturns403WhenGuestChatIsDisabled(): void
+    {
+        $_ENV['GUEST_CHAT_ENABLED'] = 'false';
+
+        try {
+            $sessionId = Uuid::v4()->toRfc4122();
+            $requests = [
+                ['POST', '/api/v1/guest/session'],
+                ['GET', '/api/v1/guest/session/'.$sessionId],
+                ['POST', '/api/v1/guest/chat'],
+                ['POST', '/api/v1/guest/stop-stream'],
+                ['GET', '/api/v1/guest/messages/'.$sessionId],
+                ['GET', '/api/v1/guest/files/'.$sessionId.'/1/download'],
+            ];
+
+            foreach ($requests as [$method, $url]) {
+                $this->client->request(
+                    $method,
+                    $url,
+                    [],
+                    [],
+                    ['CONTENT_TYPE' => 'application/json'],
+                    '{}'
+                );
+
+                $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN, "$method $url");
+                $data = json_decode($this->client->getResponse()->getContent(), true);
+                $this->assertSame('GUEST_CHAT_DISABLED', $data['code'] ?? null, "$method $url");
+            }
+        } finally {
+            unset($_ENV['GUEST_CHAT_ENABLED']);
+        }
+    }
+
     public function testCreateSessionReturnsNewSession(): void
     {
         $data = $this->createGuestSession();

--- a/backend/tests/Controller/StreamControllerGuestDisabledTest.php
+++ b/backend/tests/Controller/StreamControllerGuestDisabledTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Controller;
+
+use App\Service\GuestChatConfig;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Issue #1517: guest turns flow through the stream endpoint's guestSession
+ * parameter, not only through the (separately gated) guest endpoints, so a
+ * disabled trial must refuse here too - with the discriminating code instead
+ * of the expired-session 401 a stale client would misread as "start over".
+ */
+final class StreamControllerGuestDisabledTest extends WebTestCase
+{
+    public function testGuestTurnReturns403WhenGuestChatIsDisabled(): void
+    {
+        $_ENV['GUEST_CHAT_ENABLED'] = 'false';
+
+        try {
+            self::ensureKernelShutdown();
+            $client = static::createClient();
+
+            $client->request(
+                'POST',
+                '/api/v1/messages/stream?guestSession='.Uuid::v4()->toRfc4122(),
+                [],
+                [],
+                ['CONTENT_TYPE' => 'application/json'],
+                '{}'
+            );
+
+            self::assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+            $data = json_decode($client->getResponse()->getContent(), true);
+            self::assertSame(GuestChatConfig::DISABLED_CODE, $data['code'] ?? null);
+        } finally {
+            unset($_ENV['GUEST_CHAT_ENABLED']);
+        }
+    }
+}

--- a/backend/tests/Unit/Controller/ConfigControllerPlannerModelTest.php
+++ b/backend/tests/Unit/Controller/ConfigControllerPlannerModelTest.php
@@ -20,6 +20,7 @@ use App\Service\Client\ClientContextResolver;
 use App\Service\Client\MobileVersionService;
 use App\Service\Embedding\EmbeddingMetadataService;
 use App\Service\Embedding\EmbeddingModelChangeGuard;
+use App\Service\GuestChatConfig;
 use App\Service\Infrastructure\RedisService;
 use App\Service\LocalAi\LocalAiDownloadStatusService;
 use App\Service\MarketingNews\MarketingNewsConfig;
@@ -77,6 +78,7 @@ final class ConfigControllerPlannerModelTest extends TestCase
             $this->createStub(MarketingNewsConfig::class),
             $this->createStub(UsageTaximeterConfig::class),
             $this->createStub(RegistrationConfig::class),
+            new GuestChatConfig(),
             $this->createStub(\App\Service\SavedTask\SavedTaskConfig::class),
             $this->createStub(ChatReadinessService::class),
             $this->createStub(AiProviderDisclosure::class),

--- a/backend/tests/Unit/Controller/ConfigControllerPlannerModelTest.php
+++ b/backend/tests/Unit/Controller/ConfigControllerPlannerModelTest.php
@@ -78,7 +78,7 @@ final class ConfigControllerPlannerModelTest extends TestCase
             $this->createStub(MarketingNewsConfig::class),
             $this->createStub(UsageTaximeterConfig::class),
             $this->createStub(RegistrationConfig::class),
-            new GuestChatConfig(),
+            $this->createStub(GuestChatConfig::class),
             $this->createStub(\App\Service\SavedTask\SavedTaskConfig::class),
             $this->createStub(ChatReadinessService::class),
             $this->createStub(AiProviderDisclosure::class),

--- a/backend/tests/Unit/Controller/ConfigControllerSaveDefaultModelsTest.php
+++ b/backend/tests/Unit/Controller/ConfigControllerSaveDefaultModelsTest.php
@@ -21,6 +21,7 @@ use App\Service\Client\MobileVersionService;
 use App\Service\Embedding\EmbeddingMetadataService;
 use App\Service\Embedding\EmbeddingModelChangeGuard;
 use App\Service\Embedding\Exception\PremiumRequiredException;
+use App\Service\GuestChatConfig;
 use App\Service\Infrastructure\RedisService;
 use App\Service\LocalAi\LocalAiDownloadStatusService;
 use App\Service\MarketingNews\MarketingNewsConfig;
@@ -91,6 +92,7 @@ final class ConfigControllerSaveDefaultModelsTest extends TestCase
             $this->createStub(MarketingNewsConfig::class),
             $this->createStub(UsageTaximeterConfig::class),
             $this->createStub(RegistrationConfig::class),
+            new GuestChatConfig(),
             $this->createStub(\App\Service\SavedTask\SavedTaskConfig::class),
             $this->createStub(ChatReadinessService::class),
             $this->createStub(AiProviderDisclosure::class),

--- a/backend/tests/Unit/Controller/ConfigControllerSaveDefaultModelsTest.php
+++ b/backend/tests/Unit/Controller/ConfigControllerSaveDefaultModelsTest.php
@@ -92,7 +92,7 @@ final class ConfigControllerSaveDefaultModelsTest extends TestCase
             $this->createStub(MarketingNewsConfig::class),
             $this->createStub(UsageTaximeterConfig::class),
             $this->createStub(RegistrationConfig::class),
-            new GuestChatConfig(),
+            $this->createStub(GuestChatConfig::class),
             $this->createStub(\App\Service\SavedTask\SavedTaskConfig::class),
             $this->createStub(ChatReadinessService::class),
             $this->createStub(AiProviderDisclosure::class),

--- a/backend/tests/Unit/Controller/ConfigControllerSummaryModelTest.php
+++ b/backend/tests/Unit/Controller/ConfigControllerSummaryModelTest.php
@@ -20,6 +20,7 @@ use App\Service\Client\ClientContextResolver;
 use App\Service\Client\MobileVersionService;
 use App\Service\Embedding\EmbeddingMetadataService;
 use App\Service\Embedding\EmbeddingModelChangeGuard;
+use App\Service\GuestChatConfig;
 use App\Service\Infrastructure\RedisService;
 use App\Service\LocalAi\LocalAiDownloadStatusService;
 use App\Service\MarketingNews\MarketingNewsConfig;
@@ -82,6 +83,7 @@ final class ConfigControllerSummaryModelTest extends TestCase
             $this->createStub(MarketingNewsConfig::class),
             $this->createStub(UsageTaximeterConfig::class),
             $this->createStub(RegistrationConfig::class),
+            new GuestChatConfig(),
             $this->createStub(\App\Service\SavedTask\SavedTaskConfig::class),
             $this->createStub(ChatReadinessService::class),
             $this->createStub(AiProviderDisclosure::class),

--- a/backend/tests/Unit/Controller/ConfigControllerSummaryModelTest.php
+++ b/backend/tests/Unit/Controller/ConfigControllerSummaryModelTest.php
@@ -83,7 +83,7 @@ final class ConfigControllerSummaryModelTest extends TestCase
             $this->createStub(MarketingNewsConfig::class),
             $this->createStub(UsageTaximeterConfig::class),
             $this->createStub(RegistrationConfig::class),
-            new GuestChatConfig(),
+            $this->createStub(GuestChatConfig::class),
             $this->createStub(\App\Service\SavedTask\SavedTaskConfig::class),
             $this->createStub(ChatReadinessService::class),
             $this->createStub(AiProviderDisclosure::class),

--- a/backend/tests/Unit/Controller/StreamControllerAiModelsPayloadTest.php
+++ b/backend/tests/Unit/Controller/StreamControllerAiModelsPayloadTest.php
@@ -12,6 +12,7 @@ use App\Service\ConversationSummaryRefreshDispatcher;
 use App\Service\File\DocumentGeneratorService;
 use App\Service\File\DocumentImageReferenceResolver;
 use App\Service\File\UserUploadPathBuilder;
+use App\Service\GuestChatConfig;
 use App\Service\GuestSessionService;
 use App\Service\Media\GeneratedFileRegistrar;
 use App\Service\Media\MediaCancellationStore;
@@ -60,6 +61,7 @@ class StreamControllerAiModelsPayloadTest extends TestCase
             $this->createMock(WidgetService::class),
             $this->createMock(WidgetSessionService::class),
             $this->createMock(GuestSessionService::class),
+            new GuestChatConfig(),
             $this->createMock(RateLimitService::class),
             '/tmp/upload',
             $this->createMock(UserUploadPathBuilder::class),

--- a/backend/tests/Unit/Controller/StreamControllerAiModelsPayloadTest.php
+++ b/backend/tests/Unit/Controller/StreamControllerAiModelsPayloadTest.php
@@ -61,7 +61,7 @@ class StreamControllerAiModelsPayloadTest extends TestCase
             $this->createMock(WidgetService::class),
             $this->createMock(WidgetSessionService::class),
             $this->createMock(GuestSessionService::class),
-            new GuestChatConfig(),
+            $this->createStub(GuestChatConfig::class),
             $this->createMock(RateLimitService::class),
             '/tmp/upload',
             $this->createMock(UserUploadPathBuilder::class),

--- a/backend/tests/Unit/Controller/StreamControllerCancelledResultTest.php
+++ b/backend/tests/Unit/Controller/StreamControllerCancelledResultTest.php
@@ -11,6 +11,7 @@ use App\Service\ConversationSummaryRefreshDispatcher;
 use App\Service\File\DocumentGeneratorService;
 use App\Service\File\DocumentImageReferenceResolver;
 use App\Service\File\UserUploadPathBuilder;
+use App\Service\GuestChatConfig;
 use App\Service\GuestSessionService;
 use App\Service\Media\GeneratedFileRegistrar;
 use App\Service\Media\MediaCancellationStore;
@@ -52,6 +53,7 @@ class StreamControllerCancelledResultTest extends TestCase
             $this->createMock(WidgetService::class),
             $this->createMock(WidgetSessionService::class),
             $this->createMock(GuestSessionService::class),
+            new GuestChatConfig(),
             $this->createMock(RateLimitService::class),
             '/tmp/upload',
             $this->createMock(UserUploadPathBuilder::class),

--- a/backend/tests/Unit/Controller/StreamControllerCancelledResultTest.php
+++ b/backend/tests/Unit/Controller/StreamControllerCancelledResultTest.php
@@ -53,7 +53,7 @@ class StreamControllerCancelledResultTest extends TestCase
             $this->createMock(WidgetService::class),
             $this->createMock(WidgetSessionService::class),
             $this->createMock(GuestSessionService::class),
-            new GuestChatConfig(),
+            $this->createStub(GuestChatConfig::class),
             $this->createMock(RateLimitService::class),
             '/tmp/upload',
             $this->createMock(UserUploadPathBuilder::class),

--- a/backend/tests/Unit/Controller/StreamControllerDeferredMemoryDispatchTest.php
+++ b/backend/tests/Unit/Controller/StreamControllerDeferredMemoryDispatchTest.php
@@ -78,7 +78,7 @@ final class StreamControllerDeferredMemoryDispatchTest extends TestCase
             $this->createMock(WidgetService::class),
             $this->createMock(WidgetSessionService::class),
             $this->createMock(GuestSessionService::class),
-            new GuestChatConfig(),
+            $this->createStub(GuestChatConfig::class),
             $this->createMock(RateLimitService::class),
             '/tmp/upload',
             $this->createMock(UserUploadPathBuilder::class),

--- a/backend/tests/Unit/Controller/StreamControllerDeferredMemoryDispatchTest.php
+++ b/backend/tests/Unit/Controller/StreamControllerDeferredMemoryDispatchTest.php
@@ -12,6 +12,7 @@ use App\Service\ConversationSummaryRefreshDispatcher;
 use App\Service\File\DocumentGeneratorService;
 use App\Service\File\DocumentImageReferenceResolver;
 use App\Service\File\UserUploadPathBuilder;
+use App\Service\GuestChatConfig;
 use App\Service\GuestSessionService;
 use App\Service\Media\GeneratedFileRegistrar;
 use App\Service\Media\MediaCancellationStore;
@@ -77,6 +78,7 @@ final class StreamControllerDeferredMemoryDispatchTest extends TestCase
             $this->createMock(WidgetService::class),
             $this->createMock(WidgetSessionService::class),
             $this->createMock(GuestSessionService::class),
+            new GuestChatConfig(),
             $this->createMock(RateLimitService::class),
             '/tmp/upload',
             $this->createMock(UserUploadPathBuilder::class),

--- a/backend/tests/Unit/Controller/StreamControllerFileEnvelopeTest.php
+++ b/backend/tests/Unit/Controller/StreamControllerFileEnvelopeTest.php
@@ -11,6 +11,7 @@ use App\Service\ConversationSummaryRefreshDispatcher;
 use App\Service\File\DocumentGeneratorService;
 use App\Service\File\DocumentImageReferenceResolver;
 use App\Service\File\UserUploadPathBuilder;
+use App\Service\GuestChatConfig;
 use App\Service\GuestSessionService;
 use App\Service\Media\GeneratedFileRegistrar;
 use App\Service\Media\MediaCancellationStore;
@@ -49,6 +50,7 @@ final class StreamControllerFileEnvelopeTest extends TestCase
             $this->createMock(WidgetService::class),
             $this->createMock(WidgetSessionService::class),
             $this->createMock(GuestSessionService::class),
+            new GuestChatConfig(),
             $this->createMock(RateLimitService::class),
             '/tmp/upload',
             $this->createMock(UserUploadPathBuilder::class),

--- a/backend/tests/Unit/Controller/StreamControllerFileEnvelopeTest.php
+++ b/backend/tests/Unit/Controller/StreamControllerFileEnvelopeTest.php
@@ -50,7 +50,7 @@ final class StreamControllerFileEnvelopeTest extends TestCase
             $this->createMock(WidgetService::class),
             $this->createMock(WidgetSessionService::class),
             $this->createMock(GuestSessionService::class),
-            new GuestChatConfig(),
+            $this->createStub(GuestChatConfig::class),
             $this->createMock(RateLimitService::class),
             '/tmp/upload',
             $this->createMock(UserUploadPathBuilder::class),

--- a/backend/tests/Unit/Controller/StreamControllerOriginalMediaMetaTest.php
+++ b/backend/tests/Unit/Controller/StreamControllerOriginalMediaMetaTest.php
@@ -12,6 +12,7 @@ use App\Service\ConversationSummaryRefreshDispatcher;
 use App\Service\File\DocumentGeneratorService;
 use App\Service\File\DocumentImageReferenceResolver;
 use App\Service\File\UserUploadPathBuilder;
+use App\Service\GuestChatConfig;
 use App\Service\GuestSessionService;
 use App\Service\Media\GeneratedFileRegistrar;
 use App\Service\Media\MediaCancellationStore;
@@ -56,6 +57,7 @@ class StreamControllerOriginalMediaMetaTest extends TestCase
             $this->createMock(WidgetService::class),
             $this->createMock(WidgetSessionService::class),
             $this->createMock(GuestSessionService::class),
+            new GuestChatConfig(),
             $this->createMock(RateLimitService::class),
             '/tmp/upload',
             $this->createMock(UserUploadPathBuilder::class),

--- a/backend/tests/Unit/Controller/StreamControllerOriginalMediaMetaTest.php
+++ b/backend/tests/Unit/Controller/StreamControllerOriginalMediaMetaTest.php
@@ -57,7 +57,7 @@ class StreamControllerOriginalMediaMetaTest extends TestCase
             $this->createMock(WidgetService::class),
             $this->createMock(WidgetSessionService::class),
             $this->createMock(GuestSessionService::class),
-            new GuestChatConfig(),
+            $this->createStub(GuestChatConfig::class),
             $this->createMock(RateLimitService::class),
             '/tmp/upload',
             $this->createMock(UserUploadPathBuilder::class),

--- a/backend/tests/Unit/Controller/StreamControllerRagGroupKeyTest.php
+++ b/backend/tests/Unit/Controller/StreamControllerRagGroupKeyTest.php
@@ -11,6 +11,7 @@ use App\Service\ConversationSummaryRefreshDispatcher;
 use App\Service\File\DocumentGeneratorService;
 use App\Service\File\DocumentImageReferenceResolver;
 use App\Service\File\UserUploadPathBuilder;
+use App\Service\GuestChatConfig;
 use App\Service\GuestSessionService;
 use App\Service\Media\GeneratedFileRegistrar;
 use App\Service\Media\MediaCancellationStore;
@@ -61,6 +62,7 @@ final class StreamControllerRagGroupKeyTest extends TestCase
             $this->createMock(WidgetService::class),
             $this->createMock(WidgetSessionService::class),
             $this->createMock(GuestSessionService::class),
+            new GuestChatConfig(),
             $this->createMock(RateLimitService::class),
             '/tmp/upload',
             $this->createMock(UserUploadPathBuilder::class),

--- a/backend/tests/Unit/Controller/StreamControllerRagGroupKeyTest.php
+++ b/backend/tests/Unit/Controller/StreamControllerRagGroupKeyTest.php
@@ -62,7 +62,7 @@ final class StreamControllerRagGroupKeyTest extends TestCase
             $this->createMock(WidgetService::class),
             $this->createMock(WidgetSessionService::class),
             $this->createMock(GuestSessionService::class),
-            new GuestChatConfig(),
+            $this->createStub(GuestChatConfig::class),
             $this->createMock(RateLimitService::class),
             '/tmp/upload',
             $this->createMock(UserUploadPathBuilder::class),

--- a/backend/tests/Unit/Controller/StreamControllerTaskPlanFilesTest.php
+++ b/backend/tests/Unit/Controller/StreamControllerTaskPlanFilesTest.php
@@ -61,7 +61,7 @@ class StreamControllerTaskPlanFilesTest extends TestCase
             $this->createMock(WidgetService::class),
             $this->createMock(WidgetSessionService::class),
             $this->createMock(GuestSessionService::class),
-            new GuestChatConfig(),
+            $this->createStub(GuestChatConfig::class),
             $this->createMock(RateLimitService::class),
             '/tmp/upload',
             $this->createMock(UserUploadPathBuilder::class),

--- a/backend/tests/Unit/Controller/StreamControllerTaskPlanFilesTest.php
+++ b/backend/tests/Unit/Controller/StreamControllerTaskPlanFilesTest.php
@@ -12,6 +12,7 @@ use App\Service\ConversationSummaryRefreshDispatcher;
 use App\Service\File\DocumentGeneratorService;
 use App\Service\File\DocumentImageReferenceResolver;
 use App\Service\File\UserUploadPathBuilder;
+use App\Service\GuestChatConfig;
 use App\Service\GuestSessionService;
 use App\Service\Media\GeneratedFileRegistrar;
 use App\Service\Media\MediaCancellationStore;
@@ -60,6 +61,7 @@ class StreamControllerTaskPlanFilesTest extends TestCase
             $this->createMock(WidgetService::class),
             $this->createMock(WidgetSessionService::class),
             $this->createMock(GuestSessionService::class),
+            new GuestChatConfig(),
             $this->createMock(RateLimitService::class),
             '/tmp/upload',
             $this->createMock(UserUploadPathBuilder::class),

--- a/backend/tests/Unit/Service/GuestChatConfigTest.php
+++ b/backend/tests/Unit/Service/GuestChatConfigTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service;
+
+use App\Service\GuestChatConfig;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Issue #1517: the anonymous guest trial must be disable-able for OIDC-only
+ * instances. Covers the GUEST_CHAT_ENABLED env parsing (default ON, explicit
+ * falsey OFF), mirroring {@see RegistrationConfigTest}.
+ */
+final class GuestChatConfigTest extends TestCase
+{
+    private ?string $originalEnv = null;
+    private bool $envWasSet = false;
+
+    protected function setUp(): void
+    {
+        $this->envWasSet = \array_key_exists('GUEST_CHAT_ENABLED', $_ENV);
+        $this->originalEnv = $this->envWasSet ? (string) $_ENV['GUEST_CHAT_ENABLED'] : null;
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->envWasSet) {
+            $_ENV['GUEST_CHAT_ENABLED'] = $this->originalEnv;
+        } else {
+            unset($_ENV['GUEST_CHAT_ENABLED']);
+        }
+    }
+
+    public function testEnabledByDefaultWhenUnset(): void
+    {
+        unset($_ENV['GUEST_CHAT_ENABLED']);
+
+        self::assertTrue((new GuestChatConfig())->isEnabled());
+    }
+
+    /**
+     * @return iterable<string, array{0: string, 1: bool}>
+     */
+    public static function envValueProvider(): iterable
+    {
+        yield 'false' => ['false', false];
+        yield '0' => ['0', false];
+        yield 'off' => ['off', false];
+        yield 'no' => ['no', false];
+        yield 'true' => ['true', true];
+        yield '1' => ['1', true];
+        yield 'on' => ['on', true];
+        // Unrecognized value keeps the safe default (guest trial allowed).
+        yield 'garbage' => ['nonsense', true];
+        yield 'empty string' => ['', true];
+    }
+
+    #[DataProvider('envValueProvider')]
+    public function testIsEnabledParsesEnv(string $value, bool $expected): void
+    {
+        $_ENV['GUEST_CHAT_ENABLED'] = $value;
+
+        self::assertSame($expected, (new GuestChatConfig())->isEnabled());
+    }
+}

--- a/backend/tests/Unit/Service/GuestSessionServiceTest.php
+++ b/backend/tests/Unit/Service/GuestSessionServiceTest.php
@@ -29,13 +29,17 @@ class GuestSessionServiceTest extends TestCase
         ?UserRepository $userRepo = null,
         ?LoggerInterface $logger = null,
         ?int $maxSessionsPerIp = null,
+        bool $guestChatEnabled = true,
     ): GuestSessionService {
+        $guestChatConfig = $this->createStub(GuestChatConfig::class);
+        $guestChatConfig->method('isEnabled')->willReturn($guestChatEnabled);
+
         $args = [
             $em ?? $this->createStub(EntityManagerInterface::class),
             $sessionRepo ?? $this->createStub(GuestSessionRepository::class),
             $userRepo ?? $this->createStub(UserRepository::class),
             $logger ?? $this->createStub(LoggerInterface::class),
-            new GuestChatConfig(),
+            $guestChatConfig,
         ];
 
         if (null !== $maxSessionsPerIp) {
@@ -50,13 +54,9 @@ class GuestSessionServiceTest extends TestCase
         $sessionRepo = $this->createStub(GuestSessionRepository::class);
         $sessionRepo->method('findBySessionId')->willReturn(new GuestSession());
 
-        $_ENV['GUEST_CHAT_ENABLED'] = 'false';
+        $service = $this->createService(sessionRepo: $sessionRepo, guestChatEnabled: false);
 
-        try {
-            self::assertNull($this->createService(sessionRepo: $sessionRepo)->getSession('any-id'));
-        } finally {
-            unset($_ENV['GUEST_CHAT_ENABLED']);
-        }
+        self::assertNull($service->getSession('any-id'));
     }
 
     public function testCreateSessionWithCloudflareHeaders(): void

--- a/backend/tests/Unit/Service/GuestSessionServiceTest.php
+++ b/backend/tests/Unit/Service/GuestSessionServiceTest.php
@@ -8,6 +8,7 @@ use App\Entity\GuestSession;
 use App\Entity\User;
 use App\Repository\GuestSessionRepository;
 use App\Repository\UserRepository;
+use App\Service\GuestChatConfig;
 use App\Service\GuestSessionService;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
@@ -34,6 +35,7 @@ class GuestSessionServiceTest extends TestCase
             $sessionRepo ?? $this->createStub(GuestSessionRepository::class),
             $userRepo ?? $this->createStub(UserRepository::class),
             $logger ?? $this->createStub(LoggerInterface::class),
+            new GuestChatConfig(),
         ];
 
         if (null !== $maxSessionsPerIp) {
@@ -41,6 +43,20 @@ class GuestSessionServiceTest extends TestCase
         }
 
         return new GuestSessionService(...$args);
+    }
+
+    public function testGetSessionResolvesNothingWhileGuestChatIsDisabled(): void
+    {
+        $sessionRepo = $this->createStub(GuestSessionRepository::class);
+        $sessionRepo->method('findBySessionId')->willReturn(new GuestSession());
+
+        $_ENV['GUEST_CHAT_ENABLED'] = 'false';
+
+        try {
+            self::assertNull($this->createService(sessionRepo: $sessionRepo)->getSession('any-id'));
+        } finally {
+            unset($_ENV['GUEST_CHAT_ENABLED']);
+        }
     }
 
     public function testCreateSessionWithCloudflareHeaders(): void

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -43,6 +43,10 @@ x-app-environment: &app-environment
   AUTH_COOKIE_SECURE: "${AUTH_COOKIE_SECURE:-}"
   BOOTSTRAP_ADMIN_EMAIL: "${BOOTSTRAP_ADMIN_EMAIL:-}"
   BOOTSTRAP_ADMIN_PASSWORD: "${BOOTSTRAP_ADMIN_PASSWORD:-}"
+  # Auth-surface switches (issues #462 / #1517). Empty keeps the default
+  # (enabled); SSO-/OIDC-only deployments set both to "false".
+  REGISTRATION_ENABLED: "${REGISTRATION_ENABLED:-}"
+  GUEST_CHAT_ENABLED: "${GUEST_CHAT_ENABLED:-}"
   DB_HOST: db
   DB_PORT: "3306"
   DB_NAME: "${MARIADB_DATABASE:-synaplan}"

--- a/deploy/selfhost.env.example
+++ b/deploy/selfhost.env.example
@@ -53,6 +53,12 @@ REALTIME_ADMIN_SECRET=replace-with-a-different-stable-random-value
 BOOTSTRAP_ADMIN_EMAIL=
 BOOTSTRAP_ADMIN_PASSWORD=
 
+# Auth-surface switches, both default to enabled when left empty. SSO-/OIDC-only
+# deployments set both to false: no local email/password self-registration
+# (issue #462) and no anonymous guest trial chat (issue #1517).
+REGISTRATION_ENABLED=
+GUEST_CHAT_ENABLED=
+
 # Cloud AI is the default. Provider keys can instead be configured after login in
 # Admin > AI Providers, where they are encrypted in MariaDB.
 AI_DEFAULT_PROVIDER=groq

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -21,6 +21,8 @@ Provider keys are the common case and belong in the UI — see [AI Providers](#a
 | `FRONTEND_URL` | `http://localhost:5173` | Frontend URL for email links |
 | `REDIS_DSN` | `redis://redis:6379` | **Required.** Cache, sessions, locks, queues, realtime engine ([details](#redis-required)) |
 | `REALTIME_ENABLED` | `true` | WebSocket realtime layer (Centrifugo) — see [REALTIME.md](REALTIME.md) |
+| `REGISTRATION_ENABLED` | `true` | Local email/password self-registration; set `false` on SSO-/OIDC-only instances (#462) |
+| `GUEST_CHAT_ENABLED` | `true` | Anonymous guest trial chat; set `false` on SSO-/OIDC-only instances so unauthenticated visitors go to the login page (#1517) |
 
 ---
 

--- a/frontend/src/components/MobileNav.vue
+++ b/frontend/src/components/MobileNav.vue
@@ -131,6 +131,7 @@
 
                 <template v-if="isGuestMode">
                   <router-link
+                    v-if="configStore.auth.registrationEnabled"
                     to="/register"
                     class="v2-drawer-account font-medium"
                     style="color: var(--brand)"

--- a/frontend/src/components/SidebarV2.vue
+++ b/frontend/src/components/SidebarV2.vue
@@ -182,6 +182,7 @@
               </p>
             </div>
             <router-link
+              v-if="configStore.auth.registrationEnabled"
               to="/register"
               class="dropdown-item font-medium"
               style="color: var(--brand)"

--- a/frontend/src/components/guest/GuestBanner.vue
+++ b/frontend/src/components/guest/GuestBanner.vue
@@ -21,16 +21,18 @@
           {{ $t('guest.banner.remaining', { count: remaining }) }}
         </span>
 
-        <span class="w-px h-3.5 bg-gray-400 dark:bg-gray-500" />
+        <template v-if="config.auth.registrationEnabled">
+          <span class="w-px h-3.5 bg-gray-400 dark:bg-gray-500" />
 
-        <router-link
-          to="/register"
-          data-testid="guest-banner-signup"
-          class="group relative text-xs font-semibold text-white whitespace-nowrap px-2.5 py-1 rounded-full bg-brand shadow-sm overflow-hidden transition-shadow duration-300 hover:shadow-md hover:shadow-brand/40 sm:px-3"
-        >
-          <span class="relative z-10">{{ $t('guest.banner.signUp') }}</span>
-          <span class="cta-shimmer" />
-        </router-link>
+          <router-link
+            to="/register"
+            data-testid="guest-banner-signup"
+            class="group relative text-xs font-semibold text-white whitespace-nowrap px-2.5 py-1 rounded-full bg-brand shadow-sm overflow-hidden transition-shadow duration-300 hover:shadow-md hover:shadow-brand/40 sm:px-3"
+          >
+            <span class="relative z-10">{{ $t('guest.banner.signUp') }}</span>
+            <span class="cta-shimmer" />
+          </router-link>
+        </template>
 
         <button
           data-testid="guest-banner-dismiss"
@@ -47,6 +49,9 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { Icon } from '@iconify/vue'
+import { useConfigStore } from '@/stores/config'
+
+const config = useConfigStore()
 
 const props = defineProps<{
   visible: boolean

--- a/frontend/src/components/guest/GuestHintPopover.vue
+++ b/frontend/src/components/guest/GuestHintPopover.vue
@@ -38,6 +38,7 @@
             </p>
 
             <router-link
+              v-if="config.auth.registrationEnabled"
               to="/register"
               data-testid="guest-hint-register"
               class="block w-full py-2.5 rounded-xl bg-[var(--brand)] text-white text-center font-semibold text-sm hover:brightness-110 transition-all"
@@ -63,6 +64,9 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted } from 'vue'
 import { Icon } from '@iconify/vue'
+import { useConfigStore } from '@/stores/config'
+
+const config = useConfigStore()
 
 const props = defineProps<{
   isOpen: boolean

--- a/frontend/src/components/guest/GuestSignupModal.vue
+++ b/frontend/src/components/guest/GuestSignupModal.vue
@@ -71,6 +71,7 @@
           <!-- CTA buttons -->
           <div class="bg-white dark:bg-gray-900 px-8 pb-8 pt-2 space-y-3">
             <router-link
+              v-if="config.auth.registrationEnabled"
               to="/register"
               data-testid="guest-modal-register"
               class="group relative block w-full py-3 rounded-xl bg-brand text-white text-center font-semibold text-sm overflow-hidden transition-all duration-200 hover:shadow-lg hover:shadow-brand/30 active:scale-[0.98]"
@@ -94,6 +95,9 @@
 
 <script setup lang="ts">
 import { Icon } from '@iconify/vue'
+import { useConfigStore } from '@/stores/config'
+
+const config = useConfigStore()
 
 defineProps<{
   isOpen: boolean

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -4587,6 +4587,8 @@
     },
     "errorTitle": "Testmodus derzeit nicht verfügbar",
     "errorDescription": "Deine Gastsitzung konnte nicht gestartet werden. Bitte versuche es erneut oder erstelle einen kostenlosen Account.",
+    "disabledTitle": "Gast-Chat nicht verfügbar",
+    "disabledDescription": "Diese Instanz bietet keinen anonymen Testzugang. Bitte melde dich an, um zu chatten.",
     "expiredTitle": "Deine Sitzung ist abgelaufen",
     "expiredDescription": "Gastsitzungen sind 24 Stunden gültig. Starte einen neuen Test oder erstelle einen kostenlosen Account, um deinen Chatverlauf zu behalten.",
     "rateLimitedTitle": "Zu viele Sitzungen",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -4653,6 +4653,8 @@
     },
     "errorTitle": "Trial currently unavailable",
     "errorDescription": "We couldn't start your guest session. Please try again or create a free account.",
+    "disabledTitle": "Guest chat is not available",
+    "disabledDescription": "This instance does not offer an anonymous trial. Please sign in to start chatting.",
     "expiredTitle": "Your session has expired",
     "expiredDescription": "Guest sessions last 24 hours. Start a new trial or create a free account to keep your chat history.",
     "rateLimitedTitle": "Too many sessions",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -595,6 +595,8 @@
     "aiAgents": "Agentes de IA"
   },
   "guest": {
+    "disabledTitle": "El chat de invitados no está disponible",
+    "disabledDescription": "Esta instancia no ofrece una prueba anónima. Inicia sesión para empezar a chatear.",
     "featureGate": {
       "title": "Esta función requiere una cuenta",
       "subtitle": "Crea una cuenta gratuita para desbloquear todas las funciones",

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -595,6 +595,8 @@
     "aiAgents": "Yapay zeka ajanları"
   },
   "guest": {
+    "disabledTitle": "Misafir sohbeti kullanılamıyor",
+    "disabledDescription": "Bu sunucu anonim deneme sunmuyor. Sohbete başlamak için giriş yap.",
     "featureGate": {
       "title": "Bu özellik bir hesap gerektirir",
       "subtitle": "Tüm özellikleri açmak için ücretsiz bir hesap oluşturun",

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -662,7 +662,8 @@ router.beforeEach(async (to, from, next) => {
   }
 
   const { isAuthenticated, isAdmin } = useAuth()
-  const requiresAuth = to.meta.requiresAuth !== false // Default to true
+  const guestTrialOff = to.meta.allowGuest === true && !useConfigStore().auth.guestChatEnabled
+  const requiresAuth = to.meta.requiresAuth !== false || guestTrialOff // Default to true
   const requiresAdminAccess = to.meta.requiresAdmin === true
   const isPublicRoute = to.meta.public === true
 

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -642,7 +642,12 @@ router.beforeEach(async (to, from, next) => {
   } catch (err) {
     console.error('Auth initialization failed:', err)
     // If auth check times out, allow navigation to public routes only
-    if (to.meta.public || to.meta.requiresAuth === false) {
+    // (guest-allowed routes count as protected while the trial is disabled)
+    if (
+      to.meta.public ||
+      (to.meta.requiresAuth === false &&
+        !(to.meta.allowGuest === true && !useConfigStore().auth.guestChatEnabled))
+    ) {
       next()
       return
     }
@@ -662,7 +667,8 @@ router.beforeEach(async (to, from, next) => {
   }
 
   const { isAuthenticated, isAdmin } = useAuth()
-  const guestTrialOff = to.meta.allowGuest === true && !useConfigStore().auth.guestChatEnabled
+  const guestChatEnabled = useConfigStore().auth.guestChatEnabled
+  const guestTrialOff = to.meta.allowGuest === true && !guestChatEnabled
   const requiresAuth = to.meta.requiresAuth !== false || guestTrialOff // Default to true
   const requiresAdminAccess = to.meta.requiresAdmin === true
   const isPublicRoute = to.meta.public === true
@@ -684,11 +690,13 @@ router.beforeEach(async (to, from, next) => {
       return
     }
 
-    // Guest users: redirect to chat with feature-gate modal instead of login
+    // Guest users: redirect to chat with feature-gate modal instead of login.
+    // Skipped when the guest trial is disabled - chat itself requires auth
+    // then, so this redirect would loop; the stored key is also stale.
     const guestStore = useGuestStore()
     const hasStoredGuestSession =
       !guestStore.initialized && !!localStorage.getItem(GUEST_STORAGE_KEY)
-    if (guestStore.isGuestMode || hasStoredGuestSession) {
+    if (guestChatEnabled && (guestStore.isGuestMode || hasStoredGuestSession)) {
       const featureKey = mapPathToFeatureKey(to.path)
       next({ name: 'chat', query: { restricted: featureKey } })
       return

--- a/frontend/src/stores/config.ts
+++ b/frontend/src/stores/config.ts
@@ -74,6 +74,16 @@ const config = {
     get registrationEnabled(): boolean {
       return getConfigSync().auth?.registrationEnabled ?? true
     },
+    /**
+     * False when the operator disabled the anonymous guest trial
+     * (GUEST_CHAT_ENABLED=false, issue #1517): guest-allowed routes then
+     * require authentication like any other route. Defaults to true so
+     * unconfigured/older backends keep the trial. The backend refuses the
+     * guest endpoints regardless.
+     */
+    get guestChatEnabled(): boolean {
+      return getConfigSync().auth?.guestChatEnabled ?? true
+    },
   },
 
   /**

--- a/frontend/src/stores/guest.ts
+++ b/frontend/src/stores/guest.ts
@@ -208,6 +208,7 @@ export const useGuestStore = defineStore('guest', () => {
     initFailed.value = false
     rateLimited.value = false
     sessionExpired.value = false
+    guestChatDisabled.value = false
     bannerDismissed.value = false
     try {
       localStorage.removeItem(GUEST_STORAGE_KEY)

--- a/frontend/src/stores/guest.ts
+++ b/frontend/src/stores/guest.ts
@@ -24,6 +24,8 @@ export const useGuestStore = defineStore('guest', () => {
   const initFailed = ref(false)
   const rateLimited = ref(false)
   const sessionExpired = ref(false)
+  // GUEST_CHAT_ENABLED=false on the backend: the trial does not exist here.
+  const guestChatDisabled = ref(false)
   // Persisted so a dismissed banner stays gone across app restarts / reloads
   // for the same browser profile (cleared only on logout / session reset).
   const bannerDismissed = ref(loadBannerDismissed())
@@ -81,13 +83,18 @@ export const useGuestStore = defineStore('guest', () => {
       }
 
       if (response.status === 403) {
-        // Guest chat disabled on this instance (GUEST_CHAT_ENABLED=false):
-        // drop the stored key so future navigations route to login instead
-        // of retrying a trial that no longer exists.
-        clearExpiredStorage()
-        initFailed.value = true
-        initialized.value = true
-        return
+        const body = await response.json().catch(() => null)
+        if (body?.code === 'GUEST_CHAT_DISABLED') {
+          // Guest chat disabled on this instance (GUEST_CHAT_ENABLED=false):
+          // drop the stored key so future navigations route to login instead
+          // of retrying a trial that no longer exists.
+          clearExpiredStorage()
+          guestChatDisabled.value = true
+          initFailed.value = true
+          initialized.value = true
+          return
+        }
+        throw new Error('Failed to init guest session')
       }
 
       if (!response.ok) throw new Error('Failed to init guest session')
@@ -224,6 +231,7 @@ export const useGuestStore = defineStore('guest', () => {
     remainingMessages,
     isGuestMode,
     shouldShowBanner,
+    guestChatDisabled,
     initSession,
     retryInit,
     ensureChat,

--- a/frontend/src/stores/guest.ts
+++ b/frontend/src/stores/guest.ts
@@ -80,6 +80,16 @@ export const useGuestStore = defineStore('guest', () => {
         return
       }
 
+      if (response.status === 403) {
+        // Guest chat disabled on this instance (GUEST_CHAT_ENABLED=false):
+        // drop the stored key so future navigations route to login instead
+        // of retrying a trial that no longer exists.
+        clearExpiredStorage()
+        initFailed.value = true
+        initialized.value = true
+        return
+      }
+
       if (!response.ok) throw new Error('Failed to init guest session')
 
       const data = await response.json()

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -98,24 +98,30 @@
               </div>
               <h2 class="text-xl font-semibold txt-primary mb-2">
                 {{
-                  guestStore.sessionExpired
-                    ? $t('guest.expiredTitle')
-                    : guestStore.rateLimited
-                      ? $t('guest.rateLimitedTitle')
-                      : $t('guest.errorTitle')
+                  guestStore.guestChatDisabled
+                    ? $t('guest.disabledTitle')
+                    : guestStore.sessionExpired
+                      ? $t('guest.expiredTitle')
+                      : guestStore.rateLimited
+                        ? $t('guest.rateLimitedTitle')
+                        : $t('guest.errorTitle')
                 }}
               </h2>
               <p class="txt-secondary mb-4">
                 {{
-                  guestStore.sessionExpired
-                    ? $t('guest.expiredDescription')
-                    : guestStore.rateLimited
-                      ? $t('guest.rateLimitedDescription')
-                      : $t('guest.errorDescription')
+                  guestStore.guestChatDisabled
+                    ? $t('guest.disabledDescription')
+                    : guestStore.sessionExpired
+                      ? $t('guest.expiredDescription')
+                      : guestStore.rateLimited
+                        ? $t('guest.rateLimitedDescription')
+                        : $t('guest.errorDescription')
                 }}
               </p>
               <div class="flex gap-3 justify-center">
+                <!-- Retrying a disabled trial can never succeed. -->
                 <button
+                  v-if="!guestStore.guestChatDisabled"
                   class="px-4 py-2 rounded-lg btn-brand text-sm font-medium"
                   @click="guestStore.retryInit()"
                 >

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -121,11 +121,17 @@
                 >
                   {{ $t('guest.retry') }}
                 </button>
+                <!-- Sign-in fallback: /register is unreachable when
+                     registration is disabled (#462 route guard). -->
                 <router-link
-                  :to="{ name: 'register' }"
+                  :to="{ name: configStore.auth.registrationEnabled ? 'register' : 'login' }"
                   class="px-4 py-2 rounded-lg border border-[var(--border)] txt-secondary text-sm font-medium hover:bg-[var(--bg-secondary)] transition-colors"
                 >
-                  {{ $t('guest.createAccount') }}
+                  {{
+                    configStore.auth.registrationEnabled
+                      ? $t('guest.createAccount')
+                      : $t('auth.signIn')
+                  }}
                 </router-link>
               </div>
             </div>

--- a/frontend/tests/unit/stores/guest.spec.ts
+++ b/frontend/tests/unit/stores/guest.spec.ts
@@ -22,6 +22,7 @@ describe('Guest Store', () => {
     expect(store.maxMessages).toBe(5)
     expect(store.limitReached).toBe(false)
     expect(store.initialized).toBe(false)
+    expect(store.guestChatDisabled).toBe(false)
     expect(store.bannerDismissed).toBe(false)
   })
 
@@ -101,6 +102,7 @@ describe('Guest Store', () => {
     store.maxMessages = 10
     store.limitReached = true
     store.initialized = true
+    store.guestChatDisabled = true
     store.bannerDismissed = true
 
     store.$reset()
@@ -111,6 +113,7 @@ describe('Guest Store', () => {
     expect(store.maxMessages).toBe(5)
     expect(store.limitReached).toBe(false)
     expect(store.initialized).toBe(false)
+    expect(store.guestChatDisabled).toBe(false)
     expect(store.bannerDismissed).toBe(false)
   })
 
@@ -221,7 +224,10 @@ describe('Guest Store', () => {
       global.fetch = vi.fn().mockResolvedValue({
         ok: false,
         status: 403,
-        json: async () => ({ error: 'Guest chat is disabled on this instance.', code: 'GUEST_CHAT_DISABLED' }),
+        json: async () => ({
+          error: 'Guest chat is disabled on this instance.',
+          code: 'GUEST_CHAT_DISABLED',
+        }),
       })
 
       const store = useGuestStore()

--- a/frontend/tests/unit/stores/guest.spec.ts
+++ b/frontend/tests/unit/stores/guest.spec.ts
@@ -216,6 +216,39 @@ describe('Guest Store', () => {
       expect(store.sessionId).toBeNull()
     })
 
+    it('should clear storage and flag disabled on 403 GUEST_CHAT_DISABLED', async () => {
+      localStorage.setItem('synaplan_guest_session', 'stale-id')
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 403,
+        json: async () => ({ error: 'Guest chat is disabled on this instance.', code: 'GUEST_CHAT_DISABLED' }),
+      })
+
+      const store = useGuestStore()
+      await store.initSession()
+
+      expect(store.initialized).toBe(true)
+      expect(store.initFailed).toBe(true)
+      expect(store.guestChatDisabled).toBe(true)
+      expect(store.sessionId).toBeNull()
+      expect(store.isGuestMode).toBe(false)
+      expect(localStorage.getItem('synaplan_guest_session')).toBeNull()
+    })
+
+    it('should treat a 403 without the disabled code as a generic failure', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 403,
+        json: async () => ({ error: 'nope' }),
+      })
+
+      const store = useGuestStore()
+      await store.initSession()
+
+      expect(store.initFailed).toBe(true)
+      expect(store.guestChatDisabled).toBe(false)
+    })
+
     it('should set rateLimited on 429 response', async () => {
       global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 429 })
 


### PR DESCRIPTION
Closes #1517.

SSO-/OIDC-only instances can disable local sign-up (`REGISTRATION_ENABLED=false`, #462) but not the anonymous guest trial: visitors still get 5 trial messages including file upload, and the guest banner advertises a **Sign up free** CTA whose `/register` target the #462 router guard immediately bounces to `/login`.

**Backend**
- `GuestChatConfig` (mirrors `RegistrationConfig`): `GUEST_CHAT_ENABLED` env, default ON so existing installs are unchanged; documented in `.env.example`.
- Every `/api/v1/guest` endpoint refuses with 403 when disabled, so the switch is not merely cosmetic and stale stored sessions stop working too.
- Runtime config exposes `auth.guestChatEnabled` (OpenAPI documented).

**Frontend**
- Router: guest-allowed routes require authentication when the trial is disabled, so unauthenticated visitors land on `/login` (which auto-redirects to the OIDC provider when configured). The runtime config is loaded before mount, so the guard never races it.
- `GuestBanner`: the sign-up CTA hides when `REGISTRATION_ENABLED=false` (dead link otherwise).
- Guest error panel: offers **Sign In** instead of the unreachable **Create account** when registration is disabled.

**Tests / checks**: `GuestChatConfigTest` mirrors `RegistrationConfigTest` (20/20 green together), `php-cs-fixer` clean, `eslint` + `vue-tsc --noEmit` clean.

---

**Upgrade notes (also relevant for installs that never set the new flag):**
- Instances already running `REGISTRATION_ENABLED=false`: sign-up CTAs that previously dead-ended on the guarded `/register` route (guest banner, limit modal, feature-gate popover, sidebar/mobile guest menus, guest error panel) are now hidden or replaced with a sign-in action.
- Packaged selfhost deployments (`deploy/compose.yaml`): `REGISTRATION_ENABLED` and `GUEST_CHAT_ENABLED` are now passed through to the container. If you had set `REGISTRATION_ENABLED=false` in your env file before, it was silently ineffective and becomes effective with this release.

**Squash note:** please use the feat commit's subject (`feat: GUEST_CHAT_ENABLED switch for the anonymous guest trial (#1517)`) as the squash title.

**Suggested follow-up** (not in this PR): decide whether the two auth-surface flags should appear read-only in Admin -> System Configuration's auth tab; today both are env-only by design (install-shape decision, see the GuestChatConfig docblock).
