### PR TITLE
feat(models): hide unavailable models from pickers, grey them for admins

### DIFF
--- a/backend/src/AI/Credential/ChatReadinessService.php
+++ b/backend/src/AI/Credential/ChatReadinessService.php
@@ -6,6 +6,7 @@ namespace App\AI\Credential;
 
 use App\AI\Service\OllamaModelInventory;
 use App\AI\Service\ProviderRegistry;
+use App\Model\ModelCatalog;
 use App\Repository\ModelRepository;
 use App\Service\ModelConfigService;
 use Psr\Cache\CacheItemPoolInterface;
@@ -131,6 +132,39 @@ final class ChatReadinessService
     public function isOllamaModelPulled(string $model): bool
     {
         return $this->ollamaModelInventory->isPulled($model);
+    }
+
+    /**
+     * Availability of one concrete model row on this installation.
+     *
+     * Ollama rows are judged per model (the server answers even with nothing
+     * pulled), every other service by its provider's key/URL. A service name
+     * the registry does not know cannot be judged and counts as available —
+     * hiding an operator's custom row on a guess would be worse.
+     *
+     * @param array<string, bool>|null $availability lowercase provider => usable;
+     *                                               defaults to the cached snapshot
+     *
+     * @return array{available: bool, reason: ?string} reason is 'not_pulled' or
+     *                                                 'provider_unavailable' when unavailable
+     */
+    public function modelAvailability(string $service, string $providerId, ?array $availability = null): array
+    {
+        $provider = ModelCatalog::normalizeProvider($service);
+
+        if ('ollama' === $provider) {
+            return $this->ollamaModelInventory->isPulled($providerId)
+                ? ['available' => true, 'reason' => null]
+                : ['available' => false, 'reason' => 'not_pulled'];
+        }
+
+        $availability ??= $this->providerAvailability();
+
+        if (!array_key_exists($provider, $availability) || $availability[$provider]) {
+            return ['available' => true, 'reason' => null];
+        }
+
+        return ['available' => false, 'reason' => 'provider_unavailable'];
     }
 
     /**

--- a/backend/src/Controller/AdminModelsController.php
+++ b/backend/src/Controller/AdminModelsController.php
@@ -62,6 +62,8 @@ final class AdminModelsController extends AbstractController
                             new OA\Property(property: 'json', type: 'object', nullable: true),
                             new OA\Property(property: 'isSystemModel', type: 'boolean', example: false),
                             new OA\Property(property: 'showWhenFree', type: 'integer', example: 0, description: 'Override to show model in selection even when pricing is 0'),
+                            new OA\Property(property: 'providerAvailable', type: 'boolean', example: true, description: 'Whether this model can serve requests right now: its provider has a key/URL configured, and an Ollama model is actually pulled.'),
+                            new OA\Property(property: 'unavailableReason', type: 'string', nullable: true, enum: ['provider_unavailable', 'not_pulled'], example: null),
                         ]
                     )
                 ),

--- a/backend/src/Controller/ConfigController.php
+++ b/backend/src/Controller/ConfigController.php
@@ -3,12 +3,14 @@
 namespace App\Controller;
 
 use App\AI\Credential\ChatReadinessService;
+use App\AI\Credential\ProviderKeyStore;
 use App\AI\Credential\SecretValueGuard;
 use App\AI\Interface\ProviderMetadataInterface;
 use App\AI\Service\AiProviderDisclosure;
 use App\AI\Service\ProviderRegistry;
 use App\Entity\Config;
 use App\Entity\User;
+use App\Model\ModelCatalog;
 use App\Repository\ConfigRepository;
 use App\Repository\ModelRepository;
 use App\Service\Auth\DemoLoginHint;
@@ -739,9 +741,16 @@ class ConfigController extends AbstractController
     #[OA\Get(
         path: '/api/v1/config/models',
         summary: 'Get all available AI models',
-        description: 'Returns list of all active models grouped by capability (CHAT, IMAGE, SORT, etc.)',
+        description: 'Returns active models grouped by capability (CHAT, IMAGE, SORT, etc.), restricted to models whose provider is available on this installation (API key / URL configured; Ollama models must be pulled). Admins can pass includeUnavailable=1 to also receive models of unconfigured providers, flagged via available/unavailableReason, e.g. to grey them out.',
         security: [['Bearer' => []]],
         tags: ['Configuration']
+    )]
+    #[OA\Parameter(
+        name: 'includeUnavailable',
+        description: 'Admin only (silently ignored otherwise): also return models whose provider is not configured, flagged with available=false.',
+        in: 'query',
+        required: false,
+        schema: new OA\Schema(type: 'boolean', default: false)
     )]
     #[OA\Response(
         response: 200,
@@ -763,20 +772,42 @@ class ConfigController extends AbstractController
                                     new OA\Property(property: 'name', type: 'string', example: 'Qwen 3.6 27B'),
                                     new OA\Property(property: 'quality', type: 'integer', example: 9),
                                     new OA\Property(property: 'features', type: 'array', items: new OA\Items(type: 'string', example: 'reasoning')),
+                                    new OA\Property(property: 'available', type: 'boolean', example: true, description: 'False only in the admin includeUnavailable view: the provider has no key/URL, or the Ollama model is not pulled.'),
+                                    new OA\Property(property: 'unavailableReason', type: 'string', nullable: true, enum: ['provider_unavailable', 'not_pulled'], example: null),
                                 ]
                             )
                         ),
                     ]
                 ),
+                new OA\Property(
+                    property: 'providers',
+                    type: 'array',
+                    description: 'Availability of every registered AI provider on this installation (internal test provider excluded).',
+                    items: new OA\Items(
+                        properties: [
+                            new OA\Property(property: 'name', type: 'string', example: 'groq'),
+                            new OA\Property(property: 'displayName', type: 'string', example: 'Groq'),
+                            new OA\Property(property: 'available', type: 'boolean', example: true),
+                            new OA\Property(property: 'requiresKey', type: 'boolean', description: 'True for cloud providers configured via a platform API key (the key wizard set); false for URL/local providers like Ollama or custom OpenAI-compatible endpoints.', example: true),
+                        ]
+                    )
+                ),
             ]
         )
     )]
     #[OA\Response(response: 401, description: 'Not authenticated')]
-    public function getModels(#[CurrentUser] ?User $user): JsonResponse
+    public function getModels(Request $request, #[CurrentUser] ?User $user): JsonResponse
     {
         if (!$user) {
             return $this->json(['error' => 'Not authenticated'], Response::HTTP_UNAUTHORIZED);
         }
+
+        // Unavailable models are HIDDEN from regular users — they could not be
+        // used anyway. Admin views request them explicitly to grey them out.
+        $includeUnavailable = $request->query->getBoolean('includeUnavailable')
+            && $this->isGranted('ROLE_ADMIN');
+
+        $availability = $this->chatReadiness->providerAvailability();
 
         $models = $this->modelRepository->findBy(
             ['active' => 1],
@@ -789,6 +820,12 @@ class ConfigController extends AbstractController
             if ($model->isHiddenBecauseFree()) {
                 continue;
             }
+
+            ['available' => $available, 'reason' => $unavailableReason] = $this->chatReadiness->modelAvailability($model->getService(), $model->getProviderId(), $availability);
+            if (!$available && !$includeUnavailable) {
+                continue;
+            }
+
             $modelList[] = [
                 'id' => $model->getId(),
                 'service' => $model->getService(),
@@ -802,6 +839,8 @@ class ConfigController extends AbstractController
                 'features' => $model->getFeatures(),
                 'priceIn' => $model->getPriceIn(),
                 'priceOut' => $model->getPriceOut(),
+                'available' => $available,
+                'unavailableReason' => $unavailableReason,
             ];
         }
 
@@ -892,9 +931,25 @@ class ConfigController extends AbstractController
             }
         }
 
+        $providers = [];
+        foreach ($this->providerRegistry->getUniqueProviders() as $name => $provider) {
+            $key = ModelCatalog::normalizeProvider((string) $name);
+            if ('test' === $key) {
+                continue;
+            }
+            $providers[] = [
+                'name' => $key,
+                'displayName' => $provider->getDisplayName(),
+                'available' => $availability[$key] ?? false,
+                'requiresKey' => ProviderKeyStore::isSupported($key),
+            ];
+        }
+        usort($providers, static fn (array $a, array $b): int => strcasecmp($a['displayName'], $b['displayName']));
+
         return $this->json([
             'success' => true,
             'models' => $grouped,
+            'providers' => $providers,
         ]);
     }
 

--- a/backend/src/Service/Admin/AdminModelsService.php
+++ b/backend/src/Service/Admin/AdminModelsService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Service\Admin;
 
+use App\AI\Credential\ChatReadinessService;
 use App\Entity\Model;
 use App\Entity\ModelPriceHistory;
 use App\Repository\ConfigRepository;
@@ -20,6 +21,7 @@ final readonly class AdminModelsService
         private ModelImportService $importService,
         private ModelSqlValidator $sqlValidator,
         private ModelPriceHistoryRepository $priceHistoryRepository,
+        private ChatReadinessService $chatReadiness,
     ) {
     }
 
@@ -217,6 +219,11 @@ final readonly class AdminModelsService
      */
     public function serializeModel(Model $model): array
     {
+        // The admin catalog shows every row, so it carries the availability
+        // verdict per row — the UI greys unavailable providers out and badges
+        // Ollama models that are not pulled instead of hiding anything.
+        $availability = $this->chatReadiness->modelAvailability($model->getService(), $model->getProviderId());
+
         return [
             'id' => $model->getId(),
             'service' => $model->getService(),
@@ -235,6 +242,8 @@ final readonly class AdminModelsService
             'json' => $model->getJson(),
             'isSystemModel' => $model->isSystemModel(),
             'showWhenFree' => $model->getShowWhenFree(),
+            'providerAvailable' => $availability['available'],
+            'unavailableReason' => $availability['reason'],
         ];
     }
 

--- a/backend/tests/Controller/AdminModelsControllerAvailabilityTest.php
+++ b/backend/tests/Controller/AdminModelsControllerAvailabilityTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Controller;
+
+use App\Entity\User;
+use App\Tests\Trait\AuthenticatedTestTrait;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+/**
+ * The admin catalog never hides rows — it flags them: every serialized model
+ * carries the availability verdict so the UI can grey unavailable providers
+ * and badge unpulled Ollama models.
+ */
+final class AdminModelsControllerAvailabilityTest extends WebTestCase
+{
+    use AuthenticatedTestTrait;
+
+    private KernelBrowser $client;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+    }
+
+    private function loginAs(string $mail): void
+    {
+        $em = static::getContainer()->get(EntityManagerInterface::class);
+        $user = $em->getRepository(User::class)->findOneBy(['mail' => $mail]);
+        if (!$user) {
+            self::markTestSkipped("Fixture user $mail not found. Run fixtures first.");
+        }
+
+        $this->authenticateClient($this->client, $user);
+    }
+
+    public function testEveryRowCarriesTheAvailabilityVerdict(): void
+    {
+        $this->loginAs('admin@synaplan.com');
+
+        $this->client->request('GET', '/api/v1/admin/models');
+        self::assertResponseIsSuccessful();
+
+        $data = json_decode((string) $this->client->getResponse()->getContent(), true);
+        self::assertIsArray($data);
+        self::assertTrue($data['success']);
+        self::assertNotEmpty($data['models']);
+
+        foreach ($data['models'] as $row) {
+            self::assertArrayHasKey('providerAvailable', $row);
+            self::assertIsBool($row['providerAvailable']);
+            if ($row['providerAvailable']) {
+                self::assertNull($row['unavailableReason']);
+            } else {
+                self::assertContains($row['unavailableReason'], ['provider_unavailable', 'not_pulled']);
+            }
+        }
+    }
+
+    public function testRegularUsersGetNoAdminCatalog(): void
+    {
+        $this->loginAs('demo@synaplan.com');
+
+        $this->client->request('GET', '/api/v1/admin/models');
+        self::assertResponseStatusCodeSame(403);
+    }
+}

--- a/backend/tests/Controller/ConfigControllerModelsTest.php
+++ b/backend/tests/Controller/ConfigControllerModelsTest.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Controller;
+
+use App\Entity\User;
+use App\Tests\Trait\AuthenticatedTestTrait;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+/**
+ * /api/v1/config/models is availability-filtered: regular users only ever see
+ * models whose provider is configured on this installation, admins can opt in
+ * to the full list with unavailable rows flagged.
+ *
+ * Which providers hold credentials depends on the environment the suite runs
+ * in, so the assertions are structural (the response must be self-consistent)
+ * rather than pinning concrete providers.
+ */
+final class ConfigControllerModelsTest extends WebTestCase
+{
+    use AuthenticatedTestTrait;
+
+    private KernelBrowser $client;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+    }
+
+    private function loginAs(string $mail): void
+    {
+        $em = static::getContainer()->get(EntityManagerInterface::class);
+        $user = $em->getRepository(User::class)->findOneBy(['mail' => $mail]);
+        if (!$user) {
+            self::markTestSkipped("Fixture user $mail not found. Run fixtures first.");
+        }
+
+        $this->authenticateClient($this->client, $user);
+    }
+
+    /**
+     * The provider entries are deliberately untyped ("array<string, mixed>"):
+     * the tests assert their shape at runtime, which PHPStan would otherwise
+     * flag as always-true.
+     *
+     * @return array{models: array<string, list<array<string, mixed>>>, providers: list<array<string, mixed>>}
+     */
+    private function fetchModels(string $query = ''): array
+    {
+        $this->client->request('GET', '/api/v1/config/models'.$query);
+        self::assertResponseIsSuccessful();
+
+        $data = json_decode((string) $this->client->getResponse()->getContent(), true);
+        self::assertIsArray($data);
+        self::assertTrue($data['success']);
+        self::assertArrayHasKey('models', $data);
+        self::assertArrayHasKey('providers', $data);
+
+        return $data;
+    }
+
+    /** @return list<array<string, mixed>> every model row across all capabilities */
+    private static function allRows(array $data): array
+    {
+        $rows = [];
+        foreach ($data['models'] as $capabilityRows) {
+            foreach ($capabilityRows as $row) {
+                $rows[] = $row;
+            }
+        }
+
+        return $rows;
+    }
+
+    public function testRegularUsersOnlySeeAvailableModels(): void
+    {
+        $this->loginAs('demo@synaplan.com');
+        $data = $this->fetchModels();
+
+        foreach (self::allRows($data) as $row) {
+            self::assertTrue($row['available'], sprintf('Model "%s" (%s) is unavailable and must be hidden from regular users.', $row['name'], $row['service']));
+            self::assertNull($row['unavailableReason']);
+        }
+    }
+
+    public function testIncludeUnavailableIsSilentlyIgnoredForRegularUsers(): void
+    {
+        $this->loginAs('demo@synaplan.com');
+        $data = $this->fetchModels('?includeUnavailable=1');
+
+        foreach (self::allRows($data) as $row) {
+            self::assertTrue($row['available'], 'A regular user must never receive unavailable models, even when asking for them.');
+        }
+    }
+
+    public function testAdminIncludeUnavailableFlagsEveryRowConsistently(): void
+    {
+        $this->loginAs('admin@synaplan.com');
+        $filtered = $this->fetchModels();
+        $full = $this->fetchModels('?includeUnavailable=1');
+
+        self::assertGreaterThanOrEqual(
+            count(self::allRows($filtered)),
+            count(self::allRows($full)),
+            'The unfiltered admin view can never contain fewer rows than the filtered one.'
+        );
+
+        foreach (self::allRows($full) as $row) {
+            self::assertIsBool($row['available']);
+            if ($row['available']) {
+                self::assertNull($row['unavailableReason']);
+            } else {
+                self::assertContains($row['unavailableReason'], ['provider_unavailable', 'not_pulled']);
+            }
+        }
+    }
+
+    public function testProvidersBlockListsRegisteredProvidersWithoutTheTestFixture(): void
+    {
+        $this->loginAs('demo@synaplan.com');
+        $data = $this->fetchModels();
+
+        self::assertNotEmpty($data['providers']);
+        foreach ($data['providers'] as $provider) {
+            self::assertNotSame('test', $provider['name']);
+            self::assertIsString($provider['displayName']);
+            self::assertNotSame('', $provider['displayName']);
+            self::assertIsBool($provider['available']);
+            self::assertIsBool($provider['requiresKey']);
+        }
+
+        // The key wizard set must be flagged as key-based — the frontend uses
+        // this to gate "Select suggested models" on "all keys present".
+        $requiresKey = array_column($data['providers'], 'requiresKey', 'name');
+        foreach (['anthropic', 'openai', 'groq', 'google'] as $keyProvider) {
+            if (array_key_exists($keyProvider, $requiresKey)) {
+                self::assertTrue((bool) $requiresKey[$keyProvider], "$keyProvider must report requiresKey=true");
+            }
+        }
+        if (array_key_exists('ollama', $requiresKey)) {
+            self::assertFalse((bool) $requiresKey['ollama'], 'ollama is URL-based, not key-based');
+        }
+    }
+
+    public function testVisibleModelsBelongToAvailableProviders(): void
+    {
+        $this->loginAs('demo@synaplan.com');
+        $data = $this->fetchModels();
+
+        $availability = [];
+        foreach ($data['providers'] as $provider) {
+            $availability[(string) $provider['name']] = (bool) $provider['available'];
+        }
+
+        foreach (self::allRows($data) as $row) {
+            $service = strtolower((string) $row['service']);
+            // Ollama rows are judged per pulled model, not per provider — the
+            // provider flag additionally requires the default chat model.
+            if ('ollama' === $service || !array_key_exists($service, $availability)) {
+                continue;
+            }
+
+            self::assertTrue(
+                $availability[$service],
+                sprintf('Model "%s" is visible although its provider "%s" reports unavailable.', $row['name'], $service)
+            );
+        }
+    }
+}

--- a/frontend/src/components/config/AIModelsAdminPanel.vue
+++ b/frontend/src/components/config/AIModelsAdminPanel.vue
@@ -233,12 +233,40 @@
               </template>
 
               <template v-else>
-                <td class="py-2 px-2 txt-primary text-xs">{{ m.service }}</td>
-                <td class="py-2 px-2 txt-primary text-xs">{{ m.tag }}</td>
-                <td class="py-2 px-2 txt-primary text-xs max-w-56 truncate" :title="m.providerId">
+                <td
+                  :class="['py-2 px-2 txt-primary text-xs', !m.providerAvailable && 'opacity-50']"
+                >
+                  {{ m.service }}
+                </td>
+                <td
+                  :class="['py-2 px-2 txt-primary text-xs', !m.providerAvailable && 'opacity-50']"
+                >
+                  {{ m.tag }}
+                </td>
+                <td
+                  :class="[
+                    'py-2 px-2 txt-primary text-xs max-w-56 truncate',
+                    !m.providerAvailable && 'opacity-50',
+                  ]"
+                  :title="m.providerId"
+                >
                   {{ m.providerId }}
                 </td>
-                <td class="py-2 px-2 txt-primary text-xs font-medium">{{ m.name }}</td>
+                <td class="py-2 px-2 text-xs font-medium">
+                  <div class="flex items-center gap-1.5">
+                    <span :class="['txt-primary', !m.providerAvailable && 'opacity-50']">
+                      {{ m.name }}
+                    </span>
+                    <span
+                      v-if="!m.providerAvailable"
+                      class="pill text-[10px] whitespace-nowrap"
+                      :title="availabilityTooltip(m)"
+                      data-testid="badge-model-unavailable"
+                    >
+                      {{ availabilityBadge(m) }}
+                    </span>
+                  </div>
+                </td>
                 <td class="py-2 px-2 text-center">
                   <span
                     class="inline-block w-2 h-2 rounded-full"
@@ -559,6 +587,23 @@ const paginatedAdminModels = computed(() => {
 watch(adminSearch, () => {
   adminPage.value = 1
 })
+
+/**
+ * Unavailable rows stay in the catalog (never deleted) but are greyed and
+ * badged so the admin sees WHY users don't get them: missing provider
+ * credentials, or an Ollama model that is not pulled yet.
+ */
+function availabilityBadge(m: AdminModel): string {
+  return m.unavailableReason === 'not_pulled'
+    ? t('config.aiModels.admin.availability.notPulled')
+    : t('config.aiModels.admin.availability.providerUnavailable')
+}
+
+function availabilityTooltip(m: AdminModel): string {
+  return m.unavailableReason === 'not_pulled'
+    ? t('config.aiModels.admin.availability.notPulledTooltip')
+    : t('config.aiModels.admin.availability.providerUnavailableTooltip')
+}
 
 function startEdit(m: AdminModel) {
   editingId.value = m.id

--- a/frontend/src/components/config/AIModelsConfiguration.vue
+++ b/frontend/src/components/config/AIModelsConfiguration.vue
@@ -8,8 +8,11 @@
     >
       <!-- Reset applies to the default-model choices, so it only shows on that tab.
            v-if on the template keeps PageHeader's actions wrapper (and its flex gap)
-           from rendering empty on the other tabs. -->
-      <template v-if="activeTab === 'choice'" #actions>
+           from rendering empty on the other tabs.
+           The suggested selection spans every provider in the catalog, so the
+           button is hidden unless ALL providers have credentials — otherwise it
+           would point defaults at models this installation cannot use. -->
+      <template v-if="activeTab === 'choice' && allProvidersAvailable" #actions>
         <button
           type="button"
           class="inline-flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium border border-light-border/30 dark:border-dark-border/20 txt-secondary hover:txt-primary hover:border-[var(--brand)]/50 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
@@ -505,7 +508,7 @@ import {
 import { adminEmbeddingApi, type EmbeddingGuardStatus } from '@/services/api/adminEmbeddingApi'
 import { ApiError } from '@/services/api/httpClient'
 import { useAuthStore } from '@/stores/auth'
-import type { AIModel, Capability } from '@/types/ai-models'
+import type { AIModel, Capability, ProviderAvailability } from '@/types/ai-models'
 import {
   dedupeModelsByPurpose,
   type ModelWithPurposes,
@@ -621,6 +624,17 @@ const loading = ref(false)
 const saving = ref(false)
 const resetting = ref(false)
 const availableModels = ref<ModelsData>({})
+const providers = ref<ProviderAvailability[]>([])
+
+// "Select suggested models" applies the seeded recommendation, which spans
+// the cloud providers. Only offer it when ALL key-based providers have keys
+// (empty = not loaded yet, treat as unavailable). URL/local providers like
+// Ollama or custom endpoints don't count: they are optional extras that most
+// installations never configure, and the suggestion does not depend on them.
+const allProvidersAvailable = computed(() => {
+  const keyProviders = providers.value.filter((p) => p.requiresKey)
+  return keyProviders.length > 0 && keyProviders.every((p) => p.available)
+})
 const defaultConfig = ref<Record<Capability, number | null>>({
   SORT: null,
   CHAT: null,
@@ -820,6 +834,7 @@ const loadData = async () => {
 
     if (modelsRes.success) {
       availableModels.value = modelsRes.models
+      providers.value = modelsRes.providers ?? []
     }
 
     if (defaultsRes.success) {

--- a/frontend/src/components/config/AIModelsConfiguration.vue
+++ b/frontend/src/components/config/AIModelsConfiguration.vue
@@ -9,9 +9,10 @@
       <!-- Reset applies to the default-model choices, so it only shows on that tab.
            v-if on the template keeps PageHeader's actions wrapper (and its flex gap)
            from rendering empty on the other tabs.
-           The suggested selection spans every provider in the catalog, so the
-           button is hidden unless ALL providers have credentials — otherwise it
-           would point defaults at models this installation cannot use. -->
+           The suggested selection spans the key-based cloud providers, so the
+           button is hidden unless every requiresKey provider has credentials —
+           otherwise it would point defaults at models this install cannot use.
+           URL/local providers (Ollama, custom endpoints) do not count. -->
       <template v-if="activeTab === 'choice' && allProvidersAvailable" #actions>
         <button
           type="button"

--- a/frontend/src/components/config/TaskPromptsConfiguration.vue
+++ b/frontend/src/components/config/TaskPromptsConfiguration.vue
@@ -1192,7 +1192,7 @@ import {
 } from '@/services/api/promptsApi'
 import { configApi } from '@/services/api/configApi'
 import type { AIModel, Capability } from '@/types/ai-models'
-import { findModelIdByString } from '@/utils/aiModelDefaults'
+import { resolveModelIdForSave } from '@/utils/aiModelDefaults'
 import {
   type InternetSearchMode,
   internetModeFromMetadata,
@@ -1857,10 +1857,19 @@ const handleSave = saveChanges(async () => {
   try {
     const metadata: PromptMetadata = {}
 
+    // A pinned model whose provider is unavailable is missing from the picker
+    // list, so it loads as "default". Only an explicit change clears the pin —
+    // otherwise merely opening and saving a prompt would drop it.
+    const pinnedModelId = currentPrompt.value.metadata?.aiModel
     if (formData.value.aiModel === 'default' || !formData.value.aiModel) {
-      metadata.aiModel = 0
+      metadata.aiModel =
+        originalData.value.aiModel === formData.value.aiModel ? (pinnedModelId ?? 0) : 0
     } else {
-      metadata.aiModel = findModelIdByString(allModels.value, formData.value.aiModel)
+      metadata.aiModel = resolveModelIdForSave(
+        allModels.value,
+        formData.value.aiModel,
+        pinnedModelId
+      )
     }
 
     metadata.tool_files = (formData.value.availableTools || []).includes('files-search')

--- a/frontend/src/components/widgets/AdvancedWidgetConfig.vue
+++ b/frontend/src/components/widgets/AdvancedWidgetConfig.vue
@@ -1891,7 +1891,7 @@ import * as widgetsApi from '@/services/api/widgetsApi'
 import { promptsApi, type AvailableFile } from '@/services/api/promptsApi'
 import { configApi } from '@/services/api/configApi'
 import type { AIModel, Capability } from '@/types/ai-models'
-import { DEFAULT_AI_MODEL, findModelIdByString } from '@/utils/aiModelDefaults'
+import { DEFAULT_AI_MODEL, resolveModelIdForSave } from '@/utils/aiModelDefaults'
 import FilePicker from './FilePicker.vue'
 import WidgetSummaryPromptTab from './WidgetSummaryPromptTab.vue'
 import { parsePromptAndRulesBlock } from '@/utils/widgetBehaviorRules'
@@ -2554,9 +2554,10 @@ const removeDomain = (domain: string) => {
 const handleSave = async () => {
   saving.value = true
   try {
-    // Resolve AI model ID from the selected model string
+    // Resolve AI model ID from the selected model string, keeping the stored
+    // pin when its provider is unavailable (then it is not in the picker list).
     const resolvedModelId = hasCustomPrompt.value
-      ? findModelIdByString(allModels.value, promptData.aiModel)
+      ? resolveModelIdForSave(allModels.value, promptData.aiModel, existingMetadata.value.aiModel)
       : -1
 
     // Include custom fields and AI model ID in config for saving
@@ -2899,7 +2900,11 @@ const savePromptData = async () => {
 
   const metadata: Record<string, unknown> = { ...existingMetadata.value }
 
-  metadata.aiModel = findModelIdByString(allModels.value, promptData.aiModel)
+  metadata.aiModel = resolveModelIdForSave(
+    allModels.value,
+    promptData.aiModel,
+    existingMetadata.value.aiModel
+  )
 
   let finalContent = removeKnowledgeBaseSection(manualPromptContent.value)
   finalContent += buildKnowledgeBaseSection()

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -1587,6 +1587,12 @@
         "showWhenFreeTooltip": "Modell in der Auswahl anzeigen, auch wenn Preis ein und Preis aus beide 0 sind (kostenlos)",
         "showWhenFreeOn": "Override aktiv: Modell sichtbar, auch wenn beide Preise 0 sind",
         "showWhenFreeOff": "Standard: Modell wird ausgeblendet, wenn beide Preise 0 sind",
+        "availability": {
+          "providerUnavailable": "Anbieter nicht konfiguriert",
+          "providerUnavailableTooltip": "Für diesen KI-Anbieter ist auf dieser Installation kein API-Schlüssel bzw. keine Server-URL hinterlegt. Nutzer sehen dieses Modell erst, wenn der Anbieter konfiguriert ist.",
+          "notPulled": "Nicht heruntergeladen",
+          "notPulledTooltip": "Dieses Modell ist auf dem lokalen Ollama-Server noch nicht heruntergeladen. Nutzer sehen es erst, wenn es geladen wurde."
+        },
         "actions": "Aktionen",
         "edit": "Bearbeiten",
         "save": "Speichern",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -1501,6 +1501,12 @@
         "showWhenFreeTooltip": "Show model in selection even when both price in and price out are 0 (free)",
         "showWhenFreeOn": "Override active: model visible even when both prices are 0",
         "showWhenFreeOff": "Default: model hidden when both prices are 0",
+        "availability": {
+          "providerUnavailable": "Provider not configured",
+          "providerUnavailableTooltip": "This AI provider has no API key or server URL on this installation. Users don't see this model until the provider is configured.",
+          "notPulled": "Not pulled",
+          "notPulledTooltip": "This model is not downloaded on the local Ollama server yet. Users don't see it until it is pulled."
+        },
         "actions": "Actions",
         "edit": "Edit",
         "save": "Save",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -2742,6 +2742,12 @@
       },
       "admin": {
         "catalogSubtitle": "Busca y edita el catálogo de modelos del sistema.",
+        "availability": {
+          "providerUnavailable": "Proveedor no configurado",
+          "providerUnavailableTooltip": "Este proveedor de IA no tiene clave de API ni URL de servidor en esta instalación. Los usuarios no verán este modelo hasta que el proveedor esté configurado.",
+          "notPulled": "No descargado",
+          "notPulledTooltip": "Este modelo aún no está descargado en el servidor local de Ollama. Los usuarios no lo verán hasta que se descargue."
+        },
         "bulkImportSubtitle": "Genera y aplica SQL desde la documentación del proveedor (avanzado).",
         "addModels": "Importación masiva (SQL)",
         "failedCreate": "No se pudo crear el modelo",

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -2743,6 +2743,12 @@
       },
       "admin": {
         "catalogSubtitle": "Sistem model kataloğunu arayın ve düzenleyin.",
+        "availability": {
+          "providerUnavailable": "Sağlayıcı yapılandırılmamış",
+          "providerUnavailableTooltip": "Bu yapay zeka sağlayıcısı için bu kurulumda API anahtarı veya sunucu URL'si yok. Sağlayıcı yapılandırılana kadar kullanıcılar bu modeli görmez.",
+          "notPulled": "İndirilmemiş",
+          "notPulledTooltip": "Bu model yerel Ollama sunucusuna henüz indirilmedi. İndirilene kadar kullanıcılar bu modeli görmez."
+        },
         "bulkImportSubtitle": "Sağlayıcı belgelerinden SQL oluşturup uygulayın (gelişmiş).",
         "addModels": "Toplu içe aktarma (SQL)",
         "failedCreate": "Model oluşturulamadı",

--- a/frontend/src/services/api/adminModelsApi.ts
+++ b/frontend/src/services/api/adminModelsApi.ts
@@ -1,3 +1,4 @@
+import type { ModelUnavailableReason } from '@/types/ai-models'
 import { httpClient } from './httpClient'
 
 export interface AdminModel {
@@ -18,6 +19,9 @@ export interface AdminModel {
   json: Record<string, unknown>
   isSystemModel: boolean
   showWhenFree: number
+  /** False when the provider lacks credentials or the Ollama model is not pulled — the row is hidden from users. */
+  providerAvailable: boolean
+  unavailableReason: ModelUnavailableReason | null
 }
 
 export interface AdminModelsListResponse {

--- a/frontend/src/services/api/configApi.ts
+++ b/frontend/src/services/api/configApi.ts
@@ -1,10 +1,12 @@
-import type { AIModel, Capability } from '@/types/ai-models'
+import type { AIModel, Capability, ProviderAvailability } from '@/types/ai-models'
 import { httpClient } from './httpClient'
 import { z } from 'zod'
 
 export interface ModelsResponse {
   success: boolean
   models: Partial<Record<Capability, AIModel[]>>
+  /** Provider-level availability of this installation (key/URL configured). */
+  providers: ProviderAvailability[]
 }
 
 export interface DefaultsResponse {

--- a/frontend/src/types/ai-models.ts
+++ b/frontend/src/types/ai-models.ts
@@ -18,6 +18,13 @@ export type Capability =
   | 'TEXT2SOUND'
   | 'ANALYZE'
 
+/**
+ * Why a model cannot be used on this installation:
+ * - provider_unavailable: the provider has no API key / base URL configured
+ * - not_pulled: the Ollama model is not pulled on the local server
+ */
+export type ModelUnavailableReason = 'provider_unavailable' | 'not_pulled'
+
 export interface AIModel {
   id: number
   service: string
@@ -32,6 +39,18 @@ export interface AIModel {
   description: string | null
   isSystemModel: boolean
   features: string[]
+  /** Only false in admin views requested with includeUnavailable; regular responses contain available models only. */
+  available?: boolean
+  unavailableReason?: ModelUnavailableReason | null
+}
+
+/** Per-provider availability of this installation, from /config/models. */
+export interface ProviderAvailability {
+  name: string
+  displayName: string
+  available: boolean
+  /** True for cloud providers configured via a platform API key; false for URL/local providers (Ollama, custom endpoints). */
+  requiresKey: boolean
 }
 
 export interface AgainData {

--- a/frontend/src/utils/aiModelDefaults.ts
+++ b/frontend/src/utils/aiModelDefaults.ts
@@ -20,3 +20,25 @@ export function findModelIdByString(
 export function findDefaultModelId(models: Partial<Record<Capability, AIModel[]>>): number {
   return findModelIdByString(models, DEFAULT_AI_MODEL)
 }
+
+/**
+ * Model id to persist for a picked display string, keeping `storedId` when the
+ * string cannot be resolved.
+ *
+ * `/config/models` omits models whose provider is unavailable on this
+ * installation, so a pinned model can be absent from `models` and its
+ * `name (service)` string unresolvable. Without the fallback the save would
+ * replace the pin with the "no model" sentinel and lose the configuration.
+ */
+export function resolveModelIdForSave(
+  models: Partial<Record<Capability, AIModel[]>>,
+  modelString: string,
+  storedId: unknown
+): number {
+  const resolved = findModelIdByString(models, modelString)
+  if (resolved > 0) {
+    return resolved
+  }
+
+  return typeof storedId === 'number' && storedId > 0 ? storedId : resolved
+}

--- a/frontend/tests/e2e/helpers/selectors.ts
+++ b/frontend/tests/e2e/helpers/selectors.ts
@@ -128,6 +128,7 @@ export const selectors = {
     capabilityItem: '[data-testid="item-capability"]',
     capabilityDropdown: '[data-testid="btn-model-dropdown"]',
     capabilityOption: '[data-testid="btn-model-option"]',
+    resetDefaults: '[data-testid="btn-reset-defaults"]',
   },
   rag: {
     page: '[data-testid="page-rag-search"]',

--- a/frontend/tests/e2e/tests/layout.spec.ts
+++ b/frontend/tests/e2e/tests/layout.spec.ts
@@ -331,12 +331,19 @@ test.describe('@ci @layout UI guard — key pages', () => {
     await expect(page.locator(selectors.models.page)).toBeVisible({ timeout: TIMEOUTS.STANDARD })
     await expectNoHorizontalOverflow(page, 'ai models')
 
-    // §2.8 B1: the "reset defaults" header button used to overflow the card
-    // on ~390px viewports. It must render fully inside the viewport.
-    const resetBtn = page.locator(selectors.inboundConfig.resetDefaults)
-    await expect(resetBtn).toBeVisible({ timeout: TIMEOUTS.STANDARD })
-    await resetBtn.scrollIntoViewIfNeeded()
-    await expectInsideViewport(page, selectors.inboundConfig.resetDefaults, 'reset-defaults button')
+    // Wait for the catalog so the suggested-models button can appear.
+    await expect(page.locator(selectors.models.capabilityItem).first()).toBeVisible({
+      timeout: TIMEOUTS.STANDARD,
+    })
+
+    // §2.8 B1: when "Select suggested models" is shown, it must stay inside
+    // the viewport on ~390px. The button is hidden unless every key-based
+    // provider has credentials (the CI E2E stack typically does not).
+    const resetBtn = page.locator(selectors.models.resetDefaults)
+    if (await resetBtn.isVisible()) {
+      await resetBtn.scrollIntoViewIfNeeded()
+      await expectInsideViewport(page, selectors.models.resetDefaults, 'reset-defaults button')
+    }
   })
 
   test('login page has no overflow and reachable submit', async ({ page }) => {

--- a/frontend/tests/unit/utils/aiModelDefaults.spec.ts
+++ b/frontend/tests/unit/utils/aiModelDefaults.spec.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import { findModelIdByString, resolveModelIdForSave } from '@/utils/aiModelDefaults'
+import type { AIModel, Capability } from '@/types/ai-models'
+
+function model(id: number, name: string, service: string): AIModel {
+  return {
+    id,
+    name,
+    service,
+    tag: name.toLowerCase(),
+    providerId: `${service.toLowerCase()}/${name.toLowerCase()}`,
+    quality: 8,
+    rating: 4,
+    priceIn: 0,
+    priceOut: 0,
+    description: null,
+    isSystemModel: false,
+    features: [],
+  }
+}
+
+const models: Partial<Record<Capability, AIModel[]>> = {
+  CHAT: [model(9, 'gpt-oss-120b', 'Groq')],
+}
+
+describe('resolveModelIdForSave', () => {
+  it('resolves a model string that is present in the list', () => {
+    expect(resolveModelIdForSave(models, 'gpt-oss-120b (Groq)', 249)).toBe(9)
+  })
+
+  /**
+   * /config/models hides models whose provider is unavailable, so a pinned
+   * model can be absent from the picker. Saving must not clear the pin.
+   */
+  it('keeps the stored id when the model string cannot be resolved', () => {
+    expect(findModelIdByString(models, 'Claude Sonnet 5 (Anthropic)')).toBe(-1)
+    expect(resolveModelIdForSave(models, 'Claude Sonnet 5 (Anthropic)', 249)).toBe(249)
+  })
+
+  it('falls back to the unresolved sentinel when nothing was pinned', () => {
+    expect(resolveModelIdForSave(models, 'Claude Sonnet 5 (Anthropic)', 0)).toBe(-1)
+    expect(resolveModelIdForSave(models, 'Claude Sonnet 5 (Anthropic)', undefined)).toBe(-1)
+  })
+})


### PR DESCRIPTION
Part of #1586 (PR B of the plan).

## Summary
- `GET /api/v1/config/models` only returns models whose provider is available on this installation (API key / URL configured; Ollama models must be pulled). Regular users never see the rest.
- Admins can pass `includeUnavailable=1` to receive the full catalog, each row flagged with `available` / `unavailableReason` (`provider_unavailable` or `not_pulled`).
- The admin catalog (`GET /api/v1/admin/models`) always returns every row with `providerAvailable` + `unavailableReason` so the UI can grey unavailable entries and badge them.
- The response includes a `providers` block (`name`, `displayName`, `available`, `requiresKey`) so the frontend can hide **Select suggested models** unless every key-based cloud provider has a key. URL/local providers (Ollama, custom endpoints) do not count.
- Chat picker and settings dropdowns inherit the filtered list. Admin Edit Models greys rows and shows "Provider not configured" / "Not pulled".

Does **not** un-freeze existing per-user `DEFAULTMODEL` rows (Claude/Gemini leftovers) — that is PR C. Does **not** add local Whisper — that is PR D.

## Test plan
- [x] `make -C backend lint` — clean
- [x] `make -C backend phpstan` — no errors
- [x] `make -C backend test` — 4093 tests
- [x] `docker compose exec -T frontend npm run check:types`
- [x] `make -C frontend lint` / `make -C frontend test` — 1276 tests
- [x] Browser: suggested-models button hidden when not all keys; admin catalog badges; picker uses filtered list