### PR TITLE
fix(deploy): make AMIs ingestible by AWS Marketplace

### DIFF
--- a/.github/workflows/aws-ami.yml
+++ b/.github/workflows/aws-ami.yml
@@ -46,6 +46,7 @@ env:
   # The Marketplace ingests from us-east-1 only; other regions are produced by
   # copying the published AMI.
   AWS_REGION: us-east-1
+  AWS_MARKETPLACE_INGESTION_ACCOUNT_ID: '679593333241'
   IMAGE_REPOSITORY: ghcr.io/metadist/synaplan
 
 jobs:
@@ -164,6 +165,19 @@ jobs:
           role-session-name: synaplan-ami-${{ github.run_id }}
           aws-region: ${{ env.AWS_REGION }}
 
+      - name: Check Marketplace encryption compatibility
+        run: |
+          set -euo pipefail
+          encryption_by_default="$(
+            aws ec2 get-ebs-encryption-by-default \
+              --query EbsEncryptionByDefault \
+              --output text
+          )"
+          if [ "$encryption_by_default" != False ]; then
+            echo "::error::EBS encryption by default is enabled in ${AWS_REGION}. AWS Marketplace cannot ingest the encrypted AMI this build would produce."
+            exit 1
+          fi
+
       - name: Install Packer
         uses: hashicorp/setup-packer@ce93c3c08a6c2ff2275bf4b54ff0d9a75f6c9789 # v3
         with:
@@ -204,6 +218,50 @@ jobs:
             echo "for the free compliance scan, then verify a launch from"
             echo "\`deploy/aws/cloudformation/synaplan-new-vpc.yaml\` before submitting."
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Validate and share the AMI with AWS Marketplace
+        env:
+          AMI_ID: ${{ steps.ami.outputs.ami }}
+        run: |
+          set -euo pipefail
+          read -r -a snapshot_ids <<< "$(
+            aws ec2 describe-images \
+              --image-ids "$AMI_ID" \
+              --query 'Images[0].BlockDeviceMappings[].Ebs.SnapshotId' \
+              --output text
+          )"
+          if [ "${#snapshot_ids[@]}" -eq 0 ]; then
+            echo "::error::${AMI_ID} has no EBS snapshots."
+            exit 1
+          fi
+
+          encrypted_snapshots="$(
+            aws ec2 describe-snapshots \
+              --snapshot-ids "${snapshot_ids[@]}" \
+              --query 'Snapshots[?Encrypted].SnapshotId' \
+              --output text
+          )"
+          if [ -n "$encrypted_snapshots" ]; then
+            echo "::error::${AMI_ID} uses encrypted snapshots (${encrypted_snapshots}); AWS Marketplace cannot ingest it."
+            exit 1
+          fi
+
+          aws ec2 modify-image-attribute \
+            --image-id "$AMI_ID" \
+            --launch-permission \
+            "Add=[{UserId=${AWS_MARKETPLACE_INGESTION_ACCOUNT_ID}}]"
+
+          shared_account="$(
+            aws ec2 describe-image-attribute \
+              --image-id "$AMI_ID" \
+              --attribute launchPermission \
+              --query "LaunchPermissions[?UserId=='${AWS_MARKETPLACE_INGESTION_ACCOUNT_ID}'].UserId | [0]" \
+              --output text
+          )"
+          if [ "$shared_account" != "$AWS_MARKETPLACE_INGESTION_ACCOUNT_ID" ]; then
+            echo "::error::${AMI_ID} was not shared with the AWS Marketplace ingestion account."
+            exit 1
+          fi
 
       - name: Upload the build manifest
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -167,9 +167,13 @@ by the variable validation here, and by `validate-release.sh` at boot: with
 restart install a different application.
 
 The Marketplace ingests from **us-east-1**, and the source AMI must be
-unencrypted, EBS-backed and HVM — the build produces exactly that. Other regions
-are produced by copying the AMI. Build both architectures: the container images
-are multi-arch, so `-var architecture=arm64` yields the Graviton image.
+unencrypted, EBS-backed and HVM. The workflow rejects account-level EBS
+encryption before the build, verifies every resulting snapshot, and shares the
+AMI with Marketplace ingestion account `679593333241`. Marketplace encrypts its
+copy, and the CloudFormation templates independently encrypt every buyer volume.
+Other regions are produced by copying the AMI. Build both architectures: the
+container images are multi-arch, so `-var architecture=arm64` yields the Graviton
+image.
 
 ## Testing it without AWS
 
@@ -206,7 +210,7 @@ pipeline below.
 | Runs | Where | What it does |
 | ---- | ----- | ------------ |
 | Every push | `deployment-templates` job in [`ci.yml`](../../.github/workflows/ci.yml) | `cfn-lint` on both templates, `packer fmt -check` and `packer validate`. No AWS account, no cost. |
-| Every release tag | [`aws-ami.yml`](../../.github/workflows/aws-ami.yml) | Waits for the release's container images, builds both AMIs with Packer, then launches the x86_64 one through `synaplan-new-vpc.yaml` and runs `synaplan-smoke-test` on it over Session Manager. Deletes the stack and the snapshot it leaves behind, whatever the outcome. |
+| Every release tag | [`aws-ami.yml`](../../.github/workflows/aws-ami.yml) | Waits for the release's container images, builds both unencrypted source AMIs with Packer, verifies and shares them with the AWS Marketplace ingestion account, then launches the x86_64 one through `synaplan-new-vpc.yaml` and runs `synaplan-smoke-test` on it over Session Manager. Deletes the verification stack and the snapshot it leaves behind, whatever the outcome. |
 | Before a public listing | `taskcat` with [`.taskcat.yml`](.taskcat.yml) | Launches both templates in two or three regions. By hand, per release. |
 
 `aws-ami.yml` skips itself with a notice while the secret

--- a/deploy/aws/cloudformation/marketplace-roles.yaml
+++ b/deploy/aws/cloudformation/marketplace-roles.yaml
@@ -101,6 +101,7 @@ Resources:
                 Resource: '*'
                 Action:
                   - ec2:DescribeImages
+                  - ec2:DescribeImageAttribute
                   - ec2:DescribeInstances
                   - ec2:DescribeInstanceStatus
                   - ec2:DescribeInstanceTypeOfferings
@@ -111,6 +112,7 @@ Resources:
                   - ec2:DescribeTags
                   - ec2:DescribeVolumes
                   - ec2:DescribeVpcs
+                  - ec2:GetEbsEncryptionByDefault
                   - ec2:RunInstances
                   - ec2:StopInstances
                   - ec2:TerminateInstances

--- a/deploy/aws/packer/synaplan.pkr.hcl
+++ b/deploy/aws/packer/synaplan.pkr.hcl
@@ -102,7 +102,11 @@ source "amazon-ebs" "synaplan" {
     volume_size           = var.root_volume_size
     volume_type           = "gp3"
     delete_on_termination = true
-    encrypted             = true
+    # AWS Marketplace cannot ingest or scan an AMI backed by an encrypted
+    # snapshot. The workflow verifies this after the build and Marketplace
+    # encrypts its own copy during ingestion. Buyer launches are encrypted
+    # separately by the CloudFormation templates.
+    encrypted = false
   }
 
   # The published AMI's own root device. Marketplace re-encrypts on ingestion,

--- a/deploy/aws/scripts/tests/test-firstboot.sh
+++ b/deploy/aws/scripts/tests/test-firstboot.sh
@@ -54,6 +54,32 @@ if [[ -n "$non_ascii_ami_metadata" ]]; then
     fail "The AMI name or description carries a character EC2 will reject: $non_ascii_ami_metadata"
 fi
 
+# Marketplace must copy the source AMI into its ingestion account before it can
+# scan and publish it. An encrypted EBS snapshot cannot be shared, even when it
+# uses the seller account's default KMS key. The 4.2.4 submission reached the
+# portal with exactly that combination and failed with Image access exception.
+packer_file="$DEPLOY_ROOT/aws/packer/synaplan.pkr.hcl"
+launch_mapping="$(
+    awk '
+        /launch_block_device_mappings[[:space:]]*\{/ { capture = 1 }
+        capture { print }
+        capture && /^[[:space:]]*\}/ { exit }
+    ' "$packer_file"
+)"
+grep -Eq 'encrypted[[:space:]]*=[[:space:]]*false' <<<"$launch_mapping" ||
+    fail "The Packer launch root is not explicitly unencrypted; AWS Marketplace cannot ingest or share the resulting AMI"
+
+repo_root="$(cd "$DEPLOY_ROOT/.." && pwd)"
+ami_workflow="$repo_root/.github/workflows/aws-ami.yml"
+grep -Fq 'get-ebs-encryption-by-default' "$ami_workflow" ||
+    fail "the AMI workflow does not reject account-level default EBS encryption before paying for a Marketplace-incompatible build"
+grep -Fq 'describe-snapshots' "$ami_workflow" ||
+    fail "the AMI workflow does not verify that every built snapshot is unencrypted"
+grep -Fq '679593333241' "$ami_workflow" ||
+    fail "the AMI workflow does not name the AWS Marketplace ingestion account"
+grep -Fq 'modify-image-attribute' "$ami_workflow" ||
+    fail "the AMI workflow does not share the built AMI with the AWS Marketplace ingestion account"
+
 # --------------------------------------------------------------------------
 # The boot order the units ask of systemd
 # --------------------------------------------------------------------------

--- a/docs/AWS_MARKETPLACE_LISTING.md
+++ b/docs/AWS_MARKETPLACE_LISTING.md
@@ -52,9 +52,11 @@ Partner Network terms becomes the **alliance lead**.
    business days for the Seller Operations review of the listing itself. The
    automated AMI scan is usually under an hour.
 
-Fixed technical constraints, which the build already satisfies: the source AMI
-must live in **us-east-1**, unencrypted, EBS-backed and HVM, and every
-CloudFormation template needs an architecture diagram
+Fixed technical constraints, which the build enforces: the source AMI must live
+in **us-east-1**, be unencrypted, EBS-backed and HVM, and be shared with AWS
+Marketplace ingestion account `679593333241`. Marketplace encrypts its copy
+during ingestion; every buyer volume is also encrypted by the deployment
+templates. Every CloudFormation template needs an architecture diagram
 ([`deploy/aws/cloudformation/architecture.md`](../deploy/aws/cloudformation/architecture.md)).
 
 ## Who needs which access
@@ -138,7 +140,8 @@ Each step is cheap, and each one catches what the next would otherwise catch
 later and slower.
 
 1. **Build the AMI.** Push a release tag; the workflow builds x86_64 and arm64 in
-   us-east-1, then launches the x86_64 image through
+   us-east-1, verifies their snapshots are unencrypted, shares both source AMIs
+   with the Marketplace ingestion account, then launches the x86_64 image through
    `synaplan-new-vpc.yaml`, runs the smoke test on it over Session Manager, and
    deletes the stack. About 20 minutes and a few cents of instance time.
 2. **Test Add Version** in the Management Portal. A free automated compliance


### PR DESCRIPTION
## Summary
Make AWS Marketplace AMI builds produce ingestible source images and grant the ingestion service access before submission.

## Changes
- build the Marketplace source AMI on an explicitly unencrypted root volume
- fail before building when account-level EBS encryption would force an incompatible snapshot
- verify every AMI snapshot is unencrypted and share the AMI with AWS Marketplace account `679593333241`
- grant the build role the additional read permissions needed by these checks
- add regression coverage and document the ingestion boundary versus encrypted buyer volumes

## Verification
- [x] Manual
- [x] Tests added/updated

Commands run:
- `bash deploy/aws/scripts/tests/test-firstboot.sh`
- `bash deploy/scripts/tests/test-lifecycle.sh`
- `packer fmt -check -diff deploy/aws/packer/`
- `packer validate -evaluate-datasources=false deploy/aws/packer/synaplan.pkr.hcl`
- `cfn-lint deploy/aws/cloudformation/marketplace-roles.yaml`
- `git diff --check`

## Notes
The initial limited-listing request failed because AMI `ami-04b7e8cca928ebbca` is backed by encrypted snapshot `snap-08905cbe45f999cd2` and has no launch permission for the AWS Marketplace ingestion account. The existing ingestion role already has the correct managed policy.

After merging, redeploy `marketplace-roles.yaml` before dispatching the AMI workflow from this branch or `main`.

## Screenshots/Logs
AWS Marketplace reported `Image access exception` for the encrypted, unshared source AMI.