### PR TITLE
test(e2e): wait for Vite after restart in make test-e2e

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,17 @@ test: ## Run all tests (backend + frontend unit tests)
 	$(MAKE) -C frontend test
 
 # Restart Vite first so a stale optimize-deps cache can't serve 504s (blank app
-# -> openApp timeout). Costs a few seconds; skip with SKIP_FRONTEND_RESTART=1
-# when targeting a non-dev BASE_URL (e.g. the :8001 test stack).
+# -> openApp timeout), then wait until it actually re-serves a core module —
+# without the wait the first run races the optimize-deps rebuild and hits the
+# very blank-app it was meant to prevent. Costs a few seconds; skip both with
+# SKIP_FRONTEND_RESTART=1 when targeting a non-dev BASE_URL (e.g. :8001 stack).
 test-e2e: ## Run e2e tests (fast loop, dev stack :5173 or BASE_URL)
-	@[ -n "$(SKIP_FRONTEND_RESTART)" ] || docker compose restart frontend
+	@[ -n "$(SKIP_FRONTEND_RESTART)" ] || { \
+		docker compose restart frontend; \
+		echo "Waiting for Vite to re-optimize deps on :5173 ..."; \
+		i=0; until curl -fsS -o /dev/null http://localhost:5173/src/main.ts 2>/dev/null; do \
+			i=$$((i+1)); [ $$i -ge 60 ] && { echo "frontend :5173 not ready after 60s" >&2; exit 1; }; \
+			sleep 1; done; }
 	$(MAKE) -C frontend test-e2e
 
 test-e2e-full: ## Build test stack + run all E2E tests (CI-like, port 8001)


### PR DESCRIPTION
## Summary

`make test-e2e` restarts the frontend so a stale Vite optimize-deps cache can't serve 504s (blank app → `openApp` timeout). But the restart *clears* that cache, and the run started immediately after — so the first tests raced Vite's re-optimization and could hit the very blank-app the restart was meant to prevent (observed locally: a full shard failing on `openApp` right after a restart, green on a warm server).

This polls until Vite re-serves a core module (`/src/main.ts`, bounded to 60s) before handing off to the run. Still gated by the existing `SKIP_FRONTEND_RESTART` escape hatch, so non-dev `BASE_URL`s (e.g. the `:8001` test stack) skip both the restart and the wait. Everyone running the local dev-stack E2E loop benefits; CI is unaffected (it uses the prebuilt `:8001` stack, not `make test-e2e`).

## Test plan

- [x] `make -n test-e2e` expands correctly (tabs/syntax), both default and `SKIP_FRONTEND_RESTART=1`
- [x] The identical warmup loop was exercised locally (curl ret/retry through the optimize-deps window, then a green run)