### PR TITLE
chore(ci): delete the AMIs and builders nothing pays for

### DIFF
--- a/.github/workflows/aws-cleanup.yml
+++ b/.github/workflows/aws-cleanup.yml
@@ -1,0 +1,250 @@
+name: AWS Cleanup
+
+# Removes what the AMI pipeline leaves behind and nothing else pays for.
+#
+# Every release builds an AMI, and an AMI keeps a 30 GiB snapshot alive for as
+# long as it is registered. Nothing removed them, so twenty-six had piled up
+# since 4.2.4 — eleven from one day of iterating on a single release — next to
+# two Packer builders that a cancelled run had left stopped on 60 GiB of gp3 for
+# eleven days. Roughly $0.36 a day and rising, on an account whose only purpose
+# is publishing one listing.
+#
+# What it will not touch: an image a published Marketplace version launches from,
+# the two most recent releases, and anything without the tags this pipeline
+# writes. The listing still offers 4.2.4 next to the current release, so age
+# alone is never the reason an image goes.
+#
+# Deleting is decided in scripts/ami-retention.mjs, under test, because a wrong
+# answer here breaks a buyer's launch and cannot be undone.
+
+on:
+  schedule:
+    # Nightly, off the hour. Nothing here is urgent; a snapshot that lives half a
+    # day longer costs a fraction of a cent.
+    - cron: '43 3 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Only report what would be deleted.'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+# A second run would race the first into deleting the same snapshot and get an
+# error from AWS instead of a clean skip.
+concurrency:
+  group: aws-cleanup
+  cancel-in-progress: false
+
+env:
+  # Everything this pipeline creates lives where the Marketplace ingests from.
+  AWS_REGION: us-east-1
+
+jobs:
+  cleanup:
+    name: Delete what no longer has a purpose
+    runs-on: ubuntu-latest
+    # Same trust path as the jobs in aws-ami.yml: the AWS role trusts this
+    # environment's subject claim, not a branch.
+    environment: ami-build
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      # Checked before anything else, because this job holds credentials that
+      # can delete a published image: the ami-build environment carries no
+      # deployment branch policy, so nothing else keeps a dispatch from a
+      # feature branch out, and from there it would run that branch's copy of
+      # the retention rules.
+      - name: Require the default branch
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          SELECTED: ${{ github.ref_name }}
+          DEFAULT: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          if [ "$SELECTED" != "$DEFAULT" ]; then
+            echo "::error::Cleanup runs from ${DEFAULT}, not from ${SELECTED}."
+            exit 1
+          fi
+
+      # Skipped rather than failed while the account does not exist yet, like
+      # the other AWS workflows. A nightly schedule must not turn a
+      # not-yet-configured listing into a nightly red run.
+      - name: Check the credentials
+        id: config
+        env:
+          PRODUCT_ID: ${{ secrets.AWS_MARKETPLACE_PRODUCT_ID }}
+          BUILD_ROLE_ARN: ${{ secrets.AWS_AMI_BUILD_ROLE_ARN }}
+        run: |
+          if [ -n "${PRODUCT_ID:-}" ] && [ -n "${BUILD_ROLE_ARN:-}" ]; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "No AWS listing is configured; nothing to clean up." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Checkout
+        if: steps.config.outputs.configured == 'true'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Assume the build role
+        if: steps.config.outputs.configured == 'true'
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+        with:
+          role-to-assume: ${{ secrets.AWS_AMI_BUILD_ROLE_ARN }}
+          role-session-name: synaplan-cleanup-${{ github.run_id }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      # Packer terminates its own builder. This is for when it cannot, because a
+      # cancelled or timed-out workflow run killed it first — the instance keeps
+      # running or sits stopped, and its root volume is billed either way.
+      #
+      # Found by the tag Packer writes for exactly this purpose, never by
+      # guessing from an untagged instance: somebody else's manual instance in
+      # this account must survive a nightly job.
+      #
+      # The age cut-off is what keeps it from terminating the builder of a
+      # release that is being built right now. A build takes about twenty
+      # minutes; six hours is far past any of them and far short of a day.
+      - name: Terminate abandoned Packer builders
+        id: builders
+        if: steps.config.outputs.configured == 'true'
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+
+          cutoff="$(date -u -d '6 hours ago' +%Y-%m-%dT%H:%M:%SZ)"
+          stale="$(
+            aws ec2 describe-instances \
+              --filters 'Name=tag:PackerBuilder,Values=synaplan' \
+                        'Name=instance-state-name,Values=running,stopped,stopping' \
+              --query "Reservations[].Instances[?LaunchTime<='${cutoff}'].InstanceId" \
+              --output text | tr '\t' ' '
+          )"
+
+          if [ -z "$stale" ]; then
+            echo "No abandoned Packer builder." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          if [ "${DRY_RUN:-false}" = "true" ]; then
+            echo "Would terminate: \`${stale}\`." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          # Deliberate word splitting: one --instance-ids flag takes every id.
+          # shellcheck disable=SC2086
+          aws ec2 terminate-instances --instance-ids $stale > /dev/null
+          echo "terminated=${stale}" >> "$GITHUB_OUTPUT"
+          echo "Terminated abandoned Packer builders: \`${stale}\`. Their root volumes go with them." >> "$GITHUB_STEP_SUMMARY"
+
+      # What the listing launches from, which is the one thing that must survive
+      # regardless of age. Read before anything is deleted, and required to be
+      # answered: an empty result from a call that silently failed would make
+      # every published image look unused.
+      - name: Read what the listing publishes
+        id: published
+        if: steps.config.outputs.configured == 'true'
+        env:
+          PRODUCT_ID: ${{ secrets.AWS_MARKETPLACE_PRODUCT_ID }}
+        run: |
+          set -euo pipefail
+
+          versions="$(
+            aws marketplace-catalog describe-entity \
+              --catalog AWSMarketplace --entity-id "$PRODUCT_ID" \
+              --query 'DetailsDocument.Versions' --output json
+          )"
+          if [ "$(printf '%s' "$versions" | jq 'if type == "array" then length else 0 end')" -eq 0 ]; then
+            echo "::error::The listing reports no versions. Refusing to delete anything, because every published image would look unused."
+            exit 1
+          fi
+
+          images="$(printf '%s' "$versions" | jq -c '[.. | objects | select(.Image? != null) | .Image] | unique')"
+          echo "images=${images}" >> "$GITHUB_OUTPUT"
+          echo "The listing publishes $(printf '%s' "$images" | jq 'length') image(s): \`$(printf '%s' "$images" | jq -r 'join(", ")')\`." >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Delete expired images and their snapshots
+        if: steps.config.outputs.configured == 'true'
+        env:
+          PUBLISHED: ${{ steps.published.outputs.images }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+
+          # Only what this pipeline built. An image without SynaplanVersion is
+          # somebody else's and never reaches the retention rules.
+          images="$(
+            aws ec2 describe-images --owners self \
+              --filters 'Name=tag-key,Values=SynaplanVersion' \
+              --query 'Images[].{imageId:ImageId,version:Tags[?Key==`SynaplanVersion`]|[0].Value,snapshotIds:BlockDeviceMappings[].Ebs.SnapshotId}' \
+              --output json
+          )"
+
+          expired="$(
+            node scripts/ami-retention.mjs expired \
+              --images "$images" \
+              --protected "$PUBLISHED"
+          )"
+
+          if [ -z "$expired" ]; then
+            echo "Nothing has expired: $(printf '%s' "$images" | jq 'length') image(s), all published or recent." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          if [ "${DRY_RUN:-false}" = "true" ]; then
+            {
+              echo "### Would delete"
+              echo ""
+              printf '%s\n' "$expired" | sed 's/^/- `/; s/$/`/'
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          deleted=0
+          # An AMI has to be deregistered before its snapshot can go; the other
+          # order fails on a snapshot that is still in use by a registered image.
+          while read -r ami version snapshots; do
+            [ -z "$ami" ] && continue
+            aws ec2 deregister-image --image-id "$ami"
+            for snapshot in $snapshots; do
+              aws ec2 delete-snapshot --snapshot-id "$snapshot"
+            done
+            echo "- \`${ami}\` (${version}) and its snapshot(s): \`${snapshots}\`" >> "$GITHUB_STEP_SUMMARY"
+            deleted=$((deleted + 1))
+          done <<< "$expired"
+
+          # Written after the list, so the summary reads as a heading over it.
+          echo "### Deleted ${deleted} expired image(s)" >> "$GITHUB_STEP_SUMMARY"
+
+      # Unattached volumes cost the same as attached ones and belong to nothing.
+      # Reported rather than deleted: this job cannot tell whether one holds
+      # something somebody still wants, and the pipeline's own volumes go away
+      # with their instances.
+      - name: Report unattached volumes
+        if: steps.config.outputs.configured == 'true'
+        run: |
+          set -euo pipefail
+
+          orphans="$(
+            aws ec2 describe-volumes --filters 'Name=status,Values=available' \
+              --query 'Volumes[].[VolumeId,Size,CreateTime]' --output text
+          )"
+          if [ -n "$orphans" ]; then
+            {
+              echo "### Unattached volumes"
+              echo ""
+              echo "Billed like any other, attached to nothing. Delete them by hand if they hold nothing:"
+              echo ""
+              echo '```'
+              echo "$orphans"
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/aws-cleanup.yml
+++ b/.github/workflows/aws-cleanup.yml
@@ -167,7 +167,18 @@ jobs:
             exit 1
           fi
 
+          # The check above says the call answered; this one says the answer
+          # still has the shape the extraction reads. Every version of an AMI
+          # product launches from an image, so none of them yielding one means
+          # Versions[].Sources[].Image moved — and an empty list would travel on
+          # as "the listing protects nothing" and expire every published image
+          # older than the two most recent releases.
           images="$(printf '%s' "$versions" | jq -c '[.. | objects | select(.Image? != null) | .Image] | unique')"
+          if [ "$(printf '%s' "$images" | jq 'length')" -eq 0 ]; then
+            echo "::error::The listing reports $(printf '%s' "$versions" | jq 'length') version(s) but no image id could be read from them. Refusing to delete anything until Versions[].Sources[].Image is readable again."
+            exit 1
+          fi
+
           echo "images=${images}" >> "$GITHUB_OUTPUT"
           echo "The listing publishes $(printf '%s' "$images" | jq 'length') image(s): \`$(printf '%s' "$images" | jq -r 'join(", ")')\`." >> "$GITHUB_STEP_SUMMARY"
 

--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -211,6 +211,7 @@ pipeline below.
 | ---- | ----- | ------------ |
 | Every push | `deployment-templates` job in [`ci.yml`](../../.github/workflows/ci.yml) | `cfn-lint` on both templates, `packer fmt -check` and `packer validate`. No AWS account, no cost. |
 | Every release tag | [`aws-ami.yml`](../../.github/workflows/aws-ami.yml) | Waits for the release's container images, builds both unencrypted source AMIs with Packer, verifies and shares them with the AWS Marketplace ingestion account, then launches each one through `synaplan-new-vpc.yaml` and runs `synaplan-smoke-test` on it over Session Manager. Marks an image that passed as `SmokeTested`, which is what [`marketplace-versions.yml`](../../.github/workflows/marketplace-versions.yml) offers to the Marketplace listing. Deletes the verification stack and the snapshot it leaves behind, whatever the outcome. |
+| Nightly | [`aws-cleanup.yml`](../../.github/workflows/aws-cleanup.yml) | Deregisters expired AMIs and deletes their snapshots, and terminates Packer builders a cancelled run abandoned. Never touches an image a published listing version launches from, the two newest releases, or anything this pipeline did not tag. Dispatch it with **Only report what would be deleted** to see its reasoning first. |
 | Before a public listing | `taskcat` with [`.taskcat.yml`](.taskcat.yml) | Launches both templates in two or three regions. By hand, per release. |
 
 `aws-ami.yml` skips itself with a notice while the secret

--- a/deploy/aws/packer/synaplan.pkr.hcl
+++ b/deploy/aws/packer/synaplan.pkr.hcl
@@ -71,6 +71,12 @@ locals {
   instance_type = var.instance_type != "" ? var.instance_type : (var.architecture == "arm64" ? "c7g.large" : "c7i.large")
   ssh_username  = "ec2-user"
   repo_root     = "${path.root}/../../.."
+
+  build_tags = {
+    SynaplanVersion = var.synaplan_version
+    Architecture    = var.architecture
+    BuiltBy         = "packer"
+  }
 }
 
 # Amazon Linux 2023: AWS maintains it, it is free of licence cost for the
@@ -126,12 +132,25 @@ source "amazon-ebs" "synaplan" {
     http_put_response_hop_limit = 2
   }
 
-  tags = {
-    Name            = "${var.ami_name_prefix}-${var.synaplan_version}-${var.architecture}"
-    SynaplanVersion = var.synaplan_version
-    Architecture    = var.architecture
-    BuiltBy         = "packer"
-  }
+  tags = merge(local.build_tags, {
+    Name = "${var.ami_name_prefix}-${var.synaplan_version}-${var.architecture}"
+  })
+
+  # The temporary instance Packer provisions on, and its volumes. Packer
+  # terminates them itself; these tags are for when it does not, because a
+  # cancelled workflow run kills Packer before it can clean up. Two such
+  # builders once sat stopped and completely untagged on 60 GB of gp3 for eleven
+  # days, which nobody could attribute to anything until the bill arrived.
+  # aws-cleanup.yml finds them by PackerBuilder and terminates them.
+  run_tags = merge(local.build_tags, {
+    Name          = "packer-${var.ami_name_prefix}-${var.synaplan_version}-${var.architecture}"
+    PackerBuilder = "synaplan"
+  })
+
+  run_volume_tags = merge(local.build_tags, {
+    Name          = "packer-${var.ami_name_prefix}-${var.synaplan_version}-${var.architecture}"
+    PackerBuilder = "synaplan"
+  })
 }
 
 build {

--- a/docs/AWS_MARKETPLACE_LISTING.md
+++ b/docs/AWS_MARKETPLACE_LISTING.md
@@ -437,3 +437,34 @@ Deliberately avoided: a NAT gateway (~32 USD/month — a public subnet with an
 internet gateway does the same job here), an Application Load Balancer
 (~18 USD/month — Caddy terminates TLS on the instance), and Secrets Manager
 (0.40 USD per secret per month — the Parameter Store standard tier is free).
+
+### What the seller account itself costs
+
+Not nothing, and it does not stay flat by itself. Two things accumulate:
+
+- **Every release leaves an AMI**, and a registered AMI keeps a 30 GiB snapshot
+  alive behind it. One release is cents a month; a year of releases is not.
+- **A cancelled workflow run leaves a Packer builder**, because the cancellation
+  kills Packer before it can terminate its own instance. A stopped instance costs
+  no compute, but its root volume is billed exactly like a running one.
+
+Both happened. Twenty-six AMIs had piled up since 4.2.4 — eleven of them from a
+single day of iterating on one release — and two builders sat stopped on 60 GiB
+of gp3 for eleven days. Together roughly 0.36 USD a day and rising, which is what
+a first surprise bill looks like on an account whose only purpose is one listing.
+
+[`aws-cleanup.yml`](../.github/workflows/aws-cleanup.yml) runs nightly against
+both. It keeps every image a published listing version launches from, the two
+newest releases, and anything without this pipeline's tags; it terminates
+builders older than six hours found by the `PackerBuilder` tag; and it reports
+unattached volumes rather than deleting them, because it cannot know what is on
+one. Which images may go is decided in
+[`scripts/ami-retention.mjs`](../scripts/ami-retention.mjs) under test, since a
+wrong answer breaks a buyer's launch and cannot be undone.
+
+Age alone is never the reason an image goes: the listing still offers 4.2.4 next
+to the current release, and that version launches from an image far older than
+any retention window would keep.
+
+Dispatch the workflow with **Only report what would be deleted** to read its
+reasoning before it acts.

--- a/scripts/ami-retention.mjs
+++ b/scripts/ami-retention.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+
+// Which built AMIs may be deleted, and which may never be.
+//
+// Every release leaves an AMI and a 30 GiB snapshot behind, and nothing used to
+// remove them. Twenty-six had accumulated from 4.2.4 onwards — eleven of them
+// from a single day of iterating on one release — next to two Packer builders
+// that a cancelled run had left stopped on 60 GiB of gp3 for eleven days. It
+// reached roughly $0.36 a day, growing with every release, before anyone looked
+// at the bill.
+//
+// The decision lives here rather than inline in the workflow because getting it
+// wrong deletes an image a published Marketplace version launches from, which
+// cannot be undone. It is covered by tests for that reason.
+
+import { pathToFileURL } from 'node:url'
+import { resolve } from 'node:path'
+
+// Releases whose images are kept in full, newest first, on top of anything the
+// listing points at. Two rather than one so that the previous release is still
+// there to resubmit or compare against when a new one turns out to be broken.
+export const DEFAULT_KEEP_RELEASES = 2
+
+// Sorts newest first. Release strings only ever reach here as `x.y.z`, so the
+// comparison is numeric per segment — sorting them as text would rank 4.4.10
+// below 4.4.9 and quietly expire the newest release.
+const byVersionDescending = (a, b) => {
+  const left = a.split('.').map(Number)
+  const right = b.split('.').map(Number)
+
+  for (let index = 0; index < Math.max(left.length, right.length); index += 1) {
+    const difference = (right[index] ?? 0) - (left[index] ?? 0)
+    if (difference !== 0) {
+      return difference
+    }
+  }
+  return 0
+}
+
+const RELEASE = /^\d+\.\d+\.\d+$/
+
+/**
+ * @param {object} input
+ * @param {Array<{imageId: string, version?: string, snapshotIds?: string[]}>} input.images
+ *   Every AMI the account owns, as read from `describe-images`.
+ * @param {string[]} input.protectedImageIds
+ *   The images a Marketplace version launches from. Deleting one of these
+ *   breaks a live listing, so they are kept no matter how old they are — the
+ *   listing still offers 4.2.4 alongside the current release.
+ * @param {number} [input.keepReleases]
+ */
+export const selectExpiredImages = ({
+  images,
+  protectedImageIds,
+  keepReleases = DEFAULT_KEEP_RELEASES,
+}) => {
+  if (!Array.isArray(images)) {
+    throw new Error('images must be an array of AMIs')
+  }
+  // Not defaulted: an empty list is a legitimate answer, a missing one means the
+  // caller never asked the listing, and the difference decides whether a
+  // published image is deleted.
+  if (!Array.isArray(protectedImageIds)) {
+    throw new Error('protectedImageIds must be an array; pass [] only if the listing was read and offers nothing')
+  }
+  if (!Number.isInteger(keepReleases) || keepReleases < 1) {
+    throw new Error(`keepReleases must be a positive integer, got ${JSON.stringify(keepReleases)}`)
+  }
+
+  // An image without a release tag was not built by this pipeline. Somebody
+  // made it by hand, and it is not this job's to delete.
+  const ours = images.filter((image) => RELEASE.test(image.version ?? ''))
+
+  const keptReleases = new Set(
+    [...new Set(ours.map((image) => image.version))].sort(byVersionDescending).slice(0, keepReleases)
+  )
+  const kept = new Set(protectedImageIds)
+
+  return ours.filter((image) => !kept.has(image.imageId) && !keptReleases.has(image.version))
+}
+
+const readOption = (arguments_, name) => {
+  const index = arguments_.indexOf(name)
+  return index === -1 ? null : (arguments_[index + 1] ?? null)
+}
+
+export const runCli = (arguments_ = []) => {
+  const [command, ...options] = arguments_
+
+  if (command !== 'expired') {
+    throw new Error(`unknown command ${JSON.stringify(command ?? '')}, expected expired`)
+  }
+
+  const keepReleases = readOption(options, '--keep-releases')
+  const expired = selectExpiredImages({
+    images: JSON.parse(readOption(options, '--images') ?? 'null'),
+    protectedImageIds: JSON.parse(readOption(options, '--protected') ?? 'null'),
+    ...(keepReleases === null ? {} : { keepReleases: Number(keepReleases) }),
+  })
+
+  // One image per line, its snapshots space separated after it, because the
+  // caller is a shell that reads it line by line.
+  return expired
+    .map((image) => `${image.imageId} ${image.version} ${(image.snapshotIds ?? []).join(' ')}`.trimEnd())
+    .map((line) => `${line}\n`)
+    .join('')
+}
+
+if (process.argv[1] && pathToFileURL(resolve(process.argv[1])).href === import.meta.url) {
+  try {
+    process.stdout.write(runCli(process.argv.slice(2)))
+  } catch (error) {
+    process.stderr.write(`${error.message}\n`)
+    process.exitCode = 1
+  }
+}

--- a/tests/ami-retention.test.mjs
+++ b/tests/ami-retention.test.mjs
@@ -1,0 +1,138 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  DEFAULT_KEEP_RELEASES,
+  selectExpiredImages,
+  runCli,
+} from '../scripts/ami-retention.mjs'
+
+const image = (version, suffix = '') => ({
+  imageId: `ami-${version.replaceAll('.', '')}${suffix}`,
+  version,
+  snapshotIds: [`snap-${version.replaceAll('.', '')}${suffix}`],
+})
+
+const expiredIds = (input) => selectExpiredImages(input).map((each) => each.imageId)
+
+test('keeps the newest releases and expires the rest', () => {
+  const images = [image('4.2.4'), image('4.3.0'), image('4.4.2'), image('4.4.3')]
+
+  assert.deepEqual(expiredIds({ images, protectedImageIds: [], keepReleases: 2 }), [
+    'ami-424',
+    'ami-430',
+  ])
+  assert.deepEqual(expiredIds({ images, protectedImageIds: [], keepReleases: 1 }), [
+    'ami-424',
+    'ami-430',
+    'ami-442',
+  ])
+  assert.deepEqual(expiredIds({ images, protectedImageIds: [], keepReleases: 9 }), [])
+})
+
+test('keeps every image of a kept release, not just one', () => {
+  const images = [image('4.4.3', 'a'), image('4.4.3', 'b'), image('4.2.4')]
+
+  assert.deepEqual(expiredIds({ images, protectedImageIds: [], keepReleases: 1 }), ['ami-424'])
+})
+
+// The listing still offers 4.2.4 next to the current release, and its version
+// launches from an image this job would otherwise have expired long ago.
+// Deleting it cannot be undone: a buyer's launch of that version breaks.
+test('never expires an image a listing version launches from', () => {
+  const images = [image('4.2.4'), image('4.3.0'), image('4.4.2'), image('4.4.3')]
+
+  assert.deepEqual(
+    expiredIds({ images, protectedImageIds: ['ami-424'], keepReleases: 1 }),
+    ['ami-430', 'ami-442']
+  )
+})
+
+// Sorted as text, 4.4.10 ranks below 4.4.9 and the newest release is the first
+// thing deleted.
+test('orders releases numerically, not alphabetically', () => {
+  const images = [image('4.4.9'), image('4.4.10'), image('4.10.0'), image('4.9.0')]
+
+  assert.deepEqual(expiredIds({ images, protectedImageIds: [], keepReleases: 2 }), [
+    'ami-449',
+    'ami-4410',
+  ])
+})
+
+// An image somebody built by hand is not this job's to delete, and neither is
+// an AMI belonging to something else entirely in the same account.
+test('leaves images without a release tag alone', () => {
+  const images = [
+    image('4.4.3'),
+    image('4.2.4'),
+    { imageId: 'ami-manual', snapshotIds: ['snap-manual'] },
+    { imageId: 'ami-branch', version: '4.4.4-rc1', snapshotIds: [] },
+    { imageId: 'ami-latest', version: 'latest', snapshotIds: [] },
+  ]
+
+  assert.deepEqual(expiredIds({ images, protectedImageIds: [], keepReleases: 1 }), ['ami-424'])
+})
+
+test('reports the snapshots to delete with each image', () => {
+  const expired = selectExpiredImages({
+    images: [
+      { imageId: 'ami-old', version: '4.2.4', snapshotIds: ['snap-a', 'snap-b'] },
+      image('4.4.3'),
+    ],
+    protectedImageIds: [],
+    keepReleases: 1,
+  })
+
+  assert.deepEqual(expired, [
+    { imageId: 'ami-old', version: '4.2.4', snapshotIds: ['snap-a', 'snap-b'] },
+  ])
+})
+
+// A caller that never managed to read the listing must not be mistaken for one
+// that read it and found nothing, or a published image is deleted.
+test('refuses to decide without having been told what is published', () => {
+  const images = [image('4.4.3')]
+
+  assert.throws(() => selectExpiredImages({ images }), /protectedImageIds must be an array/)
+  assert.throws(
+    () => selectExpiredImages({ images, protectedImageIds: null }),
+    /protectedImageIds must be an array/
+  )
+  assert.throws(() => selectExpiredImages({ protectedImageIds: [] }), /images must be an array/)
+})
+
+test('refuses a retention that would keep nothing', () => {
+  const images = [image('4.4.3')]
+
+  for (const keepReleases of [0, -1, 1.5, 'two']) {
+    assert.throws(
+      () => selectExpiredImages({ images, protectedImageIds: [], keepReleases }),
+      /keepReleases must be a positive integer/
+    )
+  }
+})
+
+test('keeps two releases unless told otherwise', () => {
+  const images = [image('4.2.4'), image('4.4.2'), image('4.4.3')]
+
+  assert.equal(DEFAULT_KEEP_RELEASES, 2)
+  assert.deepEqual(expiredIds({ images, protectedImageIds: [] }), ['ami-424'])
+})
+
+test('prints one image per line for a shell to walk', () => {
+  const images = JSON.stringify([
+    { imageId: 'ami-old', version: '4.2.4', snapshotIds: ['snap-a', 'snap-b'] },
+    { imageId: 'ami-new', version: '4.4.3', snapshotIds: ['snap-c'] },
+  ])
+
+  assert.equal(
+    runCli(['expired', '--images', images, '--protected', '[]', '--keep-releases', '1']),
+    'ami-old 4.2.4 snap-a snap-b\n'
+  )
+  assert.equal(runCli(['expired', '--images', images, '--protected', '["ami-old"]']), '')
+})
+
+test('refuses a command it does not know', () => {
+  assert.throws(() => runCli(['delete-everything']), /unknown command/)
+  assert.throws(() => runCli([]), /unknown command/)
+})


### PR DESCRIPTION
The AWS seller account had been accumulating since the first release and nobody was watching it. It surfaced as an unexpected bill.

## What was on it

| Item | August | What it was |
| --- | --- | --- |
| `EBS:VolumeUsage.gp3` | 1.49 USD | two Packer builders left stopped since 22 August |
| `EBS:SnapshotUsage` | 1.48 USD | 26 AMIs accumulated since 4.2.4 |
| `BoxUsage` | 0.81 USD | the smoke tests, only while they run |
| `PublicIPv4` | 0.03 USD | the smoke tests |

Two things accumulate on their own. **Every release leaves an AMI**, and a registered AMI keeps a 30 GiB snapshot alive behind it — eleven of the twenty-six came from a single day of iterating on one release. **A cancelled workflow run leaves a Packer builder**, because the cancellation kills Packer before it can terminate its own instance; a stopped instance costs no compute, but its root volume is billed exactly like a running one.

Daily cost had climbed from 0.27 to 0.36 USD and was still rising. The account has been cleaned out by hand — only the two AMIs the listing publishes remain — and this is what keeps it clean.

## What the job does

`aws-cleanup.yml`, nightly:

- deregisters expired AMIs and deletes their snapshots;
- terminates Packer builders older than six hours, found by tag;
- reports unattached volumes rather than deleting them, because it cannot know what is on one.

## What it will never touch

- **An image a published Marketplace version launches from.** Age alone is never the reason an image goes: the listing still offers 4.2.4 next to the current release, from an image older than any window would keep.
- **The two newest releases**, so the previous one is still there to resubmit or compare against.
- **Anything without this pipeline's tags** — somebody's manual instance or image in the same account survives a nightly job.

If the listing reports no versions at all, the run **fails instead of deleting anything**. A silently failed read would otherwise make every published image look unused.

## Why the decision is a tested script, not inline YAML

Same reason as `marketplace-change-set.mjs`: a wrong answer breaks a buyer's launch and cannot be undone. `scripts/ami-retention.mjs` has 11 tests, including that releases sort numerically — sorted as text, 4.4.10 ranks below 4.4.9 and the newest release is the first thing deleted.

Verified against the live account before opening this: with the real state it selects nothing, and with older releases spliced in it selects exactly those.

## Packer tagging

The two abandoned builders carried **no tags at all**, so nothing could attribute them to this pipeline. Packer now tags its instance and volumes with `PackerBuilder`, which is how the cleanup finds them — never by guessing at an untagged instance.

Depends on nothing, but reads better after #1672, which stops building an arm64 image that can never be sold.

Mobile impact: backend-only.