### PR TITLE
fix(models): roll the gpt-oss-120b sorter default out to existing installs

### DIFF
--- a/backend/migrations/Version20260828120000.php
+++ b/backend/migrations/Version20260828120000.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Point every DEFAULTMODEL.SORT binding at Groq gpt-oss-120b (BID 76).
+ *
+ * The sorter is the one call in the pipeline where the model decides whether a
+ * message is routed at all: it has to answer with strict JSON, on every turn,
+ * fast. The routing prompts in {@see \App\Prompt\PromptCatalog} are written
+ * and regression-tested against gpt-oss-120b; a heavier chat model reasons its
+ * way past the format and degrades routing for the whole install.
+ *
+ * DefaultModelConfigSeeder already binds SORT to `groq:openai/gpt-oss-120b:chat`,
+ * but BCONFIG defaults are bootstrap-only — the seeder inserts a missing row and
+ * never rewrites an existing one, so every install seeded before that value
+ * still sorts with whatever it had. A migration is the documented way to roll a
+ * changed default out to them.
+ *
+ * Per-user rows (BOWNERID > 0) are repointed too, not just the global one: a
+ * user binding wins over the global default, so a global-only repoint would
+ * leave exactly the accounts that once picked a different sorter on it. This is
+ * a one-time correction, not a lock — the AI-models page can set another sort
+ * model again afterwards.
+ *
+ * Guarded on the target row being present, unmodified and active. An operator
+ * who deactivated the Groq row (no Groq account, self-hosted only) keeps their
+ * binding and model resolution falls back exactly as before, and an install
+ * that repurposed BID 76 for a different model is not touched at all.
+ */
+final class Version20260828120000 extends AbstractMigration
+{
+    private const SORTER_BID = 76;
+    private const SORTER_PROVID = 'openai/gpt-oss-120b';
+
+    public function getDescription(): string
+    {
+        return 'Repoint every DEFAULTMODEL.SORT binding (global and per-user) at Groq gpt-oss-120b, '
+            .'the model the routing prompts are tuned for.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            UPDATE BCONFIG
+               SET BVALUE = :sorter
+             WHERE BGROUP = 'DEFAULTMODEL'
+               AND BSETTING = 'SORT'
+               AND BVALUE <> :sorter
+               AND EXISTS (
+                   SELECT 1
+                     FROM BMODELS
+                    WHERE BID = :sorterId
+                      AND BPROVID = :providerId
+                      AND BTAG = 'chat'
+                      AND BACTIVE = 1
+               )
+        SQL, [
+            'sorter' => (string) self::SORTER_BID,
+            'sorterId' => self::SORTER_BID,
+            'providerId' => self::SORTER_PROVID,
+        ], [
+            'sorterId' => ParameterType::INTEGER,
+        ]);
+    }
+
+    public function down(Schema $schema): void
+    {
+        // Not revertible: the per-row values this overwrites are not recorded
+        // anywhere, and repointing everything back at one model would be a
+        // second forced change rather than an undo. Same contract as the other
+        // binding migrations (Version20260819080000).
+    }
+}

--- a/backend/src/Seed/DefaultModelConfigSeeder.php
+++ b/backend/src/Seed/DefaultModelConfigSeeder.php
@@ -32,6 +32,13 @@ final readonly class DefaultModelConfigSeeder
     private const PROD_MODEL_DEFAULTS = [
         ['group' => 'DEFAULTMODEL', 'setting' => 'CHAT',       'modelKey' => 'anthropic:claude-sonnet-5:chat'],
         ['group' => 'DEFAULTMODEL', 'setting' => 'TOOLS',      'modelKey' => 'anthropic:claude-sonnet-5:chat'],
+        // The routing prompts in PromptCatalog (tools:sort and the multitask
+        // planner) are written and regression-tested against gpt-oss-120b: it
+        // returns the strict JSON contract reliably and fast. Heavier chat
+        // models reason past the format and degrade routing install-wide, so
+        // this binding is a tuned pair with the prompt, not a taste. Changing
+        // it needs the prompts re-validated AND a migration — an existing
+        // install keeps its stored row (see Version20260828120000).
         ['group' => 'DEFAULTMODEL', 'setting' => 'SORT',       'modelKey' => 'groq:openai/gpt-oss-120b:chat'],
         // Multi-task routing planner. Same fast/cheap tier as SORT but a
         // dedicated binding so it can be tuned without touching the legacy

--- a/backend/tests/Migration/Version20260828120000Test.php
+++ b/backend/tests/Migration/Version20260828120000Test.php
@@ -1,0 +1,212 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Migration;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use DoctrineMigrations\Version20260828120000;
+use Psr\Log\NullLogger;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * Executes the sort-model repoint against the test database.
+ *
+ * The two things worth asserting are the ones a comment cannot enforce: that
+ * per-user bindings are covered (they win over the global row, so missing them
+ * would leave the affected accounts on the old sorter), and that the guard
+ * really holds — this migration overwrites operator data, so it must be inert
+ * whenever the target model is not the model we think it is.
+ *
+ * Everything runs inside a transaction that is rolled back, and each case
+ * builds the exact population it needs: the PHPUnit database may or may not
+ * carry fixtures, and this test must not depend on which.
+ */
+final class Version20260828120000Test extends KernelTestCase
+{
+    private const SORTER_BID = 76;
+    private const SORTER_PROVID = 'openai/gpt-oss-120b';
+
+    /** Any other chat model — stands in for "whatever this install had". */
+    private const OTHER_BID = 249;
+
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->connection = self::getContainer()->get(Connection::class);
+        $this->connection->beginTransaction();
+
+        $this->givenNoSortBindings();
+        $this->givenSorterModel(active: true);
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->connection->isTransactionActive()) {
+            $this->connection->rollBack();
+        }
+
+        parent::tearDown();
+    }
+
+    public function testItRepointsTheGlobalBinding(): void
+    {
+        $this->givenSortBinding(ownerId: 0, modelId: self::OTHER_BID);
+
+        $this->runMigration();
+
+        self::assertSame((string) self::SORTER_BID, $this->fetchSortBinding(0));
+    }
+
+    /**
+     * The expensive miss: a per-user row wins over the global default, so an
+     * account that once picked another sorter would keep it forever.
+     */
+    public function testItRepointsPerUserBindings(): void
+    {
+        $this->givenSortBinding(ownerId: 0, modelId: self::OTHER_BID);
+        $this->givenSortBinding(ownerId: 7, modelId: self::OTHER_BID);
+        $this->givenSortBinding(ownerId: 12, modelId: self::OTHER_BID);
+
+        $this->runMigration();
+
+        self::assertSame((string) self::SORTER_BID, $this->fetchSortBinding(7));
+        self::assertSame((string) self::SORTER_BID, $this->fetchSortBinding(12));
+    }
+
+    /** Only the sorter moves — CHAT and the other capabilities are not ours. */
+    public function testItLeavesOtherCapabilitiesAlone(): void
+    {
+        $this->givenSortBinding(ownerId: 0, modelId: self::OTHER_BID);
+        $this->givenBinding(ownerId: 0, setting: 'CHAT', modelId: self::OTHER_BID);
+
+        $this->runMigration();
+
+        self::assertSame((string) self::OTHER_BID, $this->fetchBinding(0, 'CHAT'));
+    }
+
+    /**
+     * An install that deactivated the Groq row has no Groq account. Binding it
+     * there anyway would trade a badly-sorting install for a broken one.
+     */
+    public function testItSkipsInstallsWhereTheSorterIsDeactivated(): void
+    {
+        $this->givenSorterModel(active: false);
+        $this->givenSortBinding(ownerId: 0, modelId: self::OTHER_BID);
+
+        $this->runMigration();
+
+        self::assertSame((string) self::OTHER_BID, $this->fetchSortBinding(0));
+    }
+
+    /** BID 76 repurposed for a different model must not be bound as the sorter. */
+    public function testItSkipsInstallsWhereTheRowWasRepurposed(): void
+    {
+        $this->connection->executeStatement(
+            'UPDATE BMODELS SET BPROVID = :providerId WHERE BID = :id',
+            ['providerId' => 'some/other-model', 'id' => self::SORTER_BID]
+        );
+        $this->givenSortBinding(ownerId: 0, modelId: self::OTHER_BID);
+
+        $this->runMigration();
+
+        self::assertSame((string) self::OTHER_BID, $this->fetchSortBinding(0));
+    }
+
+    public function testItIsIdempotent(): void
+    {
+        $this->givenSortBinding(ownerId: 0, modelId: self::OTHER_BID);
+
+        $this->runMigration();
+        $this->runMigration();
+
+        self::assertSame((string) self::SORTER_BID, $this->fetchSortBinding(0));
+    }
+
+    private function runMigration(): void
+    {
+        $migration = $this->loadMigration();
+        $migration->up(new Schema());
+
+        foreach ($migration->getSql() as $query) {
+            $this->connection->executeStatement(
+                $query->getStatement(),
+                $query->getParameters(),
+                $query->getTypes()
+            );
+        }
+    }
+
+    /**
+     * migrations/ is outside the composer autoload map — Doctrine discovers
+     * these files by path at runtime, so the test has to load it itself.
+     */
+    private function loadMigration(): AbstractMigration
+    {
+        require_once dirname(__DIR__, 2).'/migrations/Version20260828120000.php';
+
+        return new Version20260828120000($this->connection, new NullLogger());
+    }
+
+    /**
+     * Force BID 76 into the exact shape the guard looks for, whether or not the
+     * harness seeded the catalog. Rolled back with the surrounding transaction.
+     */
+    private function givenSorterModel(bool $active): void
+    {
+        $this->connection->executeStatement(
+            <<<'SQL'
+                INSERT INTO BMODELS (BID, BSERVICE, BNAME, BTAG, BSELECTABLE, BACTIVE, BPROVID, BPRICEIN, BINUNIT, BPRICEOUT, BOUTUNIT, BQUALITY, BRATING, BISDEFAULT, BSHOWWHENFREE, BJSON)
+                VALUES (:id, 'Groq', 'gpt-oss-120b', 'chat', 1, :active, :providerId, 0.15, 'per1M', 0.60, 'per1M', 10, 4, 0, 0, '{}')
+                ON DUPLICATE KEY UPDATE
+                    BSERVICE = VALUES(BSERVICE), BTAG = VALUES(BTAG),
+                    BPROVID = VALUES(BPROVID), BACTIVE = VALUES(BACTIVE)
+            SQL,
+            ['id' => self::SORTER_BID, 'active' => $active ? 1 : 0, 'providerId' => self::SORTER_PROVID]
+        );
+    }
+
+    private function givenNoSortBindings(): void
+    {
+        $this->connection->executeStatement(
+            "DELETE FROM BCONFIG WHERE BGROUP = 'DEFAULTMODEL' AND BSETTING = 'SORT'"
+        );
+    }
+
+    private function givenSortBinding(int $ownerId, int $modelId): void
+    {
+        $this->givenBinding($ownerId, 'SORT', $modelId);
+    }
+
+    /** Upsert: BCONFIG is uniquely indexed on (BOWNERID, BGROUP, BSETTING). */
+    private function givenBinding(int $ownerId, string $setting, int $modelId): void
+    {
+        $this->connection->executeStatement(
+            <<<'SQL'
+                INSERT INTO BCONFIG (BOWNERID, BGROUP, BSETTING, BVALUE)
+                VALUES (:owner, 'DEFAULTMODEL', :setting, :value)
+                ON DUPLICATE KEY UPDATE BVALUE = VALUES(BVALUE)
+            SQL,
+            ['owner' => $ownerId, 'setting' => $setting, 'value' => (string) $modelId]
+        );
+    }
+
+    private function fetchSortBinding(int $ownerId): ?string
+    {
+        return $this->fetchBinding($ownerId, 'SORT');
+    }
+
+    private function fetchBinding(int $ownerId, string $setting): ?string
+    {
+        $value = $this->connection->fetchOne(
+            "SELECT BVALUE FROM BCONFIG WHERE BOWNERID = :owner AND BGROUP = 'DEFAULTMODEL' AND BSETTING = :setting",
+            ['owner' => $ownerId, 'setting' => $setting]
+        );
+
+        return false === $value ? null : (string) $value;
+    }
+}

--- a/backend/tests/Unit/Seed/DefaultModelConfigSeederTest.php
+++ b/backend/tests/Unit/Seed/DefaultModelConfigSeederTest.php
@@ -41,6 +41,30 @@ final class DefaultModelConfigSeederTest extends TestCase
         }
     }
 
+    /**
+     * The sorter binding is a tuned pair with the tools:sort prompt, not a
+     * preference: gpt-oss-120b holds the strict JSON contract, heavier chat
+     * models reason past it and routing degrades install-wide. Moving it is a
+     * deliberate act that also needs the prompts re-validated and a migration
+     * for existing installs, so it must not drift in silently.
+     */
+    public function testTheSorterIsBoundToGptOss120b(): void
+    {
+        $reflection = new \ReflectionClass(DefaultModelConfigSeeder::class);
+        $defaults = $reflection->getReflectionConstant('PROD_MODEL_DEFAULTS');
+        $this->assertNotFalse($defaults, 'PROD_MODEL_DEFAULTS constant missing');
+
+        /** @var list<array{group: string, setting: string, modelKey: string}> $rows */
+        $rows = $defaults->getValue();
+
+        $sortKeys = array_values(array_map(
+            static fn (array $row): string => $row['modelKey'],
+            array_filter($rows, static fn (array $row): bool => 'SORT' === $row['setting']),
+        ));
+
+        $this->assertSame(['groq:openai/gpt-oss-120b:chat'], $sortKeys);
+    }
+
     public function testResolveProdDefaultsIsPrivateStaticContract(): void
     {
         // Documents the contract on resolveProdDefaults() — it must be a private


### PR DESCRIPTION
## Summary

Sorting only behaves on Groq `gpt-oss-120b`. The prompts in `PromptCatalog` (`tools:sort` and the multitask planner) are written and regression-tested against it: it holds the strict JSON contract, while heavier chat models reason past the format and degrade routing install-wide.

`DefaultModelConfigSeeder` has bound `DEFAULTMODEL.SORT` to `groq:openai/gpt-oss-120b:chat` for a while, so **new** installs were never the problem. BCONFIG defaults are bootstrap-only — the seeder inserts a missing row and never rewrites an existing one — so every install seeded before that value still sorts with whatever it had.

* **`Version20260828120000` repoints the binding**, per-user rows included. A `BOWNERID > 0` row wins over the global default, so a global-only repoint would leave exactly the accounts that once picked another sorter on it. It is a one-time correction, not a lock: the AI-models page can set another sort model again afterwards.
* **Guarded on the catalog row being present, unmodified and active.** An operator who deactivated the Groq row (no Groq account, self-hosted only) keeps their binding and model resolution falls back as before, and an install that repurposed BID 76 for a different model is not touched at all. Raw idempotent SQL, no `Schema` introspection — Galera-safe.
* **The seeder line now says why**, and a unit test locks `SORT` to the gpt-oss-120b catalog key so the pairing with the prompt cannot drift in silently.

No `BMODELS` change: `BISDEFAULT` is not a default marker. `ModelCatalog::upsert()` writes it from its `$system` argument and it only surfaces as the `isSystemModel` display flag — nothing in routing reads it. Setting it on BID 76 would relabel a user-facing chat model as system-managed without changing which model sorts.

Mobile impact: **backend-only**.

## Test plan

* `make -C backend lint` — clean
* `make -C backend phpstan` — no errors (full project, `src/` + `tests/`)
* `make -C backend test` — 4360 tests, unfiltered
* `Version20260828120000Test` runs the real SQL against MariaDB: global repoint, per-user repoint, other capabilities untouched, no-op when the row is deactivated, no-op when BID 76 was repurposed, idempotent on re-run
* Manual on the dev stack: forced both `DEFAULTMODEL.SORT` rows to Claude Sonnet 5 (249), ran `doctrine:migrations:migrate`, both owner 0 and user 1 came back as 76