### PR TITLE
fix(chat): reference prior-turn generated media in history (#1596)

### DIFF
--- a/backend/src/Service/Message/Handler/ChatHandler.php
+++ b/backend/src/Service/Message/Handler/ChatHandler.php
@@ -1439,6 +1439,7 @@ final readonly class ChatHandler implements MessageHandlerInterface
         // Check if we should include images (only if vision model is available)
         $includeImages = $options['include_images'] ?? false;
         $generatedImages = $this->generatedImagesForVision($currentMessage, $thread, $options);
+        $mediaReferences = $this->generatedMediaReferences($currentMessage, $thread);
 
         // Add system message if supported (o1 models don't support it)
         if (null !== $systemPrompt) {
@@ -1479,6 +1480,15 @@ final readonly class ChatHandler implements MessageHandlerInterface
                 $content .= "\n\n\n---\n\n\n$label\n\n".
                            substr($allFilesText, 0, 10000). // Increased limit for multiple files
                            "\n\n";
+            }
+
+            // Generated image/video/audio has no file text, so without this the
+            // assistant turn looks text-only and the model denies the media
+            // exists on a follow-up (#1596).
+            if ('assistant' === $role && isset($mediaReferences[$msg->getId()])) {
+                $content = '' === trim($content)
+                    ? $mediaReferences[$msg->getId()]
+                    : $content."\n\n".$mediaReferences[$msg->getId()];
             }
 
             // For user messages, include images as multimodal content (only if enabled)
@@ -1738,11 +1748,21 @@ final readonly class ChatHandler implements MessageHandlerInterface
         // Check if we should include images (only if vision model is available)
         $includeImages = $options['include_images'] ?? false;
         $generatedImages = $this->generatedImagesForVision($currentMessage, $thread, $options);
+        $mediaReferences = $this->generatedMediaReferences($currentMessage, $thread);
 
         // Thread Messages (JSON encoded wie im alten System)
         foreach ($thread as $msg) {
             $role = 'IN' === $msg->getDirection() ? 'user' : 'assistant';
             $content = $this->humanizeFileMarkersForModel($msg->getText());
+
+            // See buildStreamingMessages(): keep generated media visible so the
+            // model does not deny it exists on a later turn (#1596).
+            if ('assistant' === $role && isset($mediaReferences[$msg->getId()])) {
+                $content = '' === trim($content)
+                    ? $mediaReferences[$msg->getId()]
+                    : $content."\n\n".$mediaReferences[$msg->getId()];
+            }
+
             $stamped = '['.$msg->getDateTime().']: '.$content;
 
             // For user messages in thread, include images for vision (if enabled)
@@ -2131,11 +2151,64 @@ final readonly class ChatHandler implements MessageHandlerInterface
      * vision-capable, and capped at MAX_GENERATED_IMAGES — every image rides
      * along as a base64 payload on each following request of the conversation.
      *
-     * @param array<int, Message>  $thread
-     * @param array<string, mixed> $options
+     * @param array<int, Message> $thread
      *
      * @return array<int, list<string>>
      */
+    /**
+     * Always-on prose references for media the assistant produced in earlier
+     * turns of this conversation.
+     *
+     * Generated images, videos and audio carry no BFILETEXT, so replaying the
+     * thread as plain text leaves no trace of them: a follow-up such as "was ist
+     * da zu sehen?" is then answered from text-only history and the model denies
+     * the media exists (#1596). Sending the actual pixels is a separate,
+     * opt-in/token-costly path ({@see generatedImagesForVision()}); this cheap
+     * text reference is unconditional so the model at least knows the media is
+     * real. It also gives async media turns whose text was cleared
+     * ({@see \App\Service\Media\MediaJobMessageSync}) non-empty content, so they
+     * survive the empty-assistant filter (#1115) instead of vanishing entirely.
+     *
+     * Documents are intentionally excluded — they already ride along as
+     * extracted text / the __FILE_GENERATED__ marker.
+     *
+     * @param array<int, Message|array{role: string, content: string}> $thread
+     *
+     * @return array<int, string> assistant messageId => reference sentence
+     */
+    private function generatedMediaReferences(Message $currentMessage, array $thread): array
+    {
+        $catalog = $this->conversationFileCatalog->build($currentMessage, $thread);
+
+        $labelsByMessage = [];
+        foreach ($catalog as $file) {
+            if (!$file->isGenerated() || null === $file->messageId) {
+                continue;
+            }
+
+            $noun = match ($file->category) {
+                ConversationFile::CATEGORY_IMAGE => 'an image',
+                ConversationFile::CATEGORY_VIDEO => 'a video',
+                ConversationFile::CATEGORY_AUDIO => 'an audio file',
+                default => null, // documents already have a textual trace
+            };
+            if (null === $noun) {
+                continue;
+            }
+
+            $labelsByMessage[$file->messageId][] = $noun.' ("'.$file->displayName.'")';
+        }
+
+        $references = [];
+        foreach ($labelsByMessage as $messageId => $labels) {
+            $labels = array_slice($labels, 0, 4);
+            $references[$messageId] = '(For reference: earlier in this conversation you generated and delivered the following media to the user, which is shown in the chat: '
+                .implode(', ', $labels).'. These files exist — do not claim otherwise.)';
+        }
+
+        return $references;
+    }
+
     private function generatedImagesForVision(Message $currentMessage, array $thread, array $options): array
     {
         if (true !== ($options['include_generated_images'] ?? false)) {

--- a/backend/tests/Unit/Service/Message/Handler/ChatHandlerGeneratedImageVisionTest.php
+++ b/backend/tests/Unit/Service/Message/Handler/ChatHandlerGeneratedImageVisionTest.php
@@ -79,15 +79,59 @@ final class ChatHandlerGeneratedImageVisionTest extends TestCase
     }
 
     /**
-     * The default. A byte-identical request to before the feature existed.
+     * With the flag off no pixels are sent (the token-costly opt-in stays off),
+     * but the assistant turn must still carry a cheap text reference to the
+     * media it produced — otherwise the model denies it exists on a follow-up
+     * (#1596).
      */
-    public function testNothingChangesWhileTheFlagIsOff(): void
+    public function testGeneratedMediaIsReferencedInTextWhileTheFlagIsOff(): void
     {
         $handler = $this->handler([$this->imageFile(1, 'cat.png', 500)]);
 
-        $messages = $this->buildStreamingMessages($handler, []);
+        $content = $this->firstAssistantMessage($this->buildStreamingMessages($handler, []))['content'];
 
-        $this->assertIsString($this->firstAssistantMessage($messages)['content']);
+        $this->assertIsString($content, 'No image bytes may be sent while the flag is off');
+        $this->assertStringContainsString('cat.png', $content);
+        $this->assertStringContainsString('do not claim otherwise', $content);
+    }
+
+    /**
+     * The async media path clears the assistant text
+     * ({@see \App\Service\Media\MediaJobMessageSync}); the generated-media
+     * reference gives the turn non-empty content so it is not dropped by the
+     * empty-assistant filter (#1115) and the media stays visible (#1596).
+     */
+    public function testGeneratedMediaTurnWithClearedTextSurvivesAsAReference(): void
+    {
+        $handler = $this->handler([$this->imageFile(1, 'cat.png', 500)]);
+
+        $assistantTurn = $this->message(500, 'OUT', ''); // text cleared by async sync
+        $current = $this->message(501, 'IN', 'What breed is it?');
+
+        $method = new \ReflectionMethod(ChatHandler::class, 'buildStreamingMessages');
+        $messages = $method->invoke($handler, null, [$assistantTurn, $current], $current, []);
+
+        $content = $this->firstAssistantMessage($messages)['content'];
+        $this->assertIsString($content);
+        $this->assertStringContainsString('cat.png', $content);
+    }
+
+    /**
+     * With the flag on the pixels ride along AND the text reference is present,
+     * so the media is both visible and unambiguously acknowledged.
+     */
+    public function testGeneratedImageCarriesBothPixelsAndTextReferenceWithFlagOn(): void
+    {
+        $handler = $this->handler([$this->imageFile(1, 'cat.png', 500)]);
+
+        $content = $this->firstAssistantMessage(
+            $this->buildStreamingMessages($handler, ['include_generated_images' => true]),
+        )['content'];
+
+        $this->assertIsArray($content);
+        $this->assertSame('text', $content[0]['type']);
+        $this->assertStringContainsString('cat.png', $content[0]['text']);
+        $this->assertStringStartsWith('data:image/png;base64,', $content[1]['image_url']['url']);
     }
 
     public function testOnlyTheNewestImagesFitTheBudget(): void


### PR DESCRIPTION
## Summary

A follow-up question about media the assistant generated earlier (e.g. *"was ist da zu sehen?"* after an image was created) was answered from text-only history, so the model **denied the media exists** even though the UI still showed it.

Root cause (as in the issue): generated images/videos/audio carry no `BFILETEXT`, so when the thread is replayed as history they leave no trace. The Sprint 4 feature that sends the actual **pixels** back (`GeneratedImageVisionFlag` → `generatedImagesForVision()`) is opt-in and **default-off** (base64 payloads are a real token cost), so on a default install the generated media was invisible to the model entirely — no bytes *and* no text reference.

## Changes

- New `ChatHandler::generatedMediaReferences()` builds, from the existing `ConversationFileCatalog`, a short **always-on** prose reference for every assistant turn that generated an image/video/audio file (*"earlier in this conversation you generated and delivered … These files exist — do not claim otherwise."*).
- Wired into **both** message builders (`buildStreamingMessages()` and the non-streaming `buildMessages()`), so every channel (web chat, widget, WhatsApp, email/webhook) is covered.
- Documents are intentionally excluded — they already ride along as extracted text / the `__FILE_GENERATED__` marker.
- The reference gives async media turns whose text was cleared (`MediaJobMessageSync::setText('')`) non-empty content, so they now survive the empty-assistant history filter (#1115) instead of vanishing.
- The token-costly pixel path is unchanged and still flag-gated; with the flag **on** a turn now carries both the pixels and the text reference.

## Tests

`ChatHandlerGeneratedImageVisionTest`:
- generated media is referenced in text while the vision flag is **off** (no pixels, but the model is told the media exists);
- an async media turn with cleared text survives as a reference;
- with the flag **on**, the turn carries both pixels and the text reference.

## Verification (local)

- Confirmed the pre-fix gap directly against the code: with the flag off, an assistant turn that produced `cat.png` was replayed as a bare string with no mention of the image.
- Gate: `make -C backend lint`, `make -C backend phpstan`, `make -C backend test` (4432 tests) all green. Backend-only change.

Closes #1596

Made with [Cursor](https://cursor.com)