### PR TITLE
feat(chat): generate concise titles for web chats

### DIFF
--- a/backend/src/Controller/StreamController.php
+++ b/backend/src/Controller/StreamController.php
@@ -9,6 +9,7 @@ use App\Entity\Message;
 use App\Entity\Prompt;
 use App\Entity\User;
 use App\Message\ExtractMemoriesCommand;
+use App\Service\Chat\ChatTitleService;
 use App\Service\ConversationSummaryRefreshDispatcher;
 use App\Service\Exception\StreamCancelledException;
 use App\Service\File\DocumentGeneratorService;
@@ -89,6 +90,7 @@ class StreamController extends AbstractController
         private MessageForwardingService $messageForwardingService,
         private MemoryExtractionDispatcher $memoryExtractionDispatcher,
         private ConversationSummaryRefreshDispatcher $conversationSummaryRefreshDispatcher,
+        private ChatTitleService $chatTitleService,
         private DocumentGeneratorService $documentGenerator,
         private DocumentImageReferenceResolver $documentImageReferenceResolver,
         private MediaCancellationStore $cancellationStore,
@@ -1904,6 +1906,20 @@ class StreamController extends AbstractController
                     $this->messageForwardingService->forwardIfNeeded($chat, $finalText);
                 }
 
+                // Name the conversation once its first exchange is stored, so
+                // the sidebar stops filling with "Hi" and "New Chat" (#1500).
+                // Runs at most once per chat: titleWebChatIfNeeded() returns
+                // null as soon as a title exists, including one the user typed.
+                // Widget sessions title themselves on their own trigger, and
+                // incognito turns persist nothing to name.
+                $generatedChatTitle = null;
+                if (!$isWidgetMode && !$isGuestMode && !$incognito && $chat) {
+                    $generatedChatTitle = $this->chatTitleService->titleWebChatIfNeeded(
+                        $chat,
+                        (int) $user->getId(),
+                    );
+                }
+
                 $recordedChatUsage = $this->rateLimitService->recordUsage($user, 'MESSAGES', [
                     'provider' => $response['metadata']['provider'] ?? 'unknown',
                     'model' => $response['metadata']['model'] ?? 'unknown',
@@ -2044,6 +2060,12 @@ class StreamController extends AbstractController
                     'searchResults' => $searchResults,
                     'aiModels' => $this->buildAiModelsPayload($outgoingMessage),
                 ];
+
+                // Only present on the turn that named the chat, so the sidebar
+                // can pick the title up without refetching the chat list.
+                if (null !== $generatedChatTitle) {
+                    $completeData['chatTitle'] = $generatedChatTitle;
+                }
 
                 // Usage taximeter: per-message usage (switch-independent) and,
                 // only when the display is enabled for authenticated web users,

--- a/backend/src/Service/Chat/ChatTitleService.php
+++ b/backend/src/Service/Chat/ChatTitleService.php
@@ -1,0 +1,243 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Chat;
+
+use App\AI\Service\AiFacade;
+use App\Entity\Chat;
+use App\Entity\Message;
+use App\Repository\MessageRepository;
+use App\Repository\UserRepository;
+use App\Service\ModelConfigService;
+use App\Service\RateLimitService;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Generates short conversation titles.
+ *
+ * One place for both title consumers: widget sessions (which titled their
+ * sessions here first) and web chats, whose sidebar previously showed the raw
+ * truncated first user message and so filled up with "Hi" and "New Chat"
+ * (#1500).
+ *
+ * The model comes from the SUMMARIZE capability (SUMMARIZE → SORT → CHAT), so
+ * an operator can point titling at a cheap or local model; nothing here names a
+ * model. Requests are deliberately bare — a single user turn, no system prompt,
+ * no memories, no RAG context, no tools — because a title is not worth a full
+ * chat turn's tokens.
+ */
+final readonly class ChatTitleService
+{
+    /**
+     * BCHATS.BTITLE holds 255, but a sidebar entry is unreadable long before
+     * that and models like to pad. Keep it to a label.
+     */
+    public const MAX_TITLE_LENGTH = 60;
+
+    private const MAX_TURN_LENGTH = 200;
+    private const MAX_TURNS = 8;
+    private const HISTORY_MAX_MESSAGES = 20;
+    private const HISTORY_MAX_CHARS = 50000;
+
+    /**
+     * Titles the frontend treats as "no title yet". Anything else may be a
+     * rename by the user and is never replaced.
+     */
+    private const PLACEHOLDER_TITLES = ['New Chat', 'Neuer Chat'];
+
+    public function __construct(
+        private AiFacade $aiFacade,
+        private ModelConfigService $modelConfigService,
+        private MessageRepository $messageRepository,
+        private UserRepository $userRepository,
+        private RateLimitService $rateLimitService,
+        private EntityManagerInterface $em,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * Title a web chat once its first exchange is on record.
+     *
+     * Returns the stored title so the caller can hand it to the client in the
+     * same response, or null when the chat was left as it was — which is not an
+     * error: an untitled chat falls back to the first-message preview and then
+     * to the localized "New Chat" label in the sidebar.
+     */
+    public function titleWebChatIfNeeded(Chat $chat, int $userId): ?string
+    {
+        if (!$this->needsTitle($chat->getTitle())) {
+            return null;
+        }
+
+        $messages = $this->messageRepository->findChatHistory(
+            $userId,
+            (int) $chat->getId(),
+            self::HISTORY_MAX_MESSAGES,
+            self::HISTORY_MAX_CHARS,
+        );
+
+        $turns = $this->toTurns($messages);
+
+        // Wait for a complete exchange. A lone user message is what produced
+        // the useless "Hi" titles; the answer is often where the subject is.
+        if (count($turns) < 2) {
+            return null;
+        }
+
+        $title = $this->generate($turns, $userId, 'CHAT_TITLE');
+
+        if (null === $title) {
+            return null;
+        }
+
+        // Another turn of the same chat may have won the race while the model
+        // was answering. Re-read before writing; the first title wins.
+        $this->em->refresh($chat);
+        if (!$this->needsTitle($chat->getTitle())) {
+            return null;
+        }
+
+        $chat->setTitle($title);
+        $this->em->flush();
+
+        $this->logger->info('ChatTitleService: generated web chat title', [
+            'chat_id' => $chat->getId(),
+            'title' => $title,
+        ]);
+
+        return $title;
+    }
+
+    /**
+     * Turn a conversation into a label.
+     *
+     * @param list<array{role: string, text: string}> $turns
+     * @param string                                  $usageAction rate-limit action the call is booked under
+     */
+    public function generate(array $turns, int $ownerId, string $usageAction): ?string
+    {
+        if ([] === $turns) {
+            return null;
+        }
+
+        try {
+            $summaryConfig = $this->modelConfigService->getSummaryModelConfig($ownerId);
+
+            $aiOptions = ['temperature' => 0.3];
+            if ($summaryConfig['provider'] && $summaryConfig['model']) {
+                $aiOptions['provider'] = $summaryConfig['provider'];
+                $aiOptions['model'] = $summaryConfig['model'];
+            }
+
+            $prompt = $this->buildPrompt($turns);
+
+            $response = $this->aiFacade->chat(
+                [['role' => 'user', 'content' => $prompt]],
+                $ownerId,
+                $aiOptions,
+            );
+
+            $title = $this->clean((string) ($response['content'] ?? ''));
+
+            $owner = $this->userRepository->find($ownerId);
+            if ($owner) {
+                $this->rateLimitService->recordUsage($owner, $usageAction, [
+                    'provider' => $response['provider'] ?? 'unknown',
+                    'model' => $response['model'] ?? 'unknown',
+                    'model_id' => $summaryConfig['model_id'],
+                    'usage' => $response['usage'] ?? [],
+                    'response_text' => $title ?? '',
+                    'input_text' => $prompt,
+                ]);
+            }
+
+            return $title;
+        } catch (\Throwable $e) {
+            // A missing title is cosmetic; the sidebar has a fallback. Never
+            // let it disturb the turn that triggered it.
+            $this->logger->warning('ChatTitleService: title generation failed', [
+                'owner_id' => $ownerId,
+                'action' => $usageAction,
+                'error' => $e->getMessage(),
+            ]);
+
+            return null;
+        }
+    }
+
+    /**
+     * @param list<Message> $messages
+     *
+     * @return list<array{role: string, text: string}>
+     */
+    public function toTurns(array $messages): array
+    {
+        $turns = [];
+
+        foreach ($messages as $message) {
+            $text = trim($message->getText());
+            if ('' === $text) {
+                continue;
+            }
+
+            $turns[] = [
+                'role' => 'IN' === $message->getDirection() ? 'user' : 'assistant',
+                'text' => $text,
+            ];
+        }
+
+        return $turns;
+    }
+
+    private function needsTitle(?string $title): bool
+    {
+        if (null === $title || '' === trim($title)) {
+            return true;
+        }
+
+        return in_array(trim($title), self::PLACEHOLDER_TITLES, true);
+    }
+
+    /**
+     * @param list<array{role: string, text: string}> $turns
+     */
+    private function buildPrompt(array $turns): string
+    {
+        $transcript = '';
+        foreach (array_slice($turns, 0, self::MAX_TURNS) as $turn) {
+            $label = 'user' === $turn['role'] ? 'User' : 'Assistant';
+            $transcript .= $label.': '.mb_substr($turn['text'], 0, self::MAX_TURN_LENGTH)."\n";
+        }
+
+        return <<<PROMPT
+            Read this conversation and write a short title (3-5 words) describing what it is about.
+            Write the title in the language the conversation is in.
+            Only output the title, nothing else. No quotes, no punctuation at the end.
+
+            Conversation:
+            {$transcript}
+
+            Title:
+            PROMPT;
+    }
+
+    private function clean(string $raw): ?string
+    {
+        // Models like to answer in prose or add a label; keep the first line.
+        $title = trim(strtok($raw, "\n") ?: '');
+        $title = trim($title, " \t\"'`*");
+        $title = preg_replace('/^(?:title|titel)\s*:\s*/i', '', $title) ?? $title;
+        $title = trim($title, " \t\"'`*");
+        $title = rtrim($title, '.!?,;:');
+        $title = trim(preg_replace('/\s+/u', ' ', $title) ?? $title);
+
+        if ('' === $title) {
+            return null;
+        }
+
+        return mb_substr($title, 0, self::MAX_TITLE_LENGTH);
+    }
+}

--- a/backend/src/Service/WidgetSessionService.php
+++ b/backend/src/Service/WidgetSessionService.php
@@ -2,12 +2,11 @@
 
 namespace App\Service;
 
-use App\AI\Service\AiFacade;
 use App\Entity\Chat;
 use App\Entity\WidgetSession;
 use App\Repository\MessageRepository;
-use App\Repository\UserRepository;
 use App\Repository\WidgetSessionRepository;
+use App\Service\Chat\ChatTitleService;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 
@@ -43,10 +42,7 @@ final class WidgetSessionService
         private EntityManagerInterface $em,
         private WidgetSessionRepository $sessionRepository,
         private MessageRepository $messageRepository,
-        private UserRepository $userRepository,
-        private AiFacade $aiFacade,
-        private ModelConfigService $modelConfigService,
-        private RateLimitService $rateLimitService,
+        private ChatTitleService $chatTitleService,
         private LoggerInterface $logger,
     ) {
     }
@@ -254,86 +250,38 @@ final class WidgetSessionService
             'user_message_count' => $userMessageCount,
         ]);
 
-        try {
-            // Build conversation text for summarization (using already fetched user messages)
-            $conversationText = '';
-            foreach ($userMessages as $message) {
-                $text = mb_substr($message->getText(), 0, 200);
-                $conversationText .= "- {$text}\n";
-            }
+        // Generation itself is shared with the web-chat titles (#1500): same
+        // SUMMARIZE-capability model resolution, same context-free request,
+        // same cleanup. Only the trigger and the target column differ.
+        $title = $this->chatTitleService->generate(
+            $this->chatTitleService->toTurns(array_values($userMessages)),
+            $ownerId,
+            'WIDGET_TITLE',
+        );
 
-            // Resolve a cheap, fast summarization model via the SUMMARIZE
-            // capability default (SUMMARIZE → SORT → CHAT) instead of a
-            // hardcoded model id (#1320).
-            $summaryConfig = $this->modelConfigService->getSummaryModelConfig($ownerId);
-            $titleModelId = $summaryConfig['model_id'];
-            $aiOptions = ['temperature' => 0.3];
-            if ($summaryConfig['provider'] && $summaryConfig['model']) {
-                $aiOptions['provider'] = $summaryConfig['provider'];
-                $aiOptions['model'] = $summaryConfig['model'];
-            }
-
-            $prompt = <<<PROMPT
-Based on these user questions/messages, create a short title (3-5 words) that describes what the user is asking about.
-Only output the title, nothing else. No quotes, no punctuation at the end.
-
-User messages:
-{$conversationText}
-
-Title:
-PROMPT;
-
-            $response = $this->aiFacade->chat(
-                [['role' => 'user', 'content' => $prompt]],
-                $ownerId,
-                $aiOptions
-            );
-
-            $title = trim($response['content'] ?? '');
-
-            $owner = $this->userRepository->find($ownerId);
-            if ($owner) {
-                $this->rateLimitService->recordUsage($owner, 'WIDGET_TITLE', [
-                    'provider' => $response['provider'] ?? 'unknown',
-                    'model' => $response['model'] ?? 'unknown',
-                    'model_id' => $titleModelId,
-                    'usage' => $response['usage'] ?? [],
-                    'response_text' => $title,
-                    'input_text' => $prompt,
-                ]);
-            }
-
-            // Clean up: remove quotes and limit length
-            $title = trim($title, '"\'');
-            $title = mb_substr($title, 0, 50);
-
-            if (!empty($title)) {
-                // Re-fetch session to check for race condition (another request may have set title)
-                $this->em->refresh($session);
-                if (null !== $session->getTitle()) {
-                    $this->logger->debug('Title already set by another process, discarding generated title', [
-                        'session_id' => substr($session->getSessionId(), 0, 12).'...',
-                        'existing_title' => $session->getTitle(),
-                        'discarded_title' => $title,
-                    ]);
-
-                    return;
-                }
-
-                $session->setTitle($title);
-                $this->em->flush();
-
-                $this->logger->info('Generated AI title for widget session', [
-                    'session_id' => substr($session->getSessionId(), 0, 12).'...',
-                    'title' => $title,
-                ]);
-            }
-        } catch (\Exception $e) {
-            $this->logger->warning('Failed to generate AI title for session', [
-                'session_id' => substr($session->getSessionId(), 0, 12).'...',
-                'error' => $e->getMessage(),
-            ]);
+        if (null === $title) {
+            return;
         }
+
+        // Re-fetch session to check for race condition (another request may have set title)
+        $this->em->refresh($session);
+        if (null !== $session->getTitle()) {
+            $this->logger->debug('Title already set by another process, discarding generated title', [
+                'session_id' => substr($session->getSessionId(), 0, 12).'...',
+                'existing_title' => $session->getTitle(),
+                'discarded_title' => $title,
+            ]);
+
+            return;
+        }
+
+        $session->setTitle($title);
+        $this->em->flush();
+
+        $this->logger->info('Generated AI title for widget session', [
+            'session_id' => substr($session->getSessionId(), 0, 12).'...',
+            'title' => $title,
+        ]);
     }
 
     /**

--- a/backend/tests/Unit/Controller/StreamControllerAiModelsPayloadTest.php
+++ b/backend/tests/Unit/Controller/StreamControllerAiModelsPayloadTest.php
@@ -8,6 +8,7 @@ use App\AI\Service\AiFacade;
 use App\Controller\StreamController;
 use App\Entity\Message;
 use App\Repository\FileRepository;
+use App\Service\Chat\ChatTitleService;
 use App\Service\ConversationSummaryRefreshDispatcher;
 use App\Service\File\DocumentGeneratorService;
 use App\Service\File\DocumentImageReferenceResolver;
@@ -69,6 +70,7 @@ class StreamControllerAiModelsPayloadTest extends TestCase
             $this->createMock(MessageForwardingService::class),
             $this->createMock(MemoryExtractionDispatcher::class),
             $this->createMock(ConversationSummaryRefreshDispatcher::class),
+            $this->createStub(ChatTitleService::class),
             $this->createMock(DocumentGeneratorService::class),
             $this->createMock(DocumentImageReferenceResolver::class),
             $this->createMock(MediaCancellationStore::class),

--- a/backend/tests/Unit/Controller/StreamControllerCancelledResultTest.php
+++ b/backend/tests/Unit/Controller/StreamControllerCancelledResultTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Unit\Controller;
 use App\AI\Service\AiFacade;
 use App\Controller\StreamController;
 use App\Repository\FileRepository;
+use App\Service\Chat\ChatTitleService;
 use App\Service\ConversationSummaryRefreshDispatcher;
 use App\Service\File\DocumentGeneratorService;
 use App\Service\File\DocumentImageReferenceResolver;
@@ -61,6 +62,7 @@ class StreamControllerCancelledResultTest extends TestCase
             $this->createMock(MessageForwardingService::class),
             $this->createMock(MemoryExtractionDispatcher::class),
             $this->createMock(ConversationSummaryRefreshDispatcher::class),
+            $this->createStub(ChatTitleService::class),
             $this->createMock(DocumentGeneratorService::class),
             $this->createMock(DocumentImageReferenceResolver::class),
             $this->createMock(MediaCancellationStore::class),

--- a/backend/tests/Unit/Controller/StreamControllerDeferredMemoryDispatchTest.php
+++ b/backend/tests/Unit/Controller/StreamControllerDeferredMemoryDispatchTest.php
@@ -8,6 +8,7 @@ use App\AI\Service\AiFacade;
 use App\Controller\StreamController;
 use App\Message\ExtractMemoriesCommand;
 use App\Repository\FileRepository;
+use App\Service\Chat\ChatTitleService;
 use App\Service\ConversationSummaryRefreshDispatcher;
 use App\Service\File\DocumentGeneratorService;
 use App\Service\File\DocumentImageReferenceResolver;
@@ -86,6 +87,7 @@ final class StreamControllerDeferredMemoryDispatchTest extends TestCase
             $this->createMock(MessageForwardingService::class),
             $this->memoryExtractionDispatcher,
             $this->createMock(ConversationSummaryRefreshDispatcher::class),
+            $this->createStub(ChatTitleService::class),
             $this->createMock(DocumentGeneratorService::class),
             $this->createMock(DocumentImageReferenceResolver::class),
             $this->createMock(MediaCancellationStore::class),

--- a/backend/tests/Unit/Controller/StreamControllerFileEnvelopeTest.php
+++ b/backend/tests/Unit/Controller/StreamControllerFileEnvelopeTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Unit\Controller;
 use App\AI\Service\AiFacade;
 use App\Controller\StreamController;
 use App\Repository\FileRepository;
+use App\Service\Chat\ChatTitleService;
 use App\Service\ConversationSummaryRefreshDispatcher;
 use App\Service\File\DocumentGeneratorService;
 use App\Service\File\DocumentImageReferenceResolver;
@@ -58,6 +59,7 @@ final class StreamControllerFileEnvelopeTest extends TestCase
             $this->createMock(MessageForwardingService::class),
             $this->createMock(MemoryExtractionDispatcher::class),
             $this->createMock(ConversationSummaryRefreshDispatcher::class),
+            $this->createStub(ChatTitleService::class),
             $this->createMock(DocumentGeneratorService::class),
             $this->createMock(DocumentImageReferenceResolver::class),
             $this->createMock(MediaCancellationStore::class),

--- a/backend/tests/Unit/Controller/StreamControllerOriginalMediaMetaTest.php
+++ b/backend/tests/Unit/Controller/StreamControllerOriginalMediaMetaTest.php
@@ -8,6 +8,7 @@ use App\AI\Service\AiFacade;
 use App\Controller\StreamController;
 use App\Entity\Message;
 use App\Repository\FileRepository;
+use App\Service\Chat\ChatTitleService;
 use App\Service\ConversationSummaryRefreshDispatcher;
 use App\Service\File\DocumentGeneratorService;
 use App\Service\File\DocumentImageReferenceResolver;
@@ -65,6 +66,7 @@ class StreamControllerOriginalMediaMetaTest extends TestCase
             $this->createMock(MessageForwardingService::class),
             $this->createMock(MemoryExtractionDispatcher::class),
             $this->createMock(ConversationSummaryRefreshDispatcher::class),
+            $this->createStub(ChatTitleService::class),
             $this->createMock(DocumentGeneratorService::class),
             $this->createMock(DocumentImageReferenceResolver::class),
             $this->createMock(MediaCancellationStore::class),

--- a/backend/tests/Unit/Controller/StreamControllerRagGroupKeyTest.php
+++ b/backend/tests/Unit/Controller/StreamControllerRagGroupKeyTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Unit\Controller;
 use App\AI\Service\AiFacade;
 use App\Controller\StreamController;
 use App\Repository\FileRepository;
+use App\Service\Chat\ChatTitleService;
 use App\Service\ConversationSummaryRefreshDispatcher;
 use App\Service\File\DocumentGeneratorService;
 use App\Service\File\DocumentImageReferenceResolver;
@@ -70,6 +71,7 @@ final class StreamControllerRagGroupKeyTest extends TestCase
             $this->createMock(MessageForwardingService::class),
             $this->createMock(MemoryExtractionDispatcher::class),
             $this->createMock(ConversationSummaryRefreshDispatcher::class),
+            $this->createStub(ChatTitleService::class),
             $this->createMock(DocumentGeneratorService::class),
             $this->createMock(DocumentImageReferenceResolver::class),
             $this->createMock(MediaCancellationStore::class),

--- a/backend/tests/Unit/Controller/StreamControllerTaskPlanFilesTest.php
+++ b/backend/tests/Unit/Controller/StreamControllerTaskPlanFilesTest.php
@@ -8,6 +8,7 @@ use App\AI\Service\AiFacade;
 use App\Controller\StreamController;
 use App\Entity\File;
 use App\Repository\FileRepository;
+use App\Service\Chat\ChatTitleService;
 use App\Service\ConversationSummaryRefreshDispatcher;
 use App\Service\File\DocumentGeneratorService;
 use App\Service\File\DocumentImageReferenceResolver;
@@ -69,6 +70,7 @@ class StreamControllerTaskPlanFilesTest extends TestCase
             $this->createMock(MessageForwardingService::class),
             $this->createMock(MemoryExtractionDispatcher::class),
             $this->createMock(ConversationSummaryRefreshDispatcher::class),
+            $this->createStub(ChatTitleService::class),
             $this->createMock(DocumentGeneratorService::class),
             $this->createMock(DocumentImageReferenceResolver::class),
             $this->createMock(MediaCancellationStore::class),

--- a/backend/tests/Unit/Service/Chat/ChatTitleServiceTest.php
+++ b/backend/tests/Unit/Service/Chat/ChatTitleServiceTest.php
@@ -1,0 +1,311 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\Chat;
+
+use App\AI\Service\AiFacade;
+use App\Entity\Chat;
+use App\Entity\Message;
+use App\Repository\MessageRepository;
+use App\Repository\UserRepository;
+use App\Service\Chat\ChatTitleService;
+use App\Service\ModelConfigService;
+use App\Service\RateLimitService;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+/**
+ * Web chats used to store the raw truncated first user message as their title,
+ * so a "Hi" turned into a sidebar entry called "Hi" (#1500). These tests cover
+ * the replacement: an AI-generated label, generated once, never over a title
+ * the user chose, and never at the cost of the turn that triggered it.
+ */
+final class ChatTitleServiceTest extends TestCase
+{
+    private const SUMMARY_CONFIG = [
+        'model' => 'llama3.2',
+        'provider' => 'ollama',
+        'model_id' => 42,
+    ];
+
+    private AiFacade&MockObject $aiFacade;
+    private MessageRepository&MockObject $messageRepository;
+    private EntityManagerInterface&MockObject $em;
+
+    private function createService(?string $aiReply = 'Invoice import problem'): ChatTitleService
+    {
+        $this->aiFacade = $this->createMock(AiFacade::class);
+        $this->messageRepository = $this->createMock(MessageRepository::class);
+        $this->em = $this->createMock(EntityManagerInterface::class);
+
+        if (null === $aiReply) {
+            $this->aiFacade->method('chat')->willThrowException(new \RuntimeException('provider down'));
+        } else {
+            $this->aiFacade->method('chat')->willReturn([
+                'content' => $aiReply,
+                'provider' => 'ollama',
+                'model' => 'llama3.2',
+                'usage' => [],
+            ]);
+        }
+
+        $modelConfig = $this->createMock(ModelConfigService::class);
+        $modelConfig->method('getSummaryModelConfig')->willReturn(self::SUMMARY_CONFIG);
+
+        return new ChatTitleService(
+            $this->aiFacade,
+            $modelConfig,
+            $this->messageRepository,
+            $this->createStub(UserRepository::class),
+            $this->createStub(RateLimitService::class),
+            $this->em,
+            new NullLogger(),
+        );
+    }
+
+    /**
+     * Same wiring as createService(), but records what was actually sent to the
+     * model so the request shape itself can be asserted.
+     *
+     * @param array{messages: mixed, options: array<string, mixed>}|null $captured
+     */
+    private function createServiceCapturingTheRequest(?array &$captured): ChatTitleService
+    {
+        $service = $this->createService();
+
+        $this->aiFacade = $this->createMock(AiFacade::class);
+        $this->aiFacade->method('chat')->willReturnCallback(
+            function (array|string $messages, ?int $userId, array $options) use (&$captured): array {
+                $captured = ['messages' => $messages, 'options' => $options];
+
+                return ['content' => 'Greeting', 'provider' => 'ollama', 'model' => 'llama3.2', 'usage' => []];
+            }
+        );
+
+        $modelConfig = $this->createMock(ModelConfigService::class);
+        $modelConfig->method('getSummaryModelConfig')->willReturn(self::SUMMARY_CONFIG);
+
+        return new ChatTitleService(
+            $this->aiFacade,
+            $modelConfig,
+            $this->messageRepository,
+            $this->createStub(UserRepository::class),
+            $this->createStub(RateLimitService::class),
+            $this->em,
+            new NullLogger(),
+        );
+    }
+
+    private function chat(?string $title = null): Chat
+    {
+        $chat = new Chat();
+        $chat->setTitle($title);
+
+        $reflection = new \ReflectionProperty(Chat::class, 'id');
+        $reflection->setValue($chat, 7);
+
+        return $chat;
+    }
+
+    private function message(string $direction, string $text): Message
+    {
+        $message = new Message();
+        $message->setDirection($direction);
+        $message->setText($text);
+
+        return $message;
+    }
+
+    /** @param list<Message> $history */
+    private function withHistory(array $history): void
+    {
+        $this->messageRepository->method('findChatHistory')->willReturn($history);
+    }
+
+    /** @return list<Message> */
+    private function oneCompleteTurn(): array
+    {
+        return [
+            $this->message('IN', 'Hi'),
+            $this->message('OUT', 'Hello! How can I help you today?'),
+        ];
+    }
+
+    public function testFirstCompleteTurnGetsAnAiTitle(): void
+    {
+        $service = $this->createService();
+        $this->withHistory($this->oneCompleteTurn());
+        $chat = $this->chat();
+
+        $this->em->expects($this->once())->method('flush');
+
+        $title = $service->titleWebChatIfNeeded($chat, 1);
+
+        self::assertSame('Invoice import problem', $title);
+        self::assertSame('Invoice import problem', $chat->getTitle());
+    }
+
+    /**
+     * A lone user message is what produced the useless titles in the first
+     * place — the answer usually carries the subject.
+     */
+    public function testAnIncompleteTurnIsNotTitledYet(): void
+    {
+        $service = $this->createService();
+        $this->withHistory([$this->message('IN', 'Hi')]);
+
+        $this->aiFacade->expects($this->never())->method('chat');
+
+        self::assertNull($service->titleWebChatIfNeeded($this->chat(), 1));
+    }
+
+    public function testATitleTheUserChoseIsNeverReplaced(): void
+    {
+        $service = $this->createService();
+        $chat = $this->chat('Quarterly planning');
+
+        $this->messageRepository->expects($this->never())->method('findChatHistory');
+        $this->aiFacade->expects($this->never())->method('chat');
+        $this->em->expects($this->never())->method('flush');
+
+        self::assertNull($service->titleWebChatIfNeeded($chat, 1));
+        self::assertSame('Quarterly planning', $chat->getTitle());
+    }
+
+    /**
+     * Chats created before this change, and via other channels, carry the
+     * placeholder label rather than a null title.
+     *
+     * @param non-empty-string $placeholder
+     */
+    #[DataProvider('placeholderTitles')]
+    public function testAPlaceholderTitleIsTreatedAsUntitled(string $placeholder): void
+    {
+        $service = $this->createService();
+        $this->withHistory($this->oneCompleteTurn());
+        $chat = $this->chat($placeholder);
+
+        self::assertSame('Invoice import problem', $service->titleWebChatIfNeeded($chat, 1));
+    }
+
+    /** @return iterable<string, array{string}> */
+    public static function placeholderTitles(): iterable
+    {
+        yield 'english' => ['New Chat'];
+        yield 'german' => ['Neuer Chat'];
+        yield 'blank' => ['   '];
+    }
+
+    /**
+     * A title is cosmetic. If the model is unavailable the turn must still
+     * finish, and the chat stays untitled so the sidebar falls back to the
+     * first-message preview.
+     */
+    public function testAFailingModelLeavesTheChatUntitledWithoutThrowing(): void
+    {
+        $service = $this->createService(aiReply: null);
+        $this->withHistory($this->oneCompleteTurn());
+        $chat = $this->chat();
+
+        self::assertNull($service->titleWebChatIfNeeded($chat, 1));
+        self::assertNull($chat->getTitle());
+    }
+
+    public function testAnEmptyModelReplyIsNotStoredAsATitle(): void
+    {
+        $service = $this->createService(aiReply: "  \n ");
+        $this->withHistory($this->oneCompleteTurn());
+        $chat = $this->chat();
+
+        self::assertNull($service->titleWebChatIfNeeded($chat, 1));
+        self::assertNull($chat->getTitle());
+    }
+
+    /**
+     * Models pad their answers. Whatever comes back has to end up as a bare
+     * label, because it is rendered straight into the sidebar.
+     */
+    #[DataProvider('paddedReplies')]
+    public function testModelPaddingIsStrippedFromTheTitle(string $reply, string $expected): void
+    {
+        $service = $this->createService($reply);
+        $this->withHistory($this->oneCompleteTurn());
+
+        self::assertSame($expected, $service->titleWebChatIfNeeded($this->chat(), 1));
+    }
+
+    /** @return iterable<string, array{string, string}> */
+    public static function paddedReplies(): iterable
+    {
+        yield 'double quotes' => ['"Invoice import"', 'Invoice import'];
+        yield 'single quotes' => ["'Invoice import'", 'Invoice import'];
+        yield 'markdown bold' => ['**Invoice import**', 'Invoice import'];
+        yield 'trailing period' => ['Invoice import.', 'Invoice import'];
+        yield 'label prefix' => ['Title: Invoice import', 'Invoice import'];
+        yield 'german label prefix' => ['Titel: Rechnungsimport', 'Rechnungsimport'];
+        yield 'explanatory second line' => ["Invoice import\nThis title covers…", 'Invoice import'];
+        yield 'collapsed whitespace' => ["Invoice    import\t", 'Invoice import'];
+    }
+
+    public function testAnOverlongTitleIsCutToLabelLength(): void
+    {
+        $service = $this->createService(str_repeat('a', 200));
+        $this->withHistory($this->oneCompleteTurn());
+
+        $title = $service->titleWebChatIfNeeded($this->chat(), 1);
+
+        self::assertNotNull($title);
+        self::assertSame(ChatTitleService::MAX_TITLE_LENGTH, mb_strlen($title));
+    }
+
+    /**
+     * The prompt is the whole context of the request: a title must not cost a
+     * full chat turn's tokens, and must not leak a system prompt or tools.
+     */
+    public function testThePromptIsASingleBareUserTurn(): void
+    {
+        $captured = null;
+        $service = $this->createServiceCapturingTheRequest($captured);
+        $this->withHistory($this->oneCompleteTurn());
+
+        $service->titleWebChatIfNeeded($this->chat(), 1);
+
+        self::assertIsArray($captured);
+        self::assertCount(1, $captured['messages'], 'A title needs exactly one turn');
+        self::assertSame('user', $captured['messages'][0]['role'], 'No system prompt is attached');
+        self::assertStringContainsString('Hello! How can I help you today?', $captured['messages'][0]['content']);
+
+        // The model must come from the SUMMARIZE capability, never a literal.
+        self::assertSame('ollama', $captured['options']['provider']);
+        self::assertSame('llama3.2', $captured['options']['model']);
+    }
+
+    public function testTurnsAreDerivedFromMessageDirection(): void
+    {
+        $service = $this->createService();
+
+        $turns = $service->toTurns([
+            $this->message('IN', 'How do I import invoices?'),
+            $this->message('OUT', 'Open the Files page…'),
+            $this->message('IN', '   '),
+        ]);
+
+        self::assertSame([
+            ['role' => 'user', 'text' => 'How do I import invoices?'],
+            ['role' => 'assistant', 'text' => 'Open the Files page…'],
+        ], $turns, 'Blank messages contribute nothing and are dropped');
+    }
+
+    public function testGenerateWithoutTurnsMakesNoModelCall(): void
+    {
+        $service = $this->createService();
+
+        $this->aiFacade->expects($this->never())->method('chat');
+
+        self::assertNull($service->generate([], 1, 'CHAT_TITLE'));
+    }
+}

--- a/backend/tests/Unit/Service/WidgetSessionServiceTest.php
+++ b/backend/tests/Unit/Service/WidgetSessionServiceTest.php
@@ -4,13 +4,10 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\Service;
 
-use App\AI\Service\AiFacade;
 use App\Entity\WidgetSession;
 use App\Repository\MessageRepository;
-use App\Repository\UserRepository;
 use App\Repository\WidgetSessionRepository;
-use App\Service\ModelConfigService;
-use App\Service\RateLimitService;
+use App\Service\Chat\ChatTitleService;
 use App\Service\WidgetSessionService;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
@@ -42,10 +39,7 @@ class WidgetSessionServiceTest extends TestCase
             $overrides['em'] ?? $this->createStub(EntityManagerInterface::class),
             $overrides['sessionRepository'] ?? $this->createStub(WidgetSessionRepository::class),
             $overrides['messageRepository'] ?? $this->createStub(MessageRepository::class),
-            $this->createStub(UserRepository::class),
-            $this->createStub(AiFacade::class),
-            $this->createStub(ModelConfigService::class),
-            $this->createStub(RateLimitService::class),
+            $this->createStub(ChatTitleService::class),
             $this->createStub(LoggerInterface::class),
         );
     }

--- a/frontend/src/stores/chats.ts
+++ b/frontend/src/stores/chats.ts
@@ -326,6 +326,17 @@ export const useChatsStore = defineStore('chats', () => {
     }
   }
 
+  /**
+   * Reflect a title the server generated for a chat (#1500). Local-only: the
+   * value is already persisted, so re-sending it would be a redundant PATCH.
+   */
+  function applyChatTitle(chatId: number, title: string) {
+    const chat = chats.value.find((c) => c.id === chatId)
+    if (chat) {
+      chat.title = title
+    }
+  }
+
   async function deleteChat(chatId: number, silent: boolean = false) {
     if (!checkAuthOrRedirect()) return
 
@@ -501,6 +512,7 @@ export const useChatsStore = defineStore('chats', () => {
     createChat,
     findOrCreateEmptyChat,
     updateChatTitle,
+    applyChatTitle,
     deleteChat,
     shareChat,
     getShareInfo,

--- a/frontend/src/types/chatStream.ts
+++ b/frontend/src/types/chatStream.ts
@@ -132,6 +132,11 @@ export interface StreamUpdatePayload {
   topic?: string
   originalTopic?: string | null
   originalMediaType?: string | null
+  /**
+   * Title the server generated for this chat, sent only on the turn that
+   * named it (#1500).
+   */
+  chatTitle?: string
   limit_type?: string
   action_type?: string
   used?: number

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -473,7 +473,7 @@ import {
   type Message,
   type Part,
 } from '@/stores/history'
-import { useChatsStore, isDefaultChatTitle } from '@/stores/chats'
+import { useChatsStore } from '@/stores/chats'
 import { useModelsStore } from '@/stores/models'
 import { useAiConfigStore } from '@/stores/aiConfig'
 import { useAuthStore } from '@/stores/auth'
@@ -1107,34 +1107,6 @@ watch(
     }
   }
 )
-
-async function generateChatTitleFromFirstMessage(firstMessage: string) {
-  const chat = chatsStore.activeChat
-  if (!chat) return
-
-  if (chat.title && !isDefaultChatTitle(chat.title)) return
-
-  // Only generate for user messages from this chat
-  const userMessages = historyStore.messages.filter((m) => m.role === 'user')
-  if (userMessages.length !== 1) return
-
-  // Generate title from first message (take first 50 chars). Strip a leading
-  // tool-command prefix ("/pic ", "/vid ", "/search ") first — `firstMessage`
-  // is the raw content sent to the backend, which keeps the prefix for
-  // pic/vid routing (see handleSendMessage), so without this the sidebar
-  // title showed e.g. "/pic Haus" instead of just "Haus".
-  let title = firstMessage.trim()
-  const commandMatch = title.match(/^\/(search|pic|vid)\s+(.*)$/)
-  if (commandMatch) {
-    title = commandMatch[2].trim()
-  }
-  if (title.length > 50) {
-    title = title.substring(0, 47) + '...'
-  }
-
-  // Update chat title
-  await chatsStore.updateChatTitle(chat.id, title)
-}
 
 const userTextBefore = (messageId: string | number): string => {
   const list = historyStore.messages
@@ -3412,8 +3384,13 @@ const streamAIResponse = async (
             // bump, no reconcile against a stored message, no memory-
             // extraction poll (extraction is skipped server-side).
             if (!incognito && chatId) {
-              // Generate chat title from first message
-              generateChatTitleFromFirstMessage(userMessage)
+              // The server names the chat after the first exchange (#1500) and
+              // sends the title on the turn that produced it. Until then the
+              // sidebar shows the first-message preview, so there is nothing to
+              // do when the field is absent.
+              if (data.chatTitle) {
+                chatsStore.applyChatTitle(chatId, data.chatTitle)
+              }
 
               // Bump chat activity so the sidebar reflects the assistant message
               // landing without waiting for a full reload.

--- a/frontend/tests/unit/stores/chats.spec.ts
+++ b/frontend/tests/unit/stores/chats.spec.ts
@@ -159,6 +159,42 @@ describe('Chats Store', () => {
     })
   })
 
+  describe('applyChatTitle', () => {
+    const untitled = () => ({
+      id: 1,
+      title: 'New Chat',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      messageCount: 2,
+    })
+
+    it('shows the title the server generated for the chat', () => {
+      const store = useChatsStore()
+      store.chats = [untitled()]
+
+      store.applyChatTitle(1, 'Invoice import problem')
+
+      expect(store.chats[0].title).toBe('Invoice import problem')
+    })
+
+    it('does not PATCH — the server already persisted the title', () => {
+      const store = useChatsStore()
+      store.chats = [untitled()]
+
+      store.applyChatTitle(1, 'Invoice import problem')
+
+      expect(httpClientMock).not.toHaveBeenCalled()
+    })
+
+    it('ignores a title for a chat that is not in the list', () => {
+      const store = useChatsStore()
+      store.chats = [untitled()]
+
+      expect(() => store.applyChatTitle(999, 'Somewhere else')).not.toThrow()
+      expect(store.chats[0].title).toBe('New Chat')
+    })
+  })
+
   describe('bumpChatActivity', () => {
     it('updates updatedAt to a fresh ISO timestamp so the chat sorts to the top', () => {
       const store = useChatsStore()


### PR DESCRIPTION
## Summary

Closes #1500.

Web chats were titled client-side by truncating the first user message, so a greeting became a sidebar entry called "Hi" and a handful of short openers produced a column of near-identical labels that described nothing.

The server now names a chat once its first exchange is on record, and sends the title on the SSE `complete` event of the turn that produced it so the sidebar picks it up without refetching the chat list.

### Design notes

- **Both sides of the exchange go into the request.** A title generated from "Hi" alone is the bug, not the fix — the answer is usually where the subject is.
- **Shared with the widget path** rather than duplicated, as the issue requires. The new `ChatTitleService` owns model resolution, the request, and the cleanup; `WidgetSessionService::generateTitleIfNeeded()` keeps only its own trigger (5 user messages) and its own target column (`BWIDGETSESSIONS.BTITLE`). That let four now-unused dependencies drop out of `WidgetSessionService`.
- **No hardcoded model.** Resolution goes through the `SUMMARIZE` capability (`SUMMARIZE → SORT → CHAT`), so an operator can bind titling to a cheap or local model.
- **Token-lean by construction:** one user turn, no system prompt, no memories, no RAG context, no tools. A test asserts the request shape so this cannot quietly grow.
- **Cleanup matters** because the output is rendered straight into the sidebar: quotes, markdown bold, a `Title:`/`Titel:` label, trailing punctuation, an explanatory second line and runaway length are all stripped.
- **Runs at most once per chat** and returns early as soon as a title exists, so a user rename is never overwritten. Placeholder titles (`New Chat`, `Neuer Chat`, blank) still count as untitled, which covers chats created before this change. A re-read before the write means a concurrent turn cannot produce two titles.
- **Failure is cosmetic.** If the model is unavailable the chat stays untitled and the existing display fallback (first-message preview → localized "New Chat") takes over. Nothing surfaces to the user and the turn is unaffected.
- **Incognito** persists nothing and is never titled; guest and widget turns are excluded too.

No new user-facing strings, so no locale changes are needed — the fallback label `chat.newChat` already exists in all four locales.

## Test plan

New `backend/tests/Unit/Service/Chat/ChatTitleServiceTest.php` (20 tests):

- [x] The first complete turn gets an AI title, persisted to the chat
- [x] An incomplete turn (user message only) is not titled yet and makes no model call
- [x] A title the user chose is never replaced — no history read, no model call, no flush
- [x] `New Chat` / `Neuer Chat` / blank count as untitled
- [x] A failing model leaves the chat untitled without throwing
- [x] An empty model reply is not stored
- [x] Padding is stripped: quotes, markdown bold, trailing period, `Title:`/`Titel:` prefixes, explanatory second line, collapsed whitespace
- [x] An overlong title is cut to label length
- [x] The request is a single bare user turn carrying the assistant text, with provider/model from the summary config
- [x] Turns derive from message direction; blank messages are dropped
- [x] `generate()` with no turns makes no model call

Frontend `tests/unit/stores/chats.spec.ts`: `applyChatTitle` shows the server title, issues no PATCH, and ignores an unknown chat id.

Full gate:

- [x] `make -C backend lint`
- [x] `make -C backend phpstan` (unfiltered)
- [x] `make -C backend test` — 3785 tests, 14580 assertions
- [x] `make -C frontend lint`
- [x] `npm run check:types` (vue-tsc)
- [x] `make -C frontend test` — 1237 tests / 145 files