### PR TITLE
feat(frontend): document how to delete individual data

### DIFF
--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -1048,6 +1048,31 @@
       "API-Schlüssel, Widgets und Zugangsdaten"
     ],
     "retention": "Die Löschung ist endgültig und wirkt sofort. Backups mit verbliebenen Daten werden innerhalb von 30 Tagen rotiert. Gesetzlich aufbewahrungspflichtige Daten (z. B. Rechnungen) werden nur so lange aufbewahrt, wie es das Gesetz verlangt.",
+    "partialTitle": "Einzelne Daten löschen, ohne das Konto aufzugeben",
+    "partialIntro": "Du musst nicht dein ganzes Konto löschen, um Daten zu entfernen. Angemeldet kannst du Folgendes jederzeit selbst löschen – es wirkt sofort.",
+    "partialItems": [
+      {
+        "name": "Chats und Unterhaltungen",
+        "how": "Öffne den Verlauf, nutze das ⋯-Menü neben einer Unterhaltung und wähle Löschen. Mehrere auf einmal entfernst du unter Statistiken → Alle Chats: auswählen und „Ausgewählte löschen“."
+      },
+      {
+        "name": "Hochgeladene Dateien und Dokumente",
+        "how": "Öffne Quellen → Durchsuchen und nutze das Papierkorb-Symbol an einer Datei, oder wähle mehrere aus und lösche die Auswahl. Beim Löschen eines Ordners werden die enthaltenen Dateien mitgelöscht."
+      },
+      {
+        "name": "KI-generierte Bilder und Medien",
+        "how": "Öffne Quellen → Erzeugt und nutze das Papierkorb-Symbol am jeweiligen Eintrag."
+      },
+      {
+        "name": "Erinnerungen",
+        "how": "Öffne Erinnerungen und lösche einzelne Einträge oder mehrere gemeinsam."
+      },
+      {
+        "name": "Verbindungen, Chat-Widgets und API-Schlüssel",
+        "how": "Öffne Kanäle und entferne dort die Verbindung, das Widget oder den Schlüssel, den du nicht mehr brauchst."
+      }
+    ],
+    "partialRetention": "Gelöschte Inhalte verschwinden sofort aus deinem Konto. Backups mit verbliebenen Kopien werden innerhalb von 30 Tagen rotiert. Alles andere in deinem Konto bleibt unberührt.",
     "noAccessTitle": "Keine Anmeldung möglich?",
     "noAccessDesc": "Wenn du keinen Zugriff mehr auf dein Konto hast, kontaktiere uns über unsere Website und wir bearbeiten deine Löschanfrage.",
     "visitWebsite": "Website besuchen",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -3928,6 +3928,31 @@
       "API keys, widgets and credentials"
     ],
     "retention": "Deletion is permanent and takes effect immediately. Backups containing residual data are rotated out within 30 days. Data we are legally required to retain (e.g. invoices) is kept only as long as the law requires.",
+    "partialTitle": "Delete individual data without deleting your account",
+    "partialIntro": "You do not have to give up your account to remove data. While signed in you can delete any of the following yourself, and it takes effect immediately.",
+    "partialItems": [
+      {
+        "name": "Chats and conversations",
+        "how": "Open History, use the ⋯ menu next to a conversation and choose Delete. To remove several at once, open Statistics → All Chats, select them and choose Delete selected."
+      },
+      {
+        "name": "Uploaded files and documents",
+        "how": "Open Sources → Browse and use the delete icon on a file, or select several and choose Delete selected. Deleting a folder also deletes the files inside it."
+      },
+      {
+        "name": "AI-generated images and media",
+        "how": "Open Sources → Generated and use the delete icon on the item."
+      },
+      {
+        "name": "Memories",
+        "how": "Open Memories and delete individual entries, or select several and delete them together."
+      },
+      {
+        "name": "Connections, chat widgets and API keys",
+        "how": "Open Channels and remove the connection, widget or key you no longer need."
+      }
+    ],
+    "partialRetention": "Deleted items disappear from your account immediately. Backups containing residual copies are rotated out within 30 days. Everything else in your account stays untouched.",
     "noAccessTitle": "Can't sign in?",
     "noAccessDesc": "If you no longer have access to your account, contact us through our website and we will process your deletion request.",
     "visitWebsite": "Visit website",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -1638,6 +1638,31 @@
       "Claves de API, widgets y credenciales"
     ],
     "retention": "La eliminación es permanente y surte efecto de inmediato. Las copias de seguridad con datos residuales se rotan en un plazo de 30 días. Los datos que estamos legalmente obligados a conservar (p. ej. facturas) se mantienen solo durante el tiempo que exige la ley.",
+    "partialTitle": "Eliminar datos concretos sin borrar tu cuenta",
+    "partialIntro": "No necesitas renunciar a tu cuenta para eliminar datos. Con la sesión iniciada puedes borrar tú mismo lo siguiente, y surte efecto de inmediato.",
+    "partialItems": [
+      {
+        "name": "Chats y conversaciones",
+        "how": "Abre Historial, usa el menú ⋯ junto a una conversación y elige Eliminar. Para quitar varias a la vez, abre Estadísticas → Todos los Chats, selecciónalas y elige «Eliminar seleccionados»."
+      },
+      {
+        "name": "Archivos y documentos subidos",
+        "how": "Abre Fuentes → Explorar y usa el icono de papelera en un archivo, o selecciona varios y elimina la selección. Al eliminar una carpeta también se eliminan los archivos que contiene."
+      },
+      {
+        "name": "Imágenes y medios generados por IA",
+        "how": "Abre Fuentes → Generados y usa el icono de papelera en el elemento."
+      },
+      {
+        "name": "Recuerdos",
+        "how": "Abre Recuerdos y elimina entradas concretas, o selecciona varias y bórralas juntas."
+      },
+      {
+        "name": "Conexiones, widgets de chat y claves de API",
+        "how": "Abre Canales y elimina la conexión, el widget o la clave que ya no necesites."
+      }
+    ],
+    "partialRetention": "Lo que eliminas desaparece de tu cuenta de inmediato. Las copias de seguridad con copias residuales se rotan en un plazo de 30 días. Todo lo demás de tu cuenta permanece intacto.",
     "noAccessTitle": "¿No puedes iniciar sesión?",
     "noAccessDesc": "Si ya no tienes acceso a tu cuenta, contáctanos a través de nuestro sitio web y procesaremos tu solicitud de eliminación.",
     "visitWebsite": "Visitar el sitio web",

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -1638,6 +1638,31 @@
       "API anahtarları, widget'lar ve kimlik bilgileri"
     ],
     "retention": "Silme işlemi kalıcıdır ve anında geçerli olur. Artık veri içeren yedekler 30 gün içinde döngüden çıkarılır. Yasal olarak saklamakla yükümlü olduğumuz veriler (ör. faturalar) yalnızca yasanın gerektirdiği süre boyunca tutulur.",
+    "partialTitle": "Hesabını silmeden tek tek verileri sil",
+    "partialIntro": "Veri silmek için hesabından vazgeçmen gerekmez. Giriş yaptığında aşağıdakileri kendin silebilirsin; işlem anında geçerli olur.",
+    "partialItems": [
+      {
+        "name": "Sohbetler ve konuşmalar",
+        "how": "Geçmiş'i aç, bir konuşmanın yanındaki ⋯ menüsünden Sil'i seç. Birkaçını birden kaldırmak için İstatistikler → Tüm Sohbetler'i aç, seç ve „Seçilenleri sil“e dokun."
+      },
+      {
+        "name": "Yüklenen dosyalar ve belgeler",
+        "how": "Kaynaklar → Gözat'ı aç ve bir dosyadaki çöp kutusu simgesini kullan ya da birkaçını seçip seçimi sil. Bir klasörü silmek içindeki dosyaları da siler."
+      },
+      {
+        "name": "Yapay zekâ ile üretilen görseller ve medya",
+        "how": "Kaynaklar → Üretilen'i aç ve ilgili ögedeki çöp kutusu simgesini kullan."
+      },
+      {
+        "name": "Anılar",
+        "how": "Anılar'ı aç ve tek tek kayıtları sil ya da birkaçını seçip birlikte sil."
+      },
+      {
+        "name": "Bağlantılar, sohbet widget'ları ve API anahtarları",
+        "how": "Kanallar'ı aç ve artık ihtiyacın olmayan bağlantıyı, widget'ı veya anahtarı kaldır."
+      }
+    ],
+    "partialRetention": "Sildiğin ögeler hesabından anında kaybolur. Artık kopya içeren yedekler 30 gün içinde döngüden çıkarılır. Hesabındaki diğer her şey olduğu gibi kalır.",
     "noAccessTitle": "Giriş yapamıyor musun?",
     "noAccessDesc": "Hesabına artık erişemiyorsan, web sitemiz üzerinden bizimle iletişime geç; silme talebini işleme alalım.",
     "visitWebsite": "Web sitesini ziyaret et",

--- a/frontend/src/views/AccountDeletionView.vue
+++ b/frontend/src/views/AccountDeletionView.vue
@@ -101,6 +101,26 @@
           <p class="mt-3 text-xs txt-secondary">{{ $t('accountDeletion.retention') }}</p>
         </section>
 
+        <section class="mb-8" data-testid="section-partial-deletion">
+          <h2 class="text-lg font-semibold txt-primary mb-3">
+            {{ $t('accountDeletion.partialTitle') }}
+          </h2>
+          <p class="text-sm txt-secondary mb-4">{{ $t('accountDeletion.partialIntro') }}</p>
+          <ul class="space-y-3 text-sm">
+            <li v-for="(item, index) in partialItems" :key="index" class="flex items-start gap-2">
+              <Icon
+                icon="mdi:trash-can-outline"
+                class="w-4 h-4 flex-shrink-0 mt-0.5 text-[var(--brand)]"
+              />
+              <span>
+                <span class="txt-primary font-medium">{{ item.name }}</span>
+                <span class="txt-secondary"> — {{ item.how }}</span>
+              </span>
+            </li>
+          </ul>
+          <p class="mt-3 text-xs txt-secondary">{{ $t('accountDeletion.partialRetention') }}</p>
+        </section>
+
         <section class="surface-chip rounded-lg p-4">
           <h2 class="text-base font-semibold txt-primary mb-2">
             {{ $t('accountDeletion.noAccessTitle') }}
@@ -169,6 +189,15 @@ const steps = computed(() =>
 )
 const dataItems = computed(() =>
   (tm('accountDeletion.dataItems') as string[]).map((_, i) => t(`accountDeletion.dataItems.${i}`))
+)
+
+// Google Play requires the deletion link to also describe how users remove
+// individual data without closing the account, so the page carries both.
+const partialItems = computed(() =>
+  (tm('accountDeletion.partialItems') as unknown[]).map((_, i) => ({
+    name: t(`accountDeletion.partialItems.${i}.name`),
+    how: t(`accountDeletion.partialItems.${i}.how`),
+  }))
 )
 
 const cycleLanguage = () => {


### PR DESCRIPTION
## Why

Google Play's Data Safety form asks whether users can request removal of *some*
of their data without deleting their account, and requires a public URL that
shows the steps, the data types and any retention period — the same bar as the
account deletion link.

Our page at `/account-deletion` only described full account deletion, so the
honest answer in the console was "no". That understates the product: chats,
files, generated media, memories and channel items can all be deleted
individually today.

## What

Adds a section to the existing deletion page listing each self-service path,
so one URL now satisfies both Play Console fields. Text added to all four
locales.

## Test plan

- [x] `make -C frontend lint`
- [x] `make -C frontend test` (1232 passed, incl. locale parity)
- [x] Visually checked in light and dark theme
- [ ] After deploy: set the Data Safety answer to "yes" with the same URL

Type check reports a pre-existing failure in `stores/config.ts` for
`auth.guestChatEnabled`, which is missing from the committed generated
schema on `main` and unrelated to this change.

**Release classification:** ota-candidate (frontend only).