### PR TITLE
fix(ci): decide what the Marketplace listing is missing, under test

### DIFF
--- a/.github/workflows/aws-ami.yml
+++ b/.github/workflows/aws-ami.yml
@@ -11,6 +11,10 @@ name: AWS Marketplace AMI
 # allows that because the jobs below declare the ami-build environment; see
 # deploy/aws/cloudformation/marketplace-roles.yaml.
 #
+# Nothing here offers a version to the listing. It marks an image whose release
+# passed the smoke test, and marketplace-versions.yml offers what is marked —
+# one place that submits, so that a re-run cannot offer the same version twice.
+#
 # Authentication is GitHub OIDC against a role in the seller account. There are
 # no long-lived AWS keys in this repository, and there must never be.
 
@@ -214,7 +218,7 @@ jobs:
             echo ""
             echo "AMI: \`${ami}\` in \`${AWS_REGION}\`"
             echo ""
-            echo "The submit job below offers this AMI to the listing once the"
+            echo "\`marketplace-versions.yml\` offers this AMI to the listing once the"
             echo "verification launch has passed."
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -480,6 +484,57 @@ jobs:
           role-session-name: synaplan-teardown-${{ github.run_id }}
           aws-region: ${{ env.AWS_REGION }}
 
+      # The proof that this release boots and serves, written onto the images
+      # themselves so that marketplace-versions.yml can still find it hours
+      # later, from another run. It replaces what the old submit job got from
+      # `needs: verify`, and survives what a job dependency cannot: the second
+      # architecture is offered long after this run has ended.
+      #
+      # Both images are marked, although only x86_64 was launched. That is the
+      # same reasoning that let one launch gate both submissions before: the two
+      # differ in the base OS's architecture, not in the provisioning that could
+      # break, so a passing smoke test is a property of the release.
+      #
+      # A build from a feature branch is deliberately left unmarked. This
+      # workflow may be dispatched from anywhere, which is what lets a
+      # deployment fix be verified from its pull request — and the mark is now
+      # the only thing standing between an image and a public listing, so a
+      # trial build must not carry it.
+      - name: Mark the release as smoke-tested
+        if: >-
+          success() &&
+          (startsWith(github.ref, 'refs/tags/') ||
+           github.ref_name == github.event.repository.default_branch)
+        env:
+          VERSION: ${{ needs.resolve.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          ids="$(
+            aws ec2 describe-images --owners self \
+              --filters "Name=tag:SynaplanVersion,Values=${VERSION}" \
+                        "Name=state,Values=available" \
+              --query 'Images[].ImageId' --output text
+          )"
+          if [ -z "$ids" ]; then
+            echo "::error::No available AMI carries SynaplanVersion=${VERSION}; nothing could be offered to the listing."
+            exit 1
+          fi
+
+          # Deliberate word splitting: one --resources flag takes every id.
+          # shellcheck disable=SC2086
+          aws ec2 create-tags --resources $ids --tags "Key=SmokeTested,Value=${VERSION}"
+
+          {
+            echo "### Smoke test"
+            echo ""
+            echo "Marked as smoke-tested: \`${ids}\`."
+            echo ""
+            echo "\`marketplace-versions.yml\` offers \`${VERSION}\` to the AWS Marketplace listing"
+            echo "from here, one architecture per run. It runs hourly, and can be started by hand"
+            echo "from \`main\` to skip the wait."
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Show why the stack failed
         if: failure()
         run: |
@@ -586,188 +641,3 @@ jobs:
             echo "Deleting the leftover snapshot ${snapshot}."
             aws ec2 delete-snapshot --snapshot-id "$snapshot" || true
           done
-
-  submit:
-    name: Offer the version to the Marketplace listing
-    runs-on: ubuntu-latest
-    needs: [resolve, build, verify]
-    # Verification is not optional here. The build job proves an AMI exists and
-    # is ingestible; only the launch proves it boots and serves. Offering an
-    # unverified image to customers is the one mistake this listing cannot take
-    # back cheaply, so a run that skipped the launch skips the submission too.
-    if: >-
-      needs.resolve.outputs.version != '' &&
-      needs.resolve.outputs.configured == 'true' &&
-      needs.verify.result == 'success'
-    # Same trust path as the other AWS jobs: the role trusts this environment's
-    # subject claim, not a branch.
-    environment: ami-build
-    permissions:
-      contents: read
-      id-token: write
-
-    steps:
-      # The listing is created by hand in the Management Portal, and until it
-      # exists there is no entity to change. Skipped rather than failed, exactly
-      # like the missing build role above.
-      - name: Check the listing
-        id: listing
-        env:
-          PRODUCT_ID: ${{ secrets.AWS_MARKETPLACE_PRODUCT_ID }}
-          INGESTION_ROLE_ARN: ${{ secrets.AWS_MARKETPLACE_INGESTION_ROLE_ARN }}
-        run: |
-          set -euo pipefail
-
-          if [ -z "${PRODUCT_ID:-}" ] || [ -z "${INGESTION_ROLE_ARN:-}" ]; then
-            echo "configured=false" >> "$GITHUB_OUTPUT"
-            {
-              echo "### AWS Marketplace"
-              echo ""
-              echo "No \`AWS_MARKETPLACE_PRODUCT_ID\` and \`AWS_MARKETPLACE_INGESTION_ROLE_ARN\`;"
-              echo "the version was not offered to a listing. See docs/AWS_MARKETPLACE_LISTING.md."
-            } >> "$GITHUB_STEP_SUMMARY"
-            exit 0
-          fi
-
-          echo "configured=true" >> "$GITHUB_OUTPUT"
-
-      - name: Checkout
-        if: steps.listing.outputs.configured == 'true'
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-
-      - name: Assume the build role
-        if: steps.listing.outputs.configured == 'true'
-        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
-        with:
-          role-to-assume: ${{ secrets.AWS_AMI_BUILD_ROLE_ARN }}
-          role-session-name: synaplan-submit-${{ github.run_id }}
-          aws-region: ${{ env.AWS_REGION }}
-
-      - name: Download the build manifests
-        if: steps.listing.outputs.configured == 'true'
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          pattern: packer-manifest-*
-          path: manifests
-
-      - name: Offer the release to the listing
-        if: steps.listing.outputs.configured == 'true'
-        env:
-          PRODUCT_ID: ${{ secrets.AWS_MARKETPLACE_PRODUCT_ID }}
-          INGESTION_ROLE_ARN: ${{ secrets.AWS_MARKETPLACE_INGESTION_ROLE_ARN }}
-          VERSION: ${{ needs.resolve.outputs.version }}
-          ARCHITECTURES: ${{ needs.resolve.outputs.matrix }}
-          RELEASE_URL: ${{ github.server_url }}/${{ github.repository }}/releases/tag/v${{ needs.resolve.outputs.version }}
-        run: |
-          set -euo pipefail
-
-          # One AMI per version, by AWS's rule that every delivery option of a
-          # version shares a single AmiSource. Two architectures are therefore
-          # two versions — and only one of them can be offered here, because AWS
-          # rejects a second `AddDeliveryOptions` while the first is in flight
-          # ("if two requests are the same ChangeType on the same product, the
-          # second request returns an error"), and ingesting an AMI takes hours.
-          # marketplace-versions.yml submits the rest once the entity is free.
-          architecture="$(
-            printf '%s' "$ARCHITECTURES" |
-              jq -r 'if index("x86_64") then "x86_64" else .[0] end'
-          )"
-          remaining="$(
-            printf '%s' "$ARCHITECTURES" |
-              jq -r --arg first "$architecture" '[.[] | select(. != $first)] | join(", ")'
-          )"
-
-          manifest="manifests/packer-manifest-${architecture}/packer-manifest.json"
-          if [ ! -f "$manifest" ]; then
-            echo "::error::No build manifest for ${architecture}; refusing to guess an AMI id."
-            exit 1
-          fi
-
-          ami="$(jq -r '.builds[-1].artifact_id' "$manifest" | cut -d: -f2)"
-          if [ -z "$ami" ] || [ "$ami" = null ]; then
-            echo "::error::${manifest} carries no AMI id."
-            exit 1
-          fi
-
-          change_set="$(
-            node scripts/marketplace-change-set.mjs \
-              --product "$PRODUCT_ID" \
-              --version "$VERSION" \
-              --architecture "$architecture" \
-              --ami "$ami" \
-              --role "$INGESTION_ROLE_ARN" \
-              --release-url "$RELEASE_URL"
-          )"
-
-          # Validated first, then submitted, both inside this run. VALIDATE asks
-          # AWS whether it would accept the document without creating anything,
-          # which is how a wrong product id or a role AWS cannot assume is caught
-          # before a real version exists.
-          echo "::group::${architecture}: validate ${ami}"
-          aws marketplace-catalog start-change-set \
-            --catalog AWSMarketplace \
-            --intent VALIDATE \
-            --client-request-token "synaplan-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${architecture}-validate" \
-            --change-set "$change_set" > /dev/null
-          echo "Accepted."
-          echo "::endgroup::"
-
-          echo "::group::${architecture}: submit ${ami}"
-          id="$(
-            aws marketplace-catalog start-change-set \
-              --catalog AWSMarketplace \
-              --intent APPLY \
-              --client-request-token "synaplan-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${architecture}" \
-              --change-set "$change_set" \
-              --query ChangeSetId --output text
-          )"
-          echo "Change set ${id}."
-          echo "::endgroup::"
-
-          {
-            echo "### AWS Marketplace"
-            echo ""
-            echo "Submitted \`${VERSION} (${architecture})\` as change set \`${id}\`."
-          } >> "$GITHUB_STEP_SUMMARY"
-
-          # Watched briefly, not waited out. AWS copies the image into every
-          # region of the listing and scans it for vulnerabilities, which its own
-          # documentation puts at "a few hours" — far past any sensible job. What
-          # this window is for is the other outcome: a document AWS rejects fails
-          # within minutes, and that has to turn this job red rather than sit
-          # unnoticed in the portal.
-          status=PREPARING
-          for _ in $(seq 1 20); do
-            sleep 60
-            status="$(
-              aws marketplace-catalog describe-change-set \
-                --catalog AWSMarketplace --change-set-id "$id" \
-                --query Status --output text
-            )"
-            case "$status" in
-              FAILED|CANCELLED)
-                reason="$(
-                  aws marketplace-catalog describe-change-set \
-                    --catalog AWSMarketplace --change-set-id "$id" \
-                    --query 'ChangeSet[].ErrorDetailList' --output json
-                )"
-                echo "::error::Change set ${id} for ${architecture} ended as ${status}: ${reason}"
-                exit 1
-                ;;
-              SUCCEEDED) break ;;
-            esac
-          done
-
-          {
-            if [ "$status" = SUCCEEDED ]; then
-              echo "AWS has ingested it; the version is now in review."
-            else
-              echo "Still \`${status}\` after twenty minutes, which is normal — AWS scans and copies"
-              echo "the image for a few hours. \`marketplace-versions.yml\` reports the outcome."
-            fi
-            if [ -n "$remaining" ]; then
-              echo ""
-              echo "\`${remaining}\` cannot be submitted alongside it: AWS refuses a second version"
-              echo "while this one is in flight. \`marketplace-versions.yml\` picks it up hourly."
-            fi
-          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/marketplace-versions.yml
+++ b/.github/workflows/marketplace-versions.yml
@@ -1,20 +1,20 @@
 name: Marketplace Versions
 
-# Finishes what aws-ami.yml can only start, and reports how it ended.
+# Offers each release to the AWS Marketplace AMI listing, and reports how AWS
+# received it. The only place that submits a version — aws-ami.yml builds and
+# smoke-tests the images and marks them, nothing more.
 #
-# Offering a release to the AMI listing means one version per architecture,
-# because every delivery option of a version shares a single AmiSource. Those
-# versions cannot be submitted together: AWS answers a second
-# `AddDeliveryOptions` on the same product with an error while the first is in
-# flight, and ingesting an AMI takes hours — it copies the image into every
-# region of the listing and scans it for vulnerabilities. A release build
-# therefore submits one architecture and ends; this job submits the next one as
-# soon as the entity is free.
+# One version per architecture, because every delivery option of a version shares
+# a single AmiSource, and one version per run, because they cannot go together:
+# AWS answers a second `AddDeliveryOptions` on the same product with an error
+# while the first is in flight, and ingesting an AMI takes hours — it copies the
+# image into every region of the listing and scans it for vulnerabilities. So a
+# release is complete after two runs of this workflow.
 #
-# It runs from the default branch only, and keeps no state of its own: the
-# release comes from the version the deployment catalog pins there, the AMIs from
-# their build tags, and what is already offered from the listing itself. A missed
-# run therefore costs an hour, never a version.
+# It runs from the default branch only, and keeps no state of its own: the release
+# comes from the version the deployment catalog pins there, the images from their
+# tags, and what has already been sent from the listing and the change set
+# history. A missed run therefore costs an hour, never a version.
 
 on:
   schedule:
@@ -175,8 +175,7 @@ jobs:
 
           # Every VersionTitle anywhere in the document, rather than one fixed
           # path: the entity shape is AWS's to change, and reading it loosely
-          # fails safe. A title this job cannot see would at worst be offered
-          # twice, which AWS rejects, rather than silently never offered.
+          # fails safe.
           offered="$(
             aws marketplace-catalog describe-entity \
               --catalog AWSMarketplace --entity-id "$PRODUCT_ID" \
@@ -184,13 +183,39 @@ jobs:
               jq -c '[.. | objects | .VersionTitle? // empty]'
           )"
 
-          missing="$(
-            jq -nr --argjson offered "$offered" --arg version "$VERSION" '
-              ["x86_64", "arm64"]
-              | map(select(($offered | index("\($version) (\(.))")) | not))
-              | join(" ")
-            '
+          # What the listing shows is not everything it has been sent. A
+          # submission that is still being ingested is not part of the entity
+          # yet, and one that failed never will be — and both have to count,
+          # the first so it is not sent twice, the second so a rejected image is
+          # not sent again every hour. Only the change set history knows about
+          # them.
+          ids="$(
+            aws marketplace-catalog list-change-sets \
+              --catalog AWSMarketplace \
+              --filter-list "$(jq -nc --arg id "$PRODUCT_ID" '[{Name:"EntityId",ValueList:[$id]}]')" \
+              --query 'ChangeSetSummaryList[].ChangeSetId' --output json |
+              jq -r '.[]'
           )"
+
+          attempted='[]'
+          for id in $ids; do
+            # Every title anywhere in the document, for the same reason as
+            # above, and because DetailsDocument is an object for some change
+            # types and an array for others — a fixed path breaks on the ones it
+            # was not written for.
+            #
+            # VALIDATE change sets are on record too, from before this stopped
+            # sending them, and they created nothing that could collide.
+            titles="$(
+              aws marketplace-catalog describe-change-set \
+                --catalog AWSMarketplace --change-set-id "$id" --output json |
+                jq -c 'if .Intent == "APPLY" then [.. | objects | .VersionTitle? // empty] else [] end'
+            )"
+            attempted="$(printf '%s' "$attempted" | jq -c --argjson t "$titles" '. + $t')"
+          done
+
+          known="$(jq -nc --argjson a "$offered" --argjson b "$attempted" '$a + $b')"
+          missing="$(node scripts/marketplace-change-set.mjs missing --version "$VERSION" --known "$known")"
 
           echo "architectures=${missing}" >> "$GITHUB_OUTPUT"
           if [ -z "$missing" ]; then
@@ -212,26 +237,34 @@ jobs:
           # One per run, by the same AWS rule that made this workflow necessary.
           architecture="${MISSING%% *}"
 
-          # Found by the tags deploy/aws/packer/synaplan.pkr.hcl writes, so no
-          # run has to hand an AMI id to a later one. Newest wins, for a version
-          # that was rebuilt.
+          # Found by the tags Packer and the smoke test write, so no run has to
+          # hand an AMI id to a later one. Newest wins, for a version that was
+          # rebuilt.
+          #
+          # SmokeTested is what aws-ami.yml puts on the images of a release that
+          # booted and served, and it is required here rather than merely
+          # preferred: it is the only thing left between an image and a public
+          # listing now that no job dependency spans the two runs. An image
+          # built from a branch never carries it.
           ami="$(
             aws ec2 describe-images --owners self \
               --filters "Name=tag:SynaplanVersion,Values=${VERSION}" \
                         "Name=tag:Architecture,Values=${architecture}" \
+                        "Name=tag:SmokeTested,Values=${VERSION}" \
                         "Name=state,Values=available" \
               --query 'sort_by(Images, &CreationDate)[-1].ImageId' --output text
           )"
           if [ -z "$ami" ] || [ "$ami" = None ]; then
-            # Not an error: the release build may still be running, or may have
-            # failed and reported that itself. The next run picks it up.
-            echo "No AMI is built for \`${VERSION}\` on \`${architecture}\` yet; nothing offered." |
+            # Not an error: the release build may still be running, or its smoke
+            # test may have failed and reported that itself. The next run picks
+            # it up.
+            echo "No smoke-tested AMI for \`${VERSION}\` on \`${architecture}\` yet; nothing offered." |
               tee -a "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
 
           change_set="$(
-            node scripts/marketplace-change-set.mjs \
+            node scripts/marketplace-change-set.mjs change-set \
               --product "$PRODUCT_ID" \
               --version "$VERSION" \
               --architecture "$architecture" \
@@ -240,12 +273,15 @@ jobs:
               --release-url "$RELEASE_URL"
           )"
 
-          aws marketplace-catalog start-change-set \
-            --catalog AWSMarketplace \
-            --intent VALIDATE \
-            --client-request-token "synaplan-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${architecture}-validate" \
-            --change-set "$change_set" > /dev/null
-
+          # Sent once, with APPLY. An `Intent=VALIDATE` call used to go first, on
+          # the assumption that it checks the document before anything real is
+          # created — but it returns an id immediately and does its checking
+          # asynchronously, over the same half hour, so its verdict arrived long
+          # after the submission it was meant to guard. All it produced was a
+          # second change set with the same title in the portal. What it was
+          # supposed to catch, a duplicate, cannot happen now that the history
+          # above is consulted; what it cannot catch either way, a rejected
+          # image, ends as a FAILED change set and is reported.
           id="$(
             aws marketplace-catalog start-change-set \
               --catalog AWSMarketplace \

--- a/docs/AWS_MARKETPLACE_LISTING.md
+++ b/docs/AWS_MARKETPLACE_LISTING.md
@@ -122,8 +122,8 @@ meant to verify has already been built.
 
 - **`AWSMarketplaceAmiIngestion`** lets AWS Marketplace copy a submitted AMI into
   its own account for the security scan. Every submitted version names it, in the
-  Add Version form's *IAM access role ARN* field or, when the submit job does the
-  submitting, in the `AmiSource` it sends. Store its ARN as the repository secret
+  Add Version form's *IAM access role ARN* field or, when a version is submitted
+  automatically, in the `AmiSource` that goes with it. Store its ARN as the repository secret
   `AWS_MARKETPLACE_INGESTION_ROLE_ARN`.
 - **The build role** is assumed by this repository's release workflow through
   GitHub OIDC — there is no access key anywhere in this repository, and there
@@ -151,8 +151,7 @@ later and slower.
    authentication, root login, known CVEs, credentials left in the image.
    `deploy/aws/scripts/harden.sh` fails the Packer build on the first three, so
    this should be a formality. Only needed while the listing is new — once the
-   secrets below are set, the `submit` job offers each release's version by
-   itself.
+   secrets below are set, every release's versions are offered automatically.
 3. **Create the product** as a Limited listing — published, but visible only to
    the seller account and any account we allowlist. Subscribe and launch it the
    way a customer will, including one-click "Launch from Website". This is the
@@ -165,11 +164,11 @@ later and slower.
 
 ## Submitting a version automatically
 
-Once the listing exists, the `submit` job in
-[`aws-ami.yml`](../.github/workflows/aws-ami.yml) offers each release to it
-through the Marketplace Catalog API, after the AMI has been built, shared and
-verified by a real launch. It needs two secrets, and skips itself with a notice
-while either of them is missing:
+Once the listing exists,
+[`marketplace-versions.yml`](../.github/workflows/marketplace-versions.yml) offers
+each release to it through the Marketplace Catalog API. It runs hourly, and needs
+two secrets — without either of them it skips itself with a notice rather than
+failing every hour:
 
 | Secret | Value |
 | --- | --- |
@@ -177,13 +176,8 @@ while either of them is missing:
 | `AWS_MARKETPLACE_INGESTION_ROLE_ARN` | the `IngestionRoleArn` output of the roles stack |
 
 Nothing else has to be switched on, and nothing has to be switched over later.
-Each version is sent twice: first with `Intent=VALIDATE`, which asks AWS whether
-it would accept the document without creating anything, and then — only if that
-passed — with `Intent=APPLY`. That covers what a separate dry run used to cover,
-a wrong product ID or a role AWS cannot assume, without leaving a manual step
-between two releases for someone to forget.
 
-### Why one release takes two runs
+### Why one release takes several runs
 
 Each architecture becomes a **separate version**, titled `<version> (x86_64)` and
 `<version> (arm64)`. That is AWS's rule, not a choice: all delivery options of one
@@ -193,25 +187,56 @@ Those two versions cannot be submitted together. AWS answers a second
 `AddDeliveryOptions` on the same product with an error while the first is in
 flight, and ingesting an AMI is slow — AWS copies the image into every region of
 the listing and scans it for vulnerabilities, which its own documentation puts at
-*a few hours*. So the release build submits one architecture and ends;
-[`marketplace-versions.yml`](../.github/workflows/marketplace-versions.yml) runs
-hourly and submits the next one once the entity is free. When waiting out the
-hour is not worth it, start it by hand: **Actions** → **Marketplace Versions** →
-**Run workflow**, from `main` — it refuses any other branch, because it would
-read that branch's pin and offer a version nobody released.
+*a few hours*. So one version goes per run, and a release is complete after two
+of them. When waiting out the hour is not worth it, start the workflow by hand:
+**Actions** → **Marketplace Versions** → **Run workflow**, from `main` — it
+refuses any other branch, because it would read that branch's version pin and
+offer a version nobody released.
 
-That workflow keeps no state. It reads the release from the version the
-deployment catalog pins on `main`, finds each AMI by the `SynaplanVersion` and
-`Architecture` tags Packer writes, and asks the listing which versions it already
-offers. A missed run therefore costs an hour, never a version. It is also what
-reports the outcome: a change set AWS rejects turns that run red and, if
-`DISCORD_RELEASE_WEBHOOK` is set, says so in the channel. Both workflows build
-the change set with
-[`scripts/marketplace-change-set.mjs`](../scripts/marketplace-change-set.mjs), so
-the two halves of one release cannot end up described differently.
+### What it submits, and what it will not
 
-A submitted version still sits in AWS review for days, and neither job publishes
-it. If a submission turns out to be wrong, cancel its change set —
+The workflow keeps no state of its own, which is what makes an hourly job safe
+here. Everything it decides on, it reads:
+
+- **the release** from the version the deployment catalog pins on `main`, so a
+  tag whose rollout a guard held back is not offered;
+- **the image** from the `SynaplanVersion`, `Architecture` and `SmokeTested` tags
+  on the AMI;
+- **what is already submitted** from the listing *and* from the change set
+  history.
+
+Both halves of that last point are needed, because what the listing shows is not
+everything it has been sent. A version AWS is still ingesting is not part of the
+entity yet, and one that failed never becomes part of it. Only the change set
+history knows about either, and without it a version in flight would be sent a
+second time, for AWS to reject with `DUPLICATE_VERSION_TITLE`.
+
+Which architecture is still missing is decided in
+[`scripts/marketplace-change-set.mjs`](../scripts/marketplace-change-set.mjs),
+under test, rather than in the workflow. It was two lines of `jq` there once, and
+they were wrong: inside `index(...)` a `.` refers to that filter's own input, so
+the interpolated title never matched anything, every architecture always counted
+as missing, and the same version was offered again on every run.
+
+**A failed version is not retried.** AWS fails a version because it found
+something in the image, and the same image fails again; an hourly retry would
+only repeat a rejection somebody has already read. Build a new AMI, or dispatch
+the workflow once the reason is gone.
+
+`SmokeTested` is the tag [`aws-ami.yml`](../.github/workflows/aws-ami.yml) writes
+onto the images of a release whose verification launch booted and served. It is
+required, not preferred: the AMI build may be dispatched from any branch, so a
+deployment fix can be verified from its pull request, and that mark is what keeps
+such a trial build out of a public listing. Nothing in the build offers a version
+itself — one place submits, so a re-run cannot offer the same version twice.
+
+A rejection is also what this workflow reports: it turns that run red and, if
+`DISCORD_RELEASE_WEBHOOK` is set, says so in the channel. It stays silent
+otherwise, because an hourly job that reports "nothing to do" teaches everyone to
+ignore it.
+
+A submitted version still sits in AWS review for days, and nothing here
+publishes it. If a submission turns out to be wrong, cancel its change set —
 `CancelChangeSet` is part of the build role's permissions:
 
 ```bash
@@ -239,8 +264,8 @@ aws marketplace-catalog list-entities \
 ```
 
 An empty list means the listing has not been created yet — do the steps above
-first. The `submit` job stays skipped until the secret is set, so releases keep
-working in the meantime.
+first. `marketplace-versions.yml` stays skipped until the secret is set, so
+releases keep working in the meantime.
 
 ## Usage Instructions
 

--- a/scripts/marketplace-change-set.mjs
+++ b/scripts/marketplace-change-set.mjs
@@ -1,15 +1,21 @@
 #!/usr/bin/env node
 
-// Builds the AWS Marketplace change set that offers one built AMI to the
-// listing as a new version.
+// The AWS Marketplace version contract: what a version of the listing is
+// called, and which change set offers one built AMI as that version.
 //
-// It lives here rather than inline in a workflow because two of them need the
-// identical document: aws-ami.yml submits the first architecture right after a
-// release is built, and marketplace-versions.yml submits the remaining one
-// later. AWS refuses a second `AddDeliveryOptions` while the first is still in
-// flight, and an AMI version takes hours to ingest, so those two submissions
-// cannot happen in the same run — but they must produce the same version shape,
-// or the listing would carry two differently described halves of one release.
+// It lives here rather than inline in marketplace-versions.yml because it is
+// what has to stay consistent across runs. One release is two versions, one per
+// architecture, and they are submitted hours apart — AWS refuses a second
+// `AddDeliveryOptions` while the first is in flight, and ingesting an AMI takes
+// hours. The two halves of a release must still be titled and described the
+// same way.
+//
+// Deciding which architecture is still missing lives here for a second reason:
+// it was a two-line jq expression in the workflow, and it was wrong in a way no
+// eye caught. Inside `index(...)` a `.` refers to that filter's own input, so
+// the interpolated title never matched, every architecture always counted as
+// missing, and the same version was offered again on every run until AWS
+// answered DUPLICATE_VERSION_TITLE. Here it is covered by tests.
 
 import { pathToFileURL } from 'node:url'
 import { resolve } from 'node:path'
@@ -23,10 +29,12 @@ export const versionTitle = (version, architecture) => `${version} (${architectu
 // Graviton for arm64, the comparable Intel size otherwise. Only a
 // recommendation shown in the launch form; the customer may pick anything.
 const INSTANCE_TYPES = {
-  arm64: 'm7g.xlarge',
   x86_64: 'm7i.xlarge',
+  arm64: 'm7g.xlarge',
 }
 
+// In submission order, and x86_64 leads deliberately: it is what most customers
+// launch, and the one the release's smoke test launched itself.
 export const ARCHITECTURES = Object.keys(INSTANCE_TYPES)
 
 // Mirrors deploy/aws/packer/synaplan.pkr.hcl's source_ami_filter and
@@ -97,19 +105,52 @@ export const buildChangeSet = ({ product, version, architecture, ami, role, rele
   ]
 }
 
+// Which architectures of a release the listing has not been offered yet, in the
+// order they should be submitted.
+//
+// `known` is every version title the listing shows plus every one that has been
+// sent to it, including the titles of submissions that failed. A failed version
+// counts as offered on purpose: AWS fails one because it found something in the
+// image, so the same image fails again, and retrying it hourly would only repeat
+// a rejection somebody has already read.
+export const missingArchitectures = (version, known = []) => {
+  if (!version) {
+    throw new Error('missing: version')
+  }
+  if (!Array.isArray(known)) {
+    throw new Error('known must be an array of version titles')
+  }
+
+  return ARCHITECTURES.filter(
+    (architecture) => !known.includes(versionTitle(version, architecture))
+  )
+}
+
 const readOption = (arguments_, name) => {
   const index = arguments_.indexOf(name)
   return index === -1 ? null : (arguments_[index + 1] ?? null)
 }
 
 export const runCli = (arguments_ = []) => {
+  const [command, ...options] = arguments_
+
+  if (command === 'missing') {
+    const known = JSON.parse(readOption(options, '--known') ?? '[]')
+    // Space separated, because the caller is a shell that walks it word by word.
+    return `${missingArchitectures(readOption(options, '--version'), known).join(' ')}\n`
+  }
+
+  if (command !== 'change-set') {
+    throw new Error(`unknown command ${JSON.stringify(command ?? '')}, expected change-set or missing`)
+  }
+
   const changeSet = buildChangeSet({
-    product: readOption(arguments_, '--product'),
-    version: readOption(arguments_, '--version'),
-    architecture: readOption(arguments_, '--architecture'),
-    ami: readOption(arguments_, '--ami'),
-    role: readOption(arguments_, '--role'),
-    releaseUrl: readOption(arguments_, '--release-url') ?? '',
+    product: readOption(options, '--product'),
+    version: readOption(options, '--version'),
+    architecture: readOption(options, '--architecture'),
+    ami: readOption(options, '--ami'),
+    role: readOption(options, '--role'),
+    releaseUrl: readOption(options, '--release-url') ?? '',
   })
 
   return `${JSON.stringify(changeSet)}\n`

--- a/tests/marketplace-change-set.test.mjs
+++ b/tests/marketplace-change-set.test.mjs
@@ -4,6 +4,7 @@ import test from 'node:test'
 import {
   ARCHITECTURES,
   buildChangeSet,
+  missingArchitectures,
   runCli,
   versionTitle,
 } from '../scripts/marketplace-change-set.mjs'
@@ -67,8 +68,46 @@ test('refuses to build a change set with a missing field', () => {
   assert.throws(() => buildChangeSet(options({ product: '', role: '' })), /missing: product, role/)
 })
 
+// This is what a jq expression in the workflow got wrong: it compared against
+// nothing at all, so it always answered "both", and the release run kept
+// offering a version the listing already had.
+test('recognises the architectures a release has already been offered', () => {
+  assert.deepEqual(missingArchitectures('4.4.3', []), ['x86_64', 'arm64'])
+  assert.deepEqual(missingArchitectures('4.4.3', ['4.2.4', '4.4.3 (x86_64)']), ['arm64'])
+  assert.deepEqual(missingArchitectures('4.4.3', ['4.4.3 (x86_64)', '4.4.3 (arm64)']), [])
+})
+
+// A release is not the one before it, and a title that merely contains the
+// version is not that version.
+test('does not confuse one release with another', () => {
+  assert.deepEqual(missingArchitectures('4.4.3', ['4.4.2 (x86_64)', '4.4.2 (arm64)']), [
+    'x86_64',
+    'arm64',
+  ])
+  assert.deepEqual(missingArchitectures('4.4.3', ['14.4.3 (x86_64)', '4.4.30 (arm64)']), [
+    'x86_64',
+    'arm64',
+  ])
+})
+
+test('refuses to decide without a release', () => {
+  assert.throws(() => missingArchitectures('', ['4.4.3 (arm64)']), /missing: version/)
+  assert.throws(() => missingArchitectures('4.4.3', 'not an array'), /must be an array/)
+})
+
+test('prints the missing architectures for a shell to walk', () => {
+  assert.equal(runCli(['missing', '--version', '4.4.3', '--known', '["4.4.3 (arm64)"]']), 'x86_64\n')
+  assert.equal(runCli(['missing', '--version', '4.4.3']), 'x86_64 arm64\n')
+})
+
+test('refuses a command it does not know', () => {
+  assert.throws(() => runCli([]), /expected change-set or missing/)
+  assert.throws(() => runCli(['submit']), /expected change-set or missing/)
+})
+
 test('prints the change set as one JSON document', () => {
   const output = runCli([
+    'change-set',
     '--product',
     'prod-example',
     '--version',


### PR DESCRIPTION
The first hourly run after [#1668](https://github.com/metadist/synaplan/pull/1668) offered `4.4.3 (x86_64)` a second time, half an hour after the release run had already offered it. AWS rejected both attempts with `DUPLICATE_VERSION_TITLE`, so no duplicate version exists — but it would have kept doing that every hour, and `arm64` would never have been submitted at all.

## The check never worked

Which architectures the listing still needs was two lines of `jq`:

```jq
["x86_64", "arm64"] | map(select(($offered | index("\($version) (\(.))")) | not))
```

Inside `index(...)` a `.` refers to that filter's own input — the `$offered` array — not to the element of the surrounding `map`. So the interpolated title was `4.4.3 (["4.2.4","4.4.3 (x86_64)"])`, matched nothing, and every architecture always counted as missing. Verified against the real listing before and after the fix.

That decision now lives in `scripts/marketplace-change-set.mjs`, with tests that fail on exactly this mistake. A subtle comparison does not belong in a YAML string that nothing executes until it runs against a public listing.

## One place submits

Two workflows could submit, and only one of them could see what the other had sent — which is how the duplicate became possible in the first place. So the release build no longer submits. It marks the images of a release whose smoke test passed with `SmokeTested=<version>`, and `marketplace-versions.yml` offers what is marked.

That makes a re-run of the AMI build harmless, and it closes something that was open before: the build may be dispatched from any branch, which is what lets a deployment fix be verified from its pull request. Such a build is now left unmarked and can never reach a public listing. Both architectures of a release are marked although only `x86_64` is launched, which is the same reasoning that let one launch gate both submissions before — the images differ in the base OS's architecture, not in the provisioning that could break.

## Smaller things the run taught

- **`Intent=VALIDATE` is gone.** It returns an id immediately and validates asynchronously over the same half hour, so its verdict always arrived long after the submission it was meant to guard. All it produced was a second change set with the same title in the portal.
- **`DetailsDocument` is an object for some change types and an array for others.** A fixed path into it fails with `Cannot index array with string "Version"`; titles are now read shape-agnostically, as they already were for the entity.
- **A failed version is not retried.** AWS fails one because it found something in the image, so the same image fails again — an hourly retry would only repeat a rejection somebody has already read.

## After merging

The `4.4.3` images predate the `SmokeTested` tag, so it has to be set once by hand for that release; from `4.4.4` on the smoke test writes it. Then `arm64` is submitted by the next run, or by a manual dispatch.

Mobile impact: backend-only.