### PR TITLE
feat(desktop): implement desktop agent features and integration

### DIFF
--- a/_devextras/testing/desktop/fake-device.sh
+++ b/_devextras/testing/desktop/fake-device.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# DS17 — stand-in for the real Synaplan Desktop client.
+#
+# Pairs a fake computer, then drives the MCP check-in loop end to end AND every
+# refusal path the contract promises (11_security_and_compatibility.md). The
+# same assertions are gated in PHPUnit (DesktopMcpCheckinTest,
+# DesktopControllerTest); this script is the human-runnable acceptance demo and
+# the reference implementation for the client team.
+#
+# Refusal / safety paths exercised here:
+#   * hostile input.command never reaches the device payload
+#   * a refused skill is a normal "failed" (errorCode), not a transport error
+#   * a stale/wrong lease token is a clean tool error
+#   * an oversized result is rejected
+#   * a job targeted at another device is not leased by this one
+#   * an unknown device id is 404
+#   * with the flag OFF: enqueue 404s and the agent tools disappear
+#
+# Usage: ./_devextras/testing/desktop/fake-device.sh
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+require_tools
+
+echo "== Synaplan Desktop fake client =="
+echo "BASE=$BASE  EMAIL=$EMAIL"
+echo
+
+enable_flag
+login
+CODE="$(mint_code)"
+pair_device "$CODE" "Fake device (primary)"
+PRIMARY_KEY="$DESKTOP_KEY"
+PRIMARY_DEVICE_ID="$DEVICE_ID"
+echo "NOTE  Paired primary device #$PRIMARY_DEVICE_ID."
+
+# --- 1. The two agent tools appear only for a paired, desktop-scoped key ------
+mcp_init
+mapfile -t TOOLS < <(mcp_tool_names)
+tool_present() { printf '%s\n' "${TOOLS[@]}" | grep -qx "$1"; }
+assert "agent_checkin tool is offered"         "tool_present agent_checkin"
+assert "agent_report_result tool is offered"   "tool_present agent_report_result"
+assert "base tools remain (superset, not swap)" "tool_present synaplan_chat"
+
+# --- 2. Idle check-in returns no work and a next_call_at ----------------------
+# jq extractions ALWAYS land in scalar vars first; never pass a JSON blob to
+# assert (its quotes would break the eval). See lib.sh assert()/assert_eq().
+IDLE="$(mcp_call agent_checkin '{"protocol":1,"capabilities":["skill.run"],"enabledSkills":["hello-files"],"status":"idle"}')"
+IDLE_PROTO="$(jq -r '.result.structuredContent.protocol' <<<"$IDLE")"
+IDLE_JOBS="$(jq -r '.result.structuredContent.jobs | length' <<<"$IDLE")"
+IDLE_NEXT="$(jq -r '.result.structuredContent.next_call_at' <<<"$IDLE")"
+assert_eq "idle check-in speaks protocol 1" "$IDLE_PROTO" "1"
+assert_eq "idle check-in hands back 0 jobs" "$IDLE_JOBS" "0"
+assert "idle check-in sets next_call_at"    "[[ \"$IDLE_NEXT\" =~ ^[0-9]+$ ]]"
+
+# --- 3. Happy path: enqueue (with a hostile extra key) → lease → succeed ------
+# The web caller sneaks input.command; the server must strip it so the device
+# only ever sees {skill, prompt, fileIds}.
+STATUS="$(enqueue_job_raw "{\"deviceId\":$PRIMARY_DEVICE_ID,\"type\":\"skill.run\",\"input\":{\"skill\":\"hello-files\",\"prompt\":\"say hi\",\"command\":\"rm -rf /\"}}")"
+assert_eq "enqueue with hostile extra key still 201" "$STATUS" "201"
+JOB_ID="$(jq -r '.jobId' /tmp/syn-enq.json)"
+
+LEASE="$(mcp_call agent_checkin '{"protocol":1,"capabilities":["skill.run"],"enabledSkills":["hello-files"]}')"
+LEASE_COUNT="$(jq -r '.result.structuredContent.jobs | length' <<<"$LEASE")"
+LEASE_JOB_ID="$(jq -r '.result.structuredContent.jobs[0].jobId' <<<"$LEASE")"
+LEASE_KEYS="$(jq -c '.result.structuredContent.jobs[0].input | keys' <<<"$LEASE")"
+LEASE_HAS_CMD="$(jq -r '.result.structuredContent.jobs[0].input | has("command")' <<<"$LEASE")"
+LEASE_TOKEN="$(jq -r '.result.structuredContent.jobs[0].leaseToken' <<<"$LEASE")"
+assert_eq "check-in leases exactly 1 job" "$LEASE_COUNT" "1"
+assert_eq "leased job is the enqueued one" "$LEASE_JOB_ID" "$JOB_ID"
+assert_eq "device payload has ONLY skill/prompt/fileIds" "$LEASE_KEYS" '["fileIds","prompt","skill"]'
+assert_eq "hostile input.command is stripped" "$LEASE_HAS_CMD" "false"
+assert "a lease token was issued" "[[ \"$LEASE_TOKEN\" == lt_* ]]"
+
+# --- 4. A second check-in while leased sees nothing (no double-hand-out) ------
+AGAIN="$(mcp_call agent_checkin '{"protocol":1}')"
+AGAIN_COUNT="$(jq -r '.result.structuredContent.jobs | length' <<<"$AGAIN")"
+assert_eq "re-check-in while leased returns 0 jobs" "$AGAIN_COUNT" "0"
+
+# --- 5. Report success → chat completion note (asserted via job status) -------
+REPORT="$(mcp_call agent_report_result "{\"leaseToken\":\"$LEASE_TOKEN\",\"status\":\"succeeded\",\"result\":{\"summary\":\"done\",\"fileIds\":[]}}")"
+REPORT_OK="$(jq -r '.result.structuredContent.success' <<<"$REPORT")"
+assert_eq "report success returns success:true" "$REPORT_OK" "true"
+get_job "$JOB_ID" >/dev/null
+JOB_STATUS="$(jq -r '.job.status' /tmp/syn-job.json)"
+assert_eq "job is now succeeded" "$JOB_STATUS" "succeeded"
+
+# --- 6. Refusal: a stale/wrong lease token is a clean tool error --------------
+BADTOK="$(mcp_call agent_report_result '{"leaseToken":"lt_does_not_exist","status":"succeeded"}')"
+BADTOK_ERR="$(jq -r '.result.isError' <<<"$BADTOK")"
+assert_eq "stale lease token → isError" "$BADTOK_ERR" "true"
+
+# --- 7. Refusal: an unknown skill is a normal 'failed', not a transport error -
+enqueue_job "$PRIMARY_DEVICE_ID" "definitely-not-installed" "try it" >/dev/null
+REFUSE_JOB_ID="$(jq -r '.jobId' /tmp/syn-enq.json)"
+REFUSE_LEASE="$(mcp_call agent_checkin '{"protocol":1}')"
+REFUSE_TOKEN="$(jq -r '.result.structuredContent.jobs[0].leaseToken' <<<"$REFUSE_LEASE")"
+REFUSE_REPORT="$(mcp_call agent_report_result "{\"leaseToken\":\"$REFUSE_TOKEN\",\"status\":\"failed\",\"errorCode\":\"unknown_skill\"}")"
+REFUSE_OK="$(jq -r '.result.structuredContent.success' <<<"$REFUSE_REPORT")"
+assert_eq "refusal report succeeds transport-wise" "$REFUSE_OK" "true"
+get_job "$REFUSE_JOB_ID" >/dev/null
+REFUSE_STATUS="$(jq -r '.job.status' /tmp/syn-job.json)"
+REFUSE_CODE="$(jq -r '.job.errorCode' /tmp/syn-job.json)"
+assert_eq "refused job is failed" "$REFUSE_STATUS" "failed"
+assert_eq "refused job records errorCode" "$REFUSE_CODE" "unknown_skill"
+
+# --- 8. Refusal: an oversized result is rejected ------------------------------
+enqueue_job "$PRIMARY_DEVICE_ID" "hello-files" "big one" >/dev/null
+BIG_LEASE="$(mcp_call agent_checkin '{"protocol":1}')"
+BIG_TOKEN="$(jq -r '.result.structuredContent.jobs[0].leaseToken' <<<"$BIG_LEASE")"
+BIG_BLOB="$(head -c 70000 /dev/zero | tr '\0' 'x')"
+BIG_ARGS="$(jq -nc --arg t "$BIG_TOKEN" --arg b "$BIG_BLOB" '{leaseToken:$t,status:"succeeded",result:{summary:$b}}')"
+BIG_REPORT="$(mcp_call agent_report_result "$BIG_ARGS")"
+BIG_ERR="$(jq -r '.result.isError' <<<"$BIG_REPORT")"
+assert_eq "oversized result → isError" "$BIG_ERR" "true"
+# The lease survives the rejection, so the device can retry with a small result.
+mcp_call agent_report_result "{\"leaseToken\":\"$BIG_TOKEN\",\"status\":\"failed\",\"errorCode\":\"local_error\"}" >/dev/null
+
+# --- 9. A job targeted at another device is not leased by this one ------------
+CODE2="$(mint_code)"
+pair_device "$CODE2" "Fake device (secondary)"
+SECOND_KEY="$DESKTOP_KEY"
+enqueue_job "$PRIMARY_DEVICE_ID" "hello-files" "primary only" >/dev/null
+TARGETED_JOB_ID="$(jq -r '.jobId' /tmp/syn-enq.json)"
+# Check in AS the secondary device.
+DESKTOP_KEY="$SECOND_KEY"
+mcp_init
+SECOND_CHECKIN="$(mcp_call agent_checkin '{"protocol":1}')"
+SECOND_COUNT="$(jq -r '.result.structuredContent.jobs | length' <<<"$SECOND_CHECKIN")"
+assert_eq "secondary device does not lease primary's job" "$SECOND_COUNT" "0"
+# Primary reclaims and drains it so the queue is left clean.
+DESKTOP_KEY="$PRIMARY_KEY"
+mcp_init
+PRIMARY_DRAIN="$(mcp_call agent_checkin '{"protocol":1}')"
+DRAIN_JOB_ID="$(jq -r '.result.structuredContent.jobs[0].jobId' <<<"$PRIMARY_DRAIN")"
+DRAIN_TOKEN="$(jq -r '.result.structuredContent.jobs[0].leaseToken' <<<"$PRIMARY_DRAIN")"
+assert_eq "primary can still lease its own targeted job" "$DRAIN_JOB_ID" "$TARGETED_JOB_ID"
+[[ "$DRAIN_TOKEN" == lt_* ]] && mcp_call agent_report_result "{\"leaseToken\":\"$DRAIN_TOKEN\",\"status\":\"succeeded\"}" >/dev/null
+
+# --- 10. Enqueue for an unknown device id → 404 ------------------------------
+UNKNOWN_STATUS="$(enqueue_job 999999999 "hello-files" "nowhere" || true)"
+assert_eq "enqueue to an unknown device is 404" "$UNKNOWN_STATUS" "404"
+
+# --- 11. Flag OFF: enqueue 404s and the agent tools disappear ----------------
+if command -v docker >/dev/null 2>&1 && [[ "${SYNAPLAN_SKIP_FLAG:-0}" != "1" ]]; then
+  docker compose exec -T db mariadb -usynaplan_user -psynaplan_password synaplan \
+    -e "UPDATE BCONFIG SET BVALUE='0' WHERE BGROUP='DESKTOP_AGENT' AND BSETTING='ENABLED';" >/dev/null 2>&1 || true
+  OFF_STATUS="$(enqueue_job "$PRIMARY_DEVICE_ID" "hello-files" "flag off" || true)"
+  assert_eq "enqueue with flag OFF is 404" "$OFF_STATUS" "404"
+  DESKTOP_KEY="$PRIMARY_KEY"
+  mcp_init
+  mapfile -t OFF_TOOLS < <(mcp_tool_names)
+  off_tool_present() { printf '%s\n' "${OFF_TOOLS[@]}" | grep -qx "$1"; }
+  assert "agent_checkin gone with flag OFF"       "! off_tool_present agent_checkin"
+  assert "agent_report_result gone with flag OFF" "! off_tool_present agent_report_result"
+  # Restore the flag so the harness leaves the instance usable.
+  docker compose exec -T db mariadb -usynaplan_user -psynaplan_password synaplan \
+    -e "UPDATE BCONFIG SET BVALUE='1' WHERE BGROUP='DESKTOP_AGENT' AND BSETTING='ENABLED';" >/dev/null 2>&1 || true
+else
+  echo "NOTE  Skipping flag-off checks (no docker or SYNAPLAN_SKIP_FLAG=1)."
+fi
+
+echo
+summary

--- a/_devextras/testing/desktop/fixtures/README.md
+++ b/_devextras/testing/desktop/fixtures/README.md
@@ -1,0 +1,50 @@
+# Frozen Synaplan Desktop contract fixtures (`protocol: 1`)
+
+These JSON files are the **frozen** wire shapes of the Synaplan Desktop job /
+check-in contract (Sprint A3, DS18). They are the single source of truth the
+future desktop client (`synaplan-desktop`, Phase B, step DC3) **vendors
+byte-for-byte** to build its unit tests against — so the client can be developed
+and tested without a live server.
+
+**Do not edit these files as a client convenience.** They are asserted against
+the live server contract by
+`backend/tests/Unit/Service/Desktop/DesktopContractFixturesTest.php`
+(`DesktopJobContract`, the entity enums, and the MCP tool schemas). Any change
+that breaks the contract fails that test on purpose (invariant **C9**): editing
+a fixture is a `protocol: 2` decision **with a migration plan**, never a quiet
+tweak.
+
+> **Two copies, kept identical by a test.** The dev backend container only
+> mounts `backend/`, so a byte-identical mirror lives at
+> `backend/tests/Fixtures/Desktop/`. The test reads the mirror and, wherever
+> this canonical copy is also on disk (CI, host checkouts), asserts the two are
+> byte-for-byte identical — so they can never drift. If you change one, change
+> both (the test will remind you).
+
+## The files
+
+| File | Direction | Shape |
+| ---- | --------- | ----- |
+| `enqueue_request.json` | web → server (`POST /api/v1/desktop/jobs`) | Queue a `skill.run` job for a paired computer. |
+| `checkin_request.json` | device → server (MCP `agent_checkin` args) | What a device sends each poll. |
+| `checkin_response.json` | server → device (MCP `agent_checkin` result) | `protocol`, at most one job, `next_call_at`. |
+| `job_skill_run.json` | server → device (one job, isolated) | The exact device-facing payload — **only** `{skill, prompt, fileIds}`. |
+| `report_success.json` | device → server (MCP `agent_report_result` args) | A successful run. |
+| `report_unknown_skill.json` | device → server (MCP `agent_report_result` args) | A refusal: a normal `failed` with an `errorCode`, not a transport error. |
+
+## The two rules a client must never break
+
+1. **`protocol: 1`.** Both the check-in request and response carry it. A device
+   speaking an unknown protocol is answered with an empty job list and a far
+   `next_call_at` — never a guess.
+2. **A job's input is ONLY `{skill, prompt, fileIds}`.** Any other key
+   (`command`, `script`, `argv`, …) is dropped by the server and MUST be ignored
+   by the device. There is no field through which a shell string can reach the
+   computer — that is why a future server bug cannot become remote code
+   execution.
+
+The `leaseExpires` / `next_call_at` values are illustrative UNIX timestamps; a
+real response computes them from the server clock. Everything else — the keys,
+the enums, the nesting — is the contract.
+
+See [`../../../docs/DESKTOP.md`](../../../docs/DESKTOP.md) for the full picture.

--- a/_devextras/testing/desktop/fixtures/checkin_request.json
+++ b/_devextras/testing/desktop/fixtures/checkin_request.json
@@ -1,0 +1,7 @@
+{
+  "protocol": 1,
+  "agentKind": "synaplan-desktop",
+  "capabilities": ["skill.run"],
+  "enabledSkills": ["hello-files", "pptx"],
+  "status": "idle"
+}

--- a/_devextras/testing/desktop/fixtures/checkin_response.json
+++ b/_devextras/testing/desktop/fixtures/checkin_response.json
@@ -1,0 +1,18 @@
+{
+  "protocol": 1,
+  "jobs": [
+    {
+      "jobId": 1,
+      "type": "skill.run",
+      "input": {
+        "skill": "hello-files",
+        "prompt": "List the files in my Documents folder",
+        "fileIds": []
+      },
+      "leaseToken": "lt_0000000000000000000000000000000000000000000000000000",
+      "leaseExpires": 1788126300,
+      "attempt": 1
+    }
+  ],
+  "next_call_at": 1788126030
+}

--- a/_devextras/testing/desktop/fixtures/enqueue_request.json
+++ b/_devextras/testing/desktop/fixtures/enqueue_request.json
@@ -1,0 +1,10 @@
+{
+  "deviceId": 1,
+  "type": "skill.run",
+  "input": {
+    "skill": "hello-files",
+    "prompt": "List the files in my Documents folder",
+    "fileIds": []
+  },
+  "chatId": 99
+}

--- a/_devextras/testing/desktop/fixtures/job_skill_run.json
+++ b/_devextras/testing/desktop/fixtures/job_skill_run.json
@@ -1,0 +1,12 @@
+{
+  "jobId": 1,
+  "type": "skill.run",
+  "input": {
+    "skill": "hello-files",
+    "prompt": "List the files in my Documents folder",
+    "fileIds": []
+  },
+  "leaseToken": "lt_0000000000000000000000000000000000000000000000000000",
+  "leaseExpires": 1788126300,
+  "attempt": 1
+}

--- a/_devextras/testing/desktop/fixtures/report_success.json
+++ b/_devextras/testing/desktop/fixtures/report_success.json
@@ -1,0 +1,8 @@
+{
+  "leaseToken": "lt_0000000000000000000000000000000000000000000000000000",
+  "status": "succeeded",
+  "result": {
+    "summary": "Listed 12 files in Documents.",
+    "fileIds": [42]
+  }
+}

--- a/_devextras/testing/desktop/fixtures/report_unknown_skill.json
+++ b/_devextras/testing/desktop/fixtures/report_unknown_skill.json
@@ -1,0 +1,8 @@
+{
+  "leaseToken": "lt_0000000000000000000000000000000000000000000000000000",
+  "status": "failed",
+  "errorCode": "unknown_skill",
+  "result": {
+    "message": "This computer does not have a skill named 'pptx'."
+  }
+}

--- a/_devextras/testing/desktop/lib.sh
+++ b/_devextras/testing/desktop/lib.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+# Shared helpers for the Synaplan Desktop pairing + check-in harness.
+#
+# These scripts are the Phase A acceptance demo and the stand-in for the real
+# desktop client (which does not exist yet). They are NOT part of the PHPUnit
+# gate — the equivalent assertions live in:
+#   backend/tests/Controller/DesktopControllerTest.php
+#   backend/tests/Controller/DesktopMcpCheckinTest.php
+#   backend/tests/Unit/Service/Desktop/*
+#
+# Requirements: bash, curl, jq. Runs against the local Docker stack.
+#
+# Environment:
+#   SYNAPLAN_BASE_URL   default http://localhost:8000
+#   SYNAPLAN_EMAIL      default demo@synaplan.com
+#   SYNAPLAN_PASSWORD   default demo123
+#   SYNAPLAN_SKIP_FLAG  set to 1 to skip the automatic BCONFIG flag enable
+#   MCP_PROTOCOL        default 2025-11-25 (the MCP transport version, NOT the
+#                       desktop job protocol which is always 1)
+
+set -euo pipefail
+
+BASE="${SYNAPLAN_BASE_URL:-http://localhost:8000}"
+EMAIL="${SYNAPLAN_EMAIL:-demo@synaplan.com}"
+PASSWORD="${SYNAPLAN_PASSWORD:-demo123}"
+MCP_PROTOCOL="${MCP_PROTOCOL:-2025-11-25}"
+
+COOKIE_JAR="$(mktemp -t synaplan-desktop-cookies.XXXXXX)"
+CREDS_FILE="${SYNAPLAN_DESKTOP_CREDS:-/tmp/synaplan-desktop.creds}"
+
+PASS=0
+FAIL=0
+
+cleanup() { rm -f "$COOKIE_JAR"; }
+trap cleanup EXIT
+
+require_tools() {
+  for tool in curl jq; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+      echo "ERROR: '$tool' is required but not installed." >&2
+      exit 1
+    fi
+  done
+}
+
+# Boolean/condition assert. NOTE: $cond is eval'd, so ONLY pass conditions that
+# reference simple scalar tokens (numbers, lease tokens, function calls) — never
+# embed a raw JSON blob (its double quotes destroy the eval quoting). For value
+# comparisons use assert_eq, which takes the values as positional args (no eval).
+assert() {
+  local name="$1" cond="$2"
+  if eval "$cond"; then
+    echo "PASS  $name"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL  $name  (cond: $cond)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Equality assert without eval — safe for values containing quotes/spaces.
+# Args: <name> <actual> <expected>
+assert_eq() {
+  local name="$1" actual="$2" expected="$3"
+  if [[ "$actual" == "$expected" ]]; then
+    echo "PASS  $name"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL  $name  (got: '$actual', want: '$expected')"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+summary() {
+  echo
+  echo "Result: $PASS passed, $FAIL failed"
+  [[ "$FAIL" -eq 0 ]]
+}
+
+# Enable the DESKTOP_AGENT.ENABLED global flag via the db container. The whole
+# surface 404s while it is off (invariant C8), so the harness needs it on.
+enable_flag() {
+  if [[ "${SYNAPLAN_SKIP_FLAG:-0}" == "1" ]]; then
+    echo "NOTE  Skipping flag enable (SYNAPLAN_SKIP_FLAG=1)."
+    return 0
+  fi
+  if ! command -v docker >/dev/null 2>&1; then
+    echo "NOTE  docker not found — enable the flag manually:"
+    echo "      UPDATE BCONFIG SET BVALUE='1' WHERE BGROUP='DESKTOP_AGENT' AND BSETTING='ENABLED';"
+    return 0
+  fi
+  docker compose exec -T db mariadb -usynaplan_user -psynaplan_password synaplan \
+    -e "INSERT INTO BCONFIG (BOWNERID,BGROUP,BSETTING,BVALUE) VALUES (0,'DESKTOP_AGENT','ENABLED','1')
+        ON DUPLICATE KEY UPDATE BVALUE='1';" >/dev/null 2>&1 \
+    && echo "NOTE  DESKTOP_AGENT.ENABLED set to 1." \
+    || echo "NOTE  Could not auto-enable flag; set BCONFIG DESKTOP_AGENT.ENABLED=1 manually."
+}
+
+# Log in as the web user, storing session cookies in $COOKIE_JAR.
+login() {
+  local status
+  status=$(curl -sS -o /tmp/syn-login.json -w '%{http_code}' \
+    -c "$COOKIE_JAR" \
+    -X POST "$BASE/api/v1/auth/login" \
+    -H 'content-type: application/json' \
+    -d "{\"email\":\"$EMAIL\",\"password\":\"$PASSWORD\"}")
+  if [[ "$status" != "200" ]]; then
+    echo "ERROR: login failed (HTTP $status). Body:" >&2
+    cat /tmp/syn-login.json >&2
+    exit 1
+  fi
+}
+
+# Mint a pairing code (session user). Echoes the code.
+mint_code() {
+  local status
+  status=$(curl -sS -o /tmp/syn-code.json -w '%{http_code}' \
+    -b "$COOKIE_JAR" \
+    -X POST "$BASE/api/v1/desktop/pairing-codes")
+  if [[ "$status" != "201" ]]; then
+    echo "ERROR: pairing-code creation failed (HTTP $status). Is the flag on?" >&2
+    cat /tmp/syn-code.json >&2
+    exit 1
+  fi
+  jq -r '.code' /tmp/syn-code.json
+}
+
+# Exchange a code for a scoped key. Args: <code> <deviceName>. Writes KEY,
+# DEVICE_ID, API_BASE_URL to $CREDS_FILE and exports them.
+pair_device() {
+  local code="$1" name="${2:-Harness laptop}" status
+  status=$(curl -sS -o /tmp/syn-pair.json -w '%{http_code}' \
+    -X POST "$BASE/api/v1/desktop/pair" \
+    -H 'content-type: application/json' \
+    -d "{\"code\":\"$code\",\"deviceName\":\"$name\",\"capabilities\":[\"skill.run\"]}")
+  if [[ "$status" != "201" ]]; then
+    echo "ERROR: pairing failed (HTTP $status). Body:" >&2
+    cat /tmp/syn-pair.json >&2
+    exit 1
+  fi
+  DESKTOP_KEY=$(jq -r '.key' /tmp/syn-pair.json)
+  DEVICE_ID=$(jq -r '.deviceId' /tmp/syn-pair.json)
+  API_BASE_URL=$(jq -r '.apiBaseUrl' /tmp/syn-pair.json)
+  export DESKTOP_KEY DEVICE_ID API_BASE_URL
+  {
+    echo "DESKTOP_KEY=$DESKTOP_KEY"
+    echo "DEVICE_ID=$DEVICE_ID"
+    echo "API_BASE_URL=$API_BASE_URL"
+  } > "$CREDS_FILE"
+}
+
+# --- MCP helpers (device side, authenticated by the scoped key) ---------------
+
+MCP_SESSION=""
+
+# Extract a JSON-RPC result from either a plain JSON body or an SSE stream.
+_mcp_extract_json() {
+  local body="$1"
+  if grep -q '^data:' <<<"$body"; then
+    grep '^data:' <<<"$body" | tail -1 | sed 's/^data: //'
+  else
+    echo "$body"
+  fi
+}
+
+# initialize the MCP session with the desktop key; sets $MCP_SESSION.
+mcp_init() {
+  local headers body
+  curl -sS -D /tmp/syn-mcp-h.txt -o /tmp/syn-mcp-b.txt \
+    -X POST "$BASE/mcp" \
+    -H "x-api-key: $DESKTOP_KEY" \
+    -H 'content-type: application/json' \
+    -H 'accept: application/json, text/event-stream' \
+    -H "mcp-protocol-version: $MCP_PROTOCOL" \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"$MCP_PROTOCOL\",\"capabilities\":{},\"clientInfo\":{\"name\":\"fake-device\",\"version\":\"1.0.0\"}}}"
+  MCP_SESSION=$(grep -i '^mcp-session-id:' /tmp/syn-mcp-h.txt | tail -1 | tr -d '\r' | awk '{print $2}')
+}
+
+# Call an MCP tool. Args: <name> <arguments-json>. Echoes the JSON-RPC response.
+mcp_call() {
+  local name="$1" args="$2" body
+  body=$(curl -sS \
+    -X POST "$BASE/mcp" \
+    -H "x-api-key: $DESKTOP_KEY" \
+    -H 'content-type: application/json' \
+    -H 'accept: application/json, text/event-stream' \
+    -H "mcp-protocol-version: $MCP_PROTOCOL" \
+    -H "mcp-session-id: $MCP_SESSION" \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"$name\",\"arguments\":$args}}")
+  _mcp_extract_json "$body"
+}
+
+# List MCP tool names (one per line).
+mcp_tool_names() {
+  local body
+  body=$(curl -sS \
+    -X POST "$BASE/mcp" \
+    -H "x-api-key: $DESKTOP_KEY" \
+    -H 'content-type: application/json' \
+    -H 'accept: application/json, text/event-stream' \
+    -H "mcp-protocol-version: $MCP_PROTOCOL" \
+    -H "mcp-session-id: $MCP_SESSION" \
+    -d '{"jsonrpc":"2.0","id":3,"method":"tools/list","params":{}}')
+  _mcp_extract_json "$body" | jq -r '.result.tools[]?.name'
+}
+
+# Enqueue a job as the web user (session). Args: <deviceId> <skill> <prompt> [chatId]
+# Echoes the HTTP status; leaves the JSON body in /tmp/syn-enq.json.
+enqueue_job() {
+  local deviceId="$1" skill="$2" prompt="$3" chatId="${4:-null}"
+  curl -sS -o /tmp/syn-enq.json -w '%{http_code}' \
+    -b "$COOKIE_JAR" \
+    -X POST "$BASE/api/v1/desktop/jobs" \
+    -H 'content-type: application/json' \
+    -d "{\"deviceId\":$deviceId,\"type\":\"skill.run\",\"input\":{\"skill\":\"$skill\",\"prompt\":\"$prompt\"},\"chatId\":$chatId}"
+}
+
+# Enqueue with a caller-supplied raw JSON body (session). Args: <body-json>
+# Echoes the HTTP status; leaves the JSON body in /tmp/syn-enq.json. Used to
+# prove that hostile extra keys (e.g. input.command) never reach the device.
+enqueue_job_raw() {
+  curl -sS -o /tmp/syn-enq.json -w '%{http_code}' \
+    -b "$COOKIE_JAR" \
+    -X POST "$BASE/api/v1/desktop/jobs" \
+    -H 'content-type: application/json' \
+    -d "$1"
+}
+
+# Poll a job's status as the web user (session). Args: <jobId>
+# Echoes the HTTP status; leaves the JSON body in /tmp/syn-job.json.
+get_job() {
+  curl -sS -o /tmp/syn-job.json -w '%{http_code}' \
+    -b "$COOKIE_JAR" \
+    -X GET "$BASE/api/v1/desktop/jobs/$1"
+}

--- a/_devextras/testing/desktop/pair.sh
+++ b/_devextras/testing/desktop/pair.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# DS10 — pair a (fake) Synaplan Desktop computer against the local stack.
+#
+# Logs in as the web user, mints a one-time pairing code, exchanges it for a
+# scoped API key + device row, and stores the credentials for reuse by
+# fake-device.sh. This is the minimal, human-runnable pairing demo.
+#
+# Usage:
+#   ./_devextras/testing/desktop/pair.sh
+#   SYNAPLAN_EMAIL=me@example.com SYNAPLAN_PASSWORD=... ./pair.sh
+#
+# Output: writes DESKTOP_KEY / DEVICE_ID / API_BASE_URL to
+# $SYNAPLAN_DESKTOP_CREDS (default /tmp/synaplan-desktop.creds).
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+require_tools
+
+echo "== Synaplan Desktop pairing =="
+echo "BASE=$BASE  EMAIL=$EMAIL"
+echo
+
+enable_flag
+login
+echo "NOTE  Logged in."
+
+CODE="$(mint_code)"
+echo "NOTE  Pairing code: $CODE"
+
+pair_device "$CODE" "${1:-Harness laptop}"
+
+assert "pairing returned a scoped sk_ key" "[[ \"$DESKTOP_KEY\" == sk_* ]]"
+assert "pairing returned a device id"       "[[ \"$DEVICE_ID\" =~ ^[0-9]+$ ]]"
+assert "pairing returned an apiBaseUrl"     "[[ -n \"$API_BASE_URL\" ]]"
+
+echo
+echo "Paired. Credentials written to: $CREDS_FILE"
+echo "  DESKTOP_KEY=$DESKTOP_KEY"
+echo "  DEVICE_ID=$DEVICE_ID"
+echo "  API_BASE_URL=$API_BASE_URL"
+
+summary

--- a/backend/config/packages/security.yaml
+++ b/backend/config/packages/security.yaml
@@ -127,6 +127,13 @@ security:
         - { path: ^/api/v1/connections/dropbox/callback, roles: PUBLIC_ACCESS }
         - { path: ^/api/v1/mcp-servers/oauth/callback, roles: PUBLIC_ACCESS }
 
+        # Desktop pairing exchange: a fresh Synaplan Desktop client has no
+        # session yet, so it swaps a (rate-limited, one-time, TTL'd) pairing
+        # code for its scoped key here. Anchored exactly so it never exposes the
+        # other /api/v1/desktop/* routes, which stay behind the catch-all below.
+        # When DESKTOP_AGENT.ENABLED is off the controller still 404s (C8).
+        - { path: ^/api/v1/desktop/pair$, roles: PUBLIC_ACCESS }
+
         # Public shared chat endpoint (no auth required)
         - { path: ^/api/v1/chats/shared/, roles: PUBLIC_ACCESS }
 

--- a/backend/config/services.yaml
+++ b/backend/config/services.yaml
@@ -604,6 +604,12 @@ services:
         arguments:
             $appUrl: '%env(APP_URL)%'
 
+    # Synaplan Desktop: pairing mints a scoped key + device row; the returned
+    # apiBaseUrl is the public app URL the client will call.
+    App\Service\Desktop\PairingService:
+        arguments:
+            $appUrl: '%env(APP_URL)%'
+
     # Message Processing Services
     App\Service\Message\MessagePreProcessor:
         arguments:

--- a/backend/migrations/Version20260830200000.php
+++ b/backend/migrations/Version20260830200000.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Create BDESKTOPDEVICES — the registry of computers a user has paired with
+ * Synaplan Desktop (Sprint A2, DS5).
+ *
+ * Each row binds a paired computer to the scoped API key minted at pairing
+ * ({@see \App\Security\ApiKeyScope::pairingScopes()}). Revoking a device
+ * deletes/deactivates that key and flips BSTATUS to `revoked` — a stolen
+ * laptop is a revoke, not an account takeover.
+ *
+ * No foreign key to BAPIKEYS in v1 (the app deletes the key row, then marks the
+ * device revoked). The job table BDESKTOPJOBS (DS11) references BDEVICEID; a
+ * later delete-devices migration must remove job rows first (no ON DELETE
+ * CASCADE — Galera FKs on this cluster are limited by design, AGENTS.md).
+ *
+ * Galera-safe: raw idempotent DDL only, no Schema API (the production cluster's
+ * DBAL comparator throws on Schema introspection — AGENTS.md).
+ */
+final class Version20260830200000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create BDESKTOPDEVICES table for Synaplan Desktop paired-computer registry';
+    }
+
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(
+            <<<'SQL'
+                CREATE TABLE IF NOT EXISTS BDESKTOPDEVICES (
+                    BID BIGINT NOT NULL AUTO_INCREMENT,
+                    BOWNERID BIGINT NOT NULL,
+                    BNAME VARCHAR(128) NOT NULL DEFAULT '',
+                    BAPIKEYID BIGINT NOT NULL,
+                    BSTATUS VARCHAR(16) NOT NULL DEFAULT 'active',
+                    BCAPABILITIES JSON NULL,
+                    BLASTSEEN BIGINT NOT NULL DEFAULT 0,
+                    BCREATED BIGINT NOT NULL,
+                    PRIMARY KEY (BID),
+                    KEY idx_desktop_owner (BOWNERID),
+                    KEY idx_desktop_apikey (BAPIKEYID)
+                ) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB
+                SQL
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE IF EXISTS BDESKTOPDEVICES');
+    }
+}

--- a/backend/migrations/Version20260830210000.php
+++ b/backend/migrations/Version20260830210000.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Create BDESKTOPJOBS — the out-of-band job queue a paired computer leases over
+ * MCP check-in and reports results for (Sprint A3, DS11).
+ *
+ * v1 carries one job type only (`skill.run`) for a skill the device has
+ * installed and the user enabled. The closed enum and the "ignore extra keys"
+ * rule are the reason a server bug can never become remote code execution — the
+ * device only ever executes `{skill, prompt, fileIds}`.
+ *
+ * BDEVICEID is nullable: NULL means "any of the user's devices". There is no
+ * ON DELETE CASCADE (Galera FK limits), so a future delete-devices migration
+ * must remove the matching job rows first.
+ *
+ * Galera-safe: raw idempotent DDL only, no Schema API (AGENTS.md).
+ */
+final class Version20260830210000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create BDESKTOPJOBS table for the Synaplan Desktop skill.run job queue';
+    }
+
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(
+            <<<'SQL'
+                CREATE TABLE IF NOT EXISTS BDESKTOPJOBS (
+                    BID BIGINT NOT NULL AUTO_INCREMENT,
+                    BOWNERID BIGINT NOT NULL,
+                    BDEVICEID BIGINT NULL,
+                    BTYPE VARCHAR(32) NOT NULL DEFAULT 'skill.run',
+                    BINPUT JSON NULL,
+                    BSTATUS VARCHAR(16) NOT NULL DEFAULT 'queued',
+                    BLEASETOKEN VARCHAR(64) NULL,
+                    BLEASEEXPIRES BIGINT NOT NULL DEFAULT 0,
+                    BATTEMPT INT NOT NULL DEFAULT 0,
+                    BMAXATTEMPTS INT NOT NULL DEFAULT 3,
+                    BIDEMPOTENCY VARCHAR(128) NULL,
+                    BRESULT JSON NULL,
+                    BERRORCODE VARCHAR(32) NULL,
+                    BCHATID BIGINT NULL,
+                    BMESSAGEID BIGINT NULL,
+                    BCREATED BIGINT NOT NULL,
+                    BUPDATED BIGINT NOT NULL DEFAULT 0,
+                    PRIMARY KEY (BID),
+                    UNIQUE KEY uniq_desktop_job_idem (BOWNERID, BIDEMPOTENCY),
+                    KEY idx_desktop_job_owner (BOWNERID),
+                    KEY idx_desktop_job_device (BDEVICEID),
+                    KEY idx_desktop_job_lease (BSTATUS, BDEVICEID)
+                ) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB
+                SQL
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE IF EXISTS BDESKTOPJOBS');
+    }
+}

--- a/backend/src/Command/ReapDesktopJobsCommand.php
+++ b/backend/src/Command/ReapDesktopJobsCommand.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Service\Desktop\DesktopAgentConfig;
+use App\Service\Desktop\DesktopJobStore;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Lock\LockFactory;
+
+/**
+ * Requeues (or fails) desktop jobs whose lease expired because the paired
+ * computer went to sleep, lost its network, or crashed mid-run. Without this a
+ * leased job would sit forever and the web "waiting" card never resolves.
+ *
+ * A job under its attempt budget goes back to `queued` (the next check-in leases
+ * it again); a job that exhausted its attempts is failed with `timeout`.
+ *
+ * Intended to run as a cron job (e.g. every minute). The cluster-wide lock makes
+ * it safe to schedule on every node — only one run executes at a time.
+ *
+ *   * * * * * cd /path/to/synaplan && docker compose exec -T backend \
+ *       php bin/console app:desktop:reap-jobs >> /var/log/synaplan-desktop-reaper.log 2>&1
+ */
+#[AsCommand(
+    name: 'app:desktop:reap-jobs',
+    description: 'Requeue or fail desktop jobs whose device lease expired'
+)]
+final class ReapDesktopJobsCommand extends Command
+{
+    public function __construct(
+        private readonly DesktopJobStore $jobStore,
+        private readonly DesktopAgentConfig $desktopAgentConfig,
+        private readonly LockFactory $lockFactory,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        // Flag off means idle, not broken (C8): shipping this to main before any
+        // device exists must be a no-op on every production install.
+        if (!$this->desktopAgentConfig->isEnabled(null)) {
+            $io->writeln('Desktop agent feature is disabled. Nothing to reap.');
+
+            return Command::SUCCESS;
+        }
+
+        $lock = $this->lockFactory->createLock('desktop-job-reaper', 120);
+        if (!$lock->acquire()) {
+            $io->note('Previous desktop reaper run is still active. Skipping.');
+
+            return Command::SUCCESS;
+        }
+
+        try {
+            $result = $this->jobStore->requeueExpiredLeases();
+            $requeued = $result['requeued'];
+            $failed = $result['failed'];
+
+            if ($requeued > 0 || $failed > 0) {
+                $io->success(sprintf('Requeued %d and failed %d expired desktop job(s).', $requeued, $failed));
+            } else {
+                $io->writeln('No expired desktop job leases to reap.');
+            }
+        } finally {
+            $lock->release();
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/backend/src/Command/SeedAllCommand.php
+++ b/backend/src/Command/SeedAllCommand.php
@@ -7,6 +7,7 @@ namespace App\Command;
 use App\Seed\BrandingConfigSeeder;
 use App\Seed\DefaultModelConfigSeeder;
 use App\Seed\DemoWidgetConfigSeeder;
+use App\Seed\DesktopAgentConfigSeeder;
 use App\Seed\FileContextConfigSeeder;
 use App\Seed\MarketingNewsConfigSeeder;
 use App\Seed\McpConfigSeeder;
@@ -52,7 +53,8 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  *  14. messages-gateway (BCONFIG: MESSAGES_GATEWAY Anthropic-compatible API flags, ownerId=0 — default OFF)
  *  15. saved-tasks   (BCONFIG: SAVEDTASKS.ENABLED, ownerId=0 — default ON for new/local installs)
  *  16. file-context  (BCONFIG: FILE_CONTEXT conversation-file flags, ownerId=0 — default OFF)
- *  17. demo-widget   (BCONFIG: example widget for ownerId=2 — dev/test only, no-op in prod)
+ *  17. desktop-agent (BCONFIG: DESKTOP_AGENT.ENABLED, ownerId=0 — default OFF until GA)
+ *  18. demo-widget   (BCONFIG: example widget for ownerId=2 — dev/test only, no-op in prod)
  *
  * Wired into the Docker entrypoint after `doctrine:migrations:migrate`, so it runs
  * on every container startup in dev AND prod.
@@ -82,6 +84,7 @@ final class SeedAllCommand extends Command
         private readonly MessagesGatewayConfigSeeder $messagesGatewayConfigSeeder,
         private readonly SavedTaskConfigSeeder $savedTaskConfigSeeder,
         private readonly FileContextConfigSeeder $fileContextConfigSeeder,
+        private readonly DesktopAgentConfigSeeder $desktopAgentConfigSeeder,
     ) {
         parent::__construct();
     }
@@ -107,7 +110,8 @@ final class SeedAllCommand extends Command
             "  14. messages gateway flags     (BCONFIG, group=MESSAGES_GATEWAY, ownerId=0 — default OFF)\n".
             "  15. saved-tasks flag           (BCONFIG, group=SAVEDTASKS, ownerId=0 — default ON for new/local)\n".
             "  16. file-context flags         (BCONFIG, group=FILE_CONTEXT, ownerId=0 — default OFF)\n".
-            "  17. demo widget config         (BCONFIG, group=widget_1, ownerId=2 — dev/test only)\n\n".
+            "  17. desktop-agent flag         (BCONFIG, group=DESKTOP_AGENT, ownerId=0 — default OFF until GA)\n".
+            "  18. demo widget config         (BCONFIG, group=widget_1, ownerId=2 — dev/test only)\n\n".
             'All steps are idempotent and safe to run on every deploy. The demo-widget step is a no-op in prod.'
         );
     }
@@ -135,6 +139,7 @@ final class SeedAllCommand extends Command
             ['messages-gateway', fn (): SeedResult => $this->messagesGatewayConfigSeeder->seed()],
             ['saved-tasks', fn (): SeedResult => $this->savedTaskConfigSeeder->seed()],
             ['file-context', fn (): SeedResult => $this->fileContextConfigSeeder->seed()],
+            ['desktop-agent', fn (): SeedResult => $this->desktopAgentConfigSeeder->seed()],
             ['demo-widget', fn (): SeedResult => $this->demoWidgetConfigSeeder->seed()],
         ];
 

--- a/backend/src/Controller/ConfigController.php
+++ b/backend/src/Controller/ConfigController.php
@@ -19,6 +19,7 @@ use App\Service\Branding\BrandingService;
 use App\Service\Capability\CapabilityService;
 use App\Service\Client\ClientContextResolver;
 use App\Service\Client\MobileVersionService;
+use App\Service\Desktop\DesktopAgentConfig;
 use App\Service\Embedding\EmbeddingMetadataService;
 use App\Service\Embedding\EmbeddingModelChangeGuard;
 use App\Service\Embedding\Exception\PremiumRequiredException;
@@ -74,6 +75,7 @@ class ConfigController extends AbstractController
         private GuestChatConfig $guestChatConfig,
         private WebSpeechConfig $webSpeechConfig,
         private SavedTaskConfig $savedTaskConfig,
+        private DesktopAgentConfig $desktopAgentConfig,
         private ChatReadinessService $chatReadiness,
         private DemoLoginHint $demoLoginHint,
         private SetupStateService $setupState,
@@ -167,6 +169,7 @@ class ConfigController extends AbstractController
                         new OA\Property(property: 'help', type: 'boolean', example: true, description: 'Enable help system'),
                         new OA\Property(property: 'memoryService', type: 'boolean', example: true, description: 'Qdrant vector database availability'),
                         new OA\Property(property: 'savedTasks', type: 'boolean', example: false, description: 'When true, AI Instructions shows Saved Task chrome. Widget chat never runs Saved Tasks.'),
+                        new OA\Property(property: 'desktopAgentEnabled', type: 'boolean', example: false, description: 'When true, the Synaplan Desktop pairing surface (Channels → Desktop) and desktop job APIs are exposed. Off by default until the desktop client ships (server-first rollout).'),
                     ]
                 ),
                 new OA\Property(
@@ -463,6 +466,7 @@ class ConfigController extends AbstractController
             'help' => ($_ENV['FEATURE_HELP'] ?? 'false') === 'true',
             'memoryService' => !empty($_ENV['QDRANT_URL']), // Just check if configured, not if reachable
             'savedTasks' => $this->savedTaskConfig->isEnabled($user?->getId()),
+            'desktopAgentEnabled' => $this->desktopAgentConfig->isEnabled($user?->getId()),
         ];
 
         // Speech-to-text configuration

--- a/backend/src/Controller/DesktopController.php
+++ b/backend/src/Controller/DesktopController.php
@@ -1,0 +1,568 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Entity\DesktopJob;
+use App\Entity\User;
+use App\Repository\ApiKeyRepository;
+use App\Repository\DesktopDeviceRepository;
+use App\Service\Desktop\DesktopAgentConfig;
+use App\Service\Desktop\DesktopJobContract;
+use App\Service\Desktop\DesktopJobStore;
+use App\Service\Desktop\Exception\PairingException;
+use App\Service\Desktop\Exception\PairingLimitException;
+use App\Service\Desktop\PairingCodeService;
+use App\Service\Desktop\PairingService;
+use App\Service\Infrastructure\RedisService;
+use OpenApi\Attributes as OA;
+use Psr\Log\LoggerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
+
+/**
+ * Synaplan Desktop pairing + device registry (Sprint A2).
+ *
+ * Every route is flag-gated by {@see DesktopAgentConfig}: when the feature is
+ * OFF the whole surface answers 404 (invariant C8, same pattern as Saved
+ * Tasks). Session-cookie users mint and manage codes/devices; the `/pair`
+ * exchange is the only unauthenticated route (a fresh client has no session
+ * yet) and is rate-limited per IP.
+ *
+ * The job-enqueue route (`POST /jobs`, Sprint A3) queues `skill.run` work for a
+ * paired computer to lease on its next check-in.
+ */
+#[Route('/api/v1/desktop', name: 'desktop_')]
+#[OA\Tag(name: 'Desktop')]
+final class DesktopController extends AbstractController
+{
+    private const PAIR_IP_LIMIT = 60;
+    private const PAIR_IP_WINDOW = 3600;
+
+    public function __construct(
+        private readonly DesktopAgentConfig $desktopAgentConfig,
+        private readonly PairingCodeService $pairingCodeService,
+        private readonly PairingService $pairingService,
+        private readonly DesktopDeviceRepository $deviceRepository,
+        private readonly ApiKeyRepository $apiKeyRepository,
+        private readonly DesktopJobStore $jobStore,
+        private readonly RedisService $redis,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    #[Route('/pairing-codes', name: 'pairing_code_create', methods: ['POST'])]
+    #[OA\Post(
+        path: '/api/v1/desktop/pairing-codes',
+        operationId: 'createDesktopPairingCode',
+        summary: 'Create a one-time pairing code for Synaplan Desktop',
+        description: 'Mints a short-lived (10 min) pairing code the user types into Synaplan Desktop to pair the computer. Rate-limited per user.',
+        tags: ['Desktop'],
+        responses: [
+            new OA\Response(
+                response: 201,
+                description: 'Pairing code created',
+                content: new OA\JsonContent(
+                    required: ['success', 'code', 'expiresAt'],
+                    properties: [
+                        new OA\Property(property: 'success', type: 'boolean', example: true),
+                        new OA\Property(property: 'code', type: 'string', example: 'AB3K7Q2M', description: 'The 8-character pairing code (shown once).'),
+                        new OA\Property(property: 'expiresAt', type: 'integer', format: 'int64', example: 1756500000, description: 'Unix timestamp (seconds) when the code expires.'),
+                    ]
+                )
+            ),
+            new OA\Response(response: 401, description: 'Not authenticated'),
+            new OA\Response(response: 404, description: 'Feature disabled'),
+            new OA\Response(response: 429, description: 'Too many pairing codes'),
+        ]
+    )]
+    public function createPairingCode(#[CurrentUser] ?User $user): JsonResponse
+    {
+        $this->guard($user?->getId());
+
+        if (!$user instanceof User) {
+            return $this->json(['success' => false, 'error' => 'Not authenticated'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        try {
+            $result = $this->pairingCodeService->create((int) $user->getId());
+        } catch (PairingLimitException $e) {
+            return $this->json(['success' => false, 'error' => $e->getMessage()], Response::HTTP_TOO_MANY_REQUESTS);
+        }
+
+        return $this->json([
+            'success' => true,
+            'code' => $result['code'],
+            'expiresAt' => $result['expiresAt'],
+        ], Response::HTTP_CREATED);
+    }
+
+    #[Route('/pair', name: 'pair', methods: ['POST'])]
+    #[OA\Post(
+        path: '/api/v1/desktop/pair',
+        operationId: 'pairDesktopDevice',
+        summary: 'Exchange a pairing code for a scoped desktop API key',
+        description: 'Consumes a pairing code and returns a one-time scoped API key bound to a new device row. The key is shown once and never again.',
+        tags: ['Desktop'],
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                required: ['code'],
+                properties: [
+                    new OA\Property(property: 'code', type: 'string', example: 'AB3K7Q2M'),
+                    new OA\Property(property: 'deviceName', type: 'string', example: "Jan's laptop"),
+                    new OA\Property(property: 'capabilities', type: 'array', items: new OA\Items(type: 'string'), example: ['skill.run']),
+                ]
+            )
+        ),
+        responses: [
+            new OA\Response(
+                response: 201,
+                description: 'Device paired',
+                content: new OA\JsonContent(
+                    required: ['success', 'deviceId', 'key', 'apiBaseUrl'],
+                    properties: [
+                        new OA\Property(property: 'success', type: 'boolean', example: true),
+                        new OA\Property(property: 'deviceId', type: 'integer', example: 1),
+                        new OA\Property(property: 'key', type: 'string', example: 'sk_...', description: 'The scoped API key — shown once.'),
+                        new OA\Property(property: 'apiBaseUrl', type: 'string', example: 'https://web.synaplan.com'),
+                    ]
+                )
+            ),
+            new OA\Response(response: 400, description: 'Invalid or expired code'),
+            new OA\Response(response: 404, description: 'Feature disabled'),
+            new OA\Response(response: 429, description: 'Too many attempts'),
+        ]
+    )]
+    public function pair(Request $request): JsonResponse
+    {
+        // No session user here; the client is pairing for the first time. Gate on
+        // the global flag so an OFF instance answers 404 (C8).
+        $this->guard(null);
+
+        if (!$this->allowPairAttempt($request)) {
+            return $this->json(['success' => false, 'error' => 'Too many pairing attempts. Please wait and try again.'], Response::HTTP_TOO_MANY_REQUESTS);
+        }
+
+        $data = json_decode($request->getContent(), true);
+        if (!is_array($data)) {
+            $data = [];
+        }
+
+        $code = \is_string($data['code'] ?? null) ? $data['code'] : '';
+        $deviceName = \is_string($data['deviceName'] ?? null) ? $data['deviceName'] : '';
+        $capabilities = \is_array($data['capabilities'] ?? null) ? array_values($data['capabilities']) : [];
+
+        $userId = $this->pairingCodeService->consume($code);
+
+        // Same message for unknown and expired codes — no user enumeration.
+        if (null === $userId) {
+            return $this->json(['success' => false, 'error' => 'Invalid or expired pairing code.'], Response::HTTP_BAD_REQUEST);
+        }
+
+        try {
+            $result = $this->pairingService->pair($userId, $deviceName, $capabilities);
+        } catch (PairingException $e) {
+            $this->logger->warning('Desktop pairing failed after code consume', ['owner_id' => $userId, 'error' => $e->getMessage()]);
+
+            return $this->json(['success' => false, 'error' => 'Invalid or expired pairing code.'], Response::HTTP_BAD_REQUEST);
+        }
+
+        $this->logger->info('Desktop device paired', [
+            'owner_id' => $userId,
+            'device_id' => $result['deviceId'],
+        ]);
+
+        return $this->json([
+            'success' => true,
+            'deviceId' => $result['deviceId'],
+            'key' => $result['key'],
+            'apiBaseUrl' => $result['apiBaseUrl'],
+        ], Response::HTTP_CREATED);
+    }
+
+    #[Route('/devices', name: 'device_list', methods: ['GET'])]
+    #[OA\Get(
+        path: '/api/v1/desktop/devices',
+        operationId: 'listDesktopDevices',
+        summary: "List the current user's paired computers",
+        tags: ['Desktop'],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Paired devices',
+                content: new OA\JsonContent(
+                    required: ['success', 'devices'],
+                    properties: [
+                        new OA\Property(property: 'success', type: 'boolean', example: true),
+                        new OA\Property(
+                            property: 'devices',
+                            type: 'array',
+                            items: new OA\Items(
+                                required: ['id', 'name', 'status', 'lastSeen', 'created', 'capabilities'],
+                                properties: [
+                                    new OA\Property(property: 'id', type: 'integer', example: 1),
+                                    new OA\Property(property: 'name', type: 'string', example: "Jan's laptop"),
+                                    new OA\Property(property: 'keyPrefix', type: 'string', example: 'sk_1234...', nullable: true),
+                                    new OA\Property(property: 'status', type: 'string', enum: ['active', 'revoked'], example: 'active'),
+                                    new OA\Property(property: 'lastSeen', type: 'integer', format: 'int64', example: 0, description: 'Unix timestamp of the last check-in (0 = never).'),
+                                    new OA\Property(property: 'created', type: 'integer', format: 'int64', example: 1756500000),
+                                    new OA\Property(property: 'capabilities', type: 'array', items: new OA\Items(type: 'string'), example: ['skill.run']),
+                                ]
+                            )
+                        ),
+                    ]
+                )
+            ),
+            new OA\Response(response: 401, description: 'Not authenticated'),
+            new OA\Response(response: 404, description: 'Feature disabled'),
+        ]
+    )]
+    public function listDevices(#[CurrentUser] ?User $user): JsonResponse
+    {
+        $this->guard($user?->getId());
+
+        if (!$user instanceof User) {
+            return $this->json(['success' => false, 'error' => 'Not authenticated'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        $devices = $this->deviceRepository->findByOwner((int) $user->getId());
+
+        return $this->json([
+            'success' => true,
+            'devices' => array_map(function ($device): array {
+                $apiKey = $this->apiKeyRepository->find($device->getApiKeyId());
+                $keyPrefix = null !== $apiKey ? substr($apiKey->getKey(), 0, 8).'...' : null;
+
+                return [
+                    'id' => $device->getId(),
+                    'name' => $device->getName(),
+                    'keyPrefix' => $keyPrefix,
+                    'status' => $device->getStatus(),
+                    'lastSeen' => $device->getLastSeen(),
+                    'created' => $device->getCreated(),
+                    'capabilities' => $device->getCapabilities(),
+                ];
+            }, $devices),
+        ]);
+    }
+
+    #[Route('/devices/{id}', name: 'device_revoke', methods: ['DELETE'], requirements: ['id' => '\d+'])]
+    #[OA\Delete(
+        path: '/api/v1/desktop/devices/{id}',
+        operationId: 'revokeDesktopDevice',
+        summary: 'Revoke a paired computer (kills its API key)',
+        tags: ['Desktop'],
+        parameters: [
+            new OA\Parameter(name: 'id', in: 'path', required: true, schema: new OA\Schema(type: 'integer')),
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Device revoked',
+                content: new OA\JsonContent(
+                    required: ['success'],
+                    properties: [
+                        new OA\Property(property: 'success', type: 'boolean', example: true),
+                    ]
+                )
+            ),
+            new OA\Response(response: 401, description: 'Not authenticated'),
+            new OA\Response(response: 404, description: 'Feature disabled or device not found'),
+        ]
+    )]
+    public function revokeDevice(int $id, #[CurrentUser] ?User $user): JsonResponse
+    {
+        $this->guard($user?->getId());
+
+        if (!$user instanceof User) {
+            return $this->json(['success' => false, 'error' => 'Not authenticated'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        $device = $this->deviceRepository->findOwnedById($id, (int) $user->getId());
+        if (null === $device) {
+            // 404 (not 403) for another user's id — no existence disclosure.
+            throw new NotFoundHttpException('Device not found');
+        }
+
+        $this->pairingService->revoke($device);
+
+        return $this->json(['success' => true]);
+    }
+
+    #[Route('/jobs', name: 'job_enqueue', methods: ['POST'])]
+    #[OA\Post(
+        path: '/api/v1/desktop/jobs',
+        operationId: 'enqueueDesktopJob',
+        summary: 'Queue a skill.run job for a paired computer',
+        description: 'Enqueues a job for the user\'s device to lease on its next check-in. The server never verifies the device has the skill; an uninstalled skill fails honestly on the device.',
+        tags: ['Desktop'],
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                required: ['type', 'input'],
+                properties: [
+                    new OA\Property(property: 'deviceId', type: 'integer', nullable: true, example: 1, description: 'Target device; omit/null to let any of the user\'s devices pick it up.'),
+                    new OA\Property(property: 'type', type: 'string', enum: ['skill.run'], example: 'skill.run'),
+                    new OA\Property(
+                        property: 'input',
+                        type: 'object',
+                        required: ['skill'],
+                        properties: [
+                            new OA\Property(property: 'skill', type: 'string', example: 'pptx', description: 'Installed skill name (^[a-z0-9-]{1,64}$).'),
+                            new OA\Property(property: 'prompt', type: 'string', example: 'Make 3 slides about Q3'),
+                            new OA\Property(property: 'fileIds', type: 'array', items: new OA\Items(type: 'integer'), example: []),
+                        ]
+                    ),
+                    new OA\Property(property: 'chatId', type: 'integer', nullable: true, example: 99, description: 'Chat to post the completion note into.'),
+                    new OA\Property(property: 'messageId', type: 'integer', nullable: true, example: 1234),
+                ]
+            )
+        ),
+        responses: [
+            new OA\Response(
+                response: 201,
+                description: 'Job queued',
+                content: new OA\JsonContent(
+                    required: ['success', 'jobId', 'status'],
+                    properties: [
+                        new OA\Property(property: 'success', type: 'boolean', example: true),
+                        new OA\Property(property: 'jobId', type: 'integer', example: 1),
+                        new OA\Property(property: 'status', type: 'string', example: 'queued'),
+                    ]
+                )
+            ),
+            new OA\Response(response: 400, description: 'Invalid input'),
+            new OA\Response(response: 401, description: 'Not authenticated'),
+            new OA\Response(response: 404, description: 'Feature disabled or device not found'),
+        ]
+    )]
+    public function enqueueJob(Request $request, #[CurrentUser] ?User $user): JsonResponse
+    {
+        $this->guard($user?->getId());
+
+        if (!$user instanceof User) {
+            return $this->json(['success' => false, 'error' => 'Not authenticated'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        $data = json_decode($request->getContent(), true);
+        if (!is_array($data)) {
+            $data = [];
+        }
+
+        $type = \is_string($data['type'] ?? null) ? $data['type'] : '';
+        if (!DesktopJobContract::isValidType($type)) {
+            return $this->json(['success' => false, 'error' => 'Unsupported job type.'], Response::HTTP_BAD_REQUEST);
+        }
+
+        $input = \is_array($data['input'] ?? null) ? $data['input'] : [];
+        $skill = \is_string($input['skill'] ?? null) ? trim($input['skill']) : '';
+        if (1 !== preg_match('/^[a-z0-9-]{1,64}$/', $skill)) {
+            return $this->json(['success' => false, 'error' => 'Invalid skill name.'], Response::HTTP_BAD_REQUEST);
+        }
+
+        $prompt = \is_string($input['prompt'] ?? null) ? $input['prompt'] : '';
+        $fileIds = [];
+        if (\is_array($input['fileIds'] ?? null)) {
+            foreach ($input['fileIds'] as $fileId) {
+                if (is_numeric($fileId)) {
+                    $fileIds[] = (int) $fileId;
+                }
+            }
+        }
+
+        $deviceId = null;
+        if (isset($data['deviceId']) && is_numeric($data['deviceId'])) {
+            $device = $this->deviceRepository->findOwnedById((int) $data['deviceId'], (int) $user->getId());
+            if (null === $device) {
+                throw new NotFoundHttpException('Device not found');
+            }
+            if (!$device->isActive()) {
+                return $this->json(['success' => false, 'error' => 'Device is not active.'], Response::HTTP_BAD_REQUEST);
+            }
+            $deviceId = (int) $device->getId();
+        }
+
+        $chatId = isset($data['chatId']) && is_numeric($data['chatId']) ? (int) $data['chatId'] : null;
+        $messageId = isset($data['messageId']) && is_numeric($data['messageId']) ? (int) $data['messageId'] : null;
+        $idempotency = \is_string($data['idempotencyKey'] ?? null) ? $data['idempotencyKey'] : null;
+
+        $job = $this->jobStore->enqueueSkillRun(
+            (int) $user->getId(),
+            $deviceId,
+            $skill,
+            $prompt,
+            $fileIds,
+            $chatId,
+            $messageId,
+            $idempotency,
+        );
+
+        return $this->json([
+            'success' => true,
+            'jobId' => $job->getId(),
+            'status' => $job->getStatus(),
+        ], Response::HTTP_CREATED);
+    }
+
+    #[Route('/jobs', name: 'job_list', methods: ['GET'])]
+    #[OA\Get(
+        path: '/api/v1/desktop/jobs',
+        operationId: 'listDesktopJobs',
+        summary: "List the current user's recent desktop jobs",
+        tags: ['Desktop'],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Recent jobs',
+                content: new OA\JsonContent(
+                    required: ['success', 'jobs'],
+                    properties: [
+                        new OA\Property(property: 'success', type: 'boolean', example: true),
+                        new OA\Property(
+                            property: 'jobs',
+                            type: 'array',
+                            items: new OA\Items(
+                                type: 'object',
+                                required: ['id', 'type', 'skill', 'status', 'created'],
+                                properties: [
+                                    new OA\Property(property: 'id', type: 'integer', example: 1),
+                                    new OA\Property(property: 'deviceId', type: 'integer', nullable: true, example: 1),
+                                    new OA\Property(property: 'type', type: 'string', example: 'skill.run'),
+                                    new OA\Property(property: 'skill', type: 'string', example: 'pptx'),
+                                    new OA\Property(property: 'status', type: 'string', enum: ['queued', 'leased', 'succeeded', 'failed', 'cancelled'], example: 'queued'),
+                                    new OA\Property(property: 'errorCode', type: 'string', nullable: true, example: null),
+                                    new OA\Property(property: 'result', type: 'object', nullable: true),
+                                    new OA\Property(property: 'chatId', type: 'integer', nullable: true, example: 99),
+                                    new OA\Property(property: 'created', type: 'integer', format: 'int64', example: 1756500000),
+                                    new OA\Property(property: 'updated', type: 'integer', format: 'int64', example: 1756500050),
+                                ]
+                            )
+                        ),
+                    ]
+                )
+            ),
+            new OA\Response(response: 401, description: 'Not authenticated'),
+            new OA\Response(response: 404, description: 'Feature disabled'),
+        ]
+    )]
+    public function listJobs(#[CurrentUser] ?User $user): JsonResponse
+    {
+        $this->guard($user?->getId());
+
+        if (!$user instanceof User) {
+            return $this->json(['success' => false, 'error' => 'Not authenticated'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        $jobs = $this->jobStore->recentForOwner((int) $user->getId());
+
+        return $this->json([
+            'success' => true,
+            'jobs' => array_map([$this, 'jobStatusView'], $jobs),
+        ]);
+    }
+
+    #[Route('/jobs/{id}', name: 'job_status', methods: ['GET'], requirements: ['id' => '\d+'])]
+    #[OA\Get(
+        path: '/api/v1/desktop/jobs/{id}',
+        operationId: 'getDesktopJob',
+        summary: 'Poll a desktop job status (for the waiting/failed card)',
+        tags: ['Desktop'],
+        parameters: [
+            new OA\Parameter(name: 'id', in: 'path', required: true, schema: new OA\Schema(type: 'integer')),
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Job status',
+                content: new OA\JsonContent(
+                    required: ['success', 'job'],
+                    properties: [
+                        new OA\Property(property: 'success', type: 'boolean', example: true),
+                        new OA\Property(
+                            property: 'job',
+                            type: 'object',
+                            required: ['id', 'type', 'skill', 'status', 'created'],
+                            properties: [
+                                new OA\Property(property: 'id', type: 'integer', example: 1),
+                                new OA\Property(property: 'deviceId', type: 'integer', nullable: true, example: 1),
+                                new OA\Property(property: 'type', type: 'string', example: 'skill.run'),
+                                new OA\Property(property: 'skill', type: 'string', example: 'pptx'),
+                                new OA\Property(property: 'status', type: 'string', enum: ['queued', 'leased', 'succeeded', 'failed', 'cancelled'], example: 'queued'),
+                                new OA\Property(property: 'errorCode', type: 'string', nullable: true, example: null),
+                                new OA\Property(property: 'result', type: 'object', nullable: true),
+                                new OA\Property(property: 'chatId', type: 'integer', nullable: true, example: 99),
+                                new OA\Property(property: 'created', type: 'integer', format: 'int64', example: 1756500000),
+                                new OA\Property(property: 'updated', type: 'integer', format: 'int64', example: 1756500050),
+                            ]
+                        ),
+                    ]
+                )
+            ),
+            new OA\Response(response: 401, description: 'Not authenticated'),
+            new OA\Response(response: 404, description: 'Feature disabled or job not found'),
+        ]
+    )]
+    public function getJob(int $id, #[CurrentUser] ?User $user): JsonResponse
+    {
+        $this->guard($user?->getId());
+
+        if (!$user instanceof User) {
+            return $this->json(['success' => false, 'error' => 'Not authenticated'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        $job = $this->jobStore->findOwnedJob($id, (int) $user->getId());
+        if (null === $job) {
+            throw new NotFoundHttpException('Job not found');
+        }
+
+        return $this->json(['success' => true, 'job' => $this->jobStatusView($job)]);
+    }
+
+    /**
+     * @return array{id: int, deviceId: int|null, type: string, skill: string, status: string, errorCode: string|null, result: array<string, mixed>|null, chatId: int|null, created: int, updated: int}
+     */
+    private function jobStatusView(DesktopJob $job): array
+    {
+        return [
+            'id' => (int) $job->getId(),
+            'deviceId' => $job->getDeviceId(),
+            'type' => $job->getType(),
+            'skill' => (string) ($job->getInput()['skill'] ?? ''),
+            'status' => $job->getStatus(),
+            'errorCode' => $job->getErrorCode(),
+            'result' => $job->getResult(),
+            'chatId' => $job->getChatId(),
+            'created' => $job->getCreated(),
+            'updated' => $job->getUpdated(),
+        ];
+    }
+
+    /**
+     * 404 the whole surface when the Desktop feature is off (C8).
+     */
+    private function guard(?int $userId): void
+    {
+        if (!$this->desktopAgentConfig->isEnabled($userId)) {
+            throw new NotFoundHttpException();
+        }
+    }
+
+    private function allowPairAttempt(Request $request): bool
+    {
+        $ip = $request->getClientIp() ?? 'unknown';
+        $key = 'desktop_pair_attempt:'.sha1($ip);
+        $count = $this->redis->increment($key);
+        if (1 === $count) {
+            $this->redis->expire($key, self::PAIR_IP_WINDOW);
+        }
+
+        return null === $count || $count <= self::PAIR_IP_LIMIT;
+    }
+}

--- a/backend/src/Controller/McpController.php
+++ b/backend/src/Controller/McpController.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace App\Controller;
 
+use App\Entity\ApiKey;
+use App\Entity\DesktopDevice;
 use App\Entity\User;
 use App\Mcp\McpServerFactory;
+use App\Repository\DesktopDeviceRepository;
 use GuzzleHttp\Psr7\ServerRequest;
 use Mcp\Server\Transport\Http\Middleware\DnsRebindingProtectionMiddleware;
 use Mcp\Server\Transport\Http\Middleware\ProtocolVersionMiddleware;
@@ -38,6 +41,7 @@ class McpController extends AbstractController
 
     public function __construct(
         private readonly McpServerFactory $serverFactory,
+        private readonly DesktopDeviceRepository $desktopDeviceRepository,
         private readonly LoggerInterface $logger,
         private readonly string $appUrl,
         private readonly string $oidcDiscoveryUrl,
@@ -73,8 +77,10 @@ class McpController extends AbstractController
             ],
         );
 
+        $device = $this->resolveDesktopDevice($request);
+
         try {
-            $psrResponse = $this->serverFactory->build($user)->run($transport);
+            $psrResponse = $this->serverFactory->build($user, $device)->run($transport);
         } catch (\InvalidArgumentException $e) {
             // A malformed / unknown `Mcp-Session-Id` makes the SDK throw while
             // parsing the header (Uuid::fromString) instead of producing a
@@ -92,6 +98,21 @@ class McpController extends AbstractController
         }
 
         return $this->toSymfonyResponse($psrResponse);
+    }
+
+    /**
+     * If this MCP request was authenticated by an API key that backs a paired
+     * computer, resolve that device so the factory can expose the desktop
+     * check-in tools. OIDC-bearer and non-desktop key requests resolve to null.
+     */
+    private function resolveDesktopDevice(Request $request): ?DesktopDevice
+    {
+        $apiKey = $request->attributes->get('api_key');
+        if (!$apiKey instanceof ApiKey || null === $apiKey->getId()) {
+            return null;
+        }
+
+        return $this->desktopDeviceRepository->findByApiKeyId((int) $apiKey->getId());
     }
 
     /**

--- a/backend/src/Entity/DesktopDevice.php
+++ b/backend/src/Entity/DesktopDevice.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use App\Repository\DesktopDeviceRepository;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * A computer a user paired with Synaplan Desktop.
+ *
+ * The row is created by the pairing exchange (Sprint A2). It owns no key
+ * material — {@see $apiKeyId} points at the scoped {@see ApiKey} minted at
+ * pairing, which is where the secret lives (shown once, then only in the
+ * client's OS secret store).
+ */
+#[ORM\Entity(repositoryClass: DesktopDeviceRepository::class)]
+#[ORM\Table(name: 'BDESKTOPDEVICES')]
+#[ORM\Index(columns: ['BOWNERID'], name: 'idx_desktop_owner')]
+#[ORM\Index(columns: ['BAPIKEYID'], name: 'idx_desktop_apikey')]
+class DesktopDevice
+{
+    public const STATUS_ACTIVE = 'active';
+    public const STATUS_REVOKED = 'revoked';
+
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(name: 'BID', type: 'bigint')]
+    private ?int $id = null;
+
+    #[ORM\Column(name: 'BOWNERID', type: 'bigint')]
+    private int $ownerId;
+
+    #[ORM\Column(name: 'BNAME', length: 128, options: ['default' => ''])]
+    private string $name = '';
+
+    #[ORM\Column(name: 'BAPIKEYID', type: 'bigint')]
+    private int $apiKeyId;
+
+    #[ORM\Column(name: 'BSTATUS', length: 16, options: ['default' => self::STATUS_ACTIVE])]
+    private string $status = self::STATUS_ACTIVE;
+
+    /** @var list<string>|null */
+    #[ORM\Column(name: 'BCAPABILITIES', type: 'json', nullable: true)]
+    private ?array $capabilities = null;
+
+    #[ORM\Column(name: 'BLASTSEEN', type: 'bigint', options: ['default' => 0])]
+    private int $lastSeen = 0;
+
+    #[ORM\Column(name: 'BCREATED', type: 'bigint')]
+    private int $created;
+
+    public function __construct()
+    {
+        $this->created = time();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getOwnerId(): int
+    {
+        return $this->ownerId;
+    }
+
+    public function setOwnerId(int $ownerId): self
+    {
+        $this->ownerId = $ownerId;
+
+        return $this;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getApiKeyId(): int
+    {
+        return $this->apiKeyId;
+    }
+
+    public function setApiKeyId(int $apiKeyId): self
+    {
+        $this->apiKeyId = $apiKeyId;
+
+        return $this;
+    }
+
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+
+    public function setStatus(string $status): self
+    {
+        $this->status = $status;
+
+        return $this;
+    }
+
+    public function isActive(): bool
+    {
+        return self::STATUS_ACTIVE === $this->status;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getCapabilities(): array
+    {
+        return $this->capabilities ?? [];
+    }
+
+    /**
+     * @param list<string>|null $capabilities
+     */
+    public function setCapabilities(?array $capabilities): self
+    {
+        $this->capabilities = $capabilities;
+
+        return $this;
+    }
+
+    public function getLastSeen(): int
+    {
+        return $this->lastSeen;
+    }
+
+    public function setLastSeen(int $lastSeen): self
+    {
+        $this->lastSeen = $lastSeen;
+
+        return $this;
+    }
+
+    public function touchLastSeen(): self
+    {
+        $this->lastSeen = time();
+
+        return $this;
+    }
+
+    public function getCreated(): int
+    {
+        return $this->created;
+    }
+
+    public function setCreated(int $created): self
+    {
+        $this->created = $created;
+
+        return $this;
+    }
+}

--- a/backend/src/Entity/DesktopJob.php
+++ b/backend/src/Entity/DesktopJob.php
@@ -1,0 +1,321 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use App\Repository\DesktopJobRepository;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * One out-of-band desktop job.
+ *
+ * The web app (or, later, a Saved Task) enqueues a `skill.run` job for one of a
+ * user's paired computers. The device leases it over MCP check-in, runs the
+ * named skill locally, and reports a result — which may reference an uploaded
+ * file the server posts back into the originating chat.
+ *
+ * The `type` and `status` enums are closed and frozen at `protocol: 1`
+ * (Sprint A3 / DS18). No `shell.exec`, no server-supplied command: the input is
+ * only ever `{skill, prompt, fileIds}` and a device MUST ignore any other key.
+ */
+#[ORM\Entity(repositoryClass: DesktopJobRepository::class)]
+#[ORM\Table(name: 'BDESKTOPJOBS')]
+#[ORM\Index(columns: ['BOWNERID'], name: 'idx_desktop_job_owner')]
+#[ORM\Index(columns: ['BDEVICEID'], name: 'idx_desktop_job_device')]
+#[ORM\Index(columns: ['BSTATUS', 'BDEVICEID'], name: 'idx_desktop_job_lease')]
+class DesktopJob
+{
+    public const TYPE_SKILL_RUN = 'skill.run';
+
+    public const STATUS_QUEUED = 'queued';
+    public const STATUS_LEASED = 'leased';
+    public const STATUS_SUCCEEDED = 'succeeded';
+    public const STATUS_FAILED = 'failed';
+    public const STATUS_CANCELLED = 'cancelled';
+
+    /** @var list<string> */
+    public const TERMINAL_STATUSES = [self::STATUS_SUCCEEDED, self::STATUS_FAILED, self::STATUS_CANCELLED];
+
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(name: 'BID', type: 'bigint')]
+    private ?int $id = null;
+
+    #[ORM\Column(name: 'BOWNERID', type: 'bigint')]
+    private int $ownerId;
+
+    #[ORM\Column(name: 'BDEVICEID', type: 'bigint', nullable: true)]
+    private ?int $deviceId = null;
+
+    #[ORM\Column(name: 'BTYPE', length: 32, options: ['default' => self::TYPE_SKILL_RUN])]
+    private string $type = self::TYPE_SKILL_RUN;
+
+    /** @var array<string, mixed>|null */
+    #[ORM\Column(name: 'BINPUT', type: 'json', nullable: true)]
+    private ?array $input = null;
+
+    #[ORM\Column(name: 'BSTATUS', length: 16, options: ['default' => self::STATUS_QUEUED])]
+    private string $status = self::STATUS_QUEUED;
+
+    #[ORM\Column(name: 'BLEASETOKEN', length: 64, nullable: true)]
+    private ?string $leaseToken = null;
+
+    #[ORM\Column(name: 'BLEASEEXPIRES', type: 'bigint', options: ['default' => 0])]
+    private int $leaseExpires = 0;
+
+    #[ORM\Column(name: 'BATTEMPT', type: 'integer', options: ['default' => 0])]
+    private int $attempt = 0;
+
+    #[ORM\Column(name: 'BMAXATTEMPTS', type: 'integer', options: ['default' => 3])]
+    private int $maxAttempts = 3;
+
+    #[ORM\Column(name: 'BIDEMPOTENCY', length: 128, nullable: true)]
+    private ?string $idempotency = null;
+
+    /** @var array<string, mixed>|null */
+    #[ORM\Column(name: 'BRESULT', type: 'json', nullable: true)]
+    private ?array $result = null;
+
+    #[ORM\Column(name: 'BERRORCODE', length: 32, nullable: true)]
+    private ?string $errorCode = null;
+
+    #[ORM\Column(name: 'BCHATID', type: 'bigint', nullable: true)]
+    private ?int $chatId = null;
+
+    #[ORM\Column(name: 'BMESSAGEID', type: 'bigint', nullable: true)]
+    private ?int $messageId = null;
+
+    #[ORM\Column(name: 'BCREATED', type: 'bigint')]
+    private int $created;
+
+    #[ORM\Column(name: 'BUPDATED', type: 'bigint', options: ['default' => 0])]
+    private int $updated = 0;
+
+    public function __construct()
+    {
+        $this->created = time();
+        $this->updated = time();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getOwnerId(): int
+    {
+        return $this->ownerId;
+    }
+
+    public function setOwnerId(int $ownerId): self
+    {
+        $this->ownerId = $ownerId;
+
+        return $this;
+    }
+
+    public function getDeviceId(): ?int
+    {
+        return $this->deviceId;
+    }
+
+    public function setDeviceId(?int $deviceId): self
+    {
+        $this->deviceId = $deviceId;
+
+        return $this;
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    public function setType(string $type): self
+    {
+        $this->type = $type;
+
+        return $this;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getInput(): array
+    {
+        return $this->input ?? [];
+    }
+
+    /**
+     * @param array<string, mixed>|null $input
+     */
+    public function setInput(?array $input): self
+    {
+        $this->input = $input;
+
+        return $this;
+    }
+
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+
+    public function setStatus(string $status): self
+    {
+        $this->status = $status;
+
+        return $this;
+    }
+
+    public function isTerminal(): bool
+    {
+        return \in_array($this->status, self::TERMINAL_STATUSES, true);
+    }
+
+    public function getLeaseToken(): ?string
+    {
+        return $this->leaseToken;
+    }
+
+    public function setLeaseToken(?string $leaseToken): self
+    {
+        $this->leaseToken = $leaseToken;
+
+        return $this;
+    }
+
+    public function getLeaseExpires(): int
+    {
+        return $this->leaseExpires;
+    }
+
+    public function setLeaseExpires(int $leaseExpires): self
+    {
+        $this->leaseExpires = $leaseExpires;
+
+        return $this;
+    }
+
+    public function getAttempt(): int
+    {
+        return $this->attempt;
+    }
+
+    public function setAttempt(int $attempt): self
+    {
+        $this->attempt = $attempt;
+
+        return $this;
+    }
+
+    public function getMaxAttempts(): int
+    {
+        return $this->maxAttempts;
+    }
+
+    public function setMaxAttempts(int $maxAttempts): self
+    {
+        $this->maxAttempts = $maxAttempts;
+
+        return $this;
+    }
+
+    public function getIdempotency(): ?string
+    {
+        return $this->idempotency;
+    }
+
+    public function setIdempotency(?string $idempotency): self
+    {
+        $this->idempotency = $idempotency;
+
+        return $this;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function getResult(): ?array
+    {
+        return $this->result;
+    }
+
+    /**
+     * @param array<string, mixed>|null $result
+     */
+    public function setResult(?array $result): self
+    {
+        $this->result = $result;
+
+        return $this;
+    }
+
+    public function getErrorCode(): ?string
+    {
+        return $this->errorCode;
+    }
+
+    public function setErrorCode(?string $errorCode): self
+    {
+        $this->errorCode = $errorCode;
+
+        return $this;
+    }
+
+    public function getChatId(): ?int
+    {
+        return $this->chatId;
+    }
+
+    public function setChatId(?int $chatId): self
+    {
+        $this->chatId = $chatId;
+
+        return $this;
+    }
+
+    public function getMessageId(): ?int
+    {
+        return $this->messageId;
+    }
+
+    public function setMessageId(?int $messageId): self
+    {
+        $this->messageId = $messageId;
+
+        return $this;
+    }
+
+    public function getCreated(): int
+    {
+        return $this->created;
+    }
+
+    public function setCreated(int $created): self
+    {
+        $this->created = $created;
+
+        return $this;
+    }
+
+    public function getUpdated(): int
+    {
+        return $this->updated;
+    }
+
+    public function setUpdated(int $updated): self
+    {
+        $this->updated = $updated;
+
+        return $this;
+    }
+
+    public function touch(): self
+    {
+        $this->updated = time();
+
+        return $this;
+    }
+}

--- a/backend/src/Entity/DesktopJob.php
+++ b/backend/src/Entity/DesktopJob.php
@@ -24,6 +24,7 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\Index(columns: ['BOWNERID'], name: 'idx_desktop_job_owner')]
 #[ORM\Index(columns: ['BDEVICEID'], name: 'idx_desktop_job_device')]
 #[ORM\Index(columns: ['BSTATUS', 'BDEVICEID'], name: 'idx_desktop_job_lease')]
+#[ORM\UniqueConstraint(name: 'uniq_desktop_job_idem', columns: ['BOWNERID', 'BIDEMPOTENCY'])]
 class DesktopJob
 {
     public const TYPE_SKILL_RUN = 'skill.run';

--- a/backend/src/Mcp/McpServerFactory.php
+++ b/backend/src/Mcp/McpServerFactory.php
@@ -5,13 +5,21 @@ declare(strict_types=1);
 namespace App\Mcp;
 
 use App\Entity\Chat;
+use App\Entity\DesktopDevice;
+use App\Entity\DesktopJob;
 use App\Entity\File;
 use App\Entity\Message;
 use App\Entity\User;
 use App\Repository\ChatRepository;
+use App\Repository\DesktopDeviceRepository;
 use App\Repository\MessageRepository;
 use App\Repository\PromptRepository;
 use App\Service\ConversationSummaryRefreshDispatcher;
+use App\Service\Desktop\DesktopAgentConfig;
+use App\Service\Desktop\DesktopJobContract;
+use App\Service\Desktop\DesktopJobResultNotifier;
+use App\Service\Desktop\DesktopJobStore;
+use App\Service\Desktop\Exception\ResultTooLargeException;
 use App\Service\Exception\MemoryServiceUnavailableException;
 use App\Service\File\FileHelper;
 use App\Service\File\FileStorageService;
@@ -76,14 +84,25 @@ final class McpServerFactory
         private readonly EntityManagerInterface $em,
         private readonly CacheItemPoolInterface $cache,
         private readonly ConversationSummaryRefreshDispatcher $summaryRefreshDispatcher,
+        private readonly DesktopAgentConfig $desktopAgentConfig,
+        private readonly DesktopJobStore $desktopJobStore,
+        private readonly DesktopDeviceRepository $desktopDeviceRepository,
+        private readonly DesktopJobResultNotifier $desktopJobResultNotifier,
         private readonly LoggerInterface $logger,
     ) {
     }
 
     /**
      * Build a server instance with all tools bound to the given user.
+     *
+     * When the request is authenticated by a scoped key bound to a paired
+     * computer ($device is non-null) AND the Desktop feature is enabled, two
+     * extra tools are exposed — `agent_checkin` (lease work) and
+     * `agent_report_result` (return a result). They are the ONLY way a device
+     * pulls jobs; there is no push and no server-supplied shell command.
+     * A normal MCP client (Claude/Cursor, or a non-desktop key) never sees them.
      */
-    public function build(User $user): Server
+    public function build(User $user, ?DesktopDevice $device = null): Server
     {
         $builder = Server::builder()
             ->setServerInfo(
@@ -201,9 +220,206 @@ final class McpServerFactory
                 'application/json',
             );
 
+        if ($device instanceof DesktopDevice && $this->desktopAgentConfig->isEnabled((int) $user->getId())) {
+            $this->registerDesktopAgentTools($builder, $device);
+        }
+
         $this->registerPrompts($builder, $user);
 
         return $builder->build();
+    }
+
+    /**
+     * Register the Synaplan Desktop check-in tools for a paired device.
+     *
+     * These are gated twice: the device must be present (scoped key → device
+     * row) and the global flag must be ON. A revoked device's key is already
+     * inactive, so it never authenticates this far.
+     */
+    private function registerDesktopAgentTools(Builder $builder, DesktopDevice $device): void
+    {
+        $builder
+            ->addTool(
+                $this->agentCheckinHandler($device),
+                'agent_checkin',
+                'Desktop agent check-in',
+                'Synaplan Desktop calls this to lease the next queued job for THIS computer. '
+                .'Returns at most one job as {jobId, type, input:{skill,prompt,fileIds}, leaseToken, '
+                .'leaseExpires}, plus next_call_at (when to poll again). The input never contains a '
+                .'shell command — only a named skill the device already has installed.',
+                new ToolAnnotations(readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false),
+                self::agentCheckinSchema(),
+            )
+            ->addTool(
+                $this->agentReportResultHandler($device),
+                'agent_report_result',
+                'Desktop agent report result',
+                'Synaplan Desktop calls this to report the outcome of a leased job, identified by its '
+                .'leaseToken. status is "succeeded" or "failed"; a refusal (unknown/disabled skill) is '
+                .'a normal "failed" with an errorCode, not an error.',
+                new ToolAnnotations(readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false),
+                self::agentReportResultSchema(),
+            );
+    }
+
+    /**
+     * @return \Closure(int, list<mixed>, list<mixed>, string, string): array<string, mixed>
+     */
+    private function agentCheckinHandler(DesktopDevice $device): \Closure
+    {
+        return function (int $protocol = DesktopJobContract::PROTOCOL_VERSION, array $capabilities = [], array $enabledSkills = [], string $agentKind = 'synaplan-desktop', string $status = 'idle') use ($device): array {
+            $now = time();
+
+            $device->touchLastSeen();
+            if ([] !== $capabilities) {
+                $device->setCapabilities(array_values(array_filter(
+                    $capabilities,
+                    static fn ($c): bool => \is_string($c),
+                )));
+            }
+            $this->desktopDeviceRepository->save($device);
+
+            // Never guess for a client speaking a protocol we don't know — hand
+            // back no work and a far next check-in (contract invariant C9).
+            if (DesktopJobContract::PROTOCOL_VERSION !== $protocol) {
+                return [
+                    'protocol' => DesktopJobContract::PROTOCOL_VERSION,
+                    'jobs' => [],
+                    'next_call_at' => $now + DesktopJobContract::NEXT_CALL_UNKNOWN_PROTOCOL_SECONDS,
+                ];
+            }
+
+            if (!$device->isActive()) {
+                return [
+                    'protocol' => DesktopJobContract::PROTOCOL_VERSION,
+                    'jobs' => [],
+                    'next_call_at' => $now + DesktopJobContract::NEXT_CALL_IDLE_SECONDS,
+                ];
+            }
+
+            $job = $this->desktopJobStore->leaseForDevice($device);
+            $jobs = $job instanceof DesktopJob ? [DesktopJobContract::buildDevicePayload($job)] : [];
+
+            return [
+                'protocol' => DesktopJobContract::PROTOCOL_VERSION,
+                'jobs' => $jobs,
+                'next_call_at' => $now + ([] === $jobs
+                    ? DesktopJobContract::NEXT_CALL_IDLE_SECONDS
+                    : DesktopJobContract::NEXT_CALL_ACTIVE_SECONDS),
+            ];
+        };
+    }
+
+    /**
+     * @return \Closure(string, string, ?array<string, mixed>, ?string): array<string, mixed>
+     */
+    private function agentReportResultHandler(DesktopDevice $device): \Closure
+    {
+        return function (string $leaseToken, string $status, ?array $result = null, ?string $errorCode = null) use ($device): array {
+            if ('' === trim($leaseToken)) {
+                throw new ToolCallException('leaseToken is required.');
+            }
+
+            if (null !== $errorCode && !DesktopJobContract::isValidErrorCode($errorCode)) {
+                throw new ToolCallException('Unknown errorCode.');
+            }
+
+            try {
+                $job = $this->desktopJobStore->reportResult($device, $leaseToken, $status, $result, $errorCode);
+            } catch (ResultTooLargeException $e) {
+                throw new ToolCallException($e->getMessage());
+            }
+
+            // Unknown / stale / foreign lease token → a clean tool error, not a 500.
+            if (!$job instanceof DesktopJob) {
+                throw new ToolCallException('Unknown or stale lease token, or invalid status.');
+            }
+
+            // Post the "done" note into the originating chat (if any). The
+            // result text is untrusted device content, stamped as such.
+            $this->desktopJobResultNotifier->notify($job);
+
+            return [
+                'success' => true,
+                'jobId' => $job->getId(),
+                'status' => $job->getStatus(),
+            ];
+        };
+    }
+
+    /**
+     * The frozen `agent_checkin` argument schema (protocol 1, DS18). Public so
+     * the contract-fixture test can assert the committed fixtures against the
+     * live schema (invariant C9).
+     *
+     * @return array<string, mixed>
+     */
+    public static function agentCheckinSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'protocol' => [
+                    'type' => 'integer',
+                    'default' => DesktopJobContract::PROTOCOL_VERSION,
+                    'description' => 'The desktop job protocol version the client speaks. Currently 1.',
+                ],
+                'capabilities' => [
+                    'type' => 'array',
+                    'items' => ['type' => 'string'],
+                    'description' => 'Job kinds this computer supports (v1: ["skill.run"]).',
+                ],
+                'enabledSkills' => [
+                    'type' => 'array',
+                    'items' => ['type' => 'string'],
+                    'description' => 'Names of skills currently installed/enabled on the device. A hint so the server can skip jobs the device would refuse — an optimization, not a security boundary.',
+                ],
+                'agentKind' => [
+                    'type' => 'string',
+                    'description' => 'Client identifier. Always "synaplan-desktop" for the official client.',
+                ],
+                'status' => [
+                    'type' => 'string',
+                    'description' => 'Free-form device status hint (e.g. "idle", "busy").',
+                ],
+            ],
+            'additionalProperties' => false,
+        ];
+    }
+
+    /**
+     * The frozen `agent_report_result` argument schema (protocol 1, DS18).
+     * Public for the contract-fixture test (invariant C9).
+     *
+     * @return array<string, mixed>
+     */
+    public static function agentReportResultSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'leaseToken' => [
+                    'type' => 'string',
+                    'description' => 'The leaseToken from the job returned by agent_checkin.',
+                ],
+                'status' => [
+                    'type' => 'string',
+                    'enum' => [DesktopJob::STATUS_SUCCEEDED, DesktopJob::STATUS_FAILED],
+                    'description' => 'Outcome of the job. A refused skill is a normal "failed".',
+                ],
+                'result' => [
+                    'type' => ['object', 'null'],
+                    'description' => 'Structured result payload (e.g. {fileIds:[...], summary:"..."}). Size-capped.',
+                ],
+                'errorCode' => [
+                    'type' => ['string', 'null'],
+                    'enum' => [...DesktopJobContract::ERROR_CODES, null],
+                    'description' => 'Machine-readable failure reason when status is "failed".',
+                ],
+            ],
+            'required' => ['leaseToken', 'status'],
+            'additionalProperties' => false,
+        ];
     }
 
     /**

--- a/backend/src/Repository/DesktopDeviceRepository.php
+++ b/backend/src/Repository/DesktopDeviceRepository.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\DesktopDevice;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<DesktopDevice>
+ */
+class DesktopDeviceRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, DesktopDevice::class);
+    }
+
+    /**
+     * All devices owned by a user, newest first.
+     *
+     * @return list<DesktopDevice>
+     */
+    public function findByOwner(int $ownerId): array
+    {
+        return $this->createQueryBuilder('d')
+            ->where('d.ownerId = :ownerId')
+            ->setParameter('ownerId', $ownerId)
+            ->orderBy('d.created', 'DESC')
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
+     * A device by id, only if it belongs to the given owner (404-not-403 for a
+     * foreign id, same as Saved Tasks).
+     */
+    public function findOwnedById(int $id, int $ownerId): ?DesktopDevice
+    {
+        return $this->findOneBy(['id' => $id, 'ownerId' => $ownerId]);
+    }
+
+    /**
+     * Resolve the device backing an API key, if any. Used by the job/check-in
+     * loop to update BLASTSEEN and to bind a check-in to its device.
+     */
+    public function findByApiKeyId(int $apiKeyId): ?DesktopDevice
+    {
+        return $this->findOneBy(['apiKeyId' => $apiKeyId]);
+    }
+
+    /**
+     * @return list<DesktopDevice>
+     */
+    public function findActiveByOwner(int $ownerId): array
+    {
+        return $this->createQueryBuilder('d')
+            ->where('d.ownerId = :ownerId')
+            ->andWhere('d.status = :status')
+            ->setParameter('ownerId', $ownerId)
+            ->setParameter('status', DesktopDevice::STATUS_ACTIVE)
+            ->orderBy('d.created', 'DESC')
+            ->getQuery()
+            ->getResult();
+    }
+
+    public function save(DesktopDevice $device, bool $flush = true): void
+    {
+        $this->getEntityManager()->persist($device);
+
+        if ($flush) {
+            $this->getEntityManager()->flush();
+        }
+    }
+
+    public function remove(DesktopDevice $device, bool $flush = true): void
+    {
+        $this->getEntityManager()->remove($device);
+
+        if ($flush) {
+            $this->getEntityManager()->flush();
+        }
+    }
+}

--- a/backend/src/Repository/DesktopJobRepository.php
+++ b/backend/src/Repository/DesktopJobRepository.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\DesktopJob;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\DBAL\LockMode;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<DesktopJob>
+ */
+class DesktopJobRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, DesktopJob::class);
+    }
+
+    /**
+     * Oldest queued job a device may lease: one targeted at that device, or an
+     * unassigned job (BDEVICEID IS NULL) owned by the same user.
+     *
+     * MUST be called inside a transaction — the PESSIMISTIC_WRITE lock is what
+     * stops two simultaneous check-ins from leasing the same row (a second
+     * check-in blocks, then sees `leased` and moves on).
+     */
+    public function findNextLeasable(int $ownerId, int $deviceId): ?DesktopJob
+    {
+        return $this->createQueryBuilder('j')
+            ->where('j.ownerId = :ownerId')
+            ->andWhere('j.status = :queued')
+            ->andWhere('j.deviceId = :deviceId OR j.deviceId IS NULL')
+            ->setParameter('ownerId', $ownerId)
+            ->setParameter('queued', DesktopJob::STATUS_QUEUED)
+            ->setParameter('deviceId', $deviceId)
+            ->orderBy('j.created', 'ASC')
+            ->setMaxResults(1)
+            ->getQuery()
+            ->setLockMode(LockMode::PESSIMISTIC_WRITE)
+            ->getOneOrNullResult();
+    }
+
+    public function findByLeaseToken(string $leaseToken): ?DesktopJob
+    {
+        if ('' === $leaseToken) {
+            return null;
+        }
+
+        return $this->findOneBy(['leaseToken' => $leaseToken]);
+    }
+
+    public function findByOwnerIdempotency(int $ownerId, string $idempotency): ?DesktopJob
+    {
+        return $this->findOneBy(['ownerId' => $ownerId, 'idempotency' => $idempotency]);
+    }
+
+    public function findOwnedById(int $id, int $ownerId): ?DesktopJob
+    {
+        return $this->findOneBy(['id' => $id, 'ownerId' => $ownerId]);
+    }
+
+    /**
+     * A user's most recent jobs, newest first (for the web "waiting/failed" card).
+     *
+     * @return list<DesktopJob>
+     */
+    public function findRecentByOwner(int $ownerId, int $limit = 50): array
+    {
+        return $this->createQueryBuilder('j')
+            ->where('j.ownerId = :ownerId')
+            ->setParameter('ownerId', $ownerId)
+            ->orderBy('j.created', 'DESC')
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
+     * Leased jobs whose lease has expired — the reaper requeues or fails these.
+     *
+     * @return list<DesktopJob>
+     */
+    public function findExpiredLeases(int $now, int $limit = 100): array
+    {
+        return $this->createQueryBuilder('j')
+            ->where('j.status = :leased')
+            ->andWhere('j.leaseExpires < :now')
+            ->setParameter('leased', DesktopJob::STATUS_LEASED)
+            ->setParameter('now', $now)
+            ->orderBy('j.leaseExpires', 'ASC')
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
+     * Count non-terminal jobs waiting for a specific device (for the web
+     * "jobs waiting" badge). Includes unassigned jobs owned by the user.
+     */
+    public function countPendingForDevice(int $ownerId, int $deviceId): int
+    {
+        return (int) $this->createQueryBuilder('j')
+            ->select('COUNT(j.id)')
+            ->where('j.ownerId = :ownerId')
+            ->andWhere('j.status IN (:pending)')
+            ->andWhere('j.deviceId = :deviceId OR j.deviceId IS NULL')
+            ->setParameter('ownerId', $ownerId)
+            ->setParameter('pending', [DesktopJob::STATUS_QUEUED, DesktopJob::STATUS_LEASED])
+            ->setParameter('deviceId', $deviceId)
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
+    public function save(DesktopJob $job, bool $flush = true): void
+    {
+        $this->getEntityManager()->persist($job);
+
+        if ($flush) {
+            $this->getEntityManager()->flush();
+        }
+    }
+}

--- a/backend/src/Security/ApiKeyScope.php
+++ b/backend/src/Security/ApiKeyScope.php
@@ -1,0 +1,204 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Security;
+
+/**
+ * API key scope vocabulary and the path → required-scope enforcement map.
+ *
+ * Historically {@see \App\Entity\ApiKey::hasScope()} was never called: any
+ * `sk_*` key had full account access. That is the CORE-3 / July-local-agent
+ * blocker this class closes. It is a *security fix*, so it must not break the
+ * integrations that already rely on unscoped keys.
+ *
+ * Grandfather rule (do NOT narrow existing keys):
+ *   - an EMPTY scope list means full access (legacy);
+ *   - a list that only contains the legacy webhook scopes
+ *     (`webhooks:email` / `webhooks:whatsapp` / `webhooks:*`) means full access;
+ *   - an explicit `*` means full access.
+ *
+ * A key is *restricted* only when it opts into a non-empty, non-legacy list
+ * without `*`. Pairing a desktop mints exactly such a restricted key
+ * ({@see pairingScopes()}), so a stolen laptop is a revoke, not an account
+ * takeover.
+ *
+ * This class is pure logic (no I/O), so it is unit-testable in isolation and is
+ * the single source of truth shared by the entity and the enforcement
+ * subscriber ({@see ApiKeyScopeSubscriber}).
+ */
+final class ApiKeyScope
+{
+    /** Explicit full access. */
+    public const WILDCARD = '*';
+
+    /** `/v1/messages`, `/v1/models`, `/v1/messages/count_tokens`. */
+    public const DESKTOP_MESSAGES = 'desktop:messages';
+
+    /** `/mcp`. */
+    public const DESKTOP_MCP = 'desktop:mcp';
+
+    /** `/api/v1/files*` — upload/list/download the owner already may. */
+    public const DESKTOP_FILES = 'desktop:files';
+
+    /** Check-in / report (declared in Sprint A1, first enforced in Sprint A3). */
+    public const DESKTOP_JOBS = 'desktop:jobs';
+
+    /** Umbrella over every `desktop:` scope. */
+    public const DESKTOP_ALL = 'desktop:*';
+
+    /**
+     * Legacy webhook scopes. A key whose list contains ONLY these keeps full
+     * access until the later CORE-3 migration narrows them explicitly.
+     *
+     * @var list<string>
+     */
+    public const LEGACY_WEBHOOK_SCOPES = ['webhooks:email', 'webhooks:whatsapp', 'webhooks:*'];
+
+    private function __construct()
+    {
+    }
+
+    /**
+     * The exact scope set minted for a paired computer. Deliberately narrow:
+     * a desktop key can chat, use MCP, move its own files, and run the job
+     * loop — and nothing else (no admin, users, widgets, or webhooks).
+     *
+     * @return list<string>
+     */
+    public static function pairingScopes(): array
+    {
+        return [
+            self::DESKTOP_MESSAGES,
+            self::DESKTOP_MCP,
+            self::DESKTOP_FILES,
+            self::DESKTOP_JOBS,
+        ];
+    }
+
+    /**
+     * A key is restricted iff its scope list is non-empty, is not a
+     * legacy-webhook-only list, and does not contain `*`.
+     *
+     * @param list<string>|array<int|string, mixed> $scopes
+     */
+    public static function isRestricted(array $scopes): bool
+    {
+        $normalized = self::normalize($scopes);
+
+        if ([] === $normalized) {
+            return false; // legacy empty = full access
+        }
+
+        if (\in_array(self::WILDCARD, $normalized, true)) {
+            return false; // explicit full access
+        }
+
+        // A list that adds nothing beyond the legacy webhook scopes stays full
+        // access (CORE-3 grandfather). Any other opt-in scope restricts the key.
+        $beyondLegacy = array_diff($normalized, self::LEGACY_WEBHOOK_SCOPES);
+
+        return [] !== $beyondLegacy;
+    }
+
+    /**
+     * Whether a restricted key with $scopes may reach $path.
+     *
+     * Only meaningful for restricted keys — callers gate with
+     * {@see isRestricted()} first (an unrestricted key is always allowed).
+     *
+     * Prefix map (v1):
+     *   /v1/               → desktop:messages
+     *   /mcp               → desktop:mcp
+     *   /api/v1/desktop/   → desktop:jobs
+     *   /api/v1/files      → desktop:files (a paired computer uploads its
+     *                        result artifact through the existing files API
+     *                        before reporting a fileId — sprint A3 §2.4)
+     *   everything else    → denied for a restricted key (a desktop-only key
+     *                        must never administer the instance)
+     *
+     * @param list<string>|array<int|string, mixed> $scopes
+     */
+    public static function allows(array $scopes, string $path): bool
+    {
+        $normalized = self::normalize($scopes);
+
+        if (\in_array(self::WILDCARD, $normalized, true)) {
+            return true;
+        }
+
+        foreach (self::requiredScopesForPath($path) as $required) {
+            if (self::grants($normalized, $required)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * The scopes that satisfy a path, in the enforcement prefix order. An empty
+     * list means "no restricted key may reach this path" (deny).
+     *
+     * @return list<string>
+     */
+    public static function requiredScopesForPath(string $path): array
+    {
+        if ('/v1' === $path || str_starts_with($path, '/v1/')) {
+            return [self::DESKTOP_MESSAGES];
+        }
+
+        if ('/mcp' === $path || str_starts_with($path, '/mcp')) {
+            return [self::DESKTOP_MCP];
+        }
+
+        if ('/api/v1/desktop' === $path || str_starts_with($path, '/api/v1/desktop/')) {
+            return [self::DESKTOP_JOBS];
+        }
+
+        if ('/api/v1/files' === $path || str_starts_with($path, '/api/v1/files/')) {
+            return [self::DESKTOP_FILES];
+        }
+
+        return [];
+    }
+
+    /**
+     * Does $scopes grant $required, honouring the `desktop:*` umbrella?
+     *
+     * @param list<string> $scopes
+     */
+    private static function grants(array $scopes, string $required): bool
+    {
+        if (\in_array($required, $scopes, true)) {
+            return true;
+        }
+
+        if (str_starts_with($required, 'desktop:') && \in_array(self::DESKTOP_ALL, $scopes, true)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<int|string, mixed> $scopes
+     *
+     * @return list<string>
+     */
+    private static function normalize(array $scopes): array
+    {
+        $out = [];
+        foreach ($scopes as $scope) {
+            if (!\is_string($scope)) {
+                continue;
+            }
+            $trimmed = trim($scope);
+            if ('' !== $trimmed) {
+                $out[] = $trimmed;
+            }
+        }
+
+        return array_values(array_unique($out));
+    }
+}

--- a/backend/src/Security/ApiKeyScopeSubscriber.php
+++ b/backend/src/Security/ApiKeyScopeSubscriber.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Security;
+
+use App\Entity\ApiKey;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Central enforcement of API-key scopes ({@see ApiKeyScope}).
+ *
+ * Runs on kernel.request AFTER the security firewall (priority 8) has
+ * authenticated the request, so the {@see ApiKey} that
+ * {@see ApiKeyAuthenticator} stashed on `api_key` is available. Session-cookie
+ * and OIDC users never carry that attribute, so they are untouched (C6).
+ *
+ * A *restricted* key that reaches a path its scopes do not cover gets a stable
+ * `403 insufficient_scope` — never a 401, because the key itself is valid.
+ * Unrestricted (legacy / `*`) keys skip every check (C1 grandfather).
+ */
+final class ApiKeyScopeSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: int}>
+     */
+    public static function getSubscribedEvents(): array
+    {
+        // Priority 6: after the firewall (8) populates request attributes, but
+        // before the controller resolver runs, so we can short-circuit with a
+        // clean JSON response instead of throwing.
+        return [
+            KernelEvents::REQUEST => ['onKernelRequest', 6],
+        ];
+    }
+
+    public function onKernelRequest(RequestEvent $event): void
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
+        $request = $event->getRequest();
+        $apiKey = $request->attributes->get('api_key');
+
+        // No API key on the request → session / OIDC user, or anonymous. Not
+        // our concern; the firewalls and voters handle those.
+        if (!$apiKey instanceof ApiKey) {
+            return;
+        }
+
+        $scopes = $apiKey->getScopes();
+
+        // Grandfathered keys (empty / legacy-webhook-only / `*`) keep full
+        // access — this listener is a no-op for them.
+        if (!ApiKeyScope::isRestricted($scopes)) {
+            return;
+        }
+
+        $path = $request->getPathInfo();
+
+        if (ApiKeyScope::allows($scopes, $path)) {
+            return;
+        }
+
+        $required = ApiKeyScope::requiredScopesForPath($path);
+
+        $this->logger->warning('API key blocked by insufficient scope', [
+            'key_id' => $apiKey->getId(),
+            'owner_id' => $apiKey->getOwnerId(),
+            'path' => $path,
+            'required' => $required,
+            'granted' => $scopes,
+        ]);
+
+        $event->setResponse(new JsonResponse([
+            'success' => false,
+            'error' => 'insufficient_scope',
+            'code' => 'insufficient_scope',
+            'message' => 'This API key is not permitted to access this resource.',
+            'required' => $required,
+            'granted' => array_values($scopes),
+        ], Response::HTTP_FORBIDDEN));
+    }
+}

--- a/backend/src/Seed/DesktopAgentConfigSeeder.php
+++ b/backend/src/Seed/DesktopAgentConfigSeeder.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Seed;
+
+use App\Service\Desktop\DesktopAgentConfig;
+use Doctrine\DBAL\Connection;
+
+/**
+ * Idempotent seeder for the global Synaplan Desktop flag (BCONFIG, ownerId=0).
+ *
+ * Insert-if-missing only — operator overrides are never touched. Unlike most
+ * feature seeders, this one seeds the flag OFF (`0`) for every install,
+ * including new / local-dev ones: the desktop client does not exist yet
+ * (server-first order, master plan decision 21), so the surface stays inert
+ * until an operator or a later release turns it on.
+ */
+final readonly class DesktopAgentConfigSeeder
+{
+    public function __construct(
+        private Connection $connection,
+    ) {
+    }
+
+    public function seed(): SeedResult
+    {
+        $rows = [
+            ['ownerId' => 0, 'group' => DesktopAgentConfig::CONFIG_GROUP, 'setting' => DesktopAgentConfig::KEY_ENABLED, 'value' => '0'],
+        ];
+
+        return BConfigSeeder::insertIfMissing($this->connection, 'desktop_agent_config', $rows);
+    }
+}

--- a/backend/src/Service/Desktop/DesktopAgentConfig.php
+++ b/backend/src/Service/Desktop/DesktopAgentConfig.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Desktop;
+
+use App\Repository\ConfigRepository;
+
+/**
+ * Feature-flag resolver for the Synaplan Desktop agent (the whole desktop
+ * pairing / job-queue surface).
+ *
+ * Flags live in BCONFIG group {@see self::CONFIG_GROUP}:
+ *   - ENABLED — master switch: expose pairing, device CRUD, the job queue, and
+ *     the MCP check-in tools. When OFF, every desktop route is 404 and the
+ *     desktop MCP tools are absent from `tools/list` (invariant C8).
+ *
+ * Resolution mirrors {@see \App\Service\SavedTask\SavedTaskConfig}: a per-user
+ * row (BOWNERID = userId) overrides the global row (BOWNERID = 0), which
+ * overrides the built-in code default (OFF).
+ *
+ * The whole Desktop epic ships to `main` with this flag OFF (master plan
+ * decision 21): the seeder inserts a global `0` row and no migration turns it
+ * on. Turning it on is an explicit operator / per-user action, so a
+ * consumer-less feature is inert on every existing and new install until the
+ * client exists.
+ */
+final readonly class DesktopAgentConfig
+{
+    public const CONFIG_GROUP = 'DESKTOP_AGENT';
+    public const KEY_ENABLED = 'ENABLED';
+
+    private const DEFAULT_ENABLED = false;
+
+    public function __construct(
+        private ConfigRepository $configRepository,
+    ) {
+    }
+
+    /**
+     * Master switch. Per-user override wins, then global, then built-in default
+     * (OFF). Pass the effective user id (null for anonymous / unresolved).
+     */
+    public function isEnabled(?int $userId): bool
+    {
+        return $this->resolveFlag(self::KEY_ENABLED, $userId, self::DEFAULT_ENABLED);
+    }
+
+    private function resolveFlag(string $setting, ?int $userId, bool $default): bool
+    {
+        if (null !== $userId && $userId > 0) {
+            $perUser = $this->configRepository->getValue($userId, self::CONFIG_GROUP, $setting);
+            if (null !== $perUser) {
+                return $this->toBool($perUser, $default);
+            }
+        }
+
+        $global = $this->configRepository->getValue(0, self::CONFIG_GROUP, $setting);
+        if (null !== $global) {
+            return $this->toBool($global, $default);
+        }
+
+        return $default;
+    }
+
+    private function toBool(string $value, bool $default): bool
+    {
+        return filter_var($value, \FILTER_VALIDATE_BOOL, \FILTER_NULL_ON_FAILURE) ?? $default;
+    }
+}

--- a/backend/src/Service/Desktop/DesktopJobContract.php
+++ b/backend/src/Service/Desktop/DesktopJobContract.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Desktop;
+
+use App\Entity\DesktopJob;
+
+/**
+ * The frozen Synaplan Desktop job / check-in contract (Sprint A3, DS18).
+ *
+ * `protocol: 1`. Both the check-in request and response carry this version; a
+ * device that sends an unknown protocol is answered with an empty job list and
+ * a far next_call_at (never a guess). Every enum here is closed and fixture-
+ * frozen (`_devextras/testing/desktop/fixtures/`); changing it is a
+ * `protocol: 2` decision with a migration, not a client-convenience edit (C9).
+ *
+ * The single most important rule this class encodes: a job's device-facing
+ * input is ONLY `{skill, prompt, fileIds}`. Any other key (`command`,
+ * `script`, `argv`, …) is dropped by {@see buildDevicePayload()} and MUST be
+ * ignored by the device. That is why a future server bug cannot turn into
+ * remote code execution — there is no field through which a shell string could
+ * ever reach the laptop.
+ */
+final class DesktopJobContract
+{
+    public const PROTOCOL_VERSION = 1;
+
+    /** The only job type in v1. No `shell.exec`, ever. */
+    public const TYPE_SKILL_RUN = DesktopJob::TYPE_SKILL_RUN;
+
+    /** @var list<string> */
+    public const JOB_TYPES = [self::TYPE_SKILL_RUN];
+
+    /** @var list<string> */
+    public const STATUSES = [
+        DesktopJob::STATUS_QUEUED,
+        DesktopJob::STATUS_LEASED,
+        DesktopJob::STATUS_SUCCEEDED,
+        DesktopJob::STATUS_FAILED,
+        DesktopJob::STATUS_CANCELLED,
+    ];
+
+    public const ERROR_UNKNOWN_SKILL = 'unknown_skill';
+    public const ERROR_UNKNOWN_TYPE = 'unknown_type';
+    public const ERROR_SKILL_DISABLED = 'skill_disabled';
+    public const ERROR_TIMEOUT = 'timeout';
+    public const ERROR_LOCAL_ERROR = 'local_error';
+
+    /** @var list<string> */
+    public const ERROR_CODES = [
+        self::ERROR_UNKNOWN_SKILL,
+        self::ERROR_UNKNOWN_TYPE,
+        self::ERROR_SKILL_DISABLED,
+        self::ERROR_TIMEOUT,
+        self::ERROR_LOCAL_ERROR,
+    ];
+
+    /**
+     * The ONLY keys a device ever receives in a job's input. Everything else is
+     * dropped server-side and must be ignored client-side.
+     *
+     * @var list<string>
+     */
+    public const ALLOWED_INPUT_KEYS = ['skill', 'prompt', 'fileIds'];
+
+    /** Provenance stamped on results re-entering the account (RAG / chat). */
+    public const RESULT_SOURCE = 'desktop_skill';
+
+    /** Idle poll cadence (seconds) suggested to a device with no work. */
+    public const NEXT_CALL_IDLE_SECONDS = 180;
+
+    /** Poll cadence (seconds) suggested when work was handed out. */
+    public const NEXT_CALL_ACTIVE_SECONDS = 30;
+
+    /** How far ahead to defer a device speaking an unknown protocol. */
+    public const NEXT_CALL_UNKNOWN_PROTOCOL_SECONDS = 3600;
+
+    private function __construct()
+    {
+    }
+
+    public static function isValidType(string $type): bool
+    {
+        return \in_array($type, self::JOB_TYPES, true);
+    }
+
+    public static function isValidErrorCode(string $code): bool
+    {
+        return \in_array($code, self::ERROR_CODES, true);
+    }
+
+    /**
+     * Build the device-facing payload for a job, keeping ONLY the allowed input
+     * keys. A `command`/`script`/`argv` smuggled into BINPUT never appears here.
+     *
+     * @return array{jobId: int, type: string, input: array{skill: string, prompt: string, fileIds: list<int>}, leaseToken: string, leaseExpires: int, attempt: int}
+     */
+    public static function buildDevicePayload(DesktopJob $job): array
+    {
+        $input = $job->getInput();
+
+        $fileIds = [];
+        if (isset($input['fileIds']) && \is_array($input['fileIds'])) {
+            foreach ($input['fileIds'] as $fileId) {
+                if (is_numeric($fileId)) {
+                    $fileIds[] = (int) $fileId;
+                }
+            }
+        }
+
+        return [
+            'jobId' => (int) $job->getId(),
+            'type' => $job->getType(),
+            'input' => [
+                'skill' => \is_string($input['skill'] ?? null) ? $input['skill'] : '',
+                'prompt' => \is_string($input['prompt'] ?? null) ? $input['prompt'] : '',
+                'fileIds' => $fileIds,
+            ],
+            'leaseToken' => (string) $job->getLeaseToken(),
+            'leaseExpires' => $job->getLeaseExpires(),
+            'attempt' => $job->getAttempt(),
+        ];
+    }
+}

--- a/backend/src/Service/Desktop/DesktopJobResultNotifier.php
+++ b/backend/src/Service/Desktop/DesktopJobResultNotifier.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Desktop;
+
+use App\Entity\Chat;
+use App\Entity\DesktopJob;
+use App\Entity\Message;
+use App\Repository\ChatRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Posts the "done" note back into the chat that queued a desktop job, so a
+ * result computed on the user's laptop re-enters the account like any other
+ * channel's message.
+ *
+ * Provenance is stamped ({@see DesktopJobContract::RESULT_SOURCE}) because this
+ * text originates on an untrusted device — it is content, never an instruction
+ * the pipeline should act on.
+ */
+final readonly class DesktopJobResultNotifier
+{
+    public function __construct(
+        private ChatRepository $chatRepository,
+        private EntityManagerInterface $em,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * Post a completion (or failure) note into the job's chat, if it has one.
+     * Never throws — a failure to notify must not fail the device's report.
+     */
+    public function notify(DesktopJob $job): void
+    {
+        $chatId = $job->getChatId();
+        if (null === $chatId) {
+            return;
+        }
+
+        try {
+            $chat = $this->chatRepository->find($chatId);
+            if (!$chat instanceof Chat || $chat->getUserId() !== $job->getOwnerId()) {
+                return;
+            }
+
+            $message = (new Message())
+                ->setUserId($job->getOwnerId())
+                ->setChat($chat)
+                ->setTrackingId(time())
+                ->setProviderIndex('DESKTOP')
+                ->setUnixTimestamp(time())
+                ->setDateTime(date('YmdHis'))
+                ->setMessageType('API')
+                ->setFile(0)
+                ->setTopic('CHAT')
+                ->setLanguage('en')
+                ->setText($this->buildText($job))
+                ->setDirection('OUT')
+                ->setStatus('complete');
+
+            $this->em->persist($message);
+            $chat->updateTimestamp();
+            $this->em->flush();
+        } catch (\Throwable $e) {
+            $this->logger->warning('Failed to post desktop job completion note', [
+                'job_id' => $job->getId(),
+                'chat_id' => $chatId,
+                'exception' => $e,
+            ]);
+        }
+    }
+
+    private function buildText(DesktopJob $job): string
+    {
+        $skill = (string) ($job->getInput()['skill'] ?? 'skill');
+
+        if (DesktopJob::STATUS_SUCCEEDED !== $job->getStatus()) {
+            $code = $job->getErrorCode() ?? DesktopJobContract::ERROR_LOCAL_ERROR;
+
+            return \sprintf('The "%s" task on your computer did not complete (%s).', $skill, $code);
+        }
+
+        $result = $job->getResult() ?? [];
+        $lines = [\sprintf('The "%s" task finished on your computer.', $skill)];
+
+        $summary = $result['summary'] ?? null;
+        if (\is_string($summary) && '' !== trim($summary)) {
+            $lines[] = trim($summary);
+        }
+
+        $fileIds = [];
+        if (isset($result['fileIds']) && \is_array($result['fileIds'])) {
+            foreach ($result['fileIds'] as $fileId) {
+                if (is_numeric($fileId)) {
+                    $fileIds[] = (int) $fileId;
+                }
+            }
+        }
+        if ([] !== $fileIds) {
+            $lines[] = 'Files: '.implode(', ', array_map(static fn (int $id): string => '#'.$id, $fileIds));
+        }
+
+        return implode("\n", $lines);
+    }
+}

--- a/backend/src/Service/Desktop/DesktopJobStore.php
+++ b/backend/src/Service/Desktop/DesktopJobStore.php
@@ -1,0 +1,220 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Desktop;
+
+use App\Entity\DesktopDevice;
+use App\Entity\DesktopJob;
+use App\Repository\DesktopJobRepository;
+use App\Service\Desktop\Exception\ResultTooLargeException;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Enqueue / lease / expire / report lifecycle for {@see DesktopJob} rows.
+ *
+ * Modelled on the media-job store (lease + heartbeat), but DB-backed because
+ * the queue must survive across the device's sleep between check-ins and be
+ * cluster-visible. Leasing is atomic via a pessimistic row lock
+ * ({@see DesktopJobRepository::findNextLeasable()}) inside a transaction, so
+ * two check-ins can never lease the same job.
+ */
+final class DesktopJobStore
+{
+    /** How long a leased job is reserved before the reaper may requeue it. */
+    public const LEASE_TTL_SECONDS = 300;
+
+    /** Cap on the stored result JSON — untrusted input re-entering the account. */
+    public const RESULT_MAX_BYTES = 65536;
+
+    /** Cap on the enqueued prompt length. */
+    public const PROMPT_MAX_CHARS = 8000;
+
+    public function __construct(
+        private readonly DesktopJobRepository $jobRepository,
+        private readonly EntityManagerInterface $em,
+    ) {
+    }
+
+    /**
+     * Enqueue a `skill.run` job. Idempotent: if $idempotency is given and a job
+     * already exists for (owner, idempotency), the existing job is returned
+     * unchanged.
+     *
+     * @param list<int> $fileIds
+     */
+    public function enqueueSkillRun(
+        int $ownerId,
+        ?int $deviceId,
+        string $skill,
+        string $prompt,
+        array $fileIds = [],
+        ?int $chatId = null,
+        ?int $messageId = null,
+        ?string $idempotency = null,
+    ): DesktopJob {
+        if (null !== $idempotency && '' !== $idempotency) {
+            $existing = $this->jobRepository->findByOwnerIdempotency($ownerId, $idempotency);
+            if (null !== $existing) {
+                return $existing;
+            }
+        }
+
+        $job = (new DesktopJob())
+            ->setOwnerId($ownerId)
+            ->setDeviceId($deviceId)
+            ->setType(DesktopJob::TYPE_SKILL_RUN)
+            ->setStatus(DesktopJob::STATUS_QUEUED)
+            ->setInput([
+                'skill' => $skill,
+                'prompt' => mb_substr($prompt, 0, self::PROMPT_MAX_CHARS),
+                'fileIds' => array_map('intval', $fileIds),
+            ])
+            ->setChatId($chatId)
+            ->setMessageId($messageId)
+            ->setIdempotency('' !== (string) $idempotency ? $idempotency : null);
+
+        $this->jobRepository->save($job);
+
+        return $job;
+    }
+
+    /**
+     * Atomically lease the next job for a device, or null if none is waiting.
+     * The returned job is `leased` with a fresh lease token and expiry.
+     */
+    public function leaseForDevice(DesktopDevice $device): ?DesktopJob
+    {
+        $deviceId = (int) $device->getId();
+        $ownerId = $device->getOwnerId();
+
+        /** @var DesktopJob|null $leased */
+        $leased = $this->em->wrapInTransaction(function () use ($ownerId, $deviceId): ?DesktopJob {
+            $job = $this->jobRepository->findNextLeasable($ownerId, $deviceId);
+            if (null === $job) {
+                return null;
+            }
+
+            $now = time();
+            $job->setStatus(DesktopJob::STATUS_LEASED)
+                ->setDeviceId($deviceId)
+                ->setLeaseToken(self::generateLeaseToken())
+                ->setLeaseExpires($now + self::LEASE_TTL_SECONDS)
+                ->setAttempt($job->getAttempt() + 1)
+                ->touch();
+
+            $this->em->flush();
+
+            return $job;
+        });
+
+        return $leased;
+    }
+
+    /**
+     * Record a device's result for a leased job.
+     *
+     * @param array<string, mixed>|null $result
+     *
+     * @return DesktopJob|null the updated job, or null when the lease token is
+     *                         unknown / stale / not owned by this device (→ 400)
+     *
+     * @throws ResultTooLargeException when the result JSON exceeds the size cap
+     */
+    public function reportResult(
+        DesktopDevice $device,
+        string $leaseToken,
+        string $status,
+        ?array $result = null,
+        ?string $errorCode = null,
+    ): ?DesktopJob {
+        $job = $this->jobRepository->findByLeaseToken($leaseToken);
+
+        if (null === $job
+            || $job->getOwnerId() !== $device->getOwnerId()
+            || DesktopJob::STATUS_LEASED !== $job->getStatus()) {
+            return null;
+        }
+
+        if (!\in_array($status, [DesktopJob::STATUS_SUCCEEDED, DesktopJob::STATUS_FAILED], true)) {
+            return null;
+        }
+
+        if (null !== $result) {
+            $encoded = json_encode($result, \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE);
+            if (false === $encoded || \strlen($encoded) > self::RESULT_MAX_BYTES) {
+                throw new ResultTooLargeException(sprintf('Desktop job result exceeds the %d-byte cap.', self::RESULT_MAX_BYTES));
+            }
+        }
+
+        $job->setStatus($status)
+            ->setResult($result)
+            ->setErrorCode($errorCode)
+            ->setLeaseToken(null)
+            ->touch();
+
+        $this->jobRepository->save($job);
+
+        return $job;
+    }
+
+    /**
+     * Requeue (or fail) jobs whose lease expired. Called by the reaper.
+     *
+     * @return array{requeued: int, failed: int}
+     */
+    public function requeueExpiredLeases(int $limit = 100): array
+    {
+        $now = time();
+        $requeued = 0;
+        $failed = 0;
+
+        foreach ($this->jobRepository->findExpiredLeases($now, $limit) as $job) {
+            if ($job->getAttempt() < $job->getMaxAttempts()) {
+                $job->setStatus(DesktopJob::STATUS_QUEUED)
+                    ->setLeaseToken(null)
+                    ->setLeaseExpires(0)
+                    ->touch();
+                ++$requeued;
+            } else {
+                $job->setStatus(DesktopJob::STATUS_FAILED)
+                    ->setLeaseToken(null)
+                    ->setErrorCode(DesktopJobContract::ERROR_TIMEOUT)
+                    ->touch();
+                ++$failed;
+            }
+
+            $this->em->persist($job);
+        }
+
+        if ($requeued > 0 || $failed > 0) {
+            $this->em->flush();
+        }
+
+        return ['requeued' => $requeued, 'failed' => $failed];
+    }
+
+    /**
+     * A user's most recent jobs, newest first (web "waiting/failed" card).
+     *
+     * @return list<DesktopJob>
+     */
+    public function recentForOwner(int $ownerId, int $limit = 50): array
+    {
+        return $this->jobRepository->findRecentByOwner($ownerId, $limit);
+    }
+
+    /**
+     * A single owner-scoped job, or null when it does not exist / belongs to
+     * another user (the caller turns null into a 404).
+     */
+    public function findOwnedJob(int $id, int $ownerId): ?DesktopJob
+    {
+        return $this->jobRepository->findOwnedById($id, $ownerId);
+    }
+
+    private static function generateLeaseToken(): string
+    {
+        return 'lt_'.bin2hex(random_bytes(24));
+    }
+}

--- a/backend/src/Service/Desktop/Exception/PairingException.php
+++ b/backend/src/Service/Desktop/Exception/PairingException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Desktop\Exception;
+
+/**
+ * Thrown when a pairing exchange cannot complete for a reason other than a
+ * bad/expired code — e.g. the owning user was deleted after the code was minted.
+ */
+final class PairingException extends \RuntimeException
+{
+}

--- a/backend/src/Service/Desktop/Exception/PairingLimitException.php
+++ b/backend/src/Service/Desktop/Exception/PairingLimitException.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Desktop\Exception;
+
+/**
+ * Thrown when a user hits a pairing-code rate limit (too many outstanding
+ * codes, or too many created within the hour). The controller maps this to a
+ * 429 without leaking which limit tripped beyond the message.
+ */
+final class PairingLimitException extends \RuntimeException
+{
+}

--- a/backend/src/Service/Desktop/Exception/ResultTooLargeException.php
+++ b/backend/src/Service/Desktop/Exception/ResultTooLargeException.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Desktop\Exception;
+
+/**
+ * Thrown when a device reports a result whose JSON payload exceeds the size cap.
+ * The result is untrusted input re-entering the account, so an oversized
+ * payload is refused rather than stored.
+ */
+final class ResultTooLargeException extends \RuntimeException
+{
+}

--- a/backend/src/Service/Desktop/PairingCodeService.php
+++ b/backend/src/Service/Desktop/PairingCodeService.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Desktop;
+
+use App\Service\Desktop\Exception\PairingLimitException;
+use App\Service\Infrastructure\RedisService;
+
+/**
+ * Short-lived pairing codes exchanged for a scoped desktop API key.
+ *
+ * Codes live in Redis with a TTL (never a table — checklist row 14): a signed-in
+ * user mints an 8-character code in the web UI, then types it into Synaplan
+ * Desktop, which exchanges it once for its key ({@see PairingService}).
+ *
+ * Redis layout (all keys under RedisService's own prefix):
+ *   desktop_pair:code:{CODE}      -> JSON {userId, expiresAt}, TTL 600s
+ *   desktop_pair:outstanding:{uid}-> SET of a user's still-valid codes
+ *                                    (self-healed on create; caps concurrency)
+ *   desktop_pair:hour:{uid}       -> counter, TTL 3600s (creates-per-hour cap)
+ *
+ * The code alphabet excludes visually ambiguous characters (0/O, 1/I/L) so a
+ * user can read one off a screen and type it without mistakes.
+ */
+final readonly class PairingCodeService
+{
+    public const CODE_TTL_SECONDS = 600;
+    private const MAX_OUTSTANDING = 5;
+    private const MAX_PER_HOUR = 20;
+    private const CODE_LENGTH = 8;
+
+    /** Crockford-ish alphabet without 0/O/1/I/L/U. */
+    private const ALPHABET = '23456789ABCDEFGHJKMNPQRSTVWXYZ';
+
+    private const CODE_PREFIX = 'desktop_pair:code:';
+    private const OUTSTANDING_PREFIX = 'desktop_pair:outstanding:';
+    private const HOUR_PREFIX = 'desktop_pair:hour:';
+
+    public function __construct(
+        private RedisService $redis,
+    ) {
+    }
+
+    /**
+     * Mint a one-time pairing code for a signed-in user.
+     *
+     * @return array{code: string, expiresAt: int}
+     *
+     * @throws PairingLimitException when an outstanding-code or per-hour limit is hit
+     */
+    public function create(int $userId): array
+    {
+        if ($this->countOutstanding($userId) >= self::MAX_OUTSTANDING) {
+            throw new PairingLimitException('Too many outstanding pairing codes. Use or cancel an existing one and try again.');
+        }
+
+        $hourKey = self::HOUR_PREFIX.$userId;
+        $created = $this->redis->increment($hourKey);
+        if (1 === $created) {
+            $this->redis->expire($hourKey, 3600);
+        }
+        if (null !== $created && $created > self::MAX_PER_HOUR) {
+            throw new PairingLimitException('Too many pairing codes created in the last hour. Please wait before creating more.');
+        }
+
+        $code = $this->generateUniqueCode();
+        $expiresAt = time() + self::CODE_TTL_SECONDS;
+
+        $payload = json_encode(['userId' => $userId, 'expiresAt' => $expiresAt], \JSON_UNESCAPED_SLASHES);
+        if (false === $payload) {
+            throw new \RuntimeException('Failed to encode pairing code payload.');
+        }
+
+        $this->redis->set(self::CODE_PREFIX.$code, $payload, self::CODE_TTL_SECONDS);
+
+        $outstandingKey = self::OUTSTANDING_PREFIX.$userId;
+        $this->redis->sAdd($outstandingKey, $code);
+        $this->redis->expire($outstandingKey, self::CODE_TTL_SECONDS);
+
+        return ['code' => $code, 'expiresAt' => $expiresAt];
+    }
+
+    /**
+     * Consume a pairing code, returning the owning user id — or null if the code
+     * is unknown, expired, or already used. One-time: a successful consume
+     * deletes the code so it cannot be replayed.
+     */
+    public function consume(string $code): ?int
+    {
+        $normalized = self::normalize($code);
+        if ('' === $normalized) {
+            return null;
+        }
+
+        $raw = $this->redis->get(self::CODE_PREFIX.$normalized);
+        if (null === $raw) {
+            return null;
+        }
+
+        $decoded = json_decode($raw, true);
+        if (!is_array($decoded) || !isset($decoded['userId'])) {
+            $this->redis->delete(self::CODE_PREFIX.$normalized);
+
+            return null;
+        }
+
+        $userId = (int) $decoded['userId'];
+        $expiresAt = (int) ($decoded['expiresAt'] ?? 0);
+
+        // One-time: remove before returning so a race cannot pair twice.
+        $this->redis->delete(self::CODE_PREFIX.$normalized);
+        $this->redis->sRem(self::OUTSTANDING_PREFIX.$userId, $normalized);
+
+        if ($expiresAt > 0 && $expiresAt < time()) {
+            return null;
+        }
+
+        return $userId > 0 ? $userId : null;
+    }
+
+    /**
+     * Count a user's still-valid codes, self-healing set entries whose code key
+     * already expired (Redis sets do not expire members individually).
+     */
+    private function countOutstanding(int $userId): int
+    {
+        $outstandingKey = self::OUTSTANDING_PREFIX.$userId;
+        $count = 0;
+        foreach ($this->redis->sMembers($outstandingKey) as $code) {
+            if ($this->redis->exists(self::CODE_PREFIX.$code)) {
+                ++$count;
+            } else {
+                $this->redis->sRem($outstandingKey, $code);
+            }
+        }
+
+        return $count;
+    }
+
+    private function generateUniqueCode(): string
+    {
+        for ($attempt = 0; $attempt < 10; ++$attempt) {
+            $code = self::randomCode();
+            if (!$this->redis->exists(self::CODE_PREFIX.$code)) {
+                return $code;
+            }
+        }
+
+        throw new \RuntimeException('Failed to generate a unique pairing code.');
+    }
+
+    private static function randomCode(): string
+    {
+        $max = \strlen(self::ALPHABET) - 1;
+        $code = '';
+        for ($i = 0; $i < self::CODE_LENGTH; ++$i) {
+            $code .= self::ALPHABET[random_int(0, $max)];
+        }
+
+        return $code;
+    }
+
+    private static function normalize(string $code): string
+    {
+        // Uppercase and keep only alphabet characters, so spaces or dashes the
+        // user might type between groups are ignored. Codes are generated
+        // exclusively from the alphabet, so no look-alike folding is needed.
+        $upper = strtoupper(trim($code));
+        $out = preg_replace('/[^'.preg_quote(self::ALPHABET, '/').']/', '', $upper);
+
+        return \is_string($out) ? $out : '';
+    }
+}

--- a/backend/src/Service/Desktop/PairingService.php
+++ b/backend/src/Service/Desktop/PairingService.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Desktop;
+
+use App\Entity\ApiKey;
+use App\Entity\DesktopDevice;
+use App\Entity\User;
+use App\Repository\ApiKeyRepository;
+use App\Repository\DesktopDeviceRepository;
+use App\Repository\UserRepository;
+use App\Security\ApiKeyScope;
+use App\Service\Desktop\Exception\PairingException;
+
+/**
+ * Mints (and revokes) the scoped API key that binds a paired computer to a
+ * Synaplan account.
+ *
+ * The key is created with exactly {@see ApiKeyScope::pairingScopes()} — narrow
+ * by construction — and returned once. After that it lives only in the client's
+ * OS secret store; the server never shows it again.
+ */
+final readonly class PairingService
+{
+    public function __construct(
+        private ApiKeyRepository $apiKeyRepository,
+        private DesktopDeviceRepository $deviceRepository,
+        private UserRepository $userRepository,
+        private string $appUrl,
+    ) {
+    }
+
+    /**
+     * Exchange a validated pairing (userId already resolved from the code) for a
+     * scoped key and a device row.
+     *
+     * @param array<int|string, mixed> $capabilities capabilities the device declares (v1: `skill.run`); untrusted JSON, sanitized here
+     *
+     * @return array{deviceId: int, key: string, apiBaseUrl: string}
+     *
+     * @throws PairingException when the owning user no longer exists
+     */
+    public function pair(int $userId, string $deviceName, array $capabilities): array
+    {
+        // BAPIKEYS.BOWNERID is the join column of the owner relation, so the key
+        // must be bound via setOwner() (a bare setOwnerId() writes NULL).
+        $owner = $this->userRepository->find($userId);
+        if (!$owner instanceof User) {
+            throw new PairingException(\sprintf('Cannot pair: user %d no longer exists.', $userId));
+        }
+
+        $name = self::sanitizeDeviceName($deviceName);
+
+        // sk_ (3) + 58 hex chars = 61 chars (fits VARCHAR(64)) — same shape as
+        // the manually-created keys in ApiKeyController.
+        $keyValue = 'sk_'.bin2hex(random_bytes(29));
+
+        $apiKey = (new ApiKey())
+            ->setOwner($owner)
+            ->setKey($keyValue)
+            ->setName('Desktop — '.$name)
+            ->setStatus('active')
+            ->setScopes(ApiKeyScope::pairingScopes());
+
+        $this->apiKeyRepository->save($apiKey);
+
+        $device = (new DesktopDevice())
+            ->setOwnerId($userId)
+            ->setName($name)
+            ->setApiKeyId((int) $apiKey->getId())
+            ->setStatus(DesktopDevice::STATUS_ACTIVE)
+            ->setCapabilities(self::sanitizeCapabilities($capabilities));
+
+        $this->deviceRepository->save($device);
+
+        return [
+            'deviceId' => (int) $device->getId(),
+            'key' => $keyValue,
+            'apiBaseUrl' => rtrim($this->appUrl, '/'),
+        ];
+    }
+
+    /**
+     * Revoke a device: delete its API key (so the next request 401s) and flag
+     * the device row `revoked`. Idempotent — a missing key is fine.
+     */
+    public function revoke(DesktopDevice $device): void
+    {
+        $apiKey = $this->apiKeyRepository->find($device->getApiKeyId());
+        if ($apiKey instanceof ApiKey) {
+            $this->apiKeyRepository->remove($apiKey, false);
+        }
+
+        $device->setStatus(DesktopDevice::STATUS_REVOKED);
+        $this->deviceRepository->save($device);
+    }
+
+    private static function sanitizeDeviceName(string $name): string
+    {
+        $clean = trim(preg_replace('/[\x00-\x1F\x7F]+/u', ' ', $name) ?? '');
+        $clean = trim(preg_replace('/\s+/u', ' ', $clean) ?? '');
+
+        if ('' === $clean) {
+            $clean = 'Computer';
+        }
+
+        return mb_substr($clean, 0, 128);
+    }
+
+    /**
+     * @param array<int|string, mixed> $capabilities
+     *
+     * @return list<string>
+     */
+    private static function sanitizeCapabilities(array $capabilities): array
+    {
+        $out = [];
+        foreach ($capabilities as $capability) {
+            if (!\is_string($capability)) {
+                continue;
+            }
+            $trimmed = trim($capability);
+            if ('' !== $trimmed && preg_match('/^[a-z0-9._-]{1,64}$/', $trimmed)) {
+                $out[] = $trimmed;
+            }
+        }
+
+        return array_values(array_unique($out));
+    }
+}

--- a/backend/tests/Controller/DesktopControllerTest.php
+++ b/backend/tests/Controller/DesktopControllerTest.php
@@ -1,0 +1,262 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Controller;
+
+use App\Entity\ApiKey;
+use App\Entity\DesktopDevice;
+use App\Entity\User;
+use App\Repository\ConfigRepository;
+use App\Security\ApiKeyScope;
+use App\Service\Desktop\DesktopAgentConfig;
+use App\Tests\Trait\AuthenticatedTestTrait;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Functional coverage of the desktop pairing + job REST surface: flag-gating
+ * (404 when off, C8), ownership isolation (another user's device is 404), and
+ * the pair → device → revoke lifecycle.
+ */
+final class DesktopControllerTest extends WebTestCase
+{
+    use AuthenticatedTestTrait;
+
+    private KernelBrowser $client;
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        self::ensureKernelShutdown();
+        $this->client = static::createClient();
+        $this->em = static::getContainer()->get('doctrine')->getManager();
+    }
+
+    private function enableFlag(): void
+    {
+        static::getContainer()->get(ConfigRepository::class)
+            ->setValue(0, DesktopAgentConfig::CONFIG_GROUP, DesktopAgentConfig::KEY_ENABLED, '1');
+        $this->em->flush();
+    }
+
+    public function testCreatePairingCodeIs404WhenFlagOff(): void
+    {
+        $user = $this->createUser('desktop-rest-off@synaplan.internal');
+        $this->authenticateClient($this->client, $user);
+
+        $this->client->request('POST', '/api/v1/desktop/pairing-codes');
+
+        self::assertSame(Response::HTTP_NOT_FOUND, $this->client->getResponse()->getStatusCode());
+    }
+
+    public function testEnqueueJobIs404WhenFlagOff(): void
+    {
+        $user = $this->createUser('desktop-rest-enq-off@synaplan.internal');
+        $this->authenticateClient($this->client, $user);
+
+        $this->postJson('/api/v1/desktop/jobs', ['type' => 'skill.run', 'input' => ['skill' => 'pptx']]);
+
+        self::assertSame(Response::HTTP_NOT_FOUND, $this->client->getResponse()->getStatusCode());
+    }
+
+    public function testPairExchangeMintsScopedKeyAndDevice(): void
+    {
+        $this->enableFlag();
+        $user = $this->createUser('desktop-rest-pair@synaplan.internal');
+        $this->authenticateClient($this->client, $user);
+
+        $this->client->request('POST', '/api/v1/desktop/pairing-codes');
+        self::assertSame(Response::HTTP_CREATED, $this->client->getResponse()->getStatusCode());
+        $code = $this->json()['code'];
+        self::assertNotEmpty($code);
+
+        // The /pair exchange is unauthenticated (a fresh client has no cookie).
+        $this->client->getCookieJar()->clear();
+        $this->postJson('/api/v1/desktop/pair', ['code' => $code, 'deviceName' => 'CI laptop', 'capabilities' => ['skill.run']]);
+
+        self::assertSame(Response::HTTP_CREATED, $this->client->getResponse()->getStatusCode());
+        $body = $this->json();
+        self::assertStringStartsWith('sk_', $body['key']);
+        self::assertGreaterThan(0, $body['deviceId']);
+
+        $device = $this->em->getRepository(DesktopDevice::class)->find($body['deviceId']);
+        self::assertInstanceOf(DesktopDevice::class, $device);
+        self::assertSame((int) $user->getId(), $device->getOwnerId());
+
+        $apiKey = $this->em->getRepository(ApiKey::class)->findOneBy(['key' => $body['key']]);
+        self::assertInstanceOf(ApiKey::class, $apiKey);
+        self::assertSame(ApiKeyScope::pairingScopes(), $apiKey->getScopes());
+        self::assertTrue(ApiKeyScope::isRestricted($apiKey->getScopes()));
+    }
+
+    public function testPairWithInvalidCodeReturns400(): void
+    {
+        $this->enableFlag();
+
+        $this->postJson('/api/v1/desktop/pair', ['code' => 'ZZZZZZZZ']);
+
+        self::assertSame(Response::HTTP_BAD_REQUEST, $this->client->getResponse()->getStatusCode());
+    }
+
+    public function testEnqueueForOwnDeviceSucceeds(): void
+    {
+        $this->enableFlag();
+        $user = $this->createUser('desktop-rest-own@synaplan.internal');
+        $device = $this->createDevice($user);
+        $this->authenticateClient($this->client, $user);
+
+        $this->postJson('/api/v1/desktop/jobs', [
+            'deviceId' => $device->getId(),
+            'type' => 'skill.run',
+            'input' => ['skill' => 'pptx', 'prompt' => 'Make slides'],
+        ]);
+
+        self::assertSame(Response::HTTP_CREATED, $this->client->getResponse()->getStatusCode());
+        $body = $this->json();
+        self::assertTrue($body['success']);
+        self::assertSame('queued', $body['status']);
+    }
+
+    public function testEnqueueForOtherUsersDeviceReturns404(): void
+    {
+        $this->enableFlag();
+        $owner = $this->createUser('desktop-rest-owner@synaplan.internal');
+        $device = $this->createDevice($owner);
+
+        $attacker = $this->createUser('desktop-rest-attacker@synaplan.internal');
+        $this->authenticateClient($this->client, $attacker);
+
+        $this->postJson('/api/v1/desktop/jobs', [
+            'deviceId' => $device->getId(),
+            'type' => 'skill.run',
+            'input' => ['skill' => 'pptx'],
+        ]);
+
+        self::assertSame(Response::HTTP_NOT_FOUND, $this->client->getResponse()->getStatusCode());
+    }
+
+    public function testEnqueueRejectsInvalidSkillName(): void
+    {
+        $this->enableFlag();
+        $user = $this->createUser('desktop-rest-badskill@synaplan.internal');
+        $this->authenticateClient($this->client, $user);
+
+        $this->postJson('/api/v1/desktop/jobs', ['type' => 'skill.run', 'input' => ['skill' => 'Not A Skill!']]);
+
+        self::assertSame(Response::HTTP_BAD_REQUEST, $this->client->getResponse()->getStatusCode());
+    }
+
+    public function testEnqueueRejectsUnknownType(): void
+    {
+        $this->enableFlag();
+        $user = $this->createUser('desktop-rest-badtype@synaplan.internal');
+        $this->authenticateClient($this->client, $user);
+
+        $this->postJson('/api/v1/desktop/jobs', ['type' => 'shell.exec', 'input' => ['skill' => 'pptx']]);
+
+        self::assertSame(Response::HTTP_BAD_REQUEST, $this->client->getResponse()->getStatusCode());
+    }
+
+    public function testListAndRevokeDevice(): void
+    {
+        $this->enableFlag();
+        $user = $this->createUser('desktop-rest-revoke@synaplan.internal');
+        $device = $this->createDevice($user);
+        $this->authenticateClient($this->client, $user);
+
+        $this->client->request('GET', '/api/v1/desktop/devices');
+        self::assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        $devices = $this->json()['devices'];
+        self::assertCount(1, $devices);
+        self::assertSame((int) $device->getId(), $devices[0]['id']);
+
+        $this->client->request('DELETE', '/api/v1/desktop/devices/'.$device->getId());
+        self::assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+
+        $this->em->clear();
+        $reloaded = $this->em->getRepository(DesktopDevice::class)->find($device->getId());
+        self::assertInstanceOf(DesktopDevice::class, $reloaded);
+        self::assertSame(DesktopDevice::STATUS_REVOKED, $reloaded->getStatus());
+        // The backing key is gone, so the laptop's next request 401s.
+        self::assertNull($this->em->getRepository(ApiKey::class)->find($device->getApiKeyId()));
+    }
+
+    public function testRevokeOtherUsersDeviceReturns404(): void
+    {
+        $this->enableFlag();
+        $owner = $this->createUser('desktop-rest-rev-owner@synaplan.internal');
+        $device = $this->createDevice($owner);
+
+        $attacker = $this->createUser('desktop-rest-rev-attacker@synaplan.internal');
+        $this->authenticateClient($this->client, $attacker);
+
+        $this->client->request('DELETE', '/api/v1/desktop/devices/'.$device->getId());
+
+        self::assertSame(Response::HTTP_NOT_FOUND, $this->client->getResponse()->getStatusCode());
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function postJson(string $uri, array $payload): void
+    {
+        $this->client->request('POST', $uri, server: ['CONTENT_TYPE' => 'application/json'], content: (string) json_encode($payload));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function json(): array
+    {
+        $decoded = json_decode((string) $this->client->getResponse()->getContent(), true);
+        self::assertIsArray($decoded, 'Response was not JSON: '.$this->client->getResponse()->getContent());
+
+        return $decoded;
+    }
+
+    private function createUser(string $email): User
+    {
+        $existing = $this->em->getRepository(User::class)->findOneBy(['mail' => $email]);
+        if ($existing instanceof User) {
+            return $existing;
+        }
+
+        $user = (new User())
+            ->setMail($email)
+            ->setType('WEB')
+            ->setProviderId('desktop-rest-'.uniqid())
+            ->setUserLevel('NEW');
+        $user->setCreated(date('YmdHis'));
+        $user->setEmailVerified(true);
+        $this->em->persist($user);
+        $this->em->flush();
+
+        return $user;
+    }
+
+    private function createDevice(User $owner): DesktopDevice
+    {
+        $apiKey = (new ApiKey())
+            ->setOwner($owner)
+            ->setKey('sk_'.bin2hex(random_bytes(20)))
+            ->setStatus('active')
+            ->setName('Desktop test key')
+            ->setScopes(ApiKeyScope::pairingScopes());
+        $this->em->persist($apiKey);
+        $this->em->flush();
+
+        $device = (new DesktopDevice())
+            ->setOwnerId((int) $owner->getId())
+            ->setName('Owned laptop')
+            ->setApiKeyId((int) $apiKey->getId())
+            ->setStatus(DesktopDevice::STATUS_ACTIVE)
+            ->setCapabilities(['skill.run']);
+        $this->em->persist($device);
+        $this->em->flush();
+
+        return $device;
+    }
+}

--- a/backend/tests/Controller/DesktopMcpCheckinTest.php
+++ b/backend/tests/Controller/DesktopMcpCheckinTest.php
@@ -1,0 +1,294 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Controller;
+
+use App\Entity\ApiKey;
+use App\Entity\Chat;
+use App\Entity\DesktopDevice;
+use App\Entity\User;
+use App\Repository\ConfigRepository;
+use App\Security\ApiKeyScope;
+use App\Service\Desktop\DesktopAgentConfig;
+use App\Service\Desktop\DesktopJobStore;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+/**
+ * End-to-end coverage of the desktop check-in loop over the real MCP endpoint:
+ * a scoped key + device sees the two agent tools (flag on), leases an enqueued
+ * job, reports a result, and — critically — a normal key or a flag-off instance
+ * does NOT see the tools (invariants C2 + C8).
+ */
+final class DesktopMcpCheckinTest extends WebTestCase
+{
+    private const PROTOCOL_VERSION = '2025-11-25';
+    private const DESKTOP_KEY = 'sk_desktop_checkin_test_key_00000000000001';
+    private const PLAIN_KEY = 'sk_plain_mcp_test_key_00000000000000000002';
+
+    private KernelBrowser $client;
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        self::ensureKernelShutdown();
+        $this->client = static::createClient();
+        $this->em = static::getContainer()->get('doctrine')->getManager();
+    }
+
+    private function enableFlag(): void
+    {
+        static::getContainer()->get(ConfigRepository::class)
+            ->setValue(0, DesktopAgentConfig::CONFIG_GROUP, DesktopAgentConfig::KEY_ENABLED, '1');
+        $this->em->flush();
+    }
+
+    public function testDesktopToolsPresentForPairedDeviceWhenFlagOn(): void
+    {
+        $this->client->disableReboot();
+        $this->enableFlag();
+        $this->createUserWithDesktopKey('desktop-mcp-a@synaplan.internal', self::DESKTOP_KEY);
+
+        $tools = $this->toolNames(self::DESKTOP_KEY);
+
+        self::assertContains('agent_checkin', $tools);
+        self::assertContains('agent_report_result', $tools);
+        // Superset, not a replacement (C2): the base tools stay.
+        self::assertContains('synaplan_chat', $tools);
+        self::assertContains('rag_search', $tools);
+    }
+
+    public function testDesktopToolsAbsentForPlainKeyEvenWhenFlagOn(): void
+    {
+        $this->client->disableReboot();
+        $this->enableFlag();
+        $this->createUserWithApiKey('desktop-mcp-plain@synaplan.internal', self::PLAIN_KEY, scoped: false, withDevice: false);
+
+        $tools = $this->toolNames(self::PLAIN_KEY);
+
+        self::assertNotContains('agent_checkin', $tools);
+        self::assertNotContains('agent_report_result', $tools);
+        self::assertContains('synaplan_chat', $tools);
+    }
+
+    public function testDesktopToolsAbsentWhenFlagOff(): void
+    {
+        $this->client->disableReboot();
+        // Flag stays off (no enableFlag()).
+        $this->createUserWithDesktopKey('desktop-mcp-off@synaplan.internal', self::DESKTOP_KEY);
+
+        $tools = $this->toolNames(self::DESKTOP_KEY);
+
+        self::assertNotContains('agent_checkin', $tools);
+        self::assertNotContains('agent_report_result', $tools);
+    }
+
+    public function testCheckinLeasesEnqueuedJobAndReportPostsCompletion(): void
+    {
+        $this->client->disableReboot();
+        $this->enableFlag();
+        [$user, $device] = $this->createUserWithDesktopKey('desktop-mcp-loop@synaplan.internal', self::DESKTOP_KEY);
+
+        $chat = (new Chat())->setUserId((int) $user->getId())->setSource('web')->setTitle('Desktop job');
+        $this->em->persist($chat);
+        $this->em->flush();
+
+        $store = static::getContainer()->get(DesktopJobStore::class);
+        $job = $store->enqueueSkillRun((int) $user->getId(), (int) $device->getId(), 'hello-files', 'do it', [], (int) $chat->getId());
+
+        $sessionId = $this->initialize(self::DESKTOP_KEY);
+
+        // First check-in leases the job.
+        $checkin = $this->callTool($sessionId, 'agent_checkin', ['protocol' => 1, 'capabilities' => ['skill.run'], 'enabledSkills' => ['hello-files']], 10);
+        $sc = $checkin['result']['structuredContent'] ?? null;
+        self::assertIsArray($sc, json_encode($checkin));
+        self::assertSame(1, $sc['protocol']);
+        self::assertCount(1, $sc['jobs']);
+        self::assertSame((int) $job->getId(), $sc['jobs'][0]['jobId']);
+        self::assertSame(['skill', 'prompt', 'fileIds'], array_keys($sc['jobs'][0]['input']));
+        $leaseToken = $sc['jobs'][0]['leaseToken'];
+        self::assertNotEmpty($leaseToken);
+
+        // Second check-in while leased → no jobs.
+        $checkin2 = $this->callTool($sessionId, 'agent_checkin', ['protocol' => 1], 11);
+        self::assertCount(0, $checkin2['result']['structuredContent']['jobs']);
+
+        // Report success.
+        $report = $this->callTool($sessionId, 'agent_report_result', [
+            'leaseToken' => $leaseToken,
+            'status' => 'succeeded',
+            'result' => ['summary' => 'made it', 'fileIds' => [123]],
+        ], 12);
+        $rsc = $report['result']['structuredContent'] ?? null;
+        self::assertIsArray($rsc, json_encode($report));
+        self::assertTrue($rsc['success']);
+        self::assertSame('succeeded', $rsc['status']);
+
+        // A completion note was posted into the chat.
+        $messages = $this->em->getRepository(\App\Entity\Message::class)
+            ->findBy(['chatId' => (int) $chat->getId(), 'direction' => 'OUT']);
+        self::assertNotEmpty($messages, 'a completion note must be posted into the originating chat');
+    }
+
+    public function testReportWithWrongLeaseTokenIsToolError(): void
+    {
+        $this->client->disableReboot();
+        $this->enableFlag();
+        $this->createUserWithDesktopKey('desktop-mcp-badtoken@synaplan.internal', self::DESKTOP_KEY);
+
+        $sessionId = $this->initialize(self::DESKTOP_KEY);
+        $report = $this->callTool($sessionId, 'agent_report_result', [
+            'leaseToken' => 'lt_does_not_exist',
+            'status' => 'succeeded',
+        ], 20);
+
+        self::assertTrue($report['result']['isError'] ?? false, json_encode($report));
+    }
+
+    public function testUnknownProtocolReturnsNoJobsAndFarNextCall(): void
+    {
+        $this->client->disableReboot();
+        $this->enableFlag();
+        [$user, $device] = $this->createUserWithDesktopKey('desktop-mcp-proto@synaplan.internal', self::DESKTOP_KEY);
+
+        $store = static::getContainer()->get(DesktopJobStore::class);
+        $store->enqueueSkillRun((int) $user->getId(), (int) $device->getId(), 'hello-files', 'x');
+
+        $sessionId = $this->initialize(self::DESKTOP_KEY);
+        $checkin = $this->callTool($sessionId, 'agent_checkin', ['protocol' => 999], 30);
+        $sc = $checkin['result']['structuredContent'];
+
+        self::assertSame(1, $sc['protocol']);
+        self::assertCount(0, $sc['jobs'], 'an unknown protocol must never be handed work');
+        self::assertGreaterThan(time() + 600, $sc['next_call_at'], 'unknown protocol should defer far into the future');
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function toolNames(string $apiKey): array
+    {
+        $sessionId = $this->initialize($apiKey);
+        $result = $this->jsonRpc([
+            'jsonrpc' => '2.0',
+            'id' => 2,
+            'method' => 'tools/list',
+            'params' => new \stdClass(),
+        ], $sessionId, $apiKey);
+
+        self::assertArrayHasKey('result', $result, json_encode($result));
+
+        return array_map(static fn (array $t): string => $t['name'], $result['result']['tools']);
+    }
+
+    /**
+     * @param array<string, mixed> $arguments
+     *
+     * @return array<string, mixed>
+     */
+    private function callTool(string $sessionId, string $name, array $arguments, int $id): array
+    {
+        return $this->jsonRpc([
+            'jsonrpc' => '2.0',
+            'id' => $id,
+            'method' => 'tools/call',
+            'params' => ['name' => $name, 'arguments' => [] === $arguments ? new \stdClass() : $arguments],
+        ], $sessionId, self::DESKTOP_KEY);
+    }
+
+    private function initialize(string $apiKey): string
+    {
+        $result = $this->jsonRpc([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'initialize',
+            'params' => [
+                'protocolVersion' => self::PROTOCOL_VERSION,
+                'capabilities' => new \stdClass(),
+                'clientInfo' => ['name' => 'phpunit-desktop', 'version' => '1.0.0'],
+            ],
+        ], null, $apiKey);
+
+        self::assertArrayHasKey('result', $result, json_encode($result));
+
+        return (string) $this->client->getResponse()->headers->get('Mcp-Session-Id');
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     *
+     * @return array<string, mixed>
+     */
+    private function jsonRpc(array $payload, ?string $sessionId, string $apiKey): array
+    {
+        $server = [
+            'CONTENT_TYPE' => 'application/json',
+            'HTTP_ACCEPT' => 'application/json, text/event-stream',
+            'HTTP_X_API_KEY' => $apiKey,
+            'HTTP_MCP_PROTOCOL_VERSION' => self::PROTOCOL_VERSION,
+        ];
+        if (null !== $sessionId) {
+            $server['HTTP_MCP_SESSION_ID'] = $sessionId;
+        }
+
+        $this->client->request('POST', '/mcp', server: $server, content: (string) json_encode($payload));
+
+        $decoded = json_decode((string) $this->client->getResponse()->getContent(), true);
+        self::assertIsArray($decoded, 'MCP response was not valid JSON: '.$this->client->getResponse()->getContent());
+
+        return $decoded;
+    }
+
+    /**
+     * @return array{0: User, 1: DesktopDevice}
+     */
+    private function createUserWithDesktopKey(string $email, string $key): array
+    {
+        $user = $this->createUserWithApiKey($email, $key, scoped: true, withDevice: true);
+        $device = $this->em->getRepository(DesktopDevice::class)->findOneBy(['ownerId' => (int) $user->getId()]);
+        self::assertInstanceOf(DesktopDevice::class, $device);
+
+        return [$user, $device];
+    }
+
+    private function createUserWithApiKey(string $email, string $key, bool $scoped, bool $withDevice): User
+    {
+        $userRepo = $this->em->getRepository(User::class);
+        $user = $userRepo->findOneBy(['mail' => $email]);
+        if (null === $user) {
+            $user = (new User())
+                ->setMail($email)
+                ->setType('WEB')
+                ->setProviderId('desktop-mcp-test-'.uniqid())
+                ->setUserLevel('NEW');
+            $user->setCreated(date('YmdHis'));
+            $user->setEmailVerified(true);
+            $this->em->persist($user);
+            $this->em->flush();
+        }
+
+        $apiKey = (new ApiKey())
+            ->setOwner($user)
+            ->setKey($key)
+            ->setStatus('active')
+            ->setName('Desktop MCP Test')
+            ->setScopes($scoped ? ApiKeyScope::pairingScopes() : []);
+        $this->em->persist($apiKey);
+        $this->em->flush();
+
+        if ($withDevice) {
+            $device = (new DesktopDevice())
+                ->setOwnerId((int) $user->getId())
+                ->setName('Test laptop')
+                ->setApiKeyId((int) $apiKey->getId())
+                ->setStatus(DesktopDevice::STATUS_ACTIVE)
+                ->setCapabilities(['skill.run']);
+            $this->em->persist($device);
+            $this->em->flush();
+        }
+
+        return $user;
+    }
+}

--- a/backend/tests/Fixtures/Desktop/checkin_request.json
+++ b/backend/tests/Fixtures/Desktop/checkin_request.json
@@ -1,0 +1,7 @@
+{
+  "protocol": 1,
+  "agentKind": "synaplan-desktop",
+  "capabilities": ["skill.run"],
+  "enabledSkills": ["hello-files", "pptx"],
+  "status": "idle"
+}

--- a/backend/tests/Fixtures/Desktop/checkin_response.json
+++ b/backend/tests/Fixtures/Desktop/checkin_response.json
@@ -1,0 +1,18 @@
+{
+  "protocol": 1,
+  "jobs": [
+    {
+      "jobId": 1,
+      "type": "skill.run",
+      "input": {
+        "skill": "hello-files",
+        "prompt": "List the files in my Documents folder",
+        "fileIds": []
+      },
+      "leaseToken": "lt_0000000000000000000000000000000000000000000000000000",
+      "leaseExpires": 1788126300,
+      "attempt": 1
+    }
+  ],
+  "next_call_at": 1788126030
+}

--- a/backend/tests/Fixtures/Desktop/enqueue_request.json
+++ b/backend/tests/Fixtures/Desktop/enqueue_request.json
@@ -1,0 +1,10 @@
+{
+  "deviceId": 1,
+  "type": "skill.run",
+  "input": {
+    "skill": "hello-files",
+    "prompt": "List the files in my Documents folder",
+    "fileIds": []
+  },
+  "chatId": 99
+}

--- a/backend/tests/Fixtures/Desktop/job_skill_run.json
+++ b/backend/tests/Fixtures/Desktop/job_skill_run.json
@@ -1,0 +1,12 @@
+{
+  "jobId": 1,
+  "type": "skill.run",
+  "input": {
+    "skill": "hello-files",
+    "prompt": "List the files in my Documents folder",
+    "fileIds": []
+  },
+  "leaseToken": "lt_0000000000000000000000000000000000000000000000000000",
+  "leaseExpires": 1788126300,
+  "attempt": 1
+}

--- a/backend/tests/Fixtures/Desktop/report_success.json
+++ b/backend/tests/Fixtures/Desktop/report_success.json
@@ -1,0 +1,8 @@
+{
+  "leaseToken": "lt_0000000000000000000000000000000000000000000000000000",
+  "status": "succeeded",
+  "result": {
+    "summary": "Listed 12 files in Documents.",
+    "fileIds": [42]
+  }
+}

--- a/backend/tests/Fixtures/Desktop/report_unknown_skill.json
+++ b/backend/tests/Fixtures/Desktop/report_unknown_skill.json
@@ -1,0 +1,8 @@
+{
+  "leaseToken": "lt_0000000000000000000000000000000000000000000000000000",
+  "status": "failed",
+  "errorCode": "unknown_skill",
+  "result": {
+    "message": "This computer does not have a skill named 'pptx'."
+  }
+}

--- a/backend/tests/Unit/Command/ReapDesktopJobsCommandTest.php
+++ b/backend/tests/Unit/Command/ReapDesktopJobsCommandTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Command;
+
+use App\Command\ReapDesktopJobsCommand;
+use App\Service\Desktop\DesktopAgentConfig;
+use App\Service\Desktop\DesktopJobStore;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Lock\SharedLockInterface;
+
+final class ReapDesktopJobsCommandTest extends TestCase
+{
+    private DesktopJobStore&MockObject $jobStore;
+    private DesktopAgentConfig&MockObject $config;
+    private LockFactory&MockObject $lockFactory;
+
+    protected function setUp(): void
+    {
+        $this->jobStore = $this->createMock(DesktopJobStore::class);
+        $this->config = $this->createMock(DesktopAgentConfig::class);
+        $this->lockFactory = $this->createMock(LockFactory::class);
+    }
+
+    public function testReaperIsInertWhenFeatureDisabled(): void
+    {
+        $this->config->method('isEnabled')->willReturn(false);
+        // Flag off means idle, not broken (C8): no lock, no work.
+        $this->lockFactory->expects(self::never())->method('createLock');
+        $this->jobStore->expects(self::never())->method('requeueExpiredLeases');
+
+        $tester = $this->runCommand();
+
+        self::assertSame(0, $tester->getStatusCode());
+        self::assertStringContainsString('disabled', $tester->getDisplay());
+    }
+
+    public function testReaperRequeuesWhenEnabled(): void
+    {
+        $this->config->method('isEnabled')->willReturn(true);
+
+        $lock = $this->createMock(SharedLockInterface::class);
+        $lock->method('acquire')->willReturn(true);
+        $this->lockFactory->method('createLock')->willReturn($lock);
+
+        $this->jobStore->expects(self::once())
+            ->method('requeueExpiredLeases')
+            ->willReturn(['requeued' => 2, 'failed' => 1]);
+
+        $tester = $this->runCommand();
+
+        self::assertSame(0, $tester->getStatusCode());
+        self::assertStringContainsString('Requeued 2', $tester->getDisplay());
+    }
+
+    public function testReaperSkipsWhenLockHeld(): void
+    {
+        $this->config->method('isEnabled')->willReturn(true);
+
+        $lock = $this->createMock(SharedLockInterface::class);
+        $lock->method('acquire')->willReturn(false);
+        $this->lockFactory->method('createLock')->willReturn($lock);
+
+        $this->jobStore->expects(self::never())->method('requeueExpiredLeases');
+
+        $tester = $this->runCommand();
+
+        self::assertSame(0, $tester->getStatusCode());
+        self::assertStringContainsString('still active', $tester->getDisplay());
+    }
+
+    private function runCommand(): CommandTester
+    {
+        $command = new ReapDesktopJobsCommand($this->jobStore, $this->config, $this->lockFactory);
+        $tester = new CommandTester($command);
+        $tester->execute([]);
+
+        return $tester;
+    }
+}

--- a/backend/tests/Unit/Controller/ConfigControllerPlannerModelTest.php
+++ b/backend/tests/Unit/Controller/ConfigControllerPlannerModelTest.php
@@ -87,6 +87,7 @@ final class ConfigControllerPlannerModelTest extends TestCase
             $this->createStub(GuestChatConfig::class),
             $this->createStub(WebSpeechConfig::class),
             $this->createStub(\App\Service\SavedTask\SavedTaskConfig::class),
+            $this->createStub(\App\Service\Desktop\DesktopAgentConfig::class),
             $this->createStub(ChatReadinessService::class),
             new DemoLoginHint(
                 $this->createStub(UserRepository::class),

--- a/backend/tests/Unit/Controller/ConfigControllerSaveDefaultModelsTest.php
+++ b/backend/tests/Unit/Controller/ConfigControllerSaveDefaultModelsTest.php
@@ -101,6 +101,7 @@ final class ConfigControllerSaveDefaultModelsTest extends TestCase
             $this->createStub(GuestChatConfig::class),
             $this->createStub(WebSpeechConfig::class),
             $this->createStub(\App\Service\SavedTask\SavedTaskConfig::class),
+            $this->createStub(\App\Service\Desktop\DesktopAgentConfig::class),
             $this->createStub(ChatReadinessService::class),
             new DemoLoginHint(
                 $this->createStub(UserRepository::class),

--- a/backend/tests/Unit/Controller/ConfigControllerSummaryModelTest.php
+++ b/backend/tests/Unit/Controller/ConfigControllerSummaryModelTest.php
@@ -92,6 +92,7 @@ final class ConfigControllerSummaryModelTest extends TestCase
             $this->createStub(GuestChatConfig::class),
             $this->createStub(WebSpeechConfig::class),
             $this->createStub(\App\Service\SavedTask\SavedTaskConfig::class),
+            $this->createStub(\App\Service\Desktop\DesktopAgentConfig::class),
             $this->createStub(ChatReadinessService::class),
             new DemoLoginHint(
                 $this->createStub(UserRepository::class),

--- a/backend/tests/Unit/Security/ApiKeyScopeTest.php
+++ b/backend/tests/Unit/Security/ApiKeyScopeTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Security;
+
+use App\Security\ApiKeyScope;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class ApiKeyScopeTest extends TestCase
+{
+    public function testEmptyScopesAreNotRestricted(): void
+    {
+        self::assertFalse(ApiKeyScope::isRestricted([]));
+    }
+
+    public function testWildcardIsNotRestricted(): void
+    {
+        self::assertFalse(ApiKeyScope::isRestricted(['*']));
+        self::assertFalse(ApiKeyScope::isRestricted(['desktop:messages', '*']));
+    }
+
+    /**
+     * @param list<string> $scopes
+     */
+    #[DataProvider('legacyWebhookLists')]
+    public function testLegacyWebhookOnlyListsAreNotRestricted(array $scopes): void
+    {
+        self::assertFalse(ApiKeyScope::isRestricted($scopes));
+    }
+
+    /**
+     * @return iterable<string, array{0: list<string>}>
+     */
+    public static function legacyWebhookLists(): iterable
+    {
+        yield 'webhooks:*' => [['webhooks:*']];
+        yield 'webhooks:email' => [['webhooks:email']];
+        yield 'webhooks:whatsapp' => [['webhooks:whatsapp']];
+        yield 'both webhook scopes' => [['webhooks:email', 'webhooks:whatsapp']];
+    }
+
+    public function testDesktopScopesAreRestricted(): void
+    {
+        self::assertTrue(ApiKeyScope::isRestricted(['desktop:messages']));
+        self::assertTrue(ApiKeyScope::isRestricted(ApiKeyScope::pairingScopes()));
+    }
+
+    public function testLegacyPlusDesktopIsRestricted(): void
+    {
+        self::assertTrue(ApiKeyScope::isRestricted(['webhooks:email', 'desktop:messages']));
+    }
+
+    public function testBlankStringsAreIgnored(): void
+    {
+        self::assertFalse(ApiKeyScope::isRestricted(['', '  ']));
+        self::assertFalse(ApiKeyScope::isRestricted([' * ']));
+    }
+
+    public function testPairingScopesAreExactlyTheFourDesktopScopes(): void
+    {
+        self::assertSame([
+            'desktop:messages',
+            'desktop:mcp',
+            'desktop:files',
+            'desktop:jobs',
+        ], ApiKeyScope::pairingScopes());
+    }
+
+    public function testWildcardAllowsEverything(): void
+    {
+        self::assertTrue(ApiKeyScope::allows(['*'], '/api/v1/admin/config/values'));
+        self::assertTrue(ApiKeyScope::allows(['*'], '/mcp'));
+    }
+
+    public function testDesktopMessagesReachesV1ButNotAdminOrMcp(): void
+    {
+        $scopes = ['desktop:messages'];
+
+        self::assertTrue(ApiKeyScope::allows($scopes, '/v1/models'));
+        self::assertTrue(ApiKeyScope::allows($scopes, '/v1/messages'));
+        self::assertFalse(ApiKeyScope::allows($scopes, '/mcp'));
+        self::assertFalse(ApiKeyScope::allows($scopes, '/api/v1/admin/config/values'));
+    }
+
+    public function testPairingKeyReachesItsFourSurfaces(): void
+    {
+        $scopes = ApiKeyScope::pairingScopes();
+
+        self::assertTrue(ApiKeyScope::allows($scopes, '/v1/messages'));
+        self::assertTrue(ApiKeyScope::allows($scopes, '/mcp'));
+        self::assertTrue(ApiKeyScope::allows($scopes, '/api/v1/desktop/jobs'));
+        self::assertTrue(ApiKeyScope::allows($scopes, '/api/v1/files/123/download'));
+    }
+
+    public function testPairingKeyCannotReachAdmin(): void
+    {
+        $scopes = ApiKeyScope::pairingScopes();
+
+        self::assertFalse(ApiKeyScope::allows($scopes, '/api/v1/admin/config/values'));
+        self::assertFalse(ApiKeyScope::allows($scopes, '/api/v1/users'));
+        self::assertFalse(ApiKeyScope::allows($scopes, '/api/v1/webhooks/email'));
+    }
+
+    public function testDesktopUmbrellaCoversEveryDesktopSurface(): void
+    {
+        $scopes = ['desktop:*'];
+
+        self::assertTrue(ApiKeyScope::allows($scopes, '/v1/messages'));
+        self::assertTrue(ApiKeyScope::allows($scopes, '/mcp'));
+        self::assertTrue(ApiKeyScope::allows($scopes, '/api/v1/desktop/jobs'));
+        self::assertTrue(ApiKeyScope::allows($scopes, '/api/v1/files'));
+        self::assertFalse(ApiKeyScope::allows($scopes, '/api/v1/admin/config/values'));
+    }
+
+    public function testJobsScopeDoesNotReachMessagesOrMcp(): void
+    {
+        $scopes = ['desktop:jobs'];
+
+        self::assertTrue(ApiKeyScope::allows($scopes, '/api/v1/desktop/jobs'));
+        self::assertFalse(ApiKeyScope::allows($scopes, '/v1/messages'));
+        self::assertFalse(ApiKeyScope::allows($scopes, '/mcp'));
+    }
+}

--- a/backend/tests/Unit/Service/Desktop/DesktopAgentConfigTest.php
+++ b/backend/tests/Unit/Service/Desktop/DesktopAgentConfigTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\Desktop;
+
+use App\Repository\ConfigRepository;
+use App\Service\Desktop\DesktopAgentConfig;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class DesktopAgentConfigTest extends TestCase
+{
+    private ConfigRepository&MockObject $configRepository;
+    private DesktopAgentConfig $config;
+
+    protected function setUp(): void
+    {
+        $this->configRepository = $this->createMock(ConfigRepository::class);
+        $this->config = new DesktopAgentConfig($this->configRepository);
+    }
+
+    public function testDefaultsOffWhenNoRowExists(): void
+    {
+        $this->configRepository->method('getValue')->willReturn(null);
+
+        self::assertFalse($this->config->isEnabled(42));
+        self::assertFalse($this->config->isEnabled(null));
+    }
+
+    public function testGlobalRowOverridesBuiltInDefault(): void
+    {
+        $this->configRepository->method('getValue')
+            ->willReturnCallback(static fn (int $ownerId): ?string => 0 === $ownerId ? '1' : null);
+
+        self::assertTrue($this->config->isEnabled(42));
+    }
+
+    public function testPerUserRowBeatsGlobal(): void
+    {
+        // User 1 has an explicit ON row; the global row is OFF.
+        $this->configRepository->method('getValue')
+            ->willReturnCallback(static fn (int $ownerId): string => 0 === $ownerId ? '0' : '1');
+
+        self::assertTrue($this->config->isEnabled(1));
+    }
+
+    public function testGlobalOffKeepsFeatureOffForUsersWithoutOverride(): void
+    {
+        $this->configRepository->method('getValue')
+            ->willReturnCallback(static fn (int $ownerId): ?string => 0 === $ownerId ? '0' : null);
+
+        self::assertFalse($this->config->isEnabled(7));
+    }
+
+    public function testAnonymousUserSkipsPerUserLookup(): void
+    {
+        $this->configRepository->expects(self::once())
+            ->method('getValue')
+            ->with(0, DesktopAgentConfig::CONFIG_GROUP, DesktopAgentConfig::KEY_ENABLED)
+            ->willReturn('1');
+
+        self::assertTrue($this->config->isEnabled(null));
+    }
+
+    public function testMalformedValueFallsBackToDefaultOff(): void
+    {
+        $this->configRepository->method('getValue')
+            ->willReturnCallback(static fn (int $ownerId): ?string => 0 === $ownerId ? 'garbage' : null);
+
+        self::assertFalse($this->config->isEnabled(1));
+    }
+}

--- a/backend/tests/Unit/Service/Desktop/DesktopContractFixturesTest.php
+++ b/backend/tests/Unit/Service/Desktop/DesktopContractFixturesTest.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\Desktop;
+
+use App\Entity\DesktopJob;
+use App\Mcp\McpServerFactory;
+use App\Service\Desktop\DesktopJobContract;
+use App\Service\Desktop\DesktopJobStore;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * DS18 — the committed contract fixtures under
+ * `_devextras/testing/desktop/fixtures/` are the frozen `protocol: 1` wire
+ * shapes the future desktop client vendors. This test asserts every fixture
+ * against the LIVE server contract ({@see DesktopJobContract}, the entity
+ * enums, and the MCP tool schemas), so a later server change that breaks the
+ * frozen contract fails the gate here rather than silently breaking a shipped
+ * client (invariant C9).
+ *
+ * If this test fails, the fix is almost never "edit the fixture": either the
+ * server drifted from `protocol: 1` (revert it) or the change is deliberate and
+ * needs a `protocol: 2` migration.
+ */
+final class DesktopContractFixturesTest extends TestCase
+{
+    /**
+     * The published, client-vendored copy (Phase B, DC3). It is the canonical
+     * home per the plan, but it lives at the repo root, which the dev backend
+     * container does not mount — so the test READS the in-backend mirror below
+     * and, whenever the canonical copy IS on disk (CI, host), asserts the two
+     * are byte-identical. Drift between them is therefore impossible.
+     */
+    private const CANONICAL_DIR = '/_devextras/testing/desktop/fixtures';
+
+    /** The mirror the container + CI both mount (`backend/` is always present). */
+    private const MIRROR_DIR = '/Fixtures/Desktop';
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function fixture(string $name): array
+    {
+        $mirror = \dirname(__DIR__, 3).self::MIRROR_DIR.'/'.$name;
+        self::assertFileExists($mirror, "Missing frozen fixture mirror: {$name}");
+
+        $raw = (string) file_get_contents($mirror);
+
+        // C9 drift guard: the client vendors the canonical copy, so the mirror
+        // the server test validates MUST be byte-identical to it.
+        $canonical = \dirname(__DIR__, 5).self::CANONICAL_DIR.'/'.$name;
+        if (is_file($canonical)) {
+            self::assertSame(
+                file_get_contents($canonical),
+                $raw,
+                "Fixture drift: backend/tests/Fixtures/Desktop/{$name} differs from the canonical _devextras copy the client vendors."
+            );
+        }
+
+        $decoded = json_decode($raw, true);
+        self::assertIsArray($decoded, "Fixture {$name} is not valid JSON");
+
+        return $decoded;
+    }
+
+    public function testCheckinRequestMatchesLiveSchema(): void
+    {
+        $req = $this->fixture('checkin_request.json');
+        $schema = McpServerFactory::agentCheckinSchema();
+
+        self::assertSame(DesktopJobContract::PROTOCOL_VERSION, $req['protocol']);
+        self::assertSame('synaplan-desktop', $req['agentKind']);
+
+        // capabilities must be job types the server knows.
+        foreach ($req['capabilities'] as $capability) {
+            self::assertContains($capability, DesktopJobContract::JOB_TYPES);
+        }
+
+        // Every fixture key exists in the frozen tool schema, which forbids extras.
+        self::assertFalse($schema['additionalProperties'] ?? true);
+        foreach (array_keys($req) as $key) {
+            self::assertArrayHasKey($key, $schema['properties'], "checkin_request has unknown key '{$key}'");
+        }
+    }
+
+    public function testCheckinResponseMatchesLiveContract(): void
+    {
+        $res = $this->fixture('checkin_response.json');
+
+        self::assertSame(DesktopJobContract::PROTOCOL_VERSION, $res['protocol']);
+        self::assertIsArray($res['jobs']);
+        self::assertIsInt($res['next_call_at']);
+
+        foreach ($res['jobs'] as $job) {
+            $this->assertJobMatchesDevicePayloadShape($job);
+        }
+    }
+
+    public function testStandaloneJobFixtureMatchesDevicePayload(): void
+    {
+        $this->assertJobMatchesDevicePayloadShape($this->fixture('job_skill_run.json'));
+    }
+
+    /**
+     * A job fixture must have EXACTLY the keys the live builder emits, and its
+     * input must be exactly the allowed keys — never a `command`/`script`/`argv`.
+     *
+     * @param array<string, mixed> $job
+     */
+    private function assertJobMatchesDevicePayloadShape(array $job): void
+    {
+        $reference = DesktopJobContract::buildDevicePayload(
+            (new DesktopJob())
+                ->setOwnerId(1)
+                ->setType(DesktopJob::TYPE_SKILL_RUN)
+                ->setLeaseToken('lt_x')
+                ->setInput(['skill' => 'x', 'prompt' => 'y', 'fileIds' => []])
+        );
+
+        self::assertSame(array_keys($reference), array_keys($job), 'job payload keys drifted from buildDevicePayload()');
+        self::assertSame(DesktopJobContract::ALLOWED_INPUT_KEYS, array_keys($job['input']));
+        self::assertContains($job['type'], DesktopJobContract::JOB_TYPES);
+        self::assertArrayNotHasKey('command', $job['input']);
+    }
+
+    public function testSuccessReportMatchesLiveSchema(): void
+    {
+        $report = $this->fixture('report_success.json');
+        $schema = McpServerFactory::agentReportResultSchema();
+
+        self::assertSame(DesktopJob::STATUS_SUCCEEDED, $report['status']);
+        self::assertContains($report['status'], [DesktopJob::STATUS_SUCCEEDED, DesktopJob::STATUS_FAILED]);
+
+        $this->assertReportKeysAndSize($report, $schema);
+    }
+
+    public function testUnknownSkillReportMatchesLiveSchema(): void
+    {
+        $report = $this->fixture('report_unknown_skill.json');
+        $schema = McpServerFactory::agentReportResultSchema();
+
+        self::assertSame(DesktopJob::STATUS_FAILED, $report['status']);
+        self::assertSame(DesktopJobContract::ERROR_UNKNOWN_SKILL, $report['errorCode']);
+        self::assertTrue(DesktopJobContract::isValidErrorCode($report['errorCode']));
+
+        $this->assertReportKeysAndSize($report, $schema);
+    }
+
+    /**
+     * @param array<string, mixed> $report
+     * @param array<string, mixed> $schema
+     */
+    private function assertReportKeysAndSize(array $report, array $schema): void
+    {
+        self::assertFalse($schema['additionalProperties'] ?? true);
+        foreach (array_keys($report) as $key) {
+            self::assertArrayHasKey($key, $schema['properties'], "report has unknown key '{$key}'");
+        }
+
+        if (isset($report['result'])) {
+            $encoded = (string) json_encode($report['result']);
+            self::assertLessThanOrEqual(DesktopJobStore::RESULT_MAX_BYTES, \strlen($encoded));
+        }
+    }
+
+    public function testEnqueueRequestMatchesLiveValidation(): void
+    {
+        $req = $this->fixture('enqueue_request.json');
+
+        // Mirrors DesktopController::enqueueJob validation, which is the live
+        // source of truth for the POST /jobs contract.
+        self::assertTrue(DesktopJobContract::isValidType($req['type']));
+        self::assertSame(1, preg_match('/^[a-z0-9-]{1,64}$/', $req['input']['skill']));
+
+        $allowedTopKeys = ['deviceId', 'type', 'input', 'chatId', 'messageId', 'idempotencyKey'];
+        foreach (array_keys($req) as $key) {
+            self::assertContains($key, $allowedTopKeys, "enqueue_request has unsupported key '{$key}'");
+        }
+
+        // input carries only the frozen keys (skill required).
+        foreach (array_keys($req['input']) as $key) {
+            self::assertContains($key, DesktopJobContract::ALLOWED_INPUT_KEYS, "enqueue input has non-contract key '{$key}'");
+        }
+    }
+
+    public function testEveryFixtureThatCarriesProtocolPinsToOne(): void
+    {
+        foreach (['checkin_request.json', 'checkin_response.json'] as $name) {
+            $data = $this->fixture($name);
+            self::assertSame(1, $data['protocol'], "{$name} must pin protocol: 1");
+        }
+    }
+}

--- a/backend/tests/Unit/Service/Desktop/DesktopJobContractTest.php
+++ b/backend/tests/Unit/Service/Desktop/DesktopJobContractTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\Desktop;
+
+use App\Entity\DesktopJob;
+use App\Service\Desktop\DesktopJobContract;
+use PHPUnit\Framework\TestCase;
+
+final class DesktopJobContractTest extends TestCase
+{
+    public function testProtocolVersionIsOne(): void
+    {
+        self::assertSame(1, DesktopJobContract::PROTOCOL_VERSION);
+    }
+
+    public function testOnlySkillRunTypeIsValid(): void
+    {
+        self::assertTrue(DesktopJobContract::isValidType('skill.run'));
+        self::assertFalse(DesktopJobContract::isValidType('shell.exec'));
+        self::assertFalse(DesktopJobContract::isValidType(''));
+    }
+
+    public function testErrorCodeVocabularyIsClosed(): void
+    {
+        self::assertTrue(DesktopJobContract::isValidErrorCode('unknown_skill'));
+        self::assertTrue(DesktopJobContract::isValidErrorCode('timeout'));
+        self::assertFalse(DesktopJobContract::isValidErrorCode('rm_rf'));
+        self::assertFalse(DesktopJobContract::isValidErrorCode(''));
+    }
+
+    /**
+     * The security-critical invariant: whatever else ends up in BINPUT, a device
+     * only ever receives {skill, prompt, fileIds}. A smuggled `command` key must
+     * never reach the payload — that is what makes RCE structurally impossible.
+     */
+    public function testBuildDevicePayloadDropsEverythingButAllowedInputKeys(): void
+    {
+        $job = (new DesktopJob())
+            ->setOwnerId(1)
+            ->setDeviceId(7)
+            ->setType(DesktopJob::TYPE_SKILL_RUN)
+            ->setLeaseToken('lt_abc')
+            ->setLeaseExpires(1_800_000_000)
+            ->setAttempt(2)
+            ->setInput([
+                'skill' => 'pptx',
+                'prompt' => 'Make slides',
+                'fileIds' => [10, 11],
+                'command' => 'rm -rf /',
+                'script' => 'evil.sh',
+                'argv' => ['--yes'],
+            ]);
+
+        $payload = DesktopJobContract::buildDevicePayload($job);
+
+        self::assertSame(['skill', 'prompt', 'fileIds'], array_keys($payload['input']));
+        self::assertSame('pptx', $payload['input']['skill']);
+        self::assertSame('Make slides', $payload['input']['prompt']);
+        self::assertSame([10, 11], $payload['input']['fileIds']);
+        self::assertArrayNotHasKey('command', $payload['input']);
+        self::assertArrayNotHasKey('script', $payload['input']);
+        self::assertArrayNotHasKey('argv', $payload['input']);
+        self::assertSame('skill.run', $payload['type']);
+        self::assertSame('lt_abc', $payload['leaseToken']);
+        self::assertSame(1_800_000_000, $payload['leaseExpires']);
+        self::assertSame(2, $payload['attempt']);
+    }
+
+    public function testBuildDevicePayloadCoercesMissingOrOddInput(): void
+    {
+        $job = (new DesktopJob())
+            ->setOwnerId(1)
+            ->setInput([
+                'skill' => 'notes',
+                // no prompt
+                'fileIds' => [3, 'x', '4', null],
+            ]);
+
+        $payload = DesktopJobContract::buildDevicePayload($job);
+
+        self::assertSame('notes', $payload['input']['skill']);
+        self::assertSame('', $payload['input']['prompt']);
+        // Only numeric ids survive, cast to int.
+        self::assertSame([3, 4], $payload['input']['fileIds']);
+    }
+
+    public function testBuildDevicePayloadHandlesEmptyInput(): void
+    {
+        $job = (new DesktopJob())->setOwnerId(1)->setInput(null);
+
+        $payload = DesktopJobContract::buildDevicePayload($job);
+
+        self::assertSame('', $payload['input']['skill']);
+        self::assertSame('', $payload['input']['prompt']);
+        self::assertSame([], $payload['input']['fileIds']);
+    }
+}

--- a/backend/tests/Unit/Service/Desktop/DesktopJobStoreTest.php
+++ b/backend/tests/Unit/Service/Desktop/DesktopJobStoreTest.php
@@ -1,0 +1,212 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\Desktop;
+
+use App\Entity\DesktopDevice;
+use App\Entity\DesktopJob;
+use App\Repository\DesktopJobRepository;
+use App\Service\Desktop\DesktopJobStore;
+use App\Service\Desktop\Exception\ResultTooLargeException;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class DesktopJobStoreTest extends TestCase
+{
+    private DesktopJobRepository&MockObject $jobRepository;
+    private EntityManagerInterface&MockObject $em;
+    private DesktopJobStore $store;
+
+    protected function setUp(): void
+    {
+        $this->jobRepository = $this->createMock(DesktopJobRepository::class);
+        $this->em = $this->createMock(EntityManagerInterface::class);
+        $this->store = new DesktopJobStore($this->jobRepository, $this->em);
+    }
+
+    public function testEnqueueReturnsExistingJobForKnownIdempotencyKey(): void
+    {
+        $existing = (new DesktopJob())->setOwnerId(1)->setStatus(DesktopJob::STATUS_QUEUED);
+        $this->jobRepository->expects(self::once())
+            ->method('findByOwnerIdempotency')
+            ->with(1, 'idem-1')
+            ->willReturn($existing);
+        // No new job is persisted when the idempotency key is already known.
+        $this->jobRepository->expects(self::never())->method('save');
+
+        $job = $this->store->enqueueSkillRun(1, null, 'pptx', 'hi', [], null, null, 'idem-1');
+
+        self::assertSame($existing, $job);
+    }
+
+    public function testEnqueueBuildsSanitizedSkillRunJob(): void
+    {
+        $this->jobRepository->method('findByOwnerIdempotency')->willReturn(null);
+        $this->jobRepository->expects(self::once())->method('save');
+
+        $job = $this->store->enqueueSkillRun(9, 3, 'notes', 'Summarize', [5, 6], 42, 100, null);
+
+        self::assertSame(9, $job->getOwnerId());
+        self::assertSame(3, $job->getDeviceId());
+        self::assertSame(DesktopJob::TYPE_SKILL_RUN, $job->getType());
+        self::assertSame(DesktopJob::STATUS_QUEUED, $job->getStatus());
+        self::assertSame('notes', $job->getInput()['skill']);
+        self::assertSame([5, 6], $job->getInput()['fileIds']);
+        self::assertSame(42, $job->getChatId());
+        self::assertSame(100, $job->getMessageId());
+        self::assertNull($job->getIdempotency());
+    }
+
+    public function testEnqueueClampsOverlongPrompt(): void
+    {
+        $this->jobRepository->method('findByOwnerIdempotency')->willReturn(null);
+        $this->jobRepository->method('save');
+
+        $long = str_repeat('x', DesktopJobStore::PROMPT_MAX_CHARS + 500);
+        $job = $this->store->enqueueSkillRun(1, null, 'pptx', $long);
+
+        self::assertSame(DesktopJobStore::PROMPT_MAX_CHARS, mb_strlen($job->getInput()['prompt']));
+    }
+
+    public function testLeaseForDeviceMarksJobLeasedWithToken(): void
+    {
+        $device = self::device(4, 1);
+        $job = (new DesktopJob())->setOwnerId(1)->setStatus(DesktopJob::STATUS_QUEUED);
+
+        // wrapInTransaction just runs the callback in the unit test.
+        $this->em->method('wrapInTransaction')->willReturnCallback(static fn (callable $fn) => $fn());
+        $this->jobRepository->expects(self::once())
+            ->method('findNextLeasable')
+            ->with(1, 4)
+            ->willReturn($job);
+        $this->em->expects(self::once())->method('flush');
+
+        $leased = $this->store->leaseForDevice($device);
+
+        self::assertNotNull($leased);
+        self::assertSame(DesktopJob::STATUS_LEASED, $leased->getStatus());
+        self::assertSame(4, $leased->getDeviceId());
+        self::assertNotNull($leased->getLeaseToken());
+        self::assertStringStartsWith('lt_', (string) $leased->getLeaseToken());
+        self::assertGreaterThan(time(), $leased->getLeaseExpires());
+        self::assertSame(1, $leased->getAttempt());
+    }
+
+    public function testLeaseForDeviceReturnsNullWhenNothingQueued(): void
+    {
+        $device = self::device(4, 1);
+        $this->em->method('wrapInTransaction')->willReturnCallback(static fn (callable $fn) => $fn());
+        $this->jobRepository->method('findNextLeasable')->willReturn(null);
+
+        self::assertNull($this->store->leaseForDevice($device));
+    }
+
+    public function testReportResultRejectsUnknownLeaseToken(): void
+    {
+        $device = self::device(4, 1);
+        $this->jobRepository->method('findByLeaseToken')->willReturn(null);
+
+        self::assertNull($this->store->reportResult($device, 'lt_nope', DesktopJob::STATUS_SUCCEEDED));
+    }
+
+    public function testReportResultRejectsForeignOwner(): void
+    {
+        $device = self::device(4, 1);
+        $job = (new DesktopJob())->setOwnerId(999)->setStatus(DesktopJob::STATUS_LEASED)->setLeaseToken('lt_x');
+        $this->jobRepository->method('findByLeaseToken')->willReturn($job);
+
+        self::assertNull($this->store->reportResult($device, 'lt_x', DesktopJob::STATUS_SUCCEEDED));
+    }
+
+    public function testReportResultRejectsNonLeasedJob(): void
+    {
+        $device = self::device(4, 1);
+        $job = (new DesktopJob())->setOwnerId(1)->setStatus(DesktopJob::STATUS_QUEUED)->setLeaseToken('lt_x');
+        $this->jobRepository->method('findByLeaseToken')->willReturn($job);
+
+        self::assertNull($this->store->reportResult($device, 'lt_x', DesktopJob::STATUS_SUCCEEDED));
+    }
+
+    public function testReportResultRejectsInvalidStatus(): void
+    {
+        $device = self::device(4, 1);
+        $job = (new DesktopJob())->setOwnerId(1)->setStatus(DesktopJob::STATUS_LEASED)->setLeaseToken('lt_x');
+        $this->jobRepository->method('findByLeaseToken')->willReturn($job);
+
+        self::assertNull($this->store->reportResult($device, 'lt_x', 'queued'));
+    }
+
+    public function testReportResultStoresSuccessAndClearsLease(): void
+    {
+        $device = self::device(4, 1);
+        $job = (new DesktopJob())->setOwnerId(1)->setStatus(DesktopJob::STATUS_LEASED)->setLeaseToken('lt_x');
+        $this->jobRepository->method('findByLeaseToken')->willReturn($job);
+        $this->jobRepository->expects(self::once())->method('save');
+
+        $updated = $this->store->reportResult($device, 'lt_x', DesktopJob::STATUS_SUCCEEDED, ['fileIds' => [1]], null);
+
+        self::assertNotNull($updated);
+        self::assertSame(DesktopJob::STATUS_SUCCEEDED, $updated->getStatus());
+        self::assertSame(['fileIds' => [1]], $updated->getResult());
+        self::assertNull($updated->getLeaseToken());
+    }
+
+    public function testReportResultRejectsOversizedResult(): void
+    {
+        $device = self::device(4, 1);
+        $job = (new DesktopJob())->setOwnerId(1)->setStatus(DesktopJob::STATUS_LEASED)->setLeaseToken('lt_x');
+        $this->jobRepository->method('findByLeaseToken')->willReturn($job);
+
+        $huge = ['blob' => str_repeat('a', DesktopJobStore::RESULT_MAX_BYTES + 10)];
+
+        $this->expectException(ResultTooLargeException::class);
+        $this->store->reportResult($device, 'lt_x', DesktopJob::STATUS_FAILED, $huge, 'local_error');
+    }
+
+    public function testRequeueExpiredLeasesRequeuesUnderAttemptBudget(): void
+    {
+        $job = (new DesktopJob())->setOwnerId(1)->setStatus(DesktopJob::STATUS_LEASED)
+            ->setAttempt(1)->setMaxAttempts(3)->setLeaseToken('lt_x');
+        $this->jobRepository->method('findExpiredLeases')->willReturn([$job]);
+        $this->em->expects(self::once())->method('flush');
+
+        $result = $this->store->requeueExpiredLeases();
+
+        self::assertSame(['requeued' => 1, 'failed' => 0], $result);
+        self::assertSame(DesktopJob::STATUS_QUEUED, $job->getStatus());
+        self::assertNull($job->getLeaseToken());
+        self::assertSame(0, $job->getLeaseExpires());
+    }
+
+    public function testRequeueExpiredLeasesFailsWhenAttemptsExhausted(): void
+    {
+        $job = (new DesktopJob())->setOwnerId(1)->setStatus(DesktopJob::STATUS_LEASED)
+            ->setAttempt(3)->setMaxAttempts(3)->setLeaseToken('lt_x');
+        $this->jobRepository->method('findExpiredLeases')->willReturn([$job]);
+
+        $result = $this->store->requeueExpiredLeases();
+
+        self::assertSame(['requeued' => 0, 'failed' => 1], $result);
+        self::assertSame(DesktopJob::STATUS_FAILED, $job->getStatus());
+        self::assertSame('timeout', $job->getErrorCode());
+    }
+
+    public function testRequeueExpiredLeasesNoOpWhenNoneExpired(): void
+    {
+        $this->jobRepository->method('findExpiredLeases')->willReturn([]);
+        $this->em->expects(self::never())->method('flush');
+
+        self::assertSame(['requeued' => 0, 'failed' => 0], $this->store->requeueExpiredLeases());
+    }
+
+    private static function device(int $id, int $ownerId): DesktopDevice
+    {
+        $device = (new DesktopDevice())->setOwnerId($ownerId)->setStatus(DesktopDevice::STATUS_ACTIVE);
+        $ref = new \ReflectionProperty(DesktopDevice::class, 'id');
+        $ref->setValue($device, $id);
+
+        return $device;
+    }
+}

--- a/backend/tests/Unit/Service/Desktop/PairingCodeServiceTest.php
+++ b/backend/tests/Unit/Service/Desktop/PairingCodeServiceTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\Desktop;
+
+use App\Service\Desktop\Exception\PairingLimitException;
+use App\Service\Desktop\PairingCodeService;
+use App\Service\Infrastructure\RedisService;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class PairingCodeServiceTest extends TestCase
+{
+    private RedisService&MockObject $redis;
+    private PairingCodeService $service;
+
+    protected function setUp(): void
+    {
+        $this->redis = $this->createMock(RedisService::class);
+        $this->service = new PairingCodeService($this->redis);
+    }
+
+    public function testCreateMintsCodeAndRegistersOutstanding(): void
+    {
+        $this->redis->method('sMembers')->willReturn([]);
+        $this->redis->method('increment')->willReturn(1);
+        // generateUniqueCode() checks the freshly-minted code does not collide.
+        $this->redis->method('exists')->willReturn(false);
+
+        $setKeys = [];
+        $this->redis->method('set')->willReturnCallback(function (string $key) use (&$setKeys): bool {
+            $setKeys[] = $key;
+
+            return true;
+        });
+        $this->redis->expects(self::once())->method('sAdd');
+
+        $result = $this->service->create(42);
+
+        self::assertArrayHasKey('code', $result);
+        self::assertArrayHasKey('expiresAt', $result);
+        self::assertSame(8, \strlen($result['code']));
+        self::assertMatchesRegularExpression('/^[2-9A-HJ-NP-Z]{8}$/', $result['code']);
+        self::assertGreaterThan(time(), $result['expiresAt']);
+        self::assertNotEmpty($setKeys);
+    }
+
+    public function testCreateThrowsWhenTooManyOutstanding(): void
+    {
+        // Five live outstanding codes → at the cap.
+        $this->redis->method('sMembers')->willReturn(['A', 'B', 'C', 'D', 'E']);
+        $this->redis->method('exists')->willReturn(true);
+
+        $this->expectException(PairingLimitException::class);
+        $this->service->create(1);
+    }
+
+    public function testCreateThrowsWhenHourlyLimitExceeded(): void
+    {
+        $this->redis->method('sMembers')->willReturn([]);
+        // 21st creation in the hour → over the per-hour cap of 20.
+        $this->redis->method('increment')->willReturn(21);
+
+        $this->expectException(PairingLimitException::class);
+        $this->service->create(1);
+    }
+
+    public function testConsumeReturnsUserIdAndDeletesCode(): void
+    {
+        $payload = json_encode(['userId' => 77, 'expiresAt' => time() + 300]);
+        $this->redis->method('get')->willReturn($payload);
+        $this->redis->expects(self::once())->method('delete');
+        $this->redis->expects(self::once())->method('sRem');
+
+        self::assertSame(77, $this->service->consume('AB3K7Q2M'));
+    }
+
+    public function testConsumeNormalizesLowercaseAndSeparators(): void
+    {
+        $payload = json_encode(['userId' => 5, 'expiresAt' => time() + 300]);
+        $this->redis->expects(self::once())
+            ->method('get')
+            ->with(self::stringContains('AB3K7Q2M'))
+            ->willReturn($payload);
+
+        self::assertSame(5, $this->service->consume('ab3k-7q2m'));
+    }
+
+    public function testConsumeUnknownCodeReturnsNull(): void
+    {
+        $this->redis->method('get')->willReturn(null);
+
+        self::assertNull($this->service->consume('ZZZZZZZZ'));
+    }
+
+    public function testConsumeExpiredCodeReturnsNull(): void
+    {
+        $payload = json_encode(['userId' => 5, 'expiresAt' => time() - 5]);
+        $this->redis->method('get')->willReturn($payload);
+
+        self::assertNull($this->service->consume('AB3K7Q2M'));
+    }
+
+    public function testConsumeEmptyCodeReturnsNullWithoutRedisHit(): void
+    {
+        $this->redis->expects(self::never())->method('get');
+
+        self::assertNull($this->service->consume('   '));
+    }
+
+    public function testConsumeMalformedPayloadReturnsNull(): void
+    {
+        $this->redis->method('get')->willReturn('not-json');
+        $this->redis->expects(self::once())->method('delete');
+
+        self::assertNull($this->service->consume('AB3K7Q2M'));
+    }
+}

--- a/backend/tests/Unit/Service/Desktop/PairingServiceTest.php
+++ b/backend/tests/Unit/Service/Desktop/PairingServiceTest.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\Desktop;
+
+use App\Entity\ApiKey;
+use App\Entity\DesktopDevice;
+use App\Entity\User;
+use App\Repository\ApiKeyRepository;
+use App\Repository\DesktopDeviceRepository;
+use App\Repository\UserRepository;
+use App\Security\ApiKeyScope;
+use App\Service\Desktop\PairingService;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class PairingServiceTest extends TestCase
+{
+    private ApiKeyRepository&MockObject $apiKeyRepository;
+    private DesktopDeviceRepository&MockObject $deviceRepository;
+    private UserRepository&MockObject $userRepository;
+    private PairingService $service;
+
+    protected function setUp(): void
+    {
+        $this->apiKeyRepository = $this->createMock(ApiKeyRepository::class);
+        $this->deviceRepository = $this->createMock(DesktopDeviceRepository::class);
+        $this->userRepository = $this->createMock(UserRepository::class);
+        $this->service = new PairingService($this->apiKeyRepository, $this->deviceRepository, $this->userRepository, 'https://web.synaplan.com/');
+    }
+
+    private function stubUser(int $id): User
+    {
+        $user = self::userWithId($id);
+        $this->userRepository->expects(self::once())->method('find')->with($id)->willReturn($user);
+
+        return $user;
+    }
+
+    private static function userWithId(int $id): User
+    {
+        $user = new User();
+        $ref = new \ReflectionProperty(User::class, 'id');
+        $ref->setValue($user, $id);
+
+        return $user;
+    }
+
+    public function testPairMintsScopedKeyAndDevice(): void
+    {
+        $this->stubUser(7);
+        $savedKey = null;
+        $this->apiKeyRepository->expects(self::once())
+            ->method('save')
+            ->willReturnCallback(function (ApiKey $key) use (&$savedKey): void {
+                $savedKey = $key;
+            });
+
+        $savedDevice = null;
+        $this->deviceRepository->expects(self::once())
+            ->method('save')
+            ->willReturnCallback(function (DesktopDevice $device) use (&$savedDevice): void {
+                $savedDevice = $device;
+            });
+
+        $result = $this->service->pair(7, "Jan's laptop", ['skill.run']);
+
+        self::assertInstanceOf(ApiKey::class, $savedKey);
+        self::assertSame(7, $savedKey->getOwnerId());
+        self::assertStringStartsWith('sk_', $savedKey->getKey());
+        self::assertLessThanOrEqual(64, \strlen($savedKey->getKey()));
+        self::assertSame(ApiKeyScope::pairingScopes(), $savedKey->getScopes());
+        self::assertStringContainsString("Jan's laptop", $savedKey->getName());
+
+        self::assertInstanceOf(DesktopDevice::class, $savedDevice);
+        self::assertSame(7, $savedDevice->getOwnerId());
+        self::assertSame("Jan's laptop", $savedDevice->getName());
+        self::assertSame([DesktopDevice::STATUS_ACTIVE], [$savedDevice->getStatus()]);
+        self::assertSame(['skill.run'], $savedDevice->getCapabilities());
+
+        // apiBaseUrl has no trailing slash.
+        self::assertSame('https://web.synaplan.com', $result['apiBaseUrl']);
+    }
+
+    public function testPairMintsRestrictedKeyByConstruction(): void
+    {
+        $this->stubUser(1);
+        $this->deviceRepository->method('save');
+        $captured = null;
+        $this->apiKeyRepository->method('save')->willReturnCallback(function (ApiKey $key) use (&$captured): void {
+            $captured = $key;
+        });
+
+        $this->service->pair(1, 'x', []);
+
+        self::assertInstanceOf(ApiKey::class, $captured);
+        // A paired key is scoped, never a wildcard.
+        self::assertTrue(ApiKeyScope::isRestricted($captured->getScopes()));
+    }
+
+    public function testPairFallsBackToDefaultDeviceName(): void
+    {
+        $this->stubUser(1);
+        $this->apiKeyRepository->method('save');
+        $captured = null;
+        $this->deviceRepository->method('save')->willReturnCallback(function (DesktopDevice $device) use (&$captured): void {
+            $captured = $device;
+        });
+
+        $this->service->pair(1, '   ', []);
+
+        self::assertInstanceOf(DesktopDevice::class, $captured);
+        self::assertSame('Computer', $captured->getName());
+    }
+
+    public function testPairDropsInvalidCapabilities(): void
+    {
+        $this->stubUser(1);
+        $this->apiKeyRepository->method('save');
+        $captured = null;
+        $this->deviceRepository->method('save')->willReturnCallback(function (DesktopDevice $device) use (&$captured): void {
+            $captured = $device;
+        });
+
+        $this->service->pair(1, 'x', ['skill.run', 'BAD CAP!!', 'notes', 'skill.run']);
+
+        self::assertInstanceOf(DesktopDevice::class, $captured);
+        self::assertSame(['skill.run', 'notes'], $captured->getCapabilities());
+    }
+
+    public function testPairThrowsWhenOwningUserMissing(): void
+    {
+        $this->userRepository->method('find')->willReturn(null);
+        $this->apiKeyRepository->expects(self::never())->method('save');
+        $this->deviceRepository->expects(self::never())->method('save');
+
+        $this->expectException(\App\Service\Desktop\Exception\PairingException::class);
+        $this->service->pair(999, 'x', []);
+    }
+
+    public function testRevokeRemovesKeyAndFlagsDevice(): void
+    {
+        $device = (new DesktopDevice())->setOwnerId(1)->setApiKeyId(55)->setStatus(DesktopDevice::STATUS_ACTIVE);
+        $apiKey = (new ApiKey())->setOwnerId(1)->setKey('sk_x')->setName('Desktop');
+
+        $this->apiKeyRepository->expects(self::once())->method('find')->with(55)->willReturn($apiKey);
+        $this->apiKeyRepository->expects(self::once())->method('remove')->with($apiKey, false);
+        $this->deviceRepository->expects(self::once())->method('save')->with($device);
+
+        $this->service->revoke($device);
+
+        self::assertSame(DesktopDevice::STATUS_REVOKED, $device->getStatus());
+    }
+
+    public function testRevokeToleratesMissingKey(): void
+    {
+        $device = (new DesktopDevice())->setOwnerId(1)->setApiKeyId(55)->setStatus(DesktopDevice::STATUS_ACTIVE);
+        $this->apiKeyRepository->method('find')->willReturn(null);
+        $this->apiKeyRepository->expects(self::never())->method('remove');
+        $this->deviceRepository->expects(self::once())->method('save');
+
+        $this->service->revoke($device);
+
+        self::assertSame(DesktopDevice::STATUS_REVOKED, $device->getStatus());
+    }
+}

--- a/docs/ANTHROPIC_COMPATIBLE_API.md
+++ b/docs/ANTHROPIC_COMPATIBLE_API.md
@@ -37,6 +37,12 @@ Same Synaplan API keys as the OpenAI-compatible API:
 - `x-api-key: sk_…`
 - `Authorization: Bearer sk_…`
 
+Keys can carry **scopes**, but this does not affect existing keys: an unscoped
+key (the default) and a webhook-only key both keep **full access** exactly as
+before. The only restricted keys today are those minted by
+[Synaplan Desktop](./DESKTOP.md) pairing, which are limited to a small
+`desktop:*` set. See [scoped vs. legacy keys](./OPENAI_COMPATIBLE_API.md#scoped-vs-legacy-keys).
+
 ## Feature flags (`BCONFIG` group `MESSAGES_GATEWAY`)
 
 Defaults are **off** except budget notices, session summaries (both only take
@@ -176,3 +182,4 @@ Anthropic-only fields such as `thinking: {"type":"adaptive"}` are stripped befor
 - OpenAI-compatible sibling: [OPENAI_COMPATIBLE_API.md](./OPENAI_COMPATIBLE_API.md)
 - UI: **Channels → AI Agents**
 - Smoke scripts: `_devextras/testing/messages-gateway/`
+- Synaplan Desktop (agent client, server side): [DESKTOP.md](./DESKTOP.md)

--- a/docs/DESKTOP.md
+++ b/docs/DESKTOP.md
@@ -1,0 +1,228 @@
+# Synaplan Desktop (agent client)
+
+> **Status: server side only.** The Synaplan Desktop **client is not released
+> yet.** This document describes the *server* half — the pairing, scoped keys,
+> job queue, and check-in contract that ship in the main Synaplan app (Phase A).
+> The download link and install walkthrough are added in Phase B, when the
+> client exists. Until then everything below is **off by default** and invisible
+> on every install (feature flag `DESKTOP_AGENT.ENABLED`, see below).
+
+## What it is
+
+Synaplan Desktop is a small, separate desktop application (Windows, macOS,
+Linux) that a user pairs with their Synaplan workspace. It lets Synaplan run
+**Agent Skills on the user's own computer** — for example "make a PowerPoint
+from these notes" using a local LibreOffice — and post the result back into the
+chat.
+
+It works by **pull, not push**: the network path "Synaplan calls your laptop"
+is a dead end (NAT, and Synaplan's own SSRF guard). Instead the computer polls:
+
+```
+check-in  →  { jobs, next_call_at }  →  run the skill locally  →  report  →  sleep
+```
+
+### What it is NOT
+
+- **Not the web app in a wrapper.** It runs local skills; it is not an Electron
+  shell around `web.synaplan.com`.
+- **Not "Claude Code" / a general coding agent.** There is no server-supplied
+  shell command, ever. The computer only runs *named, user-installed skills*
+  under path confinement. The single most important contract rule is that a job
+  carries **only** `{skill, prompt, fileIds}` — never a `command`, `script`, or
+  `argv`. See [The job contract](#the-job-contract).
+- **Not a replacement** for the Messages gateway, Synamail, or the widget. It is
+  purely additive: new API routes and two new MCP tools, all flag-gated.
+
+## The feature flag
+
+Everything desktop-related is gated on the `BCONFIG` flag
+`DESKTOP_AGENT.ENABLED` (group `DESKTOP_AGENT`, setting `ENABLED`), resolved
+per-user → global → **false**:
+
+| State | Effect |
+| ----- | ------ |
+| Off (default) | Every `/api/v1/desktop/*` route answers **404**, the two MCP tools are **absent** from `tools/list`, the reaper command is a no-op, and no Desktop UI appears. The feature is completely invisible. |
+| On (global) | The routes and MCP tools appear for every user. |
+| On (per-user, `BOWNERID = <id>`) | Only that user sees the feature; a per-user value beats the global one. |
+
+The seeder inserts the flag as `0` if missing and never overwrites an existing
+value (`App\Seed\DesktopAgentConfigSeeder`). To turn it on for one user in dev:
+
+```sql
+INSERT INTO BCONFIG (BOWNERID, BGROUP, BSETTING, BVALUE)
+VALUES (0, 'DESKTOP_AGENT', 'ENABLED', '1')
+ON DUPLICATE KEY UPDATE BVALUE = '1';
+```
+
+The runtime-config endpoint exposes the resolved boolean as
+`features.desktopAgentEnabled` so the frontend can hide the UI when it is off.
+
+## API keys and scopes
+
+Historically any `sk_*` key had **full** account access. Desktop pairing does
+**not**: it mints a *restricted* key limited to exactly four scopes.
+
+| Scope | Grants |
+| ----- | ------ |
+| `desktop:messages` | `/v1/*` (chat/messages, models, token count) |
+| `desktop:mcp` | `/mcp` (the two agent tools + the base MCP tools) |
+| `desktop:files` | `/api/v1/files*` (upload the result artifact, list/download what the owner already may) |
+| `desktop:jobs` | `/api/v1/desktop/*` (check-in / report, job status) |
+
+A restricted key **cannot** reach admin, user management, webhooks, or anything
+else — so a stolen laptop is a *revoke*, not an account takeover. Enforcement is
+central (`App\Security\ApiKeyScopeSubscriber`); the vocabulary and prefix map
+live in `App\Security\ApiKeyScope`.
+
+**Existing keys are unaffected.** See
+[scoped vs. legacy keys](#scoped-vs-legacy-keys-grandfathering) below.
+
+### Scoped vs. legacy keys (grandfathering)
+
+Adding scopes is a **security fix**, and it deliberately does not narrow any key
+you already created. A key is treated as **full access** (exactly as before)
+when its scope list is:
+
+- **empty** — every key created before scopes existed, and every key created in
+  the UI without picking scopes; or
+- **only legacy webhook scopes** (`webhooks:email`, `webhooks:whatsapp`,
+  `webhooks:*`); or
+- an explicit **`*`**.
+
+A key is **restricted** only when it opts into a non-empty, non-legacy scope
+list without `*` — which today only happens via desktop pairing. So nothing that
+worked yesterday stops working: your existing OpenAI-/Anthropic-compatible keys,
+webhook keys, and integrations keep full access, and only freshly paired desktop
+keys are limited to the four `desktop:*` scopes above. The logic is one pure
+class, `App\Security\ApiKeyScope::isRestricted()`.
+
+## Pairing
+
+Session-authenticated web endpoints, plus the one public exchange route:
+
+| Method + path | Auth | Purpose |
+| ------------- | ---- | ------- |
+| `POST /api/v1/desktop/pairing-codes` | session | Mint a one-time 8-char code (10-min TTL, rate-limited). |
+| `POST /api/v1/desktop/pair` | **public** | Exchange a code for a scoped key + a new device row. The key is shown **once**. |
+| `GET /api/v1/desktop/devices` | session | List paired computers (name, status, last-seen, key prefix). |
+| `DELETE /api/v1/desktop/devices/{id}` | session | Revoke a computer — deactivates its API key (401 on its next call). |
+
+`POST /pair` is the only unauthenticated route (a fresh client has no session
+yet); it is rate-limited per IP and returns the same "invalid or expired" error
+for unknown and expired codes (no user enumeration). Pairing codes and keys are
+never logged at info level.
+
+Flow:
+
+1. User opens **Channels → Desktop** in the web app and clicks *Pair a
+   computer* → server mints a code.
+2. User types the code into Synaplan Desktop.
+3. The client calls `POST /pair` → gets `{ deviceId, key, apiBaseUrl }` and
+   stores the key in the OS secret store.
+4. The client polls with the key from then on.
+
+## The job contract
+
+Frozen at **`protocol: 1`** (Sprint A3 / DS18). Every enum is closed; the wire
+shapes are committed as fixtures (see [Frozen fixtures](#frozen-fixtures)).
+Changing any of it is a `protocol: 2` decision **with a migration**, not a
+convenience edit.
+
+### Enqueue (web → server)
+
+`POST /api/v1/desktop/jobs` (session user):
+
+```json
+{
+  "deviceId": 1,
+  "type": "skill.run",
+  "input": { "skill": "pptx", "prompt": "Make 3 slides about Q3", "fileIds": [] },
+  "chatId": 99
+}
+```
+
+- Flag on; the device is owned by the user and `active`.
+- `type` ∈ `{ skill.run }` (the only type in v1 — no `shell.exec`, ever).
+- `input.skill` matches `^[a-z0-9-]{1,64}$`; prompt capped at 8k chars.
+- The server does **not** verify the computer has the skill (it cannot). An
+  uninstalled skill fails honestly on the device.
+
+Poll job status with `GET /api/v1/desktop/jobs/{id}` (and list recent jobs with
+`GET /api/v1/desktop/jobs`) — this drives the web "waiting / failed" card.
+
+### Check-in and report (device ↔ server, over MCP)
+
+Two MCP tools, added to `tools/list` only when the flag is on **and** the key
+is a paired desktop key (they are a *superset* — the base tools stay), requiring
+the `desktop:jobs` scope:
+
+- **`agent_checkin`** — leases at most one job for this computer and returns
+  `{ protocol: 1, jobs: [...], next_call_at }`. A device speaking an unknown
+  protocol gets an empty job list and a far `next_call_at` — never a guess.
+- **`agent_report_result`** — reports the outcome of a leased job by its
+  `leaseToken`. A refused skill is a normal `failed` with an `errorCode`, not a
+  transport error.
+
+Leasing is atomic (pessimistic row lock), so two check-ins can never lease the
+same job. A lease that expires is requeued by `app:desktop:reap-jobs` until the
+attempt budget is spent, then the job fails with `timeout` — so the web card
+shows an honest failed state instead of a forever spinner.
+
+### The closed enums
+
+| Field | Values |
+| ----- | ------ |
+| `type` | `skill.run` |
+| `status` | `queued`, `leased`, `succeeded`, `failed`, `cancelled` |
+| `errorCode` | `unknown_skill`, `unknown_type`, `skill_disabled`, `timeout`, `local_error` |
+
+### The one rule that makes RCE structurally impossible
+
+A job's device-facing `input` is **only** `{skill, prompt, fileIds}`. The server
+drops every other key before the payload is handed out
+(`DesktopJobContract::buildDevicePayload()`), and the client **must ignore** any
+unknown key. There is no field through which a shell string could reach the
+computer, so a future server bug cannot become remote code execution.
+
+## Frozen fixtures
+
+The exact `protocol: 1` wire shapes are committed under
+[`_devextras/testing/desktop/fixtures/`](../_devextras/testing/desktop/fixtures/)
+(check-in request/response, one `skill.run` job, a success report, an
+`unknown_skill` failure report, an enqueue request). Phase B's client vendors
+these byte-for-byte to build its unit tests without a live server.
+
+They are asserted against the live server contract by
+`backend/tests/Unit/Service/Desktop/DesktopContractFixturesTest.php`, so a
+server change that breaks the frozen contract fails the gate here rather than
+breaking a shipped client (invariant C9).
+
+## Testing it without a client
+
+Because the real client does not exist yet, two shell harnesses under
+[`_devextras/testing/desktop/`](../_devextras/testing/desktop/) stand in for it.
+They run against the local Docker stack (`curl` + `jq`), auto-enable the flag,
+and are **not** part of the PHPUnit gate — the equivalent assertions also exist
+as PHPUnit tests (`DesktopControllerTest`, `DesktopMcpCheckinTest`).
+
+```bash
+cd _devextras/testing/desktop
+
+# Pair a fake computer: login → mint code → exchange for a scoped key.
+./pair.sh
+
+# Full loop + every refusal path: check-in, lease, report, and the safety
+# cases (hostile input.command stripped, unknown skill, stale lease token,
+# oversized result, cross-device isolation, flag-off).
+./fake-device.sh
+```
+
+See [`_devextras/testing/desktop/fixtures/README.md`](../_devextras/testing/desktop/fixtures/README.md)
+for the frozen-contract details.
+
+## Related
+
+- Anthropic-compatible Messages gateway: [ANTHROPIC_COMPATIBLE_API.md](./ANTHROPIC_COMPATIBLE_API.md)
+- OpenAI-compatible API: [OPENAI_COMPATIBLE_API.md](./OPENAI_COMPATIBLE_API.md)
+- Plan of record: `_devextras/planning/20260829-desktop-agent-client/`

--- a/docs/OPENAI_COMPATIBLE_API.md
+++ b/docs/OPENAI_COMPATIBLE_API.md
@@ -278,6 +278,20 @@ Two methods are supported:
 
 Both use the same Synaplan API keys. Create keys at **Settings > API Keys** in the Synaplan UI.
 
+### Scoped vs. legacy keys
+
+Synaplan API keys can carry **scopes** that limit what a key may do. This does
+**not** change existing keys: a key with no scopes (every key created before
+scopes existed, and any key you create without choosing scopes) keeps **full
+access**, exactly as before, and so does a webhook-only key. Your current
+integrations are unaffected — nothing that worked yesterday stops working.
+
+The only keys that are restricted today are the ones minted when a user pairs a
+[Synaplan Desktop](./DESKTOP.md) computer: those are limited to a small
+`desktop:*` scope set (chat, MCP, files, jobs) so a lost laptop can be revoked
+without exposing the whole account. If you never pair a desktop computer, you
+never see a scoped key.
+
 ## Error Format
 
 Errors follow the OpenAI error format:

--- a/frontend/src/components/ChatInput.vue
+++ b/frontend/src/components/ChatInput.vue
@@ -49,6 +49,17 @@
         </div>
       </div>
 
+      <!-- DS16: waiting/failed cards for jobs dispatched to a paired computer. -->
+      <div v-if="desktopJobs.length > 0" class="mb-3 flex flex-col gap-2">
+        <DesktopJobCard
+          v-for="job in desktopJobs"
+          :key="job.id"
+          :job-id="job.id"
+          :device-name="job.deviceName"
+          @dismiss="dismissDesktopJob(job.id)"
+        />
+      </div>
+
       <!-- Attached banner (e.g. guest message counter) glued to the input's top edge. -->
       <slot name="banner" />
 
@@ -269,6 +280,7 @@
                     @toggle-thinking="toggleThinking"
                     @toggle-voice-reply="toggleVoiceReply"
                     @toggle-enhance="toggleEnhance"
+                    @run-on-device="handleRunOnDevice"
                   />
                   <KnowledgeFolderPicker v-model="selectedGroupKey" :groups="knowledgeGroups" />
                 </template>
@@ -400,6 +412,7 @@ import CommandPalette from './CommandPalette.vue'
 import FileMentionPalette from './FileMentionPalette.vue'
 import ToolsDropdown from './ToolsDropdown.vue'
 import ToolBadge from './ToolBadge.vue'
+import DesktopJobCard from './DesktopJobCard.vue'
 import ModelDropdown from './ModelDropdown.vue'
 import KnowledgeFolderPicker from './KnowledgeFolderPicker.vue'
 import FileSelectionModal from './FileSelectionModal.vue'
@@ -422,6 +435,8 @@ import { useAutoPersist, useAttachmentPersist } from '@/composables/useInputPers
 import { useChatsStore } from '@/stores/chats'
 import { useAuthStore } from '@/stores/auth'
 import { useIncognitoStore } from '@/stores/incognito'
+import { useDialog } from '@/composables/useDialog'
+import { desktopApi } from '@/services/api/desktopApi'
 import QuoteChip from './QuoteChip.vue'
 import type { QuotedReference } from '@/composables/useMessageQuoting'
 
@@ -549,7 +564,59 @@ const chatsStore = useChatsStore()
 const configStore = useConfigStore()
 const authStore = useAuthStore()
 const incognitoStore = useIncognitoStore()
+const dialog = useDialog()
 const { warning, error: showError, success } = useNotification()
+
+// DS16: jobs dispatched to a paired computer via "Run on this computer".
+// Rendered as waiting/failed cards above the composer until dismissed.
+const desktopJobs = ref<Array<{ id: number; deviceName: string }>>([])
+
+/**
+ * Send the typed instruction to a paired computer as a `skill.run` job. There is
+ * deliberately no planner hook (prompt-injection risk, §2.3): the user picks the
+ * skill explicitly. The server never verifies the skill exists — an uninstalled
+ * skill fails honestly on the device, surfaced by the waiting/failed card.
+ */
+const handleRunOnDevice = async (device: { id: number; name: string }) => {
+  const prompt = message.value.trim()
+  if (!prompt) {
+    warning(t('config.desktop.run.needPrompt'))
+    return
+  }
+
+  const skill = (
+    await dialog.prompt({
+      title: t('config.desktop.run.skillTitle'),
+      message: t('config.desktop.run.skillMessage', { name: device.name }),
+      placeholder: t('config.desktop.run.skillPlaceholder'),
+      confirmText: t('config.desktop.run.action'),
+    })
+  )?.trim()
+  if (!skill) return
+
+  if (!/^[a-z0-9-]{1,64}$/.test(skill)) {
+    showError(t('config.desktop.run.invalidSkill'))
+    return
+  }
+
+  try {
+    const { jobId } = await desktopApi.enqueueJob({
+      deviceId: device.id,
+      skill,
+      prompt,
+      chatId: chatsStore.activeChatId,
+    })
+    desktopJobs.value.push({ id: jobId, deviceName: device.name })
+    message.value = ''
+    success(t('config.desktop.run.sent', { name: device.name }))
+  } catch (err) {
+    showError(err instanceof Error ? err.message : t('config.desktop.run.enqueueFailed'))
+  }
+}
+
+const dismissDesktopJob = (jobId: number) => {
+  desktopJobs.value = desktopJobs.value.filter((j) => j.id !== jobId)
+}
 const { t, locale } = useI18n()
 const route = useRoute()
 const router = useRouter()

--- a/frontend/src/components/DesktopJobCard.vue
+++ b/frontend/src/components/DesktopJobCard.vue
@@ -1,0 +1,118 @@
+<template>
+  <div
+    class="flex items-center gap-3 px-3 py-2.5 surface-chip rounded-lg"
+    :class="{ 'border-l-2 border-red-500': isFailed }"
+    data-testid="comp-desktop-job-card"
+  >
+    <ArrowPathIcon v-if="isWaiting" class="w-4 h-4 shrink-0 txt-secondary animate-spin" />
+    <CheckCircleIcon v-else-if="isSucceeded" class="w-4 h-4 shrink-0 text-green-500" />
+    <ExclamationTriangleIcon v-else class="w-4 h-4 shrink-0 text-red-500" />
+
+    <div class="flex-1 min-w-0">
+      <p class="text-sm txt-primary truncate">{{ statusLine }}</p>
+      <p v-if="detailLine" class="text-xs txt-secondary truncate">{{ detailLine }}</p>
+    </div>
+
+    <button
+      class="icon-ghost p-0 min-w-0 w-auto h-auto shrink-0"
+      :aria-label="$t('common.close')"
+      data-testid="btn-dismiss-job"
+      @click="emit('dismiss')"
+    >
+      <XMarkIcon class="w-4 h-4" />
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref } from 'vue'
+import {
+  ArrowPathIcon,
+  CheckCircleIcon,
+  ExclamationTriangleIcon,
+  XMarkIcon,
+} from '@heroicons/vue/24/outline'
+import { useI18n } from 'vue-i18n'
+import { desktopApi, type DesktopJob } from '@/services/api/desktopApi'
+
+const props = defineProps<{
+  jobId: number
+  deviceName: string
+}>()
+
+const emit = defineEmits<{ dismiss: [] }>()
+
+const { t } = useI18n()
+
+const POLL_MS = 4000
+// Client-side safety net: even if the server-side reaper is not ticking (e.g. a
+// dev install with no cron), the card must reach an honest terminal state
+// instead of spinning forever (DS16 acceptance).
+const CLIENT_TIMEOUT_MS = 5 * 60 * 1000
+
+const status = ref<DesktopJob['status']>('queued')
+const errorCode = ref<string | null>(null)
+const timedOut = ref(false)
+
+let poller: number | null = null
+let deadline = 0
+
+const isWaiting = computed(
+  () => !timedOut.value && (status.value === 'queued' || status.value === 'leased')
+)
+const isSucceeded = computed(() => status.value === 'succeeded')
+const isFailed = computed(
+  () => timedOut.value || status.value === 'failed' || status.value === 'cancelled'
+)
+
+const statusLine = computed(() => {
+  if (isSucceeded.value) return t('config.desktop.jobCard.done', { name: props.deviceName })
+  if (isFailed.value) return t('config.desktop.jobCard.failed', { name: props.deviceName })
+  return t('config.desktop.jobCard.waiting', { name: props.deviceName })
+})
+
+// A device that never answered (timeout / expiry) gets the plain-language line
+// from §3.1; a device that refused the skill gets the specific reason.
+const detailLine = computed(() => {
+  if (!isFailed.value) return ''
+  if (timedOut.value || errorCode.value === 'timeout') return t('config.desktop.jobCard.noAnswer')
+  if (errorCode.value === 'unknown_skill') return t('config.desktop.jobCard.unknownSkill')
+  if (errorCode.value === 'skill_disabled') return t('config.desktop.jobCard.skillDisabled')
+  if (errorCode.value) return t('config.desktop.jobCard.localError')
+  return t('config.desktop.jobCard.noAnswer')
+})
+
+const isTerminal = (s: DesktopJob['status']): boolean =>
+  s === 'succeeded' || s === 'failed' || s === 'cancelled'
+
+const stopPolling = () => {
+  if (poller) {
+    clearInterval(poller)
+    poller = null
+  }
+}
+
+const poll = async () => {
+  if (Date.now() > deadline) {
+    timedOut.value = true
+    stopPolling()
+    return
+  }
+  try {
+    const job = await desktopApi.getJob(props.jobId)
+    status.value = job.status
+    errorCode.value = job.errorCode ?? null
+    if (isTerminal(job.status)) stopPolling()
+  } catch {
+    // A transient poll failure is not terminal; the deadline still bounds it.
+  }
+}
+
+onMounted(() => {
+  deadline = Date.now() + CLIENT_TIMEOUT_MS
+  poll()
+  poller = window.setInterval(poll, POLL_MS)
+})
+
+onUnmounted(stopPolling)
+</script>

--- a/frontend/src/components/ToolsDropdown.vue
+++ b/frontend/src/components/ToolsDropdown.vue
@@ -171,6 +171,26 @@
         </div>
         <ArrowTopRightOnSquareIcon class="w-4 h-4 flex-shrink-0 txt-secondary" />
       </button>
+
+      <!-- DS16: dispatch the typed instruction to a paired computer. Only shown
+           when the flag is on AND the user has ≥1 active device — otherwise the
+           row is meaningless (nothing could answer). -->
+      <button
+        v-if="showRunOnDevice"
+        ref="itemRefs"
+        class="dropdown-item"
+        type="button"
+        data-testid="btn-tool-run-on-device"
+        @click="handleRunOnDevice"
+        @keydown.down.prevent="focusNext"
+        @keydown.up.prevent="focusPrevious"
+      >
+        <Icon icon="mdi:monitor-arrow-down" class="w-5 h-5 flex-shrink-0" />
+        <div class="flex-1 min-w-0">
+          <span class="text-sm font-medium">{{ $t('config.desktop.run.action') }}</span>
+          <div class="text-xs txt-secondary truncate">{{ runOnDeviceSubtext }}</div>
+        </div>
+      </button>
     </div>
   </div>
 </template>
@@ -184,11 +204,14 @@ import {
   CheckIcon,
 } from '@heroicons/vue/24/outline'
 import { Icon } from '@iconify/vue'
+import { useI18n } from 'vue-i18n'
 import { type Command, useCommandsStore } from '@/stores/commands'
 import { useAuthStore } from '@/stores/auth'
 import { getFeaturesStatus, type Feature } from '@/services/featuresService'
 import { useRouter } from 'vue-router'
 import { triggerHapticImpact } from '@/services/api/nativeHaptics'
+import { isDesktopAgentEnabled } from '@/composables/useDesktopAgentFeature'
+import { useDesktopDevices } from '@/composables/useDesktopDevices'
 
 interface Props {
   activeCommand?: string | null
@@ -208,6 +231,7 @@ const emit = defineEmits<{
   toggleThinking: []
   toggleVoiceReply: []
   toggleEnhance: []
+  runOnDevice: [device: { id: number; name: string }]
 }>()
 
 /** Feature-gated tools that toggle a removable badge in the chat input. */
@@ -236,8 +260,27 @@ const commandTools = [
 ] as const
 
 const router = useRouter()
+const { t } = useI18n()
 const authStore = useAuthStore()
 const commandsStore = useCommandsStore()
+const { activeDevices, hasActiveDevices, ensureLoaded } = useDesktopDevices()
+
+// DS16: the composer action is only meaningful with a live target. Gated on the
+// feature flag AND at least one active device (revoking the last one hides it).
+const showRunOnDevice = computed(() => isDesktopAgentEnabled() && hasActiveDevices.value)
+
+const runOnDeviceSubtext = computed(() => {
+  const list = activeDevices.value
+  if (list.length === 1) return list[0].name
+  return t('config.desktop.run.multiple', { count: list.length })
+})
+
+const handleRunOnDevice = () => {
+  const device = activeDevices.value[0]
+  if (!device) return
+  emit('runOnDevice', { id: device.id, name: device.name })
+  closeDropdown()
+}
 const isOpen = ref(false)
 const itemRefs = ref<HTMLElement[]>([])
 const dropdownRef = ref<HTMLElement | null>(null)
@@ -368,6 +411,9 @@ const handleClickOutside = (e: MouseEvent) => {
 onMounted(() => {
   document.addEventListener('click', handleClickOutside)
   mobileMq.addEventListener('change', onMobileMqChange)
+  // Know whether to offer "Run on this computer" without waiting for the menu to
+  // open. No-op (and no request) when the Desktop flag is off.
+  if (isDesktopAgentEnabled()) ensureLoaded()
 })
 onBeforeUnmount(() => {
   document.removeEventListener('click', handleClickOutside)

--- a/frontend/src/components/config/DesktopConfiguration.vue
+++ b/frontend/src/components/config/DesktopConfiguration.vue
@@ -1,0 +1,445 @@
+<template>
+  <div class="space-y-6" data-testid="page-config-desktop">
+    <PageHeader
+      :title="$t('config.desktop.title')"
+      :subtitle="$t('config.desktop.description')"
+      icon="heroicons:computer-desktop"
+      data-testid="section-header"
+    >
+      <template #actions>
+        <button
+          class="btn-primary px-5 py-2.5 rounded-lg font-medium text-sm inline-flex items-center gap-2"
+          data-testid="btn-pair"
+          @click="openPairing"
+        >
+          <PlusIcon class="w-5 h-5" />
+          {{ $t('config.desktop.pairButton') }}
+        </button>
+      </template>
+    </PageHeader>
+
+    <!-- Honest "not downloadable yet" note (§3.1): the server ships before the
+         client, so the app cannot be installed yet. Never a Download button. -->
+    <div class="surface-card p-4 flex items-start gap-3" data-testid="note-not-available">
+      <InformationCircleIcon class="w-5 h-5 txt-brand mt-0.5 shrink-0" />
+      <p class="text-sm txt-secondary">{{ $t('config.desktop.notAvailableYet') }}</p>
+    </div>
+
+    <!-- Error Alert -->
+    <div
+      v-if="error"
+      class="bg-red-500/10 border border-red-500/30 rounded-lg p-4 flex items-start gap-3"
+      data-testid="alert-error"
+    >
+      <ExclamationTriangleIcon class="w-5 h-5 text-red-500 mt-0.5 shrink-0" />
+      <p class="flex-1 text-red-500 text-sm font-medium">{{ error }}</p>
+      <button
+        class="text-red-500 hover:text-red-600 text-sm font-medium underline"
+        data-testid="btn-alert-retry"
+        @click="loadAll"
+      >
+        {{ $t('common.retry') }}
+      </button>
+    </div>
+
+    <!-- Loading -->
+    <div
+      v-if="loading && devices.length === 0"
+      class="surface-card p-12 text-center"
+      data-testid="section-loading"
+    >
+      <ArrowPathIcon class="w-10 h-10 mx-auto txt-secondary mb-4 animate-spin" />
+      <p class="txt-secondary">{{ $t('common.loading') }}</p>
+    </div>
+
+    <!-- Empty -->
+    <div
+      v-else-if="devices.length === 0"
+      class="surface-card p-12 text-center"
+      data-testid="section-empty"
+    >
+      <ComputerDesktopIcon class="w-16 h-16 mx-auto txt-secondary mb-4" />
+      <p class="txt-secondary text-lg">{{ $t('config.desktop.devices.empty') }}</p>
+    </div>
+
+    <!-- Device table -->
+    <div v-else class="surface-card overflow-hidden" data-testid="section-devices-table">
+      <div class="overflow-x-auto">
+        <table class="w-full">
+          <thead class="border-b border-light-border/30 dark:border-dark-border/20">
+            <tr class="bg-black/5 dark:bg-white/5">
+              <th
+                class="px-6 py-3 text-left text-xs font-semibold txt-primary uppercase tracking-wider"
+              >
+                {{ $t('config.desktop.devices.name') }}
+              </th>
+              <th
+                class="px-6 py-3 text-left text-xs font-semibold txt-primary uppercase tracking-wider"
+              >
+                {{ $t('config.desktop.devices.status') }}
+              </th>
+              <th
+                class="px-6 py-3 text-left text-xs font-semibold txt-primary uppercase tracking-wider"
+              >
+                {{ $t('config.desktop.devices.lastSeen') }}
+              </th>
+              <th
+                class="px-6 py-3 text-left text-xs font-semibold txt-primary uppercase tracking-wider"
+              >
+                {{ $t('config.desktop.devices.waitingJobs') }}
+              </th>
+              <th
+                class="px-6 py-3 text-left text-xs font-semibold txt-primary uppercase tracking-wider"
+              >
+                {{ $t('config.desktop.devices.actions') }}
+              </th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-light-border/30 dark:divide-dark-border/20">
+            <tr
+              v-for="device in devices"
+              :key="device.id"
+              class="hover:bg-black/5 dark:hover:bg-white/5 transition-colors"
+              data-testid="item-device"
+            >
+              <td class="px-6 py-4 whitespace-nowrap">
+                <div class="flex items-center gap-2">
+                  <ComputerDesktopIcon class="w-5 h-5 txt-secondary shrink-0" />
+                  <span class="text-sm font-medium txt-primary">{{ device.name }}</span>
+                </div>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap">
+                <span
+                  :class="[
+                    'inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium',
+                    device.status === 'active'
+                      ? 'bg-green-500/10 text-green-500'
+                      : 'bg-gray-500/10 text-gray-500',
+                  ]"
+                >
+                  <span
+                    class="w-1.5 h-1.5 rounded-full"
+                    :class="device.status === 'active' ? 'bg-green-500' : 'bg-gray-500'"
+                  ></span>
+                  {{
+                    device.status === 'active'
+                      ? $t('config.desktop.devices.statusActive')
+                      : $t('config.desktop.devices.statusRevoked')
+                  }}
+                </span>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap text-sm txt-secondary">
+                {{ formatLastSeen(device.lastSeen) }}
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap text-sm txt-secondary">
+                {{ waitingCount(device.id) }}
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap">
+                <button
+                  v-if="device.status === 'active'"
+                  class="text-sm text-red-500 hover:text-red-600 font-medium"
+                  data-testid="btn-disconnect"
+                  @click="disconnect(device)"
+                >
+                  {{ $t('config.desktop.disconnect') }}
+                </button>
+                <span v-else class="text-sm txt-muted">—</span>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <!-- Pairing modal -->
+    <Teleport to="#app">
+      <Transition
+        enter-active-class="transition-opacity duration-200"
+        leave-active-class="transition-opacity duration-150"
+        enter-from-class="opacity-0"
+        leave-to-class="opacity-0"
+      >
+        <div
+          v-if="showPairing"
+          class="modal-overlay fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm"
+          data-testid="modal-pairing"
+          @click.self="closePairing"
+        >
+          <Transition
+            enter-active-class="transition-all duration-200"
+            leave-active-class="transition-all duration-150"
+            enter-from-class="opacity-0 scale-95 translate-y-4"
+            leave-to-class="opacity-0 scale-95 translate-y-4"
+          >
+            <div v-if="showPairing" class="surface-elevated max-w-lg w-full p-6 md:p-8">
+              <div class="flex items-start gap-4 mb-6">
+                <div
+                  class="flex-shrink-0 w-12 h-12 rounded-full bg-[var(--brand-alpha-light)] flex items-center justify-center"
+                >
+                  <ComputerDesktopIcon class="w-6 h-6 txt-brand" />
+                </div>
+                <div class="flex-1 min-w-0">
+                  <h3 class="text-xl font-semibold txt-primary mb-1">
+                    {{ $t('config.desktop.pairing.title') }}
+                  </h3>
+                  <p class="text-sm txt-secondary">{{ $t('config.desktop.pairing.intro') }}</p>
+                </div>
+              </div>
+
+              <!-- Creating -->
+              <div v-if="pairingLoading" class="py-8 text-center">
+                <ArrowPathIcon class="w-8 h-8 mx-auto txt-secondary mb-3 animate-spin" />
+                <p class="text-sm txt-secondary">{{ $t('common.loading') }}</p>
+              </div>
+
+              <!-- Failed to create -->
+              <div v-else-if="pairingError" class="py-6 text-center">
+                <p class="text-sm text-red-500 mb-4">{{ pairingError }}</p>
+                <button
+                  class="btn-primary px-4 py-2.5 rounded-lg font-medium text-sm"
+                  @click="createCode"
+                >
+                  {{ $t('common.retry') }}
+                </button>
+              </div>
+
+              <template v-else-if="pairingCode">
+                <!-- Server address -->
+                <div class="mb-4">
+                  <label class="block text-sm font-medium txt-primary mb-2">
+                    {{ $t('config.desktop.pairing.addressLabel') }}
+                  </label>
+                  <div class="flex items-center gap-2">
+                    <code
+                      class="flex-1 min-w-0 truncate text-sm font-mono txt-primary surface-card px-3 py-2.5 rounded"
+                    >
+                      {{ serverAddress }}
+                    </code>
+                    <button
+                      class="surface-chip px-3 py-2.5 rounded-lg txt-primary hover:bg-black/5 dark:hover:bg-white/10 transition-colors shrink-0"
+                      :aria-label="$t('config.desktop.pairing.copyAddress')"
+                      @click="copy(serverAddress, 'address')"
+                    >
+                      <CheckIcon v-if="copiedField === 'address'" class="w-5 h-5" />
+                      <ClipboardDocumentIcon v-else class="w-5 h-5" />
+                    </button>
+                  </div>
+                </div>
+
+                <!-- Pairing code -->
+                <div class="mb-4">
+                  <label class="block text-sm font-medium txt-primary mb-2">
+                    {{ $t('config.desktop.pairing.codeLabel') }}
+                  </label>
+                  <div class="flex items-center gap-2">
+                    <code
+                      class="flex-1 text-2xl font-mono font-semibold tracking-[0.3em] txt-primary surface-card px-3 py-3 rounded text-center select-all"
+                    >
+                      {{ pairingCode.code }}
+                    </code>
+                    <button
+                      class="surface-chip px-3 py-3 rounded-lg txt-primary hover:bg-black/5 dark:hover:bg-white/10 transition-colors shrink-0"
+                      :aria-label="$t('config.desktop.pairing.copyCode')"
+                      @click="copy(pairingCode.code, 'code')"
+                    >
+                      <CheckIcon v-if="copiedField === 'code'" class="w-5 h-5" />
+                      <ClipboardDocumentIcon v-else class="w-5 h-5" />
+                    </button>
+                  </div>
+                </div>
+
+                <!-- Expiry -->
+                <div class="text-center">
+                  <p v-if="secondsLeft > 0" class="text-xs txt-secondary" data-testid="text-expiry">
+                    {{ $t('config.desktop.pairing.expiresIn', { time: countdownLabel }) }}
+                  </p>
+                  <div v-else class="space-y-3" data-testid="section-expired">
+                    <p class="text-xs text-amber-500">{{ $t('config.desktop.pairing.expired') }}</p>
+                    <button
+                      class="btn-primary px-4 py-2.5 rounded-lg font-medium text-sm"
+                      data-testid="btn-new-code"
+                      @click="createCode"
+                    >
+                      {{ $t('config.desktop.pairing.newCode') }}
+                    </button>
+                  </div>
+                </div>
+              </template>
+
+              <div class="mt-6">
+                <button
+                  class="w-full surface-chip px-4 py-3 rounded-lg font-medium txt-primary hover:bg-black/5 dark:hover:bg-white/10 transition-colors"
+                  data-testid="btn-pairing-close"
+                  @click="closePairing"
+                >
+                  {{ $t('common.close') }}
+                </button>
+              </div>
+            </div>
+          </Transition>
+        </div>
+      </Transition>
+    </Teleport>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, onActivated, onUnmounted, ref } from 'vue'
+import {
+  PlusIcon,
+  CheckIcon,
+  ClipboardDocumentIcon,
+  ComputerDesktopIcon,
+  ArrowPathIcon,
+  InformationCircleIcon,
+  ExclamationTriangleIcon,
+} from '@heroicons/vue/24/outline'
+import PageHeader from '@/components/PageHeader.vue'
+import { desktopApi, type DesktopDevice, type PairingCode } from '@/services/api/desktopApi'
+import { useDesktopDevices } from '@/composables/useDesktopDevices'
+import { useDialog } from '@/composables/useDialog'
+import { useNotification } from '@/composables/useNotification'
+import { useDateFormat } from '@/composables/useDateFormat'
+import { useI18n } from 'vue-i18n'
+import { getErrorMessage } from '@/utils/errorMessage'
+
+const { t } = useI18n()
+const dialog = useDialog()
+const { success, error: showError } = useNotification()
+const { formatRelativeTime } = useDateFormat()
+const { devices, reload } = useDesktopDevices()
+
+const loading = ref(false)
+const error = ref<string | null>(null)
+
+// Waiting-job counts per device (queued + leased), shown in the table (§3.1).
+const waitingByDevice = ref<Record<number, number>>({})
+
+const showPairing = ref(false)
+const pairingLoading = ref(false)
+const pairingError = ref<string | null>(null)
+const pairingCode = ref<PairingCode | null>(null)
+const copiedField = ref<'address' | 'code' | null>(null)
+
+// The address the user types into Synaplan Desktop is this Synaplan install's
+// origin — the same host the browser is already talking to.
+const serverAddress = window.location.origin
+
+const now = ref(Math.floor(Date.now() / 1000))
+let ticker: number | null = null
+
+const secondsLeft = computed(() =>
+  pairingCode.value ? Math.max(0, pairingCode.value.expiresAt - now.value) : 0
+)
+
+const countdownLabel = computed(() => {
+  const total = secondsLeft.value
+  const mins = Math.floor(total / 60)
+  const secs = total % 60
+  return `${mins}:${secs.toString().padStart(2, '0')}`
+})
+
+const formatLastSeen = (lastSeen: number): string => {
+  if (!lastSeen) return t('config.desktop.devices.never')
+  return formatRelativeTime(new Date(lastSeen * 1000))
+}
+
+const waitingCount = (deviceId: number): number => waitingByDevice.value[deviceId] ?? 0
+
+const loadAll = async () => {
+  loading.value = true
+  error.value = null
+  try {
+    await reload()
+    // Waiting-job counts are a display nicety; a failure here must not blank
+    // the device table, so it is caught independently.
+    try {
+      const jobs = await desktopApi.listJobs()
+      const counts: Record<number, number> = {}
+      for (const job of jobs) {
+        if ((job.status === 'queued' || job.status === 'leased') && job.deviceId) {
+          counts[job.deviceId] = (counts[job.deviceId] ?? 0) + 1
+        }
+      }
+      waitingByDevice.value = counts
+    } catch {
+      waitingByDevice.value = {}
+    }
+  } catch (err) {
+    error.value = getErrorMessage(err) || t('config.desktop.loadFailed')
+  } finally {
+    loading.value = false
+  }
+}
+
+const openPairing = () => {
+  showPairing.value = true
+  copiedField.value = null
+  createCode()
+}
+
+const createCode = async () => {
+  pairingLoading.value = true
+  pairingError.value = null
+  pairingCode.value = null
+  try {
+    pairingCode.value = await desktopApi.createPairingCode()
+    now.value = Math.floor(Date.now() / 1000)
+  } catch (err) {
+    pairingError.value = getErrorMessage(err) || t('config.desktop.pairing.createFailed')
+  } finally {
+    pairingLoading.value = false
+  }
+}
+
+const closePairing = () => {
+  showPairing.value = false
+  pairingCode.value = null
+}
+
+const copy = async (value: string, field: 'address' | 'code') => {
+  try {
+    await navigator.clipboard.writeText(value)
+    copiedField.value = field
+    setTimeout(() => {
+      if (copiedField.value === field) copiedField.value = null
+    }, 2000)
+  } catch {
+    showError(t('config.desktop.pairing.copyFailed'))
+  }
+}
+
+const disconnect = async (device: DesktopDevice) => {
+  const confirmed = await dialog.confirm({
+    title: t('config.desktop.confirmDisconnectTitle'),
+    message: t('config.desktop.confirmDisconnect', { name: device.name }),
+    confirmText: t('config.desktop.disconnect'),
+    cancelText: t('common.cancel'),
+    danger: true,
+  })
+  if (!confirmed) return
+
+  try {
+    await desktopApi.revokeDevice(device.id)
+    await reload()
+    success(t('config.desktop.disconnected'))
+  } catch (err) {
+    showError(getErrorMessage(err) || t('config.desktop.disconnectFailed'))
+  }
+}
+
+onMounted(() => {
+  loadAll()
+  ticker = window.setInterval(() => {
+    now.value = Math.floor(Date.now() / 1000)
+  }, 1000)
+})
+
+onActivated(() => {
+  loadAll()
+})
+
+onUnmounted(() => {
+  if (ticker) clearInterval(ticker)
+})
+</script>

--- a/frontend/src/composables/useDesktopAgentFeature.ts
+++ b/frontend/src/composables/useDesktopAgentFeature.ts
@@ -1,0 +1,18 @@
+import { getConfigSync } from '@/services/api/httpClient'
+
+/**
+ * Synaplan Desktop feature flag (DESKTOP_AGENT.ENABLED, delivered via runtime
+ * config). Off by default, so the whole Desktop surface (nav child, page,
+ * composer action) stays invisible on every install until an operator turns it
+ * on (invariant C8, mirrored server-side by DesktopController's 404 guard).
+ *
+ * Lives here instead of stores/config.ts on purpose: that store is on the
+ * store-required list in .github/mobile-impact-policy.json, and this flag is a
+ * pure web-layer concern that must stay OTA-deliverable.
+ *
+ * getConfigSync() reads a reactive ref, so calls inside computed() or template
+ * expressions re-evaluate when the runtime config loads.
+ */
+export function isDesktopAgentEnabled(): boolean {
+  return getConfigSync().features?.desktopAgentEnabled === true
+}

--- a/frontend/src/composables/useDesktopDevices.ts
+++ b/frontend/src/composables/useDesktopDevices.ts
@@ -1,0 +1,63 @@
+import { computed, ref } from 'vue'
+import { desktopApi, type DesktopDevice } from '@/services/api/desktopApi'
+import { isDesktopAgentEnabled } from './useDesktopAgentFeature'
+
+/**
+ * Shared list of the current user's paired computers.
+ *
+ * Module-level state (a tiny store) so the two surfaces that care about it stay
+ * in sync without re-fetching: the Channels → Desktop page owns the list and
+ * mutates it (pair/revoke), while the chat composer only reads
+ * {@link hasActiveDevices} to decide whether to offer "Run on this computer"
+ * (DS16). Revoking the last computer on the page therefore hides the composer
+ * action immediately, with no second request.
+ *
+ * Every call is a no-op when the DESKTOP_AGENT flag is off (the endpoints 404),
+ * so callers never need to guard the flag themselves.
+ */
+const devices = ref<DesktopDevice[]>([])
+const loading = ref(false)
+const loaded = ref(false)
+const error = ref<string | null>(null)
+
+const activeDevices = computed(() => devices.value.filter((d) => d.status === 'active'))
+const hasActiveDevices = computed(() => activeDevices.value.length > 0)
+
+async function reload(): Promise<void> {
+  if (!isDesktopAgentEnabled()) {
+    devices.value = []
+    loaded.value = true
+    return
+  }
+  loading.value = true
+  error.value = null
+  try {
+    devices.value = await desktopApi.listDevices()
+    loaded.value = true
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : 'Failed to load computers'
+  } finally {
+    loading.value = false
+  }
+}
+
+/**
+ * Load the list once (idempotent). The composer calls this on mount to know
+ * whether to show its action without forcing a refetch on every open.
+ */
+async function ensureLoaded(): Promise<void> {
+  if (loaded.value || loading.value) return
+  await reload()
+}
+
+export function useDesktopDevices() {
+  return {
+    devices,
+    activeDevices,
+    hasActiveDevices,
+    loading,
+    error,
+    reload,
+    ensureLoaded,
+  }
+}

--- a/frontend/src/composables/useNavItems.ts
+++ b/frontend/src/composables/useNavItems.ts
@@ -13,6 +13,7 @@ import { useConfigStore } from '../stores/config'
 import { getFeaturesStatus } from '../services/featuresService'
 import { modelStatusApi } from '../services/api/adminModelStatusApi'
 import { isSavedTasksEnabled } from './useSavedTasksFeature'
+import { isDesktopAgentEnabled } from './useDesktopAgentFeature'
 
 export interface NavChild {
   /** Stable identifier used for data-testid — never derived from the route path */
@@ -255,6 +256,16 @@ export function useNavItems() {
           label: t('nav.mcpServers'),
           ...grouped('connections', connections),
         },
+        ...(isDesktopAgentEnabled()
+          ? [
+              {
+                key: 'desktop',
+                path: '/channels/desktop',
+                label: t('nav.desktop'),
+                ...grouped('connections', connections),
+              },
+            ]
+          : []),
         {
           key: 'api-keys',
           path: '/channels/api',

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -101,6 +101,7 @@
     "poweredBy": "Bereitgestellt von"
   },
   "pageTitles": {
+    "desktop": "Desktop",
     "login": "Anmelden",
     "register": "Registrieren",
     "forgotPassword": "Passwort vergessen",
@@ -650,6 +651,7 @@
     "upgrade": "Upgrade"
   },
   "nav": {
+    "desktop": "Desktop",
     "chat": "Chat",
     "new": "Neu",
     "newDescription": "Neuen Chat starten",
@@ -2326,6 +2328,62 @@
       "errorDeleting": "Fehler beim Löschen des API-Schlüssels",
       "noKeys": "Noch keine API-Schlüssel. Erstellen Sie Ihren ersten Schlüssel.",
       "usageCount": "Anfragen"
+    },
+    "desktop": {
+      "title": "Desktop",
+      "description": "Synaplan Desktop ist eine separate App für diesen Computer. Sie nutzt dein Synaplan-Konto und kann Skills ausführen, die du installierst.",
+      "notAvailableYet": "Synaplan Desktop steht noch nicht zum Download bereit. Du kannst aber schon einen Verbindungscode erstellen, um die Verbindung zu testen.",
+      "pairButton": "Diesen Computer verbinden",
+      "loadFailed": "Die verbundenen Computer konnten nicht geladen werden.",
+      "disconnect": "Trennen",
+      "confirmDisconnectTitle": "Diesen Computer trennen",
+      "confirmDisconnect": "„{name}“ kann dein Konto dann nicht mehr erreichen. Du kannst den Computer später mit einem neuen Code erneut verbinden.",
+      "disconnected": "Computer getrennt.",
+      "disconnectFailed": "Der Computer konnte nicht getrennt werden.",
+      "pairing": {
+        "title": "Diesen Computer verbinden",
+        "intro": "Öffne Synaplan Desktop auf dem Computer, den du verbinden möchtest, und gib diese Adresse und den Code ein.",
+        "addressLabel": "Serveradresse",
+        "codeLabel": "Verbindungscode",
+        "expiresIn": "Läuft ab in {time}",
+        "expired": "Dieser Code ist abgelaufen.",
+        "newCode": "Neuen Code erstellen",
+        "copyAddress": "Adresse kopieren",
+        "copyCode": "Code kopieren",
+        "createFailed": "Der Verbindungscode konnte nicht erstellt werden.",
+        "copyFailed": "Kopieren in die Zwischenablage fehlgeschlagen."
+      },
+      "devices": {
+        "empty": "Es sind noch keine Computer verbunden.",
+        "name": "Computer",
+        "status": "Status",
+        "lastSeen": "Zuletzt gesehen",
+        "waitingJobs": "Wartende Aufgaben",
+        "actions": "Aktionen",
+        "never": "nie",
+        "statusActive": "Verbunden",
+        "statusRevoked": "Getrennt"
+      },
+      "run": {
+        "action": "Auf diesem Computer ausführen",
+        "multiple": "{count} Computer",
+        "needPrompt": "Gib zuerst ein, was der Computer tun soll.",
+        "skillTitle": "Auf diesem Computer ausführen",
+        "skillMessage": "Welcher Skill soll auf „{name}“ ausgeführt werden?",
+        "skillPlaceholder": "z. B. pptx",
+        "invalidSkill": "Nur Kleinbuchstaben, Zahlen und Bindestriche verwenden.",
+        "sent": "An „{name}“ gesendet.",
+        "enqueueFailed": "Die Aufgabe konnte nicht gesendet werden."
+      },
+      "jobCard": {
+        "waiting": "Warten auf {name}",
+        "done": "{name} ist fertig",
+        "failed": "{name} konnte nicht abschließen",
+        "noAnswer": "Dieser Computer hat nicht geantwortet.",
+        "unknownSkill": "Dieser Computer hat diesen Skill nicht.",
+        "skillDisabled": "Dieser Skill ist auf diesem Computer deaktiviert.",
+        "localError": "Der Skill ist auf diesem Computer fehlgeschlagen."
+      }
     },
     "phoneVerification": {
       "title": "Telefon-Verifizierung",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -151,6 +151,7 @@
     "aiAgents": "AI Agents",
     "connections": "Connections",
     "savedTasks": "Saved tasks",
+    "desktop": "Desktop",
     "setup": "Setup"
   },
   "adminModelStatus": {
@@ -698,6 +699,7 @@
     "moreDescription": "More sections and account",
     "menu": "Menu",
     "aiAgents": "AI Agents",
+    "desktop": "Desktop",
     "manage": "Manage",
     "manageDescription": "Assistants, channels and automations",
     "groupAssistants": "Assistants",
@@ -2249,6 +2251,62 @@
       "errorDeleting": "Failed to delete API key",
       "noKeys": "No API keys yet. Create your first key to get started.",
       "usageCount": "requests"
+    },
+    "desktop": {
+      "title": "Desktop",
+      "description": "Synaplan Desktop is a separate app for this computer. It uses your Synaplan account and can run skills you install.",
+      "notAvailableYet": "Synaplan Desktop is not available to download yet. You can already create a pairing code to test the connection.",
+      "pairButton": "Pair this computer",
+      "loadFailed": "The connected computers could not be loaded.",
+      "disconnect": "Disconnect",
+      "confirmDisconnectTitle": "Disconnect this computer",
+      "confirmDisconnect": "\"{name}\" will no longer be able to reach your account. You can pair it again later with a new code.",
+      "disconnected": "Computer disconnected.",
+      "disconnectFailed": "The computer could not be disconnected.",
+      "pairing": {
+        "title": "Pair this computer",
+        "intro": "Open Synaplan Desktop on the computer you want to connect, then enter this address and code.",
+        "addressLabel": "Server address",
+        "codeLabel": "Pairing code",
+        "expiresIn": "Expires in {time}",
+        "expired": "This code has expired.",
+        "newCode": "Create a new code",
+        "copyAddress": "Copy address",
+        "copyCode": "Copy code",
+        "createFailed": "The pairing code could not be created.",
+        "copyFailed": "Could not copy to clipboard."
+      },
+      "devices": {
+        "empty": "No computers are connected yet.",
+        "name": "Computer",
+        "status": "Status",
+        "lastSeen": "Last seen",
+        "waitingJobs": "Waiting jobs",
+        "actions": "Actions",
+        "never": "never",
+        "statusActive": "Connected",
+        "statusRevoked": "Disconnected"
+      },
+      "run": {
+        "action": "Run on this computer",
+        "multiple": "{count} computers",
+        "needPrompt": "Type what the computer should do first.",
+        "skillTitle": "Run on this computer",
+        "skillMessage": "Which skill should run on \"{name}\"?",
+        "skillPlaceholder": "e.g. pptx",
+        "invalidSkill": "Use only lowercase letters, numbers and hyphens.",
+        "sent": "Sent to \"{name}\".",
+        "enqueueFailed": "The job could not be sent."
+      },
+      "jobCard": {
+        "waiting": "Waiting for {name}",
+        "done": "{name} finished",
+        "failed": "{name} could not finish",
+        "noAnswer": "This computer did not answer.",
+        "unknownSkill": "This computer does not have that skill.",
+        "skillDisabled": "That skill is turned off on this computer.",
+        "localError": "The skill failed on this computer."
+      }
     },
     "phoneVerification": {
       "title": "Phone Verification",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -101,6 +101,7 @@
     "poweredBy": "Desarrollado por"
   },
   "pageTitles": {
+    "desktop": "Escritorio",
     "login": "Iniciar sesión",
     "register": "Registrarse",
     "forgotPassword": "Olvidé mi contraseña",
@@ -644,6 +645,7 @@
     "upgrade": "Mejorar"
   },
   "nav": {
+    "desktop": "Escritorio",
     "chat": "Chat",
     "new": "Nuevo",
     "newDescription": "Iniciar un nuevo chat",
@@ -3104,6 +3106,62 @@
       "errorDeleting": "Error al eliminar clave API",
       "noKeys": "Aún no hay claves API. Crea tu primera clave para comenzar.",
       "usageCount": "solicitudes"
+    },
+    "desktop": {
+      "title": "Escritorio",
+      "description": "Synaplan Desktop es una app independiente para este equipo. Usa tu cuenta de Synaplan y puede ejecutar skills que instales.",
+      "notAvailableYet": "Synaplan Desktop aún no está disponible para descargar. Ya puedes crear un código de vinculación para probar la conexión.",
+      "pairButton": "Vincular este equipo",
+      "loadFailed": "No se pudieron cargar los equipos conectados.",
+      "disconnect": "Desconectar",
+      "confirmDisconnectTitle": "Desconectar este equipo",
+      "confirmDisconnect": "«{name}» ya no podrá acceder a tu cuenta. Podrás volver a vincularlo más tarde con un nuevo código.",
+      "disconnected": "Equipo desconectado.",
+      "disconnectFailed": "No se pudo desconectar el equipo.",
+      "pairing": {
+        "title": "Vincular este equipo",
+        "intro": "Abre Synaplan Desktop en el equipo que quieres conectar e introduce esta dirección y este código.",
+        "addressLabel": "Dirección del servidor",
+        "codeLabel": "Código de vinculación",
+        "expiresIn": "Caduca en {time}",
+        "expired": "Este código ha caducado.",
+        "newCode": "Crear un código nuevo",
+        "copyAddress": "Copiar dirección",
+        "copyCode": "Copiar código",
+        "createFailed": "No se pudo crear el código de vinculación.",
+        "copyFailed": "No se pudo copiar al portapapeles."
+      },
+      "devices": {
+        "empty": "Aún no hay equipos conectados.",
+        "name": "Equipo",
+        "status": "Estado",
+        "lastSeen": "Última conexión",
+        "waitingJobs": "Trabajos en espera",
+        "actions": "Acciones",
+        "never": "nunca",
+        "statusActive": "Conectado",
+        "statusRevoked": "Desconectado"
+      },
+      "run": {
+        "action": "Ejecutar en este equipo",
+        "multiple": "{count} equipos",
+        "needPrompt": "Escribe primero qué debe hacer el equipo.",
+        "skillTitle": "Ejecutar en este equipo",
+        "skillMessage": "¿Qué skill debe ejecutarse en «{name}»?",
+        "skillPlaceholder": "p. ej. pptx",
+        "invalidSkill": "Usa solo minúsculas, números y guiones.",
+        "sent": "Enviado a «{name}».",
+        "enqueueFailed": "No se pudo enviar el trabajo."
+      },
+      "jobCard": {
+        "waiting": "Esperando a {name}",
+        "done": "{name} ha terminado",
+        "failed": "{name} no pudo terminar",
+        "noAnswer": "Este equipo no respondió.",
+        "unknownSkill": "Este equipo no tiene ese skill.",
+        "skillDisabled": "Ese skill está desactivado en este equipo.",
+        "localError": "El skill falló en este equipo."
+      }
     },
     "phoneVerification": {
       "title": "Verificación de Teléfono",

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -101,6 +101,7 @@
     "poweredBy": "Propulsé par"
   },
   "pageTitles": {
+    "desktop": "Ordinateur",
     "login": "Connexion",
     "register": "Inscription",
     "forgotPassword": "Mot de passe oublié",
@@ -655,6 +656,7 @@
     "upgrade": "Passer à une formule supérieure"
   },
   "nav": {
+    "desktop": "Ordinateur",
     "chat": "Chat",
     "new": "Nouveau",
     "newDescription": "Démarrer un nouveau chat",
@@ -2249,6 +2251,62 @@
       "errorDeleting": "Échec de la suppression de la clé API",
       "noKeys": "Aucune clé API pour le moment. Créez votre première clé pour commencer.",
       "usageCount": "requêtes"
+    },
+    "desktop": {
+      "title": "Ordinateur",
+      "description": "Synaplan Desktop est une application distincte pour cet ordinateur. Elle utilise votre compte Synaplan et peut exécuter les skills que vous installez.",
+      "notAvailableYet": "Synaplan Desktop n'est pas encore disponible au téléchargement. Vous pouvez déjà créer un code d'association pour tester la connexion.",
+      "pairButton": "Associer cet ordinateur",
+      "loadFailed": "Impossible de charger les ordinateurs connectés.",
+      "disconnect": "Déconnecter",
+      "confirmDisconnectTitle": "Déconnecter cet ordinateur",
+      "confirmDisconnect": "« {name} » ne pourra plus accéder à votre compte. Vous pourrez l'associer à nouveau plus tard avec un nouveau code.",
+      "disconnected": "Ordinateur déconnecté.",
+      "disconnectFailed": "Impossible de déconnecter l'ordinateur.",
+      "pairing": {
+        "title": "Associer cet ordinateur",
+        "intro": "Ouvrez Synaplan Desktop sur l'ordinateur à connecter, puis saisissez cette adresse et ce code.",
+        "addressLabel": "Adresse du serveur",
+        "codeLabel": "Code d'association",
+        "expiresIn": "Expire dans {time}",
+        "expired": "Ce code a expiré.",
+        "newCode": "Créer un nouveau code",
+        "copyAddress": "Copier l'adresse",
+        "copyCode": "Copier le code",
+        "createFailed": "Impossible de créer le code d'association.",
+        "copyFailed": "Impossible de copier dans le presse-papiers."
+      },
+      "devices": {
+        "empty": "Aucun ordinateur n'est encore connecté.",
+        "name": "Ordinateur",
+        "status": "Statut",
+        "lastSeen": "Vu pour la dernière fois",
+        "waitingJobs": "Tâches en attente",
+        "actions": "Actions",
+        "never": "jamais",
+        "statusActive": "Connecté",
+        "statusRevoked": "Déconnecté"
+      },
+      "run": {
+        "action": "Exécuter sur cet ordinateur",
+        "multiple": "{count} ordinateurs",
+        "needPrompt": "Saisissez d'abord ce que l'ordinateur doit faire.",
+        "skillTitle": "Exécuter sur cet ordinateur",
+        "skillMessage": "Quel skill exécuter sur « {name} » ?",
+        "skillPlaceholder": "p. ex. pptx",
+        "invalidSkill": "Utilisez uniquement des minuscules, des chiffres et des traits d'union.",
+        "sent": "Envoyé à « {name} ».",
+        "enqueueFailed": "Impossible d'envoyer la tâche."
+      },
+      "jobCard": {
+        "waiting": "En attente de {name}",
+        "done": "{name} a terminé",
+        "failed": "{name} n'a pas pu terminer",
+        "noAnswer": "Cet ordinateur n'a pas répondu.",
+        "unknownSkill": "Cet ordinateur n'a pas ce skill.",
+        "skillDisabled": "Ce skill est désactivé sur cet ordinateur.",
+        "localError": "Le skill a échoué sur cet ordinateur."
+      }
     },
     "phoneVerification": {
       "title": "Vérification du téléphone",

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -101,6 +101,7 @@
     "poweredBy": "Sunan"
   },
   "pageTitles": {
+    "desktop": "Masaüstü",
     "login": "Giriş",
     "register": "Kayıt Ol",
     "forgotPassword": "Şifremi Unuttum",
@@ -644,6 +645,7 @@
     "upgrade": "Yükselt"
   },
   "nav": {
+    "desktop": "Masaüstü",
     "chat": "Sohbet",
     "new": "Yeni",
     "newDescription": "Yeni bir sohbet başlat",
@@ -3105,6 +3107,62 @@
       "errorDeleting": "API anahtarı silinemedi",
       "noKeys": "Henüz API anahtarı yok. Başlamak için ilk anahtarınızı oluşturun.",
       "usageCount": "istek"
+    },
+    "desktop": {
+      "title": "Masaüstü",
+      "description": "Synaplan Desktop, bu bilgisayar için ayrı bir uygulamadır. Synaplan hesabınızı kullanır ve yüklediğiniz skill'leri çalıştırabilir.",
+      "notAvailableYet": "Synaplan Desktop henüz indirilebilir değil. Bağlantıyı test etmek için şimdiden bir eşleme kodu oluşturabilirsiniz.",
+      "pairButton": "Bu bilgisayarı bağla",
+      "loadFailed": "Bağlı bilgisayarlar yüklenemedi.",
+      "disconnect": "Bağlantıyı kes",
+      "confirmDisconnectTitle": "Bu bilgisayarın bağlantısını kes",
+      "confirmDisconnect": "„{name}” artık hesabınıza erişemeyecek. Daha sonra yeni bir kodla tekrar bağlayabilirsiniz.",
+      "disconnected": "Bilgisayarın bağlantısı kesildi.",
+      "disconnectFailed": "Bilgisayarın bağlantısı kesilemedi.",
+      "pairing": {
+        "title": "Bu bilgisayarı bağla",
+        "intro": "Bağlamak istediğiniz bilgisayarda Synaplan Desktop'ı açın, ardından bu adresi ve kodu girin.",
+        "addressLabel": "Sunucu adresi",
+        "codeLabel": "Eşleme kodu",
+        "expiresIn": "{time} içinde sona erer",
+        "expired": "Bu kodun süresi doldu.",
+        "newCode": "Yeni kod oluştur",
+        "copyAddress": "Adresi kopyala",
+        "copyCode": "Kodu kopyala",
+        "createFailed": "Eşleme kodu oluşturulamadı.",
+        "copyFailed": "Panoya kopyalanamadı."
+      },
+      "devices": {
+        "empty": "Henüz bağlı bilgisayar yok.",
+        "name": "Bilgisayar",
+        "status": "Durum",
+        "lastSeen": "Son görülme",
+        "waitingJobs": "Bekleyen işler",
+        "actions": "İşlemler",
+        "never": "hiç",
+        "statusActive": "Bağlı",
+        "statusRevoked": "Bağlantı kesildi"
+      },
+      "run": {
+        "action": "Bu bilgisayarda çalıştır",
+        "multiple": "{count} bilgisayar",
+        "needPrompt": "Önce bilgisayarın ne yapması gerektiğini yazın.",
+        "skillTitle": "Bu bilgisayarda çalıştır",
+        "skillMessage": "„{name}” üzerinde hangi skill çalıştırılsın?",
+        "skillPlaceholder": "örn. pptx",
+        "invalidSkill": "Yalnızca küçük harf, rakam ve kısa çizgi kullanın.",
+        "sent": "„{name}” gönderildi.",
+        "enqueueFailed": "İş gönderilemedi."
+      },
+      "jobCard": {
+        "waiting": "{name} bekleniyor",
+        "done": "{name} tamamlandı",
+        "failed": "{name} tamamlayamadı",
+        "noAnswer": "Bu bilgisayar yanıt vermedi.",
+        "unknownSkill": "Bu bilgisayarda bu skill yok.",
+        "skillDisabled": "Bu skill bu bilgisayarda kapalı.",
+        "localError": "Skill bu bilgisayarda başarısız oldu."
+      }
     },
     "phoneVerification": {
       "title": "Telefon Doğrulama",

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -276,6 +276,12 @@ const router = createRouter({
       meta: { requiresAuth: true, titleKey: 'pageTitles.aiAgents' },
     },
     {
+      path: '/channels/desktop',
+      name: 'channels-desktop',
+      component: () => import('@/views/ConfigView.vue'),
+      meta: { requiresAuth: true, titleKey: 'pageTitles.desktop' },
+    },
+    {
       path: '/channels/api',
       name: 'channels-api',
       component: () => import('@/views/ConfigView.vue'),

--- a/frontend/src/services/api/desktopApi.ts
+++ b/frontend/src/services/api/desktopApi.ts
@@ -1,0 +1,99 @@
+import { z } from 'zod'
+import { httpClient } from './httpClient'
+import {
+  CreateDesktopPairingCodeResponseSchema,
+  ListDesktopDevicesResponseSchema,
+  RevokeDesktopDeviceResponseSchema,
+  EnqueueDesktopJobResponseSchema,
+  GetDesktopJobResponseSchema,
+  ListDesktopJobsResponseSchema,
+} from '@/generated/api-schemas'
+
+/**
+ * Channels → Desktop: pair and manage the user's computers, and enqueue
+ * `skill.run` jobs for them.
+ *
+ * Every route 404s when the DESKTOP_AGENT feature flag is off, so callers must
+ * gate the UI with {@link isDesktopAgentEnabled} first. Pairing itself is a
+ * two-step, human-in-the-loop flow: the web app only MINTS a code
+ * (`createPairingCode`); the actual code→key exchange (`POST /pair`) happens on
+ * the desktop client, never here — the scoped key must never touch the browser.
+ */
+
+export type DesktopDevice = NonNullable<
+  z.infer<typeof ListDesktopDevicesResponseSchema>['devices']
+>[number]
+
+export type DesktopJob = z.infer<typeof GetDesktopJobResponseSchema>['job']
+
+export interface PairingCode {
+  code: string
+  expiresAt: number
+}
+
+export interface EnqueueJobPayload {
+  deviceId: number
+  skill: string
+  prompt: string
+  chatId?: number | null
+  fileIds?: number[]
+}
+
+export const desktopApi = {
+  async listDevices(): Promise<DesktopDevice[]> {
+    const data = await httpClient('/api/v1/desktop/devices', {
+      method: 'GET',
+      schema: ListDesktopDevicesResponseSchema,
+    })
+    return data.devices ?? []
+  },
+
+  async createPairingCode(): Promise<PairingCode> {
+    const data = await httpClient('/api/v1/desktop/pairing-codes', {
+      method: 'POST',
+      schema: CreateDesktopPairingCodeResponseSchema,
+    })
+    return { code: data.code, expiresAt: data.expiresAt }
+  },
+
+  async revokeDevice(id: number): Promise<void> {
+    await httpClient(`/api/v1/desktop/devices/${id}`, {
+      method: 'DELETE',
+      schema: RevokeDesktopDeviceResponseSchema,
+    })
+  },
+
+  async enqueueJob(payload: EnqueueJobPayload): Promise<{ jobId: number; status: string }> {
+    const data = await httpClient('/api/v1/desktop/jobs', {
+      method: 'POST',
+      body: JSON.stringify({
+        deviceId: payload.deviceId,
+        type: 'skill.run',
+        input: {
+          skill: payload.skill,
+          prompt: payload.prompt,
+          fileIds: payload.fileIds ?? [],
+        },
+        chatId: payload.chatId ?? null,
+      }),
+      schema: EnqueueDesktopJobResponseSchema,
+    })
+    return { jobId: data.jobId, status: data.status }
+  },
+
+  async getJob(id: number): Promise<DesktopJob> {
+    const data = await httpClient(`/api/v1/desktop/jobs/${id}`, {
+      method: 'GET',
+      schema: GetDesktopJobResponseSchema,
+    })
+    return data.job
+  },
+
+  async listJobs(): Promise<z.infer<typeof ListDesktopJobsResponseSchema>['jobs']> {
+    const data = await httpClient('/api/v1/desktop/jobs', {
+      method: 'GET',
+      schema: ListDesktopJobsResponseSchema,
+    })
+    return data.jobs ?? []
+  },
+}

--- a/frontend/src/views/ConfigView.vue
+++ b/frontend/src/views/ConfigView.vue
@@ -48,6 +48,10 @@
           <MessagesGatewayConfiguration />
         </div>
 
+        <div v-else-if="currentPage === 'desktop'" data-testid="section-desktop">
+          <DesktopConfiguration />
+        </div>
+
         <div
           v-else-if="currentPage === 'api-documentation'"
           data-testid="section-api-documentation"
@@ -74,6 +78,7 @@ import McpServersConfiguration from '@/components/config/McpServersConfiguration
 import ConnectionsConfiguration from '@/components/config/ConnectionsConfiguration.vue'
 import SavedTasksOverview from '@/components/config/SavedTasksOverview.vue'
 import MessagesGatewayConfiguration from '@/components/config/MessagesGatewayConfiguration.vue'
+import DesktopConfiguration from '@/components/config/DesktopConfiguration.vue'
 
 const route = useRoute()
 
@@ -87,6 +92,7 @@ const currentPage = computed(() => {
   if (path.startsWith('/channels/mcp')) return 'mcp-servers'
   if (path.startsWith('/channels/connections')) return 'connections'
   if (path.startsWith('/channels/tasks')) return 'saved-tasks'
+  if (path.startsWith('/channels/desktop')) return 'desktop'
   if (path.startsWith('/channels')) return 'inbound'
   if (path.startsWith('/ai/providers/higgsfield')) return 'ai-provider-higgsfield'
   if (path.startsWith('/ai/models')) return 'ai-models'


### PR DESCRIPTION
## Summary
Prep work for the desktop client

## Changes
- Added the DesktopAgentConfig service to manage desktop agent settings.
- Introduced new API routes for desktop pairing and job management, allowing paired devices to execute tasks.
- Updated the ConfigController to expose desktop agent settings and status.
- Enhanced the McpController to handle requests from paired desktop devices, including job check-ins and results reporting.
- Integrated desktop job handling in the frontend, allowing users to dispatch tasks to paired computers and view job statuses.
- Expanded internationalization support for desktop-related features across multiple languages.
- Added unit tests to ensure the functionality of new desktop agent features and their integration with existing services.

This commit lays the groundwork for the Synaplan Desktop client, enabling users to interact with their desktop devices seamlessly.

## Verification
- [ ] Not tested (explain)
- [X] Manual
- [ ] Tests added/updated
