### PR TITLE
fix(frontend): make account deletion page scrollable

### DIFF
--- a/frontend/src/views/AccountDeletionView.vue
+++ b/frontend/src/views/AccountDeletionView.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="min-h-screen bg-light-bg dark:bg-dark-bg flex items-center justify-center px-4 py-12 relative overflow-hidden"
+    class="h-screen bg-light-bg dark:bg-dark-bg flex items-start justify-center px-4 py-12 relative overflow-x-hidden overflow-y-auto scroll-thin"
     data-testid="page-account-deletion"
   >
     <div class="absolute inset-0 overflow-hidden pointer-events-none">


### PR DESCRIPTION
## Summary
- give the public account-deletion page its own vertical scroll container
- align long content at the top so instructions remain reachable on small screens
- preserve horizontal clipping for decorative background elements

## Verification
- `make -C frontend lint` — passed
- `make -C frontend test` — 145 files / 1232 tests passed
- phone viewport (390×844): scroll container moves from 0 to 1282 px
- local typecheck still reports the pre-existing `auth.guestChatEnabled` generated-schema mismatch from `main`; this change touches only the view class

**Release classification:** ota-candidate