### PR TITLE
feat(cli): provider dimension for model commands and soft-disable

### DIFF
--- a/_devextras/planning/20260826-provider-aware-model-catalog.md
+++ b/_devextras/planning/20260826-provider-aware-model-catalog.md
@@ -1,0 +1,369 @@
+# Provider-Aware Model Catalog — Concept & Development Plan
+
+**Date:** 2026-08-26
+**Status:** AGREED — all open questions resolved, implementation in progress
+in this workspace (all PRs, no ownership split).
+
+**Decisions (2026-08-26):**
+- **Never delete rows from `BMODELS`.** Disabling — by operator, CLI, or
+  missing provider credentials — only greys out or hides entries. When a key
+  is added later, the entries reappear automatically (read-time filtering).
+  The CLI gets no deletion path at all; `ModelCatalog::remove` stays reserved
+  for the retirement machinery, which also deactivates rather than deletes.
+- **Visibility split:** regular users see only available models (unavailable
+  = hidden); admin views show the full catalog with unavailable entries
+  greyed out + badge linking to `/admin/setup`.
+- **Ollama follows the same concept:** rows for models that are not pulled
+  are hidden for users; admin views show all Ollama rows with a
+  **"not pulled"** badge (instead of "no key").
+- **Local whisper.cpp** enters the catalog as service **`Whisper`**
+  (Piper precedent: tool name as `BSERVICE`).
+- **We implement everything here** (PRs A–E); the tracking issue is opened
+  by us, referencing the partner feedback.
+**Trigger:** Hosting-partner feedback (Dominik, 2026-08) on model management for
+self-hosted/on-prem installs; relates to #462 (on-premise tracker), #1521
+(no-provider tombstone), #1532/#1533 (retirements + recommendations),
+#1512/#1516 (availability/health), and the hosting-partner requirements in
+`20260709-hosting-partner-core-requirements.md`.
+**Tracking issue:** #1586
+
+---
+
+## TL;DR
+
+The catalog ships 117 models across 14 providers, and every install seeds all
+of them as active + selectable — regardless of whether the install has a
+single API key. The backend **already knows** which providers are usable
+(`ChatReadinessService::providerAvailability()`, `ModelConfigService::usableProviders()`)
+and the **routing path already respects it** — but the presentation and
+configuration surfaces do not: the model picker shows everything, "Select
+suggested models" writes cloud BIDs into user rows on every registration, and
+the CLI/charts fight the seeder. The fix is not a new subsystem; it is wiring
+the existing availability truth into four surfaces (picker endpoint, suggested
+defaults, admin UI, CLI/charts), un-freezing per-user default rows, and giving
+local Whisper a first-class catalog entry. No schema change is required for
+the core work.
+
+---
+
+## 1. Findings — what exists today (verified in code)
+
+### 1.1 The availability layer EXISTS — it is just not consumed by the catalog surfaces
+
+| Component | What it does | File |
+| --- | --- | --- |
+| `ChatReadinessService::providerAvailability()` | Probes every registered provider (`isAvailable()`), caches 30 s. Ollama counts as unavailable until the effective chat model is actually **pulled**. | `backend/src/AI/Credential/ChatReadinessService.php` |
+| `ModelConfigService::usableProviders()` | Same truth on the hot resolution path (60 s cache); `isModelUsable()` = `BACTIVE=1` + provider usable + (Ollama) model pulled. | `backend/src/Service/ModelConfigService.php` |
+| `getDefaultModel()` | Skips per-user AND global bindings whose provider is unusable; falls back to `firstUsableModelForCapability()`. | same |
+| `app:provider:apply-defaults --auto` | At container start, repoints a broken cloud default at the best available provider (`PREFERENCE_ORDER`). Never overrides a deliberate keyless (Ollama) choice. | `ProviderDefaultsService`, `_docker/backend/docker-entrypoint.sh` |
+| `/admin/setup` + `/api/v1/admin/provider-keys` | Per-provider key cards: save, test, remove, apply defaults. Keys live install-wide in encrypted `BCONFIG` (`ownerId=0`, group `provider_keys`); env vars are bootstrap-only, UI wins. | `AdminProviderKeysController`, `ProviderKeyStore`, `ProviderSetupView.vue` |
+| `setup.chatReady` tombstone (#1521) | Full-page explainer when no real provider can serve chat. | `ConfigController`, `ProviderSetupBanner.vue` |
+
+**Conclusion: routing is provider-aware. Presentation and configuration are not.**
+
+### 1.2 The surfaces that ignore availability (the actual gaps)
+
+1. **`GET /api/v1/config/models`** (`ConfigController::getModels`, ~line 775)
+   returns every `BACTIVE=1` row. On an Ollama-only install the chat picker
+   lists ~40 chat models, of which 1–2 work. This feeds: chat `ModelDropdown`,
+   the "Again with…" picker, the `/ai/models` defaults page, widget model
+   dropdowns, and the routing planner picker.
+2. **"Select suggested models"** (`POST /api/v1/config/models/defaults/reset`
+   → `ModelConfigService::resetUserDefaults()`) writes the code-recommended
+   BIDs (Anthropic chat, Groq sort/STT, …) as **per-user** `DEFAULTMODEL`
+   rows, skipping only `BACTIVE=0` models — availability is not checked. The
+   same method runs at **every registration** (`initializeNewUserDefaults()`),
+   freezing seed-time recommendations into user rows. A resolution-time
+   mitigation exists (unusable per-user bindings are skipped in favour of the
+   global default), but the UI still *displays* the frozen, non-working model
+   as the user's default.
+3. **Seeding** (`ModelSeeder` via `app:seed` at every container start) inserts
+   all 117 catalog rows with catalog defaults (mostly `selectable=1`,
+   `active=1`). Operator toggles survive re-seed (fingerprint mechanism,
+   toggles only written on INSERT) — but **deleted rows are resurrected**:
+   absent row → `ACTION_INSERT`.
+4. **CLI** — `app:model:enable|disable` exist (the Helm chart's
+   `51-init-models.sh` uses them), but:
+   - `app:model:disable` **DELETEs** the row (`ModelCatalog::remove`). Next
+     container start re-inserts it via `app:seed` → silent revert. Deletion
+     also breaks history: `BMESSAGES` references BIDs (this is exactly why
+     retirements deactivate instead of delete — see the xAI comments in
+     `ModelCatalog.php`).
+   - No provider-level operation; only per-model keys.
+   - No `app:provider:list` that shows the availability truth.
+5. **Local Whisper is special-cased, not a model.** `MessagePreProcessor`
+   falls back to `WhisperService` (whisper.cpp, `WHISPER_*` env) when no
+   SOUND2TEXT binding resolves. It has no `BMODELS` row, so it cannot be a
+   default binding, does not appear in the STT picker, and
+   `speechToTextAvailable` needs bespoke logic. Piper (local TTS) already IS a
+   catalog entry — the precedent exists.
+
+### 1.3 Browser STT reality (for the use cases)
+
+- Streaming STT in the browser = **Web Speech API** (`webSpeechService.ts`):
+  Chrome/Edge/Safari only, **and Chrome's implementation sends audio to
+  Google's servers** — it is NOT local and must be off (`WEB_SPEECH_ENABLED=false`)
+  in air-gapped installs.
+- Fallback on every browser (and the only path on Firefox): MediaRecorder →
+  `POST /api/v1/messages/upload-file` → server-side STT (API model per
+  SOUND2TEXT binding, or local whisper.cpp fallback).
+- So "STT on different browsers, fully local" already works mechanically —
+  the missing piece is that the SOUND2TEXT binding cannot point at local
+  Whisper, and the picker misleadingly offers cloud STT models with no keys.
+
+---
+
+## 2. Critical review of the partner feedback
+
+Overall diagnosis: **correct and valuable** — the catalog surfaces treat every
+install like synaplan.com. But several specifics need correction, which
+matters because they change what the issue should ask for:
+
+| Claim | Assessment |
+| --- | --- |
+| "Nichts fragt, welche Provider diese Installation hat" / "fehlt eine Ebene *Provider dieser Installation*" | **Partly wrong.** The layer exists (`providerAvailability()`, `usableProviders()`, key store, `/admin/setup`, boot-time auto-repair) and the routing path consumes it. What is missing is applying it to *presentation* (picker, suggested models, admin list) and *tooling* (CLI, charts). The issue should say "expose and consume the existing truth", not "create the layer" — otherwise someone builds a second one. |
+| AC 1: "Provider-Verfügbarkeit ist Backend-Wahrheit (Key/URL gesetzt)" | **Agree, with a sharpening:** "key set" is necessary but not sufficient. The existing semantics are better than the criterion: Ollama counts only when the model is *pulled*; health monitoring (#1516) covers "key set but broken". Keep the existing three-layer split: **configured** (key/URL present) → gates *visibility*; **healthy** (probes, #1516) → gates *routing preference*; never conflate them, or a transient outage would empty the picker. |
+| AC 2: "Katalog-**Seeding**, Picker und Suggested zeigen nur Modelle verfügbarer Provider" | **Disagree on the seeding half.** Seeding must stay provider-agnostic and the filter must be applied at **read time**: (a) keys are added at runtime in the admin UI — no re-seed happens, so seed-time filtering would show an empty catalog until the next deploy; (b) rows must exist for the fingerprint/operator-toggle machinery and for `BMESSAGES` history; (c) `app:seed` runs on every container start and resurrects absent rows anyway. Picker + suggested: **fully agree.** |
+| AC 3: "Globale Defaults für User ohne eigene Auswahl, kein Einfrieren; lokales Whisper als Katalogeintrag" | **Agree.** Note a mitigation already shipped (resolution skips unusable per-user bindings), so the remaining harm is (a) the UI lies about the effective default, (b) the freeze recreates the problem on every registration and every "Select suggested models" click. Whisper-as-catalog-entry: agree, Piper is the precedent. |
+| AC 4: "CLI: app:model:enable/disable --provider" | **Exists per-model already** (chart uses it) — the new part is the provider dimension **plus fixing the disable semantics**: today disable deletes and the seeder resurrects. Without that fix, `--provider` would inherit a broken foundation. |
+| AC 5: "Container-Defaults (Chart/Compose) konsistent" | **Mostly falls out for free**: chart `apiKeys`/`ollama.baseUrl` already drive the same env vars the availability truth reads. Remaining work: provider-level chart values, an air-gap example values file, and docs. |
+| "jedes neue Cloud-Modell läuft wieder als selectable rein" | **True and it should stay true at the DB level** — with read-time filtering it becomes harmless: the row is there (selectable=1) but invisible until its provider has credentials. That is the desired behavior: add a key → models appear, no re-seed, no handwork. |
+| "eigenes, scharf umrissenes Issue statt Tracker-Epic" | **Agree.** #462 is UX/config items around auth and subscription; this is a coherent engineering change with its own acceptance criteria. Draft issue text in §7. |
+
+Missing from the feedback (added to the plan): the STT/browser story
+(Web Speech is a *cloud* service in Chrome — an air-gap trap), what admins
+should see (grey-out vs. hide), and the disable/seed resurrection bug.
+
+---
+
+## 3. Concept — "Providers of this installation"
+
+**One principle: seed everything, filter presentation by live availability,
+route by usability.** No new tables, no new flags on `BMODELS`.
+
+### 3.1 Availability semantics (per provider, install-wide)
+
+| Provider type | *Configured* means | Examples |
+| --- | --- | --- |
+| Keyed cloud | Key present in `ProviderKeyStore` (env-bootstrapped or UI-saved) | OpenAI, Anthropic, Groq, Gemini, Mistral, xAI, HF, TrustedTokens |
+| Credential-pair cloud | Both values present | Higgsfield, Cloudflare, TheHive, ElevenLabs |
+| Local URL | URL set AND reachable | Ollama (+ per-model: pulled), Triton, Piper/`SYNAPLAN_TTS_URL` |
+| OpenAI-compatible endpoints (CORE-1) | ≥1 endpoint registered in DB | LocalAI, vLLM, LiteLLM |
+| Local Whisper (new) | `WHISPER_ENABLED` + binary + model file present | whisper.cpp |
+
+This is exactly what `ProviderRegistry` + `isAvailable()` compute today; the
+work is exposing it coherently, not building it.
+
+### 3.2 Consumers and their rules
+
+| Surface | Rule |
+| --- | --- |
+| `GET /api/v1/config/models` | Only models of available providers (plus a `providers` summary block: name, available, reason). `?includeUnavailable=1` for admin views (returns per-model availability + reason, e.g. `no_key` / `not_pulled`). Ollama models that are not pulled count as unavailable. |
+| Chat picker, "Again with…", widget/prompt model dropdowns, planner picker | Consume the filtered endpoint — no frontend logic change beyond empty states. |
+| "Select suggested models" + registration defaults | Recommend only within available providers: walk `PROVIDER_DEFAULTS` restricted to available, per-capability fallback through `PREFERENCE_ORDER`; a capability with no available provider stays **unset** and the UI says "not available on this installation". |
+| Registration | **Stop writing per-user rows entirely** (drop the freeze); resolution falls through to the global default, which boot-time auto-repair already keeps sane. |
+| Admin catalog (`/ai/models` edit tab) | Show ALL models, unavailable entries greyed with a badge — "no key configured" for keyed providers, "not pulled" for Ollama models — linking to `/admin/setup`. Admins must see what they *could* get. |
+| Admin model health (#1516) | Unchanged — health is a routing preference, not a visibility gate. |
+| Tombstone (#1521) | Unchanged (chat-scoped). |
+| CLI | `app:provider:list` (availability table); `app:model:enable/disable --provider <name>`; disable becomes **soft** (`BACTIVE=0`, `BSELECTABLE=0`, row kept — survives re-seed via operator-toggle preservation). No deletion path — rows are never removed. |
+| Charts/compose | Availability derives from the same env vars — nothing mandatory. Add: provider-level enable/disable values, an `examples/values-airgap.yaml`, docs. |
+
+### 3.3 Why filter at read time (and not seed time)
+
+1. Admin saves a key in the UI → `ChatReadinessService::invalidate()` fires →
+   models appear within seconds. Seed-time filtering would require a re-deploy.
+2. `BMESSAGES` rows reference BIDs; absent rows break history and billing.
+3. `app:seed` runs at every container start; absent rows are re-inserted.
+   Read-time filtering makes that harmless instead of fighting it.
+4. The 30–60 s caches already bound the probe cost; the picker endpoint adds
+   one cached lookup, not per-request provider probes.
+
+### 3.4 Local Whisper as a catalog entry
+
+- New service `Whisper` (display "Whisper (local)"), tag `sound2text`,
+  `priceIn/Out = 0`, `providerId` = whisper.cpp model name (`base` initially;
+  more sizes later if wanted).
+- Thin `WhisperProvider` wrapping the existing `WhisperService`;
+  `isAvailable()` = enabled + binary + model file present.
+- SOUND2TEXT can then bind to it like any model: uniform resolution, appears
+  in the STT picker on air-gapped installs, `speechToTextAvailable` and
+  `hasConfiguredSttProvider()` stop needing special cases. Billing stays
+  zero/bypassed as today.
+
+---
+
+## 4. Installation tree — expected setups
+
+```text
+Which AI does this installation use?
+│
+├─ A. "Just try it" (Linux beginner, laptop)
+│     docker compose up -d              → Ollama + AUTO_DOWNLOAD (bge-m3;
+│     no keys, no config                  chat opt-in via ENABLE_LOCAL_GPT_OSS)
+│     RESULT: picker shows ONLY pulled Ollama models; STT = local Whisper;
+│             tombstone guides to /admin/setup if no chat model is pulled.
+│
+├─ B. Local-first + 1-2 cloud keys (typical hoster)
+│     Setup as A, then: Admin → AI Providers → paste Groq/OpenAI key
+│     RESULT: that provider's models appear in pickers within seconds;
+│             "Select suggested models" recommends only within {ollama, groq}.
+│
+├─ C. Kubernetes hoster (charts)
+│     values: apiKeysSecretRef, ollama.baseUrl or triton.url,
+│             optional models.enabled/disabled to narrow further
+│     RESULT: same availability derivation; init-script model handwork
+│             becomes optional instead of mandatory.
+│
+└─ D. Air-gapped (3-4 models total)
+      OLLAMA_BASE_URL=… (models pre-pulled), no cloud keys,
+      WEB_SPEECH_ENABLED=false   ← Chrome's Web Speech sends audio to Google!
+      Local Whisper (STT) + Piper (TTS) catalog entries
+      RESULT: users see 3-4 models and nothing else, STT works on every
+              browser via record→upload→whisper.cpp; zero model handwork.
+```
+
+The happy path (A/B) requires **no CLI and no values file** — availability
+does the work. The power path (C/D) keeps every existing knob and gains
+provider-level ones.
+
+---
+
+## 5. Development plan
+
+Ordered so the partner-sized piece is independent and first-mergeable.
+Every PR passes the full gate (`make lint && make -C backend phpstan && make test`
++ frontend checks); frontend changes are `ota-candidate`, backend-only ones
+`backend-only` per the mobile-impact policy.
+
+### PR A — CLI provider dimension + disable-semantics fix
+
+- `app:provider:list`: table of provider / credential source (env, UI, none) /
+  available / model counts. Reuses `ChatReadinessService`.
+- `app:model:enable|disable --provider <name>` (all catalog models of a
+  provider); keep per-model keys.
+- **Change `app:model:disable` to soft-deactivate** (`BACTIVE=0`,
+  `BSELECTABLE=0` — operator-owned, survives re-seed). The deletion behavior
+  is removed entirely (decided 2026-08-26): rows referenced by `BMESSAGES`
+  must never disappear, and the seeder would resurrect them anyway.
+- `synaplan-charts`: `providers.enabled/disabled` values mapped to the new
+  flags in `51-init-models.sh`; `examples/values-airgap.yaml`.
+- Tests: command tests + a seeder round-trip test proving a disabled model
+  stays disabled after `app:seed`.
+- **Effort:** S–M. **No behavior change** for installs not using the CLI.
+
+### PR B — availability-filtered read surfaces *(core team)*
+
+- `ConfigController::getModels`: filter by `usableProviders()` (+ Ollama
+  pulled-model granularity), add `providers` summary block,
+  `?includeUnavailable=1`.
+- OpenAPI annotations → `make -C frontend generate-schemas` → `vue-tsc`.
+- Frontend: empty-state copy for capabilities with no available model
+  (all four locales); admin catalog tab uses `includeUnavailable=1` and greys
+  unavailable providers with a badge → link to `/admin/setup`.
+- Tests: controller tests for keyed/keyless matrices; frontend picker tests.
+- ⚠️ Check `tests/Characterization/` snapshots (routing contract) for drift.
+- **Effort:** M.
+
+### PR C — un-freeze defaults *(core team)*
+
+- `initializeNewUserDefaults()`: stop writing per-user rows at registration.
+- `resetUserDefaults()` (the explicit button): recommend within available
+  providers only (walk `PROVIDER_DEFAULTS` restricted by availability,
+  fallback through `PREFERENCE_ORDER`).
+- Frontend `/ai/models` choice tab: show the **effective** default
+  ("Default — Claude Sonnet 5") when no user override exists.
+- Existing frozen rows in the field: **leave them** (resolution already skips
+  unusable ones); document. No migration needed.
+- **Effort:** M. Depends on PR B for the availability lookup shape.
+
+### PR D — local Whisper catalog entry *(core team)*
+
+- Catalog row (service `Whisper`, tag `sound2text`, price 0) + thin
+  `WhisperProvider`; `isAvailable()` = enabled + binary + model present.
+- SOUND2TEXT binding resolution + `MessagePreProcessor` uses the binding
+  uniformly (keep the current behavior as fallback for unmigrated installs).
+- `speechToTextAvailable` derives from availability instead of bespoke checks.
+- **Effort:** M. Independent of B/C.
+
+### PR E — documentation *(after A–D land)*
+
+- `synaplan-docs`: new page **"AI Providers & Models"** (the concept: add a
+  key → models appear; the installation tree from §4) and a dedicated
+  **"Air-gapped installation"** guide (Ollama pre-pull, `WEB_SPEECH_ENABLED=false`
+  rationale, Whisper/Piper, chart values). Update `administration.md`,
+  `hosting.md`, `kubernetes.md`, `quickstart.md`. Register in `index.php`.
+- In-repo: `docs/CONFIGURATION.md` provider table gains the availability
+  column; `docs/MIGRATIONS.md` notes soft-disable semantics.
+
+### Explicitly out of scope
+
+- Per-user provider keys (keys stay install-wide).
+- New health/outage logic (#1516 covers it).
+- OpenAI-compatible endpoint registry (CORE-1, in progress in PR #1299) —
+  but PR B must treat it as a provider whose availability is DB-backed.
+
+---
+
+## 6. Open questions for discussion
+
+All resolved 2026-08-26 (see the decisions block at the top):
+
+1. **Never delete; hide for users, grey + badge for admins.**
+2. **Ollama:** same concept — users see only pulled models, admins see all
+   rows with a "not pulled" badge.
+3. **Whisper** is the `BSERVICE` name.
+4. **No ownership split** — everything is implemented in this workspace;
+   the issue is opened by us.
+5. **`AI_PROVIDERS_ALLOWLIST` env: deferred** (YAGNI — key presence already
+   expresses intent).
+
+---
+
+## 7. GitHub issue — opened as #1586 (2026-08-26); text below kept for reference
+
+> **Title:** Model catalog must reflect the providers of this installation
+>
+> **Context.** Every install seeds the full 117-model catalog as selectable.
+> On installs with few or no cloud keys (on-prem, air-gapped, local-first
+> hosters) users pick from dozens of models that cannot answer. The
+> availability truth already exists (`ChatReadinessService::providerAvailability()`,
+> `ModelConfigService::usableProviders()`) and the routing path uses it —
+> the catalog surfaces do not. Related: #462 (on-prem tracker; this aspect
+> was never part of it), #1521 (no-provider tombstone), #1516 (health).
+>
+> **Example install (air-gapped):** Ollama with 3 pulled models, no cloud
+> keys, `WEB_SPEECH_ENABLED=false`. Users should see exactly those models —
+> today they see the whole catalog.
+>
+> **Acceptance criteria**
+> 1. Provider availability is the backend truth already computed today
+>    (credentials/URL present; Ollama = model pulled) — consumed, not
+>    reimplemented, and never per-model handwork.
+> 2. `GET /api/v1/config/models`, all model pickers, and "Select suggested
+>    models" only show/recommend models of available providers. Admin views
+>    show the full catalog with unavailable providers greyed out.
+>    Seeding stays provider-agnostic; filtering happens at read time, so
+>    saving a key in the admin UI surfaces its models without a re-deploy.
+> 3. New users get no frozen per-user default rows; global defaults apply
+>    until a user explicitly chooses. Local whisper.cpp becomes a catalog
+>    entry so SOUND2TEXT can bind to it (air-gapped STT on every browser).
+> 4. CLI: `app:provider:list`, `app:model:enable|disable --provider <name>`;
+>    disable is a soft-deactivate that survives `app:seed` (today's disable
+>    deletes the row and the next container start resurrects it). Catalog
+>    rows are never deleted — disabled/unavailable entries are greyed out or
+>    hidden and reappear as soon as their provider gets credentials.
+> 5. Helm chart/compose expose provider-level enable/disable consistent with
+>    the CLI, plus an air-gap example values file; docs updated.
+
+---
+
+## 8. Test traps to respect (from AGENTS.md, verified relevant)
+
+- `tests/Characterization/` routing snapshots will drift if resolution
+  behavior changes (PR C touches `resetUserDefaults`) — re-record and review.
+- `BCONFIG` defaults are bootstrap-only — PR C must not rely on changing a
+  seeder value to affect existing installs (it doesn't: it changes code paths).
+- OpenAPI changes (PR B) → regenerate Zod schemas → `vue-tsc`.
+- All four locales for every new UI string (empty states, badges).
+- Full unfiltered gate before every commit; frontend PRs classify as
+  `ota-candidate` in `.github/mobile-impact-policy.json` terms.

--- a/backend/src/Command/ModelDisableCommand.php
+++ b/backend/src/Command/ModelDisableCommand.php
@@ -10,12 +10,13 @@ use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 #[AsCommand(
     name: 'app:model:disable',
-    description: 'Remove AI models from the database',
+    description: 'Disable AI models (kept in the database, hidden from users)',
 )]
 class ModelDisableCommand extends Command
 {
@@ -28,12 +29,19 @@ class ModelDisableCommand extends Command
     protected function configure(): void
     {
         $this
-            ->addArgument('models', InputArgument::IS_ARRAY | InputArgument::REQUIRED,
+            ->addArgument('models', InputArgument::IS_ARRAY,
                 'Model keys to disable (e.g. groq:qwen/qwen3.6-27b ollama:bge-m3)')
+            ->addOption('provider', 'p', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                'Disable every catalog model of a provider (e.g. --provider openai). Repeatable.')
             ->setHelp(
-                "Remove one or more AI models from the database.\n\n".
+                "Disable one or more AI models: they stay in the database (message history\n".
+                "references them) but are deactivated and hidden from every model picker.\n".
+                "The deactivation survives re-seeding at container start.\n".
+                "Re-enable any time with <info>app:model:enable</info>.\n\n".
                 "Key format: service:providerId (or service:providerId:tag to target a specific variant)\n\n".
-                'Run <info>app:model:list</info> to see all available models and their status.'
+                "Use <info>--provider <name></info> to disable every catalog model of a provider at once.\n\n".
+                'Run <info>app:model:list</info> to see all available models and their status, '.
+                'or <info>app:provider:list</info> for the provider overview.'
             );
     }
 
@@ -41,8 +49,19 @@ class ModelDisableCommand extends Command
     {
         $io = new SymfonyStyle($input, $output);
         $modelKeys = $input->getArgument('models');
-        $disabled = 0;
+        $providers = $input->getOption('provider');
+
+        if ([] === $modelKeys && [] === $providers) {
+            $io->error('Provide model keys and/or --provider <name>. Run app:model:list to see the catalog.');
+
+            return Command::INVALID;
+        }
+
         $errors = false;
+
+        // Collect first, then write: dedupe by BID so an explicit key and a
+        // --provider covering the same model do not disable it twice.
+        $selected = [];
 
         foreach ($modelKeys as $key) {
             $models = ModelCatalog::find($key);
@@ -54,14 +73,38 @@ class ModelDisableCommand extends Command
             }
 
             foreach ($models as $model) {
-                ModelCatalog::remove($this->connection, $model);
-                $io->writeln("  <info>Disabled</info> {$model['service']}: {$model['name']} ({$model['tag']})");
-                ++$disabled;
+                $selected[$model['id']] = $model;
             }
         }
 
+        foreach ($providers as $provider) {
+            $models = ModelCatalog::findByService($provider);
+
+            if (empty($models)) {
+                $io->warning(sprintf(
+                    'Unknown provider: %s. Known providers: %s',
+                    $provider,
+                    implode(', ', array_keys(ModelCatalog::serviceNames()))
+                ));
+                $errors = true;
+                continue;
+            }
+
+            foreach ($models as $model) {
+                $selected[$model['id']] = $model;
+            }
+        }
+
+        $disabled = 0;
+
+        foreach ($selected as $model) {
+            ModelCatalog::disable($this->connection, $model);
+            $io->writeln("  <info>Disabled</info> {$model['service']}: {$model['name']} ({$model['tag']})");
+            ++$disabled;
+        }
+
         if ($disabled > 0) {
-            $io->success("Disabled $disabled model(s)");
+            $io->success("Disabled $disabled model(s) — rows kept, re-enable with app:model:enable");
         }
 
         return $errors ? Command::FAILURE : Command::SUCCESS;

--- a/backend/src/Command/ModelEnableCommand.php
+++ b/backend/src/Command/ModelEnableCommand.php
@@ -16,7 +16,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 #[AsCommand(
     name: 'app:model:enable',
-    description: 'Add AI models to the database',
+    description: 'Enable AI models from the built-in catalog',
 )]
 class ModelEnableCommand extends Command
 {
@@ -29,15 +29,23 @@ class ModelEnableCommand extends Command
     protected function configure(): void
     {
         $this
-            ->addArgument('models', InputArgument::IS_ARRAY | InputArgument::REQUIRED,
+            ->addArgument('models', InputArgument::IS_ARRAY,
                 'Model keys to enable (e.g. groq:qwen/qwen3.6-27b ollama:bge-m3)')
+            ->addOption('provider', 'p', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                'Enable every catalog model of a provider (e.g. --provider groq). Repeatable.')
             ->addOption('system', null, InputOption::VALUE_NONE,
                 'Mark enabled models as system models (locked, users cannot change)')
             ->setHelp(
                 "Enable one or more AI models from the built-in catalog.\n\n".
                 "Key format: service:providerId (or service:providerId:tag to target a specific variant)\n\n".
-                "Use <info>--system</info> to lock models so users cannot change them.\n\n".
-                'Run <info>app:model:list</info> to see all available models and their status.'
+                "Use <info>--provider <name></info> to enable every catalog model of a provider at once.\n\n".
+                "A model already in the database gets its visibility flags restored to the\n".
+                "catalog values; admin edits to prices or names are left untouched.\n".
+                "Retired models are skipped — the upstream provider no longer serves them.\n\n".
+                "Use <info>--system</info> to lock models so users cannot change them\n".
+                "(applies when the model is first added).\n\n".
+                'Run <info>app:model:list</info> to see all available models and their status, '.
+                'or <info>app:provider:list</info> for the provider overview.'
             );
     }
 
@@ -45,9 +53,20 @@ class ModelEnableCommand extends Command
     {
         $io = new SymfonyStyle($input, $output);
         $modelKeys = $input->getArgument('models');
+        $providers = $input->getOption('provider');
         $system = $input->getOption('system');
-        $enabled = 0;
+
+        if ([] === $modelKeys && [] === $providers) {
+            $io->error('Provide model keys and/or --provider <name>. Run app:model:list to see the catalog.');
+
+            return Command::INVALID;
+        }
+
         $errors = false;
+
+        // Collect first, then write: dedupe by BID so an explicit key and a
+        // --provider covering the same model do not enable it twice.
+        $selected = [];
 
         foreach ($modelKeys as $key) {
             $models = ModelCatalog::find($key);
@@ -59,11 +78,46 @@ class ModelEnableCommand extends Command
             }
 
             foreach ($models as $model) {
-                ModelCatalog::upsert($this->connection, $model, $system);
-                $label = $system ? 'Enabled (system)' : 'Enabled';
-                $io->writeln("  <info>$label</info> {$model['service']}: {$model['name']} ({$model['tag']})");
-                ++$enabled;
+                $selected[$model['id']] = $model;
             }
+        }
+
+        foreach ($providers as $provider) {
+            $models = ModelCatalog::findByService($provider);
+
+            if (empty($models)) {
+                $io->warning(sprintf(
+                    'Unknown provider: %s. Known providers: %s',
+                    $provider,
+                    implode(', ', array_keys(ModelCatalog::serviceNames()))
+                ));
+                $errors = true;
+                continue;
+            }
+
+            foreach ($models as $model) {
+                $selected[$model['id']] = $model;
+            }
+        }
+
+        $enabled = 0;
+        $skippedRetired = 0;
+
+        foreach ($selected as $model) {
+            if (ModelCatalog::isRetired($model['id'])) {
+                $io->writeln("  <comment>Skipped (retired)</comment> {$model['service']}: {$model['name']} ({$model['tag']})");
+                ++$skippedRetired;
+                continue;
+            }
+
+            ModelCatalog::enable($this->connection, $model, $system);
+            $label = $system ? 'Enabled (system)' : 'Enabled';
+            $io->writeln("  <info>$label</info> {$model['service']}: {$model['name']} ({$model['tag']})");
+            ++$enabled;
+        }
+
+        if ($skippedRetired > 0) {
+            $io->note("Skipped $skippedRetired retired model(s) — the upstream provider no longer serves them.");
         }
 
         if ($enabled > 0) {

--- a/backend/src/Command/ModelEnableCommand.php
+++ b/backend/src/Command/ModelEnableCommand.php
@@ -33,12 +33,17 @@ class ModelEnableCommand extends Command
                 'Model keys to enable (e.g. groq:qwen/qwen3.6-27b ollama:bge-m3)')
             ->addOption('provider', 'p', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
                 'Enable every catalog model of a provider (e.g. --provider groq). Repeatable.')
+            ->addOption('only', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                'Air-gap allow-list: enable these providers and disable every other catalog provider. Repeatable. Cannot be combined with model keys or --provider.')
             ->addOption('system', null, InputOption::VALUE_NONE,
                 'Mark enabled models as system models (locked, users cannot change)')
             ->setHelp(
                 "Enable one or more AI models from the built-in catalog.\n\n".
                 "Key format: service:providerId (or service:providerId:tag to target a specific variant)\n\n".
-                "Use <info>--provider <name></info> to enable every catalog model of a provider at once.\n\n".
+                "Use <info>--provider <name></info> to enable every catalog model of a provider at once.\n".
+                "Use <info>--only <name></info> (repeatable) as an allow-list: enable those providers\n".
+                "and soft-disable every other catalog provider. New cloud providers added later\n".
+                "are disabled automatically — no deny-list to keep in sync.\n\n".
                 "A model already in the database gets its visibility flags restored to the\n".
                 "catalog values; admin edits to prices or names are left untouched.\n".
                 "Retired models are skipped — the upstream provider no longer serves them.\n\n".
@@ -54,10 +59,21 @@ class ModelEnableCommand extends Command
         $io = new SymfonyStyle($input, $output);
         $modelKeys = $input->getArgument('models');
         $providers = $input->getOption('provider');
+        $only = $input->getOption('only');
         $system = $input->getOption('system');
 
+        if ([] !== $only) {
+            if ([] !== $modelKeys || [] !== $providers) {
+                $io->error('--only cannot be combined with model keys or --provider.');
+
+                return Command::INVALID;
+            }
+
+            return $this->enableOnly($io, $only, $system);
+        }
+
         if ([] === $modelKeys && [] === $providers) {
-            $io->error('Provide model keys and/or --provider <name>. Run app:model:list to see the catalog.');
+            $io->error('Provide model keys, --provider <name>, or --only <name>. Run app:model:list to see the catalog.');
 
             return Command::INVALID;
         }
@@ -123,6 +139,75 @@ class ModelEnableCommand extends Command
         if ($enabled > 0) {
             $io->success("Enabled $enabled model(s)");
         }
+
+        return $errors ? Command::FAILURE : Command::SUCCESS;
+    }
+
+    /**
+     * Allow-list mode: enable every (non-retired) model of the named providers
+     * and soft-disable every other catalog provider. New providers added to the
+     * catalog later are disabled on the next run — no deny-list to maintain.
+     *
+     * @param list<string> $only
+     */
+    private function enableOnly(SymfonyStyle $io, array $only, bool $system): int
+    {
+        $known = ModelCatalog::serviceNames();
+        $allow = [];
+        $errors = false;
+
+        foreach ($only as $name) {
+            $key = ModelCatalog::normalizeProvider($name);
+            if (!isset($known[$key])) {
+                $io->warning(sprintf(
+                    'Unknown provider: %s. Known providers: %s',
+                    $name,
+                    implode(', ', array_keys($known))
+                ));
+                $errors = true;
+                continue;
+            }
+            $allow[$key] = true;
+        }
+
+        if ([] === $allow) {
+            return Command::FAILURE;
+        }
+
+        $enabled = 0;
+        $disabled = 0;
+        $skippedRetired = 0;
+
+        foreach ($known as $key => $_display) {
+            foreach (ModelCatalog::findByService($key) as $model) {
+                if (isset($allow[$key])) {
+                    if (ModelCatalog::isRetired($model['id'])) {
+                        $io->writeln("  <comment>Skipped (retired)</comment> {$model['service']}: {$model['name']} ({$model['tag']})");
+                        ++$skippedRetired;
+                        continue;
+                    }
+                    ModelCatalog::enable($this->connection, $model, $system);
+                    $label = $system ? 'Enabled (system)' : 'Enabled';
+                    $io->writeln("  <info>$label</info> {$model['service']}: {$model['name']} ({$model['tag']})");
+                    ++$enabled;
+                    continue;
+                }
+
+                ModelCatalog::disable($this->connection, $model);
+                $io->writeln("  <comment>Disabled</comment> {$model['service']}: {$model['name']} ({$model['tag']})");
+                ++$disabled;
+            }
+        }
+
+        if ($skippedRetired > 0) {
+            $io->note("Skipped $skippedRetired retired model(s) — the upstream provider no longer serves them.");
+        }
+
+        $io->success(sprintf(
+            'Allow-list applied: enabled %d model(s), disabled %d from other providers',
+            $enabled,
+            $disabled
+        ));
 
         return $errors ? Command::FAILURE : Command::SUCCESS;
     }

--- a/backend/src/Command/ModelListCommand.php
+++ b/backend/src/Command/ModelListCommand.php
@@ -28,14 +28,16 @@ class ModelListCommand extends Command
     {
         $io = new SymfonyStyle($input, $output);
 
-        // Get BIDs of models currently in the database
-        $enabledBids = $this->connection->fetchFirstColumn('SELECT BID FROM BMODELS');
-        $enabledBids = array_map('intval', $enabledBids);
+        // BACTIVE, not row existence: app:model:disable soft-disables (the row
+        // stays because BMESSAGES references the BID), so a present row says
+        // nothing about whether the model can serve a request.
+        $activeByBid = $this->connection->fetchAllKeyValue('SELECT BID, BACTIVE FROM BMODELS');
 
         $rows = [];
         foreach (ModelCatalog::all() as $model) {
             $key = strtolower($model['service']).':'.strtolower(str_replace(':', '-', $model['providerId']));
-            $enabled = in_array($model['id'], $enabledBids, true);
+            $state = $activeByBid[$model['id']] ?? null;
+            $enabled = null !== $state && 1 === (int) $state;
 
             $rows[] = [
                 $enabled ? '<info>yes</info>' : 'no',

--- a/backend/src/Command/ProviderListCommand.php
+++ b/backend/src/Command/ProviderListCommand.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\AI\Credential\ChatReadinessService;
+use App\AI\Credential\ProviderKeyStore;
+use App\AI\Service\ProviderRegistry;
+use App\Model\ModelCatalog;
+use Doctrine\DBAL\Connection;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:provider:list',
+    description: 'Show the AI providers of this installation and their availability',
+)]
+final class ProviderListCommand extends Command
+{
+    public function __construct(
+        private readonly ProviderRegistry $providerRegistry,
+        private readonly ProviderKeyStore $providerKeyStore,
+        private readonly ChatReadinessService $chatReadiness,
+        private readonly Connection $connection,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('fresh', null, InputOption::VALUE_NONE,
+                'Bypass the cached availability snapshot and probe every provider now')
+            ->setHelp(
+                "Availability is the installation-level truth the catalog surfaces build on:\n".
+                "a provider is available when its credentials are present (API key, or a\n".
+                "reachable URL for local providers; Ollama additionally needs the chat model\n".
+                "pulled). Users only see models of available providers.\n\n".
+                "Credentials column: <info>key (ui)</info> = saved in the admin UI,\n".
+                "<info>key (env)</info> = bootstrapped from an environment variable,\n".
+                "<info>none</info> = not configured, <info>n/a</info> = provider without a\n".
+                "platform key (local URL or per-endpoint credentials).\n\n".
+                'Enable or disable models per provider with '.
+                '<info>app:model:enable --provider <name></info> / <info>app:model:disable --provider <name></info>.'
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $availability = $this->chatReadiness->providerAvailability(fresh: (bool) $input->getOption('fresh'));
+        $modelCounts = $this->modelCountsByService();
+
+        $rows = [];
+        foreach ($this->providerRegistry->getUniqueProviders() as $name => $provider) {
+            $key = ModelCatalog::normalizeProvider((string) $name);
+
+            // Internal fixture serving dev/test — not a provider an operator manages.
+            if ('test' === $key) {
+                continue;
+            }
+
+            $counts = $modelCounts[$key] ?? ['active' => 0, 'total' => 0];
+
+            $rows[] = [
+                'name' => $provider->getDisplayName(),
+                'credentials' => $this->credentialLabel($key),
+                'available' => ($availability[$key] ?? false) ? '<info>yes</info>' : 'no',
+                'models' => sprintf('%d / %d', $counts['active'], $counts['total']),
+                'catalog' => count(ModelCatalog::findByService($key)),
+            ];
+        }
+
+        usort($rows, static fn (array $a, array $b): int => strcasecmp($a['name'], $b['name']));
+
+        $io->table(
+            ['Provider', 'Credentials', 'Available', 'Models active/DB', 'In catalog'],
+            array_map(static fn (array $row): array => array_values($row), $rows)
+        );
+
+        $io->writeln('Availability is cached briefly; use <info>--fresh</info> to re-probe.');
+        $io->writeln('Configure keys in Admin → AI Providers (/admin/setup) or via environment variables.');
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Active and total BMODELS rows per lowercase service name. Negative BIDs
+     * are dev/test mock models and never part of the operator's catalog.
+     *
+     * @return array<string, array{active: int, total: int}>
+     */
+    private function modelCountsByService(): array
+    {
+        $rows = $this->connection->fetchAllAssociative(
+            'SELECT LOWER(BSERVICE) AS service,
+                    SUM(CASE WHEN BACTIVE = 1 THEN 1 ELSE 0 END) AS active,
+                    COUNT(*) AS total
+             FROM BMODELS
+             WHERE BID > 0
+             GROUP BY LOWER(BSERVICE)'
+        );
+
+        $counts = [];
+        foreach ($rows as $row) {
+            $counts[(string) $row['service']] = [
+                'active' => (int) $row['active'],
+                'total' => (int) $row['total'],
+            ];
+        }
+
+        return $counts;
+    }
+
+    private function credentialLabel(string $provider): string
+    {
+        if (!ProviderKeyStore::isSupported($provider)) {
+            return 'n/a';
+        }
+
+        $status = $this->providerKeyStore->getStatus($provider);
+        if (!$status['configured']) {
+            return 'none';
+        }
+
+        // A DB row carries its origin; a key read straight from the
+        // environment (not yet imported) is an env credential as well.
+        $origin = 'db' === $status['source'] ? ($status['origin'] ?? ProviderKeyStore::ORIGIN_UI) : ProviderKeyStore::ORIGIN_ENV;
+
+        return sprintf('key (%s)', $origin);
+    }
+}

--- a/backend/src/Command/ProviderListCommand.php
+++ b/backend/src/Command/ProviderListCommand.php
@@ -90,8 +90,10 @@ final class ProviderListCommand extends Command
     }
 
     /**
-     * Active and total BMODELS rows per lowercase service name. Negative BIDs
+     * Active and total BMODELS rows per canonical provider key. Negative BIDs
      * are dev/test mock models and never part of the operator's catalog.
+     * Alias spellings (e.g. "Hugging Face") are collapsed onto the same key
+     * the rest of this command uses ({@see ModelCatalog::normalizeProvider()}).
      *
      * @return array<string, array{active: int, total: int}>
      */
@@ -114,7 +116,7 @@ final class ProviderListCommand extends Command
             ];
         }
 
-        return $counts;
+        return ModelCatalog::collapseCountsByProvider($counts);
     }
 
     private function credentialLabel(string $provider): string

--- a/backend/src/Model/ModelCatalog.php
+++ b/backend/src/Model/ModelCatalog.php
@@ -365,6 +365,29 @@ class ModelCatalog
     }
 
     /**
+     * Collapse DB service-name buckets onto canonical provider keys so
+     * aliases ("Hugging Face" / "HuggingFace") count as one provider.
+     *
+     * @param array<string, array{active: int, total: int}> $countsByService
+     *
+     * @return array<string, array{active: int, total: int}>
+     */
+    public static function collapseCountsByProvider(array $countsByService): array
+    {
+        $merged = [];
+        foreach ($countsByService as $service => $counts) {
+            $key = self::normalizeProvider((string) $service);
+            if (!isset($merged[$key])) {
+                $merged[$key] = ['active' => 0, 'total' => 0];
+            }
+            $merged[$key]['active'] += (int) $counts['active'];
+            $merged[$key]['total'] += (int) $counts['total'];
+        }
+
+        return $merged;
+    }
+
+    /**
      * Insert or update a model row via `INSERT … ON DUPLICATE KEY UPDATE`.
      *
      * Field ownership rules:

--- a/backend/src/Model/ModelCatalog.php
+++ b/backend/src/Model/ModelCatalog.php
@@ -475,11 +475,49 @@ class ModelCatalog
     }
 
     /**
-     * Delete a model from the database by its catalog ID.
+     * Enable a catalog model: insert it when absent, otherwise restore the
+     * operator-owned visibility flags to the catalog values. Catalog-owned
+     * columns of an existing row are left untouched — an admin's price or
+     * name edits must survive an enable exactly like they survive a re-seed.
      */
-    public static function remove(Connection $connection, array $model): void
+    public static function enable(Connection $connection, array $model, bool $system = false): void
     {
-        $connection->executeStatement('DELETE FROM BMODELS WHERE BID = ?', [$model['id']]);
+        if (!self::existsInDatabase($connection, $model)) {
+            self::upsert($connection, $model, $system);
+
+            return;
+        }
+
+        $connection->executeStatement(
+            'UPDATE BMODELS SET BACTIVE = ?, BSELECTABLE = ? WHERE BID = ?',
+            [$model['active'], $model['selectable'], $model['id']]
+        );
+    }
+
+    /**
+     * Disable a catalog model WITHOUT deleting it. Rows are never removed:
+     * BMESSAGES references the BID, and ModelSeeder re-inserts any absent
+     * catalog row on the next container start, which silently reverted the
+     * old DELETE-based disable. The flags are operator-owned (never written
+     * on the upsert UPDATE path), so the deactivation survives every re-seed.
+     * A model missing from the database is inserted first so the deactivation
+     * sticks for future seeds too.
+     */
+    public static function disable(Connection $connection, array $model): void
+    {
+        if (!self::existsInDatabase($connection, $model)) {
+            self::upsert($connection, $model);
+        }
+
+        $connection->executeStatement(
+            'UPDATE BMODELS SET BACTIVE = 0, BSELECTABLE = 0 WHERE BID = ?',
+            [$model['id']]
+        );
+    }
+
+    private static function existsInDatabase(Connection $connection, array $model): bool
+    {
+        return false !== $connection->fetchOne('SELECT BID FROM BMODELS WHERE BID = ?', [$model['id']]);
     }
 
     /**
@@ -574,6 +612,46 @@ class ModelCatalog
         $successor = self::RETIREMENTS[$bid]['successor'] ?? null;
 
         return null === $successor ? null : self::findBidByKey($successor);
+    }
+
+    /**
+     * All catalog models of a provider/service, matched via
+     * {@see normalizeProvider()} (case-insensitive, aliases collapsed —
+     * e.g. "groq", "Ollama", "Hugging Face").
+     *
+     * @return array[] matching model definitions
+     */
+    public static function findByService(string $service): array
+    {
+        $service = self::normalizeProvider($service);
+        $results = [];
+
+        foreach (self::MODELS as $model) {
+            if (self::normalizeProvider($model['service']) === $service) {
+                $results[] = $model;
+            }
+        }
+
+        return $results;
+    }
+
+    /**
+     * Every service name in the catalog, keyed by its normalized form
+     * (e.g. 'openai' => 'OpenAI'). Used to validate --provider input and to
+     * print the accepted values.
+     *
+     * @return array<string, string>
+     */
+    public static function serviceNames(): array
+    {
+        $names = [];
+        foreach (self::MODELS as $model) {
+            $names[self::normalizeProvider($model['service'])] ??= $model['service'];
+        }
+
+        ksort($names);
+
+        return $names;
     }
 
     /**

--- a/backend/tests/Command/ModelDisableCommandTest.php
+++ b/backend/tests/Command/ModelDisableCommandTest.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace App\Tests\Command;
 
 use App\Command\ModelDisableCommand;
+use App\Model\ModelCatalog;
 use Doctrine\DBAL\Connection;
-use PHPUnit\Framework\Constraint\IsType;
-use PHPUnit\Framework\NativeType;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
@@ -16,11 +16,23 @@ use Symfony\Component\Console\Tester\CommandTester;
 class ModelDisableCommandTest extends TestCase
 {
     private CommandTester $commandTester;
-    private Connection $connection;
+    private Connection&MockObject $connection;
+
+    /** @var list<string> every SQL statement the command issued */
+    private array $statements = [];
 
     protected function setUp(): void
     {
+        $this->statements = [];
+
         $this->connection = $this->createMock(Connection::class);
+        $this->connection->method('executeStatement')
+            ->willReturnCallback(function (string $sql): int {
+                $this->statements[] = $sql;
+
+                return 1;
+            });
+
         $command = new ModelDisableCommand($this->connection);
 
         $application = new Application();
@@ -29,44 +41,93 @@ class ModelDisableCommandTest extends TestCase
         $this->commandTester = new CommandTester($application->find('app:model:disable'));
     }
 
-    public function testDisableSingleModel(): void
+    private function givenModelsExist(): void
     {
-        // @phpstan-ignore-next-line
-        $this->connection->expects($this->once())->method('executeStatement')
-            ->with('DELETE FROM BMODELS WHERE BID = ?', new IsType(NativeType::Array));
+        $this->connection->method('fetchOne')->willReturn('9');
+    }
+
+    private function givenModelsAreMissing(): void
+    {
+        $this->connection->method('fetchOne')->willReturn(false);
+    }
+
+    public function testDisableDeactivatesInsteadOfDeleting(): void
+    {
+        $this->givenModelsExist();
 
         $this->commandTester->execute(['models' => ['groq:qwen/qwen3.6-27b:chat']]);
 
         $this->assertSame(Command::SUCCESS, $this->commandTester->getStatusCode());
         $this->assertStringContainsString('Disabled 1 model(s)', $this->commandTester->getDisplay());
+        $this->assertCount(1, $this->statements);
+        $this->assertStringContainsString('UPDATE BMODELS SET BACTIVE = 0, BSELECTABLE = 0', $this->statements[0]);
+        $this->assertStringNotContainsString('DELETE', $this->statements[0]);
     }
 
-    public function testDisableGroupedKeyRemovesAllVariants(): void
+    public function testDisableMissingModelInsertsItDeactivated(): void
     {
-        // @phpstan-ignore-next-line
-        $this->connection->expects($this->exactly(2))->method('executeStatement');
+        // A model that is not in the database yet is inserted first so the
+        // deactivation survives the next app:seed (an absent row would be
+        // re-inserted active).
+        $this->givenModelsAreMissing();
+
+        $this->commandTester->execute(['models' => ['groq:qwen/qwen3.6-27b:chat']]);
+
+        $this->assertSame(Command::SUCCESS, $this->commandTester->getStatusCode());
+        $this->assertCount(2, $this->statements);
+        $this->assertStringContainsString('INSERT INTO BMODELS', $this->statements[0]);
+        $this->assertStringContainsString('UPDATE BMODELS SET BACTIVE = 0, BSELECTABLE = 0', $this->statements[1]);
+    }
+
+    public function testDisableGroupedKeyDeactivatesAllVariants(): void
+    {
+        $this->givenModelsExist();
 
         $this->commandTester->execute(['models' => ['google:gemini-2.5-pro']]);
 
         $this->assertSame(Command::SUCCESS, $this->commandTester->getStatusCode());
         $this->assertStringContainsString('Disabled 2 model(s)', $this->commandTester->getDisplay());
+        $this->assertCount(2, $this->statements);
+    }
+
+    public function testDisableByProviderDeactivatesEveryCatalogModel(): void
+    {
+        $this->givenModelsExist();
+
+        $this->commandTester->execute(['--provider' => ['openai']]);
+
+        $expected = count(ModelCatalog::findByService('openai'));
+        $this->assertGreaterThan(0, $expected, 'fixture assumption: the catalog has OpenAI models');
+
+        $this->assertSame(Command::SUCCESS, $this->commandTester->getStatusCode());
+        $this->assertStringContainsString("Disabled $expected model(s)", $this->commandTester->getDisplay());
+        $this->assertCount($expected, $this->statements);
+        foreach ($this->statements as $sql) {
+            $this->assertStringNotContainsString('DELETE', $sql);
+        }
     }
 
     public function testDisableUnknownKeyReturnsFailure(): void
     {
-        // @phpstan-ignore-next-line
-        $this->connection->expects($this->never())->method('executeStatement');
-
         $this->commandTester->execute(['models' => ['nonexistent:model']]);
 
         $this->assertSame(Command::FAILURE, $this->commandTester->getStatusCode());
         $this->assertStringContainsString('Unknown model key', $this->commandTester->getDisplay());
+        $this->assertCount(0, $this->statements);
+    }
+
+    public function testDisableUnknownProviderReturnsFailure(): void
+    {
+        $this->commandTester->execute(['--provider' => ['skynet']]);
+
+        $this->assertSame(Command::FAILURE, $this->commandTester->getStatusCode());
+        $this->assertStringContainsString('Unknown provider: skynet', $this->commandTester->getDisplay());
+        $this->assertCount(0, $this->statements);
     }
 
     public function testDisableMixedKnownAndUnknown(): void
     {
-        // @phpstan-ignore-next-line
-        $this->connection->expects($this->once())->method('executeStatement');
+        $this->givenModelsExist();
 
         $this->commandTester->execute(['models' => ['groq:qwen/qwen3.6-27b:chat', 'fake:nope']]);
 
@@ -74,5 +135,14 @@ class ModelDisableCommandTest extends TestCase
         $output = $this->commandTester->getDisplay();
         $this->assertStringContainsString('Disabled 1 model(s)', $output);
         $this->assertStringContainsString('Unknown model key: fake:nope', $output);
+    }
+
+    public function testNoArgumentsIsRejected(): void
+    {
+        $this->commandTester->execute([]);
+
+        $this->assertSame(Command::INVALID, $this->commandTester->getStatusCode());
+        $this->assertStringContainsString('--provider', $this->commandTester->getDisplay());
+        $this->assertCount(0, $this->statements);
     }
 }

--- a/backend/tests/Command/ModelEnableCommandTest.php
+++ b/backend/tests/Command/ModelEnableCommandTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace App\Tests\Command;
 
 use App\Command\ModelEnableCommand;
+use App\Model\ModelCatalog;
 use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
@@ -14,11 +16,23 @@ use Symfony\Component\Console\Tester\CommandTester;
 class ModelEnableCommandTest extends TestCase
 {
     private CommandTester $commandTester;
-    private Connection $connection;
+    private Connection&MockObject $connection;
+
+    /** @var list<string> every SQL statement the command issued */
+    private array $statements = [];
 
     protected function setUp(): void
     {
+        $this->statements = [];
+
         $this->connection = $this->createMock(Connection::class);
+        $this->connection->method('executeStatement')
+            ->willReturnCallback(function (string $sql): int {
+                $this->statements[] = $sql;
+
+                return 1;
+            });
+
         $command = new ModelEnableCommand($this->connection);
 
         $application = new Application();
@@ -27,33 +41,58 @@ class ModelEnableCommandTest extends TestCase
         $this->commandTester = new CommandTester($application->find('app:model:enable'));
     }
 
-    public function testEnableSingleModel(): void
+    /** Model rows absent from the database (fetchOne finds nothing). */
+    private function givenModelsAreMissing(): void
     {
-        // @phpstan-ignore-next-line
-        $this->connection->expects($this->once())->method('executeStatement');
+        $this->connection->method('fetchOne')->willReturn(false);
+    }
+
+    /** Model rows already present in the database. */
+    private function givenModelsExist(): void
+    {
+        $this->connection->method('fetchOne')->willReturn('9');
+    }
+
+    public function testEnableMissingModelInsertsIt(): void
+    {
+        $this->givenModelsAreMissing();
 
         $this->commandTester->execute(['models' => ['groq:qwen/qwen3.6-27b:chat']]);
 
         $this->assertSame(Command::SUCCESS, $this->commandTester->getStatusCode());
         $this->assertStringContainsString('Enabled 1 model(s)', $this->commandTester->getDisplay());
+        $this->assertCount(1, $this->statements);
+        $this->assertStringContainsString('INSERT INTO BMODELS', $this->statements[0]);
+    }
+
+    public function testEnableExistingModelRestoresVisibilityFlagsOnly(): void
+    {
+        $this->givenModelsExist();
+
+        $this->commandTester->execute(['models' => ['groq:qwen/qwen3.6-27b:chat']]);
+
+        $this->assertSame(Command::SUCCESS, $this->commandTester->getStatusCode());
+        $this->assertCount(1, $this->statements);
+        $this->assertStringContainsString('UPDATE BMODELS SET BACTIVE = ?, BSELECTABLE = ?', $this->statements[0]);
+        // Catalog-owned columns (price, name) must survive an enable untouched.
+        $this->assertStringNotContainsString('BPRICEIN', $this->statements[0]);
     }
 
     public function testEnableMultipleModels(): void
     {
-        // @phpstan-ignore-next-line
-        $this->connection->expects($this->exactly(2))->method('executeStatement');
+        $this->givenModelsAreMissing();
 
         $this->commandTester->execute(['models' => ['groq:qwen/qwen3.6-27b:chat', 'ollama:bge-m3']]);
 
         $this->assertSame(Command::SUCCESS, $this->commandTester->getStatusCode());
         $this->assertStringContainsString('Enabled 2 model(s)', $this->commandTester->getDisplay());
+        $this->assertCount(2, $this->statements);
     }
 
     public function testEnableGroupedKeyEnablesAllVariants(): void
     {
         // google:gemini-2.5-pro resolves to chat + pic2text
-        // @phpstan-ignore-next-line
-        $this->connection->expects($this->exactly(2))->method('executeStatement');
+        $this->givenModelsAreMissing();
 
         $this->commandTester->execute(['models' => ['google:gemini-2.5-pro']]);
 
@@ -61,21 +100,78 @@ class ModelEnableCommandTest extends TestCase
         $this->assertStringContainsString('Enabled 2 model(s)', $this->commandTester->getDisplay());
     }
 
+    public function testEnableByProviderEnablesEveryNonRetiredCatalogModel(): void
+    {
+        $this->givenModelsAreMissing();
+
+        $this->commandTester->execute(['--provider' => ['groq']]);
+
+        $expected = count(array_filter(
+            ModelCatalog::findByService('groq'),
+            static fn (array $model): bool => !ModelCatalog::isRetired($model['id'])
+        ));
+        $this->assertGreaterThan(0, $expected, 'fixture assumption: the catalog has Groq models');
+
+        $this->assertSame(Command::SUCCESS, $this->commandTester->getStatusCode());
+        $this->assertStringContainsString("Enabled $expected model(s)", $this->commandTester->getDisplay());
+        $this->assertCount($expected, $this->statements);
+    }
+
+    public function testEnableByProviderAndExplicitKeyDeduplicates(): void
+    {
+        $this->givenModelsAreMissing();
+
+        $this->commandTester->execute([
+            'models' => ['ollama:bge-m3'],
+            '--provider' => ['ollama'],
+        ]);
+
+        $expected = count(array_filter(
+            ModelCatalog::findByService('ollama'),
+            static fn (array $model): bool => !ModelCatalog::isRetired($model['id'])
+        ));
+
+        $this->assertSame(Command::SUCCESS, $this->commandTester->getStatusCode());
+        $this->assertCount($expected, $this->statements, 'the explicit key must not be enabled twice');
+    }
+
+    public function testEnableRetiredModelIsSkipped(): void
+    {
+        // xai:grok-tts (BID 320) is kept in the catalog but recorded as retired.
+        $this->givenModelsAreMissing();
+
+        $this->commandTester->execute(['models' => ['xai:grok-tts']]);
+
+        $this->assertSame(Command::SUCCESS, $this->commandTester->getStatusCode());
+        $output = $this->commandTester->getDisplay();
+        $this->assertStringContainsString('Skipped (retired)', $output);
+        $this->assertStringNotContainsString('Enabled 1', $output);
+        $this->assertCount(0, $this->statements);
+    }
+
     public function testEnableUnknownKeyReturnsFailure(): void
     {
-        // @phpstan-ignore-next-line
-        $this->connection->expects($this->never())->method('executeStatement');
-
         $this->commandTester->execute(['models' => ['nonexistent:model']]);
 
         $this->assertSame(Command::FAILURE, $this->commandTester->getStatusCode());
         $this->assertStringContainsString('Unknown model key', $this->commandTester->getDisplay());
+        $this->assertCount(0, $this->statements);
+    }
+
+    public function testEnableUnknownProviderReturnsFailure(): void
+    {
+        $this->commandTester->execute(['--provider' => ['skynet']]);
+
+        $this->assertSame(Command::FAILURE, $this->commandTester->getStatusCode());
+        $output = $this->commandTester->getDisplay();
+        $this->assertStringContainsString('Unknown provider: skynet', $output);
+        $this->assertStringContainsString('Known providers:', $output);
+        $this->assertCount(0, $this->statements);
     }
 
     public function testEnableMixedKnownAndUnknown(): void
     {
-        // @phpstan-ignore-next-line
-        $this->connection->expects($this->once())->method('executeStatement');
+        $this->givenModelsAreMissing();
 
         $this->commandTester->execute(['models' => ['groq:qwen/qwen3.6-27b:chat', 'fake:nope']]);
 
@@ -83,5 +179,14 @@ class ModelEnableCommandTest extends TestCase
         $output = $this->commandTester->getDisplay();
         $this->assertStringContainsString('Enabled 1 model(s)', $output);
         $this->assertStringContainsString('Unknown model key: fake:nope', $output);
+    }
+
+    public function testNoArgumentsIsRejected(): void
+    {
+        $this->commandTester->execute([]);
+
+        $this->assertSame(Command::INVALID, $this->commandTester->getStatusCode());
+        $this->assertStringContainsString('--provider', $this->commandTester->getDisplay());
+        $this->assertCount(0, $this->statements);
     }
 }

--- a/backend/tests/Command/ModelEnableCommandTest.php
+++ b/backend/tests/Command/ModelEnableCommandTest.php
@@ -189,4 +189,60 @@ class ModelEnableCommandTest extends TestCase
         $this->assertStringContainsString('--provider', $this->commandTester->getDisplay());
         $this->assertCount(0, $this->statements);
     }
+
+    public function testEnableOnlyEnablesListedProvidersAndDisablesTheRest(): void
+    {
+        $this->givenModelsAreMissing();
+
+        $this->commandTester->execute(['--only' => ['ollama', 'piper']]);
+
+        $this->assertSame(Command::SUCCESS, $this->commandTester->getStatusCode());
+
+        $allow = ['ollama', 'piper'];
+        $expectedEnabled = 0;
+        $expectedDisabled = 0;
+        foreach (array_keys(ModelCatalog::serviceNames()) as $service) {
+            foreach (ModelCatalog::findByService($service) as $model) {
+                if (in_array($service, $allow, true)) {
+                    if (!ModelCatalog::isRetired($model['id'])) {
+                        ++$expectedEnabled;
+                    }
+                } else {
+                    ++$expectedDisabled;
+                }
+            }
+        }
+
+        $this->assertGreaterThan(0, $expectedEnabled);
+        $this->assertGreaterThan(0, $expectedDisabled);
+        $this->assertNotEmpty($this->statements);
+
+        $output = $this->commandTester->getDisplay();
+        $this->assertStringContainsString(
+            sprintf('enabled %d model(s), disabled %d from other providers', $expectedEnabled, $expectedDisabled),
+            $output
+        );
+        $this->assertStringNotContainsString('DELETE FROM', implode("\n", $this->statements));
+    }
+
+    public function testEnableOnlyRejectsUnknownProvider(): void
+    {
+        $this->commandTester->execute(['--only' => ['skynet']]);
+
+        $this->assertSame(Command::FAILURE, $this->commandTester->getStatusCode());
+        $this->assertStringContainsString('Unknown provider: skynet', $this->commandTester->getDisplay());
+        $this->assertCount(0, $this->statements);
+    }
+
+    public function testEnableOnlyCannotMixWithProviderOrKeys(): void
+    {
+        $this->commandTester->execute([
+            '--only' => ['ollama'],
+            '--provider' => ['groq'],
+        ]);
+
+        $this->assertSame(Command::INVALID, $this->commandTester->getStatusCode());
+        $this->assertStringContainsString('cannot be combined', $this->commandTester->getDisplay());
+        $this->assertCount(0, $this->statements);
+    }
 }

--- a/backend/tests/Command/ModelListCommandTest.php
+++ b/backend/tests/Command/ModelListCommandTest.php
@@ -27,10 +27,18 @@ class ModelListCommandTest extends TestCase
         $this->commandTester = new CommandTester($application->find('app:model:list'));
     }
 
-    public function testListWithNoEnabledModels(): void
+    /**
+     * @param array<int|string, int|string> $activeByBid
+     */
+    private function givenRows(array $activeByBid): void
     {
         // @phpstan-ignore-next-line
-        $this->connection->method('fetchFirstColumn')->willReturn([]);
+        $this->connection->method('fetchAllKeyValue')->willReturn($activeByBid);
+    }
+
+    public function testListWithNoEnabledModels(): void
+    {
+        $this->givenRows([]);
 
         $this->commandTester->execute([]);
 
@@ -45,8 +53,7 @@ class ModelListCommandTest extends TestCase
     {
         // Enable the Groq Qwen 3.6 27B chat model (BID=324). Has to be a BID the
         // catalog still carries — the command only renders catalog entries.
-        // @phpstan-ignore-next-line
-        $this->connection->method('fetchFirstColumn')->willReturn(['324']);
+        $this->givenRows(['324' => '1']);
 
         $this->commandTester->execute([]);
 
@@ -54,10 +61,23 @@ class ModelListCommandTest extends TestCase
         $this->assertStringContainsString('yes', $this->commandTester->getDisplay());
     }
 
+    /**
+     * app:model:disable keeps the row and only clears BACTIVE, so row
+     * existence must never be reported as "active".
+     */
+    public function testListShowsASoftDisabledModelAsNo(): void
+    {
+        $this->givenRows(['324' => '0']);
+
+        $this->commandTester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $this->commandTester->getStatusCode());
+        $this->assertStringNotContainsString('yes', $this->commandTester->getDisplay());
+    }
+
     public function testListShowsAllCatalogModels(): void
     {
-        // @phpstan-ignore-next-line
-        $this->connection->method('fetchFirstColumn')->willReturn([]);
+        $this->givenRows([]);
 
         $this->commandTester->execute([]);
 

--- a/backend/tests/Command/ProviderListCommandTest.php
+++ b/backend/tests/Command/ProviderListCommandTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Command;
+
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * The command only READS (availability snapshot, key status, model counts) —
+ * asserting concrete availability values would depend on which keys the
+ * current environment happens to hold, so the assertions stay structural:
+ * every operator-facing provider is listed, the internal TestProvider is not,
+ * and the exit code is clean.
+ */
+final class ProviderListCommandTest extends KernelTestCase
+{
+    private function tester(): CommandTester
+    {
+        self::bootKernel();
+        $application = new Application(self::$kernel);
+
+        return new CommandTester($application->find('app:provider:list'));
+    }
+
+    public function testListsProvidersWithAvailabilityAndModelCounts(): void
+    {
+        $tester = $this->tester();
+        $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $output = $tester->getDisplay();
+
+        foreach (['Provider', 'Credentials', 'Available', 'Models active/DB', 'In catalog'] as $header) {
+            self::assertStringContainsString($header, $output);
+        }
+
+        // Registered real providers must appear with their display names.
+        self::assertStringContainsString('Ollama', $output);
+        self::assertStringContainsString('OpenAI', $output);
+        self::assertStringContainsString('Groq', $output);
+    }
+
+    public function testInternalTestProviderIsNotListed(): void
+    {
+        $tester = $this->tester();
+        $tester->execute([]);
+
+        self::assertStringNotContainsString('Test Provider', $tester->getDisplay());
+    }
+
+    public function testFreshFlagBypassesTheCachedSnapshot(): void
+    {
+        $tester = $this->tester();
+        $tester->execute(['--fresh' => true]);
+
+        self::assertSame(Command::SUCCESS, $tester->getStatusCode());
+    }
+}

--- a/backend/tests/Unit/Model/ModelCatalogTest.php
+++ b/backend/tests/Unit/Model/ModelCatalogTest.php
@@ -33,6 +33,20 @@ class ModelCatalogTest extends TestCase
         $this->assertSame('huggingface', ModelCatalog::normalizeProvider('huggingface'));
     }
 
+    public function testCollapseCountsByProviderMergesAliasSpellings(): void
+    {
+        $merged = ModelCatalog::collapseCountsByProvider([
+            'huggingface' => ['active' => 2, 'total' => 4],
+            'hugging face' => ['active' => 1, 'total' => 1],
+            'openai' => ['active' => 3, 'total' => 3],
+        ]);
+
+        $this->assertSame([
+            'huggingface' => ['active' => 3, 'total' => 5],
+            'openai' => ['active' => 3, 'total' => 3],
+        ], $merged);
+    }
+
     public function testFindIsCaseInsensitive(): void
     {
         $lower = ModelCatalog::find('groq:qwen/qwen3.6-27b:chat');

--- a/backend/tests/Unit/Model/ModelCatalogTest.php
+++ b/backend/tests/Unit/Model/ModelCatalogTest.php
@@ -125,18 +125,118 @@ class ModelCatalogTest extends TestCase
         ModelCatalog::upsert($connection, $model);
     }
 
-    public function testRemoveCallsDeleteById(): void
+    public function testEnableInsertsMissingModel(): void
     {
         $connection = $this->createMock(Connection::class);
+        $connection->method('fetchOne')->willReturn(false);
         $model = ModelCatalog::find('groq:qwen/qwen3.6-27b:chat')[0];
 
         // @phpstan-ignore-next-line
         $connection
             ->expects($this->once())
             ->method('executeStatement')
-            ->with('DELETE FROM BMODELS WHERE BID = ?', [$model['id']]);
+            ->with($this->stringContains('INSERT INTO BMODELS'));
 
-        ModelCatalog::remove($connection, $model);
+        ModelCatalog::enable($connection, $model);
+    }
+
+    public function testEnableExistingModelRestoresVisibilityFlagsToCatalogValues(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('fetchOne')->willReturn('42');
+        $model = ModelCatalog::find('groq:qwen/qwen3.6-27b:chat')[0];
+
+        // Only the operator-owned visibility flags are written — an admin's
+        // price or name edits must survive an enable like they survive a re-seed.
+        // @phpstan-ignore-next-line
+        $connection
+            ->expects($this->once())
+            ->method('executeStatement')
+            ->with(
+                'UPDATE BMODELS SET BACTIVE = ?, BSELECTABLE = ? WHERE BID = ?',
+                [$model['active'], $model['selectable'], $model['id']]
+            );
+
+        ModelCatalog::enable($connection, $model);
+    }
+
+    /**
+     * Disabling must never DELETE: BMESSAGES references the BID, and
+     * ModelSeeder re-inserts any absent catalog row on the next container
+     * start — which is exactly how the old DELETE-based disable silently
+     * reverted itself.
+     */
+    public function testDisableDeactivatesExistingRowWithoutDeleting(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('fetchOne')->willReturn('42');
+        $model = ModelCatalog::find('groq:qwen/qwen3.6-27b:chat')[0];
+
+        // @phpstan-ignore-next-line
+        $connection
+            ->expects($this->once())
+            ->method('executeStatement')
+            ->with(
+                'UPDATE BMODELS SET BACTIVE = 0, BSELECTABLE = 0 WHERE BID = ?',
+                [$model['id']]
+            );
+
+        ModelCatalog::disable($connection, $model);
+    }
+
+    public function testDisableInsertsMissingRowSoTheDeactivationSurvivesReseed(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('fetchOne')->willReturn(false);
+        $model = ModelCatalog::find('groq:qwen/qwen3.6-27b:chat')[0];
+
+        $statements = [];
+        $connection->method('executeStatement')
+            ->willReturnCallback(static function (string $sql) use (&$statements): int {
+                $statements[] = $sql;
+
+                return 1;
+            });
+
+        ModelCatalog::disable($connection, $model);
+
+        $this->assertCount(2, $statements);
+        $this->assertStringContainsString('INSERT INTO BMODELS', $statements[0]);
+        $this->assertStringContainsString('UPDATE BMODELS SET BACTIVE = 0, BSELECTABLE = 0', $statements[1]);
+        foreach ($statements as $sql) {
+            $this->assertStringNotContainsString('DELETE', $sql);
+        }
+    }
+
+    public function testFindByServiceMatchesCaseInsensitivelyAndCollapsesAliases(): void
+    {
+        $lower = ModelCatalog::findByService('groq');
+        $upper = ModelCatalog::findByService('  GROQ ');
+
+        $this->assertNotEmpty($lower);
+        $this->assertSame($lower, $upper);
+        $this->assertSame(['Groq'], array_unique(array_column($lower, 'service')));
+
+        // The 'Hugging Face' alias must resolve like the canonical name (#1313).
+        $this->assertSame(
+            ModelCatalog::findByService('huggingface'),
+            ModelCatalog::findByService('Hugging Face')
+        );
+
+        $this->assertSame([], ModelCatalog::findByService('skynet'));
+    }
+
+    public function testServiceNamesAreKeyedByNormalizedName(): void
+    {
+        $names = ModelCatalog::serviceNames();
+
+        $this->assertSame('Groq', $names['groq']);
+        $this->assertSame('OpenAI', $names['openai']);
+        $this->assertSame('Ollama', $names['ollama']);
+
+        foreach (array_keys($names) as $key) {
+            $this->assertSame(ModelCatalog::normalizeProvider($key), $key);
+        }
     }
 
     public function testUpsertSqlDoesNotOverwriteOperatorOwnedFields(): void


### PR DESCRIPTION
Part of #1586 (PR A of the plan).

## Summary
- `app:model:disable` no longer DELETEs catalog rows. Deleting broke `BMESSAGES` references and was silently reverted by the seeder re-inserting the row on the next container start. It now soft-disables (`BACTIVE=0`, `BSELECTABLE=0`) — operator-owned flags the re-seed preserves — and a row missing from the DB is inserted first so the deactivation sticks. Models reappear when re-enabled; nothing is ever deleted.
- `app:model:enable` restores the catalog visibility flags on existing rows without touching admin price/name edits, and skips retired models with a note.
- Both commands accept repeatable `--provider <name>` to act on a provider's complete catalog (`synaplan model:disable --provider openai`). Explicit model keys and provider selections are deduplicated, so per-model entries can refine provider-wide toggles.
- New `app:provider:list`: one table with each provider's credential source (`key (ui)` / `key (env)` / `none` / `n/a`), availability (reusing `ChatReadinessService`, incl. the Ollama pulled-model gate) and active/total model counts. `--fresh` bypasses the cached snapshot.

Companion chart PR: metadist/synaplan-charts#40 (provider-level values).

## Test plan
- [x] `make -C backend lint` — clean
- [x] `make -C backend phpstan` — no errors
- [x] `make -C backend test` — 4104 tests green
- [x] New unit tests: `ModelCatalog::enable/disable/findByService/serviceNames`, soft-disable never issues DELETE, missing rows are inserted deactivated
- [x] Command tests: `--provider`, dedupe, retired-model skip, unknown provider/key failures, no-args rejection
- [x] `app:provider:list` smoke-tested against a live install
