### PR TITLE
refactor(backend): migrate Qdrant search to the query API

### DIFF
--- a/backend/src/Service/VectorSearch/QdrantClientDirect.php
+++ b/backend/src/Service/VectorSearch/QdrantClientDirect.php
@@ -184,8 +184,8 @@ final class QdrantClientDirect implements QdrantClientInterface
             // Ask for up to 2x the requested limit so dedup below doesn't
             // short-change the caller when legacy+UUID pairs sit above the
             // score threshold for the same logical point.
-            $response = $this->qdrantRequest('POST', "/collections/{$collection}/points/search", [
-                'vector' => $queryVector,
+            $response = $this->qdrantRequest('POST', "/collections/{$collection}/points/query", [
+                'query' => $queryVector,
                 'filter' => ['must' => $must],
                 'limit' => $limit * 2,
                 'score_threshold' => $minScore,
@@ -198,7 +198,7 @@ final class QdrantClientDirect implements QdrantClientInterface
             // logical point (one integer-keyed, one UUID-keyed), so the
             // same `_point_id` can appear twice in one response.
             $bestByLogical = [];
-            foreach ($response['result'] ?? [] as $hit) {
+            foreach ($response['result']['points'] ?? [] as $hit) {
                 $logical = $hit['payload']['_point_id'] ?? (string) $hit['id'];
                 if (!isset($bestByLogical[$logical]) || $hit['score'] > $bestByLogical[$logical]['score']) {
                     $bestByLogical[$logical] = [
@@ -498,8 +498,8 @@ final class QdrantClientDirect implements QdrantClientInterface
                 $must[] = ['key' => 'group_key', 'match' => ['value' => $groupKey]];
             }
 
-            $response = $this->qdrantRequest('POST', "/collections/{$this->documentsCollection}/points/search", [
-                'vector' => $vector,
+            $response = $this->qdrantRequest('POST', "/collections/{$this->documentsCollection}/points/query", [
+                'query' => $vector,
                 'filter' => ['must' => $must],
                 'limit' => $limit,
                 'score_threshold' => $minScore,
@@ -507,7 +507,7 @@ final class QdrantClientDirect implements QdrantClientInterface
             ]);
 
             $results = [];
-            foreach ($response['result'] ?? [] as $hit) {
+            foreach ($response['result']['points'] ?? [] as $hit) {
                 $results[] = [
                     'id' => $hit['payload']['_point_id'] ?? (string) $hit['id'],
                     'score' => $hit['score'],

--- a/backend/tests/Service/VectorSearch/QdrantClientDirectTest.php
+++ b/backend/tests/Service/VectorSearch/QdrantClientDirectTest.php
@@ -269,23 +269,25 @@ final class QdrantClientDirectTest extends TestCase
     public function testSearchMemoriesDedupesAndKeepsHigherScoringCopy(): void
     {
         $client = $this->buildClient([
-            '/collections/user_memories/points/search' => fn () => new MockResponse(
+            '/collections/user_memories/points/query' => fn () => new MockResponse(
                 json_encode([
                     'result' => [
-                        [
-                            'id' => 11111,
-                            'score' => 0.72,
-                            'payload' => [
-                                '_point_id' => 'mem_1_dup',
-                                'user_id' => 1, 'category' => 'a', 'key' => 'k', 'value' => 'legacy', 'active' => true,
+                        'points' => [
+                            [
+                                'id' => 11111,
+                                'score' => 0.72,
+                                'payload' => [
+                                    '_point_id' => 'mem_1_dup',
+                                    'user_id' => 1, 'category' => 'a', 'key' => 'k', 'value' => 'legacy', 'active' => true,
+                                ],
                             ],
-                        ],
-                        [
-                            'id' => QdrantPointId::uuidFor('mem_1_dup'),
-                            'score' => 0.91,
-                            'payload' => [
-                                '_point_id' => 'mem_1_dup',
-                                'user_id' => 1, 'category' => 'a', 'key' => 'k', 'value' => 'fresh-uuid', 'active' => true,
+                            [
+                                'id' => QdrantPointId::uuidFor('mem_1_dup'),
+                                'score' => 0.91,
+                                'payload' => [
+                                    '_point_id' => 'mem_1_dup',
+                                    'user_id' => 1, 'category' => 'a', 'key' => 'k', 'value' => 'fresh-uuid', 'active' => true,
+                                ],
                             ],
                         ],
                     ],


### PR DESCRIPTION
## Summary

- Migrate `QdrantClientDirect::searchMemories()` and `searchDocuments()` from the deprecated `POST /points/search` endpoint to the unified `POST /points/query` API.
- Request field `vector` → `query`; response shape `result` (bare array) → `result.points`.
- Update the corresponding unit test mock.

## Why

Qdrant **1.19** removes the legacy `/search`, `/recommend`, `/discover` endpoints from its OpenAPI spec (deprecated in gRPC). The REST handler for `/points/search` is still served at runtime in 1.19 (verified empirically: it returns HTTP 200), so the [docker-images bump #1448](https://github.com/metadist/synaplan/pull/1448) is not broken — but we should stop relying on the deprecated route before a future major removes it for real.

The unified `/points/query` API has existed since Qdrant **1.10**, so this change is fully backward-compatible with the `qdrant 1.18.x` currently on `main`. This is the compatibility change that should land before/independently of the version bump.

## Test plan

- [x] `make -C backend lint`
- [x] `make -C backend phpstan` (No errors)
- [x] `make -C backend test` (3998 tests, 0 errors / 0 failures)
- [x] Verified `/points/query` behaviour against a throwaway `qdrant:v1.19.0` container (search + query both return the expected results)
- [ ] CI green (incl. E2E against real Qdrant)