### PR TITLE
feat(ci): submit the Marketplace version without a manual gate

### DIFF
--- a/.github/workflows/aws-ami.yml
+++ b/.github/workflows/aws-ami.yml
@@ -215,8 +215,7 @@ jobs:
             echo "AMI: \`${ami}\` in \`${AWS_REGION}\`"
             echo ""
             echo "The submit job below offers this AMI to the listing once the"
-            echo "verification launch has passed. It validates by default and only"
-            echo "submits for real when the \`AWS_MARKETPLACE_SUBMIT\` variable says so."
+            echo "verification launch has passed."
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Validate and share the AMI with AWS Marketplace
@@ -656,31 +655,18 @@ jobs:
         env:
           PRODUCT_ID: ${{ secrets.AWS_MARKETPLACE_PRODUCT_ID }}
           INGESTION_ROLE_ARN: ${{ secrets.AWS_MARKETPLACE_INGESTION_ROLE_ARN }}
-          # Unset means validate. Rolling out a listing change is not something
-          # to discover by accident, and AWS keeps a submitted version in review
-          # for days — a wrong one costs a support case, not a revert.
-          SUBMIT: ${{ vars.AWS_MARKETPLACE_SUBMIT }}
           VERSION: ${{ needs.resolve.outputs.version }}
           ARCHITECTURES: ${{ needs.resolve.outputs.matrix }}
           RELEASE_URL: ${{ github.server_url }}/${{ github.repository }}/releases/tag/v${{ needs.resolve.outputs.version }}
         run: |
           set -euo pipefail
 
-          if [ "${SUBMIT:-}" = apply ]; then
-            intent=APPLY
-          else
-            intent=VALIDATE
-          fi
-
           {
             echo "### AWS Marketplace"
             echo ""
-            if [ "$intent" = VALIDATE ]; then
-              echo "Validated \`${VERSION}\` against the listing without submitting it."
-              echo "Set the repository variable \`AWS_MARKETPLACE_SUBMIT\` to \`apply\` to submit for real."
-            else
-              echo "Submitted \`${VERSION}\` to the listing. AWS reviews a new version before it becomes available."
-            fi
+            echo "Offering \`${VERSION}\` to the listing, one version per architecture."
+            echo "Each is validated before it is submitted, and AWS reviews a submitted version"
+            echo "before it becomes available."
             echo ""
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -749,22 +735,33 @@ jobs:
                 DetailsDocument: $details
               }]')"
 
-            echo "::group::${architecture}: ${intent} ${ami}"
+            # Validated first, then submitted, both inside this run. VALIDATE
+            # asks AWS whether it would accept the document without creating
+            # anything, which is how a wrong product id or a role AWS cannot
+            # assume is caught before a real version exists. This used to be a
+            # separate dry run, requested through a repository variable that a
+            # maintainer had to flip after reading a job summary — a step
+            # between two releases that nobody remembers.
+            echo "::group::${architecture}: validate ${ami}"
+            aws marketplace-catalog start-change-set \
+              --catalog AWSMarketplace \
+              --intent VALIDATE \
+              --client-request-token "synaplan-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${architecture}-validate" \
+              --change-set "$change_set" > /dev/null
+            echo "Accepted."
+            echo "::endgroup::"
+
+            echo "::group::${architecture}: submit ${ami}"
             id="$(
               aws marketplace-catalog start-change-set \
                 --catalog AWSMarketplace \
-                --intent "$intent" \
+                --intent APPLY \
                 --client-request-token "synaplan-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${architecture}" \
                 --change-set "$change_set" \
                 --query ChangeSetId --output text
             )"
             echo "Change set ${id}."
             echo "::endgroup::"
-
-            if [ "$intent" = VALIDATE ]; then
-              echo "- \`${architecture}\`: \`${ami}\` validated (change set \`${id}\`)" >> "$GITHUB_STEP_SUMMARY"
-              continue
-            fi
 
             # Waited out rather than fired and forgotten, for two reasons: the
             # next architecture cannot start while this change set holds the

--- a/docs/AWS_MARKETPLACE_LISTING.md
+++ b/docs/AWS_MARKETPLACE_LISTING.md
@@ -168,20 +168,29 @@ later and slower.
 Once the listing exists, the `submit` job in
 [`aws-ami.yml`](../.github/workflows/aws-ami.yml) offers each release to it
 through the Marketplace Catalog API, after the AMI has been built, shared and
-verified by a real launch. It needs three settings, and skips itself with a
-notice while any of them is missing:
+verified by a real launch. It needs two secrets, and skips itself with a notice
+while either of them is missing:
 
-| Setting | Kind | Value |
-| --- | --- | --- |
-| `AWS_MARKETPLACE_PRODUCT_ID` | secret | the listing's product ID, `prod-…` |
-| `AWS_MARKETPLACE_INGESTION_ROLE_ARN` | secret | the `IngestionRoleArn` output of the roles stack |
-| `AWS_MARKETPLACE_SUBMIT` | variable | `apply` to submit for real; anything else validates only |
+| Secret | Value |
+| --- | --- |
+| `AWS_MARKETPLACE_PRODUCT_ID` | the listing's product ID, `prod-…` |
+| `AWS_MARKETPLACE_INGESTION_ROLE_ARN` | the `IngestionRoleArn` output of the roles stack |
 
-**The default is validation, not submission.** Without
-`AWS_MARKETPLACE_SUBMIT=apply` the job sends the same change set with
-`Intent=VALIDATE`, which checks the document against the listing and changes
-nothing. Look at one validated run before switching it over: a submitted version
-sits in AWS review for days, so a wrong one is expensive to take back.
+Nothing else has to be switched on, and nothing has to be switched over later.
+Every architecture is sent twice: first with `Intent=VALIDATE`, which asks AWS
+whether it would accept the document without creating anything, and then — only
+if that passed — with `Intent=APPLY`. That covers what a separate dry run used
+to cover, a wrong product ID or a role AWS cannot assume, without leaving a
+manual step between two releases for someone to forget.
+
+A submitted version still sits in AWS review for days, so it is not published by
+this job. If a submission turns out to be wrong, cancel its change set —
+`CancelChangeSet` is part of the build role's permissions:
+
+```bash
+aws marketplace-catalog cancel-change-set \
+  --catalog AWSMarketplace --change-set-id <id>
+```
 
 Each architecture becomes a **separate version**, titled `<version> (x86_64)` and
 `<version> (arm64)`. That is AWS's rule, not a choice: all delivery options of one


### PR DESCRIPTION
## Why

The `submit` job validated by default and only submitted for real once somebody
set the repository variable `AWS_MARKETPLACE_SUBMIT` to `apply`, after reading a
job summary. That is a step living between two releases, and steps between two
releases get forgotten — every release would have quietly validated forever, and
the listing would never have received a version.

## What changes

Each architecture is sent twice inside the same run:

1. `Intent=VALIDATE` — asks AWS whether it would accept the document, creating
   nothing. A wrong product ID, a malformed `AmiSource`, or an ingestion role
   AWS cannot assume fails here.
2. `Intent=APPLY` — only reached if step 1 passed. Polled to `SUCCEEDED` as
   before, so a rejected document fails the job instead of sitting in the portal.

The variable is gone, and the docs now describe the two-phase call plus how to
withdraw a wrong submission (`CancelChangeSet`, already in the build role's
permissions).

## Safety, unchanged

- The job still requires a successful verification launch (`needs.verify`).
- It still skips itself with a notice while the two secrets are missing.
- AWS still reviews every submitted version before it becomes available; this
  job cannot publish anything.

## Test plan

- [x] `actionlint` (incl. shellcheck) clean; the three SC2016 notes are
      pre-existing JMESPath `--query` strings that must stay single-quoted
- [ ] Next release tag: `Launch and smoke-test the AMI` runs, then both
      architectures report a validated and submitted change set