### PR TITLE
feat(thumbnail): add thumbnail generation and serving for video files

### DIFF
--- a/backend/src/Controller/FileController.php
+++ b/backend/src/Controller/FileController.php
@@ -528,6 +528,64 @@ class FileController extends AbstractController
         return $response;
     }
 
+    #[Route('/{id}/thumb', name: 'thumb', methods: ['GET'])]
+    #[OA\Get(
+        path: '/api/v1/files/{id}/thumb',
+        summary: 'Serve a file thumbnail (e.g. a video poster frame)',
+        description: 'Returns the generated thumbnail image for a file (currently video poster frames produced by ThumbnailService). Responds 404 when the file has no thumbnail, letting the client fall back to a type icon.',
+        tags: ['Files'],
+        parameters: [
+            new OA\Parameter(name: 'id', in: 'path', required: true, schema: new OA\Schema(type: 'integer')),
+            new OA\Parameter(name: MediaAccessTokenService::QUERY_PARAM, in: 'query', required: false, description: 'Read-only media token from /api/v1/files/media-token, for clients that cannot send an Authorization header', schema: new OA\Schema(type: 'string')),
+        ],
+        responses: [
+            new OA\Response(response: 200, description: 'Thumbnail image'),
+            new OA\Response(response: 401, description: 'Not authenticated'),
+            new OA\Response(response: 403, description: 'Access denied'),
+            new OA\Response(response: 404, description: 'File or thumbnail not found'),
+        ]
+    )]
+    public function thumbnail(int $id, Request $request, #[CurrentUser] ?User $user): Response
+    {
+        // Same read-only media-token path as downloadFile(): an <img> poster
+        // carries the token in the URL because it cannot send an auth header.
+        $user ??= $this->mediaAccessTokenService->resolveUser($request);
+
+        if (!$user) {
+            return $this->json(['error' => 'Not authenticated'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        $file = $this->fileRepository->find($id);
+        if (!$file) {
+            return $this->json(['error' => 'File not found'], Response::HTTP_NOT_FOUND);
+        }
+
+        if (!$this->isFileAccessibleByUser($file, $user)) {
+            return $this->json(['error' => 'Access denied'], Response::HTTP_FORBIDDEN);
+        }
+
+        $thumbPath = $file->getThumbPath();
+        if (null === $thumbPath || '' === $thumbPath) {
+            return $this->json(['error' => 'No thumbnail'], Response::HTTP_NOT_FOUND);
+        }
+
+        $absolutePath = $this->uploadDir.'/'.ltrim($thumbPath, '/');
+        if (!FileHelper::fileExistsNfs($absolutePath)) {
+            return $this->json(['error' => 'Thumbnail not found on disk'], Response::HTTP_NOT_FOUND);
+        }
+
+        $response = new BinaryFileResponse($absolutePath);
+        $response->setContentDisposition(ResponseHeaderBag::DISPOSITION_INLINE);
+        $response->setPrivate();
+        // A poster frame is immutable for the life of the file, so it is safe to
+        // cache briefly in the browser to avoid re-fetching on every grid render.
+        $response->headers->set('Cache-Control', 'private, max-age=3600');
+        $response->headers->set('X-Content-Type-Options', 'nosniff');
+        $response->headers->set('Referrer-Policy', 'no-referrer');
+
+        return $response;
+    }
+
     /**
      * Rebuild a missing on-disk binary from the file's stored text source
      * (BFILETEXT) and return it as a one-shot download. Used as a safety net

--- a/backend/src/Service/Media/MediaJobMessageSync.php
+++ b/backend/src/Service/Media/MediaJobMessageSync.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Service\Media;
 
 use App\Repository\MessageRepository;
+use App\Service\File\ThumbnailService;
 use App\Service\Multitask\TaskPlanStore;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
@@ -40,6 +41,7 @@ final readonly class MediaJobMessageSync
         private MediaJobRealtimeNotifier $realtimeNotifier,
         private MediaJobUsageRecorder $usageRecorder,
         private TaskPlanStore $taskPlanStore,
+        private ThumbnailService $thumbnailService,
         private EntityManagerInterface $em,
         private LoggerInterface $logger,
     ) {
@@ -333,6 +335,20 @@ final readonly class MediaJobMessageSync
         }
 
         $message->addFile($file);
+
+        // Video poster: generate the ffmpeg frame and persist it on the file row
+        // so the Generated grid can serve it via GET /api/v1/files/{id}/thumb
+        // (#1499). The inline MediaGenerationHandler path already does this; the
+        // detached worker path must mirror it or async-generated videos (the
+        // common case for video) never get a poster. Best-effort — a missing
+        // poster degrades gracefully to a type icon in the grid. The flush at the
+        // end of syncTerminalState() persists BTHUMBPATH.
+        if (MediaJob::TYPE_VIDEO === $job->getType() && null === $file->getThumbPath()) {
+            $thumbnailPath = $this->thumbnailService->generateThumbnail($relativePath);
+            if (null !== $thumbnailPath) {
+                $file->setThumbPath($thumbnailPath);
+            }
+        }
 
         // Mirror the synchronous media path (StreamController) by also setting
         // the legacy file columns. The history formatter exposes generated

--- a/backend/src/Service/Message/Handler/MediaGenerationHandler.php
+++ b/backend/src/Service/Message/Handler/MediaGenerationHandler.php
@@ -5,6 +5,7 @@ namespace App\Service\Message\Handler;
 use App\AI\Exception\ProviderCancelledException;
 use App\AI\Service\AiFacade;
 use App\AI\Stream\StreamChunk;
+use App\Entity\File;
 use App\Entity\Message;
 use App\Entity\User;
 use App\Message\ExtractMemoriesCommand;
@@ -922,7 +923,7 @@ final readonly class MediaGenerationHandler implements MessageHandlerInterface
             // it here too, otherwise users on inline rendering never see their
             // chat-generated media in the file world. Best-effort + idempotent.
             // Incognito sessions mark it ephemeral for post-session cleanup.
-            $this->generatedFileRegistrar->register(
+            $registeredFile = $this->generatedFileRegistrar->register(
                 $message->getUserId(),
                 $localPath,
                 $mediaType,
@@ -941,6 +942,15 @@ final readonly class MediaGenerationHandler implements MessageHandlerInterface
                         'video' => $localPath,
                         'thumbnail' => $thumbnailPath,
                     ]);
+
+                    // Persist the poster on the file row so the Generated grid can
+                    // serve it via GET /api/v1/files/{id}/thumb (#1499). Without this
+                    // the frame is written to disk but BTHUMBPATH stays null, so the
+                    // frontend's thumb_url is always null and no poster ever shows.
+                    if ($registeredFile instanceof File) {
+                        $registeredFile->setThumbPath($thumbnailPath);
+                        $this->em->flush();
+                    }
                 }
             }
 
@@ -1035,7 +1045,10 @@ final readonly class MediaGenerationHandler implements MessageHandlerInterface
             // Stop-then-restart loop can't be used to bypass billing. The cost
             // is deterministic from the requested duration/resolution (video) or
             // a single image, mirroring the success-path media_usage shape.
-            $cancelledMediaUsage = $this->buildCancelledMediaUsage($mediaType, $options, $classification, $result ?? null);
+            // $result is initialised to null before the try, so it is always
+            // defined here (null when the abort happened before the provider call
+            // returned, the provider array otherwise) — `?? null` was redundant.
+            $cancelledMediaUsage = $this->buildCancelledMediaUsage($mediaType, $options, $classification, $result);
             $recordedMediaUsage = $this->maybeRecordMediaUsage($user, $options, $mediaAction, $modelId, $provider, $modelName, $cancelledMediaUsage);
 
             return [

--- a/backend/tests/Integration/Service/Media/AsyncMediaJobLifecycleIntegrationTest.php
+++ b/backend/tests/Integration/Service/Media/AsyncMediaJobLifecycleIntegrationTest.php
@@ -138,6 +138,7 @@ final class AsyncMediaJobLifecycleIntegrationTest extends KernelTestCase
             new MediaJobRealtimeNotifier($this->realtimePublisher, $this->jobService, $jobLogger),
             $usageRecorder,
             $container->get(\App\Service\Multitask\TaskPlanStore::class),
+            $container->get(\App\Service\File\ThumbnailService::class),
             $this->em,
             $jobLogger,
         );

--- a/backend/tests/Unit/Service/Media/MediaJobMessageSyncTest.php
+++ b/backend/tests/Unit/Service/Media/MediaJobMessageSyncTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Unit\Service\Media;
 use App\Entity\File;
 use App\Entity\Message;
 use App\Repository\MessageRepository;
+use App\Service\File\ThumbnailService;
 use App\Service\Media\GeneratedFileRegistrar;
 use App\Service\Media\MediaJob;
 use App\Service\Media\MediaJobMessageSync;
@@ -34,6 +35,7 @@ final class MediaJobMessageSyncTest extends TestCase
     private MediaJobRealtimeNotifier&MockObject $realtimeNotifier;
     private MediaJobUsageRecorder&MockObject $usageRecorder;
     private TaskPlanStore&MockObject $taskPlanStore;
+    private ThumbnailService&MockObject $thumbnailService;
     private EntityManagerInterface&MockObject $em;
     private MediaJobMessageSync $sync;
 
@@ -45,6 +47,7 @@ final class MediaJobMessageSyncTest extends TestCase
         $this->realtimeNotifier = $this->createMock(MediaJobRealtimeNotifier::class);
         $this->usageRecorder = $this->createMock(MediaJobUsageRecorder::class);
         $this->taskPlanStore = $this->createMock(TaskPlanStore::class);
+        $this->thumbnailService = $this->createMock(ThumbnailService::class);
         $this->em = $this->createMock(EntityManagerInterface::class);
 
         $this->sync = new MediaJobMessageSync(
@@ -54,6 +57,7 @@ final class MediaJobMessageSyncTest extends TestCase
             $this->realtimeNotifier,
             $this->usageRecorder,
             $this->taskPlanStore,
+            $this->thumbnailService,
             $this->em,
             new NullLogger(),
         );
@@ -106,6 +110,44 @@ final class MediaJobMessageSyncTest extends TestCase
     }
 
     /**
+     * #1499: async-generated videos are the common case for video; without a
+     * poster generated + persisted here, BTHUMBPATH stays null forever and the
+     * Generated grid never shows a video frame. Mirror the inline path.
+     */
+    public function testCompletedVideoJobGeneratesAndPersistsPoster(): void
+    {
+        $registered = new File();
+        $this->fileRegistrar->method('register')->willReturn($registered);
+
+        $this->thumbnailService->expects(self::once())
+            ->method('generateThumbnail')
+            ->with('7/2026/07/clip.mp4')
+            ->willReturn('7/2026/07/clip_thumb.jpg');
+
+        $this->sync->syncTerminalState($this->completedJob(
+            MediaJob::TYPE_VIDEO,
+            'a timelapse of a city at night',
+            '/api/v1/files/uploads/7/2026/07/clip.mp4',
+        ));
+
+        self::assertSame('7/2026/07/clip_thumb.jpg', $registered->getThumbPath());
+    }
+
+    /**
+     * Non-video jobs must never trigger ffmpeg poster extraction.
+     */
+    public function testCompletedAudioJobDoesNotGeneratePoster(): void
+    {
+        $this->fileRegistrar->method('register')->willReturn(new File());
+        $this->thumbnailService->expects(self::never())->method('generateThumbnail');
+
+        $this->sync->syncTerminalState($this->completedJob(
+            MediaJob::TYPE_AUDIO,
+            'Hello from Synaplan.',
+        ));
+    }
+
+    /**
      * @param array<string, mixed> $captured
      */
     private function captureRegisterArgs(array &$captured): callable
@@ -125,8 +167,11 @@ final class MediaJobMessageSyncTest extends TestCase
         };
     }
 
-    private function completedJob(string $type, string $prompt): MediaJob
-    {
+    private function completedJob(
+        string $type,
+        string $prompt,
+        string $url = '/api/v1/files/uploads/7/2026/07/voice.mp3',
+    ): MediaJob {
         $job = (new MediaJob('job-key-1'))
             ->setUserId(7)
             ->setType($type)
@@ -134,7 +179,7 @@ final class MediaJobMessageSyncTest extends TestCase
             ->setPrompt($prompt)
             ->setStatus(MediaJob::STATUS_COMPLETED)
             ->setResult([
-                'file' => ['url' => '/api/v1/files/uploads/7/2026/07/voice.mp3', 'type' => $type],
+                'file' => ['url' => $url, 'type' => $type],
             ]);
 
         $message = new Message();

--- a/frontend/src/components/MessageVideo.vue
+++ b/frontend/src/components/MessageVideo.vue
@@ -167,6 +167,7 @@ import { useMediaSrc } from '@/services/api/mediaAuth'
 interface Props {
   url: string
   poster?: string
+  autoplay?: boolean
 }
 
 const props = defineProps<Props>()
@@ -190,6 +191,7 @@ const maxRetries = 3
 const retryDelays = [1000, 2000, 3000] // Increasing delays: 1s, 2s, 3s
 const isRetrying = ref(false)
 const hasFailed = ref(false)
+const hasAutoPlayed = ref(false)
 
 const videoSrc = computed(() => mediaSrc(props.url))
 const posterSrc = computed(() => (props.poster ? mediaSrc(props.poster) : undefined))
@@ -233,6 +235,22 @@ const handleLoadSuccess = () => {
   isRetrying.value = false
   hasFailed.value = false
   updateDuration()
+
+  // Lazy-mounted grid tiles pass `autoplay` so a single tap on the poster both
+  // mounts the player and starts playback (#1499). Browser autoplay policies may
+  // reject this; the catch keeps the rejection from bubbling to the global
+  // handler (mirrors MessageAudio) — the user can still press play.
+  if (props.autoplay && !hasAutoPlayed.value && videoRef.value) {
+    hasAutoPlayed.value = true
+    videoRef.value
+      .play()
+      .then(() => {
+        isPlaying.value = true
+      })
+      .catch(() => {
+        // Autoplay blocked — the poster/controls remain; manual play works.
+      })
+  }
 }
 
 const formatTime = (seconds: number): string => {

--- a/frontend/src/components/files/FilePreview.vue
+++ b/frontend/src/components/files/FilePreview.vue
@@ -1,0 +1,149 @@
+<template>
+  <div
+    class="w-full aspect-video overflow-hidden bg-black/5 dark:bg-white/5 relative flex items-center justify-center"
+    data-testid="file-preview"
+  >
+    <!-- Image: inline thumbnail (unchanged behavior) -->
+    <img
+      v-if="kind === 'image'"
+      :src="imageSrc"
+      :alt="displayName"
+      class="w-full h-full object-cover transition-transform group-hover:scale-105"
+      loading="lazy"
+      data-testid="file-preview-image"
+    />
+
+    <!-- Video: lazy player — poster + play overlay by default, real player on demand -->
+    <template v-else-if="kind === 'video'">
+      <MessageVideo
+        v-if="playing"
+        :url="rawDownloadUrl"
+        :poster="rawThumbUrl ?? undefined"
+        autoplay
+        class="!my-0 w-full h-full"
+        data-testid="file-preview-video-player"
+      />
+      <button
+        v-else
+        type="button"
+        class="group/play absolute inset-0 w-full h-full flex items-center justify-center"
+        :aria-label="t('files.preview.play')"
+        data-testid="file-preview-video-play"
+        @click="emit('play')"
+      >
+        <img
+          v-if="posterSrc"
+          :src="posterSrc"
+          :alt="displayName"
+          class="absolute inset-0 w-full h-full object-cover"
+          loading="lazy"
+        />
+        <span
+          class="relative z-10 w-12 h-12 rounded-full bg-black/50 backdrop-blur-sm flex items-center justify-center text-white transition-transform group-hover/play:scale-110"
+        >
+          <Icon icon="mdi:play" class="w-6 h-6 ml-0.5" />
+        </span>
+      </button>
+    </template>
+
+    <!-- Audio: lazy player — icon + filename + compact play control by default -->
+    <template v-else-if="kind === 'audio'">
+      <div v-if="playing" class="w-full px-2">
+        <MessageAudio
+          :url="rawDownloadUrl"
+          autoplay
+          class="!my-0 w-full"
+          data-testid="file-preview-audio-player"
+        />
+      </div>
+      <button
+        v-else
+        type="button"
+        class="group/play flex flex-col items-center justify-center gap-2 w-full h-full px-3"
+        :aria-label="t('files.preview.play')"
+        data-testid="file-preview-audio-play"
+        @click="emit('play')"
+      >
+        <Icon :icon="icon" class="w-9 h-9 txt-secondary" />
+        <span class="text-xs txt-secondary truncate max-w-full" :title="displayName">
+          {{ displayName }}
+        </span>
+        <span
+          class="inline-flex items-center gap-1 px-2.5 py-1 rounded-full bg-[var(--brand)]/10 text-[var(--brand)] text-[11px] font-medium transition-colors group-hover/play:bg-[var(--brand)]/20"
+        >
+          <Icon icon="mdi:play" class="w-3.5 h-3.5" />
+          {{ t('files.preview.play') }}
+        </span>
+      </button>
+    </template>
+
+    <!-- Text / document with an extracted snippet -->
+    <div
+      v-else-if="snippet"
+      class="w-full h-full p-3 overflow-hidden text-left flex flex-col gap-1.5"
+      data-testid="file-preview-snippet"
+    >
+      <Icon :icon="icon" class="w-5 h-5 txt-secondary shrink-0" />
+      <p class="text-[11px] leading-snug txt-secondary whitespace-pre-wrap preview-clamp">
+        {{ snippet }}
+      </p>
+    </div>
+
+    <!-- Icon-only fallback (documents without text, pdf, calendar, unknown) -->
+    <Icon v-else :icon="icon" class="w-10 h-10 txt-secondary" data-testid="file-preview-icon" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { Icon } from '@iconify/vue'
+import MessageVideo from '@/components/MessageVideo.vue'
+import MessageAudio from '@/components/MessageAudio.vue'
+import type { FileItem } from '@/services/filesService'
+import { previewIconForFile, previewKindForFile, previewSnippet } from '@/services/filePreview'
+import { getApiBaseUrl } from '@/services/api/httpClient'
+import { useMediaSrc } from '@/services/api/mediaAuth'
+
+const props = defineProps<{
+  file: FileItem
+  /** True while this tile owns the single active player (mounts the real element). */
+  playing?: boolean
+}>()
+
+const emit = defineEmits<{ play: [] }>()
+
+const { t } = useI18n()
+
+// On web `mediaSrc` is a no-op; on native it appends a read-only media token so
+// a bare <img> (which cannot send auth headers) still loads. MessageVideo /
+// MessageAudio receive the RAW url and wrap it themselves.
+const { mediaSrc } = useMediaSrc()
+
+const kind = computed(() => previewKindForFile(props.file))
+const icon = computed(() => previewIconForFile(props.file))
+const snippet = computed(() => previewSnippet(props.file))
+const displayName = computed(() => props.file.display_name || props.file.filename)
+
+const rawDownloadUrl = computed(() => `${getApiBaseUrl()}/api/v1/files/${props.file.id}/download`)
+// Build the absolute thumb URL from the id (mirrors the download URL) so it
+// works when the API origin differs from the page origin (dev: :8000 vs :5173).
+// Gated on the backend having recorded a thumbnail (thumb_url present).
+const rawThumbUrl = computed(() =>
+  props.file.thumb_url ? `${getApiBaseUrl()}/api/v1/files/${props.file.id}/thumb` : null
+)
+
+const imageSrc = computed(() => mediaSrc(rawDownloadUrl.value))
+const posterSrc = computed(() => (rawThumbUrl.value ? mediaSrc(rawThumbUrl.value) : null))
+</script>
+
+<style scoped>
+/* Clamp the text snippet to a few lines without an extra dependency. */
+.preview-clamp {
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  line-clamp: 4;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+</style>

--- a/frontend/src/components/files/FilePreview.vue
+++ b/frontend/src/components/files/FilePreview.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="w-full aspect-video overflow-hidden bg-black/5 dark:bg-white/5 relative flex items-center justify-center"
+    class="w-full aspect-video overflow-hidden bg-[var(--bg-chip)] relative flex items-center justify-center"
     data-testid="file-preview"
   >
     <!-- Image: inline thumbnail (unchanged behavior) -->

--- a/frontend/src/components/files/FilesGrid.vue
+++ b/frontend/src/components/files/FilesGrid.vue
@@ -68,37 +68,12 @@
         class="group rounded-lg border border-light-border/15 dark:border-dark-border/5 bg-white dark:bg-white/[0.02]"
         data-testid="grid-tile"
       >
-        <div
-          :class="[
-            'w-full overflow-hidden rounded-t-lg bg-gray-100 dark:bg-gray-800 relative flex items-center justify-center',
-            kindOf(file) === 'audio' ? 'p-2' : 'aspect-video',
-          ]"
-        >
-          <img
-            v-if="kindOf(file) === 'image' && thumbnailUrl(file.id)"
-            :src="thumbnailUrl(file.id)"
-            :alt="file.display_name || file.filename"
-            class="w-full h-full object-cover transition-transform group-hover:scale-105"
-            loading="lazy"
+        <div class="rounded-t-lg overflow-hidden">
+          <FilePreview
+            :file="file"
+            :playing="activePlayerId === file.id"
+            @play="activePlayerId = file.id"
           />
-          <MessageVideo
-            v-else-if="kindOf(file) === 'video'"
-            :url="downloadUrl(file.id)"
-            :poster="file.thumb_url ?? undefined"
-            class="!my-0 w-full"
-          />
-          <MessageAudio
-            v-else-if="kindOf(file) === 'audio'"
-            :url="downloadUrl(file.id)"
-            class="!my-0 w-full"
-          />
-          <Icon v-else :icon="kindIcon(file)" class="w-10 h-10 text-gray-400" />
-          <div
-            v-if="!isInlineMediaKind(file)"
-            class="absolute bottom-2 right-2 bg-black/60 p-1 rounded backdrop-blur-sm"
-          >
-            <Icon :icon="kindIcon(file)" class="text-white w-4 h-4" />
-          </div>
         </div>
         <div class="p-2">
           <p class="text-xs font-medium txt-primary truncate" :title="file.filename">
@@ -254,12 +229,9 @@ import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 import { Icon } from '@iconify/vue'
 import { ArrowDownTrayIcon, ChatBubbleLeftRightIcon, TrashIcon } from '@heroicons/vue/24/outline'
-import MessageVideo from '@/components/MessageVideo.vue'
-import MessageAudio from '@/components/MessageAudio.vue'
+import FilePreview from '@/components/files/FilePreview.vue'
 import FileVectorPill from '@/components/files/FileVectorPill.vue'
 import filesService, { type FileItem, type FileOriginKind } from '@/services/filesService'
-import { getApiBaseUrl } from '@/services/api/httpClient'
-import { useMediaSrc } from '@/services/api/mediaAuth'
 import { useNotification } from '@/composables/useNotification'
 import { useDialog } from '@/composables/useDialog'
 import { useChatsStore } from '@/stores/chats'
@@ -272,6 +244,11 @@ const chatsStore = useChatsStore()
 
 const files = ref<FileItem[]>([])
 const loading = ref(false)
+// Only one media player is mounted at a time (#1499): tiles show a poster/icon
+// by default and mount the real <video>/<audio> only for the tile the user taps.
+// This keeps the grid lightweight and stays within the mobile WebView's
+// concurrent-media-element limit.
+const activePlayerId = ref<number | null>(null)
 const currentPage = ref(1)
 const totalCount = ref(0)
 const itemsPerPage = 30
@@ -322,6 +299,7 @@ const loadFolders = async () => {
 
 const load = async (page = currentPage.value) => {
   loading.value = true
+  activePlayerId.value = null
   try {
     const list = await filesService.listFiles({
       source: 'generated',
@@ -347,46 +325,6 @@ const nextPage = () => {
 const previousPage = () => {
   if (currentPage.value > 1) load(currentPage.value - 1)
 }
-
-const kindOf = (file: FileItem): FileOriginKind => {
-  if (file.origin_kind) return file.origin_kind
-  const type = (file.file_type || '').toLowerCase()
-  if (/png|jpe?g|gif|webp|image/.test(type)) return 'image'
-  if (/mp4|webm|mov|avi|mkv|video/.test(type)) return 'video'
-  if (/mp3|wav|ogg|m4a|audio/.test(type)) return 'audio'
-  if (/ics/.test(type)) return 'calendar'
-  return 'document'
-}
-
-// Image/video/audio render an inline player (or thumbnail), so the corner
-// kind-badge is only useful for the icon-only kinds (calendar/document/unknown).
-const isInlineMediaKind = (file: FileItem): boolean => {
-  const kind = kindOf(file)
-  return 'image' === kind || 'video' === kind || 'audio' === kind
-}
-
-const kindIcon = (file: FileItem): string => {
-  switch (kindOf(file)) {
-    case 'video':
-      return 'mdi:play-circle'
-    case 'audio':
-      return 'mdi:music-note'
-    case 'calendar':
-      return 'mdi:calendar'
-    case 'document':
-      return 'mdi:file-document-outline'
-    default:
-      return 'mdi:image'
-  }
-}
-
-const downloadUrl = (id: number): string => `${getApiBaseUrl()}/api/v1/files/${id}/download`
-
-// For the bare <img> thumbnail only: no-op on web, on native it appends a
-// read-only media token because <img> can't send auth headers.
-// MessageVideo/MessageAudio receive the raw URL and wrap it themselves.
-const { mediaSrc } = useMediaSrc()
-const thumbnailUrl = (id: number): string => mediaSrc(downloadUrl(id))
 
 const download = async (file: FileItem) => {
   try {

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -3139,6 +3139,9 @@
       "retry": "Erneut versuchen",
       "provenance": "von {source} · {time}"
     },
+    "preview": {
+      "play": "Abspielen"
+    },
     "generated": {
       "title": "Erzeugt",
       "subtitle": "Bilder, Videos, Audio, Dokumente und Kalendereinladungen aus deinen Chats und Aufgaben.",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -1293,6 +1293,9 @@
       "retry": "Retry",
       "provenance": "from {source} · {time}"
     },
+    "preview": {
+      "play": "Play"
+    },
     "generated": {
       "title": "Generated",
       "subtitle": "Images, videos, audio, documents and calendar invites created in your chats and tasks.",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -2466,6 +2466,9 @@
       "retry": "Reintentar",
       "provenance": "de {source} · {time}"
     },
+    "preview": {
+      "play": "Reproducir"
+    },
     "generated": {
       "title": "Generados",
       "subtitle": "Imágenes, vídeos, audio, documentos e invitaciones de calendario creados en tus chats y tareas.",

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -1293,6 +1293,9 @@
       "retry": "Réessayer",
       "provenance": "depuis {source} · {time}"
     },
+    "preview": {
+      "play": "Lire"
+    },
     "generated": {
       "title": "Générés",
       "subtitle": "Images, vidéos, audio, documents et invitations d’agenda créés dans vos chats et tâches.",

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -2467,6 +2467,9 @@
       "retry": "Yeniden dene",
       "provenance": "{source} · {time}"
     },
+    "preview": {
+      "play": "Oynat"
+    },
     "generated": {
       "title": "Üretilen",
       "subtitle": "Sohbetlerinizde ve görevlerinizde oluşturulan görseller, videolar, ses, belgeler ve takvim davetleri.",

--- a/frontend/src/services/filePreview.ts
+++ b/frontend/src/services/filePreview.ts
@@ -101,7 +101,7 @@ export const previewIconForName = (name: string): string =>
  * violated the styling convention and was visually noisy (#1499). One uniform
  * treatment, readable in light, dark, and V2.
  */
-export const previewBadgeClass = (): string => 'bg-black/5 dark:bg-white/5 txt-secondary'
+export const previewBadgeClass = (): string => 'bg-[var(--bg-chip)] txt-secondary'
 
 /** Trimmed text snippet from the already-serialized `text_preview` field. */
 export const previewSnippet = (file: FileItem): string => (file.text_preview ?? '').trim()

--- a/frontend/src/services/filePreview.ts
+++ b/frontend/src/services/filePreview.ts
@@ -1,0 +1,110 @@
+import type { FileItem } from '@/services/filesService'
+
+/**
+ * Shared file-preview logic for both Files surfaces — the `Generated` grid
+ * (`FilesGrid.vue`) and the `Browse` list (`FilesView.vue`). Centralising kind
+ * detection, iconography, and the neutral surface treatment here keeps the two
+ * surfaces consistent and avoids a divergent second implementation (#1499).
+ */
+export type PreviewKind =
+  'image' | 'video' | 'audio' | 'text' | 'document' | 'pdf' | 'calendar' | 'unknown'
+
+const IMAGE_EXTENSIONS = ['jpg', 'jpeg', 'png', 'webp', 'gif', 'heic', 'heif', 'svg', 'bmp', 'avif']
+const VIDEO_EXTENSIONS = ['mp4', 'webm', 'mov', 'avi', 'mkv', 'm4v']
+const AUDIO_EXTENSIONS = ['mp3', 'wav', 'ogg', 'm4a', 'flac', 'aac', 'opus']
+/** Plain-text types whose `text_preview` snippet reads naturally as a preview. */
+const TEXT_EXTENSIONS = ['txt', 'md', 'markdown', 'csv', 'log', 'json', 'xml', 'yml', 'yaml']
+const DOCUMENT_EXTENSIONS = [
+  'doc',
+  'docx',
+  'xls',
+  'xlsx',
+  'ppt',
+  'pptx',
+  'odt',
+  'ods',
+  'odp',
+  'odg',
+  'odf',
+  'rtf',
+]
+
+export const extensionOf = (name: string | undefined | null): string =>
+  (name ?? '').split('.').pop()?.toLowerCase() ?? ''
+
+/** Map a bare file extension to a preview kind. */
+export const kindFromExtension = (ext: string): PreviewKind => {
+  if (IMAGE_EXTENSIONS.includes(ext)) return 'image'
+  if (VIDEO_EXTENSIONS.includes(ext)) return 'video'
+  if (AUDIO_EXTENSIONS.includes(ext)) return 'audio'
+  if ('pdf' === ext) return 'pdf'
+  if ('ics' === ext) return 'calendar'
+  if (TEXT_EXTENSIONS.includes(ext)) return 'text'
+  if (DOCUMENT_EXTENSIONS.includes(ext)) return 'document'
+  return 'unknown'
+}
+
+/**
+ * Resolve the preview kind for a listed file. The filename extension is the
+ * most specific signal (it separates `txt` from `pdf` from `docx`, which the
+ * coarse `origin_kind` lumps together as `document`); the generated
+ * `origin_kind`/`file_type` fields are the fallback for extension-less media.
+ */
+export const previewKindForFile = (file: FileItem): PreviewKind => {
+  const byExtension = kindFromExtension(extensionOf(file.display_name || file.filename))
+  if ('unknown' !== byExtension) return byExtension
+
+  const originKind = file.origin_kind
+  if (
+    'image' === originKind ||
+    'video' === originKind ||
+    'audio' === originKind ||
+    'calendar' === originKind
+  ) {
+    return originKind
+  }
+
+  const byType = kindFromExtension((file.file_type || '').toLowerCase())
+  if ('unknown' !== byType) return byType
+
+  return 'document' === originKind ? 'document' : 'unknown'
+}
+
+/** Iconify id for a preview kind (mdi set, consistent across both surfaces). */
+export const previewIcon = (kind: PreviewKind): string => {
+  switch (kind) {
+    case 'image':
+      return 'mdi:image-outline'
+    case 'video':
+      return 'mdi:play-circle-outline'
+    case 'audio':
+      return 'mdi:music-note'
+    case 'pdf':
+      return 'mdi:file-pdf-box'
+    case 'calendar':
+      return 'mdi:calendar'
+    case 'text':
+    case 'document':
+      return 'mdi:file-document-outline'
+    default:
+      return 'mdi:file-outline'
+  }
+}
+
+export const previewIconForFile = (file: FileItem): string => previewIcon(previewKindForFile(file))
+export const previewIconForName = (name: string): string =>
+  previewIcon(kindFromExtension(extensionOf(name)))
+
+/**
+ * Neutral, token-based surface for a type badge/icon — replaces the previous
+ * per-extension Tailwind rainbow (`bg-red-500/10`, `bg-purple-500/10`, …) that
+ * violated the styling convention and was visually noisy (#1499). One uniform
+ * treatment, readable in light, dark, and V2.
+ */
+export const previewBadgeClass = (): string => 'bg-black/5 dark:bg-white/5 txt-secondary'
+
+/** Trimmed text snippet from the already-serialized `text_preview` field. */
+export const previewSnippet = (file: FileItem): string => (file.text_preview ?? '').trim()
+
+/** Whether a text-bearing tile should render a snippet instead of a bare icon. */
+export const hasTextSnippet = (file: FileItem): boolean => previewSnippet(file).length > 0

--- a/frontend/src/views/FilesView.vue
+++ b/frontend/src/views/FilesView.vue
@@ -810,7 +810,7 @@
                     />
                     <div
                       class="w-7 h-7 sm:w-8 sm:h-8 rounded-lg flex items-center justify-center shrink-0"
-                      :class="getFileColorClass(file.filename)"
+                      :class="getFileColorClass()"
                     >
                       <Icon :icon="getFileIcon(file.filename)" class="w-4 h-4" />
                     </div>
@@ -948,7 +948,7 @@
                         <div class="flex items-center gap-3 min-w-0">
                           <div
                             class="w-8 h-8 rounded-lg flex items-center justify-center shrink-0"
-                            :class="getFileColorClass(file.filename)"
+                            :class="getFileColorClass()"
                           >
                             <Icon :icon="getFileIcon(file.filename)" class="w-4 h-4" />
                           </div>
@@ -1215,7 +1215,7 @@
                   />
                   <div
                     class="w-7 h-7 sm:w-8 sm:h-8 rounded-lg flex items-center justify-center shrink-0"
-                    :class="getFileColorClass(file.filename)"
+                    :class="getFileColorClass()"
                   >
                     <Icon :icon="getFileIcon(file.filename)" class="w-4 h-4" />
                   </div>
@@ -1347,7 +1347,7 @@
                       <div class="flex items-center gap-3 min-w-0">
                         <div
                           class="w-8 h-8 rounded-lg flex items-center justify-center shrink-0"
-                          :class="getFileColorClass(file.filename)"
+                          :class="getFileColorClass()"
                         >
                           <Icon :icon="getFileIcon(file.filename)" class="w-4 h-4" />
                         </div>
@@ -1614,6 +1614,7 @@ import filesService, {
   type UploadProgress,
   UploadBlockedError,
 } from '@/services/filesService'
+import { previewBadgeClass, previewIconForName } from '@/services/filePreview'
 import { useNotification } from '@/composables/useNotification'
 import { useFilePersistence } from '@/composables/useInputPersistence'
 import { useRouter, useRoute } from 'vue-router'
@@ -2004,23 +2005,10 @@ const closeFolderMenu = (e: MouseEvent) => {
   }
 }
 
-const getFileColorClass = (filename: string): string => {
-  const ext = filename.split('.').pop()?.toLowerCase() || ''
-  const colorMap: Record<string, string> = {
-    pdf: 'bg-red-500/10 text-red-500',
-    docx: 'bg-blue-500/10 text-blue-500',
-    doc: 'bg-blue-500/10 text-blue-500',
-    txt: 'bg-gray-500/10 text-gray-500',
-    jpg: 'bg-purple-500/10 text-purple-500',
-    jpeg: 'bg-purple-500/10 text-purple-500',
-    png: 'bg-purple-500/10 text-purple-500',
-    mp3: 'bg-pink-500/10 text-pink-500',
-    mp4: 'bg-pink-500/10 text-pink-500',
-    xlsx: 'bg-emerald-500/10 text-emerald-500',
-    csv: 'bg-emerald-500/10 text-emerald-500',
-  }
-  return colorMap[ext] || 'bg-[var(--brand)]/10 text-[var(--brand)]'
-}
+// Neutral, token-based badge shared with the Generated grid (#1499). Replaces
+// the previous per-extension Tailwind rainbow (bg-red-500/10, bg-purple-500/10,
+// …), which was visually noisy and off-token.
+const getFileColorClass = (): string => previewBadgeClass()
 
 // Drag & Drop handlers
 const handleDragEnter = (event: DragEvent) => {
@@ -2111,27 +2099,9 @@ const onFolderDrop = async (event: DragEvent, folderName: string) => {
   }
 }
 
-const getFileIcon = (filename: string): string => {
-  const ext = filename.split('.').pop()?.toLowerCase() || ''
-
-  const iconMap: Record<string, string> = {
-    pdf: 'heroicons:document-text',
-    docx: 'heroicons:document-text',
-    doc: 'heroicons:document-text',
-    txt: 'heroicons:document-text',
-    jpg: 'heroicons:photo',
-    jpeg: 'heroicons:photo',
-    png: 'heroicons:photo',
-    gif: 'heroicons:photo',
-    webp: 'heroicons:photo',
-    mp3: 'heroicons:musical-note',
-    mp4: 'heroicons:film',
-    xlsx: 'heroicons:table-cells',
-    csv: 'heroicons:table-cells',
-  }
-
-  return iconMap[ext] || 'heroicons:document'
-}
+// Icon set shared with the Generated grid via the common preview helper (#1499)
+// so both surfaces stay consistent (no divergent second icon map).
+const getFileIcon = (filename: string): string => previewIconForName(filename)
 
 const uploadFiles = async () => {
   if (selectedFiles.value.length === 0) {

--- a/frontend/tests/unit/components/files/FilePreview.spec.ts
+++ b/frontend/tests/unit/components/files/FilePreview.spec.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+
+import FilePreview from '@/components/files/FilePreview.vue'
+import type { FileItem } from '@/services/filesService'
+
+vi.mock('@/services/api/httpClient', () => ({
+  getApiBaseUrl: () => 'http://api.test',
+}))
+
+vi.mock('@/services/api/mediaAuth', () => ({
+  useMediaSrc: () => ({ mediaSrc: (url: string) => url }),
+}))
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  missingWarn: false,
+  fallbackWarn: false,
+  messages: { en: { files: { preview: { play: 'Play' } } } },
+})
+
+const file = (overrides: Partial<FileItem>): FileItem =>
+  ({
+    id: 42,
+    filename: 'file.bin',
+    path: '/x',
+    file_type: '',
+    file_size: 0,
+    mime: '',
+    status: 'ok',
+    text_preview: '',
+    uploaded_at: 0,
+    uploaded_date: '2026-01-01',
+    message_id: null,
+    ...overrides,
+  }) as FileItem
+
+const mountPreview = (f: FileItem, playing = false) =>
+  mount(FilePreview, {
+    props: { file: f, playing },
+    global: {
+      plugins: [i18n],
+      stubs: {
+        Icon: { template: '<i class="icon" />' },
+        MessageVideo: { template: '<div class="stub-video" />' },
+        MessageAudio: { template: '<div class="stub-audio" />' },
+      },
+    },
+  })
+
+describe('FilePreview lazy playback', () => {
+  it('shows a play affordance for audio and mounts no player by default', () => {
+    const wrapper = mountPreview(file({ filename: 'song.mp3', origin_kind: 'audio' }))
+    expect(wrapper.find('[data-testid="file-preview-audio-play"]').exists()).toBe(true)
+    expect(wrapper.find('.stub-audio').exists()).toBe(false)
+  })
+
+  it('emits play when the audio affordance is clicked', async () => {
+    const wrapper = mountPreview(file({ filename: 'song.mp3', origin_kind: 'audio' }))
+    await wrapper.find('[data-testid="file-preview-audio-play"]').trigger('click')
+    expect(wrapper.emitted('play')).toHaveLength(1)
+  })
+
+  it('mounts the real audio player only once playing', () => {
+    const wrapper = mountPreview(file({ filename: 'song.mp3', origin_kind: 'audio' }), true)
+    expect(wrapper.find('.stub-audio').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="file-preview-audio-play"]').exists()).toBe(false)
+  })
+
+  it('shows a poster play overlay for video and no player until tapped', () => {
+    const wrapper = mountPreview(file({ filename: 'clip.mp4', origin_kind: 'video' }))
+    expect(wrapper.find('[data-testid="file-preview-video-play"]').exists()).toBe(true)
+    expect(wrapper.find('.stub-video').exists()).toBe(false)
+  })
+
+  it('renders a text snippet for txt files with a preview', () => {
+    const wrapper = mountPreview(file({ filename: 'notes.txt', text_preview: 'hello world' }))
+    const snippet = wrapper.find('[data-testid="file-preview-snippet"]')
+    expect(snippet.exists()).toBe(true)
+    expect(snippet.text()).toContain('hello world')
+  })
+
+  it('falls back to an icon for documents without extracted text', () => {
+    const wrapper = mountPreview(file({ filename: 'deck.pptx' }))
+    expect(wrapper.find('[data-testid="file-preview-icon"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="file-preview-snippet"]').exists()).toBe(false)
+  })
+})

--- a/frontend/tests/unit/services/filePreview.spec.ts
+++ b/frontend/tests/unit/services/filePreview.spec.ts
@@ -65,6 +65,7 @@ describe('filePreview helpers', () => {
   it('returns a token-based neutral badge (no raw tailwind colors)', () => {
     const badge = previewBadgeClass()
     expect(badge).not.toMatch(/bg-(red|blue|purple|pink|emerald|gray|green|yellow|orange)-\d/)
+    expect(badge).toContain('var(--bg-chip)')
     expect(badge).toContain('txt-secondary')
   })
 

--- a/frontend/tests/unit/services/filePreview.spec.ts
+++ b/frontend/tests/unit/services/filePreview.spec.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  extensionOf,
+  hasTextSnippet,
+  kindFromExtension,
+  previewBadgeClass,
+  previewIcon,
+  previewIconForName,
+  previewKindForFile,
+  previewSnippet,
+} from '@/services/filePreview'
+import type { FileItem } from '@/services/filesService'
+
+const file = (overrides: Partial<FileItem>): FileItem =>
+  ({
+    id: 1,
+    filename: 'file.bin',
+    path: '/x',
+    file_type: '',
+    file_size: 0,
+    mime: '',
+    status: 'ok',
+    text_preview: '',
+    uploaded_at: 0,
+    uploaded_date: '2026-01-01',
+    message_id: null,
+    ...overrides,
+  }) as FileItem
+
+describe('filePreview helpers', () => {
+  it('extracts the lowercased extension', () => {
+    expect(extensionOf('Report.PDF')).toBe('pdf')
+    expect(extensionOf('noext')).toBe('noext')
+    expect(extensionOf(null)).toBe('')
+  })
+
+  it('maps extensions to preview kinds', () => {
+    expect(kindFromExtension('png')).toBe('image')
+    expect(kindFromExtension('mp4')).toBe('video')
+    expect(kindFromExtension('mp3')).toBe('audio')
+    expect(kindFromExtension('pdf')).toBe('pdf')
+    expect(kindFromExtension('md')).toBe('text')
+    expect(kindFromExtension('docx')).toBe('document')
+    expect(kindFromExtension('ics')).toBe('calendar')
+    expect(kindFromExtension('bin')).toBe('unknown')
+  })
+
+  it('prefers the filename extension over the coarse origin_kind', () => {
+    // A .txt with origin_kind=document must resolve to text (so it renders a
+    // snippet, not a bare document icon).
+    expect(previewKindForFile(file({ filename: 'notes.txt', origin_kind: 'document' }))).toBe(
+      'text'
+    )
+    expect(previewKindForFile(file({ filename: 'sheet.xlsx', origin_kind: 'document' }))).toBe(
+      'document'
+    )
+  })
+
+  it('falls back to origin_kind for extension-less generated media', () => {
+    expect(previewKindForFile(file({ filename: 'generated', origin_kind: 'video' }))).toBe('video')
+    expect(previewKindForFile(file({ filename: 'generated', origin_kind: 'image' }))).toBe('image')
+  })
+
+  it('returns a token-based neutral badge (no raw tailwind colors)', () => {
+    const badge = previewBadgeClass()
+    expect(badge).not.toMatch(/bg-(red|blue|purple|pink|emerald|gray|green|yellow|orange)-\d/)
+    expect(badge).toContain('txt-secondary')
+  })
+
+  it('provides mdi icons per kind', () => {
+    expect(previewIcon('audio')).toBe('mdi:music-note')
+    expect(previewIcon('pdf')).toBe('mdi:file-pdf-box')
+    expect(previewIconForName('clip.mp4')).toBe('mdi:play-circle-outline')
+  })
+
+  it('reads the trimmed text_preview snippet', () => {
+    expect(previewSnippet(file({ text_preview: '  hello  ' }))).toBe('hello')
+    expect(hasTextSnippet(file({ text_preview: '' }))).toBe(false)
+    expect(hasTextSnippet(file({ text_preview: 'x' }))).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
File previews

## Changes
- Introduced a new endpoint to serve generated thumbnails for video files via GET /api/v1/files/{id}/thumb.
- Implemented thumbnail generation in MediaJobMessageSync to ensure video files have associated thumbnails.
- Updated frontend components to utilize the new thumbnail feature, enhancing user experience with video previews.
- Added internationalization support for new preview-related strings in multiple languages.
- Refactored file handling in the FilesGrid component to streamline media playback and improve performance.

## Verification
- [ ] Not tested (explain)
- [X] Manual
- [ ] Tests added/updated

## Notes
<!-- Related issues/links/threads. -->

## Screenshots/Logs
