### PR TITLE
fix(widget): allow all domains when the allowlist is empty

### DIFF
--- a/backend/src/Controller/WidgetPublicController.php
+++ b/backend/src/Controller/WidgetPublicController.php
@@ -1694,16 +1694,10 @@ class WidgetPublicController extends AbstractController
 
         $allowedDomains = $config['allowedDomains'] ?? [];
         if (empty($allowedDomains)) {
-            $this->logger->warning('Widget request blocked: no domains configured', [
-                'allowed_domains_count' => 0,
-                'config_keys' => array_keys($config),
-                'request_host' => $request->headers->get('X-Widget-Host') ?? $request->getHost(),
-            ]);
-
-            return $this->json([
-                'error' => 'Domain not allowed',
-                'reason' => 'domain_not_whitelisted',
-            ], Response::HTTP_FORBIDDEN);
+            // An empty allowlist means the widget is embeddable everywhere —
+            // restricting domains is opt-in (same semantics as the legacy
+            // widget.js loader and WidgetOriginValidator).
+            return null;
         }
 
         $host = $this->extractHostFromRequest($request);

--- a/backend/src/Service/Widget/WidgetOriginValidator.php
+++ b/backend/src/Service/Widget/WidgetOriginValidator.php
@@ -13,8 +13,9 @@ use Symfony\Component\HttpFoundation\Request;
  * Mirrors the semantics enforced on the widget chat endpoints
  * (WidgetPublicController::ensureDomainAllowed):
  *
- *   - an EMPTY allowlist blocks — a widget without configured domains is
- *     not embeddable, so no anonymous request on its behalf is legitimate;
+ *   - an EMPTY allowlist allows every domain — restricting embedding is
+ *     opt-in, matching the legacy widget.js loader and the UI copy
+ *     ("Leave empty to allow all domains");
  *   - the requesting host is taken from `X-Widget-Host` (set by the embed
  *     script), falling back to the `Origin` / `Referer` headers;
  *   - allowlist entries support `*.example.com` wildcards and optional
@@ -33,7 +34,7 @@ final readonly class WidgetOriginValidator
     public function isRequestAllowed(Request $request, array $allowedDomains): bool
     {
         if ([] === $allowedDomains) {
-            return false;
+            return true;
         }
 
         $host = $this->extractHostFromRequest($request);

--- a/backend/tests/Unit/Controller/RealtimeTokenControllerTest.php
+++ b/backend/tests/Unit/Controller/RealtimeTokenControllerTest.php
@@ -407,7 +407,7 @@ final class RealtimeTokenControllerTest extends TestCase
         $this->assertSame(403, $controller->issueWidgetToken($evilOrigin, 'wdg_abc', 'sid_xyz')->getStatusCode());
     }
 
-    public function testWidgetTokenRefusedWhenWidgetHasNoAllowedDomains(): void
+    public function testWidgetTokenIssuedWhenWidgetHasNoAllowedDomains(): void
     {
         $widgetRepo = $this->createMock(WidgetRepository::class);
         $widgetRepo->method('findByWidgetId')->willReturn($this->buildWidget(allowedDomains: []));
@@ -420,8 +420,9 @@ final class RealtimeTokenControllerTest extends TestCase
             sessionRepo: $sessionRepo,
         );
 
-        // Same fail-closed rule as the chat endpoints: no allowlist, no embed.
-        $this->assertSame(403, $controller->issueWidgetToken($this->widgetTokenRequest(), 'wdg_abc', 'sid_xyz')->getStatusCode());
+        // Same open-by-default rule as the chat endpoints: an empty allowlist
+        // means the widget is embeddable from any domain.
+        $this->assertSame(200, $controller->issueWidgetToken(new Request(server: ['HTTP_ORIGIN' => 'https://anywhere.test']), 'wdg_abc', 'sid_xyz')->getStatusCode());
     }
 
     public function testWidgetTokenEndpointIsRateLimitedPerIp(): void


### PR DESCRIPTION
## Summary

- A widget with an **empty** `allowedDomains` list was blocked on every public endpoint (chat, session, upload, history via `WidgetPublicController::ensureDomainAllowed`, and the Centrifugo token via `WidgetOriginValidator`), returning `403 domain_not_whitelisted`.
- This contradicted the legacy `widget.js` loader (which already treats an empty list as allow-all) and the UI copy ("Leave empty to allow all domains", "No domains configured. Widget can be embedded on any website.") — so widgets created without configured domains silently never worked when embedded.
- Empty allowlist now means **embeddable everywhere**; domain restriction is opt-in. A non-empty list enforces exactly as before. This enables the intended workflow: develop with an empty list (works from localhost/staging), then harden for production by adding the live domain(s).

## Test plan

- [x] `make -C backend lint` — green
- [x] `make -C backend phpstan` — green
- [x] `make -C backend test` — 4360 tests, 18610 assertions, green
- [x] Inverted `RealtimeTokenControllerTest::testWidgetTokenRefusedWhenWidgetHasNoAllowedDomains` → token is now issued from any origin for a widget without configured domains
- [x] Non-empty allowlist behavior unchanged (`testWidgetTokenRefusedForDisallowedOrigin`, `testExpiredSessionStillHonoursTheDomainAllowlist` still pass)