### PR TITLE
fix(deploy): break the boot ordering cycle that kept the AMI from ever starting

### DIFF
--- a/deploy/aws/scripts/provision.sh
+++ b/deploy/aws/scripts/provision.sh
@@ -122,10 +122,18 @@ ln -sfn "$DATA_MOUNT/.lifecycle" "$APP_DIR/deploy/.lifecycle"
 ln -sfn "$DATA_MOUNT/.env" "$APP_DIR/deploy/.env"
 
 log "Publishing the operator commands"
-ln -sfn "$APP_DIR/deploy/aws/scripts/update.sh" /usr/local/bin/synaplan-update
-ln -sfn "$APP_DIR/deploy/aws/scripts/snapshot.sh" /usr/local/bin/synaplan-snapshot
-ln -sfn "$APP_DIR/deploy/aws/scripts/configure-tls.sh" /usr/local/bin/synaplan-tls
-ln -sfn "$APP_DIR/deploy/scripts/smoke-test.sh" /usr/local/bin/synaplan-smoke-test
+# Wrappers, not symlinks. Every one of these scripts locates lib.sh relative
+# to its own path, and through a symlink that path is /usr/local/bin — each
+# command then dies with "lib.sh: No such file or directory". An exec wrapper
+# hands the script its real path as $0, so the lookup works unchanged.
+publish_command() {
+    printf '#!/usr/bin/env bash\nexec %q "$@"\n' "$2" > "/usr/local/bin/$1"
+    chmod 0755 "/usr/local/bin/$1"
+}
+publish_command synaplan-update "$APP_DIR/deploy/aws/scripts/update.sh"
+publish_command synaplan-snapshot "$APP_DIR/deploy/aws/scripts/snapshot.sh"
+publish_command synaplan-tls "$APP_DIR/deploy/aws/scripts/configure-tls.sh"
+publish_command synaplan-smoke-test "$APP_DIR/deploy/scripts/smoke-test.sh"
 
 log "Recording the baked release"
 # Read by firstboot.sh to pin deploy/.env, and by support to tell instantly

--- a/deploy/aws/scripts/tests/test-firstboot.sh
+++ b/deploy/aws/scripts/tests/test-firstboot.sh
@@ -55,6 +55,34 @@ if [[ -n "$non_ascii_ami_metadata" ]]; then
 fi
 
 # --------------------------------------------------------------------------
+# The boot order the units ask of systemd
+# --------------------------------------------------------------------------
+
+# A unit that is WantedBy=multi-user.target must not order itself after
+# cloud-init.target or cloud-final.service: both sit after multi-user.target,
+# which closes an ordering cycle that systemd resolves by deleting the unit's
+# start job. The 4.2.4 verification instance booted exactly like that — no
+# firstboot, no stack, no Caddy, an idle machine for fifty minutes.
+for unit in "$DEPLOY_ROOT/aws/systemd/"*.service; do
+    grep -Eq '^WantedBy=.*multi-user\.target' "$unit" || continue
+    if grep -Eq '^(After|Wants|Requires)=.*cloud-(init\.target|final\.service)' "$unit"; then
+        fail "$(basename "$unit") is WantedBy=multi-user.target and orders itself after cloud-init — that is an ordering cycle, and systemd answers it by never starting the unit"
+    fi
+done
+
+# --------------------------------------------------------------------------
+# The operator commands provision.sh publishes
+# --------------------------------------------------------------------------
+
+# Wrappers, never symlinks: every published script locates lib.sh relative to
+# its own path, and through a symlink that path is /usr/local/bin. Each command
+# then fails with "lib.sh: No such file or directory" — first observed when
+# synaplan-smoke-test did exactly that during a verification post-mortem.
+if grep -E '^[[:space:]]*ln\b' "$AWS_SCRIPTS_DIR/provision.sh" | grep -q '/usr/local/bin/'; then
+    fail "provision.sh symlinks a command into /usr/local/bin; publish an exec wrapper instead, or the command cannot find lib.sh next to its real path"
+fi
+
+# --------------------------------------------------------------------------
 # The instance, as far as firstboot.sh can tell
 # --------------------------------------------------------------------------
 

--- a/deploy/aws/systemd/synaplan-firstboot.service
+++ b/deploy/aws/systemd/synaplan-firstboot.service
@@ -3,7 +3,15 @@ Description=Synaplan first-boot setup (data volume, configuration, TLS)
 Documentation=https://github.com/metadist/synaplan/blob/main/deploy/aws/README.md
 # The script reads instance metadata and writes to the SSM Parameter Store, so
 # it needs the network; it also mounts the data volume every other unit uses.
-After=network-online.target cloud-init.target docker.service
+#
+# It must NOT order itself after cloud-init.target: that target sits after
+# multi-user.target, while this unit's WantedBy pulls it before it — a cycle
+# systemd resolves by silently never starting this unit, Caddy or the stack.
+# One verification instance sat idle for its whole fifty-minute window that
+# way. Nothing here needs cloud-init anyway: configuration travels as instance
+# tags and SSM parameters, never as user data, and the instance metadata
+# service answers as soon as the network is up. test-firstboot.sh enforces it.
+After=network-online.target docker.service
 Wants=network-online.target
 Requires=docker.service
 Before=synaplan.service caddy.service

--- a/deploy/scripts/tests/test-lifecycle.sh
+++ b/deploy/scripts/tests/test-lifecycle.sh
@@ -340,7 +340,7 @@ for portable in pre-update.sh post-update.sh; do
     }
 done
 
-# systemd, the symlinks in /usr/local/bin and the SSM document all invoke these
+# systemd, the wrappers in /usr/local/bin and the SSM document all invoke these
 # by path. A file that lost its executable bit fails at boot, not at build.
 for script in "$AWS_DIR/scripts"/*.sh; do
     [[ -x "$script" ]] || {


### PR DESCRIPTION
## Summary
The 4.2.4 verification failed again after 50 minutes — and this time the diagnostics from #1549 delivered the actual cause, which is not a slow first boot at all. The instance never booted anything: `systemd` found an ordering cycle, deleted the start jobs for `synaplan-firstboot`, `synaplan` and `caddy`, and the machine sat idle with only sshd listening for the whole window.

```
multi-user.target: Found ordering cycle on synaplan-firstboot.service/start
multi-user.target: Found dependency on cloud-init.target/start
multi-user.target: Found dependency on multi-user.target/start
multi-user.target: Job synaplan-firstboot.service/start deleted to break ordering cycle
```

The cycle: `synaplan-firstboot.service` is `WantedBy=multi-user.target` (so it must start *before* the target) and at the same time `After=cloud-init.target` — which itself sits *after* `multi-user.target`. This is a documented cloud-init trap ([cloud-init docs](https://docs.cloud-init.io/en/latest/howto/wait_for_cloud_init.html), [canonical/cloud-init#6245](https://github.com/canonical/cloud-init/issues/6245)).

The same diagnostics surfaced a second break: `synaplan-smoke-test` died with `lib.sh: No such file or directory`. All four operator commands in `/usr/local/bin` were symlinks, and every one of these scripts locates `lib.sh` relative to its own path — which through a symlink is `/usr/local/bin`.

## Changes
- `deploy/aws/systemd/synaplan-firstboot.service`: `cloud-init.target` removed from `After=`. Nothing in firstboot needs cloud-init — configuration travels as instance tags and SSM parameters, never as user data, and IMDS answers as soon as the network is up.
- `deploy/aws/scripts/provision.sh`: the operator commands are published as two-line `exec` wrappers instead of symlinks, so each script keeps its real path as `$0` and finds `lib.sh` unchanged.
- `deploy/aws/scripts/tests/test-firstboot.sh`: two new guards — a unit that is `WantedBy=multi-user.target` must not order itself after `cloud-init.target`/`cloud-final.service`, and `provision.sh` must not symlink commands into `/usr/local/bin`.

## Verification
- [ ] Not tested (explain)
- [x] Manual
- [x] Tests added/updated

- Both new guards mutation-tested: reintroducing `cloud-init.target` fails the suite with the cycle message, reintroducing an `ln -sfn` into `/usr/local/bin` fails it with the wrapper message; the real state passes.
- The symlink defect reproduced locally: a symlinked script sourcing `$(dirname "$0")/lib.sh` fails with exactly the instance's error; the generated wrapper runs it correctly.
- `bash deploy/aws/scripts/tests/test-firstboot.sh` and `bash deploy/scripts/tests/test-lifecycle.sh` pass; shellcheck is clean on the changed scripts.

## Notes
A claim worth recording: the suspicion that Triton/gRPC in the base image caused the timeout does not hold. `deploy/compose.yaml` — the stack the AMI runs — contains no Triton service, and the images are baked into the AMI at build time, so a first boot pulls nothing. The instance-side evidence shows Docker never started a single container; no amount of image slimming would have changed that. Triton/gRPC affect the build time of `synaplan-base-php` in its own repository, not this boot.

No roles-stack redeploy needed for this one.