### PR TITLE
feat(chat): recording indicator for record-then-transcribe voice input

### DIFF
--- a/frontend/src/components/ChatInput.vue
+++ b/frontend/src/components/ChatInput.vue
@@ -1261,9 +1261,15 @@ const toggleRecording = async () => {
       webSpeechService.value = null
     }
     if (audioRecorder.value) {
+      // Do NOT clear `isRecording` here: MediaRecorder's onstop event fires
+      // asynchronously, so a synchronous clear would unmount the activity
+      // strip for a frame before `transcribeAudio` sets `transcribing`. The
+      // recorder's onStop/onError callbacks and transcribeAudio's `finally`
+      // own the flag from this point on.
       audioRecorder.value.stopRecording()
+    } else {
+      isRecording.value = false
     }
-    isRecording.value = false
     return
   }
 
@@ -1427,9 +1433,10 @@ const transcribeAudio = async (audioBlob: Blob) => {
   }
 
   // Set before the first await so the activity strip switches straight from
-  // "recording" to "transcribing". AudioRecorder invokes this callback before
-  // its own onStop, so `isRecording` is still true at this point and the strip
-  // never blinks out between the two states.
+  // "recording" to "transcribing". This only avoids a blink because the stop
+  // tap in `toggleRecording` deliberately leaves `isRecording` true until the
+  // recorder's callbacks run, and AudioRecorder invokes this callback before
+  // its own onStop — so the strip is still mounted when `transcribing` is set.
   transcribing.value = true
   uploading.value = true
 

--- a/frontend/src/components/ChatInput.vue
+++ b/frontend/src/components/ChatInput.vue
@@ -88,6 +88,35 @@
           (via `md:contents` on the control bar).
         -->
         <div class="flex flex-col md:block">
+          <!-- Voice activity strip.
+               Only shown on the record-then-transcribe path (see
+               `showVoiceActivity`): there the transcript arrives in one piece
+               when the user stops, so between tapping the microphone and
+               releasing it the composer is completely inert. The Web Speech
+               path writes recognised words into the textarea as they arrive
+               and is its own progress indicator. -->
+          <div
+            v-if="showVoiceActivity"
+            class="voice-activity"
+            role="status"
+            aria-live="polite"
+            data-testid="chat-voice-activity"
+          >
+            <template v-if="transcribing">
+              <Icon icon="mdi:loading" class="w-4 h-4 animate-spin" aria-hidden="true" />
+            </template>
+            <template v-else>
+              <span class="voice-activity__pulse" aria-hidden="true"></span>
+              <span class="voice-activity__meter" aria-hidden="true">
+                <span class="voice-activity__bar"></span>
+                <span class="voice-activity__bar"></span>
+                <span class="voice-activity__bar"></span>
+                <span class="voice-activity__bar"></span>
+              </span>
+            </template>
+            <span>{{ voiceActivityLabel }}</span>
+          </div>
+
           <!-- Textarea row. Mobile: full width with a comfortable 12px horizontal
                inset (matches the control bar below) so text never sits flush
                against the card edge. md+: py-2 (16px) + textarea min-h-[40px] =
@@ -459,6 +488,7 @@ const isDragging = ref(false)
 const isFocused = ref(false)
 const isMobile = ref(window.innerWidth < 768)
 const isRecording = ref(false)
+const transcribing = ref(false)
 const audioRecorder = ref<AudioRecorder | null>(null)
 const webSpeechService = ref<WebSpeechService | null>(null)
 const interimTranscript = ref('')
@@ -564,6 +594,25 @@ const textareaPaddingRightPx = computed(() => {
 const useWebSpeech = computed(() => {
   return isWebSpeechSupported() && !isNativeApp() && configStore.speech.webSpeechEnabled
 })
+
+/**
+ * Whether to show the animated "recording / transcribing" strip.
+ *
+ * Scoped to the record-then-transcribe path, which is what the native app
+ * always uses (see the seam on `useWebSpeech`) and what any browser without
+ * the Web Speech API falls back to. On that path no text reaches the textarea
+ * until the upload completes, so a live microphone is otherwise indistinguishable
+ * from a dead one. The Web Speech path already streams words in as it hears them.
+ */
+const showVoiceActivity = computed(
+  () => !useWebSpeech.value && (isRecording.value || transcribing.value)
+)
+
+const voiceActivityLabel = computed(() =>
+  transcribing.value
+    ? t('chatInput.voiceStatus.transcribing')
+    : t('chatInput.voiceStatus.recording')
+)
 
 // Input persistence - auto-save with proper debouncing. Disabled during an
 // incognito session: drafts must never survive in localStorage.
@@ -1377,6 +1426,11 @@ const transcribeAudio = async (audioBlob: Blob) => {
     return
   }
 
+  // Set before the first await so the activity strip switches straight from
+  // "recording" to "transcribing". AudioRecorder invokes this callback before
+  // its own onStop, so `isRecording` is still true at this point and the strip
+  // never blinks out between the two states.
+  transcribing.value = true
   uploading.value = true
 
   try {
@@ -1401,6 +1455,7 @@ const transcribeAudio = async (audioBlob: Blob) => {
     showError(t('chatInput.transcriptionFailed', { error: error.message || 'Unknown error' }))
   } finally {
     isRecording.value = false
+    transcribing.value = false
     uploading.value = false
   }
 }
@@ -1502,3 +1557,95 @@ defineExpose<{
   submitText,
 })
 </script>
+
+<style scoped>
+/*
+ * Voice activity strip for the record-then-transcribe path.
+ *
+ * Three cues at once so the state reads at a glance: a pulsing red dot (the
+ * universal "we are recording" mark), a four-bar level meter that keeps moving
+ * so a live microphone never looks frozen, and the label. Colors come from the
+ * shared status tokens, which covers light, dark and the V2 glass design
+ * without a second definition. Follows the `.typing-dot` pattern in
+ * ChatMessage.vue.
+ */
+.voice-activity {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px 0;
+  font-size: 12px;
+  line-height: 1;
+  color: var(--txt-secondary);
+}
+
+.voice-activity__pulse {
+  width: 8px;
+  height: 8px;
+  flex-shrink: 0;
+  border-radius: 9999px;
+  background: var(--status-error);
+  animation: voice-pulse 1.4s ease-in-out infinite;
+}
+
+.voice-activity__meter {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  height: 14px;
+}
+
+.voice-activity__bar {
+  width: 3px;
+  height: 100%;
+  border-radius: 9999px;
+  background: var(--brand);
+  animation: voice-level 1s ease-in-out infinite;
+}
+
+/* Staggered so the meter sweeps left-to-right instead of pumping in unison. */
+.voice-activity__bar:nth-child(1) {
+  animation-delay: -0.9s;
+}
+.voice-activity__bar:nth-child(2) {
+  animation-delay: -0.6s;
+}
+.voice-activity__bar:nth-child(3) {
+  animation-delay: -0.3s;
+}
+
+@keyframes voice-pulse {
+  0%,
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.35;
+    transform: scale(0.7);
+  }
+}
+
+@keyframes voice-level {
+  0%,
+  100% {
+    transform: scaleY(0.3);
+    opacity: 0.5;
+  }
+  50% {
+    transform: scaleY(1);
+    opacity: 1;
+  }
+}
+
+/* The motion is decoration — the label and the live region carry the meaning. */
+@media (prefers-reduced-motion: reduce) {
+  .voice-activity__pulse,
+  .voice-activity__bar {
+    animation: none;
+  }
+  .voice-activity__bar {
+    transform: scaleY(0.7);
+  }
+}
+</style>

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -713,6 +713,10 @@
     "voiceWhisper": "Aufnehmen und mit Whisper transkribieren",
     "listeningStarted": "🎙️ Hört zu... jetzt sprechen",
     "recordingStarted": "🎙️ Aufnahme gestartet...",
+    "voiceStatus": {
+      "recording": "Aufnahme läuft...",
+      "transcribing": "Text wird erstellt..."
+    },
     "speechError": "Spracherkennungsfehler: {error}",
     "recordingError": "Aufnahme fehlgeschlagen: {error}",
     "transcribed": "🎙️ Transkribiert{language}: \"{preview}\"",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -712,6 +712,10 @@
     "voiceWhisper": "Record and transcribe with Whisper",
     "listeningStarted": "🎙️ Listening... speak now",
     "recordingStarted": "🎙️ Recording started...",
+    "voiceStatus": {
+      "recording": "Recording...",
+      "transcribing": "Transcribing..."
+    },
     "speechError": "Speech recognition error: {error}",
     "recordingError": "Recording failed: {error}",
     "transcribed": "🎙️ Transcribed{language}: \"{preview}\"",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -748,6 +748,10 @@
     "voiceWhisper": "Grabar y transcribir con Whisper",
     "listeningStarted": "🎙️ Escuchando... habla ahora",
     "recordingStarted": "🎙️ Grabación iniciada...",
+    "voiceStatus": {
+      "recording": "Grabando...",
+      "transcribing": "Transcribiendo..."
+    },
     "speechError": "Error de reconocimiento de voz: {error}",
     "recordingError": "Error de grabación: {error}",
     "transcribed": "🎙️ Transcrito{language}: \"{preview}\"",

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -748,6 +748,10 @@
     "voiceWhisper": "Kaydet ve Whisper ile yazıya dök",
     "listeningStarted": "🎙️ Dinleniyor... şimdi konuşun",
     "recordingStarted": "🎙️ Kayıt başladı...",
+    "voiceStatus": {
+      "recording": "Kaydediliyor...",
+      "transcribing": "Metne dönüştürülüyor..."
+    },
     "speechError": "Konuşma tanıma hatası: {error}",
     "recordingError": "Kayıt başarısız: {error}",
     "transcribed": "🎙️ Yazıya döküldü{language}: \"{preview}\"",

--- a/frontend/tests/unit/components/ChatInputVoiceActivity.spec.ts
+++ b/frontend/tests/unit/components/ChatInputVoiceActivity.spec.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { nextTick } from 'vue'
+import ChatInput from '@/components/ChatInput.vue'
+
+// The record-then-transcribe path hands the user nothing until the upload
+// finishes: no interim words, no partial text. That is the only path the
+// native app ever takes (the Web Speech seam is off in the app shell), so
+// without an activity strip a live microphone looks exactly like a dead one.
+// These specs pin the strip to that path and to that path only.
+
+const VOICE_ACTIVITY = '[data-testid="chat-voice-activity"]'
+const MIC_BUTTON = '[data-testid="btn-chat-voice"]'
+
+let webSpeechSupported = false
+let recorderOptions: {
+  onStart?: () => void
+  onStop?: () => void
+  onDataAvailable?: (blob: Blob) => void
+  onError?: (error: { messageKey: string }) => void
+} = {}
+
+/** Resolver for the pending transcription, so specs can hold it mid-flight. */
+let resolveTranscription: (value: { text: string; file_id: number }) => void = () => {}
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ query: {}, fullPath: '/chat' }),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+}))
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key, locale: { value: 'en' } }),
+}))
+
+vi.mock('@/stores/config', () => ({
+  useConfigStore: () => ({
+    speech: {
+      webSpeechEnabled: true,
+      whisperEnabled: true,
+      speechToTextAvailable: true,
+    },
+  }),
+}))
+
+vi.mock('@/services/webSpeechService', () => ({
+  isWebSpeechSupported: () => webSpeechSupported,
+  WebSpeechService: class {
+    start = vi.fn().mockResolvedValue(undefined)
+    stop = vi.fn()
+    abort = vi.fn()
+  },
+}))
+
+vi.mock('@/services/audioRecorder', () => ({
+  AudioRecorder: class {
+    constructor(options: typeof recorderOptions) {
+      recorderOptions = options
+    }
+    checkSupport = vi.fn().mockResolvedValue({ supported: true, hasDevices: true })
+    startRecording = vi.fn().mockImplementation(async () => {
+      recorderOptions.onStart?.()
+    })
+    stopRecording = vi.fn()
+  },
+}))
+
+vi.mock('@/services/api/chatApi', () => ({
+  chatApi: {
+    transcribeAudio: vi.fn().mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveTranscription = resolve
+        })
+    ),
+  },
+}))
+
+const mountInput = (): VueWrapper =>
+  mount(ChatInput, {
+    global: {
+      mocks: { $t: (key: string) => key },
+      stubs: {
+        Icon: true,
+        // Needs a real `focus`: the component focuses the textarea after a
+        // transcript lands, and a bare stub turns that into an unhandled
+        // rejection that has nothing to do with the behaviour under test.
+        Textarea: { template: '<textarea />', methods: { focus() {} } },
+        CommandPalette: true,
+        FileMentionPalette: true,
+        ToolsDropdown: true,
+        ToolBadge: true,
+        ModelDropdown: true,
+        KnowledgeFolderPicker: true,
+        FileSelectionModal: true,
+        QuoteChip: true,
+      },
+    },
+  })
+
+describe('ChatInput voice activity strip', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    webSpeechSupported = false
+    recorderOptions = {}
+  })
+
+  it('appears while the recorder is capturing', async () => {
+    const wrapper = mountInput()
+
+    await wrapper.get(MIC_BUTTON).trigger('click')
+    await nextTick()
+
+    expect(wrapper.find(VOICE_ACTIVITY).exists()).toBe(true)
+    expect(wrapper.get(VOICE_ACTIVITY).text()).toContain('chatInput.voiceStatus.recording')
+  })
+
+  it('switches to the transcribing label while the upload is in flight', async () => {
+    const wrapper = mountInput()
+
+    await wrapper.get(MIC_BUTTON).trigger('click')
+    recorderOptions.onDataAvailable?.(new Blob(['audio']))
+    await nextTick()
+
+    expect(wrapper.get(VOICE_ACTIVITY).text()).toContain('chatInput.voiceStatus.transcribing')
+  })
+
+  it('disappears once the transcript arrives', async () => {
+    const wrapper = mountInput()
+
+    await wrapper.get(MIC_BUTTON).trigger('click')
+    recorderOptions.onDataAvailable?.(new Blob(['audio']))
+    await nextTick()
+
+    resolveTranscription({ text: 'hello', file_id: 1 })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await nextTick()
+
+    expect(wrapper.find(VOICE_ACTIVITY).exists()).toBe(false)
+  })
+
+  it('stays hidden on the Web Speech path, which streams words into the textarea itself', async () => {
+    webSpeechSupported = true
+    const wrapper = mountInput()
+
+    await wrapper.get(MIC_BUTTON).trigger('click')
+    await nextTick()
+
+    expect(wrapper.find(VOICE_ACTIVITY).exists()).toBe(false)
+  })
+
+  it('is hidden before the microphone is used', () => {
+    expect(mountInput().find(VOICE_ACTIVITY).exists()).toBe(false)
+  })
+})

--- a/frontend/tests/unit/components/ChatInputVoiceActivity.spec.ts
+++ b/frontend/tests/unit/components/ChatInputVoiceActivity.spec.ts
@@ -115,11 +115,29 @@ describe('ChatInput voice activity strip', () => {
     expect(wrapper.get(VOICE_ACTIVITY).text()).toContain('chatInput.voiceStatus.recording')
   })
 
+  it('stays visible between tapping stop and the recorder handing over the audio', async () => {
+    // MediaRecorder's onstop fires asynchronously, so there is a real window
+    // where the user has tapped stop but no audio has arrived yet. The strip
+    // must not blink out during that window (regression test: the stop tap
+    // used to clear `isRecording` synchronously).
+    const wrapper = mountInput()
+
+    await wrapper.get(MIC_BUTTON).trigger('click')
+    await wrapper.get(MIC_BUTTON).trigger('click')
+    await nextTick()
+
+    expect(wrapper.find(VOICE_ACTIVITY).exists()).toBe(true)
+    expect(wrapper.get(VOICE_ACTIVITY).text()).toContain('chatInput.voiceStatus.recording')
+  })
+
   it('switches to the transcribing label while the upload is in flight', async () => {
     const wrapper = mountInput()
 
     await wrapper.get(MIC_BUTTON).trigger('click')
+    await wrapper.get(MIC_BUTTON).trigger('click')
+    // Real recorder order on stop: onDataAvailable first, then onStop.
     recorderOptions.onDataAvailable?.(new Blob(['audio']))
+    recorderOptions.onStop?.()
     await nextTick()
 
     expect(wrapper.get(VOICE_ACTIVITY).text()).toContain('chatInput.voiceStatus.transcribing')
@@ -129,7 +147,9 @@ describe('ChatInput voice activity strip', () => {
     const wrapper = mountInput()
 
     await wrapper.get(MIC_BUTTON).trigger('click')
+    await wrapper.get(MIC_BUTTON).trigger('click')
     recorderOptions.onDataAvailable?.(new Blob(['audio']))
+    recorderOptions.onStop?.()
     await nextTick()
 
     resolveTranscription({ text: 'hello', file_id: 1 })


### PR DESCRIPTION
## Summary

- Adds a visible **recording / transcribing** activity strip to the chat composer for the record-then-transcribe (Whisper) voice path — the only path the native iOS app uses, where until now a live microphone was indistinguishable from a dead one until the finished transcript appeared.
- The strip shows a pulsing record dot, an animated level meter, and a label that switches from "Recording…" to "Transcribing…" while the upload is in flight. Scoped to that path only: the Web Speech path streams recognized words into the textarea and is its own progress indicator.
- Follow-up fix included: the indicator no longer blinks out between tapping stop and the recorder handing over the audio (MediaRecorder's `onstop` fires asynchronously).

Colors use the shared status tokens; contrast measured in light/dark across both design variants (lowest 4.43:1). Animation collapses to a static state under `prefers-reduced-motion`. All four locales (en/de/es/tr) updated.

Note: the Speed Select (model mixes) shipped separately in #1620, already merged.

## Verification

- [x] Unit tests pin the strip's visibility and labels across recording → stop → transcribing → transcript arrival (including the stop-tap blink regression)
- [x] Full CI gate green (backend, frontend lint/types/tests, E2E shards)
- [x] Manual check in light and dark theme