### PR TITLE
chore(planning): update status of Self-Aware Routing feature

### DIFF
--- a/_devextras/planning/20260623-release4.0/06_self-aware-routing.md
+++ b/_devextras/planning/20260623-release4.0/06_self-aware-routing.md
@@ -1,6 +1,8 @@
 # Feature 6 — Self-Aware Routing ("Synaplan can explain Synaplan")
 
-**Release:** 4.0 · **Priority:** P1 · **Status:** Planned (started 2026-06-27)
+**Release:** 4.0 · **Priority:** P1 · **Status:** Superseded on 2026-09-02 by
+[`../20260902-platform-self-awareness/`](../20260902-platform-self-awareness/00_master_plan.md)
+(never started; kept as history — decisions carried over or replaced there)
 **Related:** [`00_master_plan.md`](./00_master_plan.md),
 [`03_file-management.md`](./03_file-management.md) (shares the RAG/vectorization
 backbone), routing pipeline in `backend/src/Service/Multitask/`.

--- a/_devextras/planning/20260902-collabora-integration/00_master_plan.md
+++ b/_devextras/planning/20260902-collabora-integration/00_master_plan.md
@@ -1,0 +1,107 @@
+# Collabora Integration — Master Plan
+
+Status: planned (see `STATUS.md`)
+Date: 2026-09-02
+Sibling plan: `../20260902-office-docs/` covers the **Synaplan side** (create,
+analyse, convert, merge and edit office files inside Synaplan). This plan
+covers the **Collabora side**: a user sitting in the Collabora Online editor
+(Writer, Calc, Impress) uses Synaplan — chat, image generation, tasks,
+knowledge — on the text, cells and slide elements in front of them.
+
+## Goal
+
+Synaplan becomes the AI behind the Collabora editor, in three places:
+
+1. **Our own Collabora** — the `collabora/code` sidecar from the office-docs
+   plan, opening Synaplan files via a Synaplan WOPI host.
+2. **Partner-hosted Collabora** — Nextcloud, OpenCloud, ownCloud, where the
+   platform already runs Collabora and Synaplan is installed as an app.
+3. **Any Collabora** — a standard Synaplan extension that a Collabora
+   operator can drop into their installation.
+
+## What Collabora Online offers today (investigated 2026-09-02)
+
+Collabora Online **26.04** (CODE released July 2026) changed the picture; the
+integration surfaces, from most to least standard:
+
+| Surface | What it is | Access to document | Status |
+| ------- | ---------- | ------------------ | ------ |
+| **Built-in AI Assistant** | Sidebar in Writer/Calc/Impress that talks to any **OpenAI-compatible** `/v1/chat/completions` endpoint (`/v1/models` for the model list) and lets the model call **editor-provided tools** (rephrase, formulas, slides, images, summarise). Configured in `coolwsd.xml <ai>` (`enabled`, `api_url`, `api_key`, `model`, `allow_user_settings`), per document via WOPI `CheckFileInfo.UserPrivateInfo` (`AIProviderURL`, `AIProviderAPIKey`, `AIProviderModel`), or per user in File > Options. Off by default. | Full, via Collabora's own tools; the model must support function calling | Shipped in 26.04; young (see upstream issue #15997 on tool loops) |
+| **MCP endpoint** | Collabora exposes Model Context Protocol so an external AI client can drive editor functions **without an open editor session** | Full, server side | Shipped in 26.04, details to verify |
+| **iframe-hosted extensions** | A directory `browser/dist/extensions/<reverse-dns-id>/` with `manifest.json` (0.1), an HTML entry and an icon; appears as an "Extensions" notebookbar tab / menu and opens as a sidebar iframe. `cool.js` gives `cool.callRemote(fn, ...args)` — runs a JS function **inside the kit process with the full UNO API** (text, cells, shapes) — and `cool.document.on*` hooks (selection change, modification, comments). | Full | Behind `experimental_features` in `coolwsd.xml`; manifest 0.1, "API not frozen" |
+| **postMessage API** (integrator page ↔ editor iframe) | `Insert_Button`/`Button_Clicked` (classic toolbar only, not the notebookbar), `Send_UNO_Command` (`.uno:InsertText`, `.uno:ExecuteSearch`, …), `Action_InsertGraphic` (host must be in `lok_allow`), `CallPythonScript` (needs pyuno packages on the server) | Partial: insert yes, **read selection no** without Python | Stable for years |
+| WOPI host | `CheckFileInfo` / `GetFile` / `PutFile` — the file storage side | File bytes only | Stable |
+
+Synaplan already has the two things the first surface needs:
+`OpenAICompatibleController` at `/v1/chat/completions` + `/v1/models`
+(API-key auth, `ApiKeyScope`), and an MCP connector layer
+(`AI/Messages/Mcp/*`, plan `20260821-mcp-oauth-connectors`). What it lacks:
+the OpenAI endpoint **drops `tools`** (it forwards only model, temperature,
+max_tokens, stream) and `ChatProviderInterface` has no tool calling — the
+same gap `office-plan_v2.md` Sprint 3 closes.
+
+## Decisions
+
+1. **Ride the built-in AI Assistant first.** Synaplan as the provider behind
+   Collabora's own sidebar is the standard, zero-install path that also works
+   in Nextcloud/OpenCloud. It needs no Collabora plugin — only a
+   tool-calling-transparent `/v1/chat/completions`. Everything Synaplan adds
+   (memories, RAG knowledge, file context, rate limits, plugins) rides along
+   because the request enters through our gateway.
+2. **The Synaplan WOPI host lives in this plan.** "Open in editor" is the
+   bridge between the two sides and the test bed for every epic here; it is
+   built once (Epic 0) and the office-docs plan only links to it.
+3. **Own extension = Epic 2, not Epic 1.** The iframe extension framework is
+   experimental (0.1). Build it as the richer experience (Synaplan chat UI,
+   image generation into the document, tasks) once the AI Assistant path is
+   in production, and keep the postMessage path as the fallback for
+   installations without the experimental flag.
+4. **Never patch Collabora.** Everything is configuration (`coolwsd.xml`,
+   WOPI), a drop-in extension directory, or Synaplan-side code. Partner
+   platforms get the same Synaplan endpoint, provisioned through the apps we
+   already ship (`synaplan-nextcloud`, `synaplan-opencloud`).
+
+```mermaid
+flowchart LR
+    subgraph editor [Collabora Online 26.04]
+        sidebar[AI Assistant sidebar]
+        ext[Synaplan extension iframe]
+        kit[kit process: UNO document]
+        sidebar -->|editor tools| kit
+        ext -->|cool.callRemote JS-UNO| kit
+    end
+    sidebar -->|"/v1/chat/completions + tools"| gateway[Synaplan OpenAI-compatible gateway]
+    ext -->|"Synaplan API (chat, images, tasks)"| api[Synaplan API]
+    wopi[Synaplan WOPI host] -->|CheckFileInfo UserPrivateInfo| editor
+    tasks[Synaplan tasks / agents] -->|MCP| mcp[Collabora MCP endpoint]
+    mcp --> kit
+```
+
+## Epics
+
+| Epic | Content | Detail |
+| ---- | ------- | ------ |
+| 0 | Synaplan WOPI host + "Open in editor" (bridge and test bed) | `01_epic_0_wopi_host.md` |
+| 1 | Synaplan as the provider of Collabora's built-in AI Assistant (tool-calling gateway, provisioning via WOPI / `coolwsd.xml`) | `02_epic_1_ai_assistant_provider.md` |
+| 2 | Synaplan extension for Collabora (iframe-hosted, `cool.callRemote`), postMessage fallback | `03_epic_2_synaplan_extension.md` |
+| 3 | Collabora MCP endpoint driven by Synaplan tasks / agents | `04_epic_3_mcp_and_tasks.md` |
+| 4 | Partner platforms: Nextcloud, OpenCloud, ownCloud provisioning | `05_epic_4_partner_platforms.md` |
+
+Dependencies on the office-docs plan: A0 (the `collabora/code` sidecar and
+`OFFICE_CONVERT_URL`) for Epic 0; Phase B2 (`ToolCallingChatProviderInterface`
+per provider) is **shared** with Epic 1 — build it once, in whichever plan
+gets there first, and record it in both `STATUS.md` files.
+
+## Ground rules
+
+Same as `../20260902-office-docs/00_master_plan.md`, plus:
+
+- Pin the Collabora version we test against (image tag + digest) and record
+  the postMessage IDs, `UserPrivateInfo` keys and `cool.js` calls we depend
+  on in `STATUS.md`; re-verify on every Collabora bump.
+- Everything Collabora-facing is **default off** and additive: no behavior
+  change for installations without Collabora.
+- The OpenAI-compatible gateway is a public API surface: API-key scopes,
+  rate limits and metering apply unchanged; never bypass them for the
+  editor.
+- No production hostnames, node details or keys in this public repository.

--- a/_devextras/planning/20260902-collabora-integration/01_epic_0_wopi_host.md
+++ b/_devextras/planning/20260902-collabora-integration/01_epic_0_wopi_host.md
@@ -1,0 +1,80 @@
+# Epic 0 — Synaplan WOPI host and "Open in editor"
+
+Status: planned
+Depends on: office-docs A0 (`collabora/code` sidecar, `OFFICE_CONVERT_URL`)
+Prerequisite from ops: a public HTTPS hostname per cluster for the editor
+(e.g. `office.<domain>`) terminated at the existing edge and proxied to the
+node-local `collabora` container. Conversion does not need it; the editor
+does, because the browser loads the editor iframe from it.
+
+Collabora talks to the file owner through WOPI; Synaplan becomes the WOPI
+host. Reference implementation: Nextcloud `richdocuments`.
+
+## Step 0.1 — WOPI endpoints (backend)
+
+Branch: `feat/wopi-host`
+
+- `Controller/WopiController.php`, routes under `/api/v1/wopi/files/{id}`
+  (thin; logic in `Service/Office/Wopi/*`):
+  - `GET` → `CheckFileInfo`: `BaseFileName`, `Size`, `OwnerId`, `UserId`,
+    `UserFriendlyName`, `UserCanWrite`, `LastModifiedTime` (ISO 8601 with
+    fractional seconds), `PostMessageOrigin` (frontend origin),
+    `EnableInsertRemoteImage`, `UserPrivateInfo` (Epic 1 fills it).
+  - `GET /contents` → file bytes.
+  - `POST /contents` → `PutFile`: compare `X-COOL-WOPI-Timestamp` with the
+    stored `LastModifiedTime`; on mismatch answer 409 with
+    `{"COOLStatusCode":1010}`; else write atomically, update `File`
+    size/mtime, dispatch office-docs A1 thumbnail, invalidate the A2 PDF
+    cache, and (Phase B) mark revision provenance `binary`.
+- `Service/Office/Wopi/WopiTokenService`: `access_token` query param,
+  short-lived (minutes, refreshed by the frontend), scoped to **one file and
+  one user**, signed with the existing token secret infrastructure. It is
+  the only credential on WOPI requests — never the user's API key.
+- `Service/Office/Wopi/WopiDiscovery`: fetch and cache
+  `{OFFICE_PUBLIC_URL}/hosting/discovery`; map extension → `urlsrc`.
+- `GET /api/v1/files/{id}/edit-session` → `{ editorUrl, accessToken,
+  accessTokenTtl, wopiSrc }` with OpenAPI → Zod.
+- Env: `OFFICE_PUBLIC_URL` (browser-facing Collabora URL). Compose (dev and
+  `synaplan-platform`): `aliasgroup1=<synaplan origin regex>` so Collabora
+  accepts our WOPI host; `--o:ssl.termination=true` behind the edge.
+- Feature flag: `officeEditorEnabled` in `/api/v1/config/features` — true
+  only when `OFFICE_PUBLIC_URL` is set and discovery succeeded.
+- Tests: token issue/verify/expiry/scope, `CheckFileInfo` shape,
+  `PutFile` conflict, discovery parsing from a fixture XML.
+
+## Step 0.2 — Editor view (frontend)
+
+Branch: `feat/office-editor-view`
+
+- Route `/files/:id/edit` → `views/DocumentEditView.vue`: Synaplan header
+  (back, filename, Download / Download as PDF from office-docs A2), then a
+  full-height `<iframe>`; the editor is opened by POSTing a hidden form with
+  `access_token` (and `access_token_ttl`) to `editorUrl?WOPISrc=…` — the
+  WOPI convention.
+- postMessage plumbing in `composables/useCollaboraFrame.ts`: wait for
+  `App_LoadingStatus` `Document_Loaded`, send `Host_PostmessageReady`,
+  handle `UI_Close`, `Doc_ModifiedStatus`, `Action_Save_Resp`. This is the
+  one place that knows message IDs — Epics 1–2 reuse it.
+- "Open in editor" entry in the office-docs A2 menu (chat badges, Files
+  tiles) when `configStore.features.officeEditorEnabled` and the extension
+  is in the discovery map.
+- Mobile: hide the entry in native shells (WebView + WOPI + third-party
+  cookies is its own project); mark the seam `MOBILE-APP SEAM`.
+- i18n (5 locales): `files.openInEditor`, `editor.saving`,
+  `editor.saveConflict`, `editor.close`.
+
+## Acceptance
+
+Open a generated `.docx` from chat in the editor, edit, save; the file in
+Synaplan changes, thumbnail and PDF export refresh, and the chat edit loop
+still works on the saved file (with the Phase B resync rule once it
+exists). Two browser tabs on the same file co-edit.
+
+## Security
+
+- WOPI endpoints accept only a valid short-lived, file-scoped token; log
+  every `PutFile` with user and file id.
+- Restrict which origins Collabora serves (`aliasgroup`) and which hosts may
+  call `convert-to` (`net.post_allow.host`).
+- The node-internal `collabora:9980` is never published; the editor hostname
+  is the only public surface.

--- a/_devextras/planning/20260902-collabora-integration/02_epic_1_ai_assistant_provider.md
+++ b/_devextras/planning/20260902-collabora-integration/02_epic_1_ai_assistant_provider.md
@@ -1,0 +1,116 @@
+# Epic 1 — Synaplan as the provider of Collabora's built-in AI Assistant
+
+Status: planned
+Depends on: Epic 0 (for the WOPI-provisioned path and as test bed); the
+`coolwsd.xml` path can be tested without Epic 0 against any document.
+Shared work: tool calling in the chat providers is the same building block as
+office-docs Phase B2 / `office-plan_v2.md` Sprint 3.
+
+Collabora 26.04's AI sidebar talks to an OpenAI-compatible endpoint and lets
+the model call the editor's own tools (draft/rephrase text, build formulas,
+turn notes into slides, insert images, summarise). Pointing it at Synaplan
+makes Synaplan the AI of every Writer, Calc and Impress session — with our
+memories, knowledge (RAG), file context, rate limits and metering — without
+installing anything in Collabora.
+
+## Step 1.1 — Tool-calling-transparent `/v1/chat/completions`
+
+**Built as office-docs Phase T** — the authoritative step list (T1–T7,
+branches, file names, test fixtures) is
+`../20260902-office-docs/03_phase_t_tool_calling_gateway.md`. This section
+only records the Collabora-specific requirements that Phase T must satisfy;
+Collabora's **editor** tools work after T3; Synaplan MCP + web search are
+also visible to the model after T4 (executed server-side, never colliding
+with editor tool names). Full provider coverage is T5/T6.
+
+Today `OpenAICompatibleController::chatCompletions()` forwards only
+`model`, `temperature`, `max_tokens`, `stream` and string `content`. The
+sidebar sends `tools` (function declarations), `tool_choice`, assistant
+messages with `tool_calls`, and `role: tool` results, and expects
+`tool_calls` back (streamed as `delta.tool_calls[*].function.arguments`
+chunks, `finish_reason: "tool_calls"`).
+
+- Introduce `ToolCallingChatProviderInterface` (from `office-plan_v2.md`
+  Sprint 3) with a normalized result (`content`, `toolCalls[]`,
+  `stopReason`, `usage`) and implement it for the providers we run behind
+  the gateway — order: Groq (Chat Completions wire format, simplest), OpenAI
+  (Responses API mapping), Anthropic, Google. Reuse the mapping already
+  written in `AI/Messages/Translator/OpenAiMessagesTranslator.php` and
+  `GeminiMessagesTranslator.php`.
+- Gateway: accept `tools`, `tool_choice`, multi-part `content`, `tool_calls`
+  and `role: tool` in the request; emit OpenAI-shaped `tool_calls` in
+  non-stream and stream responses. **Collabora's tools stay client-owned**
+  — the gateway never executes them; the editor does. On dual-gated
+  (`tool_use`) models Synaplan **also injects** the user's MCP catalog and
+  `web_search` (Phase T4). Those are executed server-side; intermediate
+  rounds are not streamed. Skip a Synaplan declaration if Collabora already
+  used the same function name.
+- Capability: dual gate — `ToolCallingChatProviderInterface` **and**
+  catalog `tool_use` (flags are made consistent in Phase T1). Either side
+  failing → 400 `tools_not_supported` (Collabora then shows chat-only
+  mode), never a silent text answer to a tool request.
+- `/v1/models`: Collabora queries it after the key is entered and shows the
+  list. Make sure only chat-capable models appear and that the `id` is what
+  the gateway accepts as `model`.
+- Tests: request/response fixtures recorded from a real CODE 26.04 session
+  (strip keys) in `tests/Fixtures/collabora/`; unit tests for the mapping per
+  provider; a gateway test that streams a tool call end to end with the
+  `TestProvider`.
+
+## Step 1.2 — Provisioning the sidebar
+
+Branch: `feat/collabora-ai-provisioning`
+
+Three ways to hand Collabora the endpoint, key and model; support all three,
+most specific wins (Collabora's own precedence: user settings > WOPI >
+`coolwsd.xml`):
+
+1. **Per document via WOPI (`UserPrivateInfo`)** — Epic 0's `CheckFileInfo`
+   adds `{"AIProviderURL": "<SYNAPLAN_URL>/v1", "AIProviderAPIKey": "<key>",
+   "AIProviderModel": "<model id>"}`. The key is a **Synaplan API key minted
+   per user for this purpose** (`ApiKeyScope` limited to the gateway,
+   revocable, labelled "Collabora editor"), created lazily on first
+   `CheckFileInfo`; the model is the user's default chat model with the
+   `tools` feature.
+2. **Instance-wide via `coolwsd.xml`** for our own sidecar: `ai.enabled`,
+   `ai.api_url`, `ai.api_key` (a service API key of a technical Synaplan
+   user), `ai.model`, `ai.allow_user_settings`. Rendered from env in the
+   compose `extra_params`; documented for operators. Users are then
+   attributed to the technical account unless (1) overrides — prefer (1)
+   wherever we are the WOPI host.
+3. **Per user** — nothing to build; document how a user pastes their
+   Synaplan API key into File > Options > AI Assistant (works for any
+   Collabora, including partner platforms before Epic 4).
+
+Admin UI: a "Collabora" card in the existing system-config groups showing
+the endpoint to paste, whether tool calling is available for the default
+model, and a test button that performs one gateway call with a dummy tool.
+
+## Step 1.3 — Make Synaplan's strengths reach the sidebar
+
+The sidebar's system prompt is Collabora's; what we control is the gateway.
+Small, flag-gated improvements, each its own PR:
+
+- **Knowledge**: when the API key carries a Synaplan "knowledge" scope,
+  inject RAG context for the user's message the same way the Anthropic
+  gateway does (`MessagesContextInjector`). Default off.
+- **Memories**: same, for user memories.
+- **Metering and limits**: already applied by the gateway; add a
+  `source=collabora` tag (from the `User-Agent` or a header we set via
+  `UserPrivateInfo` model alias) so admins can see editor usage separately.
+
+## Acceptance
+
+- Own sidecar with Epic 0: open a document → AI sidebar is enabled without
+  user setup → "Rewrite this paragraph more formally" changes the paragraph;
+  "Sanity check this data" in Calc answers with cell references; "Turn these
+  notes into 5 slides" adds slides. Usage appears in the user's Synaplan
+  metering.
+- Any Collabora 26.04 with a pasted Synaplan key: chat works; document tools
+  work with a tool-capable model; a non-tool model degrades to chat-only
+  with Collabora's own notice.
+- Upstream risk to watch: the permission/tool loop reported for some
+  OpenAI-compatible proxies (CollaboraOnline/online #15997). Our fixtures
+  must reproduce the exact multi-round shape; if Collabora needs a specific
+  quirk (e.g. `tool_calls` ids echoed verbatim), it belongs in the gateway,
+  not in the providers.

--- a/_devextras/planning/20260902-collabora-integration/03_epic_2_synaplan_extension.md
+++ b/_devextras/planning/20260902-collabora-integration/03_epic_2_synaplan_extension.md
@@ -1,0 +1,116 @@
+# Epic 2 — Synaplan extension for Collabora Online
+
+Status: planned, starts after Epic 1 is in production
+Depends on: Epic 0 (test bed), a Collabora build with the extension
+framework (26.04+ with `experimental_features` enabled; watch for the 1.0
+manifest)
+
+Epic 1 gives Collabora users Synaplan's brain inside Collabora's own
+sidebar. This epic gives them **Synaplan's face**: our chat UI, image
+generation, saved tasks, knowledge search and file context, as a first-class
+sidebar panel that reads and writes the document through Collabora's
+extension API. It is the "standard plugin" requested: one directory an
+operator drops into any Collabora installation.
+
+## How the framework works (as of 26.04, manifest 0.1)
+
+- An extension is a directory `browser/dist/extensions/<reverse-dns-id>/`
+  containing `manifest.json` (`manifestVersion: "0.1"`, `name`, `entry`,
+  `icon`, `supports: ["text","spreadsheet","presentation","drawing"]`) plus
+  its HTML/JS/CSS. coolwsd discovers the directories at startup; the editor
+  adds an **Extensions** notebookbar tab / menubar submenu with one item per
+  extension; clicking opens the entry HTML in a sidebar iframe.
+- The iframe loads `../cool.js`, which exposes:
+  - `cool.callRemote(fn, ...args)` — ships the function source to the kit
+    process and runs it in a JS-UNO context with the **full UNO API** (same
+    surface as Basic/Python macros: `com.sun.star.frame.Desktop`, text
+    ranges, sheets/cells, draw pages/shapes). The function cannot close over
+    iframe variables; everything goes in as arguments; the return value is
+    JSON-encoded.
+  - `cool.document.on*` hooks — selection changes, modifications, comment
+    add/change/remove.
+  - `Extension_Resize` / `Extension_Teardown` handshakes handled by the
+    helper.
+- Gated by `experimental_features` in `coolwsd.xml`; deploy is manual (copy
+  the directory, restart coolwsd).
+
+## Step 2.1 — Repository and build
+
+- New public repository `synaplan-collabora` (same layout as the other
+  integration repos: `frontend/` Vite build, `docs/`, CI, Conventional
+  Commits) producing `dist/com.synaplan.assistant/` with `manifest.json`,
+  `index.html`, `assets/`, `icon.svg`. Build output is what an operator
+  copies into `browser/dist/extensions/`.
+- Auth: the iframe is served **by Collabora**, not by Synaplan, so it is a
+  cross-origin client of the Synaplan API like the chat widget. Reuse the
+  widget's runtime detection and CORS model; first-run screen asks for the
+  Synaplan URL + login (OAuth device/redirect flow already used by
+  Synamail's `/addin/connect` bridge) and stores the session in the iframe's
+  storage. No hardcoded hosts.
+- Dev loop: our `collabora` compose service mounts `dist/` into
+  `/opt/cool/browser/dist/extensions/com.synaplan.assistant:ro` and enables
+  the experimental flag; Vite builds on change; reload the document.
+
+## Step 2.2 — Document adapters (the core of the epic)
+
+`src/document/` — one adapter per document type, each a set of small,
+self-contained functions passed to `cool.callRemote`. They are the only place
+UNO is touched; everything else sees plain JSON.
+
+| Adapter | Read | Write |
+| ------- | ---- | ----- |
+| `WriterAdapter` | selection text, paragraph at cursor, whole text with paragraph indexes and styles, headings outline, comments | insert text at cursor / replace selection (keeps paragraph style), insert heading/paragraph after index, insert image from data URL or URL, add comment on selection |
+| `CalcAdapter` | active sheet + selection range (values, formulas, number formats), sheet list, named ranges, cell at cursor | set values/formulas for a range, set number format, insert sheet, add chart from a range, add note |
+| `ImpressAdapter` | slide list with titles, current slide shapes (type, text, position), notes | set slide title/body text, add slide from outline, insert image on the current slide, set notes |
+
+Each function is exercised against fixture documents in an integration test
+that runs a real CODE container in CI (nightly tier; PR CI stubs
+`cool.callRemote`).
+
+## Step 2.3 — Panel UI
+
+- `Synaplan` panel: chat with the **document pinned as context** (adapter
+  read → sent as file context via the existing conversation-file mechanism),
+  quick actions per document type (Summarise, Translate selection, Rewrite,
+  Explain formula, Generate slide from notes, Make an image for this slide),
+  a result footer with **Insert at cursor / Replace selection / Copy**.
+- Image generation: Synaplan `mediamaker` result → `insertImage` in the
+  adapter (data URL path avoids Collabora's `lok_allow` host list).
+- Saved tasks: list the user's tasks that accept a document input and run
+  them on the current document (uses the office-docs engine on the server
+  for the heavy lifting; the adapter only exports the current bytes via
+  `.uno:Save` + WOPI, or sends text).
+- Design tokens: the panel is Synaplan-branded but must sit well in
+  Collabora's light and dark themes (read `prefers-color-scheme`; no
+  Tailwind colors).
+- i18n: 5 locales, reuse Synaplan keys where possible.
+
+## Step 2.4 — Fallback without the experimental flag
+
+For installations that cannot enable the extension framework, Epic 0's
+`DocumentEditView.vue` (Synaplan owns the page) hosts the **same panel
+component** next to the editor iframe and talks to the document through the
+stable postMessage API:
+
+- write: `Send_UNO_Command` (`.uno:InsertText` with `Text` and optional
+  `ParaStyleName`), `Action_InsertGraphic` (Synaplan origin must be in
+  `lok_allow`), `.uno:ExecuteSearch` to position the cursor;
+- read: postMessage cannot return the selection; use the WOPI file bytes +
+  office-docs engine (`convert-to txt`) for whole-document context and ask
+  the user to paste a selection. Honest limitation, documented in the UI.
+- toolbar: `Insert_Button` "Ask Synaplan" only in classic mode; rely on the
+  panel otherwise.
+
+This is also the interim experience until Epic 2.1–2.3 land, so build the
+panel component once, host it twice.
+
+## Acceptance
+
+- In our sidecar with the flag on: Extensions tab shows Synaplan; select a
+  paragraph → "Rewrite formally" → replaced in place with style kept; in Calc
+  select a range → "Explain" → answer references A1-style cells; in Impress
+  "Image for this slide" inserts a generated picture on the current slide.
+- The same `dist/` directory dropped into a vanilla CODE 26.04 container
+  behaves identically after login to any Synaplan instance.
+- Nothing in the extension depends on our WOPI host; it works on documents
+  opened from Nextcloud/OpenCloud once the operator installs it (Epic 4).

--- a/_devextras/planning/20260902-collabora-integration/04_epic_3_mcp_and_tasks.md
+++ b/_devextras/planning/20260902-collabora-integration/04_epic_3_mcp_and_tasks.md
@@ -1,0 +1,59 @@
+# Epic 3 — Collabora's MCP endpoint driven by Synaplan tasks and agents
+
+Status: planned, scoped after a short verification spike
+Depends on: Synaplan MCP connector layer (`20260821-mcp-oauth-connectors`),
+Epic 0 for file access; independent of Epics 1–2
+
+Collabora Online 26.04 exposes a **Model Context Protocol** endpoint so an
+external AI client can invoke editor functions **without an open editing
+session**. For Synaplan that is the server-side counterpart of Epic 2: saved
+tasks, multitask plans and agents can open a document on Collabora, apply
+changes with LibreOffice fidelity, and save — no browser involved.
+
+## Step 3.1 — Verification spike (time-boxed)
+
+Record in `STATUS.md`:
+
+- Where the endpoint lives on CODE 26.04 (path, transport — HTTP/SSE or
+  streamable HTTP), how it authenticates, and how a document is addressed
+  (WOPI `WOPISrc` + access token, or a server-local path).
+- The tool list it exposes per document type (text insert/replace, cells,
+  slides, export) and whether it can open a WOPI document from **our** host
+  (Epic 0 tokens) and save it back.
+- Concurrency: does an MCP session share the DocumentBroker with a live
+  editing session (i.e. edits appear to a user who has the file open)?
+
+Go/no-go: proceed only if a document can be opened, changed and saved
+through MCP with a token our WOPI host mints.
+
+## Step 3.2 — Connector
+
+- Register Collabora as an MCP connector in Synaplan's connector layer
+  (system-level, admin-configured; URL is the node-local `collabora:9980`
+  MCP path, never public). Auth is whatever the spike found; per-request
+  document access uses an Epic 0 short-lived WOPI token for the target file,
+  so the connector can never touch a file the user cannot.
+- Expose a small, curated capability set to the planner rather than the raw
+  tool list: `office.applyInstructions(fileId, instructions)`,
+  `office.insertSection(fileId, afterHeading, markdown)`,
+  `office.fillRange(fileId, sheet, range, rows)`, `office.addSlides(fileId,
+  outline)`, `office.exportPdf(fileId)`. Each maps to one MCP tool sequence.
+
+## Step 3.3 — Tasks and multitask
+
+- `Capability::DocumentEdit` runner in the multitask executor that prefers
+  the office-docs Phase B structured tools when the file has a model, and
+  the Collabora MCP connector otherwise (uploaded files with formatting we
+  must not lose).
+- Saved task example to ship as a template: "Every Monday 08:00 update the
+  KPI sheet in `<file>` from `<data source>` and export a PDF to the team
+  channel" — ties together connectors (data), MCP (edit), engine (PDF) and
+  channels (delivery).
+- Provenance: a task-driven edit writes a revision with `source=binary`
+  (office-docs Phase B rule) and refreshes thumbnail and PDF cache.
+
+## Acceptance
+
+A saved task edits a formatted uploaded `.xlsx` (styles, merged cells,
+charts intact) through Collabora MCP, the file's thumbnail updates, and a
+user who has the file open in the editor sees the change arrive.

--- a/_devextras/planning/20260902-collabora-integration/05_epic_4_partner_platforms.md
+++ b/_devextras/planning/20260902-collabora-integration/05_epic_4_partner_platforms.md
@@ -1,0 +1,63 @@
+# Epic 4 — Partner platforms: Nextcloud, OpenCloud, ownCloud
+
+Status: planned, follows Epic 1 (provisioning) and Epic 2 (extension)
+Repositories: `synaplan-nextcloud`, `synaplan-opencloud`,
+`synaplan-owncloud-online` (each with its own gates and release process)
+
+These platforms already run Collabora Online (Nextcloud `richdocuments`,
+OpenCloud/ownCloud via WOPI apps). Synaplan is installed there as an app.
+The job of this epic is **provisioning**, not new editor code: make the
+platform's Collabora use Synaplan as its AI, and ship our extension where
+the operator controls the Collabora installation.
+
+## Step 4.1 — AI provider provisioning per platform
+
+Collabora reads provider credentials from the WOPI host's `CheckFileInfo`
+`UserPrivateInfo` (per user) or from `coolwsd.xml` (instance). The WOPI host
+here is the platform, so the integration point is the platform's WOPI app:
+
+- **Nextcloud**: `richdocuments` builds `CheckFileInfo`; our app hooks the
+  event it exposes for `UserPrivateInfo` (it already merges Zotero and
+  signature settings there — same pattern the Collabora commit names) and
+  injects `AIProviderURL` / `AIProviderAPIKey` / `AIProviderModel` for the
+  logged-in Nextcloud user, using the Synaplan key the `synaplan-nextcloud`
+  app already holds for that user. If `richdocuments` offers no hook,
+  contribute one upstream (small, in their interest) and fall back to
+  instructing the admin to set `coolwsd.xml` `ai.*` to Synaplan.
+- **OpenCloud**: the WOPI app is Go; check whether it forwards
+  `UserPrivateInfo`. Our extension already performs RFC 8693 token exchange
+  to obtain a Synaplan-scoped token — mint the gateway API key from that.
+  Otherwise instance-level `coolwsd.xml`.
+- **ownCloud Online**: same investigation as OpenCloud.
+- Admin documentation per platform: the two lines to set, how to verify with
+  one prompt, how to revoke.
+
+## Step 4.2 — Extension distribution
+
+- Publish the Epic 2 `dist/` as a versioned release asset and a container
+  image layer (`synaplan-collabora-extension:<version>`) that platform
+  operators can add to their Collabora deployment (volume mount or derived
+  image). Document for Nextcloud AIO, the official `collabora/code` image
+  and native packages.
+- Keep the extension platform-agnostic: it only needs a Synaplan URL and a
+  login; the platform apps may pre-fill the URL via a small
+  `postMessage`/query handshake if the framework allows it (verify).
+
+## Step 4.3 — Platform-native AI hooks (optional, per platform)
+
+Where the platform has its own assistant framework, register Synaplan there
+too so non-editor surfaces (files app, talk, mail) get Synaplan:
+
+- Nextcloud Task Processing provider (text generation, summarise, translate,
+  image generation) in `synaplan-nextcloud` — the Nextcloud Assistant then
+  calls Synaplan across all Nextcloud apps, including its smart picker in
+  Collabora.
+- OpenCloud: extend the existing context actions (translate, summarise,
+  knowledge) with document-aware ones once Epic 2's adapters exist.
+
+## Acceptance
+
+A Nextcloud user with the Synaplan app connected opens a document in
+Collabora and the AI sidebar works against Synaplan without pasting a key;
+an operator who installs the extension directory sees the Synaplan panel in
+the same session.

--- a/_devextras/planning/20260902-collabora-integration/README.md
+++ b/_devextras/planning/20260902-collabora-integration/README.md
@@ -1,0 +1,21 @@
+# Collabora integration (Synaplan inside the editor)
+
+**Status:** planned (2026-09-02). No product code in this change.
+**Sibling:** [`../20260902-office-docs/`](../20260902-office-docs/) — create,
+analyse, convert, merge and edit office files *inside Synaplan*.
+
+This directory is the **plan of record** for the Collabora side. Cursor
+session `.plan.md` files are not authoritative.
+
+| File | Role |
+| ---- | ---- |
+| [`00_master_plan.md`](./00_master_plan.md) | Scope, surfaces, decisions, epic order |
+| [`01_epic_0_wopi_host.md`](./01_epic_0_wopi_host.md) | Synaplan WOPI host + editor view |
+| [`02_epic_1_ai_assistant_provider.md`](./02_epic_1_ai_assistant_provider.md) | Collabora 26.04 AI Assistant → Synaplan `/v1/chat/completions` (built as office-docs Phase T) |
+| [`03_epic_2_synaplan_extension.md`](./03_epic_2_synaplan_extension.md) | iframe-hosted Synaplan extension |
+| [`04_epic_3_mcp_and_tasks.md`](./04_epic_3_mcp_and_tasks.md) | Collabora MCP from Synaplan tasks |
+| [`05_epic_4_partner_platforms.md`](./05_epic_4_partner_platforms.md) | Nextcloud / OpenCloud / ownCloud |
+| [`STATUS.md`](./STATUS.md) | Step table and decision log |
+
+**Shared with office-docs:** Collabora CODE sidecar (A0) and Phase T tool
+calling (Epic 1.1). Build those once; do not duplicate them here.

--- a/_devextras/planning/20260902-collabora-integration/STATUS.md
+++ b/_devextras/planning/20260902-collabora-integration/STATUS.md
@@ -1,0 +1,65 @@
+# Status — Collabora Integration
+
+Plan of record: `00_master_plan.md`. Sibling plan for the Synaplan side of
+office documents: `../20260902-office-docs/`.
+
+## Epics
+
+| Epic / step | Branch / repo | State | Notes |
+| ----------- | ------------- | ----- | ----- |
+| 0.1 — WOPI host endpoints | `feat/wopi-host` | planned | Needs office-docs A0 (sidecar) and a public editor hostname per cluster |
+| 0.2 — Editor view + "Open in editor" | `feat/office-editor-view` | planned | `useCollaboraFrame.ts` is the single postMessage seam |
+| 1.1 — Tool-calling-transparent `/v1/chat/completions` | office-docs Phase T (T1–T7) | planned, high prio | Built once in `../20260902-office-docs/03_phase_t_tool_calling_gateway.md`; Collabora editor tools after T3; MCP + web search after T4 |
+| 1.2 — Sidebar provisioning (WOPI `UserPrivateInfo`, `coolwsd.xml`, per user) | `feat/collabora-ai-provisioning` | planned | Per-user gateway API key minted lazily |
+| 1.3 — Knowledge / memories / metering tag through the gateway | — | planned | Each flag-gated, default off |
+| 2.1 — `synaplan-collabora` repo + build + auth | new repo | planned | Extension framework is experimental (manifest 0.1) |
+| 2.2 — Writer / Calc / Impress adapters (`cool.callRemote`) | new repo | planned | Nightly integration test against a real CODE container |
+| 2.3 — Synaplan panel UI | new repo | planned | Same component hosted in Epic 0's editor view (2.4 fallback) |
+| 2.4 — postMessage fallback | `synaplan` | planned | `Send_UNO_Command`, `Action_InsertGraphic`; no selection read |
+| 3.1 — MCP verification spike | — | planned | Go/no-go recorded here |
+| 3.2 — Collabora MCP connector | — | planned | |
+| 3.3 — `DocumentEdit` runner + task template | — | planned | |
+| 4.1 — Provider provisioning per platform | integration repos | planned | Nextcloud first (`richdocuments` `UserPrivateInfo` hook) |
+| 4.2 — Extension distribution | `synaplan-collabora` | planned | |
+| 4.3 — Platform-native AI hooks | integration repos | planned | Nextcloud Task Processing provider |
+
+## Decisions
+
+| Date | Decision |
+| ---- | -------- |
+| 2026-09-02 | Ride Collabora 26.04's built-in AI Assistant first (Synaplan = OpenAI-compatible provider); own extension second; never patch Collabora. |
+| 2026-09-02 | The Synaplan WOPI host ("Open in editor") belongs to this plan as Epic 0; the office-docs plan only links to it. |
+| 2026-09-02 | Tool calling in chat providers is one shared building block for office-docs Phase B and Epic 1.1; whichever lands first records it in both STATUS files. |
+
+## Versions and contracts we depend on
+
+Fill in when Epic 0 starts; re-verify on every Collabora bump.
+
+| Item | Value |
+| ---- | ----- |
+| Collabora image tag + digest | — |
+| postMessage IDs used | `App_LoadingStatus`, `Host_PostmessageReady`, `UI_Close`, `Doc_ModifiedStatus`, `Action_Save_Resp`, `Send_UNO_Command`, `Action_InsertGraphic`, `Insert_Button` |
+| WOPI `CheckFileInfo` keys used | `UserPrivateInfo.AIProviderURL`, `.AIProviderAPIKey`, `.AIProviderModel`, `PostMessageOrigin`, `LastModifiedTime` |
+| `coolwsd.xml` keys used | `ai.enabled`, `ai.api_url`, `ai.api_key`, `ai.model`, `ai.allow_user_settings`, `aliasgroup1`, `net.post_allow.host`, `lok_allow`, `experimental_features` |
+| `cool.js` surface used | `cool.callRemote`, `cool.document.on*` |
+| MCP endpoint | — (Epic 3 spike) |
+
+## Investigation baseline (2026-09-02)
+
+- Collabora Online / CODE 26.04 (July 2026): built-in AI Assistant sidebar
+  for Writer/Calc/Impress against any OpenAI-compatible `/v1/chat/completions`
+  (+ `/v1/models`), document actions via model tool calling; configured in
+  `coolwsd.xml <ai>`, WOPI `UserPrivateInfo`, or per user; off by default.
+  Also an MCP endpoint for external clients. Upstream issue #15997 reports a
+  tool/permission loop with some OpenAI-compatible proxies.
+- iframe-hosted extension framework: `browser/dist/extensions/<id>/manifest.json`
+  (0.1), `cool.js` with `cool.callRemote` (JS-UNO in the kit) and document
+  event hooks; gated by `experimental_features`.
+- postMessage API: `Insert_Button` (classic toolbar only), `Send_UNO_Command`
+  (e.g. `.uno:InsertText`), `Action_InsertGraphic` (`lok_allow`),
+  `CallPythonScript` (pyuno packages required); cannot read the selection.
+- Synaplan: `OpenAICompatibleController` (`/v1/chat/completions`, `/v1/models`)
+  forwards only model/temperature/max_tokens/stream and string content — no
+  `tools`; `ChatProviderInterface` has no tool calling;
+  `AI/Messages/Tools/GatewayToolLoop.php` (Anthropic gateway) has the loop
+  pattern; MCP connector layer exists (`AI/Messages/Mcp/*`).

--- a/_devextras/planning/20260902-office-docs/00_master_plan.md
+++ b/_devextras/planning/20260902-office-docs/00_master_plan.md
@@ -1,0 +1,254 @@
+# Office Documents — Master Plan (v3)
+
+Status: planned (see `STATUS.md`)
+Date: 2026-09-02
+Supersedes: `office-plan_v2.md` is kept as the detailed design for Phase B
+(structured editing). This master plan re-sequences the work so users see
+improvements early and adds the missing infrastructure decision (LibreOffice).
+
+## Scope — the Synaplan side
+
+There are two sides to office documents. **This plan is side 1**: the user is
+in Synaplan and wants to **create, analyse, convert, merge and edit** Word,
+Excel, PowerPoint and PDF files. Side 2 — the user is in the **Collabora
+editor** and wants Synaplan there (chat, image generation, tasks on the
+text, cells and slide elements in front of them) — is a separate epic with
+its own plan: `../20260902-collabora-integration/`. The Collabora sidecar
+introduced here (Decision 1) is shared by both.
+
+## Two delivery surfaces (must both work)
+
+This work has **two first-class customers**. Shipping the PHP client in
+`synaplan` and "mentioning" the platform later is not enough. Every
+engine-backed step must be designed so both surfaces stay correct.
+
+| Surface | Repo | Who | What "done" means |
+| ------- | ---- | --- | ----------------- |
+| **Open source** | `synaplan` (public) | Anyone who clones, Umbrel, AWS Marketplace, Elestio, or `deploy/compose.yaml` | Core stack boots without Collabora. New office features stay **off** until the operator opts in. Docs tell them how. Default `docker compose up -d` does not grow RAM or pull `collabora/code`. |
+| **Our hosted demo / prod** | `synaplan-platform` (private) | `web.synaplan.com` on web1/2/3 | The same image, with the engine **on**. Visitors of our demo see thumbnails, PDF export, preview and (later) the editor. Operators update `CLUSTER-DOC.md` and sizing in the same change. |
+
+The PHP contract is one URL. The wiring is not:
+
+- The app talks only to `OFFICE_CONVERT_URL` over HTTP (same pattern as
+  `TIKA_BASE_URL` / `SYNAPLAN_TTS_URL`). It never execs `soffice`, never
+  bind-mounts host LibreOffice, never assumes a compose service name.
+- **OSS default is empty** (`isEnabled() === false`) → today's behaviour.
+- **Platform default is set** (`http://collabora:9980` on backend, worker
+  and worker-bulk) so our demo actually shows the product.
+
+Do **not** copy the topology of the other companions. They look similar
+and they are not:
+
+| Companion today | OSS | Our platform | Why Collabora is different |
+| --------------- | --- | ------------ | -------------------------- |
+| Tika | In-stack `tika` service | **Shared** Coolify on the tools box (`tika.synaplan.com`) | Extraction is cheap and stateless. Collabora is RAM-heavy and later serves the WOPI editor; it is **one sidecar per web node**, like Centrifugo, not a second shared Tika. |
+| Piper TTS | Compose profile `tts`, URL often `host.docker.internal` | **Shared** on the GPU box (`SYNAPLAN_TTS_URL`) | Speech can live on one machine. Convert-to + WOPI want the engine next to the node that holds the request. |
+| Centrifugo | In-stack, no published port | **Per web node**, no published port, Caddy reverse-proxy | **This is the analog.** Same compose file, `restart: unless-stopped`, log cap, no public convert-to port. |
+| Qdrant | In-stack | Per-node via `docker-host:host-gateway` (separate compose) | Unrelated; do not put Collabora there. |
+
+OSS compose files that must learn the **optional** `office` profile (A0),
+not only the dev file:
+
+- `docker-compose.yml` (local dev)
+- `docker-compose-minimal.yml` (already has `tts`)
+- `deploy/compose.yaml` — this is the portable **self-host production**
+  contract everyone else actually runs. Today it has in-stack Tika and a
+  `local-ai` profile; it has **no** `tts` / `office` profile. A0 must add
+  `office` here or self-hosters never get the engine.
+- Umbrel / AWS Marketplace / Elestio **stay off** by default (Pi-class
+  and small cloud images cannot spare ~2 GB). Document the opt-in.
+
+Platform rules (private repo, separate PR, same A0):
+
+- Add `collabora` to the existing compose (no profile). Pin tag **and**
+  digest. `mem_limit`, `num_prespawn_children=2`, healthcheck on
+  `/hosting/capabilities`, **no published port**.
+- Set `OFFICE_CONVERT_URL` on `backend`, `worker` and `worker-bulk`
+  (`worker-bulk` drains `async_index`, which will generate thumbnails).
+- Record the service in `CLUSTER-DOC.md` §2 (per-node containers), not §5
+  (shared Tika/TTS). Note the unused host `apt` LibreOffice packages.
+- Recalculate RAM in `docs/PHP-RUNTIME-SIZING.md`: each web node already
+  shares the box with native Galera, a Qdrant node, Centrifugo and two
+  workers. +~2 GB for CODE is a real budget line, not a comment.
+- Rolling update (`updatewebN.sh`) is `compose up` without `down`; a new
+  service starts on the next roll. Roll one node at a time, same as today.
+- Convert writes next to the source file on the NFS `up/` volume so every
+  node can see the artefact.
+- **Out of this epic unless we reopen it:** the Swiss box (`ch1`,
+  `synaplan-swiss`) is a separate compose, not `synaplan-platform`.
+
+Public-repo hygiene (already a ground rule, restated): no node IPs,
+credentials, or private hostnames of our cluster in `synaplan` or
+`synaplan-docs`. Those live in `synaplan-platform`.
+
+Phase T is **OSS-only** (PHP providers + gateway). The first dual-repo
+step is A0: one PR in `synaplan`, one in `synaplan-platform`, one in
+`synaplan-docs`. Our demo must not ship A1–A4 "in the image" while the
+platform compose still has no sidecar — visitors would see the same
+empty tiles they see today.
+
+## Goal
+
+Make Synaplan a good place to **work with** Office documents, not just to
+emit them:
+
+1. Every Word / Excel / PowerPoint / PDF file in Synaplan gets a real
+   thumbnail, an inline preview, and a one-click PDF export.
+2. `officemaker` can deliver PDFs and produces properly styled DOCX.
+3. Uploaded files are **analysable**: legacy formats (`.doc`, `.xls`,
+   `.ppt`, `.rtf`, `.odt`, Apple iWork) become readable, and spreadsheets /
+   decks reach the AI as structured text (sheet-by-sheet, slide-by-slide),
+   not one flat blob.
+4. Several documents can be **merged**: first as one combined PDF, later
+   as a real merged DOCX/XLSX/PPTX on the structured model.
+5. Step-by-step AI editing on a structured document model (Phase B,
+   `office-plan_v2.md`).
+
+## What exists today (investigated 2026-09-02)
+
+- `officemaker` is a **prompt topic**, not a handler. The model returns
+  `{"BFILEPATH":"x.docx","BFILETEXT":"<markdown|csv>"}`;
+  `backend/src/Service/File/DocumentGeneratorService.php` renders DOCX
+  (PhpWord via HTML), XLSX (PhpSpreadsheet), PPTX
+  (`Service/File/Presentation/PptxRenderer`). `ChatHandler::storeGeneratedFile()`
+  and `StreamController::storeGeneratedFileInStream()` persist the `File`
+  row (near-duplicate code) and replace the reply with
+  `__FILE_GENERATED__:<name>`.
+- **PDF output is explicitly unsupported** (`MessageClassifier` and the
+  officemaker prompt both exclude it).
+- Ingestion is Tika only (`Service/File/TikaClient.php`); low-quality PDFs
+  fall back to `PdfRasterizer` (Imagick / `pdftoppm`, both in the base image)
+  plus vision.
+- Thumbnails exist end to end **for videos only**: `ThumbnailService` →
+  `File.thumbPath` → `GET /api/v1/files/{id}/thumb` → `thumb_url` →
+  `frontend/src/components/files/FilePreview.vue`. Office files render as an
+  icon or a `text_preview` snippet.
+- Open issues: #1396 (DOCX has no visual formatting), #1499 (clean previews
+  across file types). Closed formative issues: #1397/#1404 (PPTX design),
+  #1382 (images in DOCX), #1406 (envelope leak), #1190 (regenerate from
+  `BFILETEXT`).
+- **LibreOffice is installed on the dev host and on web1/2/3 (Ubuntu apt,
+  24.2.7) but nothing in any repository references it.** The backend runs in
+  Docker (`ghcr.io/metadist/synaplan`, Debian bookworm base) and cannot
+  execute host binaries. Every external service in this stack is reached over
+  HTTP via an env URL (`TIKA_BASE_URL`, `QDRANT_URL`, `SYNAPLAN_TTS_URL`);
+  host services use `extra_hosts: docker-host:host-gateway`.
+
+## Decision 1 — one office engine, reached over HTTP
+
+**Run Collabora CODE (`collabora/code`) as a sidecar container, one per web
+node, and call its conversion REST API from PHP the same way we call Tika.**
+
+- `POST http://collabora:9980/cool/convert-to/<format>` with multipart field
+  `data` converts any office input to `pdf`, `png` (first page/slide/sheet
+  only), `docx`/`xlsx`/`pptx`, `odt`/`ods`/`odp`, `csv`, `html`, `txt`.
+  `GET /hosting/capabilities` reports `convert-to.available`.
+- The same container serves the WOPI editor for the Collabora integration
+  plan — one engine, one deployment path, and it is exactly what
+  Nextcloud/OpenCloud run.
+- It isolates crashes on malformed documents and manages concurrency itself
+  (forkit + per-document kits). A bare `soffice --headless` inside the PHP
+  container would need one profile directory per concurrent call and a crash
+  takes the FrankenPHP worker with it.
+
+Rejected alternatives, for the record:
+
+| Option | Why not |
+| ------ | ------- |
+| Bind-mount the host `/usr/bin/soffice` + `/usr/lib/libreoffice` into the container | Ubuntu 24.04 host vs Debian bookworm container: glibc/ICU/library coupling breaks on every host upgrade; undocumented anywhere; not reproducible in dev |
+| Bake LibreOffice into `synaplan-base-php` (whisper.cpp pattern) | +~500 MB per image on two architectures, per-process profile locking, crash coupling, still no editor |
+| Host-side `unoserver` behind `docker-host:host-gateway` | Works, but a second deployment mechanism (pip on the host) with its own upgrade path; only worth it if we never want the editor |
+| Gotenberg sidecar | Good conversion-only API (LibreOffice + Chromium); no editor, so the Collabora integration plan would need Collabora anyway |
+
+Consequence for the hosts: the apt `libreoffice-*` packages on web1/2/3 are
+**not used** by the containers. Remove them or keep them for admin one-offs;
+do not build anything on them.
+
+**Public docs:** `synaplan-docs` must say this in operator language before
+the features land (step A0-docs). New page `docs/office-documents.md`,
+cross-linked from Quickstart, FAQ, Architecture, Using Synaplan, Production
+and Desktop tools. Distinguish the server sidecar from Desktop's local
+LibreOffice (Agent Skills). See `01_phase_a_engine_and_ux.md` § A0.
+
+Sizing: CODE idles at ~0.5–1 GB RAM; set `--o:num_prespawn_children=2` and a
+compose `mem_limit`. Conversion needs **no published port** (backend →
+`collabora:9980` on the compose network). A public HTTPS hostname is required
+only for the editor (Collabora integration plan, Epic 0).
+
+```mermaid
+flowchart LR
+    subgraph node [web node]
+        backend[backend / worker]
+        collabora[collabora/code sidecar]
+        backend -->|"HTTP convert-to (pdf, png, docx)"| collabora
+    end
+    backend -->|PUT /tika| tika[Tika]
+    backend --> nfs[NFS uploads]
+    browser[Browser] -->|thumb / export / preview / merge| backend
+    browser -.->|"Collabora plan: WOPI editor iframe (public HTTPS)"| collabora
+```
+
+## Decision 2 — UX first, model second
+
+`office-plan_v2.md` builds the document model, persistence, tools, provider
+tool-calling and the loop before a user sees anything (Sprints 0–4). We ship
+the engine-backed UX wins first (Phase A, each step one PR, each shippable
+alone), then Phase B with a narrowed first slice (xlsx only).
+
+## Decision 3 — tool calling first
+
+Tool calling in the chat providers and the OpenAI-compatible gateway is the
+one building block three consumers wait for: Collabora 26.04's built-in AI
+Assistant (Collabora plan Epic 1), OpenAI-SDK clients of `/v1/chat/completions`,
+and Phase B's `ChatToolLoop`. It is pulled in front of Phase A as **Phase T**
+and built once, additively (no provider signature change).
+
+Capability is a **dual, consistent gate**: the provider implements
+`ToolCallingChatProviderInterface` **and** the catalog row has `tool_use`.
+The catalog is wrong today (flagship OpenAI/Groq/Anthropic/Gemini chat rows
+are unflagged). Phase T fixes the flags, ships a migration for existing
+installs, and locks the matrix with a consistency test.
+
+`/v1/chat/completions` is a **hybrid loop**, not pass-through only: client
+tools are relayed (Collabora/SDK execute them); Synaplan **injects and
+runs** the user's MCP catalog and `web_search` on every dual-gated model.
+That is a deliberate policy difference from `/v1/messages` (whose MCP
+default is off and which waits for Anthropic's `web_search_*` declaration).
+
+## Phases
+
+| Phase | Content | Detail |
+| ----- | ------- | ------ |
+| **T (first)** | Tool calling: consistent `tool_use` flags, additive provider contract, Chat Completions providers, `/v1/chat/completions` pass-through **plus** server-side MCP/web search, then OpenAI Responses, Anthropic/Google | `03_phase_t_tool_calling_gateway.md` |
+| A | Engine + UX quick wins: converter client, sidecar, thumbnails, PDF export, inline preview, officemaker PDF, DOCX styling, analysable ingestion, combine as PDF | `01_phase_a_engine_and_ux.md` |
+| B | Structured editing (document model + tool loop) and true document merge, re-sequenced | `02_phase_b_structured_editing.md` + `office-plan_v2.md` |
+| — | Collabora editor, Synaplan inside Collabora, partner platforms | `../20260902-collabora-integration/` (separate plan; depends on A0 here) |
+
+## Ground rules (every step)
+
+- Feature branch per step, Conventional Commits, never on `main`, no AI
+  attribution.
+- Full gate before every commit — filtered runs are not the gate:
+
+  ```bash
+  make lint && make -C backend phpstan && make test && docker compose exec -T frontend npm run check:types
+  ```
+
+- New endpoint ⇒ complete OpenAPI annotations ⇒ `make -C frontend
+  generate-schemas` ⇒ `vue-tsc`. Never hand-write TS interfaces for API
+  responses.
+- New UI text ⇒ all five locales (`en`, `de`, `es`, `fr`, `tr`);
+  `localeParity.spec.ts` gates it.
+- Colors only via `style.css` tokens; verify light, dark, and V2.
+- Any change to `MessageClassifier` / `MessageSorter` / prompts ⇒ re-record
+  `tests/Characterization/` snapshots and review every changed line.
+- New paths ⇒ classify in `.github/mobile-impact-policy.json`
+  (`backend/**` backend-only, `frontend/src/**` ota-candidate,
+  `docker-compose*.yml` / `_docker/**` / `docs/**` no-app-impact).
+- The engine is **optional on OSS, on by default on our platform**. Every
+  feature degrades to today's behavior when `OFFICE_CONVERT_URL` is empty.
+  Self-hosters without the sidecar lose nothing they have today. Our
+  `web.synaplan.com` demo must actually run the sidecar (see "Two delivery
+  surfaces").
+- This repository is public: no node IPs, credentials, or hostnames of the
+  production cluster in code or docs here (they live in `synaplan-platform`).

--- a/_devextras/planning/20260902-office-docs/01_phase_a_engine_and_ux.md
+++ b/_devextras/planning/20260902-office-docs/01_phase_a_engine_and_ux.md
@@ -1,0 +1,514 @@
+# Phase A — Office engine and UX quick wins
+
+Status: planned
+Date: 2026-09-02
+Depends on: `00_master_plan.md` (Decision 1: Collabora CODE sidecar over HTTP)
+
+Eight small steps. **Each step is one branch, one PR, shippable alone.** Do
+not start the next step until the previous PR is green and merged. Every
+step lists the files it touches, what it must NOT touch, an acceptance check
+a human can run, and the gate.
+
+Engine-optional rule: every feature must behave exactly as today when
+`OFFICE_CONVERT_URL` is empty. Check `OfficeConverterClient::isEnabled()`
+before doing anything engine-related.
+
+---
+
+## A0 — Converter client and sidecar (no UI)
+
+Branch: `feat/office-converter-client`
+
+### Backend
+
+- New `backend/src/Service/File/Office/OfficeConverterClient.php`, modelled
+  on `Service/File/TikaClient.php` (`final`, constructor DI, structured
+  logging, one-time health probe):
+  - `isEnabled(): bool` — URL non-empty and not `disabled`.
+  - `capabilities(): array` — `GET {url}/hosting/capabilities`, cached per
+    process; returns `[]` on failure.
+  - `convert(string $absoluteInputPath, string $targetFormat, array $options = []): ?string`
+    — `POST {url}/cool/convert-to/{format}` as multipart (`data` = file
+    stream, optional `lang`); writes the response body to a temp file in the
+    same directory as the input (NFS-visible, so worker and backend see it);
+    returns the absolute temp path or `null` on any failure (never throws to
+    callers; log with `endpoint`, `format`, `elapsed_ms`, `http_code`).
+  - Supported target formats as a `public const` list: `pdf`, `png`,
+    `docx`, `xlsx`, `pptx`, `odt`, `ods`, `odp`, `csv`, `html`, `txt`.
+  - Timeout from `OFFICE_CONVERT_TIMEOUT_MS` (default 60000), one retry on
+    transport error, none on HTTP 4xx.
+- Env + DI: `OFFICE_CONVERT_URL` (default empty), `OFFICE_CONVERT_TIMEOUT_MS`
+  in `backend/.env.example`, `backend/config/services.yaml` (bind
+  `$officeConvertUrl`, `$officeConvertTimeoutMs`), and `docker-compose.yml`
+  backend + worker environment (`OFFICE_CONVERT_URL: http://collabora:9980`).
+- Feature exposure: add `officeConvertEnabled` to the runtime `features`
+  array in `ConfigController` (next to `whisperEnabled`, ~line 465) and an
+  entry in `getFeaturesStatus()` under "Processing Services" that pings
+  `/hosting/capabilities`. Update the OpenAPI property list so the generated
+  Zod schema gets the new boolean.
+- Tests: `backend/tests/Unit/Service/File/Office/OfficeConverterClientTest.php`
+  with Symfony `MockHttpClient` — success, HTTP 500, timeout, disabled URL,
+  unsupported format.
+
+### Compose — two delivery surfaces (see `00_master_plan.md`)
+
+Same image, same PHP client, **two wirings**. Do not copy Tika (shared on
+the tools box) or TTS (shared on the GPU box). Copy **Centrifugo**: one
+sidecar next to the app, no published convert-to port.
+
+#### OSS (`synaplan`) — optional, default off
+
+- `docker-compose.yml` **and** `docker-compose-minimal.yml`: service
+  `collabora`, image `collabora/code` pinned by tag **and digest**,
+  `profiles: [office]`, `mem_limit: 2g`, environment
+  `extra_params=--o:ssl.enable=false --o:ssl.termination=false --o:num_prespawn_children=2`,
+  no `ports`, healthcheck `curl -f http://localhost:9980/hosting/capabilities`.
+  Do **not** set `aliasgroup1` yet (only the editor needs it).
+- `deploy/compose.yaml` (the portable self-host production contract
+  everyone else actually runs): same service, same `office` profile.
+  Today it has in-stack Tika and `local-ai` only — without this, A1–A7
+  never light up for self-hosters. Official RAM floor is 8 GB; default-on
+  CODE would break it. Follow the `local-ai` profile pattern (case
+  statement in `x-app-command` can set `OFFICE_CONVERT_URL` when `office`
+  is in `COMPOSE_PROFILES`).
+- Umbrel / AWS Marketplace / Elestio: **do not** start Collabora by
+  default (Pi-class / small images). Document the opt-in in A0-docs.
+- If convert-to answers 403, the compose subnet is outside CODE's default
+  `net.post_allow.host` regex list; add
+  `--o:net.post_allow.host[0]=<compose subnet regex>` to `extra_params` and
+  note it in `docs/DEVELOPMENT.md`.
+- Default `docker compose up -d` (without the profile) must stay unchanged;
+  the app must boot with the converter disabled.
+
+#### Our hosted demo (`synaplan-platform`, separate PR in that repo)
+
+- Same `collabora` service, **no profile**, `restart: unless-stopped`, log
+  cap like Centrifugo, `mem_limit`. This is our `web.synaplan.com` demo:
+  the engine is **on**.
+- `OFFICE_CONVERT_URL: http://collabora:9980` on `backend`, `worker` **and**
+  `worker-bulk` (`worker-bulk` drains `async_index`, which will generate
+  thumbnails in A1). Do not rely on `extends` alone — set the key
+  explicitly so a future split cannot drop it.
+- Record the container in `CLUSTER-DOC.md` **§2** (per-node list next to
+  Centrifugo), not §5 (shared Tika/TTS). Note that host `apt`
+  `libreoffice-*` is unused by the containers.
+- Update `docs/PHP-RUNTIME-SIZING.md`: +~2 GB RAM per web node on a box
+  that already runs Galera + Qdrant + two workers + Centrifugo.
+- Rolling update is `updatewebN.sh` (`compose up`, no `down`). A new
+  service starts on the next one-node-at-a-time roll. Convert artefacts
+  go next to the source on NFS `up/`.
+- **Not in this PR:** Swiss `ch1` / `synaplan-swiss` (separate compose).
+
+### Docs (this repo)
+
+- `docs/DEVELOPMENT.md`: "Office conversion (optional)" — how to start the
+  `office` profile, what it enables, the 403 note.
+- `_devextras/SYSADMIN-help.md`: the prod service and the env var.
+- `.github/mobile-impact-policy.json`: verify `backend/src/Service/File/Office/**`
+  falls under the existing `backend/**` rule; add nothing unless the test
+  fails.
+
+### Docs (`synaplan-docs`, same step — separate PR)
+
+Public docs at [docs.synaplan.com](https://docs.synaplan.com) must say, before
+the new capabilities ship, that they need a **LibreOffice engine**. Follow
+the TTS companion-service pattern (`docs/tts.md`).
+
+New page `docs/office-documents.md` (sidebar: **Office documents**),
+registered in `index.php` `$docsMap` + `$sections` (Install & self-host,
+next to `tts` / after `quickstart`) and `sitemap.php`. Outline:
+
+- **What it is.** Synaplan's office engine is **Collabora Online
+  (`collabora/code`)**, a LibreOffice-based sidecar reached over HTTP
+  (`OFFICE_CONVERT_URL`). It is optional. Without it, chat, Tika RAG and
+  today's PhpOffice officemaker (DOCX/XLSX/PPTX) keep working; the
+  capabilities below stay off.
+- **What requires LibreOffice / Collabora** (table): thumbnails for
+  Word/Excel/PowerPoint/PDF; Download as PDF and inline preview;
+  officemaker PDF output; conversion of legacy/Apple formats
+  (`.doc`/`.xls`/`.ppt`/`.rtf`/`.odt`/iWork) before analysis; combine
+  several files into one PDF; later "Open in editor" (WOPI).
+- **How to enable (dev):**
+  `docker compose --profile office up -d` — pulls `collabora/code`,
+  sets `OFFICE_CONVERT_URL=http://collabora:9980` on backend + worker.
+  ~1–2 GB RAM (`mem_limit`).
+- **How to enable (self-host / `deploy/compose.yaml`):**
+  `COMPOSE_PROFILES=office` (or `--profile office`). Same sidecar, no
+  published convert-to port. Official 8 GB floor stays valid because the
+  profile is off by default.
+- **How we enable it on our demo (`synaplan-platform`):** always-on sidecar
+  **per web node** (Centrifugo analog, not shared Tika/TTS),
+  `OFFICE_CONVERT_URL` on backend + both workers. Sizing: idle ~0.5–1 GB,
+  `mem_limit` 2g, `--o:num_prespawn_children=2`. That change lives in the
+  private platform PR, not in this public repo.
+- **Host `apt install libreoffice` is not enough.** The PHP app runs in
+  Docker and cannot execute host binaries. The Ubuntu packages on web
+  nodes are unused by the containers. Do not document bind-mounting
+  `/usr/bin/soffice` into the backend image.
+- **Not the same as Desktop LibreOffice.** [Check this computer](desktop-tools)
+  looks for LibreOffice on the *user's PC* so Agent Skills can export
+  slides/PDFs locally. Server-side office features need the Collabora
+  sidecar on the Synaplan host. Say this on both pages so operators
+  don't confuse the two.
+
+Cross-links in the same PR (short paragraphs, not a second essay):
+
+- `docs/intro.md` — add the page to "Install & self-host" and mention
+  the optional office engine next to TTS.
+- `docs/quickstart.md` — new pitfall: "Office documents need LibreOffice
+  (Collabora sidecar)", same tone as the TTS pitfall; bump the "four
+  things" lead-in to include it.
+- `docs/using-synaplan.md` — under Files & RAG: preview / PDF export /
+  combine require the engine; link the new page.
+- `docs/architecture.md` — add `collabora` to the service map (profile
+  `office`, optional).
+- `docs/faq.md` — "Do I need LibreOffice?" / "Why don't my Word files
+  get a thumbnail?" — engine optional, feature list, `OFFICE_CONVERT_URL`.
+- `docs/production.md` — Requirements: optional Collabora sidecar + RAM.
+- `docs/hosting.md` — mention Collabora next to Tika on the tools/web
+  node, not as a host apt package.
+- `docs/desktop-tools.md` — one sentence: server office features are a
+  different LibreOffice (the Collabora sidecar).
+
+Do **not** put production node IPs or private compose hostnames in this
+public repo.
+
+### Acceptance
+
+- `docker compose --profile office up -d`, then
+  `curl -s http://localhost:8000/api/v1/config/features` (admin) shows the
+  converter as available.
+- `docker compose exec -T backend php bin/console debug:container OfficeConverterClient`
+  resolves; a throwaway `php -r` call converts a `.docx` from `var/uploads`
+  to PDF (do not commit the script).
+
+### Gate
+
+`make -C backend lint && make -C backend phpstan && make -C backend test`
+(frontend untouched except the regenerated schema: run
+`make -C frontend generate-schemas` and `vue-tsc` too).
+
+---
+
+## A1 — Thumbnails for office documents and PDFs
+
+Branch: `feat/office-thumbnails` — the office/PDF half of #1499.
+
+### Backend
+
+- New `backend/src/Service/File/Office/DocumentThumbnailGenerator.php`
+  (`final readonly`):
+  - Office formats (`doc docx xls xlsx ppt pptx odt ods odp rtf`): engine
+    `convert(..., 'png')` (first page/slide/sheet), then Imagick resize to
+    the poster size used for videos, write `{basename}_thumb.jpg` next to the
+    source via `ThumbnailService::getThumbnailPath()` conventions (reuse, do
+    not duplicate the naming), `FileHelper::setFilePermissions()`.
+  - PDF: `PdfRasterizer::pdfToPng()` page 1 only (cap = 1) — works without
+    the engine.
+  - Returns the relative thumb path or `null`. Never throws.
+- New Messenger message `App\Message\GenerateDocumentThumbnailMessage(int $fileId)`
+  routed to `async_index` in `config/packages/messenger.yaml`, handler sets
+  `File::setThumbPath()` and flushes. Idempotent: skip if `thumbPath` already
+  set and the file exists (`FileHelper::fileExistsNfs`).
+- Dispatch points (dispatch only, never convert inline in the HTTP request):
+  - after a successful upload in `FileUploadService` for document/PDF types,
+  - after officemaker persists a generated file (`ChatHandler::storeGeneratedFile`,
+    `StreamController::storeGeneratedFileInStream`, `DocumentGenerationRunner`
+    if it stores separately),
+  - when a missing binary is regenerated (`FileController::regenerateMissingBinary`)
+    — optional.
+- Delete the thumb when the file is deleted (follow how video thumbs are
+  removed in `FileStorageService` / `ThumbnailService::deleteThumbnail`).
+- `FileListService` already emits `thumb_url` when `thumbPath` is set — no
+  change needed; verify with a test.
+
+### Frontend
+
+- `frontend/src/components/files/FilePreview.vue`: for `kind` in
+  `document` / `pdf`, render the poster `<img>` when `file.thumb_url` is set
+  (same `mediaSrc(rawThumbUrl)` path as the video poster, `object-cover`,
+  `loading="lazy"`); keep the snippet / icon fallbacks when it is not.
+- `frontend/src/components/ChatMessage.vue` file badges: no thumbnail yet
+  (keep the badge compact); revisit in A3.
+- Tests: extend `frontend/tests/unit/services/filePreview.spec.ts` /
+  `FilePreview.spec.ts` for the poster branch.
+
+### Acceptance
+
+Upload a `.docx`, `.xlsx`, `.pptx`, `.pdf` in Files; after the worker runs
+(seconds) the tiles show page-1 posters in light, dark and V2. With the
+engine disabled, office tiles still show icon/snippet; PDFs still get a
+poster (rasterizer path).
+
+### Gate
+
+Full gate (backend + frontend).
+
+---
+
+## A2 — "Download as PDF"
+
+Branch: `feat/office-pdf-export`
+
+### Backend
+
+- `FileController`: `GET /api/v1/files/{id}/export` with query `format`
+  (enum, initially only `pdf`) and optional `inline=1`. Reuse the exact auth
+  pattern of `downloadFile()` (`#[CurrentUser]` or media token,
+  `isFileAccessibleByUser`). Complete OpenAPI (`parameters`, 200 `File
+  content`, 400 unsupported format, 404, 503 when the engine is disabled).
+  Keep the method under 50 lines: delegate to a new
+  `Service/File/Office/DocumentExportService::exportToPdf(File $file): ?string`.
+- `DocumentExportService`: source is the on-disk binary (or the
+  `regenerateMissingBinary` path if missing); if the source already is a PDF
+  return it; else engine `convert(..., 'pdf')`, move the result to
+  `{basename}.export.pdf` next to the source, and return it. Cache rule: reuse
+  the cached PDF when its mtime is newer than the source's; delete it with
+  the file.
+- Guest variant next to the existing guest download route (widget sessions).
+- Response: `BinaryFileResponse`, `Content-Disposition` attachment (or inline
+  when `inline=1`), filename `<original name>.pdf`, same security headers as
+  `downloadFile()`.
+
+### Frontend
+
+- `frontend/src/services/filesService.ts`: `exportFile(id, format, filename)`
+  + guest twin, via `httpClient` like `downloadFile()`; URL builder
+  `exportUrl(id, format, inline)` for A3.
+- `ChatMessage.vue` (badge block ~line 405–420) and `FilesGrid.vue` /
+  `FilesView.vue` actions: replace the single click-to-download with a small
+  menu (existing dropdown pattern in the codebase; tokens only) — items:
+  **Download**, **Download as PDF** (only for office kinds and only when
+  `configStore.features.officeConvertEnabled`), **Preview** (A3, hidden until
+  then). Errors via `useNotification().error(t('files.exportFailed'))`.
+- i18n keys (all five locales): `files.download`, `files.downloadPdf`,
+  `files.exportFailed`, `files.preview`. Placeholders identical to English.
+- `make -C frontend generate-schemas` after the OpenAPI change, then
+  `vue-tsc`.
+
+### Acceptance
+
+A generated `.docx` in chat: menu → "Download as PDF" downloads
+`<name>.pdf` that opens and matches the document. Second click is served
+from cache (log shows no engine call). With the engine disabled the menu
+item is hidden and the API answers 503 with a clear message.
+
+### Gate
+
+Full gate.
+
+---
+
+## A3 — Inline preview
+
+Branch: `feat/office-inline-preview`
+
+### Frontend only (uses A2)
+
+- New `frontend/src/components/files/DocumentPreviewModal.vue`, loaded with
+  `defineAsyncComponent`. Props: `file`. Body: `<iframe>` pointing at
+  `exportUrl(id, 'pdf', true)` for office kinds, or the download URL
+  (`inline`) for PDFs, wrapped with `useMediaSrc()` so the `<iframe>` can
+  authenticate without headers. Header: filename, Download, Download as PDF,
+  close. Uses the app's modal shell / `surface-card` tokens; verify light,
+  dark, V2.
+- Wire "Preview" from the A2 menu (chat badges, Files tiles) and from a click
+  on the A1 poster.
+- Capability guard: iOS/Android WebViews do not render PDFs inside iframes
+  reliably. Detect the native shell the way the app already does for media
+  tokens (`useMediaSrc` / platform helpers) and fall back to
+  `Download as PDF` there. Mark the seam with `MOBILE-APP SEAM` if a new
+  platform check is introduced.
+- Tests: component test with stubs (no network), covering office vs PDF vs
+  engine-disabled (menu item hidden).
+
+### Acceptance
+
+Preview opens a multi-page DOCX/PPTX/XLSX as PDF inside Synaplan; keyboard
+close (Esc) works; nothing is downloaded until the user asks.
+
+### Gate
+
+Frontend gate (`make -C frontend lint && make -C frontend test` +
+`vue-tsc`).
+
+---
+
+## A4 — officemaker can deliver PDF
+
+Branch: `feat/officemaker-pdf`
+
+### Backend
+
+- Extract the duplicated persistence into
+  `Service/File/GeneratedDocumentStore::store(...)` used by
+  `ChatHandler::storeGeneratedFile()`, `StreamController::storeGeneratedFileInStream()`
+  and `DocumentGenerationRunner`. Pure refactor first (same behavior, tests
+  green), commit separately inside the PR.
+- Envelope extension: when the user asked for a PDF, the model still returns
+  a `.docx` / `.xlsx` / `.pptx` `BFILEPATH` (the editable source) plus
+  `"BEXPORT":"pdf"`. `FileGenerationEnvelope::extract()` learns the optional
+  key (ignored if unknown). `GeneratedDocumentStore` writes the source file
+  as today, then — only if the engine is enabled — converts it and attaches
+  the PDF as a second `File` (`source=generated`, `originKind=document`,
+  `fileText` = same source text so #1190 regeneration and search keep
+  working). Both files are attached to the message; the reply marker names
+  the PDF.
+- `PromptCatalog::officeMakerPrompt()`: describe `BEXPORT` and when to use
+  it; keep the "no PDF" rule when the engine is disabled (pass a flag into
+  the prompt builder, do not fork the topic).
+- `MessageClassifier`: lift the "PDF requests must not route to officemaker"
+  exclusion **only when the engine is enabled**. Re-record
+  `tests/Characterization/` snapshots and review every changed line.
+- Tests: envelope with/without `BEXPORT`, store with engine on/off,
+  classifier both modes.
+
+### Frontend
+
+- Nothing new; the PDF appears as a normal file badge with the A2/A3 menu.
+- `frontend/src/utils/fileGenerationEnvelope.ts` must still hide the
+  envelope mid-stream with the extra key (add a spec case).
+
+### Acceptance
+
+"Erstelle mir ein PDF mit ..." produces a `.pdf` badge (and the `.docx`
+source); "füge ein Kapitel hinzu" edits the source and re-exports. Engine
+off: today's behavior, PDF requests answered as before.
+
+### Gate
+
+Full gate + snapshot review.
+
+---
+
+## A5 — DOCX default styling (#1396, no engine)
+
+Branch: `fix/docx-default-styles`
+
+- `DocumentGeneratorService::writeDocx()`: define a default style set once
+  (`Service/File/Office/DocxStyleSheet.php` or a private method): body font
+  and size, Heading 1–3 sizes/spacing/color via `addTitleStyle` (independent
+  of `{{TOC}}`), paragraph spacing, list indentation, table style with
+  borders and header row shading, page margins, header/footer with page
+  number. Keep the HTML→PhpWord path; only register styles before
+  `Html::addHtml()`.
+- Use A2 (PDF export) to eyeball the result; add a unit test asserting the
+  styles are registered and a heading ends up with the style name.
+- Keep the `PptxTheme` look in mind so DOCX and PPTX feel like one product.
+
+Gate: backend gate.
+
+---
+
+## A6 — Analysable ingestion: legacy formats and structured text
+
+Branch: `feat/office-ingestion-analysis`
+
+Two halves; ship as two commits in one PR or two PRs if the second grows.
+
+### A6a — Legacy and Apple formats (engine)
+
+- `FileProcessor::extractText()`: for `doc xls ppt rtf odt ods odp pages
+  numbers key` (and when Tika returns empty/low-quality text for
+  `docx/xlsx/pptx`), convert via the engine to the OOXML sibling (or PDF)
+  first, then run the existing Tika / rasterizer path on the converted file.
+  Keep the converted file as a temp artifact only.
+- Extend `docs/RAG.md` supported-format table and the supported-formats
+  endpoint (#676) if it enumerates extensions.
+
+### A6b — Structured text for spreadsheets and decks (no engine)
+
+Tika flattens a workbook or a deck into one blob, which is why "analyse this
+Excel" answers are vague. Without waiting for Phase B importers:
+
+- New `Service/File/Office/StructuredTextExtractor.php`:
+  - `xlsx/xls/ods/csv`: PhpSpreadsheet reader (data only, no styles) →
+    per-sheet Markdown tables with the sheet name as heading, A1 cell
+    coordinates in a header row, formulas shown next to values when present,
+    capped per sheet (`OFFICE_TEXT_MAX_ROWS`, default 500) with a "N more
+    rows" note.
+  - `pptx`: reuse the existing PPTX reading in `Presentation/*` or
+    PhpPresentation reader → `## Slide N — <title>` sections with body text
+    and speaker notes.
+  - `docx`: Tika already preserves paragraphs; keep Tika.
+- `FileProcessor` prefers the structured extractor for those types and
+  falls back to Tika; the result lands in `BFILETEXT` like today, so RAG
+  chunking, digests, previews and `text_preview` benefit automatically.
+- The `analyzefile` prompt (`PromptCatalog`) gets one sentence telling the
+  model that spreadsheet context is sheet-by-sheet with A1 coordinates, so
+  answers can cite `Sheet1!B12`.
+- Tests: fixtures with two sheets + formulas, a five-slide deck with notes;
+  snapshot the produced Markdown.
+
+### Optional nightly
+
+Convert every fixture produced by `DocumentGeneratorServiceTest` to PDF
+through the engine to detect invalid OOXML early (not on PR CI).
+
+Gate: backend gate; re-record routing snapshots if the `analyzefile` prompt
+text changes.
+
+---
+
+## A7 — Combine documents as one PDF
+
+Branch: `feat/office-combine-pdf` — the first, honest "merge" feature.
+True DOCX+DOCX → DOCX merging needs the Phase B structured model; combining
+as PDF is achievable now with the engine plus `pdfunite` (poppler-utils,
+already in the base image).
+
+### Backend
+
+- `Service/File/Office/DocumentCombineService::combineToPdf(array $files, User $user): File`
+  — export each input to PDF (A2's `DocumentExportService`, so office and
+  PDF inputs mix), `pdfunite` them in the given order into a new generated
+  `File` (`source=generated`, `originKind=document`, `fileText` = a short
+  Markdown manifest "Combined from: …" so search and #1190 regeneration have
+  something), dispatch the A1 thumbnail.
+- `POST /api/v1/files/combine` with `{ fileIds: int[], filename?: string }`
+  (OpenAPI → Zod), owner check on every id, cap the count and total size
+  (`OFFICE_COMBINE_MAX_FILES`, default 20), 503 when the engine is disabled
+  and an office input is present (PDF-only combines work without it).
+- Runs in the request for small sets; above a size threshold dispatch to
+  `async_index` and return 202 with the pending `File` (reuse the media-job
+  progress pattern if it fits, otherwise poll the file status).
+- Officemaker/multitask: a `combine` intent is **not** added to the
+  classifier in this step — keep it a UI action; the chat path comes with
+  Phase B's `DocumentEdit` capability.
+
+### Frontend
+
+- Files view: multi-select → "Combine as PDF" action (order = selection
+  order, drag to reorder in a small confirm dialog via `useDialog()`), result
+  appears as a new tile with a toast (`useNotification()`).
+- Chat: when a message has two or more document/PDF badges, the A2 menu
+  gains "Combine as PDF" for the set.
+- i18n (5 locales): `files.combinePdf`, `files.combineOrderHint`,
+  `files.combineTooMany`, `files.combined`.
+
+### Acceptance
+
+Select a `.docx`, a `.pptx` and a `.pdf` → one PDF in the chosen order,
+with a thumbnail, downloadable and previewable (A3). Engine off: PDF-only
+sets still combine; mixed sets show a clear message.
+
+Gate: full gate.
+
+---
+
+## Order and dependencies
+
+```mermaid
+flowchart LR
+    A0[A0 client + sidecar] --> A1[A1 thumbnails]
+    A0 --> A2[A2 PDF export]
+    A2 --> A3[A3 inline preview]
+    A0 --> A4[A4 officemaker PDF]
+    A5[A5 DOCX styles] -.->|independent| A2
+    A0 --> A6a[A6a legacy ingestion]
+    A6b[A6b structured text] -.->|independent| A6a
+    A2 --> A7[A7 combine as PDF]
+    A1 --> A7
+```
+
+A5 and A6b need no engine and can be done at any time, even before A0.

--- a/_devextras/planning/20260902-office-docs/02_phase_b_structured_editing.md
+++ b/_devextras/planning/20260902-office-docs/02_phase_b_structured_editing.md
@@ -1,0 +1,86 @@
+# Phase B — Structured document editing
+
+Status: planned, starts after Phase A (A0–A4 merged)
+Detailed design: `office-plan_v2.md` (kept as written; this file only records
+what changes in sequencing and scope)
+
+## What stays from v2
+
+Both load-bearing decisions stand:
+
+1. **The document model is the truth, not the binary.** Versioned structured
+   model (`Service/Document/Model/*`), deterministic renderers, tools patch
+   the model and never the ZIP.
+2. **A separate `ChatToolLoop` on `ChatProviderInterface`**, copying bounds
+   and error behavior from `AI/Messages/Tools/GatewayToolLoop.php`
+   (iteration and wall-clock limits, tool errors returned as `tool_result`,
+   never thrown).
+
+Also unchanged: Galera-safe migration for `BDOCUMENT_REVISIONS` (raw
+`addSql`, `CREATE TABLE IF NOT EXISTS`, no `Schema $schema`), `BFILETEXT`
+stays a text projection (search, digests, MCP resources depend on it),
+`DOCUMENT_TOOLS.*` BCONFIG flags default off, admin toggle, mobile-impact
+policy, docs.
+
+## What changes
+
+### B-1. Ship one format end to end before widening
+
+v2 Sprints 0–4 build model + persistence + tools + provider tool-calling +
+loop for **all three** formats before the first user-visible turn. Instead:
+
+| Slice | Scope | User-visible result |
+| ----- | ----- | ------------------- |
+| B1 | `SpreadsheetModel` + `XlsxRenderer` (formulas, number formats, 2 sheets, chart) + `DocumentRevision` persistence + xlsx tool set + `ToolCallingChatProviderInterface` for **one** provider (Groq, simplest wire format) + `ChatToolLoop` + minimal SSE `document_step` | "Format column D as currency and add a bar chart" works on a generated xlsx, with a step list in the chat bubble |
+| B2 | Second and third provider (OpenAI Responses API, Anthropic), `tools` model feature in `ModelCatalog`, fallback to the classic officemaker path | Works with the user's configured model, not only Groq |
+| B3 | `WordModel` + `DocxRenderer` (reuse A5's style sheet) + docx tools | Word documents editable step by step |
+| B4 | `DeckModel` adapter on `Presentation/PptxRenderer` + pptx tools | Presentations editable step by step |
+| B5 | Importers (`IOFactory::load()` with charts for xlsx; best-effort docx/pptx) + `ImportFidelityReport` + classifier guard for "edit this uploaded file" | Uploaded files editable, with an honest fidelity notice |
+| B6 | Version history UI, `GET /files/{id}/revisions`, `POST .../restore`, i18n, admin toggle, docs | Users can see and roll back versions |
+| B7 | **True merge** on the model: `merge_documents` tool (concatenate Word blocks with heading level offset, append sheets with name de-duplication, append slides with theme of the first deck) built on B5 importers; UI action "Combine as DOCX/XLSX/PPTX" next to A7's "Combine as PDF"; chat intent via the `DocumentEdit` capability | Several documents become one editable document, not just one PDF |
+
+### B-2. The engine replaces bespoke diff UI
+
+Every revision render is exported to PDF through the Phase A engine and
+shown in the A3 preview modal. "What did the AI change" is answered by the
+step list (`document_step` labels) plus the rendered preview — v2's
+change-summary block stays, the richer per-change UI is dropped.
+
+### B-3. Revision provenance (decide before the migration)
+
+The Collabora integration plan (Epic 0) lets users edit the same file in the
+Collabora editor, and Epic 3 lets tasks edit it through MCP — both make the
+stored model stale. Add to `BDOCUMENT_REVISIONS` from day one:
+
+- `BSOURCE` enum `model` | `binary` — who authored this revision.
+- `BBINARYSHA` — hash of the on-disk file when the revision was written.
+
+Rule: before any tool turn, compare the current binary hash with the latest
+revision. If they differ (edited in Collabora, re-uploaded, or changed by a
+task), run the B5 importer to resync (or refuse with a clear message until
+B5 exists). Without this the tool loop would silently overwrite manual
+edits.
+
+### B-4a. Shared building block with the Collabora plan
+
+`ToolCallingChatProviderInterface` (v2 Sprint 3, here B1/B2) is also what
+`../20260902-collabora-integration/02_epic_1_ai_assistant_provider.md`
+Step 1.1 needs to make `/v1/chat/completions` tool-calling transparent.
+Build it once; whichever plan starts first owns the PR and both `STATUS.md`
+files record it.
+
+### B-4b. Thumbnails and exports follow revisions
+
+After each revision render, dispatch `GenerateDocumentThumbnailMessage`
+(A1) and invalidate the cached PDF export (A2) so previews never lag behind
+the file.
+
+## Risks (from v2, still valid)
+
+- Cost and latency of multi-round tool turns — bounds low, `read_*` returns
+  ranges not whole sheets.
+- Models without tool calling (Ollama, OpenAI-compatible endpoints) fall back
+  to the classic path; the classic path is never removed.
+- `phpoffice/phppresentation` is pinned to `dev-master as 1.3.0` — render
+  through the existing classes, add no new reader paths.
+- Two truths while the flag is off; the file UI must handle "no history".

--- a/_devextras/planning/20260902-office-docs/03_phase_t_tool_calling_gateway.md
+++ b/_devextras/planning/20260902-office-docs/03_phase_t_tool_calling_gateway.md
@@ -1,0 +1,380 @@
+# Phase T — Tool calling in the chat providers and the OpenAI-compatible gateway
+
+Status: planned, **highest priority — runs before Phase A**
+Date: 2026-09-02
+Revised: 2026-09-02 (dual capability gate + server-side MCP/web search on `/v1/chat/completions`)
+Delivery: **OSS-only** (`synaplan` PHP). No compose / `synaplan-platform`
+change. The dual-surface rule in `00_master_plan.md` starts at A0.
+This file is the plan of record for the Cursor session plan
+*Phase T tool calling*. Do not keep a second copy outside this directory.
+Consumers: Collabora 26.04 AI Assistant (`../20260902-collabora-integration/02_epic_1_ai_assistant_provider.md`
+Step 1.1), any OpenAI SDK client of `/v1/chat/completions` (Cursor, Continue,
+LangChain), and later Phase B's `ChatToolLoop` (`office-plan_v2.md` Sprint 3).
+
+## Where we stand (investigated 2026-09-02)
+
+- `POST /v1/chat/completions` (`Controller/OpenAICompatibleController.php`)
+  reads only `model`, `temperature`, `max_tokens`, `stream`; `tools`,
+  `tool_choice`, assistant `tool_calls` and `role: tool` messages are
+  ignored; the answer is always text with `finish_reason: "stop"`.
+  `docs/OPENAI_COMPATIBLE_API.md` says so explicitly.
+- `AI/Interface/ChatProviderInterface.php`: `chat()` returns
+  `{content, usage, response_id?}`; `chatStream()` callback receives a string
+  or `{type: content|reasoning|finish, ...}`. No tool shape anywhere.
+- Providers: Groq, OpenAICompatible, Mistral, xAI, TrustedTokens talk
+  **Chat Completions** (openai-php); OpenAI talks the **Responses API**;
+  Anthropic and Google use their native HTTP APIs; Ollama, Triton,
+  HuggingFace, Test. Only HuggingFace forwards `tools` from options — and
+  still drops `tool_calls` from the answer.
+- The Anthropic-shaped gateway (`AI/Messages/*`) already maps tools both
+  ways for OpenAI Chat Completions and Gemini
+  (`Translator/OpenAiMessagesTranslator.php`, `GeminiMessagesTranslator.php`)
+  and runs a server-side loop (`Tools/GatewayToolLoop.php`) that executes
+  Synaplan-owned MCP + `web_search` and **relays** client-owned tools.
+  Reuse the mapping tables and the catalog/loop **semantics**. Do not route
+  the OpenAI gateway through the Anthropic request body.
+- Model capability: `Model::hasFeature()` on `BJSON.features`; the string
+  `tool_use` exists but is set **inconsistently**. HuggingFace, TrustedTokens
+  and some Mistral rows have it; **OpenAI / Groq / Anthropic / Gemini
+  flagship chat rows do not** (e.g. GPT-5.4 is `['reasoning', 'vision']`
+  only). That is a catalog bug and must be fixed in this phase.
+- API-key scope for `/v1/*` is `desktop:messages`; unchanged.
+
+## Decision — dual, consistent capability gate
+
+Tool calling is allowed only when **both** are true:
+
+1. **Provider gate:** the resolved chat provider implements
+   `ToolCallingChatProviderInterface` and
+   `supportsToolCalling($providerModelId)` returns true.
+2. **Catalog flag:** the resolved `Model` has `hasFeature('tool_use')`.
+
+The two must describe the same reality. Rules:
+
+- `supportsToolCalling($model)` is `true` **iff** that model is flagged
+  `tool_use` in the catalog (providers do not hard-code a private allow-list
+  that drifts from `BJSON.features`).
+- Every chat-tag model whose upstream API documents function calling
+  **must** carry `tool_use`. Image / TTS / embedding / video rows must not.
+- `/v1/models` advertises `synaplan:tool_use` only when both gates pass.
+- A client `tools` / `tool_choice` (other than `none`) on a model that
+  fails either gate → `400` `tools_not_supported`, never a silent text
+  answer.
+- A CI/unit test (`ModelCatalogToolUseConsistencyTest`) freezes the matrix:
+  listed capable chat families must include `tool_use`; non-chat tags must
+  not. Adding a capable chat model without the flag fails the suite.
+
+**Existing installs:** `ModelSeeder` only updates rows whose fingerprint
+still matches. Operator-edited `BJSON` is PRESERVE'd. Ship a Galera-safe
+migration that **adds** `tool_use` to `BJSON.features` for the known
+`service` + `providerId` keys **without overwriting** the rest of `BJSON`
+(same `JSON_SET` / array-append pattern as
+`backend/migrations/Version20260513120000.php`). Never remove an
+operator-added feature.
+
+**"Flagship"** in this plan means those `tool_use` chat models — the
+product's capable chat rows (OpenAI GPT, Anthropic Claude, Gemini, Groq
+Llama/Qwen/GPT-OSS, Mistral, xAI Grok, and the already-flagged HuggingFace /
+TrustedTokens agentic rows). No second feature string.
+
+## Decision — `/v1/chat/completions` offers Synaplan tools
+
+Pass-through of **client** tools stays: Synaplan never executes a tool the
+client owns (Collabora editor tools, Cursor/Continue tools). Those come back
+as `finish_reason: "tool_calls"` for the client to run.
+
+On top of that, for every request whose resolved model passes the dual
+gate, the gateway **injects and executes** Synaplan-owned tools:
+
+| Tool | When it is injected | How it is run |
+| ---- | ------------------- | ------------- |
+| User MCP catalog (read-only, `includeMutating: false`) | `MCP_CLIENT_ENABLED` is on **and** the user has at least one connected MCP server | `McpClient` — same dispatch as `GatewayToolCatalog` |
+| `web_search` (`WebSearchTool`) | Brave (or the configured search provider) is available **and** `MESSAGES_GATEWAY.WEB_SEARCH_MODE` is not `off` | `WebSearchTool` |
+
+This is a **policy difference** from `POST /v1/messages`:
+
+- The Anthropic gateway injects MCP only when
+  `MESSAGES_GATEWAY.MCP_TOOLS_ENABLED` is on (default **off**), and skips
+  MCP when the client already sent `tools` unless
+  `MCP_TOOLS_WITH_CLIENT_TOOLS` is on. Web search is injected only when the
+  client declared Anthropic's `web_search_*` server tool (or mode is
+  `synaplan`).
+- OpenAI SDK clients and Collabora **never** send that Anthropic server-tool
+  declaration, and Collabora **always** sends its own `tools[]`. If we
+  reused those defaults, `/v1/chat/completions` would offer nothing.
+- Therefore this endpoint **does not** require `MESSAGES_GATEWAY.ENABLED`
+  or `MCP_TOOLS_ENABLED`. It respects the real availability switches
+  (`MCP_CLIENT_ENABLED`, search provider, `WEB_SEARCH_MODE=off`) and
+  **injects alongside client tools**. Name collision: if the client already
+  declared the same function name, skip the Synaplan declaration (client
+  owns that name).
+
+Server-owned calls are executed inside Synaplan; intermediate MCP / search
+rounds are **not** streamed to the client (same suppress rule as
+`GatewayToolLoop`). The client sees either the final text
+(`finish_reason: "stop"`) or the **client-owned** `tool_calls`.
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant G as v1_chat_completions
+    participant L as OpenAiGatewayToolLoop
+    participant P as ChatProvider
+    participant S as SynaplanTools
+    participant U as Upstream
+    C->>G: messages plus optional client tools
+    G->>L: inject MCP plus web_search if dual gate
+    L->>P: chat with merged tools
+    P->>U: provider wire format
+    U-->>P: tool_calls
+    alt Synaplan-owned only
+        P-->>L: finish_reason tool_calls
+        L->>S: execute MCP or web_search
+        S-->>L: role tool results
+        L->>P: re-prompt
+        U-->>C: final text stop
+    else client-owned present
+        L-->>C: message.tool_calls finish_reason tool_calls
+        C->>C: execute editor or SDK tool
+        C->>G: assistant.tool_calls plus role tool
+    end
+```
+
+## Design in one paragraph
+
+The provider contract is extended **additively** through `$options` and new
+chunk types — no signature change, so the 12 existing providers keep
+compiling. The gateway is a **hybrid loop**: forward client tools, inject
+Synaplan MCP + `web_search` on dual-gated models, execute only what Synaplan
+owns, relay the rest. Mapping helpers are extracted from the Messages
+translators; loop **semantics** are copied from `GatewayToolLoop` into an
+OpenAI-shaped `OpenAiGatewayToolLoop` (`finish_reason === 'tool_calls'`,
+`role: tool` messages).
+
+## Steps (one branch and PR each, in this order)
+
+### T1 — Contract, consistent `tool_use` flags, test provider
+
+Branch: `feat/chat-provider-tool-contract`
+
+- `AI/Interface/ChatProviderInterface.php` docblock: document the additive
+  contract.
+  - Options: `tools` (OpenAI function declarations
+    `[{type:'function', function:{name, description?, parameters?}}]`),
+    `tool_choice` (`'auto'|'none'|'required'|{type:'function',function:{name}}`),
+    `parallel_tool_calls` (bool).
+  - Input messages may contain assistant `tool_calls` and `role: 'tool'`
+    (`tool_call_id`, `content`) entries, and array `content`.
+  - `chat()` return gains `tool_calls?: list<{id, type:'function',
+    function:{name, arguments: string}}>` and `finish_reason?: string`.
+  - Stream chunk types gain `['type'=>'tool_call_delta','index'=>int,
+    'id'=>?string,'name'=>?string,'arguments'=>string]`; the `finish` chunk
+    may carry `finish_reason: 'tool_calls'`.
+- New marker `AI/Interface/ToolCallingChatProviderInterface extends
+  ChatProviderInterface` with `supportsToolCalling(string $model): bool`.
+  Implementations look up the catalog row and return
+  `$model->hasFeature('tool_use')`. Providers opt in during T2 / T5 / T6.
+- New `AI/Tool/ToolCallAccumulator` (final): folds `tool_call_delta` chunks
+  by `index` into complete `tool_calls`, guarantees `id` (generate
+  `call_<random>` when upstream omits it — Gemini does), validates that
+  `arguments` is a JSON object string (repair `''` → `'{}'`).
+- New `AI/Tool/OpenAiToolShapes` (final, static): validation of incoming
+  `tools`/`tool_choice`, normalization of `tool_choice` variants, and the
+  mapping helpers the providers share (`toChatCompletionsTools`,
+  `toResponsesTools`, `toAnthropicTools`, `toGeminiDeclarations`) —
+  extracted from the two Messages translators **without changing their
+  behavior** (translators call the shared helpers; their tests stay green).
+- `AI/Service/StreamChunk::visibleText()` must keep returning `''` for the
+  new chunk type (add a test).
+- `Model/ModelCatalog.php`: add `tool_use` to every chat-tag row whose
+  upstream documents function calling. Confirmed missing today: OpenAI GPT
+  chat family, Groq chat rows, Anthropic Claude chat rows, Gemini chat
+  rows, xAI Grok chat rows, remaining Mistral chat rows. Do **not** flag
+  `pic2text` / `text2pic` / `vectorize` / TTS / video slots even when they
+  share a provider id with a chat row.
+- Galera-safe Doctrine migration: for each `service`+`providerId` in that
+  list, `JSON_SET` / array-append `tool_use` onto `BJSON.$.features` if
+  absent. Idempotent; do not rewrite operator-owned toggles
+  (`BSELECTABLE`, `BACTIVE`, `BISDEFAULT`).
+- New `tests/Unit/Model/ModelCatalogToolUseConsistencyTest.php`: the
+  capable-family matrix vs catalog features. This is the lock that keeps
+  the two gates consistent when someone adds a model later.
+- `AI/Provider/TestProvider.php`: implement the marker; honor `tool_use` on
+  the test-model row (add the feature to `ModelSeeder::TEST_MODELS` / test
+  catalog json). When `tools` are present and the last user message starts
+  with `TOOLTEST:<name>:<json>` return a matching `tool_call` (stream:
+  `tool_call_delta` chunks split in two, then `finish tool_calls`); when
+  the history ends with a `role: tool` message answer
+  `Tool result received: <content>`. Extra: `TOOLTEST:web_search:...` and
+  `TOOLTEST:mcp:...` so T4 can drive the loop without a live upstream.
+- Tests: `ToolCallAccumulatorTest`, `OpenAiToolShapesTest` (incl. the
+  extracted translator mappings), `StreamChunkTest`, `TestProvider` tool
+  behavior, `ChatProviderContractTest` extended with "tools option is
+  ignored gracefully by non-tool providers".
+
+### T2 — Chat Completions providers
+
+Branch: `feat/tools-chat-completions-providers`
+
+- New trait `AI/Provider/Concerns/ChatCompletionsToolSupport` used by
+  Groq, OpenAICompatible, Mistral, xAI, TrustedTokens, HuggingFace:
+  - request: add `tools`, `tool_choice`, `parallel_tool_calls` when present;
+    pass assistant `tool_calls` and `role: tool` messages through unchanged;
+  - non-stream: read `choices[0].message.tool_calls` and `finish_reason`;
+  - stream: turn `choices[0].delta.tool_calls[*]` into `tool_call_delta`
+    chunks and the final `finish_reason` into the `finish` chunk.
+- Each provider implements `ToolCallingChatProviderInterface`;
+  `supportsToolCalling()` returns the catalog `tool_use` flag for that
+  model (HuggingFace included — no special case once flags are consistent).
+- Tests per provider with recorded upstream JSON (non-stream + SSE) under
+  `tests/Fixtures/ai/tools/<provider>/`.
+
+### T3 — Gateway: `/v1/chat/completions` speaks tools (pass-through)
+
+Branch: `feat/openai-gateway-tools`
+
+Wire format first, so Groq / OpenAI-compatible / TestProvider can serve
+Collabora editor tools immediately. Server-side injection lands in T4 on
+this same surface.
+
+- `OpenAICompatibleController::chatCompletions()`: parse and validate
+  `tools`, `tool_choice`, `parallel_tool_calls` (400 `invalid_request_error`
+  on malformed input); keep `messages` intact including `tool_calls`,
+  `role: tool`, array content. Dual gate: if tools are present and either
+  the provider is not a `ToolCallingChatProviderInterface` **or** the model
+  lacks `tool_use` → 400 `tools_not_supported` naming the model. Move the
+  growing logic into `Service/Api/OpenAiChatCompletionRequest` (parsing)
+  and `Service/Api/OpenAiChatCompletionResponder` (shaping) so the
+  controller stays thin.
+- Non-stream response: `message.tool_calls` when present, `content: null`
+  if the model returned no text, `finish_reason: "tool_calls"`.
+- Stream: first chunk `delta.role`; text `delta.content`; tool calls as
+  OpenAI does — first chunk per index carries `index`, `id`, `type`,
+  `function.name`, `function.arguments` (partial), later chunks carry
+  `index` + `function.arguments`; final chunk `finish_reason: "tool_calls"`;
+  honor `stream_options.include_usage` with a trailing usage chunk;
+  `[DONE]`.
+- Metering unchanged (`recordUsage('API_CHAT', …)`), `response_text` for the
+  session summary = text content plus a one-line `[tool_call name(...)]`
+  note per call so digests stay meaningful.
+- Upstream 4xx about tools → mapped to 400 `tools_not_supported`, never a
+  500.
+- `GET /v1/models`: add `capabilities: ["synaplan:tool_use"]` only when
+  both gates pass (additive field; OpenAI clients ignore unknown keys).
+- OpenAPI annotations; `docs/OPENAI_COMPATIBLE_API.md`: replace "not yet
+  supported" with the supported subset and a curl example of a two-round
+  client-tool exchange. T4 adds the server-tool section.
+- Tests: `OpenAICompatibleControllerToolsTest` driving the `TestProvider`
+  through non-stream and stream, two-round exchange, malformed tools,
+  unsupported provider, model missing `tool_use`; SSE golden files in
+  `tests/Fixtures/openai-compatible/tools/`.
+
+### T4 — Server-side MCP + web search on `/v1/chat/completions`
+
+Branch: `feat/openai-gateway-server-tools`
+
+This is no longer out of scope. It is the step that makes flagship models
+on this endpoint actually **offer** Synaplan tools.
+
+- New `AI/OpenAI/OpenAiGatewayToolLoop` (final): OpenAI-shaped copy of
+  `GatewayToolLoop` semantics.
+  - Inject catalog tools (converted with `OpenAiToolShapes`) at the front
+    of `tools[]`.
+  - On `finish_reason === 'tool_calls'`, partition calls into
+    Synaplan-owned (dispatch table) vs client-owned.
+  - Owned only → execute (MCP via `McpClient`, `web_search` via
+    `WebSearchTool`), append `{role:'tool', tool_call_id, content}`,
+    re-prompt. Bound by `MESSAGES_GATEWAY.MCP_MAX_ITERATIONS` (default 8),
+    16 tools/turn, 240s wall clock, 12k-char result trim — same constants
+    as the Anthropic loop.
+  - Any client-owned call → stop the loop and return those `tool_calls`
+    to the client (mixed turns prefer returning client-owned and still
+    executing owned ones first if that stays simple; if mixed is messy,
+    execute owned, then return leftover client-owned — document the
+    chosen rule in the class docblock and lock it with a test).
+  - Streaming: suppress intermediate server rounds; emit only the final
+    assistant text or the client-owned `tool_calls` SSE.
+- Reuse `GatewayToolCatalog` / `McpToolCatalogAdapter` / `WebSearchTool`
+  for the snapshot. Add a small adapter that answers "OpenAI completions
+  policy" (inject MCP even when the client sent tools; inject `web_search`
+  without an Anthropic server-tool declaration). Do **not** change the
+  Anthropic gateway's defaults.
+- Injection conditions (all must hold): dual capability gate; for MCP,
+  `MCP_CLIENT_ENABLED` + at least one user server; for web search,
+  `WebSearchTool::isAvailable()` and `WEB_SEARCH_MODE !== off`.
+- Name collision: skip a Synaplan declaration whose function name is
+  already in the client's `tools[]`.
+- `tool_choice: none` → do not inject, do not loop.
+- Metering: each loop iteration records usage; session summary notes
+  `[web_search:…]` / `[mcp:server/tool]` so digests stay meaningful.
+- Docs: `docs/OPENAI_COMPATIBLE_API.md` section "Server tools (MCP and
+  web search)" with a curl that sends **no** client tools and still gets
+  a search-backed answer when Brave is configured. Cross-link
+  `docs/ANTHROPIC_COMPATIBLE_API.md` and spell out the policy difference.
+- Tests: loop with TestProvider (`TOOLTEST:web_search`, `TOOLTEST:mcp`);
+  client-owned relay; name collision; `tool_choice: none`; MCP disabled;
+  search unavailable; stream suppression of an intermediate server round.
+  Fake `McpClient` / `WebSearchTool` — no live network.
+
+### T5 — OpenAI Responses API provider
+
+Branch: `feat/tools-openai-responses`
+
+- `OpenAIProvider::buildResponsesRequest()`: `tools` →
+  `[{type:'function', name, description, parameters, strict:false}]`,
+  `tool_choice` mapping; history: assistant `tool_calls` → `function_call`
+  input items (`call_id`, `name`, `arguments`), `role: tool` →
+  `function_call_output` items (`call_id`, `output`).
+- Non-stream: `output[*].type === 'function_call'` → `tool_calls`;
+  `finish_reason: 'tool_calls'` when any present.
+- Stream: `response.output_item.added` (function_call) → first
+  `tool_call_delta` with `id`/`name`; `response.function_call_arguments.delta`
+  → argument deltas; `response.output_item.done` closes; `response.completed`
+  → `finish`.
+- Keep `previous_response_id` behavior intact; tests with recorded Responses
+  payloads.
+- `supportsToolCalling()` = catalog `tool_use` for that model.
+
+### T6 — Anthropic and Google providers
+
+Branch: `feat/tools-anthropic-google-providers`
+
+- `AnthropicProvider`: `tools` via `OpenAiToolShapes::toAnthropicTools`
+  (`input_schema`), `tool_choice` → `{type: auto|any|tool}`; history:
+  assistant `tool_calls` → `tool_use` content blocks, `role: tool` → user
+  `tool_result` blocks; response `tool_use` blocks → `tool_calls`; stream
+  `content_block_start` (tool_use) + `input_json_delta` → `tool_call_delta`;
+  `stop_reason: tool_use` → `finish tool_calls`. Update the class comment
+  that says tools are not implemented.
+- `GoogleProvider`: `tools: [{functionDeclarations}]`, `toolConfig`
+  mapping of `tool_choice`; history: `functionCall` / `functionResponse`
+  parts; response `functionCall` parts → `tool_calls` (generate ids);
+  stream: whole-arguments delta per part.
+- Ollama: implement the marker only for models flagged `tool_use` (add the
+  flag only when Ollama metadata / our catalog says the pulled model
+  supports tools); otherwise false. Optional, last.
+
+### T7 — Wrap-up
+
+- Admin model list shows the tool badge from `hasFeature('tool_use')`
+  (the flag is now a real gate, so the badge is truthful).
+- Record in both `STATUS.md` files that `ToolCallingChatProviderInterface`
+  and `OpenAiGatewayToolLoop` exist so Phase B / Collabora Epic 1.1 build
+  on them instead of re-adding them.
+
+## Out of scope here (explicitly)
+
+- Internal chat (`ChatHandler`) using tools — that is Phase B's
+  `ChatToolLoop`.
+- Structured outputs / `response_format: json_schema` — separate, small,
+  can follow T3 if a client needs it.
+- Changing Anthropic `/v1/messages` defaults (`MCP_TOOLS_ENABLED` stays
+  off until an admin enables the Messages gateway tools).
+- Mutating MCP tools on this endpoint (`includeMutating: false`).
+
+## Gate
+
+Backend only: `make -C backend lint && make -C backend phpstan && make -C backend test`
+per PR; the frontend is untouched except when T3 changes OpenAPI
+annotations that the SPA consumes (it does not consume `/v1/*`, verify with
+`make -C frontend generate-schemas` producing no diff).

--- a/_devextras/planning/20260902-office-docs/README.md
+++ b/_devextras/planning/20260902-office-docs/README.md
@@ -1,0 +1,25 @@
+# Office documents (Synaplan side)
+
+**Status:** planned (2026-09-02). No product code in this change.
+**Sibling:** [`../20260902-collabora-integration/`](../20260902-collabora-integration/)
+— Synaplan *inside* the Collabora editor.
+
+This directory is the **plan of record**. Cursor session `.plan.md` files are
+not authoritative; everything from those sessions lives here.
+
+| File | Role |
+| ---- | ---- |
+| [`00_master_plan.md`](./00_master_plan.md) | v3 master: scope, Decisions 1–3, phase order |
+| [`office-plan_v3.md`](./office-plan_v3.md) | English v3 write-up (session plan persisted) |
+| [`office-plan_v2.md`](./office-plan_v2.md) | Original structured-editing design (Phase B detail) |
+| [`03_phase_t_tool_calling_gateway.md`](./03_phase_t_tool_calling_gateway.md) | Phase T — tool calling + MCP/web search on `/v1/chat/completions` (**first**) |
+| [`01_phase_a_engine_and_ux.md`](./01_phase_a_engine_and_ux.md) | Phase A — converter, UX, A0-docs in `synaplan-docs` |
+| [`02_phase_b_structured_editing.md`](./02_phase_b_structured_editing.md) | Phase B — xlsx-first model + true merge |
+| [`STATUS.md`](./STATUS.md) | Step table and decision log |
+
+**Order of work:** Phase T → Phase A (including A0-docs) → Phase B.
+Collabora editor / WOPI / partner platforms are not in this directory.
+
+**Two delivery surfaces** (see `00_master_plan.md`): the public OSS repo
+(`synaplan`, engine optional) and our hosted demo (`synaplan-platform`,
+engine on). Phase T is OSS-only. A0 is the first dual-repo step.

--- a/_devextras/planning/20260902-office-docs/STATUS.md
+++ b/_devextras/planning/20260902-office-docs/STATUS.md
@@ -1,0 +1,103 @@
+# Status — Office Documents (Synaplan side)
+
+Plan of record: `00_master_plan.md`. Work one step at a time; update this
+table when a branch is opened, merged, or a decision is taken. The Collabora
+side (editor, Synaplan inside Collabora, partner platforms) is tracked in
+`../20260902-collabora-integration/STATUS.md`.
+
+## Phase T — tool calling (first)
+
+| Step | Branch | State | Notes |
+| ---- | ------ | ----- | ----- |
+| T1 — Provider contract, consistent `tool_use` flags + migration, `ToolCallAccumulator`, `OpenAiToolShapes`, TestProvider | `feat/chat-provider-tool-contract` | planned | Dual gate; catalog matrix test |
+| T2 — Chat Completions providers (Groq, OpenAICompatible, Mistral, xAI, TrustedTokens, HuggingFace) | `feat/tools-chat-completions-providers` | planned | Shared trait; `supportsToolCalling` = catalog flag |
+| T3 — `/v1/chat/completions` tools pass-through (non-stream + stream), dual-gate 400 | `feat/openai-gateway-tools` | planned | Collabora client tools work from here |
+| T4 — Server-side MCP + `web_search` loop on `/v1/chat/completions` | `feat/openai-gateway-server-tools` | planned | Injected on dual-gated models; client tools still relayed |
+| T5 — OpenAI Responses API provider | `feat/tools-openai-responses` | planned | |
+| T6 — Anthropic + Google (+ Ollama optional) | `feat/tools-anthropic-google-providers` | planned | |
+| T7 — Wrap-up docs, admin badge, STATUS cross-record | — | planned | |
+
+## Phase A — engine and UX quick wins
+
+| Step | Branch | State | Notes |
+| ---- | ------ | ----- | ----- |
+| A0 — Converter client + `collabora/code` sidecar | `feat/office-converter-client` | planned | **Dual-repo:** OSS profile `office` (dev + minimal + `deploy/compose.yaml`); platform PR turns the sidecar **on** (per-node, Centrifugo analog). Shared with the Collabora plan |
+| A0-docs — LibreOffice/Collabora required for new office features | `feat/docs-office-libreoffice` in **`synaplan-docs`** | planned | New `docs/office-documents.md` + cross-links (quickstart, FAQ, architecture, using-synaplan, desktop-tools). Ships with A0 so operators see the requirement before the features land |
+| A1 — Thumbnails for office docs and PDFs | `feat/office-thumbnails` | planned | Office half of #1499 |
+| A2 — Download as PDF | `feat/office-pdf-export` | planned | New endpoint `GET /api/v1/files/{id}/export?format=pdf` |
+| A3 — Inline preview modal | `feat/office-inline-preview` | planned | Frontend only, uses A2 |
+| A4 — officemaker delivers PDF | `feat/officemaker-pdf` | planned | Includes the `GeneratedDocumentStore` refactor; snapshot re-record |
+| A5 — DOCX default styling | `fix/docx-default-styles` | planned | #1396, independent of the engine |
+| A6 — Analysable ingestion (legacy formats + structured text for xlsx/pptx) | `feat/office-ingestion-analysis` | planned | A6b needs no engine |
+| A7 — Combine documents as one PDF | `feat/office-combine-pdf` | planned | `pdfunite` from poppler-utils; first merge feature |
+
+## Phase B — structured editing and merge
+
+| Slice | Branch | State | Notes |
+| ----- | ------ | ----- | ----- |
+| B1 — xlsx end to end (model, renderer, revisions, tools, Groq, loop) | — | planned | See `02_phase_b_structured_editing.md`; provenance columns decided before migration |
+| B2 — more providers + `tools` model feature | — | planned | Shared with Collabora Epic 1.1 (`ToolCallingChatProviderInterface`) |
+| B3 — docx | — | planned | |
+| B4 — pptx | — | planned | |
+| B5 — importers + fidelity report | — | planned | |
+| B6 — version history UI + admin toggle | — | planned | |
+| B7 — true merge on the model | — | planned | "Combine as DOCX/XLSX/PPTX" |
+
+## Decisions
+
+| Date | Decision |
+| ---- | -------- |
+| 2026-09-02 | Office engine = Collabora CODE sidecar per web node, reached over HTTP (`OFFICE_CONVERT_URL`). Host apt LibreOffice on web1/2/3 is not used by the containers. See `00_master_plan.md` Decision 1. |
+| 2026-09-02 | UX first (Phase A), then structured editing and merge (Phase B, xlsx-first). |
+| 2026-09-02 | Everything that runs inside or provisions the Collabora editor moved to `../20260902-collabora-integration/` (its Epic 0 owns the Synaplan WOPI host). |
+| 2026-09-02 | Tool calling (Phase T) is built first, before Phase A; it is the shared building block for the Collabora AI Assistant, OpenAI-SDK clients and Phase B. |
+| 2026-09-02 | Dual capability gate: `ToolCallingChatProviderInterface` **and** catalog `tool_use`. Flags must be consistent; seeder + Galera-safe migration + `ModelCatalogToolUseConsistencyTest`. |
+| 2026-09-02 | `/v1/chat/completions` offers Synaplan MCP + `web_search` on dual-gated models (hybrid loop). Client-owned tools are still relayed. Does not reuse `/v1/messages` MCP-off / "client must declare web_search" defaults. |
+| 2026-09-02 | Public docs (`synaplan-docs`) must state that the new office capabilities need a LibreOffice engine — the Collabora CODE sidecar, not host `apt install libreoffice`, and not Desktop's local LibreOffice. Page + cross-links ship with A0. |
+| 2026-09-02 | **Two delivery surfaces.** OSS (`synaplan`, including `deploy/compose.yaml` / Umbrel / AWS) keeps the engine optional (profile `office`, empty URL). Our hosted demo (`synaplan-platform` on web1/2/3) turns it **on** (per-node sidecar, Centrifugo analog — not shared like Tika or TTS). Swiss `ch1` is out of this epic. See `00_master_plan.md` "Two delivery surfaces". |
+
+## Investigation baseline (2026-09-02)
+
+- `officemaker` = prompt topic + `DocumentGeneratorService` (PhpOffice); PDF
+  explicitly excluded in classifier and prompt; store logic duplicated in
+  `ChatHandler` and `StreamController`.
+- Thumbnails exist only for videos (`ThumbnailService` → `thumbPath` →
+  `/files/{id}/thumb` → `FilePreview.vue`).
+- Ingestion is Tika only; workbooks and decks arrive as one flat text blob.
+- No repository references LibreOffice/Collabora; dev host and web nodes
+  have `libreoffice-*` 24.2.7 (apt) installed but unreachable from the
+  containers.
+- External services are HTTP + env URL (`TIKA_BASE_URL`, `QDRANT_URL`,
+  `SYNAPLAN_TTS_URL`); host services via `docker-host:host-gateway`.
+- `poppler-utils` (`pdfunite`, `pdftoppm`), Imagick and ghostscript are in
+  the base image.
+
+## Current-state check-in (2026-09-02, before any product code)
+
+Verified on disk. Nothing below has been implemented yet.
+
+### `synaplan` (public OSS)
+
+| Area | State |
+| ---- | ----- |
+| Converter / `OFFICE_CONVERT_URL` | Absent. `backend/.env.example` has Tika + `SYNAPLAN_TTS_URL=` only. |
+| `OfficeConverterClient` / `Service/File/Office/` | Directory does not exist. Closest analog: `TikaClient.php`. |
+| Compose `collabora` / profile `office` | Absent in `docker-compose.yml`, `docker-compose-minimal.yml`, `deploy/compose.yaml`, Umbrel. Closest analog: `tts` profile (dev + minimal only; **not** in `deploy/compose.yaml`). |
+| `officemaker` | Prompt topic. `DocumentGeneratorService` renders DOCX/XLSX/PPTX (PhpOffice). PDF excluded in `MessageClassifier` (fast-path comment ~line 642) and in the multitask prompt (`Real PDFs are NOT supported`). `officeMakerPrompt()` lists csv/xlsx/docx/pptx/md/txt only. |
+| Thumbnails | `ThumbnailService` is **video/ffmpeg only**. `FilePreview.vue`: image / video / audio / text snippet / icon. No office poster branch. |
+| Runtime features | `whisperEnabled` etc. in `ConfigController`; no `officeConvertEnabled`. |
+| Public docs | `synaplan-docs` has `tts.md` and Tika on the architecture map. No `office-documents.md`. |
+| Self-host contract | `deploy/compose.yaml` is the portable production file (in-stack Tika, optional `local-ai`). Official self-host RAM floor is 8 GB — a default-on Collabora would break that. |
+
+### `synaplan-platform` (our demo / prod)
+
+| Area | State |
+| ---- | ----- |
+| Image | `ghcr.io/metadist/synaplan:latest` on backend / worker / worker-bulk. Schema lands on image roll (`updatewebN.sh`, one node at a time). |
+| Per-node compose today | `synaplan-platform`, `synaplan-worker`, `synaplan-worker-bulk`, `synaplan-centrifugo`, plus `whisper-models`. Qdrant is a **separate** compose via `docker-host`. |
+| Tika | Shared Coolify, `TIKA_URL=http://tika.synaplan.com` + basic auth. Not a sidecar. |
+| TTS | Shared GPU box, `SYNAPLAN_TTS_URL` (empty default in compose, set in `.env`). |
+| Collabora / `OFFICE_CONVERT_URL` | Absent. No service, no env, no `CLUSTER-DOC.md` row. |
+| Uploads | NFS `./up/` on backend + both workers. Convert artefacts must land here. |
+| Sizing | `docs/PHP-RUNTIME-SIZING.md` already treats the box as shared (Galera + Qdrant + workers). Collabora RAM is not in that budget yet. |
+| Swiss demo (`ch1` / `synaplan-swiss`) | Separate stack, not this compose. Out of this epic. |

--- a/_devextras/planning/20260902-office-docs/office-plan_v2.md
+++ b/_devextras/planning/20260902-office-docs/office-plan_v2.md
@@ -1,0 +1,221 @@
+---
+name: AI Dokument-Editing
+overview: "Synaplan bekommt echtes, schrittweises Bearbeiten von Excel-, Word- und PowerPoint-Dateien: ein strukturiertes Dokumentmodell als Wahrheit, serverseitige Werkzeuge darauf, und ein Multi-Turn-Tool-Loop im Web-Chat, damit das Modell gezielt ändert statt jedes Mal alles neu zu schreiben."
+todos:
+  - id: s0-model
+    content: "Sprint 0: Dokumentmodell + deterministisches Rendering in backend/src/Service/Document/ (Model/, Render/, Serializer/), ohne KI-Anbindung. Gate: XlsxRenderer mit Formeln, Zahlenformaten, 2 Sheets, Chart; Roundtrip-Read-Test"
+    status: pending
+  - id: s1-persist
+    content: "Sprint 1: Galera-safe Doctrine-Migration BDOCUMENT_REVISIONS (raw addSql, CREATE TABLE IF NOT EXISTS), Entity + Repository, DocumentRevisionService, DocumentTextProjector fuer BFILETEXT-Projektion"
+    status: pending
+  - id: s2-tools
+    content: "Sprint 2: DocumentToolInterface + DocumentSession + Werkzeugsatz fuer xlsx/docx/pptx inkl. read_* Tools; Tools werfen nie, Fehler als Result; Unit-Test pro Tool inkl. Fehlerfaelle"
+    status: pending
+  - id: s3-providers
+    content: "Sprint 3: ToolCallingChatProviderInterface + Implementierung in Groq (zuerst), OpenAI (Responses API), Anthropic, Google; 'tools' als Feature im ModelCatalog + hasFeature-Check mit Fallback"
+    status: pending
+  - id: s4-loop
+    content: "Sprint 4: ChatToolLoop nach Vorbild GatewayToolLoop (Bounds, Partition, Fehler als tool_result), Einbindung in ChatHandler nur fuer officemaker + Flag + tool-faehiges Modell; Routing-Snapshots pruefen"
+    status: pending
+  - id: s5-ux
+    content: "Sprint 5: SSE document_step + documentChanges, Schrittliste und Aenderungszusammenfassung in ChatMessage.vue, Versionshistorie-UI mit useDialog/useNotification, 2 REST-Endpunkte mit OpenAPI + Zod-Regeneration, i18n in allen 5 Locales"
+    status: pending
+  - id: s6-import
+    content: "Sprint 6: Importer fuer hochgeladene xlsx/docx/pptx mit ImportFidelityReport, MessageClassifier-Guard fuer 'aendere diese Datei' statt analyzefile, Snapshot mit anpassen"
+    status: pending
+  - id: s7-rollout
+    content: "Sprint 7: DOCUMENT_TOOLS.* BCONFIG-Seeder (alles default aus), Admin-Toggle, mobile-impact-policy.json + tests/mobile-impact.test.mjs erweitern, Dokumentation in docs/"
+    status: pending
+isProject: false
+---
+
+t# AI Dokument-Editing (Excel, Word, PowerPoint)
+
+## Warum heute nichts Feines geht
+
+Der `officemaker`-Pfad ist ein Einweg-Trichter: Das Modell liefert `{"BFILEPATH":…,"BFILETEXT":…}` (Markdown bzw. CSV), [backend/src/Service/File/DocumentGeneratorService.php](backend/src/Service/File/DocumentGeneratorService.php) rendert daraus **jedes Mal eine komplett neue Datei**. Konkrete Folgen:
+
+- Excel kennt keine Typen: alles landet als `TYPE_STRING`, ein einziges Sheet, keine Formeln, keine Charts (`writeXlsx`, Zeilen 517–548).
+- Ein Edit bedeutet: gesamter Dateitext zurück in den Prompt (auf 10.000 Zeichen gekürzt, [ChatHandler.php](backend/src/Service/Message/Handler/ChatHandler.php) Zeilen 1460–1482), Modell schreibt alles neu. Formatierung, die nicht in Markdown ausdrückbar ist, existiert nicht und geht daher bei jedem Turn verloren.
+- Hochgeladene Dateien kommen nur als flacher Tika-Text an ([TikaClient.php](backend/src/Service/File/TikaClient.php)) — keine Zellen, keine Folien.
+
+## Zwei tragende Entscheidungen
+
+**1. Das Dokumentmodell ist die Wahrheit, nicht die Binärdatei.**
+Binär-Round-Trip mit PhpSpreadsheet verliert Charts, sobald Reader oder Writer `setIncludeCharts(true)` fehlt, und auch dann Styles; PhpWord und PhpPresentation lesen DOCX/PPTX nur rudimentär. Wir halten stattdessen ein versioniertes, strukturiertes Modell (Sheets/Zellen/Formeln/Styles, Word-Blöcke, Folien) und rendern die Datei daraus deterministisch. Werkzeuge patchen das Modell, nie die ZIP-Datei. Damit sind beliebig viele Edit-Turns verlustfrei.
+
+**2. Der Tool-Loop wird nachgebaut, nicht umgebogen.**
+[GatewayToolLoop.php](backend/src/AI/Messages/Tools/GatewayToolLoop.php) hat das Muster fertig (Iterations- und Wall-Clock-Bounds, Server/Client-Partition, Fehler als `tool_result` statt Abbruch, Zeilen 142–238). Er hängt aber an `MessagesTranslatorInterface` und am Anthropic-Wire-Format. Der Web-Chat läuft über `ChatProviderInterface`, das gar kein Tool-Calling kennt. Wir bauen einen zweiten, schlanken Loop auf `ChatProviderInterface` und übernehmen Bounds und Fehlerverhalten 1:1.
+
+```mermaid
+flowchart TD
+    User[Nutzer: Spalte D als Waehrung, Chart dazu] --> Loop[ChatToolLoop]
+    Loop --> Provider[ChatProviderInterface mit tools]
+    Provider -->|tool_use| Registry[DocumentToolRegistry]
+    Registry --> Session[DocumentSession: Modell im Speicher]
+    Session -->|Ergebnis| Loop
+    Loop -->|tool_result, naechste Runde| Provider
+    Provider -->|end_turn| Render[DocumentRenderer]
+    Render --> Revision[Revision speichern + Datei schreiben]
+    Revision --> SSE[SSE document_step + Aenderungsliste]
+```
+
+
+
+## Sprint 0 — Dokumentmodell und Rendering, ohne KI
+
+Neues Verzeichnis `backend/src/Service/Document/`. Reine Datenklassen plus Renderer, alles `final readonly`, strict types, testbar ohne Modell.
+
+- `Model/SpreadsheetModel`, `SheetModel`, `CellModel` (Wert, Typ, Formel, Zahlenformat), `StyleModel`, `ChartModel`
+- `Model/WordModel` mit Blocktypen (Heading, Paragraph, Table, Image, TOC, PageBreak) und Style-Referenzen
+- `Model/DeckModel` — greift die bestehenden Strukturen aus [backend/src/Service/File/Presentation/](backend/src/Service/File/Presentation/) auf (`SlideDeck`, `SlideContent`, `PptxTheme`) statt sie zu duplizieren
+- `Render/DocumentRenderer` als Dispatcher plus `XlsxRenderer`, `DocxRenderer`, `PptxRenderer`-Adapter auf den vorhandenen [PptxRenderer.php](backend/src/Service/File/Presentation/PptxRenderer.php)
+- `Serializer/DocumentModelSerializer`: Modell zu/von JSON, mit `schemaVersion` für spätere Migration
+
+Der bestehende `DocumentGeneratorService` bleibt unangetastet und weiter der Default-Pfad. Neue Composer-Pakete sind nicht nötig — `phpoffice/phpspreadsheet ^5.8`, `phpword ^1.4`, `phppresentation` sind gepinnt.
+
+Gate: `XlsxRenderer` erzeugt Formeln, Zahlenformate, zwei Sheets und ein Bar-Chart; die Datei öffnet sich und `IOFactory::load()` liest die Werte zurück.
+
+## Sprint 1 — Persistenz und Versionshistorie
+
+`BFILETEXT` ist belegt: Volltextsuche ([FileRepository.php](backend/src/Repository/FileRepository.php) Zeile 65), Digests ([MessageDigestService.php](backend/src/Service/Digest/MessageDigestService.php) Zeile 380), Summaries, MCP-Ressourcen, `text_preview`. Dort darf kein JSON hinein, sonst verschlechtern wir Suche und RAG. Also eigene Tabelle.
+
+Doctrine-Migration nach [docs/MIGRATIONS.md](docs/MIGRATIONS.md), Galera-tauglich: nur rohes `addSql` mit `CREATE TABLE IF NOT EXISTS`, kein Zugriff auf `Schema $schema`.
+
+- Tabelle `BDOCUMENT_REVISIONS`: `BID`, `BFILEID`, `BUSERID`, `BVERSION`, `BSCHEMAVERSION`, `BMODEL` (LONGTEXT, JSON), `BSUMMARY`, `BCREATED`
+- Entity `App\Entity\DocumentRevision` plus `DocumentRevisionRepository`
+- `DocumentRevisionService`: `latestFor(File)`, `append(File, model, summary)`, `restore(File, version)`, Kappung auf `KEEP_REVISIONS`
+- `BFILETEXT` bekommt weiter eine **Text-Projektion** des Modells (`DocumentTextProjector`), damit Suche, Digest und Summary unverändert funktionieren
+
+Wichtig: Mehrere Fremdschlüssel im Schema haben kein `ON DELETE CASCADE` (siehe AGENTS.md). Beim Löschen einer Datei müssen Revisionen zuerst weg — in `FileController`/Service und in der Migration berücksichtigen.
+
+## Sprint 2 — Werkzeuge auf dem Modell
+
+`backend/src/Service/Document/Tool/`. Vertrag angelehnt an [WebSearchTool.php](backend/src/AI/Messages/Tools/WebSearchTool.php), diesmal aber als echtes Interface, weil es viele Tools werden:
+
+```php
+interface DocumentToolInterface
+{
+    public function name(): string;
+    public function declaration(): array;              // JSON-Schema
+    public function appliesTo(): array;                // ['xlsx'] etc.
+    public function execute(DocumentSession $s, array $input): DocumentToolResult;
+}
+```
+
+`DocumentToolResult` trägt `ok`, `message` (für das Modell), `userLabel` (i18n-Key plus Parameter für die UI) und `isError`. Tools werfen nie — Fehler kommen als Ergebnis zurück, genau wie im Gateway-Loop.
+
+Werkzeugsatz:
+
+- Excel: `read_range`, `set_cells`, `set_formula`, `set_number_format`, `set_cell_style`, `add_column`, `add_row`, `add_sheet`, `sort_range`, `add_chart`, `set_conditional_format`
+- Word: `read_outline`, `insert_block`, `replace_block`, `delete_block`, `set_block_style`, `set_table_cell`, `insert_toc`, `insert_image`
+- PowerPoint: `read_deck`, `add_slide`, `set_slide_content`, `move_slide`, `delete_slide`, `set_theme`, `insert_image`
+
+`read_*` ist Pflicht, nicht Kür: nur so sieht das Modell den Ist-Zustand und muss ihn nicht im Prompt mitgeschleppt bekommen. Genau das ersetzt die heutige 10.000-Zeichen-Volltext-Injektion.
+
+`DocumentSession` hält das Modell während eines Turns im Speicher, protokolliert die angewandten Operationen und schreibt erst am Turn-Ende Datei plus Revision — ein fehlgeschlagener Turn hinterlässt kein halb kaputtes Dokument.
+
+Gate: jedes Tool hat einen Unit-Test, inklusive Fehlerfälle (Bereich außerhalb, unbekanntes Sheet, ungültige Formel).
+
+## Sprint 3 — Tool-Calling in den Providern
+
+`ChatProviderInterface` bleibt unverändert (viele Implementierungen, auch `TestProvider` und `OpenAICompatibleProvider`). Stattdessen ein zusätzliches, optionales Interface:
+
+```php
+interface ToolCallingChatProviderInterface
+{
+    public function chatWithTools(array $messages, array $tools, array $options = []): array;
+    public function chatStreamWithTools(array $messages, array $tools, callable $cb, array $options = []): array;
+}
+```
+
+Rückgabe normalisiert auf eine interne Form (`content`, `toolCalls[]`, `stopReason`, `usage`), damit der Loop providerunabhängig bleibt. Als Mapping-Vorlage dienen die vorhandenen Translator: [OpenAiMessagesTranslator.php](backend/src/AI/Messages/Translator/OpenAiMessagesTranslator.php) Zeilen 177–223 und `GeminiMessagesTranslator`.
+
+Pro Provider:
+
+- `GroqProvider` — Chat Completions über `openai-php/client`, einfachster Fall: `tools`/`tool_choice` in `$requestOptions` (Zeilen 159–167), `delta.tool_calls` im Stream (Zeilen 261–276). Damit anfangen.
+- `OpenAIProvider` — nutzt die **Responses API**, nicht Chat Completions. `tools` in `buildResponsesRequest()` (Zeilen 344–370), Parsing des `output`-Arrays statt nur `outputText`, im Stream `response.function_call_arguments.delta` und `response.output_item.done`.
+- `AnthropicProvider` — direktes HTTP, `tools` in den Request-Body (Zeilen 188–192, 316–321), `tool_use`-Blöcke und `input_json_delta` in `parseSSEStream()` (Zeilen 891–915). Der Klassenkommentar (Zeilen 22–25) sagt heute explizit „nicht implementiert" — mit anpassen.
+- `GoogleProvider` — `functionDeclarations` im Payload (Zeilen 197–205), `functionCall`-Parts im Stream (Zeilen 378–388).
+
+Modellfähigkeit über das bestehende `features`-Muster: `'tools'` in `json.features` im [ModelCatalog.php](backend/src/Model/ModelCatalog.php), geprüft mit `Model::hasFeature('tools')` — analog zum Vision-Check in [ChatHandler.php](backend/src/Service/Message/Handler/ChatHandler.php) Zeilen 969–970. Kann ein Modell keine Tools, fällt der Turn sauber auf den heutigen `officemaker`-Pfad zurück. Das ist die Sicherheitsleine für Ollama und selbstgehostete Endpunkte.
+
+## Sprint 4 — Der Chat-Tool-Loop
+
+`backend/src/AI/Tool/ChatToolLoop.php`, Bounds und Fehlerverhalten von `GatewayToolLoop` übernommen:
+
+- Iterationsgrenze aus BCONFIG (Default 8), Wall-Clock 240 Sekunden, maximal 24 Operationen pro Turn
+- Tool wirft nie den Loop ab: Fehler geht als `tool_result` zurück, das Modell korrigiert sich
+- Loop-Ende bei `end_turn`, bei erschöpften Bounds oder wenn keine bekannten Tools mehr kommen
+- Jede Runde meldet Fortschritt über den vorhandenen Status-Callback
+
+Einstieg in [ChatHandler.php](backend/src/Service/Message/Handler/ChatHandler.php): bei `topic === 'officemaker'`, gesetztem Flag und tool-fähigem Modell statt `aiFacade->chatStream()` in den Loop. Alle anderen Topics bleiben unberührt. Der Prompt bekommt eine eigene Variante `officeMakerPrompt` für den Tool-Modus (Werkzeuge nutzen, keine JSON-Envelopes) — als **neues** Topic `officemaker` bleibt bestehen, der Prompttext wird flaggenabhängig gewählt, damit die Routing-Snapshots nicht driften.
+
+Achtung Snapshots: sobald `MessageClassifier`, `MessageSorter` oder Planner-Prompt berührt werden, driften `routing_classification.json`, `planner_system_prompt.txt` und `utterance_plans.json`. Neu aufnehmen und **jede** Zeile im Diff prüfen.
+
+## Sprint 5 — Sichtbarkeit für den Nutzer
+
+Ohne UI ist der Loop eine Blackbox. Copilot punktet vor allem damit, dass man sieht, was passiert.
+
+Backend, neues SSE-Event neben dem bestehenden `generating_file`:
+
+- `document_step` mit `{ index, total?, labelKey, labelParams }` — pro ausgeführtem Tool
+- `complete` trägt zusätzlich `documentChanges: [{ labelKey, labelParams }]` und `version`
+
+Frontend:
+
+- [ChatMessage.vue](frontend/src/components/ChatMessage.vue) Zeilen 302–326: der `generating_file`-Block bekommt eine kompakte Schrittliste unter der Unterzeile, mit `txt-tertiary` und `surface-chip` aus [style.css](frontend/src/style.css) — keine Tailwind-Farben, in Light, Dark und V2 geprüft
+- Änderungszusammenfassung als Block unter den Datei-Badges: „Spalte D als Währung formatiert, Balkendiagramm auf Blatt 1 eingefügt"
+- Versionshistorie: Aufklapper an der Datei mit „Version wiederherstellen", über `useDialog()` bestätigt, Rückmeldung über `useNotification()` — nie `confirm()`
+- `frontend/src/types/chatStream.ts` erweitern (Stream-Events sind handtypisiert, nicht aus OpenAPI generiert)
+
+Zwei neue Endpunkte, mit vollständigen OpenAPI-Annotationen, danach `make -C frontend generate-schemas` und `vue-tsc`:
+
+- `GET /api/v1/files/{id}/revisions`
+- `POST /api/v1/files/{id}/revisions/{version}/restore`
+
+i18n in **allen fünf** Locales (`en`, `de`, `es`, `fr`, `tr`), Platzhalternamen identisch zu Englisch — `localeParity.spec.ts` gated Vollparität. Neue Namensräume: `processing.documentStep`*, `message.documentChanges`*, `files.revisions*`. Copy für Laien: „Spalte hinzugefügt", nicht „add_column ausgeführt".
+
+## Sprint 6 — Hochgeladene Dateien bearbeiten
+
+Erst hier, weil es der unsicherste Teil ist.
+
+- `Import/SpreadsheetImporter` über `IOFactory::load()` mit `LOAD_WITH_CHARTS` — bei xlsx tragfähig
+- `Import/WordImporter` und `DeckImporter` als ausdrücklich verlustbehafteter Best-Effort-Import
+- `ImportFidelityReport`: was nicht übernommen wurde. Der Nutzer bekommt das **vor** dem ersten Edit zu sehen, statt es später zu merken.
+- [MessageClassifier.php](backend/src/Service/Message/MessageClassifier.php) Zeilen 210–222: heute geht jedes analysierbare Non-Image-Attachment nach `analyzefile`. Für „ändere diese Datei" auf einem xlsx muss stattdessen `officemaker` greifen — Guard und Charakterisierungs-Snapshot zusammen anpassen.
+
+## Sprint 7 — Rollout
+
+BCONFIG-Flags über einen Seeder nach dem Muster von [FileContextConfigSeeder.php](backend/src/Seed/FileContextConfigSeeder.php) (`BConfigSeeder::insertIfMissing`), alles **standardmäßig aus**:
+
+- `DOCUMENT_TOOLS.ENABLED` = 0
+- `DOCUMENT_TOOLS.MAX_ITERATIONS` = 8
+- `DOCUMENT_TOOLS.MAX_OPS_PER_TURN` = 24
+- `DOCUMENT_TOOLS.KEEP_REVISIONS` = 10
+- `DOCUMENT_TOOLS.ALLOW_UPLOAD_EDIT` = 0
+
+Bootstrap-Fallstrick aus AGENTS.md: BCONFIG-Defaults greifen nur bei Neuinstallationen. Für bestehende Installationen braucht ein Default-Wechsel eine Migration mit explizitem UPDATE. Und: ein Flag, das aus ist, macht neue Logik zum No-op — vor „fertig" prüfen, dass der Pfad wirklich erreicht wird.
+
+Weiter:
+
+- Admin-Umschalter über das bestehende Config-Gruppen-Muster in `SystemConfigService`
+- Neue Pfade in [.github/mobile-impact-policy.json](.github/mobile-impact-policy.json) einordnen: `backend/**` ist backend-only, `frontend/**` ist ota-candidate. Unbekannte Pfade fallen auf store-required und machen CI rot. `tests/mobile-impact.test.mjs` mit erweitern.
+- Dokumentation in `docs/`
+
+## Risiken
+
+- **Kosten und Latenz.** Acht Runden mit Werkzeugen sind teurer als ein Aufruf. Bounds sind niedrig gesetzt; `read_`* liefert Bereiche, keine kompletten Blätter.
+- **Modelle ohne Tools.** Ollama und OpenAI-kompatible Endpunkte fallen auf den heutigen Pfad zurück. Deshalb bleibt `officemaker` alt vollständig funktionsfähig und wird nicht ersetzt.
+- **PhpPresentation** ist auf `dev-master as 1.3.0` gepinnt — beim Rendern über die vorhandenen Klassen bleiben, keine neuen Reader-Pfade.
+- **Zwei Wahrheiten.** Solange das Flag aus ist, existieren alter und neuer Pfad parallel. Revisionen entstehen nur im neuen Pfad; die Datei-UI muss den Fall „keine Historie" beherrschen.
+
+## Qualitätsgate
+
+Vor jedem Commit vollständig, nicht gefiltert:
+
+```bash
+make lint && make -C backend phpstan && make test && docker compose exec -T frontend npm run check:types
+```
+
+`--filter` und `phpstan analyse <pfad>` sind **nicht** das Gate — Characterization- und Integrationstests liegen außerhalb der üblichen Namensräume. Snapshots nach Routing-Änderungen neu aufnehmen und Zeile für Zeile prüfen. Arbeit läuft auf einem Feature-Branch mit Conventional Commits, niemals direkt auf `main`.

--- a/_devextras/planning/20260902-office-docs/office-plan_v3.md
+++ b/_devextras/planning/20260902-office-docs/office-plan_v3.md
@@ -1,0 +1,167 @@
+# Office documents: engine, UX quick wins, then editing
+
+Status: planned (see `STATUS.md`)
+Date: 2026-09-02
+This is the persisted English v3 write-up of the Cursor session plan
+*Office docs UX and LibreOffice*. The executable step lists are
+`00_master_plan.md`, `03_phase_t_tool_calling_gateway.md`,
+`01_phase_a_engine_and_ux.md`, and `02_phase_b_structured_editing.md`.
+`office-plan_v2.md` remains the detailed design for Phase B.
+
+The Collabora-editor side (WOPI, AI Assistant, extension, MCP, partners)
+is **not** Phase C here. It is a separate plan:
+`../20260902-collabora-integration/`.
+
+## What I found
+
+- `officemaker` is a chat topic, not a handler: the model returns
+  `{"BFILEPATH","BFILETEXT"}`,
+  `backend/src/Service/File/DocumentGeneratorService.php` renders
+  DOCX/XLSX/PPTX with PhpOffice, `ChatHandler` / `StreamController` store
+  the `File` row (two near-identical store paths). PDF output is explicitly
+  excluded in `MessageClassifier` and the prompt. Open issues: #1396 (DOCX
+  has no styling), #1499 (previews/thumbnails).
+- Ingestion is Tika only (`TikaClient.php`); PDF fallback rasterizes via
+  Imagick/`pdftoppm` (`PdfRasterizer.php`). Video thumbnails already exist
+  end to end: `ThumbnailService` → `File.thumbPath` →
+  `GET /api/v1/files/{id}/thumb` → `thumb_url` → `FilePreview.vue`. Office
+  files today render as an icon or a text snippet.
+- LibreOffice 24.2 (Ubuntu apt) is on the dev host and on web1–3, but
+  **nothing in any repo references it**. The backend runs in Docker
+  (`ghcr.io/metadist/synaplan`, Debian bookworm) and cannot execute host
+  binaries. All external services already follow one pattern: HTTP URL in
+  env (`TIKA_BASE_URL`, `QDRANT_URL`, `SYNAPLAN_TTS_URL`), host reachable
+  via `extra_hosts` (`docker-host:host-gateway`).
+- `office-plan_v2.md` is a sound long-term design (document model as truth
+  + tool loop), but it is 8 sprints deep before a user sees anything, and
+  it does not use LibreOffice at all.
+
+## Decision 1 — how LibreOffice reaches Synaplan
+
+Do **not** bind-mount the host `soffice` into the container (glibc/library
+coupling Ubuntu vs Debian, undocumented, breaks on every host upgrade).
+Do **not** bake LibreOffice into `synaplan-base-php` (+~500 MB per image;
+bare `soffice --headless` needs one profile dir per concurrent call and
+crashes take the PHP worker with them).
+
+**Run Collabora CODE (`collabora/code`) as a sidecar container**, one per
+web node, and talk to it over HTTP exactly like Tika:
+
+- `POST http://collabora:9980/cool/convert-to/<format>` (multipart
+  `data=@file`) converts any office format to `pdf`, `png` (first page
+  only), `docx`/`xlsx`/`pptx`, `odt`, `csv`, `html`, `txt`.
+  `GET /hosting/capabilities` reports `convert-to.available`.
+- Same container later serves the WOPI editor (Collabora integration plan)
+  — one engine, no second deployment path. It isolates crashes on
+  malformed documents and manages concurrency (forkit/kits) itself.
+- Gotenberg would be the simpler alternative if we never wanted the
+  editor; the Collabora choice keeps the editor on the same box.
+- The apt LibreOffice on web1–3 is not needed by the containers and can
+  be removed (or kept for admin one-offs). Do not maintain a second path
+  via host-side `unoserver`.
+
+Sizing: CODE idles at roughly 0.5–1 GB RAM; set
+`--o:num_prespawn_children=2` and a memory limit in compose. Dev: compose
+profile `office`. Prod: service in `synaplan-platform` on the compose
+network, **no published port** for conversion (a public HTTPS hostname is
+only needed for the editor).
+
+```mermaid
+flowchart LR
+    subgraph node [web node]
+        backend[backend / worker containers]
+        collabora[collabora/code sidecar]
+        backend -->|"HTTP convert-to (pdf, png, docx)"| collabora
+    end
+    backend -->|PUT /tika| tika[Tika]
+    backend --> nfs[NFS uploads]
+    browser[Browser] -->|thumb / export / preview / merge| backend
+    browser -.->|"Collabora plan: WOPI editor iframe"| collabora
+```
+
+**Public docs:** `synaplan-docs` must state that the new office
+capabilities need this LibreOffice engine (step A0-docs). Host
+`apt install libreoffice` is not enough. Desktop's local LibreOffice
+(Agent Skills doctor) is a different install. See
+`01_phase_a_engine_and_ux.md` § A0.
+
+## Decision 2 — UX first, model second
+
+`office-plan_v2.md` builds the document model, persistence, tools,
+provider tool-calling and the loop before a user sees anything
+(Sprints 0–4). We ship the engine-backed UX wins first (Phase A, each
+step one PR, each shippable alone), then Phase B with a narrowed first
+slice (xlsx only).
+
+## Decision 3 — tool calling first
+
+Tool calling is pulled in front of Phase A as **Phase T**
+(`03_phase_t_tool_calling_gateway.md`). It is the shared building block
+for Collabora's AI Assistant, OpenAI-SDK clients of
+`/v1/chat/completions`, and Phase B's `ChatToolLoop`.
+
+- Dual, consistent gate: `ToolCallingChatProviderInterface` **and**
+  catalog `tool_use` (flags fixed + migration + consistency test).
+- Hybrid loop on `/v1/chat/completions`: relay client tools; inject and
+  execute MCP + `web_search` on dual-gated models.
+
+## Phase T — tool calling (first)
+
+Detail: `03_phase_t_tool_calling_gateway.md`. One PR each: T1 contract +
+flags, T2 Chat Completions providers, T3 gateway pass-through, T4
+server-side MCP + web search, T5 OpenAI Responses, T6 Anthropic/Google,
+T7 wrap-up.
+
+## Phase A — engine + UX quick wins
+
+Detail: `01_phase_a_engine_and_ux.md`. Each step independently shippable.
+The engine is optional (`OFFICE_CONVERT_URL` empty = today's behaviour).
+
+- **A0** Converter client + `collabora/code` sidecar. **Two wirings:**
+  OSS profile `office` (dev, minimal, `deploy/compose.yaml`; Umbrel/AWS
+  stay off); our `synaplan-platform` demo turns it **on** per web node
+  (Centrifugo analog). See `00_master_plan.md` "Two delivery surfaces".
+- **A0-docs** Public `synaplan-docs` page `office-documents.md` +
+  cross-links (Quickstart, FAQ, Architecture, Using Synaplan, Production,
+  Hosting, Desktop tools).
+- **A1** Thumbnails for office documents and PDFs (office half of #1499).
+- **A2** Download as PDF (`GET /api/v1/files/{id}/export?format=pdf`).
+- **A3** Inline preview modal (PDF iframe).
+- **A4** Officemaker delivers PDF; unify generated-file store; lift
+  classifier PDF exclusion; re-record routing snapshots.
+- **A5** DOCX default styling (#1396, no engine).
+- **A6** Analysable ingestion: legacy/Apple via engine + structured
+  sheet/slide text.
+- **A7** Combine documents as one PDF.
+
+## Phase B — structured editing (v2, re-sequenced)
+
+Detail: `02_phase_b_structured_editing.md` + `office-plan_v2.md`.
+
+Keep the two decisions from v2 (document model as truth; a separate
+`ChatToolLoop` on `ChatProviderInterface` mirroring `GatewayToolLoop`
+bounds). Refinements:
+
+- Ship **xlsx only first**, then docx, then pptx.
+- Every revision render passes through the engine for a PDF preview
+  (A2/A3) — cheaper than a bespoke diff UI.
+- A document edited in Collabora makes the stored model stale. Revisions
+  need a `source` (`model` | `binary`); decide before the migration.
+- B7 is true format-preserving merge on the model.
+
+## Collabora editor (not this directory)
+
+WOPI host, "Open in editor", built-in AI Assistant provider, Synaplan
+extension, Collabora MCP, partner platforms: see
+`../20260902-collabora-integration/`. That plan depends on A0 here and
+on Phase T for `/v1/chat/completions` tool calling.
+
+## Ground rules
+
+- Feature branches + Conventional Commits; never on `main`; no AI
+  attribution.
+- Full gate before each commit:
+  `make lint && make -C backend phpstan && make test && docker compose exec -T frontend npm run check:types`.
+- New endpoints: complete OpenAPI, regenerate Zod schemas. New UI text:
+  all five locales. Colors via tokens, verified in light/dark/V2.
+- No secrets or production node IPs in this public repo.

--- a/_devextras/planning/20260902-platform-self-awareness/00_master_plan.md
+++ b/_devextras/planning/20260902-platform-self-awareness/00_master_plan.md
@@ -1,0 +1,371 @@
+# Platform Self-Awareness — Master Plan
+
+Status: planned (see `STATUS.md`)
+Date: 2026-09-02
+Supersedes: `../20260623-release4.0/06_self-aware-routing.md` (Release 4.0
+Feature 6, never started). That document stays as history; every decision it
+took is either carried over or explicitly replaced in Decision 1–9 below.
+Related: `../20260902-office-docs/` (PDF export is the canonical
+install-dependent capability), `../20260606-routing/` and
+`../20260816-saved-task-workflows/` (planner vocabulary), `synaplan-docs`
+(the knowledge source, separate public repo).
+
+## Scope
+
+Synaplan can *do* a lot but cannot *talk about* what it does. A user who asks
+**"Can you create PDFs?"**, **"Would you create a song like the Beatles?"**,
+**"Was kannst du?"** or **"How do I connect WhatsApp?"** today lands in the
+`general` topic, whose prompt forbids "meta-commentary about your
+limitations", so the model guesses — and invents features, fakes files, or
+denies things the installation can actually do.
+
+This plan makes the chat **self-aware** in two grounded ways:
+
+1. It knows what **this installation** can do right now (models, keys, flags,
+   plugins, engines), and says plainly what it cannot — with the closest
+   alternative.
+2. It knows what **the product** can do and how, from the official
+   documentation in `synaplan-docs`, kept current with each release, and it
+   links to the page it used.
+
+Out of scope: a separate help center UI, in-app tutorials (the existing
+`useHelp` tours stay as they are), and answering questions about the user's
+*own* documents (that is ordinary RAG and already works).
+
+## Goal
+
+1. **"Can you X?" is answered truthfully for this install.** Yes / needs setup
+   / not available — derived from live sources, never from a hand-written
+   list. A "no" always names the nearest thing that *is* possible.
+2. **"What can you do?" / "How do I…?" is answered from the docs**, in the
+   user's language, with a clickable link to the page used.
+3. **It stays current by itself.** The docs corpus refreshes when the docs
+   change or a new release is detected; the capability inventory is computed
+   per request from the running system.
+4. **Impossible task requests degrade gracefully.** "Create a PDF of this"
+   on an install without the office engine gets "not here, but I can deliver
+   it as DOCX — want that?", not a fabricated download link.
+5. **Discoverable.** An empty chat suggests "What can you do here?"; `/help`
+   asks it explicitly.
+
+## What exists today (investigated 2026-09-02)
+
+**Nothing of the 4.0 plan was built.** No `synaplan` topic in
+`backend/src/Prompt/PromptCatalog.php`, no system-owned RAG group, no
+`SELF_AWARE.*` flags.
+
+- **Routing.** `MessageClassifier::classify()` → fast path (default OFF,
+  `CLASSIFIER.FAST_PATH_ENABLED`, `MessageClassifier.php` ~L590) →
+  `/` tool commands (`TOOL_COMMANDS`, L32) → attachments → `MessageSorter::classify()`.
+  The sorter fills `[DYNAMICLIST]` from
+  `PromptRepository::getTopicsWithDescriptions(0, $userId, excludeTools: true)`,
+  so a new routable topic is visible to the AI sorter and the multitask
+  planner (`TaskPlanner::buildSystemPrompt()`) without new code. Both prompts
+  are snapshotted in `backend/tests/Characterization/`.
+- **The `general` prompt** (`PromptCatalog::generalPrompt()`) has the right
+  anti-hallucination rules (never fake a file, never claim to have done
+  something) but rule 3 tells the model to *redirect* any file request and the
+  style section forbids talking about limitations. It has no idea what the
+  installation can do, so "can you make PDFs?" gets a guess.
+- **Live capability knowledge is scattered across nine places** and nothing
+  aggregates it:
+  `SkillCatalog::renderCapabilityList()` (planner-facing, per-user
+  flag-aware), `Capability` enum, `ModelConfigService::CAPABILITY_TAGS` +
+  `ModelRepository` (which model, if any, serves `TEXT2PIC` / `TEXT2VID` /
+  `TEXT2SOUND` / `SOUND2TEXT` / `PIC2TEXT` / `VECTORIZE`),
+  `ChatReadinessService::isChatReady()` (provider key present),
+  `ConfigController::getRuntimeConfig()` (`features.help|memoryService|savedTasks|desktopAgentEnabled`,
+  `plugins[].chatCommands`, `billing`, `build.version`),
+  `MultitaskRoutingConfig` (`URL_FETCH_ENABLED`, `MCP_*`, `EMAIL_SEARCH_ENABLED`),
+  `PluginManager`, `CapabilityService` (upload formats — the existing
+  `GET /api/v1/config/capabilities` is about files, not AI features),
+  `UpdateStatusService` (running + published version).
+- **RAG is user-scoped at the storage level.** `QdrantVectorStorage` and
+  `MariaDBVectorStorage` filter on `user_id` + `group_key`;
+  `VectorSearchService::semanticSearch($query, $userId, $groupKey)` embeds
+  with `getDefaultModel('VECTORIZE', $userId)`. `ChatHandler::loadRagContext()`
+  (~L1649) skips RAG for `general` without a group key and otherwise uses
+  `TASKPROMPT:{topic}`. `KnowledgeContextFormatter::formatRagContext()` emits
+  plain `[Source N]` text; memories have clickable `[Memory:ID]` badges via
+  `formatMemoriesContext()` + the `memories_loaded` SSE status +
+  `frontend/src/components/MessageText.vue`.
+- **Ingestion precedent that fits exactly:**
+  `backend/src/MessageHandler/CrawlWidgetUrlMessageHandler.php` fetches a URL,
+  prefixes `Source:`/`Title:`, calls
+  `VectorizationService::vectorizeAndStore($text, $ownerId, $fileId, $groupKey)`
+  with a deterministic `crc32` file id and `deleteByFile()` first, so re-runs
+  replace instead of duplicate. No `BFILES` row is required.
+- **Scheduler.** `_docker/backend/lib/container-runtime.sh` runs a daily
+  slot on the `scheduler` role: `app:updates:check` (release manifest →
+  BCONFIG) and `app:digest:run`. A third daily command drops in there.
+- **The docs (`synaplan-docs`).** Custom PHP + League CommonMark site at
+  `https://docs.synaplan.com`, **29 flat Markdown pages, ~209 KB, English
+  only**, no front-matter, no versioning, no search index, no machine-readable
+  export. Page metadata (title, description, keywords, section) lives in
+  `index.php` `$docsMap`; `sitemap.php` lists the clean URLs. Best "what can it
+  do" anchors: `docs/intro.md` (What's New, Core Features), `docs/using-synaplan.md`,
+  `docs/dag-routing.md` (the capability table), `docs/faq.md`.
+- **Two facts that make the examples in the request non-trivial:**
+  PDF output is explicitly unsupported today (`MessageClassifier.php` ~L642,
+  officemaker prompt) and arrives only when the office engine of
+  `../20260902-office-docs/` is configured (`OFFICE_CONVERT_URL`) — the
+  same question has different true answers on different installs. And **no
+  music/song generation exists anywhere** (no `Capability`, no model tag) —
+  an absence cannot be derived from any registry.
+- **Locales are five** now: `de`, `en`, `es`, `fr`, `tr`
+  (`frontend/src/i18n/index.ts`); the 4.0 plan assumed four.
+
+## Decision 1 — two truths, one answer
+
+Two sources feed every self-referential answer, with a fixed precedence:
+
+| Source | Answers | Authoritative for |
+| ------ | ------- | ----------------- |
+| **Live capability inventory** (computed per request from the running system) | "Can you X *here*?" | what is available / needs setup / absent on **this installation**, for **this user** |
+| **Docs corpus** (`synaplan-docs`, vectorized into a system-owned RAG group) | "What is X?", "How do I…?", "What's new?" | how the product works in general, where to click, links |
+
+The inventory wins on conflict: if the docs describe video generation but no
+video model is configured, the answer is "not set up here". There is **no
+third, hand-maintained feature list** anywhere — the only curated text is a
+tiny list of *known absences* (Decision 2), because "we do not compose music"
+cannot be derived from a registry.
+
+## Decision 2 — the inventory is a service, not a prompt
+
+New `backend/src/Service/SelfAware/PlatformCapabilityInventory.php`
+(`final readonly`, constructor DI) returns a typed `CapabilityReport`: a list
+of `CapabilityFact { id, label, state: available|needs_setup|absent, detail,
+alternative, adminHint, docsSlug }`, built only from sources that already
+decide behaviour (see `01_sprint_1_inventory_and_routing.md` §SA1 for the
+full source table). `CapabilityReportRenderer` turns it into one compact
+prompt block, `[PLATFORM_CAPABILITIES]`, budgeted at **≤ ~350 tokens**, cached
+per user for 5 minutes (Symfony cache, keyed on user id + flag epoch).
+
+`KNOWN_ABSENT` is a `public const` on the inventory (≈ 6–8 entries: music /
+song production, arbitrary code execution, phone calls, browsing behind a
+login, editing an existing PDF in place, …), each with an `alternative` and a
+`docsSlug`. It is reviewed in every release PR that adds a capability
+(`04_sprint_4_eval_and_rollout.md` §SA11 adds this to the release checklist).
+
+## Decision 3 — routing: a `synaplan` topic plus inventory in `general`
+
+- Seed a **routable system topic `synaplan`** (owner 0, no `tools:` prefix —
+  the AI sorter must be able to pick it) in `PromptCatalog`, with a sharp
+  `[DYNAMICLIST]` description: *questions about Synaplan itself — what it can
+  do, how to use a feature, what's new, pricing/plans, "are you ChatGPT"*.
+  Add one matching rule to `tools:sort` and `tools:plan` (the planner routes
+  it to a single `chat` node with `topic_id: synaplan`, optionally preceded by
+  `rag_query`).
+- Inject `[PLATFORM_CAPABILITIES]` into the **`synaplan` and `general`**
+  system prompts (flag `SELF_AWARE.INVENTORY_IN_GENERAL`, default ON). This is
+  what makes *task* requests degrade gracefully: "create a PDF of this" still
+  routes wherever it routes today, but the model now knows PDF is
+  `needs_setup` and offers DOCX instead of a fake link. Rewrite `general`
+  rule 3 and the "no meta-commentary" style rule accordingly.
+- **Fast path guard.** The fast path is default-OFF today, but when it is
+  re-enabled a 30-character "can you make PDFs?" would be shortcut to
+  `general` and never reach the sorter. `canFastPathClassify()` gets a
+  multilingual meta-question guard (`can you|kannst du|puedes|peux-tu|
+  yapabilir misin` + `what can you|was kannst|qué puedes|que peux|ne yapabilirsin`
+  + the word `synaplan`) that only *defers to the sorter* — it never routes by
+  itself, so a false positive costs one sorter call, not a misroute.
+- `/help` joins `MessageClassifier::TOOL_COMMANDS` → topic `synaplan`.
+
+Rejected: tool-calling ("let the model call `get_capabilities`"). Provider
+tool support is not universal yet (`../20260902-office-docs/` B2 introduces
+`ToolCallingChatProviderInterface`); prompt injection works on every provider
+today and costs one cached render.
+
+## Decision 4 — docs corpus: `SYSTEM:synaplan`, owner 0, fed by a manifest
+
+- **Storage.** Reserved group key `SYSTEM:synaplan`, **owner id 0** — the
+  same owner as system prompts (`BPROMPTS.BOWNERID = 0`) and system config
+  (`BCONFIG` owner 0). Every listing, stats, and delete path in
+  `VectorStorageFacade` is user-scoped, so the corpus is invisible to every
+  real user without a single new filter. Embedding and querying both go
+  through owner 0 (`getDefaultModel('VECTORIZE', 0)`), which guarantees the
+  corpus and the query use the same embedding model regardless of per-user
+  overrides. No schema change: `vectorizeAndStore()` with file id
+  `crc32("docs:{slug}")`, exactly like `CrawlWidgetUrlMessageHandler`.
+- **Source.** `synaplan-docs` publishes a machine-readable
+  **`/docs-manifest.json`** (and an `/llms.txt` for humans and other agents),
+  generated from `$docsMap` in `index.php`: per page `slug`, `title`,
+  `section`, `description`, `url`, `raw_url` (the page's Markdown served by
+  the docs site itself at `/raw/{slug}.md`, so mirrors work without GitHub),
+  `sha256`, `updated_at`; plus a top-level `generated_at` and `version`.
+  Synaplan fetches the manifest, diffs `sha256` per slug against its stored
+  sync state, and re-vectorizes only changed pages; removed slugs are deleted
+  by file id. Markdown (not the rendered HTML) is ingested — headings survive
+  chunking, navigation noise does not exist.
+- **Configurable URL.** `SELF_AWARE.DOCS_MANIFEST_URL` (BCONFIG, owner 0,
+  default `https://docs.synaplan.com/docs-manifest.json`) so self-hosters can
+  point at a mirror or at their own docs. Unreachable manifest ⇒ keep the
+  current corpus, log once, answer from the inventory alone with a link.
+  Air-gapped installs lose nothing they have today.
+- **Retrieval-time metadata.** The sync state (BCONFIG `SELF_AWARE.DOCS_SYNC_STATE`,
+  JSON: `{slug: {sha256, file_id, title, url, section, synced_at}}`) is also
+  the `file_id → slug/title/url` map the answer path uses for citations.
+
+Rejected: vendoring the Markdown into this repo (a second copy that goes
+stale between releases, 200 KB of non-code in a PHP tree); crawling the
+HTML via `sitemap.xml` (nav noise, lost structure); the GitHub API per query
+(latency, 60 req/h unauthenticated); authoring the corpus in five languages
+(the docs are English-only, see Decision 6).
+
+## Decision 5 — freshness follows releases, not boot
+
+- `app:selfaware:sync-docs` (idempotent, `--force` to ignore hashes,
+  `--dry-run` to print the diff) runs in the **daily scheduler slot** of
+  `container-runtime.sh`, right after `app:updates:check`.
+- When `app:updates:check` records a **new published version**, it dispatches
+  one `SyncPlatformDocsMessage` (transport `async_index`, like
+  `ReVectorizeMessage`) so the corpus follows a release within minutes, not a
+  day.
+- **Never inside `app:seed` or the container entrypoint's blocking path** — no
+  network call may delay boot. A fresh install therefore has an empty corpus
+  until the first scheduler tick or a manual run; the inventory path works
+  from the first request.
+- "What's new?" is answered from `docs/intro.md` ("What's New" section) plus
+  the running/published version from `UpdateStatusService`.
+
+## Decision 6 — language
+
+The docs are English. Retrieval is cross-lingual (bge-m3, 1024-dim) and the
+answer is written in the user's language by the existing
+`LanguageDirectiveBuilder`. The `synaplan` topic prompt is one English text,
+seeded like `general`. **This replaces 4.0 decision 3** (author the corpus in
+four languages). All *UI* strings (chip, `/help` description, badge tooltip)
+ship in all five locales and are gated by `localeParity.spec.ts`.
+
+## Decision 7 — citations you can click
+
+Docs hits are formatted by a new `formatPlatformDocsContext()` in
+`KnowledgeContextFormatter` that instructs `[Doc:slug]` references (one slug
+per bracket, only slugs from the list — the `[Memory:ID]` rules verbatim). The
+stream emits a `docs_loaded` status with `[{slug, title, url}]` before
+generation, mirroring `memories_loaded`; `MessageText.vue` renders
+`[Doc:slug]` as a link pill (`title` as text, `url` as href, new tab). No URL
+is ever hardcoded in the frontend — it comes from the event. `[Source N]` for
+user RAG is unchanged.
+
+## Decision 8 — guardrails (kept from 4.0, sharpened)
+
+1. Never claim a capability the inventory does not list as `available`.
+2. Never fabricate a file or link (the `general` hard rules apply verbatim).
+3. **Never quote prices, plan limits, or quotas.** When `billing.enabled` is
+   true, link the pricing page; when it is false (self-host), do not mention
+   plans at all.
+4. `adminHint` ("System Config → AI Models → add an image model") is rendered
+   only when the asking user is an admin; everyone else gets "ask your
+   administrator".
+5. **Widget conversations are excluded** by default. A widget answers for
+   the operator's business, not for Synaplan; `tools:widget-default` and
+   `WidgetPublicController` are not touched. WhatsApp and e-mail go through
+   the same pipeline as web chat and get the same behaviour.
+6. Identity: "I am the AI assistant of this Synaplan workspace, running on the
+   model your workspace selected (shown in the model selector)". Never reveal
+   keys, provider account details, or internal hostnames.
+7. Song-like-the-Beatles class: offer *original* lyrics in the spirit of the
+   style; never reproduce copyrighted lyrics; mention text-to-speech only if
+   `text2sound` is `available`.
+
+## Decision 9 — flags and rollout
+
+BCONFIG group `SELF_AWARE`, owner 0, seeded by `SelfAwareConfigSeeder`
+(`BConfigSeeder::insertIfMissing`, wired into `SeedAllCommand` as step 18
+before `demo-widget`). New rows are inserted on existing installs by the
+next container start; values are never overwritten.
+
+| Setting | Default | Effect when OFF |
+| ------- | ------- | --------------- |
+| `ENABLED` | `true` | `synaplan` topic hidden from `[DYNAMICLIST]`, no inventory block anywhere, `/help` falls through to `general` — byte-identical to today |
+| `INVENTORY_IN_GENERAL` | `true` | inventory block only in the `synaplan` topic |
+| `DOCS_RAG_ENABLED` | `true` | no docs retrieval, no `docs_loaded`; sync still runs |
+| `DOCS_MANIFEST_URL` | `https://docs.synaplan.com/docs-manifest.json` | empty string disables sync entirely |
+
+Defaults are ON because sprint 1 is cheap (one cached render, no network)
+and sprint 2 only ever runs on the scheduler.
+
+## Sprints
+
+| Sprint | Content | Detail |
+| ------ | ------- | ------ |
+| 1 | Capability inventory + `synaplan` topic + routing rules + graceful inability in `general` (no RAG, no network) | `01_sprint_1_inventory_and_routing.md` |
+| 2 | Docs corpus: manifest endpoints in `synaplan-docs`, sync service + command, scheduler wiring, `SYSTEM:synaplan` | `02_sprint_2_docs_corpus.md` |
+| 3 | Grounded answers: topic ↔ corpus binding, `[Doc:slug]` citations, `docs_loaded`, suggestion chip, `/help`, i18n | `03_sprint_3_grounded_answers_and_chat_ux.md` |
+| 4 | Eval corpus + `app:selfaware:eval`, characterization review, docs, mobile-impact classification, rollout | `04_sprint_4_eval_and_rollout.md` |
+| — | The golden question set the whole plan is measured against | `05_eval_question_set.md` |
+
+Sprint 1 alone is shippable and delivers most of the felt value ("no, not
+here — but DOCX yes"). Sprint 2 + 3 add "how do I…" depth and links.
+
+## Work breakdown
+
+| ID | Step | Layer | Size | Depends | Acceptance |
+| -- | ---- | ----- | ---- | ------- | ---------- |
+| SA1 | `PlatformCapabilityInventory` + `CapabilityReport` + renderer + unit tests | backend | M | — | fixture install with no keys renders only `needs_setup`/`absent`; ≤ 350 tokens |
+| SA2 | `synaplan` topic, sorter/planner rules, `general` rewrite, `SelfAwareConfigSeeder`, snapshot re-record | backend | M | SA1 | Q1–Q6 of `05_eval_question_set.md` route to `synaplan`; N1–N4 do not |
+| SA3 | Inventory injection in `ChatHandler`, fast-path guard, `/help` command, widget exclusion | backend | S | SA1, SA2 | "create a PDF of this" on a no-engine install answers with the DOCX alternative and no link |
+| SA4 | `synaplan-docs`: `/docs-manifest.json`, `/llms.txt`, `/raw/{slug}.md` | docs repo | S | — | manifest validates against the JSON schema in `02_…` §SA4; `sha256` matches file |
+| SA5 | `PlatformDocsManifestClient`, `PlatformDocsSyncService`, `app:selfaware:sync-docs`, `SyncPlatformDocsMessage` + handler, sync state | backend | M | SA4 | second run is a no-op; changed page re-vectorized; removed page deleted |
+| SA6 | Scheduler wiring + trigger from `app:updates:check` + `docs/ADMIN.md` | docker/backend | S | SA5 | daily slot logs one sync line; new version ⇒ message dispatched |
+| SA7 | `PlatformDocsRetriever` bound to `synaplan` (chat + multitask), `formatPlatformDocsContext()`, `docs_loaded` SSE | backend | M | SA3, SA5 | "How do I connect WhatsApp?" cites `[Doc:channels]` |
+| SA8 | `docs_loaded` handling + `[Doc:slug]` pill in `MessageText.vue`, i18n ×5 | frontend | S | SA7 | pill readable light/dark/V2; unknown slug renders as plain text |
+| SA9 | Empty-chat suggestion chip, `/help` in `ToolsDropdown.vue`, `features.selfAware` in runtime config + schema regen | frontend/backend | S | SA3 | chip hidden when `ENABLED=false`; parity test green |
+| SA10 | `tests/Eval/self_aware_eval_corpus.json` + `app:selfaware:eval` (pattern: `PlanEvalCommand`) | backend | M | SA7 | all rows of `05_…` pass on a dev install with one chat key |
+| SA11 | Docs (`using-synaplan.md`, `administration.md`, `faq.md`), README line, release checklist entry for `KNOWN_ABSENT`, `.github/mobile-impact-policy.json` | docs/repo | S | SA9 | `node scripts/mobile-impact.mjs` classifies new paths |
+| SA12 | Rollout on fresh install + existing install, STATUS update | ops | S | all | flags present after container start; first scheduler tick fills the corpus |
+
+Definition of done for every step: unfiltered gate green, all five locales,
+characterization diff reviewed line by line, no new hardcoded URL, no new
+schema. The plan is done when every row of `05_eval_question_set.md` passes
+in `app:selfaware:eval` on a dev install with one chat provider key.
+
+## Compatibility invariants
+
+- **C1** — Flags OFF ⇒ byte-identical behaviour to today (prompts, routing
+  snapshots, SSE events).
+- **C2** — No network call on the boot path (`app:seed`, entrypoint,
+  migrations). Sync runs only on the scheduler, on demand, or from a Messenger
+  message.
+- **C3** — No database schema change. The corpus is vectors + one BCONFIG JSON
+  row; the topic is a `BPROMPTS` row; flags are `BCONFIG` rows.
+- **C4** — The docs corpus is never visible in any per-user file, group, or
+  stats listing, and never deleted by a user action. Owner 0 must never be a
+  real login.
+- **C5** — Widget, `tools:widget-default`, `WidgetPublicController`, and the
+  guest landing are untouched.
+- **C6** — The inventory never states `available` without a live source that
+  already gates the behaviour it describes.
+- **C7** — No prices, limits, or quotas in any generated answer.
+- **C8** — Every user-facing string exists in `de`, `en`, `es`, `fr`, `tr`.
+
+## Ground rules (every step)
+
+- Feature branch per step, Conventional Commits, never on `main`, no AI
+  attribution.
+- Full gate before every commit — filtered runs are not the gate:
+
+  ```bash
+  make lint && make -C backend phpstan && make test && docker compose exec -T frontend npm run check:types
+  ```
+
+- Any change to `PromptCatalog` (`tools:sort`, `tools:plan`, `general`),
+  `MessageClassifier`, or `MessageSorter` ⇒ re-record
+  `tests/Characterization/` snapshots (`UPDATE_ROUTING_SNAPSHOTS=1`) and
+  review every changed line. The `synaplan` topic appearing in
+  `[DYNAMICLIST]` WILL change `planner_system_prompt.txt`.
+- New/changed runtime-config fields ⇒ OpenAPI annotations ⇒
+  `make -C frontend generate-schemas` ⇒ `vue-tsc`. No hand-written TS
+  interfaces.
+- New UI text ⇒ all five locales; `localeParity.spec.ts` gates it.
+- Colors only via `style.css` tokens; check the `[Doc:slug]` pill and the
+  suggestion chip in light, dark, and V2.
+- New paths ⇒ classify in `.github/mobile-impact-policy.json` (`backend/**`
+  backend-only, `frontend/src/**` ota-candidate, `_docker/**` and docs
+  no-app-impact).
+- `SA6` edits `_docker/backend/lib/container-runtime.sh` — a Docker runtime
+  file. Per `AGENTS.md` "Ask first", that PR is opened only after explicit
+  go-ahead and touches nothing but the daily slot.
+- This repository is public: no production hostnames, node IPs, or
+  credentials here; the docs manifest URL is the public docs site.

--- a/_devextras/planning/20260902-platform-self-awareness/01_sprint_1_inventory_and_routing.md
+++ b/_devextras/planning/20260902-platform-self-awareness/01_sprint_1_inventory_and_routing.md
@@ -1,0 +1,314 @@
+# Sprint 1 — Capability inventory, `synaplan` topic, graceful inability
+
+Status: planned
+Date: 2026-09-02
+Depends on: `00_master_plan.md` (Decisions 1–3, 8, 9)
+
+Three steps, each one branch and one PR, each shippable alone. No network,
+no RAG, no frontend. After this sprint the chat answers "Can you create
+PDFs?" truthfully for the install it runs on and stops faking files for
+things it cannot deliver.
+
+Flag rule: everything in this sprint is a no-op when `SELF_AWARE.ENABLED` is
+`false` (invariant C1). Check the flag through one service,
+`SelfAwareConfig`, never by reading BCONFIG inline.
+
+---
+
+## SA1 — `PlatformCapabilityInventory` (no wiring yet)
+
+Branch: `feat/self-aware-inventory`
+
+### Backend
+
+New namespace `backend/src/Service/SelfAware/`:
+
+- `SelfAwareConfig.php` — `final readonly`, modelled on
+  `Service/Multitask/MultitaskRoutingConfig.php`: `CONFIG_GROUP = 'SELF_AWARE'`,
+  `KEY_ENABLED`, `KEY_INVENTORY_IN_GENERAL`, `KEY_DOCS_RAG_ENABLED`,
+  `KEY_DOCS_MANIFEST_URL`, `KEY_DOCS_SYNC_STATE`; `isEnabled(?int $userId)`,
+  `isInventoryInGeneral(?int $userId)`, `isDocsRagEnabled(?int $userId)`,
+  `docsManifestUrl(): string`. Per-user override → owner 0 → constant
+  default, exactly like `MultitaskRoutingConfig::resolveFlag()`.
+- `CapabilityState.php` — `enum CapabilityState: string { Available = 'available'; NeedsSetup = 'needs_setup'; Absent = 'absent'; }`.
+- `CapabilityFact.php` — `final readonly` DTO:
+  `id` (stable snake_case key), `label` (English, prompt-facing),
+  `state`, `detail` (one short clause, e.g. "DOCX, XLSX, PPTX, CSV"),
+  `alternative` (`?string`, mandatory when state ≠ available),
+  `adminHint` (`?string`, where to enable it), `docsSlug` (`?string`,
+  page in `synaplan-docs`).
+- `CapabilityReport.php` — `final readonly` with `list<CapabilityFact> $facts`,
+  `string $version`, `bool $billingEnabled`, `bool $isAdmin`; helpers
+  `byState(CapabilityState)`.
+- `PlatformCapabilityInventory.php` — `final readonly`, `build(int $userId): CapabilityReport`.
+  Every fact comes from a source that **already gates the behaviour**
+  (invariant C6):
+
+  | Fact id | `available` when | Source |
+  | ------- | ---------------- | ------ |
+  | `chat` | a chat provider with a key | `ChatReadinessService::isChatReady(userId:)` |
+  | `file_analysis` | a `PIC2TEXT` model resolves + chat ready | `ModelConfigService::getDefaultModel('PIC2TEXT', $userId)` + provider availability as used by `ChatReadinessService` |
+  | `knowledge_search` | a `VECTORIZE` model resolves | `ModelConfigService::getDefaultModel('VECTORIZE', $userId)`; `detail` = `VectorStorageFacade::getProviderName()` |
+  | `memories` | Qdrant configured | same check as `ConfigController::getRuntimeConfig()` `features.memoryService` |
+  | `image_generation` | a `TEXT2PIC` model resolves | `ModelConfigService` |
+  | `video_generation` | a `TEXT2VID` model resolves | `ModelConfigService` |
+  | `text_to_speech` | a `TEXT2SOUND` model resolves **or** `SYNAPLAN_TTS_URL` set | `ModelConfigService`, TTS client `isEnabled()` |
+  | `speech_to_text` | a `SOUND2TEXT` model resolves (whisper.cpp ships in the base image) | `ModelConfigService` |
+  | `web_search` | Brave key present | the same check `BraveSearchService` / `WebSearchTopicPolicy` use today |
+  | `url_fetch`, `mcp_fetch`, `mcp_action`, `email_search` | flag on for this user | `SkillCatalog::descriptorFor()` + `MultitaskRoutingConfig::isFeatureEnabled()` — reuse, do not re-implement |
+  | `document_generation` | always (PhpOffice in image) | `detail` from `DocumentGeneratorService` supported formats; `pdf_export` is a **separate fact**: `available` iff `OfficeConverterClient::isEnabled()` (office-docs A0); until A0 lands, a constant `needs_setup` with `adminHint` "office engine (`OFFICE_CONVERT_URL`)" |
+  | `calendar_event` | always | `Capability::CalendarEvent` |
+  | `email_me` | mailer configured | the check `InternalEmailService` uses |
+  | `save_to_folder` | user has a WebDAV destination | `WebDavDestinationProvider` |
+  | `saved_tasks` | flag | `SavedTaskConfig::isEnabled($userId)` |
+  | `desktop_skills` | flag | `DesktopAgentConfig::isEnabled($userId)` |
+  | `mcp_server` | flag | `McpConfig` (server side) |
+  | `channel_whatsapp`, `channel_email` | configured for this user | the per-user channel settings the channel handlers read |
+  | `plugins` | installed plugins with `chatCommands` | `PluginManager` — `detail` lists `name (/command)` |
+  | `upload_formats` | always | `CapabilityService` (existing `/config/capabilities`) — `detail` = the format list |
+  | `custom_topics` | user has own prompts | `PromptRepository::getTopicsWithDescriptions(0, $userId, excludeTools: true)` filtered to owner = user |
+
+  Plus `KNOWN_ABSENT` (`public const`, reviewed each release):
+  `music_generation` (alternative: original lyrics + text-to-speech when
+  available), `code_execution` (alternative: Synaplan Desktop skills,
+  `docsSlug: desktop-skills`), `phone_calls`, `authenticated_browsing`,
+  `pdf_inplace_editing` (alternative: analyse the PDF, regenerate as DOCX),
+  `live_human_operator_in_chat` (alternative: widget live support is an
+  operator-side feature, `docsSlug: architecture`).
+
+  `version` from `UpdateStatusService` (running version; published version
+  when newer). `billingEnabled` from the same source the runtime config uses.
+  `isAdmin` from the user's roles.
+
+- `CapabilityReportRenderer.php` — `render(CapabilityReport): string`,
+  deterministic order (fact table order, then `KNOWN_ABSENT`), three lines
+  of grouped facts plus rules; **≤ 350 tokens** for a full install (assert
+  in a test with a rough 4-chars-per-token bound, 1 400 characters). Shape:
+
+  ```text
+  ## This Synaplan installation (live, version 4.2.1)
+  AVAILABLE NOW: chat · file analysis (PDF, Word, Excel, images, audio) · knowledge search over your files · image generation (/pic) · documents as DOCX, XLSX, PPTX, CSV · calendar invites (.ics) · web search · text-to-speech (MP3) · memories · saved tasks · plugins: Synaform (/form), FastBill (/fastbill)
+  NEEDS SETUP: video generation (no video model configured) · PDF export (office engine not configured)
+  NOT AVAILABLE: composing or producing music — alternative: original lyrics, read aloud as MP3 · running arbitrary code — alternative: Synaplan Desktop skills · …
+  RULES: When asked whether you can do something, answer from the lists above and nothing else. Say plainly what is not available here and offer the closest alternative. Never promise, describe, or link a file you are not delivering in this turn. Never quote prices, plan limits or quotas.
+  ```
+
+  Admin variant appends the `adminHint` in parentheses to each
+  `NEEDS SETUP` item; non-admin variant appends "— ask your administrator"
+  once. When `billingEnabled`, the RULES line ends with "For plans and
+  pricing, link the pricing page." Otherwise plans are not mentioned.
+
+- Caching: `CachedPlatformCapabilityInventory` decorator (`cache.app`,
+  key `selfaware.inventory.{userId}.{isAdmin}`, TTL 300 s). Invalidate on
+  the admin "AI Models" save and on provider-key save (call `forget($userId)`
+  from those services; a stale 5-minute window is acceptable everywhere else).
+
+### Tests
+
+- `tests/Unit/Service/SelfAware/PlatformCapabilityInventoryTest.php` —
+  three fixture installs (no keys; one chat key; full stack with TTS +
+  office engine) via mocked collaborators; asserts states per fact id,
+  `alternative` present for every non-available fact, `KNOWN_ABSENT` all
+  `absent`.
+- `CapabilityReportRendererTest.php` — token budget, determinism (two
+  renders identical), admin vs non-admin text, billing on/off wording,
+  contains no digit followed by a currency symbol.
+- PHPStan clean at the project level; `readonly` + `final` throughout.
+
+### Must NOT touch
+
+`ChatHandler`, `PromptCatalog`, `MessageClassifier`, frontend. This step is
+pure library code.
+
+### Acceptance
+
+`docker compose exec -T backend php bin/console debug:container PlatformCapabilityInventory`
+lists the service; a throwaway `bin/console app:selfaware:inventory --user 2`
+(dev-only command added here, kept — it is the admin's debugging tool) prints
+the rendered block for user 2 on the dev stack and shows `pdf_export` as
+`needs_setup` and `music_generation` as `absent`.
+
+### Gate
+
+```bash
+make -C backend lint && make -C backend phpstan && make -C backend test
+```
+
+---
+
+## SA2 — `synaplan` topic, routing rules, `general` rewrite, flags
+
+Branch: `feat/self-aware-topic`
+
+### Backend
+
+- `PromptCatalog::all()`: new routable entry `synaplan` (owner 0, seeded
+  like `general`) with `description` for `[DYNAMICLIST]`:
+
+  > Questions about Synaplan itself: what it can and cannot do, how to use a
+  > feature (files, widgets, channels, plugins, desktop, API), what is new,
+  > plans and pricing, "what are you / are you ChatGPT". NOT for doing the
+  > task — a request to *create* something goes to the topic that creates it.
+
+  System prompt `synaplanPrompt()` (English, one text):
+  identity line (Decision 8.6); "answer from the PLATFORM CAPABILITIES block
+  and, when present, the Documentation context; if neither covers the
+  question, say so and point to the documentation link"; the `general` hard
+  rules 1–2 and 6 verbatim; the pricing rule; the music/lyrics rule; the
+  admin-hint rule; style: short, bullets when listing capabilities, always
+  end a "no" with the alternative. Include the literal placeholder
+  `[PLATFORM_CAPABILITIES]` and `[PLATFORM_DOCS]` (the latter empty until
+  sprint 3) so the injection point is explicit and testable.
+
+- `PromptCatalog::sortPrompt()` — add rule after the media rule:
+
+  > **Questions about Synaplan itself** — whether it can do something
+  > ("can you make PDFs?", "kannst du Videos erstellen?"), how a feature
+  > works, what is new, what it costs, who/what it is → BTOPIC "synaplan".
+  > A request to actually produce the thing ("create a PDF of this text") is
+  > NOT a question about Synaplan — route it to the topic that produces it.
+
+  Same rule in `planPrompt()` next to the existing "Plain question" example:
+  one `chat` node, `topic_id: "synaplan"`, never the reply node for
+  `email_me`.
+
+- `PromptCatalog::generalPrompt()` — rewrite rule 3 and the style rule:
+
+  > 3. If the user asks for a file (audio, image, video, document,
+  > spreadsheet, slide deck, calendar invite): check the PLATFORM
+  > CAPABILITIES block. If the format is AVAILABLE NOW, reply that you will
+  > write the text and ask the user to rephrase as "create/generate …" so
+  > the request reaches the generator. If it is NEEDS SETUP or NOT
+  > AVAILABLE, say so in one sentence and offer the listed alternative.
+  > Never pretend to attach anything.
+
+  Style: "No meta-commentary about being an AI or your training —
+  **except** when the user asks what you can do; then answer from the
+  PLATFORM CAPABILITIES block." Append the `[PLATFORM_CAPABILITIES]`
+  placeholder at the end of the prompt.
+
+- `backend/src/Seed/SelfAwareConfigSeeder.php` — four rows via
+  `BConfigSeeder::insertIfMissing` (Decision 9 table), owner 0; wired into
+  `SeedAllCommand` as step 18 (renumber `demo-widget` to 19, update the
+  docblock and `setHelp()` list).
+
+- `PromptSeeder` already seeds whatever `PromptCatalog::all()` returns —
+  confirm the new row appears with `app:prompt:seed` and is `excludeTools`-
+  visible (no `tools:` prefix).
+
+### Tests
+
+- Re-record and review: `RoutingCharacterizationTest` (`routing_classification.json`),
+  `PlannerPromptCharacterizationTest` (`planner_system_prompt.txt` gains the
+  `synaplan` line in `[DYNAMICLIST]` and the new rule). Every changed line is
+  explained in the PR description.
+- `tests/Unit/Prompt/PromptCatalogTest.php` (extend or add): `synaplan`
+  present, no `tools:` prefix, description non-empty, `generalPrompt()` and
+  `synaplanPrompt()` contain `[PLATFORM_CAPABILITIES]` exactly once.
+- Sorter routing on the eval set is verified in SA10 (needs a model); here,
+  a unit test asserts the `tools:sort` text contains the new rule.
+
+### Must NOT touch
+
+`ChatHandler` (injection is SA3), `tools:widget-default`,
+`tools:widget-setup-interview`, frontend.
+
+### Acceptance
+
+On the dev stack after `app:seed`: `SELECT BTOPIC FROM BPROMPTS WHERE BOWNERID=0`
+lists `synaplan`; `SELECT * FROM BCONFIG WHERE BGROUP='SELF_AWARE'` shows four
+rows; sending "Can you create PDFs?" in the web chat is classified
+`topic=synaplan` (backend log `MessageSorter: … BTOPIC`) — the answer itself
+is still unaware of the install until SA3.
+
+### Gate
+
+```bash
+make -C backend lint && make -C backend phpstan && make -C backend test
+docker compose exec -T -e UPDATE_ROUTING_SNAPSHOTS=1 backend ./vendor/bin/phpunit tests/Characterization
+git diff backend/tests/Characterization/__snapshots__/   # review, then re-run make -C backend test
+```
+
+---
+
+## SA3 — Inject the inventory, guard the fast path, add `/help`
+
+Branch: `feat/self-aware-injection`
+
+### Backend
+
+- `ChatHandler::handle()` / `handleStream()` (system-prompt assembly,
+  ~L400–530 / ~L1001–1148): after the topic prompt is loaded and **before**
+  RAG/memories are appended, replace `[PLATFORM_CAPABILITIES]` with
+  `CapabilityReportRenderer::render($inventory->build($userId))` when
+  - `SelfAwareConfig::isEnabled($userId)`, and
+  - topic is `synaplan`, or topic is `general` and
+    `isInventoryInGeneral($userId)`, and
+  - the message did not originate from a widget session (reuse the same
+    distinction the handler already makes for widget prompts — verify the
+    exact predicate while implementing; it must be one shared helper, not a
+    duplicated condition in both code paths).
+
+  Otherwise strip the placeholder (never ship the literal token to a model).
+  Do this in one new `SelfAwarePromptDecorator::apply(string $prompt, string $topic, int $userId, bool $isWidget): string`
+  so both code paths call one line, and `StreamController` needs no change.
+
+- `MessageClassifier::TOOL_COMMANDS` — add `'/help' => 'synaplan'`.
+  `detectToolCommand()` returns the topic unchanged; verify the downstream
+  handler mapping treats a non-`tools:` topic from a command exactly like a
+  sorter result (it should — `officemaker` reaches `ChatHandler` the same
+  way). Strip the `/help` prefix like the other commands do.
+
+- `MessageClassifier::canFastPathClassify()` — add the meta-question guard
+  (Decision 3) as one `private const SELF_AWARE_GUARD_PATTERN` with a
+  comment listing the five languages; returns `false` (defer to sorter) on
+  match. Only active when `SelfAwareConfig::isEnabled()`.
+
+- `SkillCatalog`: no change. The planner path gets the inventory through the
+  `synaplan` topic's `chat` node (ChatHandler renders the prompt), so
+  multitask needs no extra wiring here.
+
+### Tests
+
+- `tests/Unit/Service/SelfAware/SelfAwarePromptDecoratorTest.php` —
+  placeholder replaced for `synaplan`; replaced for `general` only with the
+  flag; stripped for other topics, for widgets, and when disabled; never
+  leaves `[PLATFORM_CAPABILITIES]` in the output.
+- `MessageClassifier` unit tests: `/help` → `synaplan`; guard defers
+  "can you make PDFs?" / "was kannst du?" / "¿puedes buscar en internet?" /
+  "peux-tu lire mes e-mails ?" / "video yapabilir misin?" when fast path is
+  forced on; "write me a poem" still fast-paths.
+- Re-record `routing_classification.json` (the `/help` case is added to the
+  38 cases) and review.
+
+### Must NOT touch
+
+`WidgetPublicController`, `tools:widget-default`, `KnowledgeContextFormatter`,
+frontend.
+
+### Acceptance
+
+Dev stack, no office engine, one chat key:
+
+1. "Can you create PDFs?" → routed `synaplan`; answer states PDF is not set
+   up here, names DOCX/XLSX/PPTX as available, no link, no fake file, ends
+   with an offer.
+2. "Create a PDF of the following text: …" → routed as today (not
+   `synaplan`); answer offers DOCX instead of a fabricated download; the
+   `__FILE_GENERATED__` path is not triggered.
+3. "Would you create a song like the Beatles?" → answer: cannot compose or
+   produce music; offers original lyrics in that style; mentions reading
+   them aloud only if TTS is available on the stack.
+4. `/help` → the same as "What can you do here?".
+5. Same four in a widget conversation → unchanged behaviour from today.
+6. Set `SELF_AWARE.ENABLED=false` (BCONFIG, owner 0) → 1–4 behave exactly as
+   before this sprint.
+
+### Gate
+
+```bash
+make lint && make -C backend phpstan && make test
+```
+
+(Frontend unchanged; the one-shot gate is still run because `make test`
+covers both.)

--- a/_devextras/planning/20260902-platform-self-awareness/02_sprint_2_docs_corpus.md
+++ b/_devextras/planning/20260902-platform-self-awareness/02_sprint_2_docs_corpus.md
@@ -1,0 +1,262 @@
+# Sprint 2 — The docs corpus (`SYSTEM:synaplan`)
+
+Status: planned
+Date: 2026-09-02
+Depends on: `00_master_plan.md` (Decisions 4, 5), sprint 1 (`SelfAwareConfig`)
+
+Three steps. SA4 is a small PR in the separate public repo `synaplan-docs`;
+SA5 and SA6 are in this repo. After this sprint the vector store holds the
+29 documentation pages under owner 0 / `SYSTEM:synaplan`, refreshed daily
+and after each release, and nothing in the chat uses them yet (sprint 3).
+
+Invariants in play: C2 (no network on boot), C3 (no schema), C4 (corpus
+invisible to users).
+
+---
+
+## SA4 — `synaplan-docs`: machine-readable export
+
+Repo: `synaplan-docs` (branch `feat/docs-manifest`)
+
+The docs site is a custom PHP front controller (`index.php`) rendering
+`docs/*.md` with League CommonMark; page metadata is `$docsMap`
+(`file`, `nav`, `short`, `title`, `desc`, `keywords`) and section order is
+`$sections`. There is no export today. Add three endpoints, all generated
+from `$docsMap` so a new page registered there is exported automatically:
+
+### `GET /docs-manifest.json`
+
+```json
+{
+  "schema": "synaplan-docs-manifest/1",
+  "generated_at": "2026-09-02T09:00:00Z",
+  "site_url": "https://docs.synaplan.com",
+  "version": "2026.09",
+  "pages": [
+    {
+      "slug": "dag-routing",
+      "title": "Multi-Task (DAG) Routing",
+      "section": "Developers",
+      "description": "AI task planning, the capability set, live task cards …",
+      "url": "https://docs.synaplan.com/dag-routing",
+      "raw_url": "https://docs.synaplan.com/raw/dag-routing.md",
+      "sha256": "…hex…",
+      "bytes": 9123,
+      "updated_at": "2026-08-30T14:11:02Z"
+    }
+  ]
+}
+```
+
+- `sha256` and `bytes` are computed from the Markdown file on disk;
+  `updated_at` from `filemtime()`. Cache the manifest per request only
+  (the site has no build step); `Cache-Control: public, max-age=300`.
+- `version` = the year-month of the newest `updated_at` (there is no docs
+  versioning; this is a human-readable hint only).
+- Exclude `docs.bak/` and any slug whose `file` does not exist. Include the
+  `intro` page once (it is aliased to `/`).
+- `site_url` from the existing config (`config.local.php` may override it
+  for a mirror) — never hardcoded.
+
+### `GET /raw/{slug}.md`
+
+Serves the Markdown file for a registered slug as `text/markdown; charset=utf-8`
+with the same `Cache-Control`. Unknown slug → 404. Only slugs present in
+`$docsMap` are served (no path traversal — the slug is a key lookup, not a
+file path).
+
+### `GET /llms.txt`
+
+The conventional plain-text index for agents: one line per page,
+`- [title](url): description`, grouped by section, with a two-line preamble
+naming the product and the manifest URL. Generated from the same array.
+
+### Docs-repo housekeeping
+
+- `README.md`: a short "Machine-readable export" section (three URLs, the
+  schema id, how a mirror sets `site_url`).
+- `docs/contributing.md`: a sentence that every page must be registered in
+  `$docsMap` **also** because it is what the Synaplan chat learns from.
+- `sitemap.php`: list `/llms.txt` (not the manifest, not raw files).
+- Router (`router.php` / `.htaccess` / Caddy snippet in the README): the
+  three new paths must reach `index.php`; document the Caddy rule change.
+
+### Acceptance
+
+`curl -s https://<dev-host>/docs-manifest.json | jq '.pages | length'`
+prints 29; `sha256sum docs/dag-routing.md` equals the manifest value;
+`curl -I /raw/nope.md` is 404; `/llms.txt` lists every section. The
+manifest validates against `backend/tests/Fixtures/selfaware/docs-manifest.schema.json`
+(added in SA5 — copy it into the docs repo's `tests/` too so both sides
+gate the same contract).
+
+### Gate
+
+The docs repo has no CI gate; `php -l index.php`, a manual smoke of the
+three URLs, and the schema validation above.
+
+---
+
+## SA5 — Sync service and command
+
+Branch: `feat/self-aware-docs-sync`
+
+### Backend
+
+`backend/src/Service/SelfAware/Docs/`:
+
+- `DocsManifest.php`, `DocsPage.php` — `final readonly` DTOs mirroring the
+  manifest schema; `DocsManifest::fromJson(string): self` validates
+  `schema === 'synaplan-docs-manifest/1'` and rejects pages without
+  `slug|url|raw_url|sha256`. Slugs are validated `^[a-z0-9-]{1,64}$`.
+- `PlatformDocsManifestClient.php` — `fetchManifest(string $url): DocsManifest`,
+  `fetchPage(DocsPage): string` using `HttpClientInterface` (timeout 15 s,
+  max 2 MB per page, `Accept: text/markdown`), one retry on transport
+  error, none on 4xx. Only `https://` URLs; `raw_url` must share the
+  manifest's host (a manifest cannot point the sync at arbitrary hosts).
+- `PlatformDocsSyncState.php` — reads/writes BCONFIG
+  `SELF_AWARE.DOCS_SYNC_STATE` (owner 0) as JSON
+  `{ "manifest_url", "manifest_version", "synced_at", "pages": { slug: { sha256, file_id, title, url, section, synced_at } } }`
+  through `ConfigRepository`; exposes `pageByFileId(int): ?array` for
+  sprint 3.
+- `PlatformDocsSyncService.php` — `sync(bool $force = false, bool $dryRun = false): DocsSyncResult`:
+  1. `manifestUrl = SelfAwareConfig::docsManifestUrl()`; empty ⇒ return
+     `skipped`.
+  2. Fetch manifest; on failure return `failed` with the reason, **leave
+     the state and the vectors untouched**.
+  3. Diff: for each manifest page, `changed = force || state.sha256 !== page.sha256`;
+     `removed = state.pages − manifest.pages`.
+  4. For each changed page: fetch Markdown; `fileId = abs(crc32("docs:{slug}")) % 2_000_000_000`
+     (the `CrawlWidgetUrlMessageHandler::buildFileId` formula, own prefix);
+     `vectorStorage->deleteByFile(0, $fileId)`; prefix
+     `"Source: {url}\nTitle: {title}\nSection: {section}\n\n"`; strip the
+     `<!--SYNAPLAN_MODELS_TABLE-->` placeholder and HTML comments;
+     `vectorizationService->vectorizeAndStore($text, 0, $fileId, 'SYSTEM:synaplan', 0)`.
+  5. For each removed page: `deleteByFile(0, fileId)`.
+  6. Write the new state (only after the loop; a failed page keeps its
+     previous entry and is reported).
+  `DocsSyncResult` carries counts (`changed`, `unchanged`, `removed`,
+  `failed`) and per-slug messages for the command output.
+
+  Owner 0 consequences to verify while implementing (record the outcome in
+  `STATUS.md`): `ModelConfigService::getDefaultModel('VECTORIZE', 0)` must
+  resolve the system default; `RateLimitService` inside
+  `VectorizationService` must not throttle or reject user 0 (bypass or
+  whitelist explicitly if it does); `EmbeddingMetadata::filterStaleHits(userId: 0)`
+  must see the same model id at query time. If any of these needs a change,
+  it is a one-line, flag-independent fix in that service, not a fork of the
+  pipeline.
+
+- `SyncPlatformDocsMessage.php` (`backend/src/Message/`) +
+  `SyncPlatformDocsMessageHandler.php` (`backend/src/MessageHandler/`),
+  routed to `async_index` in `config/packages/messenger.yaml` next to
+  `ReVectorizeMessage`. The handler just calls `sync()` and logs the result.
+- `backend/src/Command/SelfAwareSyncDocsCommand.php` —
+  `app:selfaware:sync-docs [--force] [--dry-run] [--async]`; prints a
+  `SymfonyStyle` table (slug, action, chunks) and exits non-zero only on a
+  manifest fetch failure (page-level failures are warnings, like
+  `app:updates:check` treats an unreachable manifest as an expected
+  outcome).
+- `SelfAwareConfig::docsManifestUrl()` (sprint 1) is the single place the
+  URL is read.
+
+### Tests
+
+- `tests/Unit/Service/SelfAware/Docs/DocsManifestTest.php` — parses the
+  fixture `tests/Fixtures/selfaware/docs-manifest.json` (a trimmed 5-page
+  copy of the real one); rejects wrong schema id, bad slug, cross-host
+  `raw_url`.
+- `PlatformDocsSyncServiceTest.php` — mocked client + in-memory
+  `VectorStorageInterface` + mocked `VectorizationService`:
+  first run vectorizes 5 pages; second run with identical manifest does
+  nothing; one changed hash ⇒ one `deleteByFile` + one `vectorizeAndStore`;
+  one removed slug ⇒ one `deleteByFile`; manifest failure ⇒ state untouched,
+  result `failed`; `--dry-run` calls neither.
+- `tests/Command/SelfAwareSyncDocsCommandTest.php` — table output, exit
+  codes.
+- `tests/Fixtures/selfaware/docs-manifest.schema.json` — JSON schema used by
+  the manifest test and copied to `synaplan-docs` (SA4).
+
+### Must NOT touch
+
+`ChatHandler`, `VectorSearchService`, `KnowledgeContextFormatter`, any
+frontend file, `container-runtime.sh` (that is SA6).
+
+### Acceptance
+
+Dev stack with Qdrant (or MariaDB VECTOR) and an embedding model:
+
+```bash
+docker compose exec -T backend php bin/console app:selfaware:sync-docs
+docker compose exec -T backend php bin/console app:selfaware:sync-docs        # all "unchanged"
+docker compose exec -T backend php bin/console app:selfaware:sync-docs --dry-run
+```
+
+First run reports 29 changed pages and a chunk count; second run reports 0.
+`GET /api/v1/rag/...` group listings for the demo user do **not** show
+`SYSTEM:synaplan`; a direct `VectorSearchService::semanticSearch('how do I
+embed the widget', 0, 'SYSTEM:synaplan')` from a throwaway script returns
+`widget` chunks. `docker compose restart backend` performs **no** sync (C2).
+
+### Gate
+
+```bash
+make -C backend lint && make -C backend phpstan && make -C backend test
+```
+
+---
+
+## SA6 — Scheduler wiring and release trigger
+
+Branch: `feat/self-aware-docs-schedule`
+**Ask-first step:** edits `_docker/backend/lib/container-runtime.sh`.
+Open the PR only after explicit go-ahead; change nothing but the daily slot.
+
+### Docker runtime
+
+In the daily block of `container-runtime.sh` (the one that runs
+`app:updates:check` and `app:digest:run`), add:
+
+```sh
+if ! run_scheduler_command bin/console --env="$env" app:selfaware:sync-docs --no-interaction; then
+    runtime_log "Documentation sync failed; it will be retried on the next daily interval." >&2
+fi
+```
+
+after `app:updates:check` (so a version bump detected in the same tick is
+already recorded). Extend `_docker/backend/tests/test-container-runtime.sh`
+with the corresponding assertion, following the existing update-check case.
+
+### Backend
+
+- `CheckUpdatesCommand` / `UpdateStatusService`: when the recorded published
+  version **changes**, dispatch `SyncPlatformDocsMessage` (through
+  `MessageBusInterface`; no-op when the bus has no transport in tests). The
+  daily sync stays as the safety net; the message makes a release reach the
+  corpus within minutes.
+- `docs/ADMIN.md` (this repo): a short "Documentation knowledge for the
+  assistant" section — what is synced, from where, the `SELF_AWARE.DOCS_MANIFEST_URL`
+  override for mirrors/air-gapped installs, the manual command, and that the
+  corpus is owner 0 and never shown to users.
+
+### Tests
+
+- `tests/Command/CheckUpdatesCommandTest.php` — new version ⇒ one message
+  dispatched; same version ⇒ none.
+- Runtime script test as above.
+
+### Acceptance
+
+- Start the dev stack with `SYNAPLAN_ROLE=scheduler` for the backend (or run
+  the daily block by hand as the existing runtime test does): the log shows
+  one `app:selfaware:sync-docs` line after the update check.
+- Point `SELF_AWARE.DOCS_MANIFEST_URL` at an unreachable host: the command
+  logs the failure, exits non-zero, the previous corpus still answers.
+- Set it to an empty string: the command prints `skipped` and exits 0.
+
+### Gate
+
+```bash
+make -C backend lint && make -C backend phpstan && make -C backend test
+bash _docker/backend/tests/test-container-runtime.sh
+```

--- a/_devextras/planning/20260902-platform-self-awareness/03_sprint_3_grounded_answers_and_chat_ux.md
+++ b/_devextras/planning/20260902-platform-self-awareness/03_sprint_3_grounded_answers_and_chat_ux.md
@@ -1,0 +1,227 @@
+# Sprint 3 — Grounded answers, citations, and chat discoverability
+
+Status: planned
+Date: 2026-09-02
+Depends on: sprint 1 (topic + injection), sprint 2 (corpus + sync state)
+
+Three steps. After this sprint "How do I connect WhatsApp?" answers from
+the documentation with a clickable `[Doc:channels]` pill, and a signed-in
+user who does not know what to type sees one quiet hint that asking is
+allowed.
+
+Invariants in play: C1 (flags off ⇒ identical), C5 (widget untouched),
+C7 (no prices), C8 (five locales).
+
+---
+
+## SA7 — Bind the `synaplan` topic to the docs corpus
+
+Branch: `feat/self-aware-docs-retrieval`
+
+### Backend
+
+- `backend/src/Service/SelfAware/Docs/PlatformDocsRetriever.php` —
+  `final readonly`, `retrieve(string $query, int $userId, int $limit = 5, float $minScore = 0.35): PlatformDocsHits`:
+  - returns empty when `!SelfAwareConfig::isDocsRagEnabled($userId)` or the
+    sync state has no pages;
+  - `VectorSearchService::semanticSearch($query, 0, 'SYSTEM:synaplan', $limit, $minScore)`
+    — **owner 0**, so the query embeds with the same model the corpus used
+    (Decision 4);
+  - maps each hit's `file_id` through `PlatformDocsSyncState::pageByFileId()`
+    to `{slug, title, url, section}`; hits whose file id is unknown (state
+    rewritten mid-flight) are dropped, never rendered with a guessed URL;
+  - de-duplicates by slug, keeps the best chunk per page, max 4 pages.
+  `PlatformDocsHits` carries `list<PlatformDocsHit{slug,title,url,section,text,score}>`.
+
+- `KnowledgeContextFormatter::formatPlatformDocsContext(PlatformDocsHits): string`:
+
+  ```text
+  ## Synaplan documentation (relevant to this question):
+  [Doc:channels] Channels: WhatsApp & Email — <chunk text>
+  [Doc:widget] Widget Integration — <chunk text>
+
+  Use only what is written above for how-to and feature questions. REFERENCES: cite the page you used as [Doc:slug] (clickable). Rules:
+  - ONE slug per bracket. Good: [Doc:channels] and [Doc:widget]. Bad: [Doc:channels, widget].
+  - Only slugs from the list above. Never invent slugs or URLs.
+  - If the documentation does not answer the question, say so and refer the user to the documentation site instead of guessing.
+  ```
+
+  The wording mirrors `formatMemoriesContext()` on purpose — the model
+  already follows that pattern reliably.
+
+- `SelfAwarePromptDecorator` (sprint 1) grows a second placeholder:
+  `[PLATFORM_DOCS]` is replaced in the `synaplan` topic only (never in
+  `general` — docs retrieval is one embedding call per turn and belongs to
+  the explicit product topic). The decorator receives the hits from the
+  handler so it stays a pure string function.
+
+- `ChatHandler::handleStream()`: for topic `synaplan`, call the retriever
+  before prompt assembly and emit the status **`docs_loaded`** with
+  `metadata.docs = [{slug, title, url}]` through the same callback that
+  emits `memories_loaded` (~L2971), so `StreamController` forwards it
+  without change. `handle()` (non-stream) attaches the same list to the
+  response metadata.
+- Multitask: `ChatRunner::ragContext()` (`Service/Multitask/Execution/Runner/`)
+  — when the `chat` node's `topic_id` is `synaplan`, use the retriever
+  instead of the user-scoped `rag_query`. No new `Capability`.
+- `docs_loaded` is added to the SSE status list in the OpenAPI description
+  of the stream endpoint (`StreamController`) — documentation only, the
+  payload is free-form like `memories_loaded`.
+
+### Tests
+
+- `PlatformDocsRetrieverTest.php` — flag off ⇒ empty without touching the
+  search service; hits mapped via state; unknown file id dropped; per-slug
+  de-dup; owner 0 is what reaches `semanticSearch` (assert the argument).
+- `KnowledgeContextFormatterTest.php` — extend: `[Doc:slug]` block shape,
+  deterministic order, no URL other than the state's.
+- `ChatHandler` characterization/integration: a `synaplan` turn emits
+  `docs_loaded` before `generating`; a `general` turn does not.
+
+### Must NOT touch
+
+`WidgetPublicController`, `tools:widget-default`, user RAG (`[Source N]`),
+`MessageText.vue` (SA8).
+
+### Acceptance
+
+Dev stack after `app:selfaware:sync-docs`:
+
+1. "How do I connect WhatsApp?" → `synaplan`; SSE shows `docs_loaded` with
+   `channels`; the answer contains `[Doc:channels]` and describes the Meta
+   Business API steps from the page.
+2. "Wie binde ich das Chat-Widget ein?" → German answer, `[Doc:widget]`.
+3. "Can you create PDFs?" → still answered from the inventory; if a docs hit
+   is present it is cited, but the availability statement follows the
+   inventory (Decision 1).
+4. `SELF_AWARE.DOCS_RAG_ENABLED=false` → no `docs_loaded`, no `[Doc:…]`,
+   inventory answers unchanged.
+
+### Gate
+
+```bash
+make -C backend lint && make -C backend phpstan && make -C backend test
+```
+
+---
+
+## SA8 — `[Doc:slug]` pills and `docs_loaded` in the frontend
+
+Branch: `feat/self-aware-doc-pills`
+
+### Frontend
+
+- `frontend/src/views/ChatView.vue` — next to the `memories_loaded` handler
+  (~L3365): on `docs_loaded`, store `data.metadata.docs` on the streaming
+  message (`message.docs`) the same way memories are attached, so the pill
+  renderer can resolve slugs. Persisted messages: the backend returns the
+  list in message metadata for history reloads (SA7 non-stream path); if it
+  is absent, pills degrade to plain text — never a guessed link.
+- `frontend/src/components/MessageText.vue` — a `[Doc:slug]` transform
+  beside the `[Memory:ID]` one (regex `\[Doc:([a-z0-9-]+)\]`, tolerate the
+  trailing-dots quirk the memory regex handles). Render as a **link pill**:
+  `<a>` with `href` = the `url` from `message.docs`, `target="_blank"`,
+  `rel="noopener"`, text = `title`, a small book icon, tooltip
+  `t('selfAware.docPill.tooltip')` ("Open in the documentation"). Unknown
+  slug ⇒ plain `[Doc:slug]` text with no link. Streaming: the pill appears
+  when the closing bracket arrives, like memory pills.
+- Styling **only** through tokens/utilities from `style.css` (`.pill`,
+  `var(--txt-secondary)`, `var(--bg-card)` …) — the memory pill's
+  Tailwind-gray classes are legacy; do not copy them. Verify light, dark,
+  and V2 (`.design-v2`) with the pill inside an assistant bubble.
+- Extract the pill renderers if `MessageText.vue` grows past its current
+  size: `components/chat/refs/DocRefPill.ts` (pure function returning the
+  HTML string, unit-testable) — same shape for the memory pill is out of
+  scope.
+
+### i18n
+
+`selfAware.docPill.tooltip`, `selfAware.docPill.ariaLabel` in `en`, `de`,
+`es`, `fr`, `tr`. Canonical term: **documentation** (de: *Dokumentation*,
+es: *documentación*, fr: *documentation*, tr: *dokümantasyon*).
+
+### Tests
+
+- `tests/unit/components/MessageText.docRef.spec.ts` — renders a link for a
+  known slug with the given `url`; plain text for an unknown slug; no
+  `href` ever built from a hardcoded host; `[Doc:a, b]` left untouched.
+- `localeParity.spec.ts` stays green (no ledger additions).
+
+### Acceptance
+
+With SA7 on the dev stack, the WhatsApp question shows a "Channels:
+WhatsApp & Email" pill that opens `https://docs.synaplan.com/channels` in a
+new tab; readable in light, dark, and V2; keyboard-focusable.
+
+### Gate
+
+```bash
+make -C frontend lint && docker compose exec -T frontend npm run check:types && make -C frontend test
+```
+
+---
+
+## SA9 — Discoverability: hint line, `/help`, runtime-config feature flag
+
+Branch: `feat/self-aware-discoverability`
+
+### Backend
+
+- `ConfigController::getRuntimeConfig()` — add
+  `features.selfAware: bool` (`SelfAwareConfig::isEnabled($userId)`), with
+  the OpenAPI property (`description`, `example`) next to `savedTasks`.
+  Regenerate: `make -C frontend generate-schemas`, then `vue-tsc`.
+
+### Frontend
+
+- **Empty-chat hint (signed-in).** The streamlining decision stands:
+  signed-in empty chats keep the greeting and get **no teaser cards**. Add
+  exactly one quiet line under `welcomeGreeting` in `ChatView.vue`,
+  `txt-secondary`, rendered only when
+  `configStore.features.selfAware && !incognitoStore.active`:
+  `t('selfAware.emptyHint')` — "Not sure what's possible here? Ask me what
+  I can do." — where the second sentence is a button-styled link that sends
+  `t('selfAware.emptyHintQuestion')` ("What can you do here?") as a normal
+  message via `handleSendMessage`. No new component; ≤ 15 lines.
+- **Guest landing.** `ExamplePrompts.vue` gets one additional card
+  `selfAware.examplePrompt` ("What can you do?") when
+  `configStore.features.selfAware`. Guests go through the same pipeline; the
+  inventory is built for the guest user id, so guest-gated features show as
+  not available — which is the truth for that visitor.
+- **`/help` in the composer.** `ToolsDropdown.vue` command list: add
+  `{ command: 'help', label: t('selfAware.helpCommand.label'), description: t('selfAware.helpCommand.description') }`
+  in the same shape as `search` / `pic` / `vid`, shown only when
+  `features.selfAware`. Insertion behaviour identical to the other commands.
+
+### i18n (all five locales)
+
+`selfAware.emptyHint`, `selfAware.emptyHintQuestion`,
+`selfAware.examplePrompt`, `selfAware.helpCommand.label` ("Help"),
+`selfAware.helpCommand.description` ("Ask what this AI assistant can do
+here"). Use the canonical **AI assistant** term (de: *KI-Assistent*, es:
+*asistente de IA*, fr: *assistant IA*, tr: *AI asistanı*).
+
+### Tests
+
+- `tests/unit/views/ChatView.selfAwareHint.spec.ts` (or extend the existing
+  ChatView empty-state spec): hint visible with the flag, hidden without,
+  hidden in incognito; clicking sends the question text.
+- `ToolsDropdown` spec: `/help` present only with the flag.
+- `localeParity.spec.ts`, `vue-tsc`, generated schema diff reviewed.
+
+### Must NOT touch
+
+Widget composer, `SetupChatModal.vue`, `useHelp` tours, `MarketingNews`.
+
+### Acceptance
+
+Signed-in, empty chat, flag on: one hint line under the greeting; clicking
+it produces the "What can you do here?" turn routed to `synaplan`. Flag off
+(`SELF_AWARE.ENABLED=false`): no hint, no `/help`, no example card —
+pixel-identical to today. Incognito: no hint. Light/dark/V2 checked.
+
+### Gate
+
+```bash
+make lint && make -C backend phpstan && make test && docker compose exec -T frontend npm run check:types
+```

--- a/_devextras/planning/20260902-platform-self-awareness/04_sprint_4_eval_and_rollout.md
+++ b/_devextras/planning/20260902-platform-self-awareness/04_sprint_4_eval_and_rollout.md
@@ -1,0 +1,189 @@
+# Sprint 4 — Evaluation, documentation, rollout
+
+Status: planned
+Date: 2026-09-02
+Depends on: sprints 1–3
+
+Three steps. The plan is finished when every row of
+`05_eval_question_set.md` passes in `app:selfaware:eval` on a dev install
+with a single chat provider key, and a fresh install plus an upgraded
+install both come up with the flags present and the corpus filled by the
+first scheduler tick.
+
+---
+
+## SA10 — Eval corpus and `app:selfaware:eval`
+
+Branch: `feat/self-aware-eval`
+
+### Backend
+
+- `backend/tests/Eval/self_aware_eval_corpus.json` — the machine-readable
+  form of `05_eval_question_set.md`. One object per row:
+
+  ```json
+  {
+    "id": "Q1",
+    "lang": "en",
+    "text": "Can you create PDFs?",
+    "install": "no_engine",
+    "expect": {
+      "topic": "synaplan",
+      "must_contain_any": ["not", "nicht"],
+      "must_mention_any": ["DOCX", "Word"],
+      "must_not_contain": ["http", "download", "attached", "€", "$"],
+      "docs_cited_any": ["dag-routing", "using-synaplan"],
+      "docs_cited_optional": true
+    }
+  }
+  ```
+
+  `install` names one of the fixture profiles the eval sets up before the
+  turn (`no_keys`, `no_engine` — one chat key, no TTS, no office engine —,
+  `full`). Profiles are applied by toggling the same BCONFIG/env facts the
+  inventory reads, never by mocking the inventory.
+
+- `backend/src/Command/SelfAwareEvalCommand.php` — `app:selfaware:eval
+  [--corpus=…] [--only=Q1,Q7] [--install=no_engine] [--report=json|table]`,
+  modelled on `PlanEvalCommand`. For each row: run classification through
+  `MessageClassifier` (assert `expect.topic` — exact for `synaplan` rows,
+  "not synaplan" for `N*` rows), then a full `ChatHandler::handle()` turn
+  for the eval user, then the string assertions. Prints a table with
+  pass/fail per assertion and a summary line
+  `passed=NN failed=N skipped=N`; exit code 1 on any failure. Requires a
+  live chat model — **not** part of `make test`; documented as the release
+  spot-check.
+- Deterministic parts move into the normal suite: the routing expectations
+  of every row become cases in `RoutingCharacterizationTest` (the sorter is
+  snapshotted there already), and the inventory-only rows (`no_keys`
+  profile) are asserted against `CapabilityReportRenderer` output in a unit
+  test without a model.
+
+### Tests
+
+`tests/Command/SelfAwareEvalCommandTest.php` — corpus loads, `--only`
+filters, a failing fixture row yields exit 1 (with the chat provider mocked
+to a canned answer). Characterization snapshots re-recorded for the new
+routing cases and reviewed.
+
+### Acceptance
+
+```bash
+docker compose exec -T backend php bin/console app:selfaware:eval --install=no_engine
+docker compose exec -T backend php bin/console app:selfaware:eval --install=full
+```
+
+Both end with `failed=0`. Failures are triaged into prompt wording
+(`PromptCatalog`), inventory facts, or sorter rules — never into loosening
+the corpus assertions.
+
+### Gate
+
+```bash
+make -C backend lint && make -C backend phpstan && make -C backend test
+```
+
+---
+
+## SA11 — Documentation, release checklist, path classification
+
+Branch: `docs/self-aware`
+
+### `synaplan-docs`
+
+- `docs/using-synaplan.md` — new section "Ask the assistant what it can
+  do": the hint line, `/help`, examples ("Can you create PDFs?", "What's
+  new?"), the documentation pills, and that answers reflect *this*
+  installation.
+- `docs/administration.md` — "Self-awareness settings": the four
+  `SELF_AWARE.*` settings, what turning each off does, the manifest URL
+  override for mirrors and air-gapped installs, `app:selfaware:sync-docs`,
+  and that the corpus is refreshed daily and after each release.
+- `docs/faq.md` — "Why does the assistant say it cannot do X when the docs
+  say it can?" → the inventory/docs precedence in one paragraph.
+- Register nothing new in `$docsMap` unless a page is added; the three
+  sections above live in existing pages so they are synced automatically.
+
+### This repository
+
+- `README.md` — one feature line under the existing feature table.
+- `docs/ADMIN.md` — already extended in SA6; add the eval command.
+- **Release checklist** (`docs/RELEASE.md` or wherever the release steps
+  live — verify the path): "Review `PlatformCapabilityInventory::KNOWN_ABSENT`
+  — remove any entry a shipped feature now provides; add an `alternative`
+  for anything newly and deliberately unsupported." This is the only
+  hand-maintained list in the feature and this line is what keeps it honest.
+- `.github/mobile-impact-policy.json` — classify:
+  `backend/src/Service/SelfAware/**`, `backend/src/Command/SelfAware*.php`,
+  `backend/src/Message*/SyncPlatformDocs*.php`, `backend/src/Seed/SelfAwareConfigSeeder.php`,
+  `backend/tests/Eval/self_aware_eval_corpus.json`, `backend/tests/Fixtures/selfaware/**`
+  → backend-only; `frontend/src/components/chat/refs/**` → ota-candidate
+  (already covered by `frontend/src/**` if the allow-list is prefix-based —
+  confirm); `_docker/**` → no-app-impact. Extend `tests/mobile-impact.test.mjs`
+  and run `node scripts/mobile-impact.mjs --base main --head HEAD`.
+
+### Acceptance
+
+`node scripts/mobile-impact.mjs` reports `backend-only` for a backend-only
+diff of this plan and `ota-candidate` for SA8/SA9; `docs.synaplan.com`
+manifest shows new `sha256` values for the three edited pages and the next
+sync picks them up (visible in `app:selfaware:sync-docs` output).
+
+### Gate
+
+Markdown only in this repo, plus the mobile-impact test:
+
+```bash
+node --test tests/mobile-impact.test.mjs
+```
+
+---
+
+## SA12 — Rollout
+
+Branch: none (operations + `STATUS.md` update)
+
+### Fresh install
+
+`docker compose down -v && docker compose up -d` on the dev stack:
+`app:seed` inserts the four `SELF_AWARE` rows and the `synaplan` prompt;
+no network call happens during boot (check `docker compose logs backend`
+for the absence of `sync-docs`); the first request to "What can you do
+here?" answers from the inventory alone; after
+`app:selfaware:sync-docs` (or the first scheduler tick) the same question
+cites documentation pages.
+
+### Existing install
+
+On a copy of a pre-plan database: container start runs `app:seed`, which
+inserts the missing rows and the new prompt without touching existing
+`BCONFIG` values or user prompts (`BConfigSeeder::insertIfMissing`,
+`PromptSeeder` create-if-absent). A user's custom topic named `synaplan`
+(owner > 0) would shadow nothing — system topics and user topics are
+distinct rows; verify `[DYNAMICLIST]` lists both and the sorter rule text
+refers to the system one.
+
+### Production (`synaplan-platform`)
+
+- The `scheduler` role picks up the daily sync automatically once the image
+  contains SA6; no compose change is needed (`SYNAPLAN_ROLE=scheduler`
+  already exists).
+- Galera: no migration in this plan (C3). BCONFIG writes from the sync are
+  single-row `UPDATE`s on owner 0 — no conflict potential across nodes since
+  only the scheduler role writes them.
+- If the platform egress policy blocks `docs.synaplan.com`, set
+  `SELF_AWARE.DOCS_MANIFEST_URL` to an internal mirror of the three
+  endpoints from SA4 or to an empty string.
+
+### Definition of done (whole plan)
+
+- `app:selfaware:eval` passes on `no_engine` and `full` profiles.
+- All five locales complete; `localeParity.spec.ts` green with no ledger
+  additions.
+- Characterization snapshots re-recorded exactly twice (SA2, SA3/SA10) and
+  each diff explained in its PR.
+- Flags off ⇒ byte-identical snapshots to `main` before this plan (C1
+  verified by running the characterization suite with `SELF_AWARE.ENABLED=false`
+  in the test config once — a one-off check, not a permanent second
+  snapshot set).
+- `STATUS.md` rows all `merged`, decisions table dated.

--- a/_devextras/planning/20260902-platform-self-awareness/05_eval_question_set.md
+++ b/_devextras/planning/20260902-platform-self-awareness/05_eval_question_set.md
@@ -1,0 +1,99 @@
+# Eval question set — what "self-aware" means, row by row
+
+Status: planned (frozen when SA10 lands; additions go through a PR that
+also updates `backend/tests/Eval/self_aware_eval_corpus.json`)
+Date: 2026-09-02
+
+This is the contract the whole plan is measured against. Every row is one
+utterance, the install profile it runs on, the routing we expect, what the
+answer must contain, and what it must never contain. Languages rotate
+through all five UI locales so the sorter rule and the language directive
+are exercised together.
+
+Install profiles (applied by toggling the real facts the inventory reads):
+
+| Profile | Chat key | Image model | Video model | TTS | Office engine | Brave key | Qdrant | Billing |
+| ------- | -------- | ----------- | ----------- | --- | ------------- | --------- | ------ | ------- |
+| `no_keys` | – | – | – | – | – | – | – | off |
+| `no_engine` | yes | yes | – | – | – | yes | yes | off |
+| `full` | yes | yes | yes | yes | yes | yes | yes | on |
+
+Global must-nots for every row: no URL that is not a `[Doc:slug]` pill's
+`url`; no "I have attached / here is the file"; no digits next to a
+currency symbol; no provider key, hostname, or internal class name.
+
+## A — "Can you X?" (install-dependent truth)
+
+| ID | Lang | Utterance | Profile | Route | Answer must | Must not |
+| -- | ---- | --------- | ------- | ----- | ----------- | -------- |
+| Q1 | en | Can you create PDFs? | `no_engine` | `synaplan` | say PDF is **not available here**; name DOCX/XLSX/PPTX/CSV as available; end with an offer ("want it as DOCX?") | promise a PDF; give a download link |
+| Q2 | en | Can you create PDFs? | `full` | `synaplan` | say **yes** (PDF export via the office engine) and how to ask ("create … as PDF") | hedge with "maybe" |
+| Q3 | de | Kannst du mir eine PDF erstellen? | `no_engine` | `synaplan` | German; same content as Q1; non-admin ⇒ "Administrator" mentioned once | English answer |
+| Q4 | en | Would you create a song like the Beatles? | `no_engine` | `synaplan` | say it **cannot compose or produce music**; offer *original* lyrics in that style; **no** TTS mention (profile has none) | reproduce lyrics; mention MP3 |
+| Q5 | en | Would you create a song like the Beatles? | `full` | `synaplan` | same, plus offer to read the lyrics aloud as MP3 (TTS available) | claim to produce audio music |
+| Q6 | es | ¿Puedes buscar en internet? | `no_engine` | `synaplan` | Spanish; **yes**, web search is available; how it is triggered (ask for current information or `/search`) | "no" |
+| Q7 | es | ¿Puedes buscar en internet? | `no_keys` | `synaplan` | Spanish; **not set up**; alternative: paste the text; admin hint only for admins | "yes" |
+| Q8 | fr | Peux-tu lire mes e-mails ? | `full` | `synaplan` | French; e-mail search is **off by default** / needs the mailbox connection; point to Channels; `[Doc:channels]` when docs are synced | claim it reads mail now |
+| Q9 | tr | Bana bir video yapabilir misin? | `no_engine` | `synaplan` | Turkish; video **not set up here**; image generation **is** available as the nearest alternative | "yes" |
+| Q10 | tr | Bana bir video yapabilir misin? | `full` | `synaplan` | Turkish; **yes**; how to ask (`/vid` or "create a video …") | "no" |
+| Q11 | en | Can you run Python code for me? | `full` | `synaplan` | **no arbitrary code execution**; alternative: Synaplan Desktop skills; `[Doc:desktop-skills]` when synced | pretend to execute code |
+| Q12 | en | Can you remember things about me? | `no_engine` | `synaplan` | **yes** (memories, Qdrant present); how to see them | "no" |
+| Q13 | en | Can you remember things about me? | `no_keys` | `synaplan` | **not available** (no Qdrant); what memories would do | "yes" |
+| Q14 | de | Kannst du Audiodateien transkribieren? | `no_engine` | `synaplan` | German; **yes** (speech-to-text ships with the platform) — upload the file | "no" |
+| Q15 | en | What file types can I upload? | `no_engine` | `synaplan` | the real upload list from `CapabilityService` | an invented type |
+
+## B — "What can you do?" / "How do I…?" / "What's new?" (docs-grounded)
+
+| ID | Lang | Utterance | Profile | Route | Answer must | Must not |
+| -- | ---- | --------- | ------- | ----- | ----------- | -------- |
+| Q16 | de | Was kannst du? | `no_engine` | `synaplan` | 5–8 bullets **from the AVAILABLE NOW list only**; one line on NEEDS SETUP; closing pointer to `/help` or the documentation | list video/TTS as available |
+| Q17 | en | What can you do here? | `no_keys` | `synaplan` | say that the AI provider is not connected yet, name what works without one (upload/search if embeddings exist, otherwise nothing) and who can fix it | fake a capability list |
+| Q18 | en | How do I connect WhatsApp? | `full` | `synaplan` | steps from `channels.md`; `[Doc:channels]` | invent a menu path |
+| Q19 | de | Wie binde ich das Chat-Widget in meine Website ein? | `full` | `synaplan` | the `<script type="module">` snippet or the pointer to Widgets; `[Doc:widget]`; canonical term *Chat-Widget* | a made-up widget URL |
+| Q20 | fr | Est-ce que vous supportez Nextcloud ? | `full` | `synaplan` | yes; the Nextcloud integration app; `[Doc:plugins]` | confuse with OpenCloud / ownCloud.online |
+| Q21 | en | Can I use you from Outlook? | `full` | `synaplan` | Synamail add-in; `[Doc:synamail]` | describe it as a generic Outlook feature |
+| Q22 | es | ¿Qué hay de nuevo? | `full` | `synaplan` | items from `intro.md` "What's New"; running version; `[Doc:intro]` | invent releases |
+| Q23 | en | Are you ChatGPT? | `full` | `synaplan` | "the AI assistant of this Synaplan workspace, using the model your workspace selected" | name the provider key or a hostname |
+| Q24 | en | How much does the Pro plan cost? | `full` (billing on) | `synaplan` | one benefit sentence + link to the pricing page | any number |
+| Q25 | en | How much does the Pro plan cost? | `no_engine` (billing off) | `synaplan` | explain this is a self-hosted workspace without plans; no pricing link | a plan name |
+| Q26 | en | /help | `no_engine` | `synaplan` (command) | same as Q16 | treat `/help` as text |
+
+## C — Graceful inability on *task* requests (not routed to `synaplan`)
+
+| ID | Lang | Utterance | Profile | Route | Answer must | Must not |
+| -- | ---- | --------- | ------- | ----- | ----------- | -------- |
+| T1 | en | Create a PDF of the following text: "Quarterly notes …" | `no_engine` | not `synaplan` (today's route) | say PDF is not available here and **offer DOCX**; no `__FILE_GENERATED__` | fabricated download link |
+| T2 | de | Mach mir daraus ein Video. | `no_engine` | not `synaplan` | video not set up here; offer an image instead | "hier ist dein Video" |
+| T3 | en | Write me a poem and read it to me as MP3 | `no_engine` | `mediamaker` (existing rule) | the poem, plus a plain statement that audio is not set up here | a fake MP3 |
+| T4 | en | Write me a poem and read it to me as MP3 | `full` | `mediamaker` | poem + real audio delivered by the system | — |
+
+## N — Negative controls (must NOT route to `synaplan`)
+
+| ID | Lang | Utterance | Profile | Route | Why |
+| -- | ---- | --------- | ------- | ----- | --- |
+| N1 | en | Write me a poem about autumn | any | `general` | a request, not a question about the product |
+| N2 | en | Can you help me with my Excel formulas? | any | `general` | "can you help" + a real task ⇒ do the task |
+| N3 | de | Kannst du das zusammenfassen? *(with attachment)* | any | attachment route (`analyzefile`) | modal verb + attachment ⇒ act |
+| N4 | fr | Peux-tu traduire ce texte en anglais : … | any | `general` | a translation request |
+| N5 | en | What can you tell me about the Beatles? | any | `general` | "what can you" about the *world*, not about Synaplan |
+| N6 | en | Search the web for Synaplan reviews | any | `tools:search` / web search | mentions the product but is a web task |
+
+## W — Widget exclusion (behaviour unchanged)
+
+| ID | Utterance | Channel | Expect |
+| -- | --------- | ------- | ------ |
+| W1 | What can you do? | widget conversation | today's widget behaviour; no `[PLATFORM_CAPABILITIES]` in the prompt; no `docs_loaded` |
+| W2 | Can you create PDFs? | widget conversation | today's widget behaviour |
+
+## Reading the results
+
+- A **routing** failure (`Route` column) is a sorter/planner rule problem →
+  `PromptCatalog::sortPrompt()` / `planPrompt()`; re-record snapshots.
+- A **truth** failure ("yes" where the profile says no, or vice versa) is an
+  inventory fact problem → `PlatformCapabilityInventory` source table; never
+  patch the prompt to compensate.
+- A **grounding** failure (missing or wrong `[Doc:…]`) is retrieval or
+  corpus → `PlatformDocsRetriever` thresholds, sync state, or the docs page
+  itself (fix the docs, the corpus follows).
+- A **tone** failure (hedging, filler, prices) is the `synaplan` topic
+  prompt wording.

--- a/_devextras/planning/20260902-platform-self-awareness/STATUS.md
+++ b/_devextras/planning/20260902-platform-self-awareness/STATUS.md
@@ -1,0 +1,73 @@
+# Status — Platform Self-Awareness
+
+Plan of record: `00_master_plan.md`. Work one step at a time; update this
+table when a branch is opened, merged, or a decision is taken. The
+predecessor `../20260623-release4.0/06_self-aware-routing.md` is superseded
+by this plan and is not updated any more.
+
+## Sprint 1 — inventory and routing
+
+| Step | Branch | State | Notes |
+| ---- | ------ | ----- | ----- |
+| SA1 — `PlatformCapabilityInventory` + renderer | `feat/self-aware-inventory` | planned | Pure library code; ships the dev command `app:selfaware:inventory` |
+| SA2 — `synaplan` topic, sorter/planner rules, `general` rewrite, `SelfAwareConfigSeeder` | `feat/self-aware-topic` | planned | Snapshot re-record #1 |
+| SA3 — Inventory injection, fast-path guard, `/help`, widget exclusion | `feat/self-aware-injection` | planned | Snapshot re-record #2 (`/help` case) |
+
+## Sprint 2 — docs corpus
+
+| Step | Branch | State | Notes |
+| ---- | ------ | ----- | ----- |
+| SA4 — `synaplan-docs`: `/docs-manifest.json`, `/raw/{slug}.md`, `/llms.txt` | `feat/docs-manifest` (docs repo) | planned | Separate public repo; schema copied both ways |
+| SA5 — Sync service, `app:selfaware:sync-docs`, `SyncPlatformDocsMessage` | `feat/self-aware-docs-sync` | planned | Owner-0 checks (embedding model, rate limit, stale-hit filter) to be recorded here |
+| SA6 — Scheduler daily slot + release trigger | `feat/self-aware-docs-schedule` | planned | **Ask-first** (edits `_docker/backend/lib/container-runtime.sh`) |
+
+## Sprint 3 — grounded answers and chat UX
+
+| Step | Branch | State | Notes |
+| ---- | ------ | ----- | ----- |
+| SA7 — `PlatformDocsRetriever`, `[Doc:slug]` context, `docs_loaded` | `feat/self-aware-docs-retrieval` | planned | Owner 0 at query time |
+| SA8 — Doc pills in `MessageText.vue` | `feat/self-aware-doc-pills` | planned | Tokens only; light/dark/V2 check |
+| SA9 — Hint line, `/help` in composer, `features.selfAware` | `feat/self-aware-discoverability` | planned | Schema regen; five locales |
+
+## Sprint 4 — eval and rollout
+
+| Step | Branch | State | Notes |
+| ---- | ------ | ----- | ----- |
+| SA10 — Eval corpus + `app:selfaware:eval` | `feat/self-aware-eval` | planned | Live-model spot check, not in `make test` |
+| SA11 — Docs, release checklist, mobile-impact classification | `docs/self-aware` | planned | Edits three `synaplan-docs` pages |
+| SA12 — Rollout (fresh + upgraded install, platform notes) | — | planned | |
+
+## Decisions
+
+| Date | Decision |
+| ---- | -------- |
+| 2026-09-02 | Two truths, one answer: live per-install inventory is authoritative for "can you X here"; `synaplan-docs` corpus is authoritative for "what/how"; inventory wins on conflict. No hand-maintained feature list; only a tiny reviewed `KNOWN_ABSENT` list. (`00_master_plan.md` Decisions 1–2) |
+| 2026-09-02 | Routing via a routable system topic `synaplan` plus the inventory block injected into `general`; `/help` command; fast-path guard only defers to the sorter. Tool-calling rejected for now. (Decision 3) |
+| 2026-09-02 | Docs corpus = `SYSTEM:synaplan`, owner 0, fed by a machine-readable manifest published by `synaplan-docs`; raw Markdown ingested; URL configurable for mirrors; no vendoring, no HTML crawl, no GitHub API per query. (Decision 4) |
+| 2026-09-02 | Freshness via the daily scheduler slot + a message dispatched when `app:updates:check` sees a new version; never on the boot path. (Decision 5) |
+| 2026-09-02 | Corpus stays English; retrieval is cross-lingual; answers follow the language directive. Replaces 4.0 decision 3 (author in four languages). UI strings in all five locales. (Decision 6) |
+| 2026-09-02 | Widget conversations excluded by default; pricing never quoted (link only when billing is on); admin hints only for admins. (Decision 8) |
+| 2026-09-02 | Flags `SELF_AWARE.{ENABLED, INVENTORY_IN_GENERAL, DOCS_RAG_ENABLED, DOCS_MANIFEST_URL}` default ON / public docs URL. (Decision 9) |
+
+## Investigation baseline (2026-09-02)
+
+- Nothing from the Release 4.0 self-aware plan exists in code: no `synaplan`
+  topic, no system-owned RAG group, no `SELF_AWARE` flags.
+- `general` prompt redirects every file request and forbids meta-commentary
+  about limitations; capability questions therefore get model guesses.
+- Fast path is default-OFF (`CLASSIFIER.FAST_PATH_ENABLED`); the sorter sees
+  every message; `[DYNAMICLIST]` excludes `tools:*` only.
+- Live capability knowledge is spread over `SkillCatalog`, `ModelConfigService`,
+  `ChatReadinessService`, `ConfigController::getRuntimeConfig()`,
+  `MultitaskRoutingConfig`, `PluginManager`, `CapabilityService`,
+  `UpdateStatusService`; nothing aggregates it.
+- RAG is user-scoped at storage level; `CrawlWidgetUrlMessageHandler` is
+  the exact ingestion shape needed (deterministic file id, `deleteByFile`,
+  `vectorizeAndStore`, no `BFILES` row).
+- Scheduler daily slot in `_docker/backend/lib/container-runtime.sh` runs
+  `app:updates:check` and `app:digest:run`.
+- `synaplan-docs`: custom PHP + CommonMark, 29 flat Markdown pages
+  (~209 KB), English only, metadata in `index.php` `$docsMap`, no export.
+- PDF output is explicitly unsupported today and becomes install-dependent
+  with `../20260902-office-docs/` A0/A4; no music generation exists anywhere.
+- Five UI locales: `de`, `en`, `es`, `fr`, `tr`.


### PR DESCRIPTION
 ## Summary
Only planning documents for the next 2 weeks!

## Changes
Updated the status of the Self-Aware Routing feature to 'Superseded' as of 2026-09-02, with a reference to the new plan in `20260902-platform-self-awareness`. This change reflects the decision to keep the original document for historical context while noting that the feature was never started.

Various planning docs generated

## Verification
- [X] Not tested (explain) - text only updates!
- [ ] Manual
- [ ] Tests added/updated
