### PR TITLE
feat(chat): resume a still-generating turn after reload or navigation

### DIFF
--- a/backend/src/Controller/ChatController.php
+++ b/backend/src/Controller/ChatController.php
@@ -7,6 +7,7 @@ use App\Entity\User;
 use App\Repository\ChatRepository;
 use App\Repository\ChatSummaryRepository;
 use App\Repository\MessageRepository;
+use App\Service\Chat\Run\ChatRunService;
 use App\Service\Digest\MessageDigestMaintenance;
 use App\Service\File\OgImageService;
 use App\Service\Message\MessageApiFormatter;
@@ -35,6 +36,7 @@ class ChatController extends AbstractController
         private OgImageService $ogImageService,
         private MessageApiFormatter $messageApiFormatter,
         private InProgressTurnResolver $inProgressTurnResolver,
+        private ChatRunService $chatRunService,
         private LoggerInterface $logger,
     ) {
     }
@@ -92,6 +94,13 @@ class ChatController extends AbstractController
                         new OA\Property(property: 'offset', type: 'integer', example: 0),
                         new OA\Property(property: 'limit', type: 'integer', example: 20),
                         new OA\Property(property: 'hasMore', type: 'boolean', example: true),
+                        new OA\Property(
+                            property: 'activeRunChatIds',
+                            description: 'Chats with a turn generating right now. A turn keeps running after the client that started it disconnects, so this marks where an answer is still being written after the user moved on. Not limited to the current page.',
+                            type: 'array',
+                            items: new OA\Items(type: 'integer'),
+                            example: [7]
+                        ),
                     ]
                 )
             ),
@@ -160,6 +169,12 @@ class ChatController extends AbstractController
             'offset' => $paginate ? $offset : 0,
             'limit' => $paginate ? $limit : count($result),
             'hasMore' => $paginate ? ($offset + count($result)) < $total : false,
+            // Turns keep generating after their client disconnects, so a user
+            // who left a chat mid-answer gets a visible "still working" marker
+            // instead of having to guess whether anything is happening.
+            'activeRunChatIds' => $this->chatRunService->activeChatIds(
+                ChatRunService::ownerKeyForUser((int) $user->getId()),
+            ),
         ]);
     }
 
@@ -547,6 +562,18 @@ class ChatController extends AbstractController
                                 ),
                             ]
                         ),
+                        new OA\Property(
+                            property: 'activeRun',
+                            description: 'Present only on the first page (offset 0) when a turn in this chat is still generating. The turn survives a client disconnect and mirrors its Server-Sent Events into a replayable log, so a client that reloaded can paint `partialText` immediately and then re-attach to the live stream via GET /api/v1/messages/stream/attach. Absent in incognito mode, which is never buffered server-side.',
+                            type: 'object',
+                            nullable: true,
+                            properties: [
+                                new OA\Property(property: 'runId', type: 'string', format: 'uuid', example: '0f1e2d3c-4b5a-6978-8796-a5b4c3d2e1f0'),
+                                new OA\Property(property: 'trackId', type: 'string', example: '1234567890'),
+                                new OA\Property(property: 'lastSeq', type: 'integer', description: 'Sequence number of the newest buffered event.', example: 42),
+                                new OA\Property(property: 'partialText', type: 'string', description: 'Assistant text produced so far, for an instant repaint before the re-attach delivers the rest.', example: 'The answer so far'),
+                            ]
+                        ),
                     ]
                 )
             ),
@@ -618,6 +645,18 @@ class ChatController extends AbstractController
             $inProgress = $this->inProgressTurnResolver->resolve($messages[array_key_last($messages)]);
             if (null !== $inProgress) {
                 $payload['inProgressTurn'] = $inProgress;
+            }
+
+            // A turn that is still generating right now: hand the client the
+            // text produced so far plus the run id, so returning to the chat
+            // re-attaches to the live stream instead of waiting for the
+            // finished answer to land in BMESSAGES.
+            $activeRun = $this->chatRunService->describeActiveForChat(
+                (int) $chat->getId(),
+                ChatRunService::ownerKeyForUser((int) $user->getId()),
+            );
+            if (null !== $activeRun) {
+                $payload['activeRun'] = $activeRun;
             }
         }
 

--- a/backend/src/Controller/GuestChatController.php
+++ b/backend/src/Controller/GuestChatController.php
@@ -7,6 +7,7 @@ namespace App\Controller;
 use App\Entity\Chat;
 use App\Repository\FileRepository;
 use App\Repository\MessageRepository;
+use App\Service\Chat\Run\ChatRunService;
 use App\Service\GuestChatConfig;
 use App\Service\GuestSessionService;
 use App\Service\Media\MediaCancellationStore;
@@ -40,6 +41,7 @@ class GuestChatController extends AbstractController
         private FileRepository $fileRepository,
         private MediaCancellationStore $cancellationStore,
         private MessageApiFormatter $messageApiFormatter,
+        private ChatRunService $chatRunService,
         private LoggerInterface $logger,
         private string $uploadDir,
     ) {
@@ -418,6 +420,18 @@ class GuestChatController extends AbstractController
             properties: [
                 new OA\Property(property: 'success', type: 'boolean'),
                 new OA\Property(property: 'messages', type: 'array', items: new OA\Items(type: 'object')),
+                new OA\Property(
+                    property: 'activeRun',
+                    description: 'Present when a turn in this session is still generating. The turn survives a client disconnect and buffers its Server-Sent Events, so a reloaded guest chat can paint `partialText` and re-attach via GET /api/v1/messages/stream/attach.',
+                    type: 'object',
+                    nullable: true,
+                    properties: [
+                        new OA\Property(property: 'runId', type: 'string', format: 'uuid'),
+                        new OA\Property(property: 'trackId', type: 'string'),
+                        new OA\Property(property: 'lastSeq', type: 'integer'),
+                        new OA\Property(property: 'partialText', type: 'string'),
+                    ]
+                ),
             ]
         )
     )]
@@ -468,10 +482,22 @@ class GuestChatController extends AbstractController
             $messages
         );
 
-        return $this->json([
+        $payload = [
             'success' => true,
             'messages' => $messageData,
-        ]);
+        ];
+
+        // A turn still generating for this session: hand the returning visitor
+        // the text so far plus the run id to re-attach to.
+        $activeRun = $this->chatRunService->describeActiveForChat(
+            (int) $chatId,
+            ChatRunService::ownerKeyForGuest($session->getSessionId()),
+        );
+        if (null !== $activeRun) {
+            $payload['activeRun'] = $activeRun;
+        }
+
+        return $this->json($payload);
     }
 
     /**

--- a/backend/src/Controller/StreamAttachController.php
+++ b/backend/src/Controller/StreamAttachController.php
@@ -1,0 +1,286 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Entity\User;
+use App\Service\Chat\Run\ChatRun;
+use App\Service\Chat\Run\ChatRunService;
+use App\Service\GuestSessionService;
+use App\Service\WidgetService;
+use App\Service\WidgetSessionService;
+use OpenApi\Attributes as OA;
+use Psr\Log\LoggerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
+
+/**
+ * Re-attach to a chat turn that is still generating.
+ *
+ * A turn survives the client disconnect it was started from (see
+ * {@see StreamController}, issues #1142/#1223/#1225) and mirrors every SSE event
+ * into a replayable Redis log. This endpoint opens a second SSE connection on
+ * that log: it replays what the client missed and then tails the live tail, so
+ * reloading the page or navigating away and back continues the answer where it
+ * stopped instead of leaving the user with a bare prompt.
+ *
+ * Deliberately a separate controller: {@see StreamController} is the write path
+ * and already far past a reviewable size; nothing here touches the AI pipeline.
+ */
+#[Route('/api/v1/messages', name: 'api_messages_')]
+#[OA\Tag(name: 'Messages')]
+final class StreamAttachController extends AbstractController
+{
+    /**
+     * Tail poll interval. Fast enough that replayed text feels live, slow
+     * enough that an idle attach costs ~10 Redis reads per second.
+     */
+    private const POLL_INTERVAL_MICROSECONDS = 100000; // 100 ms
+
+    /** Upper bound for one attach connection, matching the run's own retention. */
+    private const MAX_ATTACH_SECONDS = 1800;
+
+    public function __construct(
+        private readonly ChatRunService $chatRunService,
+        private readonly WidgetService $widgetService,
+        private readonly WidgetSessionService $widgetSessionService,
+        private readonly GuestSessionService $guestSessionService,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    #[Route('/stream/attach', name: 'stream_attach', methods: ['GET'])]
+    #[OA\Get(
+        path: '/api/v1/messages/stream/attach',
+        summary: 'Re-attach to a running chat turn',
+        description: <<<'DESC'
+            Replays the Server-Sent Events of a turn that is still generating and then follows it live,
+            so a client that reloaded or navigated away can continue rendering the answer.
+
+            Events use the same envelope as `/api/v1/messages/stream` (`data: {"status": ...}`) and each
+            carries the SSE `id:` field with its sequence number, so a dropped attach can resume via `from`.
+
+            The stream ends without a terminal event when the run was cancelled, expired, or its worker
+            died. Clients treat that as a recoverable drop and fall back to reloading the chat history.
+
+            Authentication mirrors the streaming endpoint: session/Bearer for app users, the
+            `X-Widget-Id` + `X-Widget-Session` headers for widgets, and `guestSession` for guest chats.
+            DESC,
+        tags: ['Messages']
+    )]
+    #[OA\Parameter(
+        name: 'runId',
+        in: 'query',
+        required: true,
+        description: 'Run id, delivered as the `run_started` event of the original stream or as `activeRun.runId` of the chat history response.',
+        schema: new OA\Schema(type: 'string', format: 'uuid', example: '0f1e2d3c-4b5a-6978-8796-a5b4c3d2e1f0')
+    )]
+    #[OA\Parameter(
+        name: 'from',
+        in: 'query',
+        required: false,
+        description: 'Replay events after this sequence number. Defaults to 0 (replay everything the run produced).',
+        schema: new OA\Schema(type: 'integer', default: 0, example: 0)
+    )]
+    #[OA\Parameter(
+        name: 'guestSession',
+        in: 'query',
+        required: false,
+        description: 'Guest session id, for turns started from the guest chat.',
+        schema: new OA\Schema(type: 'string')
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'SSE stream replaying and then following the run',
+        content: new OA\MediaType(
+            mediaType: 'text/event-stream',
+            schema: new OA\Schema(type: 'string', example: "id: 12\ndata: {\"status\":\"data\",\"chunk\":\"Hello\"}\n\n")
+        )
+    )]
+    #[OA\Response(response: 400, description: 'Missing runId')]
+    #[OA\Response(response: 401, description: 'No usable app, widget or guest identity on the request')]
+    #[OA\Response(response: 404, description: 'Run unknown, expired, or owned by somebody else')]
+    public function attach(Request $request, #[CurrentUser] ?User $user): Response
+    {
+        $runId = trim($request->query->getString('runId'));
+        if ('' === $runId) {
+            return $this->json(['error' => 'runId is required'], Response::HTTP_BAD_REQUEST);
+        }
+
+        $ownerKey = $this->resolveOwnerKey($request, $user);
+        if (null === $ownerKey) {
+            return $this->json(['error' => 'Not authenticated'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        $run = $this->chatRunService->authorize($runId, $ownerKey);
+        if (null === $run) {
+            // Same answer for "unknown" and "not yours" so the endpoint cannot
+            // be used to probe which run ids exist.
+            return $this->json(['error' => 'Run not found'], Response::HTTP_NOT_FOUND);
+        }
+
+        $from = max(0, $request->query->getInt('from'));
+
+        $response = new StreamedResponse();
+        $response->headers->set('Content-Type', 'text/event-stream');
+        $response->headers->set('Cache-Control', 'no-cache');
+        $response->headers->set('X-Accel-Buffering', 'no');
+        $response->headers->set('Connection', 'keep-alive');
+
+        $response->setCallback(function () use ($run, $from): void {
+            $this->pump($run, $from);
+        });
+
+        return $response;
+    }
+
+    /**
+     * Replay from `$fromSeq` and then follow the run until it ends.
+     *
+     * Unlike the generating request this one does NOT set
+     * `ignore_user_abort(true)`: an attach connection is a pure reader, so once
+     * its client is gone there is nothing worth keeping alive.
+     */
+    private function pump(ChatRun $run, int $fromSeq): void
+    {
+        while (ob_get_level()) {
+            ob_end_clean();
+        }
+        ob_implicit_flush(true);
+        set_time_limit(0);
+        ignore_user_abort(false);
+
+        $runId = $run->getRunId();
+        $cursor = $fromSeq;
+        $deadline = time() + self::MAX_ATTACH_SECONDS;
+
+        while (true) {
+            $events = $this->chatRunService->readEvents($runId, $cursor);
+
+            foreach ($events as $event) {
+                $cursor = $event['seq'];
+                $this->emit($cursor, $event['payload']);
+
+                if (connection_aborted()) {
+                    return;
+                }
+
+                // `complete` / `error` end the turn on the wire, so the client
+                // has everything it needs — no reason to keep polling.
+                if ($this->isTerminalPayload($event['payload'])) {
+                    return;
+                }
+            }
+
+            if ([] !== $events) {
+                // Events are still flowing: the writer is demonstrably alive,
+                // so skip the snapshot read and go straight for the next batch.
+                continue;
+            }
+
+            $current = $this->chatRunService->find($runId);
+
+            // Everything below closes the stream WITHOUT a terminal event. The
+            // client already treats that as a recoverable drop (it is exactly
+            // what a mid-turn connection loss looks like) and recovers by
+            // reloading the chat history — see isRecoverableStreamError() and
+            // historyStore.recoverInterruptedTurn() on the frontend.
+            if (null === $current) {
+                $this->logger->info('StreamAttachController: run snapshot vanished while attached', ['run_id' => $runId]);
+
+                return;
+            }
+
+            if ($current->isTruncated()) {
+                $this->logger->info('StreamAttachController: run log was truncated, releasing client', ['run_id' => $runId]);
+
+                return;
+            }
+
+            if ($current->isTerminal()) {
+                // Terminal without a terminal event means the turn was
+                // cancelled (StreamController ends those silently).
+                return;
+            }
+
+            if ($this->chatRunService->isStale($current)) {
+                $this->logger->warning('StreamAttachController: run heartbeat went stale, releasing client', [
+                    'run_id' => $runId,
+                    'last_heartbeat_age' => time() - $current->getUpdated(),
+                ]);
+
+                return;
+            }
+
+            if (time() >= $deadline || connection_aborted()) {
+                return;
+            }
+
+            usleep(self::POLL_INTERVAL_MICROSECONDS);
+        }
+    }
+
+    private function emit(int $seq, string $payload): void
+    {
+        echo 'id: '.$seq."\n";
+        echo 'data: '.$payload."\n\n";
+
+        if (ob_get_level() > 0) {
+            ob_flush();
+        }
+        flush();
+    }
+
+    private function isTerminalPayload(string $payload): bool
+    {
+        $decoded = json_decode($payload, true);
+        if (!is_array($decoded)) {
+            return false;
+        }
+
+        return \in_array($decoded['status'] ?? null, [ChatRun::STATUS_COMPLETE, ChatRun::STATUS_ERROR], true);
+    }
+
+    /**
+     * Rebuild the caller's owner scope, mirroring how the streaming endpoint
+     * authenticates: app user first, then widget headers, then guest session.
+     */
+    private function resolveOwnerKey(Request $request, ?User $user): ?string
+    {
+        if (null !== $user) {
+            return ChatRunService::ownerKeyForUser((int) $user->getId());
+        }
+
+        $widgetId = $request->headers->get('X-Widget-Id');
+        $widgetSessionId = $request->headers->get('X-Widget-Session');
+        if (null !== $widgetId && null !== $widgetSessionId && '' !== $widgetId && '' !== $widgetSessionId) {
+            $widget = $this->widgetService->getWidgetById($widgetId);
+            if (null === $widget) {
+                return null;
+            }
+
+            // Look up only — a re-attach must never bring a session into
+            // existence, otherwise the endpoint becomes a session factory.
+            $session = $this->widgetSessionService->getSession($widgetId, $widgetSessionId);
+
+            return null === $session ? null : ChatRunService::ownerKeyForWidget($session->getSessionId());
+        }
+
+        $guestSessionId = trim($request->query->getString('guestSession'));
+        if ('' !== $guestSessionId) {
+            $session = $this->guestSessionService->getSession($guestSessionId);
+            if (null === $session || $session->isExpired()) {
+                return null;
+            }
+
+            return ChatRunService::ownerKeyForGuest($session->getSessionId());
+        }
+
+        return null;
+    }
+}

--- a/backend/src/Controller/StreamAttachController.php
+++ b/backend/src/Controller/StreamAttachController.php
@@ -45,6 +45,19 @@ final class StreamAttachController extends AbstractController
     /** Upper bound for one attach connection, matching the run's own retention. */
     private const MAX_ATTACH_SECONDS = 1800;
 
+    /**
+     * Idle time after which the stream emits an SSE comment.
+     *
+     * Two reasons, both load-bearing:
+     *  - PHP only notices a gone client when a write fails, so a stream that
+     *    sends nothing while it waits would never see `connection_aborted()` and
+     *    would keep a worker busy polling Redis for the full MAX_ATTACH_SECONDS
+     *    after the browser was closed.
+     *  - Proxies drop a connection that has been silent for too long, which a
+     *    turn between two slow phases can easily be.
+     */
+    private const IDLE_KEEPALIVE_SECONDS = 15;
+
     public function __construct(
         private readonly ChatRunService $chatRunService,
         private readonly WidgetService $widgetService,
@@ -158,6 +171,7 @@ final class StreamAttachController extends AbstractController
         $runId = $run->getRunId();
         $cursor = $fromSeq;
         $deadline = time() + self::MAX_ATTACH_SECONDS;
+        $lastWriteAt = time();
 
         while (true) {
             $events = $this->chatRunService->readEvents($runId, $cursor);
@@ -165,6 +179,7 @@ final class StreamAttachController extends AbstractController
             foreach ($events as $event) {
                 $cursor = $event['seq'];
                 $this->emit($cursor, $event['payload']);
+                $lastWriteAt = time();
 
                 if (connection_aborted()) {
                     return;
@@ -221,6 +236,18 @@ final class StreamAttachController extends AbstractController
                 return;
             }
 
+            // The run is alive but quiet. Poke the socket so a client that left
+            // in the meantime is actually detected on the next check instead of
+            // holding this worker until the deadline.
+            if ((time() - $lastWriteAt) >= self::IDLE_KEEPALIVE_SECONDS) {
+                $this->emitKeepalive();
+                $lastWriteAt = time();
+
+                if (connection_aborted()) {
+                    return;
+                }
+            }
+
             usleep(self::POLL_INTERVAL_MICROSECONDS);
         }
     }
@@ -230,6 +257,23 @@ final class StreamAttachController extends AbstractController
         echo 'id: '.$seq."\n";
         echo 'data: '.$payload."\n\n";
 
+        $this->flushOutput();
+    }
+
+    /**
+     * SSE comment frame. Carries no `data:` line, so both client parsers skip it
+     * (chatApi's `readSseBody` filters on `data:`, the widget's
+     * `consumeWidgetStream` bails when a frame has no data lines).
+     */
+    private function emitKeepalive(): void
+    {
+        echo ": keepalive\n\n";
+
+        $this->flushOutput();
+    }
+
+    private function flushOutput(): void
+    {
         if (ob_get_level() > 0) {
             ob_flush();
         }

--- a/backend/src/Controller/StreamController.php
+++ b/backend/src/Controller/StreamController.php
@@ -5,11 +5,16 @@ namespace App\Controller;
 use App\AI\Service\AiFacade;
 use App\Entity\Chat;
 use App\Entity\File;
+use App\Entity\GuestSession;
 use App\Entity\Message;
 use App\Entity\Prompt;
 use App\Entity\User;
+use App\Entity\WidgetSession;
 use App\Message\ExtractMemoriesCommand;
 use App\Service\Chat\ChatTitleService;
+use App\Service\Chat\Run\ChatRun;
+use App\Service\Chat\Run\ChatRunRecorder;
+use App\Service\Chat\Run\ChatRunService;
 use App\Service\ConversationSummaryRefreshDispatcher;
 use App\Service\Exception\StreamCancelledException;
 use App\Service\File\DocumentGeneratorService;
@@ -110,8 +115,25 @@ class StreamController extends AbstractController
         private UsageStatsService $usageStatsService,
         private UsageTaximeterConfig $usageTaximeterConfig,
         private PremiumFeatureGate $premiumFeatureGate,
+        private ChatRunService $chatRunService,
     ) {
     }
+
+    /**
+     * Recorder for the turn currently being streamed by THIS request, mirroring
+     * every SSE event into a replayable Redis log so a returning client can
+     * re-attach. Set at the top of the stream callback and cleared in its
+     * `finally`, so it never leaks into the next request in worker mode.
+     */
+    private ?ChatRunRecorder $activeRun = null;
+
+    /**
+     * One-shot guard for the "connection aborted" log line. Detaching mid-turn
+     * is the normal case now (the turn keeps generating for a client that comes
+     * back), so logging per suppressed event would flood the log with one line
+     * per token for the rest of the answer.
+     */
+    private bool $abortLogged = false;
 
     private function suppressUnparseableOfficemakerEnvelope(
         string $text,
@@ -788,6 +810,22 @@ class StreamController extends AbstractController
 
             $chat = null;
             $incomingMessage = null;
+
+            // Open a resumable run for this turn: every SSE event below is
+            // mirrored into a replayable Redis log so a client that reloads or
+            // navigates away can re-attach and keep watching (see ChatRun).
+            //
+            // Incognito is deliberately excluded — it promises that nothing of
+            // the turn is kept server-side, and a resumable buffer is exactly
+            // that. Incognito turns therefore stream as before, without resume.
+            $this->activeRun = $incognito ? null : $this->chatRunService->begin(
+                $this->resolveRunOwnerKey($user, $isWidgetMode ? $widgetSession : null, $isGuestMode ? $guestSession : null),
+                is_numeric($chatId) ? (int) $chatId : null,
+                (string) $trackId,
+            );
+            if (null !== $this->activeRun) {
+                $this->sendSSE('run_started', ['runId' => $this->activeRun->getRunId()]);
+            }
 
             try {
                 // Load chat — skipped in incognito mode: the turn has no
@@ -2308,6 +2346,11 @@ class StreamController extends AbstractController
 
                 $this->sendSSE('complete', $completeData);
 
+                // Close the run only AFTER `complete` was recorded, so a client
+                // that re-attaches in the last moments still replays the
+                // terminal event instead of an open-ended log.
+                $this->activeRun?->finish(ChatRun::STATUS_COMPLETE, $outgoingMessage->getId());
+
                 usleep(100000);
 
                 $this->logger->info('Streamed message processed', [
@@ -2345,6 +2388,7 @@ class StreamController extends AbstractController
                 }
 
                 $this->sendSSE('error', $errorData);
+                $this->activeRun?->finish(ChatRun::STATUS_ERROR, $messageId);
             } catch (StreamCancelledException) {
                 // Explicit user cancel (/stop-stream flagged the turn) — not an
                 // error and not a disconnect. The frontend persists the partial
@@ -2353,6 +2397,7 @@ class StreamController extends AbstractController
                     'user_id' => $user->getId(),
                     'track_id' => (string) $trackId,
                 ]);
+                $this->activeRun?->finish(ChatRun::STATUS_CANCELLED);
             } catch (\Exception $e) {
                 $this->logger->error('Streaming failed', [
                     'user_id' => $user->getId(),
@@ -2375,10 +2420,41 @@ class StreamController extends AbstractController
                 }
 
                 $this->sendSSE('error', $errorData);
+                $this->activeRun?->finish(ChatRun::STATUS_ERROR, $messageId);
+            } finally {
+                // Safety net: every path above marks its own outcome, but an
+                // early `return` (rate limit, chat not found, non-streaming
+                // model) or a Throwable that is not an Exception must not leave
+                // the run `running` — a client would then wait on a heartbeat
+                // that never ticks again. finish() is idempotent, so this only
+                // fires when nothing else closed the run.
+                $this->activeRun?->finishFromRecordedOutcome();
+                $this->activeRun = null;
+                $this->abortLogged = false;
             }
         });
 
         return $response;
+    }
+
+    /**
+     * Owner scope for a resumable run, used to gate the re-attach endpoint.
+     *
+     * Widget and guest turns run under a shared processing user, so the user id
+     * alone would let one visitor replay another's conversation — those scopes
+     * key on the session instead.
+     */
+    private function resolveRunOwnerKey(User $user, ?WidgetSession $widgetSession, ?GuestSession $guestSession): string
+    {
+        if (null !== $widgetSession) {
+            return ChatRunService::ownerKeyForWidget($widgetSession->getSessionId());
+        }
+
+        if (null !== $guestSession) {
+            return ChatRunService::ownerKeyForGuest($guestSession->getSessionId());
+        }
+
+        return ChatRunService::ownerKeyForUser((int) $user->getId());
     }
 
     /**
@@ -3192,12 +3268,6 @@ class StreamController extends AbstractController
 
     private function sendSSE(string $status, array $data): void
     {
-        if (connection_aborted()) {
-            error_log('🔴 StreamController: Connection aborted');
-
-            return;
-        }
-
         // Sanitize all string values in data to ensure valid UTF-8
         $sanitizedData = $this->sanitizeUtf8($data);
 
@@ -3205,6 +3275,21 @@ class StreamController extends AbstractController
             'status' => $status,
             ...$sanitizedData,
         ];
+
+        // Record BEFORE the abort guard. Below it the buffer would stop filling
+        // at exactly the moment it is needed: the client is gone, the turn keeps
+        // generating, and everything produced from here on is precisely what a
+        // re-attaching client has to replay.
+        $this->activeRun?->record($event);
+
+        if (connection_aborted()) {
+            if (!$this->abortLogged) {
+                $this->abortLogged = true;
+                error_log('🔴 StreamController: Connection aborted — continuing in background');
+            }
+
+            return;
+        }
 
         echo 'data: '.json_encode($event, JSON_INVALID_UTF8_SUBSTITUTE)."\n\n";
 

--- a/backend/src/Controller/WidgetPublicController.php
+++ b/backend/src/Controller/WidgetPublicController.php
@@ -11,6 +11,9 @@ use App\Repository\FileRepository;
 use App\Repository\MessageRepository;
 use App\Service\BillingService;
 use App\Service\Branding\BrandingService;
+use App\Service\Chat\Run\ChatRun;
+use App\Service\Chat\Run\ChatRunRecorder;
+use App\Service\Chat\Run\ChatRunService;
 use App\Service\ConversationSummaryRefreshDispatcher;
 use App\Service\DiscordNotificationService;
 use App\Service\File\FileProcessor;
@@ -68,9 +71,18 @@ class WidgetPublicController extends AbstractController
         private GeneratedFileRegistrar $generatedFileRegistrar,
         private BrandingService $brandingService,
         private ConversationSummaryRefreshDispatcher $summaryRefreshDispatcher,
+        private ChatRunService $chatRunService,
         private string $uploadDir,
     ) {
     }
+
+    /**
+     * Recorder for the turn currently being streamed by THIS request. Mirrors
+     * every SSE event into a replayable log so a visitor who reloads the host
+     * page mid-answer can re-attach instead of losing the turn. Set at the top
+     * of the stream callback, cleared in its `finally`.
+     */
+    private ?ChatRunRecorder $activeRun = null;
 
     /**
      * Resolve the URL operators land on when they click the "Take over"
@@ -780,6 +792,21 @@ class WidgetPublicController extends AbstractController
                 $chunkCount = 0;
                 $finishReason = null;
 
+                // Detach-on-navigation, matching the app chat (#1142/#1223/#1225):
+                // a visitor reloading the host page or clicking away must not
+                // kill the answer they asked for. The turn finishes in the
+                // background, is persisted, and can be re-attached to.
+                ignore_user_abort(true);
+
+                $this->activeRun = $this->chatRunService->begin(
+                    ChatRunService::ownerKeyForWidget($session->getSessionId()),
+                    $chat->getId(),
+                    (string) $incomingMessage->getId(),
+                );
+                if (null !== $this->activeRun) {
+                    $this->sendSse('run_started', ['runId' => $this->activeRun->getRunId()]);
+                }
+
                 try {
                     $result = $this->messageProcessor->processStream(
                         $incomingMessage,
@@ -792,10 +819,6 @@ class WidgetPublicController extends AbstractController
                             &$chunkCount,
                             &$finishReason
                         ) {
-                            if (connection_aborted()) {
-                                throw new \RuntimeException('Client disconnected');
-                            }
-
                             $sendChunk = function (string $content) use (&$responseText) {
                                 if ('' === $content) {
                                     return;
@@ -1057,6 +1080,7 @@ class WidgetPublicController extends AbstractController
                     }
 
                     $this->sendSse('complete', $completePayload);
+                    $this->activeRun?->finish(ChatRun::STATUS_COMPLETE, $incomingMessage->getId());
                 } catch (\Throwable $e) {
                     $this->logger->error('Widget message streaming failed', [
                         'error' => $e->getMessage(),
@@ -1088,6 +1112,12 @@ class WidgetPublicController extends AbstractController
                     $this->sendSse('error', [
                         'error' => 'Failed to process message',
                     ]);
+                } finally {
+                    // Safety net so a run can never stay `running` after the
+                    // worker is gone — a re-attaching visitor would otherwise
+                    // wait on a heartbeat that never ticks again.
+                    $this->activeRun?->finishFromRecordedOutcome();
+                    $this->activeRun = null;
                 }
             });
 
@@ -1431,6 +1461,39 @@ class WidgetPublicController extends AbstractController
         summary: 'Get widget chat history for a session',
         tags: ['Widget (Public)']
     )]
+    #[OA\Parameter(
+        name: 'sessionId',
+        in: 'query',
+        required: true,
+        description: 'Server-issued widget session id.',
+        schema: new OA\Schema(type: 'string')
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'Session history, plus a still-running turn when there is one',
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(property: 'success', type: 'boolean'),
+                new OA\Property(property: 'chatId', type: 'integer', nullable: true),
+                new OA\Property(property: 'messages', type: 'array', items: new OA\Items(type: 'object')),
+                new OA\Property(property: 'session', type: 'object'),
+                new OA\Property(
+                    property: 'activeRun',
+                    description: 'Present when a turn in this session is still generating. The turn survives a client disconnect and buffers its Server-Sent Events, so a reloaded widget can paint `partialText` and re-attach via GET /api/v1/messages/stream/attach.',
+                    type: 'object',
+                    nullable: true,
+                    properties: [
+                        new OA\Property(property: 'runId', type: 'string', format: 'uuid'),
+                        new OA\Property(property: 'trackId', type: 'string'),
+                        new OA\Property(property: 'lastSeq', type: 'integer'),
+                        new OA\Property(property: 'partialText', type: 'string'),
+                    ]
+                ),
+            ]
+        )
+    )]
+    #[OA\Response(response: 400, description: 'sessionId missing')]
+    #[OA\Response(response: 404, description: 'Widget not found')]
     public function history(string $widgetId, Request $request): JsonResponse
     {
         $sessionId = $request->query->getString('sessionId');
@@ -1550,7 +1613,7 @@ class WidgetPublicController extends AbstractController
             ];
         }, $messages);
 
-        return $this->json([
+        $payload = [
             'success' => true,
             'chatId' => $chat->getId(),
             'messages' => $history,
@@ -1561,7 +1624,20 @@ class WidgetPublicController extends AbstractController
                 'lastMessage' => $session->getLastMessage() ?: null,
                 'mode' => $session->getMode(),
             ],
-        ]);
+        ];
+
+        // A turn still generating for this session: the visitor reloaded the
+        // host page mid-answer, so hand them the text so far plus the run id to
+        // re-attach to (GET /api/v1/messages/stream/attach).
+        $activeRun = $this->chatRunService->describeActiveForChat(
+            (int) $chat->getId(),
+            ChatRunService::ownerKeyForWidget($session->getSessionId()),
+        );
+        if (null !== $activeRun) {
+            $payload['activeRun'] = $activeRun;
+        }
+
+        return $this->json($payload);
     }
 
     /**
@@ -1826,11 +1902,15 @@ class WidgetPublicController extends AbstractController
 
     private function sendSse(string $status, array $data = []): void
     {
+        $event = array_merge(['status' => $status], $this->sanitizeUtf8($data));
+
+        // Record BEFORE the abort guard — everything produced after the visitor
+        // disconnects is exactly what a re-attaching client needs to replay.
+        $this->activeRun?->record($event);
+
         if (connection_aborted()) {
             return;
         }
-
-        $event = array_merge(['status' => $status], $this->sanitizeUtf8($data));
 
         echo 'data: '.json_encode($event, JSON_INVALID_UTF8_SUBSTITUTE)."\n\n";
 

--- a/backend/src/Service/Chat/Run/ChatRun.php
+++ b/backend/src/Service/Chat/Run/ChatRun.php
@@ -147,7 +147,11 @@ final class ChatRun
         return $this->created;
     }
 
-    /** Heartbeat: the attach endpoint treats a stale run as a dead worker. */
+    /**
+     * Heartbeat: the attach endpoint treats a stale run as a dead worker. Only
+     * advanced when an event is recorded, so it lags behind a turn's silent
+     * phases — see {@see ChatRunService::STALE_AFTER_SECONDS}.
+     */
     public function getUpdated(): int
     {
         return $this->updated;

--- a/backend/src/Service/Chat/Run/ChatRun.php
+++ b/backend/src/Service/Chat/Run/ChatRun.php
@@ -1,0 +1,206 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Chat\Run;
+
+/**
+ * Durable-in-Redis record of one resumable chat turn ("run").
+ *
+ * Why a run record exists
+ * -----------------------
+ * A turn survives a client disconnect (`ignore_user_abort(true)`, issues
+ * #1142/#1223/#1225), but until now the produced tokens existed ONLY inside the
+ * HTTP response of the request that started it. Reloading the page or switching
+ * chats therefore left the user staring at their own prompt until the finished
+ * answer hit BMESSAGES. A run gives the turn an identity plus a replayable
+ * event log, so a second connection can re-attach and keep rendering where the
+ * first one stopped.
+ *
+ * Why Redis (not a DB table)
+ * --------------------------
+ * Same reasoning as {@see \App\Service\Media\MediaJob}: the events are
+ * high-write and inherently ephemeral (the persisted BMESSAGES row is the only
+ * durable artefact), and production is a multi-node Galera cluster where the
+ * re-attach request can land on a different web node than the one generating.
+ * Redis is the canonical cross-node store here.
+ *
+ * This is a plain mutable value object; persistence lives in
+ * {@see ChatRunBuffer} and the per-turn write path in {@see ChatRunRecorder}.
+ */
+final class ChatRun
+{
+    public const STATUS_RUNNING = 'running';
+    public const STATUS_COMPLETE = 'complete';
+    public const STATUS_ERROR = 'error';
+    public const STATUS_CANCELLED = 'cancelled';
+
+    private string $status = self::STATUS_RUNNING;
+    private int $lastSeq = 0;
+    private ?int $messageId = null;
+
+    /**
+     * Set once the event log hit {@see ChatRunRecorder::MAX_BUFFERED_BYTES}.
+     * A truncated run can no longer be replayed faithfully, so the attach
+     * endpoint ends it with a recoverable error and the client falls back to
+     * the existing history-poll recovery.
+     */
+    private bool $truncated = false;
+
+    private int $created;
+    private int $updated;
+
+    public function __construct(
+        private readonly string $runId,
+        private readonly string $ownerKey,
+        private readonly ?int $chatId,
+        private readonly string $trackId,
+    ) {
+        $now = time();
+        $this->created = $now;
+        $this->updated = $now;
+    }
+
+    public function getRunId(): string
+    {
+        return $this->runId;
+    }
+
+    /**
+     * Opaque owner scope (`user:12`, `guest:{sessionId}`, `widget:{sessionId}`).
+     * The attach endpoint rebuilds this from the incoming request and compares
+     * it against the stored value — a foreign runId must never replay someone
+     * else's conversation.
+     */
+    public function getOwnerKey(): string
+    {
+        return $this->ownerKey;
+    }
+
+    public function getChatId(): ?int
+    {
+        return $this->chatId;
+    }
+
+    public function getTrackId(): string
+    {
+        return $this->trackId;
+    }
+
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+
+    public function isTerminal(): bool
+    {
+        return self::STATUS_RUNNING !== $this->status;
+    }
+
+    public function getLastSeq(): int
+    {
+        return $this->lastSeq;
+    }
+
+    public function setLastSeq(int $lastSeq): self
+    {
+        $this->lastSeq = $lastSeq;
+
+        return $this;
+    }
+
+    public function getMessageId(): ?int
+    {
+        return $this->messageId;
+    }
+
+    public function setMessageId(?int $messageId): self
+    {
+        $this->messageId = $messageId;
+
+        return $this;
+    }
+
+    public function isTruncated(): bool
+    {
+        return $this->truncated;
+    }
+
+    public function markTruncated(): self
+    {
+        $this->truncated = true;
+
+        return $this;
+    }
+
+    public function markTerminal(string $status): self
+    {
+        $this->status = \in_array($status, [self::STATUS_COMPLETE, self::STATUS_ERROR, self::STATUS_CANCELLED], true)
+            ? $status
+            : self::STATUS_ERROR;
+
+        return $this;
+    }
+
+    public function getCreated(): int
+    {
+        return $this->created;
+    }
+
+    /** Heartbeat: the attach endpoint treats a stale run as a dead worker. */
+    public function getUpdated(): int
+    {
+        return $this->updated;
+    }
+
+    public function touch(): self
+    {
+        $this->updated = time();
+
+        return $this;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'runId' => $this->runId,
+            'ownerKey' => $this->ownerKey,
+            'chatId' => $this->chatId,
+            'trackId' => $this->trackId,
+            'status' => $this->status,
+            'lastSeq' => $this->lastSeq,
+            'messageId' => $this->messageId,
+            'truncated' => $this->truncated,
+            'created' => $this->created,
+            'updated' => $this->updated,
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $chatId = $data['chatId'] ?? null;
+
+        $run = new self(
+            (string) ($data['runId'] ?? ''),
+            (string) ($data['ownerKey'] ?? ''),
+            is_numeric($chatId) ? (int) $chatId : null,
+            (string) ($data['trackId'] ?? ''),
+        );
+
+        $run->status = (string) ($data['status'] ?? self::STATUS_RUNNING);
+        $run->lastSeq = (int) ($data['lastSeq'] ?? 0);
+        $messageId = $data['messageId'] ?? null;
+        $run->messageId = is_numeric($messageId) ? (int) $messageId : null;
+        $run->truncated = (bool) ($data['truncated'] ?? false);
+        $run->created = (int) ($data['created'] ?? time());
+        $run->updated = (int) ($data['updated'] ?? time());
+
+        return $run;
+    }
+}

--- a/backend/src/Service/Chat/Run/ChatRunBuffer.php
+++ b/backend/src/Service/Chat/Run/ChatRunBuffer.php
@@ -1,0 +1,220 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Chat\Run;
+
+use App\Service\Infrastructure\RedisService;
+
+/**
+ * Redis persistence for {@see ChatRun} and its replayable SSE event log.
+ *
+ * Layout
+ * ------
+ *   chatrun:{runId}         -> JSON snapshot of the run (TTL'd).
+ *   chatrun:{runId}:events  -> ZSET of SSE payloads scored by sequence number.
+ *                              Members are "{seq}\n{json}" — the seq prefix
+ *                              keeps members unique, which matters because a
+ *                              sorted set would otherwise collapse two
+ *                              identical text chunks into one entry.
+ *   chatrun:chat:{chatId}   -> runId of the chat's newest run, so the history
+ *                              endpoint can surface a still-running turn after
+ *                              a hard reload where the client lost the runId.
+ *   chatrun:owner:{key}     -> SET of that owner's chat ids with a running turn.
+ *                              Lets the chat list mark them with one round-trip
+ *                              instead of probing every listed chat.
+ *
+ * Every operation degrades to a no-op / empty result when Redis is unavailable
+ * ({@see RedisService} returns false/null instead of throwing), which reduces
+ * the feature to the pre-existing behaviour rather than breaking the turn.
+ */
+final readonly class ChatRunBuffer
+{
+    private const RUN_PREFIX = 'chatrun:';
+    private const EVENTS_SUFFIX = ':events';
+    private const CHAT_POINTER_PREFIX = 'chatrun:chat:';
+    private const OWNER_ACTIVE_PREFIX = 'chatrun:owner:';
+
+    /** Retention while the turn is generating — generous enough for a long answer. */
+    private const ACTIVE_TTL_SECONDS = 1800; // 30 min
+
+    /**
+     * Retention after the turn reached a terminal state. Short on purpose: the
+     * answer is in BMESSAGES by then, this only covers a client that re-attaches
+     * in the seconds around completion.
+     */
+    private const TERMINAL_TTL_SECONDS = 300; // 5 min
+
+    public function __construct(
+        private RedisService $redis,
+    ) {
+    }
+
+    /**
+     * @return bool whether the snapshot reached Redis; the caller uses the
+     *              first save as its availability probe, so a false here means
+     *              "run without resume support" rather than "turn failed"
+     */
+    public function save(ChatRun $run): bool
+    {
+        $ttl = $run->isTerminal() ? self::TERMINAL_TTL_SECONDS : self::ACTIVE_TTL_SECONDS;
+
+        $encoded = json_encode($run->toArray(), \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE);
+        if (false === $encoded) {
+            // Nothing here is user-controlled, so this is a programming error
+            // rather than bad input — fail loudly instead of storing a broken
+            // snapshot that would strand every re-attach on this run.
+            throw new \RuntimeException(sprintf('ChatRunBuffer: failed to serialize run %s: %s', $run->getRunId(), json_last_error_msg()));
+        }
+
+        $stored = $this->redis->set(self::RUN_PREFIX.$run->getRunId(), $encoded, $ttl);
+        $this->redis->expire($this->eventsKey($run->getRunId()), $ttl);
+
+        $chatId = $run->getChatId();
+        if (null === $chatId || $chatId <= 0) {
+            return $stored;
+        }
+
+        $ownerKey = self::OWNER_ACTIVE_PREFIX.$run->getOwnerKey();
+
+        if ($run->isTerminal()) {
+            // Only drop the pointer when it still points at THIS run — a newer
+            // turn in the same chat may already own it.
+            if ($run->getRunId() === $this->redis->get(self::CHAT_POINTER_PREFIX.$chatId)) {
+                $this->redis->delete(self::CHAT_POINTER_PREFIX.$chatId);
+                $this->redis->sRem($ownerKey, (string) $chatId);
+            }
+
+            return $stored;
+        }
+
+        $this->redis->set(self::CHAT_POINTER_PREFIX.$chatId, $run->getRunId(), self::ACTIVE_TTL_SECONDS);
+        $this->redis->sAdd($ownerKey, (string) $chatId);
+        $this->redis->expire($ownerKey, self::ACTIVE_TTL_SECONDS);
+
+        return $stored;
+    }
+
+    public function find(string $runId): ?ChatRun
+    {
+        if ('' === $runId) {
+            return null;
+        }
+
+        $raw = $this->redis->get(self::RUN_PREFIX.$runId);
+        if (null === $raw) {
+            return null;
+        }
+
+        $decoded = json_decode($raw, true);
+        if (!is_array($decoded)) {
+            return null;
+        }
+
+        /* @var array<string, mixed> $decoded */
+        return ChatRun::fromArray($decoded);
+    }
+
+    /**
+     * The chat's currently generating run, or null when nothing is running.
+     * Self-heals a pointer whose run snapshot expired or already went terminal.
+     */
+    public function findActiveForChat(int $chatId): ?ChatRun
+    {
+        if ($chatId <= 0) {
+            return null;
+        }
+
+        $runId = $this->redis->get(self::CHAT_POINTER_PREFIX.$chatId);
+        if (null === $runId || '' === $runId) {
+            return null;
+        }
+
+        $run = $this->find($runId);
+        if (null === $run || $run->isTerminal()) {
+            $this->redis->delete(self::CHAT_POINTER_PREFIX.$chatId);
+
+            return null;
+        }
+
+        return $run;
+    }
+
+    /**
+     * Chat ids of one owner that currently have a generating turn. Self-heals
+     * index entries whose run finished or expired.
+     *
+     * @return list<int>
+     */
+    public function findActiveChatIdsForOwner(string $ownerKey): array
+    {
+        $indexKey = self::OWNER_ACTIVE_PREFIX.$ownerKey;
+        $chatIds = [];
+
+        foreach ($this->redis->sMembers($indexKey) as $member) {
+            $chatId = (int) $member;
+            if ($chatId <= 0 || null === $this->findActiveForChat($chatId)) {
+                $this->redis->sRem($indexKey, $member);
+                continue;
+            }
+
+            $chatIds[] = $chatId;
+        }
+
+        return $chatIds;
+    }
+
+    /** Append one already-encoded SSE payload under its sequence number. */
+    public function append(string $runId, int $seq, string $payloadJson): void
+    {
+        $this->redis->zAdd($this->eventsKey($runId), (float) $seq, $seq."\n".$payloadJson);
+    }
+
+    /**
+     * Replay the event log, exclusive of `$fromSeq` (pass 0 for everything).
+     *
+     * @return list<array{seq: int, payload: string}>
+     */
+    public function readEvents(string $runId, int $fromSeq = 0, ?int $limit = null): array
+    {
+        $members = $this->redis->zRangeByScore(
+            $this->eventsKey($runId),
+            '('.max(0, $fromSeq),
+            '+inf',
+            $limit,
+        );
+
+        $events = [];
+        foreach ($members as $member) {
+            $separator = strpos($member, "\n");
+            if (false === $separator) {
+                continue;
+            }
+
+            $events[] = [
+                'seq' => (int) substr($member, 0, $separator),
+                'payload' => substr($member, $separator + 1),
+            ];
+        }
+
+        return $events;
+    }
+
+    /** Drop a run and its event log (used when a turn must leave no trace). */
+    public function forget(ChatRun $run): void
+    {
+        $this->redis->delete(self::RUN_PREFIX.$run->getRunId());
+        $this->redis->delete($this->eventsKey($run->getRunId()));
+
+        $chatId = $run->getChatId();
+        if (null !== $chatId && $run->getRunId() === $this->redis->get(self::CHAT_POINTER_PREFIX.$chatId)) {
+            $this->redis->delete(self::CHAT_POINTER_PREFIX.$chatId);
+            $this->redis->sRem(self::OWNER_ACTIVE_PREFIX.$run->getOwnerKey(), (string) $chatId);
+        }
+    }
+
+    private function eventsKey(string $runId): string
+    {
+        return self::RUN_PREFIX.$runId.self::EVENTS_SUFFIX;
+    }
+}

--- a/backend/src/Service/Chat/Run/ChatRunRecorder.php
+++ b/backend/src/Service/Chat/Run/ChatRunRecorder.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Chat\Run;
+
+use Psr\Log\LoggerInterface;
+
+/**
+ * Per-turn write path into a {@see ChatRun}'s event log.
+ *
+ * One instance exists for the lifetime of one streaming request; it owns the
+ * mutable coalescing state that must not be shared between turns, which is why
+ * this is created by {@see ChatRunService} instead of being a container service.
+ *
+ * Coalescing
+ * ----------
+ * A turn emits one `data` event per model token — writing each of them as its
+ * own Redis entry would mean thousands of round-trips per answer for a log that
+ * is read at most a handful of times. Consecutive text chunks are therefore
+ * merged into one entry per {@see self::FLUSH_INTERVAL_SECONDS} (or
+ * {@see self::FLUSH_BYTES}, whichever comes first). Every other event kind
+ * (`memories_loaded`, `file`, `task_*`, `complete`, …) is low-volume and is
+ * appended verbatim, after flushing the pending text so ordering is preserved.
+ */
+final class ChatRunRecorder
+{
+    private const FLUSH_INTERVAL_SECONDS = 0.25;
+    private const FLUSH_BYTES = 2048;
+
+    /**
+     * Hard ceiling for one run's event log. Beyond this the run is marked
+     * truncated and stops recording: an unbounded buffer would let a single
+     * pathological answer push everything else out of Redis, and a partial log
+     * that silently drops the middle would be worse than falling back to the
+     * existing history-poll recovery.
+     */
+    private const MAX_BUFFERED_BYTES = 1048576; // 1 MiB
+
+    private string $pendingText = '';
+    private float $lastFlushAt;
+    private int $bufferedBytes = 0;
+    private int $seq = 0;
+    private bool $finished = false;
+
+    /**
+     * Terminal event seen on the wire, if any. Lets {@see self::finishFromRecordedOutcome()}
+     * close a run correctly for paths that end without an explicit finish()
+     * (e.g. the non-streaming model branch, which returns early).
+     */
+    private ?string $recordedOutcome = null;
+
+    public function __construct(
+        private readonly ChatRun $run,
+        private readonly ChatRunBuffer $buffer,
+        private readonly LoggerInterface $logger,
+    ) {
+        $this->lastFlushAt = microtime(true);
+    }
+
+    public function getRunId(): string
+    {
+        return $this->run->getRunId();
+    }
+
+    /**
+     * Record one SSE event exactly as it goes out on the wire.
+     *
+     * @param array<string, mixed> $event the full payload including `status`
+     */
+    public function record(array $event): void
+    {
+        if ($this->finished || $this->run->isTruncated()) {
+            return;
+        }
+
+        $status = $event['status'] ?? null;
+        $chunk = $event['chunk'] ?? null;
+
+        if (ChatRun::STATUS_COMPLETE === $status || ChatRun::STATUS_ERROR === $status) {
+            $this->recordedOutcome = $status;
+        }
+
+        // Text chunks are the only high-volume event, and they only ever carry
+        // `status` + `chunk` — anything richer takes the verbatim path so we
+        // never drop a field by merging.
+        if ('data' === $status && is_string($chunk) && ['status', 'chunk'] === array_keys($event)) {
+            $this->pendingText .= $chunk;
+
+            if (strlen($this->pendingText) >= self::FLUSH_BYTES
+                || (microtime(true) - $this->lastFlushAt) >= self::FLUSH_INTERVAL_SECONDS) {
+                $this->flushPendingText();
+            }
+
+            return;
+        }
+
+        $this->flushPendingText();
+        $this->appendEvent($event);
+        $this->persistRun();
+    }
+
+    /**
+     * Close the run. Idempotent — the streaming callback marks the outcome it
+     * knows about and the surrounding `finally` acts as a safety net so a run
+     * can never stay `running` forever.
+     */
+    public function finish(string $status, ?int $messageId = null): void
+    {
+        if ($this->finished) {
+            return;
+        }
+
+        $this->flushPendingText();
+        $this->finished = true;
+
+        $this->run
+            ->markTerminal($status)
+            ->setMessageId($messageId)
+            ->setLastSeq($this->seq)
+            ->touch();
+
+        $this->buffer->save($this->run);
+    }
+
+    /**
+     * Close a run that nothing else closed, using the last terminal event that
+     * actually went out on the wire. Some paths end the turn by returning early
+     * (the non-streaming model branch) rather than by calling finish(), and a
+     * run left `running` would make a re-attaching client wait for a heartbeat
+     * that never ticks again.
+     */
+    public function finishFromRecordedOutcome(): void
+    {
+        $this->finish($this->recordedOutcome ?? ChatRun::STATUS_ERROR);
+    }
+
+    /**
+     * Remove the run and its log entirely — used when a turn must leave no
+     * server-side trace after the fact (e.g. the answer was not persisted).
+     */
+    public function discard(): void
+    {
+        $this->finished = true;
+        $this->pendingText = '';
+        $this->buffer->forget($this->run);
+    }
+
+    private function flushPendingText(): void
+    {
+        if ('' === $this->pendingText) {
+            return;
+        }
+
+        $text = $this->pendingText;
+        $this->pendingText = '';
+        $this->lastFlushAt = microtime(true);
+
+        $this->appendEvent(['status' => 'data', 'chunk' => $text]);
+        $this->persistRun();
+    }
+
+    /**
+     * @param array<string, mixed> $event
+     */
+    private function appendEvent(array $event): void
+    {
+        $payload = json_encode($event, \JSON_INVALID_UTF8_SUBSTITUTE | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE);
+        if (false === $payload) {
+            $this->logger->warning('ChatRunRecorder: dropped an unencodable event', [
+                'run_id' => $this->run->getRunId(),
+                'status' => $event['status'] ?? null,
+            ]);
+
+            return;
+        }
+
+        $this->bufferedBytes += strlen($payload);
+        if ($this->bufferedBytes > self::MAX_BUFFERED_BYTES) {
+            $this->run->markTruncated()->touch();
+            $this->buffer->save($this->run);
+            $this->logger->warning('ChatRunRecorder: event log exceeded the size cap, stopped recording', [
+                'run_id' => $this->run->getRunId(),
+                'buffered_bytes' => $this->bufferedBytes,
+            ]);
+
+            return;
+        }
+
+        $this->buffer->append($this->run->getRunId(), ++$this->seq, $payload);
+    }
+
+    /** Persists sequence progress and refreshes the heartbeat the reader watches. */
+    private function persistRun(): void
+    {
+        $this->buffer->save($this->run->setLastSeq($this->seq)->touch());
+    }
+}

--- a/backend/src/Service/Chat/Run/ChatRunRecorder.php
+++ b/backend/src/Service/Chat/Run/ChatRunRecorder.php
@@ -135,17 +135,6 @@ final class ChatRunRecorder
         $this->finish($this->recordedOutcome ?? ChatRun::STATUS_ERROR);
     }
 
-    /**
-     * Remove the run and its log entirely — used when a turn must leave no
-     * server-side trace after the fact (e.g. the answer was not persisted).
-     */
-    public function discard(): void
-    {
-        $this->finished = true;
-        $this->pendingText = '';
-        $this->buffer->forget($this->run);
-    }
-
     private function flushPendingText(): void
     {
         if ('' === $this->pendingText) {

--- a/backend/src/Service/Chat/Run/ChatRunService.php
+++ b/backend/src/Service/Chat/Run/ChatRunService.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Chat\Run;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Feature service for resumable chat turns — the only entry point controllers
+ * use, so no controller has to know about Redis (see AGENTS-DEV).
+ *
+ * Write side: {@see self::begin()} hands out a {@see ChatRunRecorder} that the
+ * streaming controller feeds with every SSE event it emits.
+ * Read side: {@see self::describeActiveForChat()} lets a history response point
+ * a returning client at a still-running turn, and {@see self::authorize()}
+ * gates the re-attach endpoint.
+ */
+final readonly class ChatRunService
+{
+    /**
+     * A run whose heartbeat is older than this is treated as abandoned: the
+     * generating worker died (deploy, crash, OOM) without ever reaching a
+     * terminal state, so a client waiting on it must be released instead of
+     * hanging until the TTL expires.
+     */
+    public const STALE_AFTER_SECONDS = 30;
+
+    public function __construct(
+        private ChatRunBuffer $buffer,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public static function ownerKeyForUser(int $userId): string
+    {
+        return 'user:'.$userId;
+    }
+
+    public static function ownerKeyForGuest(string $sessionId): string
+    {
+        return 'guest:'.$sessionId;
+    }
+
+    public static function ownerKeyForWidget(string $sessionId): string
+    {
+        return 'widget:'.$sessionId;
+    }
+
+    /**
+     * Open a run for one turn, or null when Redis did not accept the record —
+     * in that case the turn simply streams without resume support, exactly as
+     * it did before this feature existed.
+     */
+    public function begin(string $ownerKey, ?int $chatId, string $trackId): ?ChatRunRecorder
+    {
+        $run = new ChatRun(Uuid::v4()->toRfc4122(), $ownerKey, $chatId, $trackId);
+
+        if (!$this->buffer->save($run)) {
+            $this->logger->warning('ChatRunService: could not open a resumable run, streaming without resume', [
+                'chat_id' => $chatId,
+                'track_id' => $trackId,
+            ]);
+
+            return null;
+        }
+
+        return new ChatRunRecorder($run, $this->buffer, $this->logger);
+    }
+
+    /**
+     * Resolve a run for a re-attach request, or null when it does not exist or
+     * belongs to somebody else. Ownership is compared in constant time so the
+     * endpoint cannot be used to probe for foreign run ids.
+     */
+    public function authorize(string $runId, string $ownerKey): ?ChatRun
+    {
+        $run = $this->buffer->find($runId);
+        if (null === $run) {
+            return null;
+        }
+
+        if (!hash_equals($run->getOwnerKey(), $ownerKey)) {
+            $this->logger->warning('ChatRunService: rejected a re-attach for a foreign run', [
+                'run_id' => $runId,
+            ]);
+
+            return null;
+        }
+
+        return $run;
+    }
+
+    public function find(string $runId): ?ChatRun
+    {
+        return $this->buffer->find($runId);
+    }
+
+    /**
+     * @return list<array{seq: int, payload: string}>
+     */
+    public function readEvents(string $runId, int $fromSeq = 0): array
+    {
+        return $this->buffer->readEvents($runId, $fromSeq);
+    }
+
+    public function isStale(ChatRun $run): bool
+    {
+        return !$run->isTerminal() && (time() - $run->getUpdated()) > self::STALE_AFTER_SECONDS;
+    }
+
+    /**
+     * Chats of one owner with a turn generating right now, so the chat list can
+     * show where an answer is still being written after the user moved on.
+     *
+     * @return list<int>
+     */
+    public function activeChatIds(string $ownerKey): array
+    {
+        return $this->buffer->findActiveChatIdsForOwner($ownerKey);
+    }
+
+    /**
+     * Describe a chat's still-running turn for the history response, so a
+     * client that reloaded (and therefore lost the run id) can paint the text
+     * produced so far and re-attach to the live stream.
+     *
+     * @return array{runId: string, trackId: string, lastSeq: int, partialText: string}|null
+     */
+    public function describeActiveForChat(int $chatId, string $ownerKey): ?array
+    {
+        $run = $this->buffer->findActiveForChat($chatId);
+        if (null === $run || !hash_equals($run->getOwnerKey(), $ownerKey) || $this->isStale($run)) {
+            return null;
+        }
+
+        $lastSeq = 0;
+        $partialText = '';
+        foreach ($this->buffer->readEvents($run->getRunId()) as $event) {
+            $lastSeq = $event['seq'];
+
+            $decoded = json_decode($event['payload'], true);
+            if (is_array($decoded) && 'data' === ($decoded['status'] ?? null) && is_string($decoded['chunk'] ?? null)) {
+                $partialText .= $decoded['chunk'];
+            }
+        }
+
+        return [
+            'runId' => $run->getRunId(),
+            'trackId' => $run->getTrackId(),
+            'lastSeq' => $lastSeq,
+            'partialText' => $partialText,
+        ];
+    }
+}

--- a/backend/src/Service/Chat/Run/ChatRunService.php
+++ b/backend/src/Service/Chat/Run/ChatRunService.php
@@ -24,8 +24,16 @@ final readonly class ChatRunService
      * generating worker died (deploy, crash, OOM) without ever reaching a
      * terminal state, so a client waiting on it must be released instead of
      * hanging until the TTL expires.
+     *
+     * The heartbeat is NOT a timer — {@see ChatRunRecorder} only touches the run
+     * when it records an event. A live turn can therefore be silent for a long
+     * while (media generation, a slow tool call, a large context's
+     * time-to-first-token), and a tight window would declare exactly those runs
+     * dead: resume would be withheld and an attached client dropped mid-answer.
+     * The window is sized for the silence a healthy turn can produce, since the
+     * cost of being late here is only a delayed fallback to the history poll.
      */
-    public const STALE_AFTER_SECONDS = 30;
+    public const STALE_AFTER_SECONDS = 300;
 
     public function __construct(
         private ChatRunBuffer $buffer,

--- a/backend/tests/Integration/Service/Chat/Run/ChatRunBufferTest.php
+++ b/backend/tests/Integration/Service/Chat/Run/ChatRunBufferTest.php
@@ -1,0 +1,247 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Service\Chat\Run;
+
+use App\Service\Chat\Run\ChatRun;
+use App\Service\Chat\Run\ChatRunBuffer;
+use App\Service\Chat\Run\ChatRunService;
+use App\Service\Infrastructure\RedisService;
+use Psr\Log\NullLogger;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * Resumable turns live entirely in Redis (sorted sets, sets, TTLs), so they can
+ * only be verified against a real instance — a fake would test the fake. Skips
+ * gracefully when Redis is unreachable, like {@see \App\Tests\Integration\Service\Infrastructure\RedisIntegrationTest}.
+ */
+final class ChatRunBufferTest extends KernelTestCase
+{
+    private RedisService $redis;
+    private ChatRunBuffer $buffer;
+    private ChatRunService $service;
+
+    /** @var list<ChatRun> runs created by the test, dropped in tearDown */
+    private array $runs = [];
+
+    private string $ownerKey;
+    private int $chatId;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->redis = static::getContainer()->get(RedisService::class);
+
+        if (!$this->redis->isAvailable()) {
+            self::markTestSkipped('Redis is not reachable — skipping resumable-run integration test.');
+        }
+
+        // Wired by hand rather than pulled from the container: both are private,
+        // single-consumer services and would be inlined away before the test
+        // container ever sees them.
+        $this->buffer = new ChatRunBuffer($this->redis);
+        $this->service = new ChatRunService($this->buffer, new NullLogger());
+
+        // Unique per run so parallel/repeated runs never collide on the shared
+        // chat pointer and owner index keys.
+        $this->ownerKey = ChatRunService::ownerKeyForUser(random_int(100000, 999999));
+        $this->chatId = random_int(100000, 999999);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->runs as $run) {
+            $this->buffer->forget($run);
+        }
+
+        parent::tearDown();
+    }
+
+    public function testEventsReplayInOrderAndFromCanSkipWhatTheClientAlreadySaw(): void
+    {
+        $run = $this->newRun();
+        $this->buffer->append($run->getRunId(), 1, '{"status":"data","chunk":"Hel"}');
+        $this->buffer->append($run->getRunId(), 2, '{"status":"data","chunk":"lo"}');
+        $this->buffer->append($run->getRunId(), 3, '{"status":"complete"}');
+
+        $all = $this->buffer->readEvents($run->getRunId());
+        self::assertSame([1, 2, 3], array_column($all, 'seq'));
+        self::assertSame('{"status":"complete"}', $all[2]['payload']);
+
+        // `from` is exclusive: a client that saw seq 2 must not get it twice.
+        $tail = $this->buffer->readEvents($run->getRunId(), 2);
+        self::assertSame([3], array_column($tail, 'seq'));
+    }
+
+    public function testIdenticalTextChunksAreKeptApart(): void
+    {
+        // A sorted set deduplicates equal members — without the seq prefix two
+        // identical tokens would collapse and the replayed answer would silently
+        // lose a word.
+        $run = $this->newRun();
+        $this->buffer->append($run->getRunId(), 1, '{"status":"data","chunk":"the"}');
+        $this->buffer->append($run->getRunId(), 2, '{"status":"data","chunk":"the"}');
+
+        self::assertCount(2, $this->buffer->readEvents($run->getRunId()));
+    }
+
+    public function testRecorderBundlesConsecutiveTextAndKeepsOtherEventsVerbatim(): void
+    {
+        $recorder = $this->service->begin($this->ownerKey, $this->chatId, 'track-bundle');
+        self::assertNotNull($recorder);
+        $this->trackRun($recorder->getRunId());
+
+        foreach (['He', 'llo', ' wor', 'ld'] as $chunk) {
+            $recorder->record(['status' => 'data', 'chunk' => $chunk]);
+        }
+        $recorder->record(['status' => 'memories_loaded', 'memories' => []]);
+        $recorder->finish(ChatRun::STATUS_COMPLETE, 4711);
+
+        $events = array_map(
+            static fn (array $event): array => (array) json_decode($event['payload'], true),
+            $this->buffer->readEvents($recorder->getRunId()),
+        );
+
+        // Four tokens well under the flush thresholds must cost one entry, not
+        // four — otherwise a long answer floods Redis with thousands of writes.
+        self::assertSame(
+            [
+                ['status' => 'data', 'chunk' => 'Hello world'],
+                ['status' => 'memories_loaded', 'memories' => []],
+            ],
+            $events,
+        );
+
+        $stored = $this->buffer->find($recorder->getRunId());
+        self::assertNotNull($stored);
+        self::assertSame(ChatRun::STATUS_COMPLETE, $stored->getStatus());
+        self::assertSame(4711, $stored->getMessageId());
+        self::assertSame(2, $stored->getLastSeq());
+    }
+
+    public function testATerminalRunIsNoLongerOfferedForResume(): void
+    {
+        $recorder = $this->service->begin($this->ownerKey, $this->chatId, 'track-terminal');
+        self::assertNotNull($recorder);
+        $this->trackRun($recorder->getRunId());
+
+        $recorder->record(['status' => 'data', 'chunk' => 'partial']);
+        self::assertNotNull($this->buffer->findActiveForChat($this->chatId));
+        self::assertSame([$this->chatId], $this->buffer->findActiveChatIdsForOwner($this->ownerKey));
+
+        $recorder->finish(ChatRun::STATUS_COMPLETE);
+
+        self::assertNull($this->buffer->findActiveForChat($this->chatId));
+        self::assertSame([], $this->buffer->findActiveChatIdsForOwner($this->ownerKey));
+        self::assertNull($this->service->describeActiveForChat($this->chatId, $this->ownerKey));
+    }
+
+    public function testDescribeActiveForChatRebuildsTheTextProducedSoFar(): void
+    {
+        $recorder = $this->service->begin($this->ownerKey, $this->chatId, 'track-describe');
+        self::assertNotNull($recorder);
+        $this->trackRun($recorder->getRunId());
+
+        $recorder->record(['status' => 'data', 'chunk' => 'Half an ']);
+        $recorder->record(['status' => 'memories_loaded', 'memories' => []]);
+        $recorder->record(['status' => 'data', 'chunk' => 'answer']);
+        $recorder->record(['status' => 'task_update', 'task' => 'x']);
+
+        $active = $this->service->describeActiveForChat($this->chatId, $this->ownerKey);
+
+        self::assertNotNull($active);
+        self::assertSame($recorder->getRunId(), $active['runId']);
+        self::assertSame('track-describe', $active['trackId']);
+        // Only text events rebuild the bubble; the rest merely advance lastSeq.
+        self::assertSame('Half an answer', $active['partialText']);
+        self::assertGreaterThan(0, $active['lastSeq']);
+    }
+
+    public function testAForeignOwnerCanNeitherAttachNorDiscoverTheRun(): void
+    {
+        $recorder = $this->service->begin($this->ownerKey, $this->chatId, 'track-owner');
+        self::assertNotNull($recorder);
+        $this->trackRun($recorder->getRunId());
+        $recorder->record(['status' => 'data', 'chunk' => 'secret']);
+
+        $stranger = ChatRunService::ownerKeyForUser(1);
+
+        self::assertNull($this->service->authorize($recorder->getRunId(), $stranger));
+        self::assertNull($this->service->describeActiveForChat($this->chatId, $stranger));
+        self::assertNotNull($this->service->authorize($recorder->getRunId(), $this->ownerKey));
+    }
+
+    public function testAnUnknownRunIdIsNotAuthorized(): void
+    {
+        self::assertNull($this->service->authorize('does-not-exist', $this->ownerKey));
+        self::assertNull($this->service->authorize('', $this->ownerKey));
+    }
+
+    public function testAnAbandonedRunGoesStaleSoNobodyWaitsForADeadWorker(): void
+    {
+        $run = $this->newRun();
+        self::assertFalse($this->service->isStale($run));
+
+        // Simulate a worker that died mid-turn: heartbeat frozen in the past,
+        // status still "running".
+        $frozen = $run->toArray();
+        $frozen['updated'] = time() - (ChatRunService::STALE_AFTER_SECONDS + 5);
+        $stale = ChatRun::fromArray($frozen);
+        $this->buffer->save($stale);
+
+        self::assertTrue($this->service->isStale($stale));
+        self::assertNull($this->service->describeActiveForChat($this->chatId, $this->ownerKey));
+
+        // A finished run is never stale — it has an outcome to deliver.
+        $stale->markTerminal(ChatRun::STATUS_COMPLETE);
+        self::assertFalse($this->service->isStale($stale));
+    }
+
+    public function testDiscardLeavesNothingBehind(): void
+    {
+        $recorder = $this->service->begin($this->ownerKey, $this->chatId, 'track-discard');
+        self::assertNotNull($recorder);
+        $this->trackRun($recorder->getRunId());
+        $recorder->record(['status' => 'data', 'chunk' => 'nevermind']);
+
+        $recorder->discard();
+
+        self::assertNull($this->buffer->find($recorder->getRunId()));
+        self::assertSame([], $this->buffer->readEvents($recorder->getRunId()));
+        self::assertNull($this->buffer->findActiveForChat($this->chatId));
+        self::assertSame([], $this->buffer->findActiveChatIdsForOwner($this->ownerKey));
+    }
+
+    public function testTheOwnerIndexDropsChatsWhoseRunExpired(): void
+    {
+        $recorder = $this->service->begin($this->ownerKey, $this->chatId, 'track-index');
+        self::assertNotNull($recorder);
+        $run = $this->buffer->find($recorder->getRunId());
+        self::assertNotNull($run);
+        $this->runs[] = $run;
+
+        // Mimic TTL expiry of the run snapshot and its chat pointer while the
+        // owner index still lists the chat.
+        $this->redis->delete('chatrun:'.$recorder->getRunId());
+
+        self::assertSame([], $this->buffer->findActiveChatIdsForOwner($this->ownerKey));
+    }
+
+    private function newRun(): ChatRun
+    {
+        $run = new ChatRun('test-run-'.bin2hex(random_bytes(6)), $this->ownerKey, $this->chatId, 'track-'.bin2hex(random_bytes(3)));
+        $this->buffer->save($run);
+        $this->runs[] = $run;
+
+        return $run;
+    }
+
+    private function trackRun(string $runId): void
+    {
+        $run = $this->buffer->find($runId);
+        if (null !== $run) {
+            $this->runs[] = $run;
+        }
+    }
+}

--- a/backend/tests/Integration/Service/Chat/Run/ChatRunBufferTest.php
+++ b/backend/tests/Integration/Service/Chat/Run/ChatRunBufferTest.php
@@ -198,14 +198,16 @@ final class ChatRunBufferTest extends KernelTestCase
         self::assertFalse($this->service->isStale($stale));
     }
 
-    public function testDiscardLeavesNothingBehind(): void
+    public function testForgetLeavesNothingBehind(): void
     {
-        $recorder = $this->service->begin($this->ownerKey, $this->chatId, 'track-discard');
+        $recorder = $this->service->begin($this->ownerKey, $this->chatId, 'track-forget');
         self::assertNotNull($recorder);
         $this->trackRun($recorder->getRunId());
         $recorder->record(['status' => 'data', 'chunk' => 'nevermind']);
 
-        $recorder->discard();
+        $run = $this->buffer->find($recorder->getRunId());
+        self::assertNotNull($run);
+        $this->buffer->forget($run);
 
         self::assertNull($this->buffer->find($recorder->getRunId()));
         self::assertSame([], $this->buffer->readEvents($recorder->getRunId()));

--- a/backend/tests/Support/ChatRunServiceFactory.php
+++ b/backend/tests/Support/ChatRunServiceFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Support;
+
+use App\Service\Chat\Run\ChatRunBuffer;
+use App\Service\Chat\Run\ChatRunService;
+use App\Service\Infrastructure\RedisService;
+use Psr\Log\NullLogger;
+
+/**
+ * Builds a REAL {@see ChatRunService} over an unreachable Redis for DB-free
+ * unit tests. The class is final (so it cannot be mocked) and its Redis layer
+ * degrades to no-ops rather than throwing, so `begin()` simply returns null:
+ * the turn streams without resume support, exactly as it does in production
+ * when Redis is down. That is precisely the neutral behaviour a controller
+ * unit test wants.
+ */
+final class ChatRunServiceFactory
+{
+    public static function withoutRedis(): ChatRunService
+    {
+        return new ChatRunService(
+            new ChatRunBuffer(new RedisService('', 'test', new NullLogger())),
+            new NullLogger(),
+        );
+    }
+}

--- a/backend/tests/Unit/Controller/StreamAttachControllerTest.php
+++ b/backend/tests/Unit/Controller/StreamAttachControllerTest.php
@@ -1,0 +1,248 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Controller;
+
+use App\Controller\StreamAttachController;
+use App\Entity\GuestSession;
+use App\Entity\User;
+use App\Entity\Widget;
+use App\Entity\WidgetSession;
+use App\Service\Chat\Run\ChatRun;
+use App\Service\Chat\Run\ChatRunService;
+use App\Service\GuestSessionService;
+use App\Service\WidgetService;
+use App\Service\WidgetSessionService;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+/**
+ * The re-attach endpoint is PUBLIC_ACCESS (it has to serve widget visitors and
+ * guests, who have no app session), so the owner check inside the controller is
+ * the ONLY thing standing between a caller and somebody else's conversation.
+ * These tests pin that gate: which identity a request resolves to, and that
+ * every failure mode refuses instead of falling through to a stream.
+ *
+ * The stream callback is deliberately never invoked — the guards all answer
+ * before it, and running it would write SSE frames into the test output.
+ */
+final class StreamAttachControllerTest extends TestCase
+{
+    private ChatRunService&MockObject $chatRunService;
+    private WidgetService&Stub $widgetService;
+    private WidgetSessionService&Stub $widgetSessionService;
+    private GuestSessionService&Stub $guestSessionService;
+
+    protected function setUp(): void
+    {
+        $this->chatRunService = $this->createMock(ChatRunService::class);
+        $this->widgetService = $this->createStub(WidgetService::class);
+        $this->widgetSessionService = $this->createStub(WidgetSessionService::class);
+        $this->guestSessionService = $this->createStub(GuestSessionService::class);
+    }
+
+    public function testAMissingRunIdIsRejectedBeforeAnyIdentityWork(): void
+    {
+        $this->chatRunService->expects(self::never())->method('authorize');
+
+        $response = $this->controller()->attach(new Request(['runId' => '   ']), $this->userWithId(42));
+
+        self::assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+    }
+
+    public function testARequestWithoutAnyUsableIdentityIsUnauthorized(): void
+    {
+        $this->chatRunService->expects(self::never())->method('authorize');
+
+        $response = $this->controller()->attach($this->attachRequest(), null);
+
+        self::assertSame(Response::HTTP_UNAUTHORIZED, $response->getStatusCode());
+    }
+
+    public function testAnAppUserIsScopedToItsUserId(): void
+    {
+        $this->chatRunService->expects(self::once())
+            ->method('authorize')
+            ->with('run-1', 'user:42')
+            ->willReturn($this->runningRun('user:42'));
+
+        $this->assertSseStream($this->controller()->attach($this->attachRequest(), $this->userWithId(42)));
+    }
+
+    public function testAnUnknownOrForeignRunAnswersAPlain404(): void
+    {
+        // authorize() returns null both for "no such run" and "not yours", and
+        // the endpoint must not tell the two apart — otherwise it becomes a
+        // probe for which run ids exist.
+        $this->chatRunService->expects(self::once())->method('authorize')->willReturn(null);
+
+        $response = $this->controller()->attach($this->attachRequest(), $this->userWithId(42));
+
+        self::assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
+        self::assertSame('{"error":"Run not found"}', (string) $response->getContent());
+    }
+
+    public function testAWidgetIsScopedToItsSessionNotToTheWidgetOwner(): void
+    {
+        // Widget turns all run under the operator's user, so scoping on the user
+        // would let one visitor replay another visitor's conversation.
+        $this->widgetService->method('getWidgetById')->willReturn(new Widget());
+        $this->widgetSessionService->method('getSession')->willReturn($this->widgetSession('sess-1'));
+
+        $this->chatRunService->expects(self::once())
+            ->method('authorize')
+            ->with('run-1', 'widget:sess-1')
+            ->willReturn($this->runningRun('widget:sess-1'));
+
+        $this->assertSseStream($this->controller()->attach($this->widgetRequest(), null));
+    }
+
+    public function testAnUnknownWidgetIsUnauthorized(): void
+    {
+        $this->widgetService->method('getWidgetById')->willReturn(null);
+        $this->chatRunService->expects(self::never())->method('authorize');
+
+        $response = $this->controller()->attach($this->widgetRequest(), null);
+
+        self::assertSame(Response::HTTP_UNAUTHORIZED, $response->getStatusCode());
+    }
+
+    public function testAWidgetSessionIsOnlyLookedUpNeverCreated(): void
+    {
+        // A re-attach that could mint a session would turn a read endpoint into
+        // a session factory for anyone who can guess a widget id.
+        $sessionService = $this->createMock(WidgetSessionService::class);
+        $sessionService->expects(self::once())->method('getSession')->with('w-1', 'sess-1')->willReturn(null);
+        $sessionService->expects(self::never())->method('getOrCreateSession');
+
+        $this->widgetService->method('getWidgetById')->willReturn(new Widget());
+        $this->widgetSessionService = $sessionService;
+        $this->chatRunService->expects(self::never())->method('authorize');
+
+        $response = $this->controller()->attach($this->widgetRequest(), null);
+
+        self::assertSame(Response::HTTP_UNAUTHORIZED, $response->getStatusCode());
+    }
+
+    public function testAGuestIsScopedToItsSessionId(): void
+    {
+        $this->guestSessionService->method('getSession')->willReturn($this->guestSession('guest-1', false));
+
+        $this->chatRunService->expects(self::once())
+            ->method('authorize')
+            ->with('run-1', 'guest:guest-1')
+            ->willReturn($this->runningRun('guest:guest-1'));
+
+        $request = $this->attachRequest(['guestSession' => 'guest-1']);
+
+        $this->assertSseStream($this->controller()->attach($request, null));
+    }
+
+    public function testAnExpiredGuestSessionIsUnauthorized(): void
+    {
+        $this->guestSessionService->method('getSession')->willReturn($this->guestSession('g', true));
+        $this->chatRunService->expects(self::never())->method('authorize');
+
+        $request = $this->attachRequest(['guestSession' => 'g']);
+
+        self::assertSame(
+            Response::HTTP_UNAUTHORIZED,
+            $this->controller()->attach($request, null)->getStatusCode(),
+        );
+    }
+
+    public function testAnUnknownGuestSessionIsUnauthorized(): void
+    {
+        $this->guestSessionService->method('getSession')->willReturn(null);
+        $this->chatRunService->expects(self::never())->method('authorize');
+
+        $request = $this->attachRequest(['guestSession' => 'nope']);
+
+        self::assertSame(
+            Response::HTTP_UNAUTHORIZED,
+            $this->controller()->attach($request, null)->getStatusCode(),
+        );
+    }
+
+    private function controller(): StreamAttachController
+    {
+        $controller = new StreamAttachController(
+            $this->chatRunService,
+            $this->widgetService,
+            $this->widgetSessionService,
+            $this->guestSessionService,
+            new NullLogger(),
+        );
+
+        // AbstractController::json() reaches into the container to look for a
+        // serializer; an empty one makes it fall back to JsonResponse.
+        $controller->setContainer(new Container());
+
+        return $controller;
+    }
+
+    /**
+     * @param array<string, string> $extraQuery
+     */
+    private function attachRequest(array $extraQuery = []): Request
+    {
+        return new Request(['runId' => 'run-1'] + $extraQuery);
+    }
+
+    private function widgetRequest(): Request
+    {
+        return new Request(
+            ['runId' => 'run-1'],
+            server: ['HTTP_X_WIDGET_ID' => 'w-1', 'HTTP_X_WIDGET_SESSION' => 'sess-1'],
+        );
+    }
+
+    private function assertSseStream(Response $response): void
+    {
+        self::assertInstanceOf(StreamedResponse::class, $response);
+        self::assertSame('text/event-stream', $response->headers->get('Content-Type'));
+        // Symfony expands the directive it was given; what matters is that the
+        // replay is never cached by a proxy.
+        self::assertStringContainsString('no-cache', (string) $response->headers->get('Cache-Control'));
+        self::assertSame('no', $response->headers->get('X-Accel-Buffering'));
+    }
+
+    private function runningRun(string $ownerKey): ChatRun
+    {
+        return new ChatRun('run-1', $ownerKey, 7, 'track-1');
+    }
+
+    private function userWithId(int $id): User
+    {
+        $user = new User();
+
+        $reflection = new \ReflectionProperty(User::class, 'id');
+        $reflection->setValue($user, $id);
+
+        return $user;
+    }
+
+    private function widgetSession(string $sessionId): WidgetSession
+    {
+        $session = $this->createStub(WidgetSession::class);
+        $session->method('getSessionId')->willReturn($sessionId);
+
+        return $session;
+    }
+
+    private function guestSession(string $sessionId, bool $expired): GuestSession
+    {
+        $session = $this->createStub(GuestSession::class);
+        $session->method('getSessionId')->willReturn($sessionId);
+        $session->method('isExpired')->willReturn($expired);
+
+        return $session;
+    }
+}

--- a/backend/tests/Unit/Controller/StreamControllerAiModelsPayloadTest.php
+++ b/backend/tests/Unit/Controller/StreamControllerAiModelsPayloadTest.php
@@ -31,6 +31,7 @@ use App\Service\UsageStatsService;
 use App\Service\UsageTaximeterConfig;
 use App\Service\WidgetService;
 use App\Service\WidgetSessionService;
+use App\Tests\Support\ChatRunServiceFactory;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
@@ -82,6 +83,7 @@ class StreamControllerAiModelsPayloadTest extends TestCase
             $this->createMock(UsageStatsService::class),
             $this->createMock(UsageTaximeterConfig::class),
             new PremiumFeatureGate(new BillingService('', '')),
+            ChatRunServiceFactory::withoutRedis(),
         );
     }
 

--- a/backend/tests/Unit/Controller/StreamControllerCancelledResultTest.php
+++ b/backend/tests/Unit/Controller/StreamControllerCancelledResultTest.php
@@ -30,6 +30,7 @@ use App\Service\UsageStatsService;
 use App\Service\UsageTaximeterConfig;
 use App\Service\WidgetService;
 use App\Service\WidgetSessionService;
+use App\Tests\Support\ChatRunServiceFactory;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
@@ -74,6 +75,7 @@ class StreamControllerCancelledResultTest extends TestCase
             $this->createMock(UsageStatsService::class),
             $this->createMock(UsageTaximeterConfig::class),
             new PremiumFeatureGate(new BillingService('', '')),
+            ChatRunServiceFactory::withoutRedis(),
         );
     }
 

--- a/backend/tests/Unit/Controller/StreamControllerDeferredMemoryDispatchTest.php
+++ b/backend/tests/Unit/Controller/StreamControllerDeferredMemoryDispatchTest.php
@@ -31,6 +31,7 @@ use App\Service\UsageStatsService;
 use App\Service\UsageTaximeterConfig;
 use App\Service\WidgetService;
 use App\Service\WidgetSessionService;
+use App\Tests\Support\ChatRunServiceFactory;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -99,6 +100,7 @@ final class StreamControllerDeferredMemoryDispatchTest extends TestCase
             $this->createMock(UsageStatsService::class),
             $this->createMock(UsageTaximeterConfig::class),
             new PremiumFeatureGate(new BillingService('', '')),
+            ChatRunServiceFactory::withoutRedis(),
         );
     }
 

--- a/backend/tests/Unit/Controller/StreamControllerFileEnvelopeTest.php
+++ b/backend/tests/Unit/Controller/StreamControllerFileEnvelopeTest.php
@@ -30,6 +30,7 @@ use App\Service\UsageStatsService;
 use App\Service\UsageTaximeterConfig;
 use App\Service\WidgetService;
 use App\Service\WidgetSessionService;
+use App\Tests\Support\ChatRunServiceFactory;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -71,6 +72,7 @@ final class StreamControllerFileEnvelopeTest extends TestCase
             $this->createMock(UsageStatsService::class),
             $this->createMock(UsageTaximeterConfig::class),
             new PremiumFeatureGate(new BillingService('', '')),
+            ChatRunServiceFactory::withoutRedis(),
         );
     }
 

--- a/backend/tests/Unit/Controller/StreamControllerOriginalMediaMetaTest.php
+++ b/backend/tests/Unit/Controller/StreamControllerOriginalMediaMetaTest.php
@@ -31,6 +31,7 @@ use App\Service\UsageStatsService;
 use App\Service\UsageTaximeterConfig;
 use App\Service\WidgetService;
 use App\Service\WidgetSessionService;
+use App\Tests\Support\ChatRunServiceFactory;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
@@ -78,6 +79,7 @@ class StreamControllerOriginalMediaMetaTest extends TestCase
             $this->createMock(UsageStatsService::class),
             $this->createMock(UsageTaximeterConfig::class),
             new PremiumFeatureGate(new BillingService('', '')),
+            ChatRunServiceFactory::withoutRedis(),
         );
     }
 

--- a/backend/tests/Unit/Controller/StreamControllerRagGroupKeyTest.php
+++ b/backend/tests/Unit/Controller/StreamControllerRagGroupKeyTest.php
@@ -30,6 +30,7 @@ use App\Service\UsageStatsService;
 use App\Service\UsageTaximeterConfig;
 use App\Service\WidgetService;
 use App\Service\WidgetSessionService;
+use App\Tests\Support\ChatRunServiceFactory;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
@@ -83,6 +84,7 @@ final class StreamControllerRagGroupKeyTest extends TestCase
             $this->createMock(UsageStatsService::class),
             $this->createMock(UsageTaximeterConfig::class),
             new PremiumFeatureGate(new BillingService('', '')),
+            ChatRunServiceFactory::withoutRedis(),
         );
     }
 

--- a/backend/tests/Unit/Controller/StreamControllerTaskPlanFilesTest.php
+++ b/backend/tests/Unit/Controller/StreamControllerTaskPlanFilesTest.php
@@ -31,6 +31,7 @@ use App\Service\UsageStatsService;
 use App\Service\UsageTaximeterConfig;
 use App\Service\WidgetService;
 use App\Service\WidgetSessionService;
+use App\Tests\Support\ChatRunServiceFactory;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
@@ -82,6 +83,7 @@ class StreamControllerTaskPlanFilesTest extends TestCase
             $this->createMock(UsageStatsService::class),
             $this->createMock(UsageTaximeterConfig::class),
             new PremiumFeatureGate(new BillingService('', '')),
+            ChatRunServiceFactory::withoutRedis(),
         );
     }
 

--- a/backend/tests/Unit/Service/Chat/Run/ChatRunTest.php
+++ b/backend/tests/Unit/Service/Chat/Run/ChatRunTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\Chat\Run;
+
+use App\Service\Chat\Run\ChatRun;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The run record travels through Redis as JSON, so a lost or mistyped field
+ * silently breaks a re-attach: a dropped ownerKey would fail authorization for
+ * the rightful owner, a dropped status would leave a finished turn looking as
+ * if it were still generating.
+ */
+final class ChatRunTest extends TestCase
+{
+    public function testSurvivesTheRedisRoundTrip(): void
+    {
+        $run = new ChatRun('run-1', 'user:42', 7, 'track-abc');
+        $run->markTerminal(ChatRun::STATUS_COMPLETE)
+            ->setMessageId(915)
+            ->setLastSeq(12)
+            ->markTruncated();
+
+        $restored = ChatRun::fromArray(json_decode((string) json_encode($run->toArray()), true));
+
+        self::assertSame('run-1', $restored->getRunId());
+        self::assertSame('user:42', $restored->getOwnerKey());
+        self::assertSame(7, $restored->getChatId());
+        self::assertSame('track-abc', $restored->getTrackId());
+        self::assertSame(ChatRun::STATUS_COMPLETE, $restored->getStatus());
+        self::assertSame(915, $restored->getMessageId());
+        self::assertSame(12, $restored->getLastSeq());
+        self::assertTrue($restored->isTruncated());
+        self::assertSame($run->getCreated(), $restored->getCreated());
+        self::assertSame($run->getUpdated(), $restored->getUpdated());
+    }
+
+    public function testAnIncognitoStyleRunWithoutChatStaysChatless(): void
+    {
+        $run = ChatRun::fromArray(['runId' => 'run-2', 'ownerKey' => 'guest:s', 'chatId' => null, 'trackId' => 't']);
+
+        self::assertNull($run->getChatId());
+        self::assertFalse($run->isTerminal());
+        self::assertSame(ChatRun::STATUS_RUNNING, $run->getStatus());
+    }
+
+    public function testOnlyRunningCountsAsNonTerminal(): void
+    {
+        foreach ([ChatRun::STATUS_COMPLETE, ChatRun::STATUS_ERROR, ChatRun::STATUS_CANCELLED] as $status) {
+            $run = new ChatRun('run', 'user:1', 1, 't');
+            $run->markTerminal($status);
+
+            self::assertTrue($run->isTerminal(), $status.' must end the run');
+            self::assertSame($status, $run->getStatus());
+        }
+    }
+
+    public function testAnUnknownTerminalStatusDegradesToError(): void
+    {
+        // A caller passing something unexpected must still close the run —
+        // a run stuck on "running" would make every re-attach wait for a
+        // heartbeat that never ticks again.
+        $run = new ChatRun('run', 'user:1', 1, 't');
+        $run->markTerminal('whatever');
+
+        self::assertSame(ChatRun::STATUS_ERROR, $run->getStatus());
+        self::assertTrue($run->isTerminal());
+    }
+}

--- a/frontend/src/components/ChatBrowser.vue
+++ b/frontend/src/components/ChatBrowser.vue
@@ -298,6 +298,18 @@
                 <GlobeAltIcon class="w-3 h-3" />
                 <span class="text-xs font-medium">{{ $t('chat.browser.public') }}</span>
               </div>
+              <!--
+                A turn keeps generating after the tab that started it navigated
+                away, so mark the chats that are still worth returning to.
+              -->
+              <div
+                v-if="chatsStore.activeRunChatIds.has(chat.id)"
+                class="flex items-center gap-1.5 px-2 py-1 rounded-md text-[var(--brand)] bg-brand/10"
+                data-testid="indicator-chat-active-run"
+              >
+                <span class="w-1.5 h-1.5 rounded-full bg-[var(--brand)] animate-pulse" />
+                <span class="text-xs font-medium">{{ $t('chat.stillGenerating') }}</span>
+              </div>
             </div>
 
             <!-- Chat Title -->

--- a/frontend/src/components/SidebarV2.vue
+++ b/frontend/src/components/SidebarV2.vue
@@ -510,6 +510,15 @@
                     >
                       <Icon icon="mdi:link-variant" class="w-3 h-3" />
                     </span>
+                    <span
+                      v-if="isGenerating(chat)"
+                      class="text-[11px] text-[var(--brand)] flex items-center gap-1"
+                      :title="$t('chat.stillGenerating')"
+                      data-testid="indicator-chat-active-run"
+                    >
+                      <span class="w-1.5 h-1.5 rounded-full bg-[var(--brand)] animate-pulse" />
+                      <span class="sr-only">{{ $t('chat.stillGenerating') }}</span>
+                    </span>
                   </div>
                 </div>
 
@@ -925,6 +934,12 @@ const getDisplayTitle = (chat: StoreChat): string => {
 const formatTimestamp = (dateStr: string): string => {
   return formatRelativeTime(new Date(dateStr))
 }
+
+/**
+ * A turn keeps generating after the tab that started it navigated away, so the
+ * dot tells the user which chat is still worth returning to.
+ */
+const isGenerating = (chat: StoreChat): boolean => chatsStore.activeRunChatIds.has(chat.id)
 
 const getChannelIcon = (chat: StoreChat): string | null => {
   switch (chat.source) {

--- a/frontend/src/components/widgets/ChatWidget.vue
+++ b/frontend/src/components/widgets/ChatWidget.vue
@@ -1993,7 +1993,7 @@ const resumeActiveRun = async (runId: string, partialText: string) => {
     role: 'assistant',
     type: 'text',
     // Show what the turn already produced immediately; the replay that follows
-    // rewrites the same text and then continues past it.
+    // rebuilds the same text from the start and then continues past it.
     content: partialText,
     timestamp: new Date(),
     sender: 'ai',
@@ -2021,7 +2021,12 @@ const resumeActiveRun = async (runId: string, partialText: string) => {
         replayed += chunk
         const bubble = findBubble()
         if (!bubble) return
-        bubble.content = replayed
+        // The replay restarts the turn from its first token, so early chunks are
+        // shorter than the answer-so-far already painted above. Writing them
+        // straight through would rewind a long answer to its first word and
+        // re-type it; holding the painted text until the replay grows past it
+        // keeps the bubble moving forward only.
+        bubble.content = replayed.length >= partialText.length ? replayed : partialText
         await scrollToBottom()
       },
     })

--- a/frontend/src/components/widgets/ChatWidget.vue
+++ b/frontend/src/components/widgets/ChatWidget.vue
@@ -2000,7 +2000,14 @@ const resumeActiveRun = async (runId: string, partialText: string) => {
   })
   await scrollToBottom()
 
-  const appendTo = messages.value[messages.value.length - 1]
+  // Looked up by id rather than taken as the last entry: anything appended
+  // while the replay runs would otherwise receive the answer's text.
+  const findBubble = () => messages.value.find((m) => m.id === assistantMessageId)
+  const dropBubble = () => {
+    const idx = messages.value.findIndex((m) => m.id === assistantMessageId)
+    if (idx !== -1) messages.value.splice(idx, 1)
+  }
+
   let replayed = ''
 
   try {
@@ -2012,16 +2019,25 @@ const resumeActiveRun = async (runId: string, partialText: string) => {
         if (!chunk) return
         isTyping.value = false
         replayed += chunk
-        appendTo.content = replayed
+        const bubble = findBubble()
+        if (!bubble) return
+        bubble.content = replayed
         await scrollToBottom()
       },
     })
+
+    // Nothing was replayed and there was nothing to paint either — the turn
+    // most likely finished between the history read and the attach. Mirror the
+    // send path and let the persisted answer take over the empty bubble.
+    if (replayed === '' && partialText === '') {
+      dropBubble()
+      await loadConversationHistory(true)
+    }
   } catch (error) {
     console.error('Failed to re-attach to the running answer:', error)
     // The turn may have finished while we were re-attaching — the persisted
     // history is authoritative, so drop the provisional bubble and reload.
-    const idx = messages.value.findIndex((m) => m.id === assistantMessageId)
-    if (idx !== -1) messages.value.splice(idx, 1)
+    dropBubble()
     await loadConversationHistory(true)
   } finally {
     isTyping.value = false

--- a/frontend/src/components/widgets/ChatWidget.vue
+++ b/frontend/src/components/widgets/ChatWidget.vue
@@ -664,6 +664,7 @@ import {
 import {
   uploadWidgetFile,
   sendWidgetMessage,
+  attachWidgetStream,
   WidgetUnavailableError,
 } from '@/services/api/widgetsApi'
 import { useI18n } from 'vue-i18n'
@@ -884,6 +885,9 @@ const sessionId = ref<string>('')
 const isSending = ref(false)
 const chatId = ref<number | null>(null)
 const historyLoaded = ref(false)
+// Run this widget instance is already re-attached to, so a forced history
+// reload cannot open a second connection and render the same answer twice.
+const attachedRunId = ref<string | null>(null)
 const sessionCreatedEmitted = ref(false)
 const isLoadingHistory = ref(false)
 const widgetUnavailable = ref(false)
@@ -1972,6 +1976,59 @@ const normalizeServerMessage = (rawUnknown: unknown): Message => {
   }
 }
 
+/**
+ * Pick a still-generating turn back up after the visitor reloaded the host page.
+ *
+ * The backend keeps the turn alive across the disconnect and buffers its
+ * events, so this replays the answer so far and then follows it live into a
+ * fresh assistant bubble.
+ */
+const resumeActiveRun = async (runId: string, partialText: string) => {
+  if (!sessionId.value || attachedRunId.value === runId || isSending.value) return
+  attachedRunId.value = runId
+
+  const assistantMessageId = `run-${runId}`
+  messages.value.push({
+    id: assistantMessageId,
+    role: 'assistant',
+    type: 'text',
+    // Show what the turn already produced immediately; the replay that follows
+    // rewrites the same text and then continues past it.
+    content: partialText,
+    timestamp: new Date(),
+    sender: 'ai',
+  })
+  await scrollToBottom()
+
+  const appendTo = messages.value[messages.value.length - 1]
+  let replayed = ''
+
+  try {
+    isTyping.value = partialText === ''
+    await attachWidgetStream(props.widgetId, sessionId.value, runId, {
+      apiUrl: props.apiUrl,
+      headers: testModeHeaders.value,
+      onChunk: async (chunk: string) => {
+        if (!chunk) return
+        isTyping.value = false
+        replayed += chunk
+        appendTo.content = replayed
+        await scrollToBottom()
+      },
+    })
+  } catch (error) {
+    console.error('Failed to re-attach to the running answer:', error)
+    // The turn may have finished while we were re-attaching — the persisted
+    // history is authoritative, so drop the provisional bubble and reload.
+    const idx = messages.value.findIndex((m) => m.id === assistantMessageId)
+    if (idx !== -1) messages.value.splice(idx, 1)
+    await loadConversationHistory(true)
+  } finally {
+    isTyping.value = false
+    await scrollToBottom()
+  }
+}
+
 const loadConversationHistory = async (force = false) => {
   // In test/preview mode, skip loading real history but mark as loaded for auto message
   if (isTestEnvironment.value) {
@@ -2049,6 +2106,16 @@ const loadConversationHistory = async (force = false) => {
       } else if (loadedMessages.length > 0) {
         messageCount.value = loadedMessages.filter((m: Message) => m.role === 'user').length
         fileUploadCount.value = 0
+      }
+
+      // A turn that was still generating when the visitor reloaded the host
+      // page: keep watching it instead of losing the answer.
+      const activeRun = data.activeRun
+      if (isRecord(activeRun) && typeof activeRun.runId === 'string') {
+        void resumeActiveRun(
+          activeRun.runId,
+          typeof activeRun.partialText === 'string' ? activeRun.partialText : ''
+        )
       }
     }
   } catch (error) {

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -261,6 +261,7 @@
   "chat": {
     "title": "Chat",
     "newChat": "Neuer Chat",
+    "stillGenerating": "Antwortet noch",
     "quote": {
       "button": "Im Chat erwähnen",
       "remove": "Zitat entfernen"

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -266,6 +266,7 @@
     "config": "AI Config",
     "statistics": "Statistics",
     "newChat": "New Chat",
+    "stillGenerating": "Still answering",
     "quote": {
       "button": "Mention in chat",
       "remove": "Remove quote"

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -265,6 +265,7 @@
     "config": "Configuración de IA",
     "statistics": "Estadísticas",
     "newChat": "Nuevo Chat",
+    "stillGenerating": "Sigue respondiendo",
     "quote": {
       "button": "Mencionar en el chat",
       "remove": "Quitar cita"

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -266,6 +266,7 @@
     "config": "Config IA",
     "statistics": "Statistiques",
     "newChat": "Nouveau chat",
+    "stillGenerating": "Réponse en cours",
     "quote": {
       "button": "Mentionner dans le chat",
       "remove": "Retirer la citation"

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -265,6 +265,7 @@
     "config": "AI Yapılandırması",
     "statistics": "İstatistikler",
     "newChat": "Yeni Sohbet",
+    "stillGenerating": "Hâlâ yanıtlıyor",
     "quote": {
       "button": "Sohbette belirt",
       "remove": "Alıntıyı kaldır"

--- a/frontend/src/services/api/chatApi.ts
+++ b/frontend/src/services/api/chatApi.ts
@@ -387,31 +387,36 @@ export interface IncognitoHistoryEntry {
  * the client — the backend keeps streaming and persists the result
  * (detach-on-navigation, #1225); an explicit Stop goes through /stop-stream.
  */
-function openStreamPost(
-  body: Record<string, string | IncognitoHistoryEntry[]>,
-  onUpdate: (data: StreamUpdatePayload) => void
-): () => void {
-  const controller = new AbortController()
+/**
+ * Read one SSE response body, dispatching every frame to `onUpdate`.
+ *
+ * Shared by the streaming POST and the re-attach GET so both speak exactly the
+ * same event dialect — a re-attached turn must render through the identical
+ * handler as a live one, otherwise the two paths drift.
+ *
+ * Returns whether a terminal (`complete`) event was seen; the caller decides
+ * what a stream without one means.
+ */
+async function readSseBody(
+  body: ReadableStream<Uint8Array>,
+  onUpdate: (data: StreamUpdatePayload) => void,
+  isStopped: () => boolean,
+  onEventId?: (seq: number) => void
+): Promise<boolean> {
   let completionReceived = false
-  let isStopped = false
-
-  const authInit = sseTokenFetchInit()
-  const doFetch = () =>
-    fetch(`${getApiBaseUrl()}/api/v1/messages/stream`, {
-      method: 'POST',
-      credentials: authInit.credentials,
-      headers: {
-        ...(authInit.headers ?? {}),
-        'Content-Type': 'application/json',
-        Accept: 'text/event-stream',
-      },
-      body: JSON.stringify(body),
-      signal: controller.signal,
-    })
 
   const processEvent = (eventChunk: string) => {
-    const jsonStr = eventChunk
-      .split('\n')
+    const lines = eventChunk.split('\n')
+
+    // The attach endpoint tags every frame with its sequence number so a
+    // dropped re-attach can resume instead of replaying from the start.
+    const idLine = lines.find((line) => line.startsWith('id:'))
+    if (idLine && onEventId) {
+      const seq = Number.parseInt(idLine.slice(3).trim(), 10)
+      if (Number.isFinite(seq)) onEventId(seq)
+    }
+
+    const jsonStr = lines
       .filter((line) => line.startsWith('data:'))
       .map((line) => line.slice(5).trim())
       .filter(Boolean)
@@ -427,6 +432,58 @@ function openStreamPost(
       console.error('Failed to parse SSE data:', error, 'Raw data:', jsonStr)
     }
   }
+
+  const reader = body.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ''
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+
+      buffer += decoder.decode(value, { stream: true })
+      const events = buffer.split('\n\n')
+      buffer = events.pop() ?? ''
+
+      for (const eventChunk of events) {
+        if (isStopped()) return completionReceived
+        processEvent(eventChunk)
+      }
+    }
+
+    if (!isStopped() && buffer.trim() !== '') {
+      processEvent(buffer)
+    }
+  } finally {
+    reader.cancel().catch(() => {
+      // ignore cancellation errors
+    })
+  }
+
+  return completionReceived
+}
+
+function openStreamPost(
+  body: Record<string, string | IncognitoHistoryEntry[]>,
+  onUpdate: (data: StreamUpdatePayload) => void
+): () => void {
+  const controller = new AbortController()
+  let isStopped = false
+
+  const authInit = sseTokenFetchInit()
+  const doFetch = () =>
+    fetch(`${getApiBaseUrl()}/api/v1/messages/stream`, {
+      method: 'POST',
+      credentials: authInit.credentials,
+      headers: {
+        ...(authInit.headers ?? {}),
+        'Content-Type': 'application/json',
+        Accept: 'text/event-stream',
+      },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    })
 
   ;(async () => {
     try {
@@ -462,33 +519,7 @@ function openStreamPost(
         return
       }
 
-      const reader = response.body.getReader()
-      const decoder = new TextDecoder()
-      let buffer = ''
-
-      try {
-        while (true) {
-          const { done, value } = await reader.read()
-          if (done) break
-
-          buffer += decoder.decode(value, { stream: true })
-          const events = buffer.split('\n\n')
-          buffer = events.pop() ?? ''
-
-          for (const eventChunk of events) {
-            if (isStopped) return
-            processEvent(eventChunk)
-          }
-        }
-
-        if (!isStopped && buffer.trim() !== '') {
-          processEvent(buffer)
-        }
-      } finally {
-        reader.cancel().catch(() => {
-          // ignore cancellation errors
-        })
-      }
+      const completionReceived = await readSseBody(response.body, onUpdate, () => isStopped)
 
       // Stream closed without a terminal event: the backend always ends a
       // turn with 'complete' or 'error', so this is a dropped connection or
@@ -510,6 +541,128 @@ function openStreamPost(
     isStopped = true
     controller.abort()
   }
+}
+
+/** Identity a re-attach request needs when it is not an authenticated app user. */
+export interface AttachStreamIdentity {
+  /** Guest chat: the server-issued guest session id. */
+  guestSessionId?: string
+  /** Embedded widget: the widget id + its server-issued session id. */
+  widgetId?: string
+  widgetSessionId?: string
+}
+
+export interface AttachStreamOptions extends AttachStreamIdentity {
+  /** Run id from the `run_started` event or from `activeRun` in the history response. */
+  runId: string
+  /** Replay events after this sequence number; 0 replays the whole turn. */
+  from?: number
+  onUpdate: (data: StreamUpdatePayload) => void
+}
+
+/**
+ * Re-attach to a turn that is still generating on the server.
+ *
+ * The backend keeps a turn alive across a client disconnect and mirrors its
+ * events into a replayable log, so this replays whatever was missed and then
+ * follows the live tail — a reload or a trip to another view continues the
+ * answer instead of losing it.
+ *
+ * If the attach connection itself drops before the turn ends, it resumes once
+ * from the last sequence number it saw. A second failure is reported as a
+ * regular transport drop, which the chat view recovers from by reloading the
+ * persisted history.
+ *
+ * Returns a cleanup function that detaches without affecting the turn.
+ */
+function openStreamAttach(opts: AttachStreamOptions): () => void {
+  const controller = new AbortController()
+  let isStopped = false
+  let cursor = opts.from ?? 0
+
+  const authInit = sseTokenFetchInit()
+  const headers: Record<string, string> = {
+    ...((authInit.headers as Record<string, string> | undefined) ?? {}),
+    Accept: 'text/event-stream',
+  }
+  if (opts.widgetId && opts.widgetSessionId) {
+    headers['X-Widget-Id'] = opts.widgetId
+    headers['X-Widget-Session'] = opts.widgetSessionId
+  }
+
+  const doFetch = () => {
+    const params = new URLSearchParams({ runId: opts.runId, from: String(cursor) })
+    if (opts.guestSessionId) params.set('guestSession', opts.guestSessionId)
+
+    return fetch(`${getApiBaseUrl()}/api/v1/messages/stream/attach?${params}`, {
+      method: 'GET',
+      credentials: authInit.credentials,
+      headers,
+      signal: controller.signal,
+    })
+  }
+
+  ;(async () => {
+    try {
+      for (let attempt = 0; attempt < 2; attempt++) {
+        let response = await doFetch()
+
+        if (response.status === 401) {
+          const refreshed = await refreshAccessToken()
+          if (refreshed && !isStopped) {
+            response = await doFetch()
+          }
+        }
+
+        if (isStopped) return
+
+        // 404 means the run is gone (expired, or it finished and its short
+        // terminal retention lapsed). Nothing to replay — hand the caller the
+        // same transport-drop signal a mid-turn disconnect produces so it
+        // recovers from the persisted history.
+        if (!response.ok || !response.body) {
+          onAttachDrop(opts.onUpdate)
+          return
+        }
+
+        const completionReceived = await readSseBody(
+          response.body,
+          opts.onUpdate,
+          () => isStopped,
+          (seq) => {
+            cursor = seq
+          }
+        )
+
+        if (completionReceived || isStopped) return
+      }
+
+      // Two attempts, still no terminal event: treat it as a dropped stream.
+      // The turn may well have finished in the meantime — the chat view
+      // resolves that by reconciling with the server.
+      onAttachDrop(opts.onUpdate)
+    } catch (error) {
+      if (isStopped || (error instanceof DOMException && error.name === 'AbortError')) {
+        return
+      }
+      console.error('🚫 Stream re-attach failed:', error)
+      onAttachDrop(opts.onUpdate)
+    }
+  })()
+
+  return () => {
+    isStopped = true
+    controller.abort()
+  }
+}
+
+/**
+ * Report a re-attach that ended without the turn completing, using the exact
+ * message the live transport emits for a dropped connection so both paths land
+ * in the same recovery (see `isRecoverableStreamError`).
+ */
+function onAttachDrop(onUpdate: (data: StreamUpdatePayload) => void): void {
+  onUpdate({ status: 'error', error: 'Connection interrupted' })
 }
 
 export const chatApi = {
@@ -588,6 +741,15 @@ export const chatApi = {
     // POST transport: parameters travel in the JSON body, so long pasted
     // texts never hit URL length limits and no auth token leaks into the URL.
     return openStreamPost(paramsObj, opts.onUpdate)
+  },
+
+  /**
+   * Re-attach to a turn that is still generating (page reload, chat switch,
+   * second tab). Events arrive through the same `onUpdate` contract as
+   * `streamMessage`, so the caller renders them with the identical handler.
+   */
+  attachStream(opts: AttachStreamOptions): () => void {
+    return openStreamAttach(opts)
   },
 
   async getHistory(limit = 50, trackId?: number): Promise<unknown> {

--- a/frontend/src/services/api/chatApi.ts
+++ b/frontend/src/services/api/chatApi.ts
@@ -394,8 +394,13 @@ export interface IncognitoHistoryEntry {
  * same event dialect — a re-attached turn must render through the identical
  * handler as a live one, otherwise the two paths drift.
  *
- * Returns whether a terminal (`complete`) event was seen; the caller decides
- * what a stream without one means.
+ * Returns whether a terminal event was seen; the caller decides what a stream
+ * without one means. `complete` AND `error` both end a turn — every
+ * `sendSSE('error', …)` in the backend returns right after it, and the run log
+ * marks both as terminal. Counting only `complete` would make a genuine backend
+ * failure (rate limit, cost budget, missing model) look like a dropped
+ * connection, so the caller would retry the turn and then append a bogus
+ * "Connection interrupted" on top of the real error the user needs to read.
  */
 async function readSseBody(
   body: ReadableStream<Uint8Array>,
@@ -403,7 +408,7 @@ async function readSseBody(
   isStopped: () => boolean,
   onEventId?: (seq: number) => void
 ): Promise<boolean> {
-  let completionReceived = false
+  let terminalReceived = false
 
   const processEvent = (eventChunk: string) => {
     const lines = eventChunk.split('\n')
@@ -426,7 +431,7 @@ async function readSseBody(
 
     try {
       const data = JSON.parse(jsonStr) as StreamUpdatePayload
-      completionReceived = completionReceived || data.status === 'complete'
+      terminalReceived = terminalReceived || data.status === 'complete' || data.status === 'error'
       onUpdate(data)
     } catch (error) {
       console.error('Failed to parse SSE data:', error, 'Raw data:', jsonStr)
@@ -447,7 +452,7 @@ async function readSseBody(
       buffer = events.pop() ?? ''
 
       for (const eventChunk of events) {
-        if (isStopped()) return completionReceived
+        if (isStopped()) return terminalReceived
         processEvent(eventChunk)
       }
     }
@@ -461,7 +466,7 @@ async function readSseBody(
     })
   }
 
-  return completionReceived
+  return terminalReceived
 }
 
 function openStreamPost(
@@ -519,12 +524,12 @@ function openStreamPost(
         return
       }
 
-      const completionReceived = await readSseBody(response.body, onUpdate, () => isStopped)
+      const terminalReceived = await readSseBody(response.body, onUpdate, () => isStopped)
 
       // Stream closed without a terminal event: the backend always ends a
       // turn with 'complete' or 'error', so this is a dropped connection or
       // a crashed worker — surface it instead of leaving an empty bubble.
-      if (!completionReceived && !isStopped) {
+      if (!terminalReceived && !isStopped) {
         console.error('❌ Stream ended without completion event')
         onUpdate({ status: 'error', error: 'Connection interrupted' })
       }
@@ -625,7 +630,7 @@ function openStreamAttach(opts: AttachStreamOptions): () => void {
           return
         }
 
-        const completionReceived = await readSseBody(
+        const terminalReceived = await readSseBody(
           response.body,
           opts.onUpdate,
           () => isStopped,
@@ -634,7 +639,10 @@ function openStreamAttach(opts: AttachStreamOptions): () => void {
           }
         )
 
-        if (completionReceived || isStopped) return
+        // The turn is over — either it finished or it failed, and the caller
+        // has already been handed that outcome. Retrying would replay the log a
+        // second time and then report a drop that never happened.
+        if (terminalReceived || isStopped) return
       }
 
       // Two attempts, still no terminal event: treat it as a dropped stream.

--- a/frontend/src/services/api/widgetsApi.ts
+++ b/frontend/src/services/api/widgetsApi.ts
@@ -243,14 +243,7 @@ export async function sendWidgetMessage(
   sessionId: string,
   options: SendWidgetMessageOptions = {}
 ): Promise<SendWidgetMessageResult> {
-  const {
-    chatId,
-    fileIds,
-    externalUserId,
-    apiUrl: apiUrlOverride,
-    headers: extraHeaders,
-    onStatus,
-  } = options
+  const { chatId, fileIds, externalUserId, apiUrl: apiUrlOverride, headers: extraHeaders } = options
 
   const config = useConfigStore()
   const apiUrl = apiUrlOverride ?? config.apiBaseUrl
@@ -301,6 +294,22 @@ export async function sendWidgetMessage(
     const error = await response.json().catch(() => ({ error: 'Unknown error' }))
     throw new Error(error.error || `HTTP ${response.status}`)
   }
+
+  return consumeWidgetStream(response, options, chatId)
+}
+
+/**
+ * Read a widget SSE response to the end.
+ *
+ * Shared by the send path and the re-attach path so a turn picked back up
+ * after a reload renders through exactly the same event handling as a live one.
+ */
+async function consumeWidgetStream(
+  response: Response,
+  options: SendWidgetMessageOptions,
+  chatId?: number
+): Promise<SendWidgetMessageResult> {
+  const { onStatus } = options
 
   const decoder = new TextDecoder()
   let buffer = ''
@@ -439,6 +448,51 @@ export async function sendWidgetMessage(
     remainingUploads,
     text: aggregatedText,
   }
+}
+
+/**
+ * Re-attach to a widget turn that is still generating on the server.
+ *
+ * A visitor who reloads the host page mid-answer would otherwise lose it: the
+ * backend keeps the turn alive across the disconnect and buffers its events, so
+ * this replays what was missed and then follows the live tail. `runId` comes
+ * from `activeRun` in the session history response.
+ */
+export async function attachWidgetStream(
+  widgetId: string,
+  sessionId: string,
+  runId: string,
+  options: SendWidgetMessageOptions = {}
+): Promise<SendWidgetMessageResult> {
+  const config = useConfigStore()
+  const apiUrl = options.apiUrl ?? config.apiBaseUrl
+
+  const headers: Record<string, string> = {
+    Accept: 'text/event-stream',
+    'X-Widget-Id': widgetId,
+    'X-Widget-Session': sessionId,
+    ...(options.headers ?? {}),
+  }
+
+  const isDashboardMode =
+    options.headers?.['X-Widget-Test-Mode'] === 'true' ||
+    options.headers?.['X-Widget-Internal-Mode'] === 'true'
+
+  const params = new URLSearchParams({ runId, from: '0' })
+  const response = await fetch(`${apiUrl}/api/v1/messages/stream/attach?${params.toString()}`, {
+    method: 'GET',
+    headers,
+    credentials: isDashboardMode ? 'include' : 'omit',
+  })
+
+  if (!response.ok) {
+    if (response.status === 404 || response.status === 503) {
+      throw new WidgetUnavailableError(response.status)
+    }
+    throw new Error(`Re-attach failed with status ${response.status}`)
+  }
+
+  return consumeWidgetStream(response, options, options.chatId)
 }
 
 /**

--- a/frontend/src/stores/chats.ts
+++ b/frontend/src/stores/chats.ts
@@ -166,6 +166,28 @@ export const useChatsStore = defineStore('chats', () => {
   }
 
   /**
+   * Flag a chat as generating (or no longer generating) without waiting for the
+   * next chat-list fetch.
+   *
+   * `loadChats()` is the server's word on this, but it only runs on entry, so on
+   * its own the marker would be a snapshot from app start: it would never light
+   * up when the user walks away from a running turn, and never go out when that
+   * turn finishes. The chat view drives it live from the stream's own
+   * `run_started` and terminal events instead.
+   */
+  function markChatGenerating(chatId: number, generating: boolean) {
+    // Replaced rather than mutated: a Set is not deeply reactive, so template
+    // reads of activeRunChatIds would not re-render on add/delete alone.
+    const next = new Set(activeRunChatIds.value)
+    if (generating) {
+      next.add(chatId)
+    } else {
+      next.delete(chatId)
+    }
+    activeRunChatIds.value = next
+  }
+
+  /**
    * Load one page of the paginated chat history for the mobile drawer.
    *
    * @param reset When true, start over at offset 0 and replace the list
@@ -519,6 +541,7 @@ export const useChatsStore = defineStore('chats', () => {
     historyLoading,
     historyHasMore,
     activeRunChatIds,
+    markChatGenerating,
     loadChats,
     loadChatHistory,
     createChat,

--- a/frontend/src/stores/chats.ts
+++ b/frontend/src/stores/chats.ts
@@ -76,6 +76,13 @@ export const useChatsStore = defineStore('chats', () => {
   const historyHasMore = ref(true)
   const historyOffset = ref(0)
 
+  /**
+   * Chats whose answer is still being written on the server. A turn survives
+   * the client disconnect it was started from, so this marks the chats a user
+   * can return to and keep watching.
+   */
+  const activeRunChatIds = ref<Set<number>>(new Set())
+
   const normalizeChat = (chat: unknown): Chat => {
     const c = chat as Chat
     return {
@@ -144,8 +151,11 @@ export const useChatsStore = defineStore('chats', () => {
     error.value = null
 
     try {
-      const data = await httpClient<{ chats: unknown[] }>('/api/v1/chats')
+      const data = await httpClient<{ chats: unknown[]; activeRunChatIds?: number[] }>(
+        '/api/v1/chats'
+      )
       chats.value = (data.chats || []).map((chat) => normalizeChat(chat))
+      activeRunChatIds.value = new Set(data.activeRunChatIds ?? [])
       ensureValidActiveChat()
     } catch (err: unknown) {
       error.value = getErrorMessage(err) || 'Failed to load chats'
@@ -489,6 +499,7 @@ export const useChatsStore = defineStore('chats', () => {
 
   function $reset() {
     chats.value = []
+    activeRunChatIds.value = new Set()
     historyChats.value = []
     historyOffset.value = 0
     historyHasMore.value = true
@@ -507,6 +518,7 @@ export const useChatsStore = defineStore('chats', () => {
     historyChats,
     historyLoading,
     historyHasMore,
+    activeRunChatIds,
     loadChats,
     loadChatHistory,
     createChat,

--- a/frontend/src/stores/guest.ts
+++ b/frontend/src/stores/guest.ts
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
 import { getApiBaseUrl, redirectToSetupWizard } from '@/services/api/httpClient'
-import type { ApiLoadedMessageRow } from '@/utils/messageMapper'
+import type { ApiActiveRun, ApiLoadedMessageRow } from '@/utils/messageMapper'
 
 export const GUEST_STORAGE_KEY = 'synaplan_guest_session'
 export const GUEST_BANNER_DISMISSED_KEY = 'synaplan_guest_banner_dismissed'
@@ -29,6 +29,8 @@ export const useGuestStore = defineStore('guest', () => {
   // Persisted so a dismissed banner stays gone across app restarts / reloads
   // for the same browser profile (cleared only on logout / session reset).
   const bannerDismissed = ref(loadBannerDismissed())
+  /** A turn of this session that is still generating on the server. */
+  const activeRun = ref<ApiActiveRun | null>(null)
 
   const remainingMessages = computed(() => Math.max(0, maxMessages.value - messageCount.value))
   const isGuestMode = computed(() => !!sessionId.value)
@@ -184,6 +186,10 @@ export const useGuestStore = defineStore('guest', () => {
       if (!response.ok) return []
 
       const data = await response.json()
+      // A turn still generating for this session: reloading the page detached
+      // the client, but the backend kept the turn alive and buffered its
+      // events, so the chat view can re-attach and keep rendering it.
+      activeRun.value = (data.activeRun as ApiActiveRun | undefined) ?? null
       return data.messages ?? []
     } catch {
       return []
@@ -245,6 +251,7 @@ export const useGuestStore = defineStore('guest', () => {
     rateLimited,
     sessionExpired,
     bannerDismissed,
+    activeRun,
     remainingMessages,
     isGuestMode,
     shouldShowBanner,

--- a/frontend/src/stores/history.ts
+++ b/frontend/src/stores/history.ts
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 import type { AgainData } from '@/types/ai-models'
-import type { ApiInProgressTurn, ApiLoadedMessageRow } from '@/utils/messageMapper'
+import type { ApiActiveRun, ApiInProgressTurn, ApiLoadedMessageRow } from '@/utils/messageMapper'
 import {
   IN_PROGRESS_TURN_ID,
   mapApiMessageRow,
@@ -390,6 +390,16 @@ export const useHistoryStore = defineStore('history', () => {
   const currentOffset = ref(0)
   const inProgressPollIntervalMs = 2000
 
+  /**
+   * A turn of the loaded chat that is STILL generating on the server.
+   *
+   * The backend keeps a turn alive across a client disconnect and buffers its
+   * events, so a reload or a trip to another view can pick it back up. The
+   * store only reports it; ChatView owns the re-attach because rendering the
+   * events needs its stream handler.
+   */
+  const activeRun = ref<ApiActiveRun | null>(null)
+
   // Monotonic generation counter: incremented each time loadMessages is called
   // for a fresh chat (offset === 0). Responses from older generations are
   // discarded so a slow response for a previous chat never overwrites the
@@ -564,6 +574,7 @@ export const useHistoryStore = defineStore('history', () => {
     messages.value = []
     currentOffset.value = 0
     hasMoreMessages.value = false
+    activeRun.value = null
   }
 
   const loadMessages = async (chatId: number, offset = 0, limit = 50, silent = false) => {
@@ -596,12 +607,18 @@ export const useHistoryStore = defineStore('history', () => {
         messages?: ApiLoadedMessageRow[]
         pagination?: { hasMore?: boolean }
         inProgressTurn?: ApiInProgressTurn | null
+        activeRun?: ApiActiveRun | null
       }
 
       if (myGeneration !== loadGeneration) return
 
       if (response.success && response.messages) {
         const loadedMessages: Message[] = response.messages.map(mapApiMessageRow)
+
+        // Only the first page carries it, and only while the turn runs.
+        if (offset === 0) {
+          activeRun.value = response.activeRun ?? null
+        }
 
         // Issue #1142: append a provisional assistant bubble for a still-running
         // multi-task turn (only sent on the first page) so returning mid-stream
@@ -755,6 +772,7 @@ export const useHistoryStore = defineStore('history', () => {
     messages,
     isLoadingMessages,
     hasMoreMessages,
+    activeRun,
     addMessage,
     addStreamingMessage,
     updateStreamingMessage,

--- a/frontend/src/types/chatStream.ts
+++ b/frontend/src/types/chatStream.ts
@@ -112,6 +112,12 @@ export interface StreamPerfPayload {
 export interface StreamUpdatePayload {
   status?: string
   chunk?: string
+  /**
+   * Id of the resumable run backing this turn, sent once as `run_started`.
+   * Lets the client re-attach to the still-generating turn after a reload or
+   * a trip to another view (`chatApi.attachStream`).
+   */
+  runId?: string
   error?: string
   message?: string
   messageId?: number

--- a/frontend/src/utils/messageMapper.ts
+++ b/frontend/src/utils/messageMapper.ts
@@ -566,6 +566,21 @@ export interface ApiInProgressTurn {
   }>
 }
 
+/**
+ * A turn that is still generating, as reported by the chat history endpoints.
+ *
+ * The backend keeps a turn alive after the client that started it disconnects
+ * and mirrors its Server-Sent Events into a replayable log. `partialText` is
+ * the answer so far (for an instant repaint) and `runId` is what the client
+ * re-attaches to in order to receive the rest live.
+ */
+export interface ApiActiveRun {
+  runId: string
+  trackId: string
+  lastSeq: number
+  partialText: string
+}
+
 /** Stable client id for the synthesized in-progress assistant bubble (#1142). */
 export const IN_PROGRESS_TURN_ID = 'in-progress-turn'
 

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -504,6 +504,7 @@ import ModelMixControl from '@/components/chat/ModelMixControl.vue'
 import ModelMixPanel from '@/components/chat/ModelMixPanel.vue'
 import { useModelMixStore } from '@/stores/modelMix'
 import type { IncognitoHistoryEntry } from '@/services/api/chatApi'
+import type { StreamUpdatePayload } from '@/types/chatStream'
 import { useLimitCheck, type LimitCheckResult } from '@/composables/useLimitCheck'
 import { useNotification } from '@/composables/useNotification'
 import { chatApi } from '@/services/api'
@@ -770,6 +771,10 @@ let streamingAbortController: AbortController | null = null
 let stopStreamingFn: (() => void) | null = null // Store EventSource close function
 let currentTrackId: number | undefined = undefined // Store current trackId for stop request
 let currentStreamingChatId: number | undefined = undefined // Store chatId where stream was started
+// Run this view is already re-attached to, so a repeated history load (the 2s
+// in-progress poll, a chat switch back and forth) cannot open a second
+// connection and render the same answer twice.
+let attachedRunId: string | null = null
 let currentAudioStreamer: AudioStreamer | null = null
 const isAudioStreaming = ref(false)
 
@@ -895,6 +900,10 @@ onMounted(async () => {
         await nextTick()
         scrollToBottom()
       }
+
+      // A turn that was still generating when the guest reloaded keeps writing
+      // into a fresh bubble instead of being lost.
+      void resumeActiveRunIfAny()
     }
 
     const restricted = route.query.restricted as string | undefined
@@ -952,6 +961,9 @@ onMounted(async () => {
   } else {
     // Load messages for active chat
     await historyStore.loadMessages(chatsStore.activeChatId)
+    // A turn that was still generating when the page was reloaded keeps
+    // writing into this bubble instead of being lost.
+    void resumeActiveRunIfAny()
   }
 
   // Usage taximeter: seed today's totals once and rebuild the session from the
@@ -1081,6 +1093,28 @@ function handleNavigateAway() {
   finishStreamingTurnLocally()
 }
 
+/**
+ * Pick a still-generating turn back up after a reload, a chat switch, or a trip
+ * to another view.
+ *
+ * The backend keeps a turn alive across the disconnect and buffers its events,
+ * and the chat history response reports it as `activeRun`. Re-attaching replays
+ * what was missed and then follows the live tail, so the answer keeps writing
+ * itself instead of leaving the user on a bare prompt until it is persisted.
+ */
+async function resumeActiveRunIfAny() {
+  const run = isGuestMode.value ? guestStore.activeRun : historyStore.activeRun
+  if (!run) return
+
+  // Already rendering this turn — either the tab that started it never left, or
+  // a silent in-progress poll re-reported the same run. Attaching again would
+  // produce a second bubble for one answer.
+  if (attachedRunId === run.runId || isStreaming.value) return
+
+  attachedRunId = run.runId
+  await streamAIResponse('', { attach: { runId: run.runId, partialText: run.partialText } })
+}
+
 // Cleanup: detach the running stream when the component unmounts (user leaves chat)
 onBeforeUnmount(() => {
   isViewUnmounted = true
@@ -1189,6 +1223,12 @@ watch(
       // loadMessages() replaces messages when offset=0, making clear() redundant.
       // Calling clear() first causes empty chat if loadMessages() fails silently.
       await historyStore.loadMessages(newChatId)
+
+      // Coming back to a chat whose turn is still generating: keep watching it
+      // live. A different chat means a different run, so the previous
+      // attachment no longer applies.
+      attachedRunId = null
+      void resumeActiveRunIfAny()
 
       // Usage taximeter: a chat switch resets the session (not the day totals)
       // and rebuilds it from the newly loaded history.
@@ -2176,9 +2216,17 @@ const streamAIResponse = async (
     ragGroupKey?: string
     quotedText?: string
     quotedMessageId?: number
+    /**
+     * Re-attach to a turn already generating on the server instead of starting
+     * a new one. `userMessage` is then irrelevant — nothing is sent, the client
+     * only subscribes to the turn's buffered events.
+     */
+    attach?: { runId: string; partialText: string }
   }
 ) => {
   streamingAbortController = new AbortController()
+
+  const attach = options?.attach
 
   const currentModel =
     aiConfigStore.models.CHAT?.find((model) => model.id === options?.modelId) ??
@@ -2188,6 +2236,14 @@ const streamAIResponse = async (
 
   // Create empty streaming message with provider info
   const messageId = historyStore.addStreamingMessage('assistant', provider, modelLabel)
+
+  // Paint what the turn already produced right away, so returning to a running
+  // chat shows the answer-so-far instead of an empty bubble. The replay that
+  // follows rebuilds the identical text from sequence 0 and takes over; the
+  // render is rAF-throttled, so the rebuild lands as a single repaint.
+  if (attach?.partialText) {
+    historyStore.updateStreamingMessage(messageId, attach.partialText)
+  }
 
   let streamingRafId: number | null = null
   let streamingDirty = false
@@ -2225,14 +2281,17 @@ const streamAIResponse = async (
       processingStatus.value = 'started'
       processingMetadata.value = {}
 
-      const stopStreaming = chatApi.streamGuestMessage({
+      // The handler lives on an options object rather than inline at the call
+      // site so the re-attach transport can reuse the exact same one — a turn
+      // picked back up after a reload must render through identical logic.
+      const guestStreamOptions = {
         guestSessionId: guestStore.sessionId,
         message: userMessage,
         chatId: guestChatId,
         trackId,
         quotedText: options?.quotedText,
         quotedMessageId: options?.quotedMessageId,
-        onUpdate: (data) => {
+        onUpdate: (data: StreamUpdatePayload) => {
           if (streamingAbortController?.signal.aborted) return
 
           if (data.status === 'guest_limit_reached') {
@@ -2261,6 +2320,22 @@ const streamAIResponse = async (
             const reached = (data as Record<string, unknown>).limitReached as boolean
             guestStore.updateCount(remaining, max, reached)
             guestStore.showBanner()
+            return
+          }
+
+          if (data.status === 'run_started') {
+            // The server opened a resumable run for this turn. Remembering it
+            // keeps a later history load from attaching a second time to the
+            // turn this tab is already rendering.
+            if (typeof data.runId === 'string') attachedRunId = data.runId
+            return
+          }
+
+          if (data.status === 'run_started') {
+            // The server opened a resumable run for this turn. Remembering it
+            // keeps a later history load from attaching a second time to the
+            // turn this tab is already rendering.
+            if (typeof data.runId === 'string') attachedRunId = data.runId
             return
           }
 
@@ -2658,7 +2733,15 @@ const streamAIResponse = async (
             historyStore.finishStreamingMessage(messageId)
           }
         },
-      })
+      }
+
+      const stopStreaming = attach
+        ? chatApi.attachStream({
+            runId: attach.runId,
+            guestSessionId: guestStore.sessionId,
+            onUpdate: guestStreamOptions.onUpdate,
+          })
+        : chatApi.streamGuestMessage(guestStreamOptions)
 
       stopStreamingFn = stopStreaming
     } else {
@@ -2717,7 +2800,10 @@ const streamAIResponse = async (
         })
       }
 
-      const stopStreaming = chatApi.streamMessage({
+      // The handler lives on an options object rather than inline at the call
+      // site so the re-attach transport can reuse the exact same one — a turn
+      // picked back up after a reload must render through identical logic.
+      const streamOptions = {
         userId,
         message: userMessage,
         trackId,
@@ -2734,7 +2820,7 @@ const streamAIResponse = async (
         ragGroupKey: options?.ragGroupKey,
         quotedText: options?.quotedText,
         quotedMessageId: options?.quotedMessageId,
-        onUpdate: (data) => {
+        onUpdate: (data: StreamUpdatePayload) => {
           // CRITICAL: Check abort signal at the very beginning
           if (streamingAbortController?.signal.aborted) {
             return
@@ -3802,7 +3888,11 @@ const streamAIResponse = async (
             console.warn('⚠️ Unknown status:', data.status, data)
           }
         },
-      })
+      }
+
+      const stopStreaming = attach
+        ? chatApi.attachStream({ runId: attach.runId, onUpdate: streamOptions.onUpdate })
+        : chatApi.streamMessage(streamOptions)
 
       // Store EventSource cleanup function globally
       stopStreamingFn = stopStreaming

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -2309,11 +2309,25 @@ const streamAIResponse = async (
   const messageId = historyStore.addStreamingMessage('assistant', provider, modelLabel)
 
   // Paint what the turn already produced right away, so returning to a running
-  // chat shows the answer-so-far instead of an empty bubble. The replay that
-  // follows rebuilds the identical text from sequence 0 and takes over; the
-  // render is rAF-throttled, so the rebuild lands as a single repaint.
-  if (attach?.partialText) {
-    historyStore.updateStreamingMessage(messageId, attach.partialText)
+  // chat shows the answer-so-far instead of an empty bubble.
+  const paintedPrefix = attach?.partialText ?? ''
+  if (paintedPrefix) {
+    historyStore.updateStreamingMessage(messageId, paintedPrefix)
+  }
+
+  /**
+   * Render streamed text without ever letting the bubble shrink.
+   *
+   * The re-attach replays the turn from sequence 0 (which is what rebuilds the
+   * task cards and memory badges, so shortening the replay is not an option),
+   * meaning the first replayed chunks are far SHORTER than the answer-so-far
+   * already on screen. Rendering them verbatim would visibly rewind a long
+   * answer back to its first word and then re-type it. Holding the painted
+   * prefix until the replay grows past it keeps the text moving forward only;
+   * from there the replay is longer and takes over on its own.
+   */
+  const renderStreamingText = (text: string) => {
+    renderStreamingContent(text.length >= paintedPrefix.length ? text : paintedPrefix, messageId)
   }
 
   let streamingRafId: number | null = null
@@ -2593,7 +2607,7 @@ const streamAIResponse = async (
                 streamingRafId = null
                 if (!streamingDirty) return
                 streamingDirty = false
-                renderStreamingContent(fullContent, messageId)
+                renderStreamingText(fullContent)
               })
             }
           } else if (data.status === 'reasoning' && data.chunk) {
@@ -2673,7 +2687,7 @@ const streamAIResponse = async (
             }
 
             if (fullContent) {
-              renderStreamingContent(fullContent, messageId)
+              renderStreamingText(fullContent)
             } else if (data.mediaJob || data.media_job) {
               renderStreamingContent(
                 generatingTokenForMediaJob(data.mediaJob ?? data.media_job),
@@ -3227,7 +3241,7 @@ const streamAIResponse = async (
                 streamingRafId = null
                 if (!streamingDirty) return
                 streamingDirty = false
-                renderStreamingContent(fullContent, messageId)
+                renderStreamingText(fullContent)
               })
             }
           } else if (data.status === 'reasoning' && data.chunk) {
@@ -3473,7 +3487,7 @@ const streamAIResponse = async (
             streamingDirty = false
 
             if (fullContent) {
-              renderStreamingContent(fullContent, messageId)
+              renderStreamingText(fullContent)
             } else if (data.mediaJob || data.media_job) {
               renderStreamingContent(
                 generatingTokenForMediaJob(data.mediaJob ?? data.media_job),

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -526,6 +526,7 @@ import {
   parseMediaJobPayload,
   applyMediaJobUpdateToMessage,
   mapApiMessageRow,
+  IN_PROGRESS_TURN_ID,
 } from '@/utils/messageMapper'
 import type { UserMemory } from '@/services/api/userMemoriesApi'
 import { getCategories, deleteMemory as deleteMemoryApi } from '@/services/api/userMemoriesApi'
@@ -775,6 +776,8 @@ let currentStreamingChatId: number | undefined = undefined // Store chatId where
 // in-progress poll, a chat switch back and forth) cannot open a second
 // connection and render the same answer twice.
 let attachedRunId: string | null = null
+// Chat currently marked as "still answering" in the sidebar by this view.
+let generatingChatId: number | null = null
 let currentAudioStreamer: AudioStreamer | null = null
 const isAudioStreaming = ref(false)
 
@@ -1094,6 +1097,55 @@ function handleNavigateAway() {
 }
 
 /**
+ * Remember the resumable run the server opened for the turn this view is
+ * rendering, and mark its chat in the sidebar.
+ *
+ * The run id keeps a later history load from attaching a second time to a turn
+ * this tab already renders. The sidebar mark is what makes leaving mid-answer
+ * visible: the turn keeps generating, so the user needs to see which chat is
+ * worth returning to.
+ */
+function noteRunStarted(runId: unknown) {
+  if (typeof runId !== 'string' || runId === '') return
+
+  attachedRunId = runId
+
+  // Guests have no chat list to mark.
+  if (isGuestMode.value) return
+
+  // Tracked separately from currentStreamingChatId even though it starts from
+  // it: navigate-away clears that one while the turn deliberately keeps running,
+  // which is exactly when the marker has to stay.
+  generatingChatId = currentStreamingChatId ?? chatsStore.activeChatId ?? null
+  if (null !== generatingChatId) {
+    chatsStore.markChatGenerating(generatingChatId, true)
+  }
+}
+
+/**
+ * The turn ended on the wire. Releasing the run id lets the chat be picked up
+ * again later.
+ *
+ * A recoverable transport drop is NOT the end of the turn server-side — it keeps
+ * generating for whoever comes back — so that case deliberately keeps the
+ * sidebar marker, which is exactly what it exists to show.
+ */
+function noteRunTerminal(data: StreamUpdatePayload) {
+  attachedRunId = null
+
+  if (isRecoverableStreamError(data)) return
+
+  clearGeneratingMark()
+}
+
+function clearGeneratingMark() {
+  if (null !== generatingChatId) {
+    chatsStore.markChatGenerating(generatingChatId, false)
+    generatingChatId = null
+  }
+}
+
+/**
  * Pick a still-generating turn back up after a reload, a chat switch, or a trip
  * to another view.
  *
@@ -1111,8 +1163,26 @@ async function resumeActiveRunIfAny() {
   // produce a second bubble for one answer.
   if (attachedRunId === run.runId || isStreaming.value) return
 
+  // A multitask turn is reported BOTH as `inProgressTurn` (#1142 synthesizes a
+  // provisional card bubble) and as `activeRun`. The live re-attach renders the
+  // same turn more completely, so drop the provisional one instead of showing
+  // the answer twice. If the attach drops, finishStreamingMessage() clears the
+  // live flag and the next in-progress poll restores it.
+  historyStore.removeMessage(IN_PROGRESS_TURN_ID)
+
+  // The turn's REAL track id. Inventing a fresh one would leave Stop unable to
+  // flag the running turn — the answer would keep generating (and billing)
+  // while the UI claimed it was cancelled.
+  const runTrackId = Number.parseInt(run.trackId, 10)
+
   attachedRunId = run.runId
-  await streamAIResponse('', { attach: { runId: run.runId, partialText: run.partialText } })
+  await streamAIResponse('', {
+    attach: {
+      runId: run.runId,
+      partialText: run.partialText,
+      trackId: Number.isFinite(runTrackId) ? runTrackId : undefined,
+    },
+  })
 }
 
 // Cleanup: detach the running stream when the component unmounts (user leaves chat)
@@ -2219,9 +2289,10 @@ const streamAIResponse = async (
     /**
      * Re-attach to a turn already generating on the server instead of starting
      * a new one. `userMessage` is then irrelevant — nothing is sent, the client
-     * only subscribes to the turn's buffered events.
+     * only subscribes to the turn's buffered events. `trackId` is the turn's
+     * existing id, so an explicit Stop can still cancel it server-side.
      */
-    attach?: { runId: string; partialText: string }
+    attach?: { runId: string; partialText: string; trackId?: number }
   }
 ) => {
   streamingAbortController = new AbortController()
@@ -2274,7 +2345,8 @@ const streamAIResponse = async (
         return
       }
 
-      const trackId = Date.now()
+      // A re-attach adopts the running turn's id; only a NEW turn mints one.
+      const trackId = attach?.trackId ?? Date.now()
       currentTrackId = trackId
       let fullContent = ''
 
@@ -2293,6 +2365,12 @@ const streamAIResponse = async (
         quotedMessageId: options?.quotedMessageId,
         onUpdate: (data: StreamUpdatePayload) => {
           if (streamingAbortController?.signal.aborted) return
+
+          // Recognised here rather than in each terminal branch below, which
+          // exist per error kind and would each need their own reset.
+          if (data.status === 'complete' || data.status === 'error') {
+            noteRunTerminal(data)
+          }
 
           if (data.status === 'guest_limit_reached') {
             // #1128: drop the empty assistant placeholder — same as the
@@ -2324,18 +2402,7 @@ const streamAIResponse = async (
           }
 
           if (data.status === 'run_started') {
-            // The server opened a resumable run for this turn. Remembering it
-            // keeps a later history load from attaching a second time to the
-            // turn this tab is already rendering.
-            if (typeof data.runId === 'string') attachedRunId = data.runId
-            return
-          }
-
-          if (data.status === 'run_started') {
-            // The server opened a resumable run for this turn. Remembering it
-            // keeps a later history load from attaching a second time to the
-            // turn this tab is already rendering.
-            if (typeof data.runId === 'string') attachedRunId = data.runId
+            noteRunStarted(data.runId)
             return
           }
 
@@ -2764,7 +2831,8 @@ const streamAIResponse = async (
         ? buildIncognitoHistorySnapshot()
         : []
 
-      const trackId = Date.now()
+      // A re-attach adopts the running turn's id; only a NEW turn mints one.
+      const trackId = attach?.trackId ?? Date.now()
       currentTrackId = trackId // Store for stop functionality
       currentStreamingChatId = chatId ?? undefined // Store chatId for stop functionality
       let fullContent = ''
@@ -2824,6 +2892,17 @@ const streamAIResponse = async (
           // CRITICAL: Check abort signal at the very beginning
           if (streamingAbortController?.signal.aborted) {
             return
+          }
+
+          if (data.status === 'run_started') {
+            noteRunStarted(data.runId)
+            return
+          }
+
+          // Recognised here rather than in each terminal branch below, which
+          // exist per error kind and would each need their own reset.
+          if (data.status === 'complete' || data.status === 'error') {
+            noteRunTerminal(data)
           }
 
           // [i2v-debug] Opt-in multitask/media tracing: a task card stuck at
@@ -3933,6 +4012,10 @@ const handleUserStop = async () => {
   if (streamingAbortController) {
     streamingAbortController.abort()
   }
+
+  // Unlike navigating away, an explicit Stop really does end the turn.
+  attachedRunId = null
+  clearGeneratingMark()
 
   // Close the EventSource connection IMMEDIATELY
   if (stopStreamingFn) {

--- a/frontend/tests/unit/services/api/attachStream.spec.ts
+++ b/frontend/tests/unit/services/api/attachStream.spec.ts
@@ -159,6 +159,31 @@ describe('chatApi.attachStream', () => {
     expect(events).toEqual([{ status: 'data', chunk: 'half' }, { status: 'complete' }])
   })
 
+  it('treats a backend error as the end of the turn, not as a dropped connection', async () => {
+    // A real failure (rate limit, cost budget, missing model) ends the turn just
+    // like `complete` does. Retrying would replay the log a second time and then
+    // append a bogus "Connection interrupted" over the error the user has to
+    // read — and because that wording counts as recoverable, the chat view would
+    // reload history and drop the explanation entirely.
+    const fetchMock = respondWith({
+      ok: true,
+      status: 200,
+      body: sseStream([
+        'id: 1\ndata: {"status":"error","error":"Rate limit exceeded","limit_type":"lifetime"}\n\n',
+      ]),
+    })
+
+    const events: StreamUpdatePayload[] = []
+    vi.stubGlobal('fetch', fetchMock)
+    chatApi.attachStream({ runId: 'run-e', onUpdate: (data) => events.push(data) })
+    await flush()
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(events).toEqual([
+      { status: 'error', error: 'Rate limit exceeded', limit_type: 'lifetime' },
+    ])
+  })
+
   it('stops delivering events once the caller detaches', async () => {
     // Detaching is not a cancel: the turn keeps generating server-side, this
     // client just stops rendering it.

--- a/frontend/tests/unit/services/api/attachStream.spec.ts
+++ b/frontend/tests/unit/services/api/attachStream.spec.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { chatApi } from '@/services/api/chatApi'
+import type { StreamUpdatePayload } from '@/types/chatStream'
+
+vi.mock('@/services/api/httpClient', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/services/api/httpClient')>()),
+  getApiBaseUrl: () => 'http://backend.test',
+}))
+
+/**
+ * Re-attaching to a turn that kept generating after the tab left is the whole
+ * point of the feature, so the transport has to behave exactly like the live
+ * stream: same payloads, same terminal event, and a drop reported in the
+ * wording `isRecoverableStreamError()` recognises — otherwise the chat view
+ * never falls back to reloading the persisted answer.
+ */
+describe('chatApi.attachStream', () => {
+  const sseStream = (frames: string[], onCancel?: () => void) =>
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        const encoder = new TextEncoder()
+        for (const frame of frames) controller.enqueue(encoder.encode(frame))
+        controller.close()
+      },
+      cancel() {
+        onCancel?.()
+      },
+    })
+
+  /** Typed like the real `fetch` so `mock.calls` keeps the url/init arguments. */
+  const respondWith = (response: Record<string, unknown>) =>
+    vi.fn<(url: string, init?: RequestInit) => Promise<unknown>>(async () => response)
+
+  const collect = (fetchMock: ReturnType<typeof vi.fn>) => {
+    vi.stubGlobal('fetch', fetchMock)
+    const events: StreamUpdatePayload[] = []
+    const stop = chatApi.attachStream({ runId: 'run-1', onUpdate: (data) => events.push(data) })
+    return { events, stop }
+  }
+
+  const flush = () => new Promise((resolve) => setTimeout(resolve, 0))
+
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('replays the buffered turn through the same payload contract as a live stream', async () => {
+    const { events } = collect(
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        body: sseStream([
+          'id: 1\ndata: {"status":"data","chunk":"Hello "}\n\n',
+          'id: 2\ndata: {"status":"data","chunk":"world"}\n\n',
+          'id: 3\ndata: {"status":"complete","messageId":42}\n\n',
+        ]),
+      }))
+    )
+
+    await flush()
+
+    expect(events).toEqual([
+      { status: 'data', chunk: 'Hello ' },
+      { status: 'data', chunk: 'world' },
+      { status: 'complete', messageId: 42 },
+    ])
+  })
+
+  it('requests the run from the sequence the caller already rendered', async () => {
+    const fetchMock = respondWith({
+      ok: true,
+      status: 200,
+      body: sseStream(['data: {"status":"complete"}\n\n']),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    chatApi.attachStream({ runId: 'run-7', from: 12, onUpdate: () => {} })
+    await flush()
+
+    const url = new URL(fetchMock.mock.calls[0][0])
+    expect(url.pathname).toBe('/api/v1/messages/stream/attach')
+    expect(url.searchParams.get('runId')).toBe('run-7')
+    expect(url.searchParams.get('from')).toBe('12')
+  })
+
+  it('identifies a guest so the server can check ownership of the run', async () => {
+    const fetchMock = respondWith({
+      ok: true,
+      status: 200,
+      body: sseStream(['data: {"status":"complete"}\n\n']),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    chatApi.attachStream({ runId: 'run-9', guestSessionId: 'guest-abc', onUpdate: () => {} })
+    await flush()
+
+    const url = new URL(fetchMock.mock.calls[0][0])
+    expect(url.searchParams.get('guestSession')).toBe('guest-abc')
+  })
+
+  it('sends the widget session headers when attaching from an embedded widget', async () => {
+    const fetchMock = respondWith({
+      ok: true,
+      status: 200,
+      body: sseStream(['data: {"status":"complete"}\n\n']),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    chatApi.attachStream({
+      runId: 'run-w',
+      widgetId: 'w-1',
+      widgetSessionId: 'sess-1',
+      onUpdate: () => {},
+    })
+    await flush()
+
+    const headers = fetchMock.mock.calls[0][1]?.headers as Record<string, string>
+    expect(headers['X-Widget-Id']).toBe('w-1')
+    expect(headers['X-Widget-Session']).toBe('sess-1')
+  })
+
+  it('reports a vanished run as a recoverable drop instead of a dead bubble', async () => {
+    // The run expired or its terminal retention lapsed. The answer may still be
+    // in the database, so the caller must be pushed into history recovery.
+    const { events } = collect(respondWith({ ok: false, status: 404, body: null }))
+
+    await flush()
+
+    expect(events).toEqual([{ status: 'error', error: 'Connection interrupted' }])
+  })
+
+  it('resumes once from the last sequence it saw before giving up', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        body: sseStream(['id: 5\ndata: {"status":"data","chunk":"half"}\n\n']),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        body: sseStream(['id: 6\ndata: {"status":"complete"}\n\n']),
+      })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const events: StreamUpdatePayload[] = []
+    chatApi.attachStream({ runId: 'run-r', onUpdate: (data) => events.push(data) })
+    await flush()
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    // The retry must not replay what was already rendered.
+    expect(new URL(fetchMock.mock.calls[1][0] as string).searchParams.get('from')).toBe('5')
+    expect(events).toEqual([{ status: 'data', chunk: 'half' }, { status: 'complete' }])
+  })
+
+  it('stops delivering events once the caller detaches', async () => {
+    // Detaching is not a cancel: the turn keeps generating server-side, this
+    // client just stops rendering it.
+    const fetchMock = respondWith({
+      ok: true,
+      status: 200,
+      body: sseStream(['data: {"status":"data","chunk":"a"}\n\n']),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const events: StreamUpdatePayload[] = []
+    const stop = chatApi.attachStream({ runId: 'run-s', onUpdate: (data) => events.push(data) })
+    stop()
+    await flush()
+
+    expect(events).toEqual([])
+    expect(fetchMock.mock.calls[0][1]?.signal?.aborted).toBe(true)
+  })
+})

--- a/frontend/tests/unit/stores/chats.spec.ts
+++ b/frontend/tests/unit/stores/chats.spec.ts
@@ -412,5 +412,37 @@ describe('Chats Store', () => {
 
       expect(store.activeRunChatIds.size).toBe(0)
     })
+
+    /**
+     * The server's answer only arrives with a chat-list fetch, which happens on
+     * entry. Without the live updates below the marker would be a snapshot from
+     * app start: never lighting up when the user walks away from a running turn,
+     * never going out when it finishes.
+     */
+    it('marks and unmarks a chat live, replacing the Set so templates re-render', async () => {
+      const store = useChatsStore()
+      const initial = store.activeRunChatIds
+
+      store.markChatGenerating(7, true)
+
+      expect(store.activeRunChatIds.has(7)).toBe(true)
+      expect(store.activeRunChatIds).not.toBe(initial)
+
+      const marked = store.activeRunChatIds
+      store.markChatGenerating(7, false)
+
+      expect(store.activeRunChatIds.has(7)).toBe(false)
+      expect(store.activeRunChatIds).not.toBe(marked)
+    })
+
+    it('keeps the other chats when one turn ends', async () => {
+      const store = useChatsStore()
+      store.markChatGenerating(1, true)
+      store.markChatGenerating(2, true)
+
+      store.markChatGenerating(1, false)
+
+      expect([...store.activeRunChatIds]).toEqual([2])
+    })
   })
 })

--- a/frontend/tests/unit/stores/chats.spec.ts
+++ b/frontend/tests/unit/stores/chats.spec.ts
@@ -380,4 +380,37 @@ describe('Chats Store', () => {
       expect(store.chats.map((c) => c.id)).toContain(42)
     })
   })
+
+  /**
+   * A turn survives the client that started it, so the list marks the chats
+   * where an answer is still being written after the user moved on.
+   */
+  describe('loadChats — chats with a generating turn', () => {
+    it('tracks the chats the server reports as still generating', async () => {
+      const store = useChatsStore()
+      httpClientMock.mockResolvedValueOnce({
+        chats: [chatPayload(1).chat, chatPayload(2).chat],
+        activeRunChatIds: [2],
+      })
+
+      await store.loadChats()
+
+      expect(store.activeRunChatIds.has(2)).toBe(true)
+      expect(store.activeRunChatIds.has(1)).toBe(false)
+    })
+
+    it('clears the marker once the turn finished', async () => {
+      const store = useChatsStore()
+      httpClientMock.mockResolvedValueOnce({
+        chats: [chatPayload(1).chat],
+        activeRunChatIds: [1],
+      })
+      await store.loadChats()
+
+      httpClientMock.mockResolvedValueOnce({ chats: [chatPayload(1).chat] })
+      await store.loadChats()
+
+      expect(store.activeRunChatIds.size).toBe(0)
+    })
+  })
 })

--- a/frontend/tests/unit/stores/history.spec.ts
+++ b/frontend/tests/unit/stores/history.spec.ts
@@ -794,4 +794,79 @@ describe('History Store', () => {
       }
     })
   })
+
+  /**
+   * A turn keeps generating after the tab that started it navigates away, so
+   * the history response points a returning client at the still-running run.
+   * The store only has to report it faithfully — ChatView owns the re-attach.
+   */
+  describe('loadMessages — active run discovery', () => {
+    const activeRun = {
+      runId: 'run-42',
+      trackId: '1700000000',
+      lastSeq: 7,
+      partialText: 'Half an answer',
+    }
+
+    const loadWith = async (response: Record<string, unknown>, offset = 0) => {
+      vi.resetModules()
+      const getChatMessages = vi.fn().mockResolvedValue({
+        success: true,
+        messages: [],
+        pagination: { hasMore: false },
+        ...response,
+      })
+      vi.doMock('@/services/api', () => ({ chatApi: { getChatMessages } }))
+
+      const { useHistoryStore: useStore } = await import('@/stores/history')
+      const store = useStore()
+      await store.loadMessages(42, offset)
+
+      return store
+    }
+
+    it('exposes the still-running turn reported by the first page', async () => {
+      const store = await loadWith({ activeRun })
+
+      expect(store.activeRun).toEqual(activeRun)
+    })
+
+    it('reports no run when the turn already finished', async () => {
+      const store = await loadWith({ activeRun: null })
+
+      expect(store.activeRun).toBeNull()
+    })
+
+    it('keeps a known run when older pages are loaded on scroll-back', async () => {
+      // Only the first page carries `activeRun`; paging through history must
+      // not clear the run the client is currently attached to.
+      vi.resetModules()
+      const getChatMessages = vi
+        .fn()
+        .mockResolvedValueOnce({
+          success: true,
+          messages: [],
+          pagination: { hasMore: true },
+          activeRun,
+        })
+        .mockResolvedValueOnce({ success: true, messages: [], pagination: { hasMore: false } })
+      vi.doMock('@/services/api', () => ({ chatApi: { getChatMessages } }))
+
+      const { useHistoryStore: useStore } = await import('@/stores/history')
+      const store = useStore()
+
+      await store.loadMessages(42)
+      await store.loadMessages(42, 50)
+
+      expect(store.activeRun).toEqual(activeRun)
+    })
+
+    it('forgets the run when the chat is cleared', async () => {
+      const store = await loadWith({ activeRun })
+
+      store.clear()
+
+      expect(store.activeRun).toBeNull()
+    })
+  })
 })


### PR DESCRIPTION
## Summary
A turn already survived the client disconnect, but its tokens only existed inside the original HTTP response. Reloading the page or switching chats left the user staring at their own prompt until the finished answer hit the database. This PR adds a Redis-backed run log plus a re-attach SSE endpoint so the web chat, guest chat and widget can keep watching the answer where they left off.

## Changes
- Add `ChatRun` / `ChatRunBuffer` / `ChatRunRecorder` / `ChatRunService` as a Redis event log per turn (coalesced text chunks, TTL, heartbeat, no buffer for incognito or missing Redis)
- Record every SSE event in `StreamController` and `WidgetPublicController` above the `connection_aborted()` guard, emit `run_started`, and mark the run terminal on complete / error / cancel
- Add `GET /api/v1/messages/stream/attach` with owner checks (user / guest / widget), replay from `from`, live tail, and a recoverable error when the generating worker dies
- Expose `activeRun` on chat / guest / widget history and `activeRunChatIds` on the chat list so a hard reload can find the run and the sidebar can mark chats that are still answering
- Add `chatApi.attachStream()` and resume from `activeRun` in `ChatView`, guest chat and the embedded widget without rebuilding the bubble
- Add `chat.stillGenerating` in all five locales and a pulse indicator in the V2 chat list

## Verification
- [ ] Not tested (explain)
- [x] Manual
  - API: start a turn, drop the client after ~4s, history returns `activeRun` + partial text, chat list reports the chat, re-attach from `lastSeq` finishes with `complete`, rendered text matches the persisted answer (no duplication)
  - Unauthorized attach is 401, unknown `runId` is 404, Stop clears `activeRun`, incognito streams without `run_started`
  - Widget and guest paths both expose `activeRun` and re-attach to `complete`; a foreign session is 401
  - Browser F5 / second-tab UI pass was not completed (IDE browser crashed mid-stream); please confirm those two clicks before merge
- [x] Tests added/updated
  - PHPUnit: `ChatRunTest`, `ChatRunBufferTest` (bundle, exclusive `from`, identical chunks, owner isolation, stale heartbeat, discard)
  - Vitest: `attachStream` parsing / retry / detach, `historyStore` `activeRun` hydration, `chatsStore` `activeRunChatIds`
  - Local gate: `make lint`, `make -C backend phpstan` (0 errors), PHPUnit 4585, Vitest 1477, `vue-tsc`

## Notes
- Related: detach-on-navigation already landed in #1142 / #1223 / #1225; this is the missing re-attach path.
- Out of scope: no Messenger/worker move, no Centrifugo for tokens, no incremental `BMESSAGES` persist. A dead PHP worker still falls back to `recoverInterruptedTurn()`.
- No schema migration. Mobile impact: `ota-candidate` (no new native / store-required paths).
- **Do not merge until CI is green and the remaining browser checks above are done.** I will merge this myself.

## Screenshots/Logs
No UI screenshots from this run (browser automation died after login + first stream). The activity marker is a small pulsing brand dot next to chats in `activeRunChatIds`.