### PR TITLE
fix(frontend): serve 404 for missing hashed assets instead of SPA index.html

### DIFF
--- a/_docker/backend/Caddyfile
+++ b/_docker/backend/Caddyfile
@@ -165,6 +165,22 @@
 		file_server
 	}
 
+	# Missing content-hashed frontend assets must NOT fall through to the SPA
+	# fallback, which would serve index.html as HTTP 200 with a text/html MIME
+	# type. The browser then refuses the response as a module script/stylesheet
+	# ("Failed to load module script", "Refused to apply style", "Unable to
+	# preload CSS") — the post-deploy stale-shell failure mode: an open tab on
+	# an old build imports hashes that no longer exist. A clean 404 (never
+	# cached) lets the SPA's router detect the chunk-load failure and reload
+	# into the fresh bundle. Mirrors the @widget_missing guard above.
+	@frontend_missing {
+		path /assets/*
+	}
+	handle @frontend_missing {
+		header Cache-Control "no-store"
+		respond 404
+	}
+
 	# Backend static files third (bundles, uploads)
 	@backend_file {
 		path /bundles/* /uploads/*

--- a/_docker/backend/Caddyfile
+++ b/_docker/backend/Caddyfile
@@ -165,14 +165,9 @@
 		file_server
 	}
 
-	# Missing content-hashed frontend assets must NOT fall through to the SPA
-	# fallback, which would serve index.html as HTTP 200 with a text/html MIME
-	# type. The browser then refuses the response as a module script/stylesheet
-	# ("Failed to load module script", "Refused to apply style", "Unable to
-	# preload CSS") — the post-deploy stale-shell failure mode: an open tab on
-	# an old build imports hashes that no longer exist. A clean 404 (never
-	# cached) lets the SPA's router detect the chunk-load failure and reload
-	# into the fresh bundle. Mirrors the @widget_missing guard above.
+	# Missing hashed assets return a clean 404 instead of the SPA index.html
+	# (text/html), which the browser rejects as a module script/stylesheet.
+	# Mirrors the @widget_missing guard above.
 	@frontend_missing {
 		path /assets/*
 	}

--- a/cloudflare/src/worker.ts
+++ b/cloudflare/src/worker.ts
@@ -97,11 +97,8 @@ export default {
       headers.set('Pragma', 'no-cache')
       headers.set('Expires', '0')
     } else if (isHashedAsset(pathname) && response.ok) {
-      // Only the real, existing hashed file is immutable. A missing hash after
-      // a deploy is answered by the origin with a no-store 404 (see the
-      // @frontend_missing / @widget_missing guards in the backend Caddyfile);
-      // caching that 404 as immutable would pin the failure at the edge for a
-      // year, so let its no-store header pass through untouched.
+      // Only mark existing assets immutable; let the origin's no-store 404 for
+      // a missing hash pass through instead of pinning it at the edge.
       headers.set('Cache-Control', 'public, max-age=31536000, immutable')
     } else if (isHtmlNavigation(request, pathname)) {
       headers.set('Cache-Control', 'no-cache')

--- a/cloudflare/src/worker.ts
+++ b/cloudflare/src/worker.ts
@@ -96,7 +96,12 @@ export default {
       headers.set('Cache-Control', 'no-cache, no-store, must-revalidate')
       headers.set('Pragma', 'no-cache')
       headers.set('Expires', '0')
-    } else if (isHashedAsset(pathname)) {
+    } else if (isHashedAsset(pathname) && response.ok) {
+      // Only the real, existing hashed file is immutable. A missing hash after
+      // a deploy is answered by the origin with a no-store 404 (see the
+      // @frontend_missing / @widget_missing guards in the backend Caddyfile);
+      // caching that 404 as immutable would pin the failure at the edge for a
+      // year, so let its no-store header pass through untouched.
       headers.set('Cache-Control', 'public, max-age=31536000, immutable')
     } else if (isHtmlNavigation(request, pathname)) {
       headers.set('Cache-Control', 'no-cache')


### PR DESCRIPTION
## Summary

- Missing content-hashed frontend assets (`/assets/*`) now return a clean, `no-store` **404** instead of falling through to the SPA fallback that served `index.html` as `200 text/html`.
- Guard the Cloudflare worker to only mark hashed assets `immutable` on a `2xx` response, so the new 404 is not pinned at the edge for a year.

## Problem

After a deploy, an open tab still runs the old build and imports content-hashed chunks whose hashes no longer exist on the origin. Caddy fell through to the SPA fallback and answered `HTTP 200` with `index.html` (`text/html`). The browser then rejected those responses:

- `Failed to load module script: Expected a JavaScript-or-Wasm module script but the server responded with a MIME type of "text/html".`
- `Refused to apply style from '…/assets/ChatView-*.css' because its MIME type ('text/html') is not a supported stylesheet MIME type.`
- `Router error: Unable to preload CSS for …`

The bogus HTML response was even marked `Cache-Control: … immutable` (both at the origin and in the edge worker), so the failure could be cached.

## Fix

- `_docker/backend/Caddyfile`: add a `@frontend_missing` guard for `/assets/*` that returns a `no-store` 404 — mirroring the existing `@widget_missing` guard. A real 404 lets the SPA router's chunk-load-failure handler reload into the fresh bundle instead of showing MIME errors.
- `cloudflare/src/worker.ts`: only apply the `immutable` cache header to hashed assets when `response.ok`, so the origin's `no-store` 404 passes through.

Covers all deployments: the AWS Caddyfiles only reverse-proxy to `:8000`, and production uses the same base-image Caddyfile.

## Test plan

Verified locally against the running backend (`:8000`, `frontend/dist` served by Caddy):

- [x] Missing `/assets/*.js` and `/assets/*.css` → `404` + `Cache-Control: no-store` (was `200 text/html`)
- [x] Existing hashed asset → still `200`, `text/javascript`, `immutable`
- [x] SPA deep-link (`/channels/connections`) → still `200 text/html`, `no-cache` (routing intact)
- [x] `frankenphp validate` reports `Valid configuration`