### PR TITLE
feat(ci): roll out the version pin as soon as its checks pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1427,9 +1427,9 @@ jobs:
       # A pull request, deliberately, rather than a push to main. Elestio
       # pipelines redeploy on every commit to the branch they track, so pushing
       # here would restart every managed instance at an unpredictable moment.
-      # release-rollout.yml merges this proposal in a nightly maintenance window
-      # instead, once its own guards agree that it is the release the published
-      # manifest advertises. The Umbrel package lives in this same PR so a
+      # release-rollout.yml merges this proposal instead, as soon as the checks
+      # here are green and its own guards agree that it is the release the
+      # published manifest advertises. The Umbrel package lives in this same PR so a
       # release bumps every catalog pin together; carrying that package into
       # getumbrel/umbrel-apps is umbrel-store-sync.yml's job, because a foreign
       # repository cannot be pinned from here.
@@ -1557,11 +1557,14 @@ jobs:
           pinned and change it only by following the update guide, so a redeploy never
           moves a running installation to a different version.
 
-          Merging this restarts every Elestio instance that tracks \`${BASE}\`, because
-          Elestio redeploys on each commit to the branch it tracks. That is why nothing
-          merges this on the spot: \`release-rollout.yml\` does it in the next nightly
-          maintenance window, once the checks here are green and this version is still
-          the one the release manifest advertises. Merge it by hand to roll out sooner.
+          Nobody has to merge this: \`release-rollout.yml\` does it as soon as the
+          checks above are green, provided this is still the version the release
+          manifest advertises and it has not been yanked meanwhile.
+
+          Merging restarts every Elestio instance that tracks \`${BASE}\`, because
+          Elestio redeploys on each commit to the branch it tracks — as does every
+          other commit that branch receives, which is why this one is not held back
+          for it.
 
           Once merged, \`umbrel-store-sync.yml\` carries the raised package into
           [getumbrel/umbrel-apps](https://github.com/getumbrel/umbrel-apps), and the

--- a/.github/workflows/release-rollout.yml
+++ b/.github/workflows/release-rollout.yml
@@ -3,11 +3,17 @@ name: Release Rollout
 # Merges the pin proposal that ci.yml's release-version-pin job opens, so a new
 # release reaches new deployments without anyone remembering to click Merge.
 #
-# Why a scheduled job and not an auto-merge on the proposal itself: merging
-# restarts every Elestio instance that tracks the default branch, because Elestio
-# redeploys on each commit to the branch it tracks. Auto-merge would fire the
-# moment CI goes green — mid-afternoon, mid-conversation. A maintenance window
-# turns an unpredictable restart into a predictable one.
+# Merged as soon as the proposal's checks are green, not on a timer. Delaying it
+# was considered and dropped: the argument for a night-time window was that
+# merging restarts every Elestio instance tracking the default branch, and that
+# is true — but the default branch takes between four and nineteen commits a day
+# and every one of them restarts those pipelines anyway (see
+# deploy/elestio/README.md). Waiting bought a few hours of "bake time", at the
+# price of every new deployment installing yesterday's release for those hours.
+#
+# What keeps this safe is the guards below, not the hour it runs at. In
+# particular guard 3 still refuses a release that was withdrawn between the tag
+# and the merge.
 #
 # This job only ever moves the version that a NEW deployment installs. Running
 # installations are untouched: they keep the version their operator pinned and
@@ -19,9 +25,13 @@ name: Release Rollout
 # intended failure mode: no checks, no rollout.
 
 on:
+  # The proposal's own CI finishing is the signal to look at it.
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+  # A net under the trigger above, for a proposal whose CI ran before this
+  # workflow existed, or whose event was missed. Costs one no-op run a day.
   schedule:
-    # 01:00 UTC — the small hours in the timezone the instances are operated
-    # from. Deliberately not on the hour a release is usually cut.
     - cron: '0 1 * * *'
   workflow_dispatch:
     inputs:
@@ -44,6 +54,14 @@ jobs:
   rollout:
     name: Roll out the default release version
     runs-on: ubuntu-latest
+    # Every CI run on the repository reaches the workflow_run trigger, so the
+    # proposal's own branch has to be picked out here. The schedule and a manual
+    # dispatch carry no such event and always proceed to the guards.
+    if: >-
+      github.event_name != 'workflow_run' || (
+        github.event.workflow_run.head_branch == 'automation/default-release-version' &&
+        github.event.workflow_run.conclusion == 'success'
+      )
 
     env:
       BRANCH: automation/default-release-version
@@ -192,15 +210,26 @@ jobs:
           # BLOCKED on this repository for as long as the review requirement is
           # unmet — the App bypasses that requirement at merge time, so BLOCKED
           # here is normal and says nothing about the checks.
-          state="$(
-            gh pr view "$NUMBER" --repo "$GITHUB_REPOSITORY" \
-              --json mergeable,statusCheckRollup --jq '{
-                mergeable: .mergeable,
-                gate: ([.statusCheckRollup[]? | select(.name == "All Checks Passed")] | last)
-              }'
-          )"
+          # Polled rather than read once: GitHub computes mergeability
+          # asynchronously and answers UNKNOWN until it has. This workflow now
+          # arrives seconds after CI finished, so it meets that state regularly,
+          # and reading it as "not mergeable" would hold back releases for a race
+          # instead of for a reason.
+          for attempt in $(seq 1 10); do
+            state="$(
+              gh pr view "$NUMBER" --repo "$GITHUB_REPOSITORY" \
+                --json mergeable,statusCheckRollup --jq '{
+                  mergeable: .mergeable,
+                  gate: ([.statusCheckRollup[]? | select(.name == "All Checks Passed")] | last)
+                }'
+            )"
 
-          mergeable="$(printf '%s' "$state" | jq -r .mergeable)"
+            mergeable="$(printf '%s' "$state" | jq -r .mergeable)"
+            [ "$mergeable" = UNKNOWN ] || break
+            echo "Attempt ${attempt}: GitHub has not computed mergeability yet; waiting."
+            sleep 6
+          done
+
           if [ "$mergeable" != MERGEABLE ]; then
             block "GitHub reports the pull request as \`${mergeable}\` rather than mergeable"
           fi

--- a/.github/workflows/release-rollout.yml
+++ b/.github/workflows/release-rollout.yml
@@ -120,13 +120,15 @@ jobs:
           echo "number=${number}" >> "$GITHUB_OUTPUT"
           echo "sha=${sha}" >> "$GITHUB_OUTPUT"
 
-      # The proposal's own head, not the default branch: the guards below have to
-      # judge the pins that would actually be merged.
-      - name: Checkout the proposal
+      # The default branch, deliberately NOT the proposal's head. This job runs
+      # in a privileged context — a workflow_run trigger with the merge token in
+      # reach — so running a script out of the branch it is about to judge would
+      # hand that token to whatever that branch happens to contain, before any
+      # guard has looked at it. The pins are fetched as data below instead.
+      - name: Checkout
         if: steps.proposal.outputs.number != ''
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: ${{ steps.proposal.outputs.sha }}
           persist-credentials: false
 
       - name: Evaluate the guards
@@ -135,6 +137,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           NUMBER: ${{ steps.proposal.outputs.number }}
+          SHA: ${{ steps.proposal.outputs.sha }}
           MANIFEST_URL: https://raw.githubusercontent.com/${{ github.repository }}/release-manifest/versions.json
         run: |
           set -euo pipefail
@@ -158,7 +161,21 @@ jobs:
           # Guard 1: the catalog pins one released version across all five
           # anchors. A half-bumped catalog would install one version and
           # advertise another.
-          if ! pinned="$(node scripts/read-release-version.mjs 2>&1)"; then
+          #
+          # The proposal's files are fetched one by one and read by the default
+          # branch's own copy of the script, which is what keeps the proposal from
+          # contributing code to this job. The path list comes from the script, so
+          # a sixth pin cannot be forgotten here.
+          pins="$(mktemp -d)"
+          while read -r path; do
+            mkdir -p "${pins}/$(dirname "$path")"
+            if ! gh api "repos/${GITHUB_REPOSITORY}/contents/${path}?ref=${SHA}" \
+              -H 'Accept: application/vnd.github.raw' > "${pins}/${path}"; then
+              block "the proposal does not carry \`${path}\`"
+            fi
+          done < <(node scripts/read-release-version.mjs --paths)
+
+          if ! pinned="$(node scripts/read-release-version.mjs "$pins" 2>&1)"; then
             block "the pinned version could not be read (${pinned})"
           fi
           version="$(printf '%s' "$pinned" | jq -r .version)"

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -283,12 +283,12 @@ raised package into `getumbrel/umbrel-apps`; Umbrel reviews and merges it.
 ## What "automatically updated" covers, and what it does not
 
 Every release raises the version pins in this directory, and
-`.github/workflows/release-rollout.yml` merges that change in a nightly
-maintenance window. The effect is precise and worth stating plainly:
+`.github/workflows/release-rollout.yml` merges that change as soon as the
+proposal's checks are green. The effect is precise and worth stating plainly:
 
 - **New deployments** install the current release. Whoever clicks the Elestio
   template, copies `selfhost.env.example`, installs from the Umbrel App Store, or
-  launches the AWS AMI tomorrow gets what was released today.
+  launches the AWS AMI after that merge gets what was just released.
 - **Existing installations are never touched.** They keep the version their
   operator pinned. Nothing here reaches into a running deployment, and nothing
   here should: an update runs database migrations, and the backup that makes those

--- a/deploy/umbrel/README.md
+++ b/deploy/umbrel/README.md
@@ -35,7 +35,7 @@ one. Do not edit them by hand.
 
 Nothing merges that PR on the spot, because merging restarts every Elestio
 instance tracking the default branch. `.github/workflows/release-rollout.yml`
-does it in a nightly maintenance window once its guards agree.
+does it as soon as the proposal's checks are green and its guards agree.
 
 ### How the package reaches the store
 

--- a/scripts/read-release-version.mjs
+++ b/scripts/read-release-version.mjs
@@ -28,12 +28,22 @@ import {
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url))
 const DEFAULT_ROOT = resolve(SCRIPT_DIR, '..')
 
-export const readPinnedRelease = (root = DEFAULT_ROOT) => {
-  const read = (...segments) => readFileSync(join(root, ...segments), 'utf8')
+// The files this reader needs, published so a caller can collect them from
+// somewhere other than a checkout. The rollout workflow does exactly that: it
+// judges a pull request without checking that pull request out, so it fetches
+// these paths as data and never runs anything from the branch it is judging.
+export const CATALOG_PATHS = [
+  'elestio.yml',
+  'deploy/selfhost.env.example',
+  'deploy/umbrel/synaplan/umbrel-app.yml',
+  'deploy/umbrel/synaplan/docker-compose.yml',
+  'deploy/aws/packer/synaplan.pkr.hcl',
+]
 
-  const umbrelCompose = readUmbrelComposePin(
-    read('deploy', 'umbrel', 'synaplan', 'docker-compose.yml')
-  )
+export const readPinnedRelease = (root = DEFAULT_ROOT) => {
+  const read = (path) => readFileSync(join(root, path), 'utf8')
+
+  const umbrelCompose = readUmbrelComposePin(read('deploy/umbrel/synaplan/docker-compose.yml'))
 
   // Checked before the versions: an image pinned without a digest leaves both
   // the tag and the digest unreadable, and reporting that as a missing version
@@ -47,14 +57,14 @@ export const readPinnedRelease = (root = DEFAULT_ROOT) => {
 
   const pins = {
     'elestio.yml': readElestioVersion(read('elestio.yml')),
-    'deploy/selfhost.env.example': readEnvExampleVersion(read('deploy', 'selfhost.env.example')),
+    'deploy/selfhost.env.example': readEnvExampleVersion(read('deploy/selfhost.env.example')),
     'deploy/umbrel/synaplan/umbrel-app.yml': readUmbrelAppVersion(
-      read('deploy', 'umbrel', 'synaplan', 'umbrel-app.yml')
+      read('deploy/umbrel/synaplan/umbrel-app.yml')
     ),
     'deploy/umbrel/synaplan/docker-compose.yml (APP_VERSION)': umbrelCompose.appVersion,
     'deploy/umbrel/synaplan/docker-compose.yml (image tag)': umbrelCompose.version,
     'deploy/aws/packer/synaplan.pkr.hcl': readPackerVersion(
-      read('deploy', 'aws', 'packer', 'synaplan.pkr.hcl')
+      read('deploy/aws/packer/synaplan.pkr.hcl')
     ),
   }
 
@@ -82,8 +92,12 @@ export const readPinnedRelease = (root = DEFAULT_ROOT) => {
 }
 
 export const runCli = (arguments_ = []) => {
-  const root = arguments_.length > 0 ? resolve(arguments_[0]) : DEFAULT_ROOT
-  return `${JSON.stringify(readPinnedRelease(root))}\n`
+  if (arguments_.includes('--paths')) {
+    return `${CATALOG_PATHS.join('\n')}\n`
+  }
+
+  const [root] = arguments_.filter((argument) => !argument.startsWith('-'))
+  return `${JSON.stringify(readPinnedRelease(root ? resolve(root) : DEFAULT_ROOT))}\n`
 }
 
 if (process.argv[1] && pathToFileURL(resolve(process.argv[1])).href === import.meta.url) {

--- a/tests/read-release-version.test.mjs
+++ b/tests/read-release-version.test.mjs
@@ -1,10 +1,13 @@
 import assert from 'node:assert/strict'
-import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import test from 'node:test'
+import { fileURLToPath } from 'node:url'
 
-import { readPinnedRelease } from '../scripts/read-release-version.mjs'
+import { CATALOG_PATHS, readPinnedRelease } from '../scripts/read-release-version.mjs'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
 
 const DIGEST = `sha256:${'a'.repeat(64)}`
 
@@ -105,6 +108,16 @@ test('refuses an Umbrel package without a published image digest', () => {
   )
 
   assert.throws(() => readPinnedRelease(root), /image digest/)
+})
+
+// The rollout workflow collects exactly these paths from a pull request instead
+// of checking it out, so a path that does not exist would mean a guard fetching
+// nothing and a release held back for it.
+test('every catalog path it names exists in this repository', () => {
+  assert.deepEqual(
+    CATALOG_PATHS.filter((path) => !existsSync(join(ROOT, path))),
+    []
+  )
 })
 
 // The real files have to satisfy the reader, or the rollout guard would hold


### PR DESCRIPTION
## Summary

Follow-up to #1652, prompted by a fair question: why wait until 01:00 UTC?

The window was justified by Elestio redeploying every instance that tracks the default branch on each commit to it. That is true — and measuring it is what undermines the argument: `main` takes **between four and nineteen commits a day**, so those pipelines already restart roughly ten times daily. Postponing this one merge to the small hours avoided none of that, while every new deployment installed the previous release until the window came round.

So the rollout now triggers on the proposal's CI completing (`workflow_run`, filtered to `automation/default-release-version` with a successful conclusion). The nightly schedule stays as a net for a proposal whose run predates this workflow or whose event was missed — one no-op run a day.

**All five guards are unchanged**, which is what actually makes the merge safe. Guard 3 still refuses a release withdrawn between the tag and the merge; a shorter window narrows that opportunity but does not weaken the check.

One robustness fix the new timing requires: mergeability is now polled rather than read once. GitHub computes it asynchronously and answers `UNKNOWN` until it has, and arriving seconds after CI means meeting that state regularly — reading it as "not mergeable" would hold back releases for a race rather than a reason.

Documentation that promised a nightly window is corrected in the same change: the generated proposal body, the job comment in `ci.yml`, `deploy/README.md` and `deploy/umbrel/README.md`.

## Test plan

- [x] `node --test "tests/*.test.mjs"` — 58 pass
- [x] Trigger, job condition and all `run` blocks validated (YAML parse + `bash -n`)
- [x] Verified against the real dry run on #1655: guards passed at 10:19 UTC because `All Checks Passed` had completed at 10:17:46 UTC — the pin proposal's CI takes about seven minutes, since it changes only deployment config and the expensive jobs are path-filtered away
- [ ] First live proof is the next release: the proposal should merge within minutes of its checks going green