### PR TITLE
feat(frontend): two-level Manage menu and quieter shell

### DIFF
--- a/_devextras/planning/20260828-interface-streamlining-sprint/01_execution_sprints.md
+++ b/_devextras/planning/20260828-interface-streamlining-sprint/01_execution_sprints.md
@@ -1,0 +1,581 @@
+# Execution sprints — menu, wording, and shell structure
+
+**Status:** Ready to schedule  
+**Date:** 2026-08-28  
+**Parent:** [README.md](./README.md)  
+**Binding:** [02_compatibility_contract.md](./02_compatibility_contract.md) — external widget,
+plugin, add-in, shared-chat, and mobile contracts; frozen files; per-sprint regression matrix.  
+**Test plan:** [03_playwright_test_plan.md](./03_playwright_test_plan.md) — the full E2E spec
+inventory (41 specs, 16 nav-dependent), which suites are rewritten/updated/guarded per sprint,
+selector-alias process, visual re-baseline policy, and new specs to add.  
+**Classification:** `ota-candidate` (frontend shell, copy, tests). No store-required native change.
+
+## Reality check: is this “just HTML”?
+
+Mostly yes for **product behavior**. These four sprints do **not** add APIs, roles,
+tenants, or a new assistant data model. Existing pages keep their URLs and
+controllers. Authorization stays where it is (`isAdmin`, feature gates, guest
+gates).
+
+What actually changes:
+
+| Kind of work | Share | Examples |
+| --- | --- | --- |
+| Visible HTML / Vue templates | Large | Rail, flyouts, mobile More, empty states, account menu, page headers |
+| Wording | Large | `en/de/es/tr.json`, page titles, aria labels, empty states |
+| Navigation model | Medium | `useNavItems.ts`, selected-state, breadcrumbs — still one source of truth |
+| Tests | Large | `navigation.spec.ts` and siblings assert today’s flyouts and labels |
+| Backend / APIs | None intended | Keep routes; add redirects only if a path is renamed |
+
+So the risk is **regression of navigation and copy**, not broken chat or billing.
+Budget as much time for rewriting E2E as for moving the menu — the per-spec
+breakdown and effort estimate live in
+[03_playwright_test_plan.md](./03_playwright_test_plan.md); tests are adjusted
+in the **same PR** as the shell change they verify.
+
+One exception deserves respect: the embedded chat widget bundles the **same
+i18n files and the same `style.css`** as the app shell into the self-contained
+`widget.js` running on customer websites (`widget.ts` imports `./i18n` and
+`./style.css?inline`; `vite.config.widget.ts` inlines everything). Wording
+work is therefore also a widget release. The rules — values only, never key
+renames; `widget.*` namespace treated as customer copy; widget build + E2E on
+every locale change — are in the
+[compatibility contract](./02_compatibility_contract.md) §2 and are binding.
+
+Do **not** restore Easy Mode. Do **not** invent a company-admin or hoster role.
+Do **not** start the assistant-as-resource editor in these sprints.
+
+## Out of scope (later epics)
+
+- Assistant-centered widget editor (README “Follow-up sprint”).
+- Hoster console, tenants, token pools, delegated RBAC.
+- Splitting `ChatView.vue` / `AdvancedWidgetConfig.vue` for maintainability.
+- Visual rebrand or retiring the V1/V2 design tokens.
+- New command palette as a substitute for a clear menu.
+
+## Target after four sprints
+
+Everyday signed-in user (Plugins only when installed):
+
+```
+[New]  [History]  [Sources]  [Plugins*]  [Manage ▾]  [Account]
+```
+
+Guest:
+
+```
+[Chat]  [Sign in]
+```
+
+Administrator, same Work rail plus:
+
+```
+[Operate ▾]
+```
+
+`Manage` is **one** entry that groups today’s Channels + AI Setup. `Operate` is
+today’s Admin cluster, labeled for instance work. Every child still opens the
+**same URL** it opens today.
+
+**Plugins stay a top-level rail entry** (when plugins are installed), exactly as
+today. Plugin users work in their plugin daily; folding it into Manage would
+add a hop to their most frequent destination for zero disclosure gain — the
+entry only exists for users who installed a plugin. So the daily-user rail is:
+
+```
+[New]  [History]  [Sources]  [Plugins*]  [Manage ▾]  [Account]      *if installed
+```
+
+## Locked glossary (all four locales in Sprint 1)
+
+| Concept | Use this | Do not use in primary UI |
+| --- | --- | --- |
+| Knowledge library | **Sources** | File Manager, knowledge base (as a nav label) |
+| One uploaded item | **file** | — |
+| RAG scope | **knowledge folder** | knowledge group (user-facing) |
+| Embeddable product | **chat widget** | web widget, Your Widgets (as the only name) |
+| Configured answering personality | **AI assistant** | agent (except the gateway product) |
+| Guided widget setup chat | **AI Setup Assistant** | Widget AI Wizard |
+| User-facing prompt library | **Instructions** | Preconfigured Instructions, Task Prompts |
+| Classifier | **Routing** | Sorting, Classification |
+| Website / WhatsApp / email entry | **Inbound** | Standard Inbound |
+| IMAP automation | **Email handler** | IMAP Email Handler |
+| Repeatable jobs | **Automations** / **Saved tasks** | bury under AI Setup & Tools |
+| Action-oriented gateway | **AI Agents** | Messages Gateway (primary label) |
+| Installation administration | **Operate** | Admin Panel (keep “Admin” only if space is tight) |
+| Assistant / channel authoring | **Manage** | AI Setup & Tools (as a top-level name) |
+
+Internal route prefixes (`/files`, `/ai`, `/admin`) may stay. Users should not
+need them.
+
+---
+
+## Sprint 1 — Lock the words
+
+**Goal:** One name per concept in all four locales. Menu **placement** stays the
+same so this sprint is a safe copy drop.
+
+**Duration:** ~3–5 days  
+**Shippable alone:** Yes. Users see clearer labels on the current rail.
+
+### Work
+
+1. Add a short glossary comment block at the top of the `nav` / `pageTitles`
+   sections (or a planning-only table here — do not invent a runtime glossary
+   UI).
+2. Update **all four** locale files together:
+   - `nav.aiSetup` → keep the key, change the string only if Sprint 2 has not
+     landed; prefer **not** renaming the top-level item yet if it would fight
+     Sprint 2. Focus Sprint 1 on **child** labels and page titles.
+   - `Your Widgets` → Chat widgets
+   - `Standard Inbound` → Inbound
+   - `IMAP Email Handler` → Email handler
+   - `Preconfigured Instructions` → Instructions
+   - `Routing Config` / `AI Model Config` → Routing / Models
+   - `Saved Recurring Tasks` → Saved tasks
+   - `File Manager` and leftover Easy Mode strings (`settings.appMode.*`)
+   - Chat / widget / files body copy that still says “Files” as a product name
+3. Replace hardcoded English in profile, chat loading, aria labels, and weak
+   empty states (see README finding 15 and the UX-pattern audit).
+4. Align `docs/FEATURES.md` if it still advertises Easy/Advanced modes.
+5. Keep `data-testid` / `NavItem.key` values unchanged.
+6. **i18n safety (contract §2):** change values only — no key renames, moves,
+   or deletions in this sprint. Do not touch the `widget.*` namespace or any
+   key referenced by `ChatWidget.vue`: that is end-customer copy inside the
+   embedded widget on customer websites. State “widget-bundled keys touched:
+   no” (or list them with justification) in the PR description.
+
+### Primary files
+
+- `frontend/src/i18n/{en,de,es,tr}.json`
+- Scattered hardcoded strings in `ProfileView.vue`, `ChatView.vue`,
+  `ChatInput.vue`, leftover widget list copy
+- `docs/FEATURES.md` (copy only)
+
+### Tests at the end of Sprint 1
+
+Automated:
+
+```bash
+make -C frontend lint
+docker compose exec -T frontend npm run check:types
+make -C frontend test
+# i18n key parity is part of frontend lint / existing i18n checks
+make -C frontend build-widget   # locale files are bundled into widget.js
+```
+
+Widget guard (because i18n is bundled into the customer-site widget):
+
+- Widget E2E `frontend/tests/e2e/tests/widget.spec.ts` passes.
+- Diff review confirms no `widget.*` value changed unintentionally.
+
+Then E2E that **assert visible names**:
+
+- Update `frontend/tests/e2e/tests/navigation.spec.ts` only where it uses
+  visible text (prefer testids; they should still pass).
+- `layout.spec.ts` (labeled nav, 44px targets).
+- Any test that `getByRole('button', { name: '…' })` on old labels.
+
+Manual (30 minutes):
+
+- EN + DE: open rail flyouts and account menu; confirm no leftover
+  “File Manager”, “IMAP Email Handler”, “Preconfigured Instructions”,
+  “Easy Mode”.
+- Guest and signed-in: no mixed-language leftovers on the same screen.
+
+**Done when:** A grep for the retired primary labels in `frontend/src` (except
+comments and redirects) is empty, four locales share the same keys, and CI
+frontend jobs are green.
+
+---
+
+## Sprint 2 — Rebuild the menu (same pages)
+
+**Goal:** Everyday work is three items. Everything else sits under **Manage** or
+**Operate**. Same routes, same pages, new shell HTML.
+
+**Duration:** ~5–7 days  
+**Shippable alone:** Yes, if Sprint 1 labels are in. Can follow Sprint 1
+immediately.
+
+### Target information architecture (existing URLs)
+
+#### Work (always)
+
+| Rail | Opens | URL |
+| --- | --- | --- |
+| New | New chat | `/` |
+| History | Chat manager (unchanged modal) | not a route |
+| Sources | Sources | `/files` |
+
+#### Manage (signed-in, not guests)
+
+One rail item. Children grouped — **no** second top-level “AI Setup & Tools”.
+
+| Group | Label | URL (unchanged) |
+| --- | --- | --- |
+| Assistants | Models | `/ai/models` |
+| Assistants | Instructions | `/ai/instructions` |
+| Assistants | Routing | `/ai/routing` |
+| Channels | Inbound | `/channels` |
+| Channels | Chat widgets | `/channels/widgets` |
+| Channels | Email handler | `/channels/email` |
+| Channels | Connections | `/channels/connections` |
+| Channels | MCP servers | `/channels/mcp` |
+| Channels | API keys | `/channels/api` |
+| Channels | API docs | `/channels/api/docs` |
+| Channels | Live support | `/channels/widgets/live-support` |
+| Automations | Saved tasks | `/channels/tasks` |
+| Automations | AI Agents | `/channels/agents` |
+| Tools | Summarizer *(transitional)* | `/ai/summarizer` |
+
+This fixes the current bug that tasks / agents / email live in the AI Setup
+**menu** while their URLs are `/channels/*`. It also gives **Live support** a
+menu home for the first time — today it is reachable only through secondary
+flows although takeover operators use it daily. Plugins stay on the rail (see
+above), not in this panel.
+
+Guest-gate note: `/channels` and `/ai/*` map to the backend feature key
+`settings` via `mapPathToFeatureKey()`. The menu regrouping must not change any
+returned feature key — those are a backend contract, not labels.
+
+#### Operate (`isAdmin` only)
+
+Rename the Admin rail item to **Operate** (key can stay `admin` for testids).
+
+| Label | URL |
+| --- | --- |
+| Overview | `/admin` |
+| Feature status | `/admin/features` |
+| Model status | `/admin/model-status` |
+| AI providers | `/admin/setup` |
+| System configuration | `/admin/config` |
+
+Dashboard **tabs** (users, prompts, usage, subscriptions, moderation) stay on
+`/admin` for now. Do not add a Hoster tab.
+
+#### Account (avatar / More)
+
+Sprint 2 only **groups** the existing items. Sprint 3 trims them.
+
+- Profile
+- Preferences
+- Memories
+- Usage (today: Statistics)
+- Plan / Upgrade (when billing applies)
+- Sign out
+
+### Interaction rules
+
+- Desktop: Work icons stay on the rail. Manage and Operate open a **click**
+  panel (not hover-only). Last destination inside Manage/Operate is remembered.
+- Mobile: Chat / History / Sources / More. More contains Manage, Operate
+  (admin), Account. Two levels, not three nested accordions if it can be
+  avoided.
+- Guests: do **not** show dimmed Channels / AI Setup teasers. Chat + Sign in.
+- Do not hide Manage from ordinary signed-in users in this sprint. There is
+  still no workspace-admin role; collapsing two flyouts into one is the
+  disclosure win we can ship without new permissions.
+- **Workspace seam (contract §6):** each context is shown/hidden by exactly one
+  named predicate — Work: signed-in; Manage: signed-in; Operate: `isAdmin`.
+  No inline plan-level (`isPro`/`isTeam`) conditions in nav items. When a real
+  workspace capability exists later, only the Manage predicate changes.
+- Add `meta.context: 'work' | 'manage' | 'operate' | 'personal' | 'public'` to
+  routes while touching them — additive metadata only, no guard behavior
+  change in this sprint.
+
+### Primary files
+
+- `frontend/src/composables/useNavItems.ts` — groups, labels, guest children
+- `frontend/src/components/SidebarV2.vue`
+- `frontend/src/components/MobileNav.vue`
+- `frontend/src/composables/useNavItems` unit tests if present; add them if not
+- `frontend/src/router/index.ts` — only if breadcrumbs / `meta.context` are
+  added. **Do not delete routes.**
+- `frontend/tests/e2e/helpers/selectors.ts` — add Manage/Operate selectors;
+  keep old testids as aliases during the sprint if needed
+- `frontend/tests/e2e/tests/navigation.spec.ts` — rewrite flyout describes
+- `frontend/tests/e2e/tests/admin-panel.spec.ts` and impersonation specs that
+  click the Admin rail item
+
+### Tests at the end of Sprint 2
+
+Automated (must rewrite, not skip):
+
+1. **Unit:** `useNavItems` for guest / user / admin:
+   - guest rail has no Manage children and no Operate;
+   - user has Manage groups Assistants / Channels / Automations;
+   - email handler and saved tasks are under Manage, not a leftover AI Setup
+     item;
+   - admin has Operate; non-admin does not.
+2. **E2E `navigation.spec.ts`:**
+   - user rail = New, History, Sources, (Plugins when installed), Manage — no
+     Channels + AI Setup pair;
+   - Manage opens widgets, models, email handler, saved tasks, live support;
+   - History still opens the chat manager;
+   - Sources still opens `/files`;
+   - admin sees Operate; non-admin does not;
+   - `/admin` still redirects non-admins.
+3. **E2E** `layout.spec.ts`, `files-tabs.spec.ts`, `admin-panel.spec.ts`,
+   `guest-registration.spec.ts` — update selectors, keep assertions.
+4. **External-consumer checks (contract §5):**
+   - plugin smoke: with a seeded/installed plugin the rail entry is visible,
+     `/plugins/:name` mounts, and the direct URL works after re-login;
+   - deep links still resolve: `/channels/widgets/:id`,
+     `/channels/widgets/live-support`, `/channels/api/docs`,
+     `/tools/chat-widget` (redirect), `/shared/:token` (logged out),
+     `/addin/connect?redirect=…` (Synamail round-trip);
+   - guest gate `restricted=` query keys unchanged.
+5. Full frontend gate:
+
+```bash
+make -C frontend lint
+docker compose exec -T frontend npm run check:types
+make -C frontend test
+```
+
+Manual (45 minutes, desktop **and** 320px):
+
+- User: start chat, open a past chat, open a source, create/open a widget via
+  Manage — three hops or fewer.
+- Admin: open provider setup and system config from Operate.
+- Keyboard: Tab to Manage, Enter, move to Chat widgets, Enter. No hover-only
+  path.
+- Browser Back from `/channels/widgets` returns to the previous Work page and
+  does not lose the rail.
+
+**Done when:** A chat user sees at most Work + Manage + Account. An admin sees
+Operate. Every previous destination is still one click from Manage or Operate.
+CI navigation jobs are green.
+
+---
+
+## Sprint 3 — Quiet the first screens
+
+**Goal:** The pages people land on look like the new mental model. Still no new
+APIs: hide, move, or relabel existing chrome.
+
+**Duration:** ~5 days  
+**Depends on:** Sprint 2 (so setup links can point at Operate / Manage).
+
+### Work
+
+1. **Chat empty state (`ChatView.vue` and related banners)**
+   - Primary: composer + example prompts.
+   - One blocking message only if chat cannot run.
+   - Move installation / provider-setup cards to Operate (link for admins;
+     hide for non-admins).
+   - Keep a compact model control only when more than one approved model is
+     selectable.
+   - Jobs tray: show after the first background job, not on every empty land.
+   - At most one tip/banner above the composer.
+
+2. **Sources (`FilesTabs.vue`, `FilesView.vue`)**
+   - Default tab remains Browse.
+   - Hide **Vectors** for non-admins (operators still reach it).
+   - Incoming / Generated stay if they have data or an integration; otherwise
+     they may sit behind a “More” filter rather than five equal tabs.
+   - Copy says Sources / files / knowledge folder per the glossary.
+
+3. **Account**
+   - One **Preferences** destination for language, theme, timezone.
+   - Profile keeps identity + billing company fields (still not an org).
+   - Remove duplicate language/theme if both Profile and Settings show them.
+   - Relabel Statistics → Usage in the account menu.
+   - Feedback stays reachable; do not promote it to the rail.
+   - Fix tools that send people to `/settings?tab=features` (no such tab).
+
+4. **Page titles and breadcrumbs**
+   - Every retained Manage/Operate child has a document title and a crumb:
+     `Manage / Chat widgets`, `Operate / AI providers`.
+
+### Primary files
+
+- `frontend/src/views/ChatView.vue` (empty-state / banner composition only)
+- `frontend/src/components/config` banners such as `ProviderSetupBanner.vue`
+- `frontend/src/components/files/FilesTabs.vue`, `FilesView.vue`
+- `frontend/src/views/SettingsView.vue`, `ProfileView.vue`
+- `frontend/src/components/SidebarV2.vue` account menu
+- `frontend/src/components/ToolsDropdown.vue` (broken features-tab link)
+- Page header / title helpers if they already exist
+
+Resist editing `AdvancedWidgetConfig.vue` here. That is the later assistant
+epic.
+
+### Tests at the end of Sprint 3
+
+Automated:
+
+- Chat empty-state E2E: signed-in user sees composer + examples; admin-only
+  setup card is absent for a non-admin and present or linked for an admin.
+- Guest: no dimmed Manage; Sign in remains.
+- Sources: non-admin has no Vectors tab; admin does; Browse is default.
+- Preferences: language switch still works (`navigation.spec.ts` Preferences
+  describe).
+- Profile still saves (existing profile tests).
+- Deep links `/files`, `/files/search`, `/settings`, `/profile`, `/admin/setup`
+  still resolve.
+- Tools / disabled-feature links never land on a missing settings tab.
+- If any locale or `style.css` value changed: `make -C frontend build-widget`
+  plus widget E2E (contract §2 — these files are bundled into the customer
+  widget).
+
+Manual:
+
+- New user: “ask a question” without opening Manage.
+- Admin with no provider: blocking message **or** Operate link — not a wall of
+  model pickers.
+- Light, dark, and V2: empty chat, Sources, Preferences contrast.
+
+**Done when:** A chat-only user can start a conversation without seeing provider
+keys, vector jobs, or system config. Preferences has one home. Broken
+`?tab=features` links are gone.
+
+---
+
+## Sprint 4 — Prove the shell
+
+**Goal:** The new HTML is safe to ship: routes classified, keyboard path
+complete, tests blocking, leftover copy gone.
+
+**Duration:** ~3–5 days  
+**Depends on:** Sprints 1–3.
+
+### Work
+
+1. **Route inventory** in this folder (`04_route_inventory.md` or a table in
+   the PR): every registered path is `canonical` | `redirect` | `detail` |
+   `utility` | `remove-candidate`. No orphan provider page without a Manage or
+   Operate parent (live support gained its menu home in Sprint 2). Public
+   contract routes (`/shared/*`, `/addin/connect`, `/account-deletion`,
+   `/setup`) are marked `public-contract` and are never remove-candidates.
+   Deferred i18n **key** cleanup (e.g. `settings.appMode.*`) happens here,
+   each deletion backed by a zero-reference grep that includes the widget
+   entry and `ChatWidget.vue`.
+2. Shared `Dialog.vue`: focus trap + restore (pattern already exists on
+   `SubscriptionPaywallModal.vue`).
+3. Skip-to-content on `MainLayout.vue`; verify landmarks.
+4. Make axe **blocking** on login, empty chat, and the Manage panel only —
+   not the whole app yet (`layout.spec.ts` phase 0.5 → 1 for those three).
+5. Guest, user, admin screenshots or Playwright traces attached to the PR for
+   desktop and 320px.
+6. Product-doc pass: README of this folder, `docs/FEATURES.md`, any help-tour
+   strings that still say “AI Setup & Tools” or “Admin Panel” as the rail name.
+
+### Tests at the end of Sprint 4 (release gate)
+
+This is the gate for the **whole** streamlining effort. Run the full frontend
+suite, then the persona script.
+
+```bash
+make -C frontend lint
+docker compose exec -T frontend npm run check:types
+make -C frontend test
+```
+
+Playwright (CI tags plus a local desktop/mobile pass):
+
+| Journey | Guest | User | Admin |
+| --- | --- | --- | --- |
+| Land on chat and send / see composer | x | x | x |
+| Open History | | x | x |
+| Open Sources → Browse | | x | x |
+| Open Manage → Chat widgets | | x | x |
+| Open Manage → Models | | x | x |
+| Open Manage → Email handler | | x | x |
+| Open Manage → Live support | | x | x |
+| Open Plugins → plugin mounts | | x | x |
+| Open Operate → Providers | | | x |
+| Open Operate → System configuration | | | x |
+| Direct `/admin` as non-admin redirects | | x | |
+| Account → Preferences language | | x | x |
+| Keyboard through Manage | | x | x |
+| 320px More menu | x | x | x |
+| Embedded widget: load, open, send, privacy notice (widget.spec.ts) | x | | |
+| Shared chat `/shared/:token` renders | x | | |
+| `/addin/connect` relay round-trip (Synamail) | | x | |
+
+Plus the full regression matrix in
+[02_compatibility_contract.md](./02_compatibility_contract.md) §5 — the S4
+column is the release gate.
+
+Manual persona script (use real tasks, not “does it look simple?”):
+
+1. Chat-only: start a new chat in one primary action.
+2. Chat-only: find a known source without help.
+3. Assistant owner: open an existing chat widget from Manage.
+4. Operator: find provider credentials from Operate in two decisions or fewer.
+5. Nobody confuses Profile “Company” with a managed organization.
+6. Nobody looks for language under Operate.
+
+**Done when:** The README acceptance criteria that apply to **shell, wording,
+and structure** are all true. Failed E2E is a blocker, not a follow-up.
+
+README criteria **not** claimed by these four sprints:
+
+- Assistant detail IA (Overview / Instructions / Knowledge / …).
+- Operator “data processing / sovereignty” summary as a new product surface
+  (optional extra if existing status APIs already render on `/admin`; do not
+  invent a new health backend).
+- Hoster console.
+
+---
+
+## Suggested calendar
+
+```
+Week 1     Sprint 1  wording          → merge
+Week 2     Sprint 2  menu             → merge
+Week 3     Sprint 3  first screens    → merge
+Week 3–4   Sprint 4  prove + ship
+```
+
+Each sprint is a PR (or a short stack). Do not combine Sprint 2 and Sprint 3
+in one review: the menu rewrite already touches every navigation test.
+
+## Implementation notes (so the HTML stays honest)
+
+1. **Stable keys.** `NavItem.key` and `data-testid` stay (`files`, `admin`,
+   `chat-widget`, …). Visible labels change; selectors should not.
+2. **One nav source.** Desktop and mobile still read `useNavItems` only.
+3. **Redirects, not deletes.** `/tools/*` and `/config/*` aliases stay until
+   Sprint 4 classifies them.
+4. **Capabilities, not a mode toggle.** Guest vs signed-in vs `isAdmin` is
+   enough. No `localStorage` “simple shell” flag. One named predicate per
+   context (contract §6) so a future workspace scope plugs in without a third
+   IA rewrite.
+5. **Company field stays billing copy.** Do not add a Workspace item.
+6. **Frozen files.** The widget runtime (`widget.ts`, `widget-utils.ts`,
+   `ChatWidget.vue`, shadow-style adapter), `PluginView.vue`,
+   `AddinConnectView.vue`, `SharedChatView.vue`, `OnboardingView.vue`, and all
+   `MOBILE-APP SEAM` blocks are off-limits — full list in contract §3.
+7. **Mobile impact.** Record the path class in
+   `.github/mobile-impact-policy.json` if new files appear; verify each PR
+   with `node scripts/mobile-impact.mjs` — this work must classify as
+   `ota-candidate`.
+8. **No AI attribution** in commits. Conventional Commits, e.g.
+   `feat(frontend): group channels and AI setup under Manage`.
+
+## If a sprint starts to grow
+
+Cut in this order:
+
+1. Do not redesign the widget advanced modal.
+2. Do not regroup `/admin` dashboard tabs.
+3. Do not hide Incoming/Generated — only Vectors.
+4. Do not add breadcrumbs if page titles already match the glossary.
+5. Never skip the Sprint 2 navigation E2E rewrite.
+
+## Mapping to the research README
+
+| README deliverable | Sprint |
+| --- | --- |
+| 5 Terminology and destination audit | 1 (+ titles in 3) |
+| 1 Capability-aware shell | 2 |
+| 3 Simplified chat start | 3 |
+| 4 Settings consolidation | 3 |
+| 7 Route / copy / a11y hygiene | 1 (copy) + 4 (routes, a11y) |
+| 2 Operator overview (new health hub) | **Not in these sprints** unless `/admin` already has the data |
+| 6 Usability validation | 4 (persona script) |
+| Follow-up assistant editor | Later epic |
+| Hoster console | Later epic |

--- a/_devextras/planning/20260828-interface-streamlining-sprint/02_compatibility_contract.md
+++ b/_devextras/planning/20260828-interface-streamlining-sprint/02_compatibility_contract.md
@@ -1,0 +1,170 @@
+# Compatibility contract — what the streamlining sprints must not break
+
+**Status:** Binding for all four execution sprints  
+**Date:** 2026-08-28  
+**Parent:** [README.md](./README.md) · [01_execution_sprints.md](./01_execution_sprints.md)
+
+The shell rework is low-risk for product behavior but touches two files that are
+**shared with external consumers**: the i18n bundle and `style.css`. Both are
+compiled into the embedded chat widget that runs on customer websites. This
+document lists every external and internal contract, the file-level freeze
+list, and the regression matrix each sprint PR must run.
+
+## 1. External consumers of this frontend
+
+| Consumer | Entry contract | Breaks if we… |
+| --- | --- | --- |
+| **Embedded chat widget** on customer sites | `widget.js` (self-contained ES module from `frontend/src/widget.ts`; edge-cached; loads config from `/api/v1/widget/{id}/config`; API URL via `detectApiUrl()`) | rename/delete i18n keys it bundles, change `style.css` tokens/utilities it inlines, alter `widget-utils.ts`, or change the public widget config endpoint shape |
+| **Plugin users** (daily) | Rail entry from `configStore.plugins` → `/plugins/:name` → `PluginView.vue` mounts per-user ES module from `/api/v1/user/{id}/plugins/{name}/assets/index.js` with `{ userId, apiBaseUrl, pluginBaseUrl, config }` | remove/deepen the Plugins nav entry, change the `mount()` contract, or gate `/plugins/:name` behind a new context guard |
+| **Support / live takeover operators** (daily) | `/channels/widgets/live-support`, `/channels/widgets/:id/chats`, widget realtime channels | orphan these routes in the new menu or regress their reachability |
+| **Outlook add-in (Synamail)** | `/addin/connect` public route with `redirect` (relay) param round-trip | touch `AddinConnectView.vue` or its route meta (see `Synamail/docs/AUTH_FLOW.md`) |
+| **Shared chat links** in the wild | `/shared/:token`, `/shared/:lang/:token` public routes | rename or guard these paths |
+| **Mobile apps (OTA)** | `MobileNav.vue`, router `MOBILE-APP SEAM` blocks (onboarding gate, `branding.defaultRoute` / `landingPage` resolution), `/account-deletion`, `/onboarding` | move or rewrite seam-marked code, or let shell changes drift into `store-required` territory |
+| **Backend guest gating** | `mapPathToFeatureKey()` in `router/index.ts` maps `/channels`, `/ai/*`, `/settings` → feature key `settings`; `/files` → `files`; etc. | change the returned keys — they are a backend contract, not labels |
+| **External docs / bookmarks / support articles** | Every `/channels/*`, `/ai/*`, `/admin/*`, `/files/*` URL plus the `/tools/*`, `/config/*` legacy redirects | delete a route or drop a redirect before the Sprint 4 inventory approves it |
+
+## 2. The i18n and style coupling (the one real landmine)
+
+`frontend/src/widget.ts` dynamically imports **`./i18n`** (all four locale
+JSONs) and **`./style.css?inline`**, and `vite.config.widget.ts` inlines them
+into one self-contained `widget.js`. Consequences:
+
+1. **Every Sprint 1 wording commit is also a widget release.** The bundle on
+   customer sites is edge-cached and rebuilt on deploy; the next deploy after
+   the i18n change ships the new strings to end customers.
+2. **Renaming or deleting an i18n key can render a raw key string inside a
+   customer's support widget.** Values may change; keys may not.
+3. **`style.css` edits leak into widget shadow DOM** via
+   `adaptStylesForShadowDom`. The sprints do not restyle, but incidental
+   utility/token edits must be treated as widget changes.
+
+### Binding i18n rules for all sprints
+
+- **Change values, never keys.** No key rename, move, or deletion in
+  `en/de/es/tr.json` during Sprints 1–3. Key cleanup (e.g. retiring
+  `settings.appMode.*`) happens only in Sprint 4 after a grep proves zero
+  references — including from `ChatWidget.vue` and the widget entry.
+- The **`widget.*` namespace is end-customer copy**, not app copy. It is out of
+  scope for the glossary pass unless a change is deliberately intended for
+  customer widgets, reviewed as such, and checked in all four locales.
+- Namespaces bundled into the widget (at minimum `widget.*` and anything
+  referenced by `ChatWidget.vue` and its children) get a dedicated review line
+  in every Sprint 1/3 PR description: *“widget-bundled keys touched: yes/no,
+  which, why.”*
+- After any locale or `style.css` change: `make -C frontend build-widget` must
+  succeed and the widget E2E (`frontend/tests/e2e/tests/widget.spec.ts`) must
+  pass before merge.
+
+## 3. Frozen files (no edits in Sprints 1–4)
+
+Do not modify these during the streamlining work. If a sprint seems to need to,
+stop and split that into its own reviewed change:
+
+- `frontend/src/widget.ts`, `frontend/src/widget-utils.ts`
+- `frontend/src/utils/widgetShadowStyles.ts`
+- `frontend/src/components/widgets/ChatWidget.vue` (embedded runtime; the
+  *management* views around it are fair game)
+- `frontend/src/views/AddinConnectView.vue` and its route entry
+- `frontend/src/views/SharedChatView.vue` and its route entries
+- `frontend/src/views/PluginView.vue` (the plugin `mount()` seam)
+- `frontend/src/views/OnboardingView.vue` and all `MOBILE-APP SEAM` blocks
+- `mapPathToFeatureKey()` return values (the function may gain paths only if
+  the backend key set is unchanged)
+- Backend: everything (this effort is frontend shell + copy only)
+
+## 4. Self-compatibility (the app must keep agreeing with itself)
+
+Renaming a surface means renaming every reference to it in the same PR
+(house rule: “Copy must be CORRECT”). Checklist per renaming PR:
+
+- [ ] Grep all four locales for the old visible name (e.g. “AI Setup & Tools”,
+      “Your Widgets”, “Admin Panel”) in breadcrumbs, tips, help tours, error
+      hints, and “go to X” instructions (`chatInput.reasoningNotSupported`
+      points at “AI Config → Models” today, guest gate copy lists old names,
+      `guest.featureGate.*`, `help.*`).
+- [ ] `pageTitles.*` match the new nav labels.
+- [ ] `ToolsDropdown.vue` and any disabled-feature link point at destinations
+      that exist (kill `/settings?tab=features`).
+- [ ] Command palette / destination search (if enabled) reads from
+      `useNavItems`, not its own list.
+- [ ] `helpId`-based tours still anchor to elements that exist after the shell
+      change.
+- [ ] `data-testid` and `NavItem.key` values unchanged; E2E selector aliases
+      added rather than renamed mid-sprint.
+- [ ] Legacy `/tools/*`, `/config/*`, `/rag` redirects still registered and
+      still land on a 200 page.
+
+## 5. Regression matrix (run per sprint PR)
+
+Spec-by-spec Playwright detail (which suites are rewritten, updated, or act as
+guards per sprint) lives in [03_playwright_test_plan.md](./03_playwright_test_plan.md).
+
+| Check | S1 wording | S2 menu | S3 first screens | S4 gate |
+| --- | :-: | :-: | :-: | :-: |
+| `make -C frontend lint` + `check:types` + `make -C frontend test` | x | x | x | x |
+| `make -C frontend build-widget` succeeds | x | — | x (if i18n/style touched) | x |
+| Widget E2E `widget.spec.ts` (embed, open, send, theme, privacy notice) | x | — | x | x |
+| Widget copy diff review (`widget.*` keys) in PR description | x | — | x | x |
+| Plugin smoke: rail entry visible with a seeded plugin; `/plugins/:name` mounts; direct URL works after re-login | — | x | — | x |
+| Live support: `/channels/widgets/live-support` reachable from the new menu; widget sessions open | — | x | — | x |
+| Navigation E2E suite (rewritten in S2) | label-only updates | x | x | x |
+| Deep links: `/channels/widgets/:id`, `/channels/api/docs`, `/files/search`, `/admin/setup`, `/tools/chat-widget` (redirect) | — | x | x | x |
+| Guest gate: `restricted=` query keys unchanged (`settings`, `files`, `memories`, `statistics`) | — | x | — | x |
+| `/addin/connect` with `redirect` param round-trips (Synamail flow, manual or E2E) | — | x | — | x |
+| Shared chat `/shared/:token` renders logged-out | — | x | — | x |
+| Mobile 320px: Chat/History/Sources/More + Manage/Operate/Account reachable | — | x | x | x |
+| `node scripts/mobile-impact.mjs --base <base> --head <head>` classifies as `ota-candidate` | x | x | x | x |
+| Light / dark / V2 contrast on changed surfaces | x | x | x | x |
+
+The widget checks are cheap and prevent the only class of bug in this effort
+that a customer would see before we do.
+
+## 6. Workspace scope: deferred, with a reserved seam
+
+Deferring the workspace/organization scope is the right call for these sprints
+— there is no backend tenant/role model, and a menu cannot honestly offer
+“People & access” that no API enforces. But “leave it out” must not mean
+“design it out.” The sprints keep the seam open:
+
+1. **Manage is the future workspace home.** When a workspace model lands,
+   Manage becomes “Manage *(workspace name)*” and gains People & access and
+   Usage & billing children. No third IA rewrite.
+2. **Navigation visibility goes through named capability predicates** in
+   `useNavItems` (documentation-level now, one place in code later):
+
+   | Context | Predicate today | Predicate later |
+   | --- | --- | --- |
+   | Work | signed-in (guest sees Chat + Sign in) | unchanged |
+   | Manage | signed-in | `canManageWorkspace` (owner/editor capability) |
+   | Operate | `isAdmin` | `canOperateInstance` |
+   | Hoster console | — (absent) | reseller capability, separate shell |
+
+   Implementation rule: nav items check **one predicate**, never inline
+   `isAdmin`/plan-level combinations, so swapping in real capabilities is a
+   one-line change per context.
+3. **Route metadata carries ownership now** (`meta.context: work | manage |
+   operate | personal | public`), added in Sprint 2 while every route is being
+   touched anyway. The future workspace model reuses it.
+4. **Explicit non-claims stay:** Profile’s company fields remain billing copy;
+   no “Workspace”, “Team”, or “Organization” label appears anywhere in the new
+   menu until the backend model exists. TEAM/BUSINESS plan copy must not
+   promise people management these sprints do not build.
+
+Risk accepted by deferring: TEAM/BUSINESS buyers keep managing users through
+the operator area (Operate → Users) even when the “operator” is really a
+company admin. That is today’s behavior, unchanged. The mitigation is the seam
+above plus the open decision list in the README, not a rushed role model.
+
+## 7. Rollback and sequencing safety
+
+- Each sprint is an independently revertable PR. Sprint 2 (menu) must be
+  revertable without reverting Sprint 1 (wording): labels read from i18n, so
+  the old shell renders new labels harmlessly.
+- No `localStorage` schema changes except the additive “last destination per
+  context” key (Sprint 2), which must tolerate being absent or stale.
+- Feature-flag nothing: the shell swap ships whole per sprint. If Sprint 2
+  slips mid-sprint, `main` keeps the old shell — do not merge a half-migrated
+  rail.
+- Deploys rebuild `widget.js`; if a widget regression escapes, reverting the
+  frontend deploy restores the previous bundle (self-contained, no chunk
+  dependencies).

--- a/_devextras/planning/20260828-interface-streamlining-sprint/03_playwright_test_plan.md
+++ b/_devextras/planning/20260828-interface-streamlining-sprint/03_playwright_test_plan.md
@@ -1,0 +1,114 @@
+# Playwright adjustment plan — which specs change, when, and how
+
+**Status:** Binding for all four execution sprints  
+**Date:** 2026-08-28  
+**Parent:** [01_execution_sprints.md](./01_execution_sprints.md) ·
+[02_compatibility_contract.md](./02_compatibility_contract.md)  
+**House guidelines:** `docs/E2E_TESTING.md`
+
+The shell rework invalidates assumptions baked into the E2E suite (two rail
+flyouts named Channels and AI Setup, an Admin rail item, dimmed guest teasers,
+specific visible labels). This document is the complete inventory of affected
+specs so no suite is discovered broken after merge.
+
+## Process rules
+
+1. **Tests change in the same PR as the shell change.** A sprint PR that turns
+   navigation E2E red and defers the fix is not mergeable. Green CI on the PR
+   is the definition of "sprint done" — the persona script in Sprint 4 comes on
+   top, not instead.
+2. **A filtered run is not the gate** (house rule). `npx playwright test
+   navigation` while iterating is fine; the sprint gate is the full suite:
+
+   ```bash
+   make -C frontend test-e2e            # full E2E suite
+   make -C frontend test-e2e-layout     # mobile-viewport layout guard
+   make -C frontend test-e2e-plugin-castingdata   # plugin E2E (CastApp + Synaplan running)
+   ```
+
+3. **Selectors over labels.** All navigation assertions go through
+   `tests/e2e/helpers/selectors.ts`. `NavItem.key` / `data-testid` values are
+   stable across the rework (contract §4), so specs that already use testids
+   survive label changes untouched. Specs matching visible text
+   (`getByRole(... { name })`, `getByText`) are the ones that break in
+   Sprint 1 — convert them to selectors while updating, don't chase strings.
+4. **Selector aliases, not renames.** When Sprint 2 introduces Manage/Operate,
+   add new entries (`sidebarV2Manage`, `manageFlyout*`, `sidebarV2Operate`) to
+   `selectors.ts`; keep `sidebarV2Channels` / `sidebarV2AiSetup` as deprecated
+   aliases until every spec is migrated inside the same PR, then delete them
+   in that PR. No half-migrated selector file on `main`.
+5. **`@ci`-tagged tests keep their tags.** The rework must not quietly drop
+   suites from the CI subset. If a test's premise disappears (e.g. "AI Setup
+   flyout exists"), replace the test with its Manage equivalent — do not
+   delete without replacement.
+6. **Visual snapshots are re-baselined intentionally.** `visual.spec.ts` will
+   diff on every shell change. Re-record baselines once per sprint PR, review
+   every changed screenshot in the PR (the reviewer confirms the diff shows
+   the intended shell change and nothing else), and never mix a re-baseline
+   with unrelated fixes.
+
+## Spec inventory
+
+Legend — **Rewrite:** structure/premise changes. **Update:** selector or label
+touch-ups. **Guard:** must stay green unchanged; failure means we broke a
+contract. **Re-baseline:** snapshot refresh.
+
+| Spec | Depends on | S1 | S2 | S3 | S4 |
+| --- | --- | --- | --- | --- | --- |
+| `navigation.spec.ts` | rail items, both flyouts, user menu, Preferences | Update (labels) | **Rewrite** (Manage/Operate structure) | Update (account menu trim, Usage label) | Guard |
+| `layout.spec.ts` | labeled nav, 44px targets, overflow, axe report-only | Update | **Rewrite** (new rail set, More menu) | Update | **Rewrite** (axe → blocking for login/chat/Manage) |
+| `admin-panel.spec.ts` | Admin rail item + Dashboard flyout link | — | **Update** (Operate selectors) | — | Guard |
+| `admin-impersonation-chat.spec.ts` | Admin rail item + flyout | — | **Update** (Operate selectors) | — | Guard |
+| `files-tabs.spec.ts` | Files rail item, five tabs | — | Update (rail selector) | **Rewrite** (Vectors admin-only, tab set per role) | Guard |
+| `guest-registration.spec.ts` | guest sidebar contents | — | **Rewrite** (no dimmed teasers; Chat + Sign in) | — | Guard |
+| `guest-chat.spec.ts` | guest chat entry, gate hints | — | Update | Update (empty-state changes) | Guard |
+| `chat-manage.spec.ts` | History → chat manager modal | — | Update (rail selector only; modal unchanged) | — | Guard |
+| `chat-share.spec.ts` | History modal, share flow | — | Update | — | Guard |
+| `chat.spec.ts`, `chat-input.spec.ts`, `chat-again.spec.ts`, `chat-bubble-monotonic.spec.ts`, `multitask.spec.ts`, `incognito.spec.ts` | composer, banners, empty state | Update (aria/label i18n) | — | **Update** (empty-state chrome: one banner, jobs tray deferred, setup cards gone) | Guard |
+| `auth.spec.ts`, `oidc-*.spec.ts` (5 specs), `registration.spec.ts` | login/register pages, post-login landing | Update (labels if touched) | Update (post-login rail assertions) | — | Guard |
+| `profile-password.spec.ts` | profile sections | Update (i18n hardcodes) | — | Update (Preferences consolidation) | Guard |
+| `memories.spec.ts` | account menu → memories | — | Update | Update | Guard |
+| `subscription.spec.ts`, `subscription-lifecycle.spec.ts` | upgrade rail button, account menu Plan | — | Update | Update | Guard |
+| `task-prompts.spec.ts` | `/ai/instructions` page | Update (new "Instructions" labels) | Update (reached via Manage) | — | Guard |
+| `mcp-config.spec.ts` | `/channels/mcp` page | — | Update (reached via Manage) | — | Guard |
+| `inbound-email-handler*.spec.ts` (2), `email.spec.ts`, `whatsapp.spec.ts` | channel config pages | Update (Inbound/Email handler labels) | Update (menu path) | — | Guard |
+| `rag-search.spec.ts`, `file-manage.spec.ts` | Sources pages | Update (glossary copy) | Update | Update (tab changes) | Guard |
+| `saved-task-roundtrip.spec.ts` | `/channels/tasks` via nav | — | Update (Automations group) | — | Guard |
+| `redirects.spec.ts` | all `/tools/*`, `/config/*` legacy redirects | — | **Guard** | Guard | Guard — plus extend with any alias Sprint 4 adds |
+| `widget.spec.ts` | embedded widget runtime (customer contract) | **Guard** (i18n is bundled into widget.js) | Guard | **Guard** (if i18n/style touched) | Guard |
+| `castingdata-plugin.spec.ts` | plugin rail entry, `/plugins/:name` mount | — | **Guard** (plugins stay top-level) | — | Guard |
+| `account-deletion.spec.ts` | public compliance route | — | Guard | — | Guard |
+| `ollama-integration.spec.ts` | chat back-end behavior | — | — | — | Guard |
+| `visual.spec.ts` | screenshot baselines | Re-baseline | Re-baseline | Re-baseline | Re-baseline + review |
+
+The four **Guard** rows in bold — `redirects`, `widget`, `castingdata-plugin`,
+and `guest-registration` after its rewrite — are the external-compatibility
+watchdogs from the [contract](./02_compatibility_contract.md). If one goes red,
+stop and treat it as a broken contract, not a flaky test.
+
+## New specs to add
+
+| Sprint | New coverage |
+| --- | --- |
+| S2 | Manage flyout: groups Assistants / Channels / Automations render; each child navigates; last-destination memory works; keyboard traversal (Tab → Enter → child → Enter) |
+| S2 | Operate flyout: admin-only visibility; non-admin never renders it (assert absence, not just redirect) |
+| S2 | Live support reachable from Manage (`/channels/widgets/live-support`) |
+| S2 | Plugins rail entry: visible with seeded plugin, absent without |
+| S3 | Chat empty state per role: non-admin sees no setup cards; admin sees one Operate link; max one banner above composer |
+| S3 | Sources tabs per role: non-admin has no Vectors tab, admin does |
+| S4 | Axe blocking on login, empty chat, Manage panel (promote from report-only in `layout.spec.ts`) |
+| S4 | Skip-to-content and dialog focus trap/restore assertions |
+
+Unit tests (Vitest, not Playwright) for `useNavItems` — guest/user/admin item
+sets, one-predicate-per-context — are listed in Sprint 2 of the
+[execution plan](./01_execution_sprints.md) and complement, not replace, the
+E2E above.
+
+## Estimated E2E effort per sprint
+
+| Sprint | Test work |
+| --- | --- |
+| S1 | ~0.5–1 day: label/selector touch-ups + widget guard run + visual re-baseline |
+| S2 | **~2–3 days: the navigation/layout rewrite + new Manage/Operate specs.** This is the largest single test effort of the whole project — plan it as real sprint scope, not overhead |
+| S3 | ~1 day: empty-state, files-tabs, preferences updates |
+| S4 | ~1 day: axe promotion, a11y specs, full-suite gate + persona script |

--- a/_devextras/planning/20260828-interface-streamlining-sprint/04_route_inventory.md
+++ b/_devextras/planning/20260828-interface-streamlining-sprint/04_route_inventory.md
@@ -1,0 +1,58 @@
+# Route inventory — after the shell streamlining
+
+**Date:** 2026-08-28  
+**Sprint:** 4  
+**Rule:** no URL was deleted. `/tools/*` and `/config/*` stay as redirects.
+
+| Path | Class | Parent |
+| --- | --- | --- |
+| `/` | canonical | work |
+| `/files` | canonical | work |
+| `/files/search` | detail | work |
+| `/files/incoming` | detail | work |
+| `/files/generated` | detail | work |
+| `/files/vectors` | detail (admin chrome) | work |
+| `/channels` | canonical | manage |
+| `/channels/widgets` | canonical | manage |
+| `/channels/widgets/:id` | detail | manage |
+| `/channels/widgets/:id/chats` | detail | manage |
+| `/channels/widgets/live-support` | canonical | manage |
+| `/channels/email` | canonical | manage |
+| `/channels/connections` | canonical | manage |
+| `/channels/mcp` | canonical | manage |
+| `/channels/api` | canonical | manage |
+| `/channels/api/docs` | canonical | manage |
+| `/channels/tasks` | canonical | manage |
+| `/channels/agents` | canonical | manage |
+| `/ai/models` | canonical | manage |
+| `/ai/instructions` | canonical | manage |
+| `/ai/routing` | canonical | manage |
+| `/ai/summarizer` | canonical | manage |
+| `/plugins` | canonical | work (rail) |
+| `/plugins/:name` | detail | work (rail) |
+| `/admin` | canonical | operate |
+| `/admin/features` | canonical | operate |
+| `/admin/model-status` | canonical | operate |
+| `/admin/setup` | canonical | operate |
+| `/admin/config` | canonical | operate |
+| `/profile` | canonical | personal |
+| `/settings` | canonical | personal |
+| `/memories` | canonical | personal |
+| `/statistics` | canonical | personal |
+| `/feedbacks` | canonical | personal |
+| `/subscription` | canonical | personal |
+| `/login` `/register` `/forgot-password` `/reset-password` | public-contract | public |
+| `/shared/:token` | public-contract | public |
+| `/addin/connect` | public-contract | public |
+| `/account-deletion` | public-contract | public |
+| `/setup` | public-contract | operate |
+| `/onboarding` | utility | public |
+| `/tools/*` `/config/*` | redirect | manage (legacy) |
+
+No orphan destination: Live support has a Manage menu home. Public-contract
+routes are never remove-candidates.
+
+Deferred i18n **key** cleanup (values already unused in the rail):
+`settings.appMode.*`, `nav.aiSetup`, `nav.channels` as top-level labels.
+Zero-reference grep (including `ChatWidget.vue` and `widget.ts`) is required
+before any key deletion.

--- a/_devextras/planning/20260828-interface-streamlining-sprint/README.md
+++ b/_devextras/planning/20260828-interface-streamlining-sprint/README.md
@@ -1,0 +1,740 @@
+# Interface streamlining research and sprint proposal
+
+**Status:** Implemented on `feat/ux-changes` (sprints 1–4)  
+**Date:** 2026-08-28  
+**Scope:** Synaplan web interface; implementation landed with this branch
+
+## Executive recommendation
+
+Synaplan does not mainly have a styling problem. It has a product-scope and information-architecture
+problem: personal work, assistant creation, workspace administration, installation operation, and
+commercial hosting are presented in one navigation model.
+
+The recommended direction is:
+
+1. Keep everyday work extremely small: **Chat, History, Sources**.
+2. Put assistant and channel creation in a separate **Manage** context.
+3. Put installation-wide configuration in an **Operate** context visible only to instance
+   operators.
+4. Keep personal settings in the account menu.
+5. Add a hoster console only when Synaplan has real tenant/customer roles and permissions. Do not
+   imply that an optional company name in a billing profile is a managed organization.
+
+This is not a request for multiple visual themes or a user-selectable "simple/advanced mode." The
+interface should be capability-driven: people see the areas required for their responsibilities,
+while advanced controls appear in context when needed.
+
+**Execution plan (menu, wording, structure only):**
+[01_execution_sprints.md](./01_execution_sprints.md) — four shippable sprints, each ending in
+tests. No new APIs or roles. The assistant-editor and hoster-console work stays out.
+
+**Compatibility contract:** [02_compatibility_contract.md](./02_compatibility_contract.md) —
+binding rules protecting the embedded chat widget on customer sites (which bundles the app's
+i18n and `style.css`), daily plugin users, live-support operators, the Outlook add-in, shared
+chat links, and mobile OTA delivery; plus the per-sprint regression matrix and the reserved
+workspace seam.
+
+**Playwright test plan:** [03_playwright_test_plan.md](./03_playwright_test_plan.md) — complete
+E2E inventory with per-sprint rewrite/update/guard classification, selector-alias process,
+visual-snapshot re-baseline policy, new specs to add, and effort estimates.
+
+## Research inputs
+
+This proposal is based on:
+
+- A route and navigation inventory of the current frontend.
+- Inspection of the running desktop interface as an administrator.
+- Review of chat, sources, channels, widgets, AI model setup, administration, system
+  configuration, settings, profile, onboarding, and setup-wizard flows.
+- Review of the archived June 2026 navigation cleanup and the active Release 4.0 onboarding and
+  guest UX plans.
+- Review of hosting-partner requirements in `_devextras/planning`.
+
+Relevant implementation surfaces include:
+
+- `frontend/src/router/index.ts`
+- `frontend/src/composables/useNavItems.ts`
+- `frontend/src/components/SidebarV2.vue`
+- `frontend/src/components/MobileNav.vue`
+- `frontend/src/views/ChatView.vue`
+- `frontend/src/views/FilesView.vue`
+- `frontend/src/views/ChannelsView.vue`
+- `frontend/src/views/WidgetsView.vue`
+- `frontend/src/views/AdminView.vue`
+- `frontend/src/views/AdminConfigView.vue`
+- `frontend/src/views/SettingsView.vue`
+- `frontend/src/views/ProfileView.vue`
+- `frontend/src/components/config/AIModelsConfiguration.vue`
+- `frontend/src/components/widgets/AdvancedWidgetConfig.vue`
+
+The router currently contains roughly 70 explicit path declarations. Not all are simultaneous menu
+items, but this is an indication of how many product concepts the shell must organize.
+
+## What the earlier navigation cleanup already solved
+
+`_devextras/planning/archive/20260611-navigation-ia-cleanup.md` correctly identified overloaded
+labels, inconsistent routes, mobile problems, and duplicated navigation definitions. Much of the
+current shell is cleaner as a result:
+
+- Desktop and mobile navigation share `useNavItems`.
+- "Sources," "Channels," and "AI Setup & Tools" are clearer than the former labels.
+- The primary rail is visually compact.
+- Guest feature gates and mobile navigation are more consistent.
+
+The remaining problem is deeper than naming. A cleaner flyout still mixes unrelated levels of
+responsibility. The next sprint should separate product contexts rather than perform another label
+shuffle.
+
+## Main findings
+
+### 1. The navigation mixes three scopes
+
+The administrator rail presents everyday actions beside installation operations:
+
+- New chat, history, and personal sources are user work.
+- Widgets, inbound channels, connections, and API access are assistant/workspace management.
+- Provider keys, model catalogues, user administration, moderation, system health, and global
+  configuration are instance operations.
+
+These scopes have different audiences, risk levels, and frequencies. Giving them equal weight makes
+the product feel larger than it is and makes destructive or technical controls appear ordinary.
+
+### 2. Subscription levels are doing some of the work of roles
+
+The frontend principally distinguishes an administrator from a user and also checks subscription
+levels such as PRO, TEAM, and BUSINESS. That is not enough to represent:
+
+- a person who only chats;
+- a knowledge editor;
+- an AI assistant owner;
+- a company administrator;
+- an installation operator;
+- a hosting partner operating customer installations.
+
+Plan level answers "what was purchased," not "what this person is responsible for." Navigation
+should eventually be based on explicit capabilities. Until those capabilities exist, the sprint
+must use conservative existing checks and avoid claiming that unsupported organization roles exist.
+
+### 3. "Company" is billing metadata, not a product scope
+
+The profile contains optional company name and VAT fields. The inspected backend/frontend surfaces
+do not expose a true organization, tenant, workspace owner, or reseller model.
+
+This matters because a hoster console cannot be designed as navigation alone. Customer boundaries,
+delegated administration, token pools, auditability, and permissions need a domain model first.
+The shell can reserve a future place for this context, but the initial streamlining sprint should
+not fabricate it.
+
+### 4. The chat start page asks users to understand infrastructure
+
+For an administrator, the empty chat page includes setup/readiness material, multiple AI provider
+choices, a token meter, incognito controls, and chat actions. This is useful information, but it
+competes with the primary task: ask a question.
+
+The system should choose a safe default and let a simple user start. Provider readiness belongs in
+Operate. A user-level model choice can remain available as a secondary control when more than one
+approved model is selectable.
+
+### 5. AI configuration is split across several destinations
+
+Provider and model operations appear across:
+
+- the chat empty state;
+- AI model configuration;
+- provider setup;
+- model/provider status;
+- system configuration;
+- widget prompt/model controls.
+
+`AIModelsConfiguration.vue` combines friendly model choice with operator-oriented catalogue editing
+and vector-run information. The user-facing choices include technical internal purposes such as
+sorting, memory extraction, query improvement, summaries, and vectorization.
+
+A simple user should not need to know which model performs internal routing. An operator should have
+one place to manage the approved catalogue, credentials, defaults, and health.
+
+### 6. Broad menu categories hide heterogeneous destinations
+
+"AI Setup & Tools" currently covers model selection, instructions, routing, tasks, AI agents,
+summaries, and email generation. "Channels" covers inbound handlers, website widgets, personal
+connections, MCP, and API access.
+
+These names are not technically wrong, but users must open them and interpret a mixed list before
+they can act. The categories reflect implementation capabilities more than user goals.
+
+### 7. The widget flow starts well and then becomes an expert console
+
+The new-widget empty state and four-step creation wizard are clear. They use progressive disclosure
+and explain required inputs.
+
+After creation, advanced widget configuration contains seven sub-areas condensed into three
+dropdown groups because the tabs no longer fit. The component covers appearance, behavior, custom
+fields, security, privacy, AI assistance, prompts, models, and many detailed limits. This is strong
+evidence that the editor needs a resource-level information architecture, not denser tab controls.
+
+The better mental model is an **AI assistant** with one or more deployments. A website widget is a
+deployment channel, not the container for all assistant knowledge and behavior.
+
+### 8. Sources contains user and operator concepts
+
+The Sources view combines browsing, incoming items, generated items, semantic search, and vector
+management. Browsing and search are user goals. Vector runs and indexing diagnostics are operator
+goals. Incoming/generated provenance may be useful, but should be presented as filters or source
+types unless a user routinely manages those queues.
+
+### 9. Administration is fragmented
+
+The Admin dashboard includes system information, users, prompts, usage, subscriptions, and
+moderation. Installation configuration is a separate destination. Provider setup and model health
+are elsewhere again.
+
+An operator cannot answer "Is this installation ready, healthy, private, and within budget?" from a
+single overview.
+
+### 10. Account and preferences overlap
+
+The account menu leads to profile, memories, statistics, feedback, subscription, and preferences.
+The profile itself combines personal data, optional company billing data, invoice data, language,
+timezone, memories, password, app security, and account deletion. `SettingsView` also contains
+language and theme controls.
+
+Even if device language and account language have different persistence semantics, the interface
+does not make the distinction useful to an end-user. Personal settings need one predictable home.
+
+### 11. Sovereignty is a deployment property but is not summarized as one
+
+Self-hosting is visible during native onboarding, and the system supports local providers and local
+infrastructure. However, the operational UI presents individual configuration fields rather than a
+clear sovereignty posture.
+
+A sovereign operator needs immediate answers:
+
+- Which AI providers may receive data?
+- Are any cloud fallbacks enabled?
+- Where are files, vectors, memories, and logs stored?
+- Which external services are connected?
+- Is authentication local or delegated?
+- Are backups, retention, and updates healthy?
+
+Raw environment-style settings are necessary for experts, but they should sit behind a readable
+status summary.
+
+### 12. Menu ownership and route ownership disagree
+
+The canonical URL intent is `/channels/*` for conversation entry points and `/ai/*` for AI
+machinery. The current AI Setup menu nevertheless links to saved tasks, AI agents, and the email
+handler under `/channels/*`. Active-state logic has to special-case this disagreement.
+
+Users should not have to understand a technical URL taxonomy, but the mismatch is evidence that
+the product categories are unstable. Put tasks and action-oriented agents under Automations; put
+email and other delivery endpoints under Channels; keep models, instructions, and routing under AI
+assistant setup or operator infrastructure according to ownership.
+
+### 13. Removing Easy Mode left no replacement disclosure model
+
+Release 4.0 intentionally removed Easy Mode, and the shared navigation now exposes the full
+advanced product structure. Removing a second mode was the right maintenance decision, but it also
+removed the only mechanism that reduced first-session choices.
+
+Do not restore two global modes. Replace them with capability-aware navigation, sensible defaults,
+resource-local Advanced sections, and first-success milestones that progressively reveal the next
+task.
+
+### 14. Some secondary paths are stale or misleading
+
+The audit found examples that should be included in the implementation inventory:
+
+- A disabled tool can direct users to `/settings?tab=features`, although Preferences has no
+  features tab.
+- Live support and some provider detail pages are reachable only through secondary flows.
+- Legacy `/tools/*` and `/config/*` redirects remain registered.
+- Account destinations such as feedback and statistics are available but have weak placement.
+
+The sprint should classify every route as canonical, redirect, contextual detail, or removal
+candidate. A route should never be left discoverable only by accident.
+
+### 15. Accessibility quality is uneven across otherwise strong foundations
+
+The current interface has useful accessibility work, including labeled controls, mobile target
+sizes, reduced-motion handling, and inert drawer content. Important gaps remain:
+
+- the shared dialog behavior does not consistently trap and restore focus;
+- some labels and loading text remain hardcoded rather than translated;
+- no skip-to-content behavior was found in the main shell;
+- automated axe checks are currently report-only rather than blocking on primary journeys.
+
+These are not separate polish items. A new hierarchy is unsuccessful if keyboard and screen-reader
+users cannot traverse it predictably.
+
+## Personas and minimum interfaces
+
+### Chat user
+
+Primary goals:
+
+- Ask questions and continue conversations.
+- Find or add allowed knowledge.
+- Manage personal preferences and privacy.
+
+Default navigation:
+
+- Chat
+- History
+- Sources
+- Account
+
+Do not show provider credentials, internal model purposes, vector jobs, system configuration, or
+global usage.
+
+### Knowledge editor
+
+Primary goals:
+
+- Maintain approved source material.
+- Review incoming/generated material where applicable.
+- See indexing state and fix content-level errors.
+
+Add:
+
+- Source management actions
+- Content status and ownership
+
+Do not show infrastructure diagnostics unless the person is also an operator.
+
+### AI assistant owner
+
+Primary goals:
+
+- Configure an assistant's purpose, instructions, knowledge, channels, actions, and guardrails.
+- Test it before publishing.
+- Review conversations and outcomes.
+
+Add a **Manage** context containing assistants and their deployments. Avoid sending this person into
+global provider or system settings.
+
+### Company administrator
+
+Primary goals:
+
+- Manage people, access, approved assistants, shared knowledge, usage, and billing for the managed
+  scope.
+
+This requires an explicit organization/workspace concept if one is not already present in the
+backend contract. It must not be inferred from a billing profile.
+
+### Instance operator / sovereign administrator
+
+Primary goals:
+
+- Configure providers, identity, storage, messaging, security, retention, and updates.
+- Diagnose system health.
+- Enforce which external services are allowed.
+
+Show an **Operate** context. Keep it separate from daily chat and assistant authoring.
+
+### Hosting partner / reseller
+
+Primary goals:
+
+- Provision and manage customers.
+- Allocate token pools and plans.
+- Monitor usage, margins, limits, and service health.
+- Delegate customer administration and apply branding.
+
+This should become a separate **Hoster Console**, not another section in the existing Admin page.
+It is a future product epic dependent on tenancy, delegated RBAC, and billing-domain decisions.
+
+## Target mental model
+
+Use four product nouns consistently:
+
+1. **Chat** — a person's conversations.
+2. **Sources** — knowledge available to people and assistants.
+3. **AI assistants** — configured behavior, instructions, knowledge, and guardrails.
+4. **Channels** — places where an assistant is deployed: website widget, email, messaging, API,
+   MCP, or another integration.
+
+Use **Automations** for scheduled tasks and action-oriented agents. Do not use "AI agent" as a broad
+synonym for every assistant.
+
+System concepts such as providers, model catalogues, embeddings, vector runs, authentication, and
+retention belong to **Operate**.
+
+## Proposed information architecture
+
+### Work context
+
+Visible to every signed-in user, subject to capabilities:
+
+- **Chat**
+- **History**
+- **Sources**
+
+The account control remains pinned separately.
+
+### Manage context
+
+Visible to assistant owners and workspace/company administrators:
+
+- **Overview**
+- **AI assistants**
+- **Sources**
+- **Channels**
+- **Automations**
+- **People & access** when a managed multi-user scope exists
+- **Usage & billing** when the user owns that scope
+
+Selecting an AI assistant opens a stable detail navigation:
+
+- Overview
+- Instructions
+- Knowledge
+- Channels
+- Actions & automations
+- Safety & privacy
+- Test
+- Conversations & analytics
+- Advanced
+
+This replaces the pattern of placing an assistant's setup in global pages and a widget's many
+settings in a large modal.
+
+### Operate context
+
+Visible only to installation operators:
+
+- **Overview**
+  - readiness;
+  - service health;
+  - active warnings;
+  - processing/data-boundary summary;
+  - version and updates.
+- **AI infrastructure**
+  - providers and credentials;
+  - approved model catalogue;
+  - capability defaults;
+  - model health;
+  - embeddings and vector jobs.
+- **Identity & access**
+  - users;
+  - administrator access;
+  - external authentication;
+  - sessions and audit.
+- **Data & security**
+  - storage locations;
+  - retention;
+  - backups;
+  - privacy defaults;
+  - allowed external processing.
+- **Communication**
+  - inbound/outbound mail;
+  - messaging platform infrastructure;
+  - global connector health.
+- **Usage & commercial**
+  - system usage;
+  - subscriptions;
+  - moderation;
+  - global limits.
+- **Advanced configuration**
+  - raw settings;
+  - diagnostics;
+  - maintenance operations.
+
+### Personal account
+
+Keep only user-owned concerns:
+
+- Profile
+- Preferences: language, theme, timezone
+- Personal memory and privacy
+- Sign-in and security
+- Personal plan/subscription, when applicable
+- Delete account
+
+Move system statistics, global feedback operations, provider keys, and installation controls out of
+the account menu. If API keys authorize workspace or developer access, place them under Manage >
+Channels/Developer instead of Profile.
+
+## Navigation interaction
+
+### Desktop
+
+- Keep the compact rail for Work.
+- Add one clearly separated **Manage** entry when the user can manage assistants or shared content.
+- Add one clearly separated **Operate** entry for installation operators.
+- Selecting Manage or Operate opens that context's own labeled side navigation and breadcrumb.
+- Do not expose every child destination in hover flyouts from the primary rail.
+- Preserve the last destination within each context.
+
+### Mobile
+
+- Bottom navigation should contain at most four stable actions: Chat, History, Sources, More.
+- More contains Account and any authorized Manage/Operate context switches.
+- Resource detail pages use a page-local section menu, not a second giant global accordion.
+
+### Search and command access
+
+Add a global destination search/command palette only after the hierarchy is clear. Search is a
+shortcut, not a repair for confusing navigation.
+
+## Progressive-disclosure rules
+
+1. Show the recommended default first.
+2. Explain the user outcome, not the implementation primitive.
+3. Put optional settings under "Customize."
+4. Put uncommon or risky controls under "Advanced."
+5. Keep diagnostics next to the resource they diagnose, with deeper infrastructure diagnostics in
+   Operate.
+6. Never hide authorization behind visual disclosure: the backend must still enforce every
+   capability.
+7. Do not create a global "Easy mode." It produces two products, drifts over time, and makes support
+   harder.
+
+Examples:
+
+- Offer an assistant owner "Balanced," "Private/local," "Best quality," and "Lowest cost" policies
+  if product policy supports them. Let an operator inspect the exact model bindings.
+- Show "Knowledge is ready" or "3 files need attention" before exposing vector-run details.
+- Show "Data may be processed by Anthropic" before exposing provider IDs and raw endpoints.
+- Create a widget with safe defaults, then offer appearance and behavior customization after the
+  first working preview.
+
+The four-sprint breakdown, file list, and per-sprint test gates live in
+[01_execution_sprints.md](./01_execution_sprints.md). The deliverables below are the
+research contract that those sprints implement.
+
+## Proposed sprint: separation before redesign
+
+### Sprint goal
+
+Reduce cognitive load without requiring new backend domain models: separate daily work from
+installation operations, simplify the first-use chat experience, and create one predictable home
+for settings.
+
+### Deliverable 1: capability-aware shell
+
+- Keep Work to Chat, History, and Sources.
+- Add Manage and Operate as explicit contexts using existing authorization and feature flags.
+- Move current destinations into the appropriate context without deleting routes.
+- Keep legacy routes as redirects/deep-link aliases.
+- Ensure selected states, breadcrumbs, browser Back, direct links, and mobile behavior remain
+  correct.
+
+### Deliverable 2: operator overview
+
+- Create a single operator landing page from existing status APIs.
+- Present setup completeness, provider/model health, storage/indexing health, communication health,
+  version, and critical warnings.
+- Link each problem directly to its owning configuration page.
+- Add a concise "Data processing" summary that distinguishes local and external providers.
+- Keep raw configuration available under Advanced.
+
+### Deliverable 3: simplified chat start
+
+- Make the composer and example tasks the primary empty-state content.
+- Move installation setup cards to Operate.
+- Show only one blocking readiness message when chat genuinely cannot work.
+- Keep a compact model selector only when the user may choose among approved models.
+- Move token/budget detail to a secondary usage surface; retain a small warning only near a real
+  limit.
+
+### Deliverable 4: settings consolidation
+
+- Merge visible language/theme/timezone controls into one Preferences destination.
+- Keep profile identity and billing data separate from preferences.
+- Keep memory/privacy and security as clearly labeled account sections.
+- Remove duplicate destinations from the account menu.
+- Replace remaining hardcoded profile messages with translated copy during implementation.
+
+### Deliverable 5: terminology and destination audit
+
+- Apply the four-noun mental model: Chat, Sources, AI assistants, Channels.
+- Reserve provider/model/vector terminology for operator or advanced surfaces.
+- Ensure each menu item has one destination and each destination has one canonical label.
+- Update all four locales together.
+- Add route-level page titles and breadcrumbs for every retained destination.
+
+### Deliverable 6: usability validation
+
+Test clickable prototypes or the staged implementation with at least:
+
+- two chat-only users;
+- one assistant/content owner;
+- one company or installation administrator;
+- one self-hosting/sovereignty-focused operator;
+- one hosting-partner representative.
+
+Use realistic tasks rather than asking whether the interface "looks simple."
+
+### Deliverable 7: route, copy, and accessibility hygiene
+
+- Inventory every registered route as canonical, redirect, contextual detail, internal utility, or
+  removal candidate.
+- Fix misleading destinations such as links to nonexistent settings tabs.
+- Remove stale Easy Mode product copy and align current product documentation.
+- Complete the terminology pass in user-visible text, accessible names, empty states, and page
+  titles.
+- Add focus trap and focus restoration to shared dialogs.
+- Add a skip-to-content path and verify landmarks.
+- Make accessibility checks blocking for a small set of stable primary journeys before expanding
+  the gate.
+
+## Follow-up sprint: assistant-centered management
+
+The next sprint should restructure widgets and global AI setup around the AI assistant resource:
+
+1. Introduce an AI assistant overview.
+2. Associate instructions, knowledge, safety, and model policy with the assistant.
+3. Treat widgets and other integrations as deployments/channels.
+4. Replace the large advanced-widget modal with a full detail page and stable section navigation.
+5. Add test/publish states so configuration is not immediately conflated with production.
+6. Move system model catalogue and vector diagnostics to Operate.
+
+This is a product-model change and should not be squeezed into the shell-only sprint.
+
+## Separate future epic: hoster console
+
+Do not add "Hoster" to the current Admin tabs. First decide and implement:
+
+- tenant/customer boundaries;
+- operator, reseller, customer-admin, and end-user capabilities;
+- delegated administration;
+- per-tenant quotas and token pools;
+- billing ownership;
+- branding and domains;
+- audit logs;
+- data isolation;
+- support impersonation rules;
+- provisioning lifecycle.
+
+Only then design a hoster console around Customers, Plans & token pools, Usage, Provisioning, Health,
+Branding, and Audit.
+
+## Route migration approach
+
+The first sprint should change navigation and ownership, not break external links.
+
+- Retain existing route components initially.
+- Add canonical context routes and redirect old links where safe.
+- Preserve query parameters and resource IDs.
+- Maintain feature-gate behavior.
+- Add route ownership metadata such as Work, Manage, Operate, Personal, or Public.
+- Add capability metadata separately from billing-plan metadata.
+- Generate desktop, mobile, breadcrumbs, and destination search from the same route/navigation
+  source.
+
+## Accessibility and visual consistency requirements
+
+The research found a reasonably consistent current visual language. The sprint should avoid a
+simultaneous visual rebrand and focus on hierarchy.
+
+Required checks:
+
+- keyboard access to context navigation and page-local menus;
+- visible focus states;
+- meaningful headings and landmarks;
+- correct dialog focus trap and return;
+- no hover-only navigation;
+- WCAG AA contrast in light, dark, and V2;
+- usable layout from 320 px through wide desktop;
+- zoom at 200%;
+- labels that remain understandable without icons;
+- reduced-motion behavior;
+- loading, empty, error, disabled, and permission-denied states.
+
+## Success measures
+
+Capture a baseline before implementation, then compare:
+
+- A chat-only user can start a new chat with one primary action.
+- A chat-only user sees no more than four persistent navigation choices including Account.
+- At least 80% of test participants find a known source without assistance.
+- At least 80% of assistant owners find widget/assistant configuration without assistance.
+- At least 80% of operators locate provider credentials and diagnose a disabled provider within
+  two navigation decisions.
+- No participant mistakes personal settings for system settings.
+- No participant mistakes a billing company field for a managed organization.
+- Navigation-related support questions and abandoned setup flows decrease.
+- Existing deep links, mobile routes, guest gates, and browser navigation remain functional.
+- No visible action leads to a nonexistent tab or unrelated settings page.
+- Keyboard-only users can enter, traverse, and leave every changed navigation and dialog surface.
+
+Useful product events:
+
+- context selected;
+- destination selected;
+- navigation search used;
+- setup task opened/completed;
+- empty-state CTA used;
+- wizard step abandoned;
+- advanced section opened;
+- permission-denied destination attempted.
+
+Do not log user prompts, source content, credentials, or other sensitive values with these events.
+
+## Acceptance criteria for the streamlining sprint
+
+- Everyday users have a small Work navigation.
+- Manage and Operate are visibly separate and authorization-aware.
+- Provider/model/setup controls no longer dominate the chat empty state.
+- Operator readiness and configuration entry points have one home.
+- Personal preferences have one home.
+- Current routes remain link-compatible.
+- Desktop and mobile derive from one navigation model.
+- All four locales are complete.
+- Light, dark, V2, keyboard, and 320 px behavior are verified.
+- Primary chat, authentication, navigation, and shared-dialog accessibility checks are blocking.
+- The existing backend authorization remains authoritative.
+- No unsupported workspace, company-admin, or hoster capability is implied.
+
+## Decisions needed before implementation
+
+1. Is "workspace" intended to become a real domain object, or does each installation remain the
+   managed scope?
+2. Can one AI assistant have multiple channels, or are widgets intentionally independent
+   assistants?
+3. Which roles may edit shared sources versus only upload personal sources?
+4. Are model choices a user preference, an assistant policy, an operator default, or all three with
+   explicit precedence?
+5. Which usage and billing data is personal, organizational, installation-wide, or reseller-owned?
+6. What exact claim should the sovereignty summary make, and which backend facts can prove it?
+7. Should API and MCP credentials belong to a person, an assistant, or a managed scope?
+
+## Workspace scope: why it is deferred, and why that is safe
+
+Question raised in review: is it wise to leave the workspace (company/team) scope out?
+
+**Yes — for these sprints.** Reasons:
+
+1. There is no backend organization/tenant/role model to bind to. A "People & access" menu with
+   no enforcing API would be a lie the backend cannot keep; the house rule is that visual
+   disclosure never substitutes for authorization.
+2. Subscription levels (TEAM, BUSINESS) describe what was purchased, not who may administer
+   whom. Building menus on plan level would bake the wrong abstraction in.
+3. The workspace questions (decisions 1, 3, 5, 7 below) are product decisions with billing and
+   isolation consequences. Answering them under a shell-cleanup deadline produces a rushed role
+   model that the hoster console then inherits.
+
+**But deferral must not become exclusion.** The execution plan reserves the seam so the
+workspace scope can land later without a third IA rewrite
+([02_compatibility_contract.md](./02_compatibility_contract.md) §6):
+
+- **Manage is designed as the future workspace home** — it later becomes "Manage
+  *(workspace)*" and gains People & access plus Usage & billing children.
+- Navigation visibility runs through **one named capability predicate per context**
+  (Manage: signed-in today → `canManageWorkspace` later; Operate: `isAdmin` today →
+  `canOperateInstance` later). Swapping predicates is the entire migration.
+- Routes carry `meta.context` ownership metadata from Sprint 2 onward.
+- No "Workspace", "Team", or "Organization" label appears in the new menu until the backend
+  model exists, and Profile's company fields stay labeled as billing data.
+
+Accepted interim cost: TEAM/BUSINESS customers keep managing users via the operator area, as
+they do today. That is unchanged behavior, not a regression.
+
+## Recommended decision
+
+Approve the first sprint as an information-architecture separation using existing routes and
+permissions. Do not begin with a visual redesign, a global easy/advanced switch, or a hoster tab.
+
+In parallel, answer the domain questions for assistants, workspaces, and hosters. Those answers
+determine the second-stage assistant editor and future hoster console.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -120,10 +120,11 @@ Extract content from:
 - Rate limiting
 - API keys for integrations
 
-## App Modes
+## Navigation
 
-- **Easy Mode**: Simplified interface for casual users
-- **Advanced Mode**: Full features for power users
+Everyday work lives on the rail (New, History, Sources). Assistants, channels
+and automations sit under **Manage**. Installation administration sits under
+**Operate** (administrators only). There is no Easy / Advanced mode toggle.
 
 ## AI Memories & Qdrant
 

--- a/frontend/src/components/ChatInput.vue
+++ b/frontend/src/components/ChatInput.vue
@@ -40,7 +40,7 @@
           <span v-if="file.processing" class="text-xs txt-muted">(processing...)</span>
           <button
             class="icon-ghost p-0 min-w-0 w-auto h-auto"
-            aria-label="Remove file"
+            :aria-label="$t('files.removeFile')"
             :disabled="file.processing"
             @click="removeFile(index)"
           >

--- a/frontend/src/components/Dialog.vue
+++ b/frontend/src/components/Dialog.vue
@@ -15,6 +15,7 @@
 
         <!-- Dialog -->
         <div
+          ref="panelRef"
           class="relative surface-card rounded-xl shadow-2xl max-w-md w-full p-6 space-y-4 animate-scale-in"
           role="dialog"
           aria-modal="true"
@@ -102,18 +103,37 @@ const { dialog, close } = useDialog()
 const { teleportTarget } = useFullscreenTeleportTarget()
 const inputValue = ref('')
 const inputRef = ref<HTMLInputElement>()
+const panelRef = ref<HTMLElement>()
+let previouslyFocused: HTMLElement | null = null
 
-// Reset input value when dialog opens
+const FOCUSABLE =
+  'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])'
+
+function focusableInPanel(): HTMLElement[] {
+  if (!panelRef.value) return []
+  return Array.from(panelRef.value.querySelectorAll<HTMLElement>(FOCUSABLE)).filter(
+    (el) => !el.hasAttribute('disabled') && el.tabIndex !== -1
+  )
+}
+
+// Reset input value when dialog opens; trap focus inside the panel.
 watch(
   () => dialog.value.isOpen,
   async (isOpen) => {
     if (isOpen) {
+      previouslyFocused =
+        document.activeElement instanceof HTMLElement ? document.activeElement : null
       inputValue.value = dialog.value.defaultValue || ''
+      await nextTick()
       if (dialog.value.type === 'prompt') {
-        await nextTick()
         inputRef.value?.focus()
+      } else {
+        focusableInPanel()[0]?.focus()
       }
+      return
     }
+    previouslyFocused?.focus()
+    previouslyFocused = null
   }
 )
 
@@ -143,6 +163,25 @@ const handleBackdropClick = () => {
 
 const handleGlobalKeydown = (event: KeyboardEvent) => {
   if (!dialog.value.isOpen) return
+
+  if (event.key === 'Tab') {
+    const nodes = focusableInPanel()
+    if (nodes.length === 0) {
+      event.preventDefault()
+      return
+    }
+    const first = nodes[0]
+    const last = nodes[nodes.length - 1]
+    const active = document.activeElement
+    if (event.shiftKey && active === first) {
+      event.preventDefault()
+      last.focus()
+    } else if (!event.shiftKey && active === last) {
+      event.preventDefault()
+      first.focus()
+    }
+    return
+  }
 
   if (event.key === 'Enter' && dialog.value.type === 'confirm') {
     event.preventDefault()

--- a/frontend/src/components/MainLayout.vue
+++ b/frontend/src/components/MainLayout.vue
@@ -1,5 +1,12 @@
 <template>
   <div class="flex h-dvh overflow-hidden" data-testid="comp-main-layout">
+    <a
+      href="#main-content"
+      class="sr-only focus:not-sr-only focus:absolute focus:top-3 focus:left-3 focus:z-[300] focus:px-3 focus:py-2 focus:rounded-lg btn-primary"
+      data-testid="link-skip-to-content"
+    >
+      {{ $t('common.skipToContent') }}
+    </a>
     <SidebarV2 />
 
     <!--
@@ -39,8 +46,10 @@
         <div class="v2-status-bar-band" aria-hidden="true" data-testid="section-status-bar-band" />
 
         <main
+          id="main-content"
           ref="mainRef"
           class="flex-1 min-h-0 overflow-y-auto overscroll-contain"
+          tabindex="-1"
           data-testid="section-primary-content"
         >
           <slot />

--- a/frontend/src/components/MobileNav.vue
+++ b/frontend/src/components/MobileNav.vue
@@ -99,47 +99,99 @@
                 </button>
 
                 <div v-if="expandedSection === item.key && item.children" class="pl-4 pb-1">
-                  <!-- Same grouped rendering as the desktop flyout, so the two
-                       surfaces show an identical (up to 3-level) hierarchy. -->
+                  <!-- Same hierarchy as the desktop flyout: grouped items
+                       (Manage) nest under a second accordion; flat lists
+                       (Operate / Plugins) stay one tap away. -->
                   <template
                     v-for="(section, sIdx) in groupNavChildren(item.children)"
-                    :key="section.group ?? sIdx"
+                    :key="section.key ?? section.group ?? sIdx"
                   >
-                    <p
-                      v-if="section.group"
-                      class="px-3 pt-2 pb-1 text-[10px] font-semibold txt-secondary uppercase tracking-wider opacity-60"
-                    >
-                      {{ section.group }}
-                    </p>
-                    <router-link
-                      v-for="child in section.items"
-                      :key="child.key"
-                      :to="child.path"
-                      class="v2-drawer-child"
-                      :class="[
-                        route.path === child.path
-                          ? 'text-[var(--brand)] bg-[var(--brand)]/[0.06] font-medium'
-                          : 'txt-secondary',
-                        section.group && 'pl-5',
-                      ]"
-                      :data-nav-active="route.path === child.path ? 'true' : undefined"
-                      :data-testid="`link-mobile-more-${child.key}`"
-                      @click="closeDrawer"
-                    >
-                      <span
-                        class="w-1.5 h-1.5 rounded-full flex-shrink-0"
+                    <template v-if="section.key">
+                      <button
+                        type="button"
+                        class="v2-drawer-child w-full"
                         :class="
-                          route.path === child.path ? 'bg-[var(--brand)]' : 'bg-current opacity-20'
+                          expandedGroup === section.key || isGroupCurrent(item.path, section)
+                            ? 'text-[var(--brand)] font-medium'
+                            : 'txt-secondary'
                         "
-                      />
-                      <span class="flex-1 truncate">{{ child.label }}</span>
-                      <span
-                        v-if="child.badge"
-                        class="text-[10px] px-1.5 py-0.5 rounded-full bg-yellow-100 dark:bg-yellow-900/30 text-yellow-700 dark:text-yellow-200 font-medium"
+                        :aria-expanded="expandedGroup === section.key"
+                        :data-testid="`btn-mobile-more-group-${section.key}`"
+                        @click="toggleGroup(section.key)"
                       >
-                        {{ child.badge }}
-                      </span>
-                    </router-link>
+                        <span class="flex-1 text-left truncate">{{ section.group }}</span>
+                        <Icon
+                          icon="mdi:chevron-down"
+                          class="w-4 h-4 flex-shrink-0 transition-transform"
+                          :class="expandedGroup === section.key && 'rotate-180'"
+                          aria-hidden="true"
+                        />
+                      </button>
+                      <div v-if="expandedGroup === section.key" class="pl-3">
+                        <router-link
+                          v-for="child in section.items"
+                          :key="child.key"
+                          :to="child.path"
+                          class="v2-drawer-child"
+                          :class="
+                            route.path === child.path
+                              ? 'text-[var(--brand)] bg-[var(--brand)]/[0.06] font-medium'
+                              : 'txt-secondary'
+                          "
+                          :data-nav-active="route.path === child.path ? 'true' : undefined"
+                          :data-testid="`link-mobile-more-${child.key}`"
+                          @click="closeDrawer"
+                        >
+                          <span
+                            class="w-1.5 h-1.5 rounded-full flex-shrink-0"
+                            :class="
+                              route.path === child.path
+                                ? 'bg-[var(--brand)]'
+                                : 'bg-current opacity-20'
+                            "
+                          />
+                          <span class="flex-1 truncate">{{ child.label }}</span>
+                          <span
+                            v-if="child.badge"
+                            class="text-[10px] px-1.5 py-0.5 rounded-full bg-yellow-100 dark:bg-yellow-900/30 text-yellow-700 dark:text-yellow-200 font-medium"
+                          >
+                            {{ child.badge }}
+                          </span>
+                        </router-link>
+                      </div>
+                    </template>
+                    <template v-else>
+                      <router-link
+                        v-for="child in section.items"
+                        :key="child.key"
+                        :to="child.path"
+                        class="v2-drawer-child"
+                        :class="
+                          route.path === child.path
+                            ? 'text-[var(--brand)] bg-[var(--brand)]/[0.06] font-medium'
+                            : 'txt-secondary'
+                        "
+                        :data-nav-active="route.path === child.path ? 'true' : undefined"
+                        :data-testid="`link-mobile-more-${child.key}`"
+                        @click="closeDrawer"
+                      >
+                        <span
+                          class="w-1.5 h-1.5 rounded-full flex-shrink-0"
+                          :class="
+                            route.path === child.path
+                              ? 'bg-[var(--brand)]'
+                              : 'bg-current opacity-20'
+                          "
+                        />
+                        <span class="flex-1 truncate">{{ child.label }}</span>
+                        <span
+                          v-if="child.badge"
+                          class="text-[10px] px-1.5 py-0.5 rounded-full bg-yellow-100 dark:bg-yellow-900/30 text-yellow-700 dark:text-yellow-200 font-medium"
+                        >
+                          {{ child.badge }}
+                        </span>
+                      </router-link>
+                    </template>
                   </template>
                 </div>
               </div>
@@ -502,7 +554,13 @@ import { useConfigStore } from '../stores/config'
 import { useSidebarStore } from '../stores/sidebar'
 import { triggerHapticImpact } from '../services/api/nativeHaptics'
 import { useAuth } from '../composables/useAuth'
-import { useNavItems, groupNavChildren, type NavItem } from '../composables/useNavItems'
+import {
+  useNavItems,
+  groupNavChildren,
+  isNavChildActive,
+  type NavChildGroup,
+  type NavItem,
+} from '../composables/useNavItems'
 import { useDialog } from '../composables/useDialog'
 import { useDateFormat } from '@/composables/useDateFormat'
 import { useI18n } from 'vue-i18n'
@@ -526,6 +584,7 @@ const { navItems, isItemActive, isGuestMode } = useNavItems()
 
 const moreExpanded = ref(false)
 const expandedSection = ref<string | null>(null)
+const expandedGroup = ref<string | null>(null)
 const isCreatingChat = ref(false)
 const featureGateOpen = ref(false)
 const featureGateKey = ref('general')
@@ -625,6 +684,14 @@ const handleSectionClick = async (item: NavItem) => {
   closeDrawer()
   await router.push(item.path)
 }
+
+const toggleGroup = (key: string) => {
+  triggerHapticImpact('light')
+  expandedGroup.value = expandedGroup.value === key ? null : key
+}
+
+const isGroupCurrent = (sectionPath: string, section: NavChildGroup): boolean =>
+  section.items.some((child) => isNavChildActive(child, sectionPath, route.path))
 
 const handleNavigate = async (path: string) => {
   closeDrawer()
@@ -778,6 +845,16 @@ const syncExpansionToActiveRoute = () => {
   moreExpanded.value = activeSection !== undefined || accountActive.value
   expandedSection.value =
     activeSection?.children && activeSection.children.length > 0 ? activeSection.key : null
+  if (activeSection?.children) {
+    const match = groupNavChildren(activeSection.children).find(
+      (section) =>
+        section.key &&
+        section.items.some((child) => isNavChildActive(child, activeSection.path, route.path))
+    )
+    expandedGroup.value = match?.key ?? null
+  } else {
+    expandedGroup.value = null
+  }
 }
 
 // Bring the active (deepest) nav entry into view once the sections are expanded.

--- a/frontend/src/components/SidebarNavFlyout.vue
+++ b/frontend/src/components/SidebarNavFlyout.vue
@@ -1,0 +1,220 @@
+<template>
+  <div class="fixed inset-0 z-[200]" data-testid="overlay-sidebar-v2-nav" @click="emit('close')">
+    <!-- First level: groups (Manage) or a flat child list (Operate / Plugins). -->
+    <div
+      ref="primaryRef"
+      role="menu"
+      class="fixed w-56 dropdown-panel origin-top-left overflow-hidden"
+      :style="panelStyle"
+      data-testid="dropdown-sidebar-v2-nav"
+      @click.stop
+    >
+      <div class="px-3 py-2 border-b border-light-border/10 dark:border-dark-border/10">
+        <p class="text-xs font-semibold txt-secondary uppercase tracking-wider">
+          {{ item.label }}
+        </p>
+      </div>
+
+      <div v-if="nested" class="py-1">
+        <button
+          v-for="section in groups"
+          :key="section.key ?? section.group ?? 'group'"
+          :ref="(el) => setGroupBtnRef(el, section.key)"
+          type="button"
+          role="menuitem"
+          class="flex items-center gap-2.5 w-full px-3 py-2 text-sm text-left transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-[var(--brand)] focus-visible:outline-offset-[-2px]"
+          :class="groupRowClass(section)"
+          :aria-haspopup="section.key ? 'menu' : undefined"
+          :aria-expanded="section.key ? activeGroupKey === section.key : undefined"
+          :aria-controls="section.key ? 'sidebar-nav-submenu' : undefined"
+          :data-testid="`btn-sidebar-v2-group-${section.key}`"
+          @pointerenter="openGroup(section.key)"
+          @focus="openGroup(section.key)"
+          @click="openGroup(section.key)"
+        >
+          <span
+            class="w-1.5 h-1.5 rounded-full flex-shrink-0"
+            :class="isGroupCurrent(section) ? 'bg-[var(--brand)]' : 'bg-current opacity-20'"
+          />
+          <span class="flex-1 truncate">{{ section.group }}</span>
+          <ChevronRightIcon class="w-4 h-4 flex-shrink-0 opacity-60" aria-hidden="true" />
+        </button>
+      </div>
+
+      <div v-else class="py-1 max-h-[60vh] overflow-y-auto scroll-thin">
+        <router-link
+          v-for="child in item.children"
+          :key="child.key"
+          :to="child.path"
+          role="menuitem"
+          :data-testid="`link-sidebar-v2-${child.key}`"
+          class="flex items-center gap-2.5 px-3 py-2 text-sm transition-colors"
+          :class="leafClass(child.path)"
+          @click="emit('close')"
+        >
+          <span
+            class="w-1.5 h-1.5 rounded-full flex-shrink-0"
+            :class="currentPath === child.path ? 'bg-[var(--brand)]' : 'bg-current opacity-20'"
+          />
+          <span class="flex-1 truncate">{{ child.label }}</span>
+          <span
+            v-if="child.badge"
+            class="text-[10px] px-1.5 py-0.5 rounded-full bg-yellow-100 dark:bg-yellow-900/30 text-yellow-700 dark:text-yellow-200 font-medium"
+          >
+            {{ child.badge }}
+          </span>
+        </router-link>
+      </div>
+    </div>
+
+    <!-- Second level: links for the open Manage group. -->
+    <div
+      v-if="nested && activeGroup"
+      id="sidebar-nav-submenu"
+      role="menu"
+      class="fixed w-64 dropdown-panel origin-top-left overflow-hidden"
+      :style="subStyle"
+      data-testid="dropdown-sidebar-v2-nav-sub"
+      @click.stop
+    >
+      <div class="px-3 py-2 border-b border-light-border/10 dark:border-dark-border/10">
+        <p class="text-xs font-semibold txt-secondary uppercase tracking-wider">
+          {{ activeGroup.group }}
+        </p>
+      </div>
+      <div class="py-1">
+        <router-link
+          v-for="child in activeGroup.items"
+          :key="child.key"
+          :to="child.path"
+          role="menuitem"
+          :data-testid="`link-sidebar-v2-${child.key}`"
+          class="flex items-center gap-2.5 px-3 py-2 text-sm transition-colors"
+          :class="leafClass(child.path)"
+          @click="emit('close')"
+        >
+          <span
+            class="w-1.5 h-1.5 rounded-full flex-shrink-0"
+            :class="currentPath === child.path ? 'bg-[var(--brand)]' : 'bg-current opacity-20'"
+          />
+          <span class="flex-1 truncate">{{ child.label }}</span>
+          <span
+            v-if="child.badge"
+            class="text-[10px] px-1.5 py-0.5 rounded-full bg-yellow-100 dark:bg-yellow-900/30 text-yellow-700 dark:text-yellow-200 font-medium"
+          >
+            {{ child.badge }}
+          </span>
+        </router-link>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, nextTick, onMounted, ref, watch } from 'vue'
+import { ChevronRightIcon } from '@heroicons/vue/24/outline'
+import {
+  groupNavChildren,
+  hasNestedNavGroups,
+  isNavChildActive,
+  type NavChildGroup,
+  type NavItem,
+} from '../composables/useNavItems'
+
+const props = defineProps<{
+  item: NavItem
+  panelStyle: Record<string, string>
+  currentPath: string
+}>()
+
+const emit = defineEmits<{
+  close: []
+}>()
+
+const primaryRef = ref<HTMLElement | null>(null)
+const groupBtnRefs = ref<Record<string, HTMLElement | null>>({})
+const activeGroupKey = ref<string | null>(null)
+const subStyle = ref<Record<string, string>>({})
+
+const groups = computed(() => groupNavChildren(props.item.children))
+const nested = computed(() => hasNestedNavGroups(props.item.children))
+const activeGroup = computed(
+  () => groups.value.find((section) => section.key === activeGroupKey.value) ?? null
+)
+
+const setGroupBtnRef = (el: unknown, key: string | null) => {
+  if (!key) return
+  groupBtnRefs.value[key] = el as HTMLElement | null
+}
+
+const isGroupCurrent = (section: NavChildGroup): boolean =>
+  section.items.some((child) => isNavChildActive(child, props.item.path, props.currentPath))
+
+const groupRowClass = (section: NavChildGroup): string => {
+  if (activeGroupKey.value === section.key || isGroupCurrent(section)) {
+    return 'text-[var(--brand)] bg-[var(--brand)]/[0.06] font-medium'
+  }
+  return 'txt-secondary hover:txt-primary hover:bg-black/[0.03] dark:hover:bg-white/[0.03]'
+}
+
+const leafClass = (path: string): string =>
+  props.currentPath === path
+    ? 'text-[var(--brand)] bg-[var(--brand)]/[0.06] font-medium'
+    : 'txt-secondary hover:txt-primary hover:bg-black/[0.03] dark:hover:bg-white/[0.03]'
+
+const groupKeyForPath = (path: string): string | null => {
+  for (const section of groups.value) {
+    if (
+      section.key &&
+      section.items.some((child) => isNavChildActive(child, props.item.path, path))
+    ) {
+      return section.key
+    }
+  }
+  return null
+}
+
+const positionSubmenu = async () => {
+  await nextTick()
+  const primary = primaryRef.value
+  const key = activeGroupKey.value
+  const btn = key ? groupBtnRefs.value[key] : null
+  if (!primary || !btn || !activeGroup.value) return
+
+  const primaryRect = primary.getBoundingClientRect()
+  const btnRect = btn.getBoundingClientRect()
+  const width = 256
+  const gap = 4
+  let left = primaryRect.right + gap
+  if (left + width > window.innerWidth - 8) {
+    left = primaryRect.left - width - gap
+  }
+  const estimatedHeight = (activeGroup.value.items.length + 1) * 40 + 16
+  const top = Math.max(8, Math.min(btnRect.top, window.innerHeight - estimatedHeight - 8))
+  subStyle.value = {
+    left: `${Math.max(8, left)}px`,
+    top: `${top}px`,
+  }
+}
+
+const openGroup = (key: string | null) => {
+  if (!key || activeGroupKey.value === key) return
+  activeGroupKey.value = key
+}
+
+watch(
+  () => props.item.key,
+  () => {
+    activeGroupKey.value = nested.value ? groupKeyForPath(props.currentPath) : null
+  },
+  { immediate: true }
+)
+
+watch(activeGroupKey, () => {
+  void positionSubmenu()
+})
+
+onMounted(() => {
+  void positionSubmenu()
+})
+</script>

--- a/frontend/src/components/SidebarV2.vue
+++ b/frontend/src/components/SidebarV2.vue
@@ -57,10 +57,16 @@
         ]"
         :title="item.description || item.label"
         :data-testid="`btn-sidebar-v2-nav-${item.key}`"
+        :aria-haspopup="item.children?.length ? 'menu' : undefined"
+        :aria-expanded="
+          item.children?.length
+            ? activeFlyout === 'nav' && activeFlyoutItem?.key === item.key
+            : undefined
+        "
         @click="handleNavClick(item)"
       >
         <component :is="item.icon" class="w-6 h-6 flex-shrink-0" aria-hidden="true" />
-        <!-- Two-line clamp instead of truncate: "AI Setup & Tools" (and its
+        <!-- Two-line clamp instead of truncate: longer rail labels (and their
              translations) would otherwise be cut off on the 72px rail. -->
         <span
           class="v2-rail-label text-[10px] font-medium leading-tight max-w-full px-0.5 text-center line-clamp-2 break-words"
@@ -327,72 +333,13 @@
       leave-from-class="opacity-100 scale-100"
       leave-to-class="opacity-0 scale-95"
     >
-      <div
+      <SidebarNavFlyout
         v-if="activeFlyout === 'nav' && activeFlyoutItem"
-        class="fixed inset-0 z-[200]"
-        data-testid="overlay-sidebar-v2-nav"
-        @click="closeFlyout"
-      >
-        <!-- w-64: wide enough for the longest child labels in all four
-             locales (e.g. de "Vordefinierte Anweisungen") without truncation. -->
-        <div
-          class="fixed w-64 dropdown-panel origin-top-left overflow-hidden"
-          :style="navDropdownStyle"
-          data-testid="dropdown-sidebar-v2-nav"
-          @click.stop
-        >
-          <!-- Header -->
-          <div class="px-3 py-2 border-b border-light-border/10 dark:border-dark-border/10">
-            <p class="text-xs font-semibold txt-secondary uppercase tracking-wider">
-              {{ activeFlyoutItem.label }}
-            </p>
-          </div>
-
-          <!-- Children Links (with optional group headers) -->
-          <div class="py-1 max-h-[60vh] overflow-y-auto scroll-thin">
-            <template v-for="(section, sIdx) in groupedChildren" :key="sIdx">
-              <div
-                v-if="section.group"
-                class="px-3 pt-2.5 pb-1"
-                :class="{
-                  'border-t border-light-border/10 dark:border-dark-border/10 mt-1': sIdx > 0,
-                }"
-              >
-                <p
-                  class="text-[10px] font-semibold txt-secondary uppercase tracking-wider opacity-60"
-                >
-                  {{ section.group }}
-                </p>
-              </div>
-              <router-link
-                v-for="child in section.items"
-                :key="child.path"
-                :to="child.path"
-                :data-testid="`link-sidebar-v2-${child.key}`"
-                class="flex items-center gap-2.5 px-3 py-2 text-sm transition-colors"
-                :class="
-                  route.path === child.path
-                    ? 'text-[var(--brand)] bg-[var(--brand)]/[0.06] font-medium'
-                    : 'txt-secondary hover:txt-primary hover:bg-black/[0.03] dark:hover:bg-white/[0.03]'
-                "
-                @click="closeFlyout()"
-              >
-                <span
-                  class="w-1.5 h-1.5 rounded-full flex-shrink-0"
-                  :class="route.path === child.path ? 'bg-[var(--brand)]' : 'bg-current opacity-20'"
-                />
-                <span class="flex-1 truncate">{{ child.label }}</span>
-                <span
-                  v-if="child.badge"
-                  class="text-[10px] px-1.5 py-0.5 rounded-full bg-yellow-100 dark:bg-yellow-900/30 text-yellow-700 dark:text-yellow-200 font-medium"
-                >
-                  {{ child.badge }}
-                </span>
-              </router-link>
-            </template>
-          </div>
-        </div>
-      </div>
+        :item="activeFlyoutItem"
+        :panel-style="navDropdownStyle"
+        :current-path="route.path"
+        @close="closeFlyout"
+      />
     </Transition>
   </Teleport>
 
@@ -430,7 +377,7 @@
                   </h2>
                   <p class="text-xs txt-secondary mt-0.5">
                     {{ chatList.length }}
-                    {{ chatList.length === 1 ? 'conversation' : 'conversations' }}
+                    {{ chatList.length === 1 ? $t('chat.conversation') : $t('chat.conversations') }}
                   </p>
                 </div>
               </div>
@@ -693,7 +640,13 @@ import { isPurchaseAllowed } from '../services/api/nativeServer'
 import { useAuthStore } from '../stores/auth'
 import { useConfigStore } from '../stores/config'
 import { useAuth } from '../composables/useAuth'
-import { useNavItems, groupNavChildren, type NavItem } from '../composables/useNavItems'
+import {
+  useNavItems,
+  groupNavChildren,
+  hasNestedNavGroups,
+  type NavItem,
+} from '../composables/useNavItems'
+import SidebarNavFlyout from './SidebarNavFlyout.vue'
 import { useTheme } from '../composables/useTheme'
 import { useBrandLogo } from '../composables/useBrandLogo'
 import { useChatsStore, isDefaultChatTitle, type Chat as StoreChat } from '../stores/chats'
@@ -773,11 +726,18 @@ watch(
 onMounted(() => {
   loadFeatureStatus()
   document.addEventListener('keydown', handleEscape)
+  window.addEventListener('resize', handleViewportChange)
 })
 
 onBeforeUnmount(() => {
   document.removeEventListener('keydown', handleEscape)
+  window.removeEventListener('resize', handleViewportChange)
 })
+
+const handleViewportChange = () => {
+  closeFlyout()
+  userMenuOpen.value = false
+}
 
 const toggleUserMenu = () => {
   triggerHapticImpact('light')
@@ -842,8 +802,6 @@ watch(
   { immediate: true }
 )
 
-const groupedChildren = computed(() => groupNavChildren(activeFlyoutItem.value?.children))
-
 const handleQuickNewChat = async () => {
   if (isCreatingChat.value) return
   isCreatingChat.value = true
@@ -884,7 +842,9 @@ const handleNavClick = (item: NavItem) => {
       const btn = navBtnRefs.value[item.path]
       if (btn) {
         const rect = btn.getBoundingClientRect()
-        const estimatedHeight = (item.children.length + 1) * 36 + 16
+        const groups = groupNavChildren(item.children)
+        const rowCount = hasNestedNavGroups(item.children) ? groups.length : item.children.length
+        const estimatedHeight = (rowCount + 2) * 40 + 16
         const maxTop = window.innerHeight - estimatedHeight - 8
         navDropdownStyle.value = {
           left: `${rect.right + 8}px`,

--- a/frontend/src/components/ToolsDropdown.vue
+++ b/frontend/src/components/ToolsDropdown.vue
@@ -305,10 +305,7 @@ const selectToolCommand = (toolId: string, commandName: string) => {
 
   // If feature is disabled, navigate to setup instructions instead
   if (feature && !feature.enabled && feature.setup_required) {
-    router.push({
-      path: '/settings',
-      query: { tab: 'features', feature: toolId },
-    })
+    router.push(authStore.isAdmin ? '/admin/features' : '/ai/models')
     closeDropdown()
     return
   }

--- a/frontend/src/components/admin/ConfigField.vue
+++ b/frontend/src/components/admin/ConfigField.vue
@@ -238,6 +238,7 @@ const helpMeta = computed(() => providerHelpByEnvVar(props.fieldKey))
           v-if="schema.type === 'password'"
           type="button"
           class="absolute right-2 top-1/2 -translate-y-1/2 p-1 txt-secondary hover:txt-primary"
+          :aria-label="showPassword ? $t('auth.hidePassword') : $t('auth.showPassword')"
           @click="showPassword = !showPassword"
         >
           <Icon :icon="showPassword ? 'mdi:eye-off' : 'mdi:eye'" class="w-5 h-5" />

--- a/frontend/src/components/files/FilesTabs.vue
+++ b/frontend/src/components/files/FilesTabs.vue
@@ -22,6 +22,7 @@ import { useRouter } from 'vue-router'
 import PageHeader from '@/components/PageHeader.vue'
 import TabNav, { type TabNavItem } from '@/components/TabNav.vue'
 import filesService from '@/services/filesService'
+import { useAuthStore } from '@/stores/auth'
 
 type FilesTab = 'files' | 'search' | 'vectors' | 'incoming' | 'generated'
 
@@ -31,6 +32,7 @@ defineProps<{
 
 const { t } = useI18n()
 const router = useRouter()
+const authStore = useAuthStore()
 
 const pathById: Record<FilesTab, string> = {
   files: '/files',
@@ -74,13 +76,17 @@ const tabNavItems = computed<TabNavItem[]>(() => [
     testid: 'tab-files-search',
     to: pathById.search,
   },
-  {
-    id: 'vectors',
-    label: t('files.tabVectors'),
-    icon: 'heroicons:circle-stack',
-    testid: 'tab-files-vectors',
-    to: pathById.vectors,
-  },
+  ...(authStore.isAdmin
+    ? [
+        {
+          id: 'vectors',
+          label: t('files.tabVectors'),
+          icon: 'heroicons:circle-stack',
+          testid: 'tab-files-vectors',
+          to: pathById.vectors,
+        } satisfies TabNavItem,
+      ]
+    : []),
 ])
 
 function onTabChange(id: string) {

--- a/frontend/src/components/widgets/WidgetList.vue
+++ b/frontend/src/components/widgets/WidgetList.vue
@@ -3,7 +3,7 @@
     <div class="mb-6 flex items-center justify-between" data-testid="section-header">
       <h2 class="text-xl font-semibold txt-primary flex items-center gap-2">
         <ListBulletIcon class="w-5 h-5" />
-        Your Widgets
+        {{ $t('widgets.listTitle') }}
       </h2>
       <button
         class="btn-primary px-4 py-2 rounded-lg flex items-center gap-2"
@@ -11,7 +11,7 @@
         @click="$emit('create')"
       >
         <PlusIcon class="w-5 h-5" />
-        Create New Widget
+        {{ $t('widgets.createNewWidget') }}
       </button>
     </div>
 
@@ -21,7 +21,7 @@
       data-testid="section-empty"
     >
       <div class="txt-secondary mb-4">
-        No widgets created yet. Click "Create New Widget" to get started.
+        {{ $t('widgets.listEmpty') }}
       </div>
     </div>
 

--- a/frontend/src/composables/useNavItems.ts
+++ b/frontend/src/composables/useNavItems.ts
@@ -1,12 +1,11 @@
-import { computed, ref, type Component } from 'vue'
+import { computed, ref, watch, type Component } from 'vue'
 import { useRoute } from 'vue-router'
 import {
   ClockIcon,
-  CpuChipIcon,
   FolderIcon,
   PuzzlePieceIcon,
   ShieldCheckIcon,
-  SignalIcon,
+  WrenchScrewdriverIcon,
 } from '@heroicons/vue/24/outline'
 import { useI18n } from 'vue-i18n'
 import { useAuthStore } from '../stores/auth'
@@ -21,34 +20,56 @@ export interface NavChild {
   path: string
   label: string
   badge?: string
+  /** Translated group label shown in the first-level Manage flyout */
   group?: string
+  /** Stable group id (`assistants`, `channels`, …) for testids and nesting */
+  groupKey?: string
 }
 
 export interface NavChildGroup {
+  /** Stable group id, or null for a flat (ungrouped) list */
+  key: string | null
   group: string | null
   items: NavChild[]
 }
 
 /**
- * Splits a children list into consecutive sections by their `group` label so
- * both nav surfaces (desktop flyout, mobile drawer) render identical grouped
- * sub-menus. Ungrouped children form a header-less leading section.
+ * Splits a children list into consecutive sections by their `groupKey` (falling
+ * back to the translated `group` label) so both nav surfaces (desktop flyout,
+ * mobile drawer) render the same hierarchy. Ungrouped children form a
+ * header-less leading section.
  */
 export function groupNavChildren(children: NavChild[] | undefined): NavChildGroup[] {
   if (!children || children.length === 0) return []
-  if (!children.some((c) => c.group)) return [{ group: null, items: children }]
+  if (!children.some((c) => c.group || c.groupKey)) {
+    return [{ key: null, group: null, items: children }]
+  }
 
   const groups: NavChildGroup[] = []
-  let currentGroup: string | null = null
+  let currentKey: string | null = null
   for (const child of children) {
-    const group = child.group ?? null
-    if (group !== currentGroup || groups.length === 0) {
-      currentGroup = group
-      groups.push({ group, items: [] })
+    const key = child.groupKey ?? child.group ?? null
+    if (key !== currentKey || groups.length === 0) {
+      currentKey = key
+      groups.push({ key: child.groupKey ?? null, group: child.group ?? null, items: [] })
     }
     groups[groups.length - 1].items.push(child)
   }
   return groups
+}
+
+/** True when children should render as a two-level flyout / accordion. */
+export function hasNestedNavGroups(children: NavChild[] | undefined): boolean {
+  return !!children?.some((child) => !!child.groupKey)
+}
+
+/**
+ * Section-overview children share the parent's path (Inbound is `/channels`).
+ * Match those exactly so `/channels/widgets` does not light up Inbound;
+ * every other child uses prefix match.
+ */
+export function isNavChildActive(child: NavChild, sectionPath: string, routePath: string): boolean {
+  return child.path === sectionPath ? routePath === child.path : routePath.startsWith(child.path)
 }
 
 export interface NavItem {
@@ -71,8 +92,36 @@ const offlineModelsCount = ref(0)
 let featureStatusRequested = false
 
 /**
- * Single source of truth for the primary navigation (§4.4 target structure).
- * Consumed by the desktop rail (SidebarV2) and the mobile bottom nav so the
+ * Workspace seam — one named predicate per nav context
+ * (20260828-interface-streamlining-sprint / contract §6).
+ * When a real workspace capability exists later, only `canSeeManage` changes.
+ */
+export const canSeeWork = (): boolean => true
+export const canSeeManage = (signedIn: boolean): boolean => signedIn
+export const canSeeOperate = (isAdmin: boolean): boolean => isAdmin
+
+const LAST_MANAGE_KEY = 'synaplan.nav.lastManage'
+const LAST_OPERATE_KEY = 'synaplan.nav.lastOperate'
+
+export function rememberNavDestination(context: 'manage' | 'operate', path: string): void {
+  try {
+    localStorage.setItem(context === 'manage' ? LAST_MANAGE_KEY : LAST_OPERATE_KEY, path)
+  } catch {
+    // Private mode / storage blocked — last destination is optional.
+  }
+}
+
+export function lastNavDestination(context: 'manage' | 'operate'): string | null {
+  try {
+    return localStorage.getItem(context === 'manage' ? LAST_MANAGE_KEY : LAST_OPERATE_KEY)
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Single source of truth for the primary navigation.
+ * Consumed by the desktop rail (SidebarV2) and the mobile drawer so the
  * two surfaces can never drift apart.
  */
 export function useNavItems() {
@@ -82,6 +131,7 @@ export function useNavItems() {
   const configStore = useConfigStore()
 
   const isGuestMode = computed(() => !authStore.isAuthenticated)
+  const signedIn = computed(() => authStore.isAuthenticated)
 
   const loadFeatureStatus = async () => {
     try {
@@ -123,113 +173,154 @@ export function useNavItems() {
       },
     ]
 
-    // §4.4: Search lives INSIDE the Files page (Browse | Search tabs since
-    // phase 5) — the rail item is just "Files".
-    items.push({
-      key: 'files',
-      path: '/files',
-      label: t('nav.files'),
-      description: t('nav.filesDescription'),
-      icon: FolderIcon,
-      requiresAuth: true,
-      gateFeature: 'files',
-    })
+    // Guests: Chat + Sign in only. Sources is everyday work for signed-in users.
+    if (canSeeManage(signedIn.value)) {
+      items.push({
+        key: 'files',
+        path: '/files',
+        label: t('nav.files'),
+        description: t('nav.filesDescription'),
+        icon: FolderIcon,
+        requiresAuth: true,
+        gateFeature: 'files',
+      })
+    }
 
-    // Channels + AI Setup are always present (Q6: easy mode shows them locked;
-    // guests see them gate-locked). Canonical §4.6 URLs.
-    //
-    // Channels = where messages come in and go out. Grouped sub-menu:
-    // Standard Inbound, Your Widgets, Connections (Configure + MCP), API.
-    const channelsChildren: NavChild[] = [
-      { key: 'inbound', path: '/channels', label: t('nav.configInbound') },
-      { key: 'chat-widget', path: '/channels/widgets', label: t('nav.toolsChatWidget') },
-      ...(isSavedTasksEnabled()
-        ? [
-            {
-              key: 'connections',
-              path: '/channels/connections',
-              label: t('nav.configConnections'),
-              group: t('nav.connections'),
-            },
-          ]
-        : []),
-      {
-        key: 'mcp-servers',
-        path: '/channels/mcp',
-        label: t('nav.mcpServers'),
-        group: t('nav.connections'),
-      },
-      {
-        key: 'api-keys',
-        path: '/channels/api',
-        label: t('nav.configApiKeys'),
-        group: t('nav.groupApi'),
-      },
-      {
-        key: 'api-docs',
-        path: '/channels/api/docs',
-        label: t('pageTitles.configApiDocs'),
-        group: t('nav.groupApi'),
-      },
-    ]
+    if (canSeeManage(signedIn.value)) {
+      const assistants = t('nav.groupAssistants')
+      const channels = t('nav.channels')
+      const automations = t('nav.groupAutomations')
+      const tools = t('nav.groupTools')
+      const connections = t('nav.connections')
+      const api = t('nav.groupApi')
 
-    items.push({
-      key: 'channels',
-      path: '/channels',
-      label: t('nav.channels'),
-      description: t('nav.channelsDescription'),
-      icon: SignalIcon,
-      requiresAuth: true,
-      gateFeature: 'channels',
-      children: isGuestMode.value ? undefined : channelsChildren,
-    })
+      const grouped = (groupKey: string, group: string) => ({ groupKey, group })
 
-    // AI Setup & Tools = how the AI behaves plus the automation tools that
-    // run on top of it (recurring tasks, agents, summarizer, email handler).
-    const aiSetupChildren: NavChild[] = [
-      { key: 'ai-models', path: '/ai/models', label: t('nav.configAiModels') },
-      { key: 'task-prompts', path: '/ai/instructions', label: t('nav.configTaskPrompts') },
-      { key: 'sorting-prompt', path: '/ai/routing', label: t('nav.configSortingPrompt') },
-      ...(isSavedTasksEnabled()
-        ? [{ key: 'saved-tasks', path: '/channels/tasks', label: t('nav.savedTasks') }]
-        : []),
-      { key: 'ai-agents', path: '/channels/agents', label: t('nav.aiAgents') },
-      // Transitional home (Q3): retires into the in-chat Tools dropdown later.
-      { key: 'doc-summary', path: '/ai/summarizer', label: t('nav.toolsDocSummary') },
-      { key: 'mail-handler', path: '/channels/email', label: t('nav.toolsMailHandler') },
-    ]
+      const manageChildren: NavChild[] = [
+        {
+          key: 'ai-models',
+          path: '/ai/models',
+          label: t('nav.configAiModels'),
+          ...grouped('assistants', assistants),
+        },
+        {
+          key: 'task-prompts',
+          path: '/ai/instructions',
+          label: t('nav.configTaskPrompts'),
+          ...grouped('assistants', assistants),
+        },
+        {
+          key: 'sorting-prompt',
+          path: '/ai/routing',
+          label: t('nav.configSortingPrompt'),
+          ...grouped('assistants', assistants),
+        },
+        {
+          key: 'inbound',
+          path: '/channels',
+          label: t('nav.configInbound'),
+          ...grouped('channels', channels),
+        },
+        {
+          key: 'chat-widget',
+          path: '/channels/widgets',
+          label: t('nav.toolsChatWidget'),
+          ...grouped('channels', channels),
+        },
+        {
+          key: 'mail-handler',
+          path: '/channels/email',
+          label: t('nav.toolsMailHandler'),
+          ...grouped('channels', channels),
+        },
+        {
+          key: 'live-support',
+          path: '/channels/widgets/live-support',
+          label: t('nav.liveSupport'),
+          ...grouped('channels', channels),
+        },
+        ...(isSavedTasksEnabled()
+          ? [
+              {
+                key: 'connections',
+                path: '/channels/connections',
+                label: t('nav.configConnections'),
+                ...grouped('connections', connections),
+              },
+            ]
+          : []),
+        {
+          key: 'mcp-servers',
+          path: '/channels/mcp',
+          label: t('nav.mcpServers'),
+          ...grouped('connections', connections),
+        },
+        {
+          key: 'api-keys',
+          path: '/channels/api',
+          label: t('nav.configApiKeys'),
+          ...grouped('api', api),
+        },
+        {
+          key: 'api-docs',
+          path: '/channels/api/docs',
+          label: t('pageTitles.configApiDocs'),
+          ...grouped('api', api),
+        },
+        ...(isSavedTasksEnabled()
+          ? [
+              {
+                key: 'saved-tasks',
+                path: '/channels/tasks',
+                label: t('nav.savedTasks'),
+                ...grouped('automations', automations),
+              },
+            ]
+          : []),
+        {
+          key: 'ai-agents',
+          path: '/channels/agents',
+          label: t('nav.aiAgents'),
+          ...grouped('automations', automations),
+        },
+        {
+          key: 'doc-summary',
+          path: '/ai/summarizer',
+          label: t('nav.toolsDocSummary'),
+          ...grouped('tools', tools),
+        },
+      ]
 
-    items.push({
-      key: 'ai-setup',
-      path: '/ai/models',
-      label: t('nav.aiSetup'),
-      description: t('nav.aiSetupDescription'),
-      icon: CpuChipIcon,
-      requiresAuth: true,
-      gateFeature: 'aiSetup',
-      children: isGuestMode.value ? undefined : aiSetupChildren,
-    })
+      items.push({
+        key: 'manage',
+        path: '/channels',
+        label: t('nav.manage'),
+        description: t('nav.manageDescription'),
+        icon: WrenchScrewdriverIcon,
+        requiresAuth: true,
+        gateFeature: 'channels',
+        children: manageChildren,
+      })
+    }
 
-    if (configStore.plugins.length > 0) {
+    if (signedIn.value && configStore.plugins.length > 0) {
       items.push({
         key: 'plugins',
         path: '/plugins',
         label: t('nav.plugins'),
         icon: PuzzlePieceIcon,
         requiresAuth: true,
-        children: isGuestMode.value
-          ? undefined
-          : configStore.plugins.map((plugin: { name?: string }) => ({
-              key: `plugin-${plugin.name ?? 'unknown'}`,
-              path: `/plugins/${plugin.name}`,
-              label: plugin.name
-                ? plugin.name.charAt(0).toUpperCase() + plugin.name.slice(1)
-                : t('common.unknown'),
-            })),
+        children: configStore.plugins.map((plugin: { name?: string }) => ({
+          key: `plugin-${plugin.name ?? 'unknown'}`,
+          path: `/plugins/${plugin.name}`,
+          label: plugin.name
+            ? plugin.name.charAt(0).toUpperCase() + plugin.name.slice(1)
+            : t('common.unknown'),
+        })),
       })
     }
 
-    if (authStore.isAdmin) {
+    if (canSeeOperate(authStore.isAdmin)) {
       const adminChildren: NavChild[] = [
         { key: 'admin-dashboard', path: '/admin', label: t('nav.adminDashboard') },
       ]
@@ -286,16 +377,26 @@ export function useNavItems() {
       return route.path.startsWith('/files')
     }
     if (item.children && item.children.length > 0) {
-      // The section-overview child shares the section's own path (e.g. the
-      // Channels "Standard Inbound" child lives at /channels). It must match
-      // exactly, otherwise it would claim every /channels/* page — including
-      // the ones that now belong to AI Setup & Tools (tasks, agents, email).
-      return item.children.some((child) =>
-        child.path === item.path ? route.path === child.path : route.path.startsWith(child.path)
-      )
+      return item.children.some((child) => isNavChildActive(child, item.path, route.path))
     }
     return route.path.startsWith(item.path)
   }
 
-  return { navItems, isItemActive, isGuestMode, loadFeatureStatus }
+  watch(
+    () => route.path,
+    (path) => {
+      const manage = navItems.value.find((item) => item.key === 'manage')
+      if (manage?.children?.some((child) => isNavChildActive(child, manage.path, path))) {
+        rememberNavDestination('manage', path)
+      }
+      const operate = navItems.value.find((item) => item.key === 'admin')
+      if (
+        operate?.children?.some((child) => path === child.path || path.startsWith(`${child.path}/`))
+      ) {
+        rememberNavDestination('operate', path)
+      }
+    }
+  )
+
+  return { navItems, isItemActive, isGuestMode, loadFeatureStatus, signedIn }
 }

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -111,26 +111,26 @@
     "error": "Fehler",
     "chat": "Chat",
     "tools": "Tools",
-    "chatWidget": "Deine Widgets",
+    "chatWidget": "Chat-Widgets",
     "docSummary": "Zusammenfasser",
-    "mailHandler": "IMAP-E-Mail-Handler",
+    "mailHandler": "E-Mail-Handler",
     "plugins": "Plugins",
     "files": "Quellen",
     "memories": "Erinnerungen",
     "feedback": "Feedback",
     "ragSearch": "Suche",
     "vectorStorage": "Vektorspeicher",
-    "configInbound": "Standard-Eingang",
-    "configAiModels": "KI-Modell-Konfiguration",
+    "configInbound": "Eingang",
+    "configAiModels": "Modelle",
     "configProviderHiggsfield": "Higgsfield-Verbindung",
-    "configTaskPrompts": "Vordefinierte Anweisungen",
-    "configSortingPrompt": "Routing-Konfiguration",
+    "configTaskPrompts": "Anweisungen",
+    "configSortingPrompt": "Routing",
     "configApiKeys": "API-Schlüssel",
     "configApiDocs": "API-Dokumentation",
-    "statistics": "Statistiken",
+    "statistics": "Nutzung",
     "settings": "Einstellungen",
     "profile": "Profil",
-    "admin": "Admin-Panel",
+    "admin": "Betrieb",
     "adminFeatures": "Feature-Status",
     "adminModelStatus": "Modell-Status",
     "adminConfig": "Systemkonfiguration",
@@ -150,7 +150,7 @@
     "mcpServers": "MCP-Server",
     "aiAgents": "KI-Agenten",
     "connections": "Verbindungen",
-    "savedTasks": "Wiederkehrende Aufgaben",
+    "savedTasks": "Gespeicherte Aufgaben",
     "setup": "Einrichtung"
   },
   "adminModelStatus": {
@@ -329,7 +329,9 @@
       "public": "Öffentlich"
     },
     "fileOnlyDefaultMessage": "Bitte prüfe die angehängte Datei.",
-    "voiceMessageDefaultMessage": "Bitte antworte auf meine Sprachnachricht."
+    "voiceMessageDefaultMessage": "Bitte antworte auf meine Sprachnachricht.",
+    "conversation": "Unterhaltung",
+    "conversations": "Unterhaltungen"
   },
   "moderation": {
     "report": {
@@ -380,7 +382,7 @@
     }
   },
   "admin": {
-    "title": "Admin-Panel",
+    "title": "Betrieb",
     "description": "Systemverwaltung und Konfiguration",
     "tabs": {
       "overview": "Übersicht",
@@ -655,14 +657,14 @@
     "historyDescription": "Chat-Verlauf",
     "profile": "Profil",
     "tools": "Tools",
-    "toolsChatWidget": "Deine Widgets",
+    "toolsChatWidget": "Chat-Widgets",
     "toolsDocSummary": "Zusammenfasser",
-    "toolsMailHandler": "IMAP-E-Mail-Handler",
+    "toolsMailHandler": "E-Mail-Handler",
     "mcpServers": "MCP-Server",
     "connections": "Verbindungen",
     "configConnections": "Verbindungen einrichten",
     "groupApi": "API",
-    "savedTasks": "Wiederkehrende Aufgaben",
+    "savedTasks": "Gespeicherte Aufgaben",
     "plugins": "Plugins",
     "files": "Quellen",
     "filesDescription": "Quellen für deine Chats",
@@ -673,17 +675,17 @@
     "preferences": "Einstellungen",
     "account": "Konto",
     "accountDescription": "Konto & Einstellungen",
-    "configInbound": "Standard-Eingang",
-    "configAiModels": "KI-Modell-Konfiguration",
+    "configInbound": "Eingang",
+    "configAiModels": "Modelle",
     "configProviderHiggsfield": "Higgsfield-Verbindung",
-    "configTaskPrompts": "Vordefinierte Anweisungen",
-    "configSortingPrompt": "Routing-Konfiguration",
+    "configTaskPrompts": "Anweisungen",
+    "configSortingPrompt": "Routing",
     "configApiKeys": "API-Schlüssel",
-    "statistics": "Statistiken",
+    "statistics": "Nutzung",
     "subscription": "Abonnement",
     "upgrade": "Upgrade",
-    "admin": "Admin",
-    "adminDashboard": "Dashboard",
+    "admin": "Betrieb",
+    "adminDashboard": "Übersicht",
     "adminFeatureStatus": "Feature-Status",
     "adminModelStatus": "Modell-Status",
     "adminSystemConfig": "Systemkonfiguration",
@@ -691,7 +693,14 @@
     "more": "Mehr",
     "moreDescription": "Weitere Bereiche und Konto",
     "menu": "Menü",
-    "aiAgents": "KI-Agenten"
+    "aiAgents": "KI-Agenten",
+    "manage": "Verwalten",
+    "manageDescription": "Assistenten, Kanäle und Automatisierungen",
+    "groupAssistants": "Assistenten",
+    "groupAutomations": "Automatisierungen",
+    "groupTools": "Werkzeuge",
+    "liveSupport": "Live-Support",
+    "usage": "Nutzung"
   },
   "chatInput": {
     "attach": "Anhängen",
@@ -1214,7 +1223,8 @@
       "email": "E-Mail",
       "emailHint": "Deine Login-E-Mail (kann nicht geändert werden)",
       "phone": "Telefon",
-      "phonePlaceholder": "Optionale Telefonnummer"
+      "phonePlaceholder": "Optionale Telefonnummer",
+      "managedBy": "Dieses Konto wird von {provider} verwaltet"
     },
     "companyInfo": {
       "title": "Firmeninformationen",
@@ -1261,7 +1271,10 @@
       "newPasswordHint": "Mindestens 8 Zeichen",
       "confirmPassword": "Passwort bestätigen",
       "confirmPasswordPlaceholder": "Neues Passwort bestätigen",
-      "confirmPasswordHint": "Muss mit neuem Passwort übereinstimmen"
+      "confirmPasswordHint": "Muss mit neuem Passwort übereinstimmen",
+      "externalAuth": "Sie melden sich mit {provider} an. Die Passwortverwaltung erfolgt dort.",
+      "mismatch": "Die Passwörter stimmen nicht überein",
+      "tooShort": "Das Passwort muss mindestens 8 Zeichen haben"
     },
     "appSecurity": {
       "title": "App-Sicherheit",
@@ -1867,7 +1880,7 @@
       "promptContentSubtitle": "Markdown-formatierte System-Nachricht für dieses Topic.",
       "knowledgeTitle": "Wissensdatenbank",
       "knowledgeSubtitle": "Vektorisierte Dateien für RAG-Kontext verknüpfen.",
-      "openFileManager": "Dateimanager",
+      "openFileManager": "Quellen",
       "linkedFiles": "Verknüpfte Dateien ({n})",
       "noFilesLinked": "Noch keine Dateien verknüpft",
       "noFilesLinkedHint": "Verknüpfen Sie Dateien unten, um sie der Wissensdatenbank dieses Prompts hinzuzufügen.",
@@ -1876,7 +1889,7 @@
       "searchFilesPlaceholderShort": "Dateien suchen...",
       "loadingFiles": "Dateien werden geladen...",
       "noFilesMatch": "Keine Dateien für diese Suche.",
-      "noVectorizedFiles": "Keine vektorisierten Dateien verfügbar. Laden Sie zunächst Dateien im Dateimanager hoch.",
+      "noVectorizedFiles": "Keine vektorisierten Dateien verfügbar. Laden Sie zunächst Dateien unter Quellen hoch.",
       "linked": "Verknüpft",
       "linkFile": "Verknüpfen",
       "fileMeta": "{chunks} Chunks · {date}",
@@ -2844,7 +2857,9 @@
     "clearSelection": "Auswahl aufheben",
     "view": "Ansehen",
     "expand": "Erweitern",
-    "noResults": "Keine Ergebnisse"
+    "noResults": "Keine Ergebnisse",
+    "skipToContent": "Zum Inhalt springen",
+    "loadingMessages": "Nachrichten werden geladen…"
   },
   "search": {
     "sources": "Quellen",
@@ -3016,7 +3031,7 @@
     "useInChat": "Im Chat nutzen",
     "terms": {
       "vectorized": "KI-durchsuchbar",
-      "knowledgeGroup": "Wissensgruppe",
+      "knowledgeGroup": "Wissensordner",
       "incoming": "Eingang",
       "generated": "KI-erzeugt",
       "notApplicable": "nicht zutreffend"
@@ -3062,13 +3077,13 @@
     },
     "help": {
       "vectorized": "Wenn eine Datei KI-durchsuchbar ist, wird ihr Inhalt deiner Wissensbasis hinzugefügt, damit der Assistent ihn für Antworten nutzen kann.",
-      "group": "Wissensgruppen bündeln Dateien. Wenn die KI eine Gruppe durchsucht, kann sie jede Datei darin nutzen.",
+      "group": "Wissensordner bündeln Dateien. Wenn die KI einen Ordner durchsucht, kann sie jede Datei darin nutzen.",
       "source": "Woher diese Datei stammt – Upload, Chat, Outlook, Nextcloud, OpenCloud, WhatsApp, Widget, API oder KI-erzeugt.",
       "incoming": "Dateien, die andere Apps für deine Wissensbasis eingeliefert haben. Prüfe sie und behalte oder verwirf sie.",
       "typeFilter": "Nur eine Dateiart anzeigen – Dokumente, Bilder, Video oder Audio.",
       "vectorizedFilter": "Danach filtern, ob Dateien KI-durchsuchbar sind.",
       "reVectorize": "Diese Datei neu einlesen und das Wissen der KI daraus auffrischen. Nach Änderungen oder bei Fehlern verwenden.",
-      "moveGroup": "Dateien in eine andere Wissensgruppe verschieben. Das ändert, in welcher Gruppe die KI sie durchsucht – es wird nichts gelöscht.",
+      "moveGroup": "Dateien in einen anderen Wissensordner verschieben. Das ändert, in welchem Ordner die KI sucht — nichts wird gelöscht.",
       "storage": "Wie viel deines Speichers belegt ist. KI-erzeugte Medien zählen mit und werden separat angezeigt."
     },
     "empty": {
@@ -3301,7 +3316,8 @@
       "models": "Modelle",
       "adminOnlyTitle": "Admin-Zugriff erforderlich",
       "adminOnlyMessage": "Der Feature-Status ist nur für Administratoren verfügbar."
-    }
+    },
+    "notLoggedIn": "Nicht angemeldet"
   },
   "mail": {
     "status": {
@@ -3458,7 +3474,7 @@
       "knowledge": {
         "intro": "Fügen Sie Dokumente hinzu, damit der KI-Assistent Fragen zu Ihren Inhalten beantworten kann. Dieser Schritt ist optional.",
         "uploadLabel": "Dateien hochladen",
-        "pickLabel": "Aus Dateimanager wählen",
+        "pickLabel": "Aus Quellen wählen",
         "uploadHint": "PDF, Word, Text, Markdown, CSV oder JSON. Die Dateien werden nach dem Erstellen des Widgets verarbeitet.",
         "empty": "Noch keine Datenquellen — Sie können sie auch später hinzufügen."
       },
@@ -3931,7 +3947,7 @@
       "title": "Dateien auswählen",
       "searchPlaceholder": "Dateien suchen...",
       "noResults": "Keine Dateien gefunden.",
-      "noFiles": "Keine Dateien verfügbar. Laden Sie zuerst Dateien im Dateimanager hoch.",
+      "noFiles": "Keine Dateien verfügbar. Laden Sie zuerst Dateien unter Quellen hoch.",
       "selected": "{count} ausgewählt",
       "addFiles": "Dateien hinzufügen"
     },
@@ -4088,7 +4104,9 @@
       "robot": "Roboter",
       "message": "Nachricht",
       "support": "Support"
-    }
+    },
+    "listTitle": "Chat-Widgets",
+    "listEmpty": "Noch keine Widgets. Erstellen Sie ein Chat-Widget, um zu beginnen."
   },
   "widget": {
     "title": "Chat Support",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -111,26 +111,26 @@
     "error": "Error",
     "chat": "Chat",
     "tools": "Tools",
-    "chatWidget": "Your Widgets",
+    "chatWidget": "Chat widgets",
     "docSummary": "Summarizer",
-    "mailHandler": "IMAP Email Handler",
+    "mailHandler": "Email handler",
     "plugins": "Plugins",
     "files": "Sources",
     "memories": "Memories",
     "feedback": "Feedback",
     "ragSearch": "Search",
     "vectorStorage": "Vector Storage",
-    "configInbound": "Standard Inbound",
-    "configAiModels": "AI Model Config",
+    "configInbound": "Inbound",
+    "configAiModels": "Models",
     "configProviderHiggsfield": "Higgsfield Connection",
-    "configTaskPrompts": "Preconfigured Instructions",
-    "configSortingPrompt": "Routing Config",
+    "configTaskPrompts": "Instructions",
+    "configSortingPrompt": "Routing",
     "configApiKeys": "API Keys",
     "configApiDocs": "API Documentation",
-    "statistics": "Statistics",
+    "statistics": "Usage",
     "settings": "Preferences",
     "profile": "Profile",
-    "admin": "Admin Panel",
+    "admin": "Operate",
     "adminFeatures": "Feature Status",
     "adminModelStatus": "Model Status",
     "adminConfig": "System Configuration",
@@ -150,7 +150,7 @@
     "mcpServers": "MCP Servers",
     "aiAgents": "AI Agents",
     "connections": "Connections",
-    "savedTasks": "Saved Recurring Tasks",
+    "savedTasks": "Saved tasks",
     "setup": "Setup"
   },
   "adminModelStatus": {
@@ -334,7 +334,9 @@
       "public": "Public"
     },
     "fileOnlyDefaultMessage": "Please review the attached file.",
-    "voiceMessageDefaultMessage": "Please respond to my voice message."
+    "voiceMessageDefaultMessage": "Please respond to my voice message.",
+    "conversation": "conversation",
+    "conversations": "conversations"
   },
   "moderation": {
     "report": {
@@ -385,7 +387,7 @@
     }
   },
   "admin": {
-    "title": "Admin Panel",
+    "title": "Operate",
     "description": "System management and configuration",
     "tabs": {
       "overview": "Overview",
@@ -660,14 +662,14 @@
     "historyDescription": "Chat history",
     "profile": "Profile",
     "tools": "Tools",
-    "toolsChatWidget": "Your Widgets",
+    "toolsChatWidget": "Chat widgets",
     "toolsDocSummary": "Summarizer",
-    "toolsMailHandler": "IMAP Email Handler",
+    "toolsMailHandler": "Email handler",
     "mcpServers": "MCP Servers",
     "connections": "Connections",
     "configConnections": "Configure Connections",
     "groupApi": "API",
-    "savedTasks": "Saved Recurring Tasks",
+    "savedTasks": "Saved tasks",
     "plugins": "Plugins",
     "files": "Sources",
     "filesDescription": "Sources for your chats",
@@ -678,24 +680,31 @@
     "preferences": "Preferences",
     "account": "Account",
     "accountDescription": "Account & preferences",
-    "configInbound": "Standard Inbound",
-    "configAiModels": "AI Model Config",
-    "configTaskPrompts": "Preconfigured Instructions",
-    "configSortingPrompt": "Routing Config",
+    "configInbound": "Inbound",
+    "configAiModels": "Models",
+    "configTaskPrompts": "Instructions",
+    "configSortingPrompt": "Routing",
     "configApiKeys": "API Keys",
-    "statistics": "Statistics",
+    "statistics": "Usage",
     "subscription": "Subscription",
     "upgrade": "Upgrade",
-    "admin": "Admin",
-    "adminDashboard": "Dashboard",
+    "admin": "Operate",
+    "adminDashboard": "Overview",
     "adminFeatureStatus": "Feature Status",
     "adminModelStatus": "Model Status",
-    "adminSystemConfig": "System Config",
-    "adminProviderSetup": "AI Providers",
+    "adminSystemConfig": "System configuration",
+    "adminProviderSetup": "AI providers",
     "more": "More",
     "moreDescription": "More sections and account",
     "menu": "Menu",
-    "aiAgents": "AI Agents"
+    "aiAgents": "AI Agents",
+    "manage": "Manage",
+    "manageDescription": "Assistants, channels and automations",
+    "groupAssistants": "Assistants",
+    "groupAutomations": "Automations",
+    "groupTools": "Tools",
+    "liveSupport": "Live support",
+    "usage": "Usage"
   },
   "chatInput": {
     "placeholder": "Type your message...",
@@ -1176,7 +1185,7 @@
     "useInChat": "Use in chat",
     "terms": {
       "vectorized": "searchable by AI",
-      "knowledgeGroup": "knowledge group",
+      "knowledgeGroup": "knowledge folder",
       "incoming": "incoming",
       "generated": "AI-generated",
       "notApplicable": "not applicable"
@@ -1222,13 +1231,13 @@
     },
     "help": {
       "vectorized": "When a file is searchable by AI, its contents are added to your knowledge base so the assistant can use them to answer you.",
-      "group": "Knowledge groups bundle files together. When the AI searches a group, it can use every file in it.",
+      "group": "Knowledge folders bundle files together. When the AI searches a folder, it can use every file in it.",
       "source": "Where this file came from — an upload, a chat, Outlook, Nextcloud, OpenCloud, WhatsApp, the widget, the API, or AI-generated.",
       "incoming": "Files other apps pushed in for your knowledge base. Review them, then keep or dismiss.",
       "typeFilter": "Show only one kind of file — documents, images, video or audio.",
       "vectorizedFilter": "Filter by whether files are searchable by AI.",
       "reVectorize": "Re-read this file and refresh what the AI knows from it. Use after editing it or if it failed.",
-      "moveGroup": "Move files into another knowledge group. This changes which group the AI searches them in — it doesn't delete anything.",
+      "moveGroup": "Move files into another knowledge folder. This changes which folder the AI searches them in — it doesn't delete anything.",
       "storage": "How much of your storage you've used. AI-generated media counts too, shown separately."
     },
     "empty": {
@@ -1778,7 +1787,7 @@
       "promptContentSubtitle": "Markdown-formatted system message used for this topic.",
       "knowledgeTitle": "Knowledge Base",
       "knowledgeSubtitle": "Link vectorized files for retrieval-augmented context.",
-      "openFileManager": "File Manager",
+      "openFileManager": "Sources",
       "linkedFiles": "Linked files ({n})",
       "noFilesLinked": "No files linked yet",
       "noFilesLinkedHint": "Link files below to add them to this prompt's knowledge base.",
@@ -1787,7 +1796,7 @@
       "searchFilesPlaceholderShort": "Search files...",
       "loadingFiles": "Loading files...",
       "noFilesMatch": "No files match your search.",
-      "noVectorizedFiles": "No vectorized files available. Upload files in the Files page first.",
+      "noVectorizedFiles": "No vectorized files available. Upload files in Sources first.",
       "linked": "Linked",
       "linkFile": "Link",
       "fileMeta": "{chunks} chunks · {date}",
@@ -2660,7 +2669,7 @@
     "loadFailed": "Could not load provider status",
     "ownService": {
       "title": "Add your own service",
-      "description": "Need a provider that is not listed? Add it on the Edit models tab of AI Model Config.",
+      "description": "Need a provider that is not listed? Add it on the Edit models tab of Models.",
       "cta": "Add your own service"
     },
     "localAi": {
@@ -2775,7 +2784,9 @@
     "clearSelection": "Clear selection",
     "view": "View",
     "expand": "Expand",
-    "noResults": "No results"
+    "noResults": "No results",
+    "skipToContent": "Skip to content",
+    "loadingMessages": "Loading messages…"
   },
   "search": {
     "sources": "Sources",
@@ -3226,7 +3237,7 @@
       "knowledge": {
         "intro": "Add documents so the AI assistant can answer questions about your content. This step is optional.",
         "uploadLabel": "Upload files",
-        "pickLabel": "Choose from File Manager",
+        "pickLabel": "Choose from Sources",
         "uploadHint": "PDF, Word, text, Markdown, CSV or JSON. Files are processed after the widget is created.",
         "empty": "No data sources yet — you can also add them later."
       },
@@ -3699,7 +3710,7 @@
       "title": "Select Files",
       "searchPlaceholder": "Search files...",
       "noResults": "No files match your search.",
-      "noFiles": "No files available. Upload files first in the File Manager.",
+      "noFiles": "No files available. Upload files first in Sources.",
       "selected": "{count} selected",
       "addFiles": "Add Files"
     },
@@ -3856,7 +3867,9 @@
       "robot": "Robot",
       "message": "Message",
       "support": "Support"
-    }
+    },
+    "listTitle": "Chat widgets",
+    "listEmpty": "No widgets yet. Create a chat widget to get started."
   },
   "profile": {
     "title": "Profile Settings",
@@ -3870,7 +3883,8 @@
       "email": "Email",
       "emailHint": "Your login email (cannot be changed)",
       "phone": "Phone",
-      "phonePlaceholder": "Optional contact number"
+      "phonePlaceholder": "Optional contact number",
+      "managedBy": "This account is managed by {provider}"
     },
     "companyInfo": {
       "title": "Company Information",
@@ -3917,7 +3931,10 @@
       "newPasswordHint": "Minimum 8 characters",
       "confirmPassword": "Confirm Password",
       "confirmPasswordPlaceholder": "Confirm new password",
-      "confirmPasswordHint": "Must match new password"
+      "confirmPasswordHint": "Must match new password",
+      "externalAuth": "You're using {provider} to sign in. Password management is handled there.",
+      "mismatch": "Passwords do not match",
+      "tooShort": "Password must be at least 8 characters"
     },
     "appSecurity": {
       "title": "App Security",
@@ -4337,7 +4354,8 @@
       "models": "models",
       "adminOnlyTitle": "Admin access required",
       "adminOnlyMessage": "Feature status is available to administrators only."
-    }
+    },
+    "notLoggedIn": "Not logged in"
   },
   "cookies": {
     "title": "Cookie Settings",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -111,24 +111,24 @@
     "error": "Error",
     "chat": "Chat",
     "tools": "Herramientas",
-    "chatWidget": "Tus widgets",
+    "chatWidget": "Widgets de chat",
     "docSummary": "Resumidor",
-    "mailHandler": "Gestor de correo IMAP",
+    "mailHandler": "Gestor de correo",
     "plugins": "Plugins",
     "files": "Fuentes",
     "ragSearch": "Búsqueda",
     "vectorStorage": "Almacenamiento vectorial",
-    "configInbound": "Entrada estándar",
-    "configAiModels": "Configuración de modelos IA",
+    "configInbound": "Entrada",
+    "configAiModels": "Modelos",
     "configProviderHiggsfield": "Conexión con Higgsfield",
-    "configTaskPrompts": "Instrucciones predefinidas",
-    "configSortingPrompt": "Configuración de enrutamiento",
+    "configTaskPrompts": "Instrucciones",
+    "configSortingPrompt": "Enrutamiento",
     "configApiKeys": "Claves API",
     "configApiDocs": "Documentación API",
-    "statistics": "Estadísticas",
+    "statistics": "Uso",
     "settings": "Preferencias",
     "profile": "Perfil",
-    "admin": "Panel de administración",
+    "admin": "Operar",
     "adminFeatures": "Estado de funciones",
     "adminModelStatus": "Estado de modelos",
     "adminConfig": "Configuración del Sistema",
@@ -149,7 +149,7 @@
     "mcpServers": "Servidores MCP",
     "aiAgents": "Agentes de IA",
     "connections": "Conexiones",
-    "savedTasks": "Tareas recurrentes",
+    "savedTasks": "Tareas guardadas",
     "setup": "Configuración"
   },
   "adminModelStatus": {
@@ -327,7 +327,9 @@
       "public": "Público"
     },
     "fileOnlyDefaultMessage": "Por favor, revisa el archivo adjunto.",
-    "voiceMessageDefaultMessage": "Por favor, responde a mi mensaje de voz."
+    "voiceMessageDefaultMessage": "Por favor, responde a mi mensaje de voz.",
+    "conversation": "conversación",
+    "conversations": "conversaciones"
   },
   "moderation": {
     "report": {
@@ -378,7 +380,7 @@
     }
   },
   "admin": {
-    "title": "Panel de Administración",
+    "title": "Operar",
     "description": "Gestión y configuración del sistema",
     "tabs": {
       "overview": "Resumen",
@@ -648,14 +650,14 @@
     "history": "Historial",
     "historyDescription": "Historial de chats",
     "tools": "Herramientas",
-    "toolsChatWidget": "Tus widgets",
+    "toolsChatWidget": "Widgets de chat",
     "toolsDocSummary": "Resumidor",
-    "toolsMailHandler": "Gestor de correo IMAP",
+    "toolsMailHandler": "Gestor de correo",
     "mcpServers": "Servidores MCP",
     "connections": "Conexiones",
     "configConnections": "Configurar conexiones",
     "groupApi": "API",
-    "savedTasks": "Tareas recurrentes",
+    "savedTasks": "Tareas guardadas",
     "plugins": "Plugins",
     "files": "Fuentes",
     "filesDescription": "Fuentes para tus chats",
@@ -666,16 +668,16 @@
     "preferences": "Preferencias",
     "account": "Cuenta",
     "accountDescription": "Cuenta y preferencias",
-    "configInbound": "Entrada estándar",
-    "configAiModels": "Configuración de modelos IA",
-    "configTaskPrompts": "Instrucciones predefinidas",
-    "configSortingPrompt": "Configuración de enrutamiento",
+    "configInbound": "Entrada",
+    "configAiModels": "Modelos",
+    "configTaskPrompts": "Instrucciones",
+    "configSortingPrompt": "Enrutamiento",
     "configApiKeys": "Claves API",
-    "statistics": "Estadísticas",
+    "statistics": "Uso",
     "subscription": "Suscripción",
     "upgrade": "Mejorar",
-    "admin": "Admin",
-    "adminDashboard": "Panel",
+    "admin": "Operar",
+    "adminDashboard": "Resumen",
     "adminFeatureStatus": "Estado de Funciones",
     "adminModelStatus": "Estado de Modelos",
     "adminSystemConfig": "Configuración del Sistema",
@@ -684,7 +686,14 @@
     "more": "Más",
     "moreDescription": "Más secciones y cuenta",
     "menu": "Menú",
-    "aiAgents": "Agentes de IA"
+    "aiAgents": "Agentes de IA",
+    "manage": "Gestionar",
+    "manageDescription": "Asistentes, canales y automatizaciones",
+    "groupAssistants": "Asistentes",
+    "groupAutomations": "Automatizaciones",
+    "groupTools": "Herramientas",
+    "liveSupport": "Soporte en vivo",
+    "usage": "Uso"
   },
   "guest": {
     "disabledTitle": "El chat de invitados no está disponible",
@@ -1203,7 +1212,9 @@
     "disabled": "Deshabilitado",
     "reset": "Restablecer",
     "expand": "Expandir",
-    "noResults": "Sin resultados"
+    "noResults": "Sin resultados",
+    "skipToContent": "Saltar al contenido",
+    "loadingMessages": "Cargando mensajes…"
   },
   "search": {
     "sources": "Fuentes",
@@ -1412,7 +1423,7 @@
       "knowledge": {
         "intro": "Añade documentos para que el asistente de IA pueda responder preguntas sobre tu contenido. Este paso es opcional.",
         "uploadLabel": "Subir archivos",
-        "pickLabel": "Elegir del Gestor de Archivos",
+        "pickLabel": "Elegir de Fuentes",
         "uploadHint": "PDF, Word, texto, Markdown, CSV o JSON. Los archivos se procesan después de crear el widget.",
         "empty": "Aún no hay fuentes de datos — también puedes añadirlas más tarde."
       },
@@ -1592,7 +1603,9 @@
       "modelNotConfigured": "No hay modelo de IA configurado. Selecciona uno en Configuración Avanzada → Configuración IA → Prompt y Modelo.",
       "editHintTitle": "¿Quieres afinar tu asistente de IA?",
       "editHintDescription": "Después de guardar, puedes afinar tu asistente de IA en cualquier momento en Configuración Avanzada → Configuración IA → Asistente IA del Widget."
-    }
+    },
+    "listTitle": "Widgets de chat",
+    "listEmpty": "Aún no hay widgets. Crea un widget de chat para empezar."
   },
   "profile": {
     "title": "Configuración de Perfil",
@@ -1606,7 +1619,8 @@
       "email": "Correo",
       "emailHint": "Tu correo de inicio de sesión (no se puede cambiar)",
       "phone": "Teléfono",
-      "phonePlaceholder": "Número de contacto opcional"
+      "phonePlaceholder": "Número de contacto opcional",
+      "managedBy": "Esta cuenta la gestiona {provider}"
     },
     "companyInfo": {
       "title": "Información de Empresa",
@@ -1646,7 +1660,10 @@
       "newPasswordHint": "Mínimo 8 caracteres",
       "confirmPassword": "Confirmar Contraseña",
       "confirmPasswordPlaceholder": "Confirma nueva contraseña",
-      "confirmPasswordHint": "Debe coincidir con la nueva contraseña"
+      "confirmPasswordHint": "Debe coincidir con la nueva contraseña",
+      "externalAuth": "Inicias sesión con {provider}. La contraseña se gestiona allí.",
+      "mismatch": "Las contraseñas no coinciden",
+      "tooShort": "La contraseña debe tener al menos 8 caracteres"
     },
     "appSecurity": {
       "title": "Seguridad de la app",
@@ -2183,7 +2200,8 @@
       "models": "modelos",
       "adminOnlyTitle": "Se requiere acceso de administrador",
       "adminOnlyMessage": "El estado de las funciones solo está disponible para administradores."
-    }
+    },
+    "notLoggedIn": "No has iniciado sesión"
   },
   "storage": {
     "title": "Cuota de Almacenamiento",
@@ -2340,7 +2358,7 @@
     "status_error": "Error",
     "terms": {
       "vectorized": "consultable por IA",
-      "knowledgeGroup": "grupo de conocimiento",
+      "knowledgeGroup": "carpeta de conocimiento",
       "incoming": "entrantes",
       "generated": "generado por IA",
       "notApplicable": "no aplicable"
@@ -2386,13 +2404,13 @@
     },
     "help": {
       "vectorized": "Cuando un archivo es consultable por IA, su contenido se añade a tu base de conocimiento para que el asistente pueda usarlo al responderte.",
-      "group": "Los grupos de conocimiento agrupan archivos. Cuando la IA busca en un grupo, puede usar todos sus archivos.",
+      "group": "Las carpetas de conocimiento agrupan archivos. Cuando la IA busca en una carpeta, puede usar cada archivo.",
       "source": "De dónde viene este archivo: una subida, un chat, Outlook, Nextcloud, OpenCloud, WhatsApp, el widget, la API o generado por IA.",
       "incoming": "Archivos que otras apps han enviado para tu base de conocimiento. Revísalos y consérvalos o descártalos.",
       "typeFilter": "Mostrar solo un tipo de archivo: documentos, imágenes, vídeo o audio.",
       "vectorizedFilter": "Filtrar según si los archivos son consultables por IA.",
       "reVectorize": "Volver a leer este archivo y actualizar lo que la IA sabe de él. Úsalo tras editarlo o si falló.",
-      "moveGroup": "Mover archivos a otro grupo de conocimiento. Esto cambia en qué grupo los busca la IA; no elimina nada.",
+      "moveGroup": "Mueve archivos a otra carpeta de conocimiento. Cambia dónde los busca la IA — no elimina nada.",
       "storage": "Cuánto almacenamiento has usado. El contenido generado por IA también cuenta y se muestra por separado."
     },
     "empty": {

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -111,24 +111,24 @@
     "error": "Hata",
     "chat": "Sohbet",
     "tools": "Araçlar",
-    "chatWidget": "Widget'ların",
+    "chatWidget": "Sohbet widget'ları",
     "docSummary": "Özetleyici",
-    "mailHandler": "IMAP E-posta İşleyici",
+    "mailHandler": "E-posta işleyici",
     "plugins": "Eklentiler",
     "files": "Kaynaklar",
     "ragSearch": "Arama",
     "vectorStorage": "Vektör Deposu",
-    "configInbound": "Standart Gelen",
-    "configAiModels": "AI Model Yapılandırması",
+    "configInbound": "Gelen",
+    "configAiModels": "Modeller",
     "configProviderHiggsfield": "Higgsfield Bağlantısı",
-    "configTaskPrompts": "Hazır Talimatlar",
-    "configSortingPrompt": "Yönlendirme Yapılandırması",
+    "configTaskPrompts": "Talimatlar",
+    "configSortingPrompt": "Yönlendirme",
     "configApiKeys": "API Anahtarları",
     "configApiDocs": "API Dokümantasyonu",
-    "statistics": "İstatistikler",
+    "statistics": "Kullanım",
     "settings": "Tercihler",
     "profile": "Profil",
-    "admin": "Yönetici Paneli",
+    "admin": "İşlet",
     "adminFeatures": "Özellik Durumu",
     "adminModelStatus": "Model Durumu",
     "adminConfig": "Sistem Yapılandırması",
@@ -149,7 +149,7 @@
     "mcpServers": "MCP Sunucuları",
     "aiAgents": "Yapay zeka ajanları",
     "connections": "Bağlantılar",
-    "savedTasks": "Yinelenen görevler",
+    "savedTasks": "Kayıtlı görevler",
     "setup": "Kurulum"
   },
   "adminModelStatus": {
@@ -327,7 +327,9 @@
       "public": "Herkese Açık"
     },
     "fileOnlyDefaultMessage": "Lütfen ekteki dosyayı inceleyin.",
-    "voiceMessageDefaultMessage": "Lütfen sesli mesajıma yanıt verin."
+    "voiceMessageDefaultMessage": "Lütfen sesli mesajıma yanıt verin.",
+    "conversation": "sohbet",
+    "conversations": "sohbetler"
   },
   "moderation": {
     "report": {
@@ -378,7 +380,7 @@
     }
   },
   "admin": {
-    "title": "Yönetici Paneli",
+    "title": "İşlet",
     "description": "Sistem yönetimi ve yapılandırma",
     "tabs": {
       "overview": "Genel Bakış",
@@ -648,14 +650,14 @@
     "history": "Geçmiş",
     "historyDescription": "Sohbet geçmişi",
     "tools": "Araçlar",
-    "toolsChatWidget": "Widget'ların",
+    "toolsChatWidget": "Sohbet widget'ları",
     "toolsDocSummary": "Özetleyici",
-    "toolsMailHandler": "IMAP E-posta İşleyici",
+    "toolsMailHandler": "E-posta işleyici",
     "mcpServers": "MCP Sunucuları",
     "connections": "Bağlantılar",
     "configConnections": "Bağlantıları yapılandır",
     "groupApi": "API",
-    "savedTasks": "Yinelenen görevler",
+    "savedTasks": "Kayıtlı görevler",
     "plugins": "Eklentiler",
     "files": "Kaynaklar",
     "filesDescription": "Sohbetleriniz için kaynaklar",
@@ -666,16 +668,16 @@
     "preferences": "Tercihler",
     "account": "Hesap",
     "accountDescription": "Hesap ve tercihler",
-    "configInbound": "Standart Gelen",
-    "configAiModels": "AI Model Yapılandırması",
-    "configTaskPrompts": "Hazır Talimatlar",
-    "configSortingPrompt": "Yönlendirme Yapılandırması",
+    "configInbound": "Gelen",
+    "configAiModels": "Modeller",
+    "configTaskPrompts": "Talimatlar",
+    "configSortingPrompt": "Yönlendirme",
     "configApiKeys": "API Anahtarları",
-    "statistics": "İstatistikler",
+    "statistics": "Kullanım",
     "subscription": "Abonelik",
     "upgrade": "Yükselt",
-    "admin": "Yönetici",
-    "adminDashboard": "Kontrol Paneli",
+    "admin": "İşlet",
+    "adminDashboard": "Genel bakış",
     "adminFeatureStatus": "Özellik Durumu",
     "adminModelStatus": "Model Durumu",
     "adminSystemConfig": "Sistem Yapılandırması",
@@ -684,7 +686,14 @@
     "more": "Daha fazla",
     "moreDescription": "Diğer bölümler ve hesap",
     "menu": "Menü",
-    "aiAgents": "Yapay zeka ajanları"
+    "aiAgents": "Yapay zeka ajanları",
+    "manage": "Yönet",
+    "manageDescription": "Asistanlar, kanallar ve otomasyonlar",
+    "groupAssistants": "Asistanlar",
+    "groupAutomations": "Otomasyonlar",
+    "groupTools": "Araçlar",
+    "liveSupport": "Canlı destek",
+    "usage": "Kullanım"
   },
   "guest": {
     "disabledTitle": "Misafir sohbeti kullanılamıyor",
@@ -1203,7 +1212,9 @@
     "disabled": "Devre Dışı",
     "reset": "Sıfırla",
     "expand": "Genişlet",
-    "noResults": "Sonuç bulunamadı"
+    "noResults": "Sonuç bulunamadı",
+    "skipToContent": "İçeriğe geç",
+    "loadingMessages": "Mesajlar yükleniyor…"
   },
   "search": {
     "sources": "Kaynaklar",
@@ -1412,7 +1423,7 @@
       "knowledge": {
         "intro": "AI asistanının içeriğinizle ilgili soruları yanıtlayabilmesi için belgeler ekleyin. Bu adım isteğe bağlıdır.",
         "uploadLabel": "Dosya yükle",
-        "pickLabel": "Dosya Yöneticisinden seç",
+        "pickLabel": "Kaynaklardan seç",
         "uploadHint": "PDF, Word, metin, Markdown, CSV veya JSON. Dosyalar widget oluşturulduktan sonra işlenir.",
         "empty": "Henüz veri kaynağı yok — daha sonra da ekleyebilirsiniz."
       },
@@ -1592,7 +1603,9 @@
       "modelNotConfigured": "AI modeli yapılandırılmamış. Lütfen Gelişmiş Ayarlar → AI Kurulumu → Prompt ve Model altından bir model seçin.",
       "editHintTitle": "AI asistanınızı ince ayarlamak ister misiniz?",
       "editHintDescription": "Kaydettikten sonra, AI asistanınızı Gelişmiş Ayarlar → AI Kurulumu → Widget AI Sihirbazı altından istediğiniz zaman ince ayarlayabilirsiniz."
-    }
+    },
+    "listTitle": "Sohbet widget'ları",
+    "listEmpty": "Henüz widget yok. Başlamak için bir sohbet widget'ı oluşturun."
   },
   "profile": {
     "title": "Profil Ayarları",
@@ -1606,7 +1619,8 @@
       "email": "E-posta",
       "emailHint": "Giriş e-postanız (değiştirilemez)",
       "phone": "Telefon",
-      "phonePlaceholder": "İsteğe bağlı iletişim numarası"
+      "phonePlaceholder": "İsteğe bağlı iletişim numarası",
+      "managedBy": "Bu hesap {provider} tarafından yönetiliyor"
     },
     "companyInfo": {
       "title": "Şirket Bilgileri",
@@ -1646,7 +1660,10 @@
       "newPasswordHint": "En az 8 karakter",
       "confirmPassword": "Şifreyi Onayla",
       "confirmPasswordPlaceholder": "Yeni şifreyi onaylayın",
-      "confirmPasswordHint": "Yeni şifreyle eşleşmeli"
+      "confirmPasswordHint": "Yeni şifreyle eşleşmeli",
+      "externalAuth": "{provider} ile giriş yapıyorsunuz. Parola orada yönetilir.",
+      "mismatch": "Parolalar eşleşmiyor",
+      "tooShort": "Parola en az 8 karakter olmalı"
     },
     "appSecurity": {
       "title": "Uygulama güvenliği",
@@ -2184,7 +2201,8 @@
       "models": "model",
       "adminOnlyTitle": "Yönetici erişimi gerekli",
       "adminOnlyMessage": "Özellik durumu yalnızca yöneticiler için kullanılabilir."
-    }
+    },
+    "notLoggedIn": "Oturum açılmadı"
   },
   "storage": {
     "title": "Depolama Kotası",
@@ -2341,7 +2359,7 @@
     "status_error": "Hata",
     "terms": {
       "vectorized": "yapay zekâ ile aranabilir",
-      "knowledgeGroup": "bilgi grubu",
+      "knowledgeGroup": "bilgi klasörü",
       "incoming": "gelen",
       "generated": "yapay zekâ üretimi",
       "notApplicable": "uygulanamaz"
@@ -2387,13 +2405,13 @@
     },
     "help": {
       "vectorized": "Bir dosya yapay zekâ ile aranabilir olduğunda içeriği bilgi tabanınıza eklenir; böylece asistan yanıt verirken bunu kullanabilir.",
-      "group": "Bilgi grupları dosyaları bir araya getirir. Yapay zekâ bir grupta arama yaptığında içindeki tüm dosyaları kullanabilir.",
+      "group": "Bilgi klasörleri dosyaları bir araya getirir. AI bir klasörde arama yaptığında içindeki her dosyayı kullanabilir.",
       "source": "Bu dosyanın nereden geldiği — yükleme, sohbet, Outlook, Nextcloud, OpenCloud, WhatsApp, widget, API veya yapay zekâ üretimi.",
       "incoming": "Diğer uygulamaların bilgi tabanınız için gönderdiği dosyalar. İnceleyin, sonra saklayın veya çıkarın.",
       "typeFilter": "Yalnızca tek bir dosya türünü göster — belgeler, görseller, video veya ses.",
       "vectorizedFilter": "Dosyaların yapay zekâ ile aranabilir olup olmadığına göre filtrele.",
       "reVectorize": "Bu dosyayı yeniden okuyup yapay zekânın ondan öğrendiklerini tazele. Düzenledikten sonra veya başarısız olduğunda kullan.",
-      "moveGroup": "Dosyaları başka bir bilgi grubuna taşı. Bu, yapay zekânın onları hangi grupta aradığını değiştirir; hiçbir şey silinmez.",
+      "moveGroup": "Dosyaları başka bir bilgi klasörüne taşıyın. AI'nın aradığı klasör değişir — hiçbir şey silinmez.",
       "storage": "Depolamanızın ne kadarını kullandığınız. Yapay zekâ üretimi içerik de sayılır ve ayrı gösterilir."
     },
     "empty": {

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -25,6 +25,7 @@ import {
   SETUP_ROUTE,
 } from '@/router/setupGate'
 import { i18n } from '@/i18n'
+import { inferNavContext } from '@/router/navContext'
 import { getErrorMessage } from '@/utils/errorMessage'
 import LoadingView from '@/views/LoadingView.vue'
 
@@ -526,6 +527,10 @@ router.afterEach((to, from) => {
   // load or in-place query/hash updates.
   if (to.path !== from.path) {
     triggerHapticImpact('light')
+  }
+
+  if (!to.meta.context) {
+    to.meta.context = inferNavContext(to.path, to.meta as Record<string, unknown>)
   }
 
   const titleKey = to.meta.titleKey as string | undefined

--- a/frontend/src/router/navContext.ts
+++ b/frontend/src/router/navContext.ts
@@ -1,0 +1,47 @@
+/**
+ * Additive route classification for the Work / Manage / Operate shell.
+ * Does not change guards — callers may read `meta.context` only.
+ */
+export type NavContext = 'work' | 'manage' | 'operate' | 'personal' | 'public'
+
+export function inferNavContext(path: string, meta: Record<string, unknown> = {}): NavContext {
+  if (
+    meta.public === true ||
+    path.startsWith('/shared') ||
+    path.startsWith('/addin/') ||
+    path === '/account-deletion' ||
+    path === '/login' ||
+    path === '/register' ||
+    path === '/forgot-password' ||
+    path === '/reset-password'
+  ) {
+    return 'public'
+  }
+
+  if (path.startsWith('/admin') || path === '/setup' || meta.requiresAdmin === true) {
+    return 'operate'
+  }
+
+  if (
+    path.startsWith('/profile') ||
+    path.startsWith('/settings') ||
+    path.startsWith('/memories') ||
+    path.startsWith('/statistics') ||
+    path.startsWith('/feedbacks') ||
+    path.startsWith('/subscription')
+  ) {
+    return 'personal'
+  }
+
+  if (
+    path.startsWith('/channels') ||
+    path.startsWith('/ai') ||
+    path.startsWith('/plugins') ||
+    path.startsWith('/tools') ||
+    path.startsWith('/config')
+  ) {
+    return 'manage'
+  }
+
+  return 'work'
+}

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -81,7 +81,7 @@
                 d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
               />
             </svg>
-            <span class="ml-2 txt-secondary text-sm">Loading messages...</span>
+            <span class="ml-2 txt-secondary text-sm">{{ $t('common.loadingMessages') }}</span>
           </div>
 
           <div
@@ -189,7 +189,7 @@
             </div>
 
             <ExamplePrompts
-              v-if="!authStore.isAuthenticated && !configStore.marketingNews.enabled"
+              v-if="!incognitoStore.active && !configStore.marketingNews.enabled"
               @pick="handleExamplePick"
             />
             <MarketingNews v-if="!authStore.isAuthenticated && configStore.marketingNews.enabled" />
@@ -705,15 +705,7 @@ const modelMixStore = useModelMixStore()
 const mixPanelDismissed = ref(false)
 const inlineMixPanelEl = ref<HTMLElement | null>(null)
 
-const showInlineMixPanel = computed(
-  () =>
-    authStore.isAuthenticated &&
-    !needsProviderSetup.value &&
-    !incognitoStore.active &&
-    !mixPanelDismissed.value &&
-    historyStore.messages.length === 0 &&
-    !historyStore.isLoadingMessages
-)
+const showInlineMixPanel = computed(() => false)
 
 watch(showInlineMixPanel, (visible) => {
   modelMixStore.inlinePanelVisible = visible

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -300,6 +300,7 @@
                 <button
                   type="button"
                   class="absolute right-3 top-1/2 -translate-y-1/2 p-1 rounded-md txt-secondary hover:txt-primary hover:bg-black/5 dark:hover:bg-white/10 transition-all duration-150"
+                  :aria-label="showPassword ? $t('auth.hidePassword') : $t('auth.showPassword')"
                   data-testid="btn-toggle-password"
                   @click="showPassword = !showPassword"
                 >
@@ -386,18 +387,18 @@
           :href="config.branding.homepageUrl"
           target="_blank"
           rel="noopener noreferrer"
-          class="group inline-flex items-center gap-1.5 opacity-40 hover:opacity-60 transition-all duration-300"
+          class="group inline-flex items-center gap-1.5 transition-all duration-300"
           :data-testid="config.billing.enabled ? 'link-homepage' : 'link-powered-by'"
         >
           <span
             v-if="config.branding.showPoweredBy"
-            class="text-[10px] txt-secondary tracking-wide"
+            class="text-[10px] txt-secondary group-hover:txt-primary tracking-wide transition-colors duration-300"
             >{{ $t('branding.poweredBy') }}</span
           >
           <img
             :src="logoSrc"
             :alt="config.branding.name"
-            class="h-3.5 opacity-70 group-hover:opacity-100 transition-opacity duration-300"
+            class="h-3.5 opacity-50 group-hover:opacity-100 transition-opacity duration-300"
           />
         </a>
       </div>

--- a/frontend/src/views/ProfileView.vue
+++ b/frontend/src/views/ProfileView.vue
@@ -67,7 +67,7 @@
                   data-testid="input-email"
                 />
                 <p v-if="isExternalAuth" class="text-xs txt-secondary mt-1">
-                  This account is managed by {{ authProvider }}
+                  {{ $t('profile.personalInfo.managedBy', { provider: authProvider }) }}
                 </p>
               </div>
 
@@ -300,10 +300,11 @@
               <div class="flex items-start gap-3">
                 <Icon icon="mdi:shield-check" class="w-6 h-6 info-box-blue-icon flex-shrink-0" />
                 <div class="flex-1">
-                  <p class="text-sm info-box-blue-title mb-1">🔒 Managed by {{ authProvider }}</p>
+                  <p class="text-sm info-box-blue-title mb-1">
+                    {{ $t('profile.personalInfo.managedBy', { provider: authProvider }) }}
+                  </p>
                   <p class="text-sm info-box-blue-text mb-2">
-                    You're using {{ authProvider }} to sign in. Password management is handled
-                    through {{ authProvider }}.
+                    {{ $t('profile.changePassword.externalAuth', { provider: authProvider }) }}
                   </p>
                   <p v-if="externalAuthLastLogin" class="text-xs info-box-blue-text">
                     Last authenticated: {{ externalAuthLastLogin }}
@@ -817,12 +818,12 @@ const handleSave = saveChanges(async () => {
   // Validate password if provided (only for local auth users)
   if (canChangePassword.value && passwordData.value.new) {
     if (passwordData.value.new !== passwordData.value.confirm) {
-      error('Passwords do not match')
+      error(t('profile.changePassword.mismatch'))
       throw new Error('Validation failed')
     }
 
     if (passwordData.value.new.length < 8) {
-      error('Password must be at least 8 characters')
+      error(t('profile.changePassword.tooShort'))
       throw new Error('Validation failed')
     }
   }

--- a/frontend/src/views/RegisterView.vue
+++ b/frontend/src/views/RegisterView.vue
@@ -268,6 +268,7 @@
                 <button
                   type="button"
                   class="absolute right-3 top-1/2 -translate-y-1/2 p-1 rounded-md txt-secondary hover:txt-primary hover:bg-black/5 dark:hover:bg-white/10 transition-all duration-150"
+                  :aria-label="showPassword ? $t('auth.hidePassword') : $t('auth.showPassword')"
                   data-testid="btn-toggle-password"
                   @click="showPassword = !showPassword"
                 >
@@ -307,6 +308,9 @@
                 <button
                   type="button"
                   class="absolute right-3 top-1/2 -translate-y-1/2 p-1 rounded-md txt-secondary hover:txt-primary hover:bg-black/5 dark:hover:bg-white/10 transition-all duration-150"
+                  :aria-label="
+                    showConfirmPassword ? $t('auth.hidePassword') : $t('auth.showPassword')
+                  "
                   data-testid="btn-toggle-confirm-password"
                   @click="showConfirmPassword = !showConfirmPassword"
                 >
@@ -395,18 +399,18 @@
           :href="config.branding.homepageUrl"
           target="_blank"
           rel="noopener noreferrer"
-          class="group inline-flex items-center gap-1.5 opacity-40 hover:opacity-60 transition-all duration-300"
+          class="group inline-flex items-center gap-1.5 transition-all duration-300"
           :data-testid="config.billing.enabled ? 'link-homepage' : 'link-powered-by'"
         >
           <span
             v-if="config.branding.showPoweredBy"
-            class="text-[10px] txt-secondary tracking-wide"
+            class="text-[10px] txt-secondary group-hover:txt-primary tracking-wide transition-colors duration-300"
             >{{ $t('branding.poweredBy') }}</span
           >
           <img
             :src="logoSrc"
             :alt="config.branding.name"
-            class="h-3.5 opacity-70 group-hover:opacity-100 transition-opacity duration-300"
+            class="h-3.5 opacity-50 group-hover:opacity-100 transition-opacity duration-300"
           />
         </a>
       </div>

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -114,7 +114,9 @@
                 <label class="block text-sm font-medium txt-secondary mb-1">{{
                   $t('settings.account.email')
                 }}</label>
-                <div class="txt-primary">{{ authStore.user?.email || 'Not logged in' }}</div>
+                <div class="txt-primary">
+                  {{ authStore.user?.email || $t('settings.notLoggedIn') }}
+                </div>
               </div>
               <div data-testid="text-account-level">
                 <label class="block text-sm font-medium txt-secondary mb-1">{{

--- a/frontend/tests/e2e/helpers/chat.ts
+++ b/frontend/tests/e2e/helpers/chat.ts
@@ -116,7 +116,7 @@ export class ChatHelper {
     await this.page.evaluate(() => localStorage.setItem('app_mode', 'advanced'))
     await this.page.reload()
     await this.page
-      .locator(selectors.nav.sidebarV2Channels)
+      .locator(selectors.nav.sidebarV2Manage)
       .waitFor({ state: 'visible', timeout: TIMEOUTS.STANDARD })
   }
 

--- a/frontend/tests/e2e/helpers/selectors.ts
+++ b/frontend/tests/e2e/helpers/selectors.ts
@@ -51,6 +51,10 @@ export const selectors = {
   nav: {
     sidebar: '[data-testid="comp-sidebar-v2"]',
     navDropdown: '[data-testid="dropdown-sidebar-v2-nav"]',
+    /** Second-level Manage flyout (Assistants / Channels / …) */
+    navSubDropdown: '[data-testid="dropdown-sidebar-v2-nav-sub"]',
+    flyoutGroup: (key: string) => `[data-testid="btn-sidebar-v2-group-${key}"]`,
+    mobileMoreGroup: (key: string) => `[data-testid="btn-mobile-more-group-${key}"]`,
     /** Full-screen backdrop behind an open rail flyout; click it to dismiss. */
     navOverlay: '[data-testid="overlay-sidebar-v2-nav"]',
     /** Expand sidebar when collapsed (so chat dropdown is visible) */
@@ -70,7 +74,8 @@ export const selectors = {
     /** Inline "More" section that expands under the primary buttons */
     mobileMoreSheet: '[data-testid="sheet-mobile-more"]',
     mobileMoreAccountSection: '[data-testid="section-mobile-more-account"]',
-    mobileMoreChannels: '[data-testid="btn-mobile-more-channels"]',
+    mobileMoreChannels: '[data-testid="btn-mobile-more-manage"]',
+    mobileMoreManage: '[data-testid="btn-mobile-more-manage"]',
     mobileMoreInbound: '[data-testid="link-mobile-more-inbound"]',
     mobileMorePreferences: '[data-testid="btn-mobile-more-preferences"]',
     /** In-drawer chat history (paginated, infinite scroll) */
@@ -87,11 +92,13 @@ export const selectors = {
     sidebarV2ChatNav: '[data-testid="btn-sidebar-v2-nav-chat"]',
     /** V2 sidebar: files nav icon */
     sidebarV2Files: '[data-testid="btn-sidebar-v2-nav-files"]',
-    /** V2 sidebar: Channels rail item (locked in easy mode, flyout in advanced) */
-    sidebarV2Channels: '[data-testid="btn-sidebar-v2-nav-channels"]',
-    /** V2 sidebar: AI Setup rail item (locked in easy mode, flyout in advanced) */
-    sidebarV2AiSetup: '[data-testid="btn-sidebar-v2-nav-ai-setup"]',
-    /** V2 sidebar: admin nav icon (admin only) */
+    /** V2 sidebar: Manage rail item (Channels + assistants + automations) */
+    sidebarV2Manage: '[data-testid="btn-sidebar-v2-nav-manage"]',
+    /** Alias kept while specs migrate off the old Channels rail item */
+    sidebarV2Channels: '[data-testid="btn-sidebar-v2-nav-manage"]',
+    /** Alias kept while specs migrate off the old AI Setup rail item */
+    sidebarV2AiSetup: '[data-testid="btn-sidebar-v2-nav-manage"]',
+    /** V2 sidebar: admin / Operate nav icon (admin only) */
     sidebarV2Admin: '[data-testid="btn-sidebar-v2-nav-admin"]',
     /** V2 rail: always-visible label node inside each nav button (§4.1 #3) */
     railLabel: '.v2-rail-label',
@@ -103,6 +110,7 @@ export const selectors = {
     /** Channels flyout children shown only when Saved Tasks is enabled (features.savedTasks) */
     flyoutLinkConnections: '[data-testid="link-sidebar-v2-connections"]',
     flyoutLinkSavedTasks: '[data-testid="link-sidebar-v2-saved-tasks"]',
+    flyoutLinkLiveSupport: '[data-testid="link-sidebar-v2-live-support"]',
     flyoutLinkAiModels: '[data-testid="link-sidebar-v2-ai-models"]',
     flyoutLinkTaskPrompts: '[data-testid="link-sidebar-v2-task-prompts"]',
     flyoutLinkAdminDashboard: '[data-testid="link-sidebar-v2-admin-dashboard"]',

--- a/frontend/tests/e2e/tests/files-tabs.spec.ts
+++ b/frontend/tests/e2e/tests/files-tabs.spec.ts
@@ -40,10 +40,8 @@ test.describe('@ci Files tabs', () => {
       await expect(page.locator(selectors.rag.page)).toBeVisible({ timeout: TIMEOUTS.STANDARD })
     })
 
-    await test.step('Vectors tab navigates to /files/vectors', async () => {
-      await page.locator(FILES.tabVectors).click()
-      await expect(page).toHaveURL(/\/files\/vectors/, { timeout: TIMEOUTS.STANDARD })
-      await expect(page.locator(FILES.pageVectors)).toBeVisible({ timeout: TIMEOUTS.STANDARD })
+    await test.step('Vectors tab is admin-only (hidden for the worker user)', async () => {
+      await expect(page.locator(FILES.tabVectors)).toHaveCount(0)
     })
 
     await test.step('Browse tab navigates back to /files', async () => {

--- a/frontend/tests/e2e/tests/layout.spec.ts
+++ b/frontend/tests/e2e/tests/layout.spec.ts
@@ -101,6 +101,12 @@ async function expectInsideViewport(page: Page, selector: string, label: string)
  * test report and annotated, but NEVER fail the run. Flip to expect() per
  * surface once it is clean (target: blocking by end of phase 2).
  */
+async function axeBlocking(page: Page, surface: string) {
+  const results = await new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa']).analyze()
+  const severe = results.violations.filter((v) => v.impact === 'serious' || v.impact === 'critical')
+  expect(severe, `${surface}: ${severe.map((v) => v.id).join(', ')}`).toEqual([])
+}
+
 async function axeReportOnly(page: Page, surface: string, colorScheme: 'light' | 'dark') {
   await page.emulateMedia({ colorScheme })
   const results = await new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa']).analyze()
@@ -210,8 +216,12 @@ test.describe('@ci @layout UI guard — chat surface', () => {
     expect(await sections.count(), 'more section renders section rows').toBeGreaterThanOrEqual(2)
     await expect(sheet.locator(NAV.mobileMoreAccountSection)).toBeVisible()
 
-    // Accordion: tapping Channels expands its children inline (§4.3 #3).
-    await sheet.locator(NAV.mobileMoreChannels).click()
+    // Accordion: tapping Manage expands groups; Channels reveals Inbound.
+    await sheet.locator(NAV.mobileMoreManage).click()
+    await expect(sheet.locator(NAV.mobileMoreGroup('channels'))).toBeVisible({
+      timeout: TIMEOUTS.SHORT,
+    })
+    await sheet.locator(NAV.mobileMoreGroup('channels')).click()
     await expect(sheet.locator(NAV.mobileMoreInbound)).toBeVisible({
       timeout: TIMEOUTS.SHORT,
     })
@@ -382,6 +392,27 @@ test.describe('@ci @layout UI guard — axe scans (report-only, phase 0.5)', () 
     await expect(page.locator(selectors.files.page)).toBeVisible({ timeout: TIMEOUTS.STANDARD })
     await axeReportOnly(page, 'files', 'light')
     await axeReportOnly(page, 'files', 'dark')
+  })
+
+  test('login, empty chat and Manage panel — axe blocking', async ({ page }) => {
+    await openApp(page)
+    await expect(page.locator(CHAT.textInput)).toBeVisible({ timeout: TIMEOUTS.STANDARD })
+    if (!isMobileViewport(page)) {
+      await axeBlocking(page, 'empty-chat')
+      await page.locator(NAV.sidebarV2Manage).click()
+      await expect(page.locator(NAV.navDropdown)).toBeVisible({ timeout: TIMEOUTS.SHORT })
+      await axeBlocking(page, 'manage-panel')
+    }
+  })
+
+  test.describe('signed out axe blocking', () => {
+    test.use(LOGGED_OUT)
+
+    test('login page — axe blocking', async ({ page }) => {
+      await page.goto('/login')
+      await expect(page.locator(selectors.login.submit)).toBeVisible({ timeout: TIMEOUTS.STANDARD })
+      await axeBlocking(page, 'login')
+    })
   })
 
   test('AI models — light and dark', async ({ page }) => {

--- a/frontend/tests/e2e/tests/layout.spec.ts
+++ b/frontend/tests/e2e/tests/layout.spec.ts
@@ -101,7 +101,26 @@ async function expectInsideViewport(page: Page, selector: string, label: string)
  * test report and annotated, but NEVER fail the run. Flip to expect() per
  * surface once it is clean (target: blocking by end of phase 2).
  */
+/**
+ * axe composites ancestor opacity into the colors it measures, so scanning
+ * mid-fade-in reports the half-transparent frame instead of the resting one
+ * (the login entry animation alone produced seven phantom colour-contrast
+ * violations). Wait for every finite animation and transition to reach its end
+ * state first; infinite ones (background float, spinners) never finish and are
+ * skipped.
+ */
+async function waitForAnimationsSettled(page: Page) {
+  await page.evaluate(async () => {
+    const pending = document
+      .getAnimations()
+      .filter((animation) => animation.effect?.getComputedTiming().iterations !== Infinity)
+      .map((animation) => animation.finished.catch(() => undefined))
+    await Promise.all(pending)
+  })
+}
+
 async function axeBlocking(page: Page, surface: string) {
+  await waitForAnimationsSettled(page)
   const results = await new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa']).analyze()
   const severe = results.violations.filter((v) => v.impact === 'serious' || v.impact === 'critical')
   expect(severe, `${surface}: ${severe.map((v) => v.id).join(', ')}`).toEqual([])
@@ -109,6 +128,7 @@ async function axeBlocking(page: Page, surface: string) {
 
 async function axeReportOnly(page: Page, surface: string, colorScheme: 'light' | 'dark') {
   await page.emulateMedia({ colorScheme })
+  await waitForAnimationsSettled(page)
   const results = await new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa']).analyze()
   const severe = results.violations.filter((v) => v.impact === 'serious' || v.impact === 'critical')
   await test.info().attach(`axe-${surface}-${colorScheme}.json`, {

--- a/frontend/tests/e2e/tests/navigation.spec.ts
+++ b/frontend/tests/e2e/tests/navigation.spec.ts
@@ -8,13 +8,9 @@ const NAV = selectors.nav
 const SET = selectors.settings
 const USR = selectors.userMenu
 
-/**
- * "Easy Mode" was removed in Release 4.0 — the full (advanced) navigation is
- * now the only mode. This just waits until the sidebar's advanced-only rail
- * items are present, so tests that rely on Channels/AI Setup are stable.
- */
+/** Wait until the signed-in Work + Manage rail is painted. */
 async function ensureNavReady(page: Page) {
-  await expect(page.locator(NAV.sidebarV2Channels)).toBeVisible({ timeout: TIMEOUTS.STANDARD })
+  await expect(page.locator(NAV.sidebarV2Manage)).toBeVisible({ timeout: TIMEOUTS.STANDARD })
 }
 
 /** Avatar menu → Preferences → /settings page. */
@@ -25,7 +21,7 @@ async function openPreferences(page: Page) {
   await expect(page.locator(SET.page)).toBeVisible({ timeout: TIMEOUTS.STANDARD })
 }
 
-/** Open a rail flyout (Channels / AI Setup / Admin) and wait for it. */
+/** Open a rail flyout (Manage / Operate) and wait for it. */
 async function openFlyout(page: Page, railItemSelector: string) {
   await page.locator(railItemSelector).click()
   const flyout = page.locator(NAV.navDropdown)
@@ -33,20 +29,31 @@ async function openFlyout(page: Page, railItemSelector: string) {
   return flyout
 }
 
+/** Open Manage, then a named group (channels, assistants, …) in the second flyout. */
+async function openManageGroup(page: Page, groupKey: string) {
+  await openFlyout(page, NAV.sidebarV2Manage)
+  await page.locator(NAV.flyoutGroup(groupKey)).click()
+  const sub = page.locator(NAV.navSubDropdown)
+  await expect(sub).toBeVisible({ timeout: TIMEOUTS.SHORT })
+  return sub
+}
+
 test.describe('Navigation: Sidebar basics (non-admin)', () => {
-  test('@ci Sidebar shows all primary rail items (Channels + AI Setup always present)', async ({
+  test('@ci Sidebar shows Work + Manage (no leftover Channels / AI Setup pair)', async ({
     page,
   }) => {
     await test.step('Arrange: login', async () => {
       await openApp(page)
     })
 
-    await test.step('Assert: primary + advanced items all visible (no Easy Mode)', async () => {
+    await test.step('Assert: everyday rail is New / History / Sources / Manage', async () => {
       await expect(page.locator(NAV.sidebar)).toBeVisible({ timeout: TIMEOUTS.SHORT })
+      await expect(page.locator(NAV.sidebarV2NewChat)).toBeVisible({ timeout: TIMEOUTS.SHORT })
       await expect(page.locator(NAV.sidebarV2ChatNav)).toBeVisible({ timeout: TIMEOUTS.SHORT })
       await expect(page.locator(NAV.sidebarV2Files)).toBeVisible({ timeout: TIMEOUTS.SHORT })
-      await expect(page.locator(NAV.sidebarV2Channels)).toBeVisible({ timeout: TIMEOUTS.SHORT })
-      await expect(page.locator(NAV.sidebarV2AiSetup)).toBeVisible({ timeout: TIMEOUTS.SHORT })
+      await expect(page.locator(NAV.sidebarV2Manage)).toBeVisible({ timeout: TIMEOUTS.SHORT })
+      await expect(page.locator('[data-testid="btn-sidebar-v2-nav-channels"]')).toHaveCount(0)
+      await expect(page.locator('[data-testid="btn-sidebar-v2-nav-ai-setup"]')).toHaveCount(0)
     })
   })
 
@@ -96,76 +103,92 @@ test.describe('Navigation: Sidebar basics (non-admin)', () => {
 })
 
 test.describe('Navigation: Rail flyouts (non-admin)', () => {
-  test('@ci Channels flyout opens with child links', async ({ page }) => {
+  test('@ci Manage flyout opens with group entries, not a flat dump', async ({ page }) => {
     await test.step('Arrange: login and wait for nav', async () => {
       await openApp(page)
       await ensureNavReady(page)
     })
 
-    await test.step('Act+Assert: Channels flyout shows its links', async () => {
-      const flyout = await openFlyout(page, NAV.sidebarV2Channels)
-      await expect(flyout.locator(NAV.flyoutLinkInbound)).toBeVisible()
-      await expect(flyout.locator(NAV.flyoutLinkChatWidget)).toBeVisible()
-      await expect(flyout.locator(NAV.flyoutLinkApiDocs)).toBeVisible()
+    await test.step('Act+Assert: first flyout lists groups only', async () => {
+      const flyout = await openFlyout(page, NAV.sidebarV2Manage)
+      await expect(flyout.locator(NAV.flyoutGroup('assistants'))).toBeVisible()
+      await expect(flyout.locator(NAV.flyoutGroup('channels'))).toBeVisible()
+      await expect(flyout.locator(NAV.flyoutGroup('connections'))).toBeVisible()
+      await expect(flyout.locator(NAV.flyoutGroup('api'))).toBeVisible()
+      await expect(flyout.locator(NAV.flyoutGroup('automations'))).toBeVisible()
+      await expect(flyout.locator(NAV.flyoutGroup('tools'))).toBeVisible()
+      await expect(flyout.locator(NAV.flyoutLinkInbound)).toHaveCount(0)
+      await expect(flyout.locator(NAV.flyoutLinkChatWidget)).toHaveCount(0)
+    })
+
+    await test.step('Act+Assert: Channels submenu shows inbound, widgets, live support', async () => {
+      await page.locator(NAV.flyoutGroup('channels')).click()
+      const sub = page.locator(NAV.navSubDropdown)
+      await expect(sub).toBeVisible({ timeout: TIMEOUTS.SHORT })
+      await expect(sub.locator(NAV.flyoutLinkInbound)).toBeVisible()
+      await expect(sub.locator(NAV.flyoutLinkChatWidget)).toBeVisible()
+      await expect(sub.locator(NAV.flyoutLinkLiveSupport)).toBeVisible()
+    })
+
+    await test.step('Act+Assert: API submenu shows API docs', async () => {
+      await page.locator(NAV.flyoutGroup('api')).click()
+      const sub = page.locator(NAV.navSubDropdown)
+      await expect(sub.locator(NAV.flyoutLinkApiDocs)).toBeVisible()
     })
   })
 
-  // Connections and Saved Tasks are both gated behind features.savedTasks
-  // (SAVEDTASKS.ENABLED) but live in different flyouts since the nav restructure:
-  // Connections under Channels, Saved Tasks under AI Setup & Tools. The test
-  // stack runs app:seed, which seeds the global flag ON, so both must render. If
-  // this fails, check the seeded default before touching the test.
-  test('@ci Saved Tasks and Connections appear when enabled', async ({ page }) => {
+  // Connections and Saved Tasks are gated behind features.savedTasks
+  // (SAVEDTASKS.ENABLED). Both now live under Manage groups. The test
+  // stack runs app:seed, which seeds the global flag ON, so both must render.
+  test('@ci Saved Tasks and Connections appear in Manage when enabled', async ({ page }) => {
     await test.step('Arrange: login and wait for nav', async () => {
       await openApp(page)
       await ensureNavReady(page)
     })
 
-    await test.step('Assert: Connections lives in the Channels flyout', async () => {
-      const channels = await openFlyout(page, NAV.sidebarV2Channels)
-      await expect(channels.locator(NAV.flyoutLinkConnections)).toBeVisible()
-      // Dismiss via the backdrop; its overlay would otherwise intercept the
-      // click that opens the next flyout.
-      await page.locator(NAV.navOverlay).click()
-      await expect(channels).toBeHidden({ timeout: TIMEOUTS.SHORT })
+    await test.step('Assert: Connections lives under the Connections group', async () => {
+      const connections = await openManageGroup(page, 'connections')
+      await expect(connections.locator(NAV.flyoutLinkConnections)).toBeVisible()
     })
 
-    await test.step('Assert: Saved Tasks lives in the AI Setup & Tools flyout', async () => {
-      const aiSetup = await openFlyout(page, NAV.sidebarV2AiSetup)
-      await expect(aiSetup.locator(NAV.flyoutLinkSavedTasks)).toBeVisible()
-    })
-
-    await test.step('Act: Saved Tasks link navigates to /channels/tasks', async () => {
-      await page.locator(NAV.navDropdown).locator(NAV.flyoutLinkSavedTasks).click()
+    await test.step('Assert: Saved Tasks lives under Automations and navigates', async () => {
+      await page.locator(NAV.flyoutGroup('automations')).click()
+      const automations = page.locator(NAV.navSubDropdown)
+      await expect(automations.locator(NAV.flyoutLinkSavedTasks)).toBeVisible()
+      await automations.locator(NAV.flyoutLinkSavedTasks).click()
       await expect(page).toHaveURL(/\/channels\/tasks/, { timeout: TIMEOUTS.STANDARD })
     })
   })
 
-  test('@ci AI Setup flyout opens with child links', async ({ page }) => {
-    await test.step('Arrange: login and ensure advanced mode', async () => {
+  test('@ci Manage flyout includes models, instructions and email handler', async ({ page }) => {
+    await test.step('Arrange: login', async () => {
       await openApp(page)
       await ensureNavReady(page)
     })
 
-    await test.step('Act+Assert: AI Setup & Tools flyout shows its links', async () => {
-      const flyout = await openFlyout(page, NAV.sidebarV2AiSetup)
-      await expect(flyout.locator(NAV.flyoutLinkAiModels)).toBeVisible()
-      await expect(flyout.locator(NAV.flyoutLinkTaskPrompts)).toBeVisible()
-      // The IMAP email handler lives under AI Setup & Tools since the
-      // navigation restructure (it is a tool, not an inbound channel).
-      await expect(flyout.locator(NAV.flyoutLinkMailHandler)).toBeVisible()
+    await test.step('Act+Assert: Assistants submenu shows models and instructions', async () => {
+      const assistants = await openManageGroup(page, 'assistants')
+      await expect(assistants.locator(NAV.flyoutLinkAiModels)).toBeVisible()
+      await expect(assistants.locator(NAV.flyoutLinkTaskPrompts)).toBeVisible()
+    })
+
+    await test.step('Act+Assert: Channels submenu shows email handler', async () => {
+      await page.locator(NAV.flyoutGroup('channels')).click()
+      await expect(
+        page.locator(NAV.navSubDropdown).locator(NAV.flyoutLinkMailHandler)
+      ).toBeVisible()
     })
   })
 
-  test('@ci Channels flyout navigates to Chat Widget page', async ({ page }) => {
-    await test.step('Arrange: login, ensure advanced, open flyout', async () => {
+  test('@ci Manage flyout navigates to Chat Widget page', async ({ page }) => {
+    await test.step('Arrange: login, open Channels submenu', async () => {
       await openApp(page)
       await ensureNavReady(page)
-      await openFlyout(page, NAV.sidebarV2Channels)
+      await openManageGroup(page, 'channels')
     })
 
     await test.step('Act: click Chat Widget link', async () => {
-      await page.locator(NAV.navDropdown).locator(NAV.flyoutLinkChatWidget).click()
+      await page.locator(NAV.navSubDropdown).locator(NAV.flyoutLinkChatWidget).click()
     })
 
     await test.step('Assert: Widgets page visible', async () => {
@@ -175,15 +198,33 @@ test.describe('Navigation: Rail flyouts (non-admin)', () => {
     })
   })
 
-  test('@ci AI Setup flyout navigates to AI Models page', async ({ page }) => {
-    await test.step('Arrange: login, ensure advanced, open flyout', async () => {
+  test('@ci Manage flyout navigates to Live support', async ({ page }) => {
+    await test.step('Arrange: login, open Channels submenu', async () => {
       await openApp(page)
       await ensureNavReady(page)
-      await openFlyout(page, NAV.sidebarV2AiSetup)
+      await openManageGroup(page, 'channels')
+    })
+
+    await test.step('Act: click Live support', async () => {
+      await page.locator(NAV.navSubDropdown).locator(NAV.flyoutLinkLiveSupport).click()
+    })
+
+    await test.step('Assert: live support URL resolves', async () => {
+      await expect(page).toHaveURL(/\/channels\/widgets\/live-support/, {
+        timeout: TIMEOUTS.STANDARD,
+      })
+    })
+  })
+
+  test('@ci Manage flyout navigates to AI Models page', async ({ page }) => {
+    await test.step('Arrange: login, open Assistants submenu', async () => {
+      await openApp(page)
+      await ensureNavReady(page)
+      await openManageGroup(page, 'assistants')
     })
 
     await test.step('Act: click AI Models link', async () => {
-      await page.locator(NAV.navDropdown).locator(NAV.flyoutLinkAiModels).click()
+      await page.locator(NAV.navSubDropdown).locator(NAV.flyoutLinkAiModels).click()
     })
 
     await test.step('Assert: AI Models page visible', async () => {

--- a/frontend/tests/e2e/tests/visual.spec.ts
+++ b/frontend/tests/e2e/tests/visual.spec.ts
@@ -64,12 +64,11 @@ test.describe('@visual UI guard — capped snapshots', () => {
     await expect(uploadForm).toHaveScreenshot('files-upload-form.png', SNAPSHOT_OPTS)
   })
 
-  test('channels flyout', async ({ page }) => {
+  test('manage flyout', async ({ page }) => {
     await openApp(page)
-    await ensureAdvancedMode(page)
-    await page.locator(NAV.sidebarV2Channels).click()
+    await page.locator(NAV.sidebarV2Manage).click()
     const flyout = page.locator(NAV.navDropdown)
     await expect(flyout).toBeVisible({ timeout: TIMEOUTS.SHORT })
-    await expect(flyout).toHaveScreenshot('channels-flyout.png', SNAPSHOT_OPTS)
+    await expect(flyout).toHaveScreenshot('manage-flyout.png', SNAPSHOT_OPTS)
   })
 })

--- a/frontend/tests/unit/composables/useNavItems.spec.ts
+++ b/frontend/tests/unit/composables/useNavItems.spec.ts
@@ -1,0 +1,192 @@
+import { defineComponent } from 'vue'
+import { describe, expect, it, beforeEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { createI18n } from 'vue-i18n'
+import { createMemoryHistory, createRouter } from 'vue-router'
+import {
+  canSeeManage,
+  canSeeOperate,
+  groupNavChildren,
+  hasNestedNavGroups,
+  isNavChildActive,
+  useNavItems,
+} from '@/composables/useNavItems'
+import { useAuthStore, type User } from '@/stores/auth'
+
+vi.mock('@/services/api/httpClient', () => ({
+  httpClient: vi.fn(),
+  getApiBaseUrl: () => 'http://localhost:8000',
+  getConfigSync: () => ({ features: { savedTasks: true } }),
+}))
+
+const pluginList: { name: string }[] = []
+
+vi.mock('@/stores/config', () => ({
+  useConfigStore: () => ({
+    get plugins() {
+      return pluginList
+    },
+    billing: { enabled: false },
+    reload: vi.fn(),
+  }),
+}))
+
+const navMessages = {
+  nav: {
+    history: 'History',
+    historyDescription: 'Chat history',
+    files: 'Sources',
+    filesDescription: 'Sources',
+    manage: 'Manage',
+    manageDescription: 'Manage',
+    groupAssistants: 'Assistants',
+    groupAutomations: 'Automations',
+    groupTools: 'Tools',
+    channels: 'Channels',
+    connections: 'Connections',
+    groupApi: 'API',
+    configInbound: 'Inbound',
+    toolsChatWidget: 'Chat widgets',
+    toolsMailHandler: 'Email handler',
+    configConnections: 'Connections',
+    mcpServers: 'MCP Servers',
+    configApiKeys: 'API Keys',
+    savedTasks: 'Saved tasks',
+    aiAgents: 'AI Agents',
+    toolsDocSummary: 'Summarizer',
+    configAiModels: 'Models',
+    configTaskPrompts: 'Instructions',
+    configSortingPrompt: 'Routing',
+    liveSupport: 'Live support',
+    plugins: 'Plugins',
+    admin: 'Operate',
+    adminDashboard: 'Overview',
+    adminFeatureStatus: 'Feature Status',
+    adminModelStatus: 'Model Status',
+    adminProviderSetup: 'AI providers',
+    adminSystemConfig: 'System configuration',
+  },
+  pageTitles: {
+    configApiDocs: 'API docs',
+  },
+  common: { unknown: 'Unknown' },
+}
+
+function mountNav(user: { email: string; level: string; isAdmin?: boolean } | null) {
+  setActivePinia(createPinia())
+  const auth = useAuthStore()
+  auth.user = user
+    ? ({
+        id: 1,
+        email: user.email,
+        level: user.level,
+        isAdmin: user.isAdmin ?? user.level === 'ADMIN',
+      } as User)
+    : null
+
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: [{ path: '/', component: { template: '<div />' } }],
+  })
+  const i18n = createI18n({
+    legacy: false,
+    locale: 'en',
+    messages: { en: navMessages },
+  })
+
+  const Harness = defineComponent({
+    setup() {
+      return useNavItems()
+    },
+    template: '<div />',
+  })
+
+  return mount(Harness, {
+    global: {
+      plugins: [router, i18n],
+    },
+  })
+}
+
+describe('useNavItems predicates', () => {
+  it('shows Manage only when signed in', () => {
+    expect(canSeeManage(false)).toBe(false)
+    expect(canSeeManage(true)).toBe(true)
+  })
+
+  it('shows Operate only for admins', () => {
+    expect(canSeeOperate(false)).toBe(false)
+    expect(canSeeOperate(true)).toBe(true)
+  })
+})
+
+describe('isNavChildActive', () => {
+  it('matches the section-overview child only on the exact path', () => {
+    const inbound = { key: 'inbound', path: '/channels', label: 'Inbound' }
+    expect(isNavChildActive(inbound, '/channels', '/channels')).toBe(true)
+    expect(isNavChildActive(inbound, '/channels', '/channels/widgets')).toBe(false)
+  })
+})
+
+describe('groupNavChildren', () => {
+  it('keeps consecutive group keys together', () => {
+    const groups = groupNavChildren([
+      { key: 'a', path: '/a', label: 'A', group: 'Assistants', groupKey: 'assistants' },
+      { key: 'b', path: '/b', label: 'B', group: 'Channels', groupKey: 'channels' },
+    ])
+    expect(groups.map((g) => g.key)).toEqual(['assistants', 'channels'])
+    expect(groups.map((g) => g.group)).toEqual(['Assistants', 'Channels'])
+  })
+})
+
+describe('useNavItems rail', () => {
+  beforeEach(() => {
+    pluginList.length = 0
+  })
+
+  it('guest rail has History only — no Manage, Plugins or Operate', () => {
+    const wrapper = mountNav(null)
+    const keys = wrapper.vm.navItems.map((item: { key: string }) => item.key)
+    expect(keys).toEqual(['chat'])
+  })
+
+  it('signed-in user has Sources + Manage groups, no Operate', () => {
+    const wrapper = mountNav({ email: 'user@test.com', level: 'PRO' })
+    const keys = wrapper.vm.navItems.map((item: { key: string }) => item.key)
+    expect(keys).toContain('files')
+    expect(keys).toContain('manage')
+    expect(keys).not.toContain('admin')
+    expect(keys).not.toContain('channels')
+    expect(keys).not.toContain('ai-setup')
+
+    const manage = wrapper.vm.navItems.find((item: { key: string }) => item.key === 'manage')
+    expect(manage?.children).toBeDefined()
+    expect(hasNestedNavGroups(manage?.children)).toBe(true)
+    const childKeys = (manage?.children ?? []).map((child: { key: string }) => child.key)
+    expect(childKeys).toContain('mail-handler')
+    expect(childKeys).toContain('saved-tasks')
+    expect(childKeys).toContain('live-support')
+    expect(childKeys).toContain('chat-widget')
+    expect(
+      new Set((manage?.children ?? []).map((child: { groupKey?: string }) => child.groupKey))
+    ).toEqual(new Set(['assistants', 'channels', 'connections', 'api', 'automations', 'tools']))
+  })
+
+  it('admin also sees Operate', () => {
+    const wrapper = mountNav({ email: 'admin@test.com', level: 'ADMIN', isAdmin: true })
+    const keys = wrapper.vm.navItems.map((item: { key: string }) => item.key)
+    expect(keys).toContain('manage')
+    expect(keys).toContain('admin')
+    const operate = wrapper.vm.navItems.find((item: { key: string }) => item.key === 'admin')
+    expect(operate?.label).toBe('Operate')
+  })
+
+  it('plugins stay a top-level rail entry when installed', () => {
+    pluginList.push({ name: 'fastbill' })
+    const wrapper = mountNav({ email: 'user@test.com', level: 'PRO' })
+    const keys = wrapper.vm.navItems.map((item: { key: string }) => item.key)
+    expect(keys).toContain('plugins')
+    expect(keys.indexOf('plugins')).toBeLessThan(keys.indexOf('manage') + 10)
+  })
+})

--- a/frontend/tests/unit/router/navContext.spec.ts
+++ b/frontend/tests/unit/router/navContext.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { inferNavContext } from '@/router/navContext'
+
+describe('inferNavContext', () => {
+  it('marks public contract routes as public', () => {
+    expect(inferNavContext('/shared/abc', { public: true })).toBe('public')
+    expect(inferNavContext('/addin/connect')).toBe('public')
+    expect(inferNavContext('/account-deletion')).toBe('public')
+    expect(inferNavContext('/login')).toBe('public')
+  })
+
+  it('marks admin and setup as operate', () => {
+    expect(inferNavContext('/admin')).toBe('operate')
+    expect(inferNavContext('/admin/setup')).toBe('operate')
+    expect(inferNavContext('/setup')).toBe('operate')
+  })
+
+  it('marks channels and AI pages as manage', () => {
+    expect(inferNavContext('/channels/widgets')).toBe('manage')
+    expect(inferNavContext('/ai/models')).toBe('manage')
+    expect(inferNavContext('/plugins/fastbill')).toBe('manage')
+  })
+
+  it('marks account pages as personal', () => {
+    expect(inferNavContext('/settings')).toBe('personal')
+    expect(inferNavContext('/profile')).toBe('personal')
+    expect(inferNavContext('/statistics')).toBe('personal')
+  })
+
+  it('marks chat and files as work', () => {
+    expect(inferNavContext('/')).toBe('work')
+    expect(inferNavContext('/files')).toBe('work')
+  })
+})


### PR DESCRIPTION
## Summary
Rebuild the signed-in shell so everyday work stays History and Sources, while assistant, channel, and automation pages live under a short two-level **Manage** menu — without changing APIs, roles, or URLs.

## Changes
- **Wording (values only, all four locales):** Chat widgets, Inbound, Email handler, Instructions, Routing, Models, Saved tasks, Sources, Operate, Usage. Hardcoded English in profile, chat loading, settings, and widget list is now i18n.
- **Rail:** `[New] [History] [Sources] [Plugins*] [Manage ▾] [Account]`, plus `[Operate ▾]` for admins. Guests see History + Sign in. Plugins stay top-level when installed.
- **Manage is two levels:** first flyout is Assistants, Channels, Connections, API, Automations, Tools; the actual pages open in a second flyout (same accordion on mobile More). Operate stays a flat list.
- **Quieter first screens:** empty chat no longer opens the full mix wall; example prompts show for signed-in users; Vectors tab is admin-only; disabled-feature links no longer go to `/settings?tab=features`.
- **A11y:** skip-to-content, dialog focus trap, blocking axe coverage on login / empty chat / Manage.
- **Docs / planning:** `docs/FEATURES.md` drops Easy/Advanced mode; sprint notes and route inventory live under `_devextras/planning/20260828-interface-streamlining-sprint/`.

**Classification:** `ota-candidate` (frontend shell, copy, tests). No backend, role, or native change.

**Widget-bundled keys touched:** no. The `widget.*` namespace is unchanged. App-nav labels such as “Your Widgets” → “Chat widgets” are product-shell copy only.

**Unchanged on purpose:** same URLs; `data-testid` / `NavItem.key` for leaf pages; Live support still at `/channels/widgets/live-support`; widget runtime, plugins, add-in connect, shared chat, and `MOBILE-APP SEAM` blocks.

## Verification
- [x] Manual
- [x] Tests added/updated

**Local (mirrors CI jobs we touch):**
- `make -C frontend lint` — pass
- `docker compose exec -T frontend npm run check:types` — pass
- `make -C frontend test` — 176 files / 1431 tests pass
- `make -C backend lint` + `make -C backend phpstan` — pass (no PHP changes)
- `make -C backend test` — 4360 tests pass after fixing `var/cache/test` write perms
- Browser: Manage / Operate flyouts in light and dark (V2), plus mobile More → Manage → Channels

**Please still run in CI / locally:**
- [ ] Playwright `navigation.spec.ts`, `layout.spec.ts`, `files-tabs.spec.ts` (axe blocking on Manage)
- [ ] Visual snapshot `manage-flyout.png` (name changed from `channels-flyout`; needs re-baseline)
- [ ] Widget build + widget E2E (locale values changed; `widget.*` not touched)

## Notes
Planning and contract: `_devextras/planning/20260828-interface-streamlining-sprint/` (README, sprints, compatibility, Playwright plan, route inventory).

## Screenshots/Logs
Desktop Manage now opens six groups; hover/click opens the second flyout (e.g. Channels → Inbound, Chat widgets, Email handler, Live support). Operate remains a single short list.