### PR TITLE
feat(TTS): update voice mappings and descriptions for multi-language

### DIFF
--- a/_devextras/screenvideo/.env.example
+++ b/_devextras/screenvideo/.env.example
@@ -44,8 +44,9 @@ ACTION_PAUSE=2000
 TTS_URL=http://127.0.0.1:10200
 
 # Voice to use for narration. Run: curl http://127.0.0.1:10200/api/voices
-# Available: en_US-lessac-medium, de_DE-thorsten-medium, es_ES-davefx-medium,
-#            tr_TR-dfki-medium, ru_RU-irina-medium, fa_IR-reza_ibrahim-medium
+# Available: en_US-lessac-medium, de_DE-kerstin-low, es_ES-davefx-medium,
+#            fr_FR-siwis-medium, tr_TR-dfki-medium, ru_RU-irina-medium,
+#            fa_IR-reza_ibrahim-medium
 TTS_VOICE=en_US-lessac-medium
 
 # Speech speed: 1.0 = normal, <1.0 = faster, >1.0 = slower

--- a/_devextras/screenvideo/README.md
+++ b/_devextras/screenvideo/README.md
@@ -209,8 +209,9 @@ The `synaplan-tts` service (separate repo) runs [Piper TTS](https://github.com/r
 | Language | Voice Key | Speaker |
 |----------|-----------|---------|
 | English (US) | `en_US-lessac-medium` | lessac |
-| German | `de_DE-thorsten-medium` | thorsten |
+| German | `de_DE-kerstin-low` | kerstin |
 | Spanish | `es_ES-davefx-medium` | davefx |
+| French | `fr_FR-siwis-medium` | siwis |
 | Turkish | `tr_TR-dfki-medium` | dfki |
 | Russian | `ru_RU-irina-medium` | irina |
 | Persian | `fa_IR-reza_ibrahim-medium` | reza_ibrahim |

--- a/backend/src/AI/Provider/PiperProvider.php
+++ b/backend/src/AI/Provider/PiperProvider.php
@@ -16,7 +16,7 @@ class PiperProvider implements TextToSpeechProviderInterface
      * Frontend language selects the voice.
      *
      * ChatView sends the UI locale, then prefers the backend-detected reply
-     * language (meta.language) when streaming TTS. The four keys en/de/es/tr
+     * language (meta.language) when streaming TTS. The five keys en/de/es/fr/tr
      * match the voices baked into ghcr.io/metadist/synaplan-tts. ru/fa resolve
      * only when the operator added those extras under EXTRA_VOICES_DIR.
      *
@@ -24,8 +24,9 @@ class PiperProvider implements TextToSpeechProviderInterface
      */
     private const LANGUAGE_VOICE_MAP = [
         'en' => 'en_US-lessac-medium',
-        'de' => 'de_DE-thorsten-medium',
+        'de' => 'de_DE-kerstin-low',
         'es' => 'es_ES-davefx-medium',
+        'fr' => 'fr_FR-siwis-medium',
         'tr' => 'tr_TR-dfki-medium',
         'ru' => 'ru_RU-irina-medium',
         'fa' => 'fa_IR-reza_ibrahim-medium',

--- a/backend/src/Model/ModelCatalog.php
+++ b/backend/src/Model/ModelCatalog.php
@@ -3133,9 +3133,9 @@ class ModelCatalog
             'quality' => 7,
             'rating' => 0.8,
             'json' => [
-                'description' => 'Self-hosted Piper TTS via synaplan-tts. Multi-language (en, de, es, tr, ru, fa). Free, no API key required.',
+                'description' => 'Self-hosted Piper TTS via synaplan-tts. Multi-language (en, de, es, fr, tr, ru, fa). Free, no API key required.',
                 'params' => [
-                    'voices' => ['en_US-lessac-medium', 'de_DE-thorsten-medium', 'es_ES-davefx-medium', 'tr_TR-dfki-medium', 'ru_RU-irina-medium', 'fa_IR-reza_ibrahim-medium'],
+                    'voices' => ['en_US-lessac-medium', 'de_DE-kerstin-low', 'es_ES-davefx-medium', 'fr_FR-siwis-medium', 'tr_TR-dfki-medium', 'ru_RU-irina-medium', 'fa_IR-reza_ibrahim-medium'],
                 ],
                 'features' => ['multilingual', 'self-hosted', 'free'],
             ],

--- a/backend/tests/AI/Provider/PiperProviderResolveVoiceTest.php
+++ b/backend/tests/AI/Provider/PiperProviderResolveVoiceTest.php
@@ -72,7 +72,7 @@ class PiperProviderResolveVoiceTest extends TestCase
         // The core bug: a German reply must be spoken with a German voice even
         // when the configured TEXT2SOUND default model is an English voice.
         self::assertSame(
-            'de_DE-thorsten-medium',
+            'de_DE-kerstin-low',
             $this->resolveVoice([
                 'language' => 'de',
                 'model' => 'en_US-lessac-medium',
@@ -82,8 +82,8 @@ class PiperProviderResolveVoiceTest extends TestCase
 
     public function testLocaleCodeIsNormalizedToShortForm(): void
     {
-        self::assertSame('de_DE-thorsten-medium', $this->resolveVoice(['language' => 'de_DE']));
-        self::assertSame('de_DE-thorsten-medium', $this->resolveVoice(['language' => 'de-DE']));
+        self::assertSame('de_DE-kerstin-low', $this->resolveVoice(['language' => 'de_DE']));
+        self::assertSame('de_DE-kerstin-low', $this->resolveVoice(['language' => 'de-DE']));
     }
 
     public function testConfiguredModelMatchingLanguageIsPreserved(): void
@@ -91,10 +91,10 @@ class PiperProviderResolveVoiceTest extends TestCase
         // A user-picked German voice must not be flattened to the generic
         // language default when it already targets the requested language.
         self::assertSame(
-            'de_DE-kerstin-low',
+            'de_DE-thorsten-medium',
             $this->resolveVoice([
                 'language' => 'de',
-                'model' => 'de_DE-kerstin-low',
+                'model' => 'de_DE-thorsten-medium',
             ])
         );
     }

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -504,15 +504,15 @@ SYNAPLAN_TTS_URL=http://host.docker.internal:10200
 
 **Frontend language selects the voice.** `ChatView` sends the active vue-i18n
 locale with the chat request and later with each `/api/v1/tts/stream` call.
-`PiperProvider` maps `en` / `de` / `es` / `tr` to the baked voices
-(`en_US-lessac-medium`, `de_DE-thorsten-medium`, `es_ES-davefx-medium`,
-`tr_TR-dfki-medium`). If the backend detects a different reply language
+`PiperProvider` maps `en` / `de` / `es` / `fr` / `tr` to the baked voices
+(`en_US-lessac-medium`, `de_DE-kerstin-low`, `es_ES-davefx-medium`,
+`fr_FR-siwis-medium`, `tr_TR-dfki-medium`). If the backend detects a different reply language
 (`meta.language`), that short code wins over the UI locale. An explicit
 `voice=` query still overrides both. There is no separate voice dropdown.
 
 Add further Piper models by mounting `.onnx` + `.onnx.json` files into
 `EXTRA_VOICES_DIR` (`/voices-extra` on the container). Do not remount over
-`/voices` — that hides the four baked models. Details:
+`/voices` — that hides the five baked models. Details:
 [Adding more voices](https://github.com/metadist/synaplan-tts#adding-more-voices).
 
 Prefer a cloud voice? Set `ELEVENLABS_API_KEY` instead (or use Gemini / Mistral /


### PR DESCRIPTION
## Summary
French voice support in TTS server

## Changes
- Added French voice support to the PiperProvider, updating the voice mapping to include 'fr_FR-siwis-medium'.
- Changed the German voice from 'de_DE-thorsten-medium' to 'de_DE-kerstin-low'.
- Updated the ModelCatalog description and voice list to reflect the new multi-language capabilities.
- Adjusted tests to ensure the correct voices are resolved based on language input.

## Verification
- [ ] Not tested (explain)
- [X] Manual
- [ ] Tests added/updated
