### PR TITLE
fix(config): container-safe defaults for strictly-bound env vars

### DIFF
--- a/backend/config/services.yaml
+++ b/backend/config/services.yaml
@@ -122,9 +122,35 @@ parameters:
     env(IAP_STORE_PRICE_BUSINESS): '129.99'
     env(WHATSAPP_ACCESS_TOKEN): ''
     env(WHATSAPP_WEBHOOK_VERIFY_TOKEN): ''
+    env(WHATSAPP_ENABLED): 'false'
     env(CLOUDFLARE_ACCOUNT_ID): ''
     env(CLOUDFLARE_API_TOKEN): ''
     env(EMBEDDING_FALLBACK_PROVIDER): ''
+
+    # Container-safe defaults for the remaining strictly-bound env vars.
+    # Compose passes these through .env/env_file, but bare images (Kubernetes,
+    # plain docker run) ship no .env, so a missing var used to crash service
+    # instantiation (e.g. /api/v1/messages/stream 500ing on WHATSAPP_ENABLED).
+    # Values mirror backend/.env.example.
+    env(TIKA_TIMEOUT_MS): '30000'
+    env(TIKA_RETRIES): '2'
+    env(TIKA_RETRY_BACKOFF_MS): '1000'
+    env(TIKA_MIN_LENGTH): '10'
+    env(TIKA_MIN_ENTROPY): '3.0'
+    env(RASTERIZE_DPI): '150'
+    env(RASTERIZE_PAGE_CAP): '10'
+    env(RASTERIZE_TIMEOUT_MS): '30000'
+    env(WHISPER_ENABLED): 'true'
+    env(WHISPER_DEFAULT_MODEL): 'base'
+    env(WHISPER_BINARY): '/usr/local/bin/whisper'
+    env(WHISPER_MODELS_PATH): '%kernel.project_dir%/var/whisper'
+    env(FFMPEG_BINARY): '/usr/bin/ffmpeg'
+    env(BRAVE_SEARCH_ENABLED): 'true'
+    env(BRAVE_SEARCH_API_URL): 'https://api.search.brave.com/res/v1'
+    env(BRAVE_SEARCH_COUNT): '10'
+    env(BRAVE_SEARCH_COUNTRY): 'us'
+    env(BRAVE_SEARCH_SEARCH_LANG): 'en'
+    env(STRIPE_AUTOMATIC_TAX): 'false'
 
     # Piper TTS Service default (localhost for native; Docker Compose overrides via env)
     env(SYNAPLAN_TTS_URL): ''


### PR DESCRIPTION
## Problem

Bare images (Kubernetes via synaplan-charts, plain `docker run`) ship no `backend/.env`, so every `%env()%` binding without a parameter default crashes service instantiation as soon as the service is needed. Concretely: every chat message fails with **HTTP 500** because `WhatsAppService` strictly binds `WHATSAPP_ENABLED`:

```
Uncaught PHP Exception InvalidArgumentException: "The controller for URI \"/api/v1/messages/stream\" is not callable: Environment variable not found: \"WHATSAPP_ENABLED\"."
```

docker-compose deployments never see this because compose passes the vars through (`WHATSAPP_ENABLED: ${WHATSAPP_ENABLED:-false}`) and loads `backend/.env` via `env_file`.

## Fix

Add `env()` parameter defaults in `services.yaml` (the repo already does this for ~69 other vars) for the 20 strictly-bound vars that had none, values mirroring `backend/.env.example`:

- `WHATSAPP_ENABLED` (false)
- `TIKA_TIMEOUT_MS` / `TIKA_RETRIES` / `TIKA_RETRY_BACKOFF_MS` / `TIKA_MIN_LENGTH` / `TIKA_MIN_ENTROPY`
- `RASTERIZE_DPI` / `RASTERIZE_PAGE_CAP` / `RASTERIZE_TIMEOUT_MS`
- `WHISPER_ENABLED` / `WHISPER_DEFAULT_MODEL` / `WHISPER_BINARY` / `WHISPER_MODELS_PATH`
- `FFMPEG_BINARY`
- `BRAVE_SEARCH_ENABLED` / `BRAVE_SEARCH_API_URL` / `BRAVE_SEARCH_COUNT` / `BRAVE_SEARCH_COUNTRY` / `BRAVE_SEARCH_SEARCH_LANG`
- `STRIPE_AUTOMATIC_TAX`

`DATABASE_READ_URL` / `DATABASE_WRITE_URL` intentionally stay strict (fail fast without a database).

Audit method: diffed all `%env()%` bindings in `backend/config` + `backend/src` (excluding `default::`-processed ones) against existing `env()` parameter defaults; the listed 20 plus the two database URLs were the only strict leftovers.

`lint:container` passes with the change.
