### PR TITLE
fix(billing): bill Anthropic 1-hour-TTL prompt-cache writes at 2x, not 1.25x

### DIFF
--- a/_devextras/planning/20260218-mcp-and-api-enhancements/01-api-improvements/05-ANTHROPIC-COMPATIBLE.md
+++ b/_devextras/planning/20260218-mcp-and-api-enhancements/01-api-improvements/05-ANTHROPIC-COMPATIBLE.md
@@ -565,15 +565,23 @@ The Anthropic protocol has **no warning channel**, so three layers:
 Metering: `recordUsage($user, 'API_CHAT', [...])` with `source: 'MESSAGES_API'`
 and the resolved `model_id`. **Verified:** `CostCalculationService` is already
 cache-aware and provider-aware — `calculateCost(promptTokens,
-completionTokens, cachedTokens, cacheCreationTokens, modelId)` applies
-Anthropic's real 0.10x read discount and 1.25x write multiplier
-(`CACHE_READ_DISCOUNT_ANTHROPIC` / `CACHE_WRITE_MULTIPLIER_ANTHROPIC`). The
-gateway only maps fields: `cachedTokens = cache_read_input_tokens`,
+completionTokens, cachedTokens, cacheCreationTokens, modelId, timestamp,
+cacheCreation1hTokens)` applies Anthropic's real 0.10x read discount and
+1.25x/2.0x write multipliers (`CACHE_READ_DISCOUNT_ANTHROPIC` /
+`CACHE_WRITE_MULTIPLIER_ANTHROPIC` / `CACHE_WRITE_MULTIPLIER_ANTHROPIC_1H`).
+The gateway only maps fields: `cachedTokens = cache_read_input_tokens`,
 `cacheCreationTokens = cache_creation_input_tokens`, `promptTokens =
 input_tokens + both cache fields` — the same arithmetic `AnthropicProvider`
-lines 236-247 already uses. One known gap: 1-hour-TTL cache writes really
-bill 2x but are costed at 1.25x; the usage payload's `cache_creation`
-breakdown (`ephemeral_1h_input_tokens`) would allow refining this later.
+lines 236-247 already uses.
+**Fixed 2026-09-02:** the 1-hour-TTL gap noted below was real — 1h-TTL cache
+writes bill 2x but were costed at the flat 1.25x 5m rate. Fixed by reading the
+usage payload's `cache_creation.ephemeral_1h_input_tokens` breakdown via the
+new `MessagesUsage::extractCacheCreation1hTokens()` helper (shared by every
+Anthropic usage-parsing call site: `AnthropicProvider`, both
+`AnthropicPassthroughTranslator` stream paths, `GatewayToolLoop`) and billing
+that slice at `CACHE_WRITE_MULTIPLIER_ANTHROPIC_1H` (2.0x) while the remainder
+stays at 1.25x. See `docs/PRICING_MAINTENANCE.md` ("Cache-write pricing:
+5-minute vs. 1-hour TTL").
 
 **Known limitation:** usage is recorded after the stream ends, so concurrent
 requests can overshoot the budget slightly. Either accept and document, or add a

--- a/backend/phpstan-baseline.neon
+++ b/backend/phpstan-baseline.neon
@@ -435,7 +435,7 @@ parameters:
 		-
 			message: '#^Call to an undefined method Doctrine\\DBAL\\Connection\:\:expects\(\)\.$#'
 			identifier: method.notFound
-			count: 7
+			count: 8
 			path: tests/Service/RateLimitServiceUnifiedTest.php
 
 		-

--- a/backend/src/AI/Messages/MessagesUsage.php
+++ b/backend/src/AI/Messages/MessagesUsage.php
@@ -9,9 +9,16 @@ namespace App\AI\Messages;
  * by a non-Anthropic translator into the same shape).
  *
  * Field mapping into {@see \App\Service\CostCalculationService::calculateCost()}:
- *   cachedTokens         = cache_read_input_tokens
- *   cacheCreationTokens  = cache_creation_input_tokens
- *   promptTokens         = input_tokens + cache_read + cache_creation
+ *   cachedTokens          = cache_read_input_tokens
+ *   cacheCreationTokens   = cache_creation_input_tokens (TOTAL, both TTLs)
+ *   cacheCreation1hTokens = cache_creation.ephemeral_1h_input_tokens (subset of the above)
+ *   promptTokens          = input_tokens + cache_read + cache_creation
+ *
+ * Anthropic bills 1-hour cache writes (opt-in via a `cache_control` block with
+ * `"ttl": "1h"`) at 2x the base input price, versus 1.25x for the default
+ * 5-minute TTL. The `usage.cache_creation` object breaks the aggregate down by
+ * TTL so both rates can be billed correctly instead of assuming everything is
+ * 5-minute (see docs: https://platform.claude.com/docs/en/build-with-claude/prompt-caching).
  */
 final readonly class MessagesUsage
 {
@@ -21,6 +28,11 @@ final readonly class MessagesUsage
         public int $cacheCreationTokens = 0,
         public int $cacheReadTokens = 0,
         public ?string $stopReason = null,
+        // Appended after the original 5 params (rather than inserted next to
+        // cacheCreationTokens) so existing POSITIONAL constructor calls —
+        // e.g. `new MessagesUsage(10, 5, 0, 0, 'tool_use')` in tests — keep
+        // binding to the same parameters instead of silently shifting.
+        public int $cacheCreation1hTokens = 0,
     ) {
     }
 
@@ -32,7 +44,8 @@ final readonly class MessagesUsage
      *     completion_tokens: int,
      *     total_tokens: int,
      *     cached_tokens: int,
-     *     cache_creation_tokens: int
+     *     cache_creation_tokens: int,
+     *     cache_creation_1h_tokens: int
      * }
      */
     public function toRateLimitUsage(): array
@@ -45,6 +58,7 @@ final readonly class MessagesUsage
             'total_tokens' => $prompt + $this->outputTokens,
             'cached_tokens' => $this->cacheReadTokens,
             'cache_creation_tokens' => $this->cacheCreationTokens,
+            'cache_creation_1h_tokens' => $this->cacheCreation1hTokens,
         ];
     }
 
@@ -57,9 +71,25 @@ final readonly class MessagesUsage
             inputTokens: (int) ($usage['input_tokens'] ?? 0),
             outputTokens: (int) ($usage['output_tokens'] ?? 0),
             cacheCreationTokens: (int) ($usage['cache_creation_input_tokens'] ?? 0),
+            cacheCreation1hTokens: self::extractCacheCreation1hTokens($usage),
             cacheReadTokens: (int) ($usage['cache_read_input_tokens'] ?? 0),
             stopReason: $stopReason,
         );
+    }
+
+    /**
+     * Pulls the 1-hour-TTL slice out of Anthropic's `cache_creation` breakdown
+     * object, e.g. `{"ephemeral_5m_input_tokens": 148, "ephemeral_1h_input_tokens": 100}`.
+     * Shared by every call site that hand-parses a raw usage array (SSE
+     * `message_start` events don't go through fromAnthropicUsage()).
+     *
+     * @param array<string, mixed> $usage Anthropic usage object
+     */
+    public static function extractCacheCreation1hTokens(array $usage): int
+    {
+        $breakdown = $usage['cache_creation'] ?? null;
+
+        return \is_array($breakdown) ? (int) ($breakdown['ephemeral_1h_input_tokens'] ?? 0) : 0;
     }
 
     public function withStopReason(?string $stopReason): self
@@ -70,6 +100,7 @@ final readonly class MessagesUsage
             cacheCreationTokens: $this->cacheCreationTokens,
             cacheReadTokens: $this->cacheReadTokens,
             stopReason: $stopReason,
+            cacheCreation1hTokens: $this->cacheCreation1hTokens,
         );
     }
 }

--- a/backend/src/AI/Messages/Tools/GatewayToolLoop.php
+++ b/backend/src/AI/Messages/Tools/GatewayToolLoop.php
@@ -350,6 +350,7 @@ final readonly class GatewayToolLoop
         $inputTokens = 0;
         $outputTokens = 0;
         $cacheCreation = 0;
+        $cacheCreation1h = 0;
         $cacheRead = 0;
         $error = false;
 
@@ -363,6 +364,7 @@ final readonly class GatewayToolLoop
             &$inputTokens,
             &$outputTokens,
             &$cacheCreation,
+            &$cacheCreation1h,
             &$cacheRead,
             &$error,
             $emitter,
@@ -390,6 +392,7 @@ final readonly class GatewayToolLoop
                 if (\is_array($usage)) {
                     $inputTokens = (int) ($usage['input_tokens'] ?? $inputTokens);
                     $cacheCreation = (int) ($usage['cache_creation_input_tokens'] ?? $cacheCreation);
+                    $cacheCreation1h = MessagesUsage::extractCacheCreation1hTokens($usage);
                     $cacheRead = (int) ($usage['cache_read_input_tokens'] ?? $cacheRead);
                 }
                 // Emit immediately — suppressed on subsequent turns by the emitter.
@@ -503,6 +506,7 @@ final readonly class GatewayToolLoop
                 inputTokens: $inputTokens,
                 outputTokens: $outputTokens,
                 cacheCreationTokens: $cacheCreation,
+                cacheCreation1hTokens: $cacheCreation1h,
                 cacheReadTokens: $cacheRead,
                 stopReason: $stopReason,
             ),
@@ -801,6 +805,7 @@ final readonly class GatewayToolLoop
             inputTokens: $a->inputTokens + $b->inputTokens,
             outputTokens: $a->outputTokens + $b->outputTokens,
             cacheCreationTokens: $a->cacheCreationTokens + $b->cacheCreationTokens,
+            cacheCreation1hTokens: $a->cacheCreation1hTokens + $b->cacheCreation1hTokens,
             cacheReadTokens: $a->cacheReadTokens + $b->cacheReadTokens,
             stopReason: $b->stopReason ?? $a->stopReason,
         );
@@ -819,6 +824,16 @@ final readonly class GatewayToolLoop
             'cache_creation_input_tokens' => $usage->cacheCreationTokens,
             'cache_read_input_tokens' => $usage->cacheReadTokens,
         ];
+
+        // Mirror Anthropic's TTL breakdown so a client inspecting the aggregated
+        // multi-turn usage (e.g. for its own cost estimate) sees the same shape
+        // it would from a single-turn response.
+        if ($usage->cacheCreation1hTokens > 0) {
+            $body['usage']['cache_creation'] = [
+                'ephemeral_5m_input_tokens' => $usage->cacheCreationTokens - $usage->cacheCreation1hTokens,
+                'ephemeral_1h_input_tokens' => $usage->cacheCreation1hTokens,
+            ];
+        }
 
         return $body;
     }

--- a/backend/src/AI/Messages/Tools/GatewayToolLoop.php
+++ b/backend/src/AI/Messages/Tools/GatewayToolLoop.php
@@ -827,11 +827,15 @@ final readonly class GatewayToolLoop
 
         // Mirror Anthropic's TTL breakdown so a client inspecting the aggregated
         // multi-turn usage (e.g. for its own cost estimate) sees the same shape
-        // it would from a single-turn response.
+        // it would from a single-turn response. Clamp defensively: summing
+        // per-turn usage (sumUsage()) should never let the 1h count exceed the
+        // total, but a negative ephemeral_5m_input_tokens would be an invalid
+        // token count and could confuse a client parsing this breakdown.
         if ($usage->cacheCreation1hTokens > 0) {
+            $cacheCreation1h = min($usage->cacheCreation1hTokens, $usage->cacheCreationTokens);
             $body['usage']['cache_creation'] = [
-                'ephemeral_5m_input_tokens' => $usage->cacheCreationTokens - $usage->cacheCreation1hTokens,
-                'ephemeral_1h_input_tokens' => $usage->cacheCreation1hTokens,
+                'ephemeral_5m_input_tokens' => $usage->cacheCreationTokens - $cacheCreation1h,
+                'ephemeral_1h_input_tokens' => $cacheCreation1h,
             ];
         }
 

--- a/backend/src/AI/Messages/Translator/AnthropicPassthroughTranslator.php
+++ b/backend/src/AI/Messages/Translator/AnthropicPassthroughTranslator.php
@@ -165,6 +165,7 @@ final readonly class AnthropicPassthroughTranslator implements MessagesTranslato
         $inputTokens = 0;
         $outputTokens = 0;
         $cacheCreation = 0;
+        $cacheCreation1h = 0;
         $cacheRead = 0;
         $stopReason = null;
         $eventName = null;
@@ -211,6 +212,7 @@ final readonly class AnthropicPassthroughTranslator implements MessagesTranslato
                         $usage = $decoded['message']['usage'] ?? [];
                         $inputTokens = (int) ($usage['input_tokens'] ?? $inputTokens);
                         $cacheCreation = (int) ($usage['cache_creation_input_tokens'] ?? $cacheCreation);
+                        $cacheCreation1h = \is_array($usage) ? MessagesUsage::extractCacheCreation1hTokens($usage) : $cacheCreation1h;
                         $cacheRead = (int) ($usage['cache_read_input_tokens'] ?? $cacheRead);
                     } elseif ('message_delta' === $type) {
                         $usage = $decoded['usage'] ?? [];
@@ -228,6 +230,7 @@ final readonly class AnthropicPassthroughTranslator implements MessagesTranslato
             inputTokens: $inputTokens,
             outputTokens: $outputTokens,
             cacheCreationTokens: $cacheCreation,
+            cacheCreation1hTokens: $cacheCreation1h,
             cacheReadTokens: $cacheRead,
             stopReason: $stopReason,
         );
@@ -244,6 +247,7 @@ final readonly class AnthropicPassthroughTranslator implements MessagesTranslato
         $inputTokens = 0;
         $outputTokens = 0;
         $cacheCreation = 0;
+        $cacheCreation1h = 0;
         $cacheRead = 0;
         $stopReason = null;
         $eventName = null;
@@ -292,6 +296,7 @@ final readonly class AnthropicPassthroughTranslator implements MessagesTranslato
                         $usage = $decoded['message']['usage'] ?? [];
                         $inputTokens = (int) ($usage['input_tokens'] ?? $inputTokens);
                         $cacheCreation = (int) ($usage['cache_creation_input_tokens'] ?? $cacheCreation);
+                        $cacheCreation1h = \is_array($usage) ? MessagesUsage::extractCacheCreation1hTokens($usage) : $cacheCreation1h;
                         $cacheRead = (int) ($usage['cache_read_input_tokens'] ?? $cacheRead);
                     } elseif ('message_delta' === $type) {
                         $usage = $decoded['usage'] ?? [];
@@ -311,6 +316,7 @@ final readonly class AnthropicPassthroughTranslator implements MessagesTranslato
             inputTokens: $inputTokens,
             outputTokens: $outputTokens,
             cacheCreationTokens: $cacheCreation,
+            cacheCreation1hTokens: $cacheCreation1h,
             cacheReadTokens: $cacheRead,
             stopReason: $stopReason,
         );

--- a/backend/src/AI/Provider/AnthropicProvider.php
+++ b/backend/src/AI/Provider/AnthropicProvider.php
@@ -6,6 +6,7 @@ use App\AI\Credential\ProviderKeyStore;
 use App\AI\Exception\ProviderException;
 use App\AI\Interface\ChatProviderInterface;
 use App\AI\Interface\VisionProviderInterface;
+use App\AI\Messages\MessagesUsage;
 use Psr\Log\LoggerInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
@@ -251,6 +252,7 @@ class AnthropicProvider implements ChatProviderInterface, VisionProviderInterfac
             $inputTokens = $data['usage']['input_tokens'] ?? 0;
             $outputTokens = $data['usage']['output_tokens'] ?? 0;
             $cacheCreationTokens = $data['usage']['cache_creation_input_tokens'] ?? 0;
+            $cacheCreation1hTokens = MessagesUsage::extractCacheCreation1hTokens($data['usage'] ?? []);
             $cacheReadTokens = $data['usage']['cache_read_input_tokens'] ?? 0;
 
             $usage = [
@@ -259,6 +261,7 @@ class AnthropicProvider implements ChatProviderInterface, VisionProviderInterfac
                 'total_tokens' => $inputTokens + $outputTokens + $cacheCreationTokens + $cacheReadTokens,
                 'cached_tokens' => $cacheReadTokens,
                 'cache_creation_tokens' => $cacheCreationTokens,
+                'cache_creation_1h_tokens' => $cacheCreation1hTokens,
             ];
 
             $this->logger->info('Anthropic: Chat completed', [
@@ -868,6 +871,7 @@ class AnthropicProvider implements ChatProviderInterface, VisionProviderInterfac
         $inputTokens = 0;
         $outputTokens = 0;
         $cacheCreationTokens = 0;
+        $cacheCreation1hTokens = 0;
         $cacheReadTokens = 0;
         $finishReason = null;
 
@@ -896,6 +900,7 @@ class AnthropicProvider implements ChatProviderInterface, VisionProviderInterfac
                         $msgUsage = $event['data']['message']['usage'] ?? [];
                         $inputTokens = $msgUsage['input_tokens'] ?? 0;
                         $cacheCreationTokens = $msgUsage['cache_creation_input_tokens'] ?? 0;
+                        $cacheCreation1hTokens = MessagesUsage::extractCacheCreation1hTokens($msgUsage);
                         $cacheReadTokens = $msgUsage['cache_read_input_tokens'] ?? 0;
                         break;
 
@@ -969,6 +974,7 @@ class AnthropicProvider implements ChatProviderInterface, VisionProviderInterfac
             'total_tokens' => $inputTokens + $outputTokens + $cacheCreationTokens + $cacheReadTokens,
             'cached_tokens' => $cacheReadTokens,
             'cache_creation_tokens' => $cacheCreationTokens,
+            'cache_creation_1h_tokens' => $cacheCreation1hTokens,
         ];
     }
 

--- a/backend/src/Service/CostCalculationService.php
+++ b/backend/src/Service/CostCalculationService.php
@@ -14,7 +14,12 @@ use Psr\Log\LoggerInterface;
 final readonly class CostCalculationService
 {
     private const CACHE_READ_DISCOUNT_ANTHROPIC = 0.10;
+    // Default TTL (5 minutes) cache write, per https://platform.claude.com/docs/en/build-with-claude/prompt-caching.
     private const CACHE_WRITE_MULTIPLIER_ANTHROPIC = 1.25;
+    // Opt-in 1-hour TTL cache write (`cache_control: {"type": "ephemeral", "ttl": "1h"}`) — billed
+    // at 2x base input price, not the 1.25x default. Applies uniformly across the whole Anthropic
+    // lineup (Anthropic docs footnote: only cache *reads* vary per model, e.g. Fable 5.1's 0.025x).
+    private const CACHE_WRITE_MULTIPLIER_ANTHROPIC_1H = 2.0;
     private const CACHE_READ_DISCOUNT_DEFAULT = 0.50;
 
     public function __construct(
@@ -24,6 +29,14 @@ final readonly class CostCalculationService
     ) {
     }
 
+    /**
+     * @param int $cacheCreationTokens   total tokens written to the cache (both TTLs combined) —
+     *                                   Anthropic's `cache_creation_input_tokens`
+     * @param int $cacheCreation1hTokens Subset of $cacheCreationTokens written with a 1-hour TTL —
+     *                                   Anthropic's `cache_creation.ephemeral_1h_input_tokens`. The
+     *                                   remainder is billed at the default 5-minute-TTL rate.
+     *                                   Non-Anthropic providers never populate this (always 0).
+     */
     public function calculateCost(
         int $promptTokens,
         int $completionTokens,
@@ -31,6 +44,7 @@ final readonly class CostCalculationService
         int $cacheCreationTokens,
         ?int $modelId,
         ?int $timestamp = null,
+        int $cacheCreation1hTokens = 0,
     ): CostResult {
         if (!$modelId) {
             return $this->zeroCostResult();
@@ -84,6 +98,7 @@ final readonly class CostCalculationService
         $provider = ModelCatalog::normalizeProvider($model->getService());
         $cacheReadDiscount = $this->getCacheReadDiscount($provider);
         $cacheWriteMultiplier = $this->getCacheWriteMultiplier($provider);
+        $cacheWriteMultiplier1h = $this->getCacheWriteMultiplier1h($provider);
 
         // Override with explicit cache price if available
         $cacheReadPricePerToken = null !== $cachePriceIn
@@ -96,9 +111,16 @@ final readonly class CostCalculationService
             $regularInputTokens = 0;
         }
 
+        // Split cache writes by TTL: the 1-hour slice is billed at the higher
+        // multiplier, the remainder at the default (5-minute) rate. Clamp
+        // defensively so a caller-supplied 1h count can never exceed the total.
+        $cacheCreation1h = min(max($cacheCreation1hTokens, 0), $cacheCreationTokens);
+        $cacheCreation5m = $cacheCreationTokens - $cacheCreation1h;
+
         $regularInputCost = $regularInputTokens * $pricePerInputToken;
         $cachedInputCost = $cachedTokens * $cacheReadPricePerToken;
-        $cacheCreationCost = $cacheCreationTokens * $pricePerInputToken * $cacheWriteMultiplier;
+        $cacheCreationCost = ($cacheCreation5m * $pricePerInputToken * $cacheWriteMultiplier)
+            + ($cacheCreation1h * $pricePerInputToken * $cacheWriteMultiplier1h);
         $outputCost = $completionTokens * $pricePerOutputToken;
 
         $totalInputCost = $regularInputCost + $cachedInputCost + $cacheCreationCost;
@@ -459,6 +481,13 @@ final readonly class CostCalculationService
     {
         return 'anthropic' === $provider
             ? self::CACHE_WRITE_MULTIPLIER_ANTHROPIC
+            : 1.0;
+    }
+
+    private function getCacheWriteMultiplier1h(string $provider): float
+    {
+        return 'anthropic' === $provider
+            ? self::CACHE_WRITE_MULTIPLIER_ANTHROPIC_1H
             : 1.0;
     }
 

--- a/backend/src/Service/RateLimitService.php
+++ b/backend/src/Service/RateLimitService.php
@@ -302,7 +302,9 @@ final class RateLimitService
         $cacheCreationTokens = $usage['cache_creation_tokens'] ?? 0;
         // Anthropic-only: subset of $cacheCreationTokens written with a 1-hour TTL (billed at
         // 2x base input instead of the 1.25x default) — see MessagesUsage::extractCacheCreation1hTokens().
-        $cacheCreation1hTokens = $usage['cache_creation_1h_tokens'] ?? 0;
+        // Cast/clamp defensively: $usage is an untyped array, so a stray numeric
+        // string or negative value must not reach calculateCost()'s int param.
+        $cacheCreation1hTokens = max(0, (int) ($usage['cache_creation_1h_tokens'] ?? 0));
         $totalTokens = $usage['total_tokens'] ?? ($promptTokens + $completionTokens);
 
         // Legacy support: if 'tokens' was passed directly (old API)

--- a/backend/src/Service/RateLimitService.php
+++ b/backend/src/Service/RateLimitService.php
@@ -300,6 +300,9 @@ final class RateLimitService
         $completionTokens = $usage['completion_tokens'] ?? 0;
         $cachedTokens = $usage['cached_tokens'] ?? 0;
         $cacheCreationTokens = $usage['cache_creation_tokens'] ?? 0;
+        // Anthropic-only: subset of $cacheCreationTokens written with a 1-hour TTL (billed at
+        // 2x base input instead of the 1.25x default) — see MessagesUsage::extractCacheCreation1hTokens().
+        $cacheCreation1hTokens = $usage['cache_creation_1h_tokens'] ?? 0;
         $totalTokens = $usage['total_tokens'] ?? ($promptTokens + $completionTokens);
 
         // Legacy support: if 'tokens' was passed directly (old API)
@@ -413,6 +416,7 @@ final class RateLimitService
                 $cacheCreationTokens,
                 $modelId,
                 $timestamp,
+                $cacheCreation1hTokens,
             );
         }
 

--- a/backend/tests/Service/RateLimitServiceUnifiedTest.php
+++ b/backend/tests/Service/RateLimitServiceUnifiedTest.php
@@ -252,6 +252,75 @@ class RateLimitServiceUnifiedTest extends TestCase
         ]);
     }
 
+    /**
+     * Regression for a Copilot review comment on #1680: `usage` is an untyped
+     * array, so `cache_creation_1h_tokens` can arrive as a numeric string (or
+     * even negative) from a caller. recordUsage() must cast/clamp it to a
+     * non-negative int before forwarding to CostCalculationService, matching
+     * the other token fields' int contract.
+     */
+    public function testRecordUsageCastsAndClampsCacheCreation1hTokensFromUntypedUsageArray(): void
+    {
+        $user = $this->createMock(User::class);
+        $user->method('getId')->willReturn(1);
+
+        $costCalculationService = $this->createMock(CostCalculationService::class);
+        $costCalculationService->method('getPricingMode')->willReturn('per_token');
+
+        $capturedCacheCreation1hTokens = null;
+        $costCalculationService->expects($this->once())
+            ->method('calculateCost')
+            ->with(
+                $this->anything(),
+                $this->anything(),
+                $this->anything(),
+                $this->anything(),
+                $this->anything(),
+                $this->anything(),
+                $this->callback(function ($cacheCreation1hTokens) use (&$capturedCacheCreation1hTokens) {
+                    $capturedCacheCreation1hTokens = $cacheCreation1hTokens;
+
+                    return true;
+                }),
+            )
+            ->willReturn(new \App\DTO\CostResult(
+                totalCost: '0.000000',
+                inputCost: '0.000000',
+                outputCost: '0.000000',
+                cacheSavings: '0.000000',
+                priceSnapshot: [],
+                billedInputTokens: 0,
+            ));
+
+        $service = new RateLimitService(
+            $this->configRepository,
+            $this->em,
+            $this->logger,
+            new BillingService('sk_test_valid_key', 'price_1RealProId'),
+            $costCalculationService,
+            $this->createMock(SubscriptionRepository::class),
+            $this->createMock(TopupRepository::class),
+        );
+
+        $this->connection->expects($this->once())->method('executeStatement');
+
+        $service->recordUsage($user, 'API_CHAT', [
+            'provider' => 'anthropic',
+            'model' => 'claude-fable-5-1',
+            'model_id' => 338,
+            'usage' => [
+                'prompt_tokens' => 1000,
+                'completion_tokens' => 500,
+                'cached_tokens' => 0,
+                'cache_creation_tokens' => 100,
+                // Numeric string, as an untyped metadata array could carry.
+                'cache_creation_1h_tokens' => '40',
+            ],
+        ]);
+
+        $this->assertSame(40, $capturedCacheCreation1hTokens);
+    }
+
     public function testUnifiedLimitScenarioWhatsAppThenEmail(): void
     {
         $user = $this->createMock(User::class);

--- a/backend/tests/Unit/AI/Messages/GatewayToolLoopTest.php
+++ b/backend/tests/Unit/AI/Messages/GatewayToolLoopTest.php
@@ -321,4 +321,66 @@ final class GatewayToolLoopTest extends TestCase
         $this->assertSame(1, $result['iterations']);
         $this->assertSame('tool_use', $result['usage']->stopReason);
     }
+
+    /**
+     * Regression for a Copilot review comment on #1680: withUsage() must never
+     * emit a negative ephemeral_5m_input_tokens in the aggregated multi-turn
+     * usage body, even if a (defensively impossible, but not enforced by the
+     * type system) cacheCreation1hTokens > cacheCreationTokens slips through.
+     */
+    public function testWithUsageClampsOneHourCacheBreakdownToCacheCreationTotal(): void
+    {
+        $user = $this->createMock(User::class);
+        $user->method('getId')->willReturn(5);
+
+        $loop = new GatewayToolLoop(
+            new McpToolCatalogAdapter($this->createMock(\App\Service\Mcp\McpToolRegistry::class)),
+            $this->createMock(WebSearchTool::class),
+            $this->createMock(AnalyzeImageTool::class),
+            $this->createMock(McpClient::class),
+            $this->createMock(McpServerConfigRepository::class),
+            $this->createConfiguredMock(MessagesGatewayConfig::class, ['mcpMaxIterations' => 8]),
+            $this->createConfiguredMock(RateLimitService::class, [
+                'checkLimit' => ['allowed' => true],
+            ]),
+            new NullLogger(),
+        );
+
+        $translator = $this->createMock(MessagesTranslatorInterface::class);
+        $translator->expects($this->once())->method('complete')->willReturn([
+            'status' => 200,
+            'headers' => [],
+            'body' => [
+                'content' => [['type' => 'text', 'text' => 'done']],
+                'stop_reason' => 'end_turn',
+                'usage' => ['input_tokens' => 10, 'output_tokens' => 5],
+            ],
+            // Inconsistent on purpose: cacheCreation1hTokens (999) exceeds
+            // cacheCreationTokens (20). A real Anthropic response can't do
+            // this, but withUsage() must still clamp rather than compute a
+            // negative 5m count.
+            'usage' => new MessagesUsage(
+                inputTokens: 10,
+                outputTokens: 5,
+                cacheCreationTokens: 20,
+                cacheReadTokens: 0,
+                stopReason: 'end_turn',
+                cacheCreation1hTokens: 999,
+            ),
+        ]);
+
+        $result = $loop->runComplete(
+            ['model' => 'x', 'max_tokens' => 1, 'messages' => [['role' => 'user', 'content' => 'x']]],
+            ['api_key' => 'k', 'upstream_url' => 'http://example.test'],
+            $translator,
+            $user,
+            ['tools' => [], 'dispatch' => [], 'web_search' => GatewayToolCatalog::WEB_SEARCH_NONE],
+        );
+
+        $this->assertIsArray($result['body']);
+        $cacheCreation = $result['body']['usage']['cache_creation'];
+        $this->assertSame(20, $cacheCreation['ephemeral_1h_input_tokens']);
+        $this->assertSame(0, $cacheCreation['ephemeral_5m_input_tokens']);
+        $this->assertGreaterThanOrEqual(0, $cacheCreation['ephemeral_5m_input_tokens']);
+    }
 }

--- a/backend/tests/Unit/AI/Messages/MessagesUsageTest.php
+++ b/backend/tests/Unit/AI/Messages/MessagesUsageTest.php
@@ -26,6 +26,24 @@ final class MessagesUsageTest extends TestCase
         $this->assertSame(250, $mapped['total_tokens']);
         $this->assertSame(80, $mapped['cached_tokens']);
         $this->assertSame(20, $mapped['cache_creation_tokens']);
+        $this->assertSame(0, $mapped['cache_creation_1h_tokens']);
+    }
+
+    public function testToRateLimitUsageIncludesOneHourCacheBreakdown(): void
+    {
+        $usage = new MessagesUsage(
+            inputTokens: 100,
+            outputTokens: 50,
+            cacheCreationTokens: 20,
+            cacheReadTokens: 80,
+            stopReason: 'end_turn',
+            cacheCreation1hTokens: 12,
+        );
+
+        $mapped = $usage->toRateLimitUsage();
+
+        $this->assertSame(20, $mapped['cache_creation_tokens']);
+        $this->assertSame(12, $mapped['cache_creation_1h_tokens']);
     }
 
     public function testFromAnthropicUsage(): void
@@ -40,7 +58,62 @@ final class MessagesUsageTest extends TestCase
         $this->assertSame(10, $usage->inputTokens);
         $this->assertSame(5, $usage->outputTokens);
         $this->assertSame(2, $usage->cacheCreationTokens);
+        $this->assertSame(0, $usage->cacheCreation1hTokens);
         $this->assertSame(3, $usage->cacheReadTokens);
         $this->assertSame('tool_use', $usage->stopReason);
+    }
+
+    /**
+     * Real Anthropic response shape when a 1-hour-TTL cache breakpoint is used:
+     * `cache_creation_input_tokens` is the aggregate (both TTLs), and the nested
+     * `cache_creation` object breaks it down by TTL. See
+     * https://platform.claude.com/docs/en/build-with-claude/prompt-caching.
+     */
+    public function testFromAnthropicUsageExtractsOneHourCacheBreakdown(): void
+    {
+        $usage = MessagesUsage::fromAnthropicUsage([
+            'input_tokens' => 2048,
+            'output_tokens' => 503,
+            'cache_creation_input_tokens' => 248,
+            'cache_read_input_tokens' => 1800,
+            'cache_creation' => [
+                'ephemeral_5m_input_tokens' => 148,
+                'ephemeral_1h_input_tokens' => 100,
+            ],
+        ]);
+
+        $this->assertSame(248, $usage->cacheCreationTokens);
+        $this->assertSame(100, $usage->cacheCreation1hTokens);
+    }
+
+    public function testExtractCacheCreation1hTokensReturnsZeroWhenBreakdownMissing(): void
+    {
+        $this->assertSame(0, MessagesUsage::extractCacheCreation1hTokens([
+            'cache_creation_input_tokens' => 50,
+        ]));
+    }
+
+    public function testExtractCacheCreation1hTokensReturnsZeroWhenBreakdownNotAnArray(): void
+    {
+        // @phpstan-ignore-next-line — defensive against a malformed upstream payload
+        $this->assertSame(0, MessagesUsage::extractCacheCreation1hTokens([
+            'cache_creation' => 'not-an-array',
+        ]));
+    }
+
+    public function testWithStopReasonPreservesOneHourCacheBreakdown(): void
+    {
+        $usage = new MessagesUsage(
+            inputTokens: 10,
+            outputTokens: 5,
+            cacheCreationTokens: 20,
+            cacheReadTokens: 3,
+            cacheCreation1hTokens: 15,
+        );
+
+        $updated = $usage->withStopReason('end_turn');
+
+        $this->assertSame(15, $updated->cacheCreation1hTokens);
+        $this->assertSame('end_turn', $updated->stopReason);
     }
 }

--- a/backend/tests/Unit/Service/CostCalculationServiceTest.php
+++ b/backend/tests/Unit/Service/CostCalculationServiceTest.php
@@ -115,6 +115,96 @@ class CostCalculationServiceTest extends TestCase
         $this->assertSame('0.010035', $result->totalCost);
     }
 
+    /**
+     * Anthropic's 1-hour cache TTL (opt-in via `cache_control: {"ttl": "1h"}`) writes
+     * cost 2x base input, not the 1.25x default for the 5-minute TTL — see
+     * https://platform.claude.com/docs/en/build-with-claude/prompt-caching. Before
+     * this was fixed, ALL cache-creation tokens were billed at the flat 1.25x rate
+     * regardless of TTL, under-billing every 1h-TTL write.
+     */
+    public function testCalculatesCostWithFullyOneHourCacheWriteAnthropicProvider(): void
+    {
+        $model = $this->createModelMock('Anthropic', 3.0, 15.0, 'per1M', 'per1M');
+
+        // @phpstan-ignore-next-line
+        $this->modelRepository->method('find')->willReturn($model);
+        // @phpstan-ignore-next-line
+        $this->priceHistoryRepository->method('findPriceAtTimestamp')->willReturn(null);
+
+        // 1000 total prompt, 200 cached (0.10x read), 100 cache creation ALL 1h TTL (2.0x write)
+        // Regular: (1000 - 200 - 100) = 700 * 3/1M = 0.002100
+        // Cached: 200 * 3/1M * 0.10 = 0.000060
+        // Cache creation (1h): 100 * 3/1M * 2.0 = 0.000600
+        // Completion: 500 * 15/1M = 0.007500
+        $result = $this->service->calculateCost(1000, 500, 200, 100, 1, null, 100);
+
+        $this->assertSame('0.010260', $result->totalCost);
+    }
+
+    /**
+     * Mixed TTL: a single request can carry both a 5-minute-TTL breakpoint and a
+     * 1-hour-TTL breakpoint (Anthropic's `cache_creation.ephemeral_5m_input_tokens`
+     * / `ephemeral_1h_input_tokens`), so the two slices must be billed separately.
+     */
+    public function testCalculatesCostWithMixedFiveMinuteAndOneHourCacheWriteAnthropicProvider(): void
+    {
+        $model = $this->createModelMock('Anthropic', 3.0, 15.0, 'per1M', 'per1M');
+
+        // @phpstan-ignore-next-line
+        $this->modelRepository->method('find')->willReturn($model);
+        // @phpstan-ignore-next-line
+        $this->priceHistoryRepository->method('findPriceAtTimestamp')->willReturn(null);
+
+        // 1000 total prompt, 0 cached, 100 cache creation: 40 at 1h TTL, 60 at 5m TTL (remainder)
+        // Regular: (1000 - 0 - 100) = 900 * 3/1M = 0.002700
+        // Cache creation (5m): 60 * 3/1M * 1.25 = 0.000225
+        // Cache creation (1h): 40 * 3/1M * 2.0 = 0.000240
+        // Completion: 500 * 15/1M = 0.007500
+        $result = $this->service->calculateCost(1000, 500, 0, 100, 1, null, 40);
+
+        $this->assertSame('0.010665', $result->totalCost);
+    }
+
+    /**
+     * Non-Anthropic providers never carry a 1h/5m TTL distinction; a stray
+     * $cacheCreation1hTokens value (e.g. from a shared code path) must not
+     * change their (flat 1.0x) cache-write cost.
+     */
+    public function testCacheCreation1hTokensIgnoredForNonAnthropicProvider(): void
+    {
+        $model = $this->createModelMock('openai', 3.0, 15.0, 'per1M', 'per1M');
+
+        // @phpstan-ignore-next-line
+        $this->modelRepository->method('find')->willReturn($model);
+        // @phpstan-ignore-next-line
+        $this->priceHistoryRepository->method('findPriceAtTimestamp')->willReturn(null);
+
+        $withoutFlag = $this->service->calculateCost(1000, 500, 0, 100, 1);
+        $withFlag = $this->service->calculateCost(1000, 500, 0, 100, 1, null, 100);
+
+        $this->assertSame($withoutFlag->totalCost, $withFlag->totalCost);
+    }
+
+    /**
+     * Defensive clamp: a caller-supplied 1h count above the total cache-creation
+     * total (e.g. a stale/inconsistent breakdown) must never inflate the bill
+     * beyond "the whole cache-creation total billed at the 1h rate".
+     */
+    public function testCacheCreation1hTokensClampedToCacheCreationTokens(): void
+    {
+        $model = $this->createModelMock('Anthropic', 3.0, 15.0, 'per1M', 'per1M');
+
+        // @phpstan-ignore-next-line
+        $this->modelRepository->method('find')->willReturn($model);
+        // @phpstan-ignore-next-line
+        $this->priceHistoryRepository->method('findPriceAtTimestamp')->willReturn(null);
+
+        $clampedToTotal = $this->service->calculateCost(1000, 500, 0, 100, 1, null, 100);
+        $overTotal = $this->service->calculateCost(1000, 500, 0, 100, 1, null, 999);
+
+        $this->assertSame($clampedToTotal->totalCost, $overTotal->totalCost);
+    }
+
     public function testUsesHistoryPriceWhenAvailable(): void
     {
         $model = $this->createModelMock('openai', 3.0, 15.0, 'per1M', 'per1M');

--- a/docs/PRICING_MAINTENANCE.md
+++ b/docs/PRICING_MAINTENANCE.md
@@ -354,6 +354,20 @@ Source: https://platform.claude.com/docs/en/about-claude/models/overview
 
 Claude Fable 5.1 succeeds Claude Fable 5 at the same input/output price, but Anthropic cut cache-read pricing to a quarter of Fable 5's rate (0.025x base vs the 0.1x every other Anthropic model gets from `CostCalculationService::CACHE_READ_DISCOUNT_ANTHROPIC`). The catalog rows (`ModelCatalog.php` 338/339) carry an explicit `cache_read_price_per_1M: 0.25` override, which `CostCalculationService::getPriceSnapshot()` picks up ahead of the provider-wide discount — see `ModelCatalogTest::testClaudeFable51ModelsAreAvailableWithExpectedApiIds`. Claude Fable 5.1 and Claude Mythos 5.1 also reject forced `tool_choice` (`{"type": "any"}` / `{"type": "tool", ...}`) with a 400; only `"auto"`/`"none"` work — see the note in `AnthropicProvider`'s class docblock (the internal chat pipeline never sends `tool_choice`, so this only bites Messages Gateway clients that force it, and Anthropic's own 400 surfaces the mismatch through the verbatim passthrough).
 
+#### Cache-write pricing: 5-minute vs. 1-hour TTL (fixed 2026-09-02)
+
+Anthropic bills prompt-cache **writes** at two different multipliers of the base input price, per TTL — see [prompt caching](https://platform.claude.com/docs/en/build-with-claude/prompt-caching):
+
+| Cache operation | Multiplier | Constant in `CostCalculationService` |
+| ---------------- | ---------- | ------------------------------------- |
+| 5-minute cache write (default) | 1.25x | `CACHE_WRITE_MULTIPLIER_ANTHROPIC` |
+| 1-hour cache write (opt-in, `cache_control: {"type": "ephemeral", "ttl": "1h"}`, needs the client `anthropic-beta: extended-cache-ttl-2025-04-11` header) | 2.0x | `CACHE_WRITE_MULTIPLIER_ANTHROPIC_1H` |
+| Cache read (hit) | 0.1x base (0.025x on Claude Fable 5.1 / Claude Mythos 5.1, see above) | `CACHE_READ_DISCOUNT_ANTHROPIC` |
+
+Both multipliers are **provider-wide constants**, not per-model catalog fields — Anthropic's pricing page confirms every current model (Fable 5.1, Fable 5, Opus 5, Opus 4.8, Sonnet 5, Haiku 4.5) uses the same 1.25x / 2.0x cache-write split; only cache-*read* pricing varies per model.
+
+Before this fix, `CostCalculationService` applied the 1.25x multiplier to **every** cache-creation token regardless of TTL, under-billing any 1-hour-TTL write by 37.5% (2.0x actual vs. 1.25x charged). Anthropic's `usage` response breaks the aggregate `cache_creation_input_tokens` down by TTL in a nested `cache_creation: {ephemeral_5m_input_tokens, ephemeral_1h_input_tokens}` object; `MessagesUsage::extractCacheCreation1hTokens()` is the single parsing helper shared by every Anthropic usage-parsing call site (`AnthropicProvider` chat + stream, `AnthropicPassthroughTranslator` complete + both stream paths, `GatewayToolLoop`'s tool-loop stream collector), so the 1h slice flows through to `CostCalculationService::calculateCost()`'s new `$cacheCreation1hTokens` parameter and gets billed at 2.0x while the remainder stays at 1.25x. No `BUSELOG` schema change was needed — only the token *aggregate* is persisted (`BCACHE_CREATION_TOKENS`), and the row's `BCOST` now reflects the correctly blended multiplier.
+
 Retired on 2026-07-27 by `Version20260727120000` (rows deactivated, never deleted — `BMESSAGES` FKs; BIDs must never be reused): Claude Sonnet 4.5 (112/109), Claude Opus 4.6 (160/164), Claude Sonnet 4.6 (161/163), Claude Opus 4.7 (165/166), plus the catalog-orphans Claude Opus 4.1 (69/93, deprecated upstream and retired by Anthropic on 2026-08-05) and Claude Opus 4.5 (121).
 
 The same orphan cleanup continues in `Version20260727180000` for two non-Anthropic rows: **OpenAI `gpt-4.1` (BID 30)** → GPT-5.6 Terra (253) and **Groq `llama-4-maverick-17b-128e-instruct` (BID 49)** → Groq `gpt-oss-120b` (76).


### PR DESCRIPTION
## Problem

Anthropic bills prompt-cache **writes** at two different multipliers of the base input price, depending on the TTL of the `cache_control` breakpoint:

| Cache write | Multiplier |
| ----------- | ---------- |
| 5-minute TTL (default) | 1.25x |
| 1-hour TTL (opt-in, `cache_control: {"type": "ephemeral", "ttl": "1h"}`) | 2.0x |

`CostCalculationService` applied the 1.25x multiplier to **every** cache-creation token regardless of TTL — under-billing any 1-hour-TTL write by 37.5% (2.0x actual cost vs. 1.25x charged to the user). This affects both the internal chat pipeline and the Messages Gateway (`/v1/messages`, used by Claude Code and other Anthropic-protocol clients).

Verified all current Anthropic catalog prices (Fable 5.1, Fable 5, Opus 5, Opus 4.8, Sonnet 5, Haiku 4.5) against the [official pricing page](https://platform.claude.com/docs/en/about-claude/pricing) — the 1.25x/2.0x cache-write split and 0.1x cache-read discount (0.025x on Fable 5.1/Mythos 5.1, already handled via a catalog override) are **provider-wide constants** and apply identically to every model, so no catalog changes were needed, only the cost-calculation logic.

## Fix

Anthropic's `usage` response breaks the aggregate `cache_creation_input_tokens` down by TTL in a nested object:

```json
"usage": {
  "cache_creation_input_tokens": 248,
  "cache_creation": {
    "ephemeral_5m_input_tokens": 148,
    "ephemeral_1h_input_tokens": 100
  }
}
```

- Added `MessagesUsage::extractCacheCreation1hTokens()` — a single shared helper that pulls the 1h slice out of that breakdown.
- Threaded it through **every** Anthropic usage-parsing call site: `AnthropicProvider` (non-stream + stream), `AnthropicPassthroughTranslator` (`complete()` + both stream paths), `GatewayToolLoop`'s tool-loop stream collector (+ `sumUsage`/`withUsage` for multi-turn aggregation).
- `MessagesUsage`, `RateLimitService::recordUsage()`, and `CostCalculationService::calculateCost()` now carry the 1h count end-to-end. New param appended at the **end** of both signatures (not inserted mid-list) so every existing positional call site stays valid.
- `CostCalculationService` now splits the cache-creation cost: the 1h slice at the new `CACHE_WRITE_MULTIPLIER_ANTHROPIC_1H` (2.0x), the remainder at the existing `CACHE_WRITE_MULTIPLIER_ANTHROPIC` (1.25x). Defensively clamps a caller-supplied 1h count to the total.
- No `BUSELOG` schema change — only the aggregate token count is persisted (`BCACHE_CREATION_TOKENS`); `BCOST` now reflects the correctly blended rate.
- Docs: `docs/PRICING_MAINTENANCE.md` gets a new "Cache-write pricing: 5-minute vs. 1-hour TTL" section; resolved the "known gap" note in the Messages Gateway planning doc.

## Testing

- New unit tests in `CostCalculationServiceTest` (all-1h, mixed 5m/1h, non-Anthropic no-op, clamp) and `MessagesUsageTest` (breakdown extraction, `toRateLimitUsage`/`withStopReason` round-trip).
- Full local gate green: `make -C backend lint && make -C backend phpstan && make -C backend test` (4625 tests, 0 failures).