### PR TITLE
fix(prompts): multibyte-safe truncation for prompt names (#1571)

### DIFF
--- a/backend/src/Controller/PromptController.php
+++ b/backend/src/Controller/PromptController.php
@@ -1176,8 +1176,8 @@ class PromptController extends AbstractController
     private function formatPromptName(string $topic, string $shortDescription, bool $isDefault = true): string
     {
         $prefix = $isDefault ? '(default)' : '(custom)';
-        $truncatedDesc = strlen($shortDescription) > 60
-            ? substr($shortDescription, 0, 57).'...'
+        $truncatedDesc = mb_strlen($shortDescription) > 60
+            ? mb_substr($shortDescription, 0, 57).'...'
             : $shortDescription;
 
         return "{$prefix} {$topic} - {$truncatedDesc}";

--- a/backend/src/Controller/SharedChatPageController.php
+++ b/backend/src/Controller/SharedChatPageController.php
@@ -150,8 +150,8 @@ class SharedChatPageController extends AbstractController
 
                 // Get first sentence or first 60 chars
                 $firstSentence = preg_split('/[.!?]/', $text, 2)[0] ?? $text;
-                if (strlen($firstSentence) > 60) {
-                    $firstSentence = substr($firstSentence, 0, 57).'...';
+                if (mb_strlen($firstSentence) > 60) {
+                    $firstSentence = mb_substr($firstSentence, 0, 57).'...';
                 }
                 if (!empty(trim($firstSentence))) {
                     return trim($firstSentence).' | '.$this->titleBrand();
@@ -183,8 +183,8 @@ class SharedChatPageController extends AbstractController
                 // Remove slash commands from description
                 $text = $this->cleanSlashCommands($text);
 
-                if (strlen($text) > 160) {
-                    return substr($text, 0, 157).'...';
+                if (mb_strlen($text) > 160) {
+                    return mb_substr($text, 0, 157).'...';
                 }
 
                 if (!empty(trim($text))) {

--- a/backend/tests/Unit/Controller/PromptNameTruncationTest.php
+++ b/backend/tests/Unit/Controller/PromptNameTruncationTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Controller;
+
+use App\Controller\PromptController;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Regression cover for #1571: byte-level truncation of the prompt short
+ * description split a UTF-8 sequence, producing a name that the Symfony JSON
+ * encoder rejects. A single such row made GET /api/v1/prompts return 500 for
+ * the whole list.
+ */
+final class PromptNameTruncationTest extends TestCase
+{
+    private function formatPromptName(string $topic, string $shortDescription, bool $isDefault = true): string
+    {
+        $method = new \ReflectionMethod(PromptController::class, 'formatPromptName');
+
+        return $method->invoke(
+            (new \ReflectionClass(PromptController::class))->newInstanceWithoutConstructor(),
+            $topic,
+            $shortDescription,
+            $isDefault,
+        );
+    }
+
+    /**
+     * The exact payload from the report: `ü` starts at byte offset 56, so a
+     * byte-wise substr(…, 0, 57) keeps its lead byte and drops the continuation.
+     */
+    public function testMultibyteCharacterOnByte57BoundaryStaysValidUtf8(): void
+    {
+        $description = 'user asks about the daily news for germany and NRW and münster';
+        self::assertSame(63, \strlen($description), 'guard: the fixture must cross the 60-byte threshold');
+        self::assertSame(62, mb_strlen($description), 'guard: the fixture must stay under the 60-character threshold in bytes only');
+
+        $name = $this->formatPromptName('qwer', $description, false);
+
+        self::assertTrue(mb_check_encoding($name, 'UTF-8'));
+        self::assertNotFalse(json_encode(['name' => $name]));
+    }
+
+    /**
+     * Truncation is now character-based, so a description made entirely of
+     * multibyte characters must survive it intact as well.
+     */
+    public function testAllMultibyteDescriptionIsTruncatedByCharacters(): void
+    {
+        $description = str_repeat('ä', 80);
+
+        $name = $this->formatPromptName('umlauts', $description, false);
+
+        self::assertTrue(mb_check_encoding($name, 'UTF-8'));
+        self::assertNotFalse(json_encode(['name' => $name]));
+        self::assertSame('(custom) umlauts - '.str_repeat('ä', 57).'...', $name);
+    }
+
+    public function testShortDescriptionIsNotTruncated(): void
+    {
+        self::assertSame(
+            '(default) general - Answers general questions',
+            $this->formatPromptName('general', 'Answers general questions'),
+        );
+    }
+}


### PR DESCRIPTION
## Summary

`PromptController::formatPromptName()` truncated the prompt short description with byte-level `strlen()`/`substr(…, 0, 57)`. When a UTF-8 multibyte character straddled byte offset 57, the cut left a lone lead byte, producing invalid UTF-8 that Symfony's JSON encoder rejects with *"Malformed UTF-8 characters"*. Because the row is serialized by both the list and the create/update responses, a single poisoned row returned **HTTP 500 for the entire `GET /api/v1/prompts` list**.

## Changes

- `formatPromptName()` now uses `mb_strlen()`/`mb_substr()`, so truncation happens on character boundaries and can never split a multibyte sequence.
- Applied the same fix to `SharedChatPageController` (OG `title` / `description` truncation), which carried the identical byte-level defect.
- Added `PromptNameTruncationTest` — a regression test that exercises the exact byte-57 boundary payload from the report plus an all-multibyte description.

## Verification (local)

- Reproduced the original crash: `json_encode(['name' => substr($desc, 0, 57).'...'])` → `false` / "Malformed UTF-8".
- After the fix, live end-to-end against the dev stack: creating a prompt with `shortDescription = "user asks about the daily news for germany and NRW and münster"` returns **201** (was 500), and `GET /api/v1/prompts` returns **200** with the name truncated to `…and NRW and mü...`.
- Gate: `make -C backend lint`, `make -C backend phpstan`, `make -C backend test` (4433 tests) all green. Backend-only change.

## Note

Pre-existing rows persisted before this fix can still carry text that reproduces the crash on read. This PR stops new rows from being poisoned and makes truncation safe; a byte-safe backfill/cleanup of already-persisted rows (and optional `JSON_INVALID_UTF8_SUBSTITUTE` hardening of the list serializer) can follow separately if the maintainers want defense-in-depth for legacy data.

Closes #1571

Made with [Cursor](https://cursor.com)