### PR TITLE
fix(auth): recover admin session when impersonation swap is clobbered

### DIFF
--- a/backend/src/Controller/AuthController.php
+++ b/backend/src/Controller/AuthController.php
@@ -522,6 +522,38 @@ class AuthController extends AbstractController
         $result = $this->impersonationService->issueRefreshedImpersonationAccessToken($request);
 
         if (!$result) {
+            // A refresh that raced the cookie-swap can leave a valid admin stash
+            // next to a plain admin access token. Recover the admin session
+            // instead of wiping cookies (which logged the admin out).
+            $recovered = $this->impersonationService->recoverAdminSessionFromStash($request);
+            if ($recovered) {
+                /** @var User $admin */
+                $admin = $recovered['user'];
+
+                $this->logger->info('Impersonation refresh recovered admin session', [
+                    'admin_id' => $admin->getId(),
+                ]);
+
+                $response = new JsonResponse([
+                    'success' => true,
+                    'user' => [
+                        'id' => $admin->getId(),
+                        'email' => $admin->getMail(),
+                        'level' => $admin->getUserLevel(),
+                        'emailVerified' => $admin->isEmailVerified(),
+                        'isAdmin' => $admin->isAdmin(),
+                        'memoriesEnabled' => $admin->isMemoriesEnabled(),
+                        'firstName' => $this->extractFirstName($admin),
+                    ],
+                ]);
+
+                $response->headers->setCookie(
+                    $this->tokenService->createAccessCookie($recovered['access_token'])
+                );
+
+                return $response;
+            }
+
             $response = new JsonResponse([
                 'error' => 'Impersonation session expired',
                 'code' => 'IMPERSONATION_EXPIRED',

--- a/backend/src/Service/ImpersonationService.php
+++ b/backend/src/Service/ImpersonationService.php
@@ -241,6 +241,47 @@ final readonly class ImpersonationService
     }
 
     /**
+     * Recover a clean admin session when a refresh raced the cookie-swap and
+     * left a valid admin stash next to a plain admin access token (no
+     * `impersonator_id`). Mints a fresh admin access token from the stash so the
+     * still-valid admin is not logged out; the stash is kept so
+     * `/impersonate/exit` can tear it down. Returns null when this is not the
+     * recoverable state (no/invalid stash, or a genuine impersonation token).
+     *
+     * @return array{access_token: string, user: User}|null
+     */
+    public function recoverAdminSessionFromStash(Request $request): ?array
+    {
+        $stashRefresh = $request->cookies->get(self::ADMIN_REFRESH_STASH_COOKIE);
+        if (!is_string($stashRefresh) || '' === $stashRefresh) {
+            return null;
+        }
+
+        $admin = $this->resolveAdminFromStashedRefresh($stashRefresh);
+        if (!$admin) {
+            return null;
+        }
+
+        // Skip a genuine impersonation token — the normal refresh path owns it.
+        $accessTokenString = $request->cookies->get(TokenService::ACCESS_COOKIE);
+        if (is_string($accessTokenString) && '' !== $accessTokenString) {
+            $payload = $this->tokenService->decodeAccessTokenIgnoringExpiry($accessTokenString);
+            if ($payload && isset($payload['impersonator_id'])) {
+                return null;
+            }
+        }
+
+        $this->logger->info('Impersonation swap recovered to admin session', [
+            'admin_id' => $admin->getId(),
+        ]);
+
+        return [
+            'access_token' => $this->tokenService->generateAccessToken($admin),
+            'user' => $admin,
+        ];
+    }
+
+    /**
      * Read the impersonator off the active access token claim.
      *
      * Used by `/auth/me` to label the impersonation banner. Returns null when

--- a/backend/tests/Controller/AuthRefreshImpersonationRecoveryTest.php
+++ b/backend/tests/Controller/AuthRefreshImpersonationRecoveryTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Controller;
+
+use App\Entity\Token;
+use App\Entity\User;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\BrowserKit\Cookie as BrowserKitCookie;
+
+/**
+ * Deterministic reproducer of the impersonation cookie-swap race: a refresh
+ * leaves a valid admin stash next to a plain admin access token. The refresh
+ * must recover the admin session (200) instead of returning 401 and wiping
+ * cookies, and must keep the stash so `/impersonate/exit` can tear it down.
+ */
+class AuthRefreshImpersonationRecoveryTest extends WebTestCase
+{
+    public function testCorruptedSwapRefreshRecoversAdminSessionInsteadOfLoggingOut(): void
+    {
+        self::ensureKernelShutdown();
+        $client = static::createClient();
+        $em = $client->getContainer()->get('doctrine')->getManager();
+
+        $admin = new User();
+        $admin->setMail('recover-admin@example.com');
+        $admin->setPw(password_hash('AdminPass123!', PASSWORD_BCRYPT));
+        $admin->setUserLevel('ADMIN');
+        $admin->setProviderId('local');
+        $admin->setCreated(date('YmdHis'));
+        $admin->setEmailVerified(true);
+        $admin->setUserDetails(['firstName' => 'Ada', 'lastName' => 'Admin']);
+        $em->persist($admin);
+        $em->flush();
+        $adminId = (int) $admin->getId();
+
+        // --- Admin login: mints a plain admin access token (NO impersonator_id)
+        // and a DB-backed admin refresh token. ---
+        $client->request(
+            'POST',
+            '/api/v1/auth/login',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            json_encode([
+                'email' => 'recover-admin@example.com',
+                'password' => 'AdminPass123!',
+            ]),
+        );
+        $this->assertResponseIsSuccessful('Admin login should succeed');
+
+        $jar = $client->getCookieJar();
+        $refreshCookie = $jar->get('refresh_token');
+        $accessCookie = $jar->get('access_token');
+        $this->assertNotNull($refreshCookie, 'login must set a refresh_token cookie');
+        $this->assertNotNull($accessCookie, 'login must set an access_token cookie');
+
+        $adminRefreshValue = $refreshCookie->getValue();
+        $plainAdminAccessValue = $accessCookie->getValue();
+
+        // Recreate the corrupted state: stash = valid admin refresh, access =
+        // plain admin token, regular refresh cleared. Reuse the refresh cookie's
+        // path/domain so the jar replays the stash on the next request.
+        $jar->set(new BrowserKitCookie(
+            'admin_refresh_token',
+            $adminRefreshValue,
+            null,
+            $refreshCookie->getPath(),
+            (string) $refreshCookie->getDomain(),
+            $refreshCookie->isSecure(),
+            true,
+        ));
+        $jar->expire('refresh_token');
+
+        // Sanity: the state we are about to exercise matches the trace.
+        $this->assertNull($jar->get('refresh_token'), 'regular refresh cookie is cleared during impersonation');
+        $this->assertNotNull($jar->get('admin_refresh_token'), 'stash present');
+        $this->assertSame(
+            $plainAdminAccessValue,
+            $jar->get('access_token')?->getValue(),
+            'access cookie is still the plain admin token',
+        );
+
+        // --- The pre-exit refresh that used to 401 + wipe everything ---
+        $client->request('POST', '/api/v1/auth/refresh');
+
+        $this->assertResponseIsSuccessful(
+            'Corrupted-swap refresh MUST recover the admin session (200), not 401 + logout',
+        );
+
+        $payload = json_decode((string) $client->getResponse()->getContent(), true);
+        $this->assertTrue($payload['success'] ?? false, 'refresh response success=true');
+        $this->assertSame(
+            'recover-admin@example.com',
+            $payload['user']['email'] ?? null,
+            'recovered session must be the admin, not the (lost) impersonation target',
+        );
+        $this->assertTrue($payload['user']['isAdmin'] ?? false, 'recovered user is admin');
+
+        // A fresh admin access token must be installed (not a clear cookie).
+        $newAccess = $jar->get('access_token');
+        $this->assertNotNull($newAccess, 'access cookie must be refreshed, not deleted');
+        $this->assertNotSame('', $newAccess->getValue(), 'access cookie must carry a real token, not be wiped');
+
+        // Crucially the stash must survive so the follow-up /impersonate/exit
+        // can still restore the regular refresh cookie and clear the stash.
+        $stashCookie = $jar->get('admin_refresh_token');
+        $this->assertNotNull($stashCookie, 'stash must be kept on recovery so exit can tear it down cleanly');
+        $this->assertNotSame(
+            '',
+            $stashCookie->getValue(),
+            'stash must not be wiped by the recovery refresh',
+        );
+
+        // --- Cleanup (tokens first for FK safety) ---
+        $em->clear();
+        $tokens = $em->getRepository(Token::class)->findBy(['user' => $adminId]);
+        foreach ($tokens as $token) {
+            $em->remove($token);
+        }
+        $em->flush();
+        $entity = $em->getRepository(User::class)->find($adminId);
+        if ($entity) {
+            $em->remove($entity);
+            $em->flush();
+        }
+    }
+}

--- a/backend/tests/Unit/Service/ImpersonationServiceTest.php
+++ b/backend/tests/Unit/Service/ImpersonationServiceTest.php
@@ -516,6 +516,102 @@ final class ImpersonationServiceTest extends TestCase
     }
 
     // ---------------------------------------------------------------------
+    // recoverAdminSessionFromStash()
+    // ---------------------------------------------------------------------
+
+    public function testRecoverAdminSessionMintsAdminAccessWhenAccessTokenLacksImpersonatorClaim(): void
+    {
+        // Plain admin access token (no impersonator_id) next to a valid stash:
+        // recovery must mint a fresh admin token so the admin is not logged out.
+        $admin = $this->makeUser(id: 1, level: 'ADMIN');
+
+        $request = $this->requestWithAppTokens([
+            ImpersonationService::ADMIN_REFRESH_STASH_COOKIE => 'stashed-admin-refresh',
+            TokenService::ACCESS_COOKIE => 'plain-admin-access',
+        ]);
+
+        $refreshTokenEntity = $this->createMock(\App\Entity\Token::class);
+        $refreshTokenEntity->method('getUser')->willReturn($admin);
+
+        $this->tokenService
+            ->method('validateRefreshToken')
+            ->with('stashed-admin-refresh')
+            ->willReturn($refreshTokenEntity);
+
+        $this->tokenService
+            ->expects(self::once())
+            ->method('decodeAccessTokenIgnoringExpiry')
+            ->with('plain-admin-access')
+            ->willReturn([
+                'user_id' => 1,
+                'type' => 'access',
+            ]);
+
+        $this->tokenService
+            ->expects(self::once())
+            ->method('generateAccessToken')
+            ->with($admin)
+            ->willReturn('fresh-admin-access');
+
+        $result = $this->service->recoverAdminSessionFromStash($request);
+
+        self::assertNotNull($result);
+        self::assertSame('fresh-admin-access', $result['access_token']);
+        self::assertSame($admin, $result['user']);
+    }
+
+    public function testRecoverAdminSessionReturnsNullWhenAccessTokenIsStillImpersonation(): void
+    {
+        // A genuine impersonation access token must be handled by the normal
+        // impersonation-refresh path, never silently downgraded to admin.
+        $admin = $this->makeUser(id: 1, level: 'ADMIN');
+
+        $request = $this->requestWithAppTokens([
+            ImpersonationService::ADMIN_REFRESH_STASH_COOKIE => 'stashed-admin-refresh',
+            TokenService::ACCESS_COOKIE => 'impersonation-access',
+        ]);
+
+        $refreshTokenEntity = $this->createMock(\App\Entity\Token::class);
+        $refreshTokenEntity->method('getUser')->willReturn($admin);
+
+        $this->tokenService
+            ->method('validateRefreshToken')
+            ->willReturn($refreshTokenEntity);
+
+        $this->tokenService
+            ->method('decodeAccessTokenIgnoringExpiry')
+            ->willReturn([
+                'user_id' => 7,
+                'impersonator_id' => 1,
+                'type' => 'access',
+            ]);
+
+        $this->tokenService
+            ->expects(self::never())
+            ->method('generateAccessToken');
+
+        self::assertNull($this->service->recoverAdminSessionFromStash($request));
+    }
+
+    public function testRecoverAdminSessionReturnsNullWhenNoStash(): void
+    {
+        self::assertNull($this->service->recoverAdminSessionFromStash(new Request()));
+    }
+
+    public function testRecoverAdminSessionReturnsNullWhenStashInvalid(): void
+    {
+        $request = $this->requestWithAppTokens([
+            ImpersonationService::ADMIN_REFRESH_STASH_COOKIE => 'revoked-stash',
+        ]);
+
+        $this->tokenService
+            ->method('validateRefreshToken')
+            ->willReturn(null);
+
+        self::assertNull($this->service->recoverAdminSessionFromStash($request));
+    }
+
+    // ---------------------------------------------------------------------
     // resolveImpersonatorFromActiveSession()
     // ---------------------------------------------------------------------
 

--- a/frontend/src/services/api/chatApi.ts
+++ b/frontend/src/services/api/chatApi.ts
@@ -3,7 +3,7 @@
  */
 
 import { z } from 'zod'
-import { httpClient, getApiBaseUrl } from './httpClient'
+import { httpClient, getApiBaseUrl, awaitAuthMutation } from './httpClient'
 import { isNativeApp } from './nativeRuntime'
 import { getNativeAccessToken, hasNativeTokens } from './nativeAuth'
 import { UserMemorySchema } from './userMemoriesApi'
@@ -128,6 +128,11 @@ async function refreshAccessToken(): Promise<boolean> {
 
   tokenRefreshPromise = (async () => {
     try {
+      // This pool is invisible to the httpClient auth-mutation lock. Let an
+      // in-progress impersonation swap settle first, else this fires with
+      // pre-swap cookies and clobbers the new session.
+      await awaitAuthMutation()
+
       const refreshResponse = await fetch(`${getApiBaseUrl()}/api/v1/auth/refresh`, {
         method: 'POST',
         credentials: 'include',

--- a/frontend/src/services/api/httpClient.ts
+++ b/frontend/src/services/api/httpClient.ts
@@ -305,6 +305,19 @@ function getInFlightRefresh(): Promise<RefreshResult> | null {
   return refreshPromise
 }
 
+/**
+ * Await the open auth-mutation critical section, if any. Independent
+ * `/auth/refresh` pools (chatApi's SSE warmer, authService, legacy apiService)
+ * call this before their raw refresh so they don't fire with pre-swap cookies
+ * during an impersonation swap and clobber the new session. Resolves
+ * immediately when no swap is in progress.
+ */
+async function awaitAuthMutation(): Promise<void> {
+  if (authMutationPromise) {
+    await authMutationPromise
+  }
+}
+
 // Track auth failures to prevent redirect loops
 let authFailureCount = 0
 let lastAuthFailureTime = 0
@@ -722,4 +735,5 @@ export {
   beginAuthMutation,
   endAuthMutation,
   getInFlightRefresh,
+  awaitAuthMutation,
 }

--- a/frontend/tests/unit/api/chatApiAuthMutation.spec.ts
+++ b/frontend/tests/unit/api/chatApiAuthMutation.spec.ts
@@ -1,0 +1,95 @@
+/**
+ * Regression guard: chatApi's SSE-token warmer refreshes on its own pool,
+ * invisible to the httpClient auth-mutation lock. It must wait for an
+ * in-progress impersonation swap to settle before refreshing, else it fires
+ * with pre-swap cookies and clobbers the new session.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { beginAuthMutation, endAuthMutation } from '@/services/api/httpClient'
+import { prefetchSseToken, clearSseToken } from '@/services/api/chatApi'
+import { setSessionHint, clearSessionHint } from '@/services/sessionHint'
+
+const flush = async (): Promise<void> => {
+  // Let the fire-and-forget warmer chain (refresh → then → getSseToken) run.
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  await new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+describe('chatApi SSE-token warmer — auth-mutation lock (impersonation swap)', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    localStorage.clear()
+    clearSseToken()
+    setSessionHint()
+    fetchSpy = vi.spyOn(globalThis, 'fetch')
+    fetchSpy.mockImplementation(((url: RequestInfo | URL) => {
+      const target = String(url)
+      if (target.includes('/api/v1/auth/refresh')) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ success: true }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          })
+        )
+      }
+      if (target.includes('/api/v1/auth/token')) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ token: 'sse-token' }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          })
+        )
+      }
+      return Promise.resolve(new Response('', { status: 404 }))
+    }) as typeof fetch)
+  })
+
+  afterEach(async () => {
+    // Release the lock, then DRAIN any parked warmer so its fire-and-forget
+    // chain settles against THIS spy instead of leaking a stray fetch into the
+    // next test. Only then restore the spy.
+    endAuthMutation()
+    await flush()
+    clearSseToken()
+    fetchSpy.mockRestore()
+    clearSessionHint()
+  })
+
+  function refreshCalls(): unknown[][] {
+    return (fetchSpy.mock.calls as unknown as unknown[][]).filter((call) =>
+      String(call[0]).includes('/api/v1/auth/refresh')
+    )
+  }
+
+  it('does NOT fire /auth/refresh while a principal swap holds the lock', async () => {
+    beginAuthMutation()
+
+    prefetchSseToken()
+    await flush()
+
+    // The warmer must be parked behind the swap, not racing it with pre-swap cookies.
+    expect(refreshCalls()).toHaveLength(0)
+  })
+
+  it('fires /auth/refresh once the swap releases the lock', async () => {
+    beginAuthMutation()
+
+    prefetchSseToken()
+    await flush()
+    expect(refreshCalls()).toHaveLength(0)
+
+    endAuthMutation()
+    await flush()
+
+    // Now the refresh runs — against the stable post-swap cookies.
+    expect(refreshCalls()).toHaveLength(1)
+  })
+
+  it('fires /auth/refresh immediately when no swap is in progress', async () => {
+    prefetchSseToken()
+    await flush()
+
+    expect(refreshCalls()).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
## Summary

Fixes the recurring `@ci` admin-impersonation E2E flake — which is also a **real production logout bug**.

**Root cause (proven from the failing CI network trace: decoded cookies + access-token payloads).** A regular `POST /auth/refresh` that races the impersonation cookie-swap is dispatched while the browser still carries the *pre-swap* `refresh_token` cookie (the stash `Set-Cookie` has not applied yet). It takes the regular refresh path and mints a **plain admin access token (no `impersonator_id`)** that clobbers the freshly installed impersonation access token. The session is left in a corrupted-but-benign state:

- `admin_refresh_token` (stash) → still a **valid, DB-backed admin refresh**
- `access_token` → a **plain admin token, no `impersonator_id`**
- `refresh_token` → cleared at impersonation start

On exit, `/auth/refresh` routes to the impersonation-aware path (stash present), finds no `impersonator_id`, and returned `401 IMPERSONATION_EXPIRED` while wiping **every** auth cookie → the still-valid admin was redirected to `/login`, and the E2E `view-admin` wait timed out.

## Changes

- **Backend (`ImpersonationService` + `AuthController`)** — self-healing recovery: when the stash is a valid admin refresh but the access token has no `impersonator_id`, restore a clean admin session (mint a fresh admin access token) instead of clearing all cookies. The stash is intentionally **kept** so the follow-up `POST /impersonate/exit` still tears it down cleanly. This is *culprit-agnostic*: any refresh pool that causes the corrupted state now degrades gracefully to "admin logged in" instead of a logout.
- **Frontend (`httpClient` + `chatApi`)** — the app has several independent `/auth/refresh` pools that bypass the httpClient auth-mutation lock. The `chatApi` SSE-token warmer (the proven culprit, fired by proactive/prefetch timers) now waits on the lock via a new `awaitAuthMutation()` helper before issuing its raw refresh, so it no longer races the swap with pre-swap cookies. `authService`'s refresh is deliberately **not** gated (it runs inside the lock during `refreshUser()` and would deadlock; it also carries post-swap cookies there).

## Why previous attempts missed it

Earlier fixes targeted symptoms (navigation timing, longer timeouts, fire-and-forget config reload, a "concurrent revoke" hypothesis) based on guesses. Decoding the actual trace cookies revealed the corrupted access token — the true layer — and pinned the culprit refresh pool.

## Test plan

- [x] `backend/tests/Controller/AuthRefreshImpersonationRecoveryTest.php` — functional reproducer: recreates the **exact** corrupted-cookie state from real DB-backed tokens; asserts `200` + admin recovery. Verified it **fails without the fix** (reproduces the trace's `401 IMPERSONATION_EXPIRED` + triple `Set-Cookie: …=deleted`) and passes with it.
- [x] `backend/tests/Unit/Service/ImpersonationServiceTest.php` — 4 unit tests for `recoverAdminSessionFromStash` (recovers on missing claim; defers to normal path for genuine impersonation tokens; null on no/invalid stash).
- [x] `frontend/tests/unit/api/chatApiAuthMutation.spec.ts` — 3 regression tests: SSE-token warmer parks behind the lock, fires after release, fires immediately when no swap.
- [x] Full local gate green: backend lint + PHPStan + 4365 tests; frontend lint + vue-tsc + 1421 tests.
- [ ] CI green, incl. the `@ci` admin-impersonation Chromium shard (final validation — the chat step needs a real browser run, unavailable locally).