### PR TITLE
fix(health): skip Triton/Piper health checks when not configured

### DIFF
--- a/backend/src/AI/Health/Probe/LocalProviderAvailabilityProbe.php
+++ b/backend/src/AI/Health/Probe/LocalProviderAvailabilityProbe.php
@@ -12,10 +12,16 @@ use App\AI\Service\ProviderRegistry;
  * Reachability check for self-hosted providers that have no catalog endpoint
  * (Triton over gRPC, Piper TTS).
  *
- * Their own `isAvailable()` is the free check they already ship, so this probe
- * can say "the service is up" without ever running inference. It cannot say
- * anything about individual models, hence {@see ProbeResult::reachable()} — a
- * reachable service must never be used as grounds for retiring a model.
+ * Their own `isAvailable()` is the free check they already ship. For these
+ * two providers that method means "a server URL was set", not "the server
+ * answers" — Triton constructs a gRPC stub without connecting, Piper only
+ * looks at `SYNAPLAN_TTS_URL`. An empty URL is therefore a skip, the same
+ * rule every cloud probe follows, so an install that never set
+ * `TRITON_SERVER_URL` does not page operators about unused catalog rows
+ * ("3 NVIDIA Triton model(s) failing").
+ *
+ * When a URL is set the probe reports {@see ProbeResult::reachable()}. That
+ * must never be used as grounds for retiring a model: it is not a listing.
  */
 final readonly class LocalProviderAvailabilityProbe implements ModelListProbeInterface
 {
@@ -40,9 +46,14 @@ final readonly class LocalProviderAvailabilityProbe implements ModelListProbeInt
             }
 
             try {
-                return $provider->isAvailable()
-                    ? ProbeResult::reachable(sprintf('%s is reachable.', $provider->getDisplayName()))
-                    : ProbeResult::failed(FailureKind::Transient, sprintf('%s is not reachable.', $provider->getDisplayName()));
+                if (!$provider->isAvailable()) {
+                    return ProbeResult::skipped(sprintf(
+                        '%s is not configured.',
+                        $provider->getDisplayName()
+                    ));
+                }
+
+                return ProbeResult::reachable(sprintf('%s is reachable.', $provider->getDisplayName()));
             } catch (\Throwable $e) {
                 return ProbeResult::failed(FailureKind::Transient, sprintf('%s check failed: %s', $service, $e->getMessage()));
             }

--- a/backend/tests/Unit/AI/Health/ModelHealthEvaluatorUnconfiguredTest.php
+++ b/backend/tests/Unit/AI/Health/ModelHealthEvaluatorUnconfiguredTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\AI\Health;
+
+use App\AI\Health\FailureClassifier;
+use App\AI\Health\ModelAutoDisabler;
+use App\AI\Health\ModelHealthAlerter;
+use App\AI\Health\ModelHealthConfig;
+use App\AI\Health\ModelHealthEvaluator;
+use App\AI\Health\ModelHealthRecorder;
+use App\AI\Health\ModelHealthState;
+use App\AI\Health\Probe\ModelListProbeInterface;
+use App\AI\Health\Probe\ModelListProbeRegistry;
+use App\AI\Health\Probe\ProbeResult;
+use App\AI\Service\ModelProbeResult;
+use App\AI\Service\ProviderDisplayNames;
+use App\AI\Service\ProviderRegistry;
+use App\Entity\Model;
+use App\Repository\ConfigRepository;
+use App\Repository\ModelHealthRepository;
+use App\Repository\ModelRepository;
+use App\Service\DiscordNotificationService;
+use App\Service\InternalEmailService;
+use App\Service\Usage\UsageFailureLogger;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+/**
+ * A provider nobody configured is not broken. The evaluator already maps a
+ * skipped probe to Unconfigured; this locks the alert side so three unused
+ * Triton catalog rows never become "3 NVIDIA Triton model(s) failing".
+ */
+final class ModelHealthEvaluatorUnconfiguredTest extends TestCase
+{
+    public function testUnconfiguredTritonDoesNotRaiseAnIncident(): void
+    {
+        $models = [
+            self::model(1, 'llama-3.1-8b'),
+            self::model(2, 'bge-m3'),
+            self::model(3, 'whisper-large-v3'),
+        ];
+
+        $run = $this->evaluatorFor($models, ProbeResult::skipped('NVIDIA Triton is not configured.'))
+            ->run(dryRun: true);
+
+        self::assertCount(3, $run->verdicts);
+        foreach ($run->verdicts as $verdict) {
+            self::assertSame(ModelHealthState::Unconfigured, $verdict->state);
+            self::assertFalse($verdict->safeToDisable);
+        }
+        self::assertSame(['triton' => 'NVIDIA Triton is not configured.'], $run->skippedProviders);
+        self::assertSame([], $run->alertsRaised, 'Unconfigured Triton must not page operators');
+    }
+
+    /**
+     * @param list<Model> $catalog
+     */
+    private function evaluatorFor(array $catalog, ProbeResult $probeResult): ModelHealthEvaluator
+    {
+        $probe = new class($probeResult) implements ModelListProbeInterface {
+            public function __construct(private readonly ProbeResult $result)
+            {
+            }
+
+            public function supports(string $service): bool
+            {
+                return 'triton' === mb_strtolower($service);
+            }
+
+            public function probe(string $service): ProbeResult
+            {
+                return $this->result;
+            }
+
+            public function confirm(string $service, string $providerModelId): ModelProbeResult
+            {
+                return ModelProbeResult::Inconclusive;
+            }
+        };
+
+        $indexed = [];
+        foreach ($catalog as $model) {
+            $indexed[$model->getProviderId()][] = $model;
+        }
+
+        $models = $this->createStub(ModelRepository::class);
+        $models->method('findAllServices')->willReturn(['triton']);
+        $models->method('findByServiceIndexedByProviderId')->willReturn($indexed);
+
+        $configRepository = $this->createStub(ConfigRepository::class);
+        $configRepository->method('getValue')->willReturn(null);
+        $config = new ModelHealthConfig($configRepository);
+
+        $alerter = new ModelHealthAlerter(
+            new ArrayAdapter(),
+            $config,
+            $this->createStub(InternalEmailService::class),
+            $this->createStub(DiscordNotificationService::class),
+            new NullLogger(),
+        );
+
+        return new ModelHealthEvaluator(
+            $models,
+            $this->createStub(ModelHealthRepository::class),
+            new ModelListProbeRegistry([$probe]),
+            new ModelHealthRecorder(
+                new ArrayAdapter(),
+                $config,
+                new FailureClassifier(),
+                $models,
+                $this->createStub(UsageFailureLogger::class),
+                new NullLogger(),
+            ),
+            $config,
+            $alerter,
+            new ModelAutoDisabler($config, new NullLogger()),
+            $this->createStub(EntityManagerInterface::class),
+            new ArrayAdapter(),
+            new ProviderDisplayNames($this->createStub(ProviderRegistry::class)),
+            new NullLogger(),
+        );
+    }
+
+    private static function model(int $id, string $providerId): Model
+    {
+        $model = new Model();
+        $model->setService('triton')
+            ->setProviderId($providerId)
+            ->setName($providerId)
+            ->setTag('chat');
+
+        $reflection = new \ReflectionProperty(Model::class, 'id');
+        $reflection->setValue($model, $id);
+
+        return $model;
+    }
+}

--- a/backend/tests/Unit/AI/Health/Probe/LocalProviderAvailabilityProbeTest.php
+++ b/backend/tests/Unit/AI/Health/Probe/LocalProviderAvailabilityProbeTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\AI\Health\Probe;
+
+use App\AI\Health\Probe\LocalProviderAvailabilityProbe;
+use App\AI\Interface\ProviderMetadataInterface;
+use App\AI\Service\ProviderRegistry;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Locks the rule that caused the "3 NVIDIA Triton model(s) failing" incident:
+ * an empty TRITON_SERVER_URL is "not configured", not an outage.
+ */
+final class LocalProviderAvailabilityProbeTest extends TestCase
+{
+    public function testUnconfiguredTritonIsSkippedNotFailed(): void
+    {
+        $result = $this->probeFor('triton', available: false)->probe('triton');
+
+        self::assertTrue($result->isSkipped(), 'An empty TRITON_SERVER_URL must not be treated as an outage');
+        self::assertFalse($result->isFailed());
+        self::assertStringContainsString('not configured', $result->message);
+    }
+
+    public function testUnconfiguredPiperIsSkippedNotFailed(): void
+    {
+        $result = $this->probeFor('piper', available: false)->probe('piper');
+
+        self::assertTrue($result->isSkipped());
+        self::assertFalse($result->isFailed());
+    }
+
+    public function testConfiguredTritonIsReportedReachable(): void
+    {
+        $result = $this->probeFor('triton', available: true)->probe('triton');
+
+        self::assertTrue($result->isOk());
+        self::assertFalse($result->listingComplete);
+        self::assertStringContainsString('reachable', $result->message);
+    }
+
+    public function testUnknownServiceIsSkipped(): void
+    {
+        $registry = $this->createStub(ProviderRegistry::class);
+        $registry->method('getUniqueProviders')->willReturn([]);
+
+        $result = (new LocalProviderAvailabilityProbe($registry))->probe('triton');
+
+        self::assertTrue($result->isSkipped());
+        self::assertStringContainsString('not registered', $result->message);
+    }
+
+    public function testSupportsOnlyTritonAndPiper(): void
+    {
+        $probe = new LocalProviderAvailabilityProbe($this->createStub(ProviderRegistry::class));
+
+        self::assertTrue($probe->supports('triton'));
+        self::assertTrue($probe->supports('Piper'));
+        self::assertFalse($probe->supports('ollama'));
+        self::assertFalse($probe->supports('openai'));
+    }
+
+    private function probeFor(string $name, bool $available): LocalProviderAvailabilityProbe
+    {
+        $provider = $this->createStub(ProviderMetadataInterface::class);
+        $provider->method('getName')->willReturn($name);
+        $provider->method('getDisplayName')->willReturn('triton' === $name ? 'NVIDIA Triton' : 'Piper TTS');
+        $provider->method('isAvailable')->willReturn($available);
+
+        $registry = $this->createStub(ProviderRegistry::class);
+        $registry->method('getUniqueProviders')->willReturn([$name => $provider]);
+
+        return new LocalProviderAvailabilityProbe($registry);
+    }
+}


### PR DESCRIPTION
## Problem

An install that never set `TRITON_SERVER_URL` (the compose default is empty) still ran the Triton model-health probe. `TritonProvider::isAvailable()` is false when the URL is empty, and `LocalProviderAvailabilityProbe` treated that as a **transient outage**. The evaluator then marked all three catalogued Triton models `Degraded` and sent the incident **“3 NVIDIA Triton model(s) failing”**.

Triton is optional. A provider nobody configured is not broken — that is already the rule for every cloud probe (`ProbeResult::skipped` → `Unconfigured`, no alert).

## Change

- If Triton or Piper reports `isAvailable() === false`, **skip** the probe (`not configured`) instead of failing it.
- For these two providers `isAvailable()` only means “a server URL was set” (Triton builds a gRPC stub without connecting; Piper looks at `SYNAPLAN_TTS_URL`). It is not a live ping.
- Locked by unit tests on the probe and on the evaluator (three unused Triton rows must not raise an incident).

Piper is the same probe class and had the same misclassification when `SYNAPLAN_TTS_URL` is empty.

## Gate

- `make -C backend lint`
- `make -C backend phpstan`
- `make -C backend test` (3791 tests)

Frontend unchanged.