### PR TITLE
fix(deploy): let Caddy write its log under ProtectSystem=strict

### DIFF
--- a/.github/workflows/aws-ami.yml
+++ b/.github/workflows/aws-ami.yml
@@ -323,7 +323,7 @@ jobs:
                   --instance-ids "$INSTANCE_ID" \
                   --document-name AWS-RunShellScript \
                   --comment "Synaplan verification unit probe" \
-                  --parameters 'commands=["systemctl is-failed synaplan-firstboot.service; systemctl is-failed synaplan.service"]' \
+                  --parameters 'commands=["systemctl is-failed synaplan-firstboot.service; systemctl is-failed synaplan.service; systemctl is-failed caddy.service"]' \
                   --query Command.CommandId --output text 2>/dev/null || true)"
                 if [ -n "${command_id:-}" ] && [ "$command_id" != None ]; then
                   for _ in $(seq 1 12); do

--- a/deploy/aws/scripts/configure-tls.sh
+++ b/deploy/aws/scripts/configure-tls.sh
@@ -108,8 +108,8 @@ if [[ -n "$requested_domain" && -f "$ENV_FILE" ]]; then
     log "Apply it to the running stack with: sudo systemctl restart synaplan"
 fi
 
-install -d -m 0755 /etc/caddy /var/log/caddy
-chown caddy:caddy /var/log/caddy
+install -d -m 0755 /etc/caddy
+install -d -o caddy -g caddy -m 0750 /var/log/caddy
 
 if [[ -n "$domain" ]]; then
     log "Serving https://$domain with a Let's Encrypt certificate"
@@ -132,6 +132,7 @@ install -d -m 0755 /etc/systemd/system/caddy.service.d
 cat > /etc/systemd/system/caddy.service.d/10-synaplan.conf <<EOF
 [Service]
 EnvironmentFile=$CADDY_ENV
+LogsDirectory=caddy
 EOF
 
 # With the same environment the unit will run under: the domain Caddyfile is a

--- a/deploy/aws/scripts/provision.sh
+++ b/deploy/aws/scripts/provision.sh
@@ -164,8 +164,8 @@ install -m 0644 "$APP_DIR/deploy/aws/systemd/synaplan.service" /etc/systemd/syst
 # verification window. Bake the self-signed site now so 443 is the listener
 # even if firstboot is still running, and do not start Caddy until firstboot
 # has at least had its chance to write the real file.
-install -d -m 0755 /etc/caddy /var/log/caddy
-chown caddy:caddy /var/log/caddy
+install -d -m 0755 /etc/caddy
+install -d -o caddy -g caddy -m 0750 /var/log/caddy
 install -m 0644 "$APP_DIR/deploy/aws/caddy/Caddyfile.selfsigned" /etc/caddy/Caddyfile
 caddy validate --config /etc/caddy/Caddyfile --adapter caddyfile
 install -d -m 0755 /etc/systemd/system/caddy.service.d
@@ -173,6 +173,15 @@ cat > /etc/systemd/system/caddy.service.d/20-synaplan-order.conf <<'EOF'
 [Unit]
 After=synaplan-firstboot.service
 Requires=synaplan-firstboot.service
+
+[Service]
+# The Caddyfile writes /var/log/caddy/synaplan.log. The packaged unit runs as
+# user caddy and typically ProtectSystem=strict, which makes /var read-only
+# unless LogsDirectory is set — the 4.2.4 verification died on
+# "open /var/log/caddy/synaplan.log: permission denied" with a healthy stack
+# behind it. systemd then creates the directory owned by caddy and adds it
+# to the writable paths. test-firstboot.sh enforces the directive.
+LogsDirectory=caddy
 EOF
 
 systemctl daemon-reload

--- a/deploy/aws/scripts/tests/test-firstboot.sh
+++ b/deploy/aws/scripts/tests/test-firstboot.sh
@@ -83,6 +83,27 @@ if grep -E '^[[:space:]]*ln\b' "$AWS_SCRIPTS_DIR/provision.sh" | grep -q '/usr/l
 fi
 
 # --------------------------------------------------------------------------
+# Caddy must be able to write the access log
+# --------------------------------------------------------------------------
+
+# The packaged unit runs as user caddy, often with ProtectSystem=strict. A
+# chown of /var/log/caddy on the host is not enough: the namespace still has
+# /var read-only unless LogsDirectory=caddy is set. The 4.2.4 verification
+# brought the whole stack up and then died on
+# "open /var/log/caddy/synaplan.log: permission denied".
+grep -Fq 'LogsDirectory=caddy' "$AWS_SCRIPTS_DIR/provision.sh" ||
+    fail "provision.sh does not set LogsDirectory=caddy; Caddy cannot write /var/log/caddy/synaplan.log under ProtectSystem=strict"
+grep -Fq 'LogsDirectory=caddy' "$AWS_SCRIPTS_DIR/configure-tls.sh" ||
+    fail "configure-tls.sh does not set LogsDirectory=caddy; a later synaplan-tls would drop the writable log directory"
+
+# The wait used to probe only firstboot and synaplan. Both were active
+# (oneshot RemainAfterExit) while Caddy was failed, so the probe sat out
+# fifty minutes next to a stack that had been healthy for 45 of them.
+repo_root="$(cd "$DEPLOY_ROOT/.." && pwd)"
+grep -Fq 'systemctl is-failed caddy.service' "$repo_root/.github/workflows/aws-ami.yml" ||
+    fail "the AMI verification wait does not probe caddy.service; a failed TLS terminator would again cost fifty minutes next to a healthy stack"
+
+# --------------------------------------------------------------------------
 # The XFS label firstboot writes on a blank data volume
 # --------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
The last verification actually booted. Firstboot finished in ~50 seconds, `synaplan.service` had every container healthy three minutes later — and Caddy then died in 2 ms on `open /var/log/caddy/synaplan.log: permission denied`. Nothing listened on 443. The wait probed only firstboot and synaplan, both `active` (oneshot RemainAfterExit), so it sat out the remaining 47 minutes next to a working stack.

## Changes
- `deploy/aws/scripts/provision.sh` and `configure-tls.sh`: `LogsDirectory=caddy` on the systemd drop-ins, so systemd creates `/var/log/caddy` owned by `caddy` and adds it to the writable paths under `ProtectSystem=strict`. Directory created as `caddy:caddy` mode `0750`.
- `.github/workflows/aws-ami.yml`: the unit probe includes `caddy.service`. A failed TLS terminator now aborts the wait instead of sitting next to two green oneshots.
- `test-firstboot.sh`: both guards, so dropping either fails CI.

## Verification
- [ ] Not tested (explain)
- [x] Manual
- [x] Tests added/updated

`bash deploy/aws/scripts/tests/test-firstboot.sh` and `bash deploy/scripts/tests/test-lifecycle.sh` pass.

## Notes
No roles-stack redeploy. The stack side of this AMI is now known-good: volume, env, secrets, compose, backend healthcheck. This is the TLS terminator writing a file it is not allowed to write.

Instance journal, from [run 32560937854](https://github.com/metadist/synaplan/actions/runs/32560937854):

```
Finished synaplan-firstboot.service
Container synaplan-backend-1 Healthy
Finished synaplan.service - Synaplan application stack
Error: ... open /var/log/caddy/synaplan.log: permission denied
caddy.service: Failed with result 'exit-code'.
```