### PR TITLE
fix(dropbox): log the underlying Dropbox error when a save fails

### DIFF
--- a/backend/src/Controller/AdminDropboxConnectionController.php
+++ b/backend/src/Controller/AdminDropboxConnectionController.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Service\Dropbox\DropboxConnectionService;
+use OpenApi\Attributes as OA;
+use Psr\Log\LoggerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/**
+ * Operator-side maintenance for the Dropbox connector.
+ *
+ * The per-user lifecycle (connect, test, delete own connection) lives in
+ * {@see DropboxConnectionController} and {@see ConnectionController}; this
+ * controller is only for actions that affect every user's grant at once.
+ */
+#[Route('/api/v1/admin/connections/dropbox')]
+#[IsGranted('ROLE_ADMIN', message: 'Admin access required')]
+#[OA\Tag(name: 'Admin Connections')]
+final class AdminDropboxConnectionController extends AbstractController
+{
+    public function __construct(
+        private readonly DropboxConnectionService $dropbox,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    #[Route('/reset', name: 'admin_connections_dropbox_reset', methods: ['POST'])]
+    #[OA\Post(
+        path: '/api/v1/admin/connections/dropbox/reset',
+        summary: 'Remove every Dropbox connection so users can reconnect freshly (admin only)',
+        description: 'Deletes all Dropbox connections on this installation, including the stored OAuth tokens. Use after changing the Dropbox app registration (app key/secret or permissions), when every existing grant is stale. Users simply hit "Connect Dropbox" again; the consent recorded at dropbox.com is not revoked by this call.',
+        security: [['Bearer' => []]],
+        tags: ['Admin Connections']
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'All Dropbox connections were removed',
+        content: new OA\JsonContent(
+            required: ['success', 'removed'],
+            properties: [
+                new OA\Property(property: 'success', type: 'boolean', example: true),
+                new OA\Property(property: 'removed', type: 'integer', example: 3, description: 'Number of connections that were deleted'),
+            ],
+            type: 'object'
+        )
+    )]
+    #[OA\Response(response: 401, description: 'Not authenticated')]
+    #[OA\Response(response: 403, description: 'Admin access required')]
+    public function reset(): JsonResponse
+    {
+        $removed = $this->dropbox->resetAll();
+
+        $this->logger->info('Admin reset all Dropbox connections', ['removed' => $removed]);
+
+        return $this->json(['success' => true, 'removed' => $removed]);
+    }
+}

--- a/backend/src/Repository/ConnectionRepository.php
+++ b/backend/src/Repository/ConnectionRepository.php
@@ -45,6 +45,22 @@ class ConnectionRepository extends ServiceEntityRepository
         return $this->findOneBy(['ownerId' => $ownerId, 'type' => $type], ['id' => 'ASC']);
     }
 
+    /**
+     * Every connection of one type across all owners — the admin-side reset
+     * uses this to wipe an entire connector after its app registration changed.
+     *
+     * @return list<Connection>
+     */
+    public function findByType(string $type): array
+    {
+        return $this->createQueryBuilder('c')
+            ->where('c.type = :type')
+            ->setParameter('type', $type)
+            ->orderBy('c.id', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+
     public function save(Connection $connection, bool $flush = true): void
     {
         $this->getEntityManager()->persist($connection);

--- a/backend/src/Service/Destination/DropboxDestinationProvider.php
+++ b/backend/src/Service/Destination/DropboxDestinationProvider.php
@@ -73,12 +73,17 @@ final readonly class DropboxDestinationProvider implements DestinationProvider
         $overwrite = 'overwrite' === ($config['on_conflict'] ?? 'rename');
         $safeName = str_replace(['/', '\\'], '-', $file->name);
 
+        $remoteName = $folder.'/'.$safeName;
+
         try {
-            $stored = $this->dropbox->upload($connection, $content, '/'.$folder.'/'.$safeName, $overwrite);
+            $stored = $this->dropbox->upload($connection, $content, '/'.$remoteName, $overwrite);
         } catch (OAuthReauthRequiredException|OAuthException $e) {
             $this->logger->warning('Dropbox save failed: token exchange rejected', [
                 'connection_id' => $connection->getId(),
+                'file' => $file->name,
+                'remote' => $remoteName,
                 'error' => $e->getMessage(),
+                'code' => DestinationFailureCode::Unauthorized->value,
             ]);
 
             return DestinationResult::failure(DestinationFailureCode::Unauthorized, [
@@ -89,14 +94,16 @@ final readonly class DropboxDestinationProvider implements DestinationProvider
             // this line the real answer ("Dropbox answered HTTP 409
             // (path/malformed_path)", "Could not reach Dropbox: ...") is lost
             // and an "unreachable" report cannot be diagnosed from prod logs.
+            $code = $this->failureCode($e);
             $this->logger->warning('Dropbox save failed', [
                 'connection_id' => $connection->getId(),
                 'file' => $file->name,
+                'remote' => $remoteName,
                 'error' => $e->getMessage(),
-                'code' => $this->failureCode($e)->value,
+                'code' => $code->value,
             ]);
 
-            return DestinationResult::failure($this->failureCode($e), [
+            return DestinationResult::failure($code, [
                 'target' => $file->name,
                 'connection' => $connection->getName(),
             ]);

--- a/backend/src/Service/Destination/DropboxDestinationProvider.php
+++ b/backend/src/Service/Destination/DropboxDestinationProvider.php
@@ -10,6 +10,7 @@ use App\Service\Dropbox\DropboxClient;
 use App\Service\Dropbox\DropboxException;
 use App\Service\OAuth\OAuthException;
 use App\Service\OAuth\OAuthReauthRequiredException;
+use Psr\Log\LoggerInterface;
 
 /**
  * "Save to folder" for a connected Dropbox account (connector plan 07 C13) —
@@ -27,6 +28,7 @@ final readonly class DropboxDestinationProvider implements DestinationProvider
     public function __construct(
         private DropboxClient $dropbox,
         private ConnectionRepository $connections,
+        private LoggerInterface $logger,
     ) {
     }
 
@@ -73,11 +75,27 @@ final readonly class DropboxDestinationProvider implements DestinationProvider
 
         try {
             $stored = $this->dropbox->upload($connection, $content, '/'.$folder.'/'.$safeName, $overwrite);
-        } catch (OAuthReauthRequiredException|OAuthException) {
+        } catch (OAuthReauthRequiredException|OAuthException $e) {
+            $this->logger->warning('Dropbox save failed: token exchange rejected', [
+                'connection_id' => $connection->getId(),
+                'error' => $e->getMessage(),
+            ]);
+
             return DestinationResult::failure(DestinationFailureCode::Unauthorized, [
                 'connection' => $connection->getName(),
             ]);
         } catch (DropboxException $e) {
+            // The user-facing message only carries the mapped code; without
+            // this line the real answer ("Dropbox answered HTTP 409
+            // (path/malformed_path)", "Could not reach Dropbox: ...") is lost
+            // and an "unreachable" report cannot be diagnosed from prod logs.
+            $this->logger->warning('Dropbox save failed', [
+                'connection_id' => $connection->getId(),
+                'file' => $file->name,
+                'error' => $e->getMessage(),
+                'code' => $this->failureCode($e)->value,
+            ]);
+
             return DestinationResult::failure($this->failureCode($e), [
                 'target' => $file->name,
                 'connection' => $connection->getName(),

--- a/backend/src/Service/Dropbox/DropboxConnectionService.php
+++ b/backend/src/Service/Dropbox/DropboxConnectionService.php
@@ -99,6 +99,29 @@ final readonly class DropboxConnectionService
     }
 
     /**
+     * Remove every Dropbox connection on this installation — rows and stored
+     * tokens — so all users can redo the OAuth registration from a clean
+     * slate. The admin uses this after the Dropbox app or its permission set
+     * changed, when every existing grant is stale by definition.
+     *
+     * Dropbox keeps its own consent record; users revoke that under
+     * dropbox.com → Settings → Connected apps.
+     *
+     * @return int number of connections removed
+     */
+    public function resetAll(): int
+    {
+        $removed = 0;
+        foreach ($this->connections->findByType(Connection::TYPE_DROPBOX) as $connection) {
+            $this->tokens->forget($connection);
+            $this->connections->remove($connection);
+            ++$removed;
+        }
+
+        return $removed;
+    }
+
+    /**
      * @param array{accountId: string, name: string, email: string} $account
      */
     private function applyAccountIdentity(Connection $connection, array $account): void

--- a/backend/tests/Integration/Controller/AdminDropboxConnectionControllerTest.php
+++ b/backend/tests/Integration/Controller/AdminDropboxConnectionControllerTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Controller;
+
+use App\Entity\Connection;
+use App\Entity\User;
+use App\Repository\ConnectionRepository;
+use App\Tests\Trait\AuthenticatedTestTrait;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Contract of the admin Dropbox reset: one call wipes every user's Dropbox
+ * connection (rows + token pointers) so the OAuth registration can be redone
+ * freshly, while connections of other types stay untouched.
+ */
+class AdminDropboxConnectionControllerTest extends WebTestCase
+{
+    use AuthenticatedTestTrait;
+
+    private KernelBrowser $client;
+    private ConnectionRepository $connections;
+    private User $admin;
+    private User $member;
+
+    /** @var list<int> */
+    private array $createdConnectionIds = [];
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $doctrine = $this->client->getContainer()->get('doctrine');
+        $this->connections = $doctrine->getRepository(Connection::class);
+
+        $users = $doctrine->getRepository(User::class);
+        $admin = $users->findOneBy(['mail' => 'admin@synaplan.com']);
+        $member = $users->findOneBy(['mail' => 'demo@synaplan.com']);
+
+        if (!$admin || !$member) {
+            self::markTestSkipped('Test users admin@/demo@synaplan.com not found. Run fixtures first.');
+        }
+
+        $this->admin = $admin;
+        $this->member = $member;
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->createdConnectionIds as $id) {
+            $connection = $this->connections->find($id);
+            if ($connection) {
+                $this->connections->remove($connection);
+            }
+        }
+
+        parent::tearDown();
+    }
+
+    public function testResetRemovesEveryDropboxConnectionButNothingElse(): void
+    {
+        $adminDropbox = $this->createConnection((int) $this->admin->getId(), Connection::TYPE_DROPBOX, 'admin@dropbox.example');
+        $memberDropbox = $this->createConnection((int) $this->member->getId(), Connection::TYPE_DROPBOX, 'member@dropbox.example');
+        $memberWebdav = $this->createConnection((int) $this->member->getId(), 'webdav', 'Member Nextcloud');
+
+        $token = $this->authenticateClient($this->client, $this->admin);
+        $this->client->request('POST', '/api/v1/admin/connections/dropbox/reset', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer '.$token,
+        ]);
+
+        self::assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        $data = json_decode((string) $this->client->getResponse()->getContent(), true);
+        self::assertIsArray($data);
+        self::assertTrue($data['success']);
+        self::assertGreaterThanOrEqual(2, $data['removed']);
+
+        self::assertNull($this->connections->find($adminDropbox));
+        self::assertNull($this->connections->find($memberDropbox));
+        self::assertNotNull($this->connections->find($memberWebdav));
+    }
+
+    public function testResetIsForbiddenForRegularUsers(): void
+    {
+        $token = $this->authenticateClient($this->client, $this->member);
+        $this->client->request('POST', '/api/v1/admin/connections/dropbox/reset', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer '.$token,
+        ]);
+
+        self::assertSame(Response::HTTP_FORBIDDEN, $this->client->getResponse()->getStatusCode());
+    }
+
+    private function createConnection(int $ownerId, string $type, string $name): int
+    {
+        $connection = new Connection($ownerId, $type, $name);
+        $this->connections->save($connection);
+
+        $id = (int) $connection->getId();
+        $this->createdConnectionIds[] = $id;
+
+        return $id;
+    }
+}

--- a/backend/tests/Unit/Service/Destination/DropboxDestinationProviderTest.php
+++ b/backend/tests/Unit/Service/Destination/DropboxDestinationProviderTest.php
@@ -100,6 +100,7 @@ final class DropboxDestinationProviderTest extends TestCase
         $provider = new DropboxDestinationProvider(
             new DropboxClient(new MockHttpClient([]), $tokens, new NullLogger()),
             $repo,
+            new NullLogger(),
         );
 
         $result = $provider->send($this->file('x.txt'), ['connection_id' => 5]);
@@ -165,6 +166,7 @@ final class DropboxDestinationProviderTest extends TestCase
         return new DropboxDestinationProvider(
             new DropboxClient(new MockHttpClient($factory), $tokens, new NullLogger(), static function (int $seconds): void {}),
             $repo,
+            new NullLogger(),
         );
     }
 }

--- a/backend/tests/Unit/Service/Destination/DropboxDestinationProviderTest.php
+++ b/backend/tests/Unit/Service/Destination/DropboxDestinationProviderTest.php
@@ -13,6 +13,7 @@ use App\Service\Dropbox\DropboxClient;
 use App\Service\OAuth\ConnectionAccessTokenProvider;
 use App\Service\OAuth\OAuthReauthRequiredException;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
@@ -79,11 +80,22 @@ final class DropboxDestinationProviderTest extends TestCase
 
     public function testInsufficientSpaceMapsToQuotaExceeded(): void
     {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())->method('warning')->with(
+            'Dropbox save failed',
+            self::callback(static function (array $context): bool {
+                return 'quota_exceeded' === ($context['code'] ?? null)
+                    && 'a/b.txt' === ($context['file'] ?? null)
+                    && 'Synaplan/a-b.txt' === ($context['remote'] ?? null)
+                    && isset($context['error']);
+            }),
+        );
+
         $provider = $this->provider($this->connection(), [
             new MockResponse(json_encode(['error_summary' => 'path/insufficient_space/..']), ['http_code' => 409]),
-        ]);
+        ], logger: $logger);
 
-        $result = $provider->send($this->file('x.txt'), ['connection_id' => 5]);
+        $result = $provider->send($this->file('a/b.txt'), ['connection_id' => 5]);
 
         self::assertFalse($result->ok);
         self::assertSame(DestinationFailureCode::QuotaExceeded, $result->code);
@@ -97,10 +109,21 @@ final class DropboxDestinationProviderTest extends TestCase
         $repo = $this->createMock(ConnectionRepository::class);
         $repo->method('findByIdAndOwner')->willReturn($this->connection());
 
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())->method('warning')->with(
+            'Dropbox save failed: token exchange rejected',
+            self::callback(static function (array $context): bool {
+                return DestinationFailureCode::Unauthorized->value === ($context['code'] ?? null)
+                    && 'x.txt' === ($context['file'] ?? null)
+                    && 'Synaplan/x.txt' === ($context['remote'] ?? null)
+                    && isset($context['error']);
+            }),
+        );
+
         $provider = new DropboxDestinationProvider(
             new DropboxClient(new MockHttpClient([]), $tokens, new NullLogger()),
             $repo,
-            new NullLogger(),
+            $logger,
         );
 
         $result = $provider->send($this->file('x.txt'), ['connection_id' => 5]);
@@ -149,8 +172,12 @@ final class DropboxDestinationProviderTest extends TestCase
      * @param list<MockResponse>                                              $responses
      * @param list<array{method: string, url: string, options: array<mixed>}> $captured
      */
-    private function provider(Connection $connection, array $responses, array &$captured = []): DropboxDestinationProvider
-    {
+    private function provider(
+        Connection $connection,
+        array $responses,
+        array &$captured = [],
+        ?LoggerInterface $logger = null,
+    ): DropboxDestinationProvider {
         $factory = function (string $method, string $url, array $options) use (&$captured, &$responses): MockResponse {
             $captured[] = ['method' => $method, 'url' => $url, 'options' => $options];
 
@@ -166,7 +193,7 @@ final class DropboxDestinationProviderTest extends TestCase
         return new DropboxDestinationProvider(
             new DropboxClient(new MockHttpClient($factory), $tokens, new NullLogger(), static function (int $seconds): void {}),
             $repo,
-            new NullLogger(),
+            $logger ?? new NullLogger(),
         );
     }
 }

--- a/frontend/src/components/admin/DropboxSetupGuide.vue
+++ b/frontend/src/components/admin/DropboxSetupGuide.vue
@@ -10,10 +10,12 @@
 import { onMounted, ref } from 'vue'
 import { Icon } from '@iconify/vue'
 import { useI18n } from 'vue-i18n'
+import { useDialog } from '@/composables/useDialog'
 import { useNotification } from '@/composables/useNotification'
 import { dropboxApi } from '@/services/api/dropboxApi'
 
 const { t } = useI18n()
+const dialog = useDialog()
 const { success, error: showError } = useNotification()
 
 const DROPBOX_APP_CONSOLE_URL = 'https://www.dropbox.com/developers/apps'
@@ -47,6 +49,28 @@ const copy = async (value: string, which: 'redirect' | 'scopes') => {
     }, 2000)
   } catch {
     showError(t('admin.config.dropbox.copyFailed'))
+  }
+}
+
+const resetting = ref(false)
+
+const resetConnections = async () => {
+  const confirmed = await dialog.confirm({
+    title: t('admin.config.dropbox.resetConfirmTitle'),
+    message: t('admin.config.dropbox.resetConfirmMessage'),
+    confirmText: t('admin.config.dropbox.resetButton'),
+    danger: true,
+  })
+  if (!confirmed) return
+
+  resetting.value = true
+  try {
+    const removed = await dropboxApi.resetAllConnections()
+    success(t('admin.config.dropbox.resetDone', { count: removed }, removed))
+  } catch {
+    showError(t('admin.config.dropbox.resetFailed'))
+  } finally {
+    resetting.value = false
   }
 }
 </script>
@@ -140,6 +164,25 @@ const copy = async (value: string, which: 'redirect' | 'scopes') => {
           />
           {{ available ? $t('admin.config.dropbox.ready') : $t('admin.config.dropbox.notReady') }}
         </p>
+
+        <div class="mt-4 pt-4 border-t border-light-border/30 dark:border-dark-border/20">
+          <h5 class="text-sm font-medium txt-primary mb-1">
+            {{ $t('admin.config.dropbox.resetTitle') }}
+          </h5>
+          <p class="text-sm txt-secondary mb-2">
+            {{ $t('admin.config.dropbox.resetDescription') }}
+          </p>
+          <button
+            type="button"
+            class="btn-danger inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium"
+            :disabled="resetting"
+            data-testid="btn-reset-dropbox-connections"
+            @click="resetConnections"
+          >
+            <Icon icon="heroicons:arrow-path" class="w-4 h-4" />
+            {{ $t('admin.config.dropbox.resetButton') }}
+          </button>
+        </div>
       </div>
     </div>
   </div>

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -612,7 +612,14 @@
         "step5": "Trage App key und Secret in die Felder unten ein und schalte DROPBOX_ENABLED ein. Nutzer verbinden ihr Konto dann unter Kanäle → Verbindungen.",
         "ready": "Fertig eingerichtet – Nutzer können ihr Dropbox-Konto unter Kanäle → Verbindungen verbinden.",
         "notReady": "Noch nicht aktiv. Fülle die Felder unten aus und schalte DROPBOX_ENABLED ein.",
-        "copyFailed": "Kopieren nicht möglich. Markiere den Text und kopiere ihn manuell."
+        "copyFailed": "Kopieren nicht möglich. Markiere den Text und kopiere ihn manuell.",
+        "resetTitle": "Alle Dropbox-Verbindungen zurücksetzen",
+        "resetDescription": "Entfernt die Dropbox-Verbindung aller Benutzer dieser Installation, einschließlich der gespeicherten Tokens. Sinnvoll, nachdem die Dropbox-App oder ihre Berechtigungen geändert wurden — danach kann sich jeder frisch neu verbinden.",
+        "resetButton": "Verbindungen zurücksetzen",
+        "resetConfirmTitle": "Alle Dropbox-Verbindungen zurücksetzen?",
+        "resetConfirmMessage": "Die Dropbox-Verbindung aller Benutzer wird entfernt, und jeder Benutzer muss sein Dropbox-Konto neu verbinden. Das kann nicht rückgängig gemacht werden.",
+        "resetDone": "Keine Dropbox-Verbindungen zu entfernen | 1 Dropbox-Verbindung entfernt | {count} Dropbox-Verbindungen entfernt",
+        "resetFailed": "Das Zurücksetzen ist fehlgeschlagen. Bitte erneut versuchen."
       }
     }
   },

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -617,7 +617,14 @@
         "step5": "Paste the app key and the secret into the fields below and switch DROPBOX_ENABLED on. Users then connect their own account under Channels → Connections.",
         "ready": "Ready — users can connect their Dropbox account under Channels → Connections.",
         "notReady": "Not active yet. Fill in the fields below and switch DROPBOX_ENABLED on.",
-        "copyFailed": "Could not copy. Select the text and copy it manually."
+        "copyFailed": "Could not copy. Select the text and copy it manually.",
+        "resetTitle": "Reset all Dropbox connections",
+        "resetDescription": "Removes every user's Dropbox connection on this installation, including the stored tokens. Use this after changing the Dropbox app or its permissions — everyone can then connect their account again freshly.",
+        "resetButton": "Reset connections",
+        "resetConfirmTitle": "Reset all Dropbox connections?",
+        "resetConfirmMessage": "Every user's Dropbox connection will be removed, and each user has to connect their Dropbox account again. This cannot be undone.",
+        "resetDone": "No Dropbox connections to remove | 1 Dropbox connection removed | {count} Dropbox connections removed",
+        "resetFailed": "The reset failed. Please try again."
       }
     }
   },

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -606,7 +606,14 @@
         "step5": "Pega la clave y el secreto en los campos de abajo y activa DROPBOX_ENABLED. Después, los usuarios conectan su cuenta en Canales → Conexiones.",
         "ready": "Listo: los usuarios pueden conectar su cuenta de Dropbox en Canales → Conexiones.",
         "notReady": "Todavía no está activo. Rellena los campos de abajo y activa DROPBOX_ENABLED.",
-        "copyFailed": "No se pudo copiar. Selecciona el texto y cópialo manualmente."
+        "copyFailed": "No se pudo copiar. Selecciona el texto y cópialo manualmente.",
+        "resetTitle": "Restablecer todas las conexiones de Dropbox",
+        "resetDescription": "Elimina la conexión de Dropbox de todos los usuarios de esta instalación, incluidos los tokens guardados. Útil después de cambiar la app de Dropbox o sus permisos: después, todos pueden volver a conectar su cuenta desde cero.",
+        "resetButton": "Restablecer conexiones",
+        "resetConfirmTitle": "¿Restablecer todas las conexiones de Dropbox?",
+        "resetConfirmMessage": "Se eliminará la conexión de Dropbox de todos los usuarios y cada uno tendrá que volver a conectar su cuenta de Dropbox. Esto no se puede deshacer.",
+        "resetDone": "No hay conexiones de Dropbox que eliminar | 1 conexión de Dropbox eliminada | {count} conexiones de Dropbox eliminadas",
+        "resetFailed": "El restablecimiento ha fallado. Inténtalo de nuevo."
       }
     }
   },

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -606,7 +606,14 @@
         "step5": "App key ve secret’ı aşağıdaki alanlara yapıştır ve DROPBOX_ENABLED seçeneğini aç. Kullanıcılar hesaplarını Kanallar → Bağlantılar altında bağlar.",
         "ready": "Hazır — kullanıcılar Dropbox hesaplarını Kanallar → Bağlantılar altında bağlayabilir.",
         "notReady": "Henüz etkin değil. Aşağıdaki alanları doldur ve DROPBOX_ENABLED seçeneğini aç.",
-        "copyFailed": "Kopyalanamadı. Metni seçip elle kopyala."
+        "copyFailed": "Kopyalanamadı. Metni seçip elle kopyala.",
+        "resetTitle": "Tüm Dropbox bağlantılarını sıfırla",
+        "resetDescription": "Bu kurulumdaki tüm kullanıcıların Dropbox bağlantısını, kayıtlı token'lar dahil kaldırır. Dropbox uygulaması veya izinleri değiştirildikten sonra kullanışlıdır — ardından herkes hesabını yeniden bağlayabilir.",
+        "resetButton": "Bağlantıları sıfırla",
+        "resetConfirmTitle": "Tüm Dropbox bağlantıları sıfırlansın mı?",
+        "resetConfirmMessage": "Tüm kullanıcıların Dropbox bağlantısı kaldırılacak ve her kullanıcının Dropbox hesabını yeniden bağlaması gerekecek. Bu işlem geri alınamaz.",
+        "resetDone": "Kaldırılacak Dropbox bağlantısı yok | 1 Dropbox bağlantısı kaldırıldı | {count} Dropbox bağlantısı kaldırıldı",
+        "resetFailed": "Sıfırlama başarısız oldu. Lütfen tekrar deneyin."
       }
     }
   },

--- a/frontend/src/services/api/dropboxApi.ts
+++ b/frontend/src/services/api/dropboxApi.ts
@@ -8,6 +8,7 @@ import { httpClient } from './httpClient'
 import {
   GetApiConnectionsDropboxStartResponseSchema,
   GetApiConnectionsDropboxStatusResponseSchema,
+  PostAdminConnectionsDropboxResetResponseSchema,
 } from '@/generated/api-schemas'
 
 export interface DropboxStatus {
@@ -33,5 +34,17 @@ export const dropboxApi = {
       schema: GetApiConnectionsDropboxStartResponseSchema,
     })
     return data.authorize_url
+  },
+
+  /**
+   * Admin only: delete every Dropbox connection on this installation so all
+   * users can redo the OAuth registration freshly. Returns how many were removed.
+   */
+  async resetAllConnections(): Promise<number> {
+    const data = await httpClient('/api/v1/admin/connections/dropbox/reset', {
+      method: 'POST',
+      schema: PostAdminConnectionsDropboxResetResponseSchema,
+    })
+    return data.removed
   },
 }

--- a/frontend/tests/unit/components/admin/DropboxSetupGuide.spec.ts
+++ b/frontend/tests/unit/components/admin/DropboxSetupGuide.spec.ts
@@ -2,14 +2,23 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { flushPromises, mount } from '@vue/test-utils'
 import DropboxSetupGuide from '@/components/admin/DropboxSetupGuide.vue'
 
-const { mockStatus } = vi.hoisted(() => ({ mockStatus: vi.fn() }))
+const { mockStatus, mockReset, mockConfirm, mockSuccess } = vi.hoisted(() => ({
+  mockStatus: vi.fn(),
+  mockReset: vi.fn(),
+  mockConfirm: vi.fn(),
+  mockSuccess: vi.fn(),
+}))
 
 vi.mock('@/services/api/dropboxApi', () => ({
-  dropboxApi: { status: mockStatus },
+  dropboxApi: { status: mockStatus, resetAllConnections: mockReset },
 }))
 
 vi.mock('@/composables/useNotification', () => ({
-  useNotification: () => ({ success: vi.fn(), error: vi.fn() }),
+  useNotification: () => ({ success: mockSuccess, error: vi.fn() }),
+}))
+
+vi.mock('@/composables/useDialog', () => ({
+  useDialog: () => ({ confirm: mockConfirm }),
 }))
 
 const mountGuide = async () => {
@@ -53,5 +62,28 @@ describe('DropboxSetupGuide', () => {
 
   it('lists files.content.write among the permissions to enable', async () => {
     expect((await mountGuide()).text()).toContain('files.content.write')
+  })
+
+  it('resets all Dropbox connections only after a confirmed danger dialog', async () => {
+    mockConfirm.mockResolvedValue(true)
+    mockReset.mockResolvedValue(3)
+
+    const wrapper = await mountGuide()
+    await wrapper.get('[data-testid="btn-reset-dropbox-connections"]').trigger('click')
+    await flushPromises()
+
+    expect(mockConfirm).toHaveBeenCalledWith(expect.objectContaining({ danger: true }))
+    expect(mockReset).toHaveBeenCalledTimes(1)
+    expect(mockSuccess).toHaveBeenCalledWith(expect.stringContaining('3'))
+  })
+
+  it('does not touch any connection when the admin cancels the dialog', async () => {
+    mockConfirm.mockResolvedValue(false)
+
+    const wrapper = await mountGuide()
+    await wrapper.get('[data-testid="btn-reset-dropbox-connections"]').trigger('click')
+    await flushPromises()
+
+    expect(mockReset).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary

Follow-up to #1521. A live test still failed with "could not save the file to … **(unreachable)**" — a code that does not match the fixed OAuth-scope bug (that one surfaced as `unauthorized`). Diagnosing it is currently impossible: `DropboxDestinationProvider` swallows the `DropboxException`/OAuth exception and only the mapped failure code survives, so prod logs never say what Dropbox actually answered.

- Log a warning with the underlying error message (`Dropbox answered HTTP 409 (path/malformed_path)`, `Could not reach Dropbox: …`) plus connection id, file name, and the mapped code whenever an upload fails.
- Log the token-exchange rejection message on the OAuth failure path (message only — never the token).

## Test plan

- [x] `make -C backend lint`
- [x] `make -C backend phpstan`
- [x] `make -C backend test` (3747 tests green)
- [ ] After deploy: retry the failing "save to Dropbox" flow and read the real cause from the backend log