### PR TITLE
fix(ci): finish the Marketplace submission across runs

### DIFF
--- a/.github/workflows/aws-ami.yml
+++ b/.github/workflows/aws-ami.yml
@@ -650,7 +650,7 @@ jobs:
           pattern: packer-manifest-*
           path: manifests
 
-      - name: Offer each architecture as a version
+      - name: Offer the release to the listing
         if: steps.listing.outputs.configured == 'true'
         env:
           PRODUCT_ID: ${{ secrets.AWS_MARKETPLACE_PRODUCT_ID }}
@@ -661,140 +661,113 @@ jobs:
         run: |
           set -euo pipefail
 
+          # One AMI per version, by AWS's rule that every delivery option of a
+          # version shares a single AmiSource. Two architectures are therefore
+          # two versions — and only one of them can be offered here, because AWS
+          # rejects a second `AddDeliveryOptions` while the first is in flight
+          # ("if two requests are the same ChangeType on the same product, the
+          # second request returns an error"), and ingesting an AMI takes hours.
+          # marketplace-versions.yml submits the rest once the entity is free.
+          architecture="$(
+            printf '%s' "$ARCHITECTURES" |
+              jq -r 'if index("x86_64") then "x86_64" else .[0] end'
+          )"
+          remaining="$(
+            printf '%s' "$ARCHITECTURES" |
+              jq -r --arg first "$architecture" '[.[] | select(. != $first)] | join(", ")'
+          )"
+
+          manifest="manifests/packer-manifest-${architecture}/packer-manifest.json"
+          if [ ! -f "$manifest" ]; then
+            echo "::error::No build manifest for ${architecture}; refusing to guess an AMI id."
+            exit 1
+          fi
+
+          ami="$(jq -r '.builds[-1].artifact_id' "$manifest" | cut -d: -f2)"
+          if [ -z "$ami" ] || [ "$ami" = null ]; then
+            echo "::error::${manifest} carries no AMI id."
+            exit 1
+          fi
+
+          change_set="$(
+            node scripts/marketplace-change-set.mjs \
+              --product "$PRODUCT_ID" \
+              --version "$VERSION" \
+              --architecture "$architecture" \
+              --ami "$ami" \
+              --role "$INGESTION_ROLE_ARN" \
+              --release-url "$RELEASE_URL"
+          )"
+
+          # Validated first, then submitted, both inside this run. VALIDATE asks
+          # AWS whether it would accept the document without creating anything,
+          # which is how a wrong product id or a role AWS cannot assume is caught
+          # before a real version exists.
+          echo "::group::${architecture}: validate ${ami}"
+          aws marketplace-catalog start-change-set \
+            --catalog AWSMarketplace \
+            --intent VALIDATE \
+            --client-request-token "synaplan-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${architecture}-validate" \
+            --change-set "$change_set" > /dev/null
+          echo "Accepted."
+          echo "::endgroup::"
+
+          echo "::group::${architecture}: submit ${ami}"
+          id="$(
+            aws marketplace-catalog start-change-set \
+              --catalog AWSMarketplace \
+              --intent APPLY \
+              --client-request-token "synaplan-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${architecture}" \
+              --change-set "$change_set" \
+              --query ChangeSetId --output text
+          )"
+          echo "Change set ${id}."
+          echo "::endgroup::"
+
           {
             echo "### AWS Marketplace"
             echo ""
-            echo "Offering \`${VERSION}\` to the listing, one version per architecture."
-            echo "Each is validated before it is submitted, and AWS reviews a submitted version"
-            echo "before it becomes available."
-            echo ""
+            echo "Submitted \`${VERSION} (${architecture})\` as change set \`${id}\`."
           } >> "$GITHUB_STEP_SUMMARY"
 
-          # One AMI per version, by AWS's rule that every delivery option of a
-          # version shares the same AmiSource. Two architectures are therefore
-          # two versions, and they have to go one after another: a running change
-          # set locks the entity and the second call would fail with
-          # ResourceInUseException.
-          for architecture in $(printf '%s' "$ARCHITECTURES" | jq -r '.[]'); do
-            manifest="manifests/packer-manifest-${architecture}/packer-manifest.json"
-            if [ ! -f "$manifest" ]; then
-              echo "::error::No build manifest for ${architecture}; refusing to guess an AMI id."
-              exit 1
-            fi
-
-            ami="$(jq -r '.builds[-1].artifact_id' "$manifest" | cut -d: -f2)"
-            if [ -z "$ami" ] || [ "$ami" = null ]; then
-              echo "::error::${manifest} carries no AMI id."
-              exit 1
-            fi
-
-            case "$architecture" in
-              arm64) instance_type=m7g.xlarge ;;
-              *)     instance_type=m7i.xlarge ;;
-            esac
-
-            # Mirrors deploy/aws/packer/synaplan.pkr.hcl's source_ami_filter and
-            # deploy/aws/scripts/harden.sh: Amazon Linux 2023, ec2-user, sshd
-            # listening but password and root login refused.
-            details="$(jq -n \
-              --arg title "${VERSION} (${architecture})" \
-              --arg notes "Synaplan ${VERSION}. Release notes: ${RELEASE_URL}" \
-              --arg ami "$ami" \
-              --arg role "$INGESTION_ROLE_ARN" \
-              --arg instance_type "$instance_type" \
-              '{
-                Version: { VersionTitle: $title, ReleaseNotes: $notes },
-                DeliveryOptions: [{
-                  Details: {
-                    AmiDeliveryOptionDetails: {
-                      AmiSource: {
-                        AmiId: $ami,
-                        AccessRoleArn: $role,
-                        UserName: "ec2-user",
-                        ScanningPort: 22,
-                        OperatingSystemName: "AMAZONLINUX",
-                        OperatingSystemVersion: "2023"
-                      },
-                      UsageInstructions: "Launch the instance, then open https://<public IP or your domain>. Sign in with the administrator address shown in the CloudFormation outputs; the single-use password is stored in SSM Parameter Store under /synaplan/<instance-id>/admin-password and must be replaced at first sign-in. Add an AI provider key under Admin, AI Providers. Full guide: https://github.com/metadist/synaplan/blob/main/deploy/aws/README.md",
-                      RecommendedInstanceType: $instance_type,
-                      SecurityGroups: [
-                        { IpProtocol: "tcp", FromPort: 443, ToPort: 443, IpRanges: ["0.0.0.0/0"] },
-                        { IpProtocol: "tcp", FromPort: 80, ToPort: 80, IpRanges: ["0.0.0.0/0"] }
-                      ]
-                    }
-                  }
-                }]
-              }')"
-
-            change_set="$(jq -n \
-              --arg product "$PRODUCT_ID" \
-              --argjson details "$details" \
-              '[{
-                ChangeType: "AddDeliveryOptions",
-                Entity: { Identifier: $product, Type: "AmiProduct@1.0" },
-                DetailsDocument: $details
-              }]')"
-
-            # Validated first, then submitted, both inside this run. VALIDATE
-            # asks AWS whether it would accept the document without creating
-            # anything, which is how a wrong product id or a role AWS cannot
-            # assume is caught before a real version exists. This used to be a
-            # separate dry run, requested through a repository variable that a
-            # maintainer had to flip after reading a job summary — a step
-            # between two releases that nobody remembers.
-            echo "::group::${architecture}: validate ${ami}"
-            aws marketplace-catalog start-change-set \
-              --catalog AWSMarketplace \
-              --intent VALIDATE \
-              --client-request-token "synaplan-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${architecture}-validate" \
-              --change-set "$change_set" > /dev/null
-            echo "Accepted."
-            echo "::endgroup::"
-
-            echo "::group::${architecture}: submit ${ami}"
-            id="$(
-              aws marketplace-catalog start-change-set \
-                --catalog AWSMarketplace \
-                --intent APPLY \
-                --client-request-token "synaplan-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${architecture}" \
-                --change-set "$change_set" \
-                --query ChangeSetId --output text
+          # Watched briefly, not waited out. AWS copies the image into every
+          # region of the listing and scans it for vulnerabilities, which its own
+          # documentation puts at "a few hours" — far past any sensible job. What
+          # this window is for is the other outcome: a document AWS rejects fails
+          # within minutes, and that has to turn this job red rather than sit
+          # unnoticed in the portal.
+          status=PREPARING
+          for _ in $(seq 1 20); do
+            sleep 60
+            status="$(
+              aws marketplace-catalog describe-change-set \
+                --catalog AWSMarketplace --change-set-id "$id" \
+                --query Status --output text
             )"
-            echo "Change set ${id}."
-            echo "::endgroup::"
-
-            # Waited out rather than fired and forgotten, for two reasons: the
-            # next architecture cannot start while this change set holds the
-            # entity, and a rejected document has to fail this job rather than
-            # sit unnoticed in the portal.
-            for _ in $(seq 1 60); do
-              status="$(
-                aws marketplace-catalog describe-change-set \
-                  --catalog AWSMarketplace --change-set-id "$id" \
-                  --query Status --output text
-              )"
-              case "$status" in
-                SUCCEEDED)
-                  echo "- \`${architecture}\`: \`${ami}\` submitted (change set \`${id}\`)" >> "$GITHUB_STEP_SUMMARY"
-                  break
-                  ;;
-                FAILED|CANCELLED)
-                  reason="$(
-                    aws marketplace-catalog describe-change-set \
-                      --catalog AWSMarketplace --change-set-id "$id" \
-                      --query 'ChangeSet[].ErrorDetailList' --output json
-                  )"
-                  echo "::error::Change set ${id} for ${architecture} ended as ${status}: ${reason}"
-                  exit 1
-                  ;;
-                *)
-                  sleep 30
-                  ;;
-              esac
-            done
-
-            if [ "$status" != SUCCEEDED ]; then
-              echo "::error::Change set ${id} for ${architecture} was still ${status} after thirty minutes."
-              exit 1
-            fi
+            case "$status" in
+              FAILED|CANCELLED)
+                reason="$(
+                  aws marketplace-catalog describe-change-set \
+                    --catalog AWSMarketplace --change-set-id "$id" \
+                    --query 'ChangeSet[].ErrorDetailList' --output json
+                )"
+                echo "::error::Change set ${id} for ${architecture} ended as ${status}: ${reason}"
+                exit 1
+                ;;
+              SUCCEEDED) break ;;
+            esac
           done
+
+          {
+            if [ "$status" = SUCCEEDED ]; then
+              echo "AWS has ingested it; the version is now in review."
+            else
+              echo "Still \`${status}\` after twenty minutes, which is normal — AWS scans and copies"
+              echo "the image for a few hours. \`marketplace-versions.yml\` reports the outcome."
+            fi
+            if [ -n "$remaining" ]; then
+              echo ""
+              echo "\`${remaining}\` cannot be submitted alongside it: AWS refuses a second version"
+              echo "while this one is in flight. \`marketplace-versions.yml\` picks it up hourly."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/marketplace-versions.yml
+++ b/.github/workflows/marketplace-versions.yml
@@ -1,0 +1,263 @@
+name: Marketplace Versions
+
+# Finishes what aws-ami.yml can only start, and reports how it ended.
+#
+# Offering a release to the AMI listing means one version per architecture,
+# because every delivery option of a version shares a single AmiSource. Those
+# versions cannot be submitted together: AWS answers a second
+# `AddDeliveryOptions` on the same product with an error while the first is in
+# flight, and ingesting an AMI takes hours — it copies the image into every
+# region of the listing and scans it for vulnerabilities. A release build
+# therefore submits one architecture and ends; this job submits the next one as
+# soon as the entity is free.
+#
+# It derives everything it needs from AWS and from the default branch, and keeps
+# no state of its own: the release comes from the version the deployment catalog
+# pins, the AMIs from their build tags, and what is already offered from the
+# listing itself. A missed run costs an hour, never a version.
+
+on:
+  schedule:
+    # Off the hour, so it does not queue behind everything else that runs at :00.
+    - cron: '17 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Two runs would race for the same entity and the loser would get an error from
+# AWS rather than a clean skip.
+concurrency:
+  group: marketplace-versions
+  cancel-in-progress: false
+
+env:
+  # The Marketplace ingests from us-east-1 only.
+  AWS_REGION: us-east-1
+
+jobs:
+  offer:
+    name: Offer the remaining versions to the listing
+    runs-on: ubuntu-latest
+    # Same trust path as the jobs in aws-ami.yml: the AWS role trusts this
+    # environment's subject claim, not a branch.
+    environment: ami-build
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      # Skipped rather than failed while the listing does not exist yet, exactly
+      # like the submit job in aws-ami.yml. An hourly schedule must not turn a
+      # not-yet-configured listing into an hourly red run.
+      - name: Check the listing credentials
+        id: config
+        env:
+          PRODUCT_ID: ${{ secrets.AWS_MARKETPLACE_PRODUCT_ID }}
+          INGESTION_ROLE_ARN: ${{ secrets.AWS_MARKETPLACE_INGESTION_ROLE_ARN }}
+          BUILD_ROLE_ARN: ${{ secrets.AWS_AMI_BUILD_ROLE_ARN }}
+        run: |
+          if [ -n "${PRODUCT_ID:-}" ] && [ -n "${INGESTION_ROLE_ARN:-}" ] && [ -n "${BUILD_ROLE_ARN:-}" ]; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "No AWS Marketplace listing is configured; nothing to offer." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Checkout
+        if: steps.config.outputs.configured == 'true'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Assume the build role
+        if: steps.config.outputs.configured == 'true'
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+        with:
+          role-to-assume: ${{ secrets.AWS_AMI_BUILD_ROLE_ARN }}
+          role-session-name: synaplan-marketplace-${{ github.run_id }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      # The version a new deployment installs is the version the listing should
+      # offer. Reading it from the catalog rather than from the newest tag is
+      # deliberate: a tag whose rollout was held back by a guard is not a release
+      # anybody should be able to buy.
+      - name: Read the release the catalog pins
+        id: release
+        if: steps.config.outputs.configured == 'true'
+        run: |
+          set -euo pipefail
+          version="$(node scripts/read-release-version.mjs | jq -r .version)"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+      - name: Report change sets that finished
+        id: finished
+        if: steps.config.outputs.configured == 'true'
+        env:
+          PRODUCT_ID: ${{ secrets.AWS_MARKETPLACE_PRODUCT_ID }}
+        run: |
+          set -euo pipefail
+
+          summaries="$(
+            aws marketplace-catalog list-change-sets \
+              --catalog AWSMarketplace \
+              --filter-list "$(jq -nc --arg id "$PRODUCT_ID" '[{Name:"EntityId",ValueList:[$id]}]')" \
+              --query 'ChangeSetSummaryList[].{Id:ChangeSetId,Status:Status,Start:StartTime,End:EndTime}' \
+              --output json
+          )"
+
+          # ISO-8601 in UTC sorts lexicographically, so a string comparison is a
+          # date comparison here. The window matches the schedule: anything that
+          # ended since the previous run is new, and a little overlap only ever
+          # repeats a message, never drops one.
+          since="$(date -u -d '65 minutes ago' +%Y-%m-%dT%H:%M:%SZ)"
+
+          inflight="$(printf '%s' "$summaries" | jq -r '[.[] | select(.Status == "PREPARING" or .Status == "APPLYING")] | length')"
+          echo "inflight=${inflight}" >> "$GITHUB_OUTPUT"
+
+          failed="$(
+            printf '%s' "$summaries" |
+              jq -r --arg since "$since" '
+                [.[] | select(.Status == "FAILED" or .Status == "CANCELLED") | select((.End // "") > $since) | .Id]
+                | join(" ")
+              '
+          )"
+
+          for id in $failed; do
+            reason="$(
+              aws marketplace-catalog describe-change-set \
+                --catalog AWSMarketplace --change-set-id "$id" \
+                --query 'ChangeSet[].ErrorDetailList' --output json
+            )"
+            echo "::error::AWS rejected change set ${id}: ${reason}"
+            echo "AWS rejected change set \`${id}\`: ${reason}" >> "$GITHUB_STEP_SUMMARY"
+          done
+          echo "failed=${failed}" >> "$GITHUB_OUTPUT"
+
+          if [ "$inflight" -gt 0 ]; then
+            echo "A change set is still in flight; AWS accepts no further version until it ends." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      # Nothing else can be submitted while AWS is working on one, so the rest of
+      # the job is skipped rather than attempted and rejected.
+      - name: Find the versions the listing is missing
+        id: missing
+        if: steps.config.outputs.configured == 'true' && steps.finished.outputs.inflight == '0'
+        env:
+          PRODUCT_ID: ${{ secrets.AWS_MARKETPLACE_PRODUCT_ID }}
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          # Every VersionTitle anywhere in the document, rather than one fixed
+          # path: the entity shape is AWS's to change, and reading it loosely
+          # fails safe. A title this job cannot see would at worst be offered
+          # twice, which AWS rejects, rather than silently never offered.
+          offered="$(
+            aws marketplace-catalog describe-entity \
+              --catalog AWSMarketplace --entity-id "$PRODUCT_ID" \
+              --query DetailsDocument --output json |
+              jq -c '[.. | objects | .VersionTitle? // empty]'
+          )"
+
+          missing="$(
+            jq -nr --argjson offered "$offered" --arg version "$VERSION" '
+              ["x86_64", "arm64"]
+              | map(select(($offered | index("\($version) (\(.))")) | not))
+              | join(" ")
+            '
+          )"
+
+          echo "architectures=${missing}" >> "$GITHUB_OUTPUT"
+          if [ -z "$missing" ]; then
+            echo "The listing already offers \`${VERSION}\` for every architecture." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Offer the next one
+        id: offer
+        if: steps.missing.outputs.architectures != ''
+        env:
+          PRODUCT_ID: ${{ secrets.AWS_MARKETPLACE_PRODUCT_ID }}
+          INGESTION_ROLE_ARN: ${{ secrets.AWS_MARKETPLACE_INGESTION_ROLE_ARN }}
+          VERSION: ${{ steps.release.outputs.version }}
+          MISSING: ${{ steps.missing.outputs.architectures }}
+          RELEASE_URL: ${{ github.server_url }}/${{ github.repository }}/releases/tag/v${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          # One per run, by the same AWS rule that made this workflow necessary.
+          architecture="${MISSING%% *}"
+
+          # Found by the tags deploy/aws/packer/synaplan.pkr.hcl writes, so no
+          # run has to hand an AMI id to a later one. Newest wins, for a version
+          # that was rebuilt.
+          ami="$(
+            aws ec2 describe-images --owners self \
+              --filters "Name=tag:SynaplanVersion,Values=${VERSION}" \
+                        "Name=tag:Architecture,Values=${architecture}" \
+                        "Name=state,Values=available" \
+              --query 'sort_by(Images, &CreationDate)[-1].ImageId' --output text
+          )"
+          if [ -z "$ami" ] || [ "$ami" = None ]; then
+            # Not an error: the release build may still be running, or may have
+            # failed and reported that itself. The next run picks it up.
+            echo "No AMI is built for \`${VERSION}\` on \`${architecture}\` yet; nothing offered." |
+              tee -a "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          change_set="$(
+            node scripts/marketplace-change-set.mjs \
+              --product "$PRODUCT_ID" \
+              --version "$VERSION" \
+              --architecture "$architecture" \
+              --ami "$ami" \
+              --role "$INGESTION_ROLE_ARN" \
+              --release-url "$RELEASE_URL"
+          )"
+
+          aws marketplace-catalog start-change-set \
+            --catalog AWSMarketplace \
+            --intent VALIDATE \
+            --client-request-token "synaplan-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${architecture}-validate" \
+            --change-set "$change_set" > /dev/null
+
+          id="$(
+            aws marketplace-catalog start-change-set \
+              --catalog AWSMarketplace \
+              --intent APPLY \
+              --client-request-token "synaplan-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${architecture}" \
+              --change-set "$change_set" \
+              --query ChangeSetId --output text
+          )"
+
+          echo "submitted=${VERSION} (${architecture})" >> "$GITHUB_OUTPUT"
+          {
+            echo "Submitted \`${VERSION} (${architecture})\` as change set \`${id}\`, using \`${ami}\`."
+            echo ""
+            echo "AWS scans and copies the image for a few hours; a later run of this workflow reports how it ended."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # Only ever speaks when something happened. An hourly job that reports
+      # "nothing to do" teaches everyone to ignore the channel it reports to.
+      - name: Report to Discord
+        if: always() && (steps.offer.outputs.submitted != '' || steps.finished.outputs.failed != '')
+        env:
+          HOOK: ${{ secrets.DISCORD_RELEASE_WEBHOOK }}
+          SUBMITTED: ${{ steps.offer.outputs.submitted }}
+          FAILED: ${{ steps.finished.outputs.failed }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          test -n "${HOOK:-}" || exit 0
+
+          if [ -n "${FAILED:-}" ]; then
+            content="AWS Marketplace rejected a version. Change sets: ${FAILED}. ${RUN_URL}"
+          else
+            content="AWS Marketplace received \`${SUBMITTED}\`. Review takes a few days. ${RUN_URL}"
+          fi
+
+          curl --silent --show-error --fail-with-body \
+            -H 'Content-Type: application/json' \
+            -d "$(jq -nc --arg content "$content" '{content: $content}')" \
+            "$HOOK" > /dev/null

--- a/.github/workflows/marketplace-versions.yml
+++ b/.github/workflows/marketplace-versions.yml
@@ -11,15 +11,17 @@ name: Marketplace Versions
 # therefore submits one architecture and ends; this job submits the next one as
 # soon as the entity is free.
 #
-# It derives everything it needs from AWS and from the default branch, and keeps
-# no state of its own: the release comes from the version the deployment catalog
-# pins, the AMIs from their build tags, and what is already offered from the
-# listing itself. A missed run costs an hour, never a version.
+# It runs from the default branch only, and keeps no state of its own: the
+# release comes from the version the deployment catalog pins there, the AMIs from
+# their build tags, and what is already offered from the listing itself. A missed
+# run therefore costs an hour, never a version.
 
 on:
   schedule:
     # Off the hour, so it does not queue behind everything else that runs at :00.
     - cron: '17 * * * *'
+  # For not waiting out the hour — after a release, or after a rejection was
+  # fixed. Refused from anywhere but the default branch; see the first step.
   workflow_dispatch:
 
 permissions:
@@ -47,6 +49,28 @@ jobs:
       id-token: write
 
     steps:
+      # Checked before anything else, because this job holds real AWS
+      # credentials and creates real versions of a public listing: the
+      # ami-build environment carries no deployment branch policy, so nothing
+      # else keeps a dispatch from a feature branch out. From there it would
+      # read that branch's pin and its copy of the scripts, and could offer a
+      # version nobody released.
+      #
+      # Only dispatches are examined. A scheduled run is on the default branch
+      # by definition, and asking the event payload about it would make the
+      # hourly run depend on a field that a schedule payload need not carry.
+      - name: Require the default branch
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          SELECTED: ${{ github.ref_name }}
+          DEFAULT: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          if [ "$SELECTED" != "$DEFAULT" ]; then
+            echo "::error::A version is offered from ${DEFAULT}, not from ${SELECTED}."
+            exit 1
+          fi
+
       # Skipped rather than failed while the listing does not exist yet, exactly
       # like the submit job in aws-ami.yml. An hourly schedule must not turn a
       # not-yet-configured listing into an hourly red run.

--- a/docs/AWS_MARKETPLACE_LISTING.md
+++ b/docs/AWS_MARKETPLACE_LISTING.md
@@ -195,7 +195,10 @@ flight, and ingesting an AMI is slow — AWS copies the image into every region 
 the listing and scans it for vulnerabilities, which its own documentation puts at
 *a few hours*. So the release build submits one architecture and ends;
 [`marketplace-versions.yml`](../.github/workflows/marketplace-versions.yml) runs
-hourly and submits the next one once the entity is free.
+hourly and submits the next one once the entity is free. When waiting out the
+hour is not worth it, start it by hand: **Actions** → **Marketplace Versions** →
+**Run workflow**, from `main` — it refuses any other branch, because it would
+read that branch's pin and offer a version nobody released.
 
 That workflow keeps no state. It reads the release from the version the
 deployment catalog pins on `main`, finds each AMI by the `SynaplanVersion` and

--- a/docs/AWS_MARKETPLACE_LISTING.md
+++ b/docs/AWS_MARKETPLACE_LISTING.md
@@ -177,26 +177,44 @@ while either of them is missing:
 | `AWS_MARKETPLACE_INGESTION_ROLE_ARN` | the `IngestionRoleArn` output of the roles stack |
 
 Nothing else has to be switched on, and nothing has to be switched over later.
-Every architecture is sent twice: first with `Intent=VALIDATE`, which asks AWS
-whether it would accept the document without creating anything, and then — only
-if that passed — with `Intent=APPLY`. That covers what a separate dry run used
-to cover, a wrong product ID or a role AWS cannot assume, without leaving a
-manual step between two releases for someone to forget.
+Each version is sent twice: first with `Intent=VALIDATE`, which asks AWS whether
+it would accept the document without creating anything, and then — only if that
+passed — with `Intent=APPLY`. That covers what a separate dry run used to cover,
+a wrong product ID or a role AWS cannot assume, without leaving a manual step
+between two releases for someone to forget.
 
-A submitted version still sits in AWS review for days, so it is not published by
-this job. If a submission turns out to be wrong, cancel its change set —
+### Why one release takes two runs
+
+Each architecture becomes a **separate version**, titled `<version> (x86_64)` and
+`<version> (arm64)`. That is AWS's rule, not a choice: all delivery options of one
+version must share the same `AmiSource`, so one version can carry only one AMI.
+
+Those two versions cannot be submitted together. AWS answers a second
+`AddDeliveryOptions` on the same product with an error while the first is in
+flight, and ingesting an AMI is slow — AWS copies the image into every region of
+the listing and scans it for vulnerabilities, which its own documentation puts at
+*a few hours*. So the release build submits one architecture and ends;
+[`marketplace-versions.yml`](../.github/workflows/marketplace-versions.yml) runs
+hourly and submits the next one once the entity is free.
+
+That workflow keeps no state. It reads the release from the version the
+deployment catalog pins on `main`, finds each AMI by the `SynaplanVersion` and
+`Architecture` tags Packer writes, and asks the listing which versions it already
+offers. A missed run therefore costs an hour, never a version. It is also what
+reports the outcome: a change set AWS rejects turns that run red and, if
+`DISCORD_RELEASE_WEBHOOK` is set, says so in the channel. Both workflows build
+the change set with
+[`scripts/marketplace-change-set.mjs`](../scripts/marketplace-change-set.mjs), so
+the two halves of one release cannot end up described differently.
+
+A submitted version still sits in AWS review for days, and neither job publishes
+it. If a submission turns out to be wrong, cancel its change set —
 `CancelChangeSet` is part of the build role's permissions:
 
 ```bash
 aws marketplace-catalog cancel-change-set \
   --catalog AWSMarketplace --change-set-id <id>
 ```
-
-Each architecture becomes a **separate version**, titled `<version> (x86_64)` and
-`<version> (arm64)`. That is AWS's rule, not a choice: all delivery options of one
-version must share the same `AmiSource`, so one version can carry only one AMI.
-They are submitted one after the other because a running change set locks the
-entity.
 
 ### Finding the product ID
 

--- a/scripts/marketplace-change-set.mjs
+++ b/scripts/marketplace-change-set.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+
+// Builds the AWS Marketplace change set that offers one built AMI to the
+// listing as a new version.
+//
+// It lives here rather than inline in a workflow because two of them need the
+// identical document: aws-ami.yml submits the first architecture right after a
+// release is built, and marketplace-versions.yml submits the remaining one
+// later. AWS refuses a second `AddDeliveryOptions` while the first is still in
+// flight, and an AMI version takes hours to ingest, so those two submissions
+// cannot happen in the same run — but they must produce the same version shape,
+// or the listing would carry two differently described halves of one release.
+
+import { pathToFileURL } from 'node:url'
+import { resolve } from 'node:path'
+
+// Every delivery option of one version shares a single AmiSource, so one
+// version can carry exactly one AMI. Two architectures are therefore two
+// versions, and the title is what tells them apart in the customer's version
+// picker.
+export const versionTitle = (version, architecture) => `${version} (${architecture})`
+
+// Graviton for arm64, the comparable Intel size otherwise. Only a
+// recommendation shown in the launch form; the customer may pick anything.
+const INSTANCE_TYPES = {
+  arm64: 'm7g.xlarge',
+  x86_64: 'm7i.xlarge',
+}
+
+export const ARCHITECTURES = Object.keys(INSTANCE_TYPES)
+
+// Mirrors deploy/aws/packer/synaplan.pkr.hcl's source_ami_filter and
+// deploy/aws/scripts/harden.sh: Amazon Linux 2023, ec2-user, sshd listening but
+// password and root login refused.
+const AMI_SOURCE = {
+  UserName: 'ec2-user',
+  ScanningPort: 22,
+  OperatingSystemName: 'AMAZONLINUX',
+  OperatingSystemVersion: '2023',
+}
+
+const USAGE_INSTRUCTIONS = [
+  'Launch the instance, then open https://<public IP or your domain>.',
+  'Sign in with the administrator address shown in the CloudFormation outputs;',
+  'the single-use password is stored in SSM Parameter Store under',
+  '/synaplan/<instance-id>/admin-password and must be replaced at first sign-in.',
+  'Add an AI provider key under Admin, AI Providers.',
+  'Full guide: https://github.com/metadist/synaplan/blob/main/deploy/aws/README.md',
+].join(' ')
+
+// The listing is reachable over both, because the instance redirects plain HTTP
+// to HTTPS and issues its own certificate on first boot.
+const SECURITY_GROUPS = [
+  { IpProtocol: 'tcp', FromPort: 443, ToPort: 443, IpRanges: ['0.0.0.0/0'] },
+  { IpProtocol: 'tcp', FromPort: 80, ToPort: 80, IpRanges: ['0.0.0.0/0'] },
+]
+
+export const buildChangeSet = ({ product, version, architecture, ami, role, releaseUrl }) => {
+  const missing = Object.entries({ product, version, architecture, ami, role })
+    .filter(([, value]) => !value)
+    .map(([name]) => name)
+  if (missing.length > 0) {
+    throw new Error(`missing: ${missing.join(', ')}`)
+  }
+
+  const instanceType = INSTANCE_TYPES[architecture]
+  if (instanceType === undefined) {
+    throw new Error(
+      `unknown architecture ${JSON.stringify(architecture)}, expected one of ${ARCHITECTURES.join(', ')}`
+    )
+  }
+
+  const notes = releaseUrl
+    ? `Synaplan ${version}. Release notes: ${releaseUrl}`
+    : `Synaplan ${version}.`
+
+  return [
+    {
+      ChangeType: 'AddDeliveryOptions',
+      Entity: { Identifier: product, Type: 'AmiProduct@1.0' },
+      DetailsDocument: {
+        Version: { VersionTitle: versionTitle(version, architecture), ReleaseNotes: notes },
+        DeliveryOptions: [
+          {
+            Details: {
+              AmiDeliveryOptionDetails: {
+                AmiSource: { AmiId: ami, AccessRoleArn: role, ...AMI_SOURCE },
+                UsageInstructions: USAGE_INSTRUCTIONS,
+                RecommendedInstanceType: instanceType,
+                SecurityGroups: SECURITY_GROUPS,
+              },
+            },
+          },
+        ],
+      },
+    },
+  ]
+}
+
+const readOption = (arguments_, name) => {
+  const index = arguments_.indexOf(name)
+  return index === -1 ? null : (arguments_[index + 1] ?? null)
+}
+
+export const runCli = (arguments_ = []) => {
+  const changeSet = buildChangeSet({
+    product: readOption(arguments_, '--product'),
+    version: readOption(arguments_, '--version'),
+    architecture: readOption(arguments_, '--architecture'),
+    ami: readOption(arguments_, '--ami'),
+    role: readOption(arguments_, '--role'),
+    releaseUrl: readOption(arguments_, '--release-url') ?? '',
+  })
+
+  return `${JSON.stringify(changeSet)}\n`
+}
+
+if (process.argv[1] && pathToFileURL(resolve(process.argv[1])).href === import.meta.url) {
+  try {
+    process.stdout.write(runCli(process.argv.slice(2)))
+  } catch (error) {
+    process.stderr.write(`${error.message}\n`)
+    process.exitCode = 1
+  }
+}

--- a/tests/marketplace-change-set.test.mjs
+++ b/tests/marketplace-change-set.test.mjs
@@ -1,0 +1,87 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  ARCHITECTURES,
+  buildChangeSet,
+  runCli,
+  versionTitle,
+} from '../scripts/marketplace-change-set.mjs'
+
+const options = (overrides = {}) => ({
+  product: 'prod-example',
+  version: '4.4.3',
+  architecture: 'x86_64',
+  ami: 'ami-0123456789abcdef0',
+  role: 'arn:aws:iam::123456789012:role/synaplan-marketplace-ingestion',
+  releaseUrl: 'https://github.com/metadist/synaplan/releases/tag/v4.4.3',
+  ...overrides,
+})
+
+const details = (overrides) => buildChangeSet(options(overrides))[0].DetailsDocument
+
+test('offers the AMI as one version of the listing', () => {
+  const [change] = buildChangeSet(options())
+
+  assert.equal(change.ChangeType, 'AddDeliveryOptions')
+  assert.deepEqual(change.Entity, { Identifier: 'prod-example', Type: 'AmiProduct@1.0' })
+
+  const source = change.DetailsDocument.DeliveryOptions[0].Details.AmiDeliveryOptionDetails.AmiSource
+  assert.equal(source.AmiId, 'ami-0123456789abcdef0')
+  assert.equal(source.AccessRoleArn, options().role)
+  assert.equal(source.UserName, 'ec2-user')
+  assert.equal(source.OperatingSystemName, 'AMAZONLINUX')
+})
+
+// The title is the only thing distinguishing the two versions of one release in
+// the customer's version picker, and marketplace-versions.yml recognises an
+// already submitted architecture by exactly this string.
+test('titles a version by release and architecture', () => {
+  assert.equal(versionTitle('4.4.3', 'arm64'), '4.4.3 (arm64)')
+  assert.equal(details({ architecture: 'arm64' }).Version.VersionTitle, '4.4.3 (arm64)')
+})
+
+test('recommends a Graviton instance for arm64 and an Intel one otherwise', () => {
+  const recommended = (architecture) =>
+    details({ architecture }).DeliveryOptions[0].Details.AmiDeliveryOptionDetails
+      .RecommendedInstanceType
+
+  assert.equal(recommended('arm64'), 'm7g.xlarge')
+  assert.equal(recommended('x86_64'), 'm7i.xlarge')
+})
+
+test('links the release notes, and stays valid without them', () => {
+  assert.match(details().Version.ReleaseNotes, /releases\/tag\/v4\.4\.3$/)
+  assert.equal(details({ releaseUrl: '' }).Version.ReleaseNotes, 'Synaplan 4.4.3.')
+})
+
+// A silently wrong architecture would offer an arm64 image with an Intel
+// recommendation, which a customer only discovers after launching it.
+test('refuses an architecture it has no recommendation for', () => {
+  assert.throws(() => buildChangeSet(options({ architecture: 'riscv64' })), /unknown architecture/)
+  assert.deepEqual(ARCHITECTURES.toSorted(), ['arm64', 'x86_64'])
+})
+
+test('refuses to build a change set with a missing field', () => {
+  assert.throws(() => buildChangeSet(options({ ami: '' })), /missing: ami/)
+  assert.throws(() => buildChangeSet(options({ product: '', role: '' })), /missing: product, role/)
+})
+
+test('prints the change set as one JSON document', () => {
+  const output = runCli([
+    '--product',
+    'prod-example',
+    '--version',
+    '4.4.3',
+    '--architecture',
+    'arm64',
+    '--ami',
+    'ami-0123456789abcdef0',
+    '--role',
+    'arn:aws:iam::123456789012:role/ingestion',
+  ])
+
+  const parsed = JSON.parse(output)
+  assert.equal(parsed.length, 1)
+  assert.equal(parsed[0].DetailsDocument.Version.VersionTitle, '4.4.3 (arm64)')
+})


### PR DESCRIPTION
The first real Marketplace submission ran with 4.4.3 and showed that the job cannot do what it was built to do.

Offering a release to the AMI listing means one version per architecture, because every delivery option of a version shares a single `AmiSource`. Those two versions cannot be submitted together: AWS answers a second `AddDeliveryOptions` on the same product with an error while the first is in flight, and ingesting an AMI takes hours — it copies the image into every region of the listing and scans it for vulnerabilities, which AWS's own documentation puts at *a few hours*.

The job waited thirty minutes for that and then failed the run. That is exactly how 4.4.3 ended: `x86_64` submitted and still `PREPARING`, `arm64` never sent, the run red although nothing was actually wrong. The change set is still being ingested as this is written.

## What changes

The release build submits one architecture and watches it only long enough to catch a document AWS rejects outright — a wrong product ID or a role AWS cannot assume fails within minutes, and that still has to turn the run red. A version that is merely slow no longer does.

`marketplace-versions.yml` runs hourly and finishes the job: it submits what the listing is still missing once the entity is free, and reports a rejection to the run summary and, if `DISCORD_RELEASE_WEBHOOK` is set, to Discord.

It keeps no state of its own, which is what makes an hourly job safe here. The release comes from the version the deployment catalog pins on `main`, the AMIs from the `SynaplanVersion` and `Architecture` tags Packer already writes, and the versions already offered from the listing itself. A missed run costs an hour, never a version.

Both workflows build the change set with `scripts/marketplace-change-set.mjs`, so the two halves of one release cannot end up described differently — the AMI ingested a few hours apart still gets the same usage instructions, security groups and title scheme.

## Notes

- No IAM change: `ec2:DescribeImages` and the catalog actions are already on the build role.
- `arm64` for 4.4.3 will be picked up by the first scheduled run after this merges, once the `x86_64` change set finishes.
- Mobile impact: backend-only. `.github/**`, `scripts/**` and `tests/**` are already classified as app-neutral.