### PR TITLE
feat(ci): smoke-test every architecture and offer Graviton

### DIFF
--- a/.github/workflows/aws-ami.yml
+++ b/.github/workflows/aws-ami.yml
@@ -166,7 +166,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           role-to-assume: ${{ secrets.AWS_AMI_BUILD_ROLE_ARN }}
-          role-session-name: synaplan-ami-${{ github.run_id }}
+          role-session-name: synaplan-ami-${{ github.run_id }}-${{ matrix.architecture }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Check Marketplace encryption compatibility
@@ -503,7 +503,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           role-to-assume: ${{ secrets.AWS_AMI_BUILD_ROLE_ARN }}
-          role-session-name: synaplan-teardown-${{ github.run_id }}
+          role-session-name: synaplan-teardown-${{ github.run_id }}-${{ matrix.architecture }}
           aws-region: ${{ env.AWS_REGION }}
 
       # The proof that this image booted and served, written onto the image

--- a/.github/workflows/aws-ami.yml
+++ b/.github/workflows/aws-ami.yml
@@ -274,12 +274,19 @@ jobs:
           retention-days: 30
 
   verify:
-    name: Launch and smoke-test the AMI
+    name: Launch and smoke-test the AMI (${{ matrix.architecture }})
     runs-on: ubuntu-latest
     needs: [resolve, build]
-    # Only the x86_64 image is launched. The two AMIs come out of the same
-    # provisioner on the same base OS, so a second launch would re-test the
-    # scripts rather than the architecture, for a second instance-hour.
+    # Every architecture is launched, one instance each, in parallel.
+    #
+    # Only x86_64 used to be, on the argument that both images come out of the
+    # same provisioner and a second launch would re-test the scripts rather than
+    # the architecture. That holds for an internal build and does not hold for an
+    # image sold to a stranger: the arm64 build starts from a different base AMI
+    # and pulls the arm64 build of every package and container it installs, and
+    # that is exactly where an architecture breaks. Nothing is offered to the
+    # public listing that has not booted and served here.
+    #
     # The trigger is spelled out rather than tested as `inputs.verify != false`.
     # On a tag push the inputs context is empty, and GitHub compares an empty
     # string to a boolean by casting both to a number — so `'' != false` is
@@ -287,7 +294,6 @@ jobs:
     # only ever ran when someone dispatched the workflow by hand.
     if: >-
       needs.resolve.outputs.version != '' &&
-      contains(fromJSON(needs.resolve.outputs.matrix), 'x86_64') &&
       (github.event_name != 'workflow_dispatch' || inputs.verify)
     # Same reasoning as on the build job: the AWS role trusts the environment.
     environment: ami-build
@@ -295,8 +301,15 @@ jobs:
       contents: read
       id-token: write
 
+    strategy:
+      # One architecture failing must not cancel the other: which of them boots
+      # is the answer this job exists for, and each is offered on its own.
+      fail-fast: false
+      matrix:
+        architecture: ${{ fromJSON(needs.resolve.outputs.matrix) }}
+
     env:
-      STACK_NAME: synaplan-verify-${{ github.run_id }}
+      STACK_NAME: synaplan-verify-${{ github.run_id }}-${{ matrix.architecture }}
 
     steps:
       - name: Checkout
@@ -306,7 +319,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           role-to-assume: ${{ secrets.AWS_AMI_BUILD_ROLE_ARN }}
-          role-session-name: synaplan-verify-${{ github.run_id }}
+          role-session-name: synaplan-verify-${{ github.run_id }}-${{ matrix.architecture }}
           aws-region: ${{ env.AWS_REGION }}
           # The default hour is not enough any more: waiting out a cold first
           # boot alone may take fifty minutes. This is the maximum the role
@@ -317,7 +330,7 @@ jobs:
       - name: Download the build manifest
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          name: packer-manifest-x86_64
+          name: packer-manifest-${{ matrix.architecture }}
 
       - name: Read the AMI id
         id: ami
@@ -334,8 +347,17 @@ jobs:
       - name: Create the stack
         env:
           AMI_ID: ${{ steps.ami.outputs.ami }}
+          ARCHITECTURE: ${{ matrix.architecture }}
         run: |
           set -euo pipefail
+
+          # The cheapest type the template allows for this architecture, since
+          # what is being tested is the image and not the machine.
+          case "$ARCHITECTURE" in
+            arm64) instance_type=c7g.xlarge ;;
+            *)     instance_type=c7i.xlarge ;;
+          esac
+
           aws cloudformation create-stack \
             --stack-name "$STACK_NAME" \
             --template-body file://deploy/aws/cloudformation/synaplan-new-vpc.yaml \
@@ -343,7 +365,7 @@ jobs:
             --on-failure DO_NOTHING \
             --parameters \
               "ParameterKey=ImageId,ParameterValue=${AMI_ID}" \
-              ParameterKey=InstanceType,ParameterValue=c7i.xlarge \
+              "ParameterKey=InstanceType,ParameterValue=${instance_type}" \
               ParameterKey=DataVolumeSize,ParameterValue=20 \
               ParameterKey=AllowedWebCidr,ParameterValue=0.0.0.0/0 \
               ParameterKey=EnableDailySnapshots,ParameterValue=false \
@@ -484,55 +506,39 @@ jobs:
           role-session-name: synaplan-teardown-${{ github.run_id }}
           aws-region: ${{ env.AWS_REGION }}
 
-      # The proof that this release boots and serves, written onto the images
-      # themselves so that marketplace-versions.yml can still find it hours
-      # later, from another run. It replaces what the old submit job got from
-      # `needs: verify`, and survives what a job dependency cannot: the second
-      # architecture is offered long after this run has ended.
-      #
-      # Both images are marked, although only x86_64 was launched. That is the
-      # same reasoning that let one launch gate both submissions before: the two
-      # differ in the base OS's architecture, not in the provisioning that could
-      # break, so a passing smoke test is a property of the release.
+      # The proof that this image booted and served, written onto the image
+      # itself so that marketplace-versions.yml can still find it hours later,
+      # from another run. It replaces what the old submit job got from
+      # `needs: verify`, and survives what a job dependency cannot: a version is
+      # offered long after this run has ended.
       #
       # A build from a feature branch is deliberately left unmarked. This
       # workflow may be dispatched from anywhere, which is what lets a
       # deployment fix be verified from its pull request — and the mark is now
       # the only thing standing between an image and a public listing, so a
       # trial build must not carry it.
-      - name: Mark the release as smoke-tested
+      - name: Mark the image as smoke-tested
         if: >-
           success() &&
           (startsWith(github.ref, 'refs/tags/') ||
            github.ref_name == github.event.repository.default_branch)
         env:
           VERSION: ${{ needs.resolve.outputs.version }}
+          ARCHITECTURE: ${{ matrix.architecture }}
+          AMI_ID: ${{ steps.ami.outputs.ami }}
         run: |
           set -euo pipefail
 
-          ids="$(
-            aws ec2 describe-images --owners self \
-              --filters "Name=tag:SynaplanVersion,Values=${VERSION}" \
-                        "Name=state,Values=available" \
-              --query 'Images[].ImageId' --output text
-          )"
-          if [ -z "$ids" ]; then
-            echo "::error::No available AMI carries SynaplanVersion=${VERSION}; nothing could be offered to the listing."
-            exit 1
-          fi
-
-          # Deliberate word splitting: one --resources flag takes every id.
-          # shellcheck disable=SC2086
-          aws ec2 create-tags --resources $ids --tags "Key=SmokeTested,Value=${VERSION}"
+          aws ec2 create-tags --resources "$AMI_ID" --tags "Key=SmokeTested,Value=${VERSION}"
 
           {
-            echo "### Smoke test"
+            echo "### Smoke test — ${ARCHITECTURE}"
             echo ""
-            echo "Marked as smoke-tested: \`${ids}\`."
+            echo "\`${AMI_ID}\` booted and served, and is marked as smoke-tested."
             echo ""
-            echo "\`marketplace-versions.yml\` offers \`${VERSION}\` to the AWS Marketplace listing"
-            echo "from here, one architecture per run. It runs hourly, and can be started by hand"
-            echo "from \`main\` to skip the wait."
+            echo "\`marketplace-versions.yml\` offers it to the AWS Marketplace listing from here,"
+            echo "one architecture per run. It runs hourly, and can be started by hand from"
+            echo "\`main\` to skip the wait."
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Show why the stack failed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1567,9 +1567,10 @@ jobs:
           for it.
 
           Once merged, \`umbrel-store-sync.yml\` carries the raised package into
-          [getumbrel/umbrel-apps](https://github.com/getumbrel/umbrel-apps), and the
-          AWS Marketplace version is submitted from \`aws-ami.yml\`. Both are proposals
-          in someone else's queue: Umbrel merges its own store pull requests, and AWS
+          [getumbrel/umbrel-apps](https://github.com/getumbrel/umbrel-apps), and
+          \`marketplace-versions.yml\` offers the AWS Marketplace version once
+          \`aws-ami.yml\` has built and smoke-tested the image. Both are proposals in
+          someone else's queue: Umbrel merges its own store pull requests, and AWS
           reviews a submitted version before it becomes available.
 
           Opened automatically after the image for \`${GITHUB_REF_NAME}\` was published

--- a/.github/workflows/marketplace-versions.yml
+++ b/.github/workflows/marketplace-versions.yml
@@ -234,69 +234,112 @@ jobs:
         run: |
           set -euo pipefail
 
-          # One per run, by the same AWS rule that made this workflow necessary.
-          architecture="${MISSING%% *}"
-
-          # Found by the tags Packer and the smoke test write, so no run has to
-          # hand an AMI id to a later one. Newest wins, for a version that was
-          # rebuilt.
-          #
-          # SmokeTested is what aws-ami.yml puts on the images of a release that
-          # booted and served, and it is required here rather than merely
-          # preferred: it is the only thing left between an image and a public
-          # listing now that no job dependency spans the two runs. An image
-          # built from a branch never carries it.
-          ami="$(
-            aws ec2 describe-images --owners self \
-              --filters "Name=tag:SynaplanVersion,Values=${VERSION}" \
-                        "Name=tag:Architecture,Values=${architecture}" \
-                        "Name=tag:SmokeTested,Values=${VERSION}" \
-                        "Name=state,Values=available" \
-              --query 'sort_by(Images, &CreationDate)[-1].ImageId' --output text
+          # What the listing lets a customer launch. The recommended type of a
+          # version has to be one of these, and inventing one instead cost a
+          # rejected submission: the listing offered three Intel types, arm64 was
+          # offered with a Graviton recommendation, and AWS answered
+          # RECOMMENDED_INSTANCE_TYPE_NOT_AVAILABLE.
+          available="$(
+            aws marketplace-catalog describe-entity \
+              --catalog AWSMarketplace --entity-id "$PRODUCT_ID" \
+              --query 'DetailsDocument.Compatibility.AvailableInstanceTypes' --output json
           )"
-          if [ -z "$ami" ] || [ "$ami" = None ]; then
-            # Not an error: the release build may still be running, or its smoke
-            # test may have failed and reported that itself. The next run picks
-            # it up.
-            echo "No smoke-tested AMI for \`${VERSION}\` on \`${architecture}\` yet; nothing offered." |
-              tee -a "$GITHUB_STEP_SUMMARY"
-            exit 0
+
+          # Which of them runs which architecture, asked of EC2 rather than read
+          # off the family letter. A `g` in the name is a convention, not a
+          # contract, and the answer decides what a customer is told to launch.
+          names="$(printf '%s' "$available" | jq -r '.[]' | tr '\n' ' ')"
+
+          # Deliberate word splitting: --instance-types takes a list.
+          # shellcheck disable=SC2086
+          architectures="$(
+            aws ec2 describe-instance-types \
+              --instance-types $names \
+              --query 'InstanceTypes[].{type:InstanceType,architectures:ProcessorInfo.SupportedArchitectures}' \
+              --output json
+          )"
+
+          submitted=''
+          for architecture in $MISSING; do
+            # In the listing's own order, so the first type it names for an
+            # architecture is the one recommended.
+            instance_type="$(
+              printf '%s' "$architectures" |
+                jq -r --arg a "$architecture" --argjson order "$available" '
+                  (map({(.type): .architectures}) | add) as $by
+                  | [$order[] | select((($by[.]) // []) | index($a))][0] // ""
+                '
+            )"
+            if [ -z "$instance_type" ]; then
+              echo "The listing offers no \`${architecture}\` instance type, so \`${VERSION}\` cannot be offered for it. Add one under Compatibility to change that." >> "$GITHUB_STEP_SUMMARY"
+              continue
+            fi
+
+            # SmokeTested is what aws-ami.yml puts on an image that booted and
+            # served, and it is required here rather than merely preferred: it is
+            # the only thing left between an image and a public listing now that
+            # no job dependency spans the two runs. An image built from a branch
+            # never carries it.
+            ami="$(
+              aws ec2 describe-images --owners self \
+                --filters "Name=tag:SynaplanVersion,Values=${VERSION}" \
+                          "Name=tag:Architecture,Values=${architecture}" \
+                          "Name=tag:SmokeTested,Values=${VERSION}" \
+                          "Name=state,Values=available" \
+                --query 'sort_by(Images, &CreationDate)[-1].ImageId' --output text
+            )"
+            if [ -z "$ami" ] || [ "$ami" = None ]; then
+              # Not an error: the release build may still be running, or its
+              # smoke test may have failed and reported that itself.
+              echo "No smoke-tested \`${architecture}\` image for \`${VERSION}\` yet." >> "$GITHUB_STEP_SUMMARY"
+              continue
+            fi
+
+            change_set="$(
+              node scripts/marketplace-change-set.mjs change-set \
+                --product "$PRODUCT_ID" \
+                --version "$VERSION" \
+                --architecture "$architecture" \
+                --ami "$ami" \
+                --role "$INGESTION_ROLE_ARN" \
+                --instance-type "$instance_type" \
+                --release-url "$RELEASE_URL"
+            )"
+
+            # Sent once, with APPLY. An `Intent=VALIDATE` call used to go first,
+            # on the assumption that it checks the document before anything real
+            # is created — but it returns an id immediately and does its checking
+            # asynchronously, over the same half hour, so its verdict arrived
+            # long after the submission it was meant to guard. All it produced
+            # was a second change set with the same title in the portal. What it
+            # was supposed to catch, a duplicate, cannot happen now that the
+            # history above is consulted; what it cannot catch either way, a
+            # rejected image, ends as a FAILED change set and is reported.
+            id="$(
+              aws marketplace-catalog start-change-set \
+                --catalog AWSMarketplace \
+                --intent APPLY \
+                --client-request-token "synaplan-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${architecture}" \
+                --change-set "$change_set" \
+                --query ChangeSetId --output text
+            )"
+
+            # One per run: AWS answers a second AddDeliveryOptions on the same
+            # product with an error while this one is in flight.
+            submitted="$(printf '%s' "$change_set" | jq -r '.[0].DetailsDocument.Version.VersionTitle')"
+            {
+              echo "Submitted \`${submitted}\` as change set \`${id}\`, using \`${ami}\` on \`${instance_type}\`."
+              echo ""
+              echo "AWS scans and copies the image for a few hours; a later run of this workflow reports how it ended."
+            } >> "$GITHUB_STEP_SUMMARY"
+            break
+          done
+
+          echo "submitted=${submitted}" >> "$GITHUB_OUTPUT"
+          if [ -z "$submitted" ]; then
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "Nothing was offered this run." >> "$GITHUB_STEP_SUMMARY"
           fi
-
-          change_set="$(
-            node scripts/marketplace-change-set.mjs change-set \
-              --product "$PRODUCT_ID" \
-              --version "$VERSION" \
-              --architecture "$architecture" \
-              --ami "$ami" \
-              --role "$INGESTION_ROLE_ARN" \
-              --release-url "$RELEASE_URL"
-          )"
-
-          # Sent once, with APPLY. An `Intent=VALIDATE` call used to go first, on
-          # the assumption that it checks the document before anything real is
-          # created — but it returns an id immediately and does its checking
-          # asynchronously, over the same half hour, so its verdict arrived long
-          # after the submission it was meant to guard. All it produced was a
-          # second change set with the same title in the portal. What it was
-          # supposed to catch, a duplicate, cannot happen now that the history
-          # above is consulted; what it cannot catch either way, a rejected
-          # image, ends as a FAILED change set and is reported.
-          id="$(
-            aws marketplace-catalog start-change-set \
-              --catalog AWSMarketplace \
-              --intent APPLY \
-              --client-request-token "synaplan-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${architecture}" \
-              --change-set "$change_set" \
-              --query ChangeSetId --output text
-          )"
-
-          echo "submitted=${VERSION} (${architecture})" >> "$GITHUB_OUTPUT"
-          {
-            echo "Submitted \`${VERSION} (${architecture})\` as change set \`${id}\`, using \`${ami}\`."
-            echo ""
-            echo "AWS scans and copies the image for a few hours; a later run of this workflow reports how it ended."
-          } >> "$GITHUB_STEP_SUMMARY"
 
       # Only ever speaks when something happened. An hourly job that reports
       # "nothing to do" teaches everyone to ignore the channel it reports to.

--- a/.github/workflows/marketplace-versions.yml
+++ b/.github/workflows/marketplace-versions.yml
@@ -245,6 +245,17 @@ jobs:
               --query 'DetailsDocument.Compatibility.AvailableInstanceTypes' --output json
           )"
 
+          # An empty or absent list is a different thing from a missing image or
+          # an architecture the listing does not carry, and it is not skipped
+          # quietly: nothing at all could ever be offered, and no amount of
+          # waiting fixes it. Left unchecked it surfaced as `Cannot iterate over
+          # null` from jq, or as an argument error from the EC2 call below, in an
+          # hourly job nobody reads until a release is found missing.
+          if [ "$(printf '%s' "$available" | jq 'if type == "array" then length else 0 end')" -eq 0 ]; then
+            echo "::error::The listing offers no instance types under Compatibility, so no version can be offered. Add the types synaplan-new-vpc.yaml accepts."
+            exit 1
+          fi
+
           # Which of them runs which architecture, asked of EC2 rather than read
           # off the family letter. A `g` in the name is a convention, not a
           # contract, and the answer decides what a customer is told to launch.

--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -210,7 +210,7 @@ pipeline below.
 | Runs | Where | What it does |
 | ---- | ----- | ------------ |
 | Every push | `deployment-templates` job in [`ci.yml`](../../.github/workflows/ci.yml) | `cfn-lint` on both templates, `packer fmt -check` and `packer validate`. No AWS account, no cost. |
-| Every release tag | [`aws-ami.yml`](../../.github/workflows/aws-ami.yml) | Waits for the release's container images, builds both unencrypted source AMIs with Packer, verifies and shares them with the AWS Marketplace ingestion account, then launches the x86_64 one through `synaplan-new-vpc.yaml` and runs `synaplan-smoke-test` on it over Session Manager. Deletes the verification stack and the snapshot it leaves behind, whatever the outcome. |
+| Every release tag | [`aws-ami.yml`](../../.github/workflows/aws-ami.yml) | Waits for the release's container images, builds both unencrypted source AMIs with Packer, verifies and shares them with the AWS Marketplace ingestion account, then launches each one through `synaplan-new-vpc.yaml` and runs `synaplan-smoke-test` on it over Session Manager. Marks an image that passed as `SmokeTested`, which is what [`marketplace-versions.yml`](../../.github/workflows/marketplace-versions.yml) offers to the Marketplace listing. Deletes the verification stack and the snapshot it leaves behind, whatever the outcome. |
 | Before a public listing | `taskcat` with [`.taskcat.yml`](.taskcat.yml) | Launches both templates in two or three regions. By hand, per release. |
 
 `aws-ami.yml` skips itself with a notice while the secret

--- a/docs/AWS_MARKETPLACE_LISTING.md
+++ b/docs/AWS_MARKETPLACE_LISTING.md
@@ -246,8 +246,12 @@ with a Graviton recommendation against an Intel-only listing, and AWS answered
 to which architecture is asked of EC2, not read off the family letter.
 
 **An architecture the listing cannot serve is skipped**, with a line in the run
-summary rather than a failure. So `arm64` is only offered once the listing lists a
-Graviton type. The listing should offer what
+summary rather than a failure — that is a configuration choice, so `arm64` is
+simply not offered until the listing lists a Graviton type. A listing offering
+**no** types at all is the other thing entirely and fails the run: nothing could
+ever be offered, and waiting does not fix it.
+
+The listing should offer what
 [`synaplan-new-vpc.yaml`](../deploy/aws/cloudformation/synaplan-new-vpc.yaml)
 accepts, which is:
 

--- a/docs/AWS_MARKETPLACE_LISTING.md
+++ b/docs/AWS_MARKETPLACE_LISTING.md
@@ -143,9 +143,9 @@ later and slower.
 
 1. **Build the AMI.** Push a release tag; the workflow builds x86_64 and arm64 in
    us-east-1, verifies their snapshots are unencrypted, shares both source AMIs
-   with the Marketplace ingestion account, then launches the x86_64 image through
-   `synaplan-new-vpc.yaml`, runs the smoke test on it over Session Manager, and
-   deletes the stack. About 20 minutes and a few cents of instance time.
+   with the Marketplace ingestion account, then launches each of them through
+   `synaplan-new-vpc.yaml`, runs the smoke test over Session Manager, and deletes
+   the stacks. About 20 minutes and a few cents of instance time.
 2. **Test Add Version** in the Management Portal. A free automated compliance
    scan that reports exactly what the review would otherwise reject: password
    authentication, root login, known CVEs, credentials left in the image.
@@ -179,9 +179,12 @@ Nothing else has to be switched on, and nothing has to be switched over later.
 
 ### Why one release takes several runs
 
-Each architecture becomes a **separate version**, titled `<version> (x86_64)` and
-`<version> (arm64)`. That is AWS's rule, not a choice: all delivery options of one
-version must share the same `AmiSource`, so one version can carry only one AMI.
+Each architecture becomes a **separate version**, titled
+`<version> - Intel or AMD (x86_64)` and `<version> - Graviton (arm64)`. That is
+AWS's rule, not a choice: all delivery options of one version must share the same
+`AmiSource`, so one version can carry only one AMI. The two sit next to each other
+in the buyer's version picker with nothing but the title to go by, which is why it
+names the hardware and not only the architecture.
 
 Those two versions cannot be submitted together. AWS answers a second
 `AddDeliveryOptions` on the same product with an error while the first is in
@@ -202,6 +205,8 @@ here. Everything it decides on, it reads:
   tag whose rollout a guard held back is not offered;
 - **the image** from the `SynaplanVersion`, `Architecture` and `SmokeTested` tags
   on the AMI;
+- **the recommended instance type** from the listing's own available types, and
+  each type's architecture from EC2;
 - **what is already submitted** from the listing *and* from the change set
   history.
 
@@ -224,11 +229,35 @@ only repeat a rejection somebody has already read. Build a new AMI, or dispatch
 the workflow once the reason is gone.
 
 `SmokeTested` is the tag [`aws-ami.yml`](../.github/workflows/aws-ami.yml) writes
-onto the images of a release whose verification launch booted and served. It is
-required, not preferred: the AMI build may be dispatched from any branch, so a
-deployment fix can be verified from its pull request, and that mark is what keeps
-such a trial build out of a public listing. Nothing in the build offers a version
-itself — one place submits, so a re-run cannot offer the same version twice.
+onto an image that booted and served — every architecture is launched, one
+instance each. It is required, not preferred: the AMI build may be dispatched
+from any branch, so a deployment fix can be verified from its pull request, and
+that mark is what keeps such a trial build out of a public listing. Nothing in
+the build offers a version itself — one place submits, so a re-run cannot offer
+the same version twice.
+
+### The listing's instance types
+
+A version names a **recommended instance type**, and it has to be one the listing
+offers under *Compatibility*. It is read from there rather than chosen in code,
+because a type the listing does not offer is rejected — `arm64` was once offered
+with a Graviton recommendation against an Intel-only listing, and AWS answered
+`RECOMMENDED_INSTANCE_TYPE_NOT_AVAILABLE` half a minute later. Which type belongs
+to which architecture is asked of EC2, not read off the family letter.
+
+**An architecture the listing cannot serve is skipped**, with a line in the run
+summary rather than a failure. So `arm64` is only offered once the listing lists a
+Graviton type. The listing should offer what
+[`synaplan-new-vpc.yaml`](../deploy/aws/cloudformation/synaplan-new-vpc.yaml)
+accepts, which is:
+
+```text
+c7i.xlarge  m7i.xlarge  m7i.2xlarge  r7i.xlarge
+c7g.xlarge  m7g.xlarge  m7g.2xlarge
+```
+
+The first type the listing names for an architecture is the one recommended, so
+their order there is worth a thought.
 
 A rejection is also what this workflow reports: it turns that run red and, if
 `DISCORD_RELEASE_WEBHOOK` is set, says so in the channel. It stays silent

--- a/scripts/marketplace-change-set.mjs
+++ b/scripts/marketplace-change-set.mjs
@@ -20,22 +20,33 @@
 import { pathToFileURL } from 'node:url'
 import { resolve } from 'node:path'
 
-// Every delivery option of one version shares a single AmiSource, so one
-// version can carry exactly one AMI. Two architectures are therefore two
-// versions, and the title is what tells them apart in the customer's version
-// picker.
-export const versionTitle = (version, architecture) => `${version} (${architecture})`
+// In submission order, and x86_64 leads deliberately: it is what most customers
+// launch.
+export const ARCHITECTURES = ['x86_64', 'arm64']
 
-// Graviton for arm64, the comparable Intel size otherwise. Only a
-// recommendation shown in the launch form; the customer may pick anything.
-const INSTANCE_TYPES = {
-  x86_64: 'm7i.xlarge',
-  arm64: 'm7g.xlarge',
+// What a buyer is choosing between. Every delivery option of one version shares
+// a single AmiSource, so one version carries exactly one AMI and two
+// architectures are two versions — sitting next to each other in the version
+// picker, where the title is all there is to go by. `arm64` alone does not tell
+// somebody comparing instance types anything, so the hardware is named.
+//
+// The architecture stays last and parenthesised. That is not cosmetic:
+// `missingArchitectures` recognises a version by it, including the bare
+// `<version> (<architecture>)` titles submitted before the names were added.
+const HARDWARE = {
+  x86_64: 'Intel or AMD',
+  arm64: 'Graviton',
 }
 
-// In submission order, and x86_64 leads deliberately: it is what most customers
-// launch, and the one the release's smoke test launched itself.
-export const ARCHITECTURES = Object.keys(INSTANCE_TYPES)
+export const versionTitle = (version, architecture) => {
+  const hardware = HARDWARE[architecture]
+  if (hardware === undefined) {
+    throw new Error(
+      `unknown architecture ${JSON.stringify(architecture)}, expected one of ${ARCHITECTURES.join(', ')}`
+    )
+  }
+  return `${version} - ${hardware} (${architecture})`
+}
 
 // Mirrors deploy/aws/packer/synaplan.pkr.hcl's source_ami_filter and
 // deploy/aws/scripts/harden.sh: Amazon Linux 2023, ec2-user, sshd listening but
@@ -63,20 +74,24 @@ const SECURITY_GROUPS = [
   { IpProtocol: 'tcp', FromPort: 80, ToPort: 80, IpRanges: ['0.0.0.0/0'] },
 ]
 
-export const buildChangeSet = ({ product, version, architecture, ami, role, releaseUrl }) => {
-  const missing = Object.entries({ product, version, architecture, ami, role })
+export const buildChangeSet = ({
+  product,
+  version,
+  architecture,
+  ami,
+  role,
+  instanceType,
+  releaseUrl,
+}) => {
+  const missing = Object.entries({ product, version, architecture, ami, role, instanceType })
     .filter(([, value]) => !value)
     .map(([name]) => name)
   if (missing.length > 0) {
     throw new Error(`missing: ${missing.join(', ')}`)
   }
 
-  const instanceType = INSTANCE_TYPES[architecture]
-  if (instanceType === undefined) {
-    throw new Error(
-      `unknown architecture ${JSON.stringify(architecture)}, expected one of ${ARCHITECTURES.join(', ')}`
-    )
-  }
+  // Throws on an architecture that has no name, before anything is sent.
+  const title = versionTitle(version, architecture)
 
   const notes = releaseUrl
     ? `Synaplan ${version}. Release notes: ${releaseUrl}`
@@ -87,7 +102,7 @@ export const buildChangeSet = ({ product, version, architecture, ami, role, rele
       ChangeType: 'AddDeliveryOptions',
       Entity: { Identifier: product, Type: 'AmiProduct@1.0' },
       DetailsDocument: {
-        Version: { VersionTitle: versionTitle(version, architecture), ReleaseNotes: notes },
+        Version: { VersionTitle: title, ReleaseNotes: notes },
         DeliveryOptions: [
           {
             Details: {
@@ -121,9 +136,19 @@ export const missingArchitectures = (version, known = []) => {
     throw new Error('known must be an array of version titles')
   }
 
-  return ARCHITECTURES.filter(
-    (architecture) => !known.includes(versionTitle(version, architecture))
-  )
+  // Matched by shape rather than compared for equality, so that a title written
+  // before the hardware names were added still counts as this release. Only the
+  // release at the front and the architecture at the back are load-bearing;
+  // anything between them is prose.
+  //
+  // The word boundary after the release is what keeps 4.4.3 apart from 4.4.30,
+  // and the anchor keeps it apart from 14.4.3.
+  const escaped = version.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
+  return ARCHITECTURES.filter((architecture) => {
+    const offered = new RegExp(`^${escaped}\\b.*\\(${architecture}\\)$`)
+    return !known.some((title) => offered.test(title))
+  })
 }
 
 const readOption = (arguments_, name) => {
@@ -150,6 +175,7 @@ export const runCli = (arguments_ = []) => {
     architecture: readOption(options, '--architecture'),
     ami: readOption(options, '--ami'),
     role: readOption(options, '--role'),
+    instanceType: readOption(options, '--instance-type'),
     releaseUrl: readOption(options, '--release-url') ?? '',
   })
 

--- a/tests/marketplace-change-set.test.mjs
+++ b/tests/marketplace-change-set.test.mjs
@@ -15,6 +15,7 @@ const options = (overrides = {}) => ({
   architecture: 'x86_64',
   ami: 'ami-0123456789abcdef0',
   role: 'arn:aws:iam::123456789012:role/synaplan-marketplace-ingestion',
+  instanceType: 'c7i.xlarge',
   releaseUrl: 'https://github.com/metadist/synaplan/releases/tag/v4.4.3',
   ...overrides,
 })
@@ -35,20 +36,25 @@ test('offers the AMI as one version of the listing', () => {
 })
 
 // The title is the only thing distinguishing the two versions of one release in
-// the customer's version picker, and marketplace-versions.yml recognises an
-// already submitted architecture by exactly this string.
-test('titles a version by release and architecture', () => {
-  assert.equal(versionTitle('4.4.3', 'arm64'), '4.4.3 (arm64)')
-  assert.equal(details({ architecture: 'arm64' }).Version.VersionTitle, '4.4.3 (arm64)')
+// the customer's version picker, so it names the hardware rather than only the
+// architecture — and keeps the architecture last, where missingArchitectures
+// looks for it.
+test('titles a version by release and hardware', () => {
+  assert.equal(versionTitle('4.4.3', 'arm64'), '4.4.3 - Graviton (arm64)')
+  assert.equal(versionTitle('4.4.3', 'x86_64'), '4.4.3 - Intel or AMD (x86_64)')
+  assert.equal(details({ architecture: 'arm64' }).Version.VersionTitle, '4.4.3 - Graviton (arm64)')
 })
 
-test('recommends a Graviton instance for arm64 and an Intel one otherwise', () => {
-  const recommended = (architecture) =>
-    details({ architecture }).DeliveryOptions[0].Details.AmiDeliveryOptionDetails
-      .RecommendedInstanceType
+// The listing decides which instance types it offers, so the recommendation has
+// to come from there. Inventing one here cost a rejected submission:
+// RECOMMENDED_INSTANCE_TYPE_NOT_AVAILABLE, hours after the fact.
+test('recommends the instance type it was given', () => {
+  const recommended = (overrides) =>
+    details(overrides).DeliveryOptions[0].Details.AmiDeliveryOptionDetails.RecommendedInstanceType
 
-  assert.equal(recommended('arm64'), 'm7g.xlarge')
-  assert.equal(recommended('x86_64'), 'm7i.xlarge')
+  assert.equal(recommended({ architecture: 'arm64', instanceType: 'c7g.xlarge' }), 'c7g.xlarge')
+  assert.equal(recommended({ instanceType: 'm7i.2xlarge' }), 'm7i.2xlarge')
+  assert.throws(() => buildChangeSet(options({ instanceType: '' })), /missing: instanceType/)
 })
 
 test('links the release notes, and stays valid without them', () => {
@@ -56,9 +62,10 @@ test('links the release notes, and stays valid without them', () => {
   assert.equal(details({ releaseUrl: '' }).Version.ReleaseNotes, 'Synaplan 4.4.3.')
 })
 
-// A silently wrong architecture would offer an arm64 image with an Intel
-// recommendation, which a customer only discovers after launching it.
-test('refuses an architecture it has no recommendation for', () => {
+// An architecture nothing here knows about would be offered under a title that
+// says nothing about the hardware, which a customer only discovers by launching
+// it on the wrong instance.
+test('refuses an architecture it cannot describe', () => {
   assert.throws(() => buildChangeSet(options({ architecture: 'riscv64' })), /unknown architecture/)
   assert.deepEqual(ARCHITECTURES.toSorted(), ['arm64', 'x86_64'])
 })
@@ -73,6 +80,18 @@ test('refuses to build a change set with a missing field', () => {
 // offering a version the listing already had.
 test('recognises the architectures a release has already been offered', () => {
   assert.deepEqual(missingArchitectures('4.4.3', []), ['x86_64', 'arm64'])
+  assert.deepEqual(missingArchitectures('4.4.3', ['4.2.4', versionTitle('4.4.3', 'x86_64')]), [
+    'arm64',
+  ])
+  assert.deepEqual(
+    missingArchitectures('4.4.3', ARCHITECTURES.map((a) => versionTitle('4.4.3', a))),
+    []
+  )
+})
+
+// The titles submitted before the hardware names existed are in the listing for
+// good, and a version that stops being recognised is offered a second time.
+test('still recognises the titles submitted under the old scheme', () => {
   assert.deepEqual(missingArchitectures('4.4.3', ['4.2.4', '4.4.3 (x86_64)']), ['arm64'])
   assert.deepEqual(missingArchitectures('4.4.3', ['4.4.3 (x86_64)', '4.4.3 (arm64)']), [])
 })
@@ -100,6 +119,10 @@ test('prints the missing architectures for a shell to walk', () => {
   assert.equal(runCli(['missing', '--version', '4.4.3']), 'x86_64 arm64\n')
 })
 
+test('refuses to title a version for an architecture it has no name for', () => {
+  assert.throws(() => versionTitle('4.4.3', 'riscv64'), /unknown architecture/)
+})
+
 test('refuses a command it does not know', () => {
   assert.throws(() => runCli([]), /expected change-set or missing/)
   assert.throws(() => runCli(['submit']), /expected change-set or missing/)
@@ -118,9 +141,11 @@ test('prints the change set as one JSON document', () => {
     'ami-0123456789abcdef0',
     '--role',
     'arn:aws:iam::123456789012:role/ingestion',
+    '--instance-type',
+    'c7g.xlarge',
   ])
 
   const parsed = JSON.parse(output)
   assert.equal(parsed.length, 1)
-  assert.equal(parsed[0].DetailsDocument.Version.VersionTitle, '4.4.3 (arm64)')
+  assert.equal(parsed[0].DetailsDocument.Version.VersionTitle, '4.4.3 - Graviton (arm64)')
 })


### PR DESCRIPTION
Offering `4.4.3 (arm64)` was rejected with `RECOMMENDED_INSTANCE_TYPE_NOT_AVAILABLE`. The listing offers `c7i.xlarge`, `m7i.xlarge` and `m7i.2xlarge` — all Intel — while the recommendation was a Graviton type written into the script.

## The recommendation comes from the listing now

It is read from the listing's *Compatibility* rather than chosen in code, and which type runs which architecture is asked of EC2 instead of read off the family letter — a `g` in the name is a convention, not a contract. An architecture the listing cannot serve is **skipped with a line in the run summary**, and the run walks on to one it can serve rather than stopping at the first. Verified against the real listing:

| Listing offers | `x86_64` | `arm64` |
| --- | --- | --- |
| the three Intel types it has today | `c7i.xlarge` | *skipped* |
| those plus `c7g`/`m7g` | `c7i.xlarge` | `c7g.xlarge` |

## Nothing is sold that has not booted

That leaves the actual reason not to offer the arm64 image, which was never Graviton: nothing had ever launched it. The smoke test ran on `x86_64` only, on the argument that both images come out of the same provisioner and a second launch would re-test the scripts rather than the architecture.

That holds for an internal build. It does not hold for an image sold to a stranger — the arm64 build starts from a different base AMI and pulls the arm64 build of every package and container it installs, and that is exactly where an architecture breaks. The job is now a matrix over both architectures, one instance each, in parallel, with `fail-fast: false` so that which of them boots is actually answered. Each image is marked `SmokeTested` on its own, and only a marked image is ever offered.

Cost: one extra instance-hour per release, on the cheapest type the template allows for that architecture.

## Titles a buyer can read

`4.4.3 - Graviton (arm64)` beside `4.4.3 - Intel or AMD (x86_64)`. The two versions of one release sit next to each other in the version picker with nothing but the title to go by, and `arm64` alone tells somebody comparing instance types nothing.

The architecture stays last and parenthesised, and the "already offered" check matches on shape rather than by equality, so `4.4.3 (x86_64)` — submitted before the names existed and in the listing for good — still counts as offered. There is a test for exactly that; a title that stops being recognised would be offered a second time.

## What this does not do

Nothing changes on the public listing itself. Until Graviton types are added there, `arm64` is skipped with a notice. `4.4.3` also stays `x86_64`-only: its arm64 image predates the smoke test that would now launch it, and its failed submission is on record, so it is not retried. `4.4.4` gets both.

Mobile impact: backend-only.