### PR TITLE
fix(frontend): show when files are not AI-searchable

### DIFF
--- a/frontend/src/components/files/FileMakeSearchableButton.vue
+++ b/frontend/src/components/files/FileMakeSearchableButton.vue
@@ -1,0 +1,36 @@
+<template>
+  <button
+    v-if="vectorStateOf(file) !== 'vectorized'"
+    type="button"
+    class="p-1.5 rounded-lg hover:bg-[var(--brand)]/10 text-[var(--brand)] transition-colors disabled:opacity-50"
+    :title="t('files.describeSortAction')"
+    :aria-label="t('files.describeSortAction')"
+    :disabled="busy"
+    :data-testid="file.source === 'generated' ? 'btn-index-prompt' : 'btn-describe'"
+    @click="emit('activate')"
+  >
+    <Icon
+      :icon="busy ? 'mdi:loading' : 'mdi:text-box-search-outline'"
+      class="w-4 h-4"
+      :class="busy && 'animate-spin'"
+    />
+  </button>
+</template>
+
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+import { Icon } from '@iconify/vue'
+import type { FileItem } from '@/services/filesService'
+import { vectorStateOf } from '@/utils/fileDisplayName'
+
+defineProps<{
+  file: FileItem
+  busy?: boolean
+}>()
+
+const emit = defineEmits<{
+  activate: []
+}>()
+
+const { t } = useI18n()
+</script>

--- a/frontend/src/components/files/FileMakeSearchableButton.vue
+++ b/frontend/src/components/files/FileMakeSearchableButton.vue
@@ -2,7 +2,7 @@
   <button
     v-if="vectorStateOf(file) !== 'vectorized'"
     type="button"
-    class="p-1.5 rounded-lg hover:bg-[var(--brand)]/10 text-[var(--brand)] transition-colors disabled:opacity-50"
+    class="p-1.5 rounded-lg hover:bg-black/5 dark:hover:bg-white/5 txt-secondary hover:text-[var(--brand)] transition-colors disabled:opacity-50"
     :title="t('files.describeSortAction')"
     :aria-label="t('files.describeSortAction')"
     :disabled="busy"

--- a/frontend/src/components/files/FilePreview.vue
+++ b/frontend/src/components/files/FilePreview.vue
@@ -104,6 +104,7 @@ import type { FileItem } from '@/services/filesService'
 import { previewIconForFile, previewKindForFile, previewSnippet } from '@/services/filePreview'
 import { getApiBaseUrl } from '@/services/api/httpClient'
 import { useMediaSrc } from '@/services/api/mediaAuth'
+import { fileDisplayName } from '@/utils/fileDisplayName'
 
 const props = defineProps<{
   file: FileItem
@@ -113,7 +114,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{ play: [] }>()
 
-const { t } = useI18n()
+const { t, locale } = useI18n()
 
 // On web `mediaSrc` is a no-op; on native it appends a read-only media token so
 // a bare <img> (which cannot send auth headers) still loads. MessageVideo /
@@ -123,7 +124,9 @@ const { mediaSrc } = useMediaSrc()
 const kind = computed(() => previewKindForFile(props.file))
 const icon = computed(() => previewIconForFile(props.file))
 const snippet = computed(() => previewSnippet(props.file))
-const displayName = computed(() => props.file.display_name || props.file.filename)
+const displayName = computed(() =>
+  fileDisplayName(props.file, (key, values) => t(key, (values ?? {}) as never), locale.value)
+)
 
 const rawDownloadUrl = computed(() => `${getApiBaseUrl()}/api/v1/files/${props.file.id}/download`)
 // Build the absolute thumb URL from the id (mirrors the download URL) so it

--- a/frontend/src/components/files/FileSourceBadge.vue
+++ b/frontend/src/components/files/FileSourceBadge.vue
@@ -1,7 +1,9 @@
 <template>
   <!-- Same as FileVectorPill: nowrap on the outer element defeats the inner
-       truncate, so the badge could grow past its column. -->
+       truncate, so the badge could grow past its column. Default web uploads
+       are omitted — labelling every row "Upload" does not distinguish anything. -->
   <span
+    v-if="visible"
     class="inline-flex items-center gap-1 text-[11px] txt-secondary min-w-0 max-w-full overflow-hidden"
     :title="t('files.help.source')"
     data-testid="file-source-badge"
@@ -27,6 +29,8 @@ const props = withDefaults(
 )
 
 const { t } = useI18n()
+
+const visible = computed(() => props.source !== 'web_upload')
 
 const icon = computed(() => {
   const map: Record<FileSource, string> = {

--- a/frontend/src/components/files/FileVectorPill.vue
+++ b/frontend/src/components/files/FileVectorPill.vue
@@ -1,18 +1,17 @@
 <template>
-  <!-- `whitespace-nowrap` belongs on the label, not here: on the outer element
-       it kept the pill at its full text width, so the inner `truncate` never
-       took effect and a long folder name ran underneath the row's action
-       icons. -->
+  <!-- Icon-only status: colour carries the meaning (green = searchable,
+       grey = not yet), the label lives in the hover tooltip. A text pill was
+       too loud — the default "not searchable" state applies to most rows, so
+       spelling it out on every row was noise and could wrap on mobile. -->
   <span
-    v-if="visible"
-    class="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-medium min-w-0 max-w-full overflow-hidden"
-    :class="variant.classes"
+    class="inline-flex items-center shrink-0"
+    :class="variant.color"
     :title="tooltip"
     :aria-label="label"
+    role="img"
     data-testid="file-vector-pill"
   >
-    <Icon :icon="variant.icon" class="w-3 h-3 shrink-0" :class="variant.spin && 'animate-spin'" />
-    <span class="truncate whitespace-nowrap">{{ label }}</span>
+    <Icon :icon="variant.icon" class="w-4 h-4" :class="variant.spin && 'animate-spin'" />
   </span>
 </template>
 
@@ -37,52 +36,40 @@ const props = withDefaults(
 
 const { t } = useI18n()
 
-// "Not searchable" is a real state the user must see — hiding it made two
-// otherwise identical rows (e.g. voice memos) look the same.
-const visible = computed(() =>
-  ['vectorized', 'pending', 'failed', 'none', 'not_applicable'].includes(props.state)
-)
-
-// Visual variants per 03_file-management.md §5.1.2.B — standard palette
-// utilities (already used across the files UI), dark-mode safe.
+// Colour + icon per state. Standard palette utilities, dark-mode safe.
 const variant = computed(() => {
   switch (props.state) {
     case 'vectorized':
       return {
-        classes: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-400',
+        color: 'text-emerald-600 dark:text-emerald-400',
         icon: 'mdi:check-circle',
         spin: false,
       }
     case 'pending':
       return {
-        classes: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
+        color: 'text-blue-500 dark:text-blue-400',
         icon: 'mdi:loading',
         spin: true,
       }
     case 'failed':
       return {
-        classes: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400',
+        color: 'text-red-500 dark:text-red-400',
         icon: 'mdi:alert-circle',
         spin: false,
       }
     default:
       return {
-        classes: 'bg-black/[0.06] txt-secondary dark:bg-white/[0.08]',
+        color: 'txt-secondary',
         icon: 'mdi:circle-outline',
         spin: false,
       }
   }
 })
 
+// Short label for screen readers (aria-label).
 const label = computed(() => {
   switch (props.state) {
     case 'vectorized':
-      if (props.groupKey && props.chunkCount > 0) {
-        return t('files.vectorState.vectorizedDetail', {
-          group: props.groupKey,
-          count: props.chunkCount,
-        })
-      }
       return t('files.vectorState.vectorized')
     case 'pending':
       return t('files.vectorState.processing')
@@ -93,9 +80,16 @@ const label = computed(() => {
   }
 })
 
+// Hover tooltip carries the detail (folder + chunk count when searchable).
 const tooltip = computed(() => {
   switch (props.state) {
     case 'vectorized':
+      if (props.groupKey && props.chunkCount > 0) {
+        return t('files.vectorState.vectorizedDetail', {
+          group: props.groupKey,
+          count: props.chunkCount,
+        })
+      }
       return t('files.help.vectorized')
     case 'pending':
       return t('files.help.processing')

--- a/frontend/src/components/files/FileVectorPill.vue
+++ b/frontend/src/components/files/FileVectorPill.vue
@@ -1,6 +1,4 @@
 <template>
-  <!-- Nothing is shown when a file is not searchable — the absence of a pill is
-       the "not searchable" state. Only searchable / processing / failed render. -->
   <!-- `whitespace-nowrap` belongs on the label, not here: on the outer element
        it kept the pill at its full text width, so the inner `truncate` never
        took effect and a long folder name ran underneath the row's action
@@ -39,8 +37,11 @@ const props = withDefaults(
 
 const { t } = useI18n()
 
-// Only render for states that carry meaning; "none"/legacy values show nothing.
-const visible = computed(() => ['vectorized', 'pending', 'failed'].includes(props.state))
+// "Not searchable" is a real state the user must see — hiding it made two
+// otherwise identical rows (e.g. voice memos) look the same.
+const visible = computed(() =>
+  ['vectorized', 'pending', 'failed', 'none', 'not_applicable'].includes(props.state)
+)
 
 // Visual variants per 03_file-management.md §5.1.2.B — standard palette
 // utilities (already used across the files UI), dark-mode safe.
@@ -66,7 +67,7 @@ const variant = computed(() => {
       }
     default:
       return {
-        classes: 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300',
+        classes: 'bg-black/[0.06] txt-secondary dark:bg-white/[0.08]',
         icon: 'mdi:circle-outline',
         spin: false,
       }
@@ -92,5 +93,16 @@ const label = computed(() => {
   }
 })
 
-const tooltip = computed(() => t('files.help.vectorized'))
+const tooltip = computed(() => {
+  switch (props.state) {
+    case 'vectorized':
+      return t('files.help.vectorized')
+    case 'pending':
+      return t('files.help.processing')
+    case 'failed':
+      return t('files.help.failed')
+    default:
+      return t('files.help.notSearchable')
+  }
+})
 </script>

--- a/frontend/src/components/files/FilesGrid.vue
+++ b/frontend/src/components/files/FilesGrid.vue
@@ -77,12 +77,12 @@
         </div>
         <div class="p-2">
           <p class="text-xs font-medium txt-primary truncate" :title="file.filename">
-            {{ file.display_name || file.filename }}
+            {{ fileDisplayName(file, translate, locale) }}
           </p>
           <p class="text-[10px] txt-secondary truncate">{{ file.uploaded_date }}</p>
-          <div v-if="file.is_vectorized" class="mt-1">
+          <div class="mt-1">
             <FileVectorPill
-              :state="file.vector_state ?? 'vectorized'"
+              :state="vectorStateOf(file)"
               :chunk-count="file.chunk_count ?? 0"
               :group-key="file.group_key ?? null"
             />
@@ -114,16 +114,16 @@
             >
               <ChatBubbleLeftRightIcon class="w-3.5 h-3.5" />
             </button>
-            <div v-if="!file.is_vectorized" class="relative shrink-0">
+            <div v-if="vectorStateOf(file) !== 'vectorized'" class="relative shrink-0">
               <button
                 class="px-2 py-1 rounded-md border border-light-border/30 dark:border-dark-border/10 txt-secondary hover:text-[var(--brand)] transition-colors text-[11px] flex items-center gap-1 disabled:opacity-50"
-                :title="$t('files.indexPromptAction')"
+                :title="$t('files.describeSortAction')"
                 :disabled="isIndexing(file.id)"
                 :data-testid="`btn-generated-index-${file.id}`"
                 @click.stop="toggleKbMenu(file.id)"
               >
                 <Icon
-                  :icon="isIndexing(file.id) ? 'mdi:loading' : 'mdi:bookmark-plus-outline'"
+                  :icon="isIndexing(file.id) ? 'mdi:loading' : 'mdi:text-box-search-outline'"
                   class="w-3.5 h-3.5"
                   :class="isIndexing(file.id) && 'animate-spin'"
                 />
@@ -138,7 +138,7 @@
                   <div
                     class="px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wider txt-secondary"
                   >
-                    {{ $t('files.indexPromptAction') }}
+                    {{ $t('files.describeSortAction') }}
                   </div>
                   <button
                     class="w-full flex items-center gap-2 px-3 py-2 text-xs txt-primary hover:bg-[var(--brand)]/10 transition-colors text-left"
@@ -232,11 +232,14 @@ import { ArrowDownTrayIcon, ChatBubbleLeftRightIcon, TrashIcon } from '@heroicon
 import FilePreview from '@/components/files/FilePreview.vue'
 import FileVectorPill from '@/components/files/FileVectorPill.vue'
 import filesService, { type FileItem, type FileOriginKind } from '@/services/filesService'
+import { fileDisplayName, vectorStateOf } from '@/utils/fileDisplayName'
 import { useNotification } from '@/composables/useNotification'
 import { useDialog } from '@/composables/useDialog'
 import { useChatsStore } from '@/stores/chats'
 
-const { t } = useI18n()
+const { t, locale } = useI18n()
+const translate = (key: string, values?: Record<string, unknown>): string =>
+  t(key, (values ?? {}) as never)
 const router = useRouter()
 const { success: showSuccess, error: showError } = useNotification()
 const { confirm } = useDialog()
@@ -357,7 +360,7 @@ const addToKnowledgeBase = async (file: FileItem, groupKey?: string) => {
       if (res.groupKey) {
         showSuccess(t('files.describeSortDoneGroup', { group: res.groupKey }))
       } else {
-        showSuccess(t('files.indexPromptDone'))
+        showSuccess(t('files.describeSortDone'))
       }
       await Promise.all([load(), loadFolders()])
     } else {

--- a/frontend/src/components/files/IncomingInbox.vue
+++ b/frontend/src/components/files/IncomingInbox.vue
@@ -77,13 +77,13 @@
         </div>
         <div class="flex-1 min-w-0">
           <p class="text-sm font-medium txt-primary truncate" :title="file.filename">
-            {{ file.display_name || file.original_name || file.filename }}
+            {{ fileDisplayName(file, translate, locale) }}
           </p>
           <div class="flex items-center gap-2 mt-1 min-w-0 flex-wrap overflow-hidden">
             <FileSourceBadge v-if="file.source" :source="file.source" />
             <span class="text-[11px] txt-secondary truncate">{{ provenance(file) }}</span>
             <FileVectorPill
-              :state="file.vector_state ?? (file.is_vectorized ? 'vectorized' : 'pending')"
+              :state="vectorStateOf(file)"
               :chunk-count="file.chunk_count ?? file.chunks ?? 0"
               :group-key="file.group_key"
             />
@@ -142,10 +142,13 @@ import { ArrowDownTrayIcon, TrashIcon } from '@heroicons/vue/24/outline'
 import filesService, { type FileItem } from '@/services/filesService'
 import { useNotification } from '@/composables/useNotification'
 import { useDateFormat } from '@/composables/useDateFormat'
+import { fileDisplayName, vectorStateOf } from '@/utils/fileDisplayName'
 import FileVectorPill from './FileVectorPill.vue'
 import FileSourceBadge from './FileSourceBadge.vue'
 
-const { t } = useI18n()
+const { t, locale } = useI18n()
+const translate = (key: string, values?: Record<string, unknown>): string =>
+  t(key, (values ?? {}) as never)
 const { success: showSuccess, error: showError } = useNotification()
 const { formatDateTime } = useDateFormat()
 

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -3034,8 +3034,6 @@
     "describeSortDone": "Jetzt KI-durchsuchbar.",
     "describeSortDoneGroup": "Jetzt KI-durchsuchbar · abgelegt in \"{group}\".",
     "describeSortFailed": "Diese Datei konnte nicht durchsuchbar gemacht werden.",
-    "indexPromptAction": "Für den Assistenten durchsuchbar machen",
-    "indexPromptDone": "Jetzt KI-durchsuchbar.",
     "voiceMemo": "Sprachmemo",
     "voiceMemoNamed": "Sprachmemo · {time}",
     "emptyState": {

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -3030,12 +3030,14 @@
     "movedSuccess": "Datei nach \"{folder}\" verschoben",
     "removeFromFolder": "Aus Ordner entfernen",
     "removedFromFolder": "Aus Ordner entfernt (Datei und Suchindex bleiben erhalten)",
-    "describeSortAction": "Beschreiben, vektorisieren & einsortieren – KI-durchsuchbar machen",
+    "describeSortAction": "Für den Assistenten durchsuchbar machen",
     "describeSortDone": "Jetzt KI-durchsuchbar.",
     "describeSortDoneGroup": "Jetzt KI-durchsuchbar · abgelegt in \"{group}\".",
     "describeSortFailed": "Diese Datei konnte nicht durchsuchbar gemacht werden.",
-    "indexPromptAction": "Zur Wissensbasis hinzufügen",
-    "indexPromptDone": "Zu deiner Wissensbasis hinzugefügt.",
+    "indexPromptAction": "Für den Assistenten durchsuchbar machen",
+    "indexPromptDone": "Jetzt KI-durchsuchbar.",
+    "voiceMemo": "Sprachmemo",
+    "voiceMemoNamed": "Sprachmemo · {time}",
     "emptyState": {
       "title": "Noch keine Dateien",
       "description": "Lade Dateien hoch, um loszulegen. Du kannst sie in Ordnern organisieren.",
@@ -3137,6 +3139,9 @@
     },
     "help": {
       "vectorized": "Wenn eine Datei KI-durchsuchbar ist, wird ihr Inhalt deiner Wissensbasis hinzugefügt, damit der Assistent ihn für Antworten nutzen kann.",
+      "notSearchable": "Der Assistent kann diese Datei noch nicht für Antworten nutzen. Mach sie durchsuchbar, um sie ins Wissen aufzunehmen.",
+      "processing": "Diese Datei wird vorbereitet, damit der Assistent sie nutzen kann.",
+      "failed": "Diese Datei konnte nicht durchsuchbar gemacht werden. Du kannst es erneut versuchen.",
       "group": "Wissensordner bündeln Dateien. Wenn die KI einen Ordner durchsucht, kann sie jede Datei darin nutzen.",
       "source": "Woher diese Datei stammt – Upload, Chat, Outlook, Nextcloud, OpenCloud, WhatsApp, Widget, API oder KI-erzeugt.",
       "incoming": "Dateien, die andere Apps für deine Wissensbasis eingeliefert haben. Prüfe sie und behalte oder verwirf sie.",
@@ -3221,7 +3226,7 @@
       "deleteFailed": "Datei konnte nicht gelöscht werden. Bitte versuche es erneut."
     },
     "explainer": {
-      "text": "Alles, was du hochlädst oder erstellst, liegt hier. Als „KI-durchsuchbar“ markierte Dateien werden deiner Wissensbasis hinzugefügt, damit der Assistent sie nutzen kann.",
+      "text": "Alles, was du hochlädst oder erstellst, liegt hier. Der Assistent nutzt Dateien, die als „KI-durchsuchbar“ markiert sind. Fotos, Aufnahmen und KI-erzeugte Dateien musst du zuerst durchsuchbar machen.",
       "dismiss": "Verstanden",
       "reopen": "Was ist das?"
     }

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -1132,8 +1132,6 @@
     "describeSortDone": "Now searchable by AI.",
     "describeSortDoneGroup": "Now searchable by AI · filed in \"{group}\".",
     "describeSortFailed": "Couldn't make this file searchable.",
-    "indexPromptAction": "Make searchable by AI",
-    "indexPromptDone": "Now searchable by AI.",
     "voiceMemo": "Voice memo",
     "voiceMemoNamed": "Voice memo · {time}",
     "emptyState": {

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -1128,12 +1128,14 @@
     "movedSuccess": "File moved to \"{folder}\"",
     "removeFromFolder": "Remove from folder",
     "removedFromFolder": "Removed from folder (file and its search index are kept)",
-    "describeSortAction": "Describe, vectorise & sort — make searchable by AI",
+    "describeSortAction": "Make searchable by AI",
     "describeSortDone": "Now searchable by AI.",
     "describeSortDoneGroup": "Now searchable by AI · filed in \"{group}\".",
     "describeSortFailed": "Couldn't make this file searchable.",
-    "indexPromptAction": "Add to knowledge base",
-    "indexPromptDone": "Added to your knowledge base.",
+    "indexPromptAction": "Make searchable by AI",
+    "indexPromptDone": "Now searchable by AI.",
+    "voiceMemo": "Voice memo",
+    "voiceMemoNamed": "Voice memo · {time}",
     "emptyState": {
       "title": "No files yet",
       "description": "Upload files to get started. You can organize them into folders.",
@@ -1235,6 +1237,9 @@
     },
     "help": {
       "vectorized": "When a file is searchable by AI, its contents are added to your knowledge base so the assistant can use them to answer you.",
+      "notSearchable": "The assistant cannot use this file in answers yet. Make it searchable to add it to your knowledge.",
+      "processing": "This file is being prepared so the assistant can use it.",
+      "failed": "This file could not be made searchable. You can try again.",
       "group": "Knowledge folders bundle files together. When the AI searches a folder, it can use every file in it.",
       "source": "Where this file came from — an upload, a chat, Outlook, Nextcloud, OpenCloud, WhatsApp, the widget, the API, or AI-generated.",
       "incoming": "Files other apps pushed in for your knowledge base. Review them, then keep or dismiss.",
@@ -1319,7 +1324,7 @@
       "deleteFailed": "Couldn't delete the file. Please try again."
     },
     "explainer": {
-      "text": "Everything you upload or create lives here. Files marked \"searchable by AI\" are added to your knowledge base so the assistant can use them.",
+      "text": "Everything you upload or create lives here. The assistant can use files marked searchable by AI. Photos, recordings, and AI-created files need you to make them searchable first.",
       "dismiss": "Got it",
       "reopen": "What is this?"
     }

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -2300,12 +2300,14 @@
     "movedSuccess": "Archivo movido a \"{folder}\"",
     "removeFromFolder": "Quitar de la carpeta",
     "removedFromFolder": "Quitado de la carpeta (se conservan el archivo y su índice de búsqueda)",
-    "describeSortAction": "Describir, vectorizar y ordenar: hacer consultable por IA",
+    "describeSortAction": "Hacer consultable por IA",
     "describeSortDone": "Ya es consultable por IA.",
     "describeSortDoneGroup": "Ya es consultable por IA · archivado en \"{group}\".",
     "describeSortFailed": "No se pudo hacer consultable este archivo.",
-    "indexPromptAction": "Añadir a la base de conocimiento",
-    "indexPromptDone": "Añadido a tu base de conocimiento.",
+    "indexPromptAction": "Hacer consultable por IA",
+    "indexPromptDone": "Ya es consultable por IA.",
+    "voiceMemo": "Nota de voz",
+    "voiceMemoNamed": "Nota de voz · {time}",
     "emptyState": {
       "title": "Aún no hay archivos",
       "description": "Sube archivos para empezar. Puedes organizarlos en carpetas.",
@@ -2408,6 +2410,9 @@
     },
     "help": {
       "vectorized": "Cuando un archivo es consultable por IA, su contenido se añade a tu base de conocimiento para que el asistente pueda usarlo al responderte.",
+      "notSearchable": "El asistente aún no puede usar este archivo en las respuestas. Hazlo consultable para añadirlo a tu conocimiento.",
+      "processing": "Este archivo se está preparando para que el asistente pueda usarlo.",
+      "failed": "No se pudo hacer consultable este archivo. Puedes intentarlo de nuevo.",
       "group": "Las carpetas de conocimiento agrupan archivos. Cuando la IA busca en una carpeta, puede usar cada archivo.",
       "source": "De dónde viene este archivo: una subida, un chat, Outlook, Nextcloud, OpenCloud, WhatsApp, el widget, la API o generado por IA.",
       "incoming": "Archivos que otras apps han enviado para tu base de conocimiento. Revísalos y consérvalos o descártalos.",
@@ -2492,7 +2497,7 @@
       "deleteFailed": "No se pudo eliminar el archivo. Inténtalo de nuevo."
     },
     "explainer": {
-      "text": "Todo lo que subes o creas está aquí. Los archivos marcados como «consultables por IA» se añaden a tu base de conocimiento para que el asistente pueda usarlos.",
+      "text": "Todo lo que subes o creas está aquí. El asistente puede usar los archivos marcados como consultables por IA. Fotos, grabaciones y archivos creados por IA necesitan que los hagas consultables primero.",
       "dismiss": "Entendido",
       "reopen": "¿Qué es esto?"
     }

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -2304,8 +2304,6 @@
     "describeSortDone": "Ya es consultable por IA.",
     "describeSortDoneGroup": "Ya es consultable por IA · archivado en \"{group}\".",
     "describeSortFailed": "No se pudo hacer consultable este archivo.",
-    "indexPromptAction": "Hacer consultable por IA",
-    "indexPromptDone": "Ya es consultable por IA.",
     "voiceMemo": "Nota de voz",
     "voiceMemoNamed": "Nota de voz · {time}",
     "emptyState": {

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -1132,8 +1132,6 @@
     "describeSortDone": "Désormais recherchable par l’IA.",
     "describeSortDoneGroup": "Désormais recherchable par l’IA · classé dans « {group} ».",
     "describeSortFailed": "Impossible de rendre ce fichier recherchable.",
-    "indexPromptAction": "Rendre recherchable par l’IA",
-    "indexPromptDone": "Désormais recherchable par l’IA.",
     "voiceMemo": "Mémo vocal",
     "voiceMemoNamed": "Mémo vocal · {time}",
     "emptyState": {

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -1128,12 +1128,14 @@
     "movedSuccess": "Fichier déplacé vers « {folder} »",
     "removeFromFolder": "Retirer du dossier",
     "removedFromFolder": "Retiré du dossier (le fichier et son index de recherche sont conservés)",
-    "describeSortAction": "Décrire, indexer et classer — rendre recherchable par l’IA",
+    "describeSortAction": "Rendre recherchable par l’IA",
     "describeSortDone": "Désormais recherchable par l’IA.",
     "describeSortDoneGroup": "Désormais recherchable par l’IA · classé dans « {group} ».",
     "describeSortFailed": "Impossible de rendre ce fichier recherchable.",
-    "indexPromptAction": "Ajouter à la base de connaissances",
-    "indexPromptDone": "Ajouté à votre base de connaissances.",
+    "indexPromptAction": "Rendre recherchable par l’IA",
+    "indexPromptDone": "Désormais recherchable par l’IA.",
+    "voiceMemo": "Mémo vocal",
+    "voiceMemoNamed": "Mémo vocal · {time}",
     "emptyState": {
       "title": "Aucun fichier pour le moment",
       "description": "Téléversez des fichiers pour commencer. Vous pouvez les organiser en dossiers.",
@@ -1235,6 +1237,9 @@
     },
     "help": {
       "vectorized": "Lorsqu’un fichier est recherchable par l’IA, son contenu est ajouté à votre base de connaissances afin que l’assistant puisse s’en servir pour vous répondre.",
+      "notSearchable": "L’assistant ne peut pas encore utiliser ce fichier dans ses réponses. Rendez-le recherchable pour l’ajouter à vos connaissances.",
+      "processing": "Ce fichier est en cours de préparation pour que l’assistant puisse l’utiliser.",
+      "failed": "Impossible de rendre ce fichier recherchable. Vous pouvez réessayer.",
       "group": "Les dossiers de connaissances regroupent des fichiers. Lorsque l’IA recherche un dossier, elle peut utiliser chaque fichier qu’il contient.",
       "source": "D’où vient ce fichier — un téléversement, un chat, Outlook, Nextcloud, OpenCloud, WhatsApp, le widget, l’API, ou généré par l’IA.",
       "incoming": "Fichiers envoyés par d’autres applications pour votre base de connaissances. Examinez-les, puis conservez-les ou écartez-les.",
@@ -1319,7 +1324,7 @@
       "deleteFailed": "Impossible de supprimer le fichier. Veuillez réessayer."
     },
     "explainer": {
-      "text": "Tout ce que vous téléversez ou créez se trouve ici. Les fichiers marqués « recherchable par l’IA » sont ajoutés à votre base de connaissances afin que l’assistant puisse les utiliser.",
+      "text": "Tout ce que vous téléversez ou créez se trouve ici. L’assistant peut utiliser les fichiers marqués recherchables par l’IA. Photos, enregistrements et fichiers créés par l’IA doivent d’abord être rendus recherchables.",
       "dismiss": "Compris",
       "reopen": "Qu’est-ce que c’est ?"
     }

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -2305,8 +2305,6 @@
     "describeSortDone": "Artık yapay zekâ ile aranabilir.",
     "describeSortDoneGroup": "Artık yapay zekâ ile aranabilir · \"{group}\" içine eklendi.",
     "describeSortFailed": "Bu dosya aranabilir yapılamadı.",
-    "indexPromptAction": "Yapay zekâ ile aranabilir yap",
-    "indexPromptDone": "Artık yapay zekâ ile aranabilir.",
     "voiceMemo": "Sesli not",
     "voiceMemoNamed": "Sesli not · {time}",
     "emptyState": {

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -2301,12 +2301,14 @@
     "movedSuccess": "Dosya \"{folder}\" klasörüne taşındı",
     "removeFromFolder": "Klasörden çıkar",
     "removedFromFolder": "Klasörden çıkarıldı (dosya ve arama dizini korunur)",
-    "describeSortAction": "Açıkla, vektörle ve sırala — yapay zekâ ile aranabilir yap",
+    "describeSortAction": "Yapay zekâ ile aranabilir yap",
     "describeSortDone": "Artık yapay zekâ ile aranabilir.",
     "describeSortDoneGroup": "Artık yapay zekâ ile aranabilir · \"{group}\" içine eklendi.",
     "describeSortFailed": "Bu dosya aranabilir yapılamadı.",
-    "indexPromptAction": "Bilgi tabanına ekle",
-    "indexPromptDone": "Bilgi tabanınıza eklendi.",
+    "indexPromptAction": "Yapay zekâ ile aranabilir yap",
+    "indexPromptDone": "Artık yapay zekâ ile aranabilir.",
+    "voiceMemo": "Sesli not",
+    "voiceMemoNamed": "Sesli not · {time}",
     "emptyState": {
       "title": "Henüz dosya yok",
       "description": "Başlamak için dosya yükle. Dosyaları klasörler halinde düzenleyebilirsin.",
@@ -2409,6 +2411,9 @@
     },
     "help": {
       "vectorized": "Bir dosya yapay zekâ ile aranabilir olduğunda içeriği bilgi tabanınıza eklenir; böylece asistan yanıt verirken bunu kullanabilir.",
+      "notSearchable": "Asistan bu dosyayı henüz yanıtlarda kullanamaz. Bilgiye eklemek için onu aranabilir yapın.",
+      "processing": "Bu dosya, asistanın kullanabilmesi için hazırlanıyor.",
+      "failed": "Bu dosya aranabilir yapılamadı. Yeniden deneyebilirsiniz.",
       "group": "Bilgi klasörleri dosyaları bir araya getirir. AI bir klasörde arama yaptığında içindeki her dosyayı kullanabilir.",
       "source": "Bu dosyanın nereden geldiği — yükleme, sohbet, Outlook, Nextcloud, OpenCloud, WhatsApp, widget, API veya yapay zekâ üretimi.",
       "incoming": "Diğer uygulamaların bilgi tabanınız için gönderdiği dosyalar. İnceleyin, sonra saklayın veya çıkarın.",
@@ -2493,7 +2498,7 @@
       "deleteFailed": "Dosya silinemedi. Lütfen tekrar deneyin."
     },
     "explainer": {
-      "text": "Yüklediğiniz veya oluşturduğunuz her şey burada. „Yapay zekâ ile aranabilir“ olarak işaretli dosyalar bilgi tabanınıza eklenir; böylece asistan bunları kullanabilir.",
+      "text": "Yüklediğiniz veya oluşturduğunuz her şey burada. Asistan, yapay zekâ ile aranabilir işaretli dosyaları kullanabilir. Fotoğraflar, kayıtlar ve yapay zekânın ürettiği dosyalar için önce aranabilir yapmanız gerekir.",
       "dismiss": "Anladım",
       "reopen": "Bu nedir?"
     }

--- a/frontend/src/utils/fileDisplayName.ts
+++ b/frontend/src/utils/fileDisplayName.ts
@@ -1,0 +1,72 @@
+import type { FileVectorState } from '@/services/filesService'
+
+/** Generic chat voice-note names from `audioRecordingFilename()`. */
+const VOICE_MEMO_BASENAMES = new Set([
+  'recording.webm',
+  'recording.m4a',
+  'recording.ogg',
+  'recording.mp3',
+  'recording.wav',
+])
+
+export type FileNameFields = {
+  filename: string
+  display_name?: string
+  original_name?: string | null
+  uploaded_date?: string
+}
+
+export function isVoiceMemoFilename(name: string | null | undefined): boolean {
+  if (!name) return false
+  const base = name.trim().split(/[/\\]/).pop()?.toLowerCase() ?? ''
+  return VOICE_MEMO_BASENAMES.has(base)
+}
+
+/** Parse the file-list timestamp (`Y-m-d H:i:s`) as local wall time. */
+export function parseFileUploadedDate(value: string): Date | null {
+  const match = /^(\d{4})-(\d{2})-(\d{2})[ T](\d{2}):(\d{2})(?::(\d{2}))?/.exec(value.trim())
+  if (match) {
+    return new Date(
+      Number(match[1]),
+      Number(match[2]) - 1,
+      Number(match[3]),
+      Number(match[4]),
+      Number(match[5]),
+      Number(match[6] ?? 0)
+    )
+  }
+  const parsed = new Date(value)
+  return Number.isNaN(parsed.getTime()) ? null : parsed
+}
+
+export function fileDisplayName(
+  file: FileNameFields,
+  translate: (key: string, values?: Record<string, unknown>) => string,
+  locale: string
+): string {
+  const raw = file.display_name || file.original_name || file.filename
+  if (file.display_name && !isVoiceMemoFilename(file.display_name)) {
+    return file.display_name
+  }
+  if (!isVoiceMemoFilename(raw) && !isVoiceMemoFilename(file.filename)) {
+    return raw
+  }
+
+  const uploaded = file.uploaded_date ? parseFileUploadedDate(file.uploaded_date) : null
+  if (!uploaded) {
+    return translate('files.voiceMemo')
+  }
+  const time = new Intl.DateTimeFormat(locale, {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  }).format(uploaded)
+  return translate('files.voiceMemoNamed', { time })
+}
+
+export function vectorStateOf(file: {
+  vector_state?: FileVectorState
+  is_vectorized?: boolean
+}): FileVectorState {
+  return file.vector_state ?? (file.is_vectorized ? 'vectorized' : 'none')
+}

--- a/frontend/src/views/FilesView.vue
+++ b/frontend/src/views/FilesView.vue
@@ -838,11 +838,6 @@
                       </div>
                     </div>
                     <div class="flex items-center gap-0 shrink-0">
-                      <FileMakeSearchableButton
-                        :file="file"
-                        :busy="isDescribing(file.id)"
-                        @activate="describeAndSort(file)"
-                      />
                       <FolderMoveMenu
                         :open="folderMenuOpen === file.id"
                         :folders="displayedFolders"
@@ -850,6 +845,11 @@
                         @toggle="toggleFolderMenu(file.id)"
                         @move="moveFileToFolder(file.id, $event)"
                         @remove="removeFileFromFolder(file.id)"
+                      />
+                      <FileMakeSearchableButton
+                        :file="file"
+                        :busy="isDescribing(file.id)"
+                        @activate="describeAndSort(file)"
                       />
                       <button
                         class="p-1.5 rounded-lg hover:bg-black/5 dark:hover:bg-white/5 txt-secondary transition-colors"
@@ -961,45 +961,43 @@
                         {{ file.uploaded_date }}
                       </td>
                       <td class="py-2.5 px-3">
-                        <div class="flex gap-0.5 justify-end items-center">
+                        <div
+                          class="flex gap-0.5 justify-end opacity-0 pointer-coarse:opacity-100 group-hover:opacity-100 focus-within:opacity-100 transition-opacity"
+                        >
+                          <FolderMoveMenu
+                            :open="folderMenuOpen === file.id"
+                            :folders="displayedFolders"
+                            :can-remove="!!file.group_key"
+                            @toggle="toggleFolderMenu(file.id)"
+                            @move="moveFileToFolder(file.id, $event)"
+                            @remove="removeFileFromFolder(file.id)"
+                          />
                           <FileMakeSearchableButton
                             :file="file"
                             :busy="isDescribing(file.id)"
                             @activate="describeAndSort(file)"
                           />
-                          <div
-                            class="flex gap-0.5 opacity-0 pointer-coarse:opacity-100 group-hover:opacity-100 focus-within:opacity-100 transition-opacity"
+                          <button
+                            class="p-1.5 rounded-lg hover:bg-black/5 dark:hover:bg-white/5 txt-secondary hover:txt-primary transition-colors"
+                            :title="$t('files.download')"
+                            @click="downloadFile(file.id, file.filename)"
                           >
-                            <FolderMoveMenu
-                              :open="folderMenuOpen === file.id"
-                              :folders="displayedFolders"
-                              :can-remove="!!file.group_key"
-                              @toggle="toggleFolderMenu(file.id)"
-                              @move="moveFileToFolder(file.id, $event)"
-                              @remove="removeFileFromFolder(file.id)"
-                            />
-                            <button
-                              class="p-1.5 rounded-lg hover:bg-black/5 dark:hover:bg-white/5 txt-secondary hover:txt-primary transition-colors"
-                              :title="$t('files.download')"
-                              @click="downloadFile(file.id, file.filename)"
-                            >
-                              <ArrowDownTrayIcon class="w-4 h-4" />
-                            </button>
-                            <button
-                              class="p-1.5 rounded-lg hover:bg-black/5 dark:hover:bg-white/5 txt-secondary hover:txt-primary transition-colors"
-                              :title="$t('common.view')"
-                              @click="viewFileContent(file.id)"
-                            >
-                              <Icon icon="heroicons:eye" class="w-4 h-4" />
-                            </button>
-                            <button
-                              class="p-1.5 rounded-lg hover:bg-red-500/10 text-red-400/70 hover:text-red-500 transition-colors"
-                              :title="$t('files.delete')"
-                              @click="deleteFile(file.id)"
-                            >
-                              <TrashIcon class="w-4 h-4" />
-                            </button>
-                          </div>
+                            <ArrowDownTrayIcon class="w-4 h-4" />
+                          </button>
+                          <button
+                            class="p-1.5 rounded-lg hover:bg-black/5 dark:hover:bg-white/5 txt-secondary hover:txt-primary transition-colors"
+                            :title="$t('common.view')"
+                            @click="viewFileContent(file.id)"
+                          >
+                            <Icon icon="heroicons:eye" class="w-4 h-4" />
+                          </button>
+                          <button
+                            class="p-1.5 rounded-lg hover:bg-red-500/10 text-red-400/70 hover:text-red-500 transition-colors"
+                            :title="$t('files.delete')"
+                            @click="deleteFile(file.id)"
+                          >
+                            <TrashIcon class="w-4 h-4" />
+                          </button>
                         </div>
                       </td>
                     </tr>
@@ -1183,11 +1181,6 @@
                     </div>
                   </div>
                   <div class="flex items-center gap-0 shrink-0">
-                    <FileMakeSearchableButton
-                      :file="file"
-                      :busy="isDescribing(file.id)"
-                      @activate="describeAndSort(file)"
-                    />
                     <FolderMoveMenu
                       :open="folderMenuOpen === file.id"
                       :folders="displayedFolders"
@@ -1196,6 +1189,11 @@
                       @toggle="toggleFolderMenu(file.id)"
                       @move="moveFileToFolder(file.id, $event)"
                       @remove="removeFileFromFolder(file.id)"
+                    />
+                    <FileMakeSearchableButton
+                      :file="file"
+                      :busy="isDescribing(file.id)"
+                      @activate="describeAndSort(file)"
                     />
                     <button
                       class="p-1.5 rounded-lg hover:bg-black/5 dark:hover:bg-white/5 txt-secondary transition-colors"
@@ -1302,49 +1300,47 @@
                       {{ file.uploaded_date }}
                     </td>
                     <td class="py-2.5 px-3">
-                      <div class="flex gap-0.5 justify-end items-center">
+                      <div
+                        class="flex gap-0.5 justify-end opacity-0 pointer-coarse:opacity-100 group-hover:opacity-100 focus-within:opacity-100 transition-opacity"
+                      >
+                        <FolderMoveMenu
+                          :open="folderMenuOpen === file.id"
+                          :folders="displayedFolders"
+                          :current-folder="openFolder"
+                          :can-remove="!!file.group_key"
+                          @toggle="toggleFolderMenu(file.id)"
+                          @move="moveFileToFolder(file.id, $event)"
+                          @remove="removeFileFromFolder(file.id)"
+                        />
                         <FileMakeSearchableButton
                           :file="file"
                           :busy="isDescribing(file.id)"
                           @activate="describeAndSort(file)"
                         />
-                        <div
-                          class="flex gap-0.5 opacity-0 pointer-coarse:opacity-100 group-hover:opacity-100 focus-within:opacity-100 transition-opacity"
+                        <button
+                          class="p-1.5 rounded-lg hover:bg-black/5 dark:hover:bg-white/5 txt-secondary hover:txt-primary transition-colors"
+                          :title="$t('files.download')"
+                          data-testid="btn-download"
+                          @click="downloadFile(file.id, file.filename)"
                         >
-                          <FolderMoveMenu
-                            :open="folderMenuOpen === file.id"
-                            :folders="displayedFolders"
-                            :current-folder="openFolder"
-                            :can-remove="!!file.group_key"
-                            @toggle="toggleFolderMenu(file.id)"
-                            @move="moveFileToFolder(file.id, $event)"
-                            @remove="removeFileFromFolder(file.id)"
-                          />
-                          <button
-                            class="p-1.5 rounded-lg hover:bg-black/5 dark:hover:bg-white/5 txt-secondary hover:txt-primary transition-colors"
-                            :title="$t('files.download')"
-                            data-testid="btn-download"
-                            @click="downloadFile(file.id, file.filename)"
-                          >
-                            <ArrowDownTrayIcon class="w-4 h-4" />
-                          </button>
-                          <button
-                            class="p-1.5 rounded-lg hover:bg-black/5 dark:hover:bg-white/5 txt-secondary hover:txt-primary transition-colors"
-                            :title="$t('common.view')"
-                            data-testid="btn-view"
-                            @click="viewFileContent(file.id)"
-                          >
-                            <Icon icon="heroicons:eye" class="w-4 h-4" />
-                          </button>
-                          <button
-                            class="p-1.5 rounded-lg hover:bg-red-500/10 text-red-400/70 hover:text-red-500 transition-colors"
-                            :title="$t('files.delete')"
-                            data-testid="btn-delete"
-                            @click="deleteFile(file.id)"
-                          >
-                            <TrashIcon class="w-4 h-4" />
-                          </button>
-                        </div>
+                          <ArrowDownTrayIcon class="w-4 h-4" />
+                        </button>
+                        <button
+                          class="p-1.5 rounded-lg hover:bg-black/5 dark:hover:bg-white/5 txt-secondary hover:txt-primary transition-colors"
+                          :title="$t('common.view')"
+                          data-testid="btn-view"
+                          @click="viewFileContent(file.id)"
+                        >
+                          <Icon icon="heroicons:eye" class="w-4 h-4" />
+                        </button>
+                        <button
+                          class="p-1.5 rounded-lg hover:bg-red-500/10 text-red-400/70 hover:text-red-500 transition-colors"
+                          :title="$t('files.delete')"
+                          data-testid="btn-delete"
+                          @click="deleteFile(file.id)"
+                        >
+                          <TrashIcon class="w-4 h-4" />
+                        </button>
                       </div>
                     </td>
                   </tr>

--- a/frontend/src/views/FilesView.vue
+++ b/frontend/src/views/FilesView.vue
@@ -838,6 +838,11 @@
                       </div>
                     </div>
                     <div class="flex items-center gap-0 shrink-0">
+                      <FileMakeSearchableButton
+                        :file="file"
+                        :busy="isDescribing(file.id)"
+                        @activate="describeAndSort(file)"
+                      />
                       <FolderMoveMenu
                         :open="folderMenuOpen === file.id"
                         :folders="displayedFolders"
@@ -846,36 +851,6 @@
                         @move="moveFileToFolder(file.id, $event)"
                         @remove="removeFileFromFolder(file.id)"
                       />
-                      <button
-                        v-if="vectorStateOf(file) !== 'vectorized' && file.source !== 'generated'"
-                        class="p-1.5 rounded-lg hover:bg-[var(--brand)]/10 txt-secondary hover:text-[var(--brand)] transition-colors disabled:opacity-50"
-                        :title="$t('files.describeSortAction')"
-                        :disabled="isDescribing(file.id)"
-                        data-testid="btn-describe"
-                        @click="describeAndSort(file)"
-                      >
-                        <Icon
-                          :icon="isDescribing(file.id) ? 'mdi:loading' : 'mdi:brain'"
-                          class="w-4 h-4"
-                          :class="isDescribing(file.id) && 'animate-spin'"
-                        />
-                      </button>
-                      <button
-                        v-if="vectorStateOf(file) !== 'vectorized' && file.source === 'generated'"
-                        class="p-1.5 rounded-lg hover:bg-[var(--brand)]/10 txt-secondary hover:text-[var(--brand)] transition-colors disabled:opacity-50"
-                        :title="$t('files.indexPromptAction')"
-                        :disabled="isDescribing(file.id)"
-                        data-testid="btn-index-prompt"
-                        @click="describeAndSort(file)"
-                      >
-                        <Icon
-                          :icon="
-                            isDescribing(file.id) ? 'mdi:loading' : 'mdi:bookmark-plus-outline'
-                          "
-                          class="w-4 h-4"
-                          :class="isDescribing(file.id) && 'animate-spin'"
-                        />
-                      </button>
                       <button
                         class="p-1.5 rounded-lg hover:bg-black/5 dark:hover:bg-white/5 txt-secondary transition-colors"
                         :title="$t('common.view')"
@@ -986,72 +961,45 @@
                         {{ file.uploaded_date }}
                       </td>
                       <td class="py-2.5 px-3">
-                        <div
-                          class="flex gap-0.5 justify-end opacity-0 pointer-coarse:opacity-100 group-hover:opacity-100 focus-within:opacity-100 transition-opacity"
-                        >
-                          <FolderMoveMenu
-                            :open="folderMenuOpen === file.id"
-                            :folders="displayedFolders"
-                            :can-remove="!!file.group_key"
-                            @toggle="toggleFolderMenu(file.id)"
-                            @move="moveFileToFolder(file.id, $event)"
-                            @remove="removeFileFromFolder(file.id)"
+                        <div class="flex gap-0.5 justify-end items-center">
+                          <FileMakeSearchableButton
+                            :file="file"
+                            :busy="isDescribing(file.id)"
+                            @activate="describeAndSort(file)"
                           />
-                          <button
-                            v-if="
-                              vectorStateOf(file) !== 'vectorized' && file.source !== 'generated'
-                            "
-                            class="p-1.5 rounded-lg hover:bg-[var(--brand)]/10 txt-secondary hover:text-[var(--brand)] transition-colors disabled:opacity-50"
-                            :title="$t('files.describeSortAction')"
-                            :disabled="isDescribing(file.id)"
-                            data-testid="btn-describe"
-                            @click="describeAndSort(file)"
+                          <div
+                            class="flex gap-0.5 opacity-0 pointer-coarse:opacity-100 group-hover:opacity-100 focus-within:opacity-100 transition-opacity"
                           >
-                            <Icon
-                              :icon="isDescribing(file.id) ? 'mdi:loading' : 'mdi:brain'"
-                              class="w-4 h-4"
-                              :class="isDescribing(file.id) && 'animate-spin'"
+                            <FolderMoveMenu
+                              :open="folderMenuOpen === file.id"
+                              :folders="displayedFolders"
+                              :can-remove="!!file.group_key"
+                              @toggle="toggleFolderMenu(file.id)"
+                              @move="moveFileToFolder(file.id, $event)"
+                              @remove="removeFileFromFolder(file.id)"
                             />
-                          </button>
-                          <button
-                            v-if="
-                              vectorStateOf(file) !== 'vectorized' && file.source === 'generated'
-                            "
-                            class="p-1.5 rounded-lg hover:bg-[var(--brand)]/10 txt-secondary hover:text-[var(--brand)] transition-colors disabled:opacity-50"
-                            :title="$t('files.indexPromptAction')"
-                            :disabled="isDescribing(file.id)"
-                            data-testid="btn-index-prompt"
-                            @click="describeAndSort(file)"
-                          >
-                            <Icon
-                              :icon="
-                                isDescribing(file.id) ? 'mdi:loading' : 'mdi:bookmark-plus-outline'
-                              "
-                              class="w-4 h-4"
-                              :class="isDescribing(file.id) && 'animate-spin'"
-                            />
-                          </button>
-                          <button
-                            class="p-1.5 rounded-lg hover:bg-black/5 dark:hover:bg-white/5 txt-secondary hover:txt-primary transition-colors"
-                            :title="$t('files.download')"
-                            @click="downloadFile(file.id, file.filename)"
-                          >
-                            <ArrowDownTrayIcon class="w-4 h-4" />
-                          </button>
-                          <button
-                            class="p-1.5 rounded-lg hover:bg-black/5 dark:hover:bg-white/5 txt-secondary hover:txt-primary transition-colors"
-                            :title="$t('common.view')"
-                            @click="viewFileContent(file.id)"
-                          >
-                            <Icon icon="heroicons:eye" class="w-4 h-4" />
-                          </button>
-                          <button
-                            class="p-1.5 rounded-lg hover:bg-red-500/10 text-red-400/70 hover:text-red-500 transition-colors"
-                            :title="$t('files.delete')"
-                            @click="deleteFile(file.id)"
-                          >
-                            <TrashIcon class="w-4 h-4" />
-                          </button>
+                            <button
+                              class="p-1.5 rounded-lg hover:bg-black/5 dark:hover:bg-white/5 txt-secondary hover:txt-primary transition-colors"
+                              :title="$t('files.download')"
+                              @click="downloadFile(file.id, file.filename)"
+                            >
+                              <ArrowDownTrayIcon class="w-4 h-4" />
+                            </button>
+                            <button
+                              class="p-1.5 rounded-lg hover:bg-black/5 dark:hover:bg-white/5 txt-secondary hover:txt-primary transition-colors"
+                              :title="$t('common.view')"
+                              @click="viewFileContent(file.id)"
+                            >
+                              <Icon icon="heroicons:eye" class="w-4 h-4" />
+                            </button>
+                            <button
+                              class="p-1.5 rounded-lg hover:bg-red-500/10 text-red-400/70 hover:text-red-500 transition-colors"
+                              :title="$t('files.delete')"
+                              @click="deleteFile(file.id)"
+                            >
+                              <TrashIcon class="w-4 h-4" />
+                            </button>
+                          </div>
                         </div>
                       </td>
                     </tr>
@@ -1235,6 +1183,11 @@
                     </div>
                   </div>
                   <div class="flex items-center gap-0 shrink-0">
+                    <FileMakeSearchableButton
+                      :file="file"
+                      :busy="isDescribing(file.id)"
+                      @activate="describeAndSort(file)"
+                    />
                     <FolderMoveMenu
                       :open="folderMenuOpen === file.id"
                       :folders="displayedFolders"
@@ -1244,34 +1197,6 @@
                       @move="moveFileToFolder(file.id, $event)"
                       @remove="removeFileFromFolder(file.id)"
                     />
-                    <button
-                      v-if="vectorStateOf(file) !== 'vectorized' && file.source !== 'generated'"
-                      class="p-1.5 rounded-lg hover:bg-[var(--brand)]/10 txt-secondary hover:text-[var(--brand)] transition-colors disabled:opacity-50"
-                      :title="$t('files.describeSortAction')"
-                      :disabled="isDescribing(file.id)"
-                      data-testid="btn-describe"
-                      @click="describeAndSort(file)"
-                    >
-                      <Icon
-                        :icon="isDescribing(file.id) ? 'mdi:loading' : 'mdi:brain'"
-                        class="w-4 h-4"
-                        :class="isDescribing(file.id) && 'animate-spin'"
-                      />
-                    </button>
-                    <button
-                      v-if="vectorStateOf(file) !== 'vectorized' && file.source === 'generated'"
-                      class="p-1.5 rounded-lg hover:bg-[var(--brand)]/10 txt-secondary hover:text-[var(--brand)] transition-colors disabled:opacity-50"
-                      :title="$t('files.indexPromptAction')"
-                      :disabled="isDescribing(file.id)"
-                      data-testid="btn-index-prompt"
-                      @click="describeAndSort(file)"
-                    >
-                      <Icon
-                        :icon="isDescribing(file.id) ? 'mdi:loading' : 'mdi:bookmark-plus-outline'"
-                        class="w-4 h-4"
-                        :class="isDescribing(file.id) && 'animate-spin'"
-                      />
-                    </button>
                     <button
                       class="p-1.5 rounded-lg hover:bg-black/5 dark:hover:bg-white/5 txt-secondary transition-colors"
                       :title="$t('common.view')"
@@ -1377,72 +1302,49 @@
                       {{ file.uploaded_date }}
                     </td>
                     <td class="py-2.5 px-3">
-                      <div
-                        class="flex gap-0.5 justify-end opacity-0 pointer-coarse:opacity-100 group-hover:opacity-100 focus-within:opacity-100 transition-opacity"
-                      >
-                        <FolderMoveMenu
-                          :open="folderMenuOpen === file.id"
-                          :folders="displayedFolders"
-                          :current-folder="openFolder"
-                          :can-remove="!!file.group_key"
-                          @toggle="toggleFolderMenu(file.id)"
-                          @move="moveFileToFolder(file.id, $event)"
-                          @remove="removeFileFromFolder(file.id)"
+                      <div class="flex gap-0.5 justify-end items-center">
+                        <FileMakeSearchableButton
+                          :file="file"
+                          :busy="isDescribing(file.id)"
+                          @activate="describeAndSort(file)"
                         />
-                        <button
-                          v-if="vectorStateOf(file) !== 'vectorized' && file.source !== 'generated'"
-                          class="p-1.5 rounded-lg hover:bg-[var(--brand)]/10 txt-secondary hover:text-[var(--brand)] transition-colors disabled:opacity-50"
-                          :title="$t('files.describeSortAction')"
-                          :disabled="isDescribing(file.id)"
-                          data-testid="btn-describe"
-                          @click="describeAndSort(file)"
+                        <div
+                          class="flex gap-0.5 opacity-0 pointer-coarse:opacity-100 group-hover:opacity-100 focus-within:opacity-100 transition-opacity"
                         >
-                          <Icon
-                            :icon="isDescribing(file.id) ? 'mdi:loading' : 'mdi:brain'"
-                            class="w-4 h-4"
-                            :class="isDescribing(file.id) && 'animate-spin'"
+                          <FolderMoveMenu
+                            :open="folderMenuOpen === file.id"
+                            :folders="displayedFolders"
+                            :current-folder="openFolder"
+                            :can-remove="!!file.group_key"
+                            @toggle="toggleFolderMenu(file.id)"
+                            @move="moveFileToFolder(file.id, $event)"
+                            @remove="removeFileFromFolder(file.id)"
                           />
-                        </button>
-                        <button
-                          v-if="vectorStateOf(file) !== 'vectorized' && file.source === 'generated'"
-                          class="p-1.5 rounded-lg hover:bg-[var(--brand)]/10 txt-secondary hover:text-[var(--brand)] transition-colors disabled:opacity-50"
-                          :title="$t('files.indexPromptAction')"
-                          :disabled="isDescribing(file.id)"
-                          data-testid="btn-index-prompt"
-                          @click="describeAndSort(file)"
-                        >
-                          <Icon
-                            :icon="
-                              isDescribing(file.id) ? 'mdi:loading' : 'mdi:bookmark-plus-outline'
-                            "
-                            class="w-4 h-4"
-                            :class="isDescribing(file.id) && 'animate-spin'"
-                          />
-                        </button>
-                        <button
-                          class="p-1.5 rounded-lg hover:bg-black/5 dark:hover:bg-white/5 txt-secondary hover:txt-primary transition-colors"
-                          :title="$t('files.download')"
-                          data-testid="btn-download"
-                          @click="downloadFile(file.id, file.filename)"
-                        >
-                          <ArrowDownTrayIcon class="w-4 h-4" />
-                        </button>
-                        <button
-                          class="p-1.5 rounded-lg hover:bg-black/5 dark:hover:bg-white/5 txt-secondary hover:txt-primary transition-colors"
-                          :title="$t('common.view')"
-                          data-testid="btn-view"
-                          @click="viewFileContent(file.id)"
-                        >
-                          <Icon icon="heroicons:eye" class="w-4 h-4" />
-                        </button>
-                        <button
-                          class="p-1.5 rounded-lg hover:bg-red-500/10 text-red-400/70 hover:text-red-500 transition-colors"
-                          :title="$t('files.delete')"
-                          data-testid="btn-delete"
-                          @click="deleteFile(file.id)"
-                        >
-                          <TrashIcon class="w-4 h-4" />
-                        </button>
+                          <button
+                            class="p-1.5 rounded-lg hover:bg-black/5 dark:hover:bg-white/5 txt-secondary hover:txt-primary transition-colors"
+                            :title="$t('files.download')"
+                            data-testid="btn-download"
+                            @click="downloadFile(file.id, file.filename)"
+                          >
+                            <ArrowDownTrayIcon class="w-4 h-4" />
+                          </button>
+                          <button
+                            class="p-1.5 rounded-lg hover:bg-black/5 dark:hover:bg-white/5 txt-secondary hover:txt-primary transition-colors"
+                            :title="$t('common.view')"
+                            data-testid="btn-view"
+                            @click="viewFileContent(file.id)"
+                          >
+                            <Icon icon="heroicons:eye" class="w-4 h-4" />
+                          </button>
+                          <button
+                            class="p-1.5 rounded-lg hover:bg-red-500/10 text-red-400/70 hover:text-red-500 transition-colors"
+                            :title="$t('files.delete')"
+                            data-testid="btn-delete"
+                            @click="deleteFile(file.id)"
+                          >
+                            <TrashIcon class="w-4 h-4" />
+                          </button>
+                        </div>
                       </div>
                     </td>
                   </tr>
@@ -1588,6 +1490,7 @@
 
 <script setup lang="ts">
 import { getErrorMessage } from '@/utils/errorMessage'
+import { fileDisplayName, vectorStateOf } from '@/utils/fileDisplayName'
 import { ref, computed, nextTick, onMounted, onUnmounted, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import MainLayout from '@/components/MainLayout.vue'
@@ -1599,6 +1502,7 @@ import FilesIntegrationsBanner from '@/components/FilesIntegrationsBanner.vue'
 import FilesTabs from '@/components/files/FilesTabs.vue'
 import FileVectorPill from '@/components/files/FileVectorPill.vue'
 import FileSourceBadge from '@/components/files/FileSourceBadge.vue'
+import FileMakeSearchableButton from '@/components/files/FileMakeSearchableButton.vue'
 import FolderMoveMenu from '@/components/FolderMoveMenu.vue'
 import { Icon } from '@iconify/vue'
 import {
@@ -1619,7 +1523,7 @@ import { useNotification } from '@/composables/useNotification'
 import { useFilePersistence } from '@/composables/useInputPersistence'
 import { useRouter, useRoute } from 'vue-router'
 
-const { t } = useI18n()
+const { t, locale } = useI18n()
 const router = useRouter()
 const route = useRoute()
 
@@ -1948,10 +1852,9 @@ const describingIds = ref<number[]>([])
 const isDescribing = (id: number): boolean => describingIds.value.includes(id)
 
 /**
- * Make a file RAG-ready. For AI-generated files this indexes their generation
- * prompt; for everything else it describes, vectorizes & AI-sorts the file into
- * a knowledge group. Same trigger, different per-file action (decided in UI by
- * the file's source).
+ * Make a file searchable by AI. Generated artefacts use /index-prompt so a
+ * missing description can fall back to the stored generation prompt; uploads
+ * use /describe. The buttons look the same — only the endpoint differs.
  */
 const describeAndSort = async (file: FileItem) => {
   if (isDescribing(file.id)) return
@@ -1963,11 +1866,7 @@ const describeAndSort = async (file: FileItem) => {
       : await filesService.describeVectorizeSortFile(file.id)
     if (res.success) {
       if (res.groupKey) {
-        // Sorted into a knowledge group (describe path, or index-prompt that
-        // also picked a group). Show the group-aware confirmation either way.
         showSuccess(t('files.describeSortDoneGroup', { group: res.groupKey }))
-      } else if (isGenerated) {
-        showSuccess(t('files.indexPromptDone'))
       } else {
         showSuccess(t('files.describeSortDone'))
       }
@@ -2564,13 +2463,9 @@ const formatFileSize = (bytes: number): string => {
   return (bytes / (1024 * 1024 * 1024)).toFixed(1) + ' GB'
 }
 
-/** §4.4: show the original (source) name when present, else the stored name. */
+/** Prefer a human title; generic chat voice notes become "Voice memo · time". */
 const displayName = (file: FileItem): string =>
-  file.display_name || file.original_name || file.filename
-
-/** Derive the pill state, falling back to chunk count for legacy rows. */
-const vectorStateOf = (file: FileItem) =>
-  file.vector_state ?? (file.is_vectorized ? 'vectorized' : 'none')
+  fileDisplayName(file, (key, values) => t(key, values as never), locale.value)
 
 // Load initial data
 onMounted(async () => {

--- a/frontend/tests/unit/components/files/FileBadgeTruncation.spec.ts
+++ b/frontend/tests/unit/components/files/FileBadgeTruncation.spec.ts
@@ -1,37 +1,21 @@
 import { describe, it, expect } from 'vitest'
 import { mount } from '@vue/test-utils'
-import FileVectorPill from '@/components/files/FileVectorPill.vue'
 import FileSourceBadge from '@/components/files/FileSourceBadge.vue'
 
 /**
- * Both badges wrap their label in a `truncate`, but carried `whitespace-nowrap`
- * on the outer element too — which held them at full text width, so the truncate
- * never engaged. A long folder name then ran out of its column and under the
- * row's action icons. The label keeps the nowrap; the badge itself must be able
- * to shrink.
+ * The source badge wraps its label in a `truncate`, but carried
+ * `whitespace-nowrap` on the outer element too — which held it at full text
+ * width, so the truncate never engaged. A long label then ran out of its
+ * column and under the row's action icons. The label keeps the nowrap; the
+ * badge itself must be able to shrink.
+ *
+ * (`FileVectorPill` is icon-only, so it has no label to overflow.)
  */
 describe('file badges shrink instead of overflowing their row', () => {
-  const badges = [
-    {
-      name: 'FileVectorPill',
-      wrapper: () =>
-        mount(FileVectorPill, {
-          props: {
-            state: 'vectorized' as const,
-            chunkCount: 42,
-            groupKey: 'a-very-long-knowledge-folder-name-that-will-not-fit',
-          },
-        }),
-      testId: 'file-vector-pill',
-    },
-    {
-      name: 'FileSourceBadge',
-      wrapper: () => mount(FileSourceBadge, { props: { source: 'nextcloud' as const } }),
-      testId: 'file-source-badge',
-    },
-  ]
+  const wrapper = () => mount(FileSourceBadge, { props: { source: 'nextcloud' as const } })
+  const testId = 'file-source-badge'
 
-  it.each(badges)('$name can shrink below its label', ({ wrapper, testId }) => {
+  it('can shrink below its label', () => {
     const classes = wrapper().get(`[data-testid="${testId}"]`).classes()
 
     expect(classes).not.toContain('whitespace-nowrap')
@@ -40,7 +24,7 @@ describe('file badges shrink instead of overflowing their row', () => {
     expect(classes).toContain('overflow-hidden')
   })
 
-  it.each(badges)('$name still keeps its label on one line', ({ wrapper }) => {
+  it('still keeps its label on one line', () => {
     const label = wrapper().get('span > span')
 
     expect(label.classes()).toContain('truncate')

--- a/frontend/tests/unit/components/files/FileMakeSearchableButton.spec.ts
+++ b/frontend/tests/unit/components/files/FileMakeSearchableButton.spec.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+
+import FileMakeSearchableButton from '@/components/files/FileMakeSearchableButton.vue'
+import type { FileItem } from '@/services/filesService'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      files: {
+        describeSortAction: 'Make searchable by AI',
+      },
+    },
+  },
+})
+
+const file = (overrides: Partial<FileItem>): FileItem =>
+  ({
+    id: 1,
+    filename: 'recording.webm',
+    path: '/x',
+    file_type: 'webm',
+    file_size: 1,
+    mime: 'audio/webm',
+    status: 'uploaded',
+    text_preview: '',
+    uploaded_at: 0,
+    uploaded_date: '2026-08-20 12:40:41',
+    message_id: null,
+    vector_state: 'none',
+    ...overrides,
+  }) as FileItem
+
+function mountButton(overrides: Partial<FileItem> = {}, busy = false) {
+  return mount(FileMakeSearchableButton, {
+    props: { file: file(overrides), busy },
+    global: {
+      plugins: [i18n],
+      stubs: { Icon: { template: '<i />' } },
+    },
+  })
+}
+
+describe('FileMakeSearchableButton', () => {
+  it('is hidden when the file is already searchable', () => {
+    const wrapper = mountButton({ vector_state: 'vectorized' })
+    expect(wrapper.find('button').exists()).toBe(false)
+  })
+
+  it('uses the same label for uploads and generated files', () => {
+    const upload = mountButton({ source: 'web_upload' })
+    const generated = mountButton({ source: 'generated' })
+    expect(upload.find('button').attributes('title')).toBe('Make searchable by AI')
+    expect(generated.find('button').attributes('title')).toBe('Make searchable by AI')
+    expect(upload.find('button').attributes('data-testid')).toBe('btn-describe')
+    expect(generated.find('button').attributes('data-testid')).toBe('btn-index-prompt')
+  })
+
+  it('emits activate when clicked', async () => {
+    const wrapper = mountButton()
+    await wrapper.find('button').trigger('click')
+    expect(wrapper.emitted('activate')).toHaveLength(1)
+  })
+})

--- a/frontend/tests/unit/components/files/FileSourceBadge.spec.ts
+++ b/frontend/tests/unit/components/files/FileSourceBadge.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+
+import FileSourceBadge from '@/components/files/FileSourceBadge.vue'
+import type { FileSource } from '@/services/filesService'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      files: {
+        help: { source: 'Where this file came from.' },
+        sourceLabel: {
+          web_upload: 'Upload',
+          generated: 'AI-generated',
+          whatsapp: 'WhatsApp',
+        },
+      },
+    },
+  },
+})
+
+function mountBadge(source?: FileSource) {
+  return mount(FileSourceBadge, {
+    props: source ? { source } : {},
+    global: {
+      plugins: [i18n],
+      stubs: { Icon: { template: '<i />' } },
+    },
+  })
+}
+
+describe('FileSourceBadge', () => {
+  it('hides the default upload origin — it does not distinguish a file', () => {
+    const wrapper = mountBadge('web_upload')
+    expect(wrapper.find('[data-testid="file-source-badge"]').exists()).toBe(false)
+    expect(wrapper.text()).toBe('')
+  })
+
+  it('hides when source is omitted (defaults to web_upload)', () => {
+    const wrapper = mountBadge()
+    expect(wrapper.find('[data-testid="file-source-badge"]').exists()).toBe(false)
+  })
+
+  it('shows a distinctive origin', () => {
+    const wrapper = mountBadge('generated')
+    expect(wrapper.find('[data-testid="file-source-badge"]').exists()).toBe(true)
+    expect(wrapper.text()).toBe('AI-generated')
+  })
+})

--- a/frontend/tests/unit/components/files/FileVectorPill.spec.ts
+++ b/frontend/tests/unit/components/files/FileVectorPill.spec.ts
@@ -41,39 +41,52 @@ function mountPill(props: Record<string, unknown> = {}) {
   })
 }
 
+function pill(wrapper: ReturnType<typeof mountPill>) {
+  return wrapper.find('[data-testid="file-vector-pill"]')
+}
+
 describe('FileVectorPill', () => {
-  it('renders the searchable label with group + chunk detail', () => {
+  it('is icon-only (no visible text label)', () => {
     const wrapper = mountPill({ state: 'vectorized', chunkCount: 12, groupKey: 'Contracts' })
-    expect(wrapper.text()).toBe('Searchable by AI · Contracts · 12 chunks')
+    expect(wrapper.text()).toBe('')
   })
 
-  it('renders the plain searchable label without a group', () => {
-    const wrapper = mountPill({ state: 'vectorized', chunkCount: 0, groupKey: null })
-    expect(wrapper.text()).toBe('Searchable by AI')
+  it('shows green + the searchable label with group + chunk detail in the tooltip', () => {
+    const el = pill(mountPill({ state: 'vectorized', chunkCount: 12, groupKey: 'Contracts' }))
+    expect(el.classes()).toContain('text-emerald-600')
+    expect(el.attributes('aria-label')).toBe('Searchable by AI')
+    expect(el.attributes('title')).toBe('Searchable by AI · Contracts · 12 chunks')
+  })
+
+  it('falls back to the plain help tooltip when there is no group', () => {
+    const el = pill(mountPill({ state: 'vectorized', chunkCount: 0, groupKey: null }))
+    expect(el.attributes('title')).toBe('Its contents are in your knowledge base.')
   })
 
   it('renders the processing state', () => {
-    const wrapper = mountPill({ state: 'pending' })
-    expect(wrapper.text()).toBe('Processing…')
+    const el = pill(mountPill({ state: 'pending' }))
+    expect(el.classes()).toContain('text-blue-500')
+    expect(el.attributes('aria-label')).toBe('Processing…')
   })
 
   it('renders the failed state', () => {
-    const wrapper = mountPill({ state: 'failed' })
-    expect(wrapper.text()).toBe('Failed')
+    const el = pill(mountPill({ state: 'failed' }))
+    expect(el.classes()).toContain('text-red-500')
+    expect(el.attributes('aria-label')).toBe('Failed')
   })
 
-  it('renders not-searchable for the legacy not-applicable state', () => {
-    const wrapper = mountPill({ state: 'not_applicable' })
-    expect(wrapper.find('[data-testid="file-vector-pill"]').exists()).toBe(true)
-    expect(wrapper.text()).toBe('Not searchable')
+  it('renders grey not-searchable for the legacy not-applicable state', () => {
+    const el = pill(mountPill({ state: 'not_applicable' }))
+    expect(el.exists()).toBe(true)
+    expect(el.classes()).toContain('txt-secondary')
+    expect(el.attributes('aria-label')).toBe('Not searchable')
   })
 
-  it('renders not-searchable when the file is not in the knowledge base', () => {
-    const wrapper = mountPill()
-    expect(wrapper.find('[data-testid="file-vector-pill"]').exists()).toBe(true)
-    expect(wrapper.text()).toBe('Not searchable')
-    expect(wrapper.find('[data-testid="file-vector-pill"]').attributes('title')).toBe(
-      'The assistant cannot use this file yet.'
-    )
+  it('renders grey not-searchable when the file is not in the knowledge base', () => {
+    const el = pill(mountPill())
+    expect(el.exists()).toBe(true)
+    expect(el.classes()).toContain('txt-secondary')
+    expect(el.attributes('aria-label')).toBe('Not searchable')
+    expect(el.attributes('title')).toBe('The assistant cannot use this file yet.')
   })
 })

--- a/frontend/tests/unit/components/files/FileVectorPill.spec.ts
+++ b/frontend/tests/unit/components/files/FileVectorPill.spec.ts
@@ -20,6 +20,9 @@ const i18n = createI18n({
         },
         help: {
           vectorized: 'Its contents are in your knowledge base.',
+          notSearchable: 'The assistant cannot use this file yet.',
+          processing: 'This file is being prepared for the assistant.',
+          failed: 'This file could not be made searchable.',
         },
       },
     },
@@ -59,17 +62,18 @@ describe('FileVectorPill', () => {
     expect(wrapper.text()).toBe('Failed')
   })
 
-  it('renders nothing for the legacy not-applicable state', () => {
-    // Media is no longer "not applicable" — any stray legacy value renders
-    // nothing, just like the not-searchable state.
+  it('renders not-searchable for the legacy not-applicable state', () => {
     const wrapper = mountPill({ state: 'not_applicable' })
-    expect(wrapper.find('[data-testid="file-vector-pill"]').exists()).toBe(false)
-    expect(wrapper.text()).toBe('')
+    expect(wrapper.find('[data-testid="file-vector-pill"]').exists()).toBe(true)
+    expect(wrapper.text()).toBe('Not searchable')
   })
 
-  it('renders nothing when the file is not searchable', () => {
+  it('renders not-searchable when the file is not in the knowledge base', () => {
     const wrapper = mountPill()
-    expect(wrapper.find('[data-testid="file-vector-pill"]').exists()).toBe(false)
-    expect(wrapper.text()).toBe('')
+    expect(wrapper.find('[data-testid="file-vector-pill"]').exists()).toBe(true)
+    expect(wrapper.text()).toBe('Not searchable')
+    expect(wrapper.find('[data-testid="file-vector-pill"]').attributes('title')).toBe(
+      'The assistant cannot use this file yet.'
+    )
   })
 })

--- a/frontend/tests/unit/utils/fileDisplayName.spec.ts
+++ b/frontend/tests/unit/utils/fileDisplayName.spec.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  fileDisplayName,
+  isVoiceMemoFilename,
+  parseFileUploadedDate,
+  vectorStateOf,
+} from '@/utils/fileDisplayName'
+
+const t = (key: string, values?: Record<string, unknown>): string => {
+  if (key === 'files.voiceMemo') return 'Voice memo'
+  if (key === 'files.voiceMemoNamed') return `Voice memo · ${values?.time}`
+  return key
+}
+
+describe('isVoiceMemoFilename', () => {
+  it('matches generic chat recording names', () => {
+    expect(isVoiceMemoFilename('recording.webm')).toBe(true)
+    expect(isVoiceMemoFilename('recording.m4a')).toBe(true)
+    expect(isVoiceMemoFilename('recording.ogg')).toBe(true)
+    expect(isVoiceMemoFilename('Recording.WEBM')).toBe(true)
+  })
+
+  it('rejects real titles', () => {
+    expect(isVoiceMemoFilename('meeting-notes.webm')).toBe(false)
+    expect(isVoiceMemoFilename('tts_abc.mp3')).toBe(false)
+  })
+})
+
+describe('fileDisplayName', () => {
+  it('keeps ordinary names', () => {
+    expect(fileDisplayName({ filename: 'contract.pdf' }, t, 'en')).toBe('contract.pdf')
+  })
+
+  it('prefers a user-facing display_name that is not a generic recording', () => {
+    expect(
+      fileDisplayName({ filename: 'recording.webm', display_name: 'Call with Alex.webm' }, t, 'en')
+    ).toBe('Call with Alex.webm')
+  })
+
+  it('labels generic voice notes with the capture time', () => {
+    expect(
+      fileDisplayName(
+        { filename: 'recording.webm', uploaded_date: '2026-08-20 12:40:41' },
+        t,
+        'en-GB'
+      )
+    ).toBe('Voice memo · 12:40:41')
+  })
+
+  it('falls back to an untimed label when the timestamp is missing', () => {
+    expect(fileDisplayName({ filename: 'recording.m4a' }, t, 'en')).toBe('Voice memo')
+  })
+})
+
+describe('parseFileUploadedDate', () => {
+  it('parses the file-list wall-clock format', () => {
+    const date = parseFileUploadedDate('2026-08-20 12:40:41')
+    expect(date).not.toBeNull()
+    expect(date?.getFullYear()).toBe(2026)
+    expect(date?.getMonth()).toBe(7)
+    expect(date?.getDate()).toBe(20)
+    expect(date?.getHours()).toBe(12)
+    expect(date?.getMinutes()).toBe(40)
+    expect(date?.getSeconds()).toBe(41)
+  })
+})
+
+describe('vectorStateOf', () => {
+  it('prefers vector_state and falls back to is_vectorized', () => {
+    expect(vectorStateOf({ vector_state: 'failed' })).toBe('failed')
+    expect(vectorStateOf({ is_vectorized: true })).toBe('vectorized')
+    expect(vectorStateOf({})).toBe('none')
+  })
+})


### PR DESCRIPTION
## Summary
- The files list treated “not searchable” as a missing badge, so two `recording.webm` rows looked identical except for size/time. The pill now shows **Not searchable** (and processing/failed keep their own copy).
- Upload and AI-generated files used two icons and two tooltips for the same user job. One action remains: **Make searchable by AI**. Backend routing is unchanged (`/describe` vs `/index-prompt`).
- Default **Upload** source badges are hidden (they did not distinguish anything). Generic chat recordings display as **Voice memo · time** instead of `recording.webm`.

This is display-only. Chat/widget ingest, media opt-in, and Qdrant writes are untouched.

## Test plan
- [ ] Open `/files` with a mix of documents, unindexed media, and an AI-generated file.
- [ ] Confirm unindexed rows show a muted **Not searchable** / **Nicht durchsuchbar** pill, not a blank gap.
- [ ] Confirm the make-searchable control is the same icon + tooltip for uploads and generated files, and stays visible on desktop (other row actions still hover).
- [ ] Click it on an upload and on a generated file — both still succeed; generated files still get the prompt fallback on the backend.
- [ ] Confirm ordinary uploads no longer show an **Upload** chip; **AI-generated** still does.
- [ ] Confirm voice notes from chat list as **Voice memo · HH:MM:SS**, with the original filename on hover.
- [ ] Generated tab: unindexed tiles show the not-searchable pill and the same make-searchable control (folder picker unchanged).