### PR TITLE
fix(pricing): apply OpenAI GPT-5.6 Sol price cut 5/30 -> 4/20 (#1561)

### DIFF
--- a/backend/migrations/Version20260830190000.php
+++ b/backend/migrations/Version20260830190000.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Roll out OpenAI's 2026-08-21 GPT-5.6 Sol price cut to existing installs (#1561).
+ *
+ * OpenAI cut GPT-5.6 Sol API prices on 2026-08-21, verified against the official
+ * OpenAI pricing page (https://openai.com/api/pricing/) on 2026-08-30:
+ *
+ *   - Sol: 5.00 / 30.00 -> 4.00 / 20.00 per 1M tokens (input -20%, output -33%).
+ *   - Cached input 0.50 -> 0.40; long-context (>272k) 10/45 -> 8/30.
+ *   - Terra, Luna and the other GPT-5.x rows are unchanged.
+ *
+ * OpenAI marks the new card promotional "at least through 2026-11-21"; the
+ * reminder to re-verify a possible revert lives in docs/PRICING_MAINTENANCE.md.
+ *
+ * ModelCatalog is the source of truth and ModelSeeder rolls the new values into
+ * BMODELS on deploy — but only for rows still matching their last-seeded
+ * fingerprint. Rows an operator edited via the admin UI are PRESERVED and never
+ * auto-updated. Because these are billing corrections that must reach every
+ * install (costs are resold at raw + markup, so the stale higher price
+ * OVERCHARGES customers on every Sol call), this migration force-applies the new
+ * base rates via explicit, idempotent UPDATEs keyed by BPROVID — the same
+ * approach as Version20260803120000. Keying by BPROVID updates the chat and
+ * vision rows together.
+ *
+ * The long-context (>272k) tier lives only in ModelCatalog::CONTEXT_PRICING and
+ * is read from the current catalog at billing time, so the tier update ships
+ * with the deploy and needs no migration.
+ *
+ * Operator-owned columns (BSELECTABLE, BACTIVE, BISDEFAULT, BSHOWWHENFREE) are
+ * never touched. Idempotent (fixed UPDATEs re-run to the same result) and
+ * raw-SQL only (no Schema API), so it is safe on the shared MariaDB Galera
+ * cluster.
+ *
+ * @see \App\Model\ModelCatalog
+ * @see Version20260803120000
+ */
+final class Version20260830190000 extends AbstractMigration
+{
+    /**
+     * providerId => [newIn, newOut, oldIn, oldOut] (per 1M tokens).
+     *
+     * @var array<string, array{0: float, 1: float, 2: float, 3: float}>
+     */
+    private const TOKEN_PRICES = [
+        'gpt-5.6-sol' => [4.00, 20.00, 5.00, 30.00],
+    ];
+
+    public function getDescription(): string
+    {
+        return "Roll out OpenAI's 2026-08-21 GPT-5.6 Sol price cut (5/30 -> 4/20) to BMODELS so "
+            .'existing installs bill the current rate regardless of the seeder fingerprint (#1561).';
+    }
+
+    public function up(Schema $schema): void
+    {
+        foreach (self::TOKEN_PRICES as $provid => [$in, $out]) {
+            $this->addSql(
+                'UPDATE BMODELS SET BPRICEIN = :in, BPRICEOUT = :out WHERE BPROVID = :provid',
+                ['in' => $in, 'out' => $out, 'provid' => $provid]
+            );
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        foreach (self::TOKEN_PRICES as $provid => [, , $oldIn, $oldOut]) {
+            $this->addSql(
+                'UPDATE BMODELS SET BPRICEIN = :in, BPRICEOUT = :out WHERE BPROVID = :provid',
+                ['in' => $oldIn, 'out' => $oldOut, 'provid' => $provid]
+            );
+        }
+    }
+}

--- a/backend/src/Model/ModelCatalog.php
+++ b/backend/src/Model/ModelCatalog.php
@@ -344,7 +344,8 @@ class ModelCatalog
         'gpt-5.4' => ['threshold_tokens' => 272000, 'price_in_above' => 5.0, 'price_out_above' => 22.5],
         'gpt-5.5' => ['threshold_tokens' => 272000, 'price_in_above' => 10.0, 'price_out_above' => 45.0],
         'gpt-5.5-pro' => ['threshold_tokens' => 272000, 'price_in_above' => 60.0, 'price_out_above' => 270.0],
-        'gpt-5.6-sol' => ['threshold_tokens' => 272000, 'price_in_above' => 10.0, 'price_out_above' => 45.0],
+        // Price cut 2026-08-21 (see the chat row below): long-context tier fell 10/45 -> 8/30.
+        'gpt-5.6-sol' => ['threshold_tokens' => 272000, 'price_in_above' => 8.0, 'price_out_above' => 30.0],
         'gpt-5.6-terra' => ['threshold_tokens' => 272000, 'price_in_above' => 4.0, 'price_out_above' => 18.0],
         'gpt-5.6-luna' => ['threshold_tokens' => 272000, 'price_in_above' => 0.40, 'price_out_above' => 1.80],
         'gemini-2.5-pro' => ['threshold_tokens' => 200000, 'price_in_above' => 2.5, 'price_out_above' => 15.0],
@@ -1468,9 +1469,13 @@ class ModelCatalog
             'selectable' => 1,
             'active' => 1,
             'providerId' => 'gpt-5.6-sol',
-            'priceIn' => 5,
+            // Price cut 2026-08-21: OpenAI dropped Sol from 5/30 to 4/20 (cached 0.50->0.40,
+            // long-context 10/45->8/30). Verified against the official OpenAI pricing page
+            // (https://openai.com/api/pricing/) on 2026-08-30; #1561. Marked promotional
+            // "at least through 2026-11-21" — see the reminder in docs/PRICING_MAINTENANCE.md.
+            'priceIn' => 4,
             'inUnit' => 'per1M',
-            'priceOut' => 30,
+            'priceOut' => 20,
             'outUnit' => 'per1M',
             'quality' => 10,
             'rating' => 1,
@@ -1495,9 +1500,10 @@ class ModelCatalog
             'selectable' => 1,
             'active' => 1,
             'providerId' => 'gpt-5.6-sol',
-            'priceIn' => 5,
+            // Price cut 2026-08-21, same as the chat row above (#1561).
+            'priceIn' => 4,
             'inUnit' => 'per1M',
-            'priceOut' => 30,
+            'priceOut' => 20,
             'outUnit' => 'per1M',
             'quality' => 10,
             'rating' => 1,

--- a/docs/PRICING_MAINTENANCE.md
+++ b/docs/PRICING_MAINTENANCE.md
@@ -326,6 +326,8 @@ Dry-run baseline 2026-07-13: **70 unchanged (per-token + same-mode media, no dri
 
 You can run the same check locally: `docker compose exec -T backend php bin/console app:sync-model-prices --dry-run --fail-on-drift; echo $?` (0 = no drift, 2 = drift).
 
+> Resolved drift (2026-08-30, #1561): the weekly check flagged `gpt-5.6-sol` (twice — chat + vision, in 5.00 → 4.00, out 30.00 → 20.00). Verified against the [official OpenAI pricing](https://openai.com/api/pricing/): OpenAI cut Sol on 2026-08-21 — input −20% (5 → 4), output −33% (30 → 20), cached input 0.50 → 0.40, long-context (>272k) 10/45 → 8/30. Not a LiteLLM error; keeping the old (higher) rate overcharged every Sol call. Applied to `ModelCatalog.php` (base rows 251/252 + `CONTEXT_PRICING` long-context tier) and rolled out to existing installs by `Version20260830190000`. Terra/Luna and the other GPT-5.x rows did not move.
+
 > No-drift note (2026-08-12): Anthropic made Claude Sonnet 5's $2/$10 rate **permanent** and cancelled the $3/$15 increase that was scheduled for 2026-09-01. The catalog already read $2/$10, so no price change and no migration were needed; we only dropped the stale "revert to $3/$15" TODO (BID 249/250/222). The weekly drift check never surfaced this — it only diffs the current catalog number against LiteLLM (both $2/$10), and is blind to time-boxed manual reverts.
 
 > Resolved drift (2026-08-03): the weekly check flagged `gpt-5.6-terra` and `gpt-5.6-luna` (each twice — chat + vision row). Verified against the [official OpenAI pricing](https://developers.openai.com/api/docs/pricing): OpenAI cut GPT-5.6 prices on 2026-07-30 — Terra 2.50/15 → **2.00/12** (−20%), Luna 1.00/6 → **0.20/1.20** (−80%), Sol unchanged. Not a LiteLLM error; keeping the old (higher) rate overcharged every Terra/Luna call. Applied to `ModelCatalog.php` (base rows + `CONTEXT_PRICING` long-context tiers: Terra 4.00/18, Luna 0.40/1.80) and rolled out to existing installs by `Version20260803120000`.
@@ -334,7 +336,8 @@ You can run the same check locally: `docker compose exec -T backend php bin/cons
 
 ## Time-boxed / reminders
 
-- _(none active)_ — the Claude Sonnet 5 "revert to $3/$15 after 2026-08-31" reminder was **cancelled** on 2026-08-12 (Anthropic made the $2/$10 rate permanent; see the drift-log note below). Do not reintroduce it.
+- **GPT-5.6 Sol — re-verify on/after 2026-11-22 (#1561).** OpenAI's 2026-08-21 cut to $4/$20 (long-context $8/$30, cached $0.40) is labelled promotional "at least through 2026-11-21"; OpenAI has published no rate for after that, and third-party trackers flag a possible lapse back to $5/$30. On or after 2026-11-22, re-check the [official pricing page](https://openai.com/api/pricing/): if it reverted, roll the old rate back into `ModelCatalog.php` (rows 251/252 + `CONTEXT_PRICING`) + a data migration; if the promo was extended/made permanent, just refresh this note. The weekly drift check is blind to a time-boxed revert (it only diffs against LiteLLM), so this reminder is the only guard.
+- _(cancelled)_ — the Claude Sonnet 5 "revert to $3/$15 after 2026-08-31" reminder was **cancelled** on 2026-08-12 (Anthropic made the $2/$10 rate permanent; see the drift-log note below). Do not reintroduce it.
 
 ## Anthropic catalog generations (snapshot 2026-07-27)
 


### PR DESCRIPTION
## Summary

The weekly price-drift check (#1561) flagged `gpt-5.6-sol` (in `5.00 → 4.00`, out `30.00 → 20.00`, twice: chat + vision rows). I verified against the **official OpenAI pricing page** (the playbook's golden rule — LiteLLM alone is not sufficient): OpenAI cut GPT-5.6 Sol on **2026-08-21**:

| Tier | Was | Now |
| --- | --- | --- |
| Standard input / output (per 1M) | $5.00 / $30.00 | **$4.00 / $20.00** |
| Cached input | $0.50 | $0.40 |
| Long context (>272k) input / output | $10.00 / $45.00 | **$8.00 / $30.00** |

This is a genuine provider price cut, not a LiteLLM error, so keeping the old higher rate **overcharged every Sol call** (costs are resold at raw + markup). Terra, Luna and the other GPT-5.x rows did not move.

## Changes

- `ModelCatalog.php`: both Sol rows (BID 251 chat, 252 vision) → `4 / 20`; `CONTEXT_PRICING['gpt-5.6-sol']` long-context tier → `8 / 30`; dated source comment.
- `Version20260830190000`: idempotent, raw-SQL `UPDATE BMODELS ... WHERE BPROVID = 'gpt-5.6-sol'` so existing installs (whose rows the seeder preserves once operator-touched) receive the correction — Galera-safe, mirrors `Version20260803120000`.
- `docs/PRICING_MAINTENANCE.md`: drift-log entry + a **time-boxed reminder to re-verify on/after 2026-11-22** (OpenAI labels the new rate promotional "at least through 2026-11-21"; the weekly check is blind to a time-boxed revert).

## Verification (local)

- Before: `app:sync-model-prices --dry-run` → 2 per-token drifts (Sol 5/30 → 4/20).
- Updated the catalog, ran `make -C backend seed`, `BMODELS` now reads `4 / 20` for BID 251/252.
- After: `app:sync-model-prices --dry-run --fail-on-drift` → **0 updated, 0 drift, exit 0**.
- Gate: `make -C backend lint`, `make -C backend phpstan`, `make -C backend test` (4430 tests) all green.

Closes #1561

Made with [Cursor](https://cursor.com)