### PR TITLE
feat(stt): add SttSessionStore service

### DIFF
--- a/backend/config/services.yaml
+++ b/backend/config/services.yaml
@@ -545,6 +545,11 @@ services:
     App\Realtime\Publisher\RealtimePublisherInterface:
         alias: App\Realtime\Publisher\CentrifugoPublisher
 
+    App\Service\Stt\SttSessionStore:
+        arguments:
+            $storageDir: '%kernel.project_dir%/var/stt'
+            $ttlSeconds: 7200
+
     # Whisper Service for Audio Transcription
     App\Service\WhisperService:
         arguments:

--- a/backend/src/Controller/AudioTranscriptionController.php
+++ b/backend/src/Controller/AudioTranscriptionController.php
@@ -1,0 +1,617 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Entity\ApiKey;
+use App\Entity\User;
+use App\Service\Exception\RateLimitExceededException;
+use App\Service\Stt\Exception\SttModelNotFoundException;
+use App\Service\Stt\Exception\SttSessionClosedException;
+use App\Service\Stt\Exception\SttSessionNotFoundException;
+use App\Service\Stt\SttModelResolver;
+use App\Service\Stt\SttSession;
+use App\Service\Stt\SttSessionService;
+use App\Service\Stt\SttSseWriter;
+use OpenApi\Attributes as OA;
+use Psr\Log\LoggerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
+
+/**
+ * External speech-to-text: OpenAI-compatible one-shot plus session streaming.
+ *
+ * Lives on `/v1/audio` (API-key firewall) so a local program can transcribe
+ * with any configured SOUND2TEXT model and keep client 123 vs client 321
+ * apart on the same key.
+ */
+#[OA\Tag(name: 'Audio Transcription', description: 'External speech-to-text (one-shot and streaming sessions)')]
+class AudioTranscriptionController extends AbstractController
+{
+    public function __construct(
+        private SttSessionService $sttSessionService,
+        private SttModelResolver $sttModelResolver,
+        private SttSseWriter $sseWriter,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    #[Route('/v1/audio/models', name: 'openai_audio_models', methods: ['GET'])]
+    #[OA\Get(
+        path: '/v1/audio/models',
+        summary: 'List speech-to-text models',
+        security: [['Bearer' => []]],
+        tags: ['Audio Transcription']
+    )]
+    #[OA\Response(response: 200, description: 'SOUND2TEXT models')]
+    public function listModels(#[CurrentUser] ?User $user): JsonResponse
+    {
+        if (!$user) {
+            return $this->openAiError('Authentication required', 'invalid_request_error', 'invalid_api_key', 401);
+        }
+
+        return new JsonResponse([
+            'object' => 'list',
+            'data' => $this->sttModelResolver->listModels(),
+        ]);
+    }
+
+    #[Route('/v1/audio/transcriptions/sessions', name: 'openai_audio_sessions_create', methods: ['POST'])]
+    #[OA\Post(
+        path: '/v1/audio/transcriptions/sessions',
+        summary: 'Open a transcription session',
+        description: 'Creates a session scoped to this API key and a caller-chosen client_id (e.g. client 123 vs 321 on the same key).',
+        security: [['Bearer' => []]],
+        tags: ['Audio Transcription']
+    )]
+    #[OA\RequestBody(
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(property: 'client_id', type: 'string', example: '123'),
+                new OA\Property(property: 'model', type: 'string', example: 'whisper'),
+                new OA\Property(property: 'language', type: 'string', example: 'en'),
+                new OA\Property(property: 'encoding', type: 'string', example: 'pcm_s16le'),
+                new OA\Property(property: 'sample_rate', type: 'integer', example: 16000),
+                new OA\Property(property: 'channels', type: 'integer', example: 1),
+                new OA\Property(property: 'commit_after_bytes', type: 'integer', example: 96000),
+                new OA\Property(property: 'reuse', type: 'boolean', example: false),
+            ]
+        )
+    )]
+    #[OA\Response(response: 201, description: 'Session created')]
+    public function createSession(Request $request, #[CurrentUser] ?User $user): JsonResponse
+    {
+        if (!$user) {
+            return $this->openAiError('Authentication required', 'invalid_request_error', 'invalid_api_key', 401);
+        }
+
+        try {
+            $session = $this->sttSessionService->create(
+                $user,
+                $this->apiKeyId($request),
+                $this->sessionOptions($request),
+            );
+
+            return new JsonResponse($session->toPublicArray(), Response::HTTP_CREATED);
+        } catch (\Throwable $e) {
+            return $this->handleError($e);
+        }
+    }
+
+    #[Route('/v1/audio/transcriptions/sessions', name: 'openai_audio_sessions_list', methods: ['GET'])]
+    #[OA\Get(
+        path: '/v1/audio/transcriptions/sessions',
+        summary: 'List transcription sessions for this API key',
+        security: [['Bearer' => []]],
+        tags: ['Audio Transcription']
+    )]
+    #[OA\Parameter(name: 'client_id', in: 'query', required: false, schema: new OA\Schema(type: 'string'))]
+    #[OA\Parameter(name: 'status', in: 'query', required: false, schema: new OA\Schema(type: 'string'))]
+    #[OA\Response(response: 200, description: 'Sessions')]
+    public function listSessions(Request $request, #[CurrentUser] ?User $user): JsonResponse
+    {
+        if (!$user) {
+            return $this->openAiError('Authentication required', 'invalid_request_error', 'invalid_api_key', 401);
+        }
+
+        $clientId = $request->query->get('client_id');
+        $status = $request->query->get('status');
+
+        try {
+            $sessions = $this->sttSessionService->listOwned(
+                $this->apiKeyId($request),
+                is_string($clientId) ? $clientId : null,
+                is_string($status) ? $status : null,
+            );
+        } catch (\Throwable $e) {
+            return $this->handleError($e);
+        }
+
+        return new JsonResponse([
+            'object' => 'list',
+            'data' => array_map(static fn (SttSession $session): array => $session->toPublicArray(), $sessions),
+        ]);
+    }
+
+    #[Route('/v1/audio/transcriptions/sessions/{id}', name: 'openai_audio_sessions_get', methods: ['GET'])]
+    #[OA\Get(
+        path: '/v1/audio/transcriptions/sessions/{id}',
+        summary: 'Get a transcription session',
+        security: [['Bearer' => []]],
+        tags: ['Audio Transcription']
+    )]
+    #[OA\Response(response: 200, description: 'Session')]
+    public function getSession(Request $request, string $id, #[CurrentUser] ?User $user): JsonResponse
+    {
+        if (!$user) {
+            return $this->openAiError('Authentication required', 'invalid_request_error', 'invalid_api_key', 401);
+        }
+
+        try {
+            $session = $this->sttSessionService->getOwned($id, $this->apiKeyId($request));
+            $cursor = (int) $request->query->get('cursor', '0');
+
+            return new JsonResponse($session->toPublicArray() + [
+                'events' => $session->eventsAfter($cursor),
+            ]);
+        } catch (\Throwable $e) {
+            return $this->handleError($e);
+        }
+    }
+
+    #[Route('/v1/audio/transcriptions/sessions/{id}/audio', name: 'openai_audio_sessions_audio', methods: ['POST'])]
+    #[OA\Post(
+        path: '/v1/audio/transcriptions/sessions/{id}/audio',
+        summary: 'Append an audio chunk to a session',
+        description: 'Accepts multipart `file`/`audio`, raw `audio/*` / octet-stream, or JSON `audio_base64`. Set commit=true to transcribe immediately.',
+        security: [['Bearer' => []]],
+        tags: ['Audio Transcription']
+    )]
+    #[OA\Response(response: 200, description: 'Chunk accepted')]
+    public function appendAudio(Request $request, string $id, #[CurrentUser] ?User $user): JsonResponse
+    {
+        if (!$user) {
+            return $this->openAiError('Authentication required', 'invalid_request_error', 'invalid_api_key', 401);
+        }
+
+        try {
+            $result = $this->sttSessionService->appendAudio(
+                $user,
+                $this->apiKeyId($request),
+                $id,
+                $this->readAudioBytes($request),
+                $this->truthy($request, 'commit'),
+            );
+
+            return new JsonResponse($result['session']->toPublicArray() + [
+                'committed' => $result['committed'],
+                'bytes_appended' => $result['bytes_appended'],
+            ]);
+        } catch (\Throwable $e) {
+            return $this->handleError($e);
+        }
+    }
+
+    #[Route('/v1/audio/transcriptions/sessions/{id}/commit', name: 'openai_audio_sessions_commit', methods: ['POST'])]
+    #[OA\Post(
+        path: '/v1/audio/transcriptions/sessions/{id}/commit',
+        summary: 'Transcribe pending audio in a session',
+        security: [['Bearer' => []]],
+        tags: ['Audio Transcription']
+    )]
+    #[OA\Response(response: 200, description: 'Session after commit')]
+    public function commitSession(Request $request, string $id, #[CurrentUser] ?User $user): JsonResponse
+    {
+        if (!$user) {
+            return $this->openAiError('Authentication required', 'invalid_request_error', 'invalid_api_key', 401);
+        }
+
+        try {
+            $session = $this->sttSessionService->commit(
+                $user,
+                $this->apiKeyId($request),
+                $id,
+                $this->truthy($request, 'close'),
+            );
+
+            return new JsonResponse($session->toPublicArray());
+        } catch (\Throwable $e) {
+            return $this->handleError($e);
+        }
+    }
+
+    #[Route('/v1/audio/transcriptions/sessions/{id}/stream', name: 'openai_audio_sessions_stream', methods: ['GET'])]
+    #[OA\Get(
+        path: '/v1/audio/transcriptions/sessions/{id}/stream',
+        summary: 'SSE stream of session transcripts',
+        security: [['Bearer' => []]],
+        tags: ['Audio Transcription']
+    )]
+    #[OA\Parameter(name: 'cursor', in: 'query', required: false, schema: new OA\Schema(type: 'integer'))]
+    #[OA\Parameter(name: 'timeout', in: 'query', required: false, schema: new OA\Schema(type: 'integer', default: 300))]
+    #[OA\Response(response: 200, description: 'text/event-stream')]
+    public function streamSession(Request $request, string $id, #[CurrentUser] ?User $user): Response
+    {
+        if (!$user) {
+            return $this->openAiError('Authentication required', 'invalid_request_error', 'invalid_api_key', 401);
+        }
+
+        try {
+            $this->sttSessionService->getOwned($id, $this->apiKeyId($request));
+        } catch (\Throwable $e) {
+            return $this->handleError($e);
+        }
+
+        $apiKeyId = $this->apiKeyId($request);
+        $cursor = (int) $request->query->get('cursor', '0');
+        $timeout = max(0, min(600, (int) $request->query->get('timeout', '300')));
+
+        $response = new StreamedResponse(function () use ($id, $apiKeyId, $cursor, $timeout): void {
+            $this->emitSessionStream($id, $apiKeyId, $cursor, $timeout);
+        });
+        $response->headers->set('Content-Type', 'text/event-stream');
+        $response->headers->set('Cache-Control', 'no-cache');
+        $response->headers->set('X-Accel-Buffering', 'no');
+        $response->headers->set('Connection', 'keep-alive');
+
+        return $response;
+    }
+
+    #[Route('/v1/audio/transcriptions/sessions/{id}', name: 'openai_audio_sessions_delete', methods: ['DELETE'])]
+    #[OA\Delete(
+        path: '/v1/audio/transcriptions/sessions/{id}',
+        summary: 'Close a transcription session',
+        security: [['Bearer' => []]],
+        tags: ['Audio Transcription']
+    )]
+    #[OA\Response(response: 200, description: 'Session closed')]
+    public function deleteSession(Request $request, string $id, #[CurrentUser] ?User $user): JsonResponse
+    {
+        if (!$user) {
+            return $this->openAiError('Authentication required', 'invalid_request_error', 'invalid_api_key', 401);
+        }
+
+        try {
+            $session = $this->sttSessionService->close($this->apiKeyId($request), $id);
+
+            return new JsonResponse($session->toPublicArray());
+        } catch (\Throwable $e) {
+            return $this->handleError($e);
+        }
+    }
+
+    #[Route('/v1/audio/transcriptions', name: 'openai_audio_transcriptions', methods: ['POST'])]
+    #[OA\Post(
+        path: '/v1/audio/transcriptions',
+        summary: 'Create a transcription (OpenAI-compatible)',
+        description: 'One-shot file transcription. Use sessions for live streams. `stream=true` returns SSE.',
+        security: [['Bearer' => []]],
+        tags: ['Audio Transcription']
+    )]
+    #[OA\Response(response: 200, description: 'Transcription')]
+    public function transcribe(Request $request, #[CurrentUser] ?User $user): Response
+    {
+        if (!$user) {
+            return $this->openAiError('Authentication required', 'invalid_request_error', 'invalid_api_key', 401);
+        }
+
+        $tempFile = null;
+        try {
+            $tempFile = $this->persistUploadedAudio($request);
+            $result = $this->sttSessionService->transcribeFile(
+                $user,
+                $this->apiKeyId($request),
+                $tempFile,
+                $this->oneShotOptions($request),
+            );
+
+            if ($this->truthy($request, 'stream')) {
+                return $this->oneShotStream($result);
+            }
+
+            return $this->oneShotResponse($request, $result);
+        } catch (\Throwable $e) {
+            return $this->handleError($e);
+        } finally {
+            if (is_string($tempFile) && is_file($tempFile)) {
+                unlink($tempFile);
+            }
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $result
+     */
+    private function oneShotResponse(Request $request, array $result): Response
+    {
+        $format = strtolower((string) $this->requestValue($request, 'response_format', 'json'));
+        if ('text' === $format) {
+            return new Response((string) $result['text'], 200, ['Content-Type' => 'text/plain; charset=utf-8']);
+        }
+        if ('verbose_json' === $format) {
+            return new JsonResponse([
+                'task' => 'transcribe',
+                'language' => $result['language'],
+                'duration' => $result['duration'],
+                'text' => $result['text'],
+                'segments' => $result['segments'],
+                'id' => $result['id'],
+                'model' => $result['model'],
+                'provider' => $result['provider'],
+                'client_id' => $result['client_id'],
+                'api_key_id' => $result['api_key_id'],
+            ]);
+        }
+
+        return new JsonResponse([
+            'text' => $result['text'],
+            'id' => $result['id'],
+            'model' => $result['model'],
+            'language' => $result['language'],
+            'duration' => $result['duration'],
+            'client_id' => $result['client_id'],
+            'api_key_id' => $result['api_key_id'],
+        ]);
+    }
+
+    /**
+     * @param array<string, mixed> $result
+     */
+    private function oneShotStream(array $result): StreamedResponse
+    {
+        $response = new StreamedResponse(function () use ($result): void {
+            $this->sseWriter->write('transcript', [
+                'id' => $result['id'],
+                'text' => $result['text'],
+                'full_text' => $result['text'],
+                'is_final' => true,
+                'language' => $result['language'],
+                'duration' => $result['duration'],
+                'model' => $result['model'],
+                'client_id' => $result['client_id'],
+                'api_key_id' => $result['api_key_id'],
+            ]);
+            $this->sseWriter->write('done', [
+                'id' => $result['id'],
+                'text' => $result['text'],
+            ]);
+        });
+        $response->headers->set('Content-Type', 'text/event-stream');
+        $response->headers->set('Cache-Control', 'no-cache');
+        $response->headers->set('X-Accel-Buffering', 'no');
+
+        return $response;
+    }
+
+    private function emitSessionStream(string $id, int $apiKeyId, int $cursor, int $timeout): void
+    {
+        while (ob_get_level()) {
+            ob_end_clean();
+        }
+        ob_implicit_flush(true);
+
+        $deadline = time() + $timeout;
+        $lastHeartbeat = time();
+
+        while (true) {
+            if (connection_aborted()) {
+                return;
+            }
+
+            try {
+                $session = $this->sttSessionService->getOwned($id, $apiKeyId);
+            } catch (SttSessionNotFoundException) {
+                $this->sseWriter->write('error', ['message' => 'Session not found', 'code' => 'session_not_found']);
+
+                return;
+            }
+
+            foreach ($session->eventsAfter($cursor) as $event) {
+                $this->sseWriter->write($event['type'], $event['payload'] + ['cursor' => $event['cursor']]);
+                $cursor = $event['cursor'];
+            }
+
+            if (!$session->isOpen() && $cursor >= $session->cursor) {
+                return;
+            }
+
+            if (0 === $timeout || time() >= $deadline) {
+                $this->sseWriter->write('heartbeat', ['cursor' => $cursor, 'status' => $session->status]);
+
+                return;
+            }
+
+            if (time() - $lastHeartbeat >= 5) {
+                $this->sseWriter->write('heartbeat', ['cursor' => $cursor, 'status' => $session->status]);
+                $lastHeartbeat = time();
+            }
+
+            usleep(400_000);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function sessionOptions(Request $request): array
+    {
+        return [
+            'client_id' => $this->requestValue($request, 'client_id'),
+            'model' => $this->requestValue($request, 'model'),
+            'language' => $this->requestValue($request, 'language'),
+            'prompt' => $this->requestValue($request, 'prompt'),
+            'encoding' => $this->requestValue($request, 'encoding'),
+            'sample_rate' => (int) $this->requestValue($request, 'sample_rate', '16000'),
+            'channels' => (int) $this->requestValue($request, 'channels', '1'),
+            'commit_after_bytes' => (int) $this->requestValue($request, 'commit_after_bytes', (string) SttSessionService::DEFAULT_COMMIT_AFTER_BYTES),
+            'reuse' => $this->truthy($request, 'reuse'),
+        ];
+    }
+
+    /**
+     * @return array{model: ?string, language: ?string, prompt: ?string, client_id: ?string}
+     */
+    private function oneShotOptions(Request $request): array
+    {
+        return [
+            'model' => $this->requestValue($request, 'model'),
+            'language' => $this->requestValue($request, 'language'),
+            'prompt' => $this->requestValue($request, 'prompt'),
+            'client_id' => $this->requestValue($request, 'client_id'),
+        ];
+    }
+
+    private function persistUploadedAudio(Request $request): string
+    {
+        $file = $request->files->get('file') ?? $request->files->get('audio');
+        if ($file instanceof UploadedFile) {
+            if (!$file->isValid()) {
+                throw new \InvalidArgumentException('Uploaded audio file is invalid');
+            }
+            $extension = $file->guessExtension() ?: pathinfo($file->getClientOriginalName(), PATHINFO_EXTENSION) ?: 'wav';
+            $target = sys_get_temp_dir().'/stt_upload_'.bin2hex(random_bytes(8)).'.'.$extension;
+            $file->move(dirname($target), basename($target));
+
+            return $target;
+        }
+
+        $bytes = $this->readRawOrBase64($request);
+        if ('' === $bytes) {
+            throw new \InvalidArgumentException('file is required');
+        }
+
+        $target = sys_get_temp_dir().'/stt_upload_'.bin2hex(random_bytes(8)).'.wav';
+        file_put_contents($target, $bytes);
+
+        return $target;
+    }
+
+    private function readAudioBytes(Request $request): string
+    {
+        $file = $request->files->get('file') ?? $request->files->get('audio');
+        if ($file instanceof UploadedFile) {
+            if (!$file->isValid()) {
+                throw new \InvalidArgumentException('Uploaded audio file is invalid');
+            }
+            $contents = file_get_contents($file->getPathname());
+            if (false === $contents || '' === $contents) {
+                throw new \InvalidArgumentException('Audio chunk is empty');
+            }
+
+            return $contents;
+        }
+
+        $bytes = $this->readRawOrBase64($request);
+        if ('' === $bytes) {
+            throw new \InvalidArgumentException('Audio chunk is empty');
+        }
+
+        return $bytes;
+    }
+
+    private function readRawOrBase64(Request $request): string
+    {
+        $contentType = strtolower((string) $request->headers->get('Content-Type', ''));
+        if (str_contains($contentType, 'application/json')) {
+            $body = json_decode($request->getContent(), true);
+            if (is_array($body) && isset($body['audio_base64']) && is_string($body['audio_base64'])) {
+                $decoded = base64_decode($body['audio_base64'], true);
+
+                return false === $decoded ? '' : $decoded;
+            }
+
+            return '';
+        }
+
+        if (str_contains($contentType, 'multipart/form-data')) {
+            $b64 = $request->request->get('audio_base64');
+
+            return is_string($b64) ? (string) base64_decode($b64, true) : '';
+        }
+
+        return $request->getContent();
+    }
+
+    private function requestValue(Request $request, string $key, ?string $default = null): ?string
+    {
+        $query = $request->query->get($key);
+        if (is_string($query) && '' !== $query) {
+            return $query;
+        }
+
+        $form = $request->request->get($key);
+        if (is_string($form) && '' !== $form) {
+            return $form;
+        }
+
+        $contentType = strtolower((string) $request->headers->get('Content-Type', ''));
+        if (str_contains($contentType, 'application/json')) {
+            $body = json_decode($request->getContent(), true);
+            if (is_array($body) && array_key_exists($key, $body) && (is_string($body[$key]) || is_int($body[$key]) || is_float($body[$key]) || is_bool($body[$key]))) {
+                return (string) $body[$key];
+            }
+        }
+
+        return $default;
+    }
+
+    private function truthy(Request $request, string $key): bool
+    {
+        $value = $this->requestValue($request, $key);
+        if (null === $value) {
+            return false;
+        }
+
+        return in_array(strtolower($value), ['1', 'true', 'yes', 'on'], true);
+    }
+
+    private function apiKeyId(Request $request): int
+    {
+        $apiKey = $request->attributes->get('api_key');
+        if ($apiKey instanceof ApiKey && null !== $apiKey->getId()) {
+            return (int) $apiKey->getId();
+        }
+
+        return 0;
+    }
+
+    private function handleError(\Throwable $e): JsonResponse
+    {
+        return match (true) {
+            $e instanceof RateLimitExceededException => $this->openAiError($e->getMessage(), 'rate_limit_error', 'rate_limit_exceeded', 429),
+            $e instanceof SttSessionNotFoundException, $e instanceof SttModelNotFoundException => $this->openAiError($e->getMessage(), 'invalid_request_error', 'not_found', 404),
+            $e instanceof SttSessionClosedException => $this->openAiError($e->getMessage(), 'invalid_request_error', 'session_closed', 409),
+            $e instanceof \InvalidArgumentException => $this->openAiError($e->getMessage(), 'invalid_request_error', 'invalid_request', 400),
+            default => $this->logAndFail($e),
+        };
+    }
+
+    private function logAndFail(\Throwable $e): JsonResponse
+    {
+        $this->logger->error('STT API failed', [
+            'error' => $e->getMessage(),
+            'exception' => $e::class,
+        ]);
+
+        return $this->openAiError('Transcription failed', 'server_error', 'internal_error', 500);
+    }
+
+    private function openAiError(string $message, string $type, string $code, int $httpStatus): JsonResponse
+    {
+        return new JsonResponse([
+            'error' => [
+                'message' => $message,
+                'type' => $type,
+                'param' => null,
+                'code' => $code,
+            ],
+        ], $httpStatus);
+    }
+}

--- a/backend/src/Repository/ModelRepository.php
+++ b/backend/src/Repository/ModelRepository.php
@@ -261,4 +261,44 @@ class ModelRepository extends ServiceEntityRepository
 
         return array_map(static fn (array $row): string => (string) $row['service'], $results);
     }
+
+    /**
+     * Active SOUND2TEXT (or other tag) rows an external STT caller may request.
+     *
+     * @return list<Model>
+     */
+    public function findActiveByTag(string $tag): array
+    {
+        /** @var list<Model> $models */
+        $models = $this->createQueryBuilder('m')
+            ->where('m.tag = :tag')
+            ->andWhere('m.active = 1')
+            ->setParameter('tag', $tag)
+            ->orderBy('m.quality', 'DESC')
+            ->addOrderBy('m.id', 'ASC')
+            ->getQuery()
+            ->getResult();
+
+        return $models;
+    }
+
+    /**
+     * Resolve an active model of a capability by providerId or display name.
+     */
+    public function findActiveByTagAndIdentity(string $tag, string $identity): ?Model
+    {
+        /** @var Model|null $model */
+        $model = $this->createQueryBuilder('m')
+            ->where('m.tag = :tag')
+            ->andWhere('m.active = 1')
+            ->andWhere('(m.providerId = :identity OR m.name = :identity)')
+            ->setParameter('tag', $tag)
+            ->setParameter('identity', $identity)
+            ->orderBy('m.quality', 'DESC')
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        return $model;
+    }
 }

--- a/backend/src/Service/Stt/Exception/SttModelNotFoundException.php
+++ b/backend/src/Service/Stt/Exception/SttModelNotFoundException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Stt\Exception;
+
+final class SttModelNotFoundException extends \RuntimeException
+{
+    public function __construct(?string $model, ?\Throwable $previous = null)
+    {
+        $message = null !== $model && '' !== $model
+            ? sprintf('The speech-to-text model `%s` does not exist or is not available.', $model)
+            : 'No speech-to-text model specified and no default SOUND2TEXT model is configured.';
+
+        parent::__construct($message, 404, $previous);
+    }
+}

--- a/backend/src/Service/Stt/Exception/SttSessionClosedException.php
+++ b/backend/src/Service/Stt/Exception/SttSessionClosedException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Stt\Exception;
+
+final class SttSessionClosedException extends \RuntimeException
+{
+    public function __construct(string $sessionId, ?\Throwable $previous = null)
+    {
+        parent::__construct(sprintf('Transcription session `%s` is closed.', $sessionId), 409, $previous);
+    }
+}

--- a/backend/src/Service/Stt/Exception/SttSessionNotFoundException.php
+++ b/backend/src/Service/Stt/Exception/SttSessionNotFoundException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Stt\Exception;
+
+final class SttSessionNotFoundException extends \RuntimeException
+{
+    public function __construct(string $sessionId, ?\Throwable $previous = null)
+    {
+        parent::__construct(sprintf('Transcription session `%s` was not found.', $sessionId), 404, $previous);
+    }
+}

--- a/backend/src/Service/Stt/SttAudioAssembler.php
+++ b/backend/src/Service/Stt/SttAudioAssembler.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Stt;
+
+/**
+ * Appends raw audio chunks and turns the pending buffer into a file
+ * {@see \App\AI\Service\AiFacade::transcribe()} can consume.
+ */
+final class SttAudioAssembler
+{
+    public const ENCODING_AUTO = 'auto';
+    public const ENCODING_PCM = 'pcm_s16le';
+    public const ENCODING_WAV = 'wav';
+    public const ENCODING_WEBM = 'webm';
+    public const ENCODING_OGG = 'ogg';
+    public const ENCODING_MP3 = 'mp3';
+    public const ENCODING_M4A = 'm4a';
+    public const ENCODING_FLAC = 'flac';
+
+    /**
+     * @return list<string>
+     */
+    public static function encodings(): array
+    {
+        return [
+            self::ENCODING_AUTO,
+            self::ENCODING_PCM,
+            self::ENCODING_WAV,
+            self::ENCODING_WEBM,
+            self::ENCODING_OGG,
+            self::ENCODING_MP3,
+            self::ENCODING_M4A,
+            self::ENCODING_FLAC,
+        ];
+    }
+
+    public function pendingPath(string $sessionDir): string
+    {
+        return $sessionDir.'/pending.bin';
+    }
+
+    public function append(string $pendingPath, string $chunk): int
+    {
+        $dir = dirname($pendingPath);
+        if (!is_dir($dir) && !mkdir($dir, 0775, true) && !is_dir($dir)) {
+            throw new \RuntimeException('Failed to create STT session audio directory');
+        }
+
+        $written = file_put_contents($pendingPath, $chunk, FILE_APPEND | LOCK_EX);
+        if (false === $written) {
+            throw new \RuntimeException('Failed to append audio chunk');
+        }
+
+        return $written;
+    }
+
+    public function pendingSize(string $pendingPath): int
+    {
+        if (!is_file($pendingPath)) {
+            return 0;
+        }
+
+        return (int) filesize($pendingPath);
+    }
+
+    /**
+     * Build a temporary audio file suitable for the configured STT provider.
+     *
+     * Caller must unlink the returned path.
+     */
+    public function buildTranscribeFile(
+        string $pendingPath,
+        string $encoding,
+        int $sampleRate,
+        int $channels,
+    ): string {
+        if (!is_file($pendingPath) || 0 === filesize($pendingPath)) {
+            throw new \InvalidArgumentException('No pending audio to transcribe');
+        }
+
+        $data = file_get_contents($pendingPath);
+        if (false === $data || '' === $data) {
+            throw new \InvalidArgumentException('No pending audio to transcribe');
+        }
+
+        $detected = $this->detectFormat($data, $encoding);
+        $tmp = sys_get_temp_dir().'/stt_'.bin2hex(random_bytes(8)).'.'.$detected['extension'];
+        $payload = $detected['wrap_pcm']
+            ? $this->wrapPcmWav($data, $sampleRate, $channels)
+            : $data;
+
+        if (false === file_put_contents($tmp, $payload)) {
+            throw new \RuntimeException('Failed to write transcription temp file');
+        }
+
+        return $tmp;
+    }
+
+    public function clearPending(string $pendingPath): void
+    {
+        if (is_file($pendingPath)) {
+            file_put_contents($pendingPath, '', LOCK_EX);
+        }
+    }
+
+    /**
+     * @return array{extension: string, wrap_pcm: bool}
+     */
+    public function detectFormat(string $data, string $encoding): array
+    {
+        if (self::ENCODING_PCM === $encoding) {
+            return ['extension' => 'wav', 'wrap_pcm' => true];
+        }
+
+        if (self::ENCODING_AUTO !== $encoding) {
+            return ['extension' => $encoding, 'wrap_pcm' => false];
+        }
+
+        $magic = $this->sniffMagic($data);
+        if (null !== $magic) {
+            return ['extension' => $magic, 'wrap_pcm' => false];
+        }
+
+        // Bare PCM from a local capture pipeline — wrap so whisper.cpp / ffmpeg
+        // and the cloud providers all see a real WAV file.
+        return ['extension' => 'wav', 'wrap_pcm' => true];
+    }
+
+    public function wrapPcmWav(string $pcm, int $sampleRate, int $channels): string
+    {
+        $sampleRate = max(8000, min(48000, $sampleRate));
+        $channels = max(1, min(2, $channels));
+        $byteRate = $sampleRate * $channels * 2;
+        $blockAlign = $channels * 2;
+        $dataSize = strlen($pcm);
+
+        $header = pack(
+            'A4VA4A4VvvVVvvA4V',
+            'RIFF',
+            36 + $dataSize,
+            'WAVE',
+            'fmt ',
+            16,
+            1,
+            $channels,
+            $sampleRate,
+            $byteRate,
+            $blockAlign,
+            16,
+            'data',
+            $dataSize,
+        );
+
+        return $header.$pcm;
+    }
+
+    private function sniffMagic(string $data): ?string
+    {
+        if (strlen($data) < 12) {
+            return null;
+        }
+
+        if (str_starts_with($data, 'RIFF') && str_contains(substr($data, 0, 12), 'WAVE')) {
+            return 'wav';
+        }
+        if (str_starts_with($data, 'OggS')) {
+            return 'ogg';
+        }
+        if (str_starts_with($data, 'fLaC')) {
+            return 'flac';
+        }
+        if (str_starts_with($data, 'ID3') || str_starts_with($data, "\xff\xfb") || str_starts_with($data, "\xff\xf3")) {
+            return 'mp3';
+        }
+        // EBML / WebM / Matroska
+        if (str_starts_with($data, "\x1a\x45\xdf\xa3")) {
+            return 'webm';
+        }
+        // MPEG-4 / M4A (`ftyp` at offset 4)
+        if ('ftyp' === substr($data, 4, 4)) {
+            return 'm4a';
+        }
+
+        return null;
+    }
+}

--- a/backend/src/Service/Stt/SttModelResolver.php
+++ b/backend/src/Service/Stt/SttModelResolver.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Stt;
+
+use App\Entity\Model;
+use App\Repository\ModelRepository;
+use App\Service\ModelConfigService;
+use App\Service\Stt\Exception\SttModelNotFoundException;
+
+/**
+ * Resolves a SOUND2TEXT catalog row for an external transcription request.
+ *
+ * @phpstan-type ResolvedSttModel array{
+ *     provider: string,
+ *     providerModelId: string,
+ *     displayModel: string,
+ *     model_id: int
+ * }
+ */
+final readonly class SttModelResolver
+{
+    public const TAG = 'sound2text';
+
+    public function __construct(
+        private ModelRepository $modelRepository,
+        private ModelConfigService $modelConfigService,
+    ) {
+    }
+
+    /**
+     * @return ResolvedSttModel
+     */
+    public function resolve(?string $modelString, int $userId): array
+    {
+        if (null !== $modelString && '' !== trim($modelString)) {
+            $model = $this->modelRepository->findActiveByTagAndIdentity(self::TAG, trim($modelString));
+            if (null !== $model) {
+                return $this->toResolved($model);
+            }
+
+            throw new SttModelNotFoundException($modelString);
+        }
+
+        $default = $this->modelConfigService->resolveSttDefault($userId);
+        if (null !== $default['model_id']) {
+            $model = $this->modelRepository->find($default['model_id']);
+            if ($model instanceof Model && 1 === $model->getActive() && self::TAG === $model->getTag()) {
+                return $this->toResolved($model);
+            }
+        }
+
+        $fallback = $this->modelRepository->findActiveByTag(self::TAG);
+        if ([] !== $fallback) {
+            return $this->toResolved($fallback[0]);
+        }
+
+        throw new SttModelNotFoundException($modelString);
+    }
+
+    /**
+     * @return list<array{id: string, object: string, created: int, owned_by: string, tag: string}>
+     */
+    public function listModels(): array
+    {
+        $data = [];
+        foreach ($this->modelRepository->findActiveByTag(self::TAG) as $model) {
+            $data[] = [
+                'id' => $model->getProviderId() ?: $model->getName(),
+                'object' => 'model',
+                'created' => 1700000000,
+                'owned_by' => strtolower($model->getService()),
+                'tag' => $model->getTag(),
+            ];
+        }
+
+        return $data;
+    }
+
+    /**
+     * @return ResolvedSttModel
+     */
+    private function toResolved(Model $model): array
+    {
+        $providerModelId = $model->getProviderId() ?: $model->getName();
+
+        return [
+            'provider' => strtolower($model->getService()),
+            'providerModelId' => $providerModelId,
+            'displayModel' => $providerModelId,
+            'model_id' => (int) $model->getId(),
+        ];
+    }
+}

--- a/backend/src/Service/Stt/SttSession.php
+++ b/backend/src/Service/Stt/SttSession.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Stt;
+
+/**
+ * In-memory / persisted state of an external transcription session.
+ *
+ * One API key can own many sessions (client 123 and client 321 on the same key).
+ *
+ * @phpstan-type SttSegment array{
+ *     id: string,
+ *     text: string,
+ *     is_final: bool,
+ *     language: string,
+ *     duration: float,
+ *     created_at: int
+ * }
+ * @phpstan-type SttEvent array{
+ *     cursor: int,
+ *     type: string,
+ *     payload: array<string, mixed>
+ * }
+ */
+final class SttSession
+{
+    public const OBJECT = 'transcription.session';
+    public const STATUS_OPEN = 'open';
+    public const STATUS_CLOSED = 'closed';
+
+    /**
+     * @param list<SttSegment> $segments
+     * @param list<SttEvent>   $events
+     */
+    public function __construct(
+        public string $id,
+        public string $clientId,
+        public int $apiKeyId,
+        public int $userId,
+        public string $model,
+        public string $provider,
+        public ?int $modelId,
+        public ?string $language,
+        public ?string $prompt,
+        public string $status,
+        public string $encoding,
+        public int $sampleRate,
+        public int $channels,
+        public int $commitAfterBytes,
+        public int $createdAt,
+        public int $updatedAt,
+        public int $expiresAt,
+        public int $bytesReceived = 0,
+        public int $pendingBytes = 0,
+        public float $durationSeconds = 0.0,
+        public string $text = '',
+        public array $segments = [],
+        public array $events = [],
+        public int $cursor = 0,
+    ) {
+    }
+
+    public function isOpen(): bool
+    {
+        return self::STATUS_OPEN === $this->status;
+    }
+
+    public function isExpired(int $now): bool
+    {
+        return $this->expiresAt <= $now;
+    }
+
+    /**
+     * @return list<SttEvent>
+     */
+    public function eventsAfter(int $cursor): array
+    {
+        $out = [];
+        foreach ($this->events as $event) {
+            if ($event['cursor'] > $cursor) {
+                $out[] = $event;
+            }
+        }
+
+        return $out;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    public function pushEvent(string $type, array $payload): void
+    {
+        ++$this->cursor;
+        $this->events[] = [
+            'cursor' => $this->cursor,
+            'type' => $type,
+            'payload' => $payload,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toPublicArray(bool $includeEvents = false): array
+    {
+        $data = [
+            'id' => $this->id,
+            'object' => self::OBJECT,
+            'client_id' => $this->clientId,
+            'api_key_id' => $this->apiKeyId,
+            'user_id' => $this->userId,
+            'model' => $this->model,
+            'provider' => $this->provider,
+            'model_id' => $this->modelId,
+            'language' => $this->language,
+            'status' => $this->status,
+            'encoding' => $this->encoding,
+            'sample_rate' => $this->sampleRate,
+            'channels' => $this->channels,
+            'commit_after_bytes' => $this->commitAfterBytes,
+            'created_at' => $this->createdAt,
+            'updated_at' => $this->updatedAt,
+            'expires_at' => $this->expiresAt,
+            'bytes_received' => $this->bytesReceived,
+            'pending_bytes' => $this->pendingBytes,
+            'duration' => $this->durationSeconds,
+            'text' => $this->text,
+            'segments' => $this->segments,
+            'cursor' => $this->cursor,
+        ];
+
+        if ($includeEvents) {
+            $data['events'] = $this->events;
+        }
+
+        return $data;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toStorageArray(): array
+    {
+        return $this->toPublicArray(true) + [
+            'prompt' => $this->prompt,
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function fromStorageArray(array $data): self
+    {
+        $segments = [];
+        if (isset($data['segments']) && is_array($data['segments'])) {
+            foreach ($data['segments'] as $segment) {
+                if (!is_array($segment)) {
+                    continue;
+                }
+                $segments[] = [
+                    'id' => (string) ($segment['id'] ?? ''),
+                    'text' => (string) ($segment['text'] ?? ''),
+                    'is_final' => (bool) ($segment['is_final'] ?? true),
+                    'language' => (string) ($segment['language'] ?? 'unknown'),
+                    'duration' => (float) ($segment['duration'] ?? 0),
+                    'created_at' => (int) ($segment['created_at'] ?? 0),
+                ];
+            }
+        }
+
+        $events = [];
+        if (isset($data['events']) && is_array($data['events'])) {
+            foreach ($data['events'] as $event) {
+                if (!is_array($event)) {
+                    continue;
+                }
+                $payload = $event['payload'] ?? [];
+                $events[] = [
+                    'cursor' => (int) ($event['cursor'] ?? 0),
+                    'type' => (string) ($event['type'] ?? ''),
+                    'payload' => is_array($payload) ? $payload : [],
+                ];
+            }
+        }
+
+        $language = $data['language'] ?? null;
+        $prompt = $data['prompt'] ?? null;
+        $modelId = $data['model_id'] ?? null;
+
+        return new self(
+            id: (string) ($data['id'] ?? ''),
+            clientId: (string) ($data['client_id'] ?? 'default'),
+            apiKeyId: (int) ($data['api_key_id'] ?? 0),
+            userId: (int) ($data['user_id'] ?? 0),
+            model: (string) ($data['model'] ?? ''),
+            provider: (string) ($data['provider'] ?? ''),
+            modelId: is_numeric($modelId) ? (int) $modelId : null,
+            language: is_string($language) && '' !== $language ? $language : null,
+            prompt: is_string($prompt) && '' !== $prompt ? $prompt : null,
+            status: (string) ($data['status'] ?? self::STATUS_OPEN),
+            encoding: (string) ($data['encoding'] ?? 'auto'),
+            sampleRate: (int) ($data['sample_rate'] ?? 16000),
+            channels: (int) ($data['channels'] ?? 1),
+            commitAfterBytes: (int) ($data['commit_after_bytes'] ?? 96000),
+            createdAt: (int) ($data['created_at'] ?? 0),
+            updatedAt: (int) ($data['updated_at'] ?? 0),
+            expiresAt: (int) ($data['expires_at'] ?? 0),
+            bytesReceived: (int) ($data['bytes_received'] ?? 0),
+            pendingBytes: (int) ($data['pending_bytes'] ?? 0),
+            durationSeconds: (float) ($data['duration'] ?? 0),
+            text: (string) ($data['text'] ?? ''),
+            segments: $segments,
+            events: $events,
+            cursor: (int) ($data['cursor'] ?? 0),
+        );
+    }
+}

--- a/backend/src/Service/Stt/SttSessionService.php
+++ b/backend/src/Service/Stt/SttSessionService.php
@@ -1,0 +1,419 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Stt;
+
+use App\AI\Service\AiFacade;
+use App\Entity\User;
+use App\Service\Exception\RateLimitExceededException;
+use App\Service\RateLimitService;
+use App\Service\Stt\Exception\SttSessionClosedException;
+use App\Service\Stt\Exception\SttSessionNotFoundException;
+use Psr\Log\LoggerInterface;
+
+/**
+ * External, API-key-scoped speech-to-text sessions.
+ *
+ * Local programs open a session per client (client 123 vs client 321 on the
+ * same key), stream audio chunks, and read incremental transcripts via poll
+ * or SSE. Each commit window is transcribed through {@see AiFacade} so every
+ * SOUND2TEXT model (local whisper.cpp, Groq, OpenAI, Mistral, xAI, …) works.
+ */
+final readonly class SttSessionService
+{
+    public const MAX_OPEN_SESSIONS = 32;
+    public const MAX_CHUNK_BYTES = 5_242_880;
+    public const MAX_PENDING_BYTES = 8_388_608;
+    public const DEFAULT_COMMIT_AFTER_BYTES = 96_000;
+    public const DEFAULT_SAMPLE_RATE = 16_000;
+    public const CLIENT_ID_PATTERN = '/^[A-Za-z0-9._:-]{1,64}$/';
+
+    public function __construct(
+        private SttSessionStore $store,
+        private SttAudioAssembler $assembler,
+        private SttModelResolver $modelResolver,
+        private AiFacade $aiFacade,
+        private RateLimitService $rateLimitService,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @param array{
+     *     client_id?: string,
+     *     model?: string|null,
+     *     language?: string|null,
+     *     prompt?: string|null,
+     *     encoding?: string|null,
+     *     sample_rate?: int,
+     *     channels?: int,
+     *     commit_after_bytes?: int,
+     *     reuse?: bool
+     * } $options
+     */
+    public function create(User $user, int $apiKeyId, array $options = []): SttSession
+    {
+        $clientId = $this->normalizeClientId($options['client_id'] ?? null);
+        $reuse = (bool) ($options['reuse'] ?? false);
+
+        if ($reuse) {
+            $existing = $this->store->findOpenForClient($apiKeyId, $clientId);
+            if (null !== $existing) {
+                return $existing;
+            }
+        }
+
+        if ($this->store->countOpenForApiKey($apiKeyId) >= self::MAX_OPEN_SESSIONS) {
+            throw new \InvalidArgumentException(sprintf('This API key already has %d open transcription sessions. Close one first.', self::MAX_OPEN_SESSIONS));
+        }
+
+        $resolved = $this->modelResolver->resolve(
+            $this->optionalString($options['model'] ?? null),
+            (int) $user->getId(),
+        );
+
+        $encoding = $this->normalizeEncoding($options['encoding'] ?? null);
+        $sampleRate = (int) ($options['sample_rate'] ?? self::DEFAULT_SAMPLE_RATE);
+        $channels = (int) ($options['channels'] ?? 1);
+        $commitAfter = (int) ($options['commit_after_bytes'] ?? self::DEFAULT_COMMIT_AFTER_BYTES);
+        $language = $this->optionalString($options['language'] ?? null);
+        $prompt = $this->optionalString($options['prompt'] ?? null);
+
+        $now = time();
+        $session = new SttSession(
+            id: 'stt_sess_'.bin2hex(random_bytes(16)),
+            clientId: $clientId,
+            apiKeyId: $apiKeyId,
+            userId: (int) $user->getId(),
+            model: $resolved['displayModel'],
+            provider: $resolved['provider'],
+            modelId: $resolved['model_id'],
+            language: $language,
+            prompt: $prompt,
+            status: SttSession::STATUS_OPEN,
+            encoding: $encoding,
+            sampleRate: max(8000, min(48000, $sampleRate)),
+            channels: max(1, min(2, $channels)),
+            commitAfterBytes: max(8_000, min(self::MAX_PENDING_BYTES, $commitAfter)),
+            createdAt: $now,
+            updatedAt: $now,
+            expiresAt: $now + 7200,
+        );
+        $session->pushEvent('session.created', [
+            'id' => $session->id,
+            'client_id' => $session->clientId,
+            'api_key_id' => $session->apiKeyId,
+            'model' => $session->model,
+        ]);
+
+        $this->store->save($session);
+
+        $this->logger->info('STT session created', [
+            'session_id' => $session->id,
+            'client_id' => $session->clientId,
+            'api_key_id' => $session->apiKeyId,
+            'user_id' => $session->userId,
+            'model' => $session->model,
+        ]);
+
+        return $session;
+    }
+
+    public function getOwned(string $sessionId, int $apiKeyId): SttSession
+    {
+        $session = $this->store->get($sessionId);
+        if (null === $session || $session->apiKeyId !== $apiKeyId) {
+            throw new SttSessionNotFoundException($sessionId);
+        }
+
+        return $session;
+    }
+
+    /**
+     * @return list<SttSession>
+     */
+    public function listOwned(int $apiKeyId, ?string $clientId = null, ?string $status = null): array
+    {
+        $normalizedClient = null;
+        if (null !== $clientId && '' !== trim($clientId)) {
+            $normalizedClient = $this->normalizeClientId($clientId);
+        }
+
+        $sessions = $this->store->listForApiKey($apiKeyId, $normalizedClient);
+        if (null === $status || '' === $status) {
+            return $sessions;
+        }
+
+        return array_values(array_filter(
+            $sessions,
+            static fn (SttSession $session): bool => $session->status === $status,
+        ));
+    }
+
+    /**
+     * @return array{session: SttSession, committed: bool, bytes_appended: int}
+     */
+    public function appendAudio(User $user, int $apiKeyId, string $sessionId, string $chunk, bool $commit = false): array
+    {
+        if ('' === $chunk) {
+            throw new \InvalidArgumentException('Audio chunk is empty');
+        }
+        if (strlen($chunk) > self::MAX_CHUNK_BYTES) {
+            throw new \InvalidArgumentException(sprintf('Audio chunk is too large (%d bytes, max %d)', strlen($chunk), self::MAX_CHUNK_BYTES));
+        }
+
+        $session = $this->getOwned($sessionId, $apiKeyId);
+        $this->assertOpen($session);
+
+        $pendingPath = $this->assembler->pendingPath($this->store->sessionDir($session->id));
+        if ($session->pendingBytes + strlen($chunk) > self::MAX_PENDING_BYTES && $session->pendingBytes > 0) {
+            $this->commit($user, $apiKeyId, $session->id, false);
+            $session = $this->getOwned($sessionId, $apiKeyId);
+        }
+        if ($session->pendingBytes + strlen($chunk) > self::MAX_PENDING_BYTES) {
+            throw new \InvalidArgumentException('Audio chunk exceeds the pending buffer limit');
+        }
+
+        $written = $this->assembler->append($pendingPath, $chunk);
+        $session = $this->getOwned($sessionId, $apiKeyId);
+        $session->bytesReceived += $written;
+        $session->pendingBytes = $this->assembler->pendingSize($pendingPath);
+        $this->store->save($session);
+
+        $shouldCommit = $commit || $session->pendingBytes >= $session->commitAfterBytes;
+        if ($shouldCommit) {
+            $session = $this->commit($user, $apiKeyId, $session->id, false);
+        }
+
+        return [
+            'session' => $session,
+            'committed' => $shouldCommit,
+            'bytes_appended' => $written,
+        ];
+    }
+
+    public function commit(User $user, int $apiKeyId, string $sessionId, bool $close = false): SttSession
+    {
+        $session = $this->getOwned($sessionId, $apiKeyId);
+        $this->assertOpen($session);
+
+        $pendingPath = $this->assembler->pendingPath($this->store->sessionDir($session->id));
+        $pendingBytes = $this->assembler->pendingSize($pendingPath);
+
+        if ($pendingBytes > 0) {
+            $this->assertRateLimit($user);
+            $tempFile = $this->assembler->buildTranscribeFile(
+                $pendingPath,
+                $session->encoding,
+                $session->sampleRate,
+                $session->channels,
+            );
+
+            try {
+                $options = [
+                    'provider' => $session->provider,
+                    'model' => $session->model,
+                ];
+                if (null !== $session->language) {
+                    $options['language'] = $session->language;
+                }
+                if (null !== $session->prompt) {
+                    $options['prompt'] = $session->prompt;
+                }
+
+                $result = $this->aiFacade->transcribe($tempFile, $session->userId, $options);
+            } finally {
+                if (is_file($tempFile)) {
+                    unlink($tempFile);
+                }
+            }
+
+            $newText = trim((string) ($result['text'] ?? ''));
+            $language = (string) ($result['language'] ?? $session->language ?? 'unknown');
+            $duration = (float) ($result['duration'] ?? 0);
+
+            $session = $this->getOwned($sessionId, $apiKeyId);
+            if ('' !== $newText) {
+                $session->text = trim($session->text.' '.$newText);
+            }
+            $session->durationSeconds += max(0.0, $duration);
+            if ('unknown' !== $language && '' !== $language && null === $session->language) {
+                $session->language = $language;
+            }
+
+            $segment = [
+                'id' => 'seg_'.($session->cursor + 1),
+                'text' => $newText,
+                'is_final' => true,
+                'language' => $language,
+                'duration' => $duration,
+                'created_at' => time(),
+            ];
+            $session->segments[] = $segment;
+            $session->pushEvent('transcript', [
+                'id' => $segment['id'],
+                'session_id' => $session->id,
+                'client_id' => $session->clientId,
+                'api_key_id' => $session->apiKeyId,
+                'text' => $newText,
+                'full_text' => $session->text,
+                'is_final' => true,
+                'language' => $language,
+                'duration' => $duration,
+                'model' => $session->model,
+            ]);
+
+            $this->assembler->clearPending($pendingPath);
+            $session->pendingBytes = 0;
+
+            $this->logger->info('STT session committed', [
+                'session_id' => $session->id,
+                'client_id' => $session->clientId,
+                'api_key_id' => $session->apiKeyId,
+                'bytes' => $pendingBytes,
+                'text_length' => strlen($newText),
+                'model' => $session->model,
+            ]);
+        }
+
+        if ($close) {
+            $session = $this->closeSession($session);
+        } else {
+            $this->store->save($session);
+        }
+
+        return $session;
+    }
+
+    public function close(int $apiKeyId, string $sessionId): SttSession
+    {
+        $session = $this->getOwned($sessionId, $apiKeyId);
+        if (!$session->isOpen()) {
+            return $session;
+        }
+
+        return $this->closeSession($session);
+    }
+
+    /**
+     * One-shot file transcription (OpenAI `/v1/audio/transcriptions`).
+     *
+     * @param array{model?: string|null, language?: string|null, prompt?: string|null, client_id?: string|null} $options
+     *
+     * @return array<string, mixed>
+     */
+    public function transcribeFile(User $user, int $apiKeyId, string $audioPath, array $options = []): array
+    {
+        if (!is_file($audioPath)) {
+            throw new \InvalidArgumentException('Audio file is missing');
+        }
+
+        $this->assertRateLimit($user);
+        $resolved = $this->modelResolver->resolve(
+            $this->optionalString($options['model'] ?? null),
+            (int) $user->getId(),
+        );
+
+        $transcribeOptions = [
+            'provider' => $resolved['provider'],
+            'model' => $resolved['providerModelId'],
+        ];
+        $language = $this->optionalString($options['language'] ?? null);
+        $prompt = $this->optionalString($options['prompt'] ?? null);
+        if (null !== $language) {
+            $transcribeOptions['language'] = $language;
+        }
+        if (null !== $prompt) {
+            $transcribeOptions['prompt'] = $prompt;
+        }
+
+        $result = $this->aiFacade->transcribe($audioPath, (int) $user->getId(), $transcribeOptions);
+        $clientId = null;
+        $requestedClient = $this->optionalString($options['client_id'] ?? null);
+        if (null !== $requestedClient) {
+            $clientId = $this->normalizeClientId($requestedClient);
+        }
+
+        return [
+            'id' => 'transcribe_'.bin2hex(random_bytes(12)),
+            'object' => 'transcription',
+            'text' => (string) ($result['text'] ?? ''),
+            'language' => (string) ($result['language'] ?? $language ?? 'unknown'),
+            'duration' => (float) ($result['duration'] ?? 0),
+            'model' => $resolved['displayModel'],
+            'provider' => $resolved['provider'],
+            'model_id' => $resolved['model_id'],
+            'client_id' => $clientId,
+            'api_key_id' => $apiKeyId,
+            'user_id' => (int) $user->getId(),
+            'segments' => is_array($result['segments'] ?? null) ? $result['segments'] : [],
+        ];
+    }
+
+    private function closeSession(SttSession $session): SttSession
+    {
+        $session->status = SttSession::STATUS_CLOSED;
+        $session->pushEvent('done', [
+            'session_id' => $session->id,
+            'client_id' => $session->clientId,
+            'api_key_id' => $session->apiKeyId,
+            'text' => $session->text,
+        ]);
+        $this->store->save($session);
+        $this->store->deleteAudio($session->id);
+
+        return $session;
+    }
+
+    private function assertOpen(SttSession $session): void
+    {
+        if (!$session->isOpen()) {
+            throw new SttSessionClosedException($session->id);
+        }
+    }
+
+    private function assertRateLimit(User $user): void
+    {
+        $check = $this->rateLimitService->checkLimit($user, 'FILE_ANALYSIS');
+        if (!($check['allowed'] ?? false)) {
+            throw new RateLimitExceededException('FILE_ANALYSIS', (int) ($check['used'] ?? 0), (int) ($check['limit'] ?? 0));
+        }
+    }
+
+    private function normalizeClientId(?string $clientId): string
+    {
+        $value = trim((string) $clientId);
+        if ('' === $value) {
+            return 'default';
+        }
+        if (1 !== preg_match(self::CLIENT_ID_PATTERN, $value)) {
+            throw new \InvalidArgumentException('client_id must be 1–64 characters of letters, digits, `.`, `_`, `-`, or `:`');
+        }
+
+        return $value;
+    }
+
+    private function normalizeEncoding(?string $encoding): string
+    {
+        $value = strtolower(trim((string) $encoding));
+        if ('' === $value) {
+            return SttAudioAssembler::ENCODING_AUTO;
+        }
+        if (!in_array($value, SttAudioAssembler::encodings(), true)) {
+            throw new \InvalidArgumentException('encoding must be one of: '.implode(', ', SttAudioAssembler::encodings()));
+        }
+
+        return $value;
+    }
+
+    private function optionalString(mixed $value): ?string
+    {
+        if (!is_string($value)) {
+            return null;
+        }
+        $trimmed = trim($value);
+
+        return '' === $trimmed ? null : $trimmed;
+    }
+}

--- a/backend/src/Service/Stt/SttSessionService.php
+++ b/backend/src/Service/Stt/SttSessionService.php
@@ -163,37 +163,52 @@ final readonly class SttSessionService
             throw new \InvalidArgumentException(sprintf('Audio chunk is too large (%d bytes, max %d)', strlen($chunk), self::MAX_CHUNK_BYTES));
         }
 
-        $session = $this->getOwned($sessionId, $apiKeyId);
-        $this->assertOpen($session);
-
-        $pendingPath = $this->assembler->pendingPath($this->store->sessionDir($session->id));
-        if ($session->pendingBytes + strlen($chunk) > self::MAX_PENDING_BYTES && $session->pendingBytes > 0) {
-            $this->commit($user, $apiKeyId, $session->id, false);
+        /** @var array{session: SttSession, committed: bool, bytes_appended: int} $result */
+        $result = $this->store->withLock($sessionId, function () use ($user, $apiKeyId, $sessionId, $chunk, $commit): array {
             $session = $this->getOwned($sessionId, $apiKeyId);
-        }
-        if ($session->pendingBytes + strlen($chunk) > self::MAX_PENDING_BYTES) {
-            throw new \InvalidArgumentException('Audio chunk exceeds the pending buffer limit');
-        }
+            $this->assertOpen($session);
 
-        $written = $this->assembler->append($pendingPath, $chunk);
-        $session = $this->getOwned($sessionId, $apiKeyId);
-        $session->bytesReceived += $written;
-        $session->pendingBytes = $this->assembler->pendingSize($pendingPath);
-        $this->store->save($session);
+            $pendingPath = $this->assembler->pendingPath($this->store->sessionDir($session->id));
+            if ($session->pendingBytes + strlen($chunk) > self::MAX_PENDING_BYTES && $session->pendingBytes > 0) {
+                $this->commitLocked($user, $apiKeyId, $session->id, false);
+                $session = $this->getOwned($sessionId, $apiKeyId);
+            }
+            if ($session->pendingBytes + strlen($chunk) > self::MAX_PENDING_BYTES) {
+                throw new \InvalidArgumentException('Audio chunk exceeds the pending buffer limit');
+            }
 
-        $shouldCommit = $commit || $session->pendingBytes >= $session->commitAfterBytes;
-        if ($shouldCommit) {
-            $session = $this->commit($user, $apiKeyId, $session->id, false);
-        }
+            $written = $this->assembler->append($pendingPath, $chunk);
+            $session = $this->getOwned($sessionId, $apiKeyId);
+            $session->bytesReceived += $written;
+            $session->pendingBytes = $this->assembler->pendingSize($pendingPath);
+            $this->store->save($session);
 
-        return [
-            'session' => $session,
-            'committed' => $shouldCommit,
-            'bytes_appended' => $written,
-        ];
+            $shouldCommit = $commit || $session->pendingBytes >= $session->commitAfterBytes;
+            if ($shouldCommit) {
+                $session = $this->commitLocked($user, $apiKeyId, $session->id, false);
+            }
+
+            return [
+                'session' => $session,
+                'committed' => $shouldCommit,
+                'bytes_appended' => $written,
+            ];
+        });
+
+        return $result;
     }
 
     public function commit(User $user, int $apiKeyId, string $sessionId, bool $close = false): SttSession
+    {
+        /** @var SttSession $session */
+        $session = $this->store->withLock($sessionId, function () use ($user, $apiKeyId, $sessionId, $close): SttSession {
+            return $this->commitLocked($user, $apiKeyId, $sessionId, $close);
+        });
+
+        return $session;
+    }
+
+    private function commitLocked(User $user, int $apiKeyId, string $sessionId, bool $close): SttSession
     {
         $session = $this->getOwned($sessionId, $apiKeyId);
         $this->assertOpen($session);
@@ -288,12 +303,17 @@ final readonly class SttSessionService
 
     public function close(int $apiKeyId, string $sessionId): SttSession
     {
-        $session = $this->getOwned($sessionId, $apiKeyId);
-        if (!$session->isOpen()) {
-            return $session;
-        }
+        /** @var SttSession $session */
+        $session = $this->store->withLock($sessionId, function () use ($apiKeyId, $sessionId): SttSession {
+            $session = $this->getOwned($sessionId, $apiKeyId);
+            if (!$session->isOpen()) {
+                return $session;
+            }
 
-        return $this->closeSession($session);
+            return $this->closeSession($session);
+        });
+
+        return $session;
     }
 
     /**

--- a/backend/src/Service/Stt/SttSessionStore.php
+++ b/backend/src/Service/Stt/SttSessionStore.php
@@ -1,0 +1,264 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Stt;
+
+use App\Service\Infrastructure\RedisService;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Persists STT sessions. Filesystem is the source of truth (audio appends
+ * need flock); Redis mirrors metadata so a node can list sessions.
+ */
+final class SttSessionStore
+{
+    public function __construct(
+        private readonly RedisService $redis,
+        private readonly LoggerInterface $logger,
+        private readonly string $storageDir,
+        private readonly int $ttlSeconds = 7200,
+    ) {
+    }
+
+    public function sessionDir(string $sessionId): string
+    {
+        return $this->storageDir.'/'.$this->safeId($sessionId);
+    }
+
+    public function save(SttSession $session): void
+    {
+        $now = time();
+        $session->updatedAt = $now;
+        $session->expiresAt = $now + $this->ttlSeconds;
+
+        $dir = $this->sessionDir($session->id);
+        if (!is_dir($dir) && !mkdir($dir, 0775, true) && !is_dir($dir)) {
+            throw new \RuntimeException('Failed to create STT session directory');
+        }
+
+        $json = json_encode($session->toStorageArray(), JSON_INVALID_UTF8_SUBSTITUTE);
+        if (false === $json) {
+            throw new \RuntimeException('Failed to encode STT session');
+        }
+
+        $this->withLock($session->id, function () use ($dir, $json): void {
+            if (false === file_put_contents($dir.'/session.json', $json, LOCK_EX)) {
+                throw new \RuntimeException('Failed to write STT session');
+            }
+        });
+
+        $this->indexAdd($session);
+        $this->redis->set($this->redisKey($session->id), $json, $this->ttlSeconds);
+        $this->redis->sAdd($this->apiKeyIndexKey($session->apiKeyId), $session->id);
+        $this->redis->expire($this->apiKeyIndexKey($session->apiKeyId), $this->ttlSeconds);
+        $this->redis->sAdd($this->clientIndexKey($session->apiKeyId, $session->clientId), $session->id);
+        $this->redis->expire($this->clientIndexKey($session->apiKeyId, $session->clientId), $this->ttlSeconds);
+    }
+
+    public function get(string $sessionId): ?SttSession
+    {
+        $path = $this->sessionDir($sessionId).'/session.json';
+        $raw = is_file($path) ? file_get_contents($path) : null;
+        if (!is_string($raw) || '' === $raw) {
+            $raw = $this->redis->get($this->redisKey($sessionId));
+        }
+        if (!is_string($raw) || '' === $raw) {
+            return null;
+        }
+
+        $decoded = json_decode($raw, true);
+        if (!is_array($decoded)) {
+            return null;
+        }
+
+        $session = SttSession::fromStorageArray($decoded);
+        if ('' === $session->id || $session->isExpired(time())) {
+            return null;
+        }
+
+        return $session;
+    }
+
+    /**
+     * @return list<SttSession>
+     */
+    public function listForApiKey(int $apiKeyId, ?string $clientId = null): array
+    {
+        $ids = $this->indexIds($apiKeyId, $clientId);
+        $sessions = [];
+        foreach ($ids as $id) {
+            $session = $this->get($id);
+            if (null === $session) {
+                continue;
+            }
+            if (null !== $clientId && $session->clientId !== $clientId) {
+                continue;
+            }
+            $sessions[] = $session;
+        }
+
+        usort($sessions, static fn (SttSession $a, SttSession $b): int => $b->updatedAt <=> $a->updatedAt);
+
+        return $sessions;
+    }
+
+    public function findOpenForClient(int $apiKeyId, string $clientId): ?SttSession
+    {
+        foreach ($this->listForApiKey($apiKeyId, $clientId) as $session) {
+            if ($session->isOpen()) {
+                return $session;
+            }
+        }
+
+        return null;
+    }
+
+    public function countOpenForApiKey(int $apiKeyId): int
+    {
+        $count = 0;
+        foreach ($this->listForApiKey($apiKeyId) as $session) {
+            if ($session->isOpen()) {
+                ++$count;
+            }
+        }
+
+        return $count;
+    }
+
+    public function deleteAudio(string $sessionId): void
+    {
+        $pending = $this->sessionDir($sessionId).'/pending.bin';
+        if (is_file($pending)) {
+            unlink($pending);
+        }
+    }
+
+    /**
+     * @param callable(): void $callback
+     */
+    public function withLock(string $sessionId, callable $callback): void
+    {
+        $dir = $this->sessionDir($sessionId);
+        if (!is_dir($dir) && !mkdir($dir, 0775, true) && !is_dir($dir)) {
+            throw new \RuntimeException('Failed to create STT session directory');
+        }
+
+        $handle = fopen($dir.'/session.lock', 'c');
+        if (false === $handle) {
+            throw new \RuntimeException('Failed to open STT session lock');
+        }
+
+        try {
+            if (!flock($handle, LOCK_EX)) {
+                throw new \RuntimeException('Failed to lock STT session');
+            }
+            $callback();
+        } finally {
+            flock($handle, LOCK_UN);
+            fclose($handle);
+        }
+    }
+
+    private function redisKey(string $sessionId): string
+    {
+        return 'stt:session:'.$this->safeId($sessionId);
+    }
+
+    private function apiKeyIndexKey(int $apiKeyId): string
+    {
+        return 'stt:apikey:'.$apiKeyId.':sessions';
+    }
+
+    private function clientIndexKey(int $apiKeyId, string $clientId): string
+    {
+        return 'stt:apikey:'.$apiKeyId.':client:'.$this->safeId($clientId);
+    }
+
+    private function safeId(string $id): string
+    {
+        $safe = preg_replace('/[^A-Za-z0-9._:-]/', '_', $id) ?? '';
+
+        return '' === $safe ? 'invalid' : $safe;
+    }
+
+    private function indexAdd(SttSession $session): void
+    {
+        $this->writeIndex($this->apiKeyIndexPath($session->apiKeyId), $session->id);
+        $this->writeIndex($this->clientIndexPath($session->apiKeyId, $session->clientId), $session->id);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function indexIds(int $apiKeyId, ?string $clientId): array
+    {
+        $fromRedis = null !== $clientId
+            ? $this->redis->sMembers($this->clientIndexKey($apiKeyId, $clientId))
+            : $this->redis->sMembers($this->apiKeyIndexKey($apiKeyId));
+
+        $fromFile = $this->readIndex(
+            null !== $clientId
+                ? $this->clientIndexPath($apiKeyId, $clientId)
+                : $this->apiKeyIndexPath($apiKeyId)
+        );
+
+        return array_values(array_unique([...$fromRedis, ...$fromFile]));
+    }
+
+    private function apiKeyIndexPath(int $apiKeyId): string
+    {
+        return $this->storageDir.'/index/key-'.$apiKeyId.'.json';
+    }
+
+    private function clientIndexPath(int $apiKeyId, string $clientId): string
+    {
+        return $this->storageDir.'/index/key-'.$apiKeyId.'-client-'.$this->safeId($clientId).'.json';
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function readIndex(string $path): array
+    {
+        if (!is_file($path)) {
+            return [];
+        }
+
+        $raw = file_get_contents($path);
+        if (!is_string($raw) || '' === $raw) {
+            return [];
+        }
+
+        $decoded = json_decode($raw, true);
+        if (!is_array($decoded)) {
+            return [];
+        }
+
+        $ids = [];
+        foreach ($decoded as $id) {
+            if (is_string($id) && '' !== $id) {
+                $ids[] = $id;
+            }
+        }
+
+        return $ids;
+    }
+
+    private function writeIndex(string $path, string $sessionId): void
+    {
+        $dir = dirname($path);
+        if (!is_dir($dir) && !mkdir($dir, 0775, true) && !is_dir($dir)) {
+            $this->logger->warning('STT session index directory could not be created', ['path' => $dir]);
+
+            return;
+        }
+
+        $ids = $this->readIndex($path);
+        if (!in_array($sessionId, $ids, true)) {
+            $ids[] = $sessionId;
+        }
+
+        file_put_contents($path, json_encode($ids, JSON_INVALID_UTF8_SUBSTITUTE), LOCK_EX);
+    }
+}

--- a/backend/src/Service/Stt/SttSessionStore.php
+++ b/backend/src/Service/Stt/SttSessionStore.php
@@ -13,6 +13,14 @@ use Psr\Log\LoggerInterface;
  */
 final class SttSessionStore
 {
+    /**
+     * Per-process re-entrancy table so append → commit → save on the same
+     * session does not deadlock. flock() is not re-entrant across fds.
+     *
+     * @var array<string, resource>
+     */
+    private array $heldLocks = [];
+
     public function __construct(
         private readonly RedisService $redis,
         private readonly LoggerInterface $logger,
@@ -135,10 +143,22 @@ final class SttSessionStore
     }
 
     /**
-     * @param callable(): void $callback
+     * Serialize work on one session. Re-entrant in-process so append → commit
+     * → save does not deadlock.
+     *
+     * @template T
+     *
+     * @param callable(): T $callback
+     *
+     * @return T
      */
-    public function withLock(string $sessionId, callable $callback): void
+    public function withLock(string $sessionId, callable $callback): mixed
     {
+        $id = $this->safeId($sessionId);
+        if (isset($this->heldLocks[$id])) {
+            return $callback();
+        }
+
         $dir = $this->sessionDir($sessionId);
         if (!is_dir($dir) && !mkdir($dir, 0775, true) && !is_dir($dir)) {
             throw new \RuntimeException('Failed to create STT session directory');
@@ -149,14 +169,18 @@ final class SttSessionStore
             throw new \RuntimeException('Failed to open STT session lock');
         }
 
+        if (!flock($handle, LOCK_EX)) {
+            fclose($handle);
+            throw new \RuntimeException('Failed to lock STT session');
+        }
+
+        $this->heldLocks[$id] = $handle;
         try {
-            if (!flock($handle, LOCK_EX)) {
-                throw new \RuntimeException('Failed to lock STT session');
-            }
-            $callback();
+            return $callback();
         } finally {
             flock($handle, LOCK_UN);
             fclose($handle);
+            unset($this->heldLocks[$id]);
         }
     }
 
@@ -254,11 +278,29 @@ final class SttSessionStore
             return;
         }
 
-        $ids = $this->readIndex($path);
-        if (!in_array($sessionId, $ids, true)) {
-            $ids[] = $sessionId;
+        $handle = fopen($path.'.lock', 'c');
+        if (false === $handle) {
+            $this->logger->warning('STT session index lock could not be opened', ['path' => $path]);
+
+            return;
         }
 
-        file_put_contents($path, json_encode($ids, JSON_INVALID_UTF8_SUBSTITUTE), LOCK_EX);
+        try {
+            if (!flock($handle, LOCK_EX)) {
+                throw new \RuntimeException('Failed to lock STT session index');
+            }
+
+            $ids = $this->readIndex($path);
+            if (!in_array($sessionId, $ids, true)) {
+                $ids[] = $sessionId;
+            }
+
+            if (false === file_put_contents($path, json_encode($ids, JSON_INVALID_UTF8_SUBSTITUTE), LOCK_EX)) {
+                throw new \RuntimeException('Failed to write STT session index');
+            }
+        } finally {
+            flock($handle, LOCK_UN);
+            fclose($handle);
+        }
     }
 }

--- a/backend/src/Service/Stt/SttSseWriter.php
+++ b/backend/src/Service/Stt/SttSseWriter.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Stt;
+
+/**
+ * Writes Server-Sent Events for the external STT stream.
+ */
+final class SttSseWriter
+{
+    /**
+     * @param array<string, mixed> $data
+     */
+    public function write(string $event, array $data): void
+    {
+        echo 'event: '.$event."\n";
+        echo 'data: '.json_encode($data, JSON_INVALID_UTF8_SUBSTITUTE)."\n\n";
+        if (ob_get_level()) {
+            ob_flush();
+        }
+        flush();
+    }
+}

--- a/backend/tests/Unit/Controller/AudioTranscriptionControllerTest.php
+++ b/backend/tests/Unit/Controller/AudioTranscriptionControllerTest.php
@@ -1,0 +1,255 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Controller;
+
+use App\Controller\AudioTranscriptionController;
+use App\Entity\ApiKey;
+use App\Entity\User;
+use App\Service\Stt\Exception\SttSessionNotFoundException;
+use App\Service\Stt\SttModelResolver;
+use App\Service\Stt\SttSession;
+use App\Service\Stt\SttSessionService;
+use App\Service\Stt\SttSseWriter;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+final class AudioTranscriptionControllerTest extends TestCase
+{
+    private SttSessionService&MockObject $service;
+    private SttModelResolver&MockObject $resolver;
+    private AudioTranscriptionController $controller;
+    private User&MockObject $user;
+
+    protected function setUp(): void
+    {
+        $this->service = $this->createMock(SttSessionService::class);
+        $this->resolver = $this->createMock(SttModelResolver::class);
+        $this->controller = new AudioTranscriptionController(
+            $this->service,
+            $this->resolver,
+            new SttSseWriter(),
+            new NullLogger(),
+        );
+        $this->user = $this->createMock(User::class);
+        $this->user->method('getId')->willReturn(42);
+    }
+
+    public function testCreateSessionRequiresAuth(): void
+    {
+        $response = $this->controller->createSession(new Request(), null);
+
+        $this->assertSame(401, $response->getStatusCode());
+        $data = json_decode((string) $response->getContent(), true);
+        $this->assertSame('invalid_api_key', $data['error']['code']);
+    }
+
+    public function testCreateSessionReturnsClientAndApiKeyIds(): void
+    {
+        $session = $this->session('stt_sess_abc', '123', 1);
+        $this->service->expects($this->once())
+            ->method('create')
+            ->with(
+                $this->user,
+                1,
+                $this->callback(static fn (array $opts): bool => '123' === ($opts['client_id'] ?? null)),
+            )
+            ->willReturn($session);
+
+        $request = Request::create(
+            '/v1/audio/transcriptions/sessions',
+            'POST',
+            [],
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            json_encode(['client_id' => '123', 'model' => 'whisper'], JSON_THROW_ON_ERROR),
+        );
+        $request->attributes->set('api_key', $this->apiKey(1));
+
+        $response = $this->controller->createSession($request, $this->user);
+        $this->assertSame(201, $response->getStatusCode());
+
+        $data = json_decode((string) $response->getContent(), true);
+        $this->assertSame('stt_sess_abc', $data['id']);
+        $this->assertSame('123', $data['client_id']);
+        $this->assertSame(1, $data['api_key_id']);
+        $this->assertSame('transcription.session', $data['object']);
+    }
+
+    public function testGetSessionUnknownIs404(): void
+    {
+        $this->service->method('getOwned')->willThrowException(new SttSessionNotFoundException('missing'));
+        $request = new Request();
+        $request->attributes->set('api_key', $this->apiKey(1));
+
+        $response = $this->controller->getSession($request, 'missing', $this->user);
+
+        $this->assertSame(404, $response->getStatusCode());
+        $data = json_decode((string) $response->getContent(), true);
+        $this->assertSame('not_found', $data['error']['code']);
+    }
+
+    public function testAppendAudioAcceptsRawBody(): void
+    {
+        $session = $this->session('stt_sess_abc', '321', 1);
+        $this->service->expects($this->once())
+            ->method('appendAudio')
+            ->with($this->user, 1, 'stt_sess_abc', 'PCMDATA', false)
+            ->willReturn([
+                'session' => $session,
+                'committed' => false,
+                'bytes_appended' => 8,
+            ]);
+
+        $request = Request::create(
+            '/v1/audio/transcriptions/sessions/stt_sess_abc/audio',
+            'POST',
+            [],
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/octet-stream'],
+            'PCMDATA',
+        );
+        $request->attributes->set('api_key', $this->apiKey(1));
+
+        $response = $this->controller->appendAudio($request, 'stt_sess_abc', $this->user);
+        $data = json_decode((string) $response->getContent(), true);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertFalse($data['committed']);
+        $this->assertSame(8, $data['bytes_appended']);
+        $this->assertSame('321', $data['client_id']);
+    }
+
+    public function testOneShotRequiresFile(): void
+    {
+        $request = Request::create('/v1/audio/transcriptions', 'POST');
+        $request->attributes->set('api_key', $this->apiKey(1));
+
+        $response = $this->controller->transcribe($request, $this->user);
+        $this->assertInstanceOf(JsonResponse::class, $response);
+        $this->assertSame(400, $response->getStatusCode());
+    }
+
+    public function testOneShotReturnsOpenAiText(): void
+    {
+        $request = Request::create(
+            '/v1/audio/transcriptions?model=whisper&client_id=123',
+            'POST',
+            [],
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/octet-stream'],
+            'RIFF....WAVE',
+        );
+        $request->attributes->set('api_key', $this->apiKey(1));
+
+        $this->service->expects($this->once())
+            ->method('transcribeFile')
+            ->willReturn([
+                'id' => 'transcribe_abc',
+                'text' => 'hello',
+                'language' => 'en',
+                'duration' => 1.0,
+                'model' => 'whisper',
+                'provider' => 'whisper',
+                'model_id' => 330,
+                'client_id' => '123',
+                'api_key_id' => 1,
+                'user_id' => 42,
+                'segments' => [],
+            ]);
+
+        $response = $this->controller->transcribe($request, $this->user);
+        $this->assertInstanceOf(JsonResponse::class, $response);
+        $data = json_decode((string) $response->getContent(), true);
+
+        $this->assertSame('hello', $data['text']);
+        $this->assertSame('123', $data['client_id']);
+        $this->assertSame(1, $data['api_key_id']);
+    }
+
+    public function testOneShotStreamReturnsSse(): void
+    {
+        $request = Request::create(
+            '/v1/audio/transcriptions?stream=true',
+            'POST',
+            [],
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/octet-stream'],
+            'RIFF....WAVE',
+        );
+        $request->attributes->set('api_key', $this->apiKey(1));
+
+        $this->service->method('transcribeFile')->willReturn([
+            'id' => 'transcribe_abc',
+            'text' => 'hello',
+            'language' => 'en',
+            'duration' => 1.0,
+            'model' => 'whisper',
+            'provider' => 'whisper',
+            'model_id' => 330,
+            'client_id' => null,
+            'api_key_id' => 1,
+            'user_id' => 42,
+            'segments' => [],
+        ]);
+
+        $response = $this->controller->transcribe($request, $this->user);
+        $this->assertInstanceOf(StreamedResponse::class, $response);
+        $this->assertSame('text/event-stream', $response->headers->get('Content-Type'));
+    }
+
+    public function testListModels(): void
+    {
+        $this->resolver->method('listModels')->willReturn([
+            ['id' => 'whisper', 'object' => 'model', 'created' => 1700000000, 'owned_by' => 'whisper', 'tag' => 'sound2text'],
+        ]);
+
+        $response = $this->controller->listModels($this->user);
+        $data = json_decode((string) $response->getContent(), true);
+
+        $this->assertSame('list', $data['object']);
+        $this->assertSame('whisper', $data['data'][0]['id']);
+    }
+
+    private function session(string $id, string $clientId, int $apiKeyId): SttSession
+    {
+        $now = time();
+
+        return new SttSession(
+            id: $id,
+            clientId: $clientId,
+            apiKeyId: $apiKeyId,
+            userId: 42,
+            model: 'whisper',
+            provider: 'whisper',
+            modelId: 330,
+            language: 'en',
+            prompt: null,
+            status: SttSession::STATUS_OPEN,
+            encoding: 'auto',
+            sampleRate: 16000,
+            channels: 1,
+            commitAfterBytes: 96000,
+            createdAt: $now,
+            updatedAt: $now,
+            expiresAt: $now + 3600,
+        );
+    }
+
+    private function apiKey(int $id): ApiKey
+    {
+        $key = $this->createMock(ApiKey::class);
+        $key->method('getId')->willReturn($id);
+
+        return $key;
+    }
+}

--- a/backend/tests/Unit/Service/Stt/SttAudioAssemblerTest.php
+++ b/backend/tests/Unit/Service/Stt/SttAudioAssemblerTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\Stt;
+
+use App\Service\Stt\SttAudioAssembler;
+use PHPUnit\Framework\TestCase;
+
+final class SttAudioAssemblerTest extends TestCase
+{
+    private SttAudioAssembler $assembler;
+    private string $dir;
+
+    protected function setUp(): void
+    {
+        $this->assembler = new SttAudioAssembler();
+        $this->dir = sys_get_temp_dir().'/stt-asm-'.bin2hex(random_bytes(4));
+        mkdir($this->dir, 0775, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $pending = $this->assembler->pendingPath($this->dir);
+        if (is_file($pending)) {
+            unlink($pending);
+        }
+        if (is_dir($this->dir)) {
+            rmdir($this->dir);
+        }
+    }
+
+    public function testAppendAndPendingSize(): void
+    {
+        $path = $this->assembler->pendingPath($this->dir);
+
+        $this->assertSame(0, $this->assembler->pendingSize($path));
+        $this->assertSame(4, $this->assembler->append($path, 'abcd'));
+        $this->assertSame(3, $this->assembler->append($path, 'efg'));
+        $this->assertSame(7, $this->assembler->pendingSize($path));
+        $this->assertSame('abcdefg', file_get_contents($path));
+    }
+
+    public function testWrapPcmWavHasValidHeader(): void
+    {
+        $pcm = str_repeat("\x00\x01", 16);
+        $wav = $this->assembler->wrapPcmWav($pcm, 16000, 1);
+
+        $this->assertStringStartsWith('RIFF', $wav);
+        $this->assertStringContainsString('WAVE', substr($wav, 0, 12));
+        $this->assertStringContainsString('fmt ', $wav);
+        $this->assertSame(44 + strlen($pcm), strlen($wav));
+    }
+
+    public function testDetectFormatSniffsWavAndFallsBackToPcm(): void
+    {
+        $wav = $this->assembler->wrapPcmWav('xxxx', 16000, 1);
+        $this->assertSame(
+            ['extension' => 'wav', 'wrap_pcm' => false],
+            $this->assembler->detectFormat($wav, SttAudioAssembler::ENCODING_AUTO),
+        );
+        $this->assertSame(
+            ['extension' => 'wav', 'wrap_pcm' => true],
+            $this->assembler->detectFormat('not-a-container', SttAudioAssembler::ENCODING_AUTO),
+        );
+        $this->assertSame(
+            ['extension' => 'webm', 'wrap_pcm' => false],
+            $this->assembler->detectFormat('xxxx', SttAudioAssembler::ENCODING_WEBM),
+        );
+    }
+
+    public function testBuildTranscribeFileWrapsBarePcm(): void
+    {
+        $path = $this->assembler->pendingPath($this->dir);
+        $this->assembler->append($path, str_repeat("\x00\x01", 32));
+
+        $tmp = $this->assembler->buildTranscribeFile($path, SttAudioAssembler::ENCODING_PCM, 16000, 1);
+        try {
+            $this->assertStringEndsWith('.wav', $tmp);
+            $contents = file_get_contents($tmp);
+            $this->assertIsString($contents);
+            $this->assertStringStartsWith('RIFF', $contents);
+        } finally {
+            if (is_file($tmp)) {
+                unlink($tmp);
+            }
+        }
+    }
+
+    public function testClearPendingEmptiesFile(): void
+    {
+        $path = $this->assembler->pendingPath($this->dir);
+        $this->assembler->append($path, 'hello');
+        $this->assembler->clearPending($path);
+
+        $this->assertSame(0, $this->assembler->pendingSize($path));
+    }
+}

--- a/backend/tests/Unit/Service/Stt/SttModelResolverTest.php
+++ b/backend/tests/Unit/Service/Stt/SttModelResolverTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\Stt;
+
+use App\Entity\Model;
+use App\Repository\ModelRepository;
+use App\Service\ModelConfigService;
+use App\Service\Stt\Exception\SttModelNotFoundException;
+use App\Service\Stt\SttModelResolver;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class SttModelResolverTest extends TestCase
+{
+    private ModelRepository&MockObject $models;
+    private ModelConfigService&MockObject $config;
+    private SttModelResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $this->models = $this->createMock(ModelRepository::class);
+        $this->config = $this->createMock(ModelConfigService::class);
+        $this->resolver = new SttModelResolver($this->models, $this->config);
+    }
+
+    public function testResolveByRequestedIdentity(): void
+    {
+        $model = $this->sttModel(330, 'whisper', 'Whisper');
+
+        $this->models->expects($this->once())
+            ->method('findActiveByTagAndIdentity')
+            ->with('sound2text', 'whisper')
+            ->willReturn($model);
+
+        $resolved = $this->resolver->resolve('whisper', 7);
+
+        $this->assertSame('whisper', $resolved['provider']);
+        $this->assertSame('whisper', $resolved['providerModelId']);
+        $this->assertSame(330, $resolved['model_id']);
+    }
+
+    public function testResolveFallsBackToSound2TextDefault(): void
+    {
+        $this->models->method('findActiveByTagAndIdentity')->willReturn(null);
+        $this->config->expects($this->any())
+            ->method('resolveSttDefault')
+            ->with(7)
+            ->willReturn([
+                'provider' => 'groq',
+                'model' => 'whisper-large-v3',
+                'model_id' => 21,
+            ]);
+        $this->models->expects($this->any())
+            ->method('find')
+            ->with(21)
+            ->willReturn($this->sttModel(21, 'whisper-large-v3', 'Groq'));
+
+        $resolved = $this->resolver->resolve(null, 7);
+
+        $this->assertSame('groq', $resolved['provider']);
+        $this->assertSame('whisper-large-v3', $resolved['displayModel']);
+    }
+
+    public function testUnknownModelThrows(): void
+    {
+        $this->models->method('findActiveByTagAndIdentity')->willReturn(null);
+
+        $this->expectException(SttModelNotFoundException::class);
+        $this->resolver->resolve('no-such-stt', 7);
+    }
+
+    public function testListModelsReturnsOpenAiShape(): void
+    {
+        $this->models->expects($this->once())
+            ->method('findActiveByTag')
+            ->with('sound2text')
+            ->willReturn([
+                $this->sttModel(330, 'whisper', 'Whisper'),
+            ]);
+
+        $list = $this->resolver->listModels();
+
+        $this->assertCount(1, $list);
+        $this->assertSame('whisper', $list[0]['id']);
+        $this->assertSame('whisper', $list[0]['owned_by']);
+        $this->assertSame('sound2text', $list[0]['tag']);
+    }
+
+    private function sttModel(int $id, string $providerId, string $service): Model
+    {
+        $model = $this->createMock(Model::class);
+        $model->method('getId')->willReturn($id);
+        $model->method('getProviderId')->willReturn($providerId);
+        $model->method('getName')->willReturn($providerId);
+        $model->method('getService')->willReturn($service);
+        $model->method('getTag')->willReturn('sound2text');
+        $model->method('getActive')->willReturn(1);
+
+        return $model;
+    }
+}

--- a/backend/tests/Unit/Service/Stt/SttSessionServiceTest.php
+++ b/backend/tests/Unit/Service/Stt/SttSessionServiceTest.php
@@ -1,0 +1,239 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\Stt;
+
+use App\AI\Service\AiFacade;
+use App\Entity\User;
+use App\Service\Exception\RateLimitExceededException;
+use App\Service\Infrastructure\RedisService;
+use App\Service\RateLimitService;
+use App\Service\Stt\Exception\SttSessionClosedException;
+use App\Service\Stt\Exception\SttSessionNotFoundException;
+use App\Service\Stt\SttAudioAssembler;
+use App\Service\Stt\SttModelResolver;
+use App\Service\Stt\SttSessionService;
+use App\Service\Stt\SttSessionStore;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+final class SttSessionServiceTest extends TestCase
+{
+    private string $dir;
+    private SttSessionStore $store;
+    private AiFacade&MockObject $aiFacade;
+    private RateLimitService&MockObject $rateLimit;
+    private SttModelResolver&MockObject $resolver;
+    private SttSessionService $service;
+    private User&MockObject $user;
+
+    protected function setUp(): void
+    {
+        $this->dir = sys_get_temp_dir().'/stt-svc-'.bin2hex(random_bytes(4));
+        $this->store = new SttSessionStore(
+            new RedisService('', 'test', new NullLogger()),
+            new NullLogger(),
+            $this->dir,
+            3600,
+        );
+        $this->aiFacade = $this->createMock(AiFacade::class);
+        $this->rateLimit = $this->createMock(RateLimitService::class);
+        $this->resolver = $this->createMock(SttModelResolver::class);
+        $this->rateLimit->method('checkLimit')->willReturn(['allowed' => true]);
+        $this->resolver->method('resolve')->willReturn([
+            'provider' => 'whisper',
+            'providerModelId' => 'whisper',
+            'displayModel' => 'whisper',
+            'model_id' => 330,
+        ]);
+
+        $this->service = new SttSessionService(
+            $this->store,
+            new SttAudioAssembler(),
+            $this->resolver,
+            $this->aiFacade,
+            $this->rateLimit,
+            new NullLogger(),
+        );
+
+        $this->user = $this->createMock(User::class);
+        $this->user->method('getId')->willReturn(42);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDir($this->dir);
+    }
+
+    public function testCreateIsolatesClientsOnTheSameApiKey(): void
+    {
+        $first = $this->service->create($this->user, 1, ['client_id' => '123']);
+        $second = $this->service->create($this->user, 1, ['client_id' => '321']);
+
+        $this->assertNotSame($first->id, $second->id);
+        $this->assertSame('123', $first->clientId);
+        $this->assertSame('321', $second->clientId);
+        $this->assertSame(1, $first->apiKeyId);
+        $this->assertSame(1, $second->apiKeyId);
+
+        $listed = $this->service->listOwned(1, '123');
+        $this->assertCount(1, $listed);
+        $this->assertSame($first->id, $listed[0]->id);
+    }
+
+    public function testReuseReturnsExistingOpenSession(): void
+    {
+        $first = $this->service->create($this->user, 1, ['client_id' => '123']);
+        $again = $this->service->create($this->user, 1, ['client_id' => '123', 'reuse' => true]);
+
+        $this->assertSame($first->id, $again->id);
+    }
+
+    public function testAppendCommitStreamsTextThroughConfiguredModel(): void
+    {
+        $session = $this->service->create($this->user, 1, [
+            'client_id' => '123',
+            'encoding' => 'pcm_s16le',
+            'commit_after_bytes' => 1_000_000,
+        ]);
+
+        $this->aiFacade->expects($this->once())
+            ->method('transcribe')
+            ->with(
+                $this->callback(static fn (string $path): bool => is_file($path) && str_ends_with($path, '.wav')),
+                42,
+                $this->callback(static function (array $opts): bool {
+                    return 'whisper' === $opts['provider'] && 'whisper' === $opts['model'];
+                }),
+            )
+            ->willReturn([
+                'text' => 'hello from the stream',
+                'language' => 'en',
+                'duration' => 1.5,
+            ]);
+
+        $this->service->appendAudio($this->user, 1, $session->id, str_repeat("\x00\x01", 64), false);
+        $committed = $this->service->commit($this->user, 1, $session->id);
+
+        $this->assertSame('hello from the stream', $committed->text);
+        $this->assertCount(1, $committed->segments);
+        $this->assertSame(0, $committed->pendingBytes);
+        $this->assertSame('123', $committed->clientId);
+        $this->assertSame(1, $committed->apiKeyId);
+    }
+
+    public function testAutoCommitWhenBufferThresholdReached(): void
+    {
+        $session = $this->service->create($this->user, 1, [
+            'client_id' => '321',
+            'commit_after_bytes' => 8000,
+        ]);
+
+        $this->aiFacade->expects($this->once())
+            ->method('transcribe')
+            ->willReturn(['text' => 'auto', 'language' => 'en', 'duration' => 0.4]);
+
+        $result = $this->service->appendAudio(
+            $this->user,
+            1,
+            $session->id,
+            str_repeat('a', 9000),
+            false,
+        );
+
+        $this->assertTrue($result['committed']);
+        $this->assertSame('auto', $result['session']->text);
+    }
+
+    public function testOtherApiKeyCannotSeeSession(): void
+    {
+        $session = $this->service->create($this->user, 1, ['client_id' => '123']);
+
+        $this->expectException(SttSessionNotFoundException::class);
+        $this->service->getOwned($session->id, 99);
+    }
+
+    public function testClosedSessionRejectsAudio(): void
+    {
+        $session = $this->service->create($this->user, 1, ['client_id' => '123']);
+        $this->service->close(1, $session->id);
+
+        $this->expectException(SttSessionClosedException::class);
+        $this->service->appendAudio($this->user, 1, $session->id, 'xxxx');
+    }
+
+    public function testRateLimitIsEnforcedOnCommit(): void
+    {
+        $this->rateLimit = $this->createMock(RateLimitService::class);
+        $this->rateLimit->method('checkLimit')->willReturn([
+            'allowed' => false,
+            'used' => 10,
+            'limit' => 10,
+        ]);
+        $this->service = new SttSessionService(
+            $this->store,
+            new SttAudioAssembler(),
+            $this->resolver,
+            $this->aiFacade,
+            $this->rateLimit,
+            new NullLogger(),
+        );
+
+        $session = $this->service->create($this->user, 1, ['client_id' => '123']);
+        $this->service->appendAudio($this->user, 1, $session->id, 'abcd', false);
+
+        $this->expectException(RateLimitExceededException::class);
+        $this->service->commit($this->user, 1, $session->id);
+    }
+
+    public function testTranscribeFileReturnsOpenAiShapeWithClientId(): void
+    {
+        $path = $this->dir.'/one-shot.wav';
+        mkdir($this->dir, 0775, true);
+        file_put_contents($path, 'RIFF');
+
+        $this->aiFacade->method('transcribe')->willReturn([
+            'text' => 'one shot',
+            'language' => 'de',
+            'duration' => 2.0,
+            'segments' => [],
+        ]);
+
+        $result = $this->service->transcribeFile($this->user, 1, $path, [
+            'client_id' => '123',
+            'model' => 'whisper',
+        ]);
+
+        $this->assertSame('one shot', $result['text']);
+        $this->assertSame('123', $result['client_id']);
+        $this->assertSame(1, $result['api_key_id']);
+        $this->assertSame(42, $result['user_id']);
+        $this->assertSame('whisper', $result['model']);
+        $this->assertStringStartsWith('transcribe_', (string) $result['id']);
+    }
+
+    public function testInvalidClientIdRejected(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->service->create($this->user, 1, ['client_id' => 'bad id with spaces']);
+    }
+
+    private function removeDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+        foreach ($iterator as $file) {
+            $path = $file->getPathname();
+            $file->isDir() ? rmdir($path) : unlink($path);
+        }
+        rmdir($dir);
+    }
+}

--- a/backend/tests/Unit/Service/Stt/SttSessionStoreTest.php
+++ b/backend/tests/Unit/Service/Stt/SttSessionStoreTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\Stt;
+
+use App\Service\Infrastructure\RedisService;
+use App\Service\Stt\SttSession;
+use App\Service\Stt\SttSessionStore;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+final class SttSessionStoreTest extends TestCase
+{
+    private string $dir;
+    private SttSessionStore $store;
+
+    protected function setUp(): void
+    {
+        $this->dir = sys_get_temp_dir().'/stt-store-'.bin2hex(random_bytes(4));
+        $redis = new RedisService('', 'test', new NullLogger());
+        $this->store = new SttSessionStore($redis, new NullLogger(), $this->dir, 3600);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDir($this->dir);
+    }
+
+    public function testSaveAndGetRoundTrip(): void
+    {
+        $session = $this->session('stt_sess_aaa', '123', 1);
+        $this->store->save($session);
+
+        $loaded = $this->store->get('stt_sess_aaa');
+        $this->assertNotNull($loaded);
+        $this->assertSame('123', $loaded->clientId);
+        $this->assertSame(1, $loaded->apiKeyId);
+        $this->assertSame('whisper', $loaded->model);
+        $this->assertTrue($loaded->isOpen());
+    }
+
+    public function testListIsScopedToApiKeyAndClient(): void
+    {
+        $this->store->save($this->session('stt_sess_a', '123', 1));
+        $this->store->save($this->session('stt_sess_b', '321', 1));
+        $this->store->save($this->session('stt_sess_c', '123', 2));
+
+        $forKey1 = $this->store->listForApiKey(1);
+        $this->assertCount(2, $forKey1);
+        $clientIds = array_map(static fn (SttSession $s): string => $s->clientId, $forKey1);
+        sort($clientIds);
+        $this->assertSame(['123', '321'], $clientIds);
+
+        $client123 = $this->store->listForApiKey(1, '123');
+        $this->assertCount(1, $client123);
+        $this->assertSame('stt_sess_a', $client123[0]->id);
+    }
+
+    public function testFindOpenForClientIgnoresClosed(): void
+    {
+        $open = $this->session('stt_sess_open', '123', 1);
+        $closed = $this->session('stt_sess_closed', '123', 1);
+        $closed->status = SttSession::STATUS_CLOSED;
+        $this->store->save($closed);
+        $this->store->save($open);
+
+        $found = $this->store->findOpenForClient(1, '123');
+        $this->assertNotNull($found);
+        $this->assertSame('stt_sess_open', $found->id);
+    }
+
+    public function testMissingSessionReturnsNull(): void
+    {
+        $this->assertNull($this->store->get('stt_sess_missing'));
+    }
+
+    private function session(string $id, string $clientId, int $apiKeyId): SttSession
+    {
+        $now = time();
+
+        return new SttSession(
+            id: $id,
+            clientId: $clientId,
+            apiKeyId: $apiKeyId,
+            userId: 9,
+            model: 'whisper',
+            provider: 'whisper',
+            modelId: 330,
+            language: 'en',
+            prompt: null,
+            status: SttSession::STATUS_OPEN,
+            encoding: 'pcm_s16le',
+            sampleRate: 16000,
+            channels: 1,
+            commitAfterBytes: 96000,
+            createdAt: $now,
+            updatedAt: $now,
+            expiresAt: $now + 3600,
+        );
+    }
+
+    private function removeDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+        foreach ($iterator as $file) {
+            $path = $file->getPathname();
+            $file->isDir() ? rmdir($path) : unlink($path);
+        }
+        rmdir($dir);
+    }
+}

--- a/backend/tests/Unit/Service/Stt/SttSessionStoreTest.php
+++ b/backend/tests/Unit/Service/Stt/SttSessionStoreTest.php
@@ -75,6 +75,26 @@ final class SttSessionStoreTest extends TestCase
         $this->assertNull($this->store->get('stt_sess_missing'));
     }
 
+    public function testReentrantLockDoesNotDeadlockOnNestedSave(): void
+    {
+        $session = $this->session('stt_sess_lock', '123', 1);
+        $this->store->save($session);
+
+        $result = $this->store->withLock('stt_sess_lock', function () use ($session): string {
+            $session->text = 'first';
+            $this->store->save($session);
+            $session->text = 'second';
+            $this->store->save($session);
+
+            return 'ok';
+        });
+
+        $this->assertSame('ok', $result);
+        $loaded = $this->store->get('stt_sess_lock');
+        $this->assertNotNull($loaded);
+        $this->assertSame('second', $loaded->text);
+    }
+
     private function session(string $id, string $clientId, int $apiKeyId): SttSession
     {
         $now = time();

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -104,6 +104,15 @@ Extract content from:
 | Images (PNG, JPEG, etc.) | Tesseract OCR |
 | Audio (MP3, WAV, etc.) | Whisper.cpp |
 
+## External speech-to-text API
+
+Local programs can transcribe against any configured SOUND2TEXT model (whisper.cpp, Groq, OpenAI, Mistral, …) with a Synaplan API key:
+
+- **One-shot** — OpenAI-compatible `POST /v1/audio/transcriptions`
+- **Streaming sessions** — `client_id` + `api_key_id` so client 123 and client 321 on the same key stay isolated; audio chunks in, SSE or poll for transcripts
+
+→ [OpenAI-compatible API](OPENAI_COMPATIBLE_API.md)
+
 ## File Management
 
 - Upload and organize files

--- a/docs/OPENAI_COMPATIBLE_API.md
+++ b/docs/OPENAI_COMPATIBLE_API.md
@@ -106,6 +106,151 @@ The `model` field is matched against Synaplan's model registry in this order:
 
 Use `GET /v1/models` to see available model IDs.
 
+### `POST /v1/audio/transcriptions`
+
+One-shot speech-to-text. Same shape as OpenAI Whisper so local tools and the
+OpenAI SDK work against Synaplan. The `model` field is resolved against the
+user's **SOUND2TEXT** catalogue (local whisper.cpp, Groq Whisper, OpenAI
+`whisper-1`, Mistral Voxtral, …). Omit it to use the user's default.
+
+**Request:** `multipart/form-data` (`file` or `audio`) or a raw `audio/*` /
+`application/octet-stream` body.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `file` | file | Yes* | Audio to transcribe (`wav`, `webm`, `ogg`, `mp3`, `m4a`, `flac`, or raw PCM). |
+| `model` | string | No | STT model id (see `GET /v1/audio/models`). |
+| `language` | string | No | ISO-639-1 hint. |
+| `prompt` | string | No | Optional spelling / vocabulary hint. |
+| `client_id` | string | No | Caller-chosen client tag (see sessions below). |
+| `response_format` | string | No | `json` (default), `text`, or `verbose_json`. |
+| `stream` | boolean | No | If `true`, returns SSE (`transcript` then `done`). |
+
+```bash
+curl https://your-synaplan-instance.com/v1/audio/transcriptions \
+  -H "Authorization: Bearer sk-your-synaplan-api-key" \
+  -F file=@clip.wav \
+  -F model=whisper \
+  -F client_id=123
+```
+
+```json
+{
+  "text": "hello from the microphone",
+  "id": "transcribe_…",
+  "model": "whisper",
+  "language": "en",
+  "duration": 1.4,
+  "client_id": "123",
+  "api_key_id": 1
+}
+```
+
+### Streaming sessions (`client_id` on one API key)
+
+One API key can transcribe many independent live streams at once. Each session
+has its own id and a caller-chosen `client_id`, so "client 123 on API key 1"
+never mixes with "client 321 on API key 1".
+
+```
+POST   /v1/audio/transcriptions/sessions
+GET    /v1/audio/transcriptions/sessions?client_id=123
+GET    /v1/audio/transcriptions/sessions/{id}
+POST   /v1/audio/transcriptions/sessions/{id}/audio
+POST   /v1/audio/transcriptions/sessions/{id}/commit
+GET    /v1/audio/transcriptions/sessions/{id}/stream
+DELETE /v1/audio/transcriptions/sessions/{id}
+GET    /v1/audio/models
+```
+
+**Create a session**
+
+```bash
+curl -X POST https://your-synaplan-instance.com/v1/audio/transcriptions/sessions \
+  -H "Authorization: Bearer sk-your-synaplan-api-key" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "client_id": "123",
+    "model": "whisper",
+    "language": "en",
+    "encoding": "pcm_s16le",
+    "sample_rate": 16000,
+    "channels": 1
+  }'
+```
+
+```json
+{
+  "id": "stt_sess_…",
+  "object": "transcription.session",
+  "client_id": "123",
+  "api_key_id": 1,
+  "user_id": 42,
+  "model": "whisper",
+  "status": "open"
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `client_id` | Your local client tag (`[A-Za-z0-9._:-]{1,64}`). Defaults to `default`. |
+| `reuse` | If `true`, return the existing open session for this `client_id` instead of opening another. |
+| `encoding` | `auto` (default), `pcm_s16le`, `wav`, `webm`, `ogg`, `mp3`, `m4a`, `flac`. Bare PCM is wrapped as 16-bit WAV. |
+| `commit_after_bytes` | Auto-transcribe when the pending buffer reaches this size (default 96000 ≈ 3s of 16 kHz mono PCM). |
+
+**Send audio** — raw body, multipart `file`/`audio`, or JSON `audio_base64`.
+Add `commit=true` to transcribe immediately.
+
+```bash
+# raw PCM / WAV / WebM chunk
+curl -X POST https://your-synaplan-instance.com/v1/audio/transcriptions/sessions/stt_sess_…/audio \
+  -H "Authorization: Bearer sk-your-synaplan-api-key" \
+  -H "Content-Type: application/octet-stream" \
+  --data-binary @chunk.pcm
+
+# one recorded window as 16 kHz mono PCM (add commit=true to transcribe now)
+ffmpeg -i input.wav -ac 1 -ar 16000 -f s16le pipe:1 \
+  | curl -X POST \
+      -H "Authorization: Bearer sk-your-synaplan-api-key" \
+      -H "Content-Type: application/octet-stream" \
+      --data-binary @- \
+      "https://your-synaplan-instance.com/v1/audio/transcriptions/sessions/stt_sess_…/audio?commit=true"
+```
+
+**Read transcripts**
+
+- Poll `GET /v1/audio/transcriptions/sessions/{id}?cursor=0` — `text`, `segments`, and new `events`.
+- Or SSE `GET /v1/audio/transcriptions/sessions/{id}/stream?cursor=0` (`Authorization: Bearer` or `?api_key=`).
+
+Events: `session.created`, `transcript` (final window), `heartbeat`, `done`, `error`.
+
+```python
+import json, time, requests
+
+BASE = "https://your-synaplan-instance.com"
+KEY = "sk-your-synaplan-api-key"
+headers = {"Authorization": f"Bearer {KEY}"}
+
+a = requests.post(f"{BASE}/v1/audio/transcriptions/sessions",
+                  headers=headers, json={"client_id": "123", "model": "whisper"}).json()
+b = requests.post(f"{BASE}/v1/audio/transcriptions/sessions",
+                  headers=headers, json={"client_id": "321", "model": "whisper"}).json()
+# a["id"] and b["id"] are distinct; both carry api_key_id of this key.
+
+with open("chunk.wav", "rb") as fh:
+    requests.post(f"{BASE}/v1/audio/transcriptions/sessions/{a['id']}/audio",
+                  headers={**headers, "Content-Type": "application/octet-stream"},
+                  data=fh, params={"commit": "true"})
+
+print(requests.get(f"{BASE}/v1/audio/transcriptions/sessions/{a['id']}",
+                   headers=headers).json()["text"])
+```
+
+Sessions expire after two hours of inactivity (TTL refreshes on every write).
+A key may have at most 32 open sessions. Pending audio is transcribed through
+the same `AiFacade::transcribe()` path as chat uploads, so usage and SOUND2TEXT
+model choice stay consistent.
+
 ### `GET /v1/models`
 
 Returns all available models in OpenAI format.
@@ -150,9 +295,10 @@ Errors follow the OpenAI error format:
 
 | HTTP Status | Meaning |
 |-------------|---------|
-| 400 | Bad request (invalid JSON, missing messages) |
+| 400 | Bad request (invalid JSON, missing messages or audio) |
 | 401 | Authentication required or invalid API key |
-| 404 | Model not found |
+| 404 | Model or session not found |
+| 409 | Transcription session is closed |
 | 429 | Rate limit exceeded |
 | 500 | Server error |
 
@@ -162,6 +308,7 @@ Errors follow the OpenAI error format:
 - **Token usage** is not always reported (depends on the provider). The `usage` field may contain zeros.
 - **Function calling / tools** are not yet supported through this endpoint.
 - **Image inputs** (vision) are not yet supported through this endpoint.
+- **Speech-to-text** is supported at `/v1/audio/transcriptions` (one-shot) and `/v1/audio/transcriptions/sessions` (streaming, with `client_id` + `api_key_id`).
 - The existing Synaplan API at `/api/v1/` is unchanged and fully functional.
 
 ## Tools & Integrations


### PR DESCRIPTION
## Summary
New repository methods for active models

## Changes
- Introduced SttSessionStore service with configurable storage directory and TTL.
- Added methods in ModelRepository to find active models by tag and by tag and identity, enhancing the ability to query STT models.
- Updated documentation to reflect new external speech-to-text API capabilities, including one-shot and streaming session support.

## Verification
- [ ] Not tested (explain)
- [X] Manual
- [ ] Tests added/updated
