### PR TITLE
fix: retire Google Imagen 4 models after 2026-08-17 shutdown

### DIFF
--- a/backend/src/AI/Service/ModelAvailabilityChecker.php
+++ b/backend/src/AI/Service/ModelAvailabilityChecker.php
@@ -30,7 +30,8 @@ use App\Repository\ModelRepository;
  * blind spots. Only a model the provider itself reports as unknown is confirmed.
  *
  * Findings stay advisory and are never applied automatically: retirement
- * touches every user of an install and remains a reviewed migration.
+ * touches every user of an install and remains a reviewed registry entry
+ * (`ModelCatalog::RETIREMENTS`).
  */
 final readonly class ModelAvailabilityChecker
 {

--- a/backend/src/Command/CheckModelAvailabilityCommand.php
+++ b/backend/src/Command/CheckModelAvailabilityCommand.php
@@ -21,7 +21,8 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  * listing for reasons other than discontinuation (rename, region gate, account
  * tier), and an unattended `BACTIVE = 0` on a false positive would take a
  * working model away from every user of the install. Retirement stays a
- * reviewed migration — see `docs/PRICING_MAINTENANCE.md`.
+ * reviewed registry entry (`ModelCatalog::RETIREMENTS`) — see
+ * `docs/PRICING_MAINTENANCE.md`.
  */
 #[AsCommand(
     name: 'app:models:check-availability',
@@ -62,7 +63,8 @@ final class CheckModelAvailabilityCommand extends Command
             reached are reported as unchecked and never produce findings — an unreachable
             API must not look like an empty catalog.
 
-            Nothing is changed. Retire a confirmed dead model with a reviewed migration.
+            Nothing is changed. Retire a confirmed dead model with a reviewed registry entry
+            in ModelCatalog::RETIREMENTS.
             HELP)
         ;
     }
@@ -160,8 +162,8 @@ final class CheckModelAvailabilityCommand extends Command
 
         $io->warning(sprintf('%d model(s) are offered but no longer served by their provider.', count($findings)));
         $io->writeln([
-            'Verify each one against the provider\'s deprecation page, then retire it with a',
-            'migration — deactivate, never delete: see <info>docs/PRICING_MAINTENANCE.md</info>.',
+            'Verify each one against the provider\'s deprecation page, then retire it via',
+            'ModelCatalog::RETIREMENTS — deactivate, never delete: see <info>docs/PRICING_MAINTENANCE.md</info>.',
             '',
             'Rows marked as a provider default are urgent: <info>app:provider:apply-defaults --auto</info>',
             'assigns them unattended at container start.',

--- a/backend/src/Model/ModelCatalog.php
+++ b/backend/src/Model/ModelCatalog.php
@@ -289,6 +289,32 @@ class ModelCatalog
             'successor' => null,
             'reason' => 'Retired by xAI with no replacement speech endpoint (#1514).',
         ],
+
+        // --- 2026-08-17 (Google Imagen 4 hard shutdown) ---
+        // Google deprecated all Imagen 4 IDs on 2026-06-15 and hard-shut them
+        // down on 2026-08-17; direct GET now answers 404, so the availability
+        // check confirms them Gone. Nano Banana is the vendor-named successor;
+        // gemini-3.1-flash-image-preview (BID 190) is already the TEXT2PIC
+        // default, so all three tiers point at it rather than at the flat/ultra
+        // Gemini image variants we do not carry.
+        115 => [
+            'providerId' => 'imagen-4.0-generate-001',
+            'retiredOn' => '2026-08-17',
+            'successor' => 'google:gemini-3.1-flash-image-preview:text2pic',
+            'reason' => 'Shut down by Google on 2026-08-17; migrate to Nano Banana (gemini-3.1-flash-image).',
+        ],
+        230 => [
+            'providerId' => 'imagen-4.0-fast-generate-001',
+            'retiredOn' => '2026-08-17',
+            'successor' => 'google:gemini-3.1-flash-image-preview:text2pic',
+            'reason' => 'Shut down by Google on 2026-08-17; migrate to Nano Banana (gemini-3.1-flash-image).',
+        ],
+        231 => [
+            'providerId' => 'imagen-4.0-ultra-generate-001',
+            'retiredOn' => '2026-08-17',
+            'successor' => 'google:gemini-3.1-flash-image-preview:text2pic',
+            'reason' => 'Shut down by Google on 2026-08-17; migrate to Nano Banana (gemini-3.1-flash-image).',
+        ],
     ];
 
     /**
@@ -1983,8 +2009,10 @@ class ModelCatalog
             'service' => 'Google',
             'name' => 'Imagen 4.0',
             'tag' => 'text2pic',
-            'selectable' => 1,
-            'active' => 1,
+            // Retired: Google shut down the Imagen 4 endpoints on 2026-08-17.
+            // See ModelCatalog::RETIREMENTS[115].
+            'selectable' => 0,
+            'active' => 0,
             'providerId' => 'imagen-4.0-generate-001',
             // Imagen 4.0 is a flat per-image-fee model in production
             // ($0.04/image standard quality). Mirrors live BMODELS BID 115:
@@ -2400,8 +2428,10 @@ class ModelCatalog
             'service' => 'Google',
             'name' => 'Imagen 4.0 Fast',
             'tag' => 'text2pic',
-            'selectable' => 1,
-            'active' => 1,
+            // Retired: Google shut down the Imagen 4 endpoints on 2026-08-17.
+            // See ModelCatalog::RETIREMENTS[230].
+            'selectable' => 0,
+            'active' => 0,
             'providerId' => 'imagen-4.0-fast-generate-001',
             'priceIn' => 0,
             'inUnit' => 'perImage',
@@ -2424,8 +2454,10 @@ class ModelCatalog
             'service' => 'Google',
             'name' => 'Imagen 4.0 Ultra',
             'tag' => 'text2pic',
-            'selectable' => 1,
-            'active' => 1,
+            // Retired: Google shut down the Imagen 4 endpoints on 2026-08-17.
+            // See ModelCatalog::RETIREMENTS[231].
+            'selectable' => 0,
+            'active' => 0,
             'providerId' => 'imagen-4.0-ultra-generate-001',
             'priceIn' => 0,
             'inUnit' => 'perImage',

--- a/backend/src/Service/DiscordNotificationService.php
+++ b/backend/src/Service/DiscordNotificationService.php
@@ -742,7 +742,7 @@ final readonly class DiscordNotificationService
             ],
             [
                 'name' => 'Action required',
-                'value' => 'Confirm on the provider deprecation page, then retire via migration (deactivate, never delete) — docs/PRICING_MAINTENANCE.md.',
+                'value' => 'Confirm on the provider deprecation page, then retire via ModelCatalog::RETIREMENTS (deactivate, never delete) — docs/PRICING_MAINTENANCE.md.',
                 'inline' => false,
             ],
         ];

--- a/docs/PRICING_MAINTENANCE.md
+++ b/docs/PRICING_MAINTENANCE.md
@@ -112,7 +112,7 @@ docker compose exec -T backend php bin/console app:models:check-availability --f
 
 It runs in **two stages, and the second one is the point**: the provider's model list is only a cheap pre-filter, then every model missing from that list is confirmed individually via `GET {listUrl}/{modelId}`. Only a model the provider itself answers `404`/`400` for is reported. Judging by list membership alone is wrong in both directions, verified against the live APIs on 2026-08-19:
 
-- **False alarm** — Gemini serves `imagen-4.0-generate-001` through `:predict` and leaves it out of `models.list`, but answers `200` when asked directly. A list-only check reports all three Imagen rows as dead.
+- **False alarm (the mechanism, not the current status)** — the point is that list membership is not evidence either way; the confirm step is. On 2026-08-19 Gemini still served `imagen-4.0-generate-001` through `:predict` and left it out of `models.list` while answering `200` on a direct GET, so a list-only check wrongly reported all three Imagen rows as dead. **That example has since flipped:** Google hard-shut the Imagen 4 endpoints on 2026-08-17, direct GET now answers `404`, and the three rows are genuinely retired (see [Google Imagen 4 shutdown](#google-imagen-4-shutdown-2026-08-17) below). The lesson stands — only the per-model probe decides.
 - **Blind spot** — xAI's `grok-tts` is also absent from `/v1/models`, and there it really is gone (`404`). Any heuristic that excused the Imagen case (per-capability coverage, tag families) hid this one.
 
 What it deliberately does **not** do: change anything. No `BACTIVE=0`, no default repointing. A model also disappears from a listing through a rename, a region gate or an account tier, and an unattended deactivation on a false positive takes a working model away from every user of the install. Retirement stays a reviewed, human decision — now a reviewed registry entry rather than a reviewed migration (see [Retiring a model](#retiring-a-model)).
@@ -133,6 +133,18 @@ Six confirmed retirements, each re-verified by hand: Groq dropped `llama-3.3-70b
 The four Groq rows were retired in `Version20260819080000` (#1513), which also added Groq Qwen 3.6 27B (324/325) as their successor. Re-running the check after that migration reports Groq at `7/7 matched`: the retired rows are out of the active set and the freshly added successor BIDs produce no false positive.
 
 The two xAI rows were retired in `Version20260820120000` (#1514). Because the catalog has no xAI replacement for either capability, this is the **no-successor** variant of the policy: the rows are deactivated and their `DEFAULTMODEL` bindings are **deleted** instead of repointed, which hands the capability back to the normal resolution chain rather than binding the install to a provider whose key the operator may not hold. The xAI `SOUND2TEXT` recommendation was dropped from `ProviderDefaultsService` in the same change — without that, `app:provider:apply-defaults --auto` writes the dead binding back on the next container start.
+
+### Google Imagen 4 shutdown (2026-08-17)
+
+Google deprecated all three Imagen 4 IDs on 2026-06-15 and **hard-shut them down on 2026-08-17** (both the Gemini Developer API and Vertex). This is the same trio that was a *false alarm* on 2026-08-19 in the availability check's initial run — back then a direct GET still answered `200`. After the shutdown the direct GET answers `404`, so the two-stage check now **confirms** them Gone and the daily Discord digest lists them until they are retired.
+
+| BID | Model | `providerId` | Successor |
+| --- | ----- | ------------ | --------- |
+| 115 | Imagen 4.0 | `imagen-4.0-generate-001` | `google:gemini-3.1-flash-image-preview:text2pic` (Nano Banana 2, BID 190) |
+| 230 | Imagen 4.0 Fast | `imagen-4.0-fast-generate-001` | same |
+| 231 | Imagen 4.0 Ultra | `imagen-4.0-ultra-generate-001` | same |
+
+Retired via the registry (`ModelCatalog::RETIREMENTS`, no migration): the three catalog rows carry `active = selectable = 0` and a `RETIREMENTS` entry, and `ModelRetirementSeeder` stamps `BRETIREDON`/`BSUCCESSORID` on every install. Nano Banana 2 (`gemini-3.1-flash-image-preview`, BID 190) is already the seeded `DEFAULTMODEL.TEXT2PIC`/`PIC2PIC`, so no default binding is orphaned; all three tiers point at it because we do not carry the flat `gemini-3.1-flash-image` / `gemini-3-pro-image` variants Google's migration table names per tier. Google's [deprecations page](https://ai.google.dev/gemini-api/docs/deprecations) is the authority for the shutdown date.
 
 ## Maintenance links
 


### PR DESCRIPTION
## Summary

Google hard-shut the three Imagen 4 endpoints on **2026-08-17** (`imagen-4.0-generate-001`, `imagen-4.0-fast-generate-001`, `imagen-4.0-ultra-generate-001`). A direct model `GET` now answers `404`, so the daily `app:models:check-availability` confirms them **Gone** and the Discord digest lists them until they are retired. This retires them.

- Add **BID 115 / 230 / 231** to `ModelCatalog::RETIREMENTS` (`retiredOn: 2026-08-17`), successor `google:gemini-3.1-flash-image-preview:text2pic` (**Nano Banana 2**, BID 190 — already the seeded `DEFAULTMODEL.TEXT2PIC`/`PIC2PIC`, so no binding is orphaned).
- Set the three catalog rows to `active = selectable = 0`. Rows are **kept, never deleted** (`BMESSAGES` FKs). `ModelRetirementSeeder` stamps `BRETIREDON`/`BSUCCESSORID` on every install; the health monitor then skips them, so the Discord alert stops on the next run.
- Align stale copy that still said "retire via migration" with the registry flow in `DiscordNotificationService`, `CheckModelAvailabilityCommand` (class doc, `--help`, warning) and `ModelAvailabilityChecker`.
- `docs/PRICING_MAINTENANCE.md`: time-box the Imagen false-alarm note (`200` on 2026-08-19, `404` after shutdown) and add a **"Google Imagen 4 shutdown (2026-08-17)"** section.

## Test plan

- [x] `make -C backend lint` — clean
- [x] `make -C backend phpstan` — 0 errors (src + tests)
- [x] `make -C backend test` — 4101 tests, no errors/failures
- [x] `ModelCatalogRetirementTest` green; BID snapshot unchanged (rows still ship, just deactivated)
- [x] `make -C backend seed` applied 3 retirements; DB verified: BID 115/230/231 → `BACTIVE=0`, `BRETIREDON=2026-08-17`, `BSUCCESSORID=190`
- [ ] Confirm next daily availability check no longer flags Imagen on Discord

## Mobile impact

backend-only (`backend/**` + docs) — no OTA/app delivery.