### PR TITLE
fix(deploy): install Caddy from the repository that actually carries RPMs

### DIFF
--- a/deploy/aws/scripts/provision.sh
+++ b/deploy/aws/scripts/provision.sh
@@ -76,16 +76,33 @@ log "Installing Caddy from the project's own package repository"
 # Caddy terminates TLS on the host. Installed from the vendor repository rather
 # than as a loose binary so the instance keeps receiving security updates
 # through dnf like everything else.
-cat > /etc/yum.repos.d/caddy-stable.repo <<'REPO'
-[caddy-stable]
-name=Caddy stable
-baseurl=https://dl.cloudsmith.io/public/caddy/stable/rpm/fedora/40/$basearch
+#
+# The RPMs live in Fedora COPR, not in the Cloudsmith repository the Caddy
+# install page shows first — that one carries Debian packages only, and asking
+# it for an RPM yields an empty repository that fails as "Unable to find a
+# match: caddy" on every architecture. The EPEL 9 build is the one that fits
+# Amazon Linux 2023: it needs nothing beyond glibc 2.34 and systemd, both of
+# which AL2023 has, and it exists for x86_64 and aarch64 alike.
+#
+# COPR does not sign repository metadata, only the packages, so gpgcheck is on
+# and repo_gpgcheck stays off.
+cat > /etc/yum.repos.d/caddy.repo <<'REPO'
+[caddy]
+name=Caddy (COPR @caddy/caddy, EPEL 9)
+baseurl=https://download.copr.fedorainfracloud.org/results/@caddy/caddy/epel-9-$basearch/
 gpgcheck=1
 enabled=1
-gpgkey=https://dl.cloudsmith.io/public/caddy/stable/gpg.key
-repo_gpgcheck=1
+gpgkey=https://download.copr.fedorainfracloud.org/results/@caddy/caddy/pubkey.gpg
+repo_gpgcheck=0
+skip_if_unavailable=False
 REPO
 dnf -y install caddy
+
+# Same reasoning as the Compose plugin above: prove the thing that was just
+# installed actually runs on this architecture, while the build can still fail
+# cheaply. A broken TLS terminator would otherwise only surface on a customer's
+# first boot.
+caddy version
 
 log "Installing the application tree into $APP_DIR"
 install -d -m 0755 "$APP_DIR"


### PR DESCRIPTION
## Summary

The first AMI build (v4.2.4) failed on both architectures because the Caddy package repository it configured only ever carried Debian packages; this points the provisioner at the Fedora COPR repository where Caddy's RPMs actually live.

## Changes

- `deploy/aws/scripts/provision.sh`: replace the `dl.cloudsmith.io/public/caddy/stable/rpm/...` repository with the COPR `@caddy/caddy` EPEL 9 repository, which exists for `x86_64` and `aarch64`. COPR signs packages but not repository metadata, so `gpgcheck=1` stays and `repo_gpgcheck` goes to `0`.
- Run `caddy version` right after the install, for the same reason the Compose plugin is verified there: a TLS terminator that cannot start should fail the build, not a customer's first boot.

## Verification

- [x] Manual
- [x] Tests added/updated — no new test; see the note below on why this class of failure has no cheap unit-level guard

Installed the package in an `amazonlinux:2023` container on both architectures with exactly the repository file the provisioner writes:

```
--- arch: aarch64
v2.11.4 h1:XKxkMTgNSizEvKG6QHue6cAsFOteU2qA61w2tKkCWi0=
caddy-2.11.4-2.el9.aarch64

--- arch: x86_64
v2.11.4 h1:XKxkMTgNSizEvKG6QHue6cAsFOteU2qA61w2tKkCWi0=
caddy-2.11.4-2.el9.x86_64
```

Also green: `bash deploy/scripts/tests/test-lifecycle.sh`, `bash deploy/aws/scripts/tests/test-firstboot.sh`, `bash -n` on the changed script.

## Notes

Why the old URL looked fine and was not: every RPM path under the Cloudsmith repository answers `200` with a valid but empty `repomd.xml`, so there is nothing to notice short of asking `dnf` for the package. That is why it only surfaced as `Unable to find a match: caddy` on a real instance, after `Resolve the release` had already spent 14 minutes waiting for the container images.

The EPEL 9 build is the right one for Amazon Linux 2023: its only runtime requirements beyond a shell are `glibc 2.34` and `systemd`, both of which AL2023 provides.

A CI guard for this would have to fetch the repository metadata and assert that a `caddy` package is listed, which makes the pipeline depend on COPR being reachable. Happy to add it if that trade is wanted; the AMI workflow itself is the honest gate.

## Screenshots/Logs

Failing step from run [32484497238](https://github.com/metadist/synaplan/actions/runs/32484497238):

```
==> synaplan.amazon-ebs.synaplan: No match for argument: caddy
==> synaplan.amazon-ebs.synaplan: Error: Unable to find a match: caddy
Build 'synaplan.amazon-ebs.synaplan' errored after 2 minutes 8 seconds
```