### PR TITLE
fix(memories): reconcile retrieval against SQL catalog (#1570)

### DIFF
--- a/backend/src/Repository/UserMemoryRepository.php
+++ b/backend/src/Repository/UserMemoryRepository.php
@@ -75,6 +75,35 @@ final class UserMemoryRepository extends ServiceEntityRepository
         return $memories;
     }
 
+    /**
+     * Of the given memory ids, return the subset that are active rows of the
+     * user. Used to reconcile Qdrant retrieval hits against the SQL catalog so
+     * a memory the UI cannot show is never used in a reply (#1570).
+     *
+     * @param list<int> $ids
+     *
+     * @return list<int>
+     */
+    public function filterActiveIds(int $userId, array $ids): array
+    {
+        if ([] === $ids) {
+            return [];
+        }
+
+        /** @var list<array{id: int|string}> $rows */
+        $rows = $this->createQueryBuilder('m')
+            ->select('m.id AS id')
+            ->where('m.userId = :userId')
+            ->andWhere('m.active = true')
+            ->andWhere('m.id IN (:ids)')
+            ->setParameter('userId', $userId)
+            ->setParameter('ids', $ids)
+            ->getQuery()
+            ->getArrayResult();
+
+        return array_map(static fn (array $row): int => (int) $row['id'], $rows);
+    }
+
     public function countActiveForUser(int $userId): int
     {
         return (int) $this->createQueryBuilder('m')

--- a/backend/src/Service/UserMemoryService.php
+++ b/backend/src/Service/UserMemoryService.php
@@ -494,7 +494,7 @@ final readonly class UserMemoryService
                 $memories[] = $memory;
             }
 
-            return $memories;
+            return $includeHidden ? $memories : $this->reconcileWithSqlCatalog($userId, $memories);
         } catch (\Throwable $e) {
             $this->logger->error('searchMemoriesByVector failed', [
                 'user_id' => $userId,
@@ -645,12 +645,68 @@ final readonly class UserMemoryService
                 $memories[] = $memory;
             }
 
-            return $memories;
+            return $includeHidden ? $memories : $this->reconcileWithSqlCatalog($userId, $memories);
         } catch (\Throwable $e) {
             $this->logger->error('Memory search failed', ['error' => $e->getMessage()]);
 
             return [];
         }
+    }
+
+    /**
+     * Drop retrieval hits that have no active SQL row (#1570).
+     *
+     * The Qdrant `user_memories` index and the BUSERMEMORIES catalog can
+     * diverge: a point can outlive its SQL row when rows are removed/reset
+     * without a successful Qdrant purge. Such orphans were still returned and
+     * used in chat replies, yet the Memories list/dialog — which reads SQL —
+     * never showed them, so they were invisible and unmanageable. SQL is the
+     * source of truth for what the user can see and manage, so a hit that is
+     * not an active SQL row must not be used in a reply either. This keeps the
+     * "X memories used" line consistent with the Memories UI.
+     *
+     * Only applied to the user-facing memory load; hidden feedback namespaces
+     * (searched with includeHidden=true) are internal and intentionally not
+     * surfaced in the list, so they are left untouched.
+     *
+     * @param list<array<string, mixed>> $memories
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function reconcileWithSqlCatalog(int $userId, array $memories): array
+    {
+        if ([] === $memories) {
+            return $memories;
+        }
+
+        $ids = [];
+        foreach ($memories as $memory) {
+            $id = $memory['id'] ?? null;
+            if (is_int($id)) {
+                $ids[] = $id;
+            }
+        }
+
+        $activeIds = array_flip($this->memoryRepository->filterActiveIds($userId, $ids));
+
+        $reconciled = [];
+        foreach ($memories as $memory) {
+            $id = $memory['id'] ?? null;
+            if (is_int($id) && isset($activeIds[$id])) {
+                $reconciled[] = $memory;
+            }
+        }
+
+        $dropped = count($memories) - count($reconciled);
+        if ($dropped > 0) {
+            $this->logger->info('Dropped orphaned Qdrant memory hits without an active SQL row', [
+                'user_id' => $userId,
+                'dropped' => $dropped,
+                'kept' => count($reconciled),
+            ]);
+        }
+
+        return $reconciled;
     }
 
     /**

--- a/backend/tests/Service/UserMemoryServiceTest.php
+++ b/backend/tests/Service/UserMemoryServiceTest.php
@@ -483,6 +483,70 @@ final class UserMemoryServiceTest extends TestCase
         $this->assertSame('text-embedding-3-large', $upsertedPayload['embedding_model']);
     }
 
+    /**
+     * #1570: Qdrant can hold memory points that no longer have an active SQL
+     * row (SQL reset / failed purge). Those orphans were retrieved and used in
+     * replies but never shown in the SQL-backed Memories UI. Retrieval must
+     * drop any hit that is not an active SQL row so "X memories used" matches
+     * the list the user can actually manage.
+     */
+    public function testSearchRelevantMemoriesDropsHitsWithoutActiveSqlRow(): void
+    {
+        $this->aiFacade->method('embed')->willReturn([
+            'embedding' => array_fill(0, 8, 0.1),
+            'usage' => ['total_tokens' => 3],
+        ]);
+        $this->em->method('getRepository')->willReturn($this->createMock(\Doctrine\ORM\EntityRepository::class));
+
+        $this->qdrantClient->method('searchMemories')->willReturn([
+            ['id' => 'mem_1_10', 'score' => 0.9, 'payload' => ['user_id' => 1, 'category' => 'personal', 'key' => 'age', 'value' => '33']],
+            ['id' => 'mem_1_20', 'score' => 0.8, 'payload' => ['user_id' => 1, 'category' => 'personal', 'key' => 'hobby', 'value' => 'homelab']],
+        ]);
+
+        // Only memory 10 still has an active SQL row; 20 is a Qdrant orphan.
+        $this->memoryRepository->expects($this->once())
+            ->method('filterActiveIds')
+            ->with(1, [10, 20])
+            ->willReturn([10]);
+
+        $result = $this->service->searchRelevantMemories(1, 'how old am I?');
+
+        self::assertCount(1, $result);
+        self::assertSame(10, $result[0]['id']);
+    }
+
+    /**
+     * The reconciliation is scoped to the user-facing memory load. Hidden
+     * feedback namespaces are internal and never appear in the Memories list,
+     * so a feedback search (includeHidden=true) must not touch SQL.
+     */
+    public function testHiddenFeedbackSearchSkipsSqlReconciliation(): void
+    {
+        $this->aiFacade->method('embed')->willReturn([
+            'embedding' => array_fill(0, 8, 0.1),
+            'usage' => ['total_tokens' => 3],
+        ]);
+        $this->em->method('getRepository')->willReturn($this->createMock(\Doctrine\ORM\EntityRepository::class));
+
+        $this->qdrantClient->method('searchMemories')->willReturn([
+            ['id' => 'mem_1_10', 'score' => 0.9, 'payload' => ['user_id' => 1, 'category' => 'feedback_negative', 'key' => 'x', 'value' => 'y']],
+        ]);
+
+        $this->memoryRepository->expects($this->never())->method('filterActiveIds');
+
+        $result = $this->service->searchRelevantMemories(
+            1,
+            'query',
+            'feedback_negative',
+            5,
+            0.5,
+            'feedback_false_positive',
+            true,
+        );
+
+        self::assertCount(1, $result);
+    }
+
     private function makeMemory(
         int $id,
         int $userId,


### PR DESCRIPTION
## Summary

The SQL memory catalog (`BUSERMEMORIES`) and the Qdrant `user_memories` index could diverge: Qdrant can hold points that no longer have an active SQL row (a SQL reset/removal without a successful Qdrant purge). Those **orphans were retrieved and used in chat replies** ("5 memories used"), but the Memories list/dialog/View All — which reads SQL — never showed them. The memories were therefore invisible and unmanageable, and the "X memories used" count disagreed with the list.

## Fix

SQL is made the source of truth for what may be used in a reply. After the Qdrant hits are built, `UserMemoryService::searchRelevantMemories()` / `searchMemoriesByVector()` now drop any hit whose memory id is not an **active** `BUSERMEMORIES` row, via the new `UserMemoryRepository::filterActiveIds()`. The Qdrant point id already encodes the SQL id (`mem_{userId}_{memoryId}`), which `UserMemoryDTO::fromQdrantPayload()` extracts, so no new id mapping is required.

The reconciliation is scoped to the **user-facing** memory load. Hidden feedback namespaces (`feedback_negative` / `feedback_positive` / `feedback_false_positive`, searched with `includeHidden=true`) are internal and never appear in the Memories list, so they are deliberately left untouched.

## Verification (local)

Reproduced the exact divergence against the running stack:

1. Created a memory for the demo user → it exists in both SQL and Qdrant; `POST /api/v1/user/memories/search` returned it (proves the new DQL runs and valid memories are retained).
2. Deleted **only the SQL row** (left the Qdrant point in place) → `scroll` confirms the orphan point is still in Qdrant (`points_count` unchanged), yet the search now returns **0** memories. Before this change it would have surfaced the orphan.

Unit tests (`UserMemoryServiceTest`): an orphaned hit without an active SQL row is dropped from `searchRelevantMemories`, and a hidden feedback search skips reconciliation entirely.

Gate: `make -C backend lint`, `make -C backend phpstan`, `make -C backend test` (4432 tests) all green. Backend-only change.

## Scope / follow-ups

This resolves the core defect (used memories are now a subset of the manageable list, so the two can no longer disagree). The issue also lists larger, separable follow-ups that are intentionally **not** in this PR: persisting a used-memories snapshot on the assistant message so the "memories used" line survives a page reload (frontend + `MessageApiFormatter`), a soft-delete/`setActive` path, and an operator tool to repair/expose Qdrant points that lack a SQL row.

Closes #1570

Made with [Cursor](https://cursor.com)