### PR TITLE
fix(deploy): require an explicit web ingress CIDR

### DIFF
--- a/.github/workflows/aws-ami.yml
+++ b/.github/workflows/aws-ami.yml
@@ -337,6 +337,7 @@ jobs:
               "ParameterKey=ImageId,ParameterValue=${AMI_ID}" \
               ParameterKey=InstanceType,ParameterValue=c7i.xlarge \
               ParameterKey=DataVolumeSize,ParameterValue=20 \
+              ParameterKey=AllowedWebCidr,ParameterValue=0.0.0.0/0 \
               ParameterKey=EnableDailySnapshots,ParameterValue=false \
               ParameterKey=AdminEmail,ParameterValue=verify@example.com
           aws cloudformation wait stack-create-complete --stack-name "$STACK_NAME"

--- a/deploy/aws/.taskcat.yml
+++ b/deploy/aws/.taskcat.yml
@@ -40,6 +40,7 @@ tests:
       # which this test has no use for.
       InstanceType: c7i.xlarge
       DataVolumeSize: 20
+      AllowedWebCidr: 203.0.113.1/32
       # The DataVolume carries DeletionPolicy Snapshot, so leaving this on would
       # also leave paid snapshots behind after taskcat deletes the stacks.
       EnableDailySnapshots: 'false'
@@ -51,6 +52,7 @@ tests:
       ImageId: ami-00000000000000000
       InstanceType: c7i.xlarge
       DataVolumeSize: 20
+      AllowedWebCidr: 203.0.113.1/32
       EnableDailySnapshots: 'false'
       AdminEmail: $[taskcat_genuuid]@example.com
       # This template deploys into a network it does not own, and taskcat has no

--- a/deploy/aws/cloudformation/synaplan-existing-vpc.yaml
+++ b/deploy/aws/cloudformation/synaplan-existing-vpc.yaml
@@ -108,12 +108,12 @@ Parameters:
 
   AllowedWebCidr:
     Type: String
-    Default: 10.0.0.0/8
     AllowedPattern: '^(\d{1,3}\.){3}\d{1,3}/\d{1,2}$'
     ConstraintDescription: Must be a CIDR range such as 203.0.113.0/24.
     Description: >-
-      Which source addresses may reach the web interface. The default assumes an
-      internal installation; widen it to 0.0.0.0/0 for a public one.
+      Required source range for web access. Use your public IP with /32 for one
+      administrator, another trusted CIDR for a network, or 0.0.0.0/0 only when
+      you intentionally want to allow the entire internet.
 
   DomainName:
     Type: String

--- a/deploy/aws/cloudformation/synaplan-new-vpc.yaml
+++ b/deploy/aws/cloudformation/synaplan-new-vpc.yaml
@@ -85,12 +85,12 @@ Parameters:
 
   AllowedWebCidr:
     Type: String
-    Default: 0.0.0.0/0
     AllowedPattern: '^(\d{1,3}\.){3}\d{1,3}/\d{1,2}$'
     ConstraintDescription: Must be a CIDR range such as 203.0.113.0/24.
     Description: >-
-      Which source addresses may reach the web interface. 0.0.0.0/0 is the whole
-      internet - narrow it to your own range for an internal installation.
+      Required source range for web access. Use your public IP with /32 for one
+      administrator, another trusted CIDR for a network, or 0.0.0.0/0 only when
+      you intentionally want to allow the entire internet.
 
   DomainName:
     Type: String

--- a/deploy/aws/marketplace/arm64/synaplan-existing-vpc.yaml
+++ b/deploy/aws/marketplace/arm64/synaplan-existing-vpc.yaml
@@ -106,12 +106,12 @@ Parameters:
 
   AllowedWebCidr:
     Type: String
-    Default: 10.0.0.0/8
     AllowedPattern: '^(\d{1,3}\.){3}\d{1,3}/\d{1,2}$'
     ConstraintDescription: Must be a CIDR range such as 203.0.113.0/24.
     Description: >-
-      Which source addresses may reach the web interface. The default assumes an
-      internal installation; widen it to 0.0.0.0/0 for a public one.
+      Required source range for web access. Use your public IP with /32 for one
+      administrator, another trusted CIDR for a network, or 0.0.0.0/0 only when
+      you intentionally want to allow the entire internet.
 
   DomainName:
     Type: String

--- a/deploy/aws/marketplace/arm64/synaplan-new-vpc.yaml
+++ b/deploy/aws/marketplace/arm64/synaplan-new-vpc.yaml
@@ -83,12 +83,12 @@ Parameters:
 
   AllowedWebCidr:
     Type: String
-    Default: 0.0.0.0/0
     AllowedPattern: '^(\d{1,3}\.){3}\d{1,3}/\d{1,2}$'
     ConstraintDescription: Must be a CIDR range such as 203.0.113.0/24.
     Description: >-
-      Which source addresses may reach the web interface. 0.0.0.0/0 is the whole
-      internet - narrow it to your own range for an internal installation.
+      Required source range for web access. Use your public IP with /32 for one
+      administrator, another trusted CIDR for a network, or 0.0.0.0/0 only when
+      you intentionally want to allow the entire internet.
 
   DomainName:
     Type: String

--- a/deploy/aws/marketplace/x86_64/synaplan-existing-vpc.yaml
+++ b/deploy/aws/marketplace/x86_64/synaplan-existing-vpc.yaml
@@ -106,12 +106,12 @@ Parameters:
 
   AllowedWebCidr:
     Type: String
-    Default: 10.0.0.0/8
     AllowedPattern: '^(\d{1,3}\.){3}\d{1,3}/\d{1,2}$'
     ConstraintDescription: Must be a CIDR range such as 203.0.113.0/24.
     Description: >-
-      Which source addresses may reach the web interface. The default assumes an
-      internal installation; widen it to 0.0.0.0/0 for a public one.
+      Required source range for web access. Use your public IP with /32 for one
+      administrator, another trusted CIDR for a network, or 0.0.0.0/0 only when
+      you intentionally want to allow the entire internet.
 
   DomainName:
     Type: String

--- a/deploy/aws/marketplace/x86_64/synaplan-new-vpc.yaml
+++ b/deploy/aws/marketplace/x86_64/synaplan-new-vpc.yaml
@@ -83,12 +83,12 @@ Parameters:
 
   AllowedWebCidr:
     Type: String
-    Default: 0.0.0.0/0
     AllowedPattern: '^(\d{1,3}\.){3}\d{1,3}/\d{1,2}$'
     ConstraintDescription: Must be a CIDR range such as 203.0.113.0/24.
     Description: >-
-      Which source addresses may reach the web interface. 0.0.0.0/0 is the whole
-      internet - narrow it to your own range for an internal installation.
+      Required source range for web access. Use your public IP with /32 for one
+      administrator, another trusted CIDR for a network, or 0.0.0.0/0 only when
+      you intentionally want to allow the entire internet.
 
   DomainName:
     Type: String

--- a/deploy/aws/scripts/tests/test-firstboot.sh
+++ b/deploy/aws/scripts/tests/test-firstboot.sh
@@ -193,6 +193,17 @@ awk '
 # Generated listing templates expose only compatible instance types. Keep them
 # byte-for-byte reproducible so a source-template fix cannot miss the copies
 # already prepared for S3.
+for template in "$DEPLOY_ROOT/aws/cloudformation/synaplan-new-vpc.yaml" \
+    "$DEPLOY_ROOT/aws/cloudformation/synaplan-existing-vpc.yaml"; do
+    awk '
+        /^  AllowedWebCidr:/ { found = 1; in_parameter = 1; next }
+        in_parameter && /^  [A-Za-z0-9]+:/ { in_parameter = 0 }
+        in_parameter && /^[[:space:]]+Default:/ { has_default = 1 }
+        END { exit !(found && !has_default) }
+    ' "$template" ||
+        fail "$(basename "$template") gives AllowedWebCidr a default; Marketplace requires the buyer to choose the ingress range explicitly"
+done
+
 node "$repo_root/scripts/generate-aws-marketplace-templates.mjs" --check ||
     fail "AWS Marketplace CloudFormation templates are stale; regenerate them before publishing"
 


### PR DESCRIPTION
## Summary
Require AWS Marketplace buyers to choose the web ingress range explicitly so deployments are secure by default and pass the Marketplace scan.

## Changes
- remove `AllowedWebCidr` defaults from both source CloudFormation templates
- regenerate the x86_64 and arm64 Marketplace templates
- provide explicit CIDRs only in controlled workflow and taskcat test launches
- add regression coverage preventing ingress defaults from returning

## Verification
- [x] Manual
- [x] Tests added/updated

Commands run:
- `bash deploy/aws/scripts/tests/test-firstboot.sh`
- `bash deploy/scripts/tests/test-lifecycle.sh`
- `cfn-lint deploy/aws/cloudformation/*.yaml deploy/aws/marketplace/x86_64/*.yaml deploy/aws/marketplace/arm64/*.yaml`
- `node scripts/generate-aws-marketplace-templates.mjs --check`
- `git diff --check`

## Notes
AWS Marketplace scan report `fb4a3813-0e9a-465d-9204-c793f9521167` rejected the prior new-VPC template because `AllowedWebCidr` defaulted to `0.0.0.0/0`. The existing AMI remains valid and does not need rebuilding; the S3 templates must be replaced after merge before copying the failed request.

## Screenshots/Logs
Marketplace finding: “Don't set default CIDR open to world on ingress.”