### PR TITLE
fix(dropbox): keep the reason a rejected upload names in the error message

### DIFF
--- a/backend/src/Service/Dropbox/DropboxClient.php
+++ b/backend/src/Service/Dropbox/DropboxClient.php
@@ -32,6 +32,9 @@ final readonly class DropboxClient
     /** Single-call upload cap documented by Dropbox is 150 MB; stay well below. */
     public const MAX_UPLOAD_BYTES = 100 * 1024 * 1024;
 
+    /** Enough for Dropbox's plain-text rejection reason, short enough for a log line. */
+    private const MAX_ERROR_BODY_CHARS = 300;
+
     /**
      * @param (\Closure(int): void)|null $sleeper Overridden in tests so the
      *                                            throttling path can be exercised without real delays
@@ -140,7 +143,9 @@ final readonly class DropboxClient
 
                 $status = $response->getStatusCode();
                 $raw = $response->getContent(false);
-                $retryAfter = $response->getHeaders(false)['retry-after'][0] ?? null;
+                $headers = $response->getHeaders(false);
+                $retryAfter = $headers['retry-after'][0] ?? null;
+                $requestId = $headers['x-dropbox-request-id'][0] ?? null;
             } catch (TransportExceptionInterface $e) {
                 throw new DropboxException('Could not reach Dropbox: '.$e->getMessage(), '', 0, $e);
             }
@@ -164,7 +169,7 @@ final readonly class DropboxClient
                 continue;
             }
 
-            throw $this->describeFailure($status, $raw);
+            throw $this->describeFailure($status, $raw, $requestId);
         }
     }
 
@@ -184,17 +189,43 @@ final readonly class DropboxClient
         null !== $this->sleeper ? ($this->sleeper)($delay) : sleep($delay);
     }
 
-    private function describeFailure(int $status, string $raw): DropboxException
+    private function describeFailure(int $status, string $raw, ?string $requestId): DropboxException
     {
         $decoded = json_decode($raw, true);
         $summary = is_array($decoded) && is_string($decoded['error_summary'] ?? null)
             ? rtrim($decoded['error_summary'], '/.')
             : '';
 
+        // Only the endpoint-specific errors answer in JSON. A malformed
+        // request (400) answers in plain text — 'Error in call to API
+        // function "files/upload": …' — which names the actual defect. Without
+        // it the message degrades to a bare "HTTP 400" that cannot be acted on.
+        $detail = '' !== $summary ? $summary : $this->bodySnippet($raw);
+
         return new DropboxException(
-            sprintf('Dropbox answered HTTP %d%s', $status, '' !== $summary ? ' ('.$summary.')' : ''),
+            sprintf(
+                'Dropbox answered HTTP %d%s%s',
+                $status,
+                '' !== $detail ? ' ('.$detail.')' : '',
+                null !== $requestId && '' !== $requestId ? ' [request-id '.$requestId.']' : '',
+            ),
             $summary,
             $status,
         );
+    }
+
+    /**
+     * One-line, bounded excerpt of a non-JSON error body. Dropbox echoes the
+     * offending `Authorization` header back when it rejects it, so the bearer
+     * token is stripped before this text can reach a log.
+     */
+    private function bodySnippet(string $raw): string
+    {
+        $text = trim((string) preg_replace('/\s+/', ' ', $raw));
+        $text = (string) preg_replace('/Bearer\s+\S+/i', 'Bearer [redacted]', $text);
+
+        return mb_strlen($text) > self::MAX_ERROR_BODY_CHARS
+            ? mb_substr($text, 0, self::MAX_ERROR_BODY_CHARS).'…'
+            : $text;
     }
 }

--- a/backend/tests/Unit/Service/Dropbox/DropboxClientTest.php
+++ b/backend/tests/Unit/Service/Dropbox/DropboxClientTest.php
@@ -127,6 +127,43 @@ final class DropboxClientTest extends TestCase
         }
     }
 
+    public function testPlainTextRejectionReasonAndRequestIdSurvive(): void
+    {
+        $client = $this->client([
+            new MockResponse(
+                'Error in call to API function "files/upload": HTTP header "Dropbox-API-Arg": could not decode input as JSON',
+                ['http_code' => 400, 'response_headers' => ['x-dropbox-request-id' => 'req-42']],
+            ),
+        ]);
+
+        try {
+            $client->upload($this->connection(), 'bytes', '/Synaplan/plan.docx');
+            self::fail('Expected a DropboxException');
+        } catch (DropboxException $e) {
+            self::assertStringContainsString('could not decode input as JSON', $e->getMessage());
+            self::assertStringContainsString('req-42', $e->getMessage());
+            self::assertSame(400, $e->getCode());
+        }
+    }
+
+    public function testRejectedBearerTokenIsNotEchoedIntoTheMessage(): void
+    {
+        $client = $this->client([
+            new MockResponse(
+                'Error in call to API function "files/upload": Invalid authorization value in HTTP header "Authorization": "Bearer sl.secret-token".',
+                ['http_code' => 400],
+            ),
+        ]);
+
+        try {
+            $client->upload($this->connection(), 'bytes', '/Synaplan/plan.docx');
+            self::fail('Expected a DropboxException');
+        } catch (DropboxException $e) {
+            self::assertStringNotContainsString('sl.secret-token', $e->getMessage());
+            self::assertStringContainsString('Bearer [redacted]', $e->getMessage());
+        }
+    }
+
     private function connection(): Connection
     {
         $connection = new Connection(7, Connection::TYPE_DROPBOX, 'Dropbox');


### PR DESCRIPTION
## Summary

Follow-up to the Dropbox save diagnostics (#1521, #1524). Those PRs made the underlying `DropboxException` reach the log; this one makes that exception actually say something.

`describeFailure()` only read `error_summary`, which exists solely in Dropbox's **endpoint-specific** JSON errors. A malformed request answers `400` in **plain text** — `Error in call to API function "files/upload": HTTP header "Dropbox-API-Arg": could not decode input as JSON` — and that sentence names the actual defect. Reading only `error_summary` threw it away and left a bare `Dropbox answered HTTP 400`, which is indistinguishable from any other 400 and not actionable.

Now:

- the plain-text body is used as the failure detail when there is no `error_summary`,
- `x-dropbox-request-id` is carried into the message so a report can be matched against Dropbox's own logs,
- the snippet is collapsed to one line and capped at 300 characters, because an error body is not a log sink.

**Security note:** Dropbox echoes the offending `Authorization` header back when it rejects it, so a naive passthrough would write a live bearer token into the logs. `Bearer <token>` is redacted before the text can leave this method, and a test pins that.

## Test plan

- [x] `make lint` — clean
- [x] `make -C backend phpstan` — no errors (full project incl. `tests/`)
- [x] `make -C backend test` — 3751 tests green, unfiltered
- [x] New: `testPlainTextRejectionReasonAndRequestIdSurvive` — the reason and the request id reach the message, status stays 400
- [x] New: `testRejectedBearerTokenIsNotEchoedIntoTheMessage` — the token is replaced by `Bearer [redacted]`