### PR TITLE
fix(whisper): honour WHISPER_DEFAULT_MODEL for chat transcription

### DIFF
--- a/backend/src/Service/Message/MessagePreProcessor.php
+++ b/backend/src/Service/Message/MessagePreProcessor.php
@@ -573,9 +573,6 @@ final readonly class MessagePreProcessor
                 $options['language'] = $languageHint;
             }
 
-            // Use base model by default (good balance of speed/accuracy)
-            $options['model'] = 'base';
-
             return $this->whisperService->transcribe($filePath, $options);
         } catch (\Exception $e) {
             $this->logger->error("Whisper transcription failed: {$e->getMessage()}", [


### PR DESCRIPTION
`MessagePreProcessor::transcribeWithWhisper()` hardcoded `$options['model'] = 'base'`. `WhisperService::isAvailable()` checks the *configured* default model (`WHISPER_DEFAULT_MODEL`), so a deployment shipping e.g. `ggml-small.bin` only reported speech-to-text as available and then failed every chat transcription asking for `ggml-base.bin`.

Drop the override; `WhisperService::transcribe()` already falls back to its configured default when no model option is given. Behaviour is unchanged for installs that keep the default (`base`).

Found while wiring local Whisper on an air-gapped Kubernetes install where `small` is the sensible model for German.