### PR TITLE
feat(models): stop freezing per-user defaults on registration

### DIFF
--- a/backend/config/services.yaml
+++ b/backend/config/services.yaml
@@ -654,7 +654,6 @@ services:
     App\Service\ModelConfigService:
         arguments:
             $cache: '@cache.model_config'
-            $environment: '%kernel.environment%'
 
     # Shares the model_config pool so applying provider defaults invalidates
     # the same cached lookups ModelConfigService serves from.

--- a/backend/src/Controller/ConfigController.php
+++ b/backend/src/Controller/ConfigController.php
@@ -1207,15 +1207,15 @@ class ConfigController extends AbstractController
      * Replace the calling user's model configuration with the
      * code-recommended defaults from DefaultModelConfigSeeder.
      *
-     * Removes stale per-user overrides and writes fresh ones that
-     * match the catalog-recommended models. Other users and the
-     * global (ownerId=0) row are unaffected.
+     * Removes stale per-user overrides and writes fresh ones that match the
+     * catalog-recommended models, skipping any whose provider is not usable
+     * here. Other users and the global (ownerId=0) row are unaffected.
      */
     #[Route('/models/defaults/reset', name: 'models_defaults_reset', methods: ['POST'])]
     #[OA\Post(
         path: '/api/v1/config/models/defaults/reset',
         summary: 'Apply recommended model defaults to own configuration',
-        description: 'Replaces all per-user DEFAULTMODEL overrides with the code-recommended defaults (from DefaultModelConfigSeeder). Does NOT modify global defaults — other users are unaffected. Returns the newly written defaults.',
+        description: 'Replaces all per-user DEFAULTMODEL overrides with the recommended defaults (from DefaultModelConfigSeeder) that are usable on this installation: a recommended model whose provider has no key is replaced by the first usable model for that capability, and nothing is written when no provider is usable at all. Does NOT modify global defaults — other users are unaffected. Returns the newly written defaults.',
         security: [['Bearer' => []]],
         tags: ['Configuration']
     )]

--- a/backend/src/Service/ModelConfigService.php
+++ b/backend/src/Service/ModelConfigService.php
@@ -869,6 +869,10 @@ final readonly class ModelConfigService
      * A recommended binding whose provider has no key is skipped; the
      * first usable model for that capability is written instead so
      * "Select suggested models" never points at a dead cloud row.
+     * When providers are registered but none have credentials, overrides
+     * are cleared and nothing is written — {@see isModelUsable()} treats
+     * an empty usable list as "cannot tell" and would otherwise re-freeze
+     * the seed catalog's cloud defaults.
      * VECTORIZE is system-wide (single Qdrant collection) and is never
      * written as a per-user override.
      *
@@ -883,6 +887,21 @@ final readonly class ModelConfigService
 
         $this->configRepository->removeAll($userOverrides);
         $removed = count($userOverrides);
+
+        if ([] !== $this->providerRegistry->getUniqueProviders()
+            && [] === $this->usableProviders()
+        ) {
+            $this->logger->debug('Skipping suggested-model writes: no provider is available', [
+                'user_id' => $userId,
+                'removed' => $removed,
+            ]);
+
+            return [
+                'removed' => $removed,
+                'written' => 0,
+                'defaults' => [],
+            ];
+        }
 
         try {
             $recommended = DefaultModelConfigSeeder::getRecommendedDefaults();

--- a/backend/src/Service/ModelConfigService.php
+++ b/backend/src/Service/ModelConfigService.php
@@ -395,13 +395,14 @@ final readonly class ModelConfigService
      * In test env, ConfigFixtures seeds global defaults pointing to TestProvider models.
      *
      * A per-user binding whose provider currently has no credentials is skipped
-     * in favour of the global default. {@see resetUserDefaults()} writes the
-     * code-recommended bindings when an account is created, without knowing
-     * which providers this install can actually reach, while the key-save path
-     * only ever repairs the global row. Installs that receive their first API
-     * key AFTER the first account exists — every App Store or appliance
-     * install, where the operator logs in before configuring anything — would
-     * otherwise keep routing that user at a provider they never configured.
+     * in favour of the global default. Accounts created before this became the
+     * behaviour still carry bindings that {@see resetUserDefaults()} wrote
+     * without knowing which providers this install can actually reach, while
+     * the key-save path only ever repairs the global row. Installs that receive
+     * their first API key AFTER the first account exists — every App Store or
+     * appliance install, where the operator logs in before configuring
+     * anything — would otherwise keep routing that user at a provider they
+     * never configured.
      * The override stays stored and takes effect again as soon as its provider
      * has credentials.
      *

--- a/backend/src/Service/ModelConfigService.php
+++ b/backend/src/Service/ModelConfigService.php
@@ -67,7 +67,6 @@ final readonly class ModelConfigService
         private OllamaModelInventory $ollamaModelInventory,
         private ModelHealthRepository $modelHealthRepository,
         private LoggerInterface $logger,
-        private string $environment = 'prod',
     ) {
     }
 
@@ -851,25 +850,25 @@ final readonly class ModelConfigService
     }
 
     /**
-     * Seed recommended model defaults for a newly registered user.
+     * New accounts do not receive frozen per-user DEFAULTMODEL rows.
      *
-     * Skipped in test environment so E2E/integration tests keep their
-     * global test defaults (negative BIDs → TestProvider) instead of
-     * receiving production model bindings that require real API keys.
+     * Global defaults (and the runtime fallback to the first usable model)
+     * apply until the user explicitly picks a model. Copying the seed
+     * catalog into every BUSER left air-gapped installs pointed at
+     * Claude/Gemini after the provider was never configured.
      */
     public function initializeNewUserDefaults(int $userId): void
     {
-        if ('test' === $this->environment) {
-            return;
-        }
-
-        $this->resetUserDefaults($userId);
+        $this->logger->debug('Skipping per-user default-model seed', ['user_id' => $userId]);
     }
 
     /**
-     * Replace per-user DEFAULTMODEL overrides with the code-recommended
-     * defaults from {@see DefaultModelConfigSeeder::getRecommendedDefaults()}.
+     * Replace per-user DEFAULTMODEL overrides with recommended defaults
+     * that are actually usable on this installation.
      *
+     * A recommended binding whose provider has no key is skipped; the
+     * first usable model for that capability is written instead so
+     * "Select suggested models" never points at a dead cloud row.
      * VECTORIZE is system-wide (single Qdrant collection) and is never
      * written as a per-user override.
      *
@@ -899,13 +898,14 @@ final readonly class ModelConfigService
                 continue;
             }
 
-            $model = $this->modelRepository->find($modelId);
-            if (!$model || 1 !== $model->getActive()) {
+            $chosen = $this->usableRecommendedModelId($modelId)
+                ?? $this->firstUsableModelForCapability($capability);
+            if (null === $chosen) {
                 continue;
             }
 
-            $this->configRepository->setValue($userId, 'DEFAULTMODEL', $capability, (string) $modelId);
-            $defaults[$capability] = $modelId;
+            $this->configRepository->setValue($userId, 'DEFAULTMODEL', $capability, (string) $chosen);
+            $defaults[$capability] = $chosen;
             ++$written;
         }
 
@@ -914,6 +914,16 @@ final readonly class ModelConfigService
             'written' => $written,
             'defaults' => $defaults,
         ];
+    }
+
+    private function usableRecommendedModelId(int $modelId): ?int
+    {
+        $model = $this->modelRepository->find($modelId);
+        if (!$model || !$this->isModelUsable($model)) {
+            return null;
+        }
+
+        return $modelId;
     }
 
     public function getModelTag(int $modelId): ?string

--- a/backend/src/Service/UserLifecycleService.php
+++ b/backend/src/Service/UserLifecycleService.php
@@ -13,8 +13,9 @@ use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
  * Central factory for BUSER rows.
  *
  * Every code path that creates a user account should go through createUser()
- * so entity defaults and post-create side effects (per-user default model
- * config) stay consistent. Deletion lives in {@see UserDeletionService};
+ * so entity defaults stay consistent. New accounts no longer receive frozen
+ * per-user DEFAULTMODEL rows — global defaults apply until the user picks.
+ * Deletion lives in {@see UserDeletionService};
  * together they form the user lifecycle.
  *
  * Current callers: AuthController::register(), AdminUserProvisioningService.
@@ -33,7 +34,7 @@ final readonly class UserLifecycleService
     }
 
     /**
-     * Create and persist a user, then seed per-user default model config.
+     * Create and persist a user. Default models stay global until the user picks.
      *
      * @param string               $email         login email (uniqueness must be checked by the caller,
      *                                            since the required conflict behavior differs per flow)

--- a/backend/tests/Unit/AI/Credential/ChatReadinessServiceTest.php
+++ b/backend/tests/Unit/AI/Credential/ChatReadinessServiceTest.php
@@ -62,7 +62,6 @@ class ChatReadinessServiceTest extends TestCase
             $ollamaModelInventory,
             $this->createMock(ModelHealthRepository::class),
             new NullLogger(),
-            'test',
         );
 
         return new ChatReadinessService(

--- a/backend/tests/Unit/ModelConfigServiceTest.php
+++ b/backend/tests/Unit/ModelConfigServiceTest.php
@@ -1190,4 +1190,69 @@ class ModelConfigServiceTest extends TestCase
             'Web channel should return userId regardless of phone verification status'
         );
     }
+
+    public function testInitializeNewUserDefaultsDoesNotWritePerUserRows(): void
+    {
+        $this->configRepository->expects($this->never())->method('findBy');
+        $this->configRepository->expects($this->never())->method('setValue');
+        $this->configRepository->expects($this->never())->method('removeAll');
+
+        $this->service->initializeNewUserDefaults(42);
+    }
+
+    public function testResetUserDefaultsWritesOnlyUsableRecommendedModels(): void
+    {
+        $recommended = \App\Seed\DefaultModelConfigSeeder::getRecommendedDefaults();
+        $servicesById = [];
+        $keyToService = [
+            'anthropic:claude-sonnet-5:chat' => 'Anthropic',
+            'groq:openai/gpt-oss-120b:chat' => 'Groq',
+            'groq:openai/gpt-oss-120b:mem' => 'Groq',
+            'google:gemini-3.1-flash-image-preview:text2pic' => 'Google',
+            'google:veo-3.1-generate-preview:text2vid' => 'Google',
+            'higgsfield:higgsfield-ai/dop/standard:text2vid' => 'Higgsfield',
+            'google:gemini-2.5-flash-preview-tts:text2sound' => 'Google',
+            'groq:qwen/qwen3.6-27b:pic2text' => 'Groq',
+            'groq:whisper-large-v3:sound2text' => 'Groq',
+            'ollama:bge-m3:vectorize' => 'Ollama',
+        ];
+        foreach ($keyToService as $key => $service) {
+            $bid = \App\Model\ModelCatalog::findBidByKey($key);
+            $this->assertNotNull($bid, "catalog key $key must resolve");
+            $servicesById[$bid] = $service;
+        }
+
+        $this->givenModels($servicesById);
+        $this->givenUsableProviders(['groq']);
+        $this->modelRepository->method('findByTag')->willReturn([]);
+
+        $this->configRepository->method('findBy')->willReturn([]);
+        $this->configRepository->expects($this->once())->method('removeAll')->with([]);
+
+        $written = [];
+        $this->configRepository
+            ->expects($this->atLeastOnce())
+            ->method('setValue')
+            ->willReturnCallback(function (int $ownerId, string $group, string $setting, string $value) use (&$written): Config {
+                $this->assertSame(7, $ownerId);
+                $this->assertSame('DEFAULTMODEL', $group);
+                $written[$setting] = (int) $value;
+
+                return $this->createMock(Config::class);
+            });
+
+        $result = $this->service->resetUserDefaults(7);
+
+        $this->assertSame($written, $result['defaults']);
+        $this->assertArrayNotHasKey('VECTORIZE', $written);
+        $this->assertArrayNotHasKey('CHAT', $written, 'Anthropic CHAT must not be frozen when the provider has no key');
+        $this->assertArrayNotHasKey('TEXT2PIC', $written, 'Google image models must not be written without a key');
+        $this->assertArrayHasKey('SORT', $written);
+        $this->assertSame($recommended['SORT'], $written['SORT']);
+        $this->assertArrayHasKey('SOUND2TEXT', $written);
+        $this->assertSame($recommended['SOUND2TEXT'], $written['SOUND2TEXT']);
+        foreach ($written as $capability => $modelId) {
+            $this->assertSame('Groq', $servicesById[$modelId], "$capability must resolve to a Groq model");
+        }
+    }
 }

--- a/backend/tests/Unit/ModelConfigServiceTest.php
+++ b/backend/tests/Unit/ModelConfigServiceTest.php
@@ -501,14 +501,21 @@ class ModelConfigServiceTest extends TestCase
 
     /**
      * @param list<string> $names
+     * @param list<string> $unavailable registered providers that currently have no credentials
      */
-    private function givenUsableProviders(array $names): void
+    private function givenUsableProviders(array $names, array $unavailable = []): void
     {
         $providers = [];
         foreach ($names as $name) {
             $provider = $this->createMock(ProviderMetadataInterface::class);
             $provider->method('getName')->willReturn($name);
             $provider->method('isAvailable')->willReturn(true);
+            $providers[$name] = $provider;
+        }
+        foreach ($unavailable as $name) {
+            $provider = $this->createMock(ProviderMetadataInterface::class);
+            $provider->method('getName')->willReturn($name);
+            $provider->method('isAvailable')->willReturn(false);
             $providers[$name] = $provider;
         }
 
@@ -1254,5 +1261,27 @@ class ModelConfigServiceTest extends TestCase
         foreach ($written as $capability => $modelId) {
             $this->assertSame('Groq', $servicesById[$modelId], "$capability must resolve to a Groq model");
         }
+    }
+
+    /**
+     * isModelUsable() treats an empty usable list as "cannot tell". On a
+     * real install the registry is populated and [] means every provider
+     * lacks credentials — writing the seed catalog would re-freeze dead
+     * Claude/Gemini rows. Clear overrides and write nothing instead.
+     */
+    public function testResetUserDefaultsWritesNothingWhenRegisteredProvidersAreAllUnavailable(): void
+    {
+        $existing = [$this->createMock(Config::class)];
+        $this->configRepository->method('findBy')->willReturn($existing);
+        $this->configRepository->expects($this->once())->method('removeAll')->with($existing);
+        $this->configRepository->expects($this->never())->method('setValue');
+
+        $this->givenUsableProviders([], ['anthropic', 'groq', 'google', 'openai']);
+
+        $result = $this->service->resetUserDefaults(7);
+
+        $this->assertSame(1, $result['removed']);
+        $this->assertSame(0, $result['written']);
+        $this->assertSame([], $result['defaults']);
     }
 }

--- a/frontend/src/components/config/AIModelsConfiguration.vue
+++ b/frontend/src/components/config/AIModelsConfiguration.vue
@@ -1246,7 +1246,14 @@ const confirmResetDefaults = async () => {
   try {
     const response = await resetDefaultModels()
     if (response.success) {
-      success(t('config.aiModels.resetDefaultsSuccess'))
+      // The backend skips a suggested model whose provider has no key, so on an
+      // install without credentials it applies nothing. Saying "applied" then
+      // would be wrong.
+      if (Object.keys(response.defaults).length === 0) {
+        warning(t('config.aiModels.resetDefaultsNoneApplied'))
+      } else {
+        success(t('config.aiModels.resetDefaultsSuccess'))
+      }
       await loadData()
     }
   } catch {

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -1510,6 +1510,7 @@
       "resetDefaults": "Empfohlene Modelle auswählen",
       "resetDefaultsConfirm": "Die empfohlene Modellauswahl übernehmen? Deine persönlichen Änderungen werden durch die empfohlenen Standards ersetzt.",
       "resetDefaultsSuccess": "Empfohlene Modelle wurden übernommen",
+      "resetDefaultsNoneApplied": "Es konnte kein empfohlenes Modell übernommen werden – es ist noch kein KI-Anbieter konfiguriert. Hinterlege zuerst einen API-Schlüssel.",
       "resetDefaultsError": "Empfohlene Modelle konnten nicht übernommen werden",
       "tableName": "Name",
       "tableService": "Anbieter",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -1411,6 +1411,7 @@
       "resetDefaults": "Select suggested models",
       "resetDefaultsConfirm": "Apply the suggested model selection? Your personal overrides will be replaced with the recommended defaults.",
       "resetDefaultsSuccess": "Suggested models have been applied",
+      "resetDefaultsNoneApplied": "No suggested model could be applied — no AI provider is configured yet. Add an API key first.",
       "resetDefaultsError": "Failed to apply suggested models",
       "tableName": "Name",
       "tableService": "Service",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -2720,6 +2720,7 @@
       "resetDefaults": "Seleccionar modelos sugeridos",
       "resetDefaultsConfirm": "¿Aplicar la selección de modelos sugerida? Tus ajustes personales se reemplazarán por los valores predeterminados recomendados.",
       "resetDefaultsSuccess": "Se han aplicado los modelos sugeridos",
+      "resetDefaultsNoneApplied": "No se pudo aplicar ningún modelo sugerido: todavía no hay ningún proveedor de IA configurado. Añade primero una clave de API.",
       "resetDefaultsError": "No se pudieron aplicar los modelos sugeridos",
       "tableName": "Nombre",
       "tableService": "Servicio",

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -2721,6 +2721,7 @@
       "resetDefaults": "Önerilen modelleri seç",
       "resetDefaultsConfirm": "Önerilen model seçimi uygulansın mı? Kişisel ayarlarınız önerilen varsayılanlarla değiştirilecek.",
       "resetDefaultsSuccess": "Önerilen modeller uygulandı",
+      "resetDefaultsNoneApplied": "Hiçbir önerilen model uygulanamadı — henüz yapılandırılmış bir AI sağlayıcısı yok. Önce bir API anahtarı ekleyin.",
       "resetDefaultsError": "Önerilen modeller uygulanamadı",
       "tableName": "Ad",
       "tableService": "Hizmet",


### PR DESCRIPTION
Part of #1586 (PR C of the plan).

## Summary
- Registration no longer copies the seed catalog into per-user \`DEFAULTMODEL\` rows. New users inherit global defaults (and the runtime fallback to the first usable model) until they explicitly pick one.
- **Select suggested models** still writes per-user overrides, but only for models whose provider is usable on this installation. An unusable recommended binding (Claude without an Anthropic key, etc.) is skipped; the first usable model for that capability is written instead.
- This is what clears Dominik's leftover Claude/Gemini screenshot: those rows stop being created, and applying suggested models no longer re-freezes dead cloud defaults.

Pairs with #1588 (PR B) which hides unavailable models from pickers.

## Test plan
- [x] \`make -C backend lint\` — clean
- [x] \`make -C backend phpstan\` — no errors
- [x] \`make -C backend test\` — 4088 tests
- [x] New unit tests: registration writes nothing; suggested models only persist Groq rows when Groq is the only usable provider