### PR TITLE
fix(deploy): grant the build role the reads a CloudFormation handler performs

### DIFF
--- a/deploy/aws/cloudformation/marketplace-roles.yaml
+++ b/deploy/aws/cloudformation/marketplace-roles.yaml
@@ -152,18 +152,29 @@ Resources:
                   - ec2:AttachVolume
                   - ec2:DetachVolume
                   - ec2:RevokeSecurityGroupEgress
+                  - ec2:RevokeSecurityGroupIngress
                   - ec2:AuthorizeSecurityGroupEgress
+                  # Both the subnet and the data volume place themselves with
+                  # `!Select [0, !GetAZs '']`, which CloudFormation resolves with
+                  # the caller's own credentials. Without this the stack fails on
+                  # its first resource, and the AMI it was meant to verify is
+                  # already built and paid for by then.
+                  - ec2:DescribeAvailabilityZones
                   - ec2:DescribeRouteTables
                   - ec2:DescribeInternetGateways
                   - ec2:DescribeNetworkInterfaces
                   - ec2:DescribeIamInstanceProfileAssociations
+                  - ec2:DeleteTags
                   - ssm:SendCommand
                   - ssm:GetCommandInvocation
                   - ssm:DescribeInstanceInformation
                   - ssm:CreateDocument
                   - ssm:DeleteDocument
                   - ssm:DescribeDocument
+                  - ssm:GetDocument
                   - ssm:AddTagsToResource
+                  - ssm:ListTagsForResource
+                  - ssm:RemoveTagsFromResource
               - Effect: Allow
                 Action:
                   - iam:CreateRole
@@ -183,6 +194,7 @@ Resources:
                   - iam:GetInstanceProfile
                   - iam:AddRoleToInstanceProfile
                   - iam:RemoveRoleFromInstanceProfile
+                  - iam:ListInstanceProfilesForRole
                 Resource:
                   - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:role/synaplan-verify-*'
                   - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/synaplan-verify-*'

--- a/deploy/aws/cloudformation/marketplace-roles.yaml
+++ b/deploy/aws/cloudformation/marketplace-roles.yaml
@@ -154,17 +154,27 @@ Resources:
                   - ec2:RevokeSecurityGroupEgress
                   - ec2:RevokeSecurityGroupIngress
                   - ec2:AuthorizeSecurityGroupEgress
-                  # Both the subnet and the data volume place themselves with
-                  # `!Select [0, !GetAZs '']`, which CloudFormation resolves with
-                  # the caller's own credentials. Without this the stack fails on
-                  # its first resource, and the AMI it was meant to verify is
-                  # already built and paid for by then.
-                  - ec2:DescribeAvailabilityZones
-                  - ec2:DescribeRouteTables
-                  - ec2:DescribeInternetGateways
-                  - ec2:DescribeNetworkInterfaces
-                  - ec2:DescribeIamInstanceProfileAssociations
+                  # Reading is granted as a whole, deliberately. A CloudFormation
+                  # resource handler reads its own resource back after writing
+                  # it, and which Describe call it picks is an implementation
+                  # detail of the handler rather than something this template can
+                  # see: `!GetAZs` needs DescribeAvailabilityZones, the VPC needs
+                  # DescribeVpcAttribute, the security group needs
+                  # DescribeSecurityGroupRules. Each one that is missing costs a
+                  # failed stack, and this role only ever reads an account that
+                  # holds build artifacts. The writes below stay an explicit list.
+                  - ec2:Describe*
                   - ec2:DeleteTags
+                  # Set from a property the template does declare, each on a
+                  # resource this stack owns: MapPublicIpOnLaunch on the subnet,
+                  # the instance profile on the instance, and the attribute and
+                  # volume changes a stack update performs.
+                  - ec2:ModifySubnetAttribute
+                  - ec2:ModifyInstanceAttribute
+                  - ec2:ModifyVolume
+                  - ec2:AssociateIamInstanceProfile
+                  - ec2:DisassociateIamInstanceProfile
+                  - ec2:ReplaceIamInstanceProfileAssociation
                   - ssm:SendCommand
                   - ssm:GetCommandInvocation
                   - ssm:DescribeInstanceInformation

--- a/docs/AWS_MARKETPLACE_LISTING.md
+++ b/docs/AWS_MARKETPLACE_LISTING.md
@@ -112,6 +112,12 @@ aws cloudformation deploy \
   --capabilities CAPABILITY_NAMED_IAM
 ```
 
+The same command updates the roles later, and it has to be run again whenever
+the template changes: the account keeps the permissions it was deployed with, so
+a permission added here reaches the build role only after a redeploy. A missing
+one shows up as `AccessDenied` in the verification stack, after the AMI it was
+meant to verify has already been built.
+
 - **`AWSMarketplaceAmiIngestion`** lets AWS Marketplace copy a submitted AMI into
   its own account for the security scan. Name it in the Management Portal under
   Settings.


### PR DESCRIPTION
## Summary
The previous permission fix worked — the verification stack got past `!GetAZs` and created the VPC — and then failed one resource later on `ec2:ModifySubnetAttribute`. Rather than adding a third single action, reading is now granted as a whole and writes stay an explicit list.

## Changes
- `deploy/aws/cloudformation/marketplace-roles.yaml`:
  - The individual `ec2:Describe*` entries of the verification policy are replaced by `ec2:Describe*`. A CloudFormation resource handler reads its own resource back after writing it, and which call it uses is an implementation detail of the handler rather than something the template reveals — `!GetAZs` needs `DescribeAvailabilityZones`, the VPC `DescribeVpcAttribute`, the security group `DescribeSecurityGroupRules`. Enumerating them one failed stack at a time does not converge, and this role only ever reads an account that holds build artifacts.
  - Writes stay an allow-list and gained exactly what the template's properties imply: `ModifySubnetAttribute` (`MapPublicIpOnLaunch`, the failure at hand), `ModifyInstanceAttribute`, `ModifyVolume`, and the three instance-profile association actions.
  - The IAM statement is unchanged and still scoped to `synaplan-verify-*`.

## Verification
- [ ] Not tested (explain)
- [x] Manual
- [ ] Tests added/updated

- `cfn-lint deploy/aws/cloudformation/*.yaml` is clean, which is what validates the action names.
- The template was walked resource by resource rather than reasoned from the error alone, and two things it turned up need no change: the `DeletionPolicy: Snapshot` on the data volume already has `ec2:CreateSnapshot` through the Packer policy on the same role, and the workflow's cleanup already deletes both the stack and the snapshot that policy leaves behind, so a rerun is not blocked by its own leftovers.
- No test: an IAM decision inside an AWS account is not observable from this repository. The verification job itself is the test, and it now takes about 100 seconds to re-run because both AMIs of the failed run still exist.

## Notes
Requires the roles stack to be redeployed in the listing account before it takes effect, the same step as #1547.

## Screenshots/Logs
```
Subnet  CREATE_FAILED  ... is not authorized to perform: ec2:ModifySubnetAttribute
    on resource: .../subnet-064464b0598b0944d because no identity-based policy allows
    the ec2:ModifySubnetAttribute action
```