### PR TITLE
ci: run frontend-build on the free runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -564,10 +564,11 @@ jobs:
   e2e:
     name: E2E Tests (${{ matrix.browser }}${{ matrix.variant && format(' {0}', matrix.variant) || '' }}${{ matrix.auth_method == 'oidc' && ' OIDC' || matrix.auth_method == 'oidc-redirect' && ' OIDC Redirect' || '' }}${{ matrix.shard && format(' [{0}]', matrix.shard) || '' }})
     # E2E jobs run on free ubuntu-latest runners, which are unlimited for
-    # public repositories — so sharding buys wall-clock time for nothing.
-    # Chromium runs the full @ci suite sharded (--shard=N/M) so each half
-    # finishes in ~50% of the time; the free runner pool ensures all shards
-    # start instantly. Firefox is a single unsharded @crossbrowser smoke.
+    # public repositories: an extra shard costs nothing, so sharding trades
+    # runner count for wall-clock time at no price. Chromium runs the full
+    # @ci suite sharded (--shard=N/M) so each half finishes in ~50% of the
+    # time, and the free pool starts every shard immediately instead of
+    # queueing it. Firefox is a single unsharded @crossbrowser smoke.
     runs-on: ubuntu-latest
     needs: [docker-build]
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,11 @@ on:
 permissions:
   contents: read
 
-# Superseded runs on the same PR just burn runner capacity (and delay other
-# runs waiting for the limited ubuntu-latest-m pool). Push/tag runs get a
-# unique group (run_id) so main runs neither serialize nor cancel each other —
-# docker-push and cloudflare-deploy must never be interrupted or skipped.
+# Superseded runs on the same PR just burn runner capacity, which is shared
+# across the organization (the plan allows 60 concurrent standard-runner jobs
+# and one run peaks at ~7). Push/tag runs get a unique group (run_id) so main
+# runs neither serialize nor cancel each other — docker-push and
+# cloudflare-deploy must never be interrupted or skipped.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -126,12 +127,9 @@ jobs:
 
   backend:
     name: Backend (PHP/Symfony)
-    # Free runner on purpose: this job is off the critical path (done around
-    # minute 2-3 while e2e runs until ~minute 7), PHPUnit is single-process
-    # anyway, and free runners start instantly (queue p90 ~4s vs up to ~80s
-    # provisioning on the ubuntu-latest-m pool). Keeping it off the -m pool
-    # also leaves the warm -m runner to frontend-build, which IS the
-    # critical path. Revisit if this job ever becomes the longest one.
+    # Off the critical path (done around minute 2-3 while e2e runs until
+    # ~minute 7) and PHPUnit is single-process anyway, so more cores would not
+    # shorten the run. Revisit if this job ever becomes the longest one.
     runs-on: ubuntu-latest
 
     env:
@@ -294,17 +292,28 @@ jobs:
     # Head of the critical path (frontend-build → docker-build → e2e), so it
     # starts at t=0 with no `needs`: it dumps the OpenAPI spec itself (PHP
     # setup costs ~35s from caches) instead of waiting for a separate job —
-    # a mid-run job hop costs ~40-50s runner-provisioning latency on the
-    # ubuntu-latest-m pool. The spec is uploaded as the `openapi-spec`
-    # artifact for frontend-checks and mobile-release-artifacts.yml.
-    # nelmio:apidoc:dump compiles the container but never touches the DB
-    # (Doctrine connects lazily), so no MariaDB service is needed here.
+    # a mid-run job hop costs runner-provisioning latency. The spec is
+    # uploaded as the `openapi-spec` artifact for frontend-checks and
+    # mobile-release-artifacts.yml. nelmio:apidoc:dump compiles the container
+    # but never touches the DB (Doctrine connects lazily), so no MariaDB
+    # service is needed here.
     #
-    # This is the ONLY job on the paid 16-core pool: the parallel Vite builds
-    # are the one workload where the cores shorten the critical path. All
-    # other former -m jobs moved to free runners so the warm -m runner is
-    # reliably available for this job at t=0.
-    runs-on: ubuntu-latest-m
+    # Free runner, and it must stay one. This was the last job on the paid
+    # 16-core pool until the move was measured against it, job for job:
+    #
+    #   - `Build app and widget (parallel)`: 62s on 16 cores vs 69s on 4.
+    #     Rollup is largely single-thread-bound, so the extra cores buy ~7s.
+    #   - Runner provisioning: 18s on the paid pool vs 3s on the free one,
+    #     which more than cancels those 7s out.
+    #   - The paid pool has a limited number of slots and queues under load:
+    #     during a six-run PR burst three runs waited 30-59s for a -m runner
+    #     while every free-runner job in the same runs started in 2-5s.
+    #
+    # So the paid pool was slower in the only dimension that matters here
+    # (time to a green PR) and cost roughly $112/month at ~734 runs. Do not
+    # move this back to `ubuntu-latest-m` without re-measuring those three
+    # numbers first.
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
@@ -414,9 +423,8 @@ jobs:
     # Format check, lint, vue-tsc and Vitest — everything that gates merging
     # but that docker-build/e2e don't need to wait for. Consumes the
     # openapi-spec artifact from frontend-build; runs off the critical path
-    # (plenty of slack before the e2e jobs finish), so a free instant-start
-    # runner beats the paid pool: vue-tsc is single-threaded anyway and the
-    # -m pool has up to ~80s provisioning latency for mid-run job requests.
+    # (plenty of slack before the e2e jobs finish) and vue-tsc is
+    # single-threaded anyway, so more cores would not shorten the run.
     runs-on: ubuntu-latest
     needs: [frontend-build]
 
@@ -555,8 +563,8 @@ jobs:
 
   e2e:
     name: E2E Tests (${{ matrix.browser }}${{ matrix.variant && format(' {0}', matrix.variant) || '' }}${{ matrix.auth_method == 'oidc' && ' OIDC' || matrix.auth_method == 'oidc-redirect' && ' OIDC Redirect' || '' }}${{ matrix.shard && format(' [{0}]', matrix.shard) || '' }})
-    # E2E jobs run on free ubuntu-latest runners (unlimited capacity for public
-    # repos) to avoid queue contention from the limited ubuntu-latest-m pool.
+    # E2E jobs run on free ubuntu-latest runners, which are unlimited for
+    # public repositories — so sharding buys wall-clock time for nothing.
     # Chromium runs the full @ci suite sharded (--shard=N/M) so each half
     # finishes in ~50% of the time; the free runner pool ensures all shards
     # start instantly. Firefox is a single unsharded @crossbrowser smoke.


### PR DESCRIPTION
## Summary

`frontend-build` was the last job on the paid 16-core `ubuntu-latest-m` pool. This moves it to the free `ubuntu-latest` runner, which measured **faster end to end**, not slower.

Measured in the timing experiment #1595 (job-level and step-level data from the Actions API, not estimates):

| Metric | `ubuntu-latest-m` (16 cores) | `ubuntu-latest` (4 cores) |
|---|---|---|
| `Build app and widget (parallel)` | 62s | 69s (+7s) |
| Runner provisioning | 18s | 3s (-15s) |
| Job total | 118s (avg over 100 runs) | 122s |
| Queue delay during a 6-run PR burst | 30-59s on 3 of 6 runs | 2-5s on all runs |

Rollup is largely single-thread-bound, so the extra cores buy ~7s on the only CPU-relevant step, and slower provisioning more than cancels that out. The limited pool additionally queues under load, which lands directly on the critical path (`frontend-build` -> `docker-build` -> `e2e`).

Standard runners are free and unlimited on public repositories, so this also removes roughly **$112/month** (~2.4 billed min/run x ~734 runs per 30 days x $0.064/min).

Comments describing the old runner allocation are updated in the same change so they do not outlive it.

## Notes

The label `ubuntu-latest-m` is still *mentioned* once, deliberately: the `frontend-build` comment ends with a do-not-revert note naming it, so that anyone who later reaches for the paid pool finds the measurement first. What is removed is every *usage*.

## Verification

- [ ] Not tested (explain)
- [X] Manual
- [ ] Tests added/updated

Full pipeline validated green on the experiment branch: https://github.com/metadist/synaplan/actions/runs/33055778631

## Test plan

- [x] `Frontend Build` runs on `ubuntu-latest` and stays within a few seconds of the paid-pool baseline
- [x] The critical path (`frontend-build` -> `docker-build` -> `e2e`) is unaffected
- [x] No job in `.github/workflows/` runs on `ubuntu-latest-m` any more (the only remaining occurrence is the intentional do-not-revert note described above)