### PR TITLE
fix(deploy): keep the AMI description ASCII so EC2 accepts the built image

### DIFF
--- a/deploy/aws/packer/synaplan.pkr.hcl
+++ b/deploy/aws/packer/synaplan.pkr.hcl
@@ -90,8 +90,12 @@ source "amazon-ebs" "synaplan" {
     most_recent = true
   }
 
+  # Both ASCII only. EC2 rejects anything beyond it in the description, and it
+  # does so in ModifyImageAttribute, which runs after the image and its
+  # snapshots already exist: an em dash here failed a ten-minute build at its
+  # very last call. test-firstboot.sh guards the two lines.
   ami_name        = "${var.ami_name_prefix}-${var.synaplan_version}-${var.architecture}-{{timestamp}}"
-  ami_description = "Synaplan ${var.synaplan_version} — AI knowledge management, all-in-one on a single instance"
+  ami_description = "Synaplan ${var.synaplan_version} - AI knowledge management, all-in-one on a single instance"
 
   launch_block_device_mappings {
     device_name           = "/dev/xvda"

--- a/deploy/aws/scripts/tests/test-firstboot.sh
+++ b/deploy/aws/scripts/tests/test-firstboot.sh
@@ -37,6 +37,24 @@ fail() {
 }
 
 # --------------------------------------------------------------------------
+# The AMI metadata the build hands to EC2
+# --------------------------------------------------------------------------
+
+# Not firstboot, but the same build, and there is nowhere cheaper to catch it.
+# EC2 refuses a non-ASCII AMI description with "Character sets beyond ASCII are
+# not supported", and it refuses it in ModifyImageAttribute — the last call of a
+# ten-minute Packer run, once the image and its snapshots already exist. An em
+# dash in that one line burned exactly that, for both architectures at once.
+non_ascii_ami_metadata="$(
+    grep -E '^[[:space:]]*ami_(description|name)[[:space:]]*=' \
+        "$DEPLOY_ROOT/aws/packer/synaplan.pkr.hcl" |
+        LC_ALL=C grep '[^ -~]' || true
+)"
+if [[ -n "$non_ascii_ami_metadata" ]]; then
+    fail "The AMI name or description carries a character EC2 will reject: $non_ascii_ami_metadata"
+fi
+
+# --------------------------------------------------------------------------
 # The instance, as far as firstboot.sh can tell
 # --------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
The AMI description contained an em dash, which EC2 rejects — the 4.2.4 build provisioned both images successfully and then failed on the very last API call, discarding ten minutes of work per architecture.

## Changes
- `deploy/aws/packer/synaplan.pkr.hcl`: em dash replaced with a plain hyphen in `ami_description`, with a comment on why the field is ASCII-only. The comment sits above both `ami_*` assignments rather than between them, so `packer fmt` keeps their alignment.
- `deploy/aws/scripts/tests/test-firstboot.sh`: reads the `ami_name` and `ami_description` lines out of the template and fails on any byte outside printable ASCII. Strictly speaking not a first-boot concern, but it belongs to the same build and this is the only AWS suite CI already runs — the alternative was noticing it again ten minutes into a release.

## Verification
- [ ] Not tested (explain)
- [x] Manual
- [x] Tests added/updated

- `bash deploy/aws/scripts/tests/test-firstboot.sh` and `bash deploy/scripts/tests/test-lifecycle.sh` pass.
- Mutation-tested rather than trusted: restoring the em dash makes the suite exit 1 and print the offending line; replacing it makes it pass.
- `packer fmt -check -diff deploy/aws/packer/` is clean (run in `hashicorp/packer`), so the added comment does not disturb the assignment alignment.
- The remaining non-ASCII characters in the template are a code comment and a Packer variable `description`; neither is ever sent to an AWS API, and the check is scoped to the two lines that are.

## Notes
Third and last failure mode of the 4.2.4 AMI build, after #1544 (Caddy repository) and #1545 (duplicate Compose key). This run got all the way through provisioning, so the remaining unknown is the smoke test that has not been reached yet.

## Screenshots/Logs
```
==> synaplan.amazon-ebs.synaplan: Error modify AMI attributes: api error InvalidParameterValue:
    Value (Synaplan 4.2.4 — AI knowledge management, all-in-one on a single instance) for parameter
    Description is invalid. Character sets beyond ASCII are not supported.
```