### PR TITLE
feat(chat): speed-config model mixes in the chat window

### DIFF
--- a/frontend/src/components/MainLayout.vue
+++ b/frontend/src/components/MainLayout.vue
@@ -81,11 +81,16 @@
       <span>{{ $t('auth.signIn') }}</span>
     </button>
 
-    <!-- Incognito toggle (top-right, mobile) — mirrors the drawer toggle on
-         the left. Signed-in users on the chat route only (guests have the
-         login CTA in that spot and no incognito). Desktop gets its own
-         floating instance inside ChatView. -->
-    <div v-if="showIncognitoToggle" class="v2-incognito-toggle fixed right-3 z-40 md:hidden">
+    <!-- Incognito toggle + collapsed speed config (top-right, mobile) —
+         mirrors the drawer toggle on the left. Signed-in users on the chat
+         route only (guests have the login CTA in that spot and no incognito).
+         Desktop gets its own floating instances inside ChatView. The mix
+         button hides itself while ChatView shows the expanded mix card. -->
+    <div
+      v-if="showIncognitoToggle"
+      class="v2-incognito-toggle fixed right-3 z-40 md:hidden flex items-center gap-2"
+    >
+      <ModelMixControl />
       <IncognitoToggle />
     </div>
 
@@ -110,6 +115,7 @@ import MobileNav from './MobileNav.vue'
 import HelpHost from './help/HelpHost.vue'
 import JobsTrayLauncher from './jobs/JobsTrayLauncher.vue'
 import IncognitoToggle from './IncognitoToggle.vue'
+import ModelMixControl from './chat/ModelMixControl.vue'
 
 const route = useRoute()
 const router = useRouter()

--- a/frontend/src/components/chat/ModelMixControl.vue
+++ b/frontend/src/components/chat/ModelMixControl.vue
@@ -1,0 +1,79 @@
+<template>
+  <!-- Hidden while the expanded card is showing in the empty chat: the card
+       visually "turns into" this button when it collapses. -->
+  <div v-if="!mixStore.inlinePanelVisible" ref="rootEl" class="relative">
+    <button
+      type="button"
+      class="flex items-center justify-center w-10 h-10 rounded-full shadow-lg active:scale-95 transition-transform surface-card txt-primary"
+      :aria-label="buttonLabel"
+      :title="buttonLabel"
+      aria-haspopup="menu"
+      :aria-expanded="open"
+      data-testid="btn-model-mix"
+      @click="toggle"
+    >
+      <ModelMixIcon :icon="mixStore.activeMix?.icon ?? { kind: 'brand' }" :size="22" />
+    </button>
+
+    <Transition name="fade">
+      <div
+        v-if="open"
+        class="absolute right-0 top-12 z-50 w-80 max-w-[calc(100vw-1.5rem)]"
+        data-testid="dropdown-model-mix"
+      >
+        <ModelMixPanel @select="open = false" />
+      </div>
+    </Transition>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import ModelMixPanel from '@/components/chat/ModelMixPanel.vue'
+import ModelMixIcon from '@/components/chat/ModelMixIcon.vue'
+import { useModelMixStore } from '@/stores/modelMix'
+import { triggerHapticImpact } from '@/services/api/nativeHaptics'
+
+/**
+ * Collapsed speed config: a round button styled exactly like the incognito
+ * toggle it sits next to, wearing the active mix's logo so the user always
+ * sees which model family answers. Tapping it drops the mix list back down.
+ */
+const { t } = useI18n()
+const mixStore = useModelMixStore()
+
+const open = ref(false)
+const rootEl = ref<HTMLElement | null>(null)
+
+const buttonLabel = computed(() =>
+  t('modelMix.activeLabel', { name: t(`modelMix.mixes.${mixStore.activeMixId}`) })
+)
+
+const toggle = () => {
+  triggerHapticImpact('light')
+  open.value = !open.value
+}
+
+const onDocumentPointerDown = (event: PointerEvent) => {
+  if (!open.value) return
+  if (rootEl.value && !rootEl.value.contains(event.target as Node)) {
+    open.value = false
+  }
+}
+
+const onDocumentKeydown = (event: KeyboardEvent) => {
+  if (event.key === 'Escape') open.value = false
+}
+
+onMounted(() => {
+  void mixStore.ensureLoaded()
+  document.addEventListener('pointerdown', onDocumentPointerDown)
+  document.addEventListener('keydown', onDocumentKeydown)
+})
+
+onUnmounted(() => {
+  document.removeEventListener('pointerdown', onDocumentPointerDown)
+  document.removeEventListener('keydown', onDocumentKeydown)
+})
+</script>

--- a/frontend/src/components/chat/ModelMixIcon.vue
+++ b/frontend/src/components/chat/ModelMixIcon.vue
@@ -1,0 +1,40 @@
+<template>
+  <img
+    v-if="icon.kind === 'brand'"
+    :src="iconSrc"
+    :style="pxStyle"
+    class="object-contain flex-shrink-0"
+    alt=""
+    aria-hidden="true"
+  />
+  <ServiceIcon
+    v-else-if="icon.kind === 'service'"
+    :service="icon.service"
+    :size="size"
+    :show-flag="false"
+  />
+  <Icon v-else :icon="icon.icon" :style="pxStyle" class="flex-shrink-0" aria-hidden="true" />
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { Icon } from '@iconify/vue'
+import ServiceIcon from '@/components/icons/ServiceIcon.vue'
+import { useBrandLogo } from '@/composables/useBrandLogo'
+import { useTheme } from '@/composables/useTheme'
+import type { ModelMixIcon } from '@/utils/modelMixes'
+
+/**
+ * The face of a model mix: the install's brand icon for the default mix
+ * (white-label safe), a provider logo for provider mixes, or a plain Iconify
+ * icon (EU flag for the Europe mix).
+ */
+const props = withDefaults(defineProps<{ icon: ModelMixIcon; size?: number }>(), {
+  size: 20,
+})
+
+const { isDark } = useTheme()
+const { iconSrc } = useBrandLogo(isDark)
+
+const pxStyle = computed(() => ({ width: `${props.size}px`, height: `${props.size}px` }))
+</script>

--- a/frontend/src/components/chat/ModelMixPanel.vue
+++ b/frontend/src/components/chat/ModelMixPanel.vue
@@ -1,0 +1,116 @@
+<template>
+  <div
+    class="surface-card rounded-2xl shadow-lg border border-[var(--border)] p-2"
+    data-testid="panel-model-mix"
+  >
+    <p class="px-3 pt-2 pb-1 text-xs font-semibold uppercase tracking-wide txt-secondary">
+      {{ t('modelMix.title') }}
+    </p>
+
+    <button
+      v-for="mix in mixStore.resolvedMixes"
+      :key="mix.id"
+      type="button"
+      class="w-full flex items-start gap-3 px-3 py-2.5 rounded-xl text-left transition-colors"
+      :class="[
+        mix.id === mixStore.activeMixId
+          ? 'bg-[var(--bg-secondary)]'
+          : 'hover:bg-[var(--bg-secondary)]',
+        !mix.available || mixStore.applying ? 'opacity-50 cursor-not-allowed' : '',
+      ]"
+      :disabled="!mix.available || mixStore.applying"
+      :aria-pressed="mix.id === mixStore.activeMixId"
+      :data-testid="`btn-model-mix-${mix.id}`"
+      @click="pick(mix)"
+    >
+      <ModelMixIcon :icon="mix.icon" :size="22" class="mt-0.5" />
+      <span class="flex-1 min-w-0">
+        <span class="flex items-center gap-2 text-sm font-semibold txt-primary">
+          {{ t(`modelMix.mixes.${mix.id}`) }}
+          <Icon
+            v-if="mix.id === mixStore.activeMixId"
+            icon="mdi:check-circle"
+            class="w-4 h-4 txt-brand flex-shrink-0"
+            aria-hidden="true"
+          />
+          <svg
+            v-else-if="mixStore.applying && pendingId === mix.id"
+            class="w-3.5 h-3.5 animate-spin txt-brand flex-shrink-0"
+            fill="none"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <circle
+              class="opacity-25"
+              cx="12"
+              cy="12"
+              r="10"
+              stroke="currentColor"
+              stroke-width="4"
+            />
+            <path
+              class="opacity-75"
+              fill="currentColor"
+              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+            />
+          </svg>
+        </span>
+        <span class="block text-xs txt-secondary leading-snug mt-0.5">
+          {{ subtitle(mix) }}
+        </span>
+      </span>
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { Icon } from '@iconify/vue'
+import ModelMixIcon from '@/components/chat/ModelMixIcon.vue'
+import { useModelMixStore } from '@/stores/modelMix'
+import { useNotification } from '@/composables/useNotification'
+import type { ModelMixId, ResolvedModelMix } from '@/utils/modelMixes'
+
+/**
+ * The speed-config list: six model mixes, each with the provider logo, the
+ * mix name, and — in small type — the models it would activate on THIS
+ * installation. Rendered inline in the empty chat and inside the round
+ * button's dropdown, so all state lives in the modelMix store.
+ */
+const emit = defineEmits<{ select: [id: ModelMixId] }>()
+
+const { t } = useI18n()
+const mixStore = useModelMixStore()
+const { success, error } = useNotification()
+
+/** Which row is being applied, so only that row shows the spinner. */
+const pendingId = ref<ModelMixId | null>(null)
+
+onMounted(() => {
+  void mixStore.ensureLoaded()
+})
+
+const subtitle = (mix: ResolvedModelMix): string => {
+  if (mix.resetsToRecommended) return t('modelMix.defaultDescription')
+  if (!mix.available) return t('modelMix.unavailable')
+  return mix.modelNames.join(' · ')
+}
+
+const pick = async (mix: ResolvedModelMix) => {
+  // Re-applying the active mix is allowed on purpose: it restores the preset
+  // after manual tweaks on /ai/models. It still closes the panel either way.
+  pendingId.value = mix.id
+  try {
+    const applied = await mixStore.applyMix(mix.id)
+    if (applied) {
+      success(t('modelMix.applied', { name: t(`modelMix.mixes.${mix.id}`) }))
+      emit('select', mix.id)
+    }
+  } catch {
+    error(t('modelMix.applyError'))
+  } finally {
+    pendingId.value = null
+  }
+}
+</script>

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -54,6 +54,23 @@
     "endConfirmMessage": "Die Unterhaltung wird endgültig verworfen und Dateien aus dieser Sitzung werden gelöscht.",
     "endConfirmButton": "Beenden und verwerfen"
   },
+  "modelMix": {
+    "title": "Schnelle Modellwahl",
+    "buttonLabel": "Modell-Mix",
+    "activeLabel": "Aktiver Modell-Mix: {name}",
+    "mixes": {
+      "default": "Standard-Modell-Mix",
+      "openai": "ChatGPT Sol Mix",
+      "anthropic": "Claude Fable Mix",
+      "google": "Google Gemini Mix",
+      "xai": "Grok Mix",
+      "europe": "Europa-Mix"
+    },
+    "defaultDescription": "Die von dieser Installation empfohlenen Modelle",
+    "unavailable": "Auf diesem Server ist kein passender Anbieter eingerichtet",
+    "applied": "{name} ist jetzt für neue Antworten aktiv",
+    "applyError": "Der Modell-Mix konnte nicht gewechselt werden. Bitte versuche es erneut."
+  },
   "jobs": {
     "kind": {
       "video": "Video",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -54,6 +54,23 @@
     "endConfirmMessage": "The conversation will be discarded permanently and files from this session will be deleted.",
     "endConfirmButton": "End and discard"
   },
+  "modelMix": {
+    "title": "Quick model setup",
+    "buttonLabel": "Model mix",
+    "activeLabel": "Active model mix: {name}",
+    "mixes": {
+      "default": "Default Model Mix",
+      "openai": "ChatGPT Sol Mix",
+      "anthropic": "Claude Fable Mix",
+      "google": "Google Gemini Mix",
+      "xai": "Grok Mix",
+      "europe": "Europe Mix"
+    },
+    "defaultDescription": "The models recommended by this installation",
+    "unavailable": "No matching provider is set up on this server",
+    "applied": "{name} is now active for new answers",
+    "applyError": "The model mix could not be switched. Please try again."
+  },
   "jobs": {
     "kind": {
       "video": "video",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -54,6 +54,23 @@
     "endConfirmMessage": "La conversación se descartará de forma permanente y los archivos de esta sesión se eliminarán.",
     "endConfirmButton": "Finalizar y descartar"
   },
+  "modelMix": {
+    "title": "Configuración rápida de modelos",
+    "buttonLabel": "Mix de modelos",
+    "activeLabel": "Mix de modelos activo: {name}",
+    "mixes": {
+      "default": "Mix de modelos predeterminado",
+      "openai": "Mix ChatGPT Sol",
+      "anthropic": "Mix Claude Fable",
+      "google": "Mix Google Gemini",
+      "xai": "Mix Grok",
+      "europe": "Mix Europa"
+    },
+    "defaultDescription": "Los modelos recomendados por esta instalación",
+    "unavailable": "No hay ningún proveedor compatible configurado en este servidor",
+    "applied": "{name} ya está activo para las nuevas respuestas",
+    "applyError": "No se pudo cambiar el mix de modelos. Inténtalo de nuevo."
+  },
   "jobs": {
     "kind": {
       "video": "vídeo",

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -54,6 +54,23 @@
     "endConfirmMessage": "Konuşma kalıcı olarak silinecek ve bu oturumdaki dosyalar kaldırılacak.",
     "endConfirmButton": "Bitir ve sil"
   },
+  "modelMix": {
+    "title": "Hızlı model kurulumu",
+    "buttonLabel": "Model karışımı",
+    "activeLabel": "Etkin model karışımı: {name}",
+    "mixes": {
+      "default": "Varsayılan Model Karışımı",
+      "openai": "ChatGPT Sol Karışımı",
+      "anthropic": "Claude Fable Karışımı",
+      "google": "Google Gemini Karışımı",
+      "xai": "Grok Karışımı",
+      "europe": "Avrupa Karışımı"
+    },
+    "defaultDescription": "Bu kurulumun önerdiği modeller",
+    "unavailable": "Bu sunucuda uygun bir sağlayıcı yapılandırılmamış",
+    "applied": "{name} artık yeni yanıtlar için etkin",
+    "applyError": "Model karışımı değiştirilemedi. Lütfen tekrar deneyin."
+  },
   "jobs": {
     "kind": {
       "video": "video",

--- a/frontend/src/stores/modelMix.ts
+++ b/frontend/src/stores/modelMix.ts
@@ -1,0 +1,100 @@
+import { defineStore } from 'pinia'
+import { computed, ref } from 'vue'
+import { configApi } from '@/services/api/configApi'
+import { useAiConfigStore } from '@/stores/aiConfig'
+import { useAuthStore } from '@/stores/auth'
+import {
+  isModelMixId,
+  resolveModelMixes,
+  type ModelMixId,
+  type ResolvedModelMix,
+} from '@/utils/modelMixes'
+
+/**
+ * Speed-config state shared by the inline panel (empty chat) and the round
+ * top-right button (desktop ChatView + mobile MainLayout).
+ *
+ * The selected mix id is remembered per user in localStorage; the mix itself
+ * is applied server-side through the regular default-model endpoints, so it
+ * behaves exactly as if the user had configured the same models on /ai/models.
+ */
+export const useModelMixStore = defineStore('modelMix', () => {
+  const aiConfig = useAiConfigStore()
+  const authStore = useAuthStore()
+
+  const activeMixId = ref<ModelMixId>('default')
+  const applying = ref(false)
+  /**
+   * True while the expanded selection card is showing in the empty chat, so
+   * the round button stays hidden until the card collapses ("turns into" it).
+   */
+  const inlinePanelVisible = ref(false)
+
+  let initialized = false
+
+  const resolvedMixes = computed<ResolvedModelMix[]>(() => resolveModelMixes(aiConfig.models))
+
+  const activeMix = computed<ResolvedModelMix | null>(
+    () => resolvedMixes.value.find((mix) => mix.id === activeMixId.value) ?? null
+  )
+
+  const storageKey = () => `synaplan_model_mix_${authStore.user?.id ?? 'anon'}`
+
+  /** Load the model catalog (once) and restore the remembered selection. */
+  const ensureLoaded = async () => {
+    if (initialized) return
+    initialized = true
+
+    try {
+      const stored = localStorage.getItem(storageKey())
+      if (isModelMixId(stored)) activeMixId.value = stored
+    } catch {
+      // Storage can be unavailable (private mode); the default selection is fine.
+    }
+
+    if (Object.keys(aiConfig.models).length === 0) {
+      await aiConfig.loadModels()
+    }
+  }
+
+  /**
+   * Apply a mix: write the resolved defaults (or reset to the install's
+   * recommended set) and remember the choice. Returns false when the mix
+   * cannot be applied on this installation.
+   */
+  const applyMix = async (id: ModelMixId): Promise<boolean> => {
+    const mix = resolvedMixes.value.find((entry) => entry.id === id)
+    if (!mix || !mix.available || applying.value) return false
+
+    applying.value = true
+    try {
+      if (mix.resetsToRecommended) {
+        await configApi.resetDefaultModels()
+      } else {
+        await configApi.saveDefaultModels({ defaults: mix.defaults })
+      }
+      // Refresh the full picture — a mix only writes some capabilities.
+      await aiConfig.loadDefaults()
+
+      activeMixId.value = id
+      try {
+        localStorage.setItem(storageKey(), id)
+      } catch {
+        // Non-persistent selection still works for this session.
+      }
+      return true
+    } finally {
+      applying.value = false
+    }
+  }
+
+  return {
+    activeMixId,
+    activeMix,
+    resolvedMixes,
+    applying,
+    inlinePanelVisible,
+    ensureLoaded,
+    applyMix,
+  }
+})

--- a/frontend/src/utils/modelMixes.ts
+++ b/frontend/src/utils/modelMixes.ts
@@ -50,6 +50,10 @@ const google = (providerId: string): MixCandidate => ({ service: 'Google', provi
 const xai = (providerId: string): MixCandidate => ({ service: 'xAI', providerId })
 const mistral = (providerId: string): MixCandidate => ({ service: 'Mistral', providerId })
 const ollama = (providerId: string): MixCandidate => ({ service: 'Ollama', providerId })
+const trustedTokens = (providerId: string): MixCandidate => ({
+  service: 'TrustedTokens',
+  providerId,
+})
 
 export const MODEL_MIXES: ModelMixDefinition[] = [
   {
@@ -134,12 +138,14 @@ export const MODEL_MIXES: ModelMixDefinition[] = [
         ollama('gpt-oss:120b'),
         mistral('mistral-large-latest'),
         mistral('mistral-medium-latest'),
+        trustedTokens('openai/gpt-oss-120b'),
         ollama('gpt-oss:20b'),
       ],
       ANALYZE: [mistral('mistral-medium-latest'), ollama('gpt-oss:120b'), ollama('gpt-oss:20b')],
-      // Same weights the routing prompts are tuned for, hosted locally. Only
-      // applied when the Ollama model is actually pulled on this server.
-      SORT: [ollama('gpt-oss:120b')],
+      // Sorting must always move off the US default with this mix: the same
+      // gpt-oss-120b weights the routing prompts are tuned for, either pulled
+      // locally on Ollama or served by TrustedTokens (EU jurisdiction).
+      SORT: [ollama('gpt-oss:120b'), trustedTokens('openai/gpt-oss-120b')],
       PIC2TEXT: [mistral('mistral-medium-latest')],
       TEXT2SOUND: [
         mistral('voxtral-mini-tts-2603'),

--- a/frontend/src/utils/modelMixes.ts
+++ b/frontend/src/utils/modelMixes.ts
@@ -1,0 +1,232 @@
+import type { AIModel, Capability } from '@/types/ai-models'
+
+/**
+ * Speed-config model mixes: one-tap presets that point the user's default
+ * models (chat, image, video, sound, vision, sorting) at a provider family.
+ *
+ * A mix never references a model BID — BIDs are install-local. Each slot lists
+ * `service + providerId` candidates in priority order and the resolver picks
+ * the first one this installation actually serves (`/api/v1/config/models`
+ * only returns usable models, so presence implies a configured provider).
+ * Slots that resolve to nothing are simply not written, which keeps a mix
+ * honest on installs that lack a provider instead of failing the whole preset.
+ *
+ * The sorter stays on Groq gpt-oss-120b unless a mix explicitly overrides it:
+ * the routing prompts are tuned against that model (see
+ * DefaultModelConfigSeeder in the backend). Only the Google mix (Flash is a
+ * proven JSON sorter) and the Europe mix (same gpt-oss-120b weights, hosted
+ * locally on Ollama) opt out.
+ */
+
+export type ModelMixId = 'default' | 'openai' | 'anthropic' | 'google' | 'xai' | 'europe'
+
+export type ModelMixIcon =
+  /** The installation's brand icon (Synaplan bird unless white-labeled). */
+  | { kind: 'brand' }
+  /** A provider logo rendered through ServiceIcon. */
+  | { kind: 'service'; service: string }
+  /** A plain Iconify icon (e.g. the EU flag). */
+  | { kind: 'iconify'; icon: string }
+
+interface MixCandidate {
+  service: string
+  providerId: string
+}
+
+export interface ModelMixDefinition {
+  id: ModelMixId
+  icon: ModelMixIcon
+  /**
+   * The "Default Model Mix" restores the install's recommended defaults via
+   * the dedicated reset endpoint instead of writing individual slots.
+   */
+  resetsToRecommended: boolean
+  candidates: Partial<Record<Capability, MixCandidate[]>>
+}
+
+const openai = (providerId: string): MixCandidate => ({ service: 'OpenAI', providerId })
+const anthropic = (providerId: string): MixCandidate => ({ service: 'Anthropic', providerId })
+const google = (providerId: string): MixCandidate => ({ service: 'Google', providerId })
+const xai = (providerId: string): MixCandidate => ({ service: 'xAI', providerId })
+const mistral = (providerId: string): MixCandidate => ({ service: 'Mistral', providerId })
+const ollama = (providerId: string): MixCandidate => ({ service: 'Ollama', providerId })
+
+export const MODEL_MIXES: ModelMixDefinition[] = [
+  {
+    id: 'default',
+    icon: { kind: 'brand' },
+    resetsToRecommended: true,
+    candidates: {},
+  },
+  {
+    id: 'openai',
+    icon: { kind: 'service', service: 'OpenAI' },
+    resetsToRecommended: false,
+    candidates: {
+      CHAT: [openai('gpt-5.6-sol'), openai('gpt-5.5'), openai('gpt-5.4')],
+      ANALYZE: [openai('gpt-5.6-sol'), openai('gpt-5.5'), openai('gpt-5.4')],
+      PIC2TEXT: [openai('gpt-5.6-sol'), openai('gpt-5.5'), openai('gpt-5.4')],
+      TEXT2PIC: [openai('gpt-image-1.5'), openai('gpt-image-1')],
+      PIC2PIC: [openai('gpt-image-1.5'), openai('gpt-image-1')],
+      TEXT2SOUND: [openai('tts-1-hd'), openai('tts-1')],
+      // OpenAI has no video model; Grok Imagine is the mix's stand-in.
+      TEXT2VID: [xai('grok-imagine-video')],
+    },
+  },
+  {
+    id: 'anthropic',
+    icon: { kind: 'service', service: 'Anthropic' },
+    resetsToRecommended: false,
+    // Anthropic ships no image/video/sound models — those slots keep the
+    // user's current setting, and the panel subtitle only lists what is set.
+    candidates: {
+      CHAT: [anthropic('claude-fable-5'), anthropic('claude-sonnet-5')],
+      ANALYZE: [anthropic('claude-fable-5'), anthropic('claude-sonnet-5')],
+      PIC2TEXT: [anthropic('claude-fable-5'), anthropic('claude-sonnet-5')],
+    },
+  },
+  {
+    id: 'google',
+    icon: { kind: 'service', service: 'Google' },
+    resetsToRecommended: false,
+    candidates: {
+      CHAT: [google('gemini-3.1-pro-preview'), google('gemini-3.5-flash')],
+      ANALYZE: [google('gemini-3.5-flash'), google('gemini-3.1-pro-preview')],
+      // A Flash model is fast and JSON-reliable enough to take over sorting.
+      SORT: [google('gemini-3.5-flash'), google('gemini-2.5-flash')],
+      PIC2TEXT: [google('gemini-3.1-pro-preview'), google('gemini-3.5-flash')],
+      TEXT2PIC: [
+        google('gemini-3.1-flash-image-preview'),
+        google('nano-banana-pro-preview'),
+        google('gemini-2.5-flash-image'),
+      ],
+      PIC2PIC: [
+        google('gemini-3.1-flash-image-preview'),
+        google('nano-banana-pro-preview'),
+        google('gemini-2.5-flash-image'),
+      ],
+      TEXT2VID: [google('veo-3.1-generate-preview'), google('veo-3.1-fast-generate-preview')],
+      TEXT2SOUND: [google('gemini-2.5-flash-preview-tts')],
+    },
+  },
+  {
+    id: 'xai',
+    icon: { kind: 'service', service: 'xAI' },
+    resetsToRecommended: false,
+    candidates: {
+      CHAT: [xai('grok-4.6'), xai('grok-4.5')],
+      ANALYZE: [xai('grok-4.6'), xai('grok-4.5')],
+      PIC2TEXT: [xai('grok-4.6'), xai('grok-4.5')],
+      TEXT2PIC: [xai('grok-imagine-image')],
+      TEXT2VID: [xai('grok-imagine-video')],
+      IMG2VID: [xai('grok-imagine-video-1.5')],
+    },
+  },
+  {
+    id: 'europe',
+    icon: { kind: 'iconify', icon: 'circle-flags:european-union' },
+    resetsToRecommended: false,
+    // EU-jurisdiction / self-hosted models only. There is no European image or
+    // video model in the catalog, so those slots stay untouched on purpose —
+    // silently routing to a US provider would defeat the point of the mix.
+    candidates: {
+      CHAT: [
+        ollama('gpt-oss:120b'),
+        mistral('mistral-large-latest'),
+        mistral('mistral-medium-latest'),
+        ollama('gpt-oss:20b'),
+      ],
+      ANALYZE: [mistral('mistral-medium-latest'), ollama('gpt-oss:120b'), ollama('gpt-oss:20b')],
+      // Same weights the routing prompts are tuned for, hosted locally. Only
+      // applied when the Ollama model is actually pulled on this server.
+      SORT: [ollama('gpt-oss:120b')],
+      PIC2TEXT: [mistral('mistral-medium-latest')],
+      TEXT2SOUND: [
+        mistral('voxtral-mini-tts-2603'),
+        { service: 'Piper', providerId: 'piper-multi' },
+      ],
+    },
+  },
+]
+
+/** Order in which resolved model names appear in a mix subtitle. */
+const SUBTITLE_CAPABILITY_ORDER: Capability[] = [
+  'CHAT',
+  'TEXT2PIC',
+  'TEXT2VID',
+  'IMG2VID',
+  'TEXT2SOUND',
+  'PIC2TEXT',
+  'SORT',
+  'ANALYZE',
+  'PIC2PIC',
+]
+
+export interface ResolvedModelMix {
+  id: ModelMixId
+  icon: ModelMixIcon
+  resetsToRecommended: boolean
+  /** Capability -> model BID on this installation. Empty for the default mix. */
+  defaults: Partial<Record<Capability, number>>
+  /** Deduplicated display names for the subtitle, in capability order. */
+  modelNames: string[]
+  /** False when a preset cannot resolve a chat model on this installation. */
+  available: boolean
+}
+
+const findCandidate = (
+  capabilityModels: AIModel[] | undefined,
+  candidates: MixCandidate[]
+): AIModel | null => {
+  if (!capabilityModels?.length) return null
+  for (const candidate of candidates) {
+    const match = capabilityModels.find(
+      (model) =>
+        model.available !== false &&
+        model.service.toLowerCase() === candidate.service.toLowerCase() &&
+        model.providerId === candidate.providerId
+    )
+    if (match) return match
+  }
+  return null
+}
+
+/** Vision twins share the base model's name plus a suffix; fold them together. */
+const displayName = (model: AIModel): string => model.name.replace(/\s*\(vision\)$/i, '')
+
+export function resolveModelMix(
+  definition: ModelMixDefinition,
+  models: Partial<Record<Capability, AIModel[]>>
+): ResolvedModelMix {
+  const defaults: Partial<Record<Capability, number>> = {}
+  const names: string[] = []
+
+  for (const capability of SUBTITLE_CAPABILITY_ORDER) {
+    const candidates = definition.candidates[capability]
+    if (!candidates) continue
+    const match = findCandidate(models[capability], candidates)
+    if (!match) continue
+    defaults[capability] = match.id
+    const name = displayName(match)
+    if (!names.includes(name)) names.push(name)
+  }
+
+  return {
+    id: definition.id,
+    icon: definition.icon,
+    resetsToRecommended: definition.resetsToRecommended,
+    defaults,
+    modelNames: names,
+    available: definition.resetsToRecommended || defaults.CHAT !== undefined,
+  }
+}
+
+export function resolveModelMixes(
+  models: Partial<Record<Capability, AIModel[]>>
+): ResolvedModelMix[] {
+  return MODEL_MIXES.map((definition) => resolveModelMix(definition, models))
+}
+
+export function isModelMixId(value: unknown): value is ModelMixId {
+  return typeof value === 'string' && MODEL_MIXES.some((mix) => mix.id === value)
+}

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -8,14 +8,17 @@
       @dragleave="handleDragLeave"
       @drop.prevent="handleDrop"
     >
-      <!-- Incognito toggle (desktop): there is no chat header, so the button
-           floats over the top-right of the message area. The mobile instance
-           lives in MainLayout (fixed top-right, mirroring the menu button). -->
+      <!-- Incognito toggle + collapsed speed config (desktop): there is no
+           chat header, so the buttons float over the top-right of the message
+           area. The mobile instances live in MainLayout (fixed top-right,
+           mirroring the menu button). The mix button hides itself while the
+           expanded card is showing in the empty state below. -->
       <div
         v-if="authStore.isAuthenticated && !needsProviderSetup"
-        class="hidden md:block absolute top-3 right-3 z-30"
+        class="hidden md:flex items-center gap-2 absolute top-3 right-3 z-30"
         data-testid="section-incognito-toggle-desktop"
       >
+        <ModelMixControl />
         <IncognitoToggle />
       </div>
 
@@ -171,6 +174,18 @@
                   incognitoStore.active ? $t('incognito.emptyHint') : $t('chatInput.placeholder')
                 }}
               </p>
+            </div>
+
+            <!-- Speed config: the expanded mix card greets the user on every
+                 fresh chat and collapses into the round top-right button on
+                 the first tap, click, or keystroke elsewhere. -->
+            <div
+              v-if="showInlineMixPanel"
+              ref="inlineMixPanelEl"
+              class="w-full max-w-sm"
+              data-testid="section-model-mix-inline"
+            >
+              <ModelMixPanel @select="dismissInlineMixPanel" />
             </div>
 
             <ExamplePrompts
@@ -487,6 +502,9 @@ import { useFeedbackStore } from '@/stores/userFeedback'
 import { useMessageDigestsStore } from '@/stores/messageDigests'
 import { useIncognitoStore } from '@/stores/incognito'
 import IncognitoToggle from '@/components/IncognitoToggle.vue'
+import ModelMixControl from '@/components/chat/ModelMixControl.vue'
+import ModelMixPanel from '@/components/chat/ModelMixPanel.vue'
+import { useModelMixStore } from '@/stores/modelMix'
 import type { IncognitoHistoryEntry } from '@/services/api/chatApi'
 import { useLimitCheck, type LimitCheckResult } from '@/composables/useLimitCheck'
 import { useNotification } from '@/composables/useNotification'
@@ -677,6 +695,67 @@ const isEmptyLanding = computed(
 const needsProviderSetup = computed(
   () => authStore.isAuthenticated && configStore.setup.chatReady === false
 )
+
+// --- Speed config (model mixes) -------------------------------------------
+// The expanded card shows on every fresh, non-incognito chat until the user
+// interacts anywhere (tap, click, or typing); it then collapses into the
+// round ModelMixControl button next to the incognito toggle. The store flag
+// keeps that button hidden while the card is up, on desktop AND mobile.
+const modelMixStore = useModelMixStore()
+const mixPanelDismissed = ref(false)
+const inlineMixPanelEl = ref<HTMLElement | null>(null)
+
+const showInlineMixPanel = computed(
+  () =>
+    authStore.isAuthenticated &&
+    !needsProviderSetup.value &&
+    !incognitoStore.active &&
+    !mixPanelDismissed.value &&
+    historyStore.messages.length === 0 &&
+    !historyStore.isLoadingMessages
+)
+
+watch(showInlineMixPanel, (visible) => {
+  modelMixStore.inlinePanelVisible = visible
+})
+
+const dismissInlineMixPanel = () => {
+  mixPanelDismissed.value = true
+}
+
+// A fresh chat gets the card back.
+watch(
+  () => chatsStore.activeChatId,
+  () => {
+    mixPanelDismissed.value = false
+  }
+)
+
+// "Once tapped, clicked or text is entered, the popup closes": any pointer
+// press outside the card and any keystroke (the composer is focused on load,
+// so typing lands there) collapse it.
+const collapseMixPanelOnPointer = (event: PointerEvent) => {
+  if (!showInlineMixPanel.value) return
+  if (inlineMixPanelEl.value?.contains(event.target as Node)) return
+  dismissInlineMixPanel()
+}
+
+const collapseMixPanelOnKeydown = () => {
+  if (!showInlineMixPanel.value) return
+  dismissInlineMixPanel()
+}
+
+onMounted(() => {
+  modelMixStore.inlinePanelVisible = showInlineMixPanel.value
+  document.addEventListener('pointerdown', collapseMixPanelOnPointer)
+  document.addEventListener('keydown', collapseMixPanelOnKeydown)
+})
+
+onBeforeUnmount(() => {
+  modelMixStore.inlinePanelVisible = false
+  document.removeEventListener('pointerdown', collapseMixPanelOnPointer)
+  document.removeEventListener('keydown', collapseMixPanelOnKeydown)
+})
 
 function handleGuestFeatureGate(key: string) {
   featureGateKey.value = key

--- a/frontend/tests/unit/components/ModelMixPanel.spec.ts
+++ b/frontend/tests/unit/components/ModelMixPanel.spec.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import ModelMixPanel from '@/components/chat/ModelMixPanel.vue'
+import { useAiConfigStore } from '@/stores/aiConfig'
+import { configApi } from '@/services/api/configApi'
+import type { AIModel } from '@/types/ai-models'
+
+// The speed-config card is the user's one-tap model chooser: every mix must
+// show what it would really activate on this installation, a mix the server
+// cannot serve must be inert, and a tap must both apply and close.
+
+const notifySuccess = vi.fn()
+const notifyError = vi.fn()
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key, locale: { value: 'en' } }),
+}))
+
+vi.mock('@/composables/useNotification', () => ({
+  useNotification: () => ({ success: notifySuccess, error: notifyError }),
+}))
+
+vi.mock('@/services/api/configApi', () => ({
+  configApi: {
+    getModels: vi.fn().mockResolvedValue({ success: true, models: {}, providers: [] }),
+    getDefaultModels: vi.fn().mockResolvedValue({ success: true, defaults: {} }),
+    saveDefaultModels: vi.fn().mockResolvedValue({ success: true, message: 'ok' }),
+    resetDefaultModels: vi.fn().mockResolvedValue({ success: true, message: 'ok', defaults: {} }),
+  },
+}))
+
+const model = (
+  overrides: Partial<AIModel> & Pick<AIModel, 'id' | 'service' | 'name'>
+): AIModel => ({
+  tag: 'chat',
+  providerId: '',
+  quality: 1,
+  rating: 1,
+  priceIn: 0,
+  priceOut: 0,
+  description: null,
+  isSystemModel: false,
+  features: [],
+  ...overrides,
+})
+
+const mountPanel = () =>
+  mount(ModelMixPanel, {
+    global: {
+      stubs: {
+        Icon: true,
+        ModelMixIcon: true,
+      },
+    },
+  })
+
+describe('ModelMixPanel', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+    localStorage.clear()
+    useAiConfigStore().models = {
+      CHAT: [
+        model({
+          id: 240,
+          service: 'Anthropic',
+          providerId: 'claude-fable-5',
+          name: 'Claude Fable 5',
+        }),
+        model({ id: 326, service: 'xAI', providerId: 'grok-4.6', name: 'Grok 4.6' }),
+      ],
+      TEXT2PIC: [
+        model({
+          id: 316,
+          service: 'xAI',
+          providerId: 'grok-imagine-image',
+          name: 'Grok Imagine Image',
+          tag: 'text2pic',
+        }),
+      ],
+    }
+  })
+
+  it('renders one row per mix, with resolved model names as the subtitle', () => {
+    const wrapper = mountPanel()
+
+    expect(wrapper.find('[data-testid="btn-model-mix-default"]').exists()).toBe(true)
+    const grokRow = wrapper.get('[data-testid="btn-model-mix-xai"]')
+    expect(grokRow.text()).toContain('Grok 4.6')
+    expect(grokRow.text()).toContain('Grok Imagine Image')
+  })
+
+  it('disables mixes this installation cannot serve', () => {
+    const wrapper = mountPanel()
+
+    const openaiRow = wrapper.get('[data-testid="btn-model-mix-openai"]')
+    expect(openaiRow.attributes('disabled')).toBeDefined()
+    expect(openaiRow.text()).toContain('modelMix.unavailable')
+
+    expect(
+      wrapper.get('[data-testid="btn-model-mix-anthropic"]').attributes('disabled')
+    ).toBeUndefined()
+  })
+
+  it('applies a mix on click, toasts, and emits select so the host closes', async () => {
+    const wrapper = mountPanel()
+
+    await wrapper.get('[data-testid="btn-model-mix-xai"]').trigger('click')
+    await vi.waitFor(() => {
+      expect(wrapper.emitted('select')).toBeTruthy()
+    })
+
+    expect(configApi.saveDefaultModels).toHaveBeenCalledWith({
+      defaults: { CHAT: 326, TEXT2PIC: 316 },
+    })
+    expect(notifySuccess).toHaveBeenCalled()
+    expect(wrapper.emitted('select')?.[0]).toEqual(['xai'])
+  })
+
+  it('shows an error toast and keeps the panel open when applying fails', async () => {
+    vi.mocked(configApi.saveDefaultModels).mockRejectedValueOnce(new Error('boom'))
+    const wrapper = mountPanel()
+
+    await wrapper.get('[data-testid="btn-model-mix-xai"]').trigger('click')
+    await vi.waitFor(() => {
+      expect(notifyError).toHaveBeenCalled()
+    })
+
+    expect(wrapper.emitted('select')).toBeUndefined()
+  })
+})

--- a/frontend/tests/unit/stores/modelMix.spec.ts
+++ b/frontend/tests/unit/stores/modelMix.spec.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { useModelMixStore } from '@/stores/modelMix'
+import { useAiConfigStore } from '@/stores/aiConfig'
+import { useAuthStore } from '@/stores/auth'
+import { configApi } from '@/services/api/configApi'
+import type { AIModel } from '@/types/ai-models'
+
+// Applying a mix must go through the SAME endpoints the /ai/models page
+// uses — per-user BCONFIG rows on the server — so a mix survives devices and
+// behaves exactly like a manual configuration. These specs pin that contract
+// plus the two local concerns: remembering the choice and refusing presets
+// this installation cannot serve.
+
+vi.mock('@/services/api/configApi', () => ({
+  configApi: {
+    getModels: vi.fn().mockResolvedValue({ success: true, models: {}, providers: [] }),
+    getDefaultModels: vi.fn().mockResolvedValue({ success: true, defaults: {} }),
+    saveDefaultModels: vi.fn().mockResolvedValue({ success: true, message: 'ok' }),
+    resetDefaultModels: vi.fn().mockResolvedValue({ success: true, message: 'ok', defaults: {} }),
+  },
+}))
+
+const model = (
+  overrides: Partial<AIModel> & Pick<AIModel, 'id' | 'service' | 'name'>
+): AIModel => ({
+  tag: 'chat',
+  providerId: '',
+  quality: 1,
+  rating: 1,
+  priceIn: 0,
+  priceOut: 0,
+  description: null,
+  isSystemModel: false,
+  features: [],
+  ...overrides,
+})
+
+const signIn = (userId: number) => {
+  const authStore = useAuthStore()
+  authStore.user = { id: userId } as unknown as NonNullable<typeof authStore.user>
+}
+
+const serveAnthropicChat = () => {
+  const aiConfig = useAiConfigStore()
+  aiConfig.models = {
+    CHAT: [
+      model({
+        id: 240,
+        service: 'Anthropic',
+        providerId: 'claude-fable-5',
+        name: 'Claude Fable 5',
+      }),
+    ],
+  }
+}
+
+describe('modelMix store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+    localStorage.clear()
+  })
+
+  it('applies a provider mix through the defaults endpoint and remembers it per user', async () => {
+    signIn(7)
+    serveAnthropicChat()
+    const store = useModelMixStore()
+
+    const applied = await store.applyMix('anthropic')
+
+    expect(applied).toBe(true)
+    expect(configApi.saveDefaultModels).toHaveBeenCalledWith({ defaults: { CHAT: 240 } })
+    // The mix only writes some capabilities — the store must re-read the
+    // full defaults picture instead of trusting its partial payload.
+    expect(configApi.getDefaultModels).toHaveBeenCalled()
+    expect(store.activeMixId).toBe('anthropic')
+    expect(localStorage.getItem('synaplan_model_mix_7')).toBe('anthropic')
+  })
+
+  it('restores the recommended install defaults for the default mix', async () => {
+    signIn(7)
+    const store = useModelMixStore()
+
+    const applied = await store.applyMix('default')
+
+    expect(applied).toBe(true)
+    expect(configApi.resetDefaultModels).toHaveBeenCalled()
+    expect(configApi.saveDefaultModels).not.toHaveBeenCalled()
+  })
+
+  it('refuses a mix this installation cannot serve', async () => {
+    signIn(7)
+    // No models loaded at all: every provider mix is unavailable.
+    const store = useModelMixStore()
+
+    const applied = await store.applyMix('xai')
+
+    expect(applied).toBe(false)
+    expect(configApi.saveDefaultModels).not.toHaveBeenCalled()
+    expect(store.activeMixId).toBe('default')
+  })
+
+  it('restores the remembered mix for the signed-in user on load', async () => {
+    signIn(7)
+    serveAnthropicChat()
+    localStorage.setItem('synaplan_model_mix_7', 'anthropic')
+    const store = useModelMixStore()
+
+    await store.ensureLoaded()
+
+    expect(store.activeMixId).toBe('anthropic')
+  })
+
+  it('ignores a stored value that is not a mix id', async () => {
+    signIn(7)
+    serveAnthropicChat()
+    localStorage.setItem('synaplan_model_mix_7', 'totally-bogus')
+    const store = useModelMixStore()
+
+    await store.ensureLoaded()
+
+    expect(store.activeMixId).toBe('default')
+  })
+
+  it('loads the model catalog on first use when it is still empty', async () => {
+    signIn(7)
+    const store = useModelMixStore()
+
+    await store.ensureLoaded()
+
+    expect(configApi.getModels).toHaveBeenCalled()
+  })
+})

--- a/frontend/tests/unit/utils/modelMixes.spec.ts
+++ b/frontend/tests/unit/utils/modelMixes.spec.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect } from 'vitest'
+import type { AIModel, Capability } from '@/types/ai-models'
+import { isModelMixId, resolveModelMix, resolveModelMixes, MODEL_MIXES } from '@/utils/modelMixes'
+
+// The resolver turns provider-family presets into concrete model BIDs for
+// THIS installation. Everything user-visible hangs off it: the subtitle under
+// each mix name, the grayed-out state of a mix the server cannot serve, and
+// the exact defaults written when a mix is applied. BIDs are install-local,
+// so all matching goes through service + providerId.
+
+const model = (
+  overrides: Partial<AIModel> & Pick<AIModel, 'id' | 'service' | 'name'>
+): AIModel => ({
+  tag: 'chat',
+  providerId: '',
+  quality: 1,
+  rating: 1,
+  priceIn: 0,
+  priceOut: 0,
+  description: null,
+  isSystemModel: false,
+  features: [],
+  ...overrides,
+})
+
+const mixDefinition = (id: 'openai' | 'anthropic' | 'google' | 'xai' | 'europe' | 'default') => {
+  const definition = MODEL_MIXES.find((mix) => mix.id === id)
+  if (!definition) throw new Error(`mix ${id} missing`)
+  return definition
+}
+
+describe('resolveModelMix', () => {
+  it('picks the first candidate the installation serves', () => {
+    const models: Partial<Record<Capability, AIModel[]>> = {
+      CHAT: [
+        model({ id: 251, service: 'OpenAI', providerId: 'gpt-5.6-sol', name: 'GPT-5.6 Sol' }),
+        model({ id: 204, service: 'OpenAI', providerId: 'gpt-5.5', name: 'GPT-5.5' }),
+      ],
+    }
+
+    const resolved = resolveModelMix(mixDefinition('openai'), models)
+
+    expect(resolved.defaults.CHAT).toBe(251)
+    expect(resolved.available).toBe(true)
+  })
+
+  it('falls back to a later candidate when the first is not offered', () => {
+    const models: Partial<Record<Capability, AIModel[]>> = {
+      CHAT: [model({ id: 204, service: 'OpenAI', providerId: 'gpt-5.5', name: 'GPT-5.5' })],
+    }
+
+    const resolved = resolveModelMix(mixDefinition('openai'), models)
+
+    expect(resolved.defaults.CHAT).toBe(204)
+  })
+
+  it('never resolves a model the backend marked unavailable', () => {
+    const models: Partial<Record<Capability, AIModel[]>> = {
+      CHAT: [
+        model({
+          id: 251,
+          service: 'OpenAI',
+          providerId: 'gpt-5.6-sol',
+          name: 'GPT-5.6 Sol',
+          available: false,
+        }),
+        model({ id: 204, service: 'OpenAI', providerId: 'gpt-5.5', name: 'GPT-5.5' }),
+      ],
+    }
+
+    const resolved = resolveModelMix(mixDefinition('openai'), models)
+
+    expect(resolved.defaults.CHAT).toBe(204)
+  })
+
+  it('leaves capabilities the provider family cannot cover unset', () => {
+    // Anthropic has no image/video/sound models — the mix must not write
+    // those slots, so the user keeps whatever was configured before.
+    const models: Partial<Record<Capability, AIModel[]>> = {
+      CHAT: [
+        model({
+          id: 240,
+          service: 'Anthropic',
+          providerId: 'claude-fable-5',
+          name: 'Claude Fable 5',
+        }),
+      ],
+      TEXT2PIC: [
+        model({
+          id: 190,
+          service: 'Google',
+          providerId: 'gemini-3.1-flash-image-preview',
+          name: 'Nano Banana 2',
+        }),
+      ],
+    }
+
+    const resolved = resolveModelMix(mixDefinition('anthropic'), models)
+
+    expect(resolved.defaults.CHAT).toBe(240)
+    expect(resolved.defaults.TEXT2PIC).toBeUndefined()
+  })
+
+  it('marks a mix without a resolvable chat model as unavailable', () => {
+    const resolved = resolveModelMix(mixDefinition('europe'), {
+      CHAT: [model({ id: 251, service: 'OpenAI', providerId: 'gpt-5.6-sol', name: 'GPT-5.6 Sol' })],
+    })
+
+    expect(resolved.available).toBe(false)
+    expect(resolved.defaults.CHAT).toBeUndefined()
+  })
+
+  it('keeps the default mix available with no defaults of its own', () => {
+    const resolved = resolveModelMix(mixDefinition('default'), {})
+
+    expect(resolved.available).toBe(true)
+    expect(resolved.resetsToRecommended).toBe(true)
+    expect(resolved.defaults).toEqual({})
+  })
+
+  it('folds vision twins into the base model name in the subtitle', () => {
+    const models: Partial<Record<Capability, AIModel[]>> = {
+      CHAT: [
+        model({
+          id: 240,
+          service: 'Anthropic',
+          providerId: 'claude-fable-5',
+          name: 'Claude Fable 5',
+        }),
+      ],
+      PIC2TEXT: [
+        model({
+          id: 241,
+          service: 'Anthropic',
+          providerId: 'claude-fable-5',
+          name: 'Claude Fable 5 (Vision)',
+          tag: 'pic2text',
+        }),
+      ],
+    }
+
+    const resolved = resolveModelMix(mixDefinition('anthropic'), models)
+
+    expect(resolved.modelNames).toEqual(['Claude Fable 5'])
+  })
+
+  it('moves sorting to a local gpt-oss only when Ollama actually serves it', () => {
+    // The routing prompts are tuned for gpt-oss-120b; the Europe mix may only
+    // repoint SORT when the same weights are pulled locally.
+    const withOllama: Partial<Record<Capability, AIModel[]>> = {
+      CHAT: [
+        model({ id: 79, service: 'Ollama', providerId: 'gpt-oss:120b', name: 'gpt-oss:120b' }),
+      ],
+      SORT: [
+        model({ id: 79, service: 'Ollama', providerId: 'gpt-oss:120b', name: 'gpt-oss:120b' }),
+      ],
+    }
+    const withoutOllama: Partial<Record<Capability, AIModel[]>> = {
+      CHAT: [
+        model({
+          id: 245,
+          service: 'Mistral',
+          providerId: 'mistral-large-latest',
+          name: 'Mistral Large 3',
+        }),
+      ],
+      SORT: [
+        model({
+          id: 245,
+          service: 'Mistral',
+          providerId: 'mistral-large-latest',
+          name: 'Mistral Large 3',
+        }),
+      ],
+    }
+
+    expect(resolveModelMix(mixDefinition('europe'), withOllama).defaults.SORT).toBe(79)
+    expect(resolveModelMix(mixDefinition('europe'), withoutOllama).defaults.SORT).toBeUndefined()
+  })
+})
+
+describe('resolveModelMixes', () => {
+  it('returns one entry per defined mix, in definition order', () => {
+    const resolved = resolveModelMixes({})
+
+    expect(resolved.map((mix) => mix.id)).toEqual([
+      'default',
+      'openai',
+      'anthropic',
+      'google',
+      'xai',
+      'europe',
+    ])
+  })
+})
+
+describe('isModelMixId', () => {
+  it('accepts every defined mix id and nothing else', () => {
+    for (const mix of MODEL_MIXES) {
+      expect(isModelMixId(mix.id)).toBe(true)
+    }
+    expect(isModelMixId('groq')).toBe(false)
+    expect(isModelMixId(null)).toBe(false)
+    expect(isModelMixId(42)).toBe(false)
+  })
+})

--- a/frontend/tests/unit/utils/modelMixes.spec.ts
+++ b/frontend/tests/unit/utils/modelMixes.spec.ts
@@ -144,38 +144,46 @@ describe('resolveModelMix', () => {
     expect(resolved.modelNames).toEqual(['Claude Fable 5'])
   })
 
-  it('moves sorting to a local gpt-oss only when Ollama actually serves it', () => {
-    // The routing prompts are tuned for gpt-oss-120b; the Europe mix may only
-    // repoint SORT when the same weights are pulled locally.
-    const withOllama: Partial<Record<Capability, AIModel[]>> = {
-      CHAT: [
-        model({ id: 79, service: 'Ollama', providerId: 'gpt-oss:120b', name: 'gpt-oss:120b' }),
-      ],
-      SORT: [
-        model({ id: 79, service: 'Ollama', providerId: 'gpt-oss:120b', name: 'gpt-oss:120b' }),
-      ],
+  it('moves sorting to gpt-oss-120b on Ollama first, then TrustedTokens', () => {
+    // The routing prompts are tuned for gpt-oss-120b; the Europe mix repoints
+    // SORT to the same weights — pulled locally on Ollama when available,
+    // otherwise served by TrustedTokens (EU jurisdiction). A US sorter must
+    // never remain the silent default of this mix when either option exists.
+    const ollamaSorter = model({
+      id: 79,
+      service: 'Ollama',
+      providerId: 'gpt-oss:120b',
+      name: 'gpt-oss:120b',
+    })
+    const trustedTokensSorter = model({
+      id: 330,
+      service: 'TrustedTokens',
+      providerId: 'openai/gpt-oss-120b',
+      name: 'GPT OSS 120B',
+    })
+    const mistralChat = model({
+      id: 245,
+      service: 'Mistral',
+      providerId: 'mistral-large-latest',
+      name: 'Mistral Large 3',
+    })
+
+    const withBoth: Partial<Record<Capability, AIModel[]>> = {
+      CHAT: [ollamaSorter, trustedTokensSorter],
+      SORT: [ollamaSorter, trustedTokensSorter],
     }
-    const withoutOllama: Partial<Record<Capability, AIModel[]>> = {
-      CHAT: [
-        model({
-          id: 245,
-          service: 'Mistral',
-          providerId: 'mistral-large-latest',
-          name: 'Mistral Large 3',
-        }),
-      ],
-      SORT: [
-        model({
-          id: 245,
-          service: 'Mistral',
-          providerId: 'mistral-large-latest',
-          name: 'Mistral Large 3',
-        }),
-      ],
+    const trustedTokensOnly: Partial<Record<Capability, AIModel[]>> = {
+      CHAT: [mistralChat, trustedTokensSorter],
+      SORT: [mistralChat, trustedTokensSorter],
+    }
+    const neither: Partial<Record<Capability, AIModel[]>> = {
+      CHAT: [mistralChat],
+      SORT: [mistralChat],
     }
 
-    expect(resolveModelMix(mixDefinition('europe'), withOllama).defaults.SORT).toBe(79)
-    expect(resolveModelMix(mixDefinition('europe'), withoutOllama).defaults.SORT).toBeUndefined()
+    expect(resolveModelMix(mixDefinition('europe'), withBoth).defaults.SORT).toBe(79)
+    expect(resolveModelMix(mixDefinition('europe'), trustedTokensOnly).defaults.SORT).toBe(330)
+    expect(resolveModelMix(mixDefinition('europe'), neither).defaults.SORT).toBeUndefined()
   })
 })
 


### PR DESCRIPTION
## Summary

- Adds a **speed config** to the chat window: one-tap model-mix presets — **Default Model Mix** (recommended set), **ChatGPT Sol Mix**, **Claude Fable Mix**, **Google Gemini Mix**, **Grok Mix**, and **Europe Mix** (Ollama gpt-oss + Mistral, EU/self-hosted only) — that set the user's default chat, image, video, sound, and vision models in one go.
- The expanded card greets the user on every fresh chat (with the models each mix would activate on this install listed in small type) and collapses into a **round logo button next to the incognito toggle** on the first tap, click, or keystroke — so the active model family stays visible at a glance (Synaplan bird for Default, provider logos otherwise, EU flag for Europe). Desktop and mobile.
- Mixes reference models by `service + providerId` (never install-local BIDs) and resolve against `/api/v1/config/models`: a slot the install cannot serve stays untouched, a mix without a resolvable chat model is grayed out. Applying goes through the same endpoints as `/ai/models` (`POST /config/models/defaults`, reset endpoint for the default mix), so a mix behaves exactly like a manual configuration and survives devices.
- Sorting stays on Groq gpt-oss-120b (the model the routing prompts are tuned for) unless a mix explicitly overrides it: Gemini Flash in the Google mix, local Ollama gpt-oss-120b in the Europe mix — and only when that model is actually pulled.
- Frontend-only (`ota-candidate` per `scripts/mobile-impact.mjs`); no backend or schema changes.

## Test plan

- [x] 20 new unit tests: resolver (candidate priority, availability, vision-name folding, Europe SORT guard), store (endpoint contract, per-user persistence, unavailable-mix refusal), panel (rows, disabled states, apply + emit, error handling)
- [x] Full frontend gate: ESLint/Prettier, `vue-tsc`, Vitest (173 files / 1412 tests green)
- [x] Verified in the dev stack: applying ChatGPT Sol Mix writes the expected per-user `BCONFIG` rows; Default Model Mix restores the recommended set; card collapses on keystroke into the round logo button; dropdown re-opens from the button
- [x] Visual check in light and dark theme (all four locales added)