### PR TITLE
fix(deploy): make the AMI first boot actually complete

### DIFF
--- a/.github/workflows/aws-ami.yml
+++ b/.github/workflows/aws-ami.yml
@@ -290,12 +290,20 @@ jobs:
       # is still within the budget the units grant it, which is exactly what the
       # previous 15 minutes did. So: the full budget, plus five minutes for
       # Caddy and the first request.
+      #
+      # That budget is only for a boot that is still going. A unit that has
+      # already failed will never make /api/health answer, and waiting out the
+      # rest of the fifty minutes is how three verification runs each cost an
+      # hour. After a minute and a half Session Manager is up; from then on,
+      # a failed firstboot or stack aborts this wait immediately.
       - name: Wait for the web interface
         env:
           WEB_URL: ${{ steps.stack.outputs.WebUrl }}
+          INSTANCE_ID: ${{ steps.stack.outputs.InstanceId }}
         run: |
           set -euo pipefail
           deadline=$((SECONDS + 3000))
+          last_unit_check=0
           while [ "$SECONDS" -lt "$deadline" ]; do
             # -k: without a domain the instance serves the self-signed
             # certificate, which is the configuration under test.
@@ -303,6 +311,43 @@ jobs:
               echo "The instance answers on ${WEB_URL}/api/health after $((SECONDS / 60)) minutes."
               exit 0
             fi
+
+            if [ "$SECONDS" -ge 90 ] && [ $((SECONDS - last_unit_check)) -ge 60 ]; then
+              last_unit_check=$SECONDS
+              ping_status="$(aws ssm describe-instance-information \
+                --filters "Key=InstanceIds,Values=${INSTANCE_ID}" \
+                --query 'InstanceInformationList[0].PingStatus' \
+                --output text 2>/dev/null || true)"
+              if [ "$ping_status" = Online ]; then
+                command_id="$(aws ssm send-command \
+                  --instance-ids "$INSTANCE_ID" \
+                  --document-name AWS-RunShellScript \
+                  --comment "Synaplan verification unit probe" \
+                  --parameters 'commands=["systemctl is-failed synaplan-firstboot.service; systemctl is-failed synaplan.service"]' \
+                  --query Command.CommandId --output text 2>/dev/null || true)"
+                if [ -n "${command_id:-}" ] && [ "$command_id" != None ]; then
+                  for _ in $(seq 1 12); do
+                    sleep 5
+                    probe_status="$(aws ssm get-command-invocation \
+                      --command-id "$command_id" --instance-id "$INSTANCE_ID" \
+                      --query Status --output text 2>/dev/null || echo Pending)"
+                    case "$probe_status" in
+                      Success|Failed|Cancelled|TimedOut) break ;;
+                    esac
+                  done
+                  units="$(aws ssm get-command-invocation \
+                    --command-id "$command_id" --instance-id "$INSTANCE_ID" \
+                    --query StandardOutputContent --output text 2>/dev/null || true)"
+                  echo "Unit probe after $((SECONDS / 60)) minutes:"
+                  printf '%s\n' "$units"
+                  if printf '%s\n' "$units" | grep -qx failed; then
+                    echo "::error::A boot unit has already failed; /api/health will not appear. See the unit probe above."
+                    exit 1
+                  fi
+                fi
+              fi
+            fi
+
             echo "No answer yet, $((SECONDS / 60)) minutes elapsed."
             sleep 20
           done

--- a/deploy/aws/packer/synaplan.pkr.hcl
+++ b/deploy/aws/packer/synaplan.pkr.hcl
@@ -136,7 +136,7 @@ build {
 
   # The file provisioner does not create parent directories.
   provisioner "shell" {
-    inline = ["mkdir -p /tmp/synaplan/deploy"]
+    inline = ["mkdir -p /tmp/synaplan/deploy /tmp/synaplan/_docker"]
   }
 
   # The portable deployment contract, unmodified. The AWS adapter calls these
@@ -154,6 +154,15 @@ build {
   provisioner "file" {
     source      = "${local.repo_root}/deploy/aws"
     destination = "/tmp/synaplan/deploy"
+  }
+
+  # compose.yaml bind-mounts ../_docker/centrifugo/config.json relative to
+  # deploy/, which on the instance is /opt/synaplan/_docker/.... Without this
+  # file Docker creates a directory at the mount point, Centrifugo never
+  # becomes healthy, and synaplan.service waits out its 30-minute start budget.
+  provisioner "file" {
+    source      = "${local.repo_root}/_docker/centrifugo"
+    destination = "/tmp/synaplan/_docker/centrifugo"
   }
 
   provisioner "shell" {

--- a/deploy/aws/scripts/firstboot.sh
+++ b/deploy/aws/scripts/firstboot.sh
@@ -92,7 +92,19 @@ setting() {
 # --------------------------------------------------------------------------
 
 root_device() {
-    findmnt --noheadings --output SOURCE --target / | sed 's/[0-9]*$//'
+    # The disk that holds `/`, not the partition. Stripping trailing digits
+    # turns /dev/nvme0n1p1 into /dev/nvme0n1p, which then fails to match the
+    # whole-disk name nvme0n1 — so a Nitro instance would treat its own root
+    # disk as a candidate data volume. PKNAME is the parent lsblk already
+    # knows; when `/` is on a whole disk, PKNAME is empty and SOURCE is used.
+    local source parent
+    source="$(findmnt --noheadings --output SOURCE --target /)"
+    parent="$(lsblk --noheadings --output PKNAME "$source" 2>/dev/null | tr -d '[:space:]')"
+    if [[ -n "$parent" ]]; then
+        printf '/dev/%s\n' "$parent"
+        return 0
+    fi
+    printf '%s\n' "$source"
 }
 
 # The empty block device the stack attached for user data. The next step
@@ -153,6 +165,10 @@ prepare_data_volume() {
     elif device="$(find_blank_data_device)"; then
         log "Formatting $device as the Synaplan data volume"
         mkfs.xfs -L "$DATA_LABEL" "$device"
+        # udev and blkid learn the new label in the background. Mounting by
+        # LABEL= in the next lines can fail even though mkfs succeeded; wait
+        # for udev, then mount the device we just formatted.
+        command -v udevadm >/dev/null && udevadm settle --timeout=30 || true
     else
         # No separate volume. Not the recommended layout — the CloudFormation
         # templates always attach one — but a bare "launch this AMI" must still
@@ -166,7 +182,9 @@ prepare_data_volume() {
     if ! grep -q "LABEL=$DATA_LABEL" /etc/fstab; then
         printf 'LABEL=%s %s xfs defaults,nofail 0 2\n' "$DATA_LABEL" "$DATA_MOUNT" >> /etc/fstab
     fi
-    mount "$DATA_MOUNT"
+    # By the device we just identified, not by LABEL=. A LABEL= lookup right
+    # after mkfs is the udev race above; later boots go through fstab.
+    mount "$device" "$DATA_MOUNT"
     log "Mounted the data volume at $DATA_MOUNT"
 }
 

--- a/deploy/aws/scripts/firstboot.sh
+++ b/deploy/aws/scripts/firstboot.sh
@@ -18,7 +18,11 @@ set -Eeuo pipefail
 APP_DIR=/opt/synaplan
 DEPLOY_DIR="$APP_DIR/deploy"
 DATA_MOUNT=/var/lib/synaplan
-DATA_LABEL=synaplan-data
+# XFS labels are at most 12 characters. synaplan-data is 13, and mkfs.xfs
+# rejects it with "Invalid value synaplan-data for -L option" — which is how
+# the 4.2.4 verification died seven seconds into firstboot. test-firstboot.sh
+# enforces the length.
+DATA_LABEL=synaplan
 ENV_FILE="$DATA_MOUNT/.env"
 STATE_FILE="$DATA_MOUNT/.firstboot-complete"
 

--- a/deploy/aws/scripts/provision.sh
+++ b/deploy/aws/scripts/provision.sh
@@ -113,6 +113,17 @@ rsync -a --delete \
     "$STAGE_DIR/deploy/" "$APP_DIR/deploy/"
 chmod 0755 "$APP_DIR/deploy/scripts"/*.sh "$APP_DIR/deploy/aws/scripts"/*.sh
 
+# compose.yaml bind-mounts ../_docker/centrifugo/config.json from deploy/, so
+# the file has to live at $APP_DIR/_docker on the instance. Packer stages it
+# next to deploy/; a missing copy is a first boot that waits 30 minutes for a
+# healthcheck that can never pass.
+install -d -m 0755 "$APP_DIR/_docker"
+rsync -a "$STAGE_DIR/_docker/" "$APP_DIR/_docker/"
+[[ -f "$APP_DIR/_docker/centrifugo/config.json" ]] || {
+    printf 'The Centrifugo config did not land in the image; refusing to bake an AMI whose stack cannot start\n' >&2
+    exit 1
+}
+
 # Persistent state lives on a separate EBS volume so an instance can be replaced
 # without losing anything. The application tree keeps the paths lib.sh expects
 # and reaches the volume through symlinks.
@@ -147,6 +158,23 @@ chmod 0644 "$APP_DIR/ami-release"
 log "Installing the systemd units"
 install -m 0644 "$APP_DIR/deploy/aws/systemd/synaplan-firstboot.service" /etc/systemd/system/
 install -m 0644 "$APP_DIR/deploy/aws/systemd/synaplan.service" /etc/systemd/system/
+
+# The packaged Caddyfile listens on :80 only. Firstboot replaces it, but a
+# failed firstboot used to leave Caddy serving that default for the whole
+# verification window. Bake the self-signed site now so 443 is the listener
+# even if firstboot is still running, and do not start Caddy until firstboot
+# has at least had its chance to write the real file.
+install -d -m 0755 /etc/caddy /var/log/caddy
+chown caddy:caddy /var/log/caddy
+install -m 0644 "$APP_DIR/deploy/aws/caddy/Caddyfile.selfsigned" /etc/caddy/Caddyfile
+caddy validate --config /etc/caddy/Caddyfile --adapter caddyfile
+install -d -m 0755 /etc/systemd/system/caddy.service.d
+cat > /etc/systemd/system/caddy.service.d/20-synaplan-order.conf <<'EOF'
+[Unit]
+After=synaplan-firstboot.service
+Requires=synaplan-firstboot.service
+EOF
+
 systemctl daemon-reload
 systemctl enable docker amazon-ssm-agent synaplan-firstboot.service synaplan.service caddy.service
 

--- a/deploy/aws/scripts/tests/test-firstboot.sh
+++ b/deploy/aws/scripts/tests/test-firstboot.sh
@@ -95,6 +95,75 @@ if (( ${#data_label} > 12 )); then
 fi
 
 # --------------------------------------------------------------------------
+# Bind mounts the AMI has to ship, because compose.yaml asks for them
+# --------------------------------------------------------------------------
+
+# deploy/compose.yaml is the stack the instance runs. A bind mount whose source
+# is not ./data (created at first boot) is a file the AMI must contain, or
+# Docker creates a directory at the mount point and the service never becomes
+# healthy. Centrifugo's config is ../_docker/centrifugo/config.json relative to
+# deploy/ — without it, compose up waits until synaplan.service's 30-minute
+# TimeoutStartSec.
+repo_root="$(cd "$DEPLOY_ROOT/.." && pwd)"
+packer_file="$DEPLOY_ROOT/aws/packer/synaplan.pkr.hcl"
+# Bind specs look like `- ./data/uploads:...` or `- ../_docker/centrifugo/config.json:...`.
+# A YAML parser would be nicer, but this suite has to run in the lint job, which
+# has bash and a checkout and nothing else.
+while IFS= read -r spec; do
+    [[ -n "$spec" ]] || continue
+    source_path="${spec%%:*}"
+    source_path="${source_path#- }"
+    source_path="${source_path#"${source_path%%[![:space:]]*}"}"
+    case "$source_path" in
+        ./data/*) continue ;;
+        /*) continue ;;
+        -*) continue ;;
+    esac
+    [[ "$source_path" == .* ]] || continue
+    resolved="$(cd "$DEPLOY_ROOT" && python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$source_path")"
+    [[ -e "$resolved" ]] || fail "compose.yaml bind-mounts $source_path, which does not exist in the repository"
+    case "$resolved" in
+        "$repo_root/deploy"/*|"$repo_root/_docker"/*) ;;
+        *)
+            fail "compose.yaml bind-mounts $source_path ($resolved), which the AMI does not copy — only deploy/ and _docker/ ship"
+            ;;
+    esac
+    case "$resolved" in
+        "$repo_root/_docker"/*)
+            grep -Fq '_docker/centrifugo' "$packer_file" ||
+                fail "compose.yaml bind-mounts $source_path from _docker/, but the Packer template does not copy _docker/centrifugo into the image"
+            grep -Fq '_docker/' "$AWS_SCRIPTS_DIR/provision.sh" ||
+                fail "compose.yaml bind-mounts $source_path from _docker/, but provision.sh does not install it under /opt/synaplan/_docker"
+            ;;
+    esac
+done < <(grep -E '^[[:space:]]+-[[:space:]]+\.\./' "$DEPLOY_ROOT/compose.yaml" | sed 's/^[[:space:]]*-[[:space:]]*//')
+
+# After mkfs the label is not yet in udev; mounting by LABEL= is how a successful
+# format still fails firstboot. The device we just formatted has to be the mount
+# source, and LABEL= belongs only in fstab for later boots.
+if ! awk '
+    /mkfs\.xfs/ { seen = 1 }
+    seen && /mount "\$device"/ { found = 1 }
+    END { exit !found }
+' "$FIRSTBOOT"; then
+    fail "firstboot.sh formats the data volume but does not mount the device it formatted — mounting by LABEL= races udev and fails the boot"
+fi
+if awk '
+    /mkfs\.xfs/ { seen = 1 }
+    seen && /mount "\$DATA_MOUNT"/ { found = 1 }
+    /Mounted the data volume/ { seen = 0 }
+    END { exit !found }
+' "$FIRSTBOOT"; then
+    fail "firstboot.sh still mounts the data volume by mountpoint right after mkfs; that is a LABEL= lookup and udev has not learned the label yet"
+fi
+
+# NVMe partitions are named nvme0n1p1, not nvme0n11. Stripping trailing digits
+# does not yield the parent disk, so the root disk would look like a blank data
+# volume. PKNAME is the parent lsblk already reports.
+grep -Fq PKNAME "$FIRSTBOOT" ||
+    fail "firstboot.sh no longer uses lsblk PKNAME to find the root disk; NVMe partition names would make the root disk look like a data volume"
+
+# --------------------------------------------------------------------------
 # The instance, as far as firstboot.sh can tell
 # --------------------------------------------------------------------------
 

--- a/deploy/aws/scripts/tests/test-firstboot.sh
+++ b/deploy/aws/scripts/tests/test-firstboot.sh
@@ -83,6 +83,18 @@ if grep -E '^[[:space:]]*ln\b' "$AWS_SCRIPTS_DIR/provision.sh" | grep -q '/usr/l
 fi
 
 # --------------------------------------------------------------------------
+# The XFS label firstboot writes on a blank data volume
+# --------------------------------------------------------------------------
+
+# mkfs.xfs -L rejects anything longer than 12 characters. The verification of
+# 4.2.4 died seven seconds into firstboot on DATA_LABEL=synaplan-data (13).
+data_label="$(sed -n 's/^DATA_LABEL=//p' "$FIRSTBOOT" | head -n1)"
+[[ -n "$data_label" ]] || fail "firstboot.sh no longer defines DATA_LABEL on its own line; update this test"
+if (( ${#data_label} > 12 )); then
+    fail "DATA_LABEL is ${#data_label} characters ($data_label); XFS labels are at most 12, and mkfs.xfs -L will refuse to format the data volume"
+fi
+
+# --------------------------------------------------------------------------
 # The instance, as far as firstboot.sh can tell
 # --------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
A pass over the entire AMI first-boot path, after the 4.2.4 verification died on `mkfs.xfs -L synaplan-data`. The label is one of several landmines; the others would have burned the next fifty-minute run the same way. This PR closes the ones that are actually reachable, and stops the wait from sitting out 50 minutes when a unit has already failed.

## Changes
- `deploy/aws/scripts/firstboot.sh`
  - `DATA_LABEL=synaplan` (XFS labels are at most 12 characters; `synaplan-data` is 13).
  - Mount the device that was just formatted, after `udevadm settle`. A `LABEL=` lookup races udev and can fail a successful `mkfs`.
  - Identify the root disk with `lsblk PKNAME`. Stripping trailing digits turns `/dev/nvme0n1p1` into `/dev/nvme0n1p`, which does not match `nvme0n1`.
- `deploy/aws/packer/synaplan.pkr.hcl` + `provision.sh`: copy `_docker/centrifugo/config.json` into `/opt/synaplan/_docker`. `compose.yaml` bind-mounts it as `../_docker/centrifugo/config.json`; without it Docker creates a directory, Centrifugo never becomes healthy, and `synaplan.service` waits out `TimeoutStartSec=1800`.
- `provision.sh`: bake `Caddyfile.selfsigned` and order Caddy after firstboot, so port 443 is the listener even if firstboot is still running, and Caddy does not start on the packaged `:80` default when firstboot has failed.
- `.github/workflows/aws-ami.yml`: after 90 seconds the wait asks the instance whether `synaplan-firstboot` or `synaplan` has already failed, and aborts. A seven-second firstboot failure will no longer cost fifty minutes.
- `test-firstboot.sh`: guards for label length, the Centrifugo copy, mount-by-device, and PKNAME. Mutation-tested each way.

## Verification
- [ ] Not tested (explain)
- [x] Manual
- [x] Tests added/updated

- `bash deploy/aws/scripts/tests/test-firstboot.sh` and `bash deploy/scripts/tests/test-lifecycle.sh` pass.
- Mutations: restoring `synaplan-data`, removing the Packer `_docker` copy, and mounting by `LABEL=` after `mkfs` each fail the suite with the matching message.

## Notes
Checked and **not** the cause of the last timeout (and not changed):

- Triton / gRPC live in `synaplan-base-php` and affect that image's **build**. `deploy/compose.yaml` has no Triton service, `COMPOSE_PROFILES` is empty so Ollama/Whisper stay off, and the images are baked in at Packer time. The last instance never started a container.
- `/api/health` is public and does not 503 for a missing AI provider key.
- The CloudFormation instance role already grants `ec2:DescribeTags` and `ssm:PutParameter`; firstboot did read the data-volume tag last run.
- Caddy from COPR can bind privileged ports (it bound `:80` as user `caddy` on the failed instance); `:443` uses the same capability.
- No roles-stack redeploy.

What the next run should look like if this is right: firstboot finishes in well under a minute, Caddy serves HTTPS, `compose up` brings the stack up from the local cache in a few minutes, `/api/health` answers. If something else is still broken, the wait aborts as soon as the unit has failed instead of sitting until minute 50.