### PR TITLE
test(e2e): cover MCP server config UI CRUD

### DIFF
--- a/frontend/src/components/config/McpServersConfiguration.vue
+++ b/frontend/src/components/config/McpServersConfiguration.vue
@@ -160,6 +160,7 @@
             <button
               type="button"
               class="text-sm text-red-500 hover:underline"
+              :data-testid="`btn-mcp-delete-${server.id}`"
               @click="removeServer(server)"
             >
               {{ $t('common.delete') }}

--- a/frontend/tests/e2e/helpers/selectors.ts
+++ b/frontend/tests/e2e/helpers/selectors.ts
@@ -570,5 +570,19 @@ export const selectors = {
     btnSave: '[data-testid="btn-save"]',
     btnClose: '[data-testid="btn-close"]',
   },
+  mcp: {
+    page: '[data-testid="page-config-mcp-servers"]',
+    list: '[data-testid="section-mcp-list"]',
+    addBtn: '[data-testid="btn-mcp-add"]',
+    editor: '[data-testid="section-mcp-editor"]',
+    inputName: '[data-testid="input-mcp-name"]',
+    inputUrl: '[data-testid="input-mcp-url"]',
+    saveBtn: '[data-testid="btn-mcp-save"]',
+    stateEmpty: '[data-testid="mcp-empty"]',
+    /** One list entry per configured server; also a stable presence marker */
+    serverRow: (id: number) => `[data-testid="mcp-server-${id}"]`,
+    serverRowAny: '[data-testid^="mcp-server-"]',
+    deleteServer: (id: number) => `[data-testid="btn-mcp-delete-${id}"]`,
+  },
   toast: {},
 } as const

--- a/frontend/tests/e2e/tests/mcp-config.spec.ts
+++ b/frontend/tests/e2e/tests/mcp-config.spec.ts
@@ -1,0 +1,88 @@
+import { test, expect } from '../test-setup'
+import { selectors } from '../helpers/selectors'
+import { openApp, getAuthHeaders } from '../helpers/auth'
+import { TIMEOUTS, getApiUrl } from '../config/config'
+
+/**
+ * MCP server config UI (`/channels/mcp`) — full CRUD as a normal (non-admin)
+ * user: create a config, verify it survives a reload, delete it via the UI.
+ *
+ * Deterministic / @ci-safe: create + delete only persist a `BMCPSERVERS` row
+ * (no live MCP connection). The "Test connection" button is the only network
+ * action and is deliberately never clicked. The URL is a fixed, SSRF-safe
+ * public host (same as the backend integration test); uniqueness lives in the
+ * NAME so cleanup-by-prefix is exact.
+ *
+ * Configs are user-scoped to the worker, so afterEach cleans up via the worker
+ * session (survives a mid-test failure).
+ */
+const SERVER_PREFIX = 'E2E MCP'
+const SERVER_URL = 'https://crm.example.com/mcp'
+
+test.describe('@ci MCP server config', () => {
+  test.afterEach(async ({ request, credentials }) => {
+    const auth = await getAuthHeaders(request, credentials)
+    const res = await request.get(`${getApiUrl()}/api/v1/mcp-servers`, { headers: auth })
+    if (!res.ok()) return
+    const { servers } = (await res.json()) as { servers?: { id: number; name: string }[] }
+    for (const server of servers ?? []) {
+      if (typeof server.name === 'string' && server.name.startsWith(SERVER_PREFIX)) {
+        await request.delete(`${getApiUrl()}/api/v1/mcp-servers/${server.id}`, { headers: auth })
+      }
+    }
+  })
+
+  test('create a server, verify it persists across reload, delete it via UI', async ({ page }) => {
+    const serverName = `${SERVER_PREFIX} ${Date.now()}`
+    let serverId: number
+
+    await test.step('Arrange: open the MCP config page as a normal user', async () => {
+      await openApp(page)
+      await page.goto('/channels/mcp')
+      await expect(page.locator(selectors.mcp.page)).toBeVisible({ timeout: TIMEOUTS.STANDARD })
+    })
+
+    await test.step('Act: create a server via the editor', async () => {
+      await page.locator(selectors.mcp.addBtn).click()
+      await expect(page.locator(selectors.mcp.editor)).toBeVisible()
+      await page.locator(selectors.mcp.inputName).fill(serverName)
+      await page.locator(selectors.mcp.inputUrl).fill(SERVER_URL)
+
+      const created = page.waitForResponse(
+        (res) =>
+          new URL(res.url()).pathname.endsWith('/api/v1/mcp-servers') &&
+          res.request().method() === 'POST',
+        { timeout: TIMEOUTS.STANDARD }
+      )
+      await page.locator(selectors.mcp.saveBtn).click()
+      const res = await created
+      expect(res.ok()).toBeTruthy()
+      const { server } = (await res.json()) as { server: { id: number } }
+      serverId = server.id
+    })
+
+    await test.step('Assert: the new server appears in the list', async () => {
+      await expect(page.locator(selectors.mcp.serverRow(serverId))).toBeVisible({
+        timeout: TIMEOUTS.STANDARD,
+      })
+      await expect(page.locator(selectors.mcp.serverRow(serverId))).toContainText(serverName)
+    })
+
+    await test.step('Assert: the server survives a full reload', async () => {
+      await page.reload()
+      await expect(page.locator(selectors.mcp.page)).toBeVisible({ timeout: TIMEOUTS.STANDARD })
+      await expect(page.locator(selectors.mcp.serverRow(serverId))).toBeVisible({
+        timeout: TIMEOUTS.STANDARD,
+      })
+    })
+
+    await test.step('Act + Assert: delete via the UI removes the row', async () => {
+      await page.locator(selectors.mcp.deleteServer(serverId)).click()
+      await page.locator(selectors.dialog.confirmBtn).click()
+      await expect(page.locator(selectors.mcp.serverRow(serverId))).toBeHidden({
+        timeout: TIMEOUTS.STANDARD,
+      })
+      await expect(page.locator(selectors.notification.error)).toHaveCount(0)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Adds a `@ci` Playwright spec for the MCP server config page (`/channels/mcp`). Previously this UI had no end-to-end coverage.

The spec runs as a normal (non-admin) worker user and drives a full create → reload → delete cycle:

- Create a server via the editor (name + URL; POST `/api/v1/mcp-servers` is awaited for the new id).
- Assert the row appears and survives a full page reload.
- Delete via the UI confirm dialog and assert the row is gone with no error toast.

Create/delete only persist a `BMCPSERVERS` row — the "Test connection" button is never clicked, so no live MCP call. Cleanup is by `E2E MCP` name prefix in `afterEach`.

App change is one `data-testid` on the per-row delete button (`btn-mcp-delete-${id}`). The empty-state testid already on `main` (`mcp-empty`) is reused; the guest-registration work is **not** in this PR.

## Test plan

- [ ] CI `e2e` matrix green (the new `@ci MCP server config` spec runs and passes).
- [ ] `make -C frontend lint` green (verified locally on the changed files).