### PR TITLE
fix(ci): open the release-version pin proposal reliably

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1521,10 +1521,22 @@ jobs:
             "https://x-access-token:${PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
             "HEAD:refs/heads/${BRANCH}"
 
-          existing="$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // ""')"
-          if [ -n "$existing" ]; then
-            echo "Updated [pull request #${existing}](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/pull/${existing}) to \`${VERSION}\`." |
+          # Non-fatal on purpose: under `set -e` a bare assignment from a
+          # failing lookup would end the step right here — after the push, but
+          # before any of the reporting below — leaving a red job with no
+          # explanation of what to do.
+          find_open_pr() {
+            gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // ""' || true
+          }
+
+          report_existing_pr() {
+            echo "Updated [pull request #${1}](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/pull/${1}) to \`${VERSION}\`." |
               tee -a "$GITHUB_STEP_SUMMARY"
+          }
+
+          existing="$(find_open_pr)"
+          if [ -n "$existing" ]; then
+            report_existing_pr "$existing"
             exit 0
           fi
 
@@ -1589,10 +1601,35 @@ jobs:
             exit 0
           fi
 
+          github_token_error="$(tr '\n' ' ' < "$error_file")"
+
+          # Reaching this point can also mean the lookup above could not reach
+          # the API while a proposal does exist — both creates then fail with
+          # "already exists". The force-push already carried this version into
+          # it, so that is the intended outcome and not a failure. Ask once
+          # more, and otherwise believe what the create said.
+          existing="$(find_open_pr)"
+          if [ -n "$existing" ]; then
+            report_existing_pr "$existing"
+            exit 0
+          fi
+
+          case "${app_error} ${github_token_error}" in
+            *'already exists'*)
+              url="$(
+                printf '%s %s' "$app_error" "$github_token_error" |
+                  grep -oE 'https://[^ ]+/pull/[0-9]+' | head -n1 || true
+              )"
+              echo "The proposal for \`${VERSION}\` already exists${url:+ (${url})}; the force-push carried this version into it." |
+                tee -a "$GITHUB_STEP_SUMMARY"
+              exit 0
+              ;;
+          esac
+
           # The release itself is published and verified at this point; only the
           # proposal failed. Still a failure: a silent one left 4.4.1 unpinned
           # for two days.
-          echo "::error::Could not open the default-version pull request for ${VERSION} (release App: ${app_error}; GITHUB_TOKEN: $(tr '\n' ' ' < "$error_file"))"
+          echo "::error::Could not open the default-version pull request for ${VERSION} (release App: ${app_error}; GITHUB_TOKEN: ${github_token_error})"
           {
             echo "Release \`${VERSION}\` is published. Branch \`${BRANCH}\` carries the raised pins, but its pull request could not be opened automatically."
             echo ""

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1452,10 +1452,12 @@ jobs:
             echo "configured=false" >> "$GITHUB_OUTPUT"
           fi
 
-      # Refs created with the default GITHUB_TOKEN do not start workflow runs,
-      # so a pull request opened with it would carry no checks at all. The same
-      # app that creates release tags is used here for the same reason; without
-      # it the proposal is still opened, just unchecked.
+      # Push with the release App so the branch starts workflow runs
+      # (GITHUB_TOKEN-created refs do not). Opening the pull request uses
+      # GITHUB_TOKEN, which already has `pull-requests: write` on this job —
+      # the App is Contents-only and cannot createPullRequest (v4.4.1's pin
+      # sat on the branch for two days with no PR because that call was
+      # made with the App token and the job stayed green).
       - name: Create pull request token
         id: app-token
         if: steps.config.outputs.configured == 'true'
@@ -1466,7 +1468,8 @@ jobs:
 
       - name: Propose the new default version
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ needs.docker-manifest.outputs.version }}
           DIGEST: ${{ needs.docker-manifest.outputs.digest }}
           BRANCH: automation/default-release-version
@@ -1507,11 +1510,16 @@ jobs:
           git checkout -q -B "$BRANCH"
           git commit -qam "chore(release): install ${VERSION} in new deployments"
 
+          # Prefer the App token so the force-push starts checks. Fall back to
+          # GITHUB_TOKEN when the App is not configured — the PR would then
+          # open unchecked, which is still better than no proposal at all.
+          PUSH_TOKEN="${APP_TOKEN:-$GH_TOKEN}"
+
           # Force-push the fixed branch: if an earlier release's proposal is
           # still open, it is carried forward to the newest release rather than
           # leaving two competing pull requests behind.
           git push -q --force \
-            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+            "https://x-access-token:${PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
             "HEAD:refs/heads/${BRANCH}"
 
           existing="$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // ""')"
@@ -1548,30 +1556,42 @@ jobs:
           and verified.
           EOF
 
-          # The branch above already carries the change, so the release itself is
-          # complete and verified at this point. Opening the proposal needs
-          # `Pull requests: write` on top of that, which the token does not
-          # necessarily carry: the release App is scoped to Contents, and
-          # GITHUB_TOKEN cannot open pull requests while the organization
-          # forbids it. Report the branch instead of marking a published release
-          # as failed — this step proposes a convenience, it does not gate.
+          open_pr() {
+            GH_TOKEN="$1" gh pr create \
+              --base "$BASE" \
+              --head "$BRANCH" \
+              --title "chore(release): install ${VERSION} in new deployments" \
+              --body-file "$body_file"
+          }
+
           error_file="$(mktemp)"
-          if url="$(gh pr create \
-            --base "$BASE" \
-            --head "$BRANCH" \
-            --title "chore(release): install ${VERSION} in new deployments" \
-            --body-file "$body_file" 2>"$error_file")"; then
+          if url="$(open_pr "$GH_TOKEN" 2>"$error_file")"; then
             echo "Opened ${url}" | tee -a "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
 
-          echo "::warning::Could not open the default-version pull request: $(tr '\n' ' ' < "$error_file")"
+          github_token_error="$(tr '\n' ' ' < "$error_file")"
+
+          # Org policy sometimes blocks GITHUB_TOKEN from opening PRs. The App
+          # is the documented fallback; it failed for v4.4.1 (Contents only),
+          # but it is still the right second try if the App later gains
+          # pull-requests: write.
+          app_token_error="not configured"
+          if [ -n "${APP_TOKEN:-}" ]; then
+            if url="$(open_pr "$APP_TOKEN" 2>"$error_file")"; then
+              echo "Opened ${url}" | tee -a "$GITHUB_STEP_SUMMARY"
+              exit 0
+            fi
+            app_token_error="$(tr '\n' ' ' < "$error_file")"
+          fi
+
+          echo "::error::Could not open the default-version pull request (GITHUB_TOKEN: ${github_token_error}; App token: ${app_token_error})"
           {
             echo "Branch \`${BRANCH}\` was updated to \`${VERSION}\`, but its pull request could not be opened automatically."
             echo ""
-            echo "Open it from [this comparison](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/compare/${BASE}...${BRANCH}?expand=1)," \
-              "or grant the release App \`Pull requests: write\` so the proposal opens by itself."
+            echo "Open it from [this comparison](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/compare/${BASE}...${BRANCH}?expand=1)."
           } >> "$GITHUB_STEP_SUMMARY"
+          exit 1
 
   cloudflare-deploy:
     name: Deploy Cloudflare Worker

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1452,12 +1452,12 @@ jobs:
             echo "configured=false" >> "$GITHUB_OUTPUT"
           fi
 
-      # Push with the release App so the branch starts workflow runs
-      # (GITHUB_TOKEN-created refs do not). Opening the pull request uses
-      # GITHUB_TOKEN, which already has `pull-requests: write` on this job —
-      # the App is Contents-only and cannot createPullRequest (v4.4.1's pin
-      # sat on the branch for two days with no PR because that call was
-      # made with the App token and the job stayed green).
+      # CI runs on `pull_request` only, so the token that OPENS the proposal
+      # decides whether it carries checks: a pull request created with
+      # GITHUB_TOKEN starts no workflow run. The App is therefore tried first
+      # and GITHUB_TOKEN is the fallback, because the App is currently scoped
+      # to Contents and cannot createPullRequest — that is why v4.4.1's pin sat
+      # on the branch for two days with no proposal at all.
       - name: Create pull request token
         id: app-token
         if: steps.config.outputs.configured == 'true'
@@ -1510,9 +1510,8 @@ jobs:
           git checkout -q -B "$BRANCH"
           git commit -qam "chore(release): install ${VERSION} in new deployments"
 
-          # Prefer the App token so the force-push starts checks. Fall back to
-          # GITHUB_TOKEN when the App is not configured — the PR would then
-          # open unchecked, which is still better than no proposal at all.
+          # Either token may push this branch; GITHUB_TOKEN keeps the job
+          # working when the release App is not configured at all.
           PUSH_TOKEN="${APP_TOKEN:-$GH_TOKEN}"
 
           # Force-push the fixed branch: if an earlier release's proposal is
@@ -1556,8 +1555,10 @@ jobs:
           and verified.
           EOF
 
+          # Takes the NAME of the variable holding the token, so no secret is
+          # ever passed through argv.
           open_pr() {
-            GH_TOKEN="$1" gh pr create \
+            GH_TOKEN="${!1}" gh pr create \
               --base "$BASE" \
               --head "$BRANCH" \
               --title "chore(release): install ${VERSION} in new deployments" \
@@ -1565,29 +1566,35 @@ jobs:
           }
 
           error_file="$(mktemp)"
-          if url="$(open_pr "$GH_TOKEN" 2>"$error_file")"; then
-            echo "Opened ${url}" | tee -a "$GITHUB_STEP_SUMMARY"
-            exit 0
-          fi
 
-          github_token_error="$(tr '\n' ' ' < "$error_file")"
-
-          # Org policy sometimes blocks GITHUB_TOKEN from opening PRs. The App
-          # is the documented fallback; it failed for v4.4.1 (Contents only),
-          # but it is still the right second try if the App later gains
-          # pull-requests: write.
-          app_token_error="not configured"
+          app_error="the release App is not configured"
           if [ -n "${APP_TOKEN:-}" ]; then
-            if url="$(open_pr "$APP_TOKEN" 2>"$error_file")"; then
+            if url="$(open_pr APP_TOKEN 2>"$error_file")"; then
               echo "Opened ${url}" | tee -a "$GITHUB_STEP_SUMMARY"
               exit 0
             fi
-            app_token_error="$(tr '\n' ' ' < "$error_file")"
+            app_error="$(tr '\n' ' ' < "$error_file")"
           fi
 
-          echo "::error::Could not open the default-version pull request (GITHUB_TOKEN: ${github_token_error}; App token: ${app_token_error})"
+          # Second best: the proposal exists and is reviewable, but GitHub
+          # starts no workflow run for it. Say so, because merging a pin
+          # without the deployment-template checks is not the intent.
+          if url="$(open_pr GH_TOKEN 2>"$error_file")"; then
+            echo "::warning::Opened ${url} with GITHUB_TOKEN, so it carries no checks (the release App could not: ${app_error})"
+            {
+              echo "Opened ${url} for \`${VERSION}\`, but **without checks** — GitHub starts no workflow run for a pull request created with \`GITHUB_TOKEN\`."
+              echo ""
+              echo "Close and reopen it to run CI before merging, or grant the release App \`Pull requests: write\` so future proposals are checked from the start."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          # The release itself is published and verified at this point; only the
+          # proposal failed. Still a failure: a silent one left 4.4.1 unpinned
+          # for two days.
+          echo "::error::Could not open the default-version pull request for ${VERSION} (release App: ${app_error}; GITHUB_TOKEN: $(tr '\n' ' ' < "$error_file"))"
           {
-            echo "Branch \`${BRANCH}\` was updated to \`${VERSION}\`, but its pull request could not be opened automatically."
+            echo "Release \`${VERSION}\` is published. Branch \`${BRANCH}\` carries the raised pins, but its pull request could not be opened automatically."
             echo ""
             echo "Open it from [this comparison](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/compare/${BASE}...${BRANCH}?expand=1)."
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Problem

After `v4.4.1` the `release-version-pin` job pushed the raised pins to `automation/default-release-version` and then failed to open the pull request:

```
GraphQL: Resource not accessible by integration (createPullRequest)
```

It reported this as `::warning::` on a **green** job, so nobody noticed. `main` kept pinning 4.4.0 for new deployments for two days. The pin PRs have in fact always been opened by hand ([#1622](https://github.com/metadist/synaplan/pull/1622) was authored by a human, not the automation).

Root cause: `gh pr create` ran with the release App token, and that App is scoped to Contents only.

## Fix

`gh pr create` now tries two tokens and fails loudly if neither works:

1. **Release App token** — preferred, because CI only triggers on `pull_request`, and a PR created with `GITHUB_TOKEN` starts no workflow run at all.
2. **`GITHUB_TOKEN`** — fallback (the job already has `pull-requests: write`). The PR opens but carries no checks, so the step emits a `::warning::` and the step summary says to close/reopen it before merging.
3. **Neither** — `::error::` and `exit 1` instead of a green job with a buried warning.

Tokens are passed to the helper by variable name (`${!1}`), so no secret goes through argv.

Without checks, a pin PR would skip exactly the jobs that validate it: `Deployment Templates (AWS)` (`cfn-lint`, `packer validate`) and `Mobile Release Tooling` (`node --test tests/*.test.mjs`, which contains the "the shipped files name one and the same released version" pin-consistency test).

## Verification

The step's `run` block was extracted from `ci.yml` and executed against stubbed `gh`/`git`/`node`:

| Case | Result |
| --- | --- |
| App can create | exit 0, PR with checks, no warning |
| App blocked, `GITHUB_TOKEN` works (today) | exit 0, PR opened, warning about missing checks |
| App not configured, `GITHUB_TOKEN` works | exit 0, same warning |
| Both blocked | exit 1, `::error::` + compare URL |

`node --test tests/set-release-version.test.mjs` passes (18/18).

## Scope

The missing 4.4.1 pin itself is proposed separately in #1648. This PR only changes how the proposal gets opened.

This does **not** make any deployment auto-update: it only guarantees the proposal appears. Merging, the Umbrel store submission, and the AWS Marketplace submission stay manual.

Hosted `synaplan-platform` is unaffected — it has no `APP_VERSION` in `.env` (correct; the running image carries the version) and updates only by pulling a newer image.

## Test plan

- [ ] Review the two-token chain in the `Propose the new default version` step
- [ ] Next tagged release opens `chore(release): install X.Y.Z in new deployments` automatically
- [ ] If it opens via `GITHUB_TOKEN`, confirm the step summary tells the maintainer to close/reopen for checks