### PR TITLE
feat(summary): live-model eval harness for the rolling conversation summary (Sprint 1)

### DIFF
--- a/_devextras/planning/20260827-conversation-continuity/STATUS.md
+++ b/_devextras/planning/20260827-conversation-continuity/STATUS.md
@@ -2,7 +2,7 @@
 
 | Sprint | Branch | State | Notes |
 | ------ | ------ | ----- | ----- |
-| 1 — Summary eval harness | `feat/summary-eval-harness` | not started | |
+| 1 — Summary eval harness | `feat/summary-eval-harness` | implemented, eval run recorded below | `app:summary:eval`, `make -C backend summary-eval` |
 | 2 — Durable summary + channel parity | `feat/durable-summary-channel-parity` | not started | |
 | 3 — Message digest foundation | `feat/message-digest-foundation` | not started | |
 | 4 — Digest retrieval + badges | `feat/digest-retrieval` | not started | |
@@ -19,16 +19,33 @@
   extracted as a memory.
 - Eval pattern to copy: `PlanEvalCommand` + golden corpus.
 
-## Summary quality — per-provider eval results (fill in after Sprint 1)
+## Summary quality — per-provider eval results (2026-08-27, 8-case corpus)
 
-| Provider:model | Size compliance | Fact retention | Hallucination | Language | Notes |
-| -------------- | --------------- | -------------- | ------------- | -------- | ----- |
-| anthropic:? | | | | | |
-| openai:? | | | | | |
-| google:? | | | | | |
-| huggingface:? | | | | | |
-| groq:openai/gpt-oss-120b (current default) | | | | | |
-| ollama:? (big model) | | | | | |
+Run: `php bin/console app:summary:eval --models=...` with `SUMMARY_MAX_CHARS = 4000`.
+
+| Provider:model | Result | Size compliance | Language | Typical latency | Notes |
+| -------------- | ------ | --------------- | -------- | --------------- | ----- |
+| anthropic:claude-sonnet-5 | **8/8** | max ~1.9k chars | de/ru respected | 7–10 s | |
+| openai:gpt-5.5 | **8/8** | max ~1.9k chars | de/ru respected | ~7 s | |
+| google:gemini-3.1-pro-preview | **8/8** | max ~2.0k chars | de/ru respected | ~8 s | |
+| huggingface:moonshotai/Kimi-K3:deepinfra | **8/8** | max ~2.0k chars | de/ru respected | up to ~21 s (slowest) | |
+| groq:openai/gpt-oss-120b (**current SUMMARIZE default**) | **7/8 typical** | max ~1.7k chars | de/ru respected | 1–2 s (fastest by far) | Flaky **date retention**: drops the concrete effective date in ~1 of 4 runs of the rent-letter case (verified with `--repeat`). Everything else stable. |
+| ollama:gpt-oss:120b | SKIPPED | — | — | — | model not pulled in this environment (`ollama pull gpt-oss:120b`) |
+
+**Conclusions**
+
+1. The production prompts hold up well across all four requested cloud providers —
+   structure, language, size, and hallucination probes were clean everywhere.
+2. Size is not a concern in practice: no model came near the 4000-char cap
+   (max observed ~2.0k) at `tokenBudget(4000)`.
+3. The current Groq default is by far the fastest/cheapest but occasionally drops
+   concrete dates when folding long factual threads. Options (later PR, measured
+   with this harness): tighten the prompt ("always keep concrete dates, amounts,
+   deadlines") or switch the seeded SUMMARIZE default.
+4. Corpus authoring learnings baked in: forbidden probes must not appear anywhere
+   in the source conversation; date probes must accept all common formats
+   ("1 Sept", "14 Nov", "09-01", ...). The `--json` output now includes the raw
+   summary per case for exactly this kind of inspection.
 
 ## Digest retrieval tuning (fill in after Sprint 4)
 

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help lint format phpstan phpstan-baseline audit deps migrate migrate-status migrate-diff migrate-generate seed seed-models seed-prompts seed-defaults seed-ratelimits fixtures schema-update schema-diff console cache-clear shell test plan-eval
+.PHONY: help lint format phpstan phpstan-baseline audit deps migrate migrate-status migrate-diff migrate-generate seed seed-models seed-prompts seed-defaults seed-ratelimits fixtures schema-update schema-diff console cache-clear shell test plan-eval summary-eval
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
@@ -83,6 +83,9 @@ test: ## Run all PHPUnit tests
 
 plan-eval: ## Evaluate the multitask planner against the golden corpus (LIVE model — not part of the CI gate)
 	docker compose -f ../docker-compose.yml exec -T backend php bin/console app:multitask:plan-eval
+
+summary-eval: ## Evaluate the rolling conversation summary against the golden corpus (LIVE models — not part of the CI gate)
+	docker compose -f ../docker-compose.yml exec -T backend php bin/console app:summary:eval
 
 # Allow passing arguments to console target
 %:

--- a/backend/src/Command/SummaryEvalCommand.php
+++ b/backend/src/Command/SummaryEvalCommand.php
@@ -329,6 +329,9 @@ final class SummaryEvalCommand extends Command
      */
     private function buildMessages(array $raw): array
     {
+        // Reflection here is statically safe: Message::$id is a mapped Doctrine
+        // property, and PHPStan (level max) verifies the property exists — a
+        // try/catch around it would be provably dead code.
         $idProperty = new \ReflectionProperty(Message::class, 'id');
 
         $messages = [];

--- a/backend/src/Command/SummaryEvalCommand.php
+++ b/backend/src/Command/SummaryEvalCommand.php
@@ -1,0 +1,406 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\AI\Service\AiFacade;
+use App\Entity\Message;
+use App\Service\Eval\SummaryEvalScorer;
+use App\Service\Message\ConversationSummaryConfigService;
+use App\Service\Message\ConversationSummaryPrompts;
+use App\Service\ModelConfigService;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+/**
+ * Live-model evaluation of the rolling conversation summary against a golden
+ * corpus — the measurable instrument for "does the summary quality and size
+ * hold with our main chat models?" (Anthropic, OpenAI, Google, HuggingFace,
+ * Groq, Ollama, ...).
+ *
+ * Runs the REAL production prompts ({@see ConversationSummaryPrompts}) in both
+ * modes (bootstrap + incremental fold) and scores the raw model output
+ * deterministically ({@see SummaryEvalScorer}): size compliance, fact
+ * retention, hallucination probes, language, structure.
+ *
+ * Deliberately NOT part of the CI gate — it needs live models. Providers
+ * without a configured key are reported as SKIPPED, never failed, so the
+ * command is runnable on any install:
+ *
+ *   make -C backend summary-eval
+ *   php bin/console app:summary:eval --models=anthropic:claude-sonnet-4-5,openai:gpt-5
+ *   php bin/console app:summary:eval --filter=rent_letter --repeat=3 --json
+ */
+#[AsCommand(
+    name: 'app:summary:eval',
+    description: 'Evaluate the rolling conversation summary against the golden corpus (live models)',
+)]
+final class SummaryEvalCommand extends Command
+{
+    private const DEFAULT_CORPUS = 'tests/Eval/summary_eval_corpus.json';
+
+    /** Consecutive hard errors after which the remaining cases of a model are abandoned. */
+    private const MAX_CONSECUTIVE_ERRORS = 3;
+
+    public function __construct(
+        private readonly AiFacade $aiFacade,
+        private readonly ModelConfigService $modelConfigService,
+        private readonly ConversationSummaryConfigService $summaryConfig,
+        private readonly SummaryEvalScorer $scorer,
+        #[Autowire('%kernel.project_dir%')]
+        private readonly string $projectDir,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('corpus', null, InputOption::VALUE_REQUIRED, 'Path to the corpus JSON (relative to the backend dir)', self::DEFAULT_CORPUS)
+            ->addOption('models', null, InputOption::VALUE_REQUIRED, 'Comma-separated provider:model pairs (default: the configured SUMMARIZE model)')
+            ->addOption('filter', null, InputOption::VALUE_REQUIRED, 'Only run cases whose id contains this substring')
+            ->addOption('mode', null, InputOption::VALUE_REQUIRED, 'Restrict to one prompt mode: bootstrap | incremental')
+            ->addOption('repeat', null, InputOption::VALUE_REQUIRED, 'Run every case N times (stability check)', '1')
+            ->addOption('user', null, InputOption::VALUE_REQUIRED, 'Resolve the default summary model for this user id (default: global)')
+            ->addOption('json', null, InputOption::VALUE_NONE, 'Print machine-readable JSON instead of tables');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $corpus = $this->loadCorpus((string) $input->getOption('corpus'), $io);
+        if (null === $corpus) {
+            return Command::FAILURE;
+        }
+
+        $userOption = $input->getOption('user');
+        $userId = null !== $userOption ? (int) $userOption : null;
+
+        $targets = $this->resolveTargets($input->getOption('models'), $userId, $io);
+        if ([] === $targets) {
+            return Command::FAILURE;
+        }
+
+        $cases = $this->selectCases($corpus, $input->getOption('filter'), $input->getOption('mode'));
+        if ([] === $cases) {
+            $io->warning('No corpus cases matched.');
+
+            return Command::FAILURE;
+        }
+
+        $repeat = max(1, (int) $input->getOption('repeat'));
+        $summaryMax = $this->summaryConfig->getSummaryMaxChars();
+
+        $report = [];
+        $totalFailed = 0;
+        foreach ($targets as $target) {
+            $result = $this->evaluateModel($target, $cases, $repeat, $summaryMax, $userId);
+            $report[] = $result;
+            $totalFailed += $result['failed'] + $result['errors'];
+        }
+
+        if ((bool) $input->getOption('json')) {
+            $output->writeln((string) json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+        } else {
+            $this->renderTables($io, $report);
+        }
+
+        return 0 === $totalFailed ? Command::SUCCESS : Command::FAILURE;
+    }
+
+    /**
+     * @return list<array<string, mixed>>|null
+     */
+    private function loadCorpus(string $corpusPath, SymfonyStyle $io): ?array
+    {
+        if (!str_starts_with($corpusPath, '/')) {
+            $corpusPath = $this->projectDir.'/'.$corpusPath;
+        }
+        if (!is_file($corpusPath)) {
+            $io->error("Corpus file not found: {$corpusPath}");
+
+            return null;
+        }
+
+        $corpus = json_decode((string) file_get_contents($corpusPath), true);
+        if (!is_array($corpus)) {
+            $io->error('Corpus file is not valid JSON.');
+
+            return null;
+        }
+
+        return array_values(array_filter($corpus, 'is_array'));
+    }
+
+    /**
+     * @return list<array{label: string, provider: ?string, model: ?string}>
+     */
+    private function resolveTargets(mixed $modelsOption, ?int $userId, SymfonyStyle $io): array
+    {
+        if (is_string($modelsOption) && '' !== trim($modelsOption)) {
+            $targets = [];
+            foreach (explode(',', $modelsOption) as $pair) {
+                $pair = trim($pair);
+                if ('' === $pair) {
+                    continue;
+                }
+                // Split on the FIRST colon only — model names may contain colons
+                // (e.g. ollama "llama3.1:70b").
+                $parts = explode(':', $pair, 2);
+                if (2 !== count($parts) || '' === $parts[0] || '' === $parts[1]) {
+                    $io->error("Invalid --models entry '{$pair}' — expected provider:model.");
+
+                    return [];
+                }
+                $targets[] = ['label' => $pair, 'provider' => $parts[0], 'model' => $parts[1]];
+            }
+
+            return $targets;
+        }
+
+        $config = $this->modelConfigService->getSummaryModelConfig($userId);
+        if (null === ($config['model'] ?? null)) {
+            $io->error('No summary model configured (DEFAULTMODEL.SUMMARIZE/SORT/CHAT all unresolved) and no --models given.');
+
+            return [];
+        }
+
+        return [[
+            'label' => sprintf('default (%s:%s)', $config['provider'] ?? '?', $config['model']),
+            'provider' => $config['provider'] ?? null,
+            'model' => $config['model'],
+        ]];
+    }
+
+    /**
+     * @param list<array<string, mixed>> $corpus
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function selectCases(array $corpus, mixed $filter, mixed $mode): array
+    {
+        $cases = [];
+        foreach ($corpus as $case) {
+            $id = $case['id'] ?? null;
+            if (!is_string($id) || '' === $id) {
+                continue;
+            }
+            if (is_string($filter) && '' !== $filter && !str_contains($id, $filter)) {
+                continue;
+            }
+            if (is_string($mode) && '' !== $mode && ($case['mode'] ?? '') !== $mode) {
+                continue;
+            }
+            $cases[] = $case;
+        }
+
+        return $cases;
+    }
+
+    /**
+     * @param array{label: string, provider: ?string, model: ?string} $target
+     * @param list<array<string, mixed>>                              $cases
+     *
+     * @return array{model: string, skipped: bool, skip_reason: string, passed: int, failed: int, errors: int, rows: list<array{case: string, result: string, chars: int, latency_ms: int, detail: string, summary: string}>}
+     */
+    private function evaluateModel(array $target, array $cases, int $repeat, int $summaryMax, ?int $userId): array
+    {
+        $rows = [];
+        $passed = 0;
+        $failed = 0;
+        $errors = 0;
+        $skipped = false;
+        $skipReason = '';
+        $consecutiveErrors = 0;
+        $firstCall = true;
+
+        foreach ($cases as $case) {
+            for ($run = 1; $run <= $repeat; ++$run) {
+                $label = (string) $case['id'].($repeat > 1 ? " #{$run}" : '');
+
+                try {
+                    $started = microtime(true);
+                    $summary = $this->generateSummary($case, $summaryMax, $userId, $target);
+                    $latencyMs = (int) round((microtime(true) - $started) * 1000);
+                } catch (\Throwable $e) {
+                    if ($firstCall && $this->looksLikeMissingProvider($e)) {
+                        // Provider not configured on this install — the whole
+                        // model is SKIPPED, never failed.
+                        $skipped = true;
+                        $skipReason = $e->getMessage();
+                        break 2;
+                    }
+
+                    ++$errors;
+                    ++$consecutiveErrors;
+                    $rows[] = ['case' => $label, 'result' => 'ERROR', 'chars' => 0, 'latency_ms' => 0, 'detail' => mb_substr($e->getMessage(), 0, 200), 'summary' => ''];
+                    if ($consecutiveErrors >= self::MAX_CONSECUTIVE_ERRORS) {
+                        $rows[] = ['case' => '—', 'result' => 'ABORT', 'chars' => 0, 'latency_ms' => 0, 'detail' => 'too many consecutive errors, remaining cases abandoned', 'summary' => ''];
+                        break 2;
+                    }
+                    continue;
+                } finally {
+                    $firstCall = false;
+                }
+
+                $consecutiveErrors = 0;
+                $probes = is_array($case['probes'] ?? null) ? $case['probes'] : [];
+                $score = $this->scorer->score(
+                    $summary,
+                    $summaryMax,
+                    array_values(array_filter((array) ($probes['required'] ?? []), 'is_string')),
+                    array_values(array_filter((array) ($probes['forbidden'] ?? []), 'is_string')),
+                    is_string($case['expect_language'] ?? null) ? $case['expect_language'] : null,
+                );
+
+                $score->passed() ? ++$passed : ++$failed;
+                $rows[] = [
+                    'case' => $label,
+                    'result' => $score->passed() ? 'PASS' : 'FAIL',
+                    'chars' => $score->chars,
+                    'latency_ms' => $latencyMs,
+                    'detail' => $score->problems(),
+                    'summary' => $summary,
+                ];
+            }
+        }
+
+        return [
+            'model' => $target['label'],
+            'skipped' => $skipped,
+            'skip_reason' => $skipReason,
+            'passed' => $passed,
+            'failed' => $failed,
+            'errors' => $errors,
+            'rows' => $rows,
+        ];
+    }
+
+    /**
+     * Build the production prompt pair for a corpus case and run it once.
+     *
+     * @param array<string, mixed>                                    $case
+     * @param array{label: string, provider: ?string, model: ?string} $target
+     */
+    private function generateSummary(array $case, int $summaryMax, ?int $userId, array $target): string
+    {
+        $messages = $this->buildMessages((array) ($case['messages'] ?? []));
+
+        if ('incremental' === ($case['mode'] ?? '')) {
+            $systemPrompt = ConversationSummaryPrompts::incrementalSystemPrompt($summaryMax);
+            $userContent = ConversationSummaryPrompts::incrementalUserContent(
+                is_string($case['previous_summary'] ?? null) ? $case['previous_summary'] : '',
+                $messages,
+            );
+        } else {
+            $tiers = is_int($case['tiers'] ?? null) ? $case['tiers'] : $this->summaryConfig->getTiers();
+            $systemPrompt = ConversationSummaryPrompts::bootstrapSystemPrompt($summaryMax);
+            $userContent = ConversationSummaryPrompts::bootstrapUserContent($messages, $tiers);
+        }
+
+        $response = $this->aiFacade->chat([
+            ['role' => 'system', 'content' => $systemPrompt],
+            ['role' => 'user', 'content' => $userContent],
+        ], $userId, [
+            'provider' => $target['provider'],
+            'model' => $target['model'],
+            'temperature' => 0.2,
+            'max_tokens' => ConversationSummaryPrompts::tokenBudget($summaryMax),
+        ]);
+
+        // Deliberately NOT clipped: the eval measures whether the model itself
+        // respects the cap — production clipping would hide the violation.
+        return trim((string) ($response['content'] ?? ''));
+    }
+
+    /**
+     * In-memory messages (never persisted), rendered exactly like production.
+     *
+     * @param list<mixed> $raw
+     *
+     * @return list<Message>
+     */
+    private function buildMessages(array $raw): array
+    {
+        $idProperty = new \ReflectionProperty(Message::class, 'id');
+
+        $messages = [];
+        $id = 0;
+        foreach ($raw as $entry) {
+            if (!is_array($entry)) {
+                continue;
+            }
+
+            $message = new Message();
+            $idProperty->setValue($message, ++$id);
+            $message->setUserId(0);
+            $message->setTrackingId(0);
+            $message->setUnixTimestamp(time());
+            $message->setDateTime(date('YmdHis'));
+            $message->setMessageType('WEB');
+            $message->setDirection('user' === ($entry['role'] ?? '') ? 'IN' : 'OUT');
+            $message->setText(is_string($entry['text'] ?? null) ? $entry['text'] : '');
+            $message->setFile(0);
+            $message->setFilePath('');
+            $message->setFileType(is_string($entry['file_type'] ?? null) ? $entry['file_type'] : '');
+            $message->setFileText(is_string($entry['file_text'] ?? null) ? $entry['file_text'] : '');
+
+            $messages[] = $message;
+        }
+
+        return $messages;
+    }
+
+    /**
+     * Environment limitations (missing key, unknown provider, local model not
+     * pulled) mean the model cannot be evaluated HERE — that is a SKIP, not a
+     * quality failure.
+     */
+    private function looksLikeMissingProvider(\Throwable $e): bool
+    {
+        return 1 === preg_match(
+            '/api.?key|unauthori[sz]|credential|401|403|not configured|no such provider|unknown provider|provider .* not found|model .* not found|ollama pull/i',
+            $e->getMessage(),
+        );
+    }
+
+    /**
+     * @param list<array{model: string, skipped: bool, skip_reason: string, passed: int, failed: int, errors: int, rows: list<array{case: string, result: string, chars: int, latency_ms: int, detail: string, summary: string}>}> $report
+     */
+    private function renderTables(SymfonyStyle $io, array $report): void
+    {
+        foreach ($report as $modelReport) {
+            $io->section($modelReport['model']);
+
+            if ($modelReport['skipped']) {
+                $io->writeln(sprintf('<comment>SKIPPED</comment> — %s', $modelReport['skip_reason']));
+                continue;
+            }
+
+            $tableRows = [];
+            foreach ($modelReport['rows'] as $row) {
+                $decorated = match ($row['result']) {
+                    'PASS' => '<info>PASS</info>',
+                    'FAIL' => '<error>FAIL</error>',
+                    default => '<comment>'.$row['result'].'</comment>',
+                };
+                $tableRows[] = [$row['case'], $decorated, $row['chars'], $row['latency_ms'], $row['detail']];
+            }
+
+            $io->table(['case', 'result', 'chars', 'latency ms', 'detail'], $tableRows);
+            $io->writeln(sprintf(
+                '%d passed, %d failed, %d errors',
+                $modelReport['passed'],
+                $modelReport['failed'],
+                $modelReport['errors'],
+            ));
+        }
+    }
+}

--- a/backend/src/Service/Eval/SummaryEvalScore.php
+++ b/backend/src/Service/Eval/SummaryEvalScore.php
@@ -42,7 +42,9 @@ final readonly class SummaryEvalScore
     {
         $problems = [];
         if (!$this->sizeOk) {
-            $problems[] = sprintf('size %d chars over cap', $this->chars);
+            $problems[] = 0 === $this->chars
+                ? 'empty summary'
+                : sprintf('size %d chars over cap', $this->chars);
         }
         foreach ($this->missingRequired as $probe) {
             $problems[] = "missing '{$probe}'";

--- a/backend/src/Service/Eval/SummaryEvalScore.php
+++ b/backend/src/Service/Eval/SummaryEvalScore.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Eval;
+
+/**
+ * Deterministic quality verdict for one generated rolling summary.
+ *
+ * `languageOk` is tri-state: null means "no expectation or language not
+ * confidently detectable" — only a confident mismatch fails the case, so the
+ * heuristic can never produce false negatives on short summaries.
+ */
+final readonly class SummaryEvalScore
+{
+    /**
+     * @param list<string> $missingRequired required probes not found in the summary
+     * @param list<string> $forbiddenHits   forbidden probes that ARE present (hallucination signal)
+     */
+    public function __construct(
+        public int $chars,
+        public bool $sizeOk,
+        public array $missingRequired,
+        public array $forbiddenHits,
+        public bool $structureOk,
+        public ?bool $languageOk,
+        public ?string $detectedLanguage,
+    ) {
+    }
+
+    public function passed(): bool
+    {
+        return $this->sizeOk
+            && [] === $this->missingRequired
+            && [] === $this->forbiddenHits
+            && $this->structureOk
+            && false !== $this->languageOk;
+    }
+
+    /** Compact human-readable list of everything that went wrong. */
+    public function problems(): string
+    {
+        $problems = [];
+        if (!$this->sizeOk) {
+            $problems[] = sprintf('size %d chars over cap', $this->chars);
+        }
+        foreach ($this->missingRequired as $probe) {
+            $problems[] = "missing '{$probe}'";
+        }
+        foreach ($this->forbiddenHits as $probe) {
+            $problems[] = "forbidden '{$probe}' present";
+        }
+        if (!$this->structureOk) {
+            $problems[] = 'structure: no leading markdown heading';
+        }
+        if (false === $this->languageOk) {
+            $problems[] = sprintf('language: detected %s', $this->detectedLanguage ?? 'unknown');
+        }
+
+        return implode('; ', $problems);
+    }
+}

--- a/backend/src/Service/Eval/SummaryEvalScorer.php
+++ b/backend/src/Service/Eval/SummaryEvalScorer.php
@@ -95,9 +95,9 @@ final readonly class SummaryEvalScorer
     }
 
     /**
-     * The prompt forbids preamble and mandates `## <heading>` sections, so a
-     * compliant summary starts with a markdown heading and contains at least
-     * one `## ` section line.
+     * The prompt forbids preamble and mandates `## <heading>` sections, so
+     * the first non-empty line must itself be a `## <heading>` line — a
+     * lone `# Title` or any prose preamble fails.
      */
     private function structureOk(string $summary): bool
     {
@@ -112,8 +112,7 @@ final readonly class SummaryEvalScorer
                 continue;
             }
 
-            return str_starts_with($line, '#')
-                && 1 === preg_match('/^##\s+\S/mu', $summary);
+            return 1 === preg_match('/^##\s+\S/u', $line);
         }
 
         return false;

--- a/backend/src/Service/Eval/SummaryEvalScorer.php
+++ b/backend/src/Service/Eval/SummaryEvalScorer.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Eval;
+
+/**
+ * Deterministic scoring for `app:summary:eval` — no judge model.
+ *
+ * Metrics (see planning/20260827-conversation-continuity/01_sprint_1_summary_eval.md):
+ *  - size:        raw model output must respect the character cap it was given
+ *  - retention:   every required probe (substring or `re:` regex) is present
+ *  - hallucination: no forbidden probe is present
+ *  - structure:   output starts with a markdown heading, no preamble
+ *  - language:    stopword/script heuristic; only a CONFIDENT mismatch fails
+ */
+final readonly class SummaryEvalScorer
+{
+    private const REGEX_PROBE_PREFIX = 're:';
+
+    /** Minimum stopword hits before the detector commits to a language. */
+    private const MIN_STOPWORD_HITS = 3;
+
+    /** Share of Cyrillic letters that marks a Russian-script summary. */
+    private const CYRILLIC_RATIO = 0.25;
+
+    /**
+     * Distinctive stopwords only — words shared between two supported
+     * languages (e.g. "was", "in") are deliberately absent so a single
+     * ambiguous token can never flip the detection.
+     *
+     * @var array<string, list<string>>
+     */
+    private const STOPWORDS = [
+        'en' => ['the', 'and', 'with', 'for', 'that', 'this', 'from', 'are'],
+        'de' => ['und', 'der', 'die', 'das', 'nicht', 'eine', 'für', 'mit', 'wird', 'noch', 'wurde'],
+        'es' => ['el', 'la', 'que', 'los', 'una', 'para', 'con', 'las'],
+        'tr' => ['ve', 'bir', 'için', 'bu', 'ile', 'olarak'],
+    ];
+
+    /**
+     * @param list<string> $requiredProbes
+     * @param list<string> $forbiddenProbes
+     */
+    public function score(
+        string $summary,
+        int $summaryMaxChars,
+        array $requiredProbes,
+        array $forbiddenProbes,
+        ?string $expectLanguage,
+    ): SummaryEvalScore {
+        $summary = trim($summary);
+        $chars = mb_strlen($summary);
+
+        $missing = [];
+        foreach ($requiredProbes as $probe) {
+            if (!$this->probeMatches($probe, $summary)) {
+                $missing[] = $probe;
+            }
+        }
+
+        $forbiddenHits = [];
+        foreach ($forbiddenProbes as $probe) {
+            if ($this->probeMatches($probe, $summary)) {
+                $forbiddenHits[] = $probe;
+            }
+        }
+
+        $detected = $this->detectLanguage($summary);
+        $languageOk = null;
+        if (null !== $expectLanguage && '' !== $expectLanguage && null !== $detected) {
+            $languageOk = $detected === $expectLanguage;
+        }
+
+        return new SummaryEvalScore(
+            chars: $chars,
+            sizeOk: $chars > 0 && $chars <= $summaryMaxChars,
+            missingRequired: $missing,
+            forbiddenHits: $forbiddenHits,
+            structureOk: $this->structureOk($summary),
+            languageOk: $languageOk,
+            detectedLanguage: $detected,
+        );
+    }
+
+    private function probeMatches(string $probe, string $summary): bool
+    {
+        if (str_starts_with($probe, self::REGEX_PROBE_PREFIX)) {
+            $pattern = '/'.str_replace('/', '\/', substr($probe, strlen(self::REGEX_PROBE_PREFIX))).'/iu';
+
+            return 1 === @preg_match($pattern, $summary);
+        }
+
+        return false !== mb_stripos($summary, $probe);
+    }
+
+    /**
+     * The prompt forbids preamble and mandates `## <heading>` sections, so a
+     * compliant summary starts with a markdown heading and contains at least
+     * one `## ` section line.
+     */
+    private function structureOk(string $summary): bool
+    {
+        if ('' === $summary) {
+            return false;
+        }
+
+        $lines = preg_split('/\R/u', $summary) ?: [];
+        foreach ($lines as $line) {
+            $line = trim($line);
+            if ('' === $line) {
+                continue;
+            }
+
+            return str_starts_with($line, '#')
+                && 1 === preg_match('/^##\s+\S/mu', $summary);
+        }
+
+        return false;
+    }
+
+    private function detectLanguage(string $summary): ?string
+    {
+        if ('' === $summary) {
+            return null;
+        }
+
+        $letters = preg_match_all('/\p{L}/u', $summary);
+        if (is_int($letters) && $letters > 0) {
+            $cyrillic = preg_match_all('/\p{Cyrillic}/u', $summary);
+            if (is_int($cyrillic) && ($cyrillic / $letters) > self::CYRILLIC_RATIO) {
+                return 'ru';
+            }
+        }
+
+        $best = null;
+        $bestHits = 0;
+        $runnerUpHits = 0;
+        foreach (self::STOPWORDS as $language => $words) {
+            $pattern = '/\b(?:'.implode('|', array_map('preg_quote', $words)).')\b/iu';
+            $hits = preg_match_all($pattern, $summary);
+            $hits = is_int($hits) ? $hits : 0;
+
+            if ($hits > $bestHits) {
+                $runnerUpHits = $bestHits;
+                $bestHits = $hits;
+                $best = $language;
+            } elseif ($hits > $runnerUpHits) {
+                $runnerUpHits = $hits;
+            }
+        }
+
+        if (null === $best || $bestHits < self::MIN_STOPWORD_HITS || $bestHits === $runnerUpHits) {
+            return null;
+        }
+
+        return $best;
+    }
+}

--- a/backend/src/Service/Message/ConversationSummaryPrompts.php
+++ b/backend/src/Service/Message/ConversationSummaryPrompts.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Message;
+
+use App\Entity\Message;
+
+/**
+ * The production prompts and input rendering for the rolling conversation
+ * summary, extracted so the live-model eval (`app:summary:eval`) exercises
+ * EXACTLY what {@see ConversationSummaryService} sends — the eval can never
+ * drift from production.
+ *
+ * Pure string building only: no I/O, no state, no model calls.
+ */
+final class ConversationSummaryPrompts
+{
+    private function __construct()
+    {
+    }
+
+    public static function bootstrapSystemPrompt(int $summaryMaxChars): string
+    {
+        return <<<PROMPT
+            You compress the earlier part of an ongoing chat conversation into a compact "rolling summary" that a chat assistant will read as background context. The most recent turns are shown to the assistant separately and verbatim, so DO NOT restate them — summarize only what is provided below.
+
+            Rules:
+            - Write in the SAME language the conversation uses.
+            - Apply GRADIENT compression: segments are ordered oldest → newest. Condense the OLDEST segment the hardest (only durable facts / the overall topic). Condense LATER segments progressively less, keeping more specifics for the newest segment.
+            - Be factual. Never invent information that is not present in the source.
+            - Output plain prose / short bullet lines under these headings (skip a heading when empty):
+              ## Topic
+              ## User position / goal
+              ## Decisions & constraints
+              ## Open questions
+              ## Already covered / answered
+              ## External results
+            - "Already covered / answered" is what stops the assistant from repeating earlier answers — list conclusions and deliverables already produced.
+            - No preamble, no meta commentary.
+            - Keep the whole summary under {$summaryMaxChars} characters.
+            PROMPT;
+    }
+
+    public static function incrementalSystemPrompt(int $summaryMaxChars): string
+    {
+        return <<<PROMPT
+            You maintain a rolling summary of an ongoing chat. You receive the PREVIOUS rolling summary plus a small set of NEWLY AGED-OUT messages that just left the verbatim window. Fold the new messages into the previous summary and return the updated summary.
+
+            Rules:
+            - Write in the SAME language the conversation uses.
+            - Keep durable facts from the previous summary; do not drop the user's position, decisions, or open questions unless the new messages explicitly resolve or replace them.
+            - Condense older material more aggressively than the newly aged-out messages.
+            - Be factual. Never invent information.
+            - Output plain prose / short bullet lines under these headings (skip a heading when empty):
+              ## Topic
+              ## User position / goal
+              ## Decisions & constraints
+              ## Open questions
+              ## Already covered / answered
+              ## External results
+            - "Already covered / answered" must grow when the new messages contain conclusions or deliverables, so the assistant does not repeat itself.
+            - No preamble, no meta commentary.
+            - Keep the whole summary under {$summaryMaxChars} characters.
+            PROMPT;
+    }
+
+    /**
+     * Render the older span as recency-tiered segments with per-tier
+     * compression hints (the bootstrap user content).
+     *
+     * @param list<Message> $older chronological (oldest first)
+     */
+    public static function bootstrapUserContent(array $older, int $tiers): string
+    {
+        $tiers = max(1, min($tiers, count($older)));
+        $perTier = (int) ceil(count($older) / $tiers);
+        $chunks = array_chunk($older, max(1, $perTier));
+        $segmentCount = count($chunks);
+
+        $lines = [];
+        foreach ($chunks as $index => $chunk) {
+            $lines[] = sprintf('## Segment %d of %d (%s):', $index + 1, $segmentCount, self::compressionHint($index, $segmentCount));
+            foreach ($chunk as $msg) {
+                $lines[] = self::renderMessage($msg);
+            }
+            $lines[] = '';
+        }
+
+        return trim(implode("\n", $lines));
+    }
+
+    /**
+     * @param list<Message> $newMessages
+     */
+    public static function incrementalUserContent(string $previousSummary, array $newMessages): string
+    {
+        $lines = ["## Previous rolling summary\n", $previousSummary, "\n## Newly aged-out messages\n"];
+        foreach ($newMessages as $msg) {
+            $lines[] = self::renderMessage($msg);
+        }
+
+        return trim(implode("\n", $lines));
+    }
+
+    public static function renderMessage(Message $msg): string
+    {
+        $role = 'IN' === $msg->getDirection() ? 'user' : 'assistant';
+        $text = (string) $msg->getText();
+
+        $fileText = (string) $msg->getFileText();
+        if ('' !== $fileText) {
+            $text .= ' [attached '.((string) $msg->getFileType()).': '.self::clip($fileText, 500).']';
+        }
+
+        return sprintf('[#%d %s]: %s', (int) $msg->getId(), $role, self::clip($text, ConversationSummaryConstants::SOURCE_MESSAGE_CHAR_CAP));
+    }
+
+    /**
+     * Response token budget for a target character cap (reasoning headroom
+     * included — the shipped SORT/SUMMARIZE defaults think before answering).
+     */
+    public static function tokenBudget(int $summaryMaxChars): int
+    {
+        return max(256, (int) ceil($summaryMaxChars / 3) + 256);
+    }
+
+    private static function compressionHint(int $index, int $segmentCount): string
+    {
+        if ($segmentCount <= 1) {
+            return 'condense to the essentials';
+        }
+
+        if (0 === $index) {
+            return 'oldest — condense aggressively, essentials only';
+        }
+
+        if ($index === $segmentCount - 1) {
+            return 'most recent of the older turns — condense lightly, keep specifics and the current position';
+        }
+
+        return 'middle — condense moderately';
+    }
+
+    private static function clip(string $value, int $maxChars): string
+    {
+        if (mb_strlen($value) <= $maxChars) {
+            return $value;
+        }
+
+        return rtrim(mb_substr($value, 0, $maxChars)).'…';
+    }
+}

--- a/backend/src/Service/Message/ConversationSummaryService.php
+++ b/backend/src/Service/Message/ConversationSummaryService.php
@@ -198,13 +198,12 @@ final readonly class ConversationSummaryService
      */
     private function bootstrap(array $older, int $userId, int $chatId): ?string
     {
-        $summaryMax = $this->config->getSummaryMaxChars();
         $maxSource = $this->config->getMaxSourceMessages();
         $source = count($older) > $maxSource ? array_slice($older, -$maxSource) : $older;
 
         return $this->callSummarizer(
-            $this->buildBootstrapSystemPrompt($summaryMax),
-            $this->buildSourceText($source, $this->config->getTiers()),
+            ConversationSummaryPrompts::bootstrapSystemPrompt($this->config->getSummaryMaxChars()),
+            ConversationSummaryPrompts::bootstrapUserContent($source, $this->config->getTiers()),
             $userId,
             $chatId,
             'bootstrap',
@@ -216,15 +215,9 @@ final readonly class ConversationSummaryService
      */
     private function foldIncremental(string $previousSummary, array $newMessages, int $userId, int $chatId): ?string
     {
-        $summaryMax = $this->config->getSummaryMaxChars();
-        $lines = ["## Previous rolling summary\n", $previousSummary, "\n## Newly aged-out messages\n"];
-        foreach ($newMessages as $msg) {
-            $lines[] = $this->renderMessage($msg);
-        }
-
         return $this->callSummarizer(
-            $this->buildIncrementalSystemPrompt($summaryMax),
-            trim(implode("\n", $lines)),
+            ConversationSummaryPrompts::incrementalSystemPrompt($this->config->getSummaryMaxChars()),
+            ConversationSummaryPrompts::incrementalUserContent($previousSummary, $newMessages),
             $userId,
             $chatId,
             'incremental',
@@ -245,7 +238,7 @@ final readonly class ConversationSummaryService
                 'provider' => $modelConfig['provider'] ?? null,
                 'model' => $modelConfig['model'] ?? null,
                 'temperature' => 0.2,
-                'max_tokens' => $this->tokenBudgetFor($summaryMax),
+                'max_tokens' => ConversationSummaryPrompts::tokenBudget($summaryMax),
             ]);
 
             $summary = $this->clip(trim((string) ($response['content'] ?? '')), $summaryMax);
@@ -329,51 +322,6 @@ final readonly class ConversationSummaryService
         return sprintf('conv_summary.chat.%d.%s', $chatId, $fingerprint);
     }
 
-    private function buildBootstrapSystemPrompt(int $summaryMax): string
-    {
-        return <<<PROMPT
-            You compress the earlier part of an ongoing chat conversation into a compact "rolling summary" that a chat assistant will read as background context. The most recent turns are shown to the assistant separately and verbatim, so DO NOT restate them — summarize only what is provided below.
-
-            Rules:
-            - Write in the SAME language the conversation uses.
-            - Apply GRADIENT compression: segments are ordered oldest → newest. Condense the OLDEST segment the hardest (only durable facts / the overall topic). Condense LATER segments progressively less, keeping more specifics for the newest segment.
-            - Be factual. Never invent information that is not present in the source.
-            - Output plain prose / short bullet lines under these headings (skip a heading when empty):
-              ## Topic
-              ## User position / goal
-              ## Decisions & constraints
-              ## Open questions
-              ## Already covered / answered
-              ## External results
-            - "Already covered / answered" is what stops the assistant from repeating earlier answers — list conclusions and deliverables already produced.
-            - No preamble, no meta commentary.
-            - Keep the whole summary under {$summaryMax} characters.
-            PROMPT;
-    }
-
-    private function buildIncrementalSystemPrompt(int $summaryMax): string
-    {
-        return <<<PROMPT
-            You maintain a rolling summary of an ongoing chat. You receive the PREVIOUS rolling summary plus a small set of NEWLY AGED-OUT messages that just left the verbatim window. Fold the new messages into the previous summary and return the updated summary.
-
-            Rules:
-            - Write in the SAME language the conversation uses.
-            - Keep durable facts from the previous summary; do not drop the user's position, decisions, or open questions unless the new messages explicitly resolve or replace them.
-            - Condense older material more aggressively than the newly aged-out messages.
-            - Be factual. Never invent information.
-            - Output plain prose / short bullet lines under these headings (skip a heading when empty):
-              ## Topic
-              ## User position / goal
-              ## Decisions & constraints
-              ## Open questions
-              ## Already covered / answered
-              ## External results
-            - "Already covered / answered" must grow when the new messages contain conclusions or deliverables, so the assistant does not repeat itself.
-            - No preamble, no meta commentary.
-            - Keep the whole summary under {$summaryMax} characters.
-            PROMPT;
-    }
-
     /**
      * @param list<Message> $gap
      */
@@ -381,7 +329,7 @@ final readonly class ConversationSummaryService
     {
         $lines = ["\n\n## Recent (not yet condensed)"];
         foreach ($gap as $msg) {
-            $lines[] = $this->renderMessage($msg);
+            $lines[] = ConversationSummaryPrompts::renderMessage($msg);
         }
 
         return $this->clip($summary.implode("\n", $lines), $this->config->getSummaryMaxChars() + self::GAP_CHAR_CAP);
@@ -410,58 +358,6 @@ final readonly class ConversationSummaryService
         return array_reverse($reversed);
     }
 
-    /**
-     * @param list<Message> $older
-     */
-    private function buildSourceText(array $older, int $tiers): string
-    {
-        $tiers = max(1, min($tiers, count($older)));
-        $perTier = (int) ceil(count($older) / $tiers);
-        $chunks = array_chunk($older, max(1, $perTier));
-        $segmentCount = count($chunks);
-
-        $lines = [];
-        foreach ($chunks as $index => $chunk) {
-            $lines[] = sprintf('## Segment %d of %d (%s):', $index + 1, $segmentCount, $this->compressionHint($index, $segmentCount));
-            foreach ($chunk as $msg) {
-                $lines[] = $this->renderMessage($msg);
-            }
-            $lines[] = '';
-        }
-
-        return trim(implode("\n", $lines));
-    }
-
-    private function compressionHint(int $index, int $segmentCount): string
-    {
-        if ($segmentCount <= 1) {
-            return 'condense to the essentials';
-        }
-
-        if (0 === $index) {
-            return 'oldest — condense aggressively, essentials only';
-        }
-
-        if ($index === $segmentCount - 1) {
-            return 'most recent of the older turns — condense lightly, keep specifics and the current position';
-        }
-
-        return 'middle — condense moderately';
-    }
-
-    private function renderMessage(Message $msg): string
-    {
-        $role = 'IN' === $msg->getDirection() ? 'user' : 'assistant';
-        $text = (string) $msg->getText();
-
-        $fileText = (string) $msg->getFileText();
-        if ('' !== $fileText) {
-            $text .= ' [attached '.((string) $msg->getFileType()).': '.$this->clip($fileText, 500).']';
-        }
-
-        return sprintf('[#%d %s]: %s', (int) $msg->getId(), $role, $this->clip($text, ConversationSummaryConstants::SOURCE_MESSAGE_CHAR_CAP));
-    }
-
     private function messageLength(Message $msg): int
     {
         return mb_strlen((string) $msg->getText()) + mb_strlen($msg->getFileText());
@@ -474,10 +370,5 @@ final readonly class ConversationSummaryService
         }
 
         return rtrim(mb_substr($value, 0, $maxChars)).'…';
-    }
-
-    private function tokenBudgetFor(int $summaryMaxChars): int
-    {
-        return max(256, (int) ceil($summaryMaxChars / 3) + 256);
     }
 }

--- a/backend/tests/Eval/summary_eval_corpus.json
+++ b/backend/tests/Eval/summary_eval_corpus.json
@@ -1,0 +1,168 @@
+[
+  {
+    "id": "en_rent_letter_bootstrap",
+    "mode": "bootstrap",
+    "expect_language": "en",
+    "notes": "Long-running office-rent thread with an attached letter. Durable facts: landlord name, old/new rent, effective date.",
+    "probes": {
+      "required": ["Meridian", "re:1[^0-9]{0,2}450", "re:1[^0-9]{0,2}620", "re:Sept|0?1[./-]0?9|0?9[./-]0?1"],
+      "forbidden": ["lawsuit", "termination notice"]
+    },
+    "messages": [
+      { "role": "user", "text": "I received a letter from our landlord about the office rent. Can you help me understand it?" },
+      { "role": "assistant", "text": "Of course. Please share the letter or its key points and I'll walk you through it." },
+      { "role": "user", "text": "Here is the letter as a scan.", "file_type": "document", "file_text": "Meridian Properties GmbH — Notice of rent adjustment. Dear tenant, pursuant to clause 4.2 of your lease for the office unit at Dockside Park 12, the monthly base rent will increase from EUR 1450 to EUR 1620 effective 1 September. Ancillary cost prepayments remain unchanged at EUR 310 per month." },
+      { "role": "assistant", "text": "Summary of the letter: Meridian Properties raises your base rent from EUR 1450 to EUR 1620 (an 11.7% increase) effective 1 September, citing clause 4.2 of the lease. Ancillary prepayments stay at EUR 310." },
+      { "role": "user", "text": "Is an 11.7% increase even allowed under a standard commercial lease?" },
+      { "role": "assistant", "text": "Commercial leases are not subject to residential rent caps. What matters is what clause 4.2 says — typically an indexation clause tied to the consumer price index. If the CPI rose accordingly, the increase is likely valid." },
+      { "role": "user", "text": "Clause 4.2 is indeed a CPI indexation clause. The letter references the official index." },
+      { "role": "assistant", "text": "Then the adjustment is most likely enforceable. You can still verify the arithmetic: base rent at signing, index value then, index value now. If you want, draft a short reply asking Meridian for the exact index values used." },
+      { "role": "user", "text": "Yes, draft that reply to the realtor please. Polite but firm, asking for the calculation details." },
+      { "role": "assistant", "text": "Draft: 'Dear Meridian Properties team, thank you for your notice regarding the rent adjustment for Dockside Park 12. Before we confirm, please provide the exact index values and calculation used to derive the new base rent of EUR 1620. Kind regards.' Shall I finalize it?" },
+      { "role": "user", "text": "Perfect, that's the letter I'll send. Please remember we sent this to the realtor today." },
+      { "role": "assistant", "text": "Noted — the verification request was sent to Meridian Properties today. I'll treat the increase as pending their reply with the index calculation." },
+      { "role": "user", "text": "While we wait: our budget. The office costs will rise by EUR 170 per month, so about EUR 2040 per year. Where should we absorb that?" },
+      { "role": "assistant", "text": "Options: reduce the coworking day-pass budget (currently EUR 250/month, underused), renegotiate the cleaning contract, or cut the beverage subscription. The day-pass budget alone would cover the increase." },
+      { "role": "user", "text": "Good, let's cut the day-pass budget to EUR 80 and keep everything else. Decision made." },
+      { "role": "assistant", "text": "Decision recorded: day-pass budget reduced from EUR 250 to EUR 80 per month, which more than covers the EUR 170 rent increase. Cleaning and beverages unchanged." },
+      { "role": "user", "text": "One more thing — when does our lease actually expire? I think we signed for five years." },
+      { "role": "assistant", "text": "Based on what you told me earlier in this thread, the lease for Dockside Park 12 runs five years from signing; you should confirm the exact expiry date from the contract PDF. That is still an open point." }
+    ]
+  },
+  {
+    "id": "de_buero_umbau_bootstrap",
+    "mode": "bootstrap",
+    "expect_language": "de",
+    "notes": "German thread about an office refurbishment. The summary must stay in German and keep contractor name and budget.",
+    "probes": {
+      "required": ["re:Tischler(ei)? Brandt|Brandt", "re:18[.,\\s]?000", "re:Bauamt|Genehmigung"],
+      "forbidden": ["Meridian", "Insolvenz"]
+    },
+    "messages": [
+      { "role": "user", "text": "Wir wollen unser Büro im Erdgeschoss umbauen: zwei Besprechungsräume und eine kleine Teeküche." },
+      { "role": "assistant", "text": "Gern. Wichtige Punkte: Budget, Zeitplan, und ob tragende Wände betroffen sind. Gibt es dazu schon Informationen?" },
+      { "role": "user", "text": "Budget maximal 18000 Euro. Keine tragenden Wände, nur Leichtbauwände. Fertig sein soll alles bis Ende November." },
+      { "role": "assistant", "text": "Verstanden: Budget 18000 Euro, Leichtbauwände, Deadline Ende November. Für Leichtbauwände ist in der Regel keine Baugenehmigung nötig, die Teeküche mit Wasseranschluss sollte aber mit dem Vermieter abgestimmt werden." },
+      { "role": "user", "text": "Der Vermieter hat schriftlich zugestimmt. Welche Handwerker brauchen wir?" },
+      { "role": "assistant", "text": "Trockenbauer für die Wände, Elektriker für Steckdosen und Beleuchtung, Installateur für die Teeküche. Optional ein Tischler für Einbaumöbel." },
+      { "role": "user", "text": "Wir haben drei Angebote eingeholt. Die Tischlerei Brandt war mit 4200 Euro für die Einbaumöbel am günstigsten und hat gute Referenzen." },
+      { "role": "assistant", "text": "Dann ist die Tischlerei Brandt eine solide Wahl. Damit wären rund 4200 Euro des Budgets für Möbel gebunden, es blieben etwa 13800 Euro für Trockenbau, Elektrik und Sanitär." },
+      { "role": "user", "text": "Entschieden: Brandt bekommt den Zuschlag für die Möbel. Der Trockenbauer beginnt am 6. Oktober." },
+      { "role": "assistant", "text": "Festgehalten: Auftrag für Einbaumöbel an Tischlerei Brandt (4200 Euro), Trockenbau-Start am 6. Oktober, Gesamtbudget 18000 Euro, Deadline Ende November." },
+      { "role": "user", "text": "Offen ist noch, ob wir für das neue Außenschild eine Genehmigung vom Bauamt brauchen. Kannst du das im Blick behalten?" },
+      { "role": "assistant", "text": "Notiert als offener Punkt: Klärung mit dem Bauamt, ob das Außenschild genehmigungspflichtig ist. Alles andere ist entschieden." }
+    ]
+  },
+  {
+    "id": "en_whatsapp_style_bootstrap",
+    "mode": "bootstrap",
+    "expect_language": "en",
+    "notes": "Short colloquial WhatsApp-style planning thread. Facts: venue, date, headcount.",
+    "probes": {
+      "required": ["re:Caf[eé] Lumen|Lumen", "re:Nov(ember)?\\W{0,3}14|14\\W{0,3}Nov|14[./]11|11[./]14", "re:35|thirty-?five"],
+      "forbidden": ["re:cancel(l)?ed"]
+    },
+    "messages": [
+      { "role": "user", "text": "hey, team offsite planning. got a sec?" },
+      { "role": "assistant", "text": "Sure! What do you need?" },
+      { "role": "user", "text": "need a venue for ~35 ppl, relaxed vibe, mid november" },
+      { "role": "assistant", "text": "Options: Café Lumen (private back room, fits 40), The Boilerhouse (industrial, fits 60), Harbor Loft (fits 30, tight). Café Lumen is usually the best value." },
+      { "role": "user", "text": "lumen looks great. is nov 14 free?" },
+      { "role": "assistant", "text": "Café Lumen's back room is available on November 14, both afternoon and evening. They ask for a EUR 300 deposit." },
+      { "role": "user", "text": "book it. afternoon + evening. i'll wire the deposit today" },
+      { "role": "assistant", "text": "Booked: Café Lumen back room, November 14, afternoon and evening, 35 people, EUR 300 deposit to be wired today." },
+      { "role": "user", "text": "catering? nothing fancy, maybe tapas" },
+      { "role": "assistant", "text": "Café Lumen offers an in-house tapas buffet at EUR 24 per person, or we can bring an external caterer for a EUR 150 corkage-style fee. In-house is simpler." },
+      { "role": "user", "text": "in-house tapas then. still need to check dietary stuff with the team, don't let me forget" },
+      { "role": "assistant", "text": "Noted: in-house tapas buffet chosen (EUR 24 pp). Open point: collect dietary requirements from the team." }
+    ]
+  },
+  {
+    "id": "de_email_style_bootstrap",
+    "mode": "bootstrap",
+    "expect_language": "de",
+    "notes": "Formal email-style German thread: supplier contract negotiation. Long turns, gradient compression must keep the oldest tier tiny but retain supplier and delivery date.",
+    "probes": {
+      "required": ["re:Nordfeld", "re:15\\.?\\s?(März|03)|März", "re:Rahmenvertrag|Vertrag"],
+      "forbidden": ["Vertragsbruch", "Insolvenz"]
+    },
+    "messages": [
+      { "role": "user", "text": "Sehr geehrte Damen und Herren, wir prüfen derzeit den Abschluss eines Rahmenvertrags mit der Nordfeld Logistik GmbH über die Belieferung unserer drei Standorte. Bitte fassen Sie die wichtigsten vertraglichen Punkte zusammen, die wir vor der Unterzeichnung klären sollten. Mit freundlichen Grüßen" },
+      { "role": "assistant", "text": "Sehr gerne. Vor Unterzeichnung eines Rahmenvertrags mit der Nordfeld Logistik GmbH sollten insbesondere geklärt werden: Laufzeit und Verlängerungsklauseln, Service-Level (Lieferzeiten, Fehlmengenquote), Preisgleitklauseln in Abhängigkeit von Treibstoffkosten, Haftungsgrenzen bei Transportschäden sowie Sonderkündigungsrechte bei wiederholten Schlechtleistungen." },
+      { "role": "user", "text": "Nordfeld hat uns einen Entwurf zugesandt. Die Laufzeit beträgt 24 Monate mit automatischer Verlängerung um jeweils 12 Monate. Die Lieferfrist ist mit 48 Stunden ab Bestellung angegeben. Erscheint Ihnen das marktüblich?" },
+      { "role": "assistant", "text": "Eine Laufzeit von 24 Monaten mit 12-monatiger Verlängerung ist marktüblich, allerdings empfehle ich eine Kündigungsfrist von höchstens drei Monaten zum Laufzeitende. Die Lieferfrist von 48 Stunden ist für regionale Logistik gut; wichtig ist, dass sie als verbindliches Service-Level mit Vertragsstrafe und nicht nur als Zielwert formuliert ist." },
+      { "role": "user", "text": "Wir haben mit Nordfeld nachverhandelt: Vertragsstrafe von 2 Prozent des Monatsvolumens je verspäteter Lieferung, gedeckelt auf 10 Prozent. Der Vertragsbeginn soll der 15. März sein. Einverstanden?" },
+      { "role": "assistant", "text": "Die nachverhandelten Konditionen sind solide: 2 Prozent Vertragsstrafe je Verspätung mit einer Obergrenze von 10 Prozent des Monatsvolumens ist ein übliches und faires Modell. Dem Vertragsbeginn zum 15. März steht aus meiner Sicht nichts entgegen, sofern die Anlage zu den Standortadressen aktualisiert wurde." },
+      { "role": "user", "text": "Die Anlage wurde aktualisiert. Offen ist nur noch die Frage der Versicherungssumme für Transportschäden — Nordfeld bietet 250000 Euro pro Schadensfall. Reicht das?" },
+      { "role": "assistant", "text": "Für Ihre Warenwerte je Lieferung (nach früherer Angabe maximal rund 180000 Euro) ist eine Deckung von 250000 Euro pro Schadensfall ausreichend bemessen. Damit wären alle wesentlichen Punkte geklärt; einzig die finale Freigabe durch Ihre Geschäftsführung steht noch aus." }
+    ]
+  },
+  {
+    "id": "ru_support_bootstrap",
+    "mode": "bootstrap",
+    "expect_language": "ru",
+    "notes": "Non-Latin-script case: Russian support thread. The summary must be written in Russian (Cyrillic).",
+    "probes": {
+      "required": ["re:сервер|облак", "re:резервн|копир"],
+      "forbidden": []
+    },
+    "messages": [
+      { "role": "user", "text": "Здравствуйте! Наш сервер перестал делать резервные копии по ночам. Что проверить?" },
+      { "role": "assistant", "text": "Здравствуйте! Проверьте: расписание задач cron, свободное место на диске назначения и журнал ошибок службы резервного копирования." },
+      { "role": "user", "text": "Место закончилось на сетевом диске. Мы удалили старые архивы, теперь копирование работает." },
+      { "role": "assistant", "text": "Отлично. Рекомендую настроить ротацию архивов: хранить 14 ежедневных и 6 ежемесячных копий, а также добавить оповещение при заполнении диска свыше 80 процентов." },
+      { "role": "user", "text": "Сделали ротацию, как вы посоветовали. Ещё думаем перенести резервные копии в облако." },
+      { "role": "assistant", "text": "Перенос в облако — хорошая идея: настройте шифрование архивов до загрузки и проверяйте восстановление раз в квартал. Вопрос о выборе облачного провайдера остаётся открытым." }
+    ]
+  },
+  {
+    "id": "en_fold_keeps_durable_facts",
+    "mode": "incremental",
+    "expect_language": "en",
+    "notes": "Folding new messages must not drop durable facts from the previous summary (project name, launch date).",
+    "previous_summary": "## Topic\nRelaunch of the company website (project 'Beacon').\n## User position / goal\nLaunch on March 3 with a migrated blog and new pricing page.\n## Decisions & constraints\n- Hosting stays on the current provider.\n- Budget capped at EUR 9000.\n## Open questions\n- Who writes the new pricing copy?\n## Already covered / answered\n- Sitemap agreed (12 pages).",
+    "probes": {
+      "required": ["Beacon", "re:March\\s*3|03-03|3rd of March", "re:9[.,\\s]?000", "re:Anna"],
+      "forbidden": ["re:hosting (provider )?chang"]
+    },
+    "messages": [
+      { "role": "user", "text": "Update on the pricing copy: Anna from marketing will write it, draft due next Friday." },
+      { "role": "assistant", "text": "Noted — Anna owns the pricing copy with a draft due next Friday. That resolves the open question about copy ownership." },
+      { "role": "user", "text": "Also, the staging environment is now live and the blog import ran without errors." },
+      { "role": "assistant", "text": "Great: staging is live and the blog migration is verified. Remaining before the March 3 launch: pricing copy review and the final DNS switch plan." }
+    ]
+  },
+  {
+    "id": "en_fold_resolves_open_question",
+    "mode": "incremental",
+    "expect_language": "en",
+    "notes": "The new messages resolve the previously open budget question; the folded summary must reflect the approval instead of keeping it open verbatim.",
+    "previous_summary": "## Topic\nProcurement of 20 new developer laptops.\n## User position / goal\nOrder before the fiscal year ends.\n## Decisions & constraints\n- Model shortlist: Model X14 and Model P1.\n## Open questions\n- Budget approval by finance is still pending (requested: EUR 38,000).\n## Already covered / answered\n- Comparison table of both models was produced.",
+    "probes": {
+      "required": ["re:38[.,\\s]?000", "re:approv", "re:X14"],
+      "forbidden": ["re:budget[^.\\n]{0,40}(still )?pending"]
+    },
+    "messages": [
+      { "role": "user", "text": "Finance just approved the full EUR 38,000 budget for the laptops." },
+      { "role": "assistant", "text": "Excellent — the budget is approved. Shall I prepare the order for the preferred Model X14 configuration?" },
+      { "role": "user", "text": "Yes, go with the X14 for all 20 devices. Decision final." },
+      { "role": "assistant", "text": "Decision recorded: 20 units of Model X14, funded by the approved EUR 38,000 budget. Next step is sending the purchase order to the supplier." }
+    ]
+  },
+  {
+    "id": "en_hallucination_trap_bootstrap",
+    "mode": "bootstrap",
+    "expect_language": "en",
+    "notes": "Sparse conversation; the forbidden probes are plausible-sounding facts that were never said.",
+    "probes": {
+      "required": ["re:newsletter", "re:Tuesday"],
+      "forbidden": ["GDPR", "re:unsubscrib", "re:Mailchimp|SendGrid|Brevo"]
+    },
+    "messages": [
+      { "role": "user", "text": "We want to start a customer newsletter. Nothing decided yet except that it should go out on Tuesdays." },
+      { "role": "assistant", "text": "A Tuesday cadence is a good start. Open decisions: tool selection, content owner, and target segment." },
+      { "role": "user", "text": "Content will be written by the product team. Tool is completely undecided." },
+      { "role": "assistant", "text": "Understood: product team writes the content, the sending tool is still open, and the newsletter ships on Tuesdays." }
+    ]
+  }
+]

--- a/backend/tests/Unit/Eval/SummaryEvalCorpusTest.php
+++ b/backend/tests/Unit/Eval/SummaryEvalCorpusTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Eval;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The live eval (`app:summary:eval`) is not part of the CI gate, but a broken
+ * corpus must still fail CI — otherwise the instrument silently rots.
+ */
+class SummaryEvalCorpusTest extends TestCase
+{
+    private const CORPUS_PATH = __DIR__.'/../../Eval/summary_eval_corpus.json';
+
+    /**
+     * @return list<mixed>
+     */
+    private function corpus(): array
+    {
+        self::assertFileExists(self::CORPUS_PATH);
+
+        $corpus = json_decode((string) file_get_contents(self::CORPUS_PATH), true);
+        self::assertIsArray($corpus, 'corpus must be valid JSON');
+        self::assertNotEmpty($corpus);
+
+        return array_values($corpus);
+    }
+
+    public function testEveryCaseHasTheRequiredShape(): void
+    {
+        $seenIds = [];
+        foreach ($this->corpus() as $case) {
+            self::assertIsArray($case);
+
+            $id = $case['id'] ?? null;
+            self::assertIsString($id, 'every case needs a string id');
+            self::assertNotSame('', $id);
+            self::assertArrayNotHasKey($id, $seenIds, "duplicate case id '{$id}'");
+            $seenIds[$id] = true;
+
+            self::assertContains($case['mode'] ?? null, ['bootstrap', 'incremental'], "case '{$id}': mode must be bootstrap or incremental");
+
+            $messages = $case['messages'] ?? null;
+            self::assertIsArray($messages, "case '{$id}': messages missing");
+            self::assertNotEmpty($messages, "case '{$id}': messages empty");
+            foreach ($messages as $message) {
+                self::assertIsArray($message);
+                self::assertContains($message['role'] ?? null, ['user', 'assistant'], "case '{$id}': message role must be user or assistant");
+                self::assertIsString($message['text'] ?? null, "case '{$id}': message text missing");
+            }
+
+            if ('incremental' === $case['mode']) {
+                self::assertIsString($case['previous_summary'] ?? null, "case '{$id}': incremental cases need previous_summary");
+                self::assertNotSame('', trim((string) $case['previous_summary']));
+            }
+
+            $probes = $case['probes'] ?? null;
+            self::assertIsArray($probes, "case '{$id}': probes missing");
+            $required = $probes['required'] ?? null;
+            self::assertIsArray($required, "case '{$id}': probes.required missing");
+            self::assertNotEmpty($required, "case '{$id}': probes.required must not be empty — a case without retention probes measures nothing");
+            self::assertIsArray($probes['forbidden'] ?? null, "case '{$id}': probes.forbidden missing (may be empty)");
+
+            if (isset($case['expect_language'])) {
+                self::assertIsString($case['expect_language']);
+            }
+        }
+    }
+
+    public function testEveryRegexProbeCompiles(): void
+    {
+        foreach ($this->corpus() as $case) {
+            self::assertIsArray($case);
+            $probes = (array) ($case['probes'] ?? []);
+            $all = array_merge((array) ($probes['required'] ?? []), (array) ($probes['forbidden'] ?? []));
+            foreach ($all as $probe) {
+                self::assertIsString($probe);
+                if (!str_starts_with($probe, 're:')) {
+                    continue;
+                }
+                $pattern = '/'.str_replace('/', '\/', substr($probe, 3)).'/iu';
+                self::assertNotFalse(
+                    @preg_match($pattern, ''),
+                    sprintf("case '%s': regex probe '%s' does not compile", (string) ($case['id'] ?? '?'), $probe),
+                );
+            }
+        }
+    }
+
+    public function testCorpusCoversBothModesAndMultipleLanguages(): void
+    {
+        $modes = [];
+        $languages = [];
+        foreach ($this->corpus() as $case) {
+            self::assertIsArray($case);
+            $modes[(string) ($case['mode'] ?? '')] = true;
+            if (isset($case['expect_language'])) {
+                $languages[(string) $case['expect_language']] = true;
+            }
+        }
+
+        self::assertArrayHasKey('bootstrap', $modes);
+        self::assertArrayHasKey('incremental', $modes);
+        self::assertGreaterThanOrEqual(3, count($languages), 'corpus must cover at least three languages');
+    }
+}

--- a/backend/tests/Unit/Service/Eval/SummaryEvalScorerTest.php
+++ b/backend/tests/Unit/Service/Eval/SummaryEvalScorerTest.php
@@ -110,6 +110,28 @@ class SummaryEvalScorerTest extends TestCase
         self::assertFalse($score->passed());
     }
 
+    /**
+     * The prompt mandates `## <heading>` sections — a lone `# Title` first
+     * line is NOT compliant even when a `## ` section follows later.
+     */
+    public function testSingleHashFirstLineFailsStructure(): void
+    {
+        $summary = "# Summary\n## Topic\nSomething.";
+
+        $score = $this->scorer->score($summary, 4000, [], [], null);
+
+        self::assertFalse($score->structureOk);
+        self::assertFalse($score->passed());
+    }
+
+    public function testEmptySummaryIsReportedAsEmptyNotOverCap(): void
+    {
+        $score = $this->scorer->score('', 4000, [], [], null);
+
+        self::assertStringContainsString('empty summary', $score->problems());
+        self::assertStringNotContainsString('over cap', $score->problems());
+    }
+
     public function testGermanSummaryDetectedAndMatchesExpectation(): void
     {
         $summary = "## Topic\nDie Miete für das Büro wird erhöht und der Umbau ist entschieden.\n"

--- a/backend/tests/Unit/Service/Eval/SummaryEvalScorerTest.php
+++ b/backend/tests/Unit/Service/Eval/SummaryEvalScorerTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\Eval;
+
+use App\Service\Eval\SummaryEvalScorer;
+use PHPUnit\Framework\TestCase;
+
+class SummaryEvalScorerTest extends TestCase
+{
+    private SummaryEvalScorer $scorer;
+
+    protected function setUp(): void
+    {
+        $this->scorer = new SummaryEvalScorer();
+    }
+
+    private function compliantEnglishSummary(): string
+    {
+        return "## Topic\nThe office rent increase from Meridian Properties.\n"
+            ."## User position / goal\nThe user wants to verify the calculation and keep the office.\n"
+            ."## Decisions & constraints\n- The day-pass budget was cut to cover the increase and that decision is final.\n"
+            ."## Open questions\n- The exact lease expiry date is still unknown and should be checked from the contract.";
+    }
+
+    public function testCompliantSummaryPasses(): void
+    {
+        $score = $this->scorer->score(
+            $this->compliantEnglishSummary(),
+            4000,
+            ['Meridian', 're:day-?pass'],
+            ['lawsuit'],
+            'en',
+        );
+
+        self::assertTrue($score->sizeOk);
+        self::assertSame([], $score->missingRequired);
+        self::assertSame([], $score->forbiddenHits);
+        self::assertTrue($score->structureOk);
+        self::assertTrue($score->languageOk);
+        self::assertSame('en', $score->detectedLanguage);
+        self::assertTrue($score->passed());
+        self::assertSame('', $score->problems());
+    }
+
+    public function testOversizedSummaryFailsSizeOnly(): void
+    {
+        $summary = "## Topic\n".str_repeat('word and the with that from this are ', 20);
+
+        $score = $this->scorer->score($summary, 100, [], [], null);
+
+        self::assertFalse($score->sizeOk);
+        self::assertFalse($score->passed());
+        self::assertStringContainsString('over cap', $score->problems());
+    }
+
+    public function testEmptySummaryFails(): void
+    {
+        $score = $this->scorer->score('   ', 4000, ['anything'], [], null);
+
+        self::assertFalse($score->sizeOk);
+        self::assertFalse($score->structureOk);
+        self::assertSame(['anything'], $score->missingRequired);
+        self::assertFalse($score->passed());
+    }
+
+    public function testMissingRequiredSubstringIsReported(): void
+    {
+        $score = $this->scorer->score($this->compliantEnglishSummary(), 4000, ['Meridian', 'Unmentioned GmbH'], [], null);
+
+        self::assertSame(['Unmentioned GmbH'], $score->missingRequired);
+        self::assertFalse($score->passed());
+    }
+
+    public function testRequiredSubstringIsCaseInsensitive(): void
+    {
+        $score = $this->scorer->score($this->compliantEnglishSummary(), 4000, ['meridian PROPERTIES'], [], null);
+
+        self::assertSame([], $score->missingRequired);
+    }
+
+    public function testRegexProbesMatchAlternatives(): void
+    {
+        $summary = "## Topic\nThe rent rises to 1,620 euros in September.";
+
+        $score = $this->scorer->score($summary, 4000, ['re:1[.,\s]?620', 're:September|09-01'], [], null);
+
+        self::assertSame([], $score->missingRequired);
+    }
+
+    public function testForbiddenProbeHitFailsTheCase(): void
+    {
+        $summary = "## Topic\nThe newsletter will be sent via Mailchimp every Tuesday.";
+
+        $score = $this->scorer->score($summary, 4000, [], ['re:Mailchimp|SendGrid'], null);
+
+        self::assertSame(['re:Mailchimp|SendGrid'], $score->forbiddenHits);
+        self::assertFalse($score->passed());
+        self::assertStringContainsString('forbidden', $score->problems());
+    }
+
+    public function testPreambleBeforeFirstHeadingFailsStructure(): void
+    {
+        $summary = "Here is the summary you asked for:\n## Topic\nSomething.";
+
+        $score = $this->scorer->score($summary, 4000, [], [], null);
+
+        self::assertFalse($score->structureOk);
+        self::assertFalse($score->passed());
+    }
+
+    public function testGermanSummaryDetectedAndMatchesExpectation(): void
+    {
+        $summary = "## Topic\nDie Miete für das Büro wird erhöht und der Umbau ist entschieden.\n"
+            ."## Decisions & constraints\n- Die Tischlerei Brandt liefert die Möbel und das Budget wird nicht überschritten.";
+
+        $score = $this->scorer->score($summary, 4000, [], [], 'de');
+
+        self::assertSame('de', $score->detectedLanguage);
+        self::assertTrue($score->languageOk);
+    }
+
+    public function testLanguageMismatchFails(): void
+    {
+        $score = $this->scorer->score($this->compliantEnglishSummary(), 4000, [], [], 'de');
+
+        self::assertSame('en', $score->detectedLanguage);
+        self::assertFalse($score->languageOk);
+        self::assertFalse($score->passed());
+        self::assertStringContainsString('language', $score->problems());
+    }
+
+    public function testCyrillicSummaryDetectedAsRussian(): void
+    {
+        $summary = "## Topic\nРезервное копирование сервера восстановлено, ротация архивов настроена.\n"
+            ."## Open questions\n- Выбор облачного провайдера ещё не решён.";
+
+        $score = $this->scorer->score($summary, 4000, ['re:резервн'], [], 'ru');
+
+        self::assertSame('ru', $score->detectedLanguage);
+        self::assertTrue($score->languageOk);
+        self::assertTrue($score->passed());
+    }
+
+    public function testUndetectableLanguageIsNeutralNotAFailure(): void
+    {
+        // Too short for a confident stopword verdict — must not fail the case.
+        $summary = "## Topic\nRent: 1620 EUR.";
+
+        $score = $this->scorer->score($summary, 4000, [], [], 'de');
+
+        self::assertNull($score->detectedLanguage);
+        self::assertNull($score->languageOk);
+        self::assertTrue($score->passed());
+    }
+}

--- a/backend/tests/Unit/Service/Message/ConversationSummaryPromptsTest.php
+++ b/backend/tests/Unit/Service/Message/ConversationSummaryPromptsTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\Message;
+
+use App\Entity\Message;
+use App\Service\Message\ConversationSummaryPrompts;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Guards the load-bearing pieces of the production summary prompts — the
+ * live eval (`app:summary:eval`) and the worker both build on these exact
+ * strings, so silent wording regressions must fail here.
+ */
+class ConversationSummaryPromptsTest extends TestCase
+{
+    private const HEADINGS = [
+        '## Topic',
+        '## User position / goal',
+        '## Decisions & constraints',
+        '## Open questions',
+        '## Already covered / answered',
+        '## External results',
+    ];
+
+    private function makeMessage(int $id, string $direction, string $text, string $fileText = '', string $fileType = ''): Message&MockObject
+    {
+        $msg = $this->createMock(Message::class);
+        $msg->method('getId')->willReturn($id);
+        $msg->method('getDirection')->willReturn($direction);
+        $msg->method('getText')->willReturn($text);
+        $msg->method('getFileText')->willReturn($fileText);
+        $msg->method('getFileType')->willReturn($fileType);
+
+        return $msg;
+    }
+
+    public function testBootstrapSystemPromptContainsCapGradientAndHeadings(): void
+    {
+        $prompt = ConversationSummaryPrompts::bootstrapSystemPrompt(1234);
+
+        self::assertStringContainsString('under 1234 characters', $prompt);
+        self::assertStringContainsString('GRADIENT', $prompt);
+        self::assertStringContainsString('DO NOT restate', $prompt);
+        foreach (self::HEADINGS as $heading) {
+            self::assertStringContainsString($heading, $prompt);
+        }
+    }
+
+    public function testIncrementalSystemPromptContainsCapFoldInstructionAndHeadings(): void
+    {
+        $prompt = ConversationSummaryPrompts::incrementalSystemPrompt(999);
+
+        self::assertStringContainsString('under 999 characters', $prompt);
+        self::assertStringContainsString('PREVIOUS rolling summary', $prompt);
+        self::assertStringContainsString('NEWLY AGED-OUT', $prompt);
+        foreach (self::HEADINGS as $heading) {
+            self::assertStringContainsString($heading, $prompt);
+        }
+    }
+
+    public function testBootstrapUserContentSegmentsWithGradientHints(): void
+    {
+        $older = [];
+        for ($i = 1; $i <= 9; ++$i) {
+            $older[] = $this->makeMessage($i, 0 === $i % 2 ? 'OUT' : 'IN', "turn-{$i}");
+        }
+
+        $content = ConversationSummaryPrompts::bootstrapUserContent($older, 3);
+
+        self::assertStringContainsString('## Segment 1 of 3 (oldest — condense aggressively, essentials only):', $content);
+        self::assertStringContainsString('## Segment 2 of 3 (middle — condense moderately):', $content);
+        self::assertStringContainsString('## Segment 3 of 3 (most recent of the older turns', $content);
+        self::assertStringContainsString('[#1 user]: turn-1', $content);
+        self::assertStringContainsString('[#2 assistant]: turn-2', $content);
+        self::assertStringContainsString('[#9 user]: turn-9', $content);
+    }
+
+    public function testBootstrapUserContentSingleTierUsesEssentialsHint(): void
+    {
+        $content = ConversationSummaryPrompts::bootstrapUserContent(
+            [$this->makeMessage(1, 'IN', 'only turn')],
+            3,
+        );
+
+        self::assertStringContainsString('(condense to the essentials)', $content);
+    }
+
+    public function testIncrementalUserContentCombinesPreviousSummaryAndNewMessages(): void
+    {
+        $content = ConversationSummaryPrompts::incrementalUserContent(
+            'PREVIOUS SUMMARY TEXT',
+            [$this->makeMessage(42, 'IN', 'new fact')],
+        );
+
+        self::assertStringContainsString('## Previous rolling summary', $content);
+        self::assertStringContainsString('PREVIOUS SUMMARY TEXT', $content);
+        self::assertStringContainsString('## Newly aged-out messages', $content);
+        self::assertStringContainsString('[#42 user]: new fact', $content);
+    }
+
+    public function testRenderMessageIncludesClippedAttachmentText(): void
+    {
+        $rendered = ConversationSummaryPrompts::renderMessage(
+            $this->makeMessage(7, 'IN', 'see the letter', str_repeat('A', 600), 'document'),
+        );
+
+        self::assertStringStartsWith('[#7 user]: see the letter [attached document: ', $rendered);
+        // The attachment excerpt is capped at 500 chars (plus ellipsis).
+        self::assertLessThan(600, mb_strlen($rendered));
+        self::assertStringContainsString('…', $rendered);
+    }
+
+    public function testTokenBudgetScalesWithCapAndHasAFloor(): void
+    {
+        self::assertSame(max(256, (int) ceil(4000 / 3) + 256), ConversationSummaryPrompts::tokenBudget(4000));
+        self::assertSame(256, ConversationSummaryPrompts::tokenBudget(0));
+    }
+}


### PR DESCRIPTION
## Summary

Sprint 1 of the [conversation-continuity plan](https://github.com/metadist/synaplan/tree/main/_devextras/planning/20260827-conversation-continuity) — the measurable instrument for "does the rolling summary hold up across our main chat models?"

- **`ConversationSummaryPrompts`** — the production bootstrap/incremental prompts, source-text rendering, and token budget extracted from `ConversationSummaryService` (pure refactor, all existing tests pass unchanged). The eval runs *exactly* the production prompts, so it can never drift.
- **`app:summary:eval`** (+ `make -C backend summary-eval`) — runs an 8-case golden corpus (en/de/ru, WhatsApp-style, formal email-style, attachment, hallucination trap, two incremental folds) against any `provider:model` list, or the configured SUMMARIZE default. `--filter`, `--mode`, `--repeat`, `--json` (includes raw summaries for inspection). Missing keys / unpulled local models → SKIPPED, never failed.
- **`SummaryEvalScorer`** — deterministic scoring, no judge model: size cap compliance, required/forbidden probes (substring or `re:` regex), markdown structure, stopword/script language heuristic (only a *confident* mismatch fails).
- CI guards corpus validity + scorer + prompts via plain PHPUnit; the live eval itself is not part of the gate.

## First results (recorded in STATUS.md)

| model | result |
| --- | --- |
| anthropic:claude-sonnet-5 | 8/8 |
| openai:gpt-5.5 | 8/8 |
| google:gemini-3.1-pro-preview | 8/8 |
| huggingface Kimi-K3 | 8/8 (slowest, ~21 s) |
| groq:openai/gpt-oss-120b (current default) | 7/8 typical — drops concrete dates in ~1 of 4 runs, fastest by far |

## Test plan

- [x] `make -C backend lint` / `phpstan` / `test` all green (4162 tests)
- [x] Live run against 5 providers + skip-path verification (no key / model not pulled)