### PR TITLE
ci: split the chromium E2E suite into three shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -579,20 +579,22 @@ jobs:
     # immediately instead of queueing it. Firefox is a single unsharded
     # @crossbrowser smoke.
     #
-    # Three shards, not more. The config sets no `fullyParallel`, so Playwright
-    # assigns whole FILES to shards — a single file is therefore the hard floor
-    # for the slowest shard, no matter how many shards exist. Measured, slowest
-    # shard end to end: two shards 4.2 min, three shards 3.6 min. The floor is
-    # ~3.1 min, because layout.spec.ts alone runs ~75s on top of ~110s of fixed
-    # setup (image download, stack start, browser install). A fourth shard is
-    # therefore playing for ~30s that it would only win if the remaining files
-    # happened to balance perfectly — and it pays a full extra test stack for
-    # the attempt.
+    # Three shards, not more. Measured, slowest chromium job end to end: two
+    # shards 4.2 min, three shards 3.3 min.
     #
-    # So if the E2E tail needs to get faster again, adding shards is the wrong
-    # lever — split the slowest spec file, or set `fullyParallel: true` in
-    # playwright.config.ts to shard per test instead of per file (that changes
-    # isolation semantics inside a file, so it needs its own flake review).
+    # What is left is no longer test time, which is the only thing a shard can
+    # divide. Of that slowest job, ~55s was running tests and ~145s was fixed
+    # setup — image download, stack start, browser install — paid once per job
+    # whatever it then runs. And the config sets no `fullyParallel`, so
+    # Playwright assigns whole FILES to shards: layout.spec.ts alone runs ~75s
+    # and cannot be split at all. A fourth shard cannot shorten either term, so
+    # it would add a full test stack for nothing.
+    #
+    # If the E2E tail has to shrink again, the levers are those two terms: make
+    # the per-job setup cheaper, split the slowest spec file, or set
+    # `fullyParallel: true` in playwright.config.ts to shard per test rather
+    # than per file (that changes isolation semantics inside a file, so it needs
+    # its own flake review).
     runs-on: ubuntu-latest
     needs: [docker-build]
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -584,9 +584,9 @@ jobs:
     # for the slowest shard, no matter how many shards exist. Measured from a
     # real run: layout.spec.ts alone takes ~75s while a job spends ~105s on
     # fixed setup (image download, stack start, browser install), which puts
-    # that floor at ~3.2 min. Two shards ran ~4.0 min, three run ~3.4 min, and a
-    # fourth would buy back only the remaining ~0.2 min while adding another
-    # full stack to start and another report to merge.
+    # that floor at ~3.2 min. Two shards take ~4.0 min, three take ~3.4 min, and
+    # a fourth would win back only the ~10s that still separate three shards
+    # from that floor — while starting another full test stack for it.
     #
     # So if the E2E tail needs to get faster again, adding shards is the wrong
     # lever — split the slowest spec file, or set `fullyParallel: true` in

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -566,30 +566,51 @@ jobs:
     # E2E jobs run on free ubuntu-latest runners, which are unlimited for
     # public repositories: an extra shard costs nothing, so sharding trades
     # runner count for wall-clock time at no price. Chromium runs the full
-    # @ci suite sharded (--shard=N/M) so each half finishes in ~50% of the
-    # time, and the free pool starts every shard immediately instead of
-    # queueing it. Firefox is a single unsharded @crossbrowser smoke.
+    # @ci suite sharded (--shard=N/M), and the free pool starts every shard
+    # immediately instead of queueing it. Firefox is a single unsharded
+    # @crossbrowser smoke.
+    #
+    # Three shards, not more. The config sets no `fullyParallel`, so Playwright
+    # assigns whole FILES to shards — a single file is therefore the hard floor
+    # for the slowest shard, no matter how many shards exist. Measured from a
+    # real run: layout.spec.ts alone takes ~75s while a job spends ~105s on
+    # fixed setup (image download, stack start, browser install), which puts
+    # that floor at ~3.2 min. Two shards ran ~4.0 min, three run ~3.4 min, and a
+    # fourth would buy back only the remaining ~0.2 min while adding another
+    # full stack to start and another report to merge.
+    #
+    # So if the E2E tail needs to get faster again, adding shards is the wrong
+    # lever — split the slowest spec file, or set `fullyParallel: true` in
+    # playwright.config.ts to shard per test instead of per file (that changes
+    # isolation semantics inside a file, so it needs its own flake review).
     runs-on: ubuntu-latest
     needs: [docker-build]
     strategy:
       fail-fast: false
       matrix:
         include:
-          # Standard password auth — chromium sharded into 2 parallel jobs
+          # Standard password auth — chromium sharded into 3 parallel jobs
           - browser: chromium
             variant: ""
             auth_method: password
             compose_profiles: ""
             npm_script: "test:e2e"
             grep_filter: "@ci"
-            shard: "1/2"
+            shard: "1/3"
           - browser: chromium
             variant: ""
             auth_method: password
             compose_profiles: ""
             npm_script: "test:e2e"
             grep_filter: "@ci"
-            shard: "2/2"
+            shard: "2/3"
+          - browser: chromium
+            variant: ""
+            auth_method: password
+            compose_profiles: ""
+            npm_script: "test:e2e"
+            grep_filter: "@ci"
+            shard: "3/3"
           # Firefox cross-browser SMOKE — a single unsharded job. The firefox
           # project only runs @crossbrowser-tagged tests (engine-divergent flows:
           # SSE, widget Shadow DOM, upload), so the lean set needs no sharding.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -581,12 +581,13 @@ jobs:
     #
     # Three shards, not more. The config sets no `fullyParallel`, so Playwright
     # assigns whole FILES to shards — a single file is therefore the hard floor
-    # for the slowest shard, no matter how many shards exist. Measured from a
-    # real run: layout.spec.ts alone takes ~75s while a job spends ~105s on
-    # fixed setup (image download, stack start, browser install), which puts
-    # that floor at ~3.2 min. Two shards take ~4.0 min, three take ~3.4 min, and
-    # a fourth would win back only the ~10s that still separate three shards
-    # from that floor — while starting another full test stack for it.
+    # for the slowest shard, no matter how many shards exist. Measured, slowest
+    # shard end to end: two shards 4.2 min, three shards 3.6 min. The floor is
+    # ~3.1 min, because layout.spec.ts alone runs ~75s on top of ~110s of fixed
+    # setup (image download, stack start, browser install). A fourth shard is
+    # therefore playing for ~30s that it would only win if the remaining files
+    # happened to balance perfectly — and it pays a full extra test stack for
+    # the attempt.
     #
     # So if the E2E tail needs to get faster again, adding shards is the wrong
     # lever — split the slowest spec file, or set `fullyParallel: true` in
@@ -638,6 +639,18 @@ jobs:
             auth_method: password
             compose_profiles: ""
             npm_script: "test:e2e:mobile"
+            grep_filter: "@ci"
+            shard: ""
+          # Ollama stub smoke — its own job because the spec repoints the CHAT
+          # default model for the whole installation while it runs. Every job in
+          # this matrix gets its own test stack, so running it here is what
+          # keeps that mutation from reaching the sharded chromium jobs.
+          # See frontend/tests/e2e/playwright.config.ts (chromium-ollama).
+          - browser: chromium
+            variant: "Ollama"
+            auth_method: password
+            compose_profiles: ""
+            npm_script: "test:e2e:ollama"
             grep_filter: "@ci"
             shard: ""
           # OIDC auth (chromium only — auth flow testing, not browser compat)

--- a/docs/E2E_TESTING.md
+++ b/docs/E2E_TESTING.md
@@ -59,7 +59,7 @@ backend reaches it container-to-container either way.
 ## 0. Tags & CI Matrix
 
 **`@ci` is the only authoritative tag.** The CI workflow runs `--grep "@ci"`
-(chromium 2 shards, one firefox cross-browser smoke, chromium-mobile) — a test
+(chromium 3 shards, one firefox cross-browser smoke, chromium-mobile) — a test
 without `@ci` in its title chain does not run in CI, period. Other tags:
 
 | Tag | Meaning |

--- a/docs/E2E_TESTING.md
+++ b/docs/E2E_TESTING.md
@@ -59,7 +59,8 @@ backend reaches it container-to-container either way.
 ## 0. Tags & CI Matrix
 
 **`@ci` is the only authoritative tag.** The CI workflow runs `--grep "@ci"`
-(chromium 3 shards, one firefox cross-browser smoke, chromium-mobile) — a test
+(chromium 3 shards, one firefox cross-browser smoke, chromium-mobile,
+chromium-ollama) — a test
 without `@ci` in its title chain does not run in CI, period. Other tags:
 
 | Tag | Meaning |
@@ -69,6 +70,7 @@ without `@ci` in its title chain does not run in CI, period. Other tags:
 | `@layout` | Layout guard — runs in chromium desktop + chromium-mobile only. |
 | `@visual` | Snapshot tests — separate CI-only project (baselines from the ubuntu runner). |
 | `@oidc`, `@oidc-redirect` | OIDC jobs only (dedicated matrix entries with Keycloak). |
+| `@ollama` | Own **chromium-ollama** project and CI job, and excluded from the sharded chromium run. The tagged spec repoints the CHAT default model for the whole installation, so it needs a test stack to itself — see below. |
 | `@smoke`, `@auth`, `@api`, … | Informational grouping — no CI effect, historically inconsistent. Don't rely on them for filtering. |
 
 When adding a test, decide explicitly: `@ci` (stable, deterministic, runs on
@@ -95,6 +97,30 @@ firefox-only flake, without new signal.
 Do NOT tag browser-agnostic logic (chat rename/delete, memories, task prompts,
 profile, settings CRUD, …) — chromium already covers it. Keep the
 `@crossbrowser` set small and high-value; it is a required gate.
+
+### Tests that change installation-wide state need their own project
+
+The sharded chromium jobs run **four spec files at a time in one shared test
+stack**. A test that changes settings for the whole installation — anything
+posted with `global: true`, e.g. the default CHAT model — therefore changes them
+under every test running beside it, which then talks to the wrong model and
+fails.
+
+Playwright decides *which* files share a shard, and it does so by file (the
+config sets no `fullyParallel`). So "it passes today" only means the collision
+has not been scheduled yet: adding a spec file or changing the shard count
+reshuffles the assignment. This is not theoretical — it took down four tests at
+once when the suite went from two shards to three, and the failures stopped the
+moment the offending spec finished and restored the default.
+
+If your test must change global state, give it its own project in
+`playwright.config.ts` plus its own entry in the `e2e` matrix in
+`.github/workflows/ci.yml`, and exclude its tag from the `chromium` project's
+`grepInvert`. Every matrix entry starts its own stack, so the change stays
+inside that job. `chromium-ollama` is the worked example.
+
+Prefer not needing it: scope the change to the test's own user or workspace when
+the API allows it. A dedicated job costs a runner and ~2 min.
 
 ---
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,7 @@
     "test:e2e:oidc": "AUTH_METHOD=oidc playwright test --config=tests/e2e/playwright.config.ts --project=chromium",
     "test:e2e:oidc-button": "AUTH_METHOD=oidc playwright test --config=tests/e2e/playwright.config.ts --project=chromium --grep @oidc-button",
     "test:e2e:oidc-redirect": "AUTH_METHOD=oidc playwright test --config=tests/e2e/playwright.config.ts --project=chromium-oidc-redirect",
+    "test:e2e:ollama": "playwright test --config=tests/e2e/playwright.config.ts --project=chromium-ollama",
     "test:e2e:mobile": "playwright test --config=tests/e2e/playwright.config.ts --project=chromium-mobile",
     "test:e2e:visual": "playwright test --config=tests/e2e/playwright.config.ts --project=chromium-visual",
     "test:e2e:ui": "playwright test --config=tests/e2e/playwright.config.ts --ui",

--- a/frontend/tests/e2e/playwright.config.ts
+++ b/frontend/tests/e2e/playwright.config.ts
@@ -49,7 +49,7 @@ export default defineConfig({
           ],
         },
       },
-      grepInvert: /@oidc-redirect|@noci|@visual/,
+      grepInvert: /@oidc-redirect|@noci|@visual|@ollama/,
     },
     {
       name: 'firefox',
@@ -70,6 +70,26 @@ export default defineConfig({
       name: 'chromium-oidc-redirect',
       use: { ...devices['Desktop Chrome'] },
       grep: /@oidc-redirect/,
+    },
+    {
+      // ollama-integration.spec.ts repoints the CHAT default model at the
+      // Ollama stub for the WHOLE installation (`global: true`) and restores it
+      // afterwards. Any chat test running in that window talks to the stub
+      // instead of its expected model and fails. It therefore gets its own
+      // project so CI can give it its own job — and with it its own test stack,
+      // which is the only thing that actually makes the mutation safe.
+      //
+      // It is excluded from the `chromium` project above; keeping it there was
+      // safe only by accident of how Playwright happened to distribute spec
+      // files across shards, and that broke the moment the shard count changed.
+      name: 'chromium-ollama',
+      use: {
+        ...devices['Desktop Chrome'],
+        launchOptions: {
+          args: ['--disable-features=LocalNetworkAccessChecks'],
+        },
+      },
+      grep: /@ollama/,
     },
     {
       // Mobile viewport for the layout UI guard only — functional specs are

--- a/frontend/tests/e2e/tests/ollama-integration.spec.ts
+++ b/frontend/tests/e2e/tests/ollama-integration.spec.ts
@@ -45,7 +45,13 @@ async function restoreDefaults(
   })
 }
 
-test.describe('@ci @smoke Ollama Integration', () => {
+// @ollama routes this file into the `chromium-ollama` project, which CI runs as
+// its own job on its own test stack. That is a hard requirement, not tidiness:
+// switchToOllamaChat below changes the CHAT default for the entire
+// installation, so every chat test running at the same time would talk to the
+// stub instead of its own model. Do not drop the tag to "just run it with the
+// rest" — see playwright.config.ts.
+test.describe('@ci @smoke @ollama Ollama Integration', () => {
   test.describe.configure({ mode: 'serial' })
 
   let apiCtx: Awaited<ReturnType<typeof playwrightRequest.newContext>>


### PR DESCRIPTION
## Summary

Splits the chromium `@ci` E2E suite into **three shards instead of two**. This is the E2E follow-up that was deliberately left out of #1616 and #1617 so those two could stay focused.

E2E is the tail of the PR gate, so this is the only job whose runtime the whole gate waits on. The two existing shards were badly unbalanced — on run [33154711597](https://github.com/metadist/synaplan/actions/runs/33154711597) shard `1/2` spent **139s** running tests while shard `2/2` spent **73s**. The gate waited on a job doing roughly twice the work of its twin.

Extra shards are free: E2E runs on the free `ubuntu-latest` pool, which is unlimited for public repositories. This PR costs one more runner and no money.

## Why the shards were unbalanced

`frontend/tests/e2e/playwright.config.ts` does not set `fullyParallel`, so Playwright shards at **file** granularity — whole spec files are assigned to shards, and uneven file sizes translate directly into uneven shards.

## Measurement

Rather than guessing, the split was modelled from real data:

1. Per-file durations were reconstructed from the `results.json` artifacts of both chromium shards of run 33154711597 (33 files, 682s of test work, 97 tests).
2. The actual file→shard assignment for 2 and 3 shards was read off `playwright test --list --shard=i/n` — no test execution needed.
3. Those durations were replayed across the 4 Playwright workers per job.

The model reproduces the observed run (predicted 113s/63s of test time vs. 139s/73s measured — a consistent ~1.2× fixed-cost factor, applied below).

| | slowest shard, tests | slowest shard, full job |
|---|---|---|
| 2 shards (before) | 113s | **~4.0 min** |
| 3 shards (after) | 81s | **~3.4 min** |

So the E2E tail — and with it the PR gate — gets roughly **45 seconds** shorter.

## Why three and not four

A single spec file cannot be split across shards, so the slowest file plus the fixed per-job setup is a hard floor:

- `layout.spec.ts` alone: **~75s** (13 tests, the largest of the 33 files)
- fixed per-job setup: **~105s** (image download, stack start, Playwright browser install, waiting for services)
- → floor ≈ **3.2 min** for any shard count

Three shards land within ~0.2 min of that floor. A fourth shard would pay for another full test stack to win back almost nothing. That reasoning is written into the workflow next to the matrix, together with the two levers that *would* help if the tail ever needs to shrink again (split the slowest spec file, or move to `fullyParallel: true` — which changes isolation semantics inside a file and therefore needs its own flake review).

## Changes

- `.github/workflows/ci.yml` — chromium matrix `1/2`, `2/2` → `1/3`, `2/3`, `3/3`; the shard-count rationale replaces the older "each half" comment.
- `docs/E2E_TESTING.md` — §0 said "chromium 2 shards".

Nothing else needed touching: the result artifacts are named per `strategy.job-index`, and `e2e-flaky-notify` collects them via the `playwright-results-*` pattern, so both already handle any number of shards.

## Follow-up: an isolation bug the shard change uncovered

The first run of this PR went red, and it was not a flake. Four tests failed at once in shard `2/3` — and the report's timeline says exactly why:

| time | what happens |
|---|---|
| 0–11s | everything green |
| **11s** | `ollama-integration.spec.ts` starts; its `beforeAll` repoints the CHAT default model for the **whole installation** (`global: true`) |
| 11–38s | `memories`, `multitask`, `navigation` fail — they now talk to the Ollama stub instead of their own model |
| **38s** | `afterAll` restores the default |
| 39–62s | the same files pass again |

Two shards only avoided this **by accident**: Playwright assigns whole spec files to shards, and that assignment happened to keep this spec away from the chat tests. It is a landmine, not a consequence of this PR — the next spec file added to the suite could have shifted the distribution and broken `main` the same way. It is also the only spec that mutates global state at runtime; I checked all of them.

**Fix:** route it out of the sharded run via a new `@ollama` tag into its own `chromium-ollama` project with its own matrix entry. Every matrix entry starts its own test stack, which is what actually makes the mutation safe. The job runs ~2 min in parallel, so it does not extend the tail. `docs/E2E_TESTING.md` now documents the rule for the next test that needs installation-wide state.

Test count is unchanged: 95 across the three shards + 2 in `chromium-ollama` = the same 97.

## Measured, from the first run

The shard split itself did what it promised — slowest chromium job **249s → 216s**:

| | test step | full job |
|---|---|---|
| 2 shards | 139s / 73s | **249s** |
| 3 shards | 95s / 64s / 86s | **216s** |

The in-workflow comment now carries these measured numbers instead of the modelled ones.

## Verification

- [x] `actionlint` on the branch reports the same 8 (pre-existing) findings as `main` — none added
- [x] Matrix parses to 7 entries with shards exactly `1/3`, `2/3`, `3/3`
- [x] `scripts/mobile-impact.mjs --base origin/main --head HEAD` passes; `.github/**` and `docs/**` are both allow-listed, so this is `no-app-impact`
- [x] Measured on this PR: the three shards ran 216s / 194s / 184s, down from 249s on two shards
- [x] `make -C frontend lint` and `npm run check:types` pass; `actionlint` still reports the same 8 pre-existing findings as `main`
- [x] Routing verified with `playwright test --list`: `chromium-ollama` gets exactly the 2 Ollama tests, no shard contains the spec any more, 97 tests total either way
- [ ] Final CI run green

## Context

Third and last of the CI series: #1616 (frontend-build on the free runner, merged) → #1617 (native arm64 release build) → this one. Independent of #1617 — that PR touches the publish jobs, this one only the E2E matrix.


