### PR TITLE
fix(config): default BRAVE_SEARCH_ENABLED to false like the image does

### DIFF
--- a/backend/config/services.yaml
+++ b/backend/config/services.yaml
@@ -131,7 +131,9 @@ parameters:
     # Compose passes these through .env/env_file, but bare images (Kubernetes,
     # plain docker run) ship no .env, so a missing var used to crash service
     # instantiation (e.g. /api/v1/messages/stream 500ing on WHATSAPP_ENABLED).
-    # Values mirror backend/.env.example.
+    # Values mirror backend/.env.example; where the Dockerfile bakes an ENV
+    # (BRAVE_SEARCH_*, TIKA_*, RASTERIZE_*) that one wins inside containers,
+    # so these match the Dockerfile too.
     env(TIKA_TIMEOUT_MS): '30000'
     env(TIKA_RETRIES): '2'
     env(TIKA_RETRY_BACKOFF_MS): '1000'
@@ -145,7 +147,7 @@ parameters:
     env(WHISPER_BINARY): '/usr/local/bin/whisper'
     env(WHISPER_MODELS_PATH): '%kernel.project_dir%/var/whisper'
     env(FFMPEG_BINARY): '/usr/bin/ffmpeg'
-    env(BRAVE_SEARCH_ENABLED): 'true'
+    env(BRAVE_SEARCH_ENABLED): 'false'
     env(BRAVE_SEARCH_API_URL): 'https://api.search.brave.com/res/v1'
     env(BRAVE_SEARCH_COUNT): '10'
     env(BRAVE_SEARCH_COUNTRY): 'us'


### PR DESCRIPTION
Follow-up to #1522.

The Dockerfile already bakes `BRAVE_SEARCH_ENABLED=false` together with the `BRAVE_SEARCH_*`, `TIKA_*` and `RASTERIZE_*` values as image `ENV`, and a real env var wins over a `env()` parameter default. So the `'true'` default from #1522 only ever applied outside containers, and the flag behaved differently in-container vs. out. Align the parameter default with the image and note the precedence in the comment.

Correction to the #1522 description: of the 20 listed vars, 13 (`BRAVE_SEARCH_*`, `TIKA_*`, `RASTERIZE_*`) were already covered by the Dockerfile `ENV`; the ones that were actually missing in bare images were `WHATSAPP_ENABLED`, `WHISPER_*`, `FFMPEG_BINARY` and `STRIPE_AUTOMATIC_TAX`. The defaults are harmless either way (image env takes precedence), the count was just overstated.
