### PR TITLE
chore(release): install 4.4.0 in new deployments

### DIFF
--- a/deploy/aws/packer/synaplan.pkr.hcl
+++ b/deploy/aws/packer/synaplan.pkr.hcl
@@ -23,7 +23,7 @@ variable "synaplan_version" {
   # Raised by scripts/set-release-version.mjs after every published release, so
   # a build with no arguments produces the AMI for the release this branch
   # ships. The release workflow still passes it explicitly.
-  default     = "4.0.16"
+  default     = "4.4.0"
   description = "Released SemVer version to bake in, without a leading v. Never a mutable tag: the first boot pins deploy/.env to exactly this value."
 
   validation {

--- a/deploy/selfhost.env.example
+++ b/deploy/selfhost.env.example
@@ -9,7 +9,7 @@ COMPOSE_PROJECT_NAME=synaplan-production
 # and any mutable tag are rejected before a container starts, so a redeploy can
 # never pull a different version behind your back. Newer releases are listed at
 # https://github.com/metadist/synaplan/releases — see docs/UPDATE_SELFHOST.md.
-SYNAPLAN_VERSION=4.0.16
+SYNAPLAN_VERSION=4.4.0
 SYNAPLAN_PULL_POLICY=always
 SYNAPLAN_HTTP_BIND=127.0.0.1
 SYNAPLAN_HTTP_PORT=8000

--- a/deploy/umbrel/synaplan/docker-compose.yml
+++ b/deploy/umbrel/synaplan/docker-compose.yml
@@ -19,7 +19,7 @@ x-app-environment: &app-environment
   # (together with the image pin below and umbrel-app.yml) to the version whose
   # image was just published. Do not edit by hand —
   # scripts/set-release-version.mjs owns these three lines.
-  APP_VERSION: "4.0.16"
+  APP_VERSION: "4.4.0"
 
   # umbrelOS serves apps over plain HTTP on the device's .local domain. Synaplan
   # derives the auth cookies' Secure flag from this scheme, so the session
@@ -85,7 +85,7 @@ x-app-environment: &app-environment
 # then hands over to Caddy/FrankenPHP, which binds port 80 inside the container.
 # Tag and digest are maintained by CI together with APP_VERSION above —
 # scripts/set-release-version.mjs owns this line.
-x-app-image: &app-image ghcr.io/metadist/synaplan:4.0.16@sha256:a6d7cb5b57e3be9e62dce221366b0b6a8b477f8f6a84736cf2794f9eb4a51968
+x-app-image: &app-image ghcr.io/metadist/synaplan:4.4.0@sha256:2e6b4765e5edecee00524cf9648da1f2789a648fec6f4bd6820e80e1525946a7
 
 # Uploaded and generated files. The web role writes them, the worker reads them
 # back while processing a job, so all three app roles share the directory.

--- a/deploy/umbrel/synaplan/umbrel-app.yml
+++ b/deploy/umbrel/synaplan/umbrel-app.yml
@@ -4,7 +4,7 @@ category: ai
 name: Synaplan
 # Maintained by CI together with APP_VERSION and the image pin in
 # docker-compose.yml — scripts/set-release-version.mjs owns this field.
-version: "4.0.16"
+version: "4.4.0"
 tagline: Private AI workspace with chat, document search and embeddable widgets
 description: >-
   Synaplan is a self-hosted AI workspace. Chat with the model of your choice,

--- a/elestio.yml
+++ b/elestio.yml
@@ -27,7 +27,7 @@ environments:
   # new deployments; existing ones stay on their pinned version until their
   # operator changes it, as described in docs/UPDATE_ELESTIO.md.
   - key: "SYNAPLAN_VERSION"
-    value: "4.0.16"
+    value: "4.4.0"
   # Deployment hint for the release notice, so the admin UI links to the Elestio
   # update guide instead of the self-hosted one. Display only: Synaplan never
   # updates itself.


### PR DESCRIPTION
Installs `4.4.0` in **new** deployments:

- `elestio.yml` for the one-click path
- `deploy/selfhost.env.example` for self-hosting
- `deploy/umbrel/synaplan/` for the Umbrel App Store package (version, `APP_VERSION`, and the published image digest)
- `deploy/aws/packer/synaplan.pkr.hcl` for the AWS Marketplace AMI

Existing deployments are unaffected. They keep the version their operator pinned and change it only by following the update guide, so a redeploy never moves a running installation to a different version.

Merging this restarts every Elestio instance that tracks `main`, because Elestio redeploys on each commit to the branch it tracks. Merge when that is convenient.

Originally opened at 4.3.6 from the branch the release automation maintains; the v4.4.0 release force-pushed the branch and this PR carried forward to it automatically. Note: the `release-version-pin` job cannot open these PRs itself because the release App token lacks **Pull requests: write** — grant that permission and the proposal opens by itself on future releases.