### PR TITLE
feat(backend): enhance UrlContentService for improved HTML content

### DIFF
--- a/backend/src/Service/UrlContentService.php
+++ b/backend/src/Service/UrlContentService.php
@@ -33,6 +33,12 @@ final readonly class UrlContentService
     private const MAX_API_RESPONSE_LENGTH = 8000;
     private const USER_AGENT = 'SynaplanBot/1.0 (+https://synaplan.com/bot)';
     private const ROBOTS_TXT_TIMEOUT = 3;
+    /**
+     * A targeted landmark (`<main>`, `class="entry-content"`, …) that yields
+     * less than this is treated as a failed extract and we fall back to the
+     * full body — page builders often put "content" in column class names.
+     */
+    private const MIN_USEFUL_TEXT_CHARS = 80;
 
     public function __construct(
         private HttpClientInterface $httpClient,
@@ -445,40 +451,78 @@ final readonly class UrlContentService
 
     private function extractTextWithLimit(string $html, bool $fullMode): string
     {
-        $contentPatterns = [
+        $targeted = $this->selectTargetedHtml($html);
+        $body = $this->selectBodyHtml($html);
+
+        $candidates = [];
+        if ('' !== $targeted) {
+            $candidates[] = $this->htmlToPlainText($targeted, !$fullMode);
+        }
+        $candidates[] = $this->htmlToPlainText($body, !$fullMode);
+        if (!$fullMode) {
+            // Last resort: keep nav/header/footer when chrome-stripping
+            // left almost nothing (JS builders often skip those tags).
+            $candidates[] = $this->htmlToPlainText($body, false);
+        }
+
+        $best = '';
+        foreach ($candidates as $text) {
+            if ($this->isUsefulText($text)) {
+                return $text;
+            }
+            if (mb_strlen($text) > mb_strlen($best)) {
+                $best = $text;
+            }
+        }
+
+        return $best;
+    }
+
+    /**
+     * Prefer semantic landmarks. Avoid substring matches like Kubio's
+     * `h-column__content`, which previously ate the whole extract.
+     */
+    private function selectTargetedHtml(string $html): string
+    {
+        $patterns = [
             '/<main[^>]*>(.*?)<\/main>/is',
             '/<article[^>]*>(.*?)<\/article>/is',
-            '/<div[^>]*(?:role=["\']main["\']|id=["\']content["\']|class=["\'][^"\']*content[^"\']*["\'])[^>]*>(.*?)<\/div>/is',
+            '/<(?:div|section)[^>]+role=["\']main["\'][^>]*>(.*?)<\/(?:div|section)>/is',
+            '/<(?:div|section)[^>]+id=["\'](?:content|main|primary)["\'][^>]*>(.*?)<\/(?:div|section)>/is',
+            '/<(?:div|section)[^>]+class=["\'](?:[^"\']*\s)?(?:entry-content|post-content|page-content|site-content|main-content|article-content|wp-block-post-content)(?:\s[^"\']*)?["\'][^>]*>(.*?)<\/(?:div|section)>/is',
         ];
 
-        $content = '';
-        foreach ($contentPatterns as $pattern) {
+        foreach ($patterns as $pattern) {
             if (preg_match($pattern, $html, $matches)) {
-                $content = $matches[1];
-                break;
+                return $matches[1];
             }
         }
 
-        if ('' === $content) {
-            if (preg_match('/<body[^>]*>(.*)<\/body>/is', $html, $matches)) {
-                $content = $matches[1];
-            } else {
-                $content = $html;
-            }
+        return '';
+    }
+
+    private function selectBodyHtml(string $html): string
+    {
+        if (preg_match('/<body[^>]*>(.*)<\/body>/is', $html, $matches)) {
+            return $matches[1];
         }
 
+        return $html;
+    }
+
+    private function htmlToPlainText(string $content, bool $stripChrome): string
+    {
         $content = preg_replace('/<script[^>]*>.*?<\/script>/is', '', $content) ?? $content;
         $content = preg_replace('/<style[^>]*>.*?<\/style>/is', '', $content) ?? $content;
         $content = preg_replace('/<svg[^>]*>.*?<\/svg>/is', '', $content) ?? $content;
         $content = preg_replace('/<noscript[^>]*>.*?<\/noscript>/is', '', $content) ?? $content;
 
-        if (!$fullMode) {
+        if ($stripChrome) {
             $content = preg_replace('/<nav[^>]*>.*?<\/nav>/is', '', $content) ?? $content;
             $content = preg_replace('/<header[^>]*>.*?<\/header>/is', '', $content) ?? $content;
             $content = preg_replace('/<footer[^>]*>.*?<\/footer>/is', '', $content) ?? $content;
         }
 
-        // Insert newlines before block-level elements to prevent word concatenation
         $content = preg_replace('/<\/(div|p|h[1-6]|li|section|article|header|footer|nav|main|blockquote|tr|td|th|dt|dd|figcaption|details|summary)>/i', "</$1>\n", $content) ?? $content;
         $content = preg_replace('/<(br|hr)\s*\/?>/i', "\n", $content) ?? $content;
 
@@ -489,6 +533,11 @@ final readonly class UrlContentService
         $text = preg_replace('/\n{3,}/', "\n\n", $text) ?? $text;
 
         return trim($text);
+    }
+
+    private function isUsefulText(string $text): bool
+    {
+        return mb_strlen($text) >= self::MIN_USEFUL_TEXT_CHARS;
     }
 
     private function extractMetaDescription(string $html): string

--- a/backend/tests/Unit/Service/UrlContentServiceTest.php
+++ b/backend/tests/Unit/Service/UrlContentServiceTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service;
+
+use App\Service\Security\SsrfGuard;
+use App\Service\UrlContentService;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+/**
+ * HTML extraction: prefer landmarks, fall back to the full body when a
+ * targeted region is empty or too short (Kubio / page-builder pages).
+ */
+final class UrlContentServiceTest extends TestCase
+{
+    public function testPrefersArticleOverSurroundingChrome(): void
+    {
+        $html = <<<'HTML'
+<html><head><title>Article Title</title></head><body>
+<nav>Home About Pricing Contact lots of navigation chrome that is not the article</nav>
+<article><p>The actual article body with enough characters to pass the useful-text threshold on its own without falling back.</p></article>
+<footer>Copyright 2026 ignore this</footer>
+</body></html>
+HTML;
+
+        $result = $this->service([
+            new MockResponse($html, ['http_code' => 200, 'response_headers' => ['content-type' => 'text/html']]),
+        ])->fetch('https://example.com/article');
+
+        self::assertTrue($result->success);
+        self::assertSame('Article Title', $result->title);
+        self::assertStringContainsString('actual article body', $result->extractedText);
+        self::assertStringNotContainsString('navigation chrome', $result->extractedText);
+    }
+
+    public function testFallsBackToBodyWhenPageBuilderContentClassIsAFalseMatch(): void
+    {
+        $html = <<<'HTML'
+<html><head><title>Startseite - FPS Energy</title></head><body>
+<div class="h-column__content">info@fps.energy</div>
+<div class="hero">
+  <h1>Für die Energiewende</h1>
+  <p>Fuel &amp; Power Supply delivers hydrogen, EV charging and biofuels to industry and fleets that want to act today.</p>
+</div>
+</body></html>
+HTML;
+
+        $chat = $this->service([
+            new MockResponse($html, ['http_code' => 200, 'response_headers' => ['content-type' => 'text/html']]),
+        ])->fetch('https://fps.energy/');
+
+        self::assertTrue($chat->success);
+        self::assertStringContainsString('Energiewende', $chat->extractedText);
+        self::assertStringContainsString('hydrogen', $chat->extractedText);
+        self::assertGreaterThan(80, mb_strlen($chat->extractedText));
+
+        $crawl = $this->service([
+            new MockResponse("User-agent: *\nDisallow:\n", ['http_code' => 200]),
+            new MockResponse($html, ['http_code' => 200, 'response_headers' => ['content-type' => 'text/html']]),
+        ])->fetchForCrawling('https://fps.energy/');
+
+        self::assertTrue($crawl->success);
+        self::assertStringContainsString('Energiewende', $crawl->extractedText);
+        self::assertGreaterThan(80, mb_strlen($crawl->extractedText));
+    }
+
+    public function testUsesEntryContentLandmarkWhenItHasEnoughText(): void
+    {
+        $html = <<<'HTML'
+<html><body>
+<div class="sidebar">Seasonal offer banner that should lose to the landmark.</div>
+<div class="entry-content">
+<p>This WordPress entry has enough characters in the landmark so the extractor keeps it instead of dumping the whole page.</p>
+</div>
+</body></html>
+HTML;
+
+        $result = $this->service([
+            new MockResponse($html, ['http_code' => 200, 'response_headers' => ['content-type' => 'text/html']]),
+        ])->fetch('https://example.com/post');
+
+        self::assertTrue($result->success);
+        self::assertStringContainsString('WordPress entry', $result->extractedText);
+        self::assertStringNotContainsString('Seasonal offer banner', $result->extractedText);
+    }
+
+    public function testFallsBackToUnstrippedBodyWhenChromeRemovalLeavesNothing(): void
+    {
+        $html = <<<'HTML'
+<html><head><title>Short</title></head><body>
+<header>
+  <h1>Hydrogen for fleets that need a reliable supply today</h1>
+  <p>We deliver tank infrastructure, redundancy and safe H2 supply even when the grid is tight.</p>
+</header>
+</body></html>
+HTML;
+
+        $result = $this->service([
+            new MockResponse($html, ['http_code' => 200, 'response_headers' => ['content-type' => 'text/html']]),
+        ])->fetch('https://example.com/hero');
+
+        self::assertTrue($result->success);
+        self::assertStringContainsString('Hydrogen for fleets', $result->extractedText);
+        self::assertStringContainsString('tank infrastructure', $result->extractedText);
+    }
+
+    /**
+     * @param list<MockResponse> $responses
+     */
+    private function service(array $responses): UrlContentService
+    {
+        return new UrlContentService(
+            new MockHttpClient($responses),
+            new SsrfGuard(),
+            new NullLogger(),
+        );
+    }
+}


### PR DESCRIPTION
## Summary
Getting the content out

## Changes
- Introduced a new constant MIN_USEFUL_TEXT_CHARS to define a threshold for useful text extraction.
- Refactored extractTextWithLimit to prioritize semantic landmarks and improve fallback mechanisms for content extraction.
- Added selectTargetedHtml and selectBodyHtml methods to streamline the selection of relevant HTML content.
- Implemented isUsefulText method to evaluate the usefulness of extracted text based on the new threshold.

## Verification
- [ ] Not tested (explain)
- [X] Manual
- [ ] Tests added/updated

## Notes
<!-- Related issues/links/threads. -->

## Screenshots/Logs
