### PR TITLE
fix(deploy): serve a real self-signed certificate instead of tls internal

### DIFF
--- a/deploy/aws/caddy/Caddyfile.selfsigned
+++ b/deploy/aws/caddy/Caddyfile.selfsigned
@@ -5,17 +5,24 @@
 # verified by anyone. It is still the right default — the alternative is sending
 # the administrator password over plain HTTP.
 #
+# The certificate pair below is minted by configure-tls.sh on the instance,
+# with the instance's own addresses in the SANs. NOT `tls internal`: this site
+# has no host name and a client connecting by bare IP sends no SNI, so Caddy's
+# internal issuer has no name to mint a certificate for and aborts every
+# handshake with "tlsv1 alert internal error" — behind which an entire healthy
+# stack once sat unreachable for a full verification window.
+#
 # Give the instance a domain and re-run `sudo synaplan-tls <domain>` to replace
 # this with a publicly trusted certificate.
 
 {
-	# Caddy's internal CA. No ACME request is attempted, so this works in a VPC
-	# with no outbound internet access at all.
+	# No ACME request is attempted, so this works in a VPC with no outbound
+	# internet access at all.
 	auto_https disable_redirects
 }
 
 :443 {
-	tls internal
+	tls /etc/caddy/selfsigned/cert.pem /etc/caddy/selfsigned/key.pem
 
 	encode zstd gzip
 

--- a/deploy/aws/scripts/configure-tls.sh
+++ b/deploy/aws/scripts/configure-tls.sh
@@ -126,19 +126,21 @@ ensure_selfsigned_certificate() {
         return 0
     fi
 
-    local san="DNS:localhost,IP:127.0.0.1" address token public_ip
+    local san="DNS:localhost,IP:127.0.0.1,IP:::1" address token public_ip
     for address in $(hostname -I 2>/dev/null || true); do
         san+=",IP:$address"
     done
     # The public address is the one the operator's browser actually dials.
     # Best effort over IMDSv2: an instance without metadata access still gets
     # a working certificate, just without its public IP in the SANs — the
-    # browser warning is identical either way.
-    token="$(curl -sf -X PUT --connect-timeout 2 \
+    # browser warning is identical either way. --max-time bounds the whole
+    # request: an endpoint that accepts the connection and then stalls would
+    # otherwise hang the first boot here indefinitely.
+    token="$(curl -sf -X PUT --connect-timeout 2 --max-time 5 \
         -H 'X-aws-ec2-metadata-token-ttl-seconds: 60' \
         http://169.254.169.254/latest/api/token 2>/dev/null || true)"
     if [[ -n "$token" ]]; then
-        public_ip="$(curl -sf --connect-timeout 2 \
+        public_ip="$(curl -sf --connect-timeout 2 --max-time 5 \
             -H "X-aws-ec2-metadata-token: $token" \
             http://169.254.169.254/latest/meta-data/public-ipv4 2>/dev/null || true)"
         [[ -n "$public_ip" ]] && san+=",IP:$public_ip"

--- a/deploy/aws/scripts/configure-tls.sh
+++ b/deploy/aws/scripts/configure-tls.sh
@@ -18,6 +18,7 @@ APP_DIR=/opt/synaplan
 CADDY_SRC="$APP_DIR/deploy/aws/caddy"
 CADDY_FILE=/etc/caddy/Caddyfile
 CADDY_ENV=/etc/caddy/synaplan.env
+SELFSIGNED_DIR=/etc/caddy/selfsigned
 DATA_MOUNT=/var/lib/synaplan
 ENV_FILE="$DATA_MOUNT/.env"
 
@@ -108,6 +109,51 @@ if [[ -n "$requested_domain" && -f "$ENV_FILE" ]]; then
     log "Apply it to the running stack with: sudo systemctl restart synaplan"
 fi
 
+# The certificate pair Caddyfile.selfsigned serves. Not Caddy's `tls internal`:
+# that site address has no host name, a client connecting by bare IP sends no
+# SNI, and the internal issuer then has no name to mint a certificate for — it
+# aborts every handshake with "tlsv1 alert internal error". A bare IP is
+# exactly how this AMI is reached until a domain is attached, so the
+# certificate is minted here, with the instance's own addresses in the SANs.
+#
+# Minted on the instance and never baked into the image: an AMI that ships a
+# private key hands the SAME key to every customer. An existing pair is kept —
+# regenerating it on every boot would invalidate the exception the operator's
+# browser has already stored.
+ensure_selfsigned_certificate() {
+    install -d -m 0755 "$SELFSIGNED_DIR"
+    if [[ -s "$SELFSIGNED_DIR/cert.pem" && -s "$SELFSIGNED_DIR/key.pem" ]]; then
+        return 0
+    fi
+
+    local san="DNS:localhost,IP:127.0.0.1" address token public_ip
+    for address in $(hostname -I 2>/dev/null || true); do
+        san+=",IP:$address"
+    done
+    # The public address is the one the operator's browser actually dials.
+    # Best effort over IMDSv2: an instance without metadata access still gets
+    # a working certificate, just without its public IP in the SANs — the
+    # browser warning is identical either way.
+    token="$(curl -sf -X PUT --connect-timeout 2 \
+        -H 'X-aws-ec2-metadata-token-ttl-seconds: 60' \
+        http://169.254.169.254/latest/api/token 2>/dev/null || true)"
+    if [[ -n "$token" ]]; then
+        public_ip="$(curl -sf --connect-timeout 2 \
+            -H "X-aws-ec2-metadata-token: $token" \
+            http://169.254.169.254/latest/meta-data/public-ipv4 2>/dev/null || true)"
+        [[ -n "$public_ip" ]] && san+=",IP:$public_ip"
+    fi
+
+    openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:prime256v1 -nodes \
+        -keyout "$SELFSIGNED_DIR/key.pem" -out "$SELFSIGNED_DIR/cert.pem" \
+        -days 3650 -subj '/CN=synaplan' -addext "subjectAltName=$san" \
+        2>/dev/null
+    chown caddy:caddy "$SELFSIGNED_DIR/key.pem" "$SELFSIGNED_DIR/cert.pem"
+    chmod 0600 "$SELFSIGNED_DIR/key.pem"
+    chmod 0644 "$SELFSIGNED_DIR/cert.pem"
+    log "Minted a self-signed certificate ($san)"
+}
+
 install -d -m 0755 /etc/caddy
 install -d -o caddy -g caddy -m 0750 /var/log/caddy
 
@@ -121,6 +167,7 @@ EOF
 else
     log "No domain configured; serving HTTPS with a self-signed certificate"
     log "Attach one later with: sudo synaplan-tls app.example.com"
+    ensure_selfsigned_certificate
     install -m 0644 "$CADDY_SRC/Caddyfile.selfsigned" "$CADDY_FILE"
     : > "$CADDY_ENV"
 fi

--- a/deploy/aws/scripts/provision.sh
+++ b/deploy/aws/scripts/provision.sh
@@ -167,6 +167,16 @@ install -m 0644 "$APP_DIR/deploy/aws/systemd/synaplan.service" /etc/systemd/syst
 install -d -m 0755 /etc/caddy
 install -d -o caddy -g caddy -m 0750 /var/log/caddy
 install -m 0644 "$APP_DIR/deploy/aws/caddy/Caddyfile.selfsigned" /etc/caddy/Caddyfile
+# The Caddyfile serves a certificate pair that only exists once the first boot
+# has minted it for the instance (configure-tls.sh) — baking a real pair into
+# the image would hand the SAME private key to every customer. Validation still
+# needs files to load, so: a throwaway pair, validate, delete. caddy.service
+# orders itself after synaplan-firstboot below, which mints the real pair
+# before Caddy first starts.
+install -d -m 0755 /etc/caddy/selfsigned
+openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:prime256v1 -nodes \
+    -keyout /etc/caddy/selfsigned/key.pem -out /etc/caddy/selfsigned/cert.pem \
+    -days 1 -subj '/CN=throwaway' 2>/dev/null
 caddy validate --config /etc/caddy/Caddyfile --adapter caddyfile
 # validate provisions the log writer and thereby CREATES synaplan.log — as
 # root, since this whole script is root. Left alone, the AMI ships a root-owned
@@ -174,6 +184,7 @@ caddy validate --config /etc/caddy/Caddyfile --adapter caddyfile
 # milliseconds with "permission denied" and nothing ever listens on 443, which
 # is exactly how a verification run with an otherwise healthy stack died.
 chown -R caddy:caddy /var/log/caddy
+rm -f /etc/caddy/selfsigned/key.pem /etc/caddy/selfsigned/cert.pem
 install -d -m 0755 /etc/systemd/system/caddy.service.d
 cat > /etc/systemd/system/caddy.service.d/20-synaplan-order.conf <<'EOF'
 [Unit]

--- a/deploy/aws/scripts/tests/test-firstboot.sh
+++ b/deploy/aws/scripts/tests/test-firstboot.sh
@@ -121,6 +121,40 @@ grep -Fq 'systemctl is-failed caddy.service' "$repo_root/.github/workflows/aws-a
     fail "the AMI verification wait does not probe caddy.service; a failed TLS terminator would again cost fifty minutes next to a healthy stack"
 
 # --------------------------------------------------------------------------
+# The self-signed certificate an instance without a domain serves
+# --------------------------------------------------------------------------
+
+# `tls internal` cannot answer a client that dials the bare IP — which is how
+# every launch is reached until a domain is attached. The catch-all site has no
+# host name, the ClientHello carries no SNI, so the internal issuer has no name
+# to mint a certificate for and aborts every handshake with "tlsv1 alert
+# internal error". A verification run watched a fully healthy stack refuse
+# connections for fifty minutes behind exactly that. The Caddyfile must serve
+# the pair configure-tls.sh mints instead.
+selfsigned_caddyfile="$DEPLOY_ROOT/aws/caddy/Caddyfile.selfsigned"
+if grep -Eq '^[[:space:]]*tls[[:space:]]+internal([[:space:]]|$)' "$selfsigned_caddyfile"; then
+    fail "Caddyfile.selfsigned uses tls internal, which cannot answer a client connecting by bare IP (no SNI, no name to issue for) — every handshake dies with a tlsv1 internal error"
+fi
+grep -Fq '/etc/caddy/selfsigned/cert.pem' "$selfsigned_caddyfile" ||
+    fail "Caddyfile.selfsigned does not serve the minted pair under /etc/caddy/selfsigned/; without it Caddy has no certificate at all"
+grep -Fq 'openssl req' "$AWS_SCRIPTS_DIR/configure-tls.sh" ||
+    fail "configure-tls.sh does not mint the self-signed certificate that Caddyfile.selfsigned serves"
+
+# The pair is minted on the instance, never shipped in the image: an AMI that
+# carries a private key hands the SAME key to every customer. provision.sh may
+# create a throwaway pair so `caddy validate` has files to load, but it must
+# delete that pair before the image is snapshotted. Comment lines are skipped,
+# so a commented-out rm does not count as one.
+awk '
+    { line = $0; sub(/^[[:space:]]*/, "", line) }
+    index(line, "#") == 1 { next }
+    /openssl req/ { minted = NR }
+    /rm -f \/etc\/caddy\/selfsigned/ { removed = NR }
+    END { exit !(!minted || removed > minted) }
+' "$AWS_SCRIPTS_DIR/provision.sh" ||
+    fail "provision.sh mints a certificate pair without deleting it afterwards — the AMI would ship one private key to every customer"
+
+# --------------------------------------------------------------------------
 # The XFS label firstboot writes on a blank data volume
 # --------------------------------------------------------------------------
 

--- a/deploy/aws/scripts/tests/test-firstboot.sh
+++ b/deploy/aws/scripts/tests/test-firstboot.sh
@@ -143,16 +143,18 @@ grep -Fq 'openssl req' "$AWS_SCRIPTS_DIR/configure-tls.sh" ||
 # The pair is minted on the instance, never shipped in the image: an AMI that
 # carries a private key hands the SAME key to every customer. provision.sh may
 # create a throwaway pair so `caddy validate` has files to load, but it must
-# delete that pair before the image is snapshotted. Comment lines are skipped,
-# so a commented-out rm does not count as one.
+# delete BOTH files before the image is snapshotted — the key is the secret,
+# and a leftover certificate would mask the missing mint at first boot.
+# Comment lines are skipped, so a commented-out rm does not count as one.
 awk '
     { line = $0; sub(/^[[:space:]]*/, "", line) }
     index(line, "#") == 1 { next }
     /openssl req/ { minted = NR }
-    /rm -f \/etc\/caddy\/selfsigned/ { removed = NR }
-    END { exit !(!minted || removed > minted) }
+    /rm .*\/etc\/caddy\/selfsigned\/key\.pem/ { removed_key = NR }
+    /rm .*\/etc\/caddy\/selfsigned\/cert\.pem/ { removed_cert = NR }
+    END { exit !(!minted || (removed_key > minted && removed_cert > minted)) }
 ' "$AWS_SCRIPTS_DIR/provision.sh" ||
-    fail "provision.sh mints a certificate pair without deleting it afterwards — the AMI would ship one private key to every customer"
+    fail "provision.sh mints a certificate pair without deleting both files afterwards — the AMI would ship one private key to every customer"
 
 # --------------------------------------------------------------------------
 # The XFS label firstboot writes on a blank data volume

--- a/deploy/scripts/smoke-test.sh
+++ b/deploy/scripts/smoke-test.sh
@@ -7,20 +7,44 @@ source "$(dirname "$0")/lib.sh"
 # Documented as directly runnable, and every probe below is a Compose call.
 ensure_deployment_secrets
 
+# "starting" is not a verdict: it is Docker's healthcheck start window (up to
+# start_period, 300s for the backend), and it resolves to healthy or unhealthy
+# on its own. A smoke test run right after boot — which is exactly when one is
+# run — used to fail on it while the API was already answering. So: wait out
+# "starting" up to the longest start_period, fail immediately on any real
+# verdict.
+HEALTH_VERDICT_TIMEOUT=300
+
 assert_healthy() {
     local service="$1"
-    local container_id status
+    local container_id status waited=0
     container_id="$(compose ps -q "$service")"
     [[ -n "$container_id" ]] || {
         echo "$service is not running" >&2
         return 1
     }
-    status="$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "$container_id")"
-    [[ "$status" == "healthy" || "$status" == "running" ]] || {
-        echo "$service is $status" >&2
-        return 1
-    }
-    printf 'ok: %s\n' "$service"
+    while :; do
+        status="$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "$container_id")"
+        case "$status" in
+            healthy|running)
+                printf 'ok: %s\n' "$service"
+                return 0
+                ;;
+            starting)
+                if (( waited >= HEALTH_VERDICT_TIMEOUT )); then
+                    echo "$service is still starting after ${waited}s; its healthcheck never passed" >&2
+                    return 1
+                fi
+                (( waited % 30 == 0 )) && echo "$service is starting; waiting for its healthcheck to decide"
+                sleep 5
+                waited=$((waited + 5))
+                ;;
+            *)
+                echo "$service is $status" >&2
+                return 1
+                ;;
+        esac
+    done
 }
 
 compose exec -T backend curl -fsS -o /dev/null http://localhost/api/health


### PR DESCRIPTION
## Summary
The 4.2.4 verification brought the entire stack up healthy and still failed: every TLS handshake died with `tlsv1 alert internal error`. `tls internal` on the host-less `:443` site cannot serve a client that dials the bare IP — no SNI means Caddy's internal issuer has no name to mint a certificate for. The instance now mints a plain self-signed certificate with its own addresses in the SANs and serves that.

## Changes
- `deploy/aws/caddy/Caddyfile.selfsigned`: `tls internal` → `tls /etc/caddy/selfsigned/cert.pem /etc/caddy/selfsigned/key.pem`.
- `deploy/aws/scripts/configure-tls.sh`: mints the pair on first boot (OpenSSL, EC P-256, SANs = localhost, all local addresses, and the public IP via IMDSv2 best-effort). An existing pair is kept so the browser exception the operator stored survives reboots.
- `deploy/aws/scripts/provision.sh`: `caddy validate` at build time gets a throwaway pair that is deleted right after — the AMI must never ship a private key, because every customer would receive the same one.
- `deploy/aws/scripts/tests/test-firstboot.sh`: guards for all three (no `tls internal`, the pair is minted, the throwaway pair is deleted), each mutation-tested.

## Verification
- [ ] Not tested (explain)
- [x] Manual
- [x] Tests added/updated

`test-firstboot.sh` and `test-lifecycle.sh` pass; all three new guards were mutation-tested. Functional proof in a container: Caddy 2 with the new Caddyfile and a minted pair answers `curl -k https://127.0.0.1/api/health` with HTTP 502 (no backend in the container) — the handshake that used to abort now completes. The end-to-end proof is the AMI verification run dispatched from this branch.

## Notes
Fifth and final link in the first-boot chain after #1545, #1546, #1551, #1552, #1555 — this time verified from the branch itself (#1557) instead of on main.

## Screenshots/Logs
```
Aug 22 12:07:17 caddy[3394]: {"level":"error","logger":"pki.ca.local","msg":"failed to install root certificate","error":"failed to execute sudo: exit status 1"}
curl: (35) OpenSSL/3.0.13: error:0A000438:SSL routines::tlsv1 alert internal error
```