### PR TITLE
feat(models): recommend Groq's production tier and guard the recommendations

### DIFF
--- a/backend/src/AI/Credential/ProviderDefaultsService.php
+++ b/backend/src/AI/Credential/ProviderDefaultsService.php
@@ -35,15 +35,32 @@ final readonly class ProviderDefaultsService
      * @var array<string, array<string, string>>
      */
     private const PROVIDER_DEFAULTS = [
+        // gpt-oss-120b for every text tier, main and fast alike. Groq classes it
+        // as a **Production** model, while `qwen/qwen3.6-27b` — the previous
+        // MAIN pick — is **Preview**, which Groq documents as "should not be
+        // used in production environments as they may be discontinued at short
+        // notice". A recommended default is precisely the binding an operator
+        // does not watch, so it should not sit on a model that can vanish. It is
+        // also the cheaper and (per the catalog's own quality score) stronger
+        // row: $0.15/$0.60 vs $0.60/$3.00 per 1M tokens, quality 10 vs 9.
         'groq' => [
-            'CHAT' => 'groq:qwen/qwen3.6-27b:chat',
-            'TOOLS' => 'groq:qwen/qwen3.6-27b:chat',
-            'ANALYZE' => 'groq:qwen/qwen3.6-27b:chat',
+            'CHAT' => 'groq:openai/gpt-oss-120b:chat',
+            'TOOLS' => 'groq:openai/gpt-oss-120b:chat',
+            'ANALYZE' => 'groq:openai/gpt-oss-120b:chat',
             'SORT' => 'groq:openai/gpt-oss-120b:chat',
             'PLAN' => 'groq:openai/gpt-oss-120b:chat',
             'SUMMARIZE' => 'groq:openai/gpt-oss-120b:chat',
             'MEM' => 'groq:openai/gpt-oss-120b:mem',
+            // The one unavoidable Preview binding: qwen3.6-27b is the only
+            // Groq model that accepts images at all (the gpt-oss rows are
+            // text-only). Leaving PIC2TEXT unbound would be worse — it would
+            // fall through to whatever the install had, which on a Groq-only
+            // setup is nothing.
             'PIC2TEXT' => 'groq:qwen/qwen3.6-27b:pic2text',
+            // whisper-large-v3, not the cheaper -turbo ($0.111 vs $0.04 per
+            // hour): Synaplan ships four UI locales and large-v3 is the more
+            // accurate multilingual transcriber. Turbo stays selectable for
+            // operators who would rather have the cheaper run.
             'SOUND2TEXT' => 'groq:whisper-large-v3:sound2text',
         ],
         'openai' => [

--- a/backend/src/Model/ModelCatalog.php
+++ b/backend/src/Model/ModelCatalog.php
@@ -241,22 +241,29 @@ class ModelCatalog
         ],
 
         // --- 2026-08-19 (Version20260819080000) ---
+        // The chat rows point at gpt-oss-120b rather than qwen3.6-27b even
+        // though the retiring migration repointed live bindings at the latter:
+        // qwen3.6-27b is Preview on Groq ("may be discontinued at short
+        // notice"), and a successor is exactly the pointer that must outlive
+        // the model it replaces.
         9 => [
             'providerId' => 'llama-3.3-70b-versatile',
             'retiredOn' => '2026-08-19',
-            'successor' => 'groq:qwen/qwen3.6-27b:chat',
+            'successor' => 'groq:openai/gpt-oss-120b:chat',
             'reason' => 'Removed from the Groq production catalog.',
         ],
         17 => [
             'providerId' => 'meta-llama/llama-4-scout-17b-16e-instruct',
             'retiredOn' => '2026-08-19',
+            // Stays on the Preview row: Groq has no other model that takes
+            // images, so there is nothing more durable to point at.
             'successor' => 'groq:qwen/qwen3.6-27b:pic2text',
             'reason' => 'Removed from the Groq production catalog.',
         ],
         53 => [
             'providerId' => 'qwen/qwen3-32b',
             'retiredOn' => '2026-08-19',
-            'successor' => 'groq:qwen/qwen3.6-27b:chat',
+            'successor' => 'groq:openai/gpt-oss-120b:chat',
             'reason' => 'Superseded by Qwen 3.6 27B.',
         ],
         236 => [
@@ -719,7 +726,11 @@ class ModelCatalog
                     'model' => 'qwen/qwen3.6-27b',
                     'reasoning_format' => 'hidden',
                 ],
-                'meta' => ['context_window' => '131072', 'max_output' => '16384', 'quantization' => 'TruePoint Numerics'],
+                // groq_tier: Groq's own lifecycle class. "preview" carries an
+                // explicit "may be discontinued at short notice" warning, which
+                // is why this row is selectable but is not a recommended text
+                // default (see ProviderDefaultsService).
+                'meta' => ['context_window' => '131072', 'max_output' => '16384', 'quantization' => 'TruePoint Numerics', 'groq_tier' => 'preview'],
             ],
         ],
         [
@@ -744,6 +755,9 @@ class ModelCatalog
                     'model' => 'qwen/qwen3.6-27b',
                     'max_completion_tokens' => 1024,
                 ],
+                // Preview on Groq, and still the recommended PIC2TEXT default:
+                // it is the only Groq model that accepts image input at all.
+                'meta' => ['groq_tier' => 'preview'],
             ],
         ],
         [

--- a/backend/tests/AI/Credential/ProviderDefaultsServiceTest.php
+++ b/backend/tests/AI/Credential/ProviderDefaultsServiceTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\AI\Credential;
 use App\AI\Credential\ProviderDefaultsService;
 use App\AI\Credential\ProviderKeyStore;
 use App\Entity\Config;
+use App\Model\ModelCatalog;
 use App\Repository\ConfigRepository;
 use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
@@ -59,6 +60,47 @@ final class ProviderDefaultsServiceTest extends TestCase
                 self::assertGreaterThan(0, $bid, sprintf('%s/%s resolved to an invalid BID', $provider, $capability));
             }
         }
+    }
+
+    /**
+     * Resolving is not enough. "Use this provider" writes these bindings
+     * unattended — the first-run wizard, the admin button and
+     * `app:provider:apply-defaults --auto` on container start all go through
+     * here — so a recommendation pointing at a model that has since been
+     * retired or deactivated would silently bind the install to something that
+     * cannot serve a request. That is not hypothetical: the xAI SOUND2TEXT
+     * recommendation outlived `grok-stt` and had to be removed by hand in
+     * #1514, and nothing would have caught it.
+     */
+    public function testNoRecommendedDefaultPointsAtARetiredOrInactiveModel(): void
+    {
+        $byBid = [];
+        foreach (ModelCatalog::all() as $model) {
+            $byBid[(int) $model['id']] = $model;
+        }
+
+        $problems = [];
+        foreach ([...ProviderKeyStore::SUPPORTED_PROVIDERS, 'ollama'] as $provider) {
+            foreach ($this->service->getRecommendedDefaults($provider) as $capability => $bid) {
+                $reasons = [];
+                if (ModelCatalog::isRetired($bid)) {
+                    $reasons[] = 'retired';
+                }
+                if (0 === (int) ($byBid[$bid]['active'] ?? 0)) {
+                    $reasons[] = 'inactive';
+                }
+                if ([] !== $reasons) {
+                    $problems[] = sprintf('%s/%s → BID %d (%s)', $provider, $capability, $bid, implode(' + ', $reasons));
+                }
+            }
+        }
+
+        self::assertSame([], $problems, sprintf(
+            "Recommended default(s) point at a model that can no longer serve a request:\n  %s\n"
+            ."Repoint them at a live model, or drop the capability from PROVIDER_DEFAULTS so it keeps\n"
+            .'whatever the install had instead of being rebound to a dead model.',
+            implode("\n  ", $problems),
+        ));
     }
 
     public function testAutoApplyNoopsWhenCurrentDefaultIsAvailable(): void


### PR DESCRIPTION
> **Stacked on #1532** (needs `ModelCatalog::isRetired()` for the new guard). Base will be retargeted to `main` once #1532 merges.

## Are the recommended models up to date?

I audited every entry in `PROVIDER_DEFAULTS` — all nine providers, every capability — against the live provider catalogs.

**Nothing was broken.** Every key resolves to exactly one catalog entry, nothing points at a retired or inactive model, and every Groq price still matches [Groq's published list](https://console.groq.com/docs/models) exactly:

| BID | Model | Our price | Groq | Tier |
| --- | --- | --- | --- | --- |
| 76 / 220 | `openai/gpt-oss-120b` | $0.15 / $0.60 | $0.15 / $0.60 | Production |
| 75 | `openai/gpt-oss-20b` | $0.075 / $0.30 | $0.075 / $0.30 | Production |
| 21 | `whisper-large-v3` | $0.111/hr | $0.111/hr | Production |
| 50 | `whisper-large-v3-turbo` | $0.04/hr | $0.04/hr | Production |
| 324 / 325 | `qwen/qwen3.6-27b` | $0.60 / $3.00 | $0.60 / $3.00 | **Preview** |

But that last row is a problem, and it's what this PR fixes.

## The Groq text tier sat on a Preview model

`qwen/qwen3.6-27b` was the MAIN pick for `CHAT`/`TOOLS`/`ANALYZE`. Groq classes it as **Preview**, documented as *"should not be used in production environments as they may be discontinued at short notice"*. A recommended default is precisely the binding an operator never looks at again — it should not rest on a model that can vanish.

**`gpt-oss-120b` takes over the text tier** (main and fast alike, as requested). It is strictly better on every axis that matters here:

- **Production**, not Preview
- **4× cheaper input, 5× cheaper output** — $0.15/$0.60 vs $0.60/$3.00 per 1M
- **higher quality score in our own catalog** — 10 vs 9

`PIC2TEXT` stays on `qwen3.6-27b`, and that's unavoidable: it is the only Groq model that accepts image input at all (the `gpt-oss` rows are text-only — the "max file size" column in Groq's table is the tell). Leaving it unbound would be worse on a Groq-only install. Recorded in a comment so the next reader doesn't "fix" it.

`SOUND2TEXT` stays on `whisper-large-v3` rather than the 2.8× cheaper `-turbo`: we ship four UI locales and large-v3 is the more accurate multilingual transcriber. Turbo remains selectable for operators who prefer the cheaper run — say the word if you'd rather flip the default.

## Retirement successors got the same treatment

The two retired Groq **chat** rows (BID 9 `llama-3.3-70b-versatile`, BID 53 `qwen/qwen3-32b`) pointed their successor at the Preview row. A successor has to outlive what it replaces, so both now point at `gpt-oss-120b`. BID 17 (vision) stays on the Preview row for the same reason `PIC2TEXT` does.

Nice side effect: this exercised #1532's foundation end to end. Changing two successors in the registry and running `app:seed` reported **`2 updated, 27 skipped`** and converged both rows — no migration, which is the entire point of that PR.

## The guard

Resolving was already tested. Being *alive* was not — and that gap has bitten us for real: the xAI `SOUND2TEXT` recommendation outlived `grok-stt` and had to be removed by hand in #1514. Nothing would have caught it, and `app:provider:apply-defaults --auto` runs on container start, so it would have rewritten the dead binding on every boot.

`testNoRecommendedDefaultPointsAtARetiredOrInactiveModel` closes that. Verified by restoring the exact historical bug:

> Recommended default(s) point at a model that can no longer serve a request:
>   xai/SOUND2TEXT → BID 321 (retired + inactive)
> Repoint them at a live model, or drop the capability from PROVIDER_DEFAULTS so it keeps
> whatever the install had instead of being rebound to a dead model.

## Considered and deliberately not done

Groq lists models we don't carry. Most have nowhere to go:

- **`canopylabs/orpheus-v1-english` / `-arabic-saudi` (TTS)** — genuinely tempting, since Groq currently has **no** `TEXT2SOUND` row and we just retired `grok-tts` without a successor. But `GroqProvider` implements `ChatProviderInterface, VisionProviderInterface, SpeechToTextProviderInterface` — **not** `TextToSpeechProviderInterface`. Adding the catalog row without the adapter would ship a selectable model that fails the moment anyone picks it. That's a provider integration, not a catalog line, and per AGENTS.md worth asking about first. Happy to do it as a follow-up.
- **`groq/compound` / `compound-mini`** — agentic systems with built-in tools, not a plain model; no capability slot, and no published token price.
- **`openai/gpt-oss-safeguard-20b`, `meta-llama/llama-prompt-guard-2-*`** — moderation / prompt-injection guards. We have no moderation capability to bind them to.
- **`minimaxai/minimax-m2.7`** — Enterprise, "Contact Sales". Unpriceable, and a catalog row with a wrong price bills wrong.

## Verification

`make -C backend lint`, `make -C backend phpstan`, `make -C backend test` → 3942 tests, 14825 assertions, 0 failures. Backend-only: `json.meta` is documentation metadata that no code path reads, so there is no API or frontend surface in this change.