### PR TITLE
feat: distribute a release to Elestio, Umbrel and AWS automatically

### DIFF
--- a/.github/workflows/aws-ami.yml
+++ b/.github/workflows/aws-ami.yml
@@ -214,9 +214,9 @@ jobs:
             echo ""
             echo "AMI: \`${ami}\` in \`${AWS_REGION}\`"
             echo ""
-            echo "Next: run **Test Add Version** in the AWS Marketplace Management Portal"
-            echo "for the free compliance scan, then verify a launch from"
-            echo "\`deploy/aws/cloudformation/synaplan-new-vpc.yaml\` before submitting."
+            echo "The submit job below offers this AMI to the listing once the"
+            echo "verification launch has passed. It validates by default and only"
+            echo "submits for real when the \`AWS_MARKETPLACE_SUBMIT\` variable says so."
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Validate and share the AMI with AWS Marketplace
@@ -581,4 +581,218 @@ jobs:
           for snapshot in $snapshots; do
             echo "Deleting the leftover snapshot ${snapshot}."
             aws ec2 delete-snapshot --snapshot-id "$snapshot" || true
+          done
+
+  submit:
+    name: Offer the version to the Marketplace listing
+    runs-on: ubuntu-latest
+    needs: [resolve, build, verify]
+    # Verification is not optional here. The build job proves an AMI exists and
+    # is ingestible; only the launch proves it boots and serves. Offering an
+    # unverified image to customers is the one mistake this listing cannot take
+    # back cheaply, so a run that skipped the launch skips the submission too.
+    if: >-
+      needs.resolve.outputs.version != '' &&
+      needs.resolve.outputs.configured == 'true' &&
+      needs.verify.result == 'success'
+    # Same trust path as the other AWS jobs: the role trusts this environment's
+    # subject claim, not a branch.
+    environment: ami-build
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      # The listing is created by hand in the Management Portal, and until it
+      # exists there is no entity to change. Skipped rather than failed, exactly
+      # like the missing build role above.
+      - name: Check the listing
+        id: listing
+        env:
+          PRODUCT_ID: ${{ secrets.AWS_MARKETPLACE_PRODUCT_ID }}
+          INGESTION_ROLE_ARN: ${{ secrets.AWS_MARKETPLACE_INGESTION_ROLE_ARN }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${PRODUCT_ID:-}" ] || [ -z "${INGESTION_ROLE_ARN:-}" ]; then
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "### AWS Marketplace"
+              echo ""
+              echo "No \`AWS_MARKETPLACE_PRODUCT_ID\` and \`AWS_MARKETPLACE_INGESTION_ROLE_ARN\`;"
+              echo "the version was not offered to a listing. See docs/AWS_MARKETPLACE_LISTING.md."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          echo "configured=true" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout
+        if: steps.listing.outputs.configured == 'true'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Assume the build role
+        if: steps.listing.outputs.configured == 'true'
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+        with:
+          role-to-assume: ${{ secrets.AWS_AMI_BUILD_ROLE_ARN }}
+          role-session-name: synaplan-submit-${{ github.run_id }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Download the build manifests
+        if: steps.listing.outputs.configured == 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: packer-manifest-*
+          path: manifests
+
+      - name: Offer each architecture as a version
+        if: steps.listing.outputs.configured == 'true'
+        env:
+          PRODUCT_ID: ${{ secrets.AWS_MARKETPLACE_PRODUCT_ID }}
+          INGESTION_ROLE_ARN: ${{ secrets.AWS_MARKETPLACE_INGESTION_ROLE_ARN }}
+          # Unset means validate. Rolling out a listing change is not something
+          # to discover by accident, and AWS keeps a submitted version in review
+          # for days — a wrong one costs a support case, not a revert.
+          SUBMIT: ${{ vars.AWS_MARKETPLACE_SUBMIT }}
+          VERSION: ${{ needs.resolve.outputs.version }}
+          ARCHITECTURES: ${{ needs.resolve.outputs.matrix }}
+          RELEASE_URL: ${{ github.server_url }}/${{ github.repository }}/releases/tag/v${{ needs.resolve.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          if [ "${SUBMIT:-}" = apply ]; then
+            intent=APPLY
+          else
+            intent=VALIDATE
+          fi
+
+          {
+            echo "### AWS Marketplace"
+            echo ""
+            if [ "$intent" = VALIDATE ]; then
+              echo "Validated \`${VERSION}\` against the listing without submitting it."
+              echo "Set the repository variable \`AWS_MARKETPLACE_SUBMIT\` to \`apply\` to submit for real."
+            else
+              echo "Submitted \`${VERSION}\` to the listing. AWS reviews a new version before it becomes available."
+            fi
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          # One AMI per version, by AWS's rule that every delivery option of a
+          # version shares the same AmiSource. Two architectures are therefore
+          # two versions, and they have to go one after another: a running change
+          # set locks the entity and the second call would fail with
+          # ResourceInUseException.
+          for architecture in $(printf '%s' "$ARCHITECTURES" | jq -r '.[]'); do
+            manifest="manifests/packer-manifest-${architecture}/packer-manifest.json"
+            if [ ! -f "$manifest" ]; then
+              echo "::error::No build manifest for ${architecture}; refusing to guess an AMI id."
+              exit 1
+            fi
+
+            ami="$(jq -r '.builds[-1].artifact_id' "$manifest" | cut -d: -f2)"
+            if [ -z "$ami" ] || [ "$ami" = null ]; then
+              echo "::error::${manifest} carries no AMI id."
+              exit 1
+            fi
+
+            case "$architecture" in
+              arm64) instance_type=m7g.xlarge ;;
+              *)     instance_type=m7i.xlarge ;;
+            esac
+
+            # Mirrors deploy/aws/packer/synaplan.pkr.hcl's source_ami_filter and
+            # deploy/aws/scripts/harden.sh: Amazon Linux 2023, ec2-user, sshd
+            # listening but password and root login refused.
+            details="$(jq -n \
+              --arg title "${VERSION} (${architecture})" \
+              --arg notes "Synaplan ${VERSION}. Release notes: ${RELEASE_URL}" \
+              --arg ami "$ami" \
+              --arg role "$INGESTION_ROLE_ARN" \
+              --arg instance_type "$instance_type" \
+              '{
+                Version: { VersionTitle: $title, ReleaseNotes: $notes },
+                DeliveryOptions: [{
+                  Details: {
+                    AmiDeliveryOptionDetails: {
+                      AmiSource: {
+                        AmiId: $ami,
+                        AccessRoleArn: $role,
+                        UserName: "ec2-user",
+                        ScanningPort: 22,
+                        OperatingSystemName: "AMAZONLINUX",
+                        OperatingSystemVersion: "2023"
+                      },
+                      UsageInstructions: "Launch the instance, then open https://<public IP or your domain>. Sign in with the administrator address shown in the CloudFormation outputs; the single-use password is stored in SSM Parameter Store under /synaplan/<instance-id>/admin-password and must be replaced at first sign-in. Add an AI provider key under Admin, AI Providers. Full guide: https://github.com/metadist/synaplan/blob/main/deploy/aws/README.md",
+                      RecommendedInstanceType: $instance_type,
+                      SecurityGroups: [
+                        { IpProtocol: "tcp", FromPort: 443, ToPort: 443, IpRanges: ["0.0.0.0/0"] },
+                        { IpProtocol: "tcp", FromPort: 80, ToPort: 80, IpRanges: ["0.0.0.0/0"] }
+                      ]
+                    }
+                  }
+                }]
+              }')"
+
+            change_set="$(jq -n \
+              --arg product "$PRODUCT_ID" \
+              --argjson details "$details" \
+              '[{
+                ChangeType: "AddDeliveryOptions",
+                Entity: { Identifier: $product, Type: "AmiProduct@1.0" },
+                DetailsDocument: $details
+              }]')"
+
+            echo "::group::${architecture}: ${intent} ${ami}"
+            id="$(
+              aws marketplace-catalog start-change-set \
+                --catalog AWSMarketplace \
+                --intent "$intent" \
+                --client-request-token "synaplan-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${architecture}" \
+                --change-set "$change_set" \
+                --query ChangeSetId --output text
+            )"
+            echo "Change set ${id}."
+            echo "::endgroup::"
+
+            if [ "$intent" = VALIDATE ]; then
+              echo "- \`${architecture}\`: \`${ami}\` validated (change set \`${id}\`)" >> "$GITHUB_STEP_SUMMARY"
+              continue
+            fi
+
+            # Waited out rather than fired and forgotten, for two reasons: the
+            # next architecture cannot start while this change set holds the
+            # entity, and a rejected document has to fail this job rather than
+            # sit unnoticed in the portal.
+            for _ in $(seq 1 60); do
+              status="$(
+                aws marketplace-catalog describe-change-set \
+                  --catalog AWSMarketplace --change-set-id "$id" \
+                  --query Status --output text
+              )"
+              case "$status" in
+                SUCCEEDED)
+                  echo "- \`${architecture}\`: \`${ami}\` submitted (change set \`${id}\`)" >> "$GITHUB_STEP_SUMMARY"
+                  break
+                  ;;
+                FAILED|CANCELLED)
+                  reason="$(
+                    aws marketplace-catalog describe-change-set \
+                      --catalog AWSMarketplace --change-set-id "$id" \
+                      --query 'ChangeSet[].ErrorDetailList' --output json
+                  )"
+                  echo "::error::Change set ${id} for ${architecture} ended as ${status}: ${reason}"
+                  exit 1
+                  ;;
+                *)
+                  sleep 30
+                  ;;
+              esac
+            done
+
+            if [ "$status" != SUCCEEDED ]; then
+              echo "::error::Change set ${id} for ${architecture} was still ${status} after thirty minutes."
+              exit 1
+            fi
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1427,10 +1427,12 @@ jobs:
       # A pull request, deliberately, rather than a push to main. Elestio
       # pipelines redeploy on every commit to the branch they track, so pushing
       # here would restart every managed instance at an unpredictable moment.
-      # Merging is the maintainer's choice of when that happens. The Umbrel
-      # package lives in this same PR so a release bumps every catalog pin
-      # together; the getumbrel/umbrel-apps store submission stays a separate,
-      # manual step because it targets a foreign repository.
+      # release-rollout.yml merges this proposal in a nightly maintenance window
+      # instead, once its own guards agree that it is the release the published
+      # manifest advertises. The Umbrel package lives in this same PR so a
+      # release bumps every catalog pin together; carrying that package into
+      # getumbrel/umbrel-apps is umbrel-store-sync.yml's job, because a foreign
+      # repository cannot be pinned from here.
       - name: Checkout the default branch
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -1537,12 +1539,16 @@ jobs:
           moves a running installation to a different version.
 
           Merging this restarts every Elestio instance that tracks \`${BASE}\`, because
-          Elestio redeploys on each commit to the branch it tracks. Merge when that is
-          convenient.
+          Elestio redeploys on each commit to the branch it tracks. That is why nothing
+          merges this on the spot: \`release-rollout.yml\` does it in the next nightly
+          maintenance window, once the checks here are green and this version is still
+          the one the release manifest advertises. Merge it by hand to roll out sooner.
 
-          The Umbrel pin lives in this repository only. Submitting the raised package
-          to [getumbrel/umbrel-apps](https://github.com/getumbrel/umbrel-apps) remains
-          a separate, manual pull request.
+          Once merged, \`umbrel-store-sync.yml\` carries the raised package into
+          [getumbrel/umbrel-apps](https://github.com/getumbrel/umbrel-apps), and the
+          AWS Marketplace version is submitted from \`aws-ami.yml\`. Both are proposals
+          in someone else's queue: Umbrel merges its own store pull requests, and AWS
+          reviews a submitted version before it becomes available.
 
           Opened automatically after the image for \`${GITHUB_REF_NAME}\` was published
           and verified.

--- a/.github/workflows/release-rollout.yml
+++ b/.github/workflows/release-rollout.yml
@@ -1,0 +1,314 @@
+name: Release Rollout
+
+# Merges the pin proposal that ci.yml's release-version-pin job opens, so a new
+# release reaches new deployments without anyone remembering to click Merge.
+#
+# Why a scheduled job and not an auto-merge on the proposal itself: merging
+# restarts every Elestio instance that tracks the default branch, because Elestio
+# redeploys on each commit to the branch it tracks. Auto-merge would fire the
+# moment CI goes green — mid-afternoon, mid-conversation. A maintenance window
+# turns an unpredictable restart into a predictable one.
+#
+# This job only ever moves the version that a NEW deployment installs. Running
+# installations are untouched: they keep the version their operator pinned and
+# change it only through docs/UPDATE_ELESTIO.md or docs/UPDATE_SELFHOST.md.
+#
+# Requires the release App to be a bypass actor of the review ruleset, and to
+# hold `Pull requests: write` so its proposals carry checks in the first place.
+# Without checks the status guard below can never be satisfied, which is the
+# intended failure mode: no checks, no rollout.
+
+on:
+  schedule:
+    # 01:00 UTC — the small hours in the timezone the instances are operated
+    # from. Deliberately not on the hour a release is usually cut.
+    - cron: '0 1 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Evaluate the guards and report what would happen, without merging.'
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+# One rollout at a time. Two concurrent runs would race on the same proposal and
+# the loser would report a confusing "already merged".
+concurrency:
+  group: release-rollout
+  cancel-in-progress: false
+
+jobs:
+  rollout:
+    name: Roll out the default release version
+    runs-on: ubuntu-latest
+
+    env:
+      BRANCH: automation/default-release-version
+      DRY_RUN: ${{ inputs.dry_run || false }}
+
+    steps:
+      # The secrets context is not available in an `if` expression, so their
+      # presence is carried through an output — the same workaround
+      # release-version-pin and aws-ami.yml use.
+      - name: Check the merge credentials
+        id: config
+        env:
+          APP_ID: ${{ secrets.MOBILE_TAG_APP_ID }}
+          APP_PRIVATE_KEY: ${{ secrets.MOBILE_TAG_APP_PRIVATE_KEY }}
+        run: |
+          if test -n "$APP_ID" && test -n "$APP_PRIVATE_KEY"; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "No release App is configured; the rollout is skipped." |
+              tee -a "$GITHUB_STEP_SUMMARY"
+          fi
+
+      # GITHUB_TOKEN is deliberately not a fallback here. It cannot bypass the
+      # review ruleset, so it would fail at the merge — after the guards had
+      # already reported success, which reads like the rollout worked.
+      - name: Create merge token
+        id: app-token
+        if: steps.config.outputs.configured == 'true'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ secrets.MOBILE_TAG_APP_ID }}
+          private-key: ${{ secrets.MOBILE_TAG_APP_PRIVATE_KEY }}
+
+      - name: Find the pin proposal
+        id: proposal
+        if: steps.config.outputs.configured == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+
+          number="$(
+            gh pr list --repo "$GITHUB_REPOSITORY" --head "$BRANCH" --state open \
+              --json number --jq '.[0].number // ""'
+          )"
+
+          if [ -z "$number" ]; then
+            echo "number=" >> "$GITHUB_OUTPUT"
+            echo "No open pin proposal on \`${BRANCH}\`; nothing to roll out." |
+              tee -a "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          sha="$(gh pr view "$number" --repo "$GITHUB_REPOSITORY" --json headRefOid --jq .headRefOid)"
+          echo "number=${number}" >> "$GITHUB_OUTPUT"
+          echo "sha=${sha}" >> "$GITHUB_OUTPUT"
+
+      # The proposal's own head, not the default branch: the guards below have to
+      # judge the pins that would actually be merged.
+      - name: Checkout the proposal
+        if: steps.proposal.outputs.number != ''
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ steps.proposal.outputs.sha }}
+          persist-credentials: false
+
+      - name: Evaluate the guards
+        id: guards
+        if: steps.proposal.outputs.number != ''
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          NUMBER: ${{ steps.proposal.outputs.number }}
+          MANIFEST_URL: https://raw.githubusercontent.com/${{ github.repository }}/release-manifest/versions.json
+        run: |
+          set -euo pipefail
+
+          # Flattened to one line before it is written: a step output is
+          # newline-delimited, so a reason quoting a multi-line error message
+          # would corrupt the outputs that follow it.
+          block() {
+            reason="$(printf '%s' "$1" | tr '\n\r' '  ')"
+            echo "decision=blocked" >> "$GITHUB_OUTPUT"
+            echo "reason=${reason}" >> "$GITHUB_OUTPUT"
+            echo "::warning::Not rolling out #${NUMBER}: ${reason}"
+            {
+              echo "### Rollout held back"
+              echo ""
+              echo "[Pull request #${NUMBER}](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/pull/${NUMBER}) was not merged: ${reason}"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          }
+
+          # Guard 1: the catalog pins one released version across all five
+          # anchors. A half-bumped catalog would install one version and
+          # advertise another.
+          if ! pinned="$(node scripts/read-release-version.mjs 2>&1)"; then
+            block "the pinned version could not be read (${pinned})"
+          fi
+          version="$(printf '%s' "$pinned" | jq -r .version)"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+          manifest="$(curl --fail-with-body --silent --show-error --retry 3 "$MANIFEST_URL")"
+
+          # Guard 2: only ever roll out the release that the published manifest
+          # advertises. A proposal left behind by an older release is stale, and
+          # merging it would move new deployments backwards.
+          stable="$(printf '%s' "$manifest" | jq -r '.stable.version')"
+          if [ "$version" != "$stable" ]; then
+            block "it pins \`${version}\` while the release manifest advertises \`${stable}\`"
+          fi
+
+          # Guard 3: a release withdrawn between the tag and this window must not
+          # become anybody's default. Tolerates both shapes the manifest may use
+          # for an entry, so a future object form does not read as "not yanked".
+          yanked="$(
+            printf '%s' "$manifest" | jq -r --arg v "$version" '
+              [.yanked[]? | if type == "object" then (.version // empty) else tostring end]
+              | if index($v) then "yes" else "" end
+            '
+          )"
+          if [ -n "$yanked" ]; then
+            block "\`${version}\` is listed as yanked in the release manifest"
+          fi
+
+          # Guard 4: nothing but the deployment pins may travel to the default
+          # branch on this automation branch.
+          unexpected="$(
+            gh pr view "$NUMBER" --repo "$GITHUB_REPOSITORY" --json files --jq '
+              [.files[].path]
+              | map(select(
+                  test("^elestio\\.yml$") == false and
+                  test("^deploy/selfhost\\.env\\.example$") == false and
+                  test("^deploy/umbrel/synaplan/") == false and
+                  test("^deploy/aws/packer/synaplan\\.pkr\\.hcl$") == false
+                ))
+              | join(", ")
+            '
+          )"
+          if [ -n "$unexpected" ]; then
+            block "it also changes files outside the deployment pins (${unexpected})"
+          fi
+
+          # Guard 5: the deployment templates must be green. Note that this reads
+          # the check by name instead of trusting mergeStateStatus, which stays
+          # BLOCKED on this repository for as long as the review requirement is
+          # unmet — the App bypasses that requirement at merge time, so BLOCKED
+          # here is normal and says nothing about the checks.
+          state="$(
+            gh pr view "$NUMBER" --repo "$GITHUB_REPOSITORY" \
+              --json mergeable,statusCheckRollup --jq '{
+                mergeable: .mergeable,
+                gate: ([.statusCheckRollup[]? | select(.name == "All Checks Passed")] | last)
+              }'
+          )"
+
+          mergeable="$(printf '%s' "$state" | jq -r .mergeable)"
+          if [ "$mergeable" != MERGEABLE ]; then
+            block "GitHub reports the pull request as \`${mergeable}\` rather than mergeable"
+          fi
+
+          gate_status="$(printf '%s' "$state" | jq -r '.gate.status // "MISSING"')"
+          gate_conclusion="$(printf '%s' "$state" | jq -r '.gate.conclusion // "MISSING"')"
+          if [ "$gate_status" != COMPLETED ] || [ "$gate_conclusion" != SUCCESS ]; then
+            block "the \`All Checks Passed\` gate is ${gate_status}/${gate_conclusion} instead of COMPLETED/SUCCESS"
+          fi
+
+          echo "decision=merge" >> "$GITHUB_OUTPUT"
+
+      - name: Merge the proposal
+        id: merge
+        if: steps.guards.outputs.decision == 'merge'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          NUMBER: ${{ steps.proposal.outputs.number }}
+          VERSION: ${{ steps.guards.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/pull/${NUMBER}"
+
+          if [ "$DRY_RUN" = true ]; then
+            echo "merged=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "### Dry run"
+              echo ""
+              echo "Every guard passed for \`${VERSION}\`. A real run would merge [#${NUMBER}](${url}) now."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          # Squash, to keep one commit per release on the default branch.
+          gh pr merge "$NUMBER" --repo "$GITHUB_REPOSITORY" --squash
+
+          echo "merged=true" >> "$GITHUB_OUTPUT"
+          {
+            echo "### Rolled out ${VERSION}"
+            echo ""
+            echo "Merged [#${NUMBER}](${url}). New deployments now install \`${VERSION}\`:"
+            echo ""
+            echo "- \`elestio.yml\` for the one-click path"
+            echo "- \`deploy/selfhost.env.example\` for self-hosting"
+            echo "- \`deploy/umbrel/synaplan/\` for the Umbrel App Store package"
+            echo "- \`deploy/aws/packer/synaplan.pkr.hcl\` for the AWS Marketplace AMI"
+            echo ""
+            echo "Elestio instances that track the default branch are redeploying now."
+            echo "Running installations keep the version their operator pinned."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # Deliberately a separate, optional channel from DISCORD_E2E_FLAKY_WEBHOOK:
+      # a version rollout is an operations event, not a test result. Silent when
+      # nothing happened, so a nightly run on an empty branch stays quiet.
+      - name: Report to Discord
+        if: always() && steps.proposal.outputs.number != ''
+        env:
+          HOOK: ${{ secrets.DISCORD_RELEASE_WEBHOOK }}
+          NUMBER: ${{ steps.proposal.outputs.number }}
+          VERSION: ${{ steps.guards.outputs.version }}
+          DECISION: ${{ steps.guards.outputs.decision }}
+          REASON: ${{ steps.guards.outputs.reason }}
+          MERGED: ${{ steps.merge.outputs.merged }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          [ -n "${HOOK:-}" ] || exit 0
+
+          pr_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/pull/${NUMBER}"
+
+          if [ "${MERGED:-}" = true ]; then
+            title="Rolled out ${VERSION} to new deployments"
+            colour=3066993
+            detail="Elestio instances tracking the default branch are redeploying. Running installations are unaffected."
+          elif [ "${DECISION:-}" = blocked ]; then
+            title="Release rollout held back"
+            colour=16776960
+            detail="${REASON:-no reason recorded}"
+          else
+            # Covers the dry run and an unexpected failure of a step above.
+            exit 0
+          fi
+
+          # Match DiscordNotificationService embed shape (title/fields/footer/timestamp).
+          payload="$(jq -n \
+            --arg title "$title" \
+            --arg detail "$detail" \
+            --arg pr "$pr_url" \
+            --arg run "$RUN_URL" \
+            --argjson colour "$colour" \
+            --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            '{
+              embeds: [{
+                title: $title,
+                color: $colour,
+                fields: [
+                  { name: "Details", value: ($detail | .[0:1000]), inline: false },
+                  { name: "Proposal", value: ("[Open pull request](" + $pr + ")"), inline: true },
+                  { name: "Workflow", value: ("[Open run](" + $run + ")"), inline: true }
+                ],
+                footer: { text: "Synaplan release rollout" },
+                timestamp: $ts
+              }]
+            }')"
+
+          curl --fail-with-body --silent --show-error --retry 3 \
+            -H 'Content-Type: application/json' \
+            -d "$payload" \
+            "$HOOK" \
+            || echo "::warning::Discord notification failed"

--- a/.github/workflows/umbrel-store-sync.yml
+++ b/.github/workflows/umbrel-store-sync.yml
@@ -1,0 +1,284 @@
+name: Umbrel Store Sync
+
+# Carries deploy/umbrel/synaplan/ into the Umbrel App Store, so the store
+# package follows a release without anyone copying files by hand.
+#
+# Two different jobs hide behind that one sentence, and which one applies is
+# decided by the store itself:
+#
+#   * Synaplan is not in the store yet. The submission is still an open pull
+#     request, and keeping it current means updating the branch it is built from.
+#     Umbrel's linter requires `releaseNotes` and `gallery` to stay EMPTY for a
+#     new submission — Umbrel produces the final store assets — so nothing here
+#     fills them.
+#   * Synaplan is in the store. Then a release is a version bump, which is a new
+#     pull request of its own, and Umbrel expects user-facing `releaseNotes`.
+#
+# Runs on the default branch after the version pins land there, which is what
+# release-rollout.yml does in its maintenance window. The merge itself cannot be
+# automated: getumbrel/umbrel-apps belongs to Umbrel.
+
+on:
+  push:
+    branches: [main]
+    paths: ['deploy/umbrel/synaplan/**']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# The fork branch is rewritten in place, so two runs must never overlap.
+concurrency:
+  group: umbrel-store-sync
+  cancel-in-progress: false
+
+env:
+  FORK: metadist/umbrel-apps
+  UPSTREAM: getumbrel/umbrel-apps
+  APP_ID: synaplan
+  SUBMISSION_BRANCH: synaplan
+
+jobs:
+  sync:
+    name: Update the Umbrel App Store package
+    runs-on: ubuntu-latest
+
+    steps:
+      # The token belongs to the fork, not to this repository, so it cannot be
+      # derived from anything available here. Skipped rather than failed while it
+      # is unset: the store package is still correct in this repository.
+      - name: Check the fork credentials
+        id: config
+        env:
+          TOKEN: ${{ secrets.UMBREL_FORK_TOKEN }}
+        run: |
+          if test -n "${TOKEN:-}"; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "No \`UMBREL_FORK_TOKEN\`; the Umbrel App Store sync is skipped." |
+              tee -a "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Checkout
+        if: steps.config.outputs.configured == 'true'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          path: synaplan
+          persist-credentials: false
+
+      - name: Read the packaged version
+        id: package
+        if: steps.config.outputs.configured == 'true'
+        working-directory: synaplan
+        run: |
+          set -euo pipefail
+          version="$(node scripts/read-release-version.mjs | jq -r .version)"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "Packaging Synaplan ${version} for the Umbrel App Store." >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Clone the fork
+        if: steps.config.outputs.configured == 'true'
+        env:
+          TOKEN: ${{ secrets.UMBREL_FORK_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Credentials in a helper rather than the remote URL, so no later `git
+          # remote -v` in a log can expose the token.
+          git clone --quiet --no-tags "https://github.com/${FORK}.git" fork
+          cd fork
+          git config credential.helper '!f() { echo "username=x-access-token"; echo "password=${TOKEN}"; }; f'
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git remote add upstream "https://github.com/${UPSTREAM}.git"
+          git fetch --quiet --no-tags upstream master
+
+      # Whether the store already carries the app decides everything below: the
+      # branch to build, the pull request to open, and whether release notes are
+      # required or forbidden.
+      - name: Decide submission or version bump
+        id: mode
+        if: steps.config.outputs.configured == 'true'
+        working-directory: fork
+        run: |
+          set -euo pipefail
+
+          if git cat-file -e "upstream/master:${APP_ID}/umbrel-app.yml" 2>/dev/null; then
+            echo "mode=bump" >> "$GITHUB_OUTPUT"
+            echo "The store already carries \`${APP_ID}\`; this release is a version bump." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "mode=submission" >> "$GITHUB_OUTPUT"
+            echo "\`${APP_ID}\` is not in the store yet; the open submission is updated instead." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      # Guards the one thing a forced update could destroy. The automation owns
+      # `<app>/` on the submission branch, but anything a maintainer added
+      # outside it — tooling, another app, a fix to the store itself — would be
+      # lost, and losing someone else's work silently is not acceptable.
+      - name: Check the submission branch for foreign changes
+        if: steps.config.outputs.configured == 'true' && steps.mode.outputs.mode == 'submission'
+        working-directory: fork
+        run: |
+          set -euo pipefail
+
+          git rev-parse --verify --quiet "origin/${SUBMISSION_BRANCH}" >/dev/null || exit 0
+
+          foreign="$(
+            git diff --name-only "upstream/master...origin/${SUBMISSION_BRANCH}" \
+              | grep -v "^${APP_ID}/" || true
+          )"
+          if [ -n "$foreign" ]; then
+            echo "::error::\`${FORK}:${SUBMISSION_BRANCH}\` changes files outside \`${APP_ID}/\`, which this sync would discard: $(echo "$foreign" | tr '\n' ' ')"
+            exit 1
+          fi
+
+      - name: Build the store package
+        id: build
+        if: steps.config.outputs.configured == 'true'
+        env:
+          MODE: ${{ steps.mode.outputs.mode }}
+          VERSION: ${{ steps.package.outputs.version }}
+          # Reads this repository's own release, so the run's own token is enough
+          # — the fork credentials have no business here.
+          GH_TOKEN: ${{ github.token }}
+        working-directory: fork
+        run: |
+          set -euo pipefail
+
+          if [ "$MODE" = submission ]; then
+            branch="$SUBMISSION_BRANCH"
+          else
+            branch="${APP_ID}-${VERSION}"
+          fi
+          echo "branch=${branch}" >> "$GITHUB_OUTPUT"
+
+          # Rebuilt from upstream rather than rebased onto it: the branch carries
+          # exactly one directory, so recreating it can never conflict, and the
+          # result stays mergeable for as long as upstream leaves that directory
+          # alone.
+          git checkout --quiet -B "$branch" upstream/master
+
+          # Mirrored, not merged: a file dropped from the package here has to
+          # disappear from the store package too.
+          rsync --archive --delete "../synaplan/deploy/umbrel/${APP_ID}/" "${APP_ID}/"
+
+          if [ "$MODE" = bump ]; then
+            # Umbrel shows these in the update dialog and its linter asks for them
+            # on a version bump. Absent for a new submission, where the same
+            # linter rejects them.
+            body="$(gh release view "v${VERSION}" --repo "$GITHUB_REPOSITORY" --json body --jq .body 2>/dev/null || true)"
+            node ../synaplan/scripts/set-umbrel-release-notes.mjs \
+              --manifest "${APP_ID}/umbrel-app.yml" \
+              --body "$body" \
+              --url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases/tag/v${VERSION}" \
+              > /dev/null
+          fi
+
+          # --porcelain rather than `git diff`: the submission path starts from an
+          # upstream that has no such directory at all, so every file is untracked
+          # and a diff would report no change at all.
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "The store package already matches this repository; nothing to push." |
+              tee -a "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+          git add --all "${APP_ID}"
+          if [ "$MODE" = submission ]; then
+            git commit --quiet -m "${APP_ID}: add Synaplan ${VERSION}"
+          else
+            git commit --quiet -m "${APP_ID}: update to ${VERSION}"
+          fi
+
+      # Umbrel's own rules, run before Umbrel has to look at it: manifest fields,
+      # port conflicts, and with --check-images that every pinned digest really
+      # exists. --changed is what tells the linter whether this is a new
+      # submission or an update, so its release-notes rule matches reality.
+      - name: Lint the package with Umbrel's linter
+        if: steps.build.outputs.changed == 'true'
+        working-directory: fork
+        run: |
+          set -euo pipefail
+
+          if ! jq -e '.scripts["lint:apps"]' package.json >/dev/null 2>&1; then
+            echo "::warning::${UPSTREAM} no longer provides \`lint:apps\`; the store package is pushed unlinted."
+            exit 0
+          fi
+
+          npm ci --no-audit --no-fund
+          npm run lint:apps -- --changed "upstream/master...HEAD" --check-images --format github
+
+      - name: Push and propose
+        if: steps.build.outputs.changed == 'true'
+        env:
+          # TOKEN feeds the credential helper the clone step installed, GH_TOKEN
+          # the API calls. Same secret, two consumers that read it differently.
+          TOKEN: ${{ secrets.UMBREL_FORK_TOKEN }}
+          GH_TOKEN: ${{ secrets.UMBREL_FORK_TOKEN }}
+          MODE: ${{ steps.mode.outputs.mode }}
+          VERSION: ${{ steps.package.outputs.version }}
+          BRANCH: ${{ steps.build.outputs.branch }}
+        working-directory: fork
+        run: |
+          set -euo pipefail
+
+          # Force, because the branch was rebuilt on upstream/master. For the
+          # submission branch this updates the pull request that is already open;
+          # the step above proved it carries nothing but this app.
+          git push --quiet --force origin "HEAD:refs/heads/${BRANCH}"
+
+          existing="$(
+            gh pr list --repo "$UPSTREAM" --state open \
+              --head "$BRANCH" --json number,url --jq '.[0].url // ""' || true
+          )"
+
+          if [ -n "$existing" ]; then
+            {
+              echo "### Umbrel App Store"
+              echo ""
+              echo "Updated ${existing} to Synaplan \`${VERSION}\`. Umbrel merges its own store pull requests."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          # Only a version bump opens a new one. A missing submission pull request
+          # is not something to guess at: reopening it silently could duplicate a
+          # submission Umbrel already closed for a reason.
+          if [ "$MODE" = submission ]; then
+            {
+              echo "### Umbrel App Store"
+              echo ""
+              echo "Pushed Synaplan \`${VERSION}\` to \`${FORK}:${BRANCH}\`, but no open submission pull request was found."
+              echo ""
+              echo "Open one against [${UPSTREAM}](${GITHUB_SERVER_URL}/${UPSTREAM}/compare) from that branch if the submission should be revived."
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::warning::No open submission pull request for ${BRANCH}; the branch was updated but nothing was proposed."
+            exit 0
+          fi
+
+          body_file="$(mktemp)"
+          cat > "$body_file" <<EOF
+          Updates Synaplan to \`${VERSION}\`.
+
+          Release notes: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases/tag/v${VERSION}
+
+          The package is generated from \`deploy/umbrel/${APP_ID}/\` in
+          ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY} and pins the image by digest.
+          Opened automatically after the release was published and verified.
+          EOF
+
+          url="$(
+            gh pr create --repo "$UPSTREAM" \
+              --base master \
+              --head "${FORK%%/*}:${BRANCH}" \
+              --title "${APP_ID}: update to ${VERSION}" \
+              --body-file "$body_file"
+          )"
+
+          {
+            echo "### Umbrel App Store"
+            echo ""
+            echo "Opened ${url} for Synaplan \`${VERSION}\`. Umbrel merges its own store pull requests."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -277,5 +277,26 @@ absent local-AI services and the missing consistent-backup hook, are listed in
 The release pin for that package (store `version`, `APP_VERSION`, and the
 `tag@sha256:…` image) is raised automatically together with `elestio.yml` and
 `deploy/selfhost.env.example` by `scripts/set-release-version.mjs` after every
-published release. Submitting the raised package to the Umbrel App Store remains
-a separate, manual pull request against `getumbrel/umbrel-apps`.
+published release. `.github/workflows/umbrel-store-sync.yml` then carries the
+raised package into `getumbrel/umbrel-apps`; Umbrel reviews and merges it.
+
+## What "automatically updated" covers, and what it does not
+
+Every release raises the version pins in this directory, and
+`.github/workflows/release-rollout.yml` merges that change in a nightly
+maintenance window. The effect is precise and worth stating plainly:
+
+- **New deployments** install the current release. Whoever clicks the Elestio
+  template, copies `selfhost.env.example`, installs from the Umbrel App Store, or
+  launches the AWS AMI tomorrow gets what was released today.
+- **Existing installations are never touched.** They keep the version their
+  operator pinned. Nothing here reaches into a running deployment, and nothing
+  here should: an update runs database migrations, and the backup that makes those
+  survivable is the operator's to take. `validate_release_pin()` in
+  `scripts/lib.sh` rejects a mutable tag for the same reason.
+
+Updating a running installation is the operator's decision, documented per
+platform in [`../docs/UPDATE_ELESTIO.md`](../docs/UPDATE_ELESTIO.md) and
+[`../docs/UPDATE_SELFHOST.md`](../docs/UPDATE_SELFHOST.md). The application says
+the same thing in the admin area: it reports a newer version and never installs
+one.

--- a/deploy/aws/cloudformation/marketplace-roles.yaml
+++ b/deploy/aws/cloudformation/marketplace-roles.yaml
@@ -229,6 +229,38 @@ Resources:
                   - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:role/synaplan-verify-*'
                   - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/synaplan-verify-*'
 
+        # Offers a built and verified AMI to the listing as a new version, which
+        # is what the submit job in .github/workflows/aws-ami.yml does instead of
+        # a maintainer filling in the Add Version form.
+        - PolicyName: marketplace-catalog
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              # The Catalog API takes the entity in the request body rather than
+              # in the resource ARN, so these cannot be narrowed to one product.
+              # Read plus a change set is the whole blast radius: none of them can
+              # publish anything, because AWS reviews a submitted version first.
+              - Effect: Allow
+                Action:
+                  - aws-marketplace:ListEntities
+                  - aws-marketplace:DescribeEntity
+                  - aws-marketplace:StartChangeSet
+                  - aws-marketplace:ListChangeSets
+                  - aws-marketplace:DescribeChangeSet
+                  - aws-marketplace:CancelChangeSet
+                Resource: '*'
+
+              # Handing the ingestion role to the Marketplace is part of the
+              # change set: the AmiSource names it as the role AWS assumes to
+              # copy the image. Restricted to that one role, and to the service
+              # that is allowed to use it.
+              - Effect: Allow
+                Action: iam:PassRole
+                Resource: !GetAtt AmiIngestionRole.Arn
+                Condition:
+                  StringEquals:
+                    iam:PassedToService: assets.marketplace.amazonaws.com
+
   # AWS Marketplace assumes this to copy a submitted AMI into its own account.
   # The managed policy is the one AWS documents for it; writing the permissions
   # out by hand here would go stale the next time they change it.
@@ -255,6 +287,8 @@ Outputs:
 
   IngestionRoleArn:
     Description: >-
-      Name this role in the AWS Marketplace Management Portal, under Settings,
-      so the AMI scan can read a submitted image.
+      Store this as the repository secret AWS_MARKETPLACE_INGESTION_ROLE_ARN. The
+      submit job names it in every version it offers, as the role AWS Marketplace
+      assumes to copy and scan the image. Submitting a version by hand asks for
+      the same ARN, in the Add Version form's IAM access role field.
     Value: !GetAtt AmiIngestionRole.Arn

--- a/deploy/umbrel/README.md
+++ b/deploy/umbrel/README.md
@@ -33,13 +33,41 @@ Publishing a release tag opens one pull request
 multi-arch manifest the release workflow just published, so the PR never invents
 one. Do not edit them by hand.
 
-Merging that PR updates **this** repository only. Submitting the raised package
-to [getumbrel/umbrel-apps](https://github.com/getumbrel/umbrel-apps) remains a
-separate, manual pull request — Umbrel cannot pull from our repo on its own.
+Nothing merges that PR on the spot, because merging restarts every Elestio
+instance tracking the default branch. `.github/workflows/release-rollout.yml`
+does it in a nightly maintenance window once its guards agree.
 
-Three other manifest fields are still placeholders and have to be filled in for
-a store submission: `releaseNotes`, `gallery` (the store expects screenshots)
-and `submission`, which currently reads `.../pull/PENDING`.
+### How the package reaches the store
+
+Umbrel cannot pull from this repository, so the package has to be carried into
+[getumbrel/umbrel-apps](https://github.com/getumbrel/umbrel-apps) — and that is
+`.github/workflows/umbrel-store-sync.yml`'s job, triggered by the raised pins
+landing on the default branch. It rebuilds
+[`metadist/umbrel-apps`](https://github.com/metadist/umbrel-apps) from upstream
+`master`, mirrors `synaplan/` from this directory, runs Umbrel's own
+`lint:apps --check-images`, and pushes.
+
+What happens next depends on whether the store already carries the app, because
+Umbrel's linter applies different rules to each case:
+
+| | Not in the store yet (today) | Already in the store |
+| --- | --- | --- |
+| Branch | `synaplan`, the one the open submission is built from | `synaplan-<version>` |
+| Pull request | the existing submission is updated | a new one is opened |
+| `releaseNotes` | **must stay empty** — an error otherwise | filled from the GitHub release |
+| `gallery`, `icon` | **must stay empty** — Umbrel produces the final assets | unchanged |
+
+That is why `releaseNotes: ""` and `gallery: []` in `umbrel-app.yml` are not
+placeholders waiting to be filled: for a new submission they are the required
+values, and the sync fills `releaseNotes` in the fork only once the app is
+released. `submission` points at the pull request the submission lives in.
+
+The merge itself stays Umbrel's: they review and merge store pull requests, and
+no automation here can shorten that.
+
+The sync owns `synaplan/` on that branch and force-pushes it. It refuses to run
+if the branch has grown changes outside `synaplan/`, so a maintainer's work
+elsewhere in the fork can never be discarded silently.
 
 Re-run the login check from *Testing* below against every raised pin: cookies
 must be issued without `Secure` over plain HTTP.
@@ -125,13 +153,20 @@ exists, so a changed value cannot lock anyone out.
 
 ## Testing
 
-Linting is necessary but proves nothing about runtime. From a fork of
-`umbrel-apps` with `deploy/umbrel/synaplan/` copied in as `synaplan/`:
+Linting is necessary but proves nothing about runtime. The store sync runs the
+linter on every release, so this is for trying a change before it is committed.
+From a fork of `umbrel-apps` with `deploy/umbrel/synaplan/` copied in as
+`synaplan/`:
 
 ```bash
 npm run lint:apps -- synaplan --check-images
 git diff --check
 ```
+
+Add `--changed upstream/master...HEAD` instead of naming the app to get the rules
+that depend on whether this is a new submission or an update — without it the
+linter cannot tell, and silently skips those checks. That is the form the sync
+uses.
 
 Then install it on a real umbrelOS. A containerised instance is enough and is
 what the current package was verified on:

--- a/docs/AWS_MARKETPLACE_LISTING.md
+++ b/docs/AWS_MARKETPLACE_LISTING.md
@@ -121,8 +121,10 @@ one shows up as `AccessDenied` in the verification stack, after the AMI it was
 meant to verify has already been built.
 
 - **`AWSMarketplaceAmiIngestion`** lets AWS Marketplace copy a submitted AMI into
-  its own account for the security scan. Name it in the Management Portal under
-  Settings.
+  its own account for the security scan. Every submitted version names it, in the
+  Add Version form's *IAM access role ARN* field or, when the submit job does the
+  submitting, in the `AmiSource` it sends. Store its ARN as the repository secret
+  `AWS_MARKETPLACE_INGESTION_ROLE_ARN`.
 - **The build role** is assumed by this repository's release workflow through
   GitHub OIDC — there is no access key anywhere in this repository, and there
   must never be. Store its ARN as the repository secret
@@ -148,7 +150,9 @@ later and slower.
    scan that reports exactly what the review would otherwise reject: password
    authentication, root login, known CVEs, credentials left in the image.
    `deploy/aws/scripts/harden.sh` fails the Packer build on the first three, so
-   this should be a formality.
+   this should be a formality. Only needed while the listing is new — once the
+   secrets below are set, the `submit` job offers each release's version by
+   itself.
 3. **Create the product** as a Limited listing — published, but visible only to
    the seller account and any account we allowlist. Subscribe and launch it the
    way a customer will, including one-click "Launch from Website". This is the
@@ -158,6 +162,55 @@ later and slower.
    three regions. Each region is real instance time for no extra signal beyond
    the third.
 5. **Request public visibility.**
+
+## Submitting a version automatically
+
+Once the listing exists, the `submit` job in
+[`aws-ami.yml`](../.github/workflows/aws-ami.yml) offers each release to it
+through the Marketplace Catalog API, after the AMI has been built, shared and
+verified by a real launch. It needs three settings, and skips itself with a
+notice while any of them is missing:
+
+| Setting | Kind | Value |
+| --- | --- | --- |
+| `AWS_MARKETPLACE_PRODUCT_ID` | secret | the listing's product ID, `prod-…` |
+| `AWS_MARKETPLACE_INGESTION_ROLE_ARN` | secret | the `IngestionRoleArn` output of the roles stack |
+| `AWS_MARKETPLACE_SUBMIT` | variable | `apply` to submit for real; anything else validates only |
+
+**The default is validation, not submission.** Without
+`AWS_MARKETPLACE_SUBMIT=apply` the job sends the same change set with
+`Intent=VALIDATE`, which checks the document against the listing and changes
+nothing. Look at one validated run before switching it over: a submitted version
+sits in AWS review for days, so a wrong one is expensive to take back.
+
+Each architecture becomes a **separate version**, titled `<version> (x86_64)` and
+`<version> (arm64)`. That is AWS's rule, not a choice: all delivery options of one
+version must share the same `AmiSource`, so one version can carry only one AMI.
+They are submitted one after the other because a running change set locks the
+entity.
+
+### Finding the product ID
+
+Management Portal → **Products** → **Server**. Open the listing; the ID is in the
+detail view and in the URL:
+
+```text
+https://aws.amazon.com/marketplace/management/products/server/prod-xxxxxxxxxxxxx
+```
+
+Or ask the API, with the build role's new catalog permissions:
+
+```bash
+aws marketplace-catalog list-entities \
+  --region us-east-1 \
+  --catalog AWSMarketplace \
+  --entity-type AmiProduct \
+  --query 'EntitySummaryList[].{Id:EntityId,Name:Name,Visibility:Visibility}'
+```
+
+An empty list means the listing has not been created yet — do the steps above
+first. The `submit` job stays skipped until the secret is set, so releases keep
+working in the meantime.
 
 ## Usage Instructions
 

--- a/docs/UPDATE_ELESTIO.md
+++ b/docs/UPDATE_ELESTIO.md
@@ -40,3 +40,11 @@ before anything starts.
 Your pipeline may restart by itself when the Synaplan repository receives a new
 commit. That is a restart, not an update: it reuses the version and the settings
 your pipeline already has.
+
+This includes the commit that raises the version for **new** installations. Every
+release, an automation updates the version that the one-click template installs,
+so someone deploying Synaplan tomorrow gets the current release without asking.
+Your pipeline is not touched by it: Elestio copied the environment variables into
+your pipeline when it was created and reads them from there ever after, so
+`SYNAPLAN_VERSION` stays exactly what you set. Updating is still the four steps
+above, and still yours to start.

--- a/scripts/read-release-version.mjs
+++ b/scripts/read-release-version.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+
+// Reads back the version that the deployment catalog currently pins, using the
+// same anchors set-release-version.mjs writes with. Two automations need this:
+// the rollout workflow, which may only merge a pin that matches the published
+// release manifest, and the Umbrel store sync, which has to name the version it
+// carries into the store package.
+//
+// Reading all five pins rather than one is the point. Any disagreement between
+// them means the catalog is half-bumped, and a half-bumped catalog must never be
+// merged or submitted anywhere — it would install one version and advertise
+// another.
+
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+import {
+  parseImageDigest,
+  parseReleaseVersion,
+  readElestioVersion,
+  readEnvExampleVersion,
+  readPackerVersion,
+  readUmbrelAppVersion,
+  readUmbrelComposePin,
+} from './set-release-version.mjs'
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url))
+const DEFAULT_ROOT = resolve(SCRIPT_DIR, '..')
+
+export const readPinnedRelease = (root = DEFAULT_ROOT) => {
+  const read = (...segments) => readFileSync(join(root, ...segments), 'utf8')
+
+  const umbrelCompose = readUmbrelComposePin(
+    read('deploy', 'umbrel', 'synaplan', 'docker-compose.yml')
+  )
+
+  // Checked before the versions: an image pinned without a digest leaves both
+  // the tag and the digest unreadable, and reporting that as a missing version
+  // would send the reader looking for the wrong thing.
+  const digest = parseImageDigest(umbrelCompose.digest)
+  if (digest === null) {
+    throw new Error(
+      `deploy/umbrel/synaplan/docker-compose.yml does not pin a published image digest, found ${JSON.stringify(umbrelCompose.image)}`
+    )
+  }
+
+  const pins = {
+    'elestio.yml': readElestioVersion(read('elestio.yml')),
+    'deploy/selfhost.env.example': readEnvExampleVersion(read('deploy', 'selfhost.env.example')),
+    'deploy/umbrel/synaplan/umbrel-app.yml': readUmbrelAppVersion(
+      read('deploy', 'umbrel', 'synaplan', 'umbrel-app.yml')
+    ),
+    'deploy/umbrel/synaplan/docker-compose.yml (APP_VERSION)': umbrelCompose.appVersion,
+    'deploy/umbrel/synaplan/docker-compose.yml (image tag)': umbrelCompose.version,
+    'deploy/aws/packer/synaplan.pkr.hcl': readPackerVersion(
+      read('deploy', 'aws', 'packer', 'synaplan.pkr.hcl')
+    ),
+  }
+
+  const missing = Object.entries(pins)
+    .filter(([, version]) => version === null)
+    .map(([source]) => source)
+  if (missing.length > 0) {
+    throw new Error(`no version pin found in: ${missing.join(', ')}`)
+  }
+
+  const distinct = [...new Set(Object.values(pins))]
+  if (distinct.length !== 1) {
+    const detail = Object.entries(pins)
+      .map(([source, version]) => `${source}=${version}`)
+      .join(', ')
+    throw new Error(`the deployment catalog pins more than one version: ${detail}`)
+  }
+
+  const [version] = distinct
+  if (parseReleaseVersion(version) !== version) {
+    throw new Error(`the pinned version ${JSON.stringify(version)} is not a plain release`)
+  }
+
+  return { version, digest }
+}
+
+export const runCli = (arguments_ = []) => {
+  const root = arguments_.length > 0 ? resolve(arguments_[0]) : DEFAULT_ROOT
+  return `${JSON.stringify(readPinnedRelease(root))}\n`
+}
+
+if (process.argv[1] && pathToFileURL(resolve(process.argv[1])).href === import.meta.url) {
+  try {
+    process.stdout.write(runCli(process.argv.slice(2)))
+  } catch (error) {
+    process.stderr.write(`${error.message}\n`)
+    process.exitCode = 1
+  }
+}

--- a/scripts/set-umbrel-release-notes.mjs
+++ b/scripts/set-umbrel-release-notes.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+
+// Fills the `releaseNotes` field of the Umbrel App Store manifest with the text
+// of a GitHub release, for the store package only.
+//
+// Deliberately not applied to the copy in this repository. Umbrel's linter
+// requires `releaseNotes` to be EMPTY for a new app submission and only expects
+// it to be filled once the app is already in the store, so the committed
+// manifest keeps the empty string and umbrel-store-sync.yml fills it in the fork
+// when — and only when — the store already carries the app.
+//
+// The value is written as a JSON-encoded scalar. YAML's double-quoted style
+// shares JSON's escaping rules, so release notes containing colons, quotes, `#`
+// or newlines cannot break the manifest.
+
+import { readFileSync, writeFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+// Long enough for a real changelog, short enough for an update dialog on a
+// phone. Umbrel renders this to the user, not to a maintainer.
+const DEFAULT_LIMIT = 1500
+
+const RELEASE_NOTES = /^releaseNotes:[ \t]*(.*)$/
+
+export const formatUmbrelReleaseNotes = (body, url, limit = DEFAULT_LIMIT) => {
+  const suffix = url ? `\n\nFull release notes: ${url}` : ''
+  const text = String(body ?? '')
+    .replace(/\r\n?/g, '\n')
+    .trim()
+
+  if (text === '') {
+    return suffix.trim()
+  }
+
+  const room = limit - suffix.length
+  if (text.length <= room) {
+    return `${text}${suffix}`
+  }
+
+  // Cut on a boundary the reader can see, so the notes never end mid-word.
+  const head = text.slice(0, Math.max(room - 1, 0))
+  const boundary = Math.max(head.lastIndexOf('\n'), head.lastIndexOf(' '))
+  const trimmed = (boundary > 0 ? head.slice(0, boundary) : head).trimEnd()
+
+  return `${trimmed}…${suffix}`
+}
+
+export const applyUmbrelReleaseNotes = (text, notes) => {
+  let replaced = 0
+
+  const result = text
+    .split('\n')
+    .map((line) => {
+      const match = RELEASE_NOTES.exec(line)
+      if (!match) return line
+
+      // A block scalar carries its value on the following lines, which a
+      // line-for-line replacement would leave behind as stray YAML.
+      const existing = match[1].trim()
+      if (existing.startsWith('|') || existing.startsWith('>')) {
+        throw new Error(
+          'umbrel-app.yml: `releaseNotes` is a block scalar; this script only rewrites an inline value'
+        )
+      }
+
+      replaced += 1
+      return `releaseNotes: ${JSON.stringify(notes)}`
+    })
+    .join('\n')
+
+  if (replaced !== 1) {
+    throw new Error(
+      `umbrel-app.yml: expected exactly one top-level releaseNotes field, found ${replaced}`
+    )
+  }
+
+  return result
+}
+
+const readOption = (arguments_, name) => {
+  const index = arguments_.indexOf(name)
+  return index === -1 ? null : (arguments_[index + 1] ?? null)
+}
+
+export const runCli = (arguments_ = []) => {
+  const manifest = readOption(arguments_, '--manifest')
+  if (manifest === null) {
+    throw new Error('--manifest must be the path of the umbrel-app.yml to rewrite')
+  }
+
+  const notes = formatUmbrelReleaseNotes(
+    readOption(arguments_, '--body') ?? '',
+    readOption(arguments_, '--url') ?? ''
+  )
+
+  const path = resolve(manifest)
+  writeFileSync(path, applyUmbrelReleaseNotes(readFileSync(path, 'utf8'), notes))
+
+  return notes
+}
+
+if (process.argv[1] && pathToFileURL(resolve(process.argv[1])).href === import.meta.url) {
+  try {
+    process.stdout.write(`${runCli(process.argv.slice(2))}\n`)
+  } catch (error) {
+    process.stderr.write(`${error.message}\n`)
+    process.exitCode = 1
+  }
+}

--- a/tests/read-release-version.test.mjs
+++ b/tests/read-release-version.test.mjs
@@ -1,0 +1,117 @@
+import assert from 'node:assert/strict'
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test from 'node:test'
+
+import { readPinnedRelease } from '../scripts/read-release-version.mjs'
+
+const DIGEST = `sha256:${'a'.repeat(64)}`
+
+// A catalog whose five pins all name the same version, as the release
+// automation leaves it. Individual tests bend one file at a time.
+const catalog = (overrides = {}) => ({
+  'elestio.yml': ['environments:', '  - key: "SYNAPLAN_VERSION"', '    value: "4.4.1"'].join('\n'),
+  'deploy/selfhost.env.example': 'SYNAPLAN_VERSION=4.4.1\n',
+  'deploy/umbrel/synaplan/umbrel-app.yml': 'manifestVersion: 1\nversion: "4.4.1"\n',
+  'deploy/umbrel/synaplan/docker-compose.yml': [
+    'x-app-environment: &app-environment',
+    '  APP_VERSION: "4.4.1"',
+    '',
+    `x-app-image: &app-image ghcr.io/metadist/synaplan:4.4.1@${DIGEST}`,
+  ].join('\n'),
+  'deploy/aws/packer/synaplan.pkr.hcl': [
+    'variable "synaplan_version" {',
+    '  type        = string',
+    '  default     = "4.4.1"',
+    '}',
+  ].join('\n'),
+  ...overrides,
+})
+
+const writeCatalog = (files) => {
+  const root = mkdtempSync(join(tmpdir(), 'synaplan-pins-'))
+  for (const [path, contents] of Object.entries(files)) {
+    const absolute = join(root, path)
+    mkdirSync(join(absolute, '..'), { recursive: true })
+    writeFileSync(absolute, contents)
+  }
+  return root
+}
+
+test('reads the version and digest a consistent catalog pins', () => {
+  const result = readPinnedRelease(writeCatalog(catalog()))
+
+  assert.deepEqual(result, { version: '4.4.1', digest: DIGEST })
+})
+
+// The failure this reader exists to catch: a bump that reached some files but
+// not all of them would otherwise be rolled out as if it were complete.
+test('refuses a catalog whose files disagree', () => {
+  const root = writeCatalog(
+    catalog({ 'deploy/selfhost.env.example': 'SYNAPLAN_VERSION=4.4.0\n' })
+  )
+
+  assert.throws(() => readPinnedRelease(root), /pins more than one version/)
+})
+
+test('refuses a catalog whose Umbrel package lags behind its own image tag', () => {
+  const root = writeCatalog(
+    catalog({
+      'deploy/umbrel/synaplan/docker-compose.yml': [
+        '  APP_VERSION: "4.4.0"',
+        `x-app-image: &app-image ghcr.io/metadist/synaplan:4.4.1@${DIGEST}`,
+      ].join('\n'),
+    })
+  )
+
+  assert.throws(() => readPinnedRelease(root), /pins more than one version/)
+})
+
+test('refuses a pin that is not a plain release', () => {
+  const root = writeCatalog({
+    ...catalog(),
+    'elestio.yml': ['  - key: "SYNAPLAN_VERSION"', '    value: "4.4.2-rc.1"'].join('\n'),
+    'deploy/selfhost.env.example': 'SYNAPLAN_VERSION=4.4.2-rc.1\n',
+    'deploy/umbrel/synaplan/umbrel-app.yml': 'version: "4.4.2-rc.1"\n',
+    'deploy/umbrel/synaplan/docker-compose.yml': [
+      '  APP_VERSION: "4.4.2-rc.1"',
+      `x-app-image: &app-image ghcr.io/metadist/synaplan:4.4.2-rc.1@${DIGEST}`,
+    ].join('\n'),
+    'deploy/aws/packer/synaplan.pkr.hcl': [
+      'variable "synaplan_version" {',
+      '  default     = "4.4.2-rc.1"',
+      '}',
+    ].join('\n'),
+  })
+
+  assert.throws(() => readPinnedRelease(root), /is not a plain release/)
+})
+
+test('names the file that carries no pin at all', () => {
+  const root = writeCatalog(catalog({ 'deploy/selfhost.env.example': '# nothing here\n' }))
+
+  assert.throws(() => readPinnedRelease(root), /deploy\/selfhost\.env\.example/)
+})
+
+test('refuses an Umbrel package without a published image digest', () => {
+  const root = writeCatalog(
+    catalog({
+      'deploy/umbrel/synaplan/docker-compose.yml': [
+        '  APP_VERSION: "4.4.1"',
+        'x-app-image: &app-image ghcr.io/metadist/synaplan:4.4.1',
+      ].join('\n'),
+    })
+  )
+
+  assert.throws(() => readPinnedRelease(root), /image digest/)
+})
+
+// The real files have to satisfy the reader, or the rollout guard would hold
+// back every release for a reason that has nothing to do with the release.
+test('the shipped catalog is readable', () => {
+  const result = readPinnedRelease()
+
+  assert.match(result.version, /^\d+\.\d+\.\d+$/)
+  assert.match(result.digest, /^sha256:[a-f0-9]{64}$/)
+})

--- a/tests/read-release-version.test.mjs
+++ b/tests/read-release-version.test.mjs
@@ -39,7 +39,7 @@ const writeCatalog = (files) => {
   return root
 }
 
-test('reads the version and digest a consistent catalog pins', () => {
+test('reads the version and digest that a consistent catalog pins', () => {
   const result = readPinnedRelease(writeCatalog(catalog()))
 
   assert.deepEqual(result, { version: '4.4.1', digest: DIGEST })

--- a/tests/set-umbrel-release-notes.test.mjs
+++ b/tests/set-umbrel-release-notes.test.mjs
@@ -1,0 +1,95 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+import {
+  applyUmbrelReleaseNotes,
+  formatUmbrelReleaseNotes,
+} from '../scripts/set-umbrel-release-notes.mjs'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
+
+const MANIFEST_SAMPLE = [
+  'manifestVersion: 1',
+  'id: synaplan',
+  'version: "4.4.1"',
+  'releaseNotes: ""',
+  'developer: Metadist',
+].join('\n')
+
+test('writes the notes into the single releaseNotes field', () => {
+  const result = applyUmbrelReleaseNotes(MANIFEST_SAMPLE, 'Fixes the login loop.')
+
+  assert.ok(result.includes('releaseNotes: "Fixes the login loop."'))
+  assert.ok(result.includes('version: "4.4.1"'), 'the version pin must survive untouched')
+})
+
+// The manifest is parsed by Umbrel, so a value that breaks YAML breaks the store
+// package. Colons, quotes, hashes and newlines all appear in real release notes.
+test('escapes characters that would otherwise break the manifest', () => {
+  const notes = 'Fixed: the "widget" bug #1649\nAlso: a second line'
+
+  const result = applyUmbrelReleaseNotes(MANIFEST_SAMPLE, notes)
+  const line = result.split('\n').find((candidate) => candidate.startsWith('releaseNotes:'))
+
+  assert.equal(line, `releaseNotes: ${JSON.stringify(notes)}`)
+  assert.equal(JSON.parse(line.slice('releaseNotes: '.length)), notes)
+})
+
+test('refuses a block scalar rather than corrupting it', () => {
+  const manifest = ['releaseNotes: |', '  Some notes', '  over two lines', 'developer: Metadist'].join(
+    '\n'
+  )
+
+  assert.throws(() => applyUmbrelReleaseNotes(manifest, 'new'), /block scalar/)
+})
+
+test('refuses a manifest without exactly one releaseNotes field', () => {
+  assert.throws(() => applyUmbrelReleaseNotes('id: synaplan\n', 'new'), /found 0/)
+  assert.throws(
+    () => applyUmbrelReleaseNotes('releaseNotes: ""\nreleaseNotes: ""\n', 'new'),
+    /found 2/
+  )
+})
+
+test('appends the release link to the notes', () => {
+  const result = formatUmbrelReleaseNotes('Adds memories.', 'https://example.test/v4.4.1')
+
+  assert.equal(result, 'Adds memories.\n\nFull release notes: https://example.test/v4.4.1')
+})
+
+test('falls back to the link alone when a release has no body', () => {
+  const result = formatUmbrelReleaseNotes('   ', 'https://example.test/v4.4.1')
+
+  assert.equal(result, 'Full release notes: https://example.test/v4.4.1')
+})
+
+test('truncates long notes on a word boundary and keeps the link', () => {
+  const body = `${'word '.repeat(500)}end`
+
+  const result = formatUmbrelReleaseNotes(body, 'https://example.test/v4.4.1', 200)
+
+  assert.ok(result.length <= 200, `expected at most 200 characters, got ${result.length}`)
+  assert.ok(result.includes('…'))
+  assert.ok(result.endsWith('Full release notes: https://example.test/v4.4.1'))
+  assert.doesNotMatch(result, /wor…/, 'must not cut in the middle of a word')
+})
+
+test('normalizes Windows line endings', () => {
+  const result = formatUmbrelReleaseNotes('First line\r\nSecond line', '')
+
+  assert.equal(result, 'First line\nSecond line')
+})
+
+// The committed manifest must stay empty: Umbrel's linter rejects release notes
+// on a new app submission, and Synaplan is still an open submission.
+test('the shipped Umbrel manifest still carries an empty releaseNotes', () => {
+  const manifest = readFileSync(
+    join(ROOT, 'deploy', 'umbrel', 'synaplan', 'umbrel-app.yml'),
+    'utf8'
+  )
+
+  assert.match(manifest, /^releaseNotes:\s*""\s*$/m)
+})


### PR DESCRIPTION
## Summary

A release already produced everything needed to update the catalogs — a verified image, a manifest entry, a pull request raising all four version pins, and two AMIs — and then stopped, waiting for someone to merge and to fill in two web forms. Until that happened, anyone deploying Synaplan installed the previous release. That is how `main` kept pinning 4.4.0 after 4.4.1 shipped.

This closes the last mile in three places.

**`release-rollout.yml`** merges the pin proposal in a nightly maintenance window, not on the spot: merging restarts every Elestio instance tracking the default branch, and auto-merge would do that mid-afternoon. Five guards must agree first — the catalog pins one released version across all five anchors, that version is what the published manifest advertises, it is not yanked, the pull request touches nothing but the four pin paths, and `All Checks Passed` is green. Anything else holds the rollout back with a warning instead of merging.

**`umbrel-store-sync.yml`** carries the raised package into `getumbrel/umbrel-apps`, which cannot pull from here. It rebuilds our fork from upstream `master`, mirrors the package, runs Umbrel's own `lint:apps --check-images`, and pushes. Which pull request it lands in is decided by the store, because Umbrel's linter applies opposite rules to each case: a new submission must leave `releaseNotes` and `gallery` empty, an update to a released app is expected to carry release notes. This corrects a wrong assumption in the plan — those two fields were treated as placeholders waiting to be filled, and for a new submission they are the required values.

**`aws-ami.yml`** gains a `submit` job that offers the built and verified AMI to the listing through the Catalog API. Each architecture becomes its own version, sequentially: AWS requires all delivery options of a version to share one `AmiSource`, and a running change set locks the entity. The default intent is `VALIDATE` — a submitted version sits in AWS review for days, so a real submission is a deliberate act (`AWS_MARKETPLACE_SUBMIT=apply`), not the side effect of setting a secret.

Running installations are deliberately untouched, everywhere. They keep the version their operator pinned, because an update runs database migrations and the backup that makes those survivable is the operator's to take. The admin area's promise — it reports a newer version and never installs one — still holds.

## What still needs a human

- Merging the Umbrel store pull request (Umbrel's repository, Umbrel's review).
- AWS's review of a submitted version, 5–14 working days.
- Existing Elestio pipelines: their environment is materialized once at creation and ignores `elestio.yml` afterwards, so nothing in this repository can reach them.

## Prerequisites

The release App needs `Pull requests: write` and a bypass entry in the `ReviewCodeSyn` org ruleset, or the rollout can never merge — without checks on its proposal, guard 5 is unsatisfiable by design. New secrets: `UMBREL_FORK_TOKEN`, `AWS_MARKETPLACE_PRODUCT_ID`, `AWS_MARKETPLACE_INGESTION_ROLE_ARN`, and optionally `DISCORD_RELEASE_WEBHOOK`. New variable: `AWS_MARKETPLACE_SUBMIT`. The `synaplan-marketplace-roles` stack needs redeploying for the new catalog permissions. Every workflow skips itself with a notice while its own settings are missing.

## Test plan

- [x] `node --test "tests/*.test.mjs"` — 58 pass, including new suites for the pin reader and the release-notes writer
- [x] Umbrel's real linter against the generated package, both paths: new submission and version bump — `No issues found`
- [x] `cfn-lint deploy/aws/cloudformation/*.yaml` — clean; `aws cloudformation validate-template` accepts the template
- [x] `bash deploy/scripts/tests/test-lifecycle.sh` and `bash deploy/aws/scripts/tests/test-firstboot.sh`
- [x] Every guard's jq expression exercised against the shapes it has to survive, including a yanked entry as both a string and an object
- [x] All 97 workflow `run` blocks parse under `bash -n`
- [ ] `release-rollout.yml` via `workflow_dispatch` with `dry_run` against the next real proposal
- [ ] `aws-ami.yml` on the next release tag, to see one `VALIDATE` change set before `AWS_MARKETPLACE_SUBMIT` is switched

Independent of #1649; both touch `ci.yml` but not the same lines.