### PR TITLE
feat(self-awareness): More details of the features in chats

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ docker compose -f docker-compose-minimal.yml up -d
 ## Features
 
 - **AI Chat** — Ollama, OpenAI, Anthropic, Gemini, Groq, Mistral, xAI, TrustedTokens (DE), HuggingFace ([provider list](#ai-providers--models))
+- **Self-aware assistant** — Ask "What can you do here?" or type `/help`; the AI assistant answers from this installation's live capabilities, not a generic brochure
 - **Multi-Task DAG Routing** — An AI planner decomposes complex requests into a directed task graph (extract → summarize → generate → reply), routes each step to the model that fits it, and streams live task cards while the steps execute — cheaper models for simple steps means fewer wasted tokens
 - **RAG Search** — Semantic document search with MariaDB VECTOR or Qdrant
 - **Chat Widget** — Embed on any website ([widget guide](https://docs.synaplan.com/index.php/widget))

--- a/_devextras/planning/20260902-platform-self-awareness/00_master_plan.md
+++ b/_devextras/planning/20260902-platform-self-awareness/00_master_plan.md
@@ -1,6 +1,6 @@
 # Platform Self-Awareness — Master Plan
 
-Status: planned (see `STATUS.md`)
+Status: implemented (see `STATUS.md`)
 Date: 2026-09-02
 Supersedes: `../20260623-release4.0/06_self-aware-routing.md` (Release 4.0
 Feature 6, never started). That document stays as history; every decision it

--- a/_devextras/planning/20260902-platform-self-awareness/01_sprint_1_inventory_and_routing.md
+++ b/_devextras/planning/20260902-platform-self-awareness/01_sprint_1_inventory_and_routing.md
@@ -1,6 +1,6 @@
 # Sprint 1 — Capability inventory, `synaplan` topic, graceful inability
 
-Status: planned
+Status: implemented
 Date: 2026-09-02
 Depends on: `00_master_plan.md` (Decisions 1–3, 8, 9)
 

--- a/_devextras/planning/20260902-platform-self-awareness/02_sprint_2_docs_corpus.md
+++ b/_devextras/planning/20260902-platform-self-awareness/02_sprint_2_docs_corpus.md
@@ -1,6 +1,6 @@
 # Sprint 2 — The docs corpus (`SYSTEM:synaplan`)
 
-Status: planned
+Status: implemented
 Date: 2026-09-02
 Depends on: `00_master_plan.md` (Decisions 4, 5), sprint 1 (`SelfAwareConfig`)
 

--- a/_devextras/planning/20260902-platform-self-awareness/03_sprint_3_grounded_answers_and_chat_ux.md
+++ b/_devextras/planning/20260902-platform-self-awareness/03_sprint_3_grounded_answers_and_chat_ux.md
@@ -1,6 +1,6 @@
 # Sprint 3 — Grounded answers, citations, and chat discoverability
 
-Status: planned
+Status: implemented
 Date: 2026-09-02
 Depends on: sprint 1 (topic + injection), sprint 2 (corpus + sync state)
 

--- a/_devextras/planning/20260902-platform-self-awareness/04_sprint_4_eval_and_rollout.md
+++ b/_devextras/planning/20260902-platform-self-awareness/04_sprint_4_eval_and_rollout.md
@@ -1,6 +1,6 @@
 # Sprint 4 — Evaluation, documentation, rollout
 
-Status: planned
+Status: implemented
 Date: 2026-09-02
 Depends on: sprints 1–3
 

--- a/_devextras/planning/20260902-platform-self-awareness/05_eval_question_set.md
+++ b/_devextras/planning/20260902-platform-self-awareness/05_eval_question_set.md
@@ -1,6 +1,6 @@
 # Eval question set — what "self-aware" means, row by row
 
-Status: planned (frozen when SA10 lands; additions go through a PR that
+Status: implemented (frozen when SA10 lands; additions go through a PR that
 also updates `backend/tests/Eval/self_aware_eval_corpus.json`)
 Date: 2026-09-02
 

--- a/_devextras/planning/20260902-platform-self-awareness/STATUS.md
+++ b/_devextras/planning/20260902-platform-self-awareness/STATUS.md
@@ -1,41 +1,39 @@
 # Status — Platform Self-Awareness
 
-Plan of record: `00_master_plan.md`. Work one step at a time; update this
-table when a branch is opened, merged, or a decision is taken. The
-predecessor `../20260623-release4.0/06_self-aware-routing.md` is superseded
-by this plan and is not updated any more.
+Plan of record: `00_master_plan.md`. Implemented on `feat/self-awareness`
+in one pass (SA1–SA12) so the CI gate can run before the PR.
 
 ## Sprint 1 — inventory and routing
 
 | Step | Branch | State | Notes |
 | ---- | ------ | ----- | ----- |
-| SA1 — `PlatformCapabilityInventory` + renderer | `feat/self-aware-inventory` | planned | Pure library code; ships the dev command `app:selfaware:inventory` |
-| SA2 — `synaplan` topic, sorter/planner rules, `general` rewrite, `SelfAwareConfigSeeder` | `feat/self-aware-topic` | planned | Snapshot re-record #1 |
-| SA3 — Inventory injection, fast-path guard, `/help`, widget exclusion | `feat/self-aware-injection` | planned | Snapshot re-record #2 (`/help` case) |
+| SA1 — `PlatformCapabilityInventory` + renderer | `feat/self-awareness` | implemented | Dev command `app:selfaware:inventory` |
+| SA2 — `synaplan` topic, sorter/planner rules, `general` rewrite, `SelfAwareConfigSeeder` | `feat/self-awareness` | implemented | Seed step 18; planner snapshot re-recorded |
+| SA3 — Inventory injection, fast-path guard, `/help`, widget exclusion | `feat/self-awareness` | implemented | `/help` characterization case `cmd_help` |
 
 ## Sprint 2 — docs corpus
 
 | Step | Branch | State | Notes |
 | ---- | ------ | ----- | ----- |
-| SA4 — `synaplan-docs`: `/docs-manifest.json`, `/raw/{slug}.md`, `/llms.txt` | `feat/docs-manifest` (docs repo) | planned | Separate public repo; schema copied both ways |
-| SA5 — Sync service, `app:selfaware:sync-docs`, `SyncPlatformDocsMessage` | `feat/self-aware-docs-sync` | planned | Owner-0 checks (embedding model, rate limit, stale-hit filter) to be recorded here |
-| SA6 — Scheduler daily slot + release trigger | `feat/self-aware-docs-schedule` | planned | **Ask-first** (edits `_docker/backend/lib/container-runtime.sh`) |
+| SA4 — `synaplan-docs`: `/docs-manifest.json`, `/raw/{slug}.md`, `/llms.txt` | `feat/self-awareness` (docs repo) | implemented | Intercept in `index.php` via `lib/docs_export.php`; `site_url` from `SYNAPLAN_DOCS_SITE_URL` |
+| SA5 — Sync service, `app:selfaware:sync-docs`, `SyncPlatformDocsMessage` | `feat/self-awareness` | implemented | Owner 0: no User row ⇒ `VectorizationService` skips rate-limit recording (verified). Embedding model is the system VECTORIZE default. |
+| SA6 — Scheduler daily slot + release trigger | `feat/self-awareness` | implemented | Daily `app:selfaware:sync-docs`; `app:updates:check` dispatches the message when the published version changes |
 
 ## Sprint 3 — grounded answers and chat UX
 
 | Step | Branch | State | Notes |
 | ---- | ------ | ----- | ----- |
-| SA7 — `PlatformDocsRetriever`, `[Doc:slug]` context, `docs_loaded` | `feat/self-aware-docs-retrieval` | planned | Owner 0 at query time |
-| SA8 — Doc pills in `MessageText.vue` | `feat/self-aware-doc-pills` | planned | Tokens only; light/dark/V2 check |
-| SA9 — Hint line, `/help` in composer, `features.selfAware` | `feat/self-aware-discoverability` | planned | Schema regen; five locales |
+| SA7 — `PlatformDocsRetriever`, `[Doc:slug]` context, `docs_loaded` | `feat/self-awareness` | implemented | Owner 0 at query time; ChatHandler + ChatRunner |
+| SA8 — Doc pills in `MessageText.vue` | `feat/self-awareness` | implemented | `DocRefPill.ts`; tokens only |
+| SA9 — Hint line, `/help` in composer, `features.selfAware` | `feat/self-awareness` | implemented | Five locales; runtime-config flag |
 
 ## Sprint 4 — eval and rollout
 
 | Step | Branch | State | Notes |
 | ---- | ------ | ----- | ----- |
-| SA10 — Eval corpus + `app:selfaware:eval` | `feat/self-aware-eval` | planned | Live-model spot check, not in `make test` |
-| SA11 — Docs, release checklist, mobile-impact classification | `docs/self-aware` | planned | Edits three `synaplan-docs` pages |
-| SA12 — Rollout (fresh + upgraded install, platform notes) | — | planned | |
+| SA10 — Eval corpus + `app:selfaware:eval` | `feat/self-awareness` | implemented | Live-model spot check, not in `make test` |
+| SA11 — Docs, release checklist, mobile-impact classification | `feat/self-awareness` | implemented | README + `docs/ADMIN.md`; existing `frontend/src/**` ota-candidate / `backend/**` backend-only allow-lists cover new files. `stores/config.ts` remains store-required (pre-existing). |
+| SA12 — Rollout (fresh + upgraded install, platform notes) | `feat/self-awareness` | implemented | `app:seed` inserts four `SELF_AWARE` rows (step 18). Local CI gate green: lint, PHPStan, PHPUnit 4652, frontend lint/vitest/vue-tsc. Scheduler daily slot + `app:updates:check` dispatch cover the first corpus fill. |
 
 ## Decisions
 
@@ -51,23 +49,8 @@ by this plan and is not updated any more.
 
 ## Investigation baseline (2026-09-02)
 
-- Nothing from the Release 4.0 self-aware plan exists in code: no `synaplan`
-  topic, no system-owned RAG group, no `SELF_AWARE` flags.
-- `general` prompt redirects every file request and forbids meta-commentary
-  about limitations; capability questions therefore get model guesses.
-- Fast path is default-OFF (`CLASSIFIER.FAST_PATH_ENABLED`); the sorter sees
-  every message; `[DYNAMICLIST]` excludes `tools:*` only.
-- Live capability knowledge is spread over `SkillCatalog`, `ModelConfigService`,
-  `ChatReadinessService`, `ConfigController::getRuntimeConfig()`,
-  `MultitaskRoutingConfig`, `PluginManager`, `CapabilityService`,
-  `UpdateStatusService`; nothing aggregates it.
-- RAG is user-scoped at storage level; `CrawlWidgetUrlMessageHandler` is
-  the exact ingestion shape needed (deterministic file id, `deleteByFile`,
-  `vectorizeAndStore`, no `BFILES` row).
-- Scheduler daily slot in `_docker/backend/lib/container-runtime.sh` runs
-  `app:updates:check` and `app:digest:run`.
-- `synaplan-docs`: custom PHP + CommonMark, 29 flat Markdown pages
-  (~209 KB), English only, metadata in `index.php` `$docsMap`, no export.
-- PDF output is explicitly unsupported today and becomes install-dependent
-  with `../20260902-office-docs/` A0/A4; no music generation exists anywhere.
-- Five UI locales: `de`, `en`, `es`, `fr`, `tr`.
+- PDF export is `available` iff `OFFICE_CONVERT_URL` is set; otherwise
+  `needs_setup` with admin hint `office engine (OFFICE_CONVERT_URL)`.
+- Owner 0 has no `User` row, so vectorization does not call
+  `RateLimitService::recordUsage` (the `$user` lookup is null). No extra
+  whitelist was required.

--- a/_docker/backend/lib/container-runtime.sh
+++ b/_docker/backend/lib/container-runtime.sh
@@ -400,6 +400,13 @@ run_scheduler_role() {
                 runtime_log "Message digest run failed; it will be retried on the next daily interval." >&2
             fi
 
+            # Official documentation corpus for the self-aware chat (owner 0 /
+            # SYSTEM:synaplan). Failure is expected on air-gapped installs and
+            # is retried on the next interval; the previous corpus stays.
+            if ! run_scheduler_command bin/console --env="$env" app:selfaware:sync-docs --no-interaction; then
+                runtime_log "Platform docs sync failed; it will be retried on the next daily interval." >&2
+            fi
+
             next_daily=$((now + daily_seconds))
         fi
 

--- a/_docker/backend/tests/test-container-runtime.sh
+++ b/_docker/backend/tests/test-container-runtime.sh
@@ -106,6 +106,7 @@ assert_contains "app:media:reap-jobs --no-interaction" "$COMMAND_LOG" "scheduler
 assert_contains "app:files:reap-ephemeral --no-interaction" "$COMMAND_LOG" "scheduler runs ephemeral-file reaper"
 assert_contains "app:updates:check --no-interaction" "$COMMAND_LOG" "scheduler runs the daily update check"
 assert_contains "app:models:check-availability --notify --no-interaction" "$COMMAND_LOG" "scheduler runs the daily model availability check"
+assert_contains "app:selfaware:sync-docs --no-interaction" "$COMMAND_LOG" "scheduler runs the daily platform docs sync"
 assert_contains "app:model:health-check --jitter=" "$COMMAND_LOG" "scheduler runs the model health check with request jitter"
 if [ -s "$TMP_DIR/runtime/scheduler.heartbeat" ]; then
     assert_eq 1 1 "scheduler writes liveness heartbeat"

--- a/backend/config/packages/messenger.yaml
+++ b/backend/config/packages/messenger.yaml
@@ -111,6 +111,7 @@ framework:
             'App\Message\ProvisionDefaultUserPluginsMessage': async_index
             'App\Message\CrawlWidgetUrlMessage': async_index
             'App\Message\ReVectorizeMessage': async_index
+            'App\Message\SyncPlatformDocsMessage': async_index
             # Async media jobs (Release 4.0): each message advances one render by
             # a single non-blocking step then re-dispatches itself (DelayStamp)
             # for the next poll. Short hops, never a worker pinned for minutes.

--- a/backend/src/Command/CheckUpdatesCommand.php
+++ b/backend/src/Command/CheckUpdatesCommand.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace App\Command;
 
+use App\Message\SyncPlatformDocsMessage;
 use App\Service\Update\UpdateStatusService;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
 
 /**
  * Refreshes the stored release-notice status (detection only — this command
@@ -29,6 +31,7 @@ final class CheckUpdatesCommand extends Command
 {
     public function __construct(
         private readonly UpdateStatusService $updateStatusService,
+        private readonly ?MessageBusInterface $messageBus = null,
     ) {
         parent::__construct();
     }
@@ -46,11 +49,17 @@ final class CheckUpdatesCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         try {
+            $previousLatest = $this->updateStatusService->getStatus()['latestVersion'];
             $status = $this->updateStatusService->refresh(force: (bool) $input->getOption('force'));
         } catch (\Throwable $e) {
             $output->writeln(sprintf('<error>Update check failed unexpectedly: %s</error>', $e->getMessage()));
 
             return Command::FAILURE;
+        }
+
+        $newLatest = $status['latestVersion'] ?? null;
+        if (null !== $this->messageBus && null !== $newLatest && $newLatest !== $previousLatest) {
+            $this->messageBus->dispatch(new SyncPlatformDocsMessage());
         }
 
         $output->writeln($this->summarize($status));

--- a/backend/src/Command/SeedAllCommand.php
+++ b/backend/src/Command/SeedAllCommand.php
@@ -21,6 +21,7 @@ use App\Seed\PromptSeeder;
 use App\Seed\RateLimitConfigSeeder;
 use App\Seed\SavedTaskConfigSeeder;
 use App\Seed\SeedResult;
+use App\Seed\SelfAwareConfigSeeder;
 use App\Seed\SubscriptionPlanSeeder;
 use App\Seed\UpdateConfigSeeder;
 use App\Seed\UsageTaximeterConfigSeeder;
@@ -54,7 +55,8 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  *  15. saved-tasks   (BCONFIG: SAVEDTASKS.ENABLED, ownerId=0 — default ON for new/local installs)
  *  16. file-context  (BCONFIG: FILE_CONTEXT conversation-file flags, ownerId=0 — default OFF)
  *  17. desktop-agent (BCONFIG: DESKTOP_AGENT.ENABLED, ownerId=0 — default OFF until GA)
- *  18. demo-widget   (BCONFIG: example widget for ownerId=2 — dev/test only, no-op in prod)
+ *  18. self-aware    (BCONFIG: SELF_AWARE flags, ownerId=0 — default ON)
+ *  19. demo-widget   (BCONFIG: example widget for ownerId=2 — dev/test only, no-op in prod)
  *
  * Wired into the Docker entrypoint after `doctrine:migrations:migrate`, so it runs
  * on every container startup in dev AND prod.
@@ -85,6 +87,7 @@ final class SeedAllCommand extends Command
         private readonly SavedTaskConfigSeeder $savedTaskConfigSeeder,
         private readonly FileContextConfigSeeder $fileContextConfigSeeder,
         private readonly DesktopAgentConfigSeeder $desktopAgentConfigSeeder,
+        private readonly SelfAwareConfigSeeder $selfAwareConfigSeeder,
     ) {
         parent::__construct();
     }
@@ -111,7 +114,8 @@ final class SeedAllCommand extends Command
             "  15. saved-tasks flag           (BCONFIG, group=SAVEDTASKS, ownerId=0 — default ON for new/local)\n".
             "  16. file-context flags         (BCONFIG, group=FILE_CONTEXT, ownerId=0 — default OFF)\n".
             "  17. desktop-agent flag         (BCONFIG, group=DESKTOP_AGENT, ownerId=0 — default OFF until GA)\n".
-            "  18. demo widget config         (BCONFIG, group=widget_1, ownerId=2 — dev/test only)\n\n".
+            "  18. self-aware flags           (BCONFIG, group=SELF_AWARE, ownerId=0 — default ON)\n".
+            "  19. demo widget config         (BCONFIG, group=widget_1, ownerId=2 — dev/test only)\n\n".
             'All steps are idempotent and safe to run on every deploy. The demo-widget step is a no-op in prod.'
         );
     }
@@ -140,6 +144,7 @@ final class SeedAllCommand extends Command
             ['saved-tasks', fn (): SeedResult => $this->savedTaskConfigSeeder->seed()],
             ['file-context', fn (): SeedResult => $this->fileContextConfigSeeder->seed()],
             ['desktop-agent', fn (): SeedResult => $this->desktopAgentConfigSeeder->seed()],
+            ['self-aware', fn (): SeedResult => $this->selfAwareConfigSeeder->seed()],
             ['demo-widget', fn (): SeedResult => $this->demoWidgetConfigSeeder->seed()],
         ];
 

--- a/backend/src/Command/SelfAwareEvalCommand.php
+++ b/backend/src/Command/SelfAwareEvalCommand.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Entity\Message;
+use App\Service\Message\Handler\ChatHandler;
+use App\Service\Message\MessageClassifier;
+use App\Service\SelfAware\Eval\SelfAwareEvalAssertions;
+use App\Service\SelfAware\Eval\SelfAwareEvalCorpus;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+/**
+ * Live-model evaluation of platform self-awareness (routing + answer text).
+ *
+ * Not part of `make test` — needs a chat model. Release spot-check:
+ *
+ *   php bin/console app:selfaware:eval --install=no_engine
+ *   php bin/console app:selfaware:eval --install=full
+ */
+#[AsCommand(
+    name: 'app:selfaware:eval',
+    description: 'Evaluate self-aware routing and answers against the frozen question set (live model)',
+)]
+final class SelfAwareEvalCommand extends Command
+{
+    private const DEFAULT_CORPUS = 'tests/Eval/self_aware_eval_corpus.json';
+
+    public function __construct(
+        private readonly MessageClassifier $classifier,
+        private readonly ChatHandler $chatHandler,
+        #[Autowire('%kernel.project_dir%')]
+        private readonly string $projectDir,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('corpus', null, InputOption::VALUE_REQUIRED, 'Path to the corpus JSON', self::DEFAULT_CORPUS)
+            ->addOption('only', null, InputOption::VALUE_REQUIRED, 'Comma-separated row ids (Q1,N2)')
+            ->addOption('install', null, InputOption::VALUE_REQUIRED, 'Only rows for this install profile (no_keys|no_engine|full)')
+            ->addOption('report', null, InputOption::VALUE_REQUIRED, 'json or table', 'table')
+            ->addOption('routing-only', null, InputOption::VALUE_NONE, 'Assert classification only (no live chat call)')
+            ->addOption('user', null, InputOption::VALUE_REQUIRED, 'User id for inventory + chat', '2');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $corpusPath = (string) $input->getOption('corpus');
+        if (!str_starts_with($corpusPath, '/')) {
+            $corpusPath = $this->projectDir.'/'.$corpusPath;
+        }
+
+        try {
+            $rows = SelfAwareEvalCorpus::select(
+                SelfAwareEvalCorpus::load($corpusPath),
+                $input->getOption('only'),
+                $input->getOption('install'),
+            );
+        } catch (\InvalidArgumentException $e) {
+            $io->error($e->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        $routingOnly = (bool) $input->getOption('routing-only');
+        $userId = (int) $input->getOption('user');
+        $passed = 0;
+        $failed = 0;
+        $skipped = 0;
+        $table = [];
+
+        foreach ($rows as $row) {
+            $id = $row['id'];
+            $expect = $row['expect'];
+            $message = new Message();
+            $message->setUserId($userId);
+            $message->setTrackingId(0);
+            $message->setText($row['text']);
+            $message->setLanguage($row['lang']);
+            $message->setDirection('IN');
+            $message->setUnixTimestamp(time());
+            $message->setDateTime(date('YmdHis'));
+
+            try {
+                $classification = $this->classifier->classify($message);
+            } catch (\Throwable $e) {
+                ++$failed;
+                $table[] = [$id, 'FAIL', 'classify: '.$e->getMessage()];
+                continue;
+            }
+
+            $topic = (string) ($classification['topic'] ?? '');
+            if (!SelfAwareEvalAssertions::topicMatches($topic, $expect)) {
+                ++$failed;
+                $table[] = [$id, 'FAIL', sprintf('topic=%s expected=%s', $topic, (string) ($expect['topic'] ?? ''))];
+                continue;
+            }
+
+            if ($routingOnly || str_starts_with($id, 'W') || str_starts_with($id, 'N')) {
+                ++$passed;
+                $table[] = [$id, 'PASS', 'topic='.$topic];
+                continue;
+            }
+
+            try {
+                $response = $this->chatHandler->handle($message, [], $classification, null, []);
+                $answer = is_string($response['content'] ?? null) ? $response['content'] : '';
+            } catch (\Throwable $e) {
+                ++$failed;
+                $table[] = [$id, 'FAIL', 'chat: '.$e->getMessage()];
+                continue;
+            }
+
+            $answerFails = SelfAwareEvalAssertions::answerFailures($answer, $expect);
+            if ([] !== $answerFails) {
+                ++$failed;
+                $table[] = [$id, 'FAIL', implode('; ', $answerFails)];
+                continue;
+            }
+
+            ++$passed;
+            $table[] = [$id, 'PASS', 'topic='.$topic];
+        }
+
+        if ([] === $rows) {
+            ++$skipped;
+        }
+
+        if ('json' === $input->getOption('report')) {
+            $io->writeln(json_encode([
+                'passed' => $passed,
+                'failed' => $failed,
+                'skipped' => $skipped,
+                'rows' => $table,
+            ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES));
+        } else {
+            $io->table(['Id', 'Result', 'Detail'], $table);
+            $io->writeln(sprintf('passed=%d failed=%d skipped=%d', $passed, $failed, $skipped));
+        }
+
+        return $failed > 0 ? Command::FAILURE : Command::SUCCESS;
+    }
+}

--- a/backend/src/Command/SelfAwareInventoryCommand.php
+++ b/backend/src/Command/SelfAwareInventoryCommand.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Service\SelfAware\CapabilityInventory;
+use App\Service\SelfAware\CapabilityReportRenderer;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Print the live capability block for a user. Admin debugging tool.
+ */
+#[AsCommand(
+    name: 'app:selfaware:inventory',
+    description: 'Print the live platform-capability prompt block for a user',
+)]
+final class SelfAwareInventoryCommand extends Command
+{
+    public function __construct(
+        private readonly CapabilityInventory $inventory,
+        private readonly CapabilityReportRenderer $renderer,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addOption('user', 'u', InputOption::VALUE_REQUIRED, 'User id to build the report for', '2');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $userId = (int) $input->getOption('user');
+        $report = $this->inventory->build($userId);
+        $io->writeln($this->renderer->render($report));
+        $io->newLine();
+        $io->writeln(sprintf(
+            'facts=%d billing=%s admin=%s version=%s',
+            count($report->facts),
+            $report->billingEnabled ? 'on' : 'off',
+            $report->isAdmin ? 'yes' : 'no',
+            $report->version,
+        ));
+
+        return Command::SUCCESS;
+    }
+}

--- a/backend/src/Command/SelfAwareSyncDocsCommand.php
+++ b/backend/src/Command/SelfAwareSyncDocsCommand.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Message\SyncPlatformDocsMessage;
+use App\Service\SelfAware\Docs\PlatformDocsSyncService;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+#[AsCommand(
+    name: 'app:selfaware:sync-docs',
+    description: 'Refresh the owner-0 SYSTEM:synaplan documentation corpus from the docs manifest',
+)]
+final class SelfAwareSyncDocsCommand extends Command
+{
+    public function __construct(
+        private readonly PlatformDocsSyncService $syncService,
+        private readonly MessageBusInterface $messageBus,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('force', null, InputOption::VALUE_NONE, 'Re-vectorize every page, ignoring hashes')
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Print the diff without writing vectors or state')
+            ->addOption('async', null, InputOption::VALUE_NONE, 'Dispatch SyncPlatformDocsMessage instead of running inline');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $force = (bool) $input->getOption('force');
+        $dryRun = (bool) $input->getOption('dry-run');
+
+        if ((bool) $input->getOption('async')) {
+            $this->messageBus->dispatch(new SyncPlatformDocsMessage(force: $force));
+            $io->success('Queued documentation sync on async_index.');
+
+            return Command::SUCCESS;
+        }
+
+        $result = $this->syncService->sync(force: $force, dryRun: $dryRun);
+
+        if ('skipped' === $result->status) {
+            $io->writeln('skipped: '.$result->reason);
+
+            return Command::SUCCESS;
+        }
+
+        $table = [];
+        foreach ($result->rows as $row) {
+            $table[] = [$row['slug'], $row['action'], (string) $row['chunks'], $row['message']];
+        }
+        if ([] !== $table) {
+            $io->table(['Slug', 'Action', 'Chunks', 'Message'], $table);
+        }
+
+        $io->writeln(sprintf(
+            'changed=%d unchanged=%d removed=%d failed=%d',
+            $result->changed,
+            $result->unchanged,
+            $result->removed,
+            $result->failed,
+        ));
+
+        if ($result->isFailed()) {
+            $io->error('Documentation sync failed: '.$result->reason);
+
+            return Command::FAILURE;
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/backend/src/Controller/AdminProviderKeysController.php
+++ b/backend/src/Controller/AdminProviderKeysController.php
@@ -11,6 +11,7 @@ use App\AI\Credential\ProviderKeyStore;
 use App\AI\Credential\ProviderKeyValidator;
 use App\Entity\User;
 use App\Repository\ConfigRepository;
+use App\Service\SelfAware\CapabilityInventory;
 use OpenApi\Attributes as OA;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -36,6 +37,7 @@ final class AdminProviderKeysController extends AbstractController
         private readonly ProviderDefaultsService $defaults,
         private readonly ConfigRepository $configRepository,
         private readonly ChatReadinessService $chatReadiness,
+        private readonly ?CapabilityInventory $capabilityInventory = null,
     ) {
     }
 
@@ -167,6 +169,7 @@ final class AdminProviderKeysController extends AbstractController
         // The setup banner reads a short-lived availability snapshot — drop it so
         // the new key takes effect on the next page load instead of up to 30 s later.
         $this->chatReadiness->invalidate();
+        $this->capabilityInventory?->forget();
 
         $defaultsApplied = false;
         if ($applyDefaults && ProviderDefaultsService::supports($provider)) {
@@ -231,6 +234,7 @@ final class AdminProviderKeysController extends AbstractController
             return $this->json(['error' => 'No stored key for this provider.'], Response::HTTP_NOT_FOUND);
         }
         $this->chatReadiness->invalidate();
+        $this->capabilityInventory?->forget();
 
         return $this->json([
             'success' => true,
@@ -316,6 +320,7 @@ final class AdminProviderKeysController extends AbstractController
 
         $applied = $this->defaults->applyGlobalDefaults($provider);
         $this->chatReadiness->invalidate();
+        $this->capabilityInventory?->forget();
 
         return $this->json([
             'success' => true,

--- a/backend/src/Controller/ChatController.php
+++ b/backend/src/Controller/ChatController.php
@@ -187,7 +187,7 @@ class ChatController extends AbstractController
      */
     private function stripToolCommandPrefix(string $text): string
     {
-        return preg_replace('/^\/(?:pic|vid|audio|tts|image|video|search)\s*/i', '', $text) ?? $text;
+        return preg_replace('/^\/(?:pic|vid|audio|tts|image|video|search|help)\s*/i', '', $text) ?? $text;
     }
 
     #[Route('', name: 'create', methods: ['POST'])]

--- a/backend/src/Controller/ConfigController.php
+++ b/backend/src/Controller/ConfigController.php
@@ -33,6 +33,8 @@ use App\Service\Plugin\PluginManager;
 use App\Service\RegistrationConfig;
 use App\Service\SavedTask\SavedTaskConfig;
 use App\Service\Search\BraveSearchService;
+use App\Service\SelfAware\CapabilityInventory;
+use App\Service\SelfAware\SelfAwareConfig;
 use App\Service\Setup\SetupStateService;
 use App\Service\UsageTaximeterConfig;
 use App\Service\UserMemoryService;
@@ -85,6 +87,8 @@ class ConfigController extends AbstractController
         private CapabilityService $capabilityService,
         #[Autowire('%env(string:default::QDRANT_URL)%')]
         private readonly string $qdrantUrl,
+        private readonly ?SelfAwareConfig $selfAwareConfig = null,
+        private readonly ?CapabilityInventory $capabilityInventory = null,
     ) {
     }
 
@@ -169,6 +173,7 @@ class ConfigController extends AbstractController
                         new OA\Property(property: 'help', type: 'boolean', example: true, description: 'Enable help system'),
                         new OA\Property(property: 'memoryService', type: 'boolean', example: true, description: 'Qdrant vector database availability'),
                         new OA\Property(property: 'savedTasks', type: 'boolean', example: false, description: 'When true, AI Instructions shows Saved Task chrome. Widget chat never runs Saved Tasks.'),
+                        new OA\Property(property: 'selfAware', type: 'boolean', example: true, description: 'When true, the web chat can answer what this installation can do and cite official documentation. Off restores the previous chat behaviour.'),
                         new OA\Property(property: 'desktopAgentEnabled', type: 'boolean', example: false, description: 'When true, the Synaplan Desktop pairing surface (Channels → Desktop) and desktop job APIs are exposed. Off by default until the desktop client ships (server-first rollout).'),
                     ]
                 ),
@@ -467,6 +472,7 @@ class ConfigController extends AbstractController
             'memoryService' => !empty($_ENV['QDRANT_URL']), // Just check if configured, not if reachable
             'savedTasks' => $this->savedTaskConfig->isEnabled($user?->getId()),
             'desktopAgentEnabled' => $this->desktopAgentConfig->isEnabled($user?->getId()),
+            'selfAware' => null !== $this->selfAwareConfig && $this->selfAwareConfig->isEnabled($user?->getId()),
         ];
 
         // Speech-to-text configuration
@@ -1276,6 +1282,8 @@ class ConfigController extends AbstractController
         if ($vectorizeChanged) {
             $this->embeddingMetadata->invalidate();
         }
+
+        $this->capabilityInventory?->forget($global ? null : $user->getId());
 
         $response = [
             'success' => true,

--- a/backend/src/Controller/SharedChatPageController.php
+++ b/backend/src/Controller/SharedChatPageController.php
@@ -167,7 +167,7 @@ class SharedChatPageController extends AbstractController
      */
     private function cleanSlashCommands(string $text): string
     {
-        return preg_replace('/^\/(?:pic|vid|audio|tts|image|video)\s*/i', '', $text);
+        return preg_replace('/^\/(?:pic|vid|audio|tts|image|video|search|help)\s*/i', '', $text);
     }
 
     /**

--- a/backend/src/Controller/StreamController.php
+++ b/backend/src/Controller/StreamController.php
@@ -256,7 +256,7 @@ class StreamController extends AbstractController
     #[OA\Get(
         path: '/api/v1/messages/stream',
         summary: 'Stream AI chat response',
-        description: 'Stream AI chat messages with Server-Sent Events (SSE). Supports reasoning models, web search, and file attachments. NOTE: the message rides in the URL, so long texts can exceed proxy request-line limits (HTTP 431/414) — prefer the POST variant for anything beyond a few KB.',
+        description: 'Stream AI chat messages with Server-Sent Events (SSE). Supports reasoning models, web search, and file attachments. Status events include memories_loaded and docs_loaded (documentation citations for the synaplan topic). NOTE: the message rides in the URL, so long texts can exceed proxy request-line limits (HTTP 431/414) — prefer the POST variant for anything beyond a few KB.',
         security: [['Bearer' => []]],
         tags: ['Messages']
     )]
@@ -1797,6 +1797,10 @@ class StreamController extends AbstractController
                     $outgoingMessage->setMeta('ai_chat_usage', json_encode($response['metadata']['usage']));
                 }
 
+                if (isset($response['metadata']['docs']) && is_array($response['metadata']['docs']) && [] !== $response['metadata']['docs']) {
+                    $outgoingMessage->setMeta('docs', json_encode($response['metadata']['docs'], JSON_UNESCAPED_SLASHES));
+                }
+
                 if (!empty($response['metadata']['response_id'])) {
                     $outgoingMessage->setMeta('openai_response_id', $response['metadata']['response_id']);
                 }
@@ -2141,6 +2145,10 @@ class StreamController extends AbstractController
                     $this->logger->info('StreamController: Including memory IDs in complete event', [
                         'count' => count($response['metadata']['memories']),
                     ]);
+                }
+
+                if (isset($response['metadata']['docs']) && is_array($response['metadata']['docs']) && [] !== $response['metadata']['docs']) {
+                    $completeData['docs'] = $response['metadata']['docs'];
                 }
 
                 // Include feedbacks used for this response
@@ -2721,6 +2729,10 @@ class StreamController extends AbstractController
                 $outgoingMessage->setMeta('ai_chat_usage', json_encode($metadata['usage']));
             }
 
+            if (isset($metadata['docs']) && is_array($metadata['docs']) && [] !== $metadata['docs']) {
+                $outgoingMessage->setMeta('docs', json_encode($metadata['docs'], JSON_UNESCAPED_SLASHES));
+            }
+
             if (!empty($metadata['response_id'])) {
                 $outgoingMessage->setMeta('openai_response_id', $metadata['response_id']);
             }
@@ -2900,6 +2912,11 @@ class StreamController extends AbstractController
 
             if (isset($metadata['memories']) && is_array($metadata['memories'])) {
                 $completeData['memoryIds'] = array_map(fn ($memory) => $memory['id'], $metadata['memories']);
+            }
+
+            if (isset($metadata['docs']) && is_array($metadata['docs']) && [] !== $metadata['docs']) {
+                $completeData['docs'] = $metadata['docs'];
+                $outgoingMessage->setMeta('docs', json_encode($metadata['docs'], JSON_UNESCAPED_SLASHES));
             }
 
             if (isset($metadata['feedbacks']) && is_array($metadata['feedbacks'])) {

--- a/backend/src/Message/SyncPlatformDocsMessage.php
+++ b/backend/src/Message/SyncPlatformDocsMessage.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Message;
+
+/**
+ * Refresh the owner-0 / SYSTEM:synaplan documentation corpus.
+ *
+ * Dispatched when `app:updates:check` records a new published version;
+ * the daily scheduler also runs the command directly.
+ */
+final readonly class SyncPlatformDocsMessage
+{
+    public function __construct(
+        public bool $force = false,
+    ) {
+    }
+}

--- a/backend/src/MessageHandler/SyncPlatformDocsMessageHandler.php
+++ b/backend/src/MessageHandler/SyncPlatformDocsMessageHandler.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MessageHandler;
+
+use App\Message\SyncPlatformDocsMessage;
+use App\Service\SelfAware\Docs\PlatformDocsSyncService;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+#[AsMessageHandler]
+final readonly class SyncPlatformDocsMessageHandler
+{
+    public function __construct(
+        private PlatformDocsSyncService $syncService,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function __invoke(SyncPlatformDocsMessage $message): void
+    {
+        $result = $this->syncService->sync(force: $message->force);
+        $this->logger->info('Platform docs sync finished', [
+            'status' => $result->status,
+            'changed' => $result->changed,
+            'unchanged' => $result->unchanged,
+            'removed' => $result->removed,
+            'failed' => $result->failed,
+            'reason' => $result->reason,
+        ]);
+    }
+}

--- a/backend/src/Prompt/PromptCatalog.php
+++ b/backend/src/Prompt/PromptCatalog.php
@@ -27,6 +27,7 @@ class PromptCatalog
      *
      *  Routing topics (offered to the AI sorter / DYNAMICLIST):
      *    - general             ← smalltalk, lifestyle, coding, technical Q&A, everything that resolves to a chat answer
+     *    - synaplan            ← questions about Synaplan itself (what it can do, how to use a feature)
      *    - mediamaker          ← create/edit images, videos and audio
      *    - docsummary          ← summarize a document or attached file text
      *    - officemaker         ← generate XLSX/DOCX/PPTX/CSV documents
@@ -66,6 +67,12 @@ class PromptCatalog
                 //     be WebSearchTopicPolicy rule 1, a hard disable that
                 //     even beats the per-message toggle.
                 'metadata' => ['tool_mcp' => '1'],
+            ],
+            [
+                'topic' => 'synaplan',
+                'language' => 'en',
+                'shortDescription' => 'Questions about Synaplan itself: what it can and cannot do, how to use a feature (files, widgets, channels, plugins, desktop, API), what is new, plans and pricing, "what are you / are you ChatGPT". NOT for doing the task — a request to *create* something goes to the topic that creates it.',
+                'prompt' => self::synaplanPrompt(),
             ],
             [
                 'topic' => 'mediamaker',
@@ -256,13 +263,12 @@ You answer the user's question. That's it. Be direct, accurate, and on-point.
    delivered with this reply (in which case the system attaches it — you
    never write the URL yourself).
 
-3. If the user asks for an MP3, audio, image, video, document, spreadsheet,
-   slide deck, calendar invite, or any file output, you are NOT the right
-   tool to deliver it. Reply briefly in the user's language with: "I can
-   write the text for you, but to deliver it as <format> I need to use the
-   <format> generator — please rephrase as 'create/generate ...' so the
-   request goes to the right tool." Then stop. Do NOT pretend to attach
-   anything.
+3. If the user asks for a file (audio, image, video, document, spreadsheet,
+   slide deck, calendar invite): check the PLATFORM CAPABILITIES block. If
+   the format is AVAILABLE NOW, reply that you will write the text and ask
+   the user to rephrase as "create/generate …" so the request reaches the
+   generator. If it is NEEDS SETUP or NOT AVAILABLE, say so in one sentence
+   and offer the listed alternative. Never pretend to attach anything.
 
 4. If the user asks for current information you don't have (news, prices,
    weather, recent events), say so plainly. The system handles web search
@@ -280,9 +286,65 @@ You answer the user's question. That's it. Be direct, accurate, and on-point.
 - Short paragraphs. Use markdown for structure (lists, bold) when it helps;
   plain prose when it doesn't.
 - No JSON, no code fences around your answer text.
-- No meta-commentary about being an AI, your limitations, or your training.
+- No meta-commentary about being an AI or your training — except when the
+  user asks what you can do; then answer from the PLATFORM CAPABILITIES block.
+
+[PLATFORM_CAPABILITIES]
 
 Respond with plain text directly to the user.
+PROMPT;
+    }
+
+    private static function synaplanPrompt(): string
+    {
+        return <<<'PROMPT'
+# Synaplan — questions about this product
+
+You are Synaplan, an AI knowledge assistant. The user is asking what you
+can do, how a feature works, what is new, or who/what you are. Answer
+from the PLATFORM CAPABILITIES block and, when present, the Documentation
+context. If neither covers the question, say so and point the user to the
+documentation site. Never invent capabilities, prices, or file links.
+
+## Hard rules (non-negotiable)
+
+1. NEVER fabricate a download link, file URL, attachment, or any reference to
+   a file that does not actually exist in this turn. Do NOT write fake URLs
+   like `https://files.example.com/...`, `https://example.com/...mp3`,
+   `/uploads/...`, blob URLs, or "click here to download". If you cannot
+   produce a real file in this turn, you MUST say so plainly.
+
+2. NEVER claim you have done something you did not do. Do NOT write phrases
+   like "I have recorded", "I have attached", "Here is the MP3", "I have
+   saved the file", "Here is the audio", "Du kannst die MP3 hier anhören",
+   or any equivalent in any language, unless a real file is genuinely being
+   delivered with this reply (in which case the system attaches it — you
+   never write the URL yourself).
+
+3. Never quote prices, plan limits, or quotas. When billing is mentioned in
+   the capabilities block, link the pricing page and stop. Otherwise say
+   plans are not configured here.
+
+4. You cannot compose or produce music. If the user asks for a song, say so
+   and offer original lyrics in the requested style. Mention reading them
+   aloud only when text-to-speech is listed as AVAILABLE NOW.
+
+5. Admin hints in the capabilities block are for administrators. Non-admins
+   get "ask your administrator" — never invent a settings path.
+
+6. Answer in the user's language. If the directive at the bottom of the
+   system prompt names a language, follow it exactly.
+
+## Style
+
+- Short. Use bullets when listing what is available.
+- A "no" always ends with the listed alternative.
+- Cite documentation as [Doc:slug] when the Documentation context is present.
+  One slug per bracket. Never invent slugs or URLs.
+
+[PLATFORM_CAPABILITIES]
+
+[PLATFORM_DOCS]
 PROMPT;
     }
 
@@ -333,6 +395,12 @@ This is the list, use only this:
    - "Make a video invitation for a company retreat, and write the schedule below it" → BTOPIC: "mediamaker", BMEDIA: "video"
    - "Create an image of a mountain and write a short story about it" → BTOPIC: "mediamaker", BMEDIA: "image"
    - "Write a poem and read it to me as MP3" → BTOPIC: "mediamaker", BMEDIA: "audio"
+
+   **Questions about Synaplan itself** — whether it can do something
+   ("can you make PDFs?", "kannst du Videos erstellen?"), how a feature
+   works, what is new, what it costs, who/what it is → BTOPIC "synaplan".
+   A request to actually produce the thing ("create a PDF of this text") is
+   NOT a question about Synaplan — route it to the topic that produces it.
 
 3. **Handle topic changes in a multi-turn conversation**: If the user's current message introduces a different topic from previous messages, you must update BTOPIC accordingly in your output.
 
@@ -762,7 +830,10 @@ Allowed topic keys: [KEYLIST]
    emit `mcp_action` for read-only questions (use `mcp_fetch`), and NEVER
    emit it when it is not in the capability list.
 10. Plain question / smalltalk / advice → one `chat` node. `reply_node` = that
-   node, no `compose_reply` needed.
+   node, no `compose_reply` needed. A question about Synaplan itself
+   (what it can do, how a feature works, what is new, who/what it is) is
+   still one `chat` node, with `topic_id: "synaplan"`. Never use that
+   question as the reply node for `email_me`.
 11. A SINGLE media request with no follow-up step ("make an image of X",
     "generate a video of Y", "read this aloud", "make an excel table") → ONE
     generator node (`image_generation` / `video_generation` / `text2sound` /
@@ -1090,7 +1161,19 @@ User: "Wer bist du?"
   "language": "de",
   "reply_node": "n1",
   "tasks": [
-    { "id": "n1", "capability": "chat", "inputs": { "text": "$message.text" }, "params": { "topic_id": "general" } }
+    { "id": "n1", "capability": "chat", "inputs": { "text": "$message.text" }, "params": { "topic_id": "synaplan" } }
+  ]
+}
+
+### Question about Synaplan itself
+User: "Can you create PDFs?"
+
+{
+  "version": 1,
+  "language": "en",
+  "reply_node": "n1",
+  "tasks": [
+    { "id": "n1", "capability": "chat", "inputs": { "text": "$message.text" }, "params": { "topic_id": "synaplan" } }
   ]
 }
 

--- a/backend/src/Seed/SelfAwareConfigSeeder.php
+++ b/backend/src/Seed/SelfAwareConfigSeeder.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Seed;
+
+use App\Service\SelfAware\SelfAwareConfig;
+use Doctrine\DBAL\Connection;
+
+/**
+ * Idempotent seeder for SELF_AWARE flags (BCONFIG, ownerId=0).
+ *
+ * Insert-if-missing only — operator overrides are never touched.
+ */
+final readonly class SelfAwareConfigSeeder
+{
+    public function __construct(
+        private Connection $connection,
+    ) {
+    }
+
+    public function seed(): SeedResult
+    {
+        $rows = [
+            [
+                'ownerId' => 0,
+                'group' => SelfAwareConfig::CONFIG_GROUP,
+                'setting' => SelfAwareConfig::KEY_ENABLED,
+                'value' => '1',
+            ],
+            [
+                'ownerId' => 0,
+                'group' => SelfAwareConfig::CONFIG_GROUP,
+                'setting' => SelfAwareConfig::KEY_INVENTORY_IN_GENERAL,
+                'value' => '1',
+            ],
+            [
+                'ownerId' => 0,
+                'group' => SelfAwareConfig::CONFIG_GROUP,
+                'setting' => SelfAwareConfig::KEY_DOCS_RAG_ENABLED,
+                'value' => '1',
+            ],
+            [
+                'ownerId' => 0,
+                'group' => SelfAwareConfig::CONFIG_GROUP,
+                'setting' => SelfAwareConfig::KEY_DOCS_MANIFEST_URL,
+                'value' => SelfAwareConfig::DEFAULT_DOCS_MANIFEST_URL,
+            ],
+        ];
+
+        return BConfigSeeder::insertIfMissing($this->connection, 'self_aware_config', $rows);
+    }
+}

--- a/backend/src/Service/Knowledge/KnowledgeContextFormatter.php
+++ b/backend/src/Service/Knowledge/KnowledgeContextFormatter.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Service\Knowledge;
 
+use App\Service\SelfAware\Docs\PlatformDocsHits;
+
 /**
  * Shared wording for RAG / memory context blocks injected into prompts.
  *
@@ -78,6 +80,29 @@ final class KnowledgeContextFormatter
         $memoriesContext .= "- Only use IDs from the list above. Never invent IDs.\n";
 
         return $memoriesContext;
+    }
+
+    public function formatPlatformDocsContext(PlatformDocsHits $hits): string
+    {
+        if ($hits->isEmpty()) {
+            return '';
+        }
+
+        $block = "\n\n## Synaplan documentation (relevant to this question):\n";
+        foreach ($hits->hits as $hit) {
+            $block .= sprintf(
+                "[Doc:%s] %s — %s\n",
+                $hit->slug,
+                $hit->title,
+                trim($hit->text),
+            );
+        }
+        $block .= "\nUse only what is written above for how-to and feature questions. REFERENCES: cite the page you used as [Doc:slug] (clickable). Rules:\n";
+        $block .= "- ONE slug per bracket. Good: [Doc:channels] and [Doc:widget]. Bad: [Doc:channels, widget].\n";
+        $block .= "- Only slugs from the list above. Never invent slugs or URLs.\n";
+        $block .= "- If the documentation does not answer the question, say so and refer the user to the documentation site instead of guessing.\n";
+
+        return $block;
     }
 
     /**

--- a/backend/src/Service/Message/Handler/ChatHandler.php
+++ b/backend/src/Service/Message/Handler/ChatHandler.php
@@ -38,11 +38,15 @@ use App\Service\Prompt\TimeContextBuilder;
 use App\Service\PromptService;
 use App\Service\RAG\VectorSearchService;
 use App\Service\RateLimitService;
+use App\Service\SelfAware\Docs\PlatformDocsRetriever;
+use App\Service\SelfAware\SelfAwareConfig;
+use App\Service\SelfAware\SelfAwarePromptDecorator;
 use App\Service\UserMemoryService;
 use App\Service\Vision\VisionModelResolver;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 /**
  * Chat Handler - Normaler Konversations-Chat.
@@ -102,6 +106,10 @@ final readonly class ChatHandler implements MessageHandlerInterface
         private ConversationFileCatalog $conversationFileCatalog,
         private GeneratedImageVisionFlag $generatedImageVisionFlag,
         iterable $pluginContextProviders = [],
+        #[Autowire(lazy: true)]
+        private ?SelfAwarePromptDecorator $selfAwarePromptDecorator = null,
+        #[Autowire(lazy: true)]
+        private ?PlatformDocsRetriever $platformDocsRetriever = null,
     ) {
         $this->pluginContextProviders = $pluginContextProviders;
     }
@@ -406,6 +414,11 @@ final readonly class ChatHandler implements MessageHandlerInterface
             ]);
         }
 
+        $docsList = [];
+        $decorated = $this->decorateSelfAwarePrompt($systemPrompt, $topic, $message, $classification, $options, $progressCallback);
+        $systemPrompt = $decorated['prompt'];
+        $docsList = $decorated['docs'];
+
         if (!empty($ragContext)) {
             $systemPrompt .= $ragContext;
             $this->logger->info('ChatHandler: RAG context appended to system prompt', [
@@ -709,6 +722,7 @@ final readonly class ChatHandler implements MessageHandlerInterface
                 'memories' => $loadedMemories,
                 'feedbacks' => $loadedFeedbacks,
                 'digests' => $loadedDigests,
+                'docs' => $docsList,
                 'extraction_payload' => $deferExtraction ? $extractionPayload : null,
             ]),
         ];
@@ -1008,6 +1022,11 @@ final readonly class ChatHandler implements MessageHandlerInterface
                 'prompt_length' => strlen($systemPrompt),
             ]);
         }
+
+        $docsList = [];
+        $decorated = $this->decorateSelfAwarePrompt($systemPrompt, $topic, $message, $classification, $options, $progressCallback);
+        $systemPrompt = $decorated['prompt'];
+        $docsList = $decorated['docs'];
 
         // Append RAG context to system prompt if available
         if (!empty($ragContext)) {
@@ -1348,8 +1367,73 @@ final readonly class ChatHandler implements MessageHandlerInterface
                 'memories' => $loadedMemories,
                 'feedbacks' => $loadedFeedbacks,
                 'digests' => $loadedDigests,
+                'docs' => $docsList,
                 'extraction_payload' => $deferExtraction ? $extractionPayload : null,
             ],
+        ];
+    }
+
+    /**
+     * Replace or strip `[PLATFORM_CAPABILITIES]` / `[PLATFORM_DOCS]` after the
+     * topic prompt is loaded and before RAG/memories are appended.
+     *
+     * @param array<string, mixed> $classification
+     * @param array<string, mixed> $options
+     *
+     * @return array{prompt: string, docs: list<array{slug: string, title: string, url: string}>}
+     */
+    private function decorateSelfAwarePrompt(
+        string $systemPrompt,
+        string $topic,
+        Message $message,
+        array $classification,
+        array $options,
+        ?callable $progressCallback,
+    ): array {
+        $docsList = [];
+        if (null === $this->selfAwarePromptDecorator) {
+            return ['prompt' => $systemPrompt, 'docs' => $docsList];
+        }
+
+        $isWidget = SelfAwarePromptDecorator::isWidgetConversation($classification, $options);
+        $docsHits = null;
+        if (SelfAwareConfig::ROUTABLE_TOPIC === $topic && null !== $this->platformDocsRetriever && !$isWidget) {
+            $query = trim($message->getText());
+            if ('' === $query || 1 === preg_match('/^\/help\b/i', $query)) {
+                $query = 'What can you do here?';
+            }
+            try {
+                $docsHits = $this->platformDocsRetriever->retrieve($query, $message->getUserId());
+                $docsList = $docsHits->toClientList();
+            } catch (\Throwable $e) {
+                $this->logger->warning('ChatHandler: Platform docs retrieval failed, continuing without', [
+                    'error' => $e->getMessage(),
+                ]);
+                $docsHits = null;
+                $docsList = [];
+            }
+            if ([] !== $docsList && null !== $progressCallback) {
+                $progressCallback([
+                    'status' => 'docs_loaded',
+                    'message' => 'Documentation loaded',
+                    'metadata' => [
+                        'docs' => $docsList,
+                        'count' => count($docsList),
+                    ],
+                    'timestamp' => time(),
+                ]);
+            }
+        }
+
+        return [
+            'prompt' => $this->selfAwarePromptDecorator->apply(
+                $systemPrompt,
+                $topic,
+                $message->getUserId(),
+                $isWidget,
+                $docsHits,
+            ),
+            'docs' => $docsList,
         ];
     }
 

--- a/backend/src/Service/Message/MessageClassifier.php
+++ b/backend/src/Service/Message/MessageClassifier.php
@@ -9,6 +9,7 @@ use App\Repository\MessageMetaRepository;
 use App\Service\File\ConversationFile;
 use App\Service\File\FileTypeResolver;
 use App\Service\ModelConfigService;
+use App\Service\SelfAware\SelfAwareConfig;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 
@@ -38,7 +39,18 @@ final readonly class MessageClassifier
         '/web' => 'tools:web',
         '/list' => 'tools:list',
         '/docs' => 'tools:filesort',
+        '/help' => 'synaplan',
     ];
+
+    /**
+     * Meta-questions about this product (EN/DE/ES/FR/TR). A match only
+     * defers to the AI sorter — it never routes by itself.
+     *
+     * Languages: can you / what can you (en), kannst du / was kannst (de),
+     * puedes / qué puedes (es), peux-tu / que peux (fr), yapabilir misin /
+     * ne yapabilirsin (tr), plus the word "synaplan".
+     */
+    private const SELF_AWARE_GUARD_PATTERN = '/(?:can you|what can you|kannst du|was kannst|puedes|qu[eé] puedes|peux-tu|que peux|yapabilir misin|ne yapabilirsin|synaplan)/iu';
 
     public function __construct(
         private MessageSorter $messageSorter,
@@ -47,6 +59,7 @@ final readonly class MessageClassifier
         private ConfigRepository $configRepository,
         private EntityManagerInterface $em,
         private LoggerInterface $logger,
+        private ?SelfAwareConfig $selfAwareConfig = null,
     ) {
     }
 
@@ -626,6 +639,13 @@ final readonly class MessageClassifier
         // Tool prefixes are already handled earlier in classify(); be defensive
         // in case the order changes.
         if (str_starts_with($trimmed, '/')) {
+            return false;
+        }
+
+        if (null !== $this->selfAwareConfig
+            && $this->selfAwareConfig->isEnabled($message->getUserId() > 0 ? $message->getUserId() : null)
+            && 1 === preg_match(self::SELF_AWARE_GUARD_PATTERN, $trimmed)
+        ) {
             return false;
         }
 

--- a/backend/src/Service/Message/MessageSorter.php
+++ b/backend/src/Service/Message/MessageSorter.php
@@ -11,6 +11,7 @@ use App\Service\File\ConversationFile;
 use App\Service\ModelConfigService;
 use App\Service\PromptService;
 use App\Service\RateLimitService;
+use App\Service\SelfAware\SelfAwareConfig;
 use App\Service\Usage\RecordedUsage;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
@@ -105,6 +106,7 @@ final readonly class MessageSorter
         private EntityManagerInterface $em,
         private LoggerInterface $logger,
         private DiscordNotificationService $discord,
+        private ?SelfAwareConfig $selfAwareConfig = null,
     ) {
     }
 
@@ -176,6 +178,16 @@ final readonly class MessageSorter
         // Get all available topics (exclude tools:* internal topics).
         $topics = $this->promptRepository->getAllTopics(0, $userId, excludeTools: true);
         $topicsWithDesc = $this->promptRepository->getTopicsWithDescriptions(0, '', $userId, excludeTools: true);
+        if (null !== $this->selfAwareConfig && !$this->selfAwareConfig->isEnabled($userId)) {
+            $topics = array_values(array_filter(
+                $topics,
+                static fn (string $topic): bool => SelfAwareConfig::ROUTABLE_TOPIC !== $topic,
+            ));
+            $topicsWithDesc = array_values(array_filter(
+                $topicsWithDesc,
+                static fn (array $item): bool => SelfAwareConfig::ROUTABLE_TOPIC !== ($item['topic'] ?? ''),
+            ));
+        }
 
         // Build dynamic list and key list for prompt
         $dynamicList = $this->buildDynamicList($topicsWithDesc);

--- a/backend/src/Service/Multitask/Execution/Runner/ChatRunner.php
+++ b/backend/src/Service/Multitask/Execution/Runner/ChatRunner.php
@@ -18,7 +18,11 @@ use App\Service\Multitask\Plan\TaskNode;
 use App\Service\Multitask\Skill\SkillDescriptor;
 use App\Service\PromptService;
 use App\Service\RAG\VectorSearchService;
+use App\Service\SelfAware\Docs\PlatformDocsRetriever;
+use App\Service\SelfAware\SelfAwareConfig;
+use App\Service\SelfAware\SelfAwarePromptDecorator;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 /**
  * Text-capability runner for `chat`, `summarize`, `translate`, `rag_query`.
@@ -48,6 +52,10 @@ final readonly class ChatRunner implements TaskRunner
         private KnowledgeContextFormatter $knowledgeContextFormatter,
         private PromptService $promptService,
         private LoggerInterface $logger,
+        #[Autowire(lazy: true)]
+        private ?SelfAwarePromptDecorator $selfAwarePromptDecorator = null,
+        #[Autowire(lazy: true)]
+        private ?PlatformDocsRetriever $platformDocsRetriever = null,
     ) {
     }
 
@@ -86,6 +94,7 @@ final readonly class ChatRunner implements TaskRunner
         $modelName = $modelId ? $this->modelConfigService->getModelName($modelId) : null;
 
         $systemPrompt = $this->systemPrompt($node, $language, $context, $topicBinding['systemPrompt']);
+        $systemPrompt = $this->decorateSelfAwareTopic($systemPrompt, $node, $context, $text);
         $ragChunks = 0;
         if (Capability::RagQuery === $node->capability) {
             $ragContext = $this->ragContext($text, $context, $ragChunks);
@@ -270,6 +279,46 @@ final readonly class ChatRunner implements TaskRunner
         $chunks = count($results);
 
         return $this->knowledgeContextFormatter->formatRagContext($results);
+    }
+
+    private function decorateSelfAwareTopic(string $systemPrompt, TaskNode $node, NodeContext $context, string $query): string
+    {
+        if (null === $this->selfAwarePromptDecorator) {
+            return $systemPrompt;
+        }
+
+        $topicId = $node->params['topic_id'] ?? null;
+        $topic = is_string($topicId) ? trim($topicId) : '';
+        $isWidget = SelfAwarePromptDecorator::isWidgetConversation(
+            $context->classification,
+            $context->options,
+        );
+        $docsHits = null;
+        if (SelfAwareConfig::ROUTABLE_TOPIC === $topic && null !== $this->platformDocsRetriever && !$isWidget) {
+            $retrievalQuery = trim($query);
+            if ('' === $retrievalQuery || 1 === preg_match('/^\/help\b/i', $retrievalQuery)) {
+                $retrievalQuery = 'What can you do here?';
+            }
+            try {
+                $docsHits = $this->platformDocsRetriever->retrieve(
+                    $retrievalQuery,
+                    $context->userId ?? $context->message->getUserId(),
+                );
+            } catch (\Throwable $e) {
+                $this->logger->warning('ChatRunner: Platform docs retrieval failed, continuing without', [
+                    'error' => $e->getMessage(),
+                ]);
+                $docsHits = null;
+            }
+        }
+
+        return $this->selfAwarePromptDecorator->apply(
+            $systemPrompt,
+            '' !== $topic ? $topic : 'general',
+            $context->userId ?? $context->message->getUserId(),
+            $isWidget,
+            $docsHits,
+        );
     }
 
     private function systemPrompt(TaskNode $node, string $language, NodeContext $context, ?string $topicPrompt = null): string

--- a/backend/src/Service/Multitask/TaskPlanner.php
+++ b/backend/src/Service/Multitask/TaskPlanner.php
@@ -16,6 +16,7 @@ use App\Service\Multitask\Skill\SkillCatalog;
 use App\Service\Prompt\TimeContextBuilder;
 use App\Service\PromptService;
 use App\Service\RateLimitService;
+use App\Service\SelfAware\SelfAwareConfig;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -58,6 +59,7 @@ final readonly class TaskPlanner
         private PromptService $promptService,
         private RateLimitService $rateLimitService,
         private ?PlannerChannelCatalog $channelCatalog = null,
+        private ?SelfAwareConfig $selfAwareConfig = null,
     ) {
     }
 
@@ -222,6 +224,16 @@ final readonly class TaskPlanner
     {
         $topics = $this->promptRepository->getAllTopics(0, $userId, excludeTools: true);
         $topicsWithDesc = $this->promptRepository->getTopicsWithDescriptions(0, '', $userId, excludeTools: true);
+        if (null !== $this->selfAwareConfig && !$this->selfAwareConfig->isEnabled($userId)) {
+            $topics = array_values(array_filter(
+                $topics,
+                static fn (string $topic): bool => SelfAwareConfig::ROUTABLE_TOPIC !== $topic,
+            ));
+            $topicsWithDesc = array_values(array_filter(
+                $topicsWithDesc,
+                static fn (array $item): bool => SelfAwareConfig::ROUTABLE_TOPIC !== ($item['topic'] ?? ''),
+            ));
+        }
 
         // Catalog-lite (release 4.0): the capability list is assembled from the
         // SkillDescriptors the runners declare — one source of truth per block.

--- a/backend/src/Service/SelfAware/CachedPlatformCapabilityInventory.php
+++ b/backend/src/Service/SelfAware/CachedPlatformCapabilityInventory.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\SelfAware;
+
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\DependencyInjection\Attribute\AsAlias;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+/**
+ * 5-minute per-user cache in front of {@see PlatformCapabilityInventory}.
+ *
+ * Key: `selfaware.inventory.{userId}.{isAdmin}.{epoch}`. A global
+ * {@see forget()} bumps the epoch so every cached report expires (provider
+ * keys and default-model saves).
+ */
+#[AsAlias(id: CapabilityInventory::class, public: true)]
+final readonly class CachedPlatformCapabilityInventory implements CapabilityInventory
+{
+    private const TTL_SECONDS = 300;
+    private const EPOCH_KEY = 'selfaware.inventory.epoch';
+
+    public function __construct(
+        private PlatformCapabilityInventory $inner,
+        #[Autowire(service: 'cache.app')]
+        private CacheItemPoolInterface $cache,
+    ) {
+    }
+
+    public function build(int $userId): CapabilityReport
+    {
+        $key = $this->itemKey($userId);
+        $item = $this->cache->getItem($key);
+        if ($item->isHit() && $item->get() instanceof CapabilityReport) {
+            return $item->get();
+        }
+
+        $probe = $this->inner->build($userId);
+        $item->set($probe);
+        $item->expiresAfter(self::TTL_SECONDS);
+        $this->cache->save($item);
+
+        return $probe;
+    }
+
+    public function forget(?int $userId = null): void
+    {
+        if (null !== $userId) {
+            $this->cache->deleteItem($this->itemKey($userId));
+
+            return;
+        }
+
+        $item = $this->cache->getItem(self::EPOCH_KEY);
+        $epoch = is_int($item->get()) ? $item->get() : 0;
+        $item->set($epoch + 1);
+        $this->cache->save($item);
+    }
+
+    private function itemKey(int $userId): string
+    {
+        $epochItem = $this->cache->getItem(self::EPOCH_KEY);
+        $epoch = is_int($epochItem->get()) ? $epochItem->get() : 0;
+
+        return sprintf('selfaware.inventory.%d.%d', $userId, $epoch);
+    }
+}

--- a/backend/src/Service/SelfAware/CapabilityFact.php
+++ b/backend/src/Service/SelfAware/CapabilityFact.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\SelfAware;
+
+/**
+ * One live (or known-absent) capability of this installation, for this user.
+ */
+final readonly class CapabilityFact
+{
+    public function __construct(
+        public string $id,
+        public string $label,
+        public CapabilityState $state,
+        public string $detail,
+        public ?string $alternative,
+        public ?string $adminHint,
+        public ?string $docsSlug,
+    ) {
+    }
+}

--- a/backend/src/Service/SelfAware/CapabilityInventory.php
+++ b/backend/src/Service/SelfAware/CapabilityInventory.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\SelfAware;
+
+/**
+ * Live per-install / per-user capability snapshot used by the self-aware chat.
+ */
+interface CapabilityInventory
+{
+    public function build(int $userId): CapabilityReport;
+
+    /**
+     * Drop cached reports. Pass a user id to invalidate that user only;
+     * omit it (or pass null) to bump the generation so every cached report
+     * expires (provider-key / default-model changes).
+     */
+    public function forget(?int $userId = null): void;
+}

--- a/backend/src/Service/SelfAware/CapabilityReport.php
+++ b/backend/src/Service/SelfAware/CapabilityReport.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\SelfAware;
+
+/**
+ * Snapshot of what this installation can do for one user, right now.
+ *
+ * @phpstan-type FactList list<CapabilityFact>
+ */
+final readonly class CapabilityReport
+{
+    /**
+     * @param list<CapabilityFact> $facts
+     */
+    public function __construct(
+        public array $facts,
+        public string $version,
+        public bool $billingEnabled,
+        public bool $isAdmin,
+    ) {
+    }
+
+    /**
+     * @return list<CapabilityFact>
+     */
+    public function byState(CapabilityState $state): array
+    {
+        $matched = [];
+        foreach ($this->facts as $fact) {
+            if ($fact->state === $state) {
+                $matched[] = $fact;
+            }
+        }
+
+        return $matched;
+    }
+
+    public function fact(string $id): ?CapabilityFact
+    {
+        foreach ($this->facts as $fact) {
+            if ($fact->id === $id) {
+                return $fact;
+            }
+        }
+
+        return null;
+    }
+}

--- a/backend/src/Service/SelfAware/CapabilityReportRenderer.php
+++ b/backend/src/Service/SelfAware/CapabilityReportRenderer.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\SelfAware;
+
+/**
+ * Compact, deterministic prompt block for a {@see CapabilityReport}.
+ *
+ * Budget: ≤ ~350 tokens (~1 400 characters at 4 chars/token).
+ */
+final readonly class CapabilityReportRenderer
+{
+    public const MAX_CHARS = 1400;
+
+    public function render(CapabilityReport $report): string
+    {
+        $available = $this->joinFacts($report->byState(CapabilityState::Available), includeAlternative: false);
+        $needsSetup = $this->joinNeedsSetup($report);
+        $absent = $this->joinFacts($report->byState(CapabilityState::Absent), includeAlternative: true);
+
+        $lines = [
+            '## This Synaplan installation (live, version '.$report->version.')',
+            'AVAILABLE NOW: '.('' !== $available ? $available : 'none'),
+            'NEEDS SETUP: '.('' !== $needsSetup ? $needsSetup : 'none'),
+            'NOT AVAILABLE: '.('' !== $absent ? $absent : 'none'),
+            $this->rulesLine($report),
+        ];
+
+        $block = implode("\n", $lines);
+        if (strlen($block) <= self::MAX_CHARS) {
+            return $block;
+        }
+
+        return substr($block, 0, self::MAX_CHARS - 1).'…';
+    }
+
+    /**
+     * @param list<CapabilityFact> $facts
+     */
+    private function joinFacts(array $facts, bool $includeAlternative): string
+    {
+        $parts = [];
+        foreach ($facts as $fact) {
+            $parts[] = $this->formatFact($fact, includeAlternative: $includeAlternative, includeAdminHint: false);
+        }
+
+        return implode(' · ', $parts);
+    }
+
+    private function joinNeedsSetup(CapabilityReport $report): string
+    {
+        $facts = $report->byState(CapabilityState::NeedsSetup);
+        if ([] === $facts) {
+            return '';
+        }
+
+        $parts = [];
+        foreach ($facts as $fact) {
+            $parts[] = $this->formatFact($fact, includeAlternative: false, includeAdminHint: $report->isAdmin);
+        }
+        $line = implode(' · ', $parts);
+        if (!$report->isAdmin) {
+            $line .= ' — ask your administrator';
+        }
+
+        return $line;
+    }
+
+    private function formatFact(CapabilityFact $fact, bool $includeAlternative, bool $includeAdminHint): string
+    {
+        $text = $fact->label;
+        if ('' !== $fact->detail && CapabilityState::Available === $fact->state) {
+            $text .= ' ('.$fact->detail.')';
+        } elseif ('' !== $fact->detail && CapabilityState::NeedsSetup === $fact->state) {
+            $text .= ' ('.$fact->detail.')';
+        }
+        if ($includeAlternative && null !== $fact->alternative && '' !== $fact->alternative) {
+            $text .= ' — alternative: '.$fact->alternative;
+        }
+        if ($includeAdminHint && null !== $fact->adminHint && '' !== $fact->adminHint) {
+            $text .= ' ('.$fact->adminHint.')';
+        }
+
+        return $text;
+    }
+
+    private function rulesLine(CapabilityReport $report): string
+    {
+        $rules = 'RULES: When asked whether you can do something, answer from the lists above and nothing else. '
+            .'Say plainly what is not available here and offer the closest alternative. '
+            .'Never promise, describe, or link a file you are not delivering in this turn. '
+            .'Never quote prices, plan limits or quotas.';
+        if ($report->billingEnabled) {
+            $rules .= ' For plans and pricing, link the pricing page.';
+        }
+
+        return $rules;
+    }
+}

--- a/backend/src/Service/SelfAware/CapabilityState.php
+++ b/backend/src/Service/SelfAware/CapabilityState.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\SelfAware;
+
+enum CapabilityState: string
+{
+    case Available = 'available';
+    case NeedsSetup = 'needs_setup';
+    case Absent = 'absent';
+}

--- a/backend/src/Service/SelfAware/Docs/DocsManifest.php
+++ b/backend/src/Service/SelfAware/Docs/DocsManifest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\SelfAware\Docs;
+
+/**
+ * Machine-readable export published by synaplan-docs (`synaplan-docs-manifest/1`).
+ */
+final readonly class DocsManifest
+{
+    public const SCHEMA_ID = 'synaplan-docs-manifest/1';
+
+    private const SLUG_PATTERN = '/^[a-z0-9-]{1,64}$/';
+
+    /**
+     * @param list<DocsPage> $pages
+     */
+    public function __construct(
+        public string $schema,
+        public string $generatedAt,
+        public string $siteUrl,
+        public string $version,
+        public array $pages,
+    ) {
+    }
+
+    /**
+     * @throws \InvalidArgumentException
+     */
+    public static function fromJson(string $json): self
+    {
+        try {
+            $data = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException $e) {
+            throw new \InvalidArgumentException('Docs manifest is not valid JSON: '.$e->getMessage(), 0, $e);
+        }
+        if (!is_array($data)) {
+            throw new \InvalidArgumentException('Docs manifest must be a JSON object.');
+        }
+
+        $schema = (string) ($data['schema'] ?? '');
+        if (self::SCHEMA_ID !== $schema) {
+            throw new \InvalidArgumentException(sprintf('Unsupported docs manifest schema "%s".', $schema));
+        }
+
+        $siteUrl = rtrim((string) ($data['site_url'] ?? ''), '/');
+        $siteHost = self::hostOf($siteUrl.'/', 'site_url');
+
+        $pages = [];
+        foreach ($data['pages'] ?? [] as $row) {
+            if (!is_array($row)) {
+                throw new \InvalidArgumentException('Each docs manifest page must be an object.');
+            }
+            $pages[] = self::pageFromArray($row, $siteHost);
+        }
+
+        return new self(
+            $schema,
+            (string) ($data['generated_at'] ?? ''),
+            $siteUrl,
+            (string) ($data['version'] ?? ''),
+            $pages,
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private static function pageFromArray(array $row, string $siteHost): DocsPage
+    {
+        $slug = (string) ($row['slug'] ?? '');
+        $url = (string) ($row['url'] ?? '');
+        $rawUrl = (string) ($row['raw_url'] ?? '');
+        $sha256 = (string) ($row['sha256'] ?? '');
+        if ('' === $slug || '' === $url || '' === $rawUrl || '' === $sha256) {
+            throw new \InvalidArgumentException('Docs manifest page is missing slug, url, raw_url or sha256.');
+        }
+        if (1 !== preg_match(self::SLUG_PATTERN, $slug)) {
+            throw new \InvalidArgumentException(sprintf('Invalid docs slug "%s".', $slug));
+        }
+        if (self::hostOf($rawUrl, 'raw_url') !== $siteHost) {
+            throw new \InvalidArgumentException(sprintf('raw_url for slug "%s" is not on the manifest host.', $slug));
+        }
+
+        return new DocsPage(
+            $slug,
+            (string) ($row['title'] ?? $slug),
+            (string) ($row['section'] ?? ''),
+            (string) ($row['description'] ?? ''),
+            $url,
+            $rawUrl,
+            $sha256,
+            (int) ($row['bytes'] ?? 0),
+            (string) ($row['updated_at'] ?? ''),
+        );
+    }
+
+    private static function hostOf(string $url, string $field): string
+    {
+        $host = parse_url($url, PHP_URL_HOST);
+        $scheme = parse_url($url, PHP_URL_SCHEME);
+        if (!is_string($host) || '' === $host || 'https' !== $scheme) {
+            throw new \InvalidArgumentException(sprintf('Docs manifest %s must be an https URL.', $field));
+        }
+
+        return strtolower($host);
+    }
+}

--- a/backend/src/Service/SelfAware/Docs/DocsManifest.php
+++ b/backend/src/Service/SelfAware/Docs/DocsManifest.php
@@ -79,6 +79,9 @@ final readonly class DocsManifest
         if (1 !== preg_match(self::SLUG_PATTERN, $slug)) {
             throw new \InvalidArgumentException(sprintf('Invalid docs slug "%s".', $slug));
         }
+        if (self::hostOf($url, 'url') !== $siteHost) {
+            throw new \InvalidArgumentException(sprintf('url for slug "%s" is not on the manifest host.', $slug));
+        }
         if (self::hostOf($rawUrl, 'raw_url') !== $siteHost) {
             throw new \InvalidArgumentException(sprintf('raw_url for slug "%s" is not on the manifest host.', $slug));
         }

--- a/backend/src/Service/SelfAware/Docs/DocsPage.php
+++ b/backend/src/Service/SelfAware/Docs/DocsPage.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\SelfAware\Docs;
+
+final readonly class DocsPage
+{
+    public function __construct(
+        public string $slug,
+        public string $title,
+        public string $section,
+        public string $description,
+        public string $url,
+        public string $rawUrl,
+        public string $sha256,
+        public int $bytes,
+        public string $updatedAt,
+    ) {
+    }
+}

--- a/backend/src/Service/SelfAware/Docs/DocsSyncResult.php
+++ b/backend/src/Service/SelfAware/Docs/DocsSyncResult.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\SelfAware\Docs;
+
+final readonly class DocsSyncResult
+{
+    /**
+     * @param list<array{slug: string, action: string, chunks: int, message: string}> $rows
+     */
+    public function __construct(
+        public string $status,
+        public int $changed,
+        public int $unchanged,
+        public int $removed,
+        public int $failed,
+        public array $rows,
+        public string $reason = '',
+    ) {
+    }
+
+    public static function skipped(string $reason): self
+    {
+        return new self('skipped', 0, 0, 0, 0, [], $reason);
+    }
+
+    public static function failed(string $reason): self
+    {
+        return new self('failed', 0, 0, 0, 0, [], $reason);
+    }
+
+    public function isFailed(): bool
+    {
+        return 'failed' === $this->status;
+    }
+}

--- a/backend/src/Service/SelfAware/Docs/PlatformDocsHit.php
+++ b/backend/src/Service/SelfAware/Docs/PlatformDocsHit.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\SelfAware\Docs;
+
+final readonly class PlatformDocsHit
+{
+    public function __construct(
+        public string $slug,
+        public string $title,
+        public string $url,
+        public string $section,
+        public string $text,
+        public float $score,
+    ) {
+    }
+
+    /**
+     * @return array{slug: string, title: string, url: string}
+     */
+    public function toClient(): array
+    {
+        return [
+            'slug' => $this->slug,
+            'title' => $this->title,
+            'url' => $this->url,
+        ];
+    }
+}

--- a/backend/src/Service/SelfAware/Docs/PlatformDocsHits.php
+++ b/backend/src/Service/SelfAware/Docs/PlatformDocsHits.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\SelfAware\Docs;
+
+final readonly class PlatformDocsHits
+{
+    /**
+     * @param list<PlatformDocsHit> $hits
+     */
+    public function __construct(
+        public array $hits,
+    ) {
+    }
+
+    public function isEmpty(): bool
+    {
+        return [] === $this->hits;
+    }
+
+    /**
+     * @return list<array{slug: string, title: string, url: string}>
+     */
+    public function toClientList(): array
+    {
+        $rows = [];
+        foreach ($this->hits as $hit) {
+            $rows[] = $hit->toClient();
+        }
+
+        return $rows;
+    }
+}

--- a/backend/src/Service/SelfAware/Docs/PlatformDocsManifestClient.php
+++ b/backend/src/Service/SelfAware/Docs/PlatformDocsManifestClient.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\SelfAware\Docs;
+
+use Symfony\Contracts\HttpClient\Exception\HttpExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * Fetches the docs manifest and page Markdown. HTTPS only; raw_url host
+ * must already have been checked by {@see DocsManifest}.
+ */
+final readonly class PlatformDocsManifestClient
+{
+    private const TIMEOUT_SECONDS = 15;
+    private const MAX_BYTES = 2_000_000;
+
+    public function __construct(
+        private HttpClientInterface $httpClient,
+    ) {
+    }
+
+    /**
+     * @throws \RuntimeException
+     */
+    public function fetchManifest(string $url): DocsManifest
+    {
+        $this->assertHttps($url);
+        $body = $this->get($url, 'application/json');
+
+        try {
+            return DocsManifest::fromJson($body);
+        } catch (\InvalidArgumentException $e) {
+            throw new \RuntimeException('Docs manifest rejected: '.$e->getMessage(), 0, $e);
+        }
+    }
+
+    /**
+     * @throws \RuntimeException
+     */
+    public function fetchPage(DocsPage $page): string
+    {
+        $this->assertHttps($page->rawUrl);
+
+        return $this->get($page->rawUrl, 'text/markdown');
+    }
+
+    private function get(string $url, string $accept): string
+    {
+        try {
+            return $this->requestOnce($url, $accept);
+        } catch (TransportExceptionInterface $first) {
+            try {
+                return $this->requestOnce($url, $accept);
+            } catch (TransportExceptionInterface $retry) {
+                throw new \RuntimeException(sprintf('Transport error fetching %s: %s', $url, $retry->getMessage()), 0, $retry);
+            }
+        }
+    }
+
+    /**
+     * @throws TransportExceptionInterface
+     * @throws \RuntimeException
+     */
+    private function requestOnce(string $url, string $accept): string
+    {
+        try {
+            $response = $this->httpClient->request('GET', $url, [
+                'timeout' => self::TIMEOUT_SECONDS,
+                'max_redirects' => 3,
+                'headers' => ['Accept' => $accept],
+            ]);
+            $status = $response->getStatusCode();
+            if ($status >= 400) {
+                throw new \RuntimeException(sprintf('HTTP %d fetching %s', $status, $url));
+            }
+            $body = $response->getContent();
+            if (strlen($body) > self::MAX_BYTES) {
+                throw new \RuntimeException(sprintf('Response from %s exceeds %d bytes.', $url, self::MAX_BYTES));
+            }
+
+            return $body;
+        } catch (HttpExceptionInterface $e) {
+            throw new \RuntimeException(sprintf('HTTP error fetching %s: %s', $url, $e->getMessage()), 0, $e);
+        }
+    }
+
+    private function assertHttps(string $url): void
+    {
+        if (!str_starts_with(strtolower($url), 'https://')) {
+            throw new \RuntimeException('Docs sync only accepts https:// URLs.');
+        }
+    }
+}

--- a/backend/src/Service/SelfAware/Docs/PlatformDocsRetriever.php
+++ b/backend/src/Service/SelfAware/Docs/PlatformDocsRetriever.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\SelfAware\Docs;
+
+use App\Service\RAG\VectorSearchService;
+use App\Service\SelfAware\SelfAwareConfig;
+
+/**
+ * Retrieves official documentation chunks for the `synaplan` topic.
+ *
+ * Queries owner 0 / SYSTEM:synaplan so the embedding model matches the
+ * corpus (Decision 4). Unknown file ids are dropped — never guessed.
+ */
+final readonly class PlatformDocsRetriever
+{
+    public const DEFAULT_LIMIT = 5;
+    public const DEFAULT_MIN_SCORE = 0.35;
+    public const MAX_PAGES = 4;
+
+    public function __construct(
+        private SelfAwareConfig $config,
+        private PlatformDocsSyncState $state,
+        private VectorSearchService $vectorSearch,
+    ) {
+    }
+
+    public function retrieve(
+        string $query,
+        int $userId,
+        int $limit = self::DEFAULT_LIMIT,
+        float $minScore = self::DEFAULT_MIN_SCORE,
+    ): PlatformDocsHits {
+        if (!$this->config->isDocsRagEnabled($userId > 0 ? $userId : null)) {
+            return new PlatformDocsHits([]);
+        }
+        if (!$this->state->hasPages()) {
+            return new PlatformDocsHits([]);
+        }
+
+        $results = $this->vectorSearch->semanticSearch(
+            $query,
+            PlatformDocsSyncService::OWNER_ID,
+            PlatformDocsSyncService::GROUP_KEY,
+            $limit,
+            $minScore,
+        );
+
+        $bestBySlug = [];
+        foreach ($results as $row) {
+            $fileId = (int) ($row['file_id'] ?? 0);
+            $page = $this->state->pageByFileId($fileId);
+            if (null === $page) {
+                continue;
+            }
+            $slug = $page['slug'];
+            $score = (float) ($row['score'] ?? $row['distance'] ?? 0.0);
+            $existing = $bestBySlug[$slug] ?? null;
+            if (null !== $existing && $existing->score >= $score) {
+                continue;
+            }
+            $bestBySlug[$slug] = new PlatformDocsHit(
+                $slug,
+                (string) $page['title'],
+                (string) $page['url'],
+                (string) $page['section'],
+                trim((string) ($row['chunk_text'] ?? '')),
+                $score,
+            );
+        }
+
+        usort(
+            $bestBySlug,
+            static fn (PlatformDocsHit $a, PlatformDocsHit $b): int => $b->score <=> $a->score,
+        );
+
+        return new PlatformDocsHits(array_slice($bestBySlug, 0, self::MAX_PAGES));
+    }
+}

--- a/backend/src/Service/SelfAware/Docs/PlatformDocsSyncService.php
+++ b/backend/src/Service/SelfAware/Docs/PlatformDocsSyncService.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\SelfAware\Docs;
+
+use App\Service\File\VectorizationService;
+use App\Service\RAG\VectorStorage\VectorStorageFacade;
+use App\Service\SelfAware\SelfAwareConfig;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Idempotent sync of synaplan-docs into owner 0 / SYSTEM:synaplan.
+ *
+ * Never called from boot (`app:seed` / entrypoint). Scheduler, messenger,
+ * or an operator command only.
+ */
+final readonly class PlatformDocsSyncService
+{
+    public const GROUP_KEY = 'SYSTEM:synaplan';
+    public const OWNER_ID = 0;
+
+    public function __construct(
+        private SelfAwareConfig $config,
+        private PlatformDocsManifestClient $client,
+        private PlatformDocsSyncState $state,
+        private VectorStorageFacade $vectorStorage,
+        private VectorizationService $vectorizationService,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public static function buildFileId(string $slug): int
+    {
+        return abs(crc32('docs:'.$slug)) % 2_000_000_000;
+    }
+
+    public function sync(bool $force = false, bool $dryRun = false): DocsSyncResult
+    {
+        $manifestUrl = $this->config->docsManifestUrl();
+        if ('' === $manifestUrl) {
+            return DocsSyncResult::skipped('SELF_AWARE.DOCS_MANIFEST_URL is empty; sync disabled.');
+        }
+
+        try {
+            $manifest = $this->client->fetchManifest($manifestUrl);
+        } catch (\Throwable $e) {
+            $this->logger->warning('Platform docs sync: manifest fetch failed', [
+                'url' => $manifestUrl,
+                'error' => $e->getMessage(),
+            ]);
+
+            return DocsSyncResult::failed($e->getMessage());
+        }
+
+        $previous = $this->state->read();
+        $previousPages = $previous['pages'];
+        $manifestSlugs = [];
+        foreach ($manifest->pages as $page) {
+            $manifestSlugs[$page->slug] = true;
+        }
+
+        $rows = [];
+        $changed = 0;
+        $unchanged = 0;
+        $removed = 0;
+        $failed = 0;
+        $nextPages = $previousPages;
+
+        foreach ($manifest->pages as $page) {
+            $prior = $previousPages[$page->slug] ?? null;
+            $isChanged = $force || null === $prior || $prior['sha256'] !== $page->sha256;
+            if (!$isChanged) {
+                ++$unchanged;
+                $rows[] = ['slug' => $page->slug, 'action' => 'unchanged', 'chunks' => 0, 'message' => ''];
+                continue;
+            }
+
+            if ($dryRun) {
+                ++$changed;
+                $rows[] = ['slug' => $page->slug, 'action' => 'would-change', 'chunks' => 0, 'message' => ''];
+                continue;
+            }
+
+            try {
+                $markdown = $this->client->fetchPage($page);
+                $fileId = self::buildFileId($page->slug);
+                $this->vectorStorage->deleteByFile(self::OWNER_ID, $fileId);
+                $text = $this->prefixPage($page, $this->stripNoise($markdown));
+                $result = $this->vectorizationService->vectorizeAndStore(
+                    $text,
+                    self::OWNER_ID,
+                    $fileId,
+                    self::GROUP_KEY,
+                    0,
+                );
+                $chunks = (int) ($result['chunks_created'] ?? 0);
+                if (empty($result['success'])) {
+                    throw new \RuntimeException((string) ($result['error'] ?? 'vectorizeAndStore failed'));
+                }
+                $nextPages[$page->slug] = [
+                    'sha256' => $page->sha256,
+                    'file_id' => $fileId,
+                    'title' => $page->title,
+                    'url' => $page->url,
+                    'section' => $page->section,
+                    'synced_at' => gmdate('c'),
+                    'slug' => $page->slug,
+                ];
+                ++$changed;
+                $rows[] = ['slug' => $page->slug, 'action' => 'changed', 'chunks' => $chunks, 'message' => ''];
+            } catch (\Throwable $e) {
+                ++$failed;
+                $rows[] = ['slug' => $page->slug, 'action' => 'failed', 'chunks' => 0, 'message' => $e->getMessage()];
+                $this->logger->warning('Platform docs sync: page failed', [
+                    'slug' => $page->slug,
+                    'error' => $e->getMessage(),
+                ]);
+            }
+        }
+
+        foreach ($previousPages as $slug => $page) {
+            if (isset($manifestSlugs[$slug])) {
+                continue;
+            }
+            if ($dryRun) {
+                ++$removed;
+                $rows[] = ['slug' => $slug, 'action' => 'would-remove', 'chunks' => 0, 'message' => ''];
+                continue;
+            }
+            $this->vectorStorage->deleteByFile(self::OWNER_ID, (int) $page['file_id']);
+            unset($nextPages[$slug]);
+            ++$removed;
+            $rows[] = ['slug' => $slug, 'action' => 'removed', 'chunks' => 0, 'message' => ''];
+        }
+
+        if (!$dryRun) {
+            $this->state->write([
+                'manifest_url' => $manifestUrl,
+                'manifest_version' => $manifest->version,
+                'synced_at' => gmdate('c'),
+                'pages' => $nextPages,
+            ]);
+        }
+
+        return new DocsSyncResult(
+            $failed > 0 && 0 === $changed && 0 === $removed ? 'failed' : 'ok',
+            $changed,
+            $unchanged,
+            $removed,
+            $failed,
+            $rows,
+        );
+    }
+
+    private function prefixPage(DocsPage $page, string $markdown): string
+    {
+        return "Source: {$page->url}\nTitle: {$page->title}\nSection: {$page->section}\n\n".$markdown;
+    }
+
+    private function stripNoise(string $markdown): string
+    {
+        $stripped = preg_replace('/<!--SYNAPLAN_MODELS_TABLE-->/', '', $markdown) ?? $markdown;
+
+        return preg_replace('/<!--.*?-->/s', '', $stripped) ?? $stripped;
+    }
+}

--- a/backend/src/Service/SelfAware/Docs/PlatformDocsSyncState.php
+++ b/backend/src/Service/SelfAware/Docs/PlatformDocsSyncState.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\SelfAware\Docs;
+
+use App\Repository\ConfigRepository;
+use App\Service\SelfAware\SelfAwareConfig;
+
+/**
+ * Persists the docs-corpus sync state in BCONFIG `SELF_AWARE.DOCS_SYNC_STATE`.
+ *
+ * @phpstan-type PageState array{sha256: string, file_id: int, title: string, url: string, section: string, synced_at: string, slug: string}
+ * @phpstan-type State array{manifest_url: string, manifest_version: string, synced_at: string, pages: array<string, PageState>}
+ */
+final readonly class PlatformDocsSyncState
+{
+    public function __construct(
+        private ConfigRepository $configRepository,
+    ) {
+    }
+
+    /**
+     * @return State
+     */
+    public function read(): array
+    {
+        $raw = $this->configRepository->getValue(0, SelfAwareConfig::CONFIG_GROUP, SelfAwareConfig::KEY_DOCS_SYNC_STATE);
+        if (null === $raw || '' === $raw) {
+            return $this->empty();
+        }
+
+        try {
+            $decoded = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            return $this->empty();
+        }
+        if (!is_array($decoded)) {
+            return $this->empty();
+        }
+
+        $pages = [];
+        foreach ($decoded['pages'] ?? [] as $slug => $page) {
+            if (!is_string($slug) || !is_array($page)) {
+                continue;
+            }
+            $pages[$slug] = [
+                'sha256' => (string) ($page['sha256'] ?? ''),
+                'file_id' => (int) ($page['file_id'] ?? 0),
+                'title' => (string) ($page['title'] ?? $slug),
+                'url' => (string) ($page['url'] ?? ''),
+                'section' => (string) ($page['section'] ?? ''),
+                'synced_at' => (string) ($page['synced_at'] ?? ''),
+                'slug' => $slug,
+            ];
+        }
+
+        return [
+            'manifest_url' => (string) ($decoded['manifest_url'] ?? ''),
+            'manifest_version' => (string) ($decoded['manifest_version'] ?? ''),
+            'synced_at' => (string) ($decoded['synced_at'] ?? ''),
+            'pages' => $pages,
+        ];
+    }
+
+    /**
+     * @param State $state
+     */
+    public function write(array $state): void
+    {
+        $this->configRepository->setValue(
+            0,
+            SelfAwareConfig::CONFIG_GROUP,
+            SelfAwareConfig::KEY_DOCS_SYNC_STATE,
+            json_encode($state, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES),
+        );
+    }
+
+    /**
+     * @return PageState|null
+     */
+    public function pageByFileId(int $fileId): ?array
+    {
+        foreach ($this->read()['pages'] as $page) {
+            if ($page['file_id'] === $fileId) {
+                return $page;
+            }
+        }
+
+        return null;
+    }
+
+    public function hasPages(): bool
+    {
+        return [] !== $this->read()['pages'];
+    }
+
+    /**
+     * @return State
+     */
+    public function empty(): array
+    {
+        return [
+            'manifest_url' => '',
+            'manifest_version' => '',
+            'synced_at' => '',
+            'pages' => [],
+        ];
+    }
+}

--- a/backend/src/Service/SelfAware/Eval/SelfAwareEvalAssertions.php
+++ b/backend/src/Service/SelfAware/Eval/SelfAwareEvalAssertions.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\SelfAware\Eval;
+
+/**
+ * String/topic assertions for one eval row. Used by the live command and unit tests.
+ */
+final class SelfAwareEvalAssertions
+{
+    /**
+     * @param array<string, mixed> $expect
+     */
+    public static function topicMatches(string $actualTopic, array $expect): bool
+    {
+        $expected = $expect['topic'] ?? null;
+        if (null === $expected) {
+            return true;
+        }
+        if ('not_synaplan' === $expected) {
+            return 'synaplan' !== $actualTopic;
+        }
+
+        return $actualTopic === $expected;
+    }
+
+    /**
+     * @param array<string, mixed> $expect
+     *
+     * @return list<string> failure messages (empty = pass)
+     */
+    public static function answerFailures(string $answer, array $expect): array
+    {
+        $failures = [];
+        $haystack = mb_strtolower($answer);
+
+        foreach (self::stringList($expect['must_contain_any'] ?? null) as $needles) {
+            $hit = false;
+            foreach ($needles as $needle) {
+                if (str_contains($haystack, mb_strtolower($needle))) {
+                    $hit = true;
+                    break;
+                }
+            }
+            if (!$hit) {
+                $failures[] = 'missing any of: '.implode('|', $needles);
+            }
+        }
+
+        foreach (self::stringList($expect['must_mention_any'] ?? null) as $needles) {
+            $hit = false;
+            foreach ($needles as $needle) {
+                if (str_contains($haystack, mb_strtolower($needle))) {
+                    $hit = true;
+                    break;
+                }
+            }
+            if (!$hit) {
+                $failures[] = 'did not mention any of: '.implode('|', $needles);
+            }
+        }
+
+        foreach (self::flatList($expect['must_not_contain'] ?? null) as $forbidden) {
+            if (str_contains($haystack, mb_strtolower($forbidden))) {
+                $failures[] = 'contained forbidden "'.$forbidden.'"';
+            }
+        }
+
+        return $failures;
+    }
+
+    /**
+     * @return list<list<string>>
+     */
+    private static function stringList(mixed $value): array
+    {
+        if (!is_array($value) || [] === $value) {
+            return [];
+        }
+        if (array_is_list($value) && is_string($value[0] ?? null)) {
+            return [$value];
+        }
+
+        $groups = [];
+        foreach ($value as $group) {
+            if (is_array($group)) {
+                $groups[] = array_values(array_filter($group, 'is_string'));
+            } elseif (is_string($group)) {
+                $groups[] = [$group];
+            }
+        }
+
+        return $groups;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function flatList(mixed $value): array
+    {
+        if (!is_array($value)) {
+            return [];
+        }
+
+        $out = [];
+        foreach ($value as $item) {
+            if (is_string($item)) {
+                $out[] = $item;
+            }
+        }
+
+        return $out;
+    }
+}

--- a/backend/src/Service/SelfAware/Eval/SelfAwareEvalCorpus.php
+++ b/backend/src/Service/SelfAware/Eval/SelfAwareEvalCorpus.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\SelfAware\Eval;
+
+/**
+ * Loader for {@see backend/tests/Eval/self_aware_eval_corpus.json}.
+ *
+ * @phpstan-type EvalRow array{
+ *     id: string,
+ *     lang: string,
+ *     text: string,
+ *     install: string,
+ *     expect: array<string, mixed>
+ * }
+ */
+final class SelfAwareEvalCorpus
+{
+    /**
+     * @return list<EvalRow>
+     */
+    public static function load(string $path): array
+    {
+        if (!is_file($path)) {
+            throw new \InvalidArgumentException('Eval corpus not found: '.$path);
+        }
+
+        try {
+            $decoded = json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException $e) {
+            throw new \InvalidArgumentException('Eval corpus is not valid JSON: '.$e->getMessage(), 0, $e);
+        }
+        if (!is_array($decoded)) {
+            throw new \InvalidArgumentException('Eval corpus must be a JSON array.');
+        }
+
+        $rows = [];
+        foreach ($decoded as $row) {
+            if (!is_array($row) || !isset($row['id'], $row['text'], $row['expect']) || !is_array($row['expect'])) {
+                throw new \InvalidArgumentException('Eval corpus row is missing id, text or expect.');
+            }
+            $lang = isset($row['lang']) && is_string($row['lang']) && '' !== $row['lang'] ? $row['lang'] : 'en';
+            $install = isset($row['install']) && is_string($row['install']) && '' !== $row['install']
+                ? $row['install']
+                : 'any';
+            $rows[] = [
+                'id' => (string) $row['id'],
+                'lang' => $lang,
+                'text' => (string) $row['text'],
+                'install' => $install,
+                'expect' => $row['expect'],
+            ];
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @param list<EvalRow> $rows
+     *
+     * @return list<EvalRow>
+     */
+    public static function select(array $rows, ?string $only, ?string $install): array
+    {
+        $wanted = [];
+        if (null !== $only && '' !== trim($only)) {
+            foreach (explode(',', $only) as $id) {
+                $id = trim($id);
+                if ('' !== $id) {
+                    $wanted[$id] = true;
+                }
+            }
+        }
+
+        $filtered = [];
+        foreach ($rows as $row) {
+            if ([] !== $wanted && !isset($wanted[(string) $row['id']])) {
+                continue;
+            }
+            if (null !== $install && '' !== $install && $row['install'] !== $install && 'any' !== $row['install']) {
+                continue;
+            }
+            $filtered[] = $row;
+        }
+
+        return $filtered;
+    }
+}

--- a/backend/src/Service/SelfAware/PlatformCapabilityInventory.php
+++ b/backend/src/Service/SelfAware/PlatformCapabilityInventory.php
@@ -1,0 +1,562 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\SelfAware;
+
+use App\AI\Credential\ChatReadinessService;
+use App\Entity\User;
+use App\Repository\ConnectionRepository;
+use App\Repository\PromptRepository;
+use App\Repository\UserRepository;
+use App\Service\BillingService;
+use App\Service\Capability\CapabilityService;
+use App\Service\Desktop\DesktopAgentConfig;
+use App\Service\MailerConfig;
+use App\Service\Mcp\McpClientConfig;
+use App\Service\ModelConfigService;
+use App\Service\Multitask\MultitaskRoutingConfig;
+use App\Service\Plugin\PluginManager;
+use App\Service\RAG\VectorStorage\VectorStorageFacade;
+use App\Service\SavedTask\SavedTaskConfig;
+use App\Service\Search\BraveSearchService;
+use App\Service\Update\UpdateStatusService;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+/**
+ * Builds a live capability report from sources that already gate behaviour
+ * (invariant C6). There is no hand-maintained feature list — only
+ * {@see self::KNOWN_ABSENT}, because an absence cannot be derived from a
+ * registry.
+ */
+final readonly class PlatformCapabilityInventory implements CapabilityInventory
+{
+    /**
+     * Deliberately unsupported capabilities. Reviewed on every release that
+     * adds a capability (see docs/ADMIN.md).
+     *
+     * @var list<array{id: string, label: string, detail: string, alternative: string, adminHint: ?string, docsSlug: ?string}>
+     */
+    public const KNOWN_ABSENT = [
+        [
+            'id' => 'music_generation',
+            'label' => 'Composing or producing music',
+            'detail' => 'No music or song model exists',
+            'alternative' => 'original lyrics in that style',
+            'adminHint' => null,
+            'docsSlug' => null,
+        ],
+        [
+            'id' => 'code_execution',
+            'label' => 'Running arbitrary code',
+            'detail' => 'The assistant cannot execute Python, shell, or other code on the server',
+            'alternative' => 'Synaplan Desktop skills on the user\'s computer',
+            'adminHint' => 'Channels → Desktop',
+            'docsSlug' => 'desktop-skills',
+        ],
+        [
+            'id' => 'phone_calls',
+            'label' => 'Phone calls',
+            'detail' => 'The assistant cannot place or receive voice calls',
+            'alternative' => 'WhatsApp or email when those channels are configured',
+            'adminHint' => null,
+            'docsSlug' => 'channels',
+        ],
+        [
+            'id' => 'authenticated_browsing',
+            'label' => 'Browsing sites behind a login',
+            'detail' => 'Web fetch only reads public pages',
+            'alternative' => 'paste the text, or connect an MCP server for that system',
+            'adminHint' => 'Channels → MCP Servers',
+            'docsSlug' => 'mcp',
+        ],
+        [
+            'id' => 'pdf_inplace_editing',
+            'label' => 'Editing an existing PDF in place',
+            'detail' => 'PDFs can be analysed; they cannot be rewritten as PDF',
+            'alternative' => 'analyse the PDF and regenerate the result as DOCX',
+            'adminHint' => null,
+            'docsSlug' => 'using-synaplan',
+        ],
+        [
+            'id' => 'live_human_operator_in_chat',
+            'label' => 'A live human operator in this chat',
+            'detail' => 'This conversation is with the AI assistant',
+            'alternative' => 'widget live support is an operator-side feature',
+            'adminHint' => null,
+            'docsSlug' => 'architecture',
+        ],
+    ];
+
+    public function __construct(
+        private ChatReadinessService $chatReadiness,
+        private ModelConfigService $modelConfig,
+        private VectorStorageFacade $vectorStorage,
+        private BraveSearchService $braveSearch,
+        private MultitaskRoutingConfig $routingConfig,
+        private MailerConfig $mailerConfig,
+        private SavedTaskConfig $savedTaskConfig,
+        private DesktopAgentConfig $desktopAgentConfig,
+        private McpClientConfig $mcpClientConfig,
+        private PluginManager $pluginManager,
+        private CapabilityService $capabilityService,
+        private PromptRepository $promptRepository,
+        private UpdateStatusService $updateStatus,
+        private BillingService $billingService,
+        private ConnectionRepository $connectionRepository,
+        private UserRepository $userRepository,
+        #[Autowire('%env(bool:WHATSAPP_ENABLED)%')]
+        private bool $whatsappEnabled = false,
+        #[Autowire('%env(WHATSAPP_ACCESS_TOKEN)%')]
+        private string $whatsappAccessToken = '',
+    ) {
+    }
+
+    public function build(int $userId): CapabilityReport
+    {
+        $user = $userId > 0 ? $this->userRepository->find($userId) : null;
+        $isAdmin = $user instanceof User && $user->isAdmin();
+        $chatReady = $this->chatReadiness->isChatReady(userId: $userId > 0 ? $userId : null);
+        $ttsAvailable = $this->modelResolves('TEXT2SOUND', $userId) || $this->ttsUrlConfigured();
+
+        $facts = [];
+        $facts[] = $this->fact(
+            'chat',
+            'Chat',
+            $chatReady,
+            $chatReady ? 'AI chat with the workspace model' : 'no chat provider key configured',
+            'ask your administrator to connect an AI provider',
+            'System Config → AI Providers',
+            'using-synaplan',
+        );
+        $facts[] = $this->fact(
+            'file_analysis',
+            'File analysis',
+            $this->modelResolves('PIC2TEXT', $userId) && $chatReady,
+            'PDF, Word, Excel, images, audio',
+            'upload the file once a vision / analysis model is configured',
+            'System Config → AI Models → add a PIC2TEXT model',
+            'using-synaplan',
+        );
+        $vectorizeReady = $this->modelResolves('VECTORIZE', $userId);
+        $facts[] = $this->fact(
+            'knowledge_search',
+            'Knowledge search over your files',
+            $vectorizeReady,
+            $vectorizeReady ? $this->vectorStorage->getProviderName() : 'no embedding model configured',
+            'upload files after an embedding model is set',
+            'System Config → AI Models → VECTORIZE',
+            'using-synaplan',
+        );
+        $qdrantConfigured = $this->envNonEmpty('QDRANT_URL');
+        $facts[] = $this->fact(
+            'memories',
+            'Memories',
+            $qdrantConfigured,
+            $qdrantConfigured ? 'Qdrant memory service' : 'Qdrant is not configured',
+            'memories remember preferences across chats once Qdrant is set',
+            'Set QDRANT_URL',
+            'using-synaplan',
+        );
+        $facts[] = $this->fact(
+            'image_generation',
+            'Image generation (/pic)',
+            $this->modelResolves('TEXT2PIC', $userId),
+            'ask for an image or use /pic',
+            'describe the image in words, or add an image model',
+            'System Config → AI Models → add an image model',
+            'using-synaplan',
+        );
+        $facts[] = $this->fact(
+            'video_generation',
+            'Video generation (/vid)',
+            $this->modelResolves('TEXT2VID', $userId),
+            'ask for a video or use /vid',
+            'image generation is the nearest alternative',
+            'System Config → AI Models → add a video model',
+            'using-synaplan',
+        );
+        $facts[] = $this->fact(
+            'text_to_speech',
+            'Text-to-speech',
+            $ttsAvailable,
+            $ttsAvailable ? 'MP3' : 'no TTS model or SYNAPLAN_TTS_URL',
+            'I can write the text; audio needs a TTS model or the local speech service',
+            'System Config → AI Models → TEXT2SOUND, or set SYNAPLAN_TTS_URL',
+            'tts',
+        );
+        $facts[] = $this->fact(
+            'speech_to_text',
+            'Speech-to-text',
+            $this->modelResolves('SOUND2TEXT', $userId),
+            'upload an audio file to transcribe',
+            'type the words, or add a transcription model',
+            'System Config → AI Models → SOUND2TEXT',
+            'using-synaplan',
+        );
+        $webSearchOn = $this->braveSearch->isEnabled();
+        $facts[] = $this->fact(
+            'web_search',
+            'Web search',
+            $webSearchOn,
+            $webSearchOn ? 'ask for current information or /search' : 'no Brave search key',
+            'paste the text you want analysed',
+            'System Config → set the Brave search API key',
+            'using-synaplan',
+        );
+        $facts[] = $this->flagFact(
+            'url_fetch',
+            'URL fetch',
+            $userId,
+            MultitaskRoutingConfig::KEY_URL_FETCH_ENABLED,
+            true,
+            'read a public page the user named',
+            'paste the page text',
+            'System Config → Multi-task → URL fetch',
+            'dag-routing',
+        );
+        $facts[] = $this->flagFact(
+            'mcp_fetch',
+            'MCP data sources',
+            $userId,
+            MultitaskRoutingConfig::KEY_MCP_FETCH_ENABLED,
+            false,
+            'read from connected MCP servers',
+            'paste the data, or connect an MCP server',
+            'Channels → MCP Servers',
+            'mcp',
+        );
+        $facts[] = $this->flagFact(
+            'mcp_action',
+            'MCP write actions',
+            $userId,
+            MultitaskRoutingConfig::KEY_MCP_ACTION_ENABLED,
+            false,
+            'create or update items on write-enabled MCP servers',
+            'do the write in that system, or enable MCP write actions',
+            'Channels → MCP Servers → allow write actions',
+            'mcp',
+        );
+        $facts[] = $this->flagFact(
+            'email_search',
+            'Mailbox search',
+            $userId,
+            MultitaskRoutingConfig::KEY_EMAIL_SEARCH_ENABLED,
+            false,
+            'search a connected mailbox',
+            'paste the mail, or connect a mailbox under Channels',
+            'Channels → Email / Microsoft 365',
+            'channels',
+        );
+        $facts[] = new CapabilityFact(
+            'document_generation',
+            'Documents',
+            CapabilityState::Available,
+            'DOCX, XLSX, PPTX, CSV',
+            null,
+            null,
+            'using-synaplan',
+        );
+        $pdfReady = $this->envNonEmpty('OFFICE_CONVERT_URL');
+        $facts[] = $this->fact(
+            'pdf_export',
+            'PDF export',
+            $pdfReady,
+            $pdfReady ? 'office engine' : 'office engine not configured',
+            'DOCX, XLSX, PPTX, CSV',
+            'office engine (OFFICE_CONVERT_URL)',
+            'using-synaplan',
+        );
+        $facts[] = new CapabilityFact(
+            'calendar_event',
+            'Calendar invites (.ics)',
+            CapabilityState::Available,
+            '.ics download; Outlook when connected',
+            null,
+            null,
+            'using-synaplan',
+        );
+        $mailerOn = $this->mailerConfig->isConfigured();
+        $facts[] = $this->fact(
+            'email_me',
+            'Email a result',
+            $mailerOn,
+            $mailerOn ? 'mailer configured' : 'mailer not configured',
+            'download the file in chat',
+            'Set MAILER_DSN',
+            'channels',
+        );
+        $hasWebDav = $this->userHasWebDav($userId);
+        $facts[] = $this->fact(
+            'save_to_folder',
+            'Save to a folder',
+            $hasWebDav,
+            $hasWebDav ? 'WebDAV / Nextcloud / ownCloud destination' : 'no folder destination connected',
+            'download the file in chat',
+            'Channels → Connections',
+            'using-synaplan',
+        );
+        $savedTasksOn = $this->savedTaskConfig->isEnabled($userId > 0 ? $userId : null);
+        $facts[] = $this->fact(
+            'saved_tasks',
+            'Saved tasks',
+            $savedTasksOn,
+            $savedTasksOn ? 'pin a plan and run it again' : 'not enabled',
+            'ask me to do the steps again in chat',
+            'Channels → Saved Tasks',
+            'using-synaplan',
+        );
+        $desktopOn = $this->desktopAgentConfig->isEnabled($userId > 0 ? $userId : null);
+        $facts[] = $this->fact(
+            'desktop_skills',
+            'Desktop skills',
+            $desktopOn,
+            $desktopOn ? 'run skills on the user\'s computer' : 'not enabled',
+            'ask me to draft the steps here',
+            'Channels → Desktop',
+            'desktop-skills',
+        );
+        $mcpServerOn = $this->mcpClientConfig->isClientEnabled($userId > 0 ? $userId : null);
+        $facts[] = $this->fact(
+            'mcp_server',
+            'MCP client',
+            $mcpServerOn,
+            $mcpServerOn ? 'connect external MCP servers' : 'not enabled',
+            'paste the data from that system',
+            'Channels → MCP Servers',
+            'mcp',
+        );
+        $whatsAppOn = $this->whatsappEnabled
+            && '' !== trim($this->whatsappAccessToken)
+            && $user instanceof User
+            && $user->hasVerifiedPhone();
+        $facts[] = $this->fact(
+            'channel_whatsapp',
+            'WhatsApp',
+            $whatsAppOn,
+            $whatsAppOn ? 'verified phone on this account' : 'WhatsApp is not configured for this user',
+            'use this web chat, or add a verified phone number',
+            'Profile → phone number; operator: WhatsApp access token',
+            'channels',
+        );
+        $emailKeyword = $user instanceof User ? trim((string) ($user->getUserDetails()['email_keyword'] ?? '')) : '';
+        $emailChannelOn = $mailerOn && '' !== $emailKeyword;
+        $facts[] = $this->fact(
+            'channel_email',
+            'Email',
+            $emailChannelOn,
+            $emailChannelOn ? 'inbound email keyword set' : 'no inbound email keyword',
+            'use this web chat, or set an email keyword in the profile',
+            'Profile → email keyword; operator: MAILER_DSN',
+            'channels',
+        );
+
+        $pluginDetail = $this->pluginDetail($userId);
+        $facts[] = $this->fact(
+            'plugins',
+            'Plugins',
+            '' !== $pluginDetail,
+            '' !== $pluginDetail ? $pluginDetail : 'no chat-command plugins installed',
+            'ask in this chat without a plugin command',
+            'install a plugin from the plugin list',
+            'plugins',
+        );
+        $facts[] = new CapabilityFact(
+            'upload_formats',
+            'Upload formats',
+            CapabilityState::Available,
+            $this->uploadFormatList(),
+            null,
+            null,
+            'using-synaplan',
+        );
+        $customTopics = $this->customTopicNames($userId);
+        $facts[] = $this->fact(
+            'custom_topics',
+            'Custom topics',
+            [] !== $customTopics,
+            [] !== $customTopics ? implode(', ', $customTopics) : 'no user-owned topics',
+            'use the built-in topics, or create one under AI Instructions',
+            'AI Instructions → new topic',
+            'using-synaplan',
+        );
+
+        foreach (self::KNOWN_ABSENT as $row) {
+            $alternative = $row['alternative'];
+            if ('music_generation' === $row['id'] && $ttsAvailable) {
+                $alternative = 'original lyrics, read aloud as MP3';
+            }
+            $facts[] = new CapabilityFact(
+                $row['id'],
+                $row['label'],
+                CapabilityState::Absent,
+                $row['detail'],
+                $alternative,
+                $row['adminHint'],
+                $row['docsSlug'],
+            );
+        }
+
+        return new CapabilityReport(
+            $facts,
+            $this->versionLabel(),
+            $this->billingService->isEnabled(),
+            $isAdmin,
+        );
+    }
+
+    public function forget(?int $userId = null): void
+    {
+        // Uncached implementation — the decorator owns the cache.
+    }
+
+    private function fact(
+        string $id,
+        string $label,
+        bool $available,
+        string $detail,
+        string $alternative,
+        string $adminHint,
+        ?string $docsSlug,
+    ): CapabilityFact {
+        if ($available) {
+            return new CapabilityFact(
+                $id,
+                $label,
+                CapabilityState::Available,
+                $detail,
+                null,
+                $adminHint,
+                $docsSlug,
+            );
+        }
+
+        return new CapabilityFact(
+            $id,
+            $label,
+            CapabilityState::NeedsSetup,
+            $detail,
+            $alternative,
+            $adminHint,
+            $docsSlug,
+        );
+    }
+
+    private function flagFact(
+        string $id,
+        string $label,
+        int $userId,
+        string $flag,
+        bool $default,
+        string $availableDetail,
+        string $alternative,
+        string $adminHint,
+        string $docsSlug,
+    ): CapabilityFact {
+        $on = $this->routingConfig->isFeatureEnabled($flag, $userId > 0 ? $userId : null, $default);
+
+        return $this->fact($id, $label, $on, $availableDetail, $alternative, $adminHint, $docsSlug);
+    }
+
+    private function modelResolves(string $capability, int $userId): bool
+    {
+        return null !== $this->modelConfig->getDefaultModel($capability, $userId > 0 ? $userId : null);
+    }
+
+    private function ttsUrlConfigured(): bool
+    {
+        return $this->envNonEmpty('SYNAPLAN_TTS_URL');
+    }
+
+    private function envNonEmpty(string $key): bool
+    {
+        $value = $_ENV[$key] ?? $_SERVER[$key] ?? getenv($key);
+        if (!is_string($value)) {
+            return false;
+        }
+
+        return '' !== trim($value);
+    }
+
+    private function userHasWebDav(int $userId): bool
+    {
+        if ($userId <= 0) {
+            return false;
+        }
+        foreach ($this->connectionRepository->findByOwner($userId) as $connection) {
+            if ('webdav' === $connection->getType()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function pluginDetail(int $userId): string
+    {
+        if ($userId <= 0) {
+            return '';
+        }
+        $parts = [];
+        foreach ($this->pluginManager->listInstalledPlugins($userId) as $plugin) {
+            $commands = [];
+            foreach ($plugin->chatCommands as $entry) {
+                $command = ltrim($entry['command'], '/');
+                if ('' !== $command) {
+                    $commands[] = '/'.$command;
+                }
+            }
+            if ([] === $commands) {
+                continue;
+            }
+            $parts[] = $plugin->name.' ('.implode(', ', $commands).')';
+        }
+
+        return implode(', ', $parts);
+    }
+
+    private function uploadFormatList(): string
+    {
+        $formats = $this->capabilityService->getCapabilities()['file_formats'];
+        $flat = [];
+        foreach ($formats as $list) {
+            foreach ($list as $ext) {
+                if ('' !== $ext) {
+                    $flat[] = strtoupper($ext);
+                }
+            }
+        }
+
+        return [] === $flat ? 'common documents, images, audio and video' : implode(', ', $flat);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function customTopicNames(int $userId): array
+    {
+        if ($userId <= 0) {
+            return [];
+        }
+        $names = [];
+        foreach ($this->promptRepository->getTopicsWithDescriptions(0, '', $userId, excludeTools: true) as $row) {
+            if (($row['ownerId'] ?? 0) === $userId) {
+                $names[] = (string) $row['topic'];
+            }
+        }
+
+        return $names;
+    }
+
+    private function versionLabel(): string
+    {
+        $status = $this->updateStatus->getStatus();
+        $current = $status['currentVersion'];
+        $latest = $status['latestVersion'];
+        if (is_string($latest) && '' !== $latest && !empty($status['updateAvailable'])) {
+            return $current.' (published '.$latest.')';
+        }
+
+        return $current;
+    }
+}

--- a/backend/src/Service/SelfAware/SelfAwareConfig.php
+++ b/backend/src/Service/SelfAware/SelfAwareConfig.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\SelfAware;
+
+use App\Repository\ConfigRepository;
+
+/**
+ * Feature-flag resolver for platform self-awareness.
+ *
+ * Flags live in BCONFIG group {@see self::CONFIG_GROUP}, owner 0 (global)
+ * with optional per-user overrides. Resolution matches
+ * {@see \App\Service\Multitask\MultitaskRoutingConfig}: per-user → owner 0 →
+ * built-in default.
+ */
+final readonly class SelfAwareConfig
+{
+    public const CONFIG_GROUP = 'SELF_AWARE';
+
+    public const KEY_ENABLED = 'ENABLED';
+    public const KEY_INVENTORY_IN_GENERAL = 'INVENTORY_IN_GENERAL';
+    public const KEY_DOCS_RAG_ENABLED = 'DOCS_RAG_ENABLED';
+    public const KEY_DOCS_MANIFEST_URL = 'DOCS_MANIFEST_URL';
+    public const KEY_DOCS_SYNC_STATE = 'DOCS_SYNC_STATE';
+
+    public const DEFAULT_DOCS_MANIFEST_URL = 'https://docs.synaplan.com/docs-manifest.json';
+
+    public const ROUTABLE_TOPIC = 'synaplan';
+
+    private const DEFAULT_ENABLED = true;
+    private const DEFAULT_INVENTORY_IN_GENERAL = true;
+    private const DEFAULT_DOCS_RAG_ENABLED = true;
+
+    public function __construct(
+        private ConfigRepository $configRepository,
+    ) {
+    }
+
+    public function isEnabled(?int $userId): bool
+    {
+        return $this->resolveFlag(self::KEY_ENABLED, $userId, self::DEFAULT_ENABLED);
+    }
+
+    public function isInventoryInGeneral(?int $userId): bool
+    {
+        return $this->resolveFlag(self::KEY_INVENTORY_IN_GENERAL, $userId, self::DEFAULT_INVENTORY_IN_GENERAL);
+    }
+
+    public function isDocsRagEnabled(?int $userId): bool
+    {
+        return $this->resolveFlag(self::KEY_DOCS_RAG_ENABLED, $userId, self::DEFAULT_DOCS_RAG_ENABLED);
+    }
+
+    /**
+     * Manifest URL for the docs corpus sync. Empty string disables sync.
+     * Not overridable per user — mirrors are an operator decision.
+     */
+    public function docsManifestUrl(): string
+    {
+        $value = $this->configRepository->getValue(0, self::CONFIG_GROUP, self::KEY_DOCS_MANIFEST_URL);
+        if (null === $value) {
+            return self::DEFAULT_DOCS_MANIFEST_URL;
+        }
+
+        return trim($value);
+    }
+
+    /**
+     * Hide the system `synaplan` topic from a routing topic list when the
+     * feature is off (invariant C1).
+     *
+     * @param list<array{topic: string, description?: string, ownerId?: int}|string> $topics
+     *
+     * @return list<array{topic: string, description?: string, ownerId?: int}|string>
+     */
+    public function filterRoutableTopics(array $topics, ?int $userId): array
+    {
+        if ($this->isEnabled($userId)) {
+            return $topics;
+        }
+
+        $filtered = [];
+        foreach ($topics as $topic) {
+            $name = is_array($topic) ? $topic['topic'] : $topic;
+            if (self::ROUTABLE_TOPIC === $name) {
+                continue;
+            }
+            $filtered[] = $topic;
+        }
+
+        return $filtered;
+    }
+
+    private function resolveFlag(string $setting, ?int $userId, bool $default): bool
+    {
+        if (null !== $userId && $userId > 0) {
+            $perUser = $this->configRepository->getValue($userId, self::CONFIG_GROUP, $setting);
+            if (null !== $perUser) {
+                return $this->toBool($perUser, $default);
+            }
+        }
+
+        $global = $this->configRepository->getValue(0, self::CONFIG_GROUP, $setting);
+        if (null !== $global) {
+            return $this->toBool($global, $default);
+        }
+
+        return $default;
+    }
+
+    private function toBool(string $value, bool $default): bool
+    {
+        return filter_var($value, \FILTER_VALIDATE_BOOL, \FILTER_NULL_ON_FAILURE) ?? $default;
+    }
+}

--- a/backend/src/Service/SelfAware/SelfAwarePromptDecorator.php
+++ b/backend/src/Service/SelfAware/SelfAwarePromptDecorator.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\SelfAware;
+
+use App\Service\Knowledge\KnowledgeContextFormatter;
+use App\Service\SelfAware\Docs\PlatformDocsHits;
+
+/**
+ * Replaces (or strips) the `[PLATFORM_CAPABILITIES]` and `[PLATFORM_DOCS]`
+ * placeholders in a topic prompt. One call site for both ChatHandler paths.
+ */
+final readonly class SelfAwarePromptDecorator
+{
+    public const PLACEHOLDER_CAPABILITIES = '[PLATFORM_CAPABILITIES]';
+    public const PLACEHOLDER_DOCS = '[PLATFORM_DOCS]';
+
+    public function __construct(
+        private SelfAwareConfig $config,
+        private CapabilityInventory $inventory,
+        private CapabilityReportRenderer $renderer,
+        private KnowledgeContextFormatter $knowledgeContextFormatter,
+    ) {
+    }
+
+    /**
+     * Widget conversations (public embeds) are excluded — they answer for the
+     * operator's business, not for Synaplan.
+     *
+     * @param array<string, mixed> $classification
+     * @param array<string, mixed> $options
+     */
+    public static function isWidgetConversation(array $classification, array $options): bool
+    {
+        return 'WIDGET' === ($options['channel'] ?? null)
+            || 'widget' === ($classification['source'] ?? null);
+    }
+
+    public function apply(
+        string $prompt,
+        string $topic,
+        int $userId,
+        bool $isWidget,
+        ?PlatformDocsHits $docsHits = null,
+    ): string {
+        $enabled = $this->config->isEnabled($userId > 0 ? $userId : null);
+        $injectInventory = $enabled && !$isWidget && (
+            SelfAwareConfig::ROUTABLE_TOPIC === $topic
+            || ('general' === $topic && $this->config->isInventoryInGeneral($userId > 0 ? $userId : null))
+        );
+
+        if ($injectInventory) {
+            $block = $this->renderer->render($this->inventory->build($userId));
+            $prompt = str_replace(self::PLACEHOLDER_CAPABILITIES, $block, $prompt);
+        } else {
+            $prompt = str_replace(self::PLACEHOLDER_CAPABILITIES, '', $prompt);
+        }
+
+        $injectDocs = $enabled
+            && !$isWidget
+            && SelfAwareConfig::ROUTABLE_TOPIC === $topic
+            && null !== $docsHits
+            && !$docsHits->isEmpty();
+
+        if ($injectDocs) {
+            $prompt = str_replace(
+                self::PLACEHOLDER_DOCS,
+                $this->knowledgeContextFormatter->formatPlatformDocsContext($docsHits),
+                $prompt,
+            );
+        } else {
+            $prompt = str_replace(self::PLACEHOLDER_DOCS, '', $prompt);
+        }
+
+        return $prompt;
+    }
+}

--- a/backend/tests/Characterization/PlannerPromptCharacterizationTest.php
+++ b/backend/tests/Characterization/PlannerPromptCharacterizationTest.php
@@ -45,6 +45,7 @@ final class PlannerPromptCharacterizationTest extends TestCase
     /** Fixed topic fixture standing in for the BPROMPTS routing pool. */
     private const TOPIC_FIXTURE = [
         ['topic' => 'general', 'description' => 'Catch-all topic for everyday questions.'],
+        ['topic' => 'synaplan', 'description' => 'Questions about Synaplan itself: what it can and cannot do, how to use a feature, what is new, plans and pricing.'],
         ['topic' => 'mediamaker', 'description' => 'Media-generation topic for images, videos and audio.'],
         ['topic' => 'officemaker', 'description' => 'Generate a single Office document.'],
         ['topic' => 'docsummary', 'description' => 'Summarize a document or attached file text.'],

--- a/backend/tests/Characterization/RoutingCharacterizationTest.php
+++ b/backend/tests/Characterization/RoutingCharacterizationTest.php
@@ -120,6 +120,7 @@ final class RoutingCharacterizationTest extends TestCase
             ['id' => 'cmd_web', 'text' => '/web example.com', 'language' => 'en'],
             ['id' => 'cmd_list', 'text' => '/list', 'language' => 'en'],
             ['id' => 'cmd_docs', 'text' => '/docs sort my files', 'language' => 'en'],
+            ['id' => 'cmd_help', 'text' => '/help', 'language' => 'en'],
 
             // ---- Again overrides (fast-path off, like the existing override tests) ----
             ['id' => 'again_prompt_override', 'text' => 'redo that', 'language' => 'en', 'fastPath' => false, 'meta' => ['PROMPTID' => 'tools:pic']],

--- a/backend/tests/Characterization/__snapshots__/planner_system_prompt.txt
+++ b/backend/tests/Characterization/__snapshots__/planner_system_prompt.txt
@@ -77,12 +77,13 @@ When the request maps to one of these task topics, use capability `chat` and
 put the topic key in `params.topic_id`:
 
 - "general": Catch-all topic for everyday questions.
+- "synaplan": Questions about Synaplan itself: what it can and cannot do, how to use a feature, what is new, plans and pricing.
 - "mediamaker": Media-generation topic for images, videos and audio.
 - "officemaker": Generate a single Office document.
 - "docsummary": Summarize a document or attached file text.
 - "legal-review": Custom user topic: review legal clauses.
 
-Allowed topic keys: "general" | "mediamaker" | "officemaker" | "docsummary" | "legal-review"
+Allowed topic keys: "general" | "synaplan" | "mediamaker" | "officemaker" | "docsummary" | "legal-review"
 
 ## Routing decisions (apply in order)
 
@@ -221,7 +222,10 @@ Allowed topic keys: "general" | "mediamaker" | "officemaker" | "docsummary" | "l
    emit `mcp_action` for read-only questions (use `mcp_fetch`), and NEVER
    emit it when it is not in the capability list.
 10. Plain question / smalltalk / advice → one `chat` node. `reply_node` = that
-   node, no `compose_reply` needed.
+   node, no `compose_reply` needed. A question about Synaplan itself
+   (what it can do, how a feature works, what is new, who/what it is) is
+   still one `chat` node, with `topic_id: "synaplan"`. Never use that
+   question as the reply node for `email_me`.
 11. A SINGLE media request with no follow-up step ("make an image of X",
     "generate a video of Y", "read this aloud", "make an excel table") → ONE
     generator node (`image_generation` / `video_generation` / `text2sound` /
@@ -549,7 +553,19 @@ User: "Wer bist du?"
   "language": "de",
   "reply_node": "n1",
   "tasks": [
-    { "id": "n1", "capability": "chat", "inputs": { "text": "$message.text" }, "params": { "topic_id": "general" } }
+    { "id": "n1", "capability": "chat", "inputs": { "text": "$message.text" }, "params": { "topic_id": "synaplan" } }
+  ]
+}
+
+### Question about Synaplan itself
+User: "Can you create PDFs?"
+
+{
+  "version": 1,
+  "language": "en",
+  "reply_node": "n1",
+  "tasks": [
+    { "id": "n1", "capability": "chat", "inputs": { "text": "$message.text" }, "params": { "topic_id": "synaplan" } }
   ]
 }
 

--- a/backend/tests/Characterization/__snapshots__/routing_classification.json
+++ b/backend/tests/Characterization/__snapshots__/routing_classification.json
@@ -115,6 +115,13 @@
         "source": "tool_command",
         "topic": "tools:filesort"
     },
+    "cmd_help": {
+        "intent": "chat",
+        "language": "en",
+        "skip_sorting": true,
+        "source": "tool_command",
+        "topic": "synaplan"
+    },
     "cmd_lang": {
         "intent": "chat",
         "language": "en",

--- a/backend/tests/Command/CheckUpdatesCommandTest.php
+++ b/backend/tests/Command/CheckUpdatesCommandTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Command;
 
 use App\Command\CheckUpdatesCommand;
 use App\Entity\Config;
+use App\Message\SyncPlatformDocsMessage;
 use App\Repository\ConfigRepository;
 use App\Service\Update\UpdateConfig;
 use App\Service\Update\UpdateManifestClient;
@@ -19,6 +20,8 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
 
 /**
  * The scheduler runs this once a day, unattended. An unreachable manifest is an
@@ -114,6 +117,42 @@ final class CheckUpdatesCommandTest extends TestCase
         self::assertSame('4.0.14', $this->rows[UpdateConfig::KEY_LATEST_VERSION]);
     }
 
+    public function testDispatchesDocsSyncWhenPublishedVersionChanges(): void
+    {
+        $this->stubConfigRepository();
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects(self::once())
+            ->method('dispatch')
+            ->with(self::isInstanceOf(SyncPlatformDocsMessage::class))
+            ->willReturn(new Envelope(new SyncPlatformDocsMessage()));
+
+        $tester = $this->testerWith('4.0.12', new MockHttpClient(new MockResponse((string) json_encode([
+            'schema' => 1,
+            'stable' => ['version' => '4.0.13', 'severity' => 'security'],
+        ]))), $bus);
+
+        $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $tester->getStatusCode());
+    }
+
+    public function testDoesNotDispatchDocsSyncWhenVersionIsUnchanged(): void
+    {
+        $this->stubConfigRepository();
+        $this->rows[UpdateConfig::KEY_LATEST_VERSION] = '4.0.13';
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects(self::never())->method('dispatch');
+
+        $tester = $this->testerWith('4.0.13', new MockHttpClient(new MockResponse((string) json_encode([
+            'schema' => 1,
+            'stable' => ['version' => '4.0.13'],
+        ]))), $bus);
+
+        $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $tester->getStatusCode());
+    }
+
     public function testAnUnexpectedErrorExitsNonZero(): void
     {
         $this->configRepository
@@ -148,8 +187,11 @@ final class CheckUpdatesCommandTest extends TestCase
         return $this->testerWith($currentVersion, new MockHttpClient($response));
     }
 
-    private function testerWith(string $currentVersion, MockHttpClient $httpClient): CommandTester
-    {
+    private function testerWith(
+        string $currentVersion,
+        MockHttpClient $httpClient,
+        ?MessageBusInterface $messageBus = null,
+    ): CommandTester {
         $service = new UpdateStatusService(
             new UpdateConfig($this->configRepository),
             new UpdateManifestClient($httpClient, new ArrayAdapter(), new NullLogger()),
@@ -158,7 +200,7 @@ final class CheckUpdatesCommandTest extends TestCase
         );
 
         $application = new Application();
-        $application->addCommand(new CheckUpdatesCommand($service));
+        $application->addCommand(new CheckUpdatesCommand($service, $messageBus));
 
         return new CommandTester($application->find('app:updates:check'));
     }

--- a/backend/tests/Command/SelfAwareEvalCommandTest.php
+++ b/backend/tests/Command/SelfAwareEvalCommandTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Command;
+
+use App\Command\SelfAwareEvalCommand;
+use App\Service\Message\Handler\ChatHandler;
+use App\Service\Message\MessageClassifier;
+use App\Service\SelfAware\Eval\SelfAwareEvalCorpus;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class SelfAwareEvalCommandTest extends TestCase
+{
+    public function testRoutingOnlyWithCannedClassifier(): void
+    {
+        $classifier = $this->createMock(MessageClassifier::class);
+        $classifier->method('classify')->willReturn([
+            'topic' => 'synaplan',
+            'language' => 'en',
+            'source' => 'tool_command',
+        ]);
+
+        $command = new SelfAwareEvalCommand(
+            $classifier,
+            $this->createMock(ChatHandler::class),
+            dirname(__DIR__, 2),
+        );
+        $tester = new CommandTester($command);
+        $status = $tester->execute([
+            '--only' => 'Q26',
+            '--routing-only' => true,
+            '--corpus' => 'tests/Eval/self_aware_eval_corpus.json',
+        ]);
+
+        $this->assertSame(0, $status);
+        $this->assertStringContainsString('passed=1', $tester->getDisplay());
+    }
+
+    public function testFailingTopicYieldsExitOne(): void
+    {
+        $classifier = $this->createMock(MessageClassifier::class);
+        $classifier->method('classify')->willReturn([
+            'topic' => 'general',
+            'language' => 'en',
+        ]);
+
+        $command = new SelfAwareEvalCommand(
+            $classifier,
+            $this->createMock(ChatHandler::class),
+            dirname(__DIR__, 2),
+        );
+        $tester = new CommandTester($command);
+        $status = $tester->execute([
+            '--only' => 'Q1',
+            '--routing-only' => true,
+        ]);
+
+        $this->assertSame(1, $status);
+        $this->assertStringContainsString('failed=1', $tester->getDisplay());
+    }
+
+    public function testCorpusFileIsValid(): void
+    {
+        $rows = SelfAwareEvalCorpus::load(dirname(__DIR__).'/Eval/self_aware_eval_corpus.json');
+        $this->assertGreaterThanOrEqual(26, count($rows));
+    }
+}

--- a/backend/tests/Eval/self_aware_eval_corpus.json
+++ b/backend/tests/Eval/self_aware_eval_corpus.json
@@ -1,0 +1,388 @@
+[
+  {
+    "id": "Q1",
+    "lang": "en",
+    "text": "Can you create PDFs?",
+    "install": "no_engine",
+    "expect": {
+      "topic": "synaplan",
+      "must_contain_any": ["not", "nicht", "not available", "not set"],
+      "must_mention_any": ["DOCX", "Word", "XLSX"],
+      "must_not_contain": ["http://", "https://files", "I have attached", "€", "$"]
+    }
+  },
+  {
+    "id": "Q2",
+    "lang": "en",
+    "text": "Can you create PDFs?",
+    "install": "full",
+    "expect": {
+      "topic": "synaplan",
+      "must_contain_any": ["yes", "can", "PDF"],
+      "must_not_contain": ["maybe", "I have attached", "€"]
+    }
+  },
+  {
+    "id": "Q3",
+    "lang": "de",
+    "text": "Kannst du mir eine PDF erstellen?",
+    "install": "no_engine",
+    "expect": {
+      "topic": "synaplan",
+      "must_contain_any": ["nicht", "keine"],
+      "must_mention_any": ["DOCX", "Word", "Administrator"],
+      "must_not_contain": ["I have attached", "€"]
+    }
+  },
+  {
+    "id": "Q4",
+    "lang": "en",
+    "text": "Would you create a song like the Beatles?",
+    "install": "no_engine",
+    "expect": {
+      "topic": "synaplan",
+      "must_contain_any": ["cannot", "can't", "not"],
+      "must_mention_any": ["lyrics"],
+      "must_not_contain": ["MP3", "I have attached", "€"]
+    }
+  },
+  {
+    "id": "Q5",
+    "lang": "en",
+    "text": "Would you create a song like the Beatles?",
+    "install": "full",
+    "expect": {
+      "topic": "synaplan",
+      "must_contain_any": ["cannot", "can't", "not"],
+      "must_mention_any": ["lyrics", "MP3"],
+      "must_not_contain": ["I have attached", "€"]
+    }
+  },
+  {
+    "id": "Q6",
+    "lang": "es",
+    "text": "¿Puedes buscar en internet?",
+    "install": "no_engine",
+    "expect": {
+      "topic": "synaplan",
+      "must_contain_any": ["sí", "si", "puedo", "/search"],
+      "must_not_contain": ["no puedo", "€"]
+    }
+  },
+  {
+    "id": "Q7",
+    "lang": "es",
+    "text": "¿Puedes buscar en internet?",
+    "install": "no_keys",
+    "expect": {
+      "topic": "synaplan",
+      "must_contain_any": ["no", "aún", "configur"],
+      "must_not_contain": ["sí, puedo buscar", "€"]
+    }
+  },
+  {
+    "id": "Q8",
+    "lang": "fr",
+    "text": "Peux-tu lire mes e-mails ?",
+    "install": "full",
+    "expect": {
+      "topic": "synaplan",
+      "must_contain_any": ["pas", "non", "Channels", "canal"],
+      "must_not_contain": ["€", "$"]
+    }
+  },
+  {
+    "id": "Q9",
+    "lang": "tr",
+    "text": "Bana bir video yapabilir misin?",
+    "install": "no_engine",
+    "expect": {
+      "topic": "synaplan",
+      "must_contain_any": ["değil", "yok", "hayır"],
+      "must_not_contain": ["€"]
+    }
+  },
+  {
+    "id": "Q10",
+    "lang": "tr",
+    "text": "Bana bir video yapabilir misin?",
+    "install": "full",
+    "expect": {
+      "topic": "synaplan",
+      "must_contain_any": ["evet", "/vid", "video"],
+      "must_not_contain": ["€"]
+    }
+  },
+  {
+    "id": "Q11",
+    "lang": "en",
+    "text": "Can you run Python code for me?",
+    "install": "full",
+    "expect": {
+      "topic": "synaplan",
+      "must_contain_any": ["cannot", "can't", "not"],
+      "must_mention_any": ["Desktop", "skills"],
+      "must_not_contain": ["```python", "€"]
+    }
+  },
+  {
+    "id": "Q12",
+    "lang": "en",
+    "text": "Can you remember things about me?",
+    "install": "no_engine",
+    "expect": {
+      "topic": "synaplan",
+      "must_contain_any": ["yes", "memor"],
+      "must_not_contain": ["€"]
+    }
+  },
+  {
+    "id": "Q13",
+    "lang": "en",
+    "text": "Can you remember things about me?",
+    "install": "no_keys",
+    "expect": {
+      "topic": "synaplan",
+      "must_contain_any": ["not", "Qdrant", "administrator"],
+      "must_not_contain": ["€"]
+    }
+  },
+  {
+    "id": "Q14",
+    "lang": "de",
+    "text": "Kannst du Audiodateien transkribieren?",
+    "install": "no_engine",
+    "expect": {
+      "topic": "synaplan",
+      "must_contain_any": ["ja", "kann", "hochladen"],
+      "must_not_contain": ["€"]
+    }
+  },
+  {
+    "id": "Q15",
+    "lang": "en",
+    "text": "What file types can I upload?",
+    "install": "no_engine",
+    "expect": {
+      "topic": "synaplan",
+      "must_mention_any": ["PDF", "DOCX", "PNG"],
+      "must_not_contain": ["€"]
+    }
+  },
+  {
+    "id": "Q16",
+    "lang": "de",
+    "text": "Was kannst du?",
+    "install": "no_engine",
+    "expect": {
+      "topic": "synaplan",
+      "must_contain_any": ["Chat", "Dokument", "/help", "Dokumentation"],
+      "must_not_contain": ["€"]
+    }
+  },
+  {
+    "id": "Q17",
+    "lang": "en",
+    "text": "What can you do here?",
+    "install": "no_keys",
+    "expect": {
+      "topic": "synaplan",
+      "must_contain_any": ["not", "administrator", "provider"],
+      "must_not_contain": ["€"]
+    }
+  },
+  {
+    "id": "Q18",
+    "lang": "en",
+    "text": "How do I connect WhatsApp?",
+    "install": "full",
+    "expect": {
+      "topic": "synaplan",
+      "must_contain_any": ["WhatsApp", "Meta"],
+      "must_not_contain": ["€"]
+    }
+  },
+  {
+    "id": "Q19",
+    "lang": "de",
+    "text": "Wie binde ich das Chat-Widget in meine Website ein?",
+    "install": "full",
+    "expect": {
+      "topic": "synaplan",
+      "must_contain_any": ["Widget", "script"],
+      "must_not_contain": ["€"]
+    }
+  },
+  {
+    "id": "Q20",
+    "lang": "fr",
+    "text": "Est-ce que vous supportez Nextcloud ?",
+    "install": "full",
+    "expect": {
+      "topic": "synaplan",
+      "must_contain_any": ["Nextcloud"],
+      "must_not_contain": ["€"]
+    }
+  },
+  {
+    "id": "Q21",
+    "lang": "en",
+    "text": "Can I use you from Outlook?",
+    "install": "full",
+    "expect": {
+      "topic": "synaplan",
+      "must_contain_any": ["Synamail", "Outlook"],
+      "must_not_contain": ["€"]
+    }
+  },
+  {
+    "id": "Q22",
+    "lang": "es",
+    "text": "¿Qué hay de nuevo?",
+    "install": "full",
+    "expect": {
+      "topic": "synaplan",
+      "must_contain_any": ["nuevo", "versión", "version"],
+      "must_not_contain": ["€"]
+    }
+  },
+  {
+    "id": "Q23",
+    "lang": "en",
+    "text": "Are you ChatGPT?",
+    "install": "full",
+    "expect": {
+      "topic": "synaplan",
+      "must_contain_any": ["Synaplan", "assistant"],
+      "must_not_contain": ["sk-", "api_key", "€"]
+    }
+  },
+  {
+    "id": "Q24",
+    "lang": "en",
+    "text": "How much does the Pro plan cost?",
+    "install": "full",
+    "expect": {
+      "topic": "synaplan",
+      "must_contain_any": ["pricing", "plan"],
+      "must_not_contain": ["€", "$", "£"]
+    }
+  },
+  {
+    "id": "Q25",
+    "lang": "en",
+    "text": "How much does the Pro plan cost?",
+    "install": "no_engine",
+    "expect": {
+      "topic": "synaplan",
+      "must_contain_any": ["self-hosted", "not configured", "plans"],
+      "must_not_contain": ["€", "$"]
+    }
+  },
+  {
+    "id": "Q26",
+    "lang": "en",
+    "text": "/help",
+    "install": "no_engine",
+    "expect": {
+      "topic": "synaplan",
+      "must_not_contain": ["€"]
+    }
+  },
+  {
+    "id": "T1",
+    "lang": "en",
+    "text": "Create a PDF of the following text: \"Quarterly notes …\"",
+    "install": "no_engine",
+    "expect": {
+      "topic": "not_synaplan",
+      "must_mention_any": ["DOCX", "Word"],
+      "must_not_contain": ["__FILE_GENERATED__", "https://files"]
+    }
+  },
+  {
+    "id": "T2",
+    "lang": "de",
+    "text": "Mach mir daraus ein Video.",
+    "install": "no_engine",
+    "expect": {
+      "topic": "not_synaplan",
+      "must_not_contain": ["hier ist dein Video", "https://files"]
+    }
+  },
+  {
+    "id": "T3",
+    "lang": "en",
+    "text": "Write me a poem and read it to me as MP3",
+    "install": "no_engine",
+    "expect": {
+      "topic": "not_synaplan",
+      "must_not_contain": ["https://files"]
+    }
+  },
+  {
+    "id": "T4",
+    "lang": "en",
+    "text": "Write me a poem and read it to me as MP3",
+    "install": "full",
+    "expect": {
+      "topic": "not_synaplan"
+    }
+  },
+  {
+    "id": "N1",
+    "lang": "en",
+    "text": "Write me a poem about autumn",
+    "install": "any",
+    "expect": { "topic": "not_synaplan" }
+  },
+  {
+    "id": "N2",
+    "lang": "en",
+    "text": "Can you help me with my Excel formulas?",
+    "install": "any",
+    "expect": { "topic": "not_synaplan" }
+  },
+  {
+    "id": "N3",
+    "lang": "de",
+    "text": "Kannst du das zusammenfassen?",
+    "install": "any",
+    "expect": { "topic": "not_synaplan" }
+  },
+  {
+    "id": "N4",
+    "lang": "fr",
+    "text": "Peux-tu traduire ce texte en anglais : Bonjour",
+    "install": "any",
+    "expect": { "topic": "not_synaplan" }
+  },
+  {
+    "id": "N5",
+    "lang": "en",
+    "text": "What can you tell me about the Beatles?",
+    "install": "any",
+    "expect": { "topic": "not_synaplan" }
+  },
+  {
+    "id": "N6",
+    "lang": "en",
+    "text": "Search the web for Synaplan reviews",
+    "install": "any",
+    "expect": { "topic": "not_synaplan" }
+  },
+  {
+    "id": "W1",
+    "lang": "en",
+    "text": "What can you do?",
+    "install": "any",
+    "expect": {}
+  },
+  {
+    "id": "W2",
+    "lang": "en",
+    "text": "Can you create PDFs?",
+    "install": "any",
+    "expect": {}
+  }
+]

--- a/backend/tests/Fixtures/selfaware/docs-manifest.json
+++ b/backend/tests/Fixtures/selfaware/docs-manifest.json
@@ -1,0 +1,41 @@
+{
+  "schema": "synaplan-docs-manifest/1",
+  "generated_at": "2026-09-02T09:00:00Z",
+  "site_url": "https://docs.synaplan.com",
+  "version": "2026.09",
+  "pages": [
+    {
+      "slug": "intro",
+      "title": "Introduction & Auth",
+      "section": "Getting started",
+      "description": "Official Synaplan documentation: self-host an open-source AI knowledge platform with RAG, an embeddable chat widget, and a REST API.",
+      "url": "https://docs.synaplan.com/",
+      "raw_url": "https://docs.synaplan.com/raw/intro.md",
+      "sha256": "4b227777d4dd1fc61c6f884f48641d02b4d121d3fd328cb08b5531fcacdabf8a",
+      "bytes": 1842,
+      "updated_at": "2026-08-30T14:11:02Z"
+    },
+    {
+      "slug": "using-synaplan",
+      "title": "Using Synaplan",
+      "section": "Using Synaplan",
+      "description": "A task-oriented tour of chat, files and RAG, memories, and saved tasks.",
+      "url": "https://docs.synaplan.com/using-synaplan",
+      "raw_url": "https://docs.synaplan.com/raw/using-synaplan.md",
+      "sha256": "2c624232cdd221771294dfbb310aca000a0df6ac8b66b696d90ef06dced5c0ae",
+      "bytes": 2560,
+      "updated_at": "2026-09-01T08:22:11Z"
+    },
+    {
+      "slug": "dag-routing",
+      "title": "Multi-Task (DAG) Routing",
+      "section": "Developers",
+      "description": "How Synaplan turns a complex request into a DAG of tasks with live task cards.",
+      "url": "https://docs.synaplan.com/dag-routing",
+      "raw_url": "https://docs.synaplan.com/raw/dag-routing.md",
+      "sha256": "6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b",
+      "bytes": 9123,
+      "updated_at": "2026-08-30T14:11:02Z"
+    }
+  ]
+}

--- a/backend/tests/Fixtures/selfaware/docs-manifest.schema.json
+++ b/backend/tests/Fixtures/selfaware/docs-manifest.schema.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "synaplan-docs-manifest/1",
+  "description": "Machine-readable catalog exported by the Synaplan docs site.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "generated_at", "site_url", "version", "pages"],
+  "properties": {
+    "schema": {
+      "type": "string",
+      "const": "synaplan-docs-manifest/1"
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "site_url": {
+      "type": "string",
+      "format": "uri"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^[0-9]{4}\\.[0-9]{2}$"
+    },
+    "pages": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/page"
+      }
+    }
+  },
+  "$defs": {
+    "page": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "slug",
+        "title",
+        "section",
+        "description",
+        "url",
+        "raw_url",
+        "sha256",
+        "bytes",
+        "updated_at"
+      ],
+      "properties": {
+        "slug": {
+          "type": "string",
+          "pattern": "^[a-z0-9-]{1,64}$"
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1
+        },
+        "section": {
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "raw_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "sha256": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        },
+        "bytes": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    }
+  }
+}

--- a/backend/tests/Unit/MessageClassifierTest.php
+++ b/backend/tests/Unit/MessageClassifierTest.php
@@ -97,6 +97,24 @@ class MessageClassifierTest extends TestCase
         $this->assertTrue($result['skip_sorting']);
     }
 
+    public function testHelpCommandRoutesToSynaplan(): void
+    {
+        $message = $this->createMock(Message::class);
+        $message->method('getId')->willReturn(21);
+        $message->method('getUserId')->willReturn(10);
+        $message->method('getText')->willReturn('/help');
+        $message->method('getLanguage')->willReturn('en');
+
+        $this->messageMetaRepository->method('findOneBy')->willReturn(null);
+
+        $result = $this->service->classify($message);
+
+        $this->assertSame('synaplan', $result['topic']);
+        $this->assertSame('chat', $result['intent']);
+        $this->assertSame('tool_command', $result['source']);
+        $this->assertTrue($result['skip_sorting']);
+    }
+
     public function testClassifyWithAiSorting(): void
     {
         $message = $this->createMock(Message::class);
@@ -1325,6 +1343,47 @@ class MessageClassifierTest extends TestCase
         $this->assertArrayNotHasKey('input_mode', $this->service->classify($this->plainMessage(306, 'hello there')));
     }
 
+    /**
+     * @return list<array{0: string}>
+     */
+    public static function selfAwareGuardUtterances(): array
+    {
+        return [
+            ['can you make PDFs?'],
+            ['was kannst du?'],
+            ['¿puedes buscar en internet?'],
+            ['peux-tu lire mes e-mails ?'],
+            ['video yapabilir misin?'],
+        ];
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('selfAwareGuardUtterances')]
+    public function testFastPathDefersSelfAwareMetaQuestions(string $text): void
+    {
+        $sorter = $this->createMock(MessageSorter::class);
+        $sorter->expects($this->once())
+            ->method('classify')
+            ->willReturn(['topic' => 'synaplan', 'language' => 'en']);
+
+        $classifier = $this->classifierWithFastPathEnabled($sorter);
+        $result = $classifier->classify($this->plainMessage(410, $text));
+
+        $this->assertSame('synaplan', $result['topic']);
+        $this->assertSame('ai_sorting', $result['source']);
+    }
+
+    public function testFastPathStillClassifiesOrdinaryChat(): void
+    {
+        $sorter = $this->createMock(MessageSorter::class);
+        $sorter->expects($this->never())->method('classify');
+
+        $classifier = $this->classifierWithFastPathEnabled($sorter);
+        $result = $classifier->classify($this->plainMessage(411, 'write me a poem'));
+
+        $this->assertSame('general', $result['topic']);
+        $this->assertSame('fast_path_heuristic', $result['source']);
+    }
+
     private function classifierWithFastPathEnabled(MessageSorter $sorter): MessageClassifier
     {
         $configRepo = $this->createMock(ConfigRepository::class);
@@ -1343,6 +1402,7 @@ class MessageClassifierTest extends TestCase
             $configRepo,
             $this->createMock(EntityManagerInterface::class),
             $this->createMock(LoggerInterface::class),
+            new \App\Service\SelfAware\SelfAwareConfig($configRepo),
         );
     }
 

--- a/backend/tests/Unit/PromptCatalogTest.php
+++ b/backend/tests/Unit/PromptCatalogTest.php
@@ -20,6 +20,7 @@ final class PromptCatalogTest extends TestCase
         $topics = array_column(PromptCatalog::all(), 'topic');
 
         $this->assertContains('general', $topics);
+        $this->assertContains('synaplan', $topics);
         $this->assertContains('mediamaker', $topics);
         $this->assertContains('docsummary', $topics);
         $this->assertContains('officemaker', $topics);
@@ -109,6 +110,44 @@ final class PromptCatalogTest extends TestCase
         $this->assertStringContainsString('NEVER search for the literal question words', $prompt);
         // Worked example: deictic price question + product photo.
         $this->assertStringContainsString('sony wh-1000xm6 price', $prompt);
+    }
+
+    public function testSynaplanTopicIsRoutableAndHasPlaceholders(): void
+    {
+        $synaplan = null;
+        $general = null;
+        $sort = null;
+        $plan = null;
+        foreach (PromptCatalog::all() as $entry) {
+            if ('synaplan' === $entry['topic']) {
+                $synaplan = $entry;
+            }
+            if ('general' === $entry['topic']) {
+                $general = $entry;
+            }
+            if ('tools:sort' === $entry['topic']) {
+                $sort = $entry;
+            }
+            if ('tools:plan' === $entry['topic']) {
+                $plan = $entry;
+            }
+        }
+
+        $this->assertNotNull($synaplan);
+        $this->assertStringStartsNotWith('tools:', $synaplan['topic']);
+        $this->assertNotSame('', $synaplan['shortDescription']);
+        $this->assertSame(1, substr_count($synaplan['prompt'], '[PLATFORM_CAPABILITIES]'));
+        $this->assertSame(1, substr_count($synaplan['prompt'], '[PLATFORM_DOCS]'));
+
+        $this->assertNotNull($general);
+        $this->assertSame(1, substr_count($general['prompt'], '[PLATFORM_CAPABILITIES]'));
+
+        $this->assertNotNull($sort);
+        $this->assertStringContainsString('Questions about Synaplan itself', $sort['prompt']);
+        $this->assertStringContainsString('BTOPIC "synaplan"', $sort['prompt']);
+
+        $this->assertNotNull($plan);
+        $this->assertStringContainsString('topic_id: "synaplan"', $plan['prompt']);
     }
 
     public function testTopicsAreUniquePerLanguage(): void

--- a/backend/tests/Unit/Service/Knowledge/KnowledgeContextFormatterTest.php
+++ b/backend/tests/Unit/Service/Knowledge/KnowledgeContextFormatterTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Tests\Unit\Service\Knowledge;
 
 use App\Service\Knowledge\KnowledgeContextFormatter;
+use App\Service\SelfAware\Docs\PlatformDocsHit;
+use App\Service\SelfAware\Docs\PlatformDocsHits;
 use PHPUnit\Framework\TestCase;
 
 final class KnowledgeContextFormatterTest extends TestCase
@@ -28,6 +30,35 @@ final class KnowledgeContextFormatterTest extends TestCase
 
         $clamped = $fmt->combineAndClamp('ABCDEFGHIJ', '', 5);
         $this->assertSame("ABCDE\n…", $clamped);
+    }
+
+    public function testFormatPlatformDocsContextRendersDocPillsAndRules(): void
+    {
+        $fmt = new KnowledgeContextFormatter();
+        $block = $fmt->formatPlatformDocsContext(new PlatformDocsHits([
+            new PlatformDocsHit(
+                'channels',
+                'Channels: WhatsApp & Email',
+                'https://docs.synaplan.com/channels',
+                'Using',
+                'Connect WhatsApp via the Meta Business API.',
+                0.8,
+            ),
+            new PlatformDocsHit(
+                'widget',
+                'Widget Integration',
+                'https://docs.synaplan.com/widget',
+                'Using',
+                'Embed the chat widget with a script tag.',
+                0.7,
+            ),
+        ]));
+
+        $this->assertStringContainsString('[Doc:channels] Channels: WhatsApp & Email', $block);
+        $this->assertStringContainsString('[Doc:widget] Widget Integration', $block);
+        $this->assertStringContainsString('ONE slug per bracket', $block);
+        $this->assertStringContainsString('Never invent slugs', $block);
+        $this->assertSame('', (new KnowledgeContextFormatter())->formatPlatformDocsContext(new PlatformDocsHits([])));
     }
 
     public function testFormatDigestContextEmptyInputYieldsEmptyString(): void

--- a/backend/tests/Unit/Service/SelfAware/CapabilityReportRendererTest.php
+++ b/backend/tests/Unit/Service/SelfAware/CapabilityReportRendererTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\SelfAware;
+
+use App\Service\SelfAware\CapabilityFact;
+use App\Service\SelfAware\CapabilityReport;
+use App\Service\SelfAware\CapabilityReportRenderer;
+use App\Service\SelfAware\CapabilityState;
+use PHPUnit\Framework\TestCase;
+
+final class CapabilityReportRendererTest extends TestCase
+{
+    public function testRenderIsDeterministicAndWithinBudget(): void
+    {
+        $report = $this->fullReport(isAdmin: false, billingEnabled: false);
+        $renderer = new CapabilityReportRenderer();
+
+        $first = $renderer->render($report);
+        $second = $renderer->render($report);
+
+        $this->assertSame($first, $second);
+        $this->assertLessThanOrEqual(CapabilityReportRenderer::MAX_CHARS, strlen($first));
+        $this->assertStringContainsString('AVAILABLE NOW:', $first);
+        $this->assertStringContainsString('NEEDS SETUP:', $first);
+        $this->assertStringContainsString('NOT AVAILABLE:', $first);
+        $this->assertStringContainsString('ask your administrator', $first);
+        $this->assertStringNotContainsString('pricing page', $first);
+        $this->assertDoesNotMatchRegularExpression('/\d\s*[€$£]|[€$£]\s*\d/', $first);
+    }
+
+    public function testAdminSeesHintsAndBillingAddsPricingRule(): void
+    {
+        $renderer = new CapabilityReportRenderer();
+        $admin = $renderer->render($this->fullReport(isAdmin: true, billingEnabled: true));
+
+        $this->assertStringContainsString('office engine (OFFICE_CONVERT_URL)', $admin);
+        $this->assertStringNotContainsString('ask your administrator', $admin);
+        $this->assertStringContainsString('For plans and pricing, link the pricing page.', $admin);
+    }
+
+    private function fullReport(bool $isAdmin, bool $billingEnabled): CapabilityReport
+    {
+        $facts = [
+            new CapabilityFact('chat', 'Chat', CapabilityState::Available, 'workspace model', null, null, null),
+            new CapabilityFact('document_generation', 'Documents', CapabilityState::Available, 'DOCX, XLSX, PPTX, CSV', null, null, null),
+            new CapabilityFact('pdf_export', 'PDF export', CapabilityState::NeedsSetup, 'office engine not configured', 'DOCX, XLSX, PPTX, CSV', 'office engine (OFFICE_CONVERT_URL)', 'using-synaplan'),
+            new CapabilityFact('music_generation', 'Composing or producing music', CapabilityState::Absent, 'No music or song model exists', 'original lyrics in that style', null, null),
+        ];
+
+        return new CapabilityReport($facts, '4.2.1', $billingEnabled, $isAdmin);
+    }
+}

--- a/backend/tests/Unit/Service/SelfAware/Docs/DocsManifestTest.php
+++ b/backend/tests/Unit/Service/SelfAware/Docs/DocsManifestTest.php
@@ -42,6 +42,29 @@ final class DocsManifestTest extends TestCase
         ], JSON_THROW_ON_ERROR));
     }
 
+    public function testRejectsForeignPublicUrl(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('url for slug "intro" is not on the manifest host.');
+        DocsManifest::fromJson(json_encode([
+            'schema' => DocsManifest::SCHEMA_ID,
+            'generated_at' => '2026-09-02T09:00:00Z',
+            'site_url' => 'https://docs.synaplan.com',
+            'version' => '2026.09',
+            'pages' => [[
+                'slug' => 'intro',
+                'title' => 'Intro',
+                'section' => 'Start',
+                'description' => 'd',
+                'url' => 'https://evil.example/intro',
+                'raw_url' => 'https://docs.synaplan.com/raw/intro.md',
+                'sha256' => str_repeat('a', 64),
+                'bytes' => 1,
+                'updated_at' => '2026-09-02T00:00:00Z',
+            ]],
+        ], JSON_THROW_ON_ERROR));
+    }
+
     public function testRejectsInvalidSlug(): void
     {
         $this->expectException(\InvalidArgumentException::class);

--- a/backend/tests/Unit/Service/SelfAware/Docs/DocsManifestTest.php
+++ b/backend/tests/Unit/Service/SelfAware/Docs/DocsManifestTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\SelfAware\Docs;
+
+use App\Service\SelfAware\Docs\DocsManifest;
+use PHPUnit\Framework\TestCase;
+
+final class DocsManifestTest extends TestCase
+{
+    public function testParsesFixture(): void
+    {
+        $json = (string) file_get_contents(dirname(__DIR__, 4).'/Fixtures/selfaware/docs-manifest.json');
+        $manifest = DocsManifest::fromJson($json);
+
+        $this->assertSame(DocsManifest::SCHEMA_ID, $manifest->schema);
+        $this->assertCount(3, $manifest->pages);
+        $this->assertSame('intro', $manifest->pages[0]->slug);
+        $this->assertSame('https://docs.synaplan.com/raw/intro.md', $manifest->pages[0]->rawUrl);
+    }
+
+    public function testRejectsHttpAndForeignHost(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        DocsManifest::fromJson(json_encode([
+            'schema' => DocsManifest::SCHEMA_ID,
+            'generated_at' => '2026-09-02T09:00:00Z',
+            'site_url' => 'https://docs.synaplan.com',
+            'version' => '2026.09',
+            'pages' => [[
+                'slug' => 'intro',
+                'title' => 'Intro',
+                'section' => 'Start',
+                'description' => 'd',
+                'url' => 'https://docs.synaplan.com/',
+                'raw_url' => 'https://evil.example/raw/intro.md',
+                'sha256' => str_repeat('a', 64),
+                'bytes' => 1,
+                'updated_at' => '2026-09-02T00:00:00Z',
+            ]],
+        ], JSON_THROW_ON_ERROR));
+    }
+
+    public function testRejectsInvalidSlug(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        DocsManifest::fromJson(json_encode([
+            'schema' => DocsManifest::SCHEMA_ID,
+            'site_url' => 'https://docs.synaplan.com',
+            'pages' => [[
+                'slug' => '../etc/passwd',
+                'title' => 'x',
+                'url' => 'https://docs.synaplan.com/x',
+                'raw_url' => 'https://docs.synaplan.com/raw/x.md',
+                'sha256' => str_repeat('b', 64),
+            ]],
+        ], JSON_THROW_ON_ERROR));
+    }
+}

--- a/backend/tests/Unit/Service/SelfAware/Docs/PlatformDocsRetrieverTest.php
+++ b/backend/tests/Unit/Service/SelfAware/Docs/PlatformDocsRetrieverTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\SelfAware\Docs;
+
+use App\Repository\ConfigRepository;
+use App\Service\RAG\VectorSearchService;
+use App\Service\SelfAware\Docs\PlatformDocsRetriever;
+use App\Service\SelfAware\Docs\PlatformDocsSyncService;
+use App\Service\SelfAware\Docs\PlatformDocsSyncState;
+use App\Service\SelfAware\SelfAwareConfig;
+use PHPUnit\Framework\TestCase;
+
+final class PlatformDocsRetrieverTest extends TestCase
+{
+    public function testFlagOffDoesNotTouchSearch(): void
+    {
+        $search = $this->createMock(VectorSearchService::class);
+        $search->expects($this->never())->method('semanticSearch');
+
+        $retriever = new PlatformDocsRetriever(
+            $this->config(docsRag: false),
+            $this->stateWithPages(),
+            $search,
+        );
+
+        $this->assertTrue($retriever->retrieve('WhatsApp', 2)->isEmpty());
+    }
+
+    public function testMapsHitsDropsUnknownAndDedupsBySlug(): void
+    {
+        $fileId = PlatformDocsSyncService::buildFileId('channels');
+        $search = $this->createMock(VectorSearchService::class);
+        $search->expects($this->once())
+            ->method('semanticSearch')
+            ->with(
+                'How do I connect WhatsApp?',
+                0,
+                'SYSTEM:synaplan',
+                5,
+                0.35,
+            )
+            ->willReturn([
+                ['file_id' => $fileId, 'chunk_text' => 'weak', 'score' => 0.4],
+                ['file_id' => $fileId, 'chunk_text' => 'strong', 'score' => 0.9],
+                ['file_id' => 999999, 'chunk_text' => 'unknown', 'score' => 0.99],
+            ]);
+
+        $retriever = new PlatformDocsRetriever(
+            $this->config(docsRag: true),
+            $this->stateWithPages($fileId),
+            $search,
+        );
+
+        $hits = $retriever->retrieve('How do I connect WhatsApp?', 2);
+        $this->assertCount(1, $hits->hits);
+        $this->assertSame('channels', $hits->hits[0]->slug);
+        $this->assertSame('strong', $hits->hits[0]->text);
+        $this->assertSame(0.9, $hits->hits[0]->score);
+    }
+
+    public function testEmptyStateSkipsSearch(): void
+    {
+        $search = $this->createMock(VectorSearchService::class);
+        $search->expects($this->never())->method('semanticSearch');
+
+        $state = new PlatformDocsSyncState($this->emptyConfigRepo());
+        $retriever = new PlatformDocsRetriever($this->config(docsRag: true), $state, $search);
+
+        $this->assertTrue($retriever->retrieve('x', 2)->isEmpty());
+    }
+
+    private function config(bool $docsRag): SelfAwareConfig
+    {
+        $repo = $this->createMock(ConfigRepository::class);
+        $repo->method('getValue')->willReturnCallback(
+            static function (int $owner, string $group, string $setting) use ($docsRag): string {
+                if (SelfAwareConfig::CONFIG_GROUP === $group && SelfAwareConfig::KEY_DOCS_RAG_ENABLED === $setting) {
+                    return $docsRag ? '1' : '0';
+                }
+
+                return '1';
+            }
+        );
+
+        return new SelfAwareConfig($repo);
+    }
+
+    private function stateWithPages(int $fileId = 42): PlatformDocsSyncState
+    {
+        $repo = $this->createMock(ConfigRepository::class);
+        $repo->method('getValue')->willReturn(json_encode([
+            'manifest_url' => 'https://docs.synaplan.com/docs-manifest.json',
+            'manifest_version' => '2026.09',
+            'synced_at' => '2026-09-02T00:00:00Z',
+            'pages' => [
+                'channels' => [
+                    'sha256' => str_repeat('a', 64),
+                    'file_id' => $fileId,
+                    'title' => 'Channels',
+                    'url' => 'https://docs.synaplan.com/channels',
+                    'section' => 'Using',
+                    'synced_at' => '2026-09-02T00:00:00Z',
+                ],
+            ],
+        ], JSON_THROW_ON_ERROR));
+
+        return new PlatformDocsSyncState($repo);
+    }
+
+    private function emptyConfigRepo(): ConfigRepository
+    {
+        $repo = $this->createMock(ConfigRepository::class);
+        $repo->method('getValue')->willReturn(null);
+
+        return $repo;
+    }
+}

--- a/backend/tests/Unit/Service/SelfAware/Docs/PlatformDocsSyncServiceTest.php
+++ b/backend/tests/Unit/Service/SelfAware/Docs/PlatformDocsSyncServiceTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\SelfAware\Docs;
+
+use App\Repository\ConfigRepository;
+use App\Service\File\VectorizationService;
+use App\Service\RAG\VectorStorage\VectorStorageFacade;
+use App\Service\SelfAware\Docs\DocsManifest;
+use App\Service\SelfAware\Docs\PlatformDocsManifestClient;
+use App\Service\SelfAware\Docs\PlatformDocsSyncService;
+use App\Service\SelfAware\Docs\PlatformDocsSyncState;
+use App\Service\SelfAware\SelfAwareConfig;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+final class PlatformDocsSyncServiceTest extends TestCase
+{
+    public function testEmptyUrlIsSkipped(): void
+    {
+        $service = $this->service(manifestUrl: '', client: $this->createMock(PlatformDocsManifestClient::class));
+        $result = $service->sync();
+
+        $this->assertSame('skipped', $result->status);
+        $this->assertStringContainsString('empty', $result->reason);
+    }
+
+    public function testManifestFailureLeavesStateUntouched(): void
+    {
+        $client = $this->createMock(PlatformDocsManifestClient::class);
+        $client->method('fetchManifest')->willThrowException(new \RuntimeException('timeout'));
+
+        $configRepo = $this->createMock(ConfigRepository::class);
+        $configRepo->expects($this->never())->method('setValue');
+
+        $service = $this->service(
+            manifestUrl: 'https://docs.synaplan.com/docs-manifest.json',
+            client: $client,
+            configRepo: $configRepo,
+        );
+        $result = $service->sync();
+
+        $this->assertTrue($result->isFailed());
+        $this->assertSame('timeout', $result->reason);
+    }
+
+    public function testDryRunDoesNotWrite(): void
+    {
+        $json = (string) file_get_contents(dirname(__DIR__, 4).'/Fixtures/selfaware/docs-manifest.json');
+        $client = $this->createMock(PlatformDocsManifestClient::class);
+        $client->method('fetchManifest')->willReturn(DocsManifest::fromJson($json));
+        $client->expects($this->never())->method('fetchPage');
+
+        $vector = $this->createMock(VectorStorageFacade::class);
+        $vector->expects($this->never())->method('deleteByFile');
+
+        $configRepo = $this->createMock(ConfigRepository::class);
+        $configRepo->expects($this->never())->method('setValue');
+
+        $service = $this->service(
+            manifestUrl: 'https://docs.synaplan.com/docs-manifest.json',
+            client: $client,
+            configRepo: $configRepo,
+            vectorStorage: $vector,
+        );
+        $result = $service->sync(dryRun: true);
+
+        $this->assertSame('ok', $result->status);
+        $this->assertSame(3, $result->changed);
+    }
+
+    private function service(
+        string $manifestUrl,
+        PlatformDocsManifestClient $client,
+        ?ConfigRepository $configRepo = null,
+        ?VectorStorageFacade $vectorStorage = null,
+    ): PlatformDocsSyncService {
+        /** @var ConfigRepository&MockObject $repo */
+        $repo = $configRepo ?? $this->createMock(ConfigRepository::class);
+        $repo->method('getValue')->willReturnCallback(
+            static function (int $owner, string $group, string $setting) use ($manifestUrl): ?string {
+                if (SelfAwareConfig::KEY_DOCS_MANIFEST_URL === $setting) {
+                    return $manifestUrl;
+                }
+
+                return null;
+            }
+        );
+
+        return new PlatformDocsSyncService(
+            new SelfAwareConfig($repo),
+            $client,
+            new PlatformDocsSyncState($repo),
+            $vectorStorage ?? $this->createMock(VectorStorageFacade::class),
+            $this->createMock(VectorizationService::class),
+            new NullLogger(),
+        );
+    }
+}

--- a/backend/tests/Unit/Service/SelfAware/Eval/SelfAwareEvalCorpusTest.php
+++ b/backend/tests/Unit/Service/SelfAware/Eval/SelfAwareEvalCorpusTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\SelfAware\Eval;
+
+use App\Service\SelfAware\Eval\SelfAwareEvalAssertions;
+use App\Service\SelfAware\Eval\SelfAwareEvalCorpus;
+use PHPUnit\Framework\TestCase;
+
+final class SelfAwareEvalCorpusTest extends TestCase
+{
+    public function testCorpusLoadsAndOnlyFilterWorks(): void
+    {
+        $path = dirname(__DIR__, 4).'/Eval/self_aware_eval_corpus.json';
+        $rows = SelfAwareEvalCorpus::load($path);
+        $this->assertNotEmpty($rows);
+
+        $only = SelfAwareEvalCorpus::select($rows, 'Q1,Q26', null);
+        $this->assertCount(2, $only);
+        $this->assertSame(['Q1', 'Q26'], array_column($only, 'id'));
+
+        $install = SelfAwareEvalCorpus::select($rows, null, 'no_keys');
+        foreach ($install as $row) {
+            $this->assertContains($row['install'], ['no_keys', 'any']);
+        }
+    }
+
+    public function testAssertions(): void
+    {
+        $this->assertTrue(SelfAwareEvalAssertions::topicMatches('synaplan', ['topic' => 'synaplan']));
+        $this->assertTrue(SelfAwareEvalAssertions::topicMatches('general', ['topic' => 'not_synaplan']));
+        $this->assertFalse(SelfAwareEvalAssertions::topicMatches('synaplan', ['topic' => 'not_synaplan']));
+
+        $this->assertSame(
+            [],
+            SelfAwareEvalAssertions::answerFailures('PDF is not available. I can write a DOCX.', [
+                'must_contain_any' => ['not', 'nicht'],
+                'must_mention_any' => ['DOCX', 'Word'],
+                'must_not_contain' => ['€', '$'],
+            ]),
+        );
+        $this->assertNotEmpty(SelfAwareEvalAssertions::answerFailures('Here is a €9 plan', [
+            'must_not_contain' => ['€'],
+        ]));
+    }
+}

--- a/backend/tests/Unit/Service/SelfAware/PlatformCapabilityInventoryTest.php
+++ b/backend/tests/Unit/Service/SelfAware/PlatformCapabilityInventoryTest.php
@@ -1,0 +1,233 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\SelfAware;
+
+use App\AI\Credential\ChatReadinessService;
+use App\Entity\User;
+use App\Repository\ConnectionRepository;
+use App\Repository\PromptRepository;
+use App\Repository\UserRepository;
+use App\Service\BillingService;
+use App\Service\Capability\CapabilityService;
+use App\Service\Desktop\DesktopAgentConfig;
+use App\Service\MailerConfig;
+use App\Service\Mcp\McpClientConfig;
+use App\Service\ModelConfigService;
+use App\Service\Multitask\MultitaskRoutingConfig;
+use App\Service\Plugin\PluginManager;
+use App\Service\RAG\VectorStorage\VectorStorageFacade;
+use App\Service\SavedTask\SavedTaskConfig;
+use App\Service\Search\BraveSearchService;
+use App\Service\SelfAware\CapabilityState;
+use App\Service\SelfAware\PlatformCapabilityInventory;
+use App\Service\Update\UpdateStatusService;
+use PHPUnit\Framework\TestCase;
+
+final class PlatformCapabilityInventoryTest extends TestCase
+{
+    /** @var array<string, string|false> */
+    private array $envBackup = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->envBackup as $key => $value) {
+            if (false === $value) {
+                unset($_ENV[$key], $_SERVER[$key]);
+                putenv($key);
+            } else {
+                $_ENV[$key] = $value;
+                $_SERVER[$key] = $value;
+                putenv($key.'='.$value);
+            }
+        }
+        parent::tearDown();
+    }
+
+    public function testNoKeysInstallMarksChatAndSearchAsNeedsSetup(): void
+    {
+        $this->setEnv('QDRANT_URL', '');
+        $this->setEnv('OFFICE_CONVERT_URL', '');
+        $this->setEnv('SYNAPLAN_TTS_URL', '');
+
+        $report = $this->inventory(
+            chatReady: false,
+            models: [],
+            brave: false,
+            billing: false,
+        )->build(2);
+
+        $chat = $report->fact('chat');
+        $this->assertNotNull($chat);
+        $this->assertSame(CapabilityState::NeedsSetup, $chat->state);
+
+        $pdf = $report->fact('pdf_export');
+        $this->assertNotNull($pdf);
+        $this->assertSame(CapabilityState::NeedsSetup, $pdf->state);
+        $this->assertNotNull($pdf->alternative);
+
+        $memories = $report->fact('memories');
+        $this->assertNotNull($memories);
+        $this->assertSame(CapabilityState::NeedsSetup, $memories->state);
+
+        $documents = $report->fact('document_generation');
+        $this->assertNotNull($documents);
+        $this->assertSame(CapabilityState::Available, $documents->state);
+        foreach (PlatformCapabilityInventory::KNOWN_ABSENT as $row) {
+            $fact = $report->fact($row['id']);
+            $this->assertNotNull($fact);
+            $this->assertSame(CapabilityState::Absent, $fact->state);
+            $this->assertNotNull($fact->alternative);
+        }
+        $this->assertSame('original lyrics in that style', $report->fact('music_generation')?->alternative);
+        $this->assertFalse($report->billingEnabled);
+    }
+
+    public function testNoEngineInstallHasChatAndImagesButNotPdfOrVideo(): void
+    {
+        $this->setEnv('QDRANT_URL', 'http://qdrant:6333');
+        $this->setEnv('OFFICE_CONVERT_URL', '');
+        $this->setEnv('SYNAPLAN_TTS_URL', '');
+
+        $report = $this->inventory(
+            chatReady: true,
+            models: ['PIC2TEXT' => 1, 'VECTORIZE' => 2, 'TEXT2PIC' => 3, 'SOUND2TEXT' => 4],
+            brave: true,
+            billing: false,
+        )->build(2);
+
+        $this->assertSame(CapabilityState::Available, $report->fact('chat')?->state);
+        $this->assertSame(CapabilityState::Available, $report->fact('image_generation')?->state);
+        $this->assertSame(CapabilityState::Available, $report->fact('memories')?->state);
+        $this->assertSame(CapabilityState::Available, $report->fact('web_search')?->state);
+        $this->assertSame(CapabilityState::NeedsSetup, $report->fact('video_generation')?->state);
+        $this->assertSame(CapabilityState::NeedsSetup, $report->fact('pdf_export')?->state);
+        $this->assertSame(CapabilityState::NeedsSetup, $report->fact('text_to_speech')?->state);
+        $this->assertSame('original lyrics in that style', $report->fact('music_generation')?->alternative);
+    }
+
+    public function testFullInstallMarksPdfAndTtsAvailableAndUpgradesMusicAlternative(): void
+    {
+        $this->setEnv('QDRANT_URL', 'http://qdrant:6333');
+        $this->setEnv('OFFICE_CONVERT_URL', 'http://office:8080');
+        $this->setEnv('SYNAPLAN_TTS_URL', 'http://tts:8090');
+
+        $report = $this->inventory(
+            chatReady: true,
+            models: [
+                'PIC2TEXT' => 1,
+                'VECTORIZE' => 2,
+                'TEXT2PIC' => 3,
+                'TEXT2VID' => 5,
+                'TEXT2SOUND' => 6,
+                'SOUND2TEXT' => 4,
+            ],
+            brave: true,
+            billing: true,
+        )->build(2);
+
+        $this->assertSame(CapabilityState::Available, $report->fact('pdf_export')?->state);
+        $this->assertSame(CapabilityState::Available, $report->fact('text_to_speech')?->state);
+        $this->assertSame(CapabilityState::Available, $report->fact('video_generation')?->state);
+        $this->assertSame('original lyrics, read aloud as MP3', $report->fact('music_generation')?->alternative);
+        $this->assertTrue($report->billingEnabled);
+        $this->assertSame('4.2.1', $report->version);
+    }
+
+    /**
+     * @param array<string, int> $models
+     */
+    private function inventory(bool $chatReady, array $models, bool $brave, bool $billing): PlatformCapabilityInventory
+    {
+        $chatReadiness = $this->createMock(ChatReadinessService::class);
+        $chatReadiness->method('isChatReady')->willReturn($chatReady);
+
+        $modelConfig = $this->createMock(ModelConfigService::class);
+        $modelConfig->method('getDefaultModel')->willReturnCallback(
+            static fn (string $capability, ?int $userId): ?int => $models[$capability] ?? null,
+        );
+
+        $vectorStorage = $this->createMock(VectorStorageFacade::class);
+        $vectorStorage->method('getProviderName')->willReturn('qdrant');
+
+        $braveSearch = $this->createMock(BraveSearchService::class);
+        $braveSearch->method('isEnabled')->willReturn($brave);
+
+        $routing = $this->createMock(MultitaskRoutingConfig::class);
+        $routing->method('isFeatureEnabled')->willReturnCallback(
+            static fn (string $setting, ?int $userId, bool $default): bool => $default,
+        );
+
+        $this->setEnv('MAILER_DSN', '');
+        $mailer = new MailerConfig();
+
+        $savedTasks = $this->createMock(SavedTaskConfig::class);
+        $savedTasks->method('isEnabled')->willReturn(true);
+
+        $desktop = $this->createMock(DesktopAgentConfig::class);
+        $desktop->method('isEnabled')->willReturn(false);
+
+        $mcp = $this->createMock(McpClientConfig::class);
+        $mcp->method('isClientEnabled')->willReturn(false);
+
+        $plugins = $this->createMock(PluginManager::class);
+        $plugins->method('listInstalledPlugins')->willReturn([]);
+
+        $update = $this->createMock(UpdateStatusService::class);
+        $update->method('getStatus')->willReturn([
+            'currentVersion' => '4.2.1',
+            'latestVersion' => null,
+            'updateAvailable' => false,
+        ]);
+
+        $billingService = $this->createMock(BillingService::class);
+        $billingService->method('isEnabled')->willReturn($billing);
+
+        $connections = $this->createMock(ConnectionRepository::class);
+        $connections->method('findByOwner')->willReturn([]);
+
+        $prompts = $this->createMock(PromptRepository::class);
+        $prompts->method('getTopicsWithDescriptions')->willReturn([]);
+
+        $user = $this->createMock(User::class);
+        $user->method('isAdmin')->willReturn(false);
+        $user->method('hasVerifiedPhone')->willReturn(false);
+        $user->method('getUserDetails')->willReturn([]);
+
+        $users = $this->createMock(UserRepository::class);
+        $users->method('find')->willReturn($user);
+
+        return new PlatformCapabilityInventory(
+            $chatReadiness,
+            $modelConfig,
+            $vectorStorage,
+            $braveSearch,
+            $routing,
+            $mailer,
+            $savedTasks,
+            $desktop,
+            $mcp,
+            $plugins,
+            new CapabilityService(),
+            $prompts,
+            $update,
+            $billingService,
+            $connections,
+            $users,
+            false,
+            '',
+        );
+    }
+
+    private function setEnv(string $key, string $value): void
+    {
+        if (!array_key_exists($key, $this->envBackup)) {
+            $existing = $_ENV[$key] ?? $_SERVER[$key] ?? getenv($key);
+            $this->envBackup[$key] = is_string($existing) ? $existing : false;
+        }
+        $_ENV[$key] = $value;
+        $_SERVER[$key] = $value;
+        putenv($key.'='.$value);
+    }
+}

--- a/backend/tests/Unit/Service/SelfAware/SelfAwareConfigTest.php
+++ b/backend/tests/Unit/Service/SelfAware/SelfAwareConfigTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\SelfAware;
+
+use App\Repository\ConfigRepository;
+use App\Service\SelfAware\SelfAwareConfig;
+use PHPUnit\Framework\TestCase;
+
+final class SelfAwareConfigTest extends TestCase
+{
+    public function testDefaultsAreOnAndFilterHidesTopicWhenDisabled(): void
+    {
+        $repo = $this->createMock(ConfigRepository::class);
+        $repo->method('getValue')->willReturn(null);
+        $config = new SelfAwareConfig($repo);
+
+        $this->assertTrue($config->isEnabled(2));
+        $this->assertTrue($config->isInventoryInGeneral(2));
+        $this->assertTrue($config->isDocsRagEnabled(2));
+        $this->assertSame(SelfAwareConfig::DEFAULT_DOCS_MANIFEST_URL, $config->docsManifestUrl());
+
+        $topics = [
+            ['topic' => 'general', 'description' => 'x'],
+            ['topic' => 'synaplan', 'description' => 'y'],
+        ];
+        $this->assertCount(2, $config->filterRoutableTopics($topics, 2));
+    }
+
+    public function testDisabledDropsSynaplanTopic(): void
+    {
+        $repo = $this->createMock(ConfigRepository::class);
+        $repo->method('getValue')->willReturnCallback(
+            static function (int $owner, string $group, string $setting): ?string {
+                if (SelfAwareConfig::CONFIG_GROUP === $group && SelfAwareConfig::KEY_ENABLED === $setting) {
+                    return '0';
+                }
+
+                return null;
+            }
+        );
+        $config = new SelfAwareConfig($repo);
+
+        $this->assertFalse($config->isEnabled(2));
+        $filtered = $config->filterRoutableTopics(['general', 'synaplan', 'officemaker'], 2);
+        $this->assertSame(['general', 'officemaker'], $filtered);
+    }
+}

--- a/backend/tests/Unit/Service/SelfAware/SelfAwarePromptDecoratorTest.php
+++ b/backend/tests/Unit/Service/SelfAware/SelfAwarePromptDecoratorTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\SelfAware;
+
+use App\Repository\ConfigRepository;
+use App\Service\Knowledge\KnowledgeContextFormatter;
+use App\Service\SelfAware\CapabilityFact;
+use App\Service\SelfAware\CapabilityInventory;
+use App\Service\SelfAware\CapabilityReport;
+use App\Service\SelfAware\CapabilityReportRenderer;
+use App\Service\SelfAware\CapabilityState;
+use App\Service\SelfAware\Docs\PlatformDocsHit;
+use App\Service\SelfAware\Docs\PlatformDocsHits;
+use App\Service\SelfAware\SelfAwareConfig;
+use App\Service\SelfAware\SelfAwarePromptDecorator;
+use PHPUnit\Framework\TestCase;
+
+final class SelfAwarePromptDecoratorTest extends TestCase
+{
+    public function testReplacesCapabilitiesForSynaplanAndStripsOtherwise(): void
+    {
+        $decorator = $this->decorator(enabled: true, inventoryInGeneral: true);
+
+        $synaplan = $decorator->apply(
+            "Hello\n[PLATFORM_CAPABILITIES]\n[PLATFORM_DOCS]\n",
+            'synaplan',
+            2,
+            false,
+        );
+        $this->assertStringContainsString('AVAILABLE NOW:', $synaplan);
+        $this->assertStringNotContainsString('[PLATFORM_CAPABILITIES]', $synaplan);
+        $this->assertStringNotContainsString('[PLATFORM_DOCS]', $synaplan);
+
+        $general = $decorator->apply('x [PLATFORM_CAPABILITIES] y', 'general', 2, false);
+        $this->assertStringContainsString('AVAILABLE NOW:', $general);
+
+        $other = $decorator->apply('x [PLATFORM_CAPABILITIES] y', 'officemaker', 2, false);
+        $this->assertSame('x  y', $other);
+    }
+
+    public function testGeneralHonoursInventoryFlagAndWidgetsAreStripped(): void
+    {
+        $decorator = $this->decorator(enabled: true, inventoryInGeneral: false);
+        $general = $decorator->apply('[PLATFORM_CAPABILITIES]', 'general', 2, false);
+        $this->assertSame('', $general);
+
+        $on = $this->decorator(enabled: true, inventoryInGeneral: true);
+        $widget = $on->apply('[PLATFORM_CAPABILITIES]', 'synaplan', 2, true);
+        $this->assertSame('', $widget);
+    }
+
+    public function testDisabledFlagStripsPlaceholders(): void
+    {
+        $decorator = $this->decorator(enabled: false, inventoryInGeneral: true);
+        $out = $decorator->apply('[PLATFORM_CAPABILITIES][PLATFORM_DOCS]', 'synaplan', 2, false);
+        $this->assertSame('', $out);
+    }
+
+    public function testDocsPlaceholderFilledOnlyForSynaplanHits(): void
+    {
+        $decorator = $this->decorator(enabled: true, inventoryInGeneral: true);
+        $hits = new PlatformDocsHits([
+            new PlatformDocsHit('channels', 'Channels', 'https://docs.synaplan.com/channels', 'Using', 'WhatsApp steps', 0.9),
+        ]);
+
+        $withDocs = $decorator->apply('[PLATFORM_DOCS]', 'synaplan', 2, false, $hits);
+        $this->assertStringContainsString('[Doc:channels]', $withDocs);
+
+        $general = $decorator->apply('[PLATFORM_DOCS]', 'general', 2, false, $hits);
+        $this->assertSame('', $general);
+    }
+
+    public function testWidgetConversationHelper(): void
+    {
+        $this->assertTrue(SelfAwarePromptDecorator::isWidgetConversation(['source' => 'widget'], []));
+        $this->assertTrue(SelfAwarePromptDecorator::isWidgetConversation([], ['channel' => 'WIDGET']));
+        $this->assertFalse(SelfAwarePromptDecorator::isWidgetConversation(['source' => 'web'], ['channel' => 'WEB']));
+    }
+
+    private function decorator(bool $enabled, bool $inventoryInGeneral): SelfAwarePromptDecorator
+    {
+        $configRepo = $this->createMock(ConfigRepository::class);
+        $configRepo->method('getValue')->willReturnCallback(
+            static function (int $owner, string $group, string $setting) use ($enabled, $inventoryInGeneral): ?string {
+                if (SelfAwareConfig::CONFIG_GROUP !== $group) {
+                    return null;
+                }
+
+                return match ($setting) {
+                    SelfAwareConfig::KEY_ENABLED => $enabled ? '1' : '0',
+                    SelfAwareConfig::KEY_INVENTORY_IN_GENERAL => $inventoryInGeneral ? '1' : '0',
+                    default => null,
+                };
+            }
+        );
+
+        $inventory = $this->createMock(CapabilityInventory::class);
+        $inventory->method('build')->willReturn(new CapabilityReport(
+            [new CapabilityFact('chat', 'Chat', CapabilityState::Available, 'ready', null, null, null)],
+            '4.2.1',
+            false,
+            false,
+        ));
+
+        return new SelfAwarePromptDecorator(
+            new SelfAwareConfig($configRepo),
+            $inventory,
+            new CapabilityReportRenderer(),
+            new KnowledgeContextFormatter(),
+        );
+    }
+}

--- a/docs/ADMIN.md
+++ b/docs/ADMIN.md
@@ -368,6 +368,64 @@ Always use `BID` (primary key) in UPDATE statements to avoid affecting the wrong
 
 ---
 
+## Self-awareness (`SELF_AWARE`)
+
+The assistant can answer "what can you do here?" from a live capability
+inventory, and "how do I …?" from a system-owned copy of
+[docs.synaplan.com](https://docs.synaplan.com/). Both are gated by the
+`SELF_AWARE` BCONFIG group (owner 0). Rows are insert-if-missing on
+`app:seed` and are never overwritten.
+
+### Flags
+
+| Group / Key | Default | Effect when off |
+|-------------|---------|-----------------|
+| `SELF_AWARE / ENABLED` | `true` | No inventory block, `/help` falls through to ordinary chat, the `synaplan` topic is hidden from routing. Byte-identical to a pre-feature install. |
+| `SELF_AWARE / INVENTORY_IN_GENERAL` | `true` | Inventory is injected only into the `synaplan` topic, not into everyday `general` chat. |
+| `SELF_AWARE / DOCS_RAG_ENABLED` | `true` | No documentation retrieval and no `docs_loaded` citations. The corpus sync still runs. |
+| `SELF_AWARE / DOCS_MANIFEST_URL` | `https://docs.synaplan.com/docs-manifest.json` | Empty string disables sync (air-gapped). Point at a mirror that serves the same three endpoints (`/docs-manifest.json`, `/raw/{slug}.md`, `/llms.txt`). |
+
+Resolution for the boolean flags is per-user → owner 0 → built-in default.
+`DOCS_MANIFEST_URL` is operator-only (owner 0).
+
+### Commands
+
+```bash
+# Live capability block for a user (default user id 2)
+docker compose exec -T backend php bin/console app:selfaware:inventory --user 2
+
+# Refresh the SYSTEM:synaplan documentation corpus
+docker compose exec -T backend php bin/console app:selfaware:sync-docs
+docker compose exec -T backend php bin/console app:selfaware:sync-docs --dry-run
+docker compose exec -T backend php bin/console app:selfaware:sync-docs --force
+
+# Release spot-check (needs a live chat model; not part of `make test`)
+docker compose exec -T backend php bin/console app:selfaware:eval --install=no_engine
+```
+
+`app:selfaware:sync-docs` also runs in the daily scheduler slot (after
+`app:updates:check`) and is queued when a new published version is
+recorded. It never runs at container boot. The corpus is owner 0 /
+`SYSTEM:synaplan` and does not appear in any user's file list.
+
+An unreachable manifest leaves the previous corpus in place. An empty
+`DOCS_MANIFEST_URL` prints `skipped` and exits 0.
+
+### Release checklist: `KNOWN_ABSENT`
+
+There is no `docs/RELEASE.md`. Before every release that ships a capability,
+review `PlatformCapabilityInventory::KNOWN_ABSENT`:
+
+1. **Remove** any entry a shipped feature now provides.
+2. **Add** an `alternative` (and an `adminHint` when an operator can enable
+   the missing piece) for anything newly and deliberately unsupported.
+
+This is the only hand-maintained list in the feature. Leaving a stale
+entry makes the assistant deny something the install can do; missing an
+entry makes it invent a capability.
+
+---
+
 ## Integrations
 
 | Channel | Guide |

--- a/frontend/src/assets/markdown.css
+++ b/frontend/src/assets/markdown.css
@@ -215,12 +215,12 @@
 }
 
 /* Links */
-.markdown-content a {
+.markdown-content a:not(.pill) {
   color: var(--brand, #3b82f6);
   text-decoration: underline;
 }
 
-.markdown-content a:hover {
+.markdown-content a:not(.pill):hover {
   color: var(--brand-hover, #2563eb);
 }
 
@@ -409,7 +409,7 @@
   border-color: #4b5563;
 }
 
-.dark .markdown-content a {
+.dark .markdown-content a:not(.pill) {
   color: var(--brand-light, #60a5fa);
 }
 

--- a/frontend/src/components/ChatInput.vue
+++ b/frontend/src/components/ChatInput.vue
@@ -417,7 +417,7 @@ import ModelDropdown from './ModelDropdown.vue'
 import KnowledgeFolderPicker from './KnowledgeFolderPicker.vue'
 import FileSelectionModal from './FileSelectionModal.vue'
 import { parseCommand } from '../commands/parse'
-import { type Command } from '@/stores/commands'
+import { type Command, useCommandsStore } from '@/stores/commands'
 import { useAiConfigStore } from '@/stores/aiConfig'
 import { useNotification } from '@/composables/useNotification'
 import { useKeyboardOpen } from '@/composables/useKeyboardOpen'
@@ -563,6 +563,7 @@ const aiConfigStore = useAiConfigStore()
 const chatsStore = useChatsStore()
 const configStore = useConfigStore()
 const authStore = useAuthStore()
+const commandsStore = useCommandsStore()
 const incognitoStore = useIncognitoStore()
 const dialog = useDialog()
 const { warning, error: showError, success } = useNotification()
@@ -767,10 +768,14 @@ const canSend = computed(() => {
     return false
   }
 
-  // Prevent sending if only a raw command is typed (e.g., just "/pic" without arguments)
+  // Prevent sending if only a raw command is typed (e.g., just "/pic" without arguments).
+  // Commands that take no arguments (e.g. /help) are sendable as-is.
   const isOnlyCommand = trimmedMessage.startsWith('/') && !trimmedMessage.includes(' ')
   if (isOnlyCommand && !hasFiles) {
-    return false
+    const cmd = commandsStore.getCommand(trimmedMessage.slice(1))
+    if (!cmd || cmd.requiresArgs) {
+      return false
+    }
   }
 
   return (hasMessage || hasFiles) && filesReady && !uploading.value

--- a/frontend/src/components/ChatMessage.vue
+++ b/frontend/src/components/ChatMessage.vue
@@ -508,6 +508,7 @@
             :part="part"
             :is-streaming="isStreaming"
             :memories="memories"
+            :docs="docs"
           />
 
           <!-- Continue Button (truncated response) -->
@@ -1198,6 +1199,7 @@ interface Props {
   } | null // Tool metadata (e.g., web search, file generation)
   memoryIds?: number[] | null // IDs of memories used (resolved from memoriesStore)
   feedbackIds?: number[] | null // IDs of feedbacks used (resolved from feedbackStore)
+  docs?: { slug: string; title: string; url: string }[] | null
   truncated?: boolean
   // Multitask routing: live task-card state while a multi-node plan streams.
   taskPlan?: TaskPlanState | null

--- a/frontend/src/components/ExamplePrompts.vue
+++ b/frontend/src/components/ExamplePrompts.vue
@@ -10,7 +10,7 @@
         type="button"
         class="surface-card hover-surface p-4 rounded-xl text-left flex flex-col gap-2 transition-all"
         :data-testid="`btn-example-prompt-${example.id}`"
-        @click="emit('pick', $t(`examplePrompts.items.${example.id}`))"
+        @click="emit('pick', $t(example.textKey))"
       >
         <span
           class="w-8 h-8 rounded-lg bg-[var(--brand)]/15 flex items-center justify-center flex-shrink-0"
@@ -18,7 +18,7 @@
           <Icon :icon="example.icon" class="w-5 h-5 text-[var(--brand)]" />
         </span>
         <span class="text-sm txt-secondary leading-snug">
-          {{ $t(`examplePrompts.items.${example.id}`) }}
+          {{ $t(example.textKey) }}
         </span>
       </button>
     </div>
@@ -26,15 +26,29 @@
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue'
 import { Icon } from '@iconify/vue'
+import { useConfigStore } from '@/stores/config'
 
 const emit = defineEmits<{
   pick: [prompt: string]
 }>()
 
-const examples = [
-  { id: 'poemMp3', icon: 'mdi:music-note' },
-  { id: 'everglades', icon: 'mdi:file-word-box' },
-  { id: 'cabinImage', icon: 'mdi:image' },
-] as const
+const configStore = useConfigStore()
+
+const examples = computed(() => {
+  const items: Array<{ id: string; icon: string; textKey: string }> = [
+    { id: 'poemMp3', icon: 'mdi:music-note', textKey: 'examplePrompts.items.poemMp3' },
+    { id: 'everglades', icon: 'mdi:file-word-box', textKey: 'examplePrompts.items.everglades' },
+    { id: 'cabinImage', icon: 'mdi:image', textKey: 'examplePrompts.items.cabinImage' },
+  ]
+  if (configStore.features.selfAware) {
+    items.push({
+      id: 'selfAware',
+      icon: 'mdi:help-circle-outline',
+      textKey: 'selfAware.examplePrompt',
+    })
+  }
+  return items
+})
 </script>

--- a/frontend/src/components/MessagePart.vue
+++ b/frontend/src/components/MessagePart.vue
@@ -6,6 +6,7 @@
 import { computed } from 'vue'
 import type { Part } from '../stores/history'
 import type { UserMemory } from '@/services/api/userMemoriesApi'
+import type { PlatformDocRef } from '@/components/chat/refs/DocRefPill'
 import MessageText from './MessageText.vue'
 import MessageImage from './MessageImage.vue'
 import MessageVideo from './MessageVideo.vue'
@@ -25,6 +26,7 @@ interface Props {
   part: Part
   isStreaming?: boolean
   memories?: UserMemory[] | null // Full memory objects (resolved from IDs)
+  docs?: PlatformDocRef[] | null
 }
 
 const props = defineProps<Props>()
@@ -71,6 +73,7 @@ const componentProps = computed(() => {
         content: props.part.content || '',
         isStreaming: props.isStreaming,
         memories: props.memories,
+        docs: props.docs,
       }
     case 'image':
       return { url: props.part.url || '', alt: props.part.alt }
@@ -113,7 +116,7 @@ const componentProps = computed(() => {
         isStreaming: props.part.isStreaming,
       }
     default:
-      return { content: props.part.content || '', memories: props.memories }
+      return { content: props.part.content || '', memories: props.memories, docs: props.docs }
   }
 })
 </script>

--- a/frontend/src/components/MessageText.vue
+++ b/frontend/src/components/MessageText.vue
@@ -35,11 +35,13 @@ import { useNotification } from '@/composables/useNotification'
 import { findStableMarkdownBoundary } from '@/utils/streamingBoundary'
 import { completeInlineMarkdown } from '@/utils/partialMarkdown'
 import type { UserMemory } from '@/services/api/userMemoriesApi'
+import { renderDocRefPill, type PlatformDocRef } from '@/components/chat/refs/DocRefPill'
 
 interface Props {
   content: string
   isStreaming?: boolean
   memories?: UserMemory[] | null | undefined
+  docs?: PlatformDocRef[] | null
   /** When true, disables memory fetching (for shared/anonymous views) */
   readonly?: boolean
 }
@@ -639,8 +641,8 @@ function normalizeInlineReferences(text: string): string {
   // does not wrap them in separate <p> blocks.
   // Handles both numeric IDs ([Memory:12345]) and named keys ([Memory:hobby]).
   return text
-    .replace(/\n+(\[(?:Feedback|Memory|Message)\s*:\s*[\w.-]+\])/gi, ' $1')
-    .replace(/(\[(?:Feedback|Memory|Message)\s*:\s*[\w.-]+\])\n+/gi, '$1 ')
+    .replace(/\n+(\[(?:Feedback|Memory|Message|Doc)\s*:\s*[\w.-]+\])/gi, ' $1')
+    .replace(/(\[(?:Feedback|Memory|Message|Doc)\s*:\s*[\w.-]+\])\n+/gi, '$1 ')
 }
 
 // Normalize special file markers + reference markers + apply badge / table
@@ -669,8 +671,24 @@ function normalizeContentForRender(input: string): string {
   return input
 }
 
+function processDocRefPills(html: string): string {
+  if (!html.includes('[Doc:')) {
+    return html
+  }
+
+  return html.replace(/\[Doc:([a-z0-9-]+)\.{0,3}\]/g, (_match, slug: string) => {
+    const title = props.docs?.find((doc) => doc.slug === slug)?.title ?? slug
+    return renderDocRefPill(slug, props.docs, {
+      tooltip: t('selfAware.docPill.tooltip'),
+      ariaLabel: t('selfAware.docPill.ariaLabel', { title }),
+    })
+  })
+}
+
 function postProcessHtml(html: string): string {
-  html = processMessageReferenceBadges(processFeedbackBadges(processMemoryBadges(html)))
+  html = processDocRefPills(
+    processMessageReferenceBadges(processFeedbackBadges(processMemoryBadges(html)))
+  )
   html = html.replace(/<table(\s|>)/g, '<div class="table-scroll"><table$1')
   html = html.replace(/<\/table>/g, '</table></div>')
   // Demo-mode CTA from TestProvider. A <button> (not an <a>) so ChatView
@@ -766,7 +784,9 @@ function renderStreamingIncremental(content: string): string {
   let tailHtml = ''
   if (trailingTail.length > 0) {
     tailHtml = renderStreamingTail(trailingTail)
-    tailHtml = processMessageReferenceBadges(processFeedbackBadges(processMemoryBadges(tailHtml)))
+    tailHtml = processDocRefPills(
+      processMessageReferenceBadges(processFeedbackBadges(processMemoryBadges(tailHtml)))
+    )
   }
 
   // Concatenation is fine now: morphdom diffs the combined HTML against the
@@ -1099,6 +1119,22 @@ watch(
       }
     }
   }
+)
+
+// Re-render when docs_loaded arrives so [Doc:slug] tokens become pills.
+watch(
+  () => props.docs,
+  async () => {
+    if (props.content.includes('[Doc:')) {
+      invalidateStreamingCache()
+      const currentVersion = ++renderVersion
+      const result = await processContent(props.content, currentVersion)
+      if (result !== null) {
+        applyHtml(result)
+      }
+    }
+  },
+  { deep: true }
 )
 </script>
 

--- a/frontend/src/components/ToolsDropdown.vue
+++ b/frontend/src/components/ToolsDropdown.vue
@@ -212,6 +212,7 @@ import { useRouter } from 'vue-router'
 import { triggerHapticImpact } from '@/services/api/nativeHaptics'
 import { isDesktopAgentEnabled } from '@/composables/useDesktopAgentFeature'
 import { useDesktopDevices } from '@/composables/useDesktopDevices'
+import { useConfigStore } from '@/stores/config'
 
 interface Props {
   activeCommand?: string | null
@@ -234,30 +235,52 @@ const emit = defineEmits<{
   runOnDevice: [device: { id: number; name: string }]
 }>()
 
+const configStore = useConfigStore()
+
 /** Feature-gated tools that toggle a removable badge in the chat input. */
-const commandTools = [
-  {
-    id: 'web-search',
-    command: 'search',
-    icon: 'mdi:web',
-    labelKey: 'chatInput.tools.webSearch',
-    descKey: 'chatInput.tools.webSearchDesc',
-  },
-  {
-    id: 'image-gen',
-    command: 'pic',
-    icon: 'mdi:image',
-    labelKey: 'chatInput.tools.imageGen',
-    descKey: 'chatInput.tools.imageGenDesc',
-  },
-  {
-    id: 'video-gen',
-    command: 'vid',
-    icon: 'mdi:video',
-    labelKey: 'chatInput.tools.videoGen',
-    descKey: 'chatInput.tools.videoGenDesc',
-  },
-] as const
+const commandTools = computed(() => {
+  const tools: Array<{
+    id: string
+    command: string
+    icon: string
+    labelKey: string
+    descKey: string
+  }> = [
+    {
+      id: 'web-search',
+      command: 'search',
+      icon: 'mdi:web',
+      labelKey: 'chatInput.tools.webSearch',
+      descKey: 'chatInput.tools.webSearchDesc',
+    },
+    {
+      id: 'image-gen',
+      command: 'pic',
+      icon: 'mdi:image',
+      labelKey: 'chatInput.tools.imageGen',
+      descKey: 'chatInput.tools.imageGenDesc',
+    },
+    {
+      id: 'video-gen',
+      command: 'vid',
+      icon: 'mdi:video',
+      labelKey: 'chatInput.tools.videoGen',
+      descKey: 'chatInput.tools.videoGenDesc',
+    },
+  ]
+
+  if (configStore.features.selfAware) {
+    tools.push({
+      id: 'help',
+      command: 'help',
+      icon: 'mdi:help-circle-outline',
+      labelKey: 'selfAware.helpCommand.label',
+      descKey: 'selfAware.helpCommand.description',
+    })
+  }
+
+  return tools
+})
 
 const router = useRouter()
 const { t } = useI18n()

--- a/frontend/src/components/chat/SelfAwareEmptyHint.vue
+++ b/frontend/src/components/chat/SelfAwareEmptyHint.vue
@@ -1,0 +1,47 @@
+<template>
+  <p v-if="visible" class="txt-secondary mt-2" data-testid="self-aware-empty-hint">
+    <span>{{ lead }}</span>
+    <button
+      type="button"
+      class="underline txt-brand ml-1"
+      data-testid="btn-self-aware-empty-hint"
+      @click="emit('ask', question)"
+    >
+      {{ action }}
+    </button>
+  </p>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useConfigStore } from '@/stores/config'
+import { useIncognitoStore } from '@/stores/incognito'
+
+const emit = defineEmits<{
+  ask: [question: string]
+}>()
+
+const { t } = useI18n()
+const configStore = useConfigStore()
+const incognitoStore = useIncognitoStore()
+
+const visible = computed(() => configStore.features.selfAware && !incognitoStore.active)
+const question = computed(() => t('selfAware.emptyHintQuestion'))
+
+const splitHint = computed(() => {
+  const hint = t('selfAware.emptyHint')
+  const idx = hint.lastIndexOf('?')
+  if (idx === -1) {
+    return { lead: hint, action: question.value }
+  }
+  const action = hint.slice(idx + 1).trim()
+  return {
+    lead: hint.slice(0, idx + 1).trimEnd(),
+    action: action || question.value,
+  }
+})
+
+const lead = computed(() => splitHint.value.lead)
+const action = computed(() => splitHint.value.action)
+</script>

--- a/frontend/src/components/chat/refs/DocRefPill.ts
+++ b/frontend/src/components/chat/refs/DocRefPill.ts
@@ -1,0 +1,74 @@
+export interface PlatformDocRef {
+  slug: string
+  title: string
+  url: string
+}
+
+const BOOK_ICON =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>'
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+function isSafeDocUrl(url: string): boolean {
+  if (url.startsWith('/') && !url.startsWith('//')) {
+    return true
+  }
+  try {
+    const parsed = new URL(url)
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
+export function parsePlatformDocs(value: unknown): PlatformDocRef[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined
+  }
+
+  const docs: PlatformDocRef[] = []
+  for (const item of value) {
+    if (!item || typeof item !== 'object') {
+      continue
+    }
+    const rec = item as Record<string, unknown>
+    const slug = typeof rec.slug === 'string' ? rec.slug.trim() : ''
+    const title = typeof rec.title === 'string' ? rec.title.trim() : ''
+    const url = typeof rec.url === 'string' ? rec.url.trim() : ''
+    if (slug && title && url) {
+      docs.push({ slug, title, url })
+    }
+  }
+
+  return docs.length > 0 ? docs : undefined
+}
+
+/**
+ * Render a `[Doc:slug]` token. Known slugs become a `.pill` link whose href
+ * comes only from the provided docs list — never a constructed host.
+ */
+export function renderDocRefPill(
+  slug: string,
+  docs: PlatformDocRef[] | null | undefined,
+  labels: { tooltip: string; ariaLabel: string }
+): string {
+  const doc = docs?.find((entry) => entry.slug === slug)
+  if (!doc || !isSafeDocUrl(doc.url)) {
+    return `[Doc:${slug}]`
+  }
+
+  const title = escapeHtml(doc.title)
+  const href = escapeHtml(doc.url)
+  const tooltip = escapeHtml(labels.tooltip)
+  const ariaLabel = escapeHtml(labels.ariaLabel)
+  const safeSlug = escapeHtml(slug)
+
+  return `<a class="pill no-underline align-middle" href="${href}" target="_blank" rel="noopener" title="${tooltip}" aria-label="${ariaLabel}" data-doc-slug="${safeSlug}">${BOOK_ICON}<span>${title}</span></a>`
+}

--- a/frontend/src/components/chat/refs/DocRefPill.ts
+++ b/frontend/src/components/chat/refs/DocRefPill.ts
@@ -70,5 +70,5 @@ export function renderDocRefPill(
   const ariaLabel = escapeHtml(labels.ariaLabel)
   const safeSlug = escapeHtml(slug)
 
-  return `<a class="pill no-underline align-middle" href="${href}" target="_blank" rel="noopener" title="${tooltip}" aria-label="${ariaLabel}" data-doc-slug="${safeSlug}">${BOOK_ICON}<span>${title}</span></a>`
+  return `<a class="pill no-underline align-middle" href="${href}" target="_blank" rel="noopener noreferrer" title="${tooltip}" aria-label="${ariaLabel}" data-doc-slug="${safeSlug}">${BOOK_ICON}<span>${title}</span></a>`
 }

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -235,6 +235,19 @@
   },
   "welcome": "Willkommen bei Synaplan",
   "welcomeUser": "Willkommen, {name}",
+  "selfAware": {
+    "emptyHint": "Nicht sicher, was hier möglich ist? Frag mich, was ich tun kann.",
+    "emptyHintQuestion": "Was kannst du hier tun?",
+    "examplePrompt": "Was kannst du tun?",
+    "helpCommand": {
+      "label": "Hilfe",
+      "description": "Fragen, was dieser KI-Assistent hier tun kann"
+    },
+    "docPill": {
+      "tooltip": "In der Dokumentation öffnen",
+      "ariaLabel": "{title} in der Dokumentation öffnen"
+    }
+  },
   "examplePrompts": {
     "heading": "Probiere eines davon",
     "items": {

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -235,6 +235,19 @@
   },
   "welcome": "Welcome",
   "welcomeUser": "Welcome, {name}",
+  "selfAware": {
+    "emptyHint": "Not sure what's possible here? Ask me what I can do.",
+    "emptyHintQuestion": "What can you do here?",
+    "examplePrompt": "What can you do?",
+    "helpCommand": {
+      "label": "Help",
+      "description": "Ask what this AI assistant can do here"
+    },
+    "docPill": {
+      "tooltip": "Open in the documentation",
+      "ariaLabel": "Open {title} in the documentation"
+    }
+  },
   "examplePrompts": {
     "heading": "Try one of these",
     "items": {

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -234,6 +234,19 @@
   },
   "welcome": "Bienvenido",
   "welcomeUser": "Bienvenido, {name}",
+  "selfAware": {
+    "emptyHint": "¿No sabes qué es posible aquí? Pregúntame qué puedo hacer.",
+    "emptyHintQuestion": "¿Qué puedes hacer aquí?",
+    "examplePrompt": "¿Qué puedes hacer?",
+    "helpCommand": {
+      "label": "Ayuda",
+      "description": "Preguntar qué puede hacer este asistente de IA aquí"
+    },
+    "docPill": {
+      "tooltip": "Abrir en la documentación",
+      "ariaLabel": "Abrir {title} en la documentación"
+    }
+  },
   "examplePrompts": {
     "heading": "Prueba una de estas",
     "items": {

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -235,6 +235,19 @@
   },
   "welcome": "Bienvenue",
   "welcomeUser": "Bienvenue, {name}",
+  "selfAware": {
+    "emptyHint": "Vous ne savez pas ce qui est possible ici ? Demandez-moi ce que je peux faire.",
+    "emptyHintQuestion": "Que pouvez-vous faire ici ?",
+    "examplePrompt": "Que pouvez-vous faire ?",
+    "helpCommand": {
+      "label": "Aide",
+      "description": "Demander ce que cet assistant IA peut faire ici"
+    },
+    "docPill": {
+      "tooltip": "Ouvrir dans la documentation",
+      "ariaLabel": "Ouvrir {title} dans la documentation"
+    }
+  },
   "examplePrompts": {
     "heading": "Essayez l’une de ces idées",
     "items": {

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -234,6 +234,19 @@
   },
   "welcome": "Hoş Geldiniz",
   "welcomeUser": "Hoş geldin, {name}",
+  "selfAware": {
+    "emptyHint": "Burada neler mümkün olduğundan emin değil misiniz? Bana neler yapabileceğimi sorun.",
+    "emptyHintQuestion": "Burada neler yapabilirsin?",
+    "examplePrompt": "Ne yapabilirsin?",
+    "helpCommand": {
+      "label": "Yardım",
+      "description": "Bu AI asistanının burada neler yapabileceğini sor"
+    },
+    "docPill": {
+      "tooltip": "Dokümantasyonda aç",
+      "ariaLabel": "{title} dokümantasyonunda aç"
+    }
+  },
   "examplePrompts": {
     "heading": "Bunlardan birini deneyin",
     "items": {

--- a/frontend/src/stores/commands.ts
+++ b/frontend/src/stores/commands.ts
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
 import config from '@/stores/config'
+import { i18n } from '@/i18n'
 
 export interface Command {
   name: string
@@ -48,6 +49,16 @@ export const commandsData: Command[] = [
   },
 ]
 
+function helpCommand(): Command {
+  return {
+    name: 'help',
+    description: String(i18n.global.t('selfAware.helpCommand.description')),
+    usage: '/help',
+    requiresArgs: false,
+    icon: 'mdi:help-circle-outline',
+  }
+}
+
 /**
  * Slash-commands contributed by installed plugins via their manifest
  * `chatCommands`, exposed through the runtime config. This is the generic seam
@@ -83,7 +94,11 @@ export function pluginCommands(): Command[] {
 }
 
 export const useCommandsStore = defineStore('commands', () => {
-  const commands = computed<Command[]>(() => [...commandsData, ...pluginCommands()])
+  const commands = computed<Command[]>(() => [
+    ...commandsData,
+    ...(config.features.selfAware ? [helpCommand()] : []),
+    ...pluginCommands(),
+  ])
 
   const recentCommands = ref<string[]>(JSON.parse(localStorage.getItem('recentCommands') || '[]'))
 

--- a/frontend/src/stores/config.ts
+++ b/frontend/src/stores/config.ts
@@ -108,6 +108,12 @@ const config = {
       const features = getConfigSync().features
       return features?.help === true
     },
+    get selfAware(): boolean {
+      // Defensive: the generated schema omits this until the backend OpenAPI
+      // property lands; passthrough still delivers the runtime flag.
+      const features = getConfigSync().features as { selfAware?: boolean } | undefined
+      return features?.selfAware === true
+    },
     get memoryService(): boolean {
       // Return cached async check if available, otherwise fall back to config flag
       if (memoryServiceAvailable.value !== null) {

--- a/frontend/src/stores/config.ts
+++ b/frontend/src/stores/config.ts
@@ -109,8 +109,8 @@ const config = {
       return features?.help === true
     },
     get selfAware(): boolean {
-      // Defensive: the generated schema omits this until the backend OpenAPI
-      // property lands; passthrough still delivers the runtime flag.
+      // Current backends send features.selfAware. Older ones omit it — treat
+      // a missing flag as off so the hint and /help stay hidden.
       const features = getConfigSync().features as { selfAware?: boolean } | undefined
       return features?.selfAware === true
     },

--- a/frontend/src/stores/history.ts
+++ b/frontend/src/stores/history.ts
@@ -179,6 +179,8 @@ export interface Message {
   } | null // Tool metadata (e.g., web search, file generation)
   memoryIds?: number[] | null // IDs of memories used (resolved from memoriesStore)
   feedbackIds?: number[] | null // IDs of feedbacks used (resolved from feedbackStore)
+  /** Platform docs cited in this answer (`docs_loaded` / complete.docs). */
+  docs?: { slug: string; title: string; url: string }[]
   processingStatus?: string
   processingMetadata?: Record<string, unknown> | null
   // Multitask routing: live task-card state while a multi-node plan streams.

--- a/frontend/src/types/chatStream.ts
+++ b/frontend/src/types/chatStream.ts
@@ -50,6 +50,12 @@ export interface StreamFeedbackRow {
   value?: string
 }
 
+export interface StreamDocRef {
+  slug: string
+  title: string
+  url: string
+}
+
 /** A task node as announced in the `plan` event (multitask routing). */
 export interface StreamTaskNode {
   node_id: string
@@ -73,6 +79,8 @@ export interface StreamEventMetadata {
   language?: string
   memories?: StreamMemoryRow[]
   feedbacks?: StreamFeedbackRow[]
+  /** Platform documentation cited for this turn (`docs_loaded`). */
+  docs?: StreamDocRef[]
   /** Multitask routing (status === 'plan'): the visible task list + reply node. */
   plan?: StreamTaskNode[]
   reply_node?: string
@@ -132,6 +140,7 @@ export interface StreamUpdatePayload {
   searchResults?: StreamSearchResult[]
   memoryIds?: number[]
   feedbackIds?: number[]
+  docs?: StreamDocRef[]
   provider?: string
   model?: string
   model_id?: number | null

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -174,6 +174,7 @@
                   incognitoStore.active ? $t('incognito.emptyHint') : $t('chatInput.placeholder')
                 }}
               </p>
+              <SelfAwareEmptyHint @ask="handleSendMessage" />
             </div>
 
             <!-- Speed config: the expanded mix card greets the user on every
@@ -223,6 +224,7 @@
               :web-search="message.webSearch"
               :memory-ids="message.memoryIds"
               :feedback-ids="message.feedbackIds"
+              :docs="message.docs"
               :status="message.status"
               :error-type="message.errorType"
               :error-data="message.errorData"
@@ -472,6 +474,8 @@ import ChatInput from '@/components/ChatInput.vue'
 import ChatMessage from '@/components/ChatMessage.vue'
 import MarketingNews from '@/components/MarketingNews.vue'
 import ExamplePrompts from '@/components/ExamplePrompts.vue'
+import SelfAwareEmptyHint from '@/components/chat/SelfAwareEmptyHint.vue'
+import { parsePlatformDocs } from '@/components/chat/refs/DocRefPill'
 import ConsumptionBar from '@/components/usage/ConsumptionBar.vue'
 import ConsumptionRing from '@/components/usage/ConsumptionRing.vue'
 import QuoteSelectionButton from '@/components/QuoteSelectionButton.vue'
@@ -607,6 +611,13 @@ const messageDigestsStore = useMessageDigestsStore()
 const incognitoStore = useIncognitoStore()
 const promoTips = usePromoTips()
 const { getDateLabel } = useDateFormat()
+
+function applyDocsToMessage(message: Message, raw: unknown): void {
+  const docs = parsePlatformDocs(raw)
+  if (docs) {
+    message.docs = docs
+  }
+}
 
 const isGuestMode = computed(() => !authStore.isAuthenticated && guestStore.isGuestMode)
 
@@ -1907,6 +1918,8 @@ const handleContinueResponse = async (message: Message) => {
           message.truncated = true
         }
 
+        applyDocsToMessage(message, data.docs)
+
         message.isStreaming = false
         historyStore.finishStreamingMessage(message.id)
 
@@ -2675,6 +2688,11 @@ const streamAIResponse = async (
                 }),
               })
             }
+          } else if (data.status === 'docs_loaded') {
+            const streamingMessage = historyStore.messages.find((m) => m.id === messageId)
+            if (streamingMessage) {
+              applyDocsToMessage(streamingMessage, data.metadata?.docs)
+            }
           } else if (data.status === 'complete') {
             if (streamingRafId !== null) {
               cancelAnimationFrame(streamingRafId)
@@ -2762,6 +2780,8 @@ const streamAIResponse = async (
                   resultsCount: data.searchResults.length,
                 }
               }
+
+              applyDocsToMessage(message, data.docs)
 
               applyAssistantChatModelFooter(
                 message,
@@ -3394,6 +3414,11 @@ const streamAIResponse = async (
                 streamingMessage.memoryIds = memoryIds
               }
             }
+          } else if (data.status === 'docs_loaded') {
+            const streamingMessage = historyStore.messages.find((m) => m.id === messageId)
+            if (streamingMessage) {
+              applyDocsToMessage(streamingMessage, data.metadata?.docs)
+            }
           } else if (data.status === 'feedback_loaded') {
             // Feedback examples loaded - store in feedbackStore for badge rendering
             const feedbacks = data.metadata?.feedbacks
@@ -3617,6 +3642,8 @@ const streamAIResponse = async (
               if (data.memoryIds && Array.isArray(data.memoryIds) && data.memoryIds.length > 0) {
                 message.memoryIds = data.memoryIds
               }
+
+              applyDocsToMessage(message, data.docs)
 
               // Store feedback IDs if provided
               if (

--- a/frontend/tests/unit/components/MessageText.docRef.spec.ts
+++ b/frontend/tests/unit/components/MessageText.docRef.spec.ts
@@ -34,7 +34,7 @@ describe('MessageText [Doc:slug] pills', () => {
     expect(link).not.toBeNull()
     expect(link?.getAttribute('href')).toBe(channelsDoc.url)
     expect(link?.getAttribute('target')).toBe('_blank')
-    expect(link?.getAttribute('rel')).toBe('noopener')
+    expect(link?.getAttribute('rel')).toBe('noopener noreferrer')
     expect(el.textContent).toContain('Channels: WhatsApp & Email')
     expect(el.textContent).not.toContain('[Doc:channels]')
   })

--- a/frontend/tests/unit/components/MessageText.docRef.spec.ts
+++ b/frontend/tests/unit/components/MessageText.docRef.spec.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import MessageText from '@/components/MessageText.vue'
+import type { PlatformDocRef } from '@/components/chat/refs/DocRefPill'
+
+function messageTextEl(wrapper: ReturnType<typeof mount>): HTMLElement {
+  return wrapper.get('[data-testid="message-text"]').element as HTMLElement
+}
+
+const channelsDoc: PlatformDocRef = {
+  slug: 'channels',
+  title: 'Channels: WhatsApp & Email',
+  url: 'https://docs.synaplan.com/channels',
+}
+
+describe('MessageText [Doc:slug] pills', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('renders a known slug as a link with the given url', async () => {
+    const wrapper = mount(MessageText, {
+      props: {
+        content: 'See [Doc:channels] for setup.',
+        docs: [channelsDoc],
+        readonly: true,
+      },
+    })
+    await wrapper.vm.$nextTick()
+
+    const el = messageTextEl(wrapper)
+    const link = el.querySelector('a.pill[data-doc-slug="channels"]')
+    expect(link).not.toBeNull()
+    expect(link?.getAttribute('href')).toBe(channelsDoc.url)
+    expect(link?.getAttribute('target')).toBe('_blank')
+    expect(link?.getAttribute('rel')).toBe('noopener')
+    expect(el.textContent).toContain('Channels: WhatsApp & Email')
+    expect(el.textContent).not.toContain('[Doc:channels]')
+  })
+
+  it('renders an unknown slug as plain text with no link', async () => {
+    const wrapper = mount(MessageText, {
+      props: {
+        content: 'See [Doc:missing-page] for setup.',
+        docs: [channelsDoc],
+        readonly: true,
+      },
+    })
+    await wrapper.vm.$nextTick()
+
+    const el = messageTextEl(wrapper)
+    expect(el.querySelector('a.pill')).toBeNull()
+    expect(el.textContent).toContain('[Doc:missing-page]')
+  })
+
+  it('never builds an href from a hardcoded host', async () => {
+    const listedUrl = 'https://example.test/guide/channels'
+    const wrapper = mount(MessageText, {
+      props: {
+        content: 'See [Doc:channels] for setup.',
+        docs: [{ ...channelsDoc, url: listedUrl }],
+        readonly: true,
+      },
+    })
+    await wrapper.vm.$nextTick()
+
+    const href = messageTextEl(wrapper)
+      .querySelector('a.pill[data-doc-slug="channels"]')
+      ?.getAttribute('href')
+    expect(href).toBe(listedUrl)
+    expect(href).not.toContain('docs.synaplan.com')
+    expect(href).not.toContain('localhost')
+  })
+
+  it('leaves [Doc:a, b] untouched', async () => {
+    const wrapper = mount(MessageText, {
+      props: {
+        content: 'Bad cite [Doc:a, b] stays raw.',
+        docs: [channelsDoc],
+        readonly: true,
+      },
+    })
+    await wrapper.vm.$nextTick()
+
+    const el = messageTextEl(wrapper)
+    expect(el.querySelector('a.pill')).toBeNull()
+    expect(el.textContent).toContain('[Doc:a, b]')
+  })
+
+  it('turns the token into a pill only after the closing bracket arrives', async () => {
+    const wrapper = mount(MessageText, {
+      props: {
+        content: 'See [Doc:channels',
+        docs: [channelsDoc],
+        isStreaming: true,
+        readonly: true,
+      },
+    })
+    await wrapper.vm.$nextTick()
+
+    expect(messageTextEl(wrapper).querySelector('a.pill')).toBeNull()
+
+    await wrapper.setProps({ content: 'See [Doc:channels] for setup.' })
+    await wrapper.vm.$nextTick()
+
+    expect(messageTextEl(wrapper).querySelector('a.pill[data-doc-slug="channels"]')).not.toBeNull()
+  })
+})

--- a/frontend/tests/unit/components/ToolsDropdown.spec.ts
+++ b/frontend/tests/unit/components/ToolsDropdown.spec.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { createMemoryHistory, createRouter } from 'vue-router'
+import ToolsDropdown from '@/components/ToolsDropdown.vue'
+
+const { features } = vi.hoisted(() => ({
+  features: { selfAware: false, help: false, memoryService: false },
+}))
+
+vi.mock('@/stores/config', () => ({
+  useConfigStore: () => ({ features }),
+  default: { features, plugins: [] },
+}))
+
+vi.mock('@/services/api/nativeHaptics', () => ({
+  triggerHapticImpact: vi.fn(),
+}))
+
+vi.mock('@/composables/useDesktopAgentFeature', () => ({
+  isDesktopAgentEnabled: () => false,
+}))
+
+vi.mock('@/composables/useDesktopDevices', () => ({
+  useDesktopDevices: () => ({
+    activeDevices: { value: [] },
+    hasActiveDevices: { value: false },
+    ensureLoaded: vi.fn(),
+  }),
+}))
+
+vi.mock('@/services/featuresService', () => ({
+  getFeaturesStatus: vi.fn().mockResolvedValue({ features: {} }),
+}))
+
+function stubMatchMedia() {
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }))
+  )
+}
+
+async function mountDropdown() {
+  const pinia = createPinia()
+  setActivePinia(pinia)
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: [{ path: '/', component: { template: '<div />' } }],
+  })
+  await router.push('/')
+  await router.isReady()
+
+  return mount(ToolsDropdown, {
+    global: {
+      plugins: [pinia, router],
+      stubs: { Icon: true },
+    },
+  })
+}
+
+describe('ToolsDropdown /help', () => {
+  beforeEach(() => {
+    stubMatchMedia()
+    features.selfAware = false
+  })
+
+  it('hides /help when features.selfAware is off', async () => {
+    const wrapper = await mountDropdown()
+    await wrapper.get('[data-testid="btn-tools-toggle"]').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="btn-tool-help"]').exists()).toBe(false)
+  })
+
+  it('shows /help when features.selfAware is on', async () => {
+    features.selfAware = true
+    const wrapper = await mountDropdown()
+    await wrapper.get('[data-testid="btn-tools-toggle"]').trigger('click')
+    await flushPromises()
+
+    const help = wrapper.get('[data-testid="btn-tool-help"]')
+    expect(help.text()).toContain('Help')
+    expect(help.text()).toContain('Ask what this AI assistant can do here')
+  })
+})

--- a/frontend/tests/unit/components/chat/SelfAwareEmptyHint.spec.ts
+++ b/frontend/tests/unit/components/chat/SelfAwareEmptyHint.spec.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import SelfAwareEmptyHint from '@/components/chat/SelfAwareEmptyHint.vue'
+import { useIncognitoStore } from '@/stores/incognito'
+
+const features = { selfAware: false }
+
+vi.mock('@/stores/config', () => ({
+  useConfigStore: () => ({ features }),
+}))
+
+describe('SelfAwareEmptyHint', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    features.selfAware = false
+    useIncognitoStore().active = false
+  })
+
+  it('is visible when the self-aware flag is on', () => {
+    features.selfAware = true
+    const wrapper = mount(SelfAwareEmptyHint)
+
+    expect(wrapper.find('[data-testid="self-aware-empty-hint"]').exists()).toBe(true)
+    expect(wrapper.text()).toContain("Not sure what's possible here?")
+    expect(wrapper.text()).toContain('Ask me what I can do.')
+  })
+
+  it('is hidden when the self-aware flag is off', () => {
+    const wrapper = mount(SelfAwareEmptyHint)
+
+    expect(wrapper.find('[data-testid="self-aware-empty-hint"]').exists()).toBe(false)
+  })
+
+  it('is hidden in incognito even when the flag is on', () => {
+    features.selfAware = true
+    useIncognitoStore().active = true
+    const wrapper = mount(SelfAwareEmptyHint)
+
+    expect(wrapper.find('[data-testid="self-aware-empty-hint"]').exists()).toBe(false)
+  })
+
+  it('sends the question text when the action is clicked', async () => {
+    features.selfAware = true
+    const wrapper = mount(SelfAwareEmptyHint)
+
+    await wrapper.get('[data-testid="btn-self-aware-empty-hint"]').trigger('click')
+
+    expect(wrapper.emitted('ask')).toEqual([['What can you do here?']])
+  })
+})


### PR DESCRIPTION
## Summary
Implement self-aware assistant features and update related documentation

## Changes
- Added a self-aware assistant feature that responds to user queries about its capabilities with a live context.
- Updated the status of the self-awareness planning documents to 'implemented' across all sprints.
- Enhanced the README to include the new self-aware assistant feature.
- Implemented necessary backend changes to support documentation retrieval and response formatting for the self-aware assistant.
- Updated various controllers and services to integrate self-awareness functionality, including message classification and handling.

This commit marks the completion of the self-awareness feature set, enabling users to interact with the AI in a more informed manner.

## Verification
- [ ] Not tested (explain)
- [x] Manual
- [ ] Tests added/updated
