### PR TITLE
fix(frontend): address Copilot review feedback on #1521

### DIFF
--- a/frontend/src/components/MessageJson.vue
+++ b/frontend/src/components/MessageJson.vue
@@ -164,10 +164,14 @@ const headerTitle = computed(() => {
 
 const headerSubtitle = computed(() => {
   const list = recordList.value
-  if (!list || list.total === null || list.total === list.records.length) {
+  if (!list || list.total === null) {
     return ''
   }
-  return t('message.jsonViewer.shownOf', { shown: list.records.length, total: list.total })
+  const shown = visibleRecords.value.length
+  if (shown === list.total) {
+    return ''
+  }
+  return t('message.jsonViewer.shownOf', { shown, total: list.total })
 })
 
 const copyJson = async () => {

--- a/frontend/src/components/setup/ProviderSetupBanner.vue
+++ b/frontend/src/components/setup/ProviderSetupBanner.vue
@@ -3,7 +3,6 @@
     v-if="visible"
     class="flex-1 min-h-0 flex flex-col items-center justify-center px-6 py-12"
     data-testid="provider-setup-tombstone"
-    role="status"
   >
     <div class="w-full max-w-lg text-center">
       <div

--- a/frontend/src/views/SharedChatView.vue
+++ b/frontend/src/views/SharedChatView.vue
@@ -202,13 +202,14 @@
                   {{ formatDate(message.timestamp) }}
                 </span>
               </div>
-              <!-- Message parts (text, code blocks) -->
+              <!-- Message parts (text, code blocks, JSON payloads) -->
               <template v-for="(part, partIndex) in parseMessageParts(message)" :key="partIndex">
                 <MessageCode
                   v-if="part.type === 'code'"
                   :content="part.content"
                   :language="part.language"
                 />
+                <MessageJson v-else-if="part.type === 'json'" :content="part.content" />
                 <MessageText
                   v-else-if="part.type === 'text'"
                   :content="part.content"
@@ -359,6 +360,7 @@ import MessageImage from '../components/MessageImage.vue'
 import MessageVideo from '../components/MessageVideo.vue'
 import MessageAudio from '../components/MessageAudio.vue'
 import MessageCode from '../components/MessageCode.vue'
+import MessageJson from '../components/MessageJson.vue'
 import MessageText from '../components/MessageText.vue'
 import BrandAttribution from '../components/BrandAttribution.vue'
 import {
@@ -651,13 +653,13 @@ const formatDate = (timestamp: number): string => {
 }
 
 interface MessagePart {
-  type: 'text' | 'code'
+  type: 'text' | 'code' | 'json'
   content: string
   language?: string
 }
 
 /**
- * Parse message text into parts (text and code blocks).
+ * Parse message text into parts (text, code blocks, JSON payloads).
  * Uses the same parser as the main chat for consistent rendering.
  */
 const parseMessageParts = (message: Message): MessagePart[] => {
@@ -671,9 +673,9 @@ const parseMessageParts = (message: Message): MessagePart[] => {
   // For assistant messages, parse into parts
   const parsed = parseAIResponse(message.text)
   return parsed.parts
-    .filter((part) => part.type === 'text' || part.type === 'code')
+    .filter((part) => part.type === 'text' || part.type === 'code' || part.type === 'json')
     .map((part) => ({
-      type: part.type as 'text' | 'code',
+      type: part.type as 'text' | 'code' | 'json',
       content: part.content,
       language: part.language,
     }))

--- a/frontend/tests/unit/MessageJson.spec.ts
+++ b/frontend/tests/unit/MessageJson.spec.ts
@@ -50,6 +50,22 @@ describe('MessageJson', () => {
     expect(wrapper.find('[data-testid="json-truncated-hint"]').exists()).toBe(true)
   })
 
+  it('reports only the visible rows in the "Showing X of Y" subtitle', async () => {
+    const records = Array.from({ length: 25 }, (_, i) => ({ id: i + 1, title: `Chat ${i + 1}` }))
+    const wrapper = mount(MessageJson, {
+      props: { content: JSON.stringify({ total: 30, chats: records }) },
+    })
+
+    // 20 of the 25 recovered records are rendered initially
+    expect(wrapper.findAll('[data-testid="json-record-row"]')).toHaveLength(20)
+    expect(wrapper.text()).toContain('Showing 20 of 30')
+
+    await wrapper.get('[data-testid="btn-json-show-more"]').trigger('click')
+
+    expect(wrapper.findAll('[data-testid="json-record-row"]')).toHaveLength(25)
+    expect(wrapper.text()).toContain('Showing 25 of 30')
+  })
+
   it('copies pretty JSON', async () => {
     const writeText = vi.fn().mockResolvedValue(undefined)
     Object.defineProperty(navigator, 'clipboard', {


### PR DESCRIPTION
## Summary

Follow-up to #1521, fixing the three valid points from the Copilot review:

- **Shared chats dropped JSON-only messages**: `SharedChatView.vue` filtered parsed parts down to `text`/`code`, so an assistant message that is a whole-message JSON payload rendered as an empty bubble. It now renders `json` parts with the `MessageJson` viewer, same as the main chat.
- **Misleading "Showing X of Y" subtitle**: `MessageJson.vue` reported all recovered records as "shown" even though only the first 20 rows are rendered before "Show more". The subtitle now reflects the rows actually visible and updates when the list is expanded.
- **`role="status"` on a static region**: removed from the no-provider tombstone in `ProviderSetupBanner.vue` — it marked static content as a live region, which is an accessibility anti-pattern.

## Test plan

- [x] `make -C frontend lint`
- [x] `docker compose exec -T frontend npm run check:types`
- [x] `make -C frontend test` (145 files, 1232 tests, all green; includes a new regression test for the subtitle/show-more behavior)
- [ ] Open a shared chat containing a JSON-only assistant message and confirm it renders in the JSON viewer