### PR TITLE
feat(media): integrate OutboundChannelMedia for document handling

### DIFF
--- a/backend/src/Controller/StaticUploadController.php
+++ b/backend/src/Controller/StaticUploadController.php
@@ -8,6 +8,7 @@ use App\Repository\FileRepository;
 use App\Repository\MessageRepository;
 use App\Service\File\FileHelper;
 use App\Service\Media\MediaAccessTokenService;
+use App\Service\Media\OutboundChannelMedia;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
@@ -90,18 +91,18 @@ class StaticUploadController extends AbstractController
         // because third parties fetch these URLs anonymously and cannot be
         // given a credential:
         //
-        // - `tts_*` and `{messageId}_{provider}_{timestamp}.{ext}`: Meta's
-        //   WhatsApp servers fetch the `link` we hand them
+        // - `tts_*` and `{id}_{kind}_{timestamp}.{ext}`: Meta's WhatsApp
+        //   servers fetch the `link` we hand them
         //   (`WhatsAppService::sendMedia`), and the public widget/guest chat
-        //   renders them in anonymous browsers.
+        //   renders them in anonymous browsers. DAG documents are copied
+        //   into this shape via `OutboundChannelMedia::publishCopy`.
         // - `ai_i2vsrc_*`: `MediaGenerationHandler::publishInputImageForRemoteFetch`
         //   hands the URL to image-to-video providers, which fetch it directly.
         //
         // Do not widen this list. Anything reachable only from our own
         // authenticated UI must go through the ownership check below.
-        $isRemoteFetchedSource = str_starts_with($filename, 'ai_i2vsrc_');
-        $isOutboundChannelMedia = str_starts_with($filename, 'tts_')
-            || 1 === preg_match('/^\d+_[a-z]+_\d+\.[a-z0-9]+$/i', $filename);
+        $isRemoteFetchedSource = OutboundChannelMedia::isRemoteFetchedSource($filename);
+        $isOutboundChannelMedia = OutboundChannelMedia::isOutboundChannelMedia($filename);
 
         if ($isRemoteFetchedSource || $isOutboundChannelMedia) {
             // Security rests on the path being unguessable (user-specific

--- a/backend/src/Service/Media/OutboundChannelMedia.php
+++ b/backend/src/Service/Media/OutboundChannelMedia.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Media;
+
+use App\Service\File\FileHelper;
+use App\Service\File\UserUploadPathBuilder;
+
+/**
+ * Filenames third parties (Meta WhatsApp, i2v providers) may fetch without auth.
+ *
+ * Must stay in lockstep with {@see \App\Controller\StaticUploadController}'s
+ * anonymous-serve gate. Do not add patterns here unless that controller
+ * (and its tests) gain the same bypass.
+ */
+final class OutboundChannelMedia
+{
+    /**
+     * AI-generated images/videos/audio: `{messageId}_{provider}_{timestamp}.{ext}`.
+     * WhatsApp document copies published by {@see self::publishCopy()}:
+     * `{userId}_{kind}_{timestamp}{nonce}.{ext}`.
+     */
+    public const OUTBOUND_FILENAME_PATTERN = '/^\d+_[a-z]+_\d+\.[a-z0-9]+$/i';
+
+    public static function isOutboundChannelMedia(string $filename): bool
+    {
+        return str_starts_with($filename, 'tts_')
+            || 1 === preg_match(self::OUTBOUND_FILENAME_PATTERN, $filename);
+    }
+
+    public static function isRemoteFetchedSource(string $filename): bool
+    {
+        return str_starts_with($filename, 'ai_i2vsrc_');
+    }
+
+    public static function isAnonymouslyFetchable(string $filename): bool
+    {
+        return self::isRemoteFetchedSource($filename)
+            || self::isOutboundChannelMedia($filename);
+    }
+
+    /**
+     * Strip the public serve prefix so a DAG `/api/v1/files/uploads/…` path
+     * and a raw upload-dir-relative path both resolve to the same relative key.
+     */
+    public static function relativeUploadPath(string $mediaPath): string
+    {
+        $prefix = '/api/v1/files/uploads/';
+        if (str_starts_with($mediaPath, $prefix)) {
+            $mediaPath = substr($mediaPath, strlen($prefix));
+        }
+
+        return ltrim($mediaPath, '/');
+    }
+
+    /**
+     * Copy a generated file to an anonymously-fetchable name so Meta can
+     * retrieve the WhatsApp `link` without credentials.
+     *
+     * @return string|null upload-dir-relative path of the published copy
+     */
+    public static function publishCopy(
+        string $absoluteSource,
+        string $uploadDir,
+        int $userId,
+        string $kind,
+        UserUploadPathBuilder $pathBuilder,
+    ): ?string {
+        if (!is_file($absoluteSource)) {
+            return null;
+        }
+
+        $extension = strtolower(pathinfo($absoluteSource, PATHINFO_EXTENSION));
+        if ('' === $extension || 1 !== preg_match('/^[a-z0-9]+$/', $extension)) {
+            $extension = 'bin';
+        }
+
+        $sanitizedKind = preg_replace('/[^a-z]/', '', strtolower($kind));
+        $kind = (is_string($sanitizedKind) && '' !== $sanitizedKind) ? $sanitizedKind : 'file';
+        $filename = sprintf('%d_%s_%d%d.%s', $userId, $kind, time(), random_int(100, 999), $extension);
+
+        $userBase = $pathBuilder->buildUserBaseRelativePath($userId);
+        $relativePath = $userBase.'/'.date('Y').'/'.date('m').'/'.$filename;
+        $absoluteTarget = rtrim($uploadDir, '/').'/'.$relativePath;
+
+        if (!FileHelper::ensureParentDirectory($absoluteTarget)) {
+            return null;
+        }
+
+        if (!@copy($absoluteSource, $absoluteTarget)) {
+            return null;
+        }
+
+        FileHelper::setFilePermissions($absoluteTarget);
+
+        return $relativePath;
+    }
+}

--- a/backend/src/Service/WhatsAppService.php
+++ b/backend/src/Service/WhatsAppService.php
@@ -12,6 +12,7 @@ use App\Entity\User;
 use App\Realtime\Notifier\ChatActivityNotifier;
 use App\Service\File\FileProcessor;
 use App\Service\File\UserUploadPathBuilder;
+use App\Service\Media\OutboundChannelMedia;
 use App\Service\Message\MessageProcessor;
 use App\Service\Usage\RecordedUsage;
 use Doctrine\ORM\EntityManagerInterface;
@@ -414,6 +415,7 @@ final class WhatsAppService
         string $mediaUrl,
         string $phoneNumberId,
         ?string $caption = null,
+        ?string $filename = null,
     ): array {
         if (!$this->isAvailable()) {
             throw new \RuntimeException('WhatsApp service is not available');
@@ -438,9 +440,14 @@ final class WhatsAppService
             'link' => $mediaUrl,
         ];
 
-        // WhatsApp API requires 'filename' for document type
+        // WhatsApp API requires 'filename' for document type. Prefer the
+        // original display name so a published `{userId}_document_{ts}.docx`
+        // copy still arrives as "notes.docx" rather than the fetchable alias.
         if ('document' === $mediaType) {
-            $mediaPayload['filename'] = basename(parse_url($mediaUrl, PHP_URL_PATH)) ?: 'document';
+            $fromUrl = basename((string) parse_url($mediaUrl, PHP_URL_PATH));
+            $mediaPayload['filename'] = (null !== $filename && '' !== $filename)
+                ? $filename
+                : ($fromUrl ?: 'document');
         }
 
         // Convert caption markdown to WhatsApp format if present
@@ -488,6 +495,56 @@ final class WhatsAppService
                 'error' => $e->getMessage(),
             ];
         }
+    }
+
+    /**
+     * Build the URL Meta should fetch, rewriting generated documents (and any
+     * other file whose basename is not already anonymously fetchable) to a
+     * copy whose name matches {@see OutboundChannelMedia} so
+     * StaticUploadController will serve it without auth.
+     *
+     * @return array{0: string, 1: string} [absolute URL, original display filename]
+     */
+    private function mediaLinkForMeta(string $mediaPath, string $mediaType, int $userId): array
+    {
+        $displayFilename = basename(OutboundChannelMedia::relativeUploadPath($mediaPath));
+        if ('' === $displayFilename) {
+            $displayFilename = $mediaType;
+        }
+
+        $originalUrl = rtrim($this->appUrl, '/').'/'.ltrim($mediaPath, '/');
+
+        if (OutboundChannelMedia::isAnonymouslyFetchable($displayFilename)) {
+            return [$originalUrl, $displayFilename];
+        }
+
+        $relative = OutboundChannelMedia::relativeUploadPath($mediaPath);
+        if ('' === $relative || str_contains($relative, '..')) {
+            return [$originalUrl, $displayFilename];
+        }
+
+        $absoluteSource = rtrim($this->uploadsDir, '/').'/'.$relative;
+        $published = OutboundChannelMedia::publishCopy(
+            $absoluteSource,
+            $this->uploadsDir,
+            $userId,
+            $mediaType,
+            $this->userUploadPathBuilder,
+        );
+
+        if (null === $published) {
+            $this->logger->warning('WhatsApp: Could not publish media for anonymous Meta fetch', [
+                'media_path' => $mediaPath,
+                'media_type' => $mediaType,
+            ]);
+
+            return [$originalUrl, $displayFilename];
+        }
+
+        return [
+            rtrim($this->appUrl, '/').'/api/v1/files/uploads/'.$published,
+            $displayFilename,
+        ];
     }
 
     /**
@@ -889,7 +946,7 @@ final class WhatsAppService
             $mediaPath = $fileData['path'] ?? null;
 
             if ($mediaPath && !empty($this->appUrl) && in_array($generatedMediaType, ['audio', 'video', 'image', 'document'], true)) {
-                $mediaUrl = rtrim($this->appUrl, '/').'/'.ltrim($mediaPath, '/');
+                [$mediaUrl, $displayFilename] = $this->mediaLinkForMeta($mediaPath, $generatedMediaType, (int) $effectiveUserId);
 
                 $this->logger->info('WhatsApp: Sending AI-generated media response', [
                     'to' => $dto->from,
@@ -899,14 +956,18 @@ final class WhatsAppService
 
                 // The response text must never be lost: WhatsApp captions only
                 // exist on image/video/document and cap at 1024 chars — audio
-                // has no caption at all. Short text rides as the caption
-                // (kept clean of the sources block, issue #652); otherwise the
-                // FULL text (incl. sources) goes out as its own message BEFORE
-                // the media, mirroring how the web chat shows text + media.
+                // has no caption at all. Short text rides as the caption on
+                // image/video (kept clean of the sources block, issue #652).
+                // Documents are excluded: Meta accepts sendMedia() then fetches
+                // the link asynchronously. A 401 on that fetch drops the whole
+                // message — caption included — which is exactly how a successful
+                // Dropbox DAG left the user with no WhatsApp reply. Confirmation
+                // therefore goes out as its own message BEFORE the document,
+                // the same way audio already works.
                 $caption = null;
                 $textSentSeparately = false;
                 $textMessageId = '';
-                $canUseCaption = in_array($generatedMediaType, ['image', 'video', 'document'], true)
+                $canUseCaption = in_array($generatedMediaType, ['image', 'video'], true)
                     && !empty($responseText)
                     && mb_strlen($responseText) <= 1024;
 
@@ -924,7 +985,7 @@ final class WhatsAppService
                     }
                 }
 
-                $sendResult = $this->sendMedia($dto->from, $generatedMediaType, $mediaUrl, $dto->phoneNumberId, $caption);
+                $sendResult = $this->sendMedia($dto->from, $generatedMediaType, $mediaUrl, $dto->phoneNumberId, $caption, $displayFilename);
                 if ($sendResult['success']) {
                     // Documents have no dedicated media quota — the MESSAGES
                     // usage recorded above already covers the turn.
@@ -1035,7 +1096,7 @@ final class WhatsAppService
                     if (!is_string($path) || '' === $path || !in_array($type, ['audio', 'video', 'image', 'document'], true)) {
                         continue;
                     }
-                    $url = rtrim($this->appUrl, '/').'/'.ltrim($path, '/');
+                    [$url, $extraFilename] = $this->mediaLinkForMeta($path, $type, (int) $effectiveUserId);
                     $this->logger->info('WhatsApp: Sending additional multi-task media', [
                         'to' => $dto->from,
                         'media_type' => $type,
@@ -1043,7 +1104,7 @@ final class WhatsAppService
                     ]);
 
                     try {
-                        $extraResult = $this->sendMedia($dto->from, $type, $url, $dto->phoneNumberId, null);
+                        $extraResult = $this->sendMedia($dto->from, $type, $url, $dto->phoneNumberId, null, $extraFilename);
                         if (empty($extraResult['success'])) {
                             $this->logger->warning('WhatsApp: Failed to send additional multi-task media', [
                                 'to' => $dto->from,

--- a/backend/tests/Controller/StaticUploadControllerTest.php
+++ b/backend/tests/Controller/StaticUploadControllerTest.php
@@ -281,6 +281,23 @@ class StaticUploadControllerTest extends WebTestCase
     }
 
     /**
+     * DAG documents published via OutboundChannelMedia::publishCopy use
+     * `{userId}_document_{timestamp}.docx` so Meta can fetch them without auth.
+     */
+    public function testServesPublishedDocumentCopyAnonymously(): void
+    {
+        $relativePath = $this->createUploadOnDisk(
+            $this->user->getId().'_document_'.time().random_int(100, 999).'.docx',
+            'docx-bytes',
+        );
+
+        $this->client->getCookieJar()->clear();
+        $this->client->request('GET', '/api/v1/files/uploads/'.$relativePath);
+
+        $this->assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+    }
+
+    /**
      * Unknown paths must still return 404 — the new fallback must not
      * accidentally widen the surface to anything on disk.
      */

--- a/backend/tests/Service/WhatsAppServiceTest.php
+++ b/backend/tests/Service/WhatsAppServiceTest.php
@@ -2047,9 +2047,11 @@ class WhatsAppServiceTest extends TestCase
     /**
      * Document outputs (.ics / .docx from DAG nodes) were silently dropped
      * before — the primary-file gate must accept type 'document' and pass the
-     * required filename.
+     * required filename. Confirmation text is a separate message: Meta accepts
+     * sendMedia() then fetches the link asynchronously, and a 401 on that
+     * fetch would otherwise drop both the file and a caption-only reply.
      */
-    public function testDocumentPrimaryFileIsSentWithFilenameAndCaption(): void
+    public function testDocumentPrimaryFileSendsTextThenDocument(): void
     {
         $sends = $this->dispatchTurn([
             'content' => 'Your meeting invite is attached.',
@@ -2058,10 +2060,59 @@ class WhatsAppServiceTest extends TestCase
             ],
         ]);
 
-        $this->assertCount(1, $sends);
-        $this->assertSame('document', $sends[0]['type']);
-        $this->assertSame('meeting.ics', $sends[0]['document']['filename']);
-        $this->assertSame('Your meeting invite is attached.', $sends[0]['document']['caption']);
+        $this->assertCount(2, $sends);
+        $this->assertSame('text', $sends[0]['type']);
+        $this->assertStringContainsString('Your meeting invite is attached.', $sends[0]['text']['body']);
+        $this->assertSame('document', $sends[1]['type']);
+        $this->assertSame('meeting.ics', $sends[1]['document']['filename']);
+        $this->assertArrayNotHasKey('caption', $sends[1]['document']);
+    }
+
+    /**
+     * Generated office files use `{name}_{timestamp}.docx`, which
+     * StaticUploadController will not serve anonymously. When the file is on
+     * disk we publish a `{userId}_document_{ts}.docx` copy Meta can fetch,
+     * while the WhatsApp filename stays the original display name.
+     */
+    public function testDocumentUrlIsRewrittenToAnonymouslyFetchableFilename(): void
+    {
+        $relative = '01/000/00001/'.date('Y').'/'.date('m').'/notes_1736189000.docx';
+        $absolute = '/tmp/test_uploads/'.$relative;
+        if (!is_dir(dirname($absolute))) {
+            mkdir(dirname($absolute), 0775, true);
+        }
+        file_put_contents($absolute, 'docx-bytes');
+
+        $publishedCopies = [];
+        try {
+            $sends = $this->dispatchTurn([
+                'content' => 'The requested text has been saved to your Dropbox as a Word document.',
+                'metadata' => [
+                    'file' => ['path' => '/api/v1/files/uploads/'.$relative, 'type' => 'document'],
+                ],
+            ]);
+
+            $this->assertCount(2, $sends);
+            $this->assertSame('text', $sends[0]['type']);
+            $this->assertStringContainsString('saved to your Dropbox', $sends[0]['text']['body']);
+            $this->assertSame('document', $sends[1]['type']);
+            $this->assertSame('notes_1736189000.docx', $sends[1]['document']['filename']);
+            $linkPath = (string) parse_url($sends[1]['document']['link'], PHP_URL_PATH);
+            $this->assertMatchesRegularExpression(
+                '/\/\d+_document_\d+\.docx$/',
+                $linkPath,
+                'Meta must fetch an anonymously-servable filename, not the generated office name',
+            );
+            $publishedRelative = ltrim((string) preg_replace('#^/api/v1/files/uploads/#', '', $linkPath), '/');
+            if ('' !== $publishedRelative) {
+                $publishedCopies[] = '/tmp/test_uploads/'.$publishedRelative;
+            }
+        } finally {
+            @unlink($absolute);
+            foreach ($publishedCopies as $copy) {
+                @unlink($copy);
+            }
+        }
     }
 
     /**

--- a/backend/tests/Unit/Service/Media/OutboundChannelMediaTest.php
+++ b/backend/tests/Unit/Service/Media/OutboundChannelMediaTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\Media;
+
+use App\Service\File\UserUploadPathBuilder;
+use App\Service\Media\OutboundChannelMedia;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class OutboundChannelMediaTest extends TestCase
+{
+    /**
+     * @var list<string>
+     */
+    private array $tempFiles = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->tempFiles as $path) {
+            if (is_file($path)) {
+                @unlink($path);
+            }
+        }
+
+        parent::tearDown();
+    }
+
+    #[DataProvider('anonymouslyFetchableProvider')]
+    public function testIsAnonymouslyFetchable(string $filename, bool $expected): void
+    {
+        $this->assertSame($expected, OutboundChannelMedia::isAnonymouslyFetchable($filename));
+    }
+
+    /**
+     * @return iterable<string, array{0: string, 1: bool}>
+     */
+    public static function anonymouslyFetchableProvider(): iterable
+    {
+        yield 'tts prefix' => ['tts_reply.mp3', true];
+        yield 'ai image pattern' => ['123_google_1736189000.mp4', true];
+        yield 'published document copy' => ['1_document_1736189000847.docx', true];
+        yield 'i2v source' => ['ai_i2vsrc_1_1736189000_abc.jpg', true];
+        yield 'generated office doc' => ['notes_1736189000.docx', false];
+        yield 'human filename' => ['meeting.ics', false];
+        yield 'legacy generated prefix' => ['generated_abc123.png', false];
+    }
+
+    public function testRelativeUploadPathStripsServePrefix(): void
+    {
+        $this->assertSame(
+            '01/000/00001/2026/08/notes_1736189000.docx',
+            OutboundChannelMedia::relativeUploadPath('/api/v1/files/uploads/01/000/00001/2026/08/notes_1736189000.docx'),
+        );
+        $this->assertSame(
+            '01/000/00001/2026/08/notes_1736189000.docx',
+            OutboundChannelMedia::relativeUploadPath('01/000/00001/2026/08/notes_1736189000.docx'),
+        );
+    }
+
+    public function testPublishCopyWritesAnonymouslyFetchableFilename(): void
+    {
+        $uploadDir = sys_get_temp_dir().'/outbound-media-'.bin2hex(random_bytes(4));
+        $source = $uploadDir.'/source/notes_1736189000.docx';
+        $this->assertTrue(@mkdir(dirname($source), 0775, true));
+        file_put_contents($source, 'docx-bytes');
+        $this->tempFiles[] = $source;
+
+        $published = OutboundChannelMedia::publishCopy(
+            $source,
+            $uploadDir,
+            1,
+            'document',
+            new UserUploadPathBuilder(),
+        );
+
+        $this->assertIsString($published);
+        $this->assertTrue(OutboundChannelMedia::isAnonymouslyFetchable(basename($published)));
+        $this->assertStringEndsWith('.docx', $published);
+        $this->assertFileExists($uploadDir.'/'.$published);
+        $this->assertSame('docx-bytes', (string) file_get_contents($uploadDir.'/'.$published));
+        $this->tempFiles[] = $uploadDir.'/'.$published;
+    }
+
+    public function testPublishCopyReturnsNullWhenSourceMissing(): void
+    {
+        $this->assertNull(OutboundChannelMedia::publishCopy(
+            '/tmp/does-not-exist-'.bin2hex(random_bytes(4)).'.docx',
+            sys_get_temp_dir(),
+            1,
+            'document',
+            new UserUploadPathBuilder(),
+        ));
+    }
+}


### PR DESCRIPTION
## Summary
WhatsApp fix: documents blocked the answer

## Changes
- Refactored StaticUploadController to utilize OutboundChannelMedia for determining remote fetchability of media files.
- Enhanced WhatsAppService to build media URLs for Meta, ensuring documents are served with original filenames while allowing anonymous access to published copies.
- Added tests to verify that documents are served correctly and that the filename handling aligns with WhatsApp API requirements.
- Updated documentation comments to clarify the changes in media handling and security measures for anonymous fetches.

## Verification
- [ ] Not tested (explain)
- [X] Manual
- [ ] Tests added/updated

## Notes
<!-- Related issues/links/threads. -->

## Screenshots/Logs
