### PR TITLE
fix(deploy): drop the duplicate REGISTRATION_ENABLED the AWS merge left behind

### DIFF
--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -44,8 +44,10 @@ x-app-environment: &app-environment
   BOOTSTRAP_ADMIN_EMAIL: "${BOOTSTRAP_ADMIN_EMAIL:-}"
   BOOTSTRAP_ADMIN_PASSWORD: "${BOOTSTRAP_ADMIN_PASSWORD:-}"
   BOOTSTRAP_ADMIN_FORCE_PASSWORD_CHANGE: "${BOOTSTRAP_ADMIN_FORCE_PASSWORD_CHANGE:-false}"
-  # Auth-surface switches (issues #462 / #1517). Empty keeps the default
-  # (enabled); SSO-/OIDC-only deployments set both to "false".
+  # Auth-surface switches (issues #462 / #1517). Empty keeps the application
+  # default, which is enabled, so an existing deployment is unaffected. An
+  # install reachable from the open internet that nobody watches wants
+  # registration off; SSO-/OIDC-only deployments set both to "false".
   REGISTRATION_ENABLED: "${REGISTRATION_ENABLED:-}"
   GUEST_CHAT_ENABLED: "${GUEST_CHAT_ENABLED:-}"
   DB_HOST: db
@@ -85,10 +87,6 @@ x-app-environment: &app-environment
   GOOGLE_GEMINI_API_KEY: "${GOOGLE_GEMINI_API_KEY:-}"
   MISTRAL_API_KEY: "${MISTRAL_API_KEY:-}"
   XAI_API_KEY: "${XAI_API_KEY:-}"
-  # Whether visitors can create their own account. An install reachable from the
-  # open internet that nobody watches wants this off; the application default
-  # stays `true` so an existing deployment is unaffected.
-  REGISTRATION_ENABLED: "${REGISTRATION_ENABLED:-true}"
   # Operator billing. Empty keys mean open-source mode: no plans, no quotas, no
   # upgrade prompts, and every tier gate open (see docs/BILLING_SELFHOST.md).
   # Setting them turns this install into a paid product run by YOU, billed

--- a/deploy/scripts/tests/test-lifecycle.sh
+++ b/deploy/scripts/tests/test-lifecycle.sh
@@ -50,10 +50,25 @@ fi
 #
 # Duplicate keys are the case worth spelling out, because a lenient parser
 # keeps the last one without complaining. This loader refuses instead.
-if python3 -c 'import yaml' 2>/dev/null; then
-    python3 - "$COMPOSE_FILE" <<'PARSE' || exit 1
+#
+# A missing interpreter or PyYAML fails the suite rather than skipping the
+# check. A guard that quietly turns itself off in an environment nobody
+# inspected is the same silence this test exists to end.
+command -v python3 > /dev/null || {
+    echo "python3 is required to parse compose.yaml in this suite" >&2
+    exit 1
+}
+python3 - "$COMPOSE_FILE" <<'PARSE' || exit 1
 import sys
-import yaml
+
+try:
+    import yaml
+except ImportError:
+    sys.exit(
+        'PyYAML is required to parse compose.yaml. Install it with '
+        '"python3 -m pip install pyyaml", or "apt-get install python3-yaml" '
+        'on Debian and Ubuntu.'
+    )
 
 
 class StrictLoader(yaml.SafeLoader):
@@ -91,9 +106,6 @@ with open(sys.argv[1], encoding='utf-8') as handle:
     except yaml.YAMLError as error:
         sys.exit('compose.yaml is not valid YAML: %s' % error)
 PARSE
-else
-    echo "compose.yaml parse test skipped; PyYAML is not importable for python3." >&2
-fi
 
 # The same defect in the file operators actually copy. A repeated key is legal
 # in a .env, which is what makes it worse than in compose.yaml: the last

--- a/deploy/scripts/tests/test-lifecycle.sh
+++ b/deploy/scripts/tests/test-lifecycle.sh
@@ -41,6 +41,74 @@ if grep -q 'ggml-${WHISPER_DEFAULT_MODEL' "$COMPOSE_FILE"; then
     exit 1
 fi
 
+# Every check above reads the file as text, and Compose never parses it in this
+# suite because `docker` is stubbed further down so the tests run without it. A
+# structural YAML defect therefore survives the whole suite and surfaces where
+# it is most expensive: a merge once left REGISTRATION_ENABLED defined twice,
+# which Compose rejects outright, and it was only caught on a Packer-built AMI
+# in the middle of a release build.
+#
+# Duplicate keys are the case worth spelling out, because a lenient parser
+# keeps the last one without complaining. This loader refuses instead.
+if python3 -c 'import yaml' 2>/dev/null; then
+    python3 - "$COMPOSE_FILE" <<'PARSE' || exit 1
+import sys
+import yaml
+
+
+class StrictLoader(yaml.SafeLoader):
+    pass
+
+
+MERGE_TAG = 'tag:yaml.org,2002:merge'
+
+
+def reject_duplicate_keys(loader, node, deep=False):
+    # Only the keys actually written at this level, which is what a merge
+    # conflict duplicates. A `<<: *anchor` is skipped and left to the parent
+    # constructor: it flattens the anchor into this mapping, where a key the
+    # anchor already carries is a legitimate override rather than a duplicate.
+    seen = set()
+    for key_node, _ in node.value:
+        if key_node.tag == MERGE_TAG:
+            continue
+
+        key = loader.construct_object(key_node, deep=deep)
+        if key in seen:
+            sys.exit('compose.yaml defines "%s" twice in the same mapping' % key)
+        seen.add(key)
+
+    return yaml.SafeLoader.construct_mapping(loader, node, deep)
+
+
+StrictLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, reject_duplicate_keys
+)
+
+with open(sys.argv[1], encoding='utf-8') as handle:
+    try:
+        yaml.load(handle, StrictLoader)
+    except yaml.YAMLError as error:
+        sys.exit('compose.yaml is not valid YAML: %s' % error)
+PARSE
+else
+    echo "compose.yaml parse test skipped; PyYAML is not importable for python3." >&2
+fi
+
+# The same defect in the file operators actually copy. A repeated key is legal
+# in a .env, which is what makes it worse than in compose.yaml: the last
+# occurrence silently wins, so the comment above the first one documents a
+# default that never takes effect.
+duplicate_env_keys="$(
+    awk -F= '/^[A-Z_][A-Z0-9_]*=/ { print $1 }' "$SCRIPT_DIR/../selfhost.env.example" |
+        sort | uniq -d | tr '\n' ' '
+)"
+if [[ -n "${duplicate_env_keys// /}" ]]; then
+    printf 'selfhost.env.example defines these keys more than once, and the last one silently wins: %s\n' \
+        "$duplicate_env_keys" >&2
+    exit 1
+fi
+
 # Where the deployment reads its configuration from, for each layout that has to
 # work. A managed platform may materialise the configured environment as a .env
 # at the CHECKOUT ROOT, which Compose ignores for `-f deploy/compose.yaml`,

--- a/deploy/selfhost.env.example
+++ b/deploy/selfhost.env.example
@@ -53,9 +53,12 @@ REALTIME_ADMIN_SECRET=replace-with-a-different-stable-random-value
 BOOTSTRAP_ADMIN_EMAIL=
 BOOTSTRAP_ADMIN_PASSWORD=
 
-# Auth-surface switches, both default to enabled when left empty. SSO-/OIDC-only
-# deployments set both to false: no local email/password self-registration
-# (issue #462) and no anonymous guest trial chat (issue #1517).
+# Auth-surface switches, both default to enabled when left empty. Set
+# REGISTRATION_ENABLED to false on an install that is reachable from the
+# internet and has no operator watching sign-ups: the app then offers no
+# self-registration and every account is created by an administrator.
+# SSO-/OIDC-only deployments set both to false: no local email/password
+# self-registration (issue #462) and no anonymous guest trial chat (#1517).
 REGISTRATION_ENABLED=
 GUEST_CHAT_ENABLED=
 
@@ -74,11 +77,6 @@ XAI_API_KEY=
 COMPOSE_PROFILES=
 ENABLE_LOCAL_GPT_OSS=false
 WHISPER_DEFAULT_MODEL=tiny
-
-# Set to false on an install that is reachable from the internet and has no
-# operator watching sign-ups: the app then offers no self-registration and every
-# account is created by an administrator.
-REGISTRATION_ENABLED=true
 
 # Operator billing, off by default. While STRIPE_SECRET_KEY is empty, the install
 # runs in open-source mode: no plans, no quotas, no upgrade prompts, and every


### PR DESCRIPTION
## Summary
`deploy/compose.yaml` declared `REGISTRATION_ENABLED` twice after the AWS Marketplace branch was merged, which Compose rejects outright — the AMI build for 4.2.4 failed on both architectures right after provisioning the instance.

## Changes
- `deploy/compose.yaml`: one `REGISTRATION_ENABLED` entry instead of two. Kept the position next to `GUEST_CHAT_ENABLED`, since the two belong together, and folded the more useful explanation from the removed entry into its comment. The empty default is the one that survives, so the application stays the single source of truth for what "enabled" means.
- `deploy/selfhost.env.example`: same duplication, same fix. A repeated key is legal in a `.env` and the last one silently wins, so the documented empty default above was dead text.
- `deploy/scripts/tests/test-lifecycle.sh`: both files are now parsed, not just grepped. The suite stubs `docker` so it can run without it, which means Compose never parsed `compose.yaml` here and no check in the suite could have caught this. A strict YAML load rejects duplicate keys (a lenient parser keeps the last one quietly), and a short `awk` check does the same for the env example.

## Verification
- [ ] Not tested (explain)
- [x] Manual
- [x] Tests added/updated

- `bash deploy/scripts/tests/test-lifecycle.sh` and `bash deploy/aws/scripts/tests/test-firstboot.sh` pass.
- `docker compose -f deploy/compose.yaml config -q` now succeeds; before this change it failed with `mapping key "REGISTRATION_ENABLED" already defined at line 49` on the same Compose version the AMI uses (v5.4.0).
- Both new checks were mutation-tested rather than trusted: re-adding the duplicate to each file makes the suite exit 1 with the matching message, and removing it makes it pass again.
- The strict loader skips `<<` merge keys and delegates flattening to the parent constructor, so a service overriding a key it inherits from an anchor is not misread as a duplicate.

## Notes
Follow-up to #1490 and #1544. The Caddy fix from #1544 works — this build got well past the package install and failed on the Compose file instead. The AMI build for 4.2.4 needs one more run once this is on `main`.

## Screenshots/Logs
```
==> synaplan.amazon-ebs.synaplan: failed to parse /tmp/tmp.3zNWQuumBw/deploy/compose.yaml:
    yaml: construct errors: line 1: line 91: mapping key "REGISTRATION_ENABLED" already defined at line 49
```