### PR TITLE
ci(aws): wait out a cold first boot and keep the evidence when it fails

### DIFF
--- a/.github/workflows/aws-ami.yml
+++ b/.github/workflows/aws-ami.yml
@@ -232,10 +232,10 @@ jobs:
           role-session-name: synaplan-verify-${{ github.run_id }}
           aws-region: ${{ env.AWS_REGION }}
           # The default hour is not enough any more: waiting out a cold first
-          # boot, collecting diagnostics and deleting the stack can approach it,
-          # and credentials expiring mid-teardown leaves a billing instance
-          # running. The role allows 7200.
-          role-duration-seconds: 5400
+          # boot alone may take fifty minutes. This is the maximum the role
+          # permits; the teardown re-assumes below rather than trusting even
+          # this to outlast a pathological run.
+          role-duration-seconds: 7200
 
       - name: Download the build manifest
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -283,18 +283,19 @@ jobs:
             echo "${key}=${value}" >> "$GITHUB_OUTPUT"
           done
 
-      # firstboot.sh writes the configuration, then synaplan.service brings the
-      # stack up, and only a healthy stack gets served. On a fresh data volume
-      # that start runs the database migrations and waits for eight services, so
-      # synaplan.service allows itself TimeoutStartSec=1800. This wait has to
-      # outlast that budget, or it reports an AMI as dead while its first boot is
-      # still perfectly on schedule — which is exactly what a 15-minute wait did.
+      # The instance answers once firstboot.sh has written the configuration and
+      # synaplan.service has brought the stack up — the two units run in that
+      # order and allow themselves TimeoutStartSec=900 and 1800. A wait shorter
+      # than their combined 2700 seconds calls an AMI dead while its first boot
+      # is still within the budget the units grant it, which is exactly what the
+      # previous 15 minutes did. So: the full budget, plus five minutes for
+      # Caddy and the first request.
       - name: Wait for the web interface
         env:
           WEB_URL: ${{ steps.stack.outputs.WebUrl }}
         run: |
           set -euo pipefail
-          deadline=$((SECONDS + 2400))
+          deadline=$((SECONDS + 3000))
           while [ "$SECONDS" -lt "$deadline" ]; do
             # -k: without a domain the instance serves the self-signed
             # certificate, which is the configuration under test.
@@ -305,7 +306,7 @@ jobs:
             echo "No answer yet, $((SECONDS / 60)) minutes elapsed."
             sleep 20
           done
-          echo "::error::${WEB_URL} never became healthy within 40 minutes."
+          echo "::error::${WEB_URL} never became healthy within 50 minutes."
           exit 1
 
       # The same smoke test a self-hosted installation runs, executed on the
@@ -344,6 +345,22 @@ jobs:
             exit 1
           }
 
+      # A session of its own for everything that follows. The steps above can
+      # legitimately run for hours — each CloudFormation waiter allows roughly
+      # one, the wait for the web interface another fifty minutes — and no
+      # session length can be chosen that certainly outlasts all of them.
+      # Expired credentials in the steps below would cost the diagnosis of the
+      # failure and, worse, the deletion of an instance that bills by the hour.
+      # The OIDC token stays valid for as long as the job does, so this assume
+      # succeeds even where the first one has long expired.
+      - name: Refresh the credentials
+        if: always()
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+        with:
+          role-to-assume: ${{ secrets.AWS_AMI_BUILD_ROLE_ARN }}
+          role-session-name: synaplan-teardown-${{ github.run_id }}
+          aws-region: ${{ env.AWS_REGION }}
+
       - name: Show why the stack failed
         if: failure()
         run: |
@@ -362,7 +379,17 @@ jobs:
           INSTANCE_ID: ${{ steps.stack.outputs.InstanceId }}
         run: |
           set -uo pipefail
-          if [ -z "${INSTANCE_ID:-}" ] || [ "$INSTANCE_ID" = None ]; then
+          instance_id="${INSTANCE_ID:-}"
+          if [ -z "$instance_id" ] || [ "$instance_id" = None ]; then
+            # The outputs are only read on the way through, so a creation that
+            # failed skips them. --on-failure DO_NOTHING can still leave the
+            # instance standing, and then it is the only witness there is.
+            instance_id="$(aws cloudformation describe-stack-resource \
+              --stack-name "$STACK_NAME" --logical-resource-id Instance \
+              --query StackResourceDetail.PhysicalResourceId \
+              --output text 2>/dev/null || true)"
+          fi
+          if [ -z "$instance_id" ] || [ "$instance_id" = None ]; then
             echo "The stack never produced an instance, so there is nothing to collect."
             exit 0
           fi
@@ -372,12 +399,12 @@ jobs:
           # ec2:GetConsoleOutput is missing from an older deployment of
           # marketplace-roles.yaml, and that must not hide the rest.
           echo "::group::Console output"
-          aws ec2 get-console-output --instance-id "$INSTANCE_ID" \
+          aws ec2 get-console-output --instance-id "$instance_id" \
             --query Output --output text || echo "Not available."
           echo "::endgroup::"
 
           ping_status="$(aws ssm describe-instance-information \
-            --filters "Key=InstanceIds,Values=${INSTANCE_ID}" \
+            --filters "Key=InstanceIds,Values=${instance_id}" \
             --query 'InstanceInformationList[0].PingStatus' \
             --output text 2>/dev/null || true)"
           echo "Session Manager reports the instance as ${ping_status:-unreachable}."
@@ -387,7 +414,7 @@ jobs:
           # the deployment configuration itself, which a bare `compose ps` in a
           # remote shell cannot.
           command_id="$(aws ssm send-command \
-            --instance-ids "$INSTANCE_ID" \
+            --instance-ids "$instance_id" \
             --document-name AWS-RunShellScript \
             --comment "Synaplan verification diagnostics" \
             --parameters 'commands=[
@@ -401,7 +428,7 @@ jobs:
           for _ in $(seq 1 30); do
             sleep 10
             status="$(aws ssm get-command-invocation \
-              --command-id "$command_id" --instance-id "$INSTANCE_ID" \
+              --command-id "$command_id" --instance-id "$instance_id" \
               --query Status --output text 2>/dev/null || echo Pending)"
             case "$status" in
               Success|Failed|Cancelled|TimedOut) break ;;
@@ -410,7 +437,7 @@ jobs:
 
           echo "::group::The instance's own view"
           aws ssm get-command-invocation --command-id "$command_id" \
-            --instance-id "$INSTANCE_ID" \
+            --instance-id "$instance_id" \
             --query 'join(`"\n"`, [StandardOutputContent, StandardErrorContent])' \
             --output text || true
           echo "::endgroup::"

--- a/.github/workflows/aws-ami.yml
+++ b/.github/workflows/aws-ami.yml
@@ -231,6 +231,11 @@ jobs:
           role-to-assume: ${{ secrets.AWS_AMI_BUILD_ROLE_ARN }}
           role-session-name: synaplan-verify-${{ github.run_id }}
           aws-region: ${{ env.AWS_REGION }}
+          # The default hour is not enough any more: waiting out a cold first
+          # boot, collecting diagnostics and deleting the stack can approach it,
+          # and credentials expiring mid-teardown leaves a billing instance
+          # running. The role allows 7200.
+          role-duration-seconds: 5400
 
       - name: Download the build manifest
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -278,25 +283,29 @@ jobs:
             echo "${key}=${value}" >> "$GITHUB_OUTPUT"
           done
 
-      # firstboot.sh generates the configuration, starts the stack and waits for
-      # it to be healthy before it enables the service, so the instance is
-      # reachable well after the stack reports CREATE_COMPLETE.
+      # firstboot.sh writes the configuration, then synaplan.service brings the
+      # stack up, and only a healthy stack gets served. On a fresh data volume
+      # that start runs the database migrations and waits for eight services, so
+      # synaplan.service allows itself TimeoutStartSec=1800. This wait has to
+      # outlast that budget, or it reports an AMI as dead while its first boot is
+      # still perfectly on schedule — which is exactly what a 15-minute wait did.
       - name: Wait for the web interface
         env:
           WEB_URL: ${{ steps.stack.outputs.WebUrl }}
         run: |
           set -euo pipefail
-          for attempt in $(seq 1 60); do
+          deadline=$((SECONDS + 2400))
+          while [ "$SECONDS" -lt "$deadline" ]; do
             # -k: without a domain the instance serves the self-signed
             # certificate, which is the configuration under test.
             if curl -ksSf --max-time 10 "${WEB_URL}/api/health" >/dev/null; then
-              echo "The instance answers on ${WEB_URL}/api/health."
+              echo "The instance answers on ${WEB_URL}/api/health after $((SECONDS / 60)) minutes."
               exit 0
             fi
-            echo "Attempt ${attempt}: no answer yet."
-            sleep 15
+            echo "No answer yet, $((SECONDS / 60)) minutes elapsed."
+            sleep 20
           done
-          echo "::error::${WEB_URL} never became healthy."
+          echo "::error::${WEB_URL} never became healthy within 40 minutes."
           exit 1
 
       # The same smoke test a self-hosted installation runs, executed on the
@@ -341,6 +350,70 @@ jobs:
           aws cloudformation describe-stack-events --stack-name "$STACK_NAME" \
             --query 'reverse(StackEvents[?ResourceStatus!=`CREATE_COMPLETE`].[Timestamp,LogicalResourceId,ResourceStatus,ResourceStatusReason])' \
             --output table || true
+
+      # Stack events describe the delivery, not the instance, so a boot that
+      # never served anything used to leave nothing behind at all: the next step
+      # deletes the instance, and the only fact on record was that port 443 stayed
+      # quiet. Everything here is best-effort — a diagnosis must not replace the
+      # failure it is diagnosing.
+      - name: Collect the instance diagnostics
+        if: failure()
+        env:
+          INSTANCE_ID: ${{ steps.stack.outputs.InstanceId }}
+        run: |
+          set -uo pipefail
+          if [ -z "${INSTANCE_ID:-}" ] || [ "$INSTANCE_ID" = None ]; then
+            echo "The stack never produced an instance, so there is nothing to collect."
+            exit 0
+          fi
+
+          # Reaches a boot that failed before Session Manager came up, which is
+          # the one case the commands below cannot observe. Allowed to fail:
+          # ec2:GetConsoleOutput is missing from an older deployment of
+          # marketplace-roles.yaml, and that must not hide the rest.
+          echo "::group::Console output"
+          aws ec2 get-console-output --instance-id "$INSTANCE_ID" \
+            --query Output --output text || echo "Not available."
+          echo "::endgroup::"
+
+          ping_status="$(aws ssm describe-instance-information \
+            --filters "Key=InstanceIds,Values=${INSTANCE_ID}" \
+            --query 'InstanceInformationList[0].PingStatus' \
+            --output text 2>/dev/null || true)"
+          echo "Session Manager reports the instance as ${ping_status:-unreachable}."
+          [ "$ping_status" = Online ] || exit 0
+
+          # synaplan-smoke-test is the project's own status command and resolves
+          # the deployment configuration itself, which a bare `compose ps` in a
+          # remote shell cannot.
+          command_id="$(aws ssm send-command \
+            --instance-ids "$INSTANCE_ID" \
+            --document-name AWS-RunShellScript \
+            --comment "Synaplan verification diagnostics" \
+            --parameters 'commands=[
+              "systemctl --no-pager --full status synaplan-firstboot synaplan caddy || true",
+              "journalctl --no-pager -u synaplan-firstboot -u synaplan -u caddy -n 300 || true",
+              "ss -lntp || true",
+              "/usr/local/bin/synaplan-smoke-test || true"
+            ]' \
+            --query Command.CommandId --output text)" || exit 0
+
+          for _ in $(seq 1 30); do
+            sleep 10
+            status="$(aws ssm get-command-invocation \
+              --command-id "$command_id" --instance-id "$INSTANCE_ID" \
+              --query Status --output text 2>/dev/null || echo Pending)"
+            case "$status" in
+              Success|Failed|Cancelled|TimedOut) break ;;
+            esac
+          done
+
+          echo "::group::The instance's own view"
+          aws ssm get-command-invocation --command-id "$command_id" \
+            --instance-id "$INSTANCE_ID" \
+            --query 'join(`"\n"`, [StandardOutputContent, StandardErrorContent])' \
+            --output text || true
+          echo "::endgroup::"
 
       # Unconditional, including after a cancelled run: what is left behind here
       # is a running instance that bills by the hour. The data volume has

--- a/deploy/aws/cloudformation/marketplace-roles.yaml
+++ b/deploy/aws/cloudformation/marketplace-roles.yaml
@@ -164,6 +164,11 @@ Resources:
                   # failed stack, and this role only ever reads an account that
                   # holds build artifacts. The writes below stay an explicit list.
                   - ec2:Describe*
+                  # The only window into a boot that failed before Session
+                  # Manager came up. Without it a failed verification can leave
+                  # no evidence at all, because the cleanup deletes the instance
+                  # that held it.
+                  - ec2:GetConsoleOutput
                   - ec2:DeleteTags
                   # Set from a property the template does declare, each on a
                   # resource this stack owns: MapPublicIpOnLaunch on the subnet,


### PR DESCRIPTION
## Summary
The verification of the 4.2.4 AMI failed with no usable evidence: the stack was complete and the instance was running, `https://<ip>/api/health` stayed silent for the whole 15-minute window, and the instance was then deleted. This makes that window long enough for a cold first boot and, more importantly, makes a failure diagnosable.

## Changes
- `.github/workflows/aws-ami.yml`
  - **Wait for the web interface**: 15 minutes → 50, and the progress line now reports elapsed minutes instead of an attempt counter. The instance boots through two units in sequence, `synaplan-firstboot.service` and `synaplan.service`, which allow themselves `TimeoutStartSec=900` and `1800`. Anything below their combined 2700 seconds calls an AMI dead inside the budget systemd grants it; the deadline is that budget plus five minutes for Caddy and the first request.
  - **New step, `Collect the instance diagnostics`** (`if: failure()`, before the cleanup): console output, whether Session Manager considers the instance online, and — when it does — `systemctl status` and `journalctl` for `synaplan-firstboot`, `synaplan` and `caddy`, the listening sockets, and `synaplan-smoke-test`, which is the project's own status command and resolves the deployment configuration itself. Every part is best-effort, so a diagnosis cannot replace the failure it describes. The instance is resolved from the stack with `describe-stack-resource` when the outputs were never read, which is every failure during creation itself — precisely where `--on-failure DO_NOTHING` leaves an instance worth asking.
  - **New step, `Refresh the credentials`** (`always()`, before the failure and teardown steps): a run may now legitimately last hours — two CloudFormation waiters of roughly an hour each plus this wait — and no session length certainly outlasts that. Expired credentials would cost the diagnosis and, worse, the deletion of an instance that bills by the hour. The OIDC token stays valid for as long as the job does, so the assume succeeds where the first one has long expired. `role-duration-seconds` goes to the permitted 7200 for the steps ahead of that point.
- `deploy/aws/cloudformation/marketplace-roles.yaml`: `ec2:GetConsoleOutput`, the only window into a boot that fails before Session Manager comes up.

## Verification
- [ ] Not tested (explain)
- [x] Manual
- [ ] Tests added/updated

I could not reproduce the failure, so I went the other way and eliminated what was checkable without an instance. None of these is the cause:

- `/api/health` exists and is `PUBLIC_ACCESS` in `security.yaml`, and it answers 503 only when Redis is unreachable — a missing AI provider key, which this launch has, does not affect its status.
- `AllowedWebCidr` defaults to `0.0.0.0/0` and `WebUrl` is `https://<PublicIp>`, so the runner was allowed to reach port 443.
- The Caddy package from COPR provides exactly what `configure-tls.sh` assumes — a `caddy` user, `caddy.service`, and `ExecStart` reading `/etc/caddy/Caddyfile` — verified by installing it in `amazonlinux:2023`.
- `caddy validate` accepts `Caddyfile.selfsigned` with that same packaged binary ("Valid configuration").
- Caddy proxies to `127.0.0.1:8000`, which is where `deploy/compose.yaml` publishes the backend.
- The instance role grants `ssm:PutParameter` under `parameter/synaplan/*`, matching the `/synaplan/$INSTANCE_ID/admin-password` that `firstboot.sh` writes — and that write is explicitly non-fatal, so it cannot stall a boot.

What remains is a first boot that had not finished inside 15 minutes, or a `firstboot.sh` / `synaplan.service` that failed on the instance. Those two are indistinguishable from the outside, which is the actual defect this PR fixes: the next failure will say which.

Checked mechanically: `cfn-lint` is clean, the workflow parses, and every `run` block of the job passes `bash -n`.

## Notes
`ec2:GetConsoleOutput` needs the roles stack redeployed to take effect. Deliberately not a blocker — the console step tolerates the denial and prints "Not available.", so the rest of the diagnostics work on the next run either way.