### PR TITLE
fix(ci): stop taking the release digest from a cached tag lookup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1079,6 +1079,7 @@ jobs:
         id: release
         env:
           AMD64_REF: ${{ steps.amd64.outputs.ref }}
+          TESTED_AMD64_DIGEST: ${{ steps.amd64.outputs.digest }}
           ARM64_DIGEST: ${{ steps.arm64.outputs.digest }}
           IMAGE_TAGS: ${{ steps.meta.outputs.tags }}
           REGISTRY_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
@@ -1093,9 +1094,12 @@ jobs:
               --tag "$image" \
               "$AMD64_REF" \
               "$arm64_ref"
+            # Not a plain tag lookup: GHCR can still answer a tag from cache
+            # right after the push, and this digest leaves the job as the
+            # release digest the Umbrel pin is built from.
             current_digest="$(
-              docker buildx imagetools inspect "$image" \
-                --format '{{ .Manifest.Digest }}'
+              scripts/resolve-manifest-digest.sh \
+                "$image" "$TESTED_AMD64_DIGEST" "$ARM64_DIGEST"
             )"
             if [ -z "$manifest_digest" ]; then
               manifest_digest="$current_digest"
@@ -1126,8 +1130,8 @@ jobs:
             echo "Verifying ${image}"
 
             resolved_digest="$(
-              docker buildx imagetools inspect "$image" \
-                --format '{{ .Manifest.Digest }}'
+              scripts/resolve-manifest-digest.sh \
+                "$image" "$TESTED_AMD64_DIGEST" "$ARM64_DIGEST"
             )"
             if [ "$resolved_digest" != "$IMAGE_DIGEST" ]; then
               echo "::error::${image} resolved to ${resolved_digest}, expected ${IMAGE_DIGEST}"

--- a/scripts/resolve-manifest-digest.sh
+++ b/scripts/resolve-manifest-digest.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+# Resolves a just-pushed tag to the digest of the multi-arch index it names,
+# and refuses to answer until that index is the one this run built.
+#
+# Usage: resolve-manifest-digest.sh <image-ref> <linux/amd64 digest> <linux/arm64 digest>
+#
+# GHCR answers a tag from a cache that can still hold the previous value for a
+# moment after a push, so `imagetools create --tag latest` followed immediately
+# by `imagetools inspect latest` can report the PREVIOUS release. That is not a
+# cosmetic race: the publish job passes that digest on as its job output, and
+# release-version-pin writes it into the Umbrel package as the pinned
+# tag@digest. A stale read there pins the store submission to the wrong image.
+#
+# A tag lookup alone cannot tell a fresh answer from a cached one, so every
+# candidate digest is re-fetched by digest — immutable, therefore never
+# cached-stale — and accepted only if it names the amd64 image that passed the
+# gates and the arm64 image built next to it.
+
+set -Eeuo pipefail
+
+image="${1:?image reference required}"
+expected_amd64="${2:?linux/amd64 digest required}"
+expected_arm64="${3:?linux/arm64 digest required}"
+
+# Observed staleness is on the order of a second; the ceiling only exists so a
+# registry that never converges fails the build instead of hanging on it.
+timeout_seconds="${MANIFEST_TIMEOUT_SECONDS:-60}"
+poll_interval_seconds="${MANIFEST_POLL_INTERVAL_SECONDS:-2}"
+
+child_digest() {
+    local raw="$1" architecture="$2"
+    jq -r --arg architecture "$architecture" '
+        [.manifests[]?
+            | select(.platform.os == "linux" and .platform.architecture == $architecture)
+            | .digest]
+        | first // ""
+    ' <<<"$raw"
+}
+
+deadline=$((SECONDS + timeout_seconds))
+candidate=""
+amd64=""
+arm64=""
+
+while :; do
+    candidate="$(
+        docker buildx imagetools inspect "$image" \
+            --format '{{ .Manifest.Digest }}' 2>/dev/null || true
+    )"
+
+    if [[ -n "$candidate" ]]; then
+        raw="$(
+            docker buildx imagetools inspect --raw "${image%:*}@${candidate}" 2>/dev/null || true
+        )"
+        amd64="$(child_digest "$raw" amd64)"
+        arm64="$(child_digest "$raw" arm64)"
+
+        if [[ "$amd64" == "$expected_amd64" && "$arm64" == "$expected_arm64" ]]; then
+            printf '%s\n' "$candidate"
+            exit 0
+        fi
+    fi
+
+    if ((SECONDS >= deadline)); then
+        {
+            echo "::error::${image} still resolves to ${candidate:-nothing} after ${timeout_seconds}s"
+            echo "::error::its linux/amd64 is ${amd64:-none} (expected ${expected_amd64})"
+            echo "::error::its linux/arm64 is ${arm64:-none} (expected ${expected_arm64})"
+        } >&2
+        exit 1
+    fi
+
+    sleep "$poll_interval_seconds"
+done

--- a/scripts/resolve-manifest-digest.sh
+++ b/scripts/resolve-manifest-digest.sh
@@ -28,6 +28,9 @@ expected_arm64="${3:?linux/arm64 digest required}"
 timeout_seconds="${MANIFEST_TIMEOUT_SECONDS:-60}"
 poll_interval_seconds="${MANIFEST_POLL_INTERVAL_SECONDS:-2}"
 
+# A body that is not a manifest index — empty, truncated, an error page the
+# registry served instead — means "not converged yet", not "fail the build", so
+# an unparsable answer resolves to no digest and leaves the retry to the loop.
 child_digest() {
     local raw="$1" architecture="$2"
     jq -r --arg architecture "$architecture" '
@@ -35,15 +38,19 @@ child_digest() {
             | select(.platform.os == "linux" and .platform.architecture == $architecture)
             | .digest]
         | first // ""
-    ' <<<"$raw"
+    ' <<<"$raw" 2>/dev/null || true
 }
 
 deadline=$((SECONDS + timeout_seconds))
-candidate=""
-amd64=""
-arm64=""
+announced_wait=false
 
 while :; do
+    # Reset per attempt: the diagnostic below must describe what the registry
+    # answers now, not what an earlier poll happened to see.
+    candidate=""
+    amd64=""
+    arm64=""
+
     candidate="$(
         docker buildx imagetools inspect "$image" \
             --format '{{ .Manifest.Digest }}' 2>/dev/null || true
@@ -69,6 +76,14 @@ while :; do
             echo "::error::its linux/arm64 is ${arm64:-none} (expected ${expected_arm64})"
         } >&2
         exit 1
+    fi
+
+    if [[ "$announced_wait" == false ]]; then
+        # Said once, not per poll: a step that goes quiet for a minute reads
+        # like a hang, and the reason it waits is worth one line in the log.
+        echo "${image} does not serve this run's index yet" \
+            "(currently ${candidate:-nothing}); waiting up to ${timeout_seconds}s" >&2
+        announced_wait=true
     fi
 
     sleep "$poll_interval_seconds"


### PR DESCRIPTION
## What broke

The `Publish Multi-Arch Docker Image` job failed on `main` (2fcb915b0), which took the `All Checks Passed` gate down with it:

```
ghcr.io/metadist/synaplan:latest resolved to sha256:2cdc24b1…, expected sha256:8f7a49af…
```

Both digests exist in GHCR, and only one of them belongs to that run:

| Index | linux/amd64 | linux/arm64 | Whose image |
|-------|-------------|-------------|-------------|
| `2cdc24b1…` | `2a3b08ce…` = tested amd64 | `f9e64a56…` = built arm64 | **this run** |
| `8f7a49af…` | `af801737…` | `2ae11a0f…` | a previous run |

So the publish itself was correct — `:latest` points at `2cdc24b1…` to this day. What was wrong is how the job learned the digest: it ran `imagetools inspect <tag>` immediately after `imagetools create --tag <tag>`, and GHCR answered that tag from cache with the previous `latest`. The verify step read the same tag 1.5 s later, got the fresh value, and failed on the mismatch. No concurrent run touched `latest` — it is a plain read-after-write window.

## Why this is worth fixing rather than re-running

That digest is the job's `outputs.digest`, and `release-version-pin` writes it into the Umbrel package as the pinned `tag@digest`. A stale read on a release tag would have pinned a store submission to the previous image. The verify step was right to refuse.

## The fix

A tag lookup cannot distinguish a fresh answer from a cached one, so `scripts/resolve-manifest-digest.sh` validates the candidate instead of trusting it: every digest it gets from the tag is re-fetched **by digest** — immutable, therefore never cached-stale — and accepted only if that index names the amd64 image that passed the gates plus the arm64 image built beside it. It waits for the registry to converge, bounded (60 s default) so a registry that never does fails the build instead of hanging on it.

Both the publish and the verify step resolve through it now; the verify step keeps its own independent tag read for the platform set and child digests, which is what catches a tag that flaps back.

## Test plan

- [x] `shellcheck` clean; `bash -n` clean; `ci.yml` parses.
- [x] Resolver against the real GHCR image — correct children: prints `sha256:2cdc24b1…`.
- [x] Resolver with the stale run's children: fails with the three-line diagnostic instead of returning a digest.
- [x] Resolver against a non-existent tag: fails, no digest.
- [x] `scripts/mobile-impact.mjs` → `no-app-impact` (both paths already allow-listed).
- [ ] Green `docker-push` on the merge commit, publishing `latest` with a verified digest.