### PR TITLE
feat(deploy): let the AMI workflow run from pull request branches

### DIFF
--- a/.github/workflows/aws-ami.yml
+++ b/.github/workflows/aws-ami.yml
@@ -6,7 +6,10 @@ name: AWS Marketplace AMI
 # release whose container images are already published and verified. Release
 # tags therefore trigger it, and it waits for the images to exist before Packer
 # starts. Run it by hand to rebuild an older release, or to try a change without
-# tagging.
+# tagging — from any branch of this repository, so a deployment fix can be built
+# and verified from its pull request before it is merged. The AWS trust policy
+# allows that because the jobs below declare the ami-build environment; see
+# deploy/aws/cloudformation/marketplace-roles.yaml.
 #
 # Authentication is GitHub OIDC against a role in the seller account. There are
 # no long-lived AWS keys in this repository, and there must never be.
@@ -134,6 +137,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: [resolve]
     if: needs.resolve.outputs.version != '' && needs.resolve.outputs.configured == 'true'
+    # The AWS build role trusts this environment's subject claim rather than a
+    # branch, so a run dispatched from a pull request branch can authenticate
+    # too. GitHub creates the environment on first use; protection rules (for
+    # example required reviewers) can be added to it in the repository settings
+    # without touching the trust policy.
+    environment: ami-build
     permissions:
       contents: read
       # Required for the OIDC token that the AWS role trusts. This is what
@@ -214,6 +223,8 @@ jobs:
       needs.resolve.outputs.version != '' &&
       contains(fromJSON(needs.resolve.outputs.matrix), 'x86_64') &&
       inputs.verify != false
+    # Same reasoning as on the build job: the AWS role trusts the environment.
+    environment: ami-build
     permissions:
       contents: read
       id-token: write

--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -215,10 +215,13 @@ account exists.
 
 That secret is the ARN of a role in the seller account that trusts GitHub's OIDC
 provider — **not** an access key, of which this repository holds none. Its trust
-policy must be narrowed to this repository, and it needs the permissions Packer
-uses to build an AMI (EC2 instance, key pair, security group, snapshot, image),
-plus CloudFormation, IAM, SSM and EC2 for the verification stack. The AWS
-managed policy `AWSMarketplaceAmiIngestion` goes on a separate role, the one the
+policy is narrowed to this repository's `ami-build` environment, which the
+workflow's jobs declare — so the workflow can also be dispatched by hand from a
+pull request branch to build and verify a deployment fix *before* it is merged,
+while forks stay excluded. The role needs the permissions Packer uses to build
+an AMI (EC2 instance, key pair, security group, snapshot, image), plus
+CloudFormation, IAM, SSM and EC2 for the verification stack. The AWS managed
+policy `AWSMarketplaceAmiIngestion` goes on a separate role, the one the
 Marketplace assumes to read the finished AMI.
 
 The AMI bakes the version pinned in `packer/synaplan.pkr.hcl`, which

--- a/deploy/aws/cloudformation/marketplace-roles.yaml
+++ b/deploy/aws/cloudformation/marketplace-roles.yaml
@@ -26,8 +26,8 @@ Parameters:
     ConstraintDescription: Must be owner/repository.
     Description: >-
       Only workflow runs of this repository may assume the build role. The trust
-      policy below narrows it further, to the branches and tags that build a
-      release.
+      policy below narrows it further, to the ami-build environment that the
+      release workflow's jobs declare.
 
   CreateOidcProvider:
     Type: String
@@ -71,10 +71,23 @@ Resources:
               StringEquals:
                 token.actions.githubusercontent.com:aud: sts.amazonaws.com
               # Without a subject condition, ANY repository on GitHub could
-              # assume this role. Release tags and manual runs on the default
-              # branch are the only things that build an AMI.
+              # assume this role. The jobs in aws-ami.yml that assume it all
+              # declare `environment: ami-build`, which puts the environment —
+              # not the ref — into the token's subject. That is what lets a fix
+              # be built and verified from a pull request branch BEFORE it is
+              # merged, instead of merging blind and testing on main. Forks
+              # stay excluded either way: their subject names the fork, not
+              # this repository. To gate builds on a human approval, add a
+              # required-reviewers protection rule to the ami-build environment
+              # in the repository settings; the trust policy needs no change
+              # for that.
+              #
+              # The two ref entries keep an older revision of the workflow
+              # (before it declared the environment) able to release; they can
+              # be removed once no such revision is expected to run again.
               StringLike:
                 token.actions.githubusercontent.com:sub:
+                  - !Sub 'repo:${GitHubRepository}:environment:ami-build'
                   - !Sub 'repo:${GitHubRepository}:ref:refs/tags/v*'
                   - !Sub 'repo:${GitHubRepository}:ref:refs/heads/main'
       Policies:

--- a/docs/AWS_MARKETPLACE_LISTING.md
+++ b/docs/AWS_MARKETPLACE_LISTING.md
@@ -126,7 +126,11 @@ meant to verify has already been built.
   must never be. Store its ARN as the repository secret
   `AWS_AMI_BUILD_ROLE_ARN`. Until that secret exists,
   [`aws-ami.yml`](../.github/workflows/aws-ami.yml) skips itself with a notice,
-  so releases stay green in the meantime.
+  so releases stay green in the meantime. The role trusts the workflow's
+  `ami-build` GitHub environment rather than a branch, so a deployment fix can
+  be built and verified from its pull request branch before it is merged; to
+  require a human approval per build, add a required-reviewers protection rule
+  to that environment in the repository settings.
 
 ## Submission sequence
 


### PR DESCRIPTION
## Summary
Bind the AMI build/verify jobs to an `ami-build` GitHub environment and trust that environment in the AWS build role, so a deployment fix can be built and verified from its pull request branch before it is merged — instead of merging blind and testing on main.

## Changes
- `.github/workflows/aws-ami.yml`: the `build` and `verify` jobs declare `environment: ami-build`, which puts the environment into the OIDC token's subject claim regardless of the ref the run was dispatched from.
- `deploy/aws/cloudformation/marketplace-roles.yaml`: the build role's trust policy accepts `repo:metadist/synaplan:environment:ami-build`. The two ref-based entries (`refs/tags/v*`, `refs/heads/main`) stay in place so an older workflow revision keeps working while the stack update rolls out; forks remain excluded either way because their subject names the fork.
- `deploy/aws/README.md`, `docs/AWS_MARKETPLACE_LISTING.md`: document the environment-based trust and the optional required-reviewers protection rule on the environment.

## Verification
- [ ] Not tested (explain)
- [ ] Manual
- [x] Tests added/updated

`cfn-lint` on the changed template, `test-lifecycle.sh` and `test-firstboot.sh` all pass locally. The end-to-end proof is dispatching `aws-ami.yml` from this very branch once the roles stack has been updated (see notes).

## Notes
Order matters: the roles stack must be redeployed **before** this PR's workflow change runs, because a job that declares an environment presents the environment subject, which the currently deployed trust policy does not accept. The stack update is purely additive, so runs from `main` keep working throughout:

```bash
aws cloudformation deploy \
  --region us-east-1 \
  --stack-name synaplan-marketplace-roles \
  --template-file deploy/aws/cloudformation/marketplace-roles.yaml \
  --capabilities CAPABILITY_NAMED_IAM
```

GitHub creates the `ami-build` environment automatically on first use. To gate AMI builds on a human approval, add a required-reviewers protection rule to it under Settings → Environments — no trust policy change needed.

## Screenshots/Logs