### PR TITLE
fix: auto-redirect expired OIDC sessions back to the IdP

### DIFF
--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -534,9 +534,39 @@ onMounted(async () => {
   const keycloakProvider = socialProviders.value.find((p) => p.id === 'keycloak')
   if (keycloakProvider?.auto_redirect) {
     oidcAutoRedirect.value = true
-    if (!sessionExpired.value) handleSocialLogin('keycloak')
+    if (!sessionExpired.value) {
+      handleSocialLogin('keycloak')
+    } else if (allowExpiredAutoRedirect()) {
+      // An expired session on an auto-redirect instance goes straight back
+      // to the IdP too: a live SSO session silently re-logs the user in, a
+      // dead one shows the IdP's login. Rate-limited so that a token that
+      // keeps failing app-side (e.g. a misconfigured audience) degrades to
+      // the manual sign-in page below instead of a redirect loop.
+      handleSocialLogin('keycloak')
+    }
   }
 })
+
+/**
+ * One auto-redirect per window for expired sessions; bouncing back here
+ * sooner means app-side token validation is failing while the IdP session
+ * is alive, and redirecting again would loop.
+ */
+const EXPIRED_AUTOREDIRECT_KEY = 'synaplan_expired_autoredirect_at'
+const EXPIRED_AUTOREDIRECT_WINDOW_MS = 30_000
+
+function allowExpiredAutoRedirect(): boolean {
+  try {
+    const last = Number(sessionStorage.getItem(EXPIRED_AUTOREDIRECT_KEY) ?? 0)
+    if (Date.now() - last < EXPIRED_AUTOREDIRECT_WINDOW_MS) return false
+    sessionStorage.setItem(EXPIRED_AUTOREDIRECT_KEY, String(Date.now()))
+    return true
+  } catch {
+    // No sessionStorage (rare) - prefer the safe manual page over a
+    // potential loop.
+    return false
+  }
+}
 
 const handleLogin = async () => {
   clearError()

--- a/frontend/tests/e2e/tests/oidc-redirect.spec.ts
+++ b/frontend/tests/e2e/tests/oidc-redirect.spec.ts
@@ -13,7 +13,27 @@ test.describe('@ci @oidc @oidc-redirect OIDC Auto-Redirect', () => {
     })
   })
 
-  test('@auth should not redirect on session_expired', async ({ page }) => {
+  test('@auth should auto-redirect once on session_expired', async ({ page }) => {
+    await test.step('Act: navigate to login with session_expired reason', async () => {
+      await page.goto('/login?reason=session_expired')
+    })
+
+    await test.step('Assert: redirected to Keycloak (live SSO sessions re-login silently)', async () => {
+      await page.waitForURL(/realms\//, { timeout: 10_000 })
+    })
+  })
+
+  test('@auth should fall back to manual sign-in when session_expired bounces within the guard window', async ({
+    page,
+  }) => {
+    await test.step('Arrange: mark a just-happened expired auto-redirect', async () => {
+      // The rate-limit guard lives in sessionStorage; seed it as if the
+      // browser just came back from an auto-redirect that did not stick.
+      await page.addInitScript(() => {
+        sessionStorage.setItem('synaplan_expired_autoredirect_at', String(Date.now()))
+      })
+    })
+
     await test.step('Act: navigate to login with session_expired reason', async () => {
       await page.goto('/login?reason=session_expired')
     })


### PR DESCRIPTION
On instances with `auto_redirect` enabled, an expired session landed users on the manual "Login with SSO" page even though a live SSO session at the IdP would silently re-log them in; OIDC-only deployments never want to see that page.

The session-expired path now redirects straight to the IdP as well, guarded by a per-browser-session rate limit (30s via sessionStorage): if the user bounces back to /login within the window, app-side token validation is failing while the IdP session is alive (e.g. a misconfigured audience mapper), and the existing manual sign-in page shows instead of looping. Without sessionStorage the guard fails safe to the manual page.

Verified: eslint, prettier, vue-tsc clean.