### PR TITLE
fix(deploy): let the build role read the availability zones it places resources in

### DIFF
--- a/deploy/aws/cloudformation/marketplace-roles.yaml
+++ b/deploy/aws/cloudformation/marketplace-roles.yaml
@@ -152,18 +152,29 @@ Resources:
                   - ec2:AttachVolume
                   - ec2:DetachVolume
                   - ec2:RevokeSecurityGroupEgress
+                  - ec2:RevokeSecurityGroupIngress
                   - ec2:AuthorizeSecurityGroupEgress
+                  # Both the subnet and the data volume place themselves with
+                  # `!Select [0, !GetAZs '']`, which CloudFormation resolves with
+                  # the caller's own credentials. Without this the stack fails on
+                  # its first resource, and the AMI it was meant to verify is
+                  # already built and paid for by then.
+                  - ec2:DescribeAvailabilityZones
                   - ec2:DescribeRouteTables
                   - ec2:DescribeInternetGateways
                   - ec2:DescribeNetworkInterfaces
                   - ec2:DescribeIamInstanceProfileAssociations
+                  - ec2:DeleteTags
                   - ssm:SendCommand
                   - ssm:GetCommandInvocation
                   - ssm:DescribeInstanceInformation
                   - ssm:CreateDocument
                   - ssm:DeleteDocument
                   - ssm:DescribeDocument
+                  - ssm:GetDocument
                   - ssm:AddTagsToResource
+                  - ssm:ListTagsForResource
+                  - ssm:RemoveTagsFromResource
               - Effect: Allow
                 Action:
                   - iam:CreateRole
@@ -183,6 +194,7 @@ Resources:
                   - iam:GetInstanceProfile
                   - iam:AddRoleToInstanceProfile
                   - iam:RemoveRoleFromInstanceProfile
+                  - iam:ListInstanceProfilesForRole
                 Resource:
                   - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:role/synaplan-verify-*'
                   - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/synaplan-verify-*'

--- a/docs/AWS_MARKETPLACE_LISTING.md
+++ b/docs/AWS_MARKETPLACE_LISTING.md
@@ -112,6 +112,12 @@ aws cloudformation deploy \
   --capabilities CAPABILITY_NAMED_IAM
 ```
 
+The same command updates the roles later, and it has to be run again whenever
+the template changes: the account keeps the permissions it was deployed with, so
+a permission added here reaches the build role only after a redeploy. A missing
+one shows up as `AccessDenied` in the verification stack, after the AMI it was
+meant to verify has already been built.
+
 - **`AWSMarketplaceAmiIngestion`** lets AWS Marketplace copy a submitted AMI into
   its own account for the security scan. Name it in the Management Portal under
   Settings.


### PR DESCRIPTION
## Summary
The AMI build for 4.2.4 now succeeds for both architectures, and the verification stack that follows it failed on its first resource: the build role may not call `ec2:DescribeAvailabilityZones`, which CloudFormation needs to resolve the `!GetAZs` the subnet and the data volume place themselves with.

## Changes
- `deploy/aws/cloudformation/marketplace-roles.yaml`: added `ec2:DescribeAvailabilityZones` to the verification-stack policy, with a comment on why it is not optional. Added alongside it the delete-path counterparts of permissions already granted for creation — `ec2:DeleteTags`, `ec2:RevokeSecurityGroupIngress`, `ssm:GetDocument`, `ssm:ListTagsForResource`, `ssm:RemoveTagsFromResource`, `iam:ListInstanceProfilesForRole` — so the teardown cannot fail on a call nobody anticipated. The IAM statement stays scoped to `synaplan-verify-*`.
- `docs/AWS_MARKETPLACE_LISTING.md`: noted that the roles stack has to be redeployed when the template changes, since the account keeps the permissions it was deployed with, and that a missing one only surfaces after an AMI has already been built.

## Verification
- [ ] Not tested (explain)
- [x] Manual
- [ ] Tests added/updated

- `cfn-lint deploy/aws/cloudformation/*.yaml` is clean, which is what validates the action names — the same check caught an invented `bedrock:Converse` earlier in this series.
- No test added: the effect is an IAM decision inside an AWS account, which nothing in this repository can observe. It is confirmed by the verification job itself, and that job can now be re-run on its own: both AMIs of the failed run exist (`ami-09b2e6e3aa38daafe` for x86_64, `ami-087e6da08847623bf` for arm64) and their Packer manifests are still available as artifacts, so re-running only the failed job costs a few minutes instead of a full rebuild.
- The permissions the verification stack needs were walked through resource by resource against the template rather than guessed from the one error: `EnableDailySnapshots=false` in the workflow means the DLM policy is never created, so no `dlm:*` action is required.

## Notes
Fourth and last known failure mode of the 4.2.4 AMI build, after #1544 (Caddy repository), #1545 (duplicate Compose key) and #1546 (non-ASCII AMI description). The build stage itself is now green on both architectures.

**This one needs a step in AWS before it takes effect**: the roles stack must be redeployed in the listing account, otherwise the role keeps its current permissions.

## Screenshots/Logs
```
DataVolume  CREATE_FAILED  AccessDenied. User doesn't have permission to call ec2:DescribeAvailabilityZones
synaplan-verify-32490123588  CREATE_FAILED  The following resource(s) failed to create:
    [InternetGateway, InstanceRole, DataVolume, Vpc, SnapshotHookDocument].
```