### PR TITLE
fix(frontend): make the login axe guard deterministic and fix its two real findings

### DIFF
--- a/frontend/src/components/admin/ConfigField.vue
+++ b/frontend/src/components/admin/ConfigField.vue
@@ -238,6 +238,7 @@ const helpMeta = computed(() => providerHelpByEnvVar(props.fieldKey))
           v-if="schema.type === 'password'"
           type="button"
           class="absolute right-2 top-1/2 -translate-y-1/2 p-1 txt-secondary hover:txt-primary"
+          :aria-label="showPassword ? $t('auth.hidePassword') : $t('auth.showPassword')"
           @click="showPassword = !showPassword"
         >
           <Icon :icon="showPassword ? 'mdi:eye-off' : 'mdi:eye'" class="w-5 h-5" />

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -300,6 +300,7 @@
                 <button
                   type="button"
                   class="absolute right-3 top-1/2 -translate-y-1/2 p-1 rounded-md txt-secondary hover:txt-primary hover:bg-black/5 dark:hover:bg-white/10 transition-all duration-150"
+                  :aria-label="showPassword ? $t('auth.hidePassword') : $t('auth.showPassword')"
                   data-testid="btn-toggle-password"
                   @click="showPassword = !showPassword"
                 >
@@ -386,18 +387,18 @@
           :href="config.branding.homepageUrl"
           target="_blank"
           rel="noopener noreferrer"
-          class="group inline-flex items-center gap-1.5 opacity-40 hover:opacity-60 transition-all duration-300"
+          class="group inline-flex items-center gap-1.5 transition-all duration-300"
           :data-testid="config.billing.enabled ? 'link-homepage' : 'link-powered-by'"
         >
           <span
             v-if="config.branding.showPoweredBy"
-            class="text-[10px] txt-secondary tracking-wide"
+            class="text-[10px] txt-secondary group-hover:txt-primary tracking-wide transition-colors duration-300"
             >{{ $t('branding.poweredBy') }}</span
           >
           <img
             :src="logoSrc"
             :alt="config.branding.name"
-            class="h-3.5 opacity-70 group-hover:opacity-100 transition-opacity duration-300"
+            class="h-3.5 opacity-50 group-hover:opacity-100 transition-opacity duration-300"
           />
         </a>
       </div>

--- a/frontend/src/views/RegisterView.vue
+++ b/frontend/src/views/RegisterView.vue
@@ -268,6 +268,7 @@
                 <button
                   type="button"
                   class="absolute right-3 top-1/2 -translate-y-1/2 p-1 rounded-md txt-secondary hover:txt-primary hover:bg-black/5 dark:hover:bg-white/10 transition-all duration-150"
+                  :aria-label="showPassword ? $t('auth.hidePassword') : $t('auth.showPassword')"
                   data-testid="btn-toggle-password"
                   @click="showPassword = !showPassword"
                 >
@@ -307,6 +308,9 @@
                 <button
                   type="button"
                   class="absolute right-3 top-1/2 -translate-y-1/2 p-1 rounded-md txt-secondary hover:txt-primary hover:bg-black/5 dark:hover:bg-white/10 transition-all duration-150"
+                  :aria-label="
+                    showConfirmPassword ? $t('auth.hidePassword') : $t('auth.showPassword')
+                  "
                   data-testid="btn-toggle-confirm-password"
                   @click="showConfirmPassword = !showConfirmPassword"
                 >
@@ -395,18 +399,18 @@
           :href="config.branding.homepageUrl"
           target="_blank"
           rel="noopener noreferrer"
-          class="group inline-flex items-center gap-1.5 opacity-40 hover:opacity-60 transition-all duration-300"
+          class="group inline-flex items-center gap-1.5 transition-all duration-300"
           :data-testid="config.billing.enabled ? 'link-homepage' : 'link-powered-by'"
         >
           <span
             v-if="config.branding.showPoweredBy"
-            class="text-[10px] txt-secondary tracking-wide"
+            class="text-[10px] txt-secondary group-hover:txt-primary tracking-wide transition-colors duration-300"
             >{{ $t('branding.poweredBy') }}</span
           >
           <img
             :src="logoSrc"
             :alt="config.branding.name"
-            class="h-3.5 opacity-70 group-hover:opacity-100 transition-opacity duration-300"
+            class="h-3.5 opacity-50 group-hover:opacity-100 transition-opacity duration-300"
           />
         </a>
       </div>

--- a/frontend/tests/e2e/tests/layout.spec.ts
+++ b/frontend/tests/e2e/tests/layout.spec.ts
@@ -101,7 +101,26 @@ async function expectInsideViewport(page: Page, selector: string, label: string)
  * test report and annotated, but NEVER fail the run. Flip to expect() per
  * surface once it is clean (target: blocking by end of phase 2).
  */
+/**
+ * axe composites ancestor opacity into the colors it measures, so scanning
+ * mid-fade-in reports the half-transparent frame instead of the resting one
+ * (the login entry animation alone produced seven phantom colour-contrast
+ * violations). Wait for every finite animation and transition to reach its end
+ * state first; infinite ones (background float, spinners) never finish and are
+ * skipped.
+ */
+async function waitForAnimationsSettled(page: Page) {
+  await page.evaluate(async () => {
+    const pending = document
+      .getAnimations()
+      .filter((animation) => animation.effect?.getComputedTiming().iterations !== Infinity)
+      .map((animation) => animation.finished.catch(() => undefined))
+    await Promise.all(pending)
+  })
+}
+
 async function axeBlocking(page: Page, surface: string) {
+  await waitForAnimationsSettled(page)
   const results = await new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa']).analyze()
   const severe = results.violations.filter((v) => v.impact === 'serious' || v.impact === 'critical')
   expect(severe, `${surface}: ${severe.map((v) => v.id).join(', ')}`).toEqual([])
@@ -109,6 +128,7 @@ async function axeBlocking(page: Page, surface: string) {
 
 async function axeReportOnly(page: Page, surface: string, colorScheme: 'light' | 'dark') {
   await page.emulateMedia({ colorScheme })
+  await waitForAnimationsSettled(page)
   const results = await new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa']).analyze()
   const severe = results.violations.filter((v) => v.impact === 'serious' || v.impact === 'critical')
   await test.info().attach(`axe-${surface}-${colorScheme}.json`, {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the two red E2E jobs on #1625 (`E2E Tests (chromium [1/3])` and `E2E Tests (chromium Mobile)`), both failing on the newly added `login page — axe blocking` test: the scan was racing the login entrance animation, and it also surfaced two genuine accessibility defects.

## Changes

- **`layout.spec.ts` — wait for animations before scanning.** axe composites ancestor opacity into the colours it measures, so scanning mid-fade graded the entrance animation's half-transparent frame rather than the resting one. That alone produced 11 of the 12 reported violations on desktop (e.g. `text-brand` measured as `#7496e0` instead of `#003fc7`). `axeBlocking` and `axeReportOnly` now await every finite animation and transition via `document.getAnimations()`; infinite ones (background float, spinners) are skipped because they never settle.
- **Password toggles had no accessible name** (`button-name`, critical — the one violation that survived the wait). Added `aria-label` using the existing `auth.showPassword` / `auth.hidePassword` strings, which were already present and translated in all four locales. Applied to `LoginView`, both toggles in `RegisterView`, and `ConfigField`; `SetupAdminStep` already had one.
- **"Powered by" footer contrast** (`color-contrast`, serious — the other surviving violation). A blanket `opacity-40` on the link dragged 10px secondary text down to 1.99:1. The dimming now applies to the logo image only, so the caption renders at its token colour (8.57:1), and the opacity hover is replaced by a `group-hover:txt-primary` accent. Same footer fixed on `RegisterView`.

## Verification

- [x] Manual
- [x] Tests added/updated

**Note: `ci.yml` only triggers on pull requests into `main` or `develop`, so the CI suite does not run on this PR.** To get real signal anyway, I reproduced both failing jobs locally against the authentic CI artifacts — `synaplan-test:ci` built from `_docker/backend/Dockerfile`, brought up with `docker-compose.test.yml` + `docker-compose.test.ci.yml`, using the same npm scripts and grep filters as the `e2e` matrix:

| Job | Before | After |
| --- | --- | --- |
| `E2E Tests (chromium Mobile)` | 1 failed | **16 passed** |
| `E2E Tests (chromium [1/3])` | 1 failed | **42 passed, 1 skipped** |

Both runs include `login, empty chat and Manage panel — axe blocking`, which confirms the new wait does not hang on the chat surface or the Manage dropdown.

Also verified:

- Direct axe scan of `/login`: **12 → 0** serious/critical nodes on desktop, **6 → 0** on mobile.
- Frontend gate green: `make -C frontend lint`, `vue-tsc`, and 1431 unit tests in 176 files.
- Mobile release impact: `ota-candidate` (same as the parent PR); all touched paths are already allow-listed, so `.github/mobile-impact-policy.json` needs no change. `tests/mobile-impact.test.mjs` passes 15/15.

## Notes

Two pre-existing issues were found but deliberately left alone, since both are app-wide design-token decisions well outside this fix:

- In **dark theme**, `btn-primary` is white text on `#6d9ae0` (2.85:1). This affects every primary button, not just login, and the blocking scan runs in light theme only.
- On **`/register`**, the terms and privacy links are `text-brand` at ~3.3:1. Register has no blocking scan yet.

## Screenshots/Logs

[Login footer Powered by caption, before and after](https://cursor.com/agents/bc-01a0497d-7610-79ad-bc21-6f3c7e7e23aa/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flogin-footer-contrast.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0497d-7610-79ad-bc21-6f3c7e7e23aa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0497d-7610-79ad-bc21-6f3c7e7e23aa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

