### PR TITLE
chore(deploy): probe runtime config in smoke test

### DIFF
--- a/deploy/scripts/smoke-test.sh
+++ b/deploy/scripts/smoke-test.sh
@@ -51,6 +51,12 @@ compose exec -T backend curl -fsS -o /dev/null http://localhost/api/health
 printf 'ok: api health\n'
 compose exec -T backend curl -fsS -o /dev/null http://localhost/
 printf 'ok: web ui\n'
+# `GET /` only proves the static SPA shell is served. The runtime config is the
+# one API route the app fetches at boot to learn its apiBaseUrl; if it fails the
+# shell still loads but the app stays blank. Probe it so a deploy misconfig here
+# is caught instead of surfacing as a "white screen" for users.
+compose exec -T backend curl -fsS -o /dev/null http://localhost/api/v1/config/runtime
+printf 'ok: runtime config\n'
 
 assert_healthy backend
 assert_healthy worker


### PR DESCRIPTION
## Summary

The deployment smoke test verifies the API health endpoint and that `GET /` serves the SPA — but `GET /` only proves the **static shell** is delivered. The app then fetches `/api/v1/config/runtime` at boot to learn its `apiBaseUrl` and feature flags; if that route is misconfigured post-deploy, the shell still loads and the app stays **blank**.

This adds one reachability probe (same one-line-per-check style as the surrounding probes) so a runtime-config misconfiguration is caught by the smoke test instead of surfacing as a white screen for users.

## Test plan

- [x] `bash -n deploy/scripts/smoke-test.sh` (syntax)
- [ ] Runs green in a deployment smoke run (probe returns 200 against a healthy stack)