### PR TITLE
feat(health): enhance model health evaluation by skipping re-probing

### DIFF
--- a/backend/src/AI/Health/ModelHealthEvaluator.php
+++ b/backend/src/AI/Health/ModelHealthEvaluator.php
@@ -30,6 +30,11 @@ use Psr\Log\LoggerInterface;
  *
  * The catalog wins where it speaks, because a model the provider no longer
  * lists is gone no matter what the counters say.
+ *
+ * Rows that already carry BRETIREDON are skipped: a recorded retirement is
+ * expected to be missing, so probing it again is wasted work and alerting on
+ * it trains operators to ignore the mail. Operator-disabled rows without a
+ * date stay in the check.
  */
 final readonly class ModelHealthEvaluator
 {
@@ -99,11 +104,24 @@ final readonly class ModelHealthEvaluator
 
             $serviceVerdicts = [];
             foreach ($catalogModels as $providerId => $rows) {
+                // A recorded retirement is a closed decision, not news. Probing
+                // those rows again only reconfirms what BRETIREDON already says
+                // and turns the hourly incident mail into a reminder about work
+                // that is already done. Operator-disabled rows (BACTIVE=0, no
+                // retirement date) stay in the check: those can come back.
+                $liveRows = array_values(array_filter(
+                    $rows,
+                    static fn (Model $model): bool => !$model->isRetired()
+                ));
+                if ([] === $liveRows) {
+                    continue;
+                }
+
                 // One confirmation per provider model id, not per BMODELS row:
                 // the same id appears once per capability it is bound to.
                 $presence = $this->presence($service, $probe, $result, (string) $providerId, $budget);
 
-                foreach ($rows as $model) {
+                foreach ($liveRows as $model) {
                     $verdict = $this->judge($service, $model, (string) $providerId, $result, $presence, $now);
                     if (!$dryRun) {
                         $verdict = $this->commit($verdict, $model, $now);

--- a/backend/tests/Unit/AI/Health/ModelHealthEvaluatorRetirementTest.php
+++ b/backend/tests/Unit/AI/Health/ModelHealthEvaluatorRetirementTest.php
@@ -51,11 +51,18 @@ final class ModelHealthEvaluatorRetirementTest extends TestCase
     private object $lastProbe;
 
     /**
+     * @param Model|list<Model>               $catalog       one model or every model of the service
      * @param array<string, ModelProbeResult> $confirmations provider model id => what the provider says
      * @param list<string>                    $listed        model ids the bulk listing returns
      */
-    private function evaluatorFor(Model $model, array $listed, array $confirmations, bool $authoritative = false): ModelHealthEvaluator
+    private function evaluatorFor(Model|array $catalog, array $listed, array $confirmations, bool $authoritative = false): ModelHealthEvaluator
     {
+        $rows = $catalog instanceof Model ? [$catalog] : $catalog;
+        $indexed = [];
+        foreach ($rows as $model) {
+            $indexed[$model->getProviderId()][] = $model;
+        }
+
         $probe = new class($listed, $confirmations, $authoritative) implements ModelListProbeInterface {
             public int $confirmCalls = 0;
 
@@ -95,9 +102,8 @@ final class ModelHealthEvaluatorRetirementTest extends TestCase
         $config = new ModelHealthConfig($configRepository);
 
         $models = $this->createMock(ModelRepository::class);
-        $models->method('findAllServices')->willReturn([$model->getService()]);
-        $models->method('findByServiceIndexedByProviderId')
-            ->willReturn([$model->getProviderId() => [$model]]);
+        $models->method('findAllServices')->willReturn([$rows[0]->getService()]);
+        $models->method('findByServiceIndexedByProviderId')->willReturn($indexed);
 
         $recorder = new ModelHealthRecorder(
             new ArrayAdapter(),
@@ -250,5 +256,72 @@ final class ModelHealthEvaluatorRetirementTest extends TestCase
 
         self::assertSame(ModelHealthState::Offline, $run->verdicts[0]->state);
         self::assertTrue($run->verdicts[0]->safeToDisable);
+    }
+
+    /**
+     * BRETIREDON is the operator (or the retirement seeder) saying this model
+     * is gone on purpose. Re-probing it and paging about the same 404 every
+     * hour is how the incident mail trained people to ignore it.
+     */
+    public function testARecordedRetirementIsNotNews(): void
+    {
+        $tts = self::model(320, 'xAI', 'grok-tts', 'text2sound');
+        $tts->setRetiredOn(new \DateTimeImmutable('2026-08-20'));
+
+        $run = $this->evaluatorFor(
+            $tts,
+            ['grok-4.5'],
+            ['grok-tts' => ModelProbeResult::Gone],
+        )->run(dryRun: true);
+
+        self::assertSame([], $run->verdicts, 'A retired model must not produce a verdict');
+        self::assertSame([], $run->alertsRaised, 'A recorded retirement must not page operators');
+        self::assertSame(0, $this->lastProbe->confirmCalls, 'A retired model must not be re-asked');
+    }
+
+    /**
+     * An operator-disabled row without a retirement date is a different claim
+     * ("we switched this off") and must still be checked — it can come back.
+     */
+    public function testAnOperatorDisabledRowWithoutRetirementIsStillChecked(): void
+    {
+        $model = self::model(320, 'xAI', 'grok-tts', 'text2sound');
+        $model->setActive(0);
+
+        $run = $this->evaluatorFor(
+            $model,
+            ['grok-4.5'],
+            ['grok-tts' => ModelProbeResult::Gone],
+        )->run(dryRun: true);
+
+        self::assertSame(ModelHealthState::Offline, $run->verdicts[0]->state);
+        self::assertCount(1, $run->alertsRaised);
+    }
+
+    /**
+     * Skipping the retired sibling must not hide a live model of the same
+     * provider that the provider has also dropped.
+     */
+    public function testALiveSiblingOfARetiredModelStillAlerts(): void
+    {
+        $retired = self::model(320, 'xAI', 'grok-tts', 'text2sound');
+        $retired->setRetiredOn(new \DateTimeImmutable('2026-08-20'));
+        $live = self::model(400, 'xAI', 'grok-new-dead', 'chat');
+
+        $run = $this->evaluatorFor(
+            [$retired, $live],
+            ['grok-4.5'],
+            [
+                'grok-tts' => ModelProbeResult::Gone,
+                'grok-new-dead' => ModelProbeResult::Gone,
+            ],
+        )->run(dryRun: true);
+
+        self::assertCount(1, $run->verdicts);
+        self::assertSame('grok-new-dead', $run->verdicts[0]->providerId);
+        self::assertSame(ModelHealthState::Offline, $run->verdicts[0]->state);
+        self::assertCount(1, $run->alertsRaised);
+        self::assertSame(['grok-new-dead'], $run->alertsRaised[0]->modelNames);
+        self::assertSame(1, $this->lastProbe->confirmCalls, 'Only the live sibling may be confirmed');
     }
 }

--- a/docs/PRICING_MAINTENANCE.md
+++ b/docs/PRICING_MAINTENANCE.md
@@ -379,6 +379,8 @@ Every retirement above needed its own hand-written migration, and three of them 
 
 **What the seeder does**, idempotently and on every container start, for each entry whose row exists and still matches `providerId`: stamps `BRETIREDON` and `BSUCCESSORID`, and forces `BACTIVE = BSELECTABLE = BISDEFAULT = 0`. A re-run writes nothing. A BID an operator repurposed is skipped with a warning. Rows are never deleted — `BMESSAGES` has FKs into `BMODELS` and **BIDs must never be reused**.
 
+The health monitor (`app:model:health-check`) skips every row that carries `BRETIREDON`. A recorded retirement is expected to be missing, so it is not probed and it must not raise the hourly incident mail. Operator-disabled rows without a date stay in the check.
+
 **Why a separate seeder from `ModelSeeder`:** that one treats `BACTIVE`/`BSELECTABLE`/`BISDEFAULT` as operator-owned and never overwrites them, which is right for a live model and wrong for a dead one. A retirement outranks an operator preference — "please keep offering this" on a model the provider switched off only produces a failing request. Keeping the override in its own seeder makes it explicit instead of punching a hole in `ModelSeeder`'s preservation rules.
 
 **`successor: null` is a statement, not a gap.** It means no substitution may be made — an embedding model (a different model is a different vector space; see the `VECTORIZE` warning above) or a provider that shipped no replacement at all. Do not fill it with another provider's model to avoid the null: that assumes an API key the operator may not hold.


### PR DESCRIPTION
## Summary
Mostly platform related "retire models"

## Changes
Updated the ModelHealthEvaluator to skip rows marked with BRETIREDON during health checks, preventing unnecessary alerts for already retired models. Operator-disabled rows without a retirement date will still be evaluated. Added tests to ensure correct behavior for retired models and operator-disabled rows, confirming that alerts are raised appropriately for live models even if a sibling is retired.

## Verification
- [ ] Not tested (explain)
- [X] Manual
- [ ] Tests added/updated

## Notes
<!-- Related issues/links/threads. -->

## Screenshots/Logs
