### PR TITLE
fix: on-demand update check, duplicate cancellation cards, retired xAI speech models

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ Synaplan is provider-neutral: connect the providers you want in **Admin → AI P
 | Google Gemini | `GOOGLE_GEMINI_API_KEY` | Gemini 3.x / 2.5 chat + vision, Imagen 4, Nano Banana, Veo 3.1, Gemini TTS |
 | Groq | `GROQ_API_KEY` | Qwen 3.6 27B (chat + vision), GPT-OSS 20B/120B, Whisper Large v3 |
 | Mistral 🇫🇷 | `MISTRAL_API_KEY` | Mistral Medium 3.5 (+ vision), Mistral Large 3, Voxtral transcription + TTS |
-| xAI | `XAI_API_KEY` | Grok 4.5 (+ vision, 500K context), Grok Imagine image + video (incl. Pro / 1.5 tiers), Grok TTS + STT |
+| xAI | `XAI_API_KEY` | Grok 4.5 (+ vision, 500K context), Grok Imagine image + video (incl. Pro / 1.5 tiers) |
 | [TrustedTokens](https://trustedtokens.eu/) 🇩🇪 | `TRUSTEDTOKENS_API_KEY` | GLM 5.2, Qwen3.6 35B (+ vision), GPT OSS 120B — sovereign inference on German GPUs (TNG), zero data retention |
 | HuggingFace | `HUGGINGFACE_API_KEY` | Kimi K2.5 / K2.6 / K2.7 Code (chat + vision) |
 | TheHive | `THEHIVE_API_KEY` | Flux Schnell, SDXL |

--- a/backend/migrations/Version20260820120000.php
+++ b/backend/migrations/Version20260820120000.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Retire the two xAI speech models the provider no longer serves:
+ *
+ *   - BID 320 grok-tts (text2sound)
+ *   - BID 321 grok-stt (sound2text)
+ *
+ * Both answer 404 on GET /v1/models/<id> and are absent from the xAI model
+ * listing, so any install routing speech at them fails at request time (#1514).
+ * Deactivated, never deleted: BMESSAGES rows reference the BIDs via FK. Same
+ * contract as {@see Version20260819080000}.
+ *
+ * Unlike the Groq retirement there is NO successor to repoint to: xAI offers no
+ * replacement for either capability, and binding an install to another
+ * provider's model would assume an API key the operator may not hold. The
+ * DEFAULTMODEL bindings are therefore REMOVED rather than repointed, which
+ * hands the capability back to the normal resolution chain — the same state as
+ * an install that never chose a speech model. {@see \App\Service\ModelConfigService}
+ * treats a deactivated row as unusable and degrades through its logged
+ * fallback, so removing the row loses nothing that still worked.
+ *
+ * The xAI SOUND2TEXT recommendation is dropped from ProviderDefaultsService in
+ * the same release. Without that, `app:provider:apply-defaults --auto` would
+ * write the dead binding straight back on the next container start.
+ */
+final class Version20260820120000 extends AbstractMigration
+{
+    /**
+     * Retired BID => upstream API model id, used as a guard so the row is left
+     * alone when it was manually repurposed, and a re-run stays idempotent.
+     *
+     * @var array<int, string>
+     */
+    private const RETIRED_MODELS = [
+        320 => 'grok-tts',
+        321 => 'grok-stt',
+    ];
+
+    public function getDescription(): string
+    {
+        return 'Deactivate the retired xAI speech models (grok-tts BID 320, grok-stt BID 321) and drop the '
+            .'DEFAULTMODEL bindings pointing at them, so speech resolution falls back to a live model.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        foreach (self::RETIRED_MODELS as $retiredBid => $providerId) {
+            // Global (ownerId 0) and per-user bindings alike: a dead id is no
+            // more usable for one user than for the install.
+            $this->addSql(<<<'SQL'
+                DELETE FROM BCONFIG
+                 WHERE BGROUP = 'DEFAULTMODEL'
+                   AND BVALUE = :retired
+            SQL, [
+                'retired' => (string) $retiredBid,
+            ]);
+
+            $this->addSql(<<<'SQL'
+                UPDATE BMODELS
+                   SET BACTIVE = 0,
+                       BSELECTABLE = 0,
+                       BISDEFAULT = 0
+                 WHERE BID = :retired
+                   AND BPROVID = :providerId
+            SQL, [
+                'retired' => $retiredBid,
+                'providerId' => $providerId,
+            ]);
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        // Reactivate the rows so they reappear in the admin UI. The deleted
+        // bindings are deliberately NOT restored: they pointed at a model the
+        // provider does not serve, and the capability has since resolved
+        // through the fallback chain. Same contract as Version20260819080000.
+        foreach (self::RETIRED_MODELS as $retiredBid => $providerId) {
+            $this->addSql(<<<'SQL'
+                UPDATE BMODELS
+                   SET BACTIVE = 1,
+                       BSELECTABLE = 1
+                 WHERE BID = :retired
+                   AND BPROVID = :providerId
+            SQL, [
+                'retired' => $retiredBid,
+                'providerId' => $providerId,
+            ]);
+        }
+    }
+}

--- a/backend/src/AI/Credential/ProviderDefaultsService.php
+++ b/backend/src/AI/Credential/ProviderDefaultsService.php
@@ -113,7 +113,12 @@ final readonly class ProviderDefaultsService
             'PLAN' => 'xai:grok-4.5:chat',
             'SUMMARIZE' => 'xai:grok-4.5:chat',
             'PIC2TEXT' => 'xai:grok-4.5:pic2text',
-            'SOUND2TEXT' => 'xai:grok-stt:sound2text',
+            // No SOUND2TEXT recommendation: xAI retired grok-stt and offers no
+            // replacement, and there is no cross-provider substitute to
+            // recommend here — a key the operator may not hold cannot be a
+            // default. Without the entry the capability keeps whatever it was
+            // bound to instead of being rebound to a dead model on every
+            // container start by `app:provider:apply-defaults --auto` (#1514).
         ],
         // Local Ollama — last resort when a chat-capable model is already present.
         // providerId "gpt-oss:120b" normalises to "gpt-oss-120b" in ModelCatalog keys.

--- a/backend/src/Controller/AdminUpdatesController.php
+++ b/backend/src/Controller/AdminUpdatesController.php
@@ -24,6 +24,10 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
  * BCONFIG, so it works offline; `POST /check` is the manual "check now" button
  * and is the only endpoint that may perform an outbound request.
  *
+ * `POST /check` deliberately bypasses the manifest cache: it exists so an
+ * operator who sees a wrong "latest release" can correct it immediately, and a
+ * button that answers from a cache up to six hours old cannot do that.
+ *
  * SECURITY: all endpoints require ROLE_ADMIN (class-level IsGranted).
  */
 #[Route('/api/v1/admin/updates')]
@@ -164,7 +168,7 @@ final class AdminUpdatesController extends AbstractController
     #[OA\Post(
         path: '/api/v1/admin/updates/check',
         summary: 'Check for a newer release now',
-        description: 'Fetches the release manifest, stores the outcome and returns the refreshed status. A network failure is reported through lastError, not as an HTTP error. Does nothing when the master switch is off (admin only).',
+        description: 'Fetches the release manifest, stores the outcome and returns the refreshed status. Always re-downloads the manifest instead of answering from the cache, so a stale stored version can be corrected on demand. A network failure is reported through lastError, not as an HTTP error. Does nothing when the master switch is off (admin only).',
         security: [['Bearer' => []]],
         tags: ['Admin Updates']
     )]
@@ -221,7 +225,7 @@ final class AdminUpdatesController extends AbstractController
     #[OA\Response(response: 403, description: 'Admin access required')]
     public function check(): JsonResponse
     {
-        $status = $this->updateStatusService->refresh();
+        $status = $this->updateStatusService->refresh(force: true);
 
         return $this->json($this->payload($status));
     }

--- a/backend/src/Controller/StreamController.php
+++ b/backend/src/Controller/StreamController.php
@@ -3013,11 +3013,26 @@ class StreamController extends AbstractController
      * it as an error would add a second outgoing message for the same tracking
      * id, so the chat showed two cancellation cards for one Stop click.
      *
+     * The `cancelled` marker is the intended signal. The message match is a
+     * safety net for any path that still reports a cancel as a plain failure:
+     * one leaked result would otherwise persist a second card carrying raw
+     * English text (#1501), which no translation layer can repair afterwards.
+     *
      * @param array<string, mixed> $result
      */
     private function isCancelledResult(array $result): bool
     {
-        return true !== ($result['success'] ?? false) && true === ($result['cancelled'] ?? false);
+        if (true === ($result['success'] ?? false)) {
+            return false;
+        }
+
+        if (true === ($result['cancelled'] ?? false)) {
+            return true;
+        }
+
+        $error = $result['error'] ?? null;
+
+        return \is_string($error) && 1 === preg_match('/cancell?ed by user/i', $error);
     }
 
     /**

--- a/backend/src/Model/ModelCatalog.php
+++ b/backend/src/Model/ModelCatalog.php
@@ -3162,8 +3162,11 @@ class ModelCatalog
             'service' => 'xAI',
             'name' => 'Grok TTS',
             'tag' => 'text2sound',
-            'selectable' => 1,
-            'active' => 1,
+            // Retired: xAI no longer serves this model (GET /v1/models/grok-tts
+            // answers 404). Deactivated, never deleted — BMESSAGES rows
+            // reference the BID (#1514, see Version20260820120000).
+            'selectable' => 0,
+            'active' => 0,
             // POST /v1/tts takes no `model` field — the endpoint selects the
             // model. This is xAI's documentation name, kept so the row has a
             // stable provider key.
@@ -3198,8 +3201,11 @@ class ModelCatalog
             'service' => 'xAI',
             'name' => 'Grok STT',
             'tag' => 'sound2text',
-            'selectable' => 1,
-            'active' => 1,
+            // Retired: xAI no longer serves this model (GET /v1/models/grok-stt
+            // answers 404). Deactivated, never deleted — BMESSAGES rows
+            // reference the BID (#1514, see Version20260820120000).
+            'selectable' => 0,
+            'active' => 0,
             'providerId' => 'grok-stt',
             // REST transcription is $0.10 per hour of audio. (The streaming
             // WebSocket variant costs $0.20/hour and is not implemented, so no

--- a/backend/src/Service/Multitask/Execution/DagExecutor.php
+++ b/backend/src/Service/Multitask/Execution/DagExecutor.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Service\Multitask\Execution;
 
+use App\Service\Exception\StreamCancelledException;
 use App\Service\Multitask\Execution\Parallel\MediaNodeDispatcher;
 use App\Service\Multitask\Execution\Parallel\MediaNodeRequest;
 use App\Service\Multitask\MultitaskRoutingConfig;
@@ -229,6 +230,17 @@ final readonly class DagExecutor
 
         try {
             $result = $runner->run($node, $context);
+        } catch (StreamCancelledException $e) {
+            // Pressing Stop ends the whole turn, not one node. Demoting it to a
+            // failed node result would strip the `cancelled` marker the caller
+            // needs, and the failure path then persists a second assistant card
+            // for the same Stop click (#1501).
+            $this->logger->info('DagExecutor: turn cancelled by user', [
+                'node' => $node->id,
+                'capability' => $node->capability->value,
+            ]);
+
+            throw $e;
         } catch (\Throwable $e) {
             $result = NodeResult::failed($e->getMessage());
             $this->logger->warning('DagExecutor: runner threw', [

--- a/backend/src/Service/Multitask/Execution/Runner/ChatRunner.php
+++ b/backend/src/Service/Multitask/Execution/Runner/ChatRunner.php
@@ -7,6 +7,7 @@ namespace App\Service\Multitask\Execution\Runner;
 use App\AI\Service\AiFacade;
 use App\AI\Stream\StreamChunk;
 use App\Entity\Prompt;
+use App\Service\Exception\StreamCancelledException;
 use App\Service\Knowledge\KnowledgeContextFormatter;
 use App\Service\ModelConfigService;
 use App\Service\Multitask\Execution\NodeContext;
@@ -119,6 +120,11 @@ final readonly class ChatRunner implements TaskRunner
                     'temperature' => 0.3,
                 ], static fn ($v) => null !== $v),
             );
+        } catch (StreamCancelledException $e) {
+            // Not a model failure: the user pressed Stop. Reporting it as a
+            // failed node would drop the `cancelled` marker and make the turn
+            // persist a second, untranslated cancellation card (#1501).
+            throw $e;
         } catch (\Throwable $e) {
             $this->logger->warning('ChatRunner: model call failed', [
                 'capability' => $node->capability->value,

--- a/backend/tests/Migration/Version20260820120000Test.php
+++ b/backend/tests/Migration/Version20260820120000Test.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Migration;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use DoctrineMigrations\Version20260820120000;
+use Psr\Log\NullLogger;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * Executes the xAI speech-retirement migration's real SQL against the test
+ * database.
+ *
+ * This is the NO-SUCCESSOR variant of the retirement policy: xAI serves no
+ * replacement for grok-stt/grok-tts, so the bindings are deleted rather than
+ * repointed. Deleting the wrong row would silently take a working speech model
+ * away from an install, so the guards are asserted here, not just described.
+ *
+ * Everything runs inside a transaction that is rolled back, so the fixture rows
+ * never survive the test.
+ */
+final class Version20260820120000Test extends KernelTestCase
+{
+    private const RETIRED_STT_BID = 321;
+    private const RETIRED_STT_PROVIDER_ID = 'grok-stt';
+
+    /** Any live model of the same capability, used as the "untouched" control. */
+    private const UNRELATED_BID = 322;
+
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->connection = self::getContainer()->get(Connection::class);
+        $this->connection->beginTransaction();
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->connection->isTransactionActive()) {
+            $this->connection->rollBack();
+        }
+
+        parent::tearDown();
+    }
+
+    public function testItDeactivatesTheRetiredRowAndDropsItsBinding(): void
+    {
+        $this->givenModelRow(self::RETIRED_STT_BID, self::RETIRED_STT_PROVIDER_ID);
+        $ownerId = $this->anyUserId();
+        $this->givenDefaultModelBinding($ownerId, 'SOUND2TEXT', self::RETIRED_STT_BID);
+
+        $this->runMigration();
+
+        self::assertSame(0, $this->fetchModelActive(self::RETIRED_STT_BID));
+        self::assertSame(0, $this->fetchModelSelectable(self::RETIRED_STT_BID));
+        self::assertNull(
+            $this->fetchDefaultModelBinding($ownerId, 'SOUND2TEXT'),
+            'the binding must be gone so resolution falls back to a live model'
+        );
+    }
+
+    /**
+     * Migrations run again on every container start of every node in the
+     * cluster, and a partially applied one has to be safe to repeat.
+     */
+    public function testItIsIdempotent(): void
+    {
+        $this->givenModelRow(self::RETIRED_STT_BID, self::RETIRED_STT_PROVIDER_ID);
+        $ownerId = $this->anyUserId();
+        $this->givenDefaultModelBinding($ownerId, 'SOUND2TEXT', self::RETIRED_STT_BID);
+
+        $this->runMigration();
+        $this->runMigration();
+
+        self::assertSame(0, $this->fetchModelActive(self::RETIRED_STT_BID));
+        self::assertNull($this->fetchDefaultModelBinding($ownerId, 'SOUND2TEXT'));
+    }
+
+    /**
+     * The BPROVID guard: a BID an operator repurposed for a different upstream
+     * model is not the retired model and must keep working.
+     */
+    public function testItLeavesARepurposedRowActive(): void
+    {
+        $this->givenModelRow(self::RETIRED_STT_BID, 'some-other-upstream-model');
+
+        $this->runMigration();
+
+        self::assertSame(1, $this->fetchModelActive(self::RETIRED_STT_BID));
+    }
+
+    public function testItLeavesBindingsForOtherModelsAlone(): void
+    {
+        $this->givenModelRow(self::RETIRED_STT_BID, self::RETIRED_STT_PROVIDER_ID);
+        $this->givenModelRow(self::UNRELATED_BID, 'whisper-large-v3');
+        $ownerId = $this->anyUserId();
+        $this->givenDefaultModelBinding($ownerId, 'SOUND2TEXT', self::UNRELATED_BID);
+
+        $this->runMigration();
+
+        self::assertSame(
+            (string) self::UNRELATED_BID,
+            $this->fetchDefaultModelBinding($ownerId, 'SOUND2TEXT'),
+            'a binding pointing at a live model must survive'
+        );
+        self::assertSame(1, $this->fetchModelActive(self::UNRELATED_BID));
+    }
+
+    private function runMigration(): void
+    {
+        $migration = $this->loadMigration();
+        $migration->up(new Schema());
+
+        foreach ($migration->getSql() as $query) {
+            $this->connection->executeStatement(
+                $query->getStatement(),
+                $query->getParameters(),
+                $query->getTypes()
+            );
+        }
+    }
+
+    /**
+     * migrations/ is outside the composer autoload map — Doctrine discovers
+     * these files by path at runtime, so the test has to load it itself.
+     */
+    private function loadMigration(): AbstractMigration
+    {
+        require_once dirname(__DIR__, 2).'/migrations/Version20260820120000.php';
+
+        return new Version20260820120000($this->connection, new NullLogger());
+    }
+
+    private function givenModelRow(int $bid, string $providerId): void
+    {
+        $this->connection->executeStatement(
+            <<<'SQL'
+                INSERT INTO BMODELS (BID, BSERVICE, BNAME, BTAG, BSELECTABLE, BACTIVE, BPROVID, BPRICEIN, BINUNIT, BPRICEOUT, BOUTUNIT, BQUALITY, BRATING, BISDEFAULT, BSHOWWHENFREE, BJSON)
+                VALUES (:id, 'xAI', 'migration fixture', 'sound2text', 1, 1, :providerId, 0.10, 'perhour', 0, '-', 9, 1, 0, 0, '{}')
+                ON DUPLICATE KEY UPDATE BACTIVE = 1, BSELECTABLE = 1, BPROVID = VALUES(BPROVID)
+                SQL,
+            ['id' => $bid, 'providerId' => $providerId]
+        );
+    }
+
+    private function anyUserId(): int
+    {
+        $userId = $this->connection->fetchOne('SELECT BID FROM BUSER ORDER BY BID ASC LIMIT 1');
+        self::assertNotFalse($userId, 'test database has no user to attach fixtures to');
+
+        return (int) $userId;
+    }
+
+    private function givenDefaultModelBinding(int $ownerId, string $setting, int $modelId): void
+    {
+        $this->connection->executeStatement(
+            "DELETE FROM BCONFIG WHERE BOWNERID = :owner AND BGROUP = 'DEFAULTMODEL' AND BSETTING = :setting",
+            ['owner' => $ownerId, 'setting' => $setting]
+        );
+        $this->connection->executeStatement(
+            "INSERT INTO BCONFIG (BOWNERID, BGROUP, BSETTING, BVALUE) VALUES (:owner, 'DEFAULTMODEL', :setting, :value)",
+            ['owner' => $ownerId, 'setting' => $setting, 'value' => (string) $modelId]
+        );
+    }
+
+    private function fetchDefaultModelBinding(int $ownerId, string $setting): ?string
+    {
+        $value = $this->connection->fetchOne(
+            "SELECT BVALUE FROM BCONFIG WHERE BOWNERID = :owner AND BGROUP = 'DEFAULTMODEL' AND BSETTING = :setting",
+            ['owner' => $ownerId, 'setting' => $setting]
+        );
+
+        return false === $value ? null : (string) $value;
+    }
+
+    private function fetchModelActive(int $modelId): int
+    {
+        return (int) $this->connection->fetchOne(
+            'SELECT BACTIVE FROM BMODELS WHERE BID = :id',
+            ['id' => $modelId]
+        );
+    }
+
+    private function fetchModelSelectable(int $modelId): int
+    {
+        return (int) $this->connection->fetchOne(
+            'SELECT BSELECTABLE FROM BMODELS WHERE BID = :id',
+            ['id' => $modelId]
+        );
+    }
+}

--- a/backend/tests/Unit/Controller/AdminUpdatesControllerTest.php
+++ b/backend/tests/Unit/Controller/AdminUpdatesControllerTest.php
@@ -99,10 +99,7 @@ final class AdminUpdatesControllerTest extends TestCase
 
     public function testCheckRefreshesAndReturnsTheSamePayloadShape(): void
     {
-        $controller = $this->controller(new MockResponse((string) json_encode([
-            'schema' => 1,
-            'stable' => ['version' => '4.0.13', 'notesUrl' => 'https://example.com/notes'],
-        ])));
+        $controller = $this->controller([$this->manifestResponse('4.0.13')]);
 
         $payload = $this->decode($controller->check()->getContent());
 
@@ -111,6 +108,36 @@ final class AdminUpdatesControllerTest extends TestCase
         self::assertNotNull($payload['lastCheckedAt']);
         self::assertSame(UpdatePlatformGuide::GUIDE_URL_SELFHOST, $payload['guideUrl']);
         self::assertSame('4.0.13', $this->rows[UpdateConfig::KEY_LATEST_VERSION]);
+    }
+
+    /**
+     * "Check now" is the button an operator presses BECAUSE the stored version
+     * looks wrong, so it must re-download the manifest. Answering from the
+     * six-hour cache would keep showing the very number being corrected.
+     */
+    public function testCheckReDownloadsTheManifestInsteadOfServingTheCachedOne(): void
+    {
+        $controller = $this->controller([
+            $this->manifestResponse('4.1.1'),
+            $this->manifestResponse('4.2.2'),
+        ]);
+
+        $controller->check();
+        $payload = $this->decode($controller->check()->getContent());
+
+        self::assertSame('4.2.2', $payload['latestVersion']);
+        self::assertSame('4.2.2', $this->rows[UpdateConfig::KEY_LATEST_VERSION]);
+    }
+
+    private function manifestResponse(string $version): MockResponse
+    {
+        return new MockResponse((string) json_encode([
+            'schema' => 1,
+            'stable' => [
+                'version' => $version,
+                'notesUrl' => 'https://github.com/metadist/synaplan/releases/tag/v'.$version,
+            ],
+        ]));
     }
 
     public function testDismissStoresTheAcknowledgedVersion(): void
@@ -150,9 +177,13 @@ final class AdminUpdatesControllerTest extends TestCase
         return $decoded;
     }
 
-    private function controller(?MockResponse $response = null, string $platform = 'selfhost'): AdminUpdatesController
+    /**
+     * @param list<MockResponse> $responses answered in order, so a test can
+     *                                      assert what a SECOND check sees
+     */
+    private function controller(array $responses = [], string $platform = 'selfhost'): AdminUpdatesController
     {
-        $httpClient = null === $response ? new MockHttpClient() : new MockHttpClient($response);
+        $httpClient = [] === $responses ? new MockHttpClient() : new MockHttpClient($responses);
 
         $controller = new AdminUpdatesController(
             new UpdateStatusService(

--- a/backend/tests/Unit/Controller/StreamControllerCancelledResultTest.php
+++ b/backend/tests/Unit/Controller/StreamControllerCancelledResultTest.php
@@ -95,6 +95,28 @@ class StreamControllerCancelledResultTest extends TestCase
     }
 
     /**
+     * The DAG path used to report a cancel as an ordinary node failure, whose
+     * message was then persisted as a second, raw-English card (#1501). The
+     * marker is fixed at the source; this is the net that keeps a regression
+     * from reaching the chat.
+     */
+    public function testDagFailureThatIsReallyACancellationIsRecognised(): void
+    {
+        $this->assertTrue($this->isCancelledResult([
+            'success' => false,
+            'error' => 'chat failed: Stream cancelled by user',
+        ]));
+    }
+
+    public function testUnrelatedFailureMentioningTheUserIsStillAnError(): void
+    {
+        $this->assertFalse($this->isCancelledResult([
+            'success' => false,
+            'error' => 'chat failed: no input text for user prompt',
+        ]));
+    }
+
+    /**
      * @param array<string, mixed> $result
      */
     private function isCancelledResult(array $result): bool

--- a/backend/tests/Unit/Service/Multitask/Execution/DagExecutorTest.php
+++ b/backend/tests/Unit/Service/Multitask/Execution/DagExecutorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Unit\Service\Multitask\Execution;
 
 use App\Entity\Message;
+use App\Service\Exception\StreamCancelledException;
 use App\Service\Multitask\Execution\DagExecutor;
 use App\Service\Multitask\Execution\NodeContext;
 use App\Service\Multitask\Execution\NodeResult;
@@ -20,6 +21,7 @@ use App\Service\Multitask\Plan\Capability;
 use App\Service\Multitask\Plan\TaskNode;
 use App\Service\Multitask\Plan\TaskPlan;
 use Doctrine\Common\Collections\ArrayCollection;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
@@ -271,6 +273,34 @@ final class DagExecutorTest extends TestCase
         self::assertSame('failed', $result['node_statuses']['n1']);
         // Best-effort content rather than a crash.
         self::assertNotSame('', $result['content']);
+    }
+
+    /**
+     * A user cancel is the ONE throw that must not be isolated: ending the turn
+     * is the point. Swallowing it into a failed node dropped the `cancelled`
+     * marker, and the caller's failure path then wrote a second assistant card
+     * with raw English text for a single Stop click (#1501).
+     */
+    #[DataProvider('executionModes')]
+    public function testUserCancellationEndsTheWholeTurnInsteadOfFailingOneNode(bool $parallel): void
+    {
+        $runner = $this->runner(function (): NodeResult {
+            throw new StreamCancelledException('Stream cancelled by user');
+        });
+
+        $this->expectException(StreamCancelledException::class);
+
+        $this->executor($runner, parallel: $parallel)
+            ->execute(TaskPlan::singleChatPlan('en'), $this->context());
+    }
+
+    /**
+     * @return iterable<string, array{bool}>
+     */
+    public static function executionModes(): iterable
+    {
+        yield 'sequential' => [false];
+        yield 'parallel' => [true];
     }
 
     public function testProgressCallbackEmitsPerNodeStateUpdates(): void

--- a/docs/PRICING_MAINTENANCE.md
+++ b/docs/PRICING_MAINTENANCE.md
@@ -121,7 +121,9 @@ Exit codes match `app:sync-model-prices`: `0` clean, `1` the command broke, `2` 
 
 Six confirmed retirements, each re-verified by hand: Groq dropped `llama-3.3-70b-versatile` (BID 9), `llama-3.1-8b-instant` (236), `qwen/qwen3-32b` (53) and `meta-llama/llama-4-scout-17b-16e-instruct` (17 — the Groq `PIC2TEXT` default), xAI dropped `grok-stt` (321 — the xAI `SOUND2TEXT` default) and `grok-tts` (320). Groq's current list is 13 models; `whisper-large-v3` and `openai/gpt-oss-*` are unaffected.
 
-The four Groq rows were retired in `Version20260819080000` (#1513), which also added Groq Qwen 3.6 27B (324/325) as their successor. Re-running the check after that migration reports Groq at `7/7 matched`: the retired rows are out of the active set and the freshly added successor BIDs produce no false positive. The two xAI rows stay open (#1514) — the catalog has no xAI replacement for either capability, so the `SOUND2TEXT` recommendation has to move to another provider or be dropped rather than repointed within xAI.
+The four Groq rows were retired in `Version20260819080000` (#1513), which also added Groq Qwen 3.6 27B (324/325) as their successor. Re-running the check after that migration reports Groq at `7/7 matched`: the retired rows are out of the active set and the freshly added successor BIDs produce no false positive.
+
+The two xAI rows were retired in `Version20260820120000` (#1514). Because the catalog has no xAI replacement for either capability, this is the **no-successor** variant of the policy: the rows are deactivated and their `DEFAULTMODEL` bindings are **deleted** instead of repointed, which hands the capability back to the normal resolution chain rather than binding the install to a provider whose key the operator may not hold. The xAI `SOUND2TEXT` recommendation was dropped from `ProviderDefaultsService` in the same change — without that, `app:provider:apply-defaults --auto` writes the dead binding back on the next container start.
 
 ## Maintenance links
 


### PR DESCRIPTION
## Summary

Three fixes plus the answer to the reported version-check problem.

### The version check is not broken — the instance never re-checks

The published manifest is correct: `release-manifest/versions.json` says `4.2.2` (released `2026-08-20T10:15:02Z`), so the tagger and the `Publish Release Manifest` job work as intended.

Two separate things went wrong on `web.synaplan.com`:

1. **The daily check never runs there.** `app:updates:check` is only invoked by the scheduler role (`_docker/backend/lib/container-runtime.sh`). The production compose in `synaplan-platform` defines `backend`, `worker`, `worker-bulk` and `centrifugo` — no scheduler service — and there is no `cron-updates.sh` alongside the other host cron scripts. So `UPDATES.LATEST_VERSION` is frozen at whatever the last manual check wrote, which is why it still reads `4.1.1`. **That fix belongs in the platform repo and is not part of this PR.**
2. **The manual "check now" button could not correct it.** `POST /api/v1/admin/updates/check` called `refresh()` without `force`, so it answered from the `UpdateManifestClient` cache (6 h TTL). The one button that exists precisely because the stored value looks wrong kept reporting that same value. It now forces a re-download.

### #1501 — cancelling a multitask/DAG turn showed two cancellation cards

`DagExecutor::runNodeInline()` caught every `\Throwable` from a runner and turned it into `NodeResult::failed()`. For a user cancel that stripped the `cancelled` marker `StreamController::isCancelledResult()` looks for, so the failure branch ran and persisted a second `OUT` row rendering the raw English `## ⚠️ Stream cancelled by user`.

A cancel now propagates out of the DAG (it ends the turn, it does not fail one node), `ChatRunner` re-raises it explicitly instead of logging it as a model failure, and `isCancelledResult()` additionally recognises a failure whose message says it was cancelled — a net so no future path can persist that card again.

### #1514 — retired xAI speech models

`grok-stt` (BID 321) and `grok-tts` (BID 320) are gone upstream (both 404), yet both rows were active and selectable, and `grok-stt` was the recommended xAI `SOUND2TEXT` default that `app:provider:apply-defaults --auto` rewrote on every container start.

Both rows are deactivated in `ModelCatalog` and the xAI `SOUND2TEXT` recommendation is dropped, so the preference order moves on. This is the **no-successor** variant of the retirement policy: xAI ships no replacement, and binding installs to another provider's model would assume an API key the operator may not hold — so `Version20260820120000` **deletes** the `DEFAULTMODEL` bindings instead of repointing them, handing the capability back to the normal resolution chain, which already degrades through a logged fallback for a deactivated row.

### Already fixed, no code needed

While triaging the ten newest issues, three turned out to be fixed in `main` by #1348 and were simply never closed — verified in the tree, not assumed:

- **#1268** — `RagSearchView.vue` passes `?file=<id>`, `FilesView.vue` opens `FileContentModal` on mount.
- **#1140** — `chatApi.ts` refreshes the access cookie before warming the SSE token, and skips the token fetch when the refresh fails.
- **#1128** — `ChatView.vue` removes the placeholder message on `guest_limit_reached`.

The remaining issues (#1520, #1515, #1500, #1499, #1491, #1396, #1322) are features or need a product decision and are out of scope here.

## Test plan

- [x] `make lint` — clean
- [x] `make -C backend phpstan` — no errors (full project incl. `tests/`)
- [x] `make -C backend test` — 3760 tests green, unfiltered
- [x] New: `AdminUpdatesControllerTest::testCheckReDownloadsTheManifestInsteadOfServingTheCachedOne`
- [x] New: `DagExecutorTest::testUserCancellationEndsTheWholeTurnInsteadOfFailingOneNode` (sequential + parallel)
- [x] New: `StreamControllerCancelledResultTest` DAG-failure and false-positive cases
- [x] New: `Version20260820120000Test` — real SQL against the test DB: deactivation, binding removal, idempotency, `BPROVID` guard, unrelated bindings untouched
- [ ] Manual: admin config → "check now" reports `4.2.2` on an instance whose stored value is stale