### PR TITLE
fix(deploy): hand the log file caddy validate creates back to the service user

### DIFF
--- a/deploy/aws/scripts/configure-tls.sh
+++ b/deploy/aws/scripts/configure-tls.sh
@@ -141,6 +141,14 @@ EOF
 SYNAPLAN_DOMAIN="$domain" SYNAPLAN_ACME_EMAIL="$acme_email" \
     caddy validate --config "$CADDY_FILE" --adapter caddyfile
 
+# validate PROVISIONS the configuration, and provisioning a `log { output file }`
+# block OPENS the file — as root, because this script runs as root. That leaves
+# /var/log/caddy/synaplan.log owned by root, mode 0600, and caddy.service
+# (User=caddy) then dies in milliseconds on "permission denied" opening its own
+# log. This killed a verification run whose whole stack was healthy behind the
+# dead proxy. Hand everything back to the service user, every time validate ran.
+chown -R caddy:caddy /var/log/caddy
+
 # During the first boot systemd starts Caddy itself, right after this unit.
 if systemctl is-active --quiet caddy.service; then
     systemctl daemon-reload

--- a/deploy/aws/scripts/provision.sh
+++ b/deploy/aws/scripts/provision.sh
@@ -168,6 +168,12 @@ install -d -m 0755 /etc/caddy
 install -d -o caddy -g caddy -m 0750 /var/log/caddy
 install -m 0644 "$APP_DIR/deploy/aws/caddy/Caddyfile.selfsigned" /etc/caddy/Caddyfile
 caddy validate --config /etc/caddy/Caddyfile --adapter caddyfile
+# validate provisions the log writer and thereby CREATES synaplan.log — as
+# root, since this whole script is root. Left alone, the AMI ships a root-owned
+# 0600 log file that caddy.service (User=caddy) cannot open: it exits in
+# milliseconds with "permission denied" and nothing ever listens on 443, which
+# is exactly how a verification run with an otherwise healthy stack died.
+chown -R caddy:caddy /var/log/caddy
 install -d -m 0755 /etc/systemd/system/caddy.service.d
 cat > /etc/systemd/system/caddy.service.d/20-synaplan-order.conf <<'EOF'
 [Unit]
@@ -175,12 +181,11 @@ After=synaplan-firstboot.service
 Requires=synaplan-firstboot.service
 
 [Service]
-# The Caddyfile writes /var/log/caddy/synaplan.log. The packaged unit runs as
-# user caddy and typically ProtectSystem=strict, which makes /var read-only
-# unless LogsDirectory is set — the 4.2.4 verification died on
-# "open /var/log/caddy/synaplan.log: permission denied" with a healthy stack
-# behind it. systemd then creates the directory owned by caddy and adds it
-# to the writable paths. test-firstboot.sh enforces the directive.
+# The Caddyfile writes /var/log/caddy/synaplan.log. LogsDirectory makes systemd
+# own the directory for the service user and keep it writable under any
+# ProtectSystem setting; the ownership of the FILE inside is handled where
+# `caddy validate` runs as root (provision.sh, configure-tls.sh), because
+# validate creates it. test-firstboot.sh enforces both.
 LogsDirectory=caddy
 EOF
 

--- a/deploy/aws/scripts/tests/test-firstboot.sh
+++ b/deploy/aws/scripts/tests/test-firstboot.sh
@@ -96,6 +96,23 @@ grep -Fq 'LogsDirectory=caddy' "$AWS_SCRIPTS_DIR/provision.sh" ||
 grep -Fq 'LogsDirectory=caddy' "$AWS_SCRIPTS_DIR/configure-tls.sh" ||
     fail "configure-tls.sh does not set LogsDirectory=caddy; a later synaplan-tls would drop the writable log directory"
 
+# LogsDirectory alone is not enough. `caddy validate` PROVISIONS the config,
+# and provisioning a `log { output file }` block opens the file — as root,
+# because both scripts run as root. The file then belongs to root, mode 0600,
+# and caddy.service (User=caddy) dies on "permission denied" opening its own
+# log while the whole stack behind it is healthy. Proven with the packaged
+# caddy binary: validate as root leaves -rw------- root root synaplan.log.
+# So after the LAST validate in each script, ownership must be handed back.
+for script in "$AWS_SCRIPTS_DIR/provision.sh" "$AWS_SCRIPTS_DIR/configure-tls.sh"; do
+    awk '
+        { line = $0; sub(/^[[:space:]]*/, "", line) }
+        index(line, "#") == 1 { next }
+        /caddy validate/ { validate = NR }
+        /chown -R caddy:caddy \/var\/log\/caddy/ { restored = NR }
+        END { exit !(validate && restored > validate) }
+    ' "$script" || fail "$(basename "$script") runs caddy validate (as root, which creates a root-owned synaplan.log) without a chown -R caddy:caddy /var/log/caddy afterwards — caddy.service cannot open its own log"
+done
+
 # The wait used to probe only firstboot and synaplan. Both were active
 # (oneshot RemainAfterExit) while Caddy was failed, so the probe sat out
 # fifty minutes next to a stack that had been healthy for 45 of them.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Run [32565751365](https://github.com/metadist/synaplan/actions/runs/32565751365) failed on the same `open /var/log/caddy/synaplan.log: permission denied` as the run before it — which proves #1554's `LogsDirectory` was the wrong fix, because the directory was never the problem. The fail-fast from #1552 worked: the run aborted after **1 minute** instead of 50, with the evidence in the log.

The actual cause, reproduced with the packaged binary (v2.11.4, the instance's exact version): **`caddy validate` provisions the configuration, and provisioning a `log { output file }` block opens the file.** Both `provision.sh` and `configure-tls.sh` run validate as root, so `/var/log/caddy/synaplan.log` comes into existence as `root:root` mode `0600`. `caddy.service` (`User=caddy`) then dies in milliseconds opening its own log.

```
$ sudo caddy validate --config Caddyfile   # what firstboot does
Valid configuration
$ ls -ln /var/log/caddy/
-rw------- 1 0 0 0 synaplan.log            # root-owned
$ setpriv --reuid caddy ... >> synaplan.log
Permission denied                          # what caddy.service hits
```

## Changes
- `deploy/aws/scripts/configure-tls.sh` and `provision.sh`: `chown -R caddy:caddy /var/log/caddy` after the last `caddy validate`. This covers the first boot, the baked image (whose validate also poisoned the file), and every later `sudo synaplan-tls` run.
- `deploy/aws/scripts/tests/test-firstboot.sh`: the guard now requires the chown to follow the last validate in each script (comment lines excluded from the match); the misleading `LogsDirectory` comments were corrected. `LogsDirectory=caddy` stays — it is correct hardening, just not this bug's fix.

## Verification
- [ ] Not tested (explain)
- [x] Manual
- [x] Tests added/updated

- Root cause and fix proven against caddy v2.11.4: validate as root leaves a root-owned `0600` file the service user cannot append to; after `chown -R` it can.
- Both mutations (removing either chown) fail the suite with the matching message; `test-firstboot.sh` and `test-lifecycle.sh` pass.

## Notes
Everything else in the last run was green: firstboot 36 seconds, volume formatted and mounted, secrets recorded, containers starting. Caddy was the only failed unit, and the new unit probe caught it — 1 minute of instance time instead of 50.

No roles-stack redeploy needed.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dbb31302-1c72-44fa-9b1e-6e9906fc7b5e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dbb31302-1c72-44fa-9b1e-6e9906fc7b5e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

