### PR TITLE
fix(i18n): stop promising guest chats are retained after signup

### DIFF
--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -2522,7 +2522,7 @@
       "reminder": "Hol mehr aus Synaplan heraus"
     },
     "subtitle": {
-      "guest_limit": "Wähle einen Tarif und chatte weiter – mit eigenem Verlauf, Erinnerungen und Dateien.",
+      "guest_limit": "Wähle einen Tarif und chatte weiter. Mit einem Account bekommst du ab dann eigenen Verlauf, Erinnerungen und Dateien.",
       "free_limit": "Dein Gratis-Kontingent ist verbraucht. Wähle einen Tarif und chatte ohne Limit weiter.",
       "quota_exhausted": "Wechsle in einen größeren Tarif und mach sofort weiter, oder warte bis dein Kontingent nächsten Monat zurückgesetzt wird.",
       "reminder": "Mit einem Tarif bekommst du mehr Nachrichten, stärkere KI-Modelle und mehr Speicher."
@@ -4712,7 +4712,7 @@
     "disabledTitle": "Gast-Chat nicht verfügbar",
     "disabledDescription": "Diese Instanz bietet keinen anonymen Testzugang. Bitte melde dich an, um zu chatten.",
     "expiredTitle": "Deine Sitzung ist abgelaufen",
-    "expiredDescription": "Gastsitzungen sind 24 Stunden gültig. Starte einen neuen Test oder erstelle einen kostenlosen Account, um deinen Chatverlauf zu behalten.",
+    "expiredDescription": "Gastsitzungen sind 24 Stunden gültig, und dieses Testgespräch lässt sich nicht wiederherstellen. Starte einen neuen Test oder erstelle einen kostenlosen Account, damit deine Chats ab dann gespeichert werden.",
     "rateLimitedTitle": "Zu viele Sitzungen",
     "rateLimitedDescription": "Du hast das Sitzungslimit erreicht. Bitte versuche es später erneut oder erstelle einen kostenlosen Account.",
     "retry": "Erneut versuchen",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -2456,7 +2456,7 @@
       "reminder": "Get more out of Synaplan"
     },
     "subtitle": {
-      "guest_limit": "Pick a plan to keep chatting — with your own history, memories and files.",
+      "guest_limit": "Pick a plan to keep chatting. An account gives you your own history, memories and files from here on.",
       "free_limit": "Your free allowance is spent. Pick a plan to keep chatting without limits.",
       "quota_exhausted": "Move up a plan to keep going right away, or wait for your allowance to reset next month.",
       "reminder": "A plan gives you more messages, stronger AI models and more storage."
@@ -4778,7 +4778,7 @@
     "disabledTitle": "Guest chat is not available",
     "disabledDescription": "This instance does not offer an anonymous trial. Please sign in to start chatting.",
     "expiredTitle": "Your session has expired",
-    "expiredDescription": "Guest sessions last 24 hours. Start a new trial or create a free account to keep your chat history.",
+    "expiredDescription": "Guest sessions last 24 hours, and this trial conversation can't be restored. Start a new trial, or create a free account so your chats are saved from now on.",
     "rateLimitedTitle": "Too many sessions",
     "rateLimitedDescription": "You've reached the session limit. Please try again later or create a free account.",
     "retry": "Try again",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -667,6 +667,32 @@
   "guest": {
     "disabledTitle": "El chat de invitados no está disponible",
     "disabledDescription": "Esta instancia no ofrece una prueba anónima. Inicia sesión para empezar a chatear.",
+    "banner": {
+      "title": "Estás usando Synaplan como invitado",
+      "subtitle": "Regístrate para tener memorias, historial de chats y más",
+      "remaining": "Quedan {count} mensajes",
+      "signUp": "Regístrate gratis"
+    },
+    "limitModal": {
+      "title": "Has alcanzado el límite de invitado",
+      "subtitle": "Crea una cuenta gratuita para seguir chateando con la IA",
+      "features": {
+        "memories": "Una IA que recuerda tus preferencias",
+        "history": "Historial de chats permanente",
+        "files": "Subida de archivos y análisis de documentos",
+        "models": "Elige entre varios modelos de IA"
+      },
+      "registerButton": "Crear cuenta gratuita",
+      "loginButton": "¿Ya tienes una cuenta? Inicia sesión"
+    },
+    "errorTitle": "La prueba no está disponible ahora mismo",
+    "errorDescription": "No hemos podido iniciar tu sesión de invitado. Inténtalo de nuevo o crea una cuenta gratuita.",
+    "expiredTitle": "Tu sesión ha caducado",
+    "expiredDescription": "Las sesiones de invitado duran 24 horas y esta conversación de prueba no se puede recuperar. Empieza una nueva prueba o crea una cuenta gratuita para que tus chats se guarden a partir de ahora.",
+    "rateLimitedTitle": "Demasiadas sesiones",
+    "rateLimitedDescription": "Has alcanzado el límite de sesiones. Inténtalo más tarde o crea una cuenta gratuita.",
+    "retry": "Inténtalo de nuevo",
+    "createAccount": "Crear cuenta",
     "featureGate": {
       "title": "Esta función requiere una cuenta",
       "subtitle": "Crea una cuenta gratuita para desbloquear todas las funciones",
@@ -1901,7 +1927,7 @@
       "reminder": "Saca más partido a Synaplan"
     },
     "subtitle": {
-      "guest_limit": "Elige un plan para seguir chateando, con tu propio historial, memorias y archivos.",
+      "guest_limit": "Elige un plan para seguir chateando. Con una cuenta tendrás, a partir de ahora, tu propio historial, memorias y archivos.",
       "free_limit": "Tu cuota gratuita está agotada. Elige un plan para seguir chateando sin límites.",
       "quota_exhausted": "Cambia a un plan superior para continuar ahora mismo, o espera a que tu cuota se reinicie el mes que viene.",
       "reminder": "Un plan te da más mensajes, modelos de IA más potentes y más almacenamiento."

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -667,6 +667,32 @@
   "guest": {
     "disabledTitle": "Misafir sohbeti kullanılamıyor",
     "disabledDescription": "Bu sunucu anonim deneme sunmuyor. Sohbete başlamak için giriş yap.",
+    "banner": {
+      "title": "Synaplan'ı misafir olarak kullanıyorsun",
+      "subtitle": "Hafızalar, sohbet geçmişi ve dahası için kaydol",
+      "remaining": "{count} mesaj kaldı",
+      "signUp": "Ücretsiz kaydol"
+    },
+    "limitModal": {
+      "title": "Misafir sınırına ulaştın",
+      "subtitle": "Yapay zeka ile sohbete devam etmek için ücretsiz bir hesap oluştur",
+      "features": {
+        "memories": "Tercihlerini hatırlayan bir yapay zeka",
+        "history": "Kalıcı sohbet geçmişi",
+        "files": "Dosya yükleme ve belge analizi",
+        "models": "Birden fazla yapay zeka modeli arasından seç"
+      },
+      "registerButton": "Ücretsiz hesap oluştur",
+      "loginButton": "Zaten hesabın var mı? Giriş yap"
+    },
+    "errorTitle": "Deneme şu anda kullanılamıyor",
+    "errorDescription": "Misafir oturumun başlatılamadı. Lütfen tekrar dene ya da ücretsiz bir hesap oluştur.",
+    "expiredTitle": "Oturumun sona erdi",
+    "expiredDescription": "Misafir oturumları 24 saat sürer ve bu deneme sohbeti geri getirilemez. Yeni bir deneme başlat ya da bundan sonraki sohbetlerinin kaydedilmesi için ücretsiz bir hesap oluştur.",
+    "rateLimitedTitle": "Çok fazla oturum",
+    "rateLimitedDescription": "Oturum sınırına ulaştın. Lütfen daha sonra tekrar dene ya da ücretsiz bir hesap oluştur.",
+    "retry": "Tekrar dene",
+    "createAccount": "Hesap oluştur",
     "featureGate": {
       "title": "Bu özellik bir hesap gerektirir",
       "subtitle": "Tüm özellikleri açmak için ücretsiz bir hesap oluşturun",
@@ -1901,7 +1927,7 @@
       "reminder": "Synaplan'dan daha fazlasını al"
     },
     "subtitle": {
-      "guest_limit": "Kendi geçmişin, hafızaların ve dosyalarınla sohbete devam etmek için bir plan seç.",
+      "guest_limit": "Sohbete devam etmek için bir plan seç. Hesap açtığında bundan sonrası için kendi geçmişin, hafızaların ve dosyaların olur.",
       "free_limit": "Ücretsiz kotan tükendi. Sınır olmadan sohbete devam etmek için bir plan seç.",
       "quota_exhausted": "Hemen devam etmek için üst bir plana geç ya da kotanın gelecek ay sıfırlanmasını bekle.",
       "reminder": "Bir plan sana daha fazla mesaj, daha güçlü AI modelleri ve daha fazla depolama verir."


### PR DESCRIPTION
## Summary

Closes #1491.

The guest conversion copy promised something the product does not do. The paywall subtitle offered a plan "with your own history", and the expired-session screen said to create an account "to keep your chat history" — but the trial conversation is discarded on registration, and an expired session is gone entirely. Both are now forward-looking: an account gives you history *from that point on*, and the expired trial conversation is explicitly described as unrecoverable.

While checking the four locales I found Spanish and Turkish were missing the entire `guest.*` block below `featureGate` — 20 keys covering the guest banner, the limit modal, and the error/expired/rate-limited screens. Every one of those strings, including the misleading copy this issue is about, silently fell back to English for Spanish and Turkish users. Added them in both locales with the corrected wording, so all four are now at parity for the guest flow.

## Test plan

- [x] `make -C frontend lint` — Prettier + ESLint clean
- [x] `make -C frontend test` — 1234 tests / 145 files pass
- [x] `npm run check:types` (vue-tsc)
- [x] Key-parity check: `guest.*` has zero missing keys in de/es/tr relative to en