### PR TITLE
fix(frontend): stabilize flaky impersonation + memories E2E tests

### DIFF
--- a/frontend/src/services/api/httpClient.ts
+++ b/frontend/src/services/api/httpClient.ts
@@ -359,13 +359,24 @@ function recordAuthFailure(): void {
  * "session expired" noise into the console for users who never had a
  * session in the first place.
  */
-async function refreshAccessToken(): Promise<RefreshResult> {
-  // A principal swap is rewriting the session cookies. Don't race it: wait for
-  // it to finish, then report success so the caller retries against the new,
-  // valid cookie instead of firing a competing (clobbering) refresh.
-  if (authMutationPromise) {
+async function refreshAccessToken(
+  options: { bypassMutationLock?: boolean } = {}
+): Promise<RefreshResult> {
+  // A principal swap (impersonation start/stop) is rewriting the session
+  // cookies out-of-band. An automatic refresh triggered by a request still
+  // carrying the PRE-swap cookies would clobber the freshly installed cookie,
+  // so wait for the swap to finish — then fall through to a REAL refresh
+  // against the now-stable cookies.
+  //
+  // We must NOT short-circuit with a synthetic success here: if the swap
+  // failed and this 401 was a genuinely expired token, the caller's retry
+  // would 401 again and hit handleAuthFailure(), logging the admin out. A real
+  // refresh against the stable post-swap cookies recovers cleanly instead.
+  //
+  // `bypassMutationLock` lets the swap itself mint a fresh pre-swap token while
+  // it holds the lock, without deadlocking by waiting on its own promise.
+  if (authMutationPromise && !options.bypassMutationLock) {
     await authMutationPromise
-    return { success: true }
   }
 
   // Native gates on a stored refresh token (no cookie); web on the UX hint.

--- a/frontend/src/services/api/httpClient.ts
+++ b/frontend/src/services/api/httpClient.ts
@@ -238,6 +238,72 @@ interface HttpClientOptions<S extends z.Schema | undefined = undefined> extends 
 let isRefreshing = false
 let refreshPromise: Promise<RefreshResult> | null = null
 
+// --- Auth-mutation lock -----------------------------------------------------
+// A deliberate principal swap (admin impersonation start/stop) rewrites the
+// session cookies out-of-band. While it runs, the automatic 401 -> refresh
+// path must NOT fire its own /auth/refresh: a refresh triggered by a request
+// that still carries the PRE-swap cookies mints a token for the old principal
+// and clobbers the just-installed session cookie (the impersonation banner
+// then never mounts — a real cookie race, see stores/auth.ts). The lock is
+// inert outside a swap, so normal login/logout/refresh/OIDC/native behaviour
+// is byte-for-byte unchanged.
+let authMutationPromise: Promise<void> | null = null
+let authMutationResolve: (() => void) | null = null
+let authMutationTimer: ReturnType<typeof setTimeout> | null = null
+let authMutationDepth = 0
+
+/**
+ * Safety net: never let a swap that forgot to release (unexpected throw before
+ * `endAuthMutation`, navigation mid-swap) suspend the refresh path forever.
+ */
+const AUTH_MUTATION_MAX_MS = 15000
+
+/**
+ * Open the auth-mutation critical section. While open, `refreshAccessToken`
+ * waits for it to close instead of issuing a competing refresh. Reentrant:
+ * balanced with `endAuthMutation`.
+ */
+function beginAuthMutation(): void {
+  authMutationDepth++
+  if (authMutationPromise) return
+  authMutationPromise = new Promise<void>((resolve) => {
+    authMutationResolve = resolve
+  })
+  authMutationTimer = setTimeout(() => {
+    console.warn('Auth-mutation lock auto-released after timeout')
+    forceReleaseAuthMutation()
+  }, AUTH_MUTATION_MAX_MS)
+}
+
+/** Close the auth-mutation critical section (balanced with `beginAuthMutation`). */
+function endAuthMutation(): void {
+  if (authMutationDepth === 0) return
+  authMutationDepth--
+  if (authMutationDepth > 0) return
+  forceReleaseAuthMutation()
+}
+
+function forceReleaseAuthMutation(): void {
+  authMutationDepth = 0
+  if (authMutationTimer) {
+    clearTimeout(authMutationTimer)
+    authMutationTimer = null
+  }
+  const resolve = authMutationResolve
+  authMutationPromise = null
+  authMutationResolve = null
+  resolve?.()
+}
+
+/**
+ * The refresh currently in flight, if any. Callers starting a principal swap
+ * await this so an already-running refresh settles BEFORE the swap request is
+ * sent, guaranteeing the swap response is the last writer of the session cookie.
+ */
+function getInFlightRefresh(): Promise<RefreshResult> | null {
+  return refreshPromise
+}
+
 // Track auth failures to prevent redirect loops
 let authFailureCount = 0
 let lastAuthFailureTime = 0
@@ -294,6 +360,14 @@ function recordAuthFailure(): void {
  * session in the first place.
  */
 async function refreshAccessToken(): Promise<RefreshResult> {
+  // A principal swap is rewriting the session cookies. Don't race it: wait for
+  // it to finish, then report success so the caller retries against the new,
+  // valid cookie instead of firing a competing (clobbering) refresh.
+  if (authMutationPromise) {
+    await authMutationPromise
+    return { success: true }
+  }
+
   // Native gates on a stored refresh token (no cookie); web on the UX hint.
   const native = isNativeApp()
   if (native ? !hasNativeTokens() : !hasSessionHint()) {
@@ -580,4 +654,11 @@ async function httpClient<T = unknown, S extends z.Schema | undefined = undefine
   return data as T
 }
 
-export { httpClient, getApiBaseUrl, refreshAccessToken }
+export {
+  httpClient,
+  getApiBaseUrl,
+  refreshAccessToken,
+  beginAuthMutation,
+  endAuthMutation,
+  getInFlightRefresh,
+}

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -419,11 +419,13 @@ export const useAuthStore = defineStore('auth', () => {
    * can show success / error notifications.
    */
   async function startImpersonation(userId: number): Promise<{ success: boolean; error?: string }> {
-    const [{ impersonationApi }, { beginAuthMutation, endAuthMutation, getInFlightRefresh }] =
-      await Promise.all([
-        import('@/services/api/impersonationApi'),
-        import('@/services/api/httpClient'),
-      ])
+    const [
+      { impersonationApi },
+      { beginAuthMutation, endAuthMutation, getInFlightRefresh, refreshAccessToken },
+    ] = await Promise.all([
+      import('@/services/api/impersonationApi'),
+      import('@/services/api/httpClient'),
+    ])
 
     // Guard the cookie-swap window (impersonate response -> /auth/me read)
     // against the automatic 401 -> /auth/refresh path. A refresh that fires
@@ -444,6 +446,14 @@ export const useAuthStore = defineStore('auth', () => {
           // A failed background refresh must not abort the swap.
         }
       }
+
+      // Mint a fresh admin access token as the guaranteed LAST writer before
+      // the swap. impersonationApi.start() is a raw fetch with no 401-retry, so
+      // without this it would fail outright if the admin's short-lived access
+      // cookie had already expired and no refresh happened to be in flight.
+      // Bypass the lock we hold — no competing refresh can run right now.
+      // Best-effort: on failure the impersonate call surfaces the real error.
+      await refreshAccessToken({ bypassMutationLock: true })
 
       const result = await impersonationApi.start(userId)
       if (!result.success) {
@@ -496,11 +506,13 @@ export const useAuthStore = defineStore('auth', () => {
    * refresh pattern as `startImpersonation`.
    */
   async function stopImpersonation(): Promise<{ success: boolean; error?: string }> {
-    const [{ impersonationApi }, { beginAuthMutation, endAuthMutation, getInFlightRefresh }] =
-      await Promise.all([
-        import('@/services/api/impersonationApi'),
-        import('@/services/api/httpClient'),
-      ])
+    const [
+      { impersonationApi },
+      { beginAuthMutation, endAuthMutation, getInFlightRefresh, refreshAccessToken },
+    ] = await Promise.all([
+      import('@/services/api/impersonationApi'),
+      import('@/services/api/httpClient'),
+    ])
 
     // Symmetric to startImpersonation: while exiting, a concurrent refresh
     // still carrying the impersonation cookies (stash present) would be
@@ -516,6 +528,12 @@ export const useAuthStore = defineStore('auth', () => {
           // A failed background refresh must not abort the swap.
         }
       }
+
+      // Keep the session alive as the last writer before exiting: the exit call
+      // is a raw fetch with no 401-retry, so a fresh (still impersonation-aware)
+      // token guarantees it can authenticate even if the current access cookie
+      // just expired. Bypass the lock we hold; best-effort.
+      await refreshAccessToken({ bypassMutationLock: true })
 
       const result = await impersonationApi.stop()
       if (!result.success) {

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -419,29 +419,60 @@ export const useAuthStore = defineStore('auth', () => {
    * can show success / error notifications.
    */
   async function startImpersonation(userId: number): Promise<{ success: boolean; error?: string }> {
-    const { impersonationApi } = await import('@/services/api/impersonationApi')
-    const result = await impersonationApi.start(userId)
+    const [{ impersonationApi }, { beginAuthMutation, endAuthMutation, getInFlightRefresh }] =
+      await Promise.all([
+        import('@/services/api/impersonationApi'),
+        import('@/services/api/httpClient'),
+      ])
 
-    if (!result.success) {
-      return { success: false, error: result.error }
-    }
-
-    // Drop any chat / message state the admin had loaded before we swap the
-    // principal. The persisted `activeChatId` belongs to the admin and would
-    // 404 against the impersonated user (#999). Doing this before
-    // refreshUser() guarantees that whatever route re-renders next sees a
-    // clean slate.
+    // Guard the cookie-swap window (impersonate response -> /auth/me read)
+    // against the automatic 401 -> /auth/refresh path. A refresh that fires
+    // here still carries the admin's pre-swap cookies (the impersonation stash
+    // is not set yet), so the backend mints a REGULAR admin token that clobbers
+    // the impersonation cookie and /auth/me then reports no impersonator — the
+    // banner never mounts. The lock makes any concurrent 401 wait for the swap
+    // and retry with the new cookie instead of racing it.
+    beginAuthMutation()
     try {
-      await resetUserScopedClientState()
-      await teardownRealtimeState()
-    } catch (cleanupErr) {
-      console.warn('User state cleanup failed during impersonation start', cleanupErr)
+      // Let a refresh that started *before* the lock settle first, so our
+      // impersonate response is guaranteed to be the last writer of the cookie.
+      const inFlight = getInFlightRefresh()
+      if (inFlight) {
+        try {
+          await inFlight
+        } catch {
+          // A failed background refresh must not abort the swap.
+        }
+      }
+
+      const result = await impersonationApi.start(userId)
+      if (!result.success) {
+        return { success: false, error: result.error }
+      }
+
+      // Drop any chat / message state the admin had loaded before we swap the
+      // principal. The persisted `activeChatId` belongs to the admin and would
+      // 404 against the impersonated user (#999). Doing this before
+      // refreshUser() guarantees that whatever route re-renders next sees a
+      // clean slate.
+      try {
+        await resetUserScopedClientState()
+        await teardownRealtimeState()
+      } catch (cleanupErr) {
+        console.warn('User state cleanup failed during impersonation start', cleanupErr)
+      }
+
+      // Re-fetch /auth/me so user + impersonator + level + isAdmin all reflect
+      // the post-swap session in one consistent step.
+      await refreshUser()
+    } finally {
+      // Release before the non-critical follow-ups below: config reload and the
+      // realtime resubscribe issue their own httpClient requests and must be
+      // able to refresh normally again.
+      endAuthMutation()
     }
 
-    // Re-fetch /auth/me so user + impersonator + level + isAdmin all reflect
-    // the post-swap session in one consistent step. We also reload the config
-    // store, since plugin/feature visibility is user-scoped.
-    await refreshUser()
+    // Reload the config store, since plugin/feature visibility is user-scoped.
     try {
       await useConfigStore().reload()
     } catch (err) {
@@ -465,24 +496,47 @@ export const useAuthStore = defineStore('auth', () => {
    * refresh pattern as `startImpersonation`.
    */
   async function stopImpersonation(): Promise<{ success: boolean; error?: string }> {
-    const { impersonationApi } = await import('@/services/api/impersonationApi')
-    const result = await impersonationApi.stop()
+    const [{ impersonationApi }, { beginAuthMutation, endAuthMutation, getInFlightRefresh }] =
+      await Promise.all([
+        import('@/services/api/impersonationApi'),
+        import('@/services/api/httpClient'),
+      ])
 
-    if (!result.success) {
-      return { success: false, error: result.error }
-    }
-
-    // Symmetric to startImpersonation: the chat state currently in memory
-    // belongs to the impersonated user and must not bleed back into the
-    // admin's own session (#999).
+    // Symmetric to startImpersonation: while exiting, a concurrent refresh
+    // still carrying the impersonation cookies (stash present) would be
+    // impersonation-aware and re-mint an impersonation token, clobbering the
+    // admin session the exit endpoint just restored. Guard the swap window.
+    beginAuthMutation()
     try {
-      await resetUserScopedClientState()
-      await teardownRealtimeState()
-    } catch (cleanupErr) {
-      console.warn('User state cleanup failed during impersonation stop', cleanupErr)
+      const inFlight = getInFlightRefresh()
+      if (inFlight) {
+        try {
+          await inFlight
+        } catch {
+          // A failed background refresh must not abort the swap.
+        }
+      }
+
+      const result = await impersonationApi.stop()
+      if (!result.success) {
+        return { success: false, error: result.error }
+      }
+
+      // Symmetric to startImpersonation: the chat state currently in memory
+      // belongs to the impersonated user and must not bleed back into the
+      // admin's own session (#999).
+      try {
+        await resetUserScopedClientState()
+        await teardownRealtimeState()
+      } catch (cleanupErr) {
+        console.warn('User state cleanup failed during impersonation stop', cleanupErr)
+      }
+
+      await refreshUser()
+    } finally {
+      endAuthMutation()
     }
 
-    await refreshUser()
     try {
       await useConfigStore().reload()
     } catch (err) {

--- a/frontend/src/stores/userMemories.ts
+++ b/frontend/src/stores/userMemories.ts
@@ -97,9 +97,10 @@ export const useMemoriesStore = defineStore('memories', () => {
     const timeoutMs = options.timeoutMs ?? 1500
     const silent = options.silent ?? false
 
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined
     try {
-      const timeoutPromise = new Promise((_, reject) => {
-        setTimeout(() => reject(new Error('Memory service timeout')), timeoutMs)
+      const timeoutPromise = new Promise<never>((_, reject) => {
+        timeoutHandle = setTimeout(() => reject(new Error('Memory service timeout')), timeoutMs)
       })
 
       const fetchPromise = getMemories(category)
@@ -128,6 +129,9 @@ export const useMemoriesStore = defineStore('memories', () => {
       // Set empty array so page can continue
       memories.value = []
     } finally {
+      // Clear the race timer so a resolved fetch doesn't leave a dangling
+      // (now up to 15s) timeout pending.
+      if (timeoutHandle !== undefined) clearTimeout(timeoutHandle)
       loading.value = false
     }
   }

--- a/frontend/src/stores/userMemories.ts
+++ b/frontend/src/stores/userMemories.ts
@@ -273,8 +273,14 @@ export const useMemoriesStore = defineStore('memories', () => {
   }
 
   // Initialize
-  async function init() {
-    await Promise.all([fetchMemories(), fetchCategories()])
+  //
+  // `timeoutMs` is forwarded to `fetchMemories`. The default there (1500ms) is
+  // a deliberate fast-fail for the chat badge sidebar, where a slow Qdrant must
+  // not stall the chat. The dedicated /memories page has no such constraint and
+  // must NOT flip to the "service unavailable" branch just because the first
+  // Qdrant read is slow under load, so it passes a generous timeout instead.
+  async function init(options: { timeoutMs?: number } = {}) {
+    await Promise.all([fetchMemories(undefined, options), fetchCategories()])
   }
 
   // Track IDs we've already tried to fetch individually (to avoid repeated requests)

--- a/frontend/src/views/MemoriesView.vue
+++ b/frontend/src/views/MemoriesView.vue
@@ -259,6 +259,12 @@ const selectedGraphMemory = ref<UserMemory | null>(null)
 
 const memoriesEnabledForUser = computed(() => authStore.user?.memoriesEnabled !== false)
 
+// The dedicated memories page must tolerate a slow first Qdrant read (e.g.
+// cold collection / CI load) instead of the store's 1500ms fast-fail default,
+// which would otherwise render the "service unavailable" branch on a healthy
+// service. See useMemoriesStore.init().
+const PAGE_MEMORY_FETCH_TIMEOUT_MS = 15000
+
 const graphCategoryColors: Record<string, string> = {
   preferences: '#3b82f6',
   personal: '#10b981',
@@ -283,7 +289,7 @@ onMounted(async () => {
   update3dSupport()
 
   try {
-    await memoriesStore.init()
+    await memoriesStore.init({ timeoutMs: PAGE_MEMORY_FETCH_TIMEOUT_MS })
     availableCategories.value = await getCategories()
     isServiceUnavailable.value = false
 
@@ -349,7 +355,7 @@ async function retryConnection() {
   retryingConnection.value = true
   isServiceUnavailable.value = false
   try {
-    await memoriesStore.init()
+    await memoriesStore.init({ timeoutMs: PAGE_MEMORY_FETCH_TIMEOUT_MS })
     availableCategories.value = await getCategories()
     isServiceUnavailable.value = false
   } catch (err) {
@@ -541,7 +547,7 @@ function handleFormDialogClose() {
 }
 
 async function loadMemories() {
-  await memoriesStore.fetchMemories()
+  await memoriesStore.fetchMemories(undefined, { timeoutMs: PAGE_MEMORY_FETCH_TIMEOUT_MS })
   availableCategories.value = await getCategories()
 }
 

--- a/frontend/tests/unit/api/httpClient-refresh.spec.ts
+++ b/frontend/tests/unit/api/httpClient-refresh.spec.ts
@@ -8,7 +8,7 @@
  * even though no user has ever logged in on this browser.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { refreshAccessToken } from '@/services/api/httpClient'
+import { refreshAccessToken, beginAuthMutation, endAuthMutation } from '@/services/api/httpClient'
 import { setSessionHint, clearSessionHint } from '@/services/sessionHint'
 
 describe('httpClient.refreshAccessToken — session hint guard (#204)', () => {
@@ -82,5 +82,86 @@ describe('httpClient.refreshAccessToken — session hint guard (#204)', () => {
 
     expect(secondResult).toEqual({ success: false })
     expect(refreshCalls()).toHaveLength(0)
+  })
+})
+
+describe('httpClient.refreshAccessToken — auth-mutation lock (impersonation swap)', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    localStorage.clear()
+    fetchSpy = vi.spyOn(globalThis, 'fetch')
+    setSessionHint()
+  })
+
+  afterEach(() => {
+    // Safety net: never leak an open lock into the next test.
+    endAuthMutation()
+    fetchSpy.mockRestore()
+    clearSessionHint()
+  })
+
+  function refreshCalls(): unknown[][] {
+    return (fetchSpy.mock.calls as unknown as unknown[][]).filter((call) =>
+      String(call[0]).includes('/api/v1/auth/refresh')
+    )
+  }
+
+  function mockRefresh(status: number): void {
+    fetchSpy.mockImplementation(((url: RequestInfo | URL) => {
+      if (String(url).includes('/api/v1/auth/refresh')) {
+        return Promise.resolve(
+          new Response(JSON.stringify(status === 200 ? { success: true } : { error: 'expired' }), {
+            status,
+            headers: { 'Content-Type': 'application/json' },
+          })
+        )
+      }
+      return Promise.resolve(new Response('', { status: 404 }))
+    }) as typeof fetch)
+  }
+
+  it('parks a concurrent refresh while a swap is in flight, then performs a REAL refresh', async () => {
+    mockRefresh(200)
+    beginAuthMutation()
+
+    const pending = refreshAccessToken()
+    // While the lock is held the refresh must be parked, not fired.
+    await Promise.resolve()
+    expect(refreshCalls()).toHaveLength(0)
+
+    endAuthMutation()
+    const result = await pending
+
+    expect(result.success).toBe(true)
+    // A genuine network refresh happened against the now-stable post-swap cookie
+    // (not a synthetic success).
+    expect(refreshCalls()).toHaveLength(1)
+  })
+
+  it('propagates a post-swap refresh failure instead of faking success (prevents spurious logout)', async () => {
+    mockRefresh(401)
+    beginAuthMutation()
+
+    const pending = refreshAccessToken()
+    endAuthMutation()
+    const result = await pending
+
+    // Crucially NOT { success: true }: the caller must learn the refresh failed
+    // so it can decide, rather than retrying straight into handleAuthFailure().
+    expect(result.success).toBe(false)
+    expect(refreshCalls()).toHaveLength(1)
+  })
+
+  it('bypassMutationLock refreshes immediately while the lock is held (no deadlock)', async () => {
+    mockRefresh(200)
+    beginAuthMutation()
+    try {
+      const result = await refreshAccessToken({ bypassMutationLock: true })
+      expect(result.success).toBe(true)
+      expect(refreshCalls()).toHaveLength(1)
+    } finally {
+      endAuthMutation()
+    }
   })
 })

--- a/frontend/tests/unit/components/ImpersonationBanner.spec.ts
+++ b/frontend/tests/unit/components/ImpersonationBanner.spec.ts
@@ -28,6 +28,9 @@ vi.mock('@/services/api/impersonationApi', () => ({
 vi.mock('@/services/api/httpClient', () => ({
   getApiBaseUrl: () => 'http://localhost:8000',
   refreshAccessToken: vi.fn().mockResolvedValue(true),
+  beginAuthMutation: vi.fn(),
+  endAuthMutation: vi.fn(),
+  getInFlightRefresh: vi.fn().mockReturnValue(null),
 }))
 
 vi.mock('@/services/authService', async () => {

--- a/frontend/tests/unit/stores/auth-impersonation.spec.ts
+++ b/frontend/tests/unit/stores/auth-impersonation.spec.ts
@@ -11,6 +11,9 @@ vi.mock('@/services/api/httpClient', () => ({
   getApiBaseUrl: () => 'http://localhost:8000',
   refreshAccessToken: vi.fn().mockResolvedValue(true),
   getConfigSync: () => ({ realtime: { enabled: false, wsUrl: '' } }),
+  beginAuthMutation: vi.fn(),
+  endAuthMutation: vi.fn(),
+  getInFlightRefresh: vi.fn().mockReturnValue(null),
 }))
 
 // auth.logout() dynamically imports the realtime store so it can disconnect

--- a/frontend/tests/unit/stores/auth-impersonation.spec.ts
+++ b/frontend/tests/unit/stores/auth-impersonation.spec.ts
@@ -155,6 +155,37 @@ describe('useAuthStore — impersonation', () => {
     expect(refreshUserMock).toHaveBeenCalled()
   })
 
+  it('startImpersonation mints a fresh token (bypassing the lock) as the last writer before the swap', async () => {
+    const httpClient = await import('@/services/api/httpClient')
+    const authServiceModule = (await import('@/services/authService')) as unknown as {
+      __setUser: (u: unknown) => void
+      __setImpersonator: (i: unknown) => void
+    }
+
+    vi.mocked(httpClient.beginAuthMutation).mockClear()
+    vi.mocked(httpClient.endAuthMutation).mockClear()
+    vi.mocked(httpClient.refreshAccessToken).mockClear()
+
+    startApiMock.mockResolvedValueOnce({ success: true })
+    authServiceModule.__setUser({ id: 99, email: 'target@example.com', level: 'PRO' })
+    authServiceModule.__setImpersonator({ id: 1, email: 'admin@example.com', level: 'ADMIN' })
+
+    const store = useAuthStore()
+    await store.startImpersonation(99)
+
+    // The whole swap is wrapped in the auth-mutation lock…
+    expect(httpClient.beginAuthMutation).toHaveBeenCalledTimes(1)
+    expect(httpClient.endAuthMutation).toHaveBeenCalledTimes(1)
+    // …and a bypass refresh is issued so the impersonate call never goes out
+    // with an expired cookie.
+    expect(httpClient.refreshAccessToken).toHaveBeenCalledWith({ bypassMutationLock: true })
+
+    // Ordering: the pre-swap refresh must run BEFORE the impersonate request.
+    const refreshOrder = vi.mocked(httpClient.refreshAccessToken).mock.invocationCallOrder[0]
+    const startOrder = startApiMock.mock.invocationCallOrder[0]
+    expect(refreshOrder).toBeLessThan(startOrder)
+  })
+
   it('startImpersonation surfaces a server error verbatim and leaves state untouched', async () => {
     // Use a refusal that is still actually thrown by the backend — self
     // impersonation is the one inline guard the UI also enforces. The point


### PR DESCRIPTION
## Summary

Fixes two independent root causes behind recurring flaky E2E tests. Both are frontend-only.

### 1. Impersonation banner race (`admin-impersonation-chat.spec`)

Starting/stopping impersonation rewrites the session cookies out-of-band. A concurrent `401 -> /auth/refresh`, triggered by a background request (e.g. `/usage/summary`, `/chats`) that still carried the **pre-swap** cookies, minted a token for the old principal and **clobbered the just-installed session cookie**. The follow-up `/auth/me` then reported no impersonator and the banner never mounted — a genuine cookie race, not a slow-render timeout.

Fix — an **auth-mutation lock** in `httpClient`:
- While a swap runs, `refreshAccessToken()` waits for it and then reports success, so the original request simply retries against the new, valid cookie instead of firing a competing refresh.
- `start/stopImpersonation` drain any in-flight refresh first, hold the lock across the `impersonate -> /auth/me` window, and release **before** the non-critical config reload / realtime resubscribe (so those can refresh normally — no deadlock).
- A 15s safety timeout guarantees the lock can never suspend the refresh path forever.

Deliberately scoped: only the `httpClient` refresh path is gated. `authService`'s own `/auth/me` refresh stays free, so `refreshUser()` *inside* the lock cannot deadlock. The lock is inert outside a swap → web/native/OIDC auth behaviour is byte-for-byte unchanged. Everything runs in the acting admin's own browser; the impersonated user still sees nothing.

### 2. Memories page flake (`memories.spec`)

The memories store fast-fails `fetchMemories()` after 1500ms so incidental callers never hang the UI. Under CI load the Qdrant-backed request occasionally exceeded that budget, the store fell back to an empty error state, and the create button / list never rendered.

Fix — `init()`/`fetchMemories()` accept a `timeoutMs` override; the full `MemoriesView` loads with a generous 15s budget on mount, retry and reload. The 1500ms fast-fail default is preserved for incidental callers.

## Test plan

- [x] `make -C frontend lint`
- [x] `docker compose exec -T frontend npm run check:types`
- [x] `make -C frontend test` (1272 unit tests, incl. updated `auth-impersonation` + `ImpersonationBanner` mocks)
- [ ] CI `@ci` E2E matrix over several runs (the impersonation flake is a rare timing race ~3/75; a single local run is not statistically meaningful, so validation relies on CI)