### PR TITLE
ci: timing experiment — frontend-build on the free runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,11 +300,13 @@ jobs:
     # nelmio:apidoc:dump compiles the container but never touches the DB
     # (Doctrine connects lazily), so no MariaDB service is needed here.
     #
-    # This is the ONLY job on the paid 16-core pool: the parallel Vite builds
-    # are the one workload where the cores shorten the critical path. All
-    # other former -m jobs moved to free runners so the warm -m runner is
-    # reliably available for this job at t=0.
-    runs-on: ubuntu-latest-m
+    # TIMING EXPERIMENT (do not merge as-is): temporarily on the free runner
+    # to measure how much the paid 16-core pool actually shortens this job.
+    # The Vite build step is suspected to be single-thread-bound (July data:
+    # widget build took 63s on the free 4-core runner, and today both builds
+    # in parallel take 62s on 16 cores), in which case the -m pool buys
+    # almost nothing here. Compare this run's job duration against main.
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

- **Timing experiment, not meant to be merged as-is.** Moves `frontend-build` from the paid 16-core `ubuntu-latest-m` pool to the free `ubuntu-latest` runner to measure the real speed difference.
- Hypothesis: the Vite build step is largely single-thread-bound, so the 16 cores barely help. Evidence from run history: on 2026-07-08 the widget build alone took 63s on the free 4-core runner; today both builds run in parallel in 62s on 16 cores.
- `frontend-build` is the only job still on the paid pool (~2.4 billed min/run × ~734 runs/month ≈ $112/month).

## Test plan

- [ ] Compare the `Frontend Build` job duration (and the `Build app and widget (parallel)` step) in this PR's CI run against recent runs on `main` (~144s job / ~62s build step on 16 cores).
- [ ] Check the effect on the critical path (`frontend-build → docker-build → e2e`): total PR gate time vs ~12 min baseline.
- [ ] Decide: if the delta is small (~20-40s), keep the free runner and drop the paid pool.