### PR TITLE
fix(docs): clarify desktop pairing instructions and update translations

### DIFF
--- a/docs/DESKTOP.md
+++ b/docs/DESKTOP.md
@@ -134,7 +134,8 @@ Flow:
 
 1. User opens **Channels → Desktop** in the web app and clicks *Pair a
    computer* → server mints a code. The address shown is the API origin
-   (`http://localhost:8000` in local Vite, not `:5173` or Keycloak `:8080`).
+   (`http://localhost:8000` in local Vite — or the same host on `:8000` when
+   the UI is opened via a LAN IP — not `:5173` or Keycloak `:8080`).
 2. User types the address and code into Synaplan Desktop (or pastes an API
    key on the desktop **API key** tab).
 3. The client calls `POST /pair` → gets `{ deviceId, key, apiBaseUrl }` and

--- a/docs/DESKTOP.md
+++ b/docs/DESKTOP.md
@@ -133,8 +133,10 @@ never logged at info level.
 Flow:
 
 1. User opens **Channels → Desktop** in the web app and clicks *Pair a
-   computer* → server mints a code.
-2. User types the code into Synaplan Desktop.
+   computer* → server mints a code. The address shown is the API origin
+   (`http://localhost:8000` in local Vite, not `:5173` or Keycloak `:8080`).
+2. User types the address and code into Synaplan Desktop (or pastes an API
+   key on the desktop **API key** tab).
 3. The client calls `POST /pair` → gets `{ deviceId, key, apiBaseUrl }` and
    stores the key in the OS secret store.
 4. The client polls with the key from then on.

--- a/frontend/src/components/config/DesktopConfiguration.vue
+++ b/frontend/src/components/config/DesktopConfiguration.vue
@@ -209,6 +209,9 @@
                   <label class="block text-sm font-medium txt-primary mb-2">
                     {{ $t('config.desktop.pairing.addressLabel') }}
                   </label>
+                  <p class="text-xs txt-secondary mb-2">
+                    {{ $t('config.desktop.pairing.addressHint') }}
+                  </p>
                   <div class="flex items-center gap-2">
                     <code
                       class="flex-1 min-w-0 truncate text-sm font-mono txt-primary surface-card px-3 py-2.5 rounded"
@@ -302,6 +305,7 @@ import { useNotification } from '@/composables/useNotification'
 import { useDateFormat } from '@/composables/useDateFormat'
 import { useI18n } from 'vue-i18n'
 import { getErrorMessage } from '@/utils/errorMessage'
+import { desktopPairingAddress } from '@/utils/desktopPairingAddress'
 
 const { t } = useI18n()
 const dialog = useDialog()
@@ -321,9 +325,9 @@ const pairingError = ref<string | null>(null)
 const pairingCode = ref<PairingCode | null>(null)
 const copiedField = ref<'address' | 'code' | null>(null)
 
-// The address the user types into Synaplan Desktop is this Synaplan install's
-// origin — the same host the browser is already talking to.
-const serverAddress = window.location.origin
+// Desktop talks to the API origin. In local Vite that is :8000, not this
+// page's :5173 (and never Keycloak on :8080).
+const serverAddress = desktopPairingAddress()
 
 const now = ref(Math.floor(Date.now() / 1000))
 let ticker: number | null = null

--- a/frontend/src/components/config/DesktopConfiguration.vue
+++ b/frontend/src/components/config/DesktopConfiguration.vue
@@ -325,8 +325,9 @@ const pairingError = ref<string | null>(null)
 const pairingCode = ref<PairingCode | null>(null)
 const copiedField = ref<'address' | 'code' | null>(null)
 
-// Desktop talks to the API origin. In local Vite that is :8000, not this
-// page's :5173 (and never Keycloak on :8080).
+// Desktop talks to the API origin. In local Vite that is :8000 on the same
+// host as this page (LAN IP and custom hostnames included), never :5173
+// and never Keycloak on :8080.
 const serverAddress = desktopPairingAddress()
 
 const now = ref(Math.floor(Date.now() / 1000))

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -2359,6 +2359,7 @@
         "title": "Diesen Computer verbinden",
         "intro": "Öffne Synaplan Desktop auf dem Computer, den du verbinden möchtest, und gib diese Adresse und den Code ein.",
         "addressLabel": "Serveradresse",
+        "addressHint": "Diese Adresse in Synaplan Desktop eingeben. Lokal ist das die API (http://localhost:8000), nicht der Port der Web-Oberfläche.",
         "codeLabel": "Verbindungscode",
         "expiresIn": "Läuft ab in {time}",
         "expired": "Dieser Code ist abgelaufen.",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -2285,6 +2285,7 @@
         "title": "Pair this computer",
         "intro": "Open Synaplan Desktop on the computer you want to connect, then enter this address and code.",
         "addressLabel": "Server address",
+        "addressHint": "Type this address in Synaplan Desktop. On a local install it is the API (http://localhost:8000), not the web UI port.",
         "codeLabel": "Pairing code",
         "expiresIn": "Expires in {time}",
         "expired": "This code has expired.",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -3140,6 +3140,7 @@
         "title": "Vincular este equipo",
         "intro": "Abre Synaplan Desktop en el equipo que quieres conectar e introduce esta dirección y este código.",
         "addressLabel": "Dirección del servidor",
+        "addressHint": "Escribe esta dirección en Synaplan Desktop. En local es la API (http://localhost:8000), no el puerto de la interfaz web.",
         "codeLabel": "Código de vinculación",
         "expiresIn": "Caduca en {time}",
         "expired": "Este código ha caducado.",

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -2285,6 +2285,7 @@
         "title": "Associer cet ordinateur",
         "intro": "Ouvrez Synaplan Desktop sur l'ordinateur à connecter, puis saisissez cette adresse et ce code.",
         "addressLabel": "Adresse du serveur",
+        "addressHint": "Saisissez cette adresse dans Synaplan Desktop. En local, c’est l’API (http://localhost:8000), pas le port de l’interface web.",
         "codeLabel": "Code d'association",
         "expiresIn": "Expire dans {time}",
         "expired": "Ce code a expiré.",

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -3141,6 +3141,7 @@
         "title": "Bu bilgisayarı bağla",
         "intro": "Bağlamak istediğiniz bilgisayarda Synaplan Desktop'ı açın, ardından bu adresi ve kodu girin.",
         "addressLabel": "Sunucu adresi",
+        "addressHint": "Bu adresi Synaplan Desktop’a yazın. Yerelde bu API’dir (http://localhost:8000), web arayüzü bağlantı noktası değil.",
         "codeLabel": "Eşleme kodu",
         "expiresIn": "{time} içinde sona erer",
         "expired": "Bu kodun süresi doldu.",

--- a/frontend/src/utils/desktopPairingAddress.ts
+++ b/frontend/src/utils/desktopPairingAddress.ts
@@ -1,0 +1,19 @@
+/**
+ * Address the user should type into Synaplan Desktop.
+ *
+ * In production the web UI and API share one origin. In local Vite the page is
+ * on :5173 (or :4173 preview) while the API is published on :8000. Keycloak
+ * occupies :8080 and must never be copied into the desktop client.
+ */
+export function desktopPairingAddress(origin: string = window.location.origin): string {
+  try {
+    const url = new URL(origin)
+    const local = url.hostname === 'localhost' || url.hostname === '127.0.0.1'
+    if (local && (url.port === '5173' || url.port === '4173')) {
+      return `${url.protocol}//${url.hostname}:8000`
+    }
+  } catch {
+    // Keep the given origin when it is not a valid URL.
+  }
+  return origin
+}

--- a/frontend/src/utils/desktopPairingAddress.ts
+++ b/frontend/src/utils/desktopPairingAddress.ts
@@ -1,16 +1,20 @@
+const VITE_DEV_PORTS = new Set(['5173', '4173'])
+const API_PORT = '8000'
+
 /**
  * Address the user should type into Synaplan Desktop.
  *
  * In production the web UI and API share one origin. In local Vite the page is
- * on :5173 (or :4173 preview) while the API is published on :8000. Keycloak
- * occupies :8080 and must never be copied into the desktop client.
+ * on :5173 (or :4173 preview) while the API is published on :8000 — including
+ * when the UI is opened via a LAN IP or a custom hostname. Keycloak occupies
+ * :8080 and must never be copied into the desktop client.
  */
 export function desktopPairingAddress(origin: string = window.location.origin): string {
   try {
     const url = new URL(origin)
-    const local = url.hostname === 'localhost' || url.hostname === '127.0.0.1'
-    if (local && (url.port === '5173' || url.port === '4173')) {
-      return `${url.protocol}//${url.hostname}:8000`
+    if (VITE_DEV_PORTS.has(url.port)) {
+      url.port = API_PORT
+      return url.origin
     }
   } catch {
     // Keep the given origin when it is not a valid URL.

--- a/frontend/tests/unit/utils/desktopPairingAddress.spec.ts
+++ b/frontend/tests/unit/utils/desktopPairingAddress.spec.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+
+import { desktopPairingAddress } from '@/utils/desktopPairingAddress'
+
+describe('desktopPairingAddress', () => {
+  it('maps the Vite dev origin to the published API port', () => {
+    expect(desktopPairingAddress('http://localhost:5173')).toBe('http://localhost:8000')
+    expect(desktopPairingAddress('http://127.0.0.1:4173')).toBe('http://127.0.0.1:8000')
+  })
+
+  it('keeps a production or already-correct API origin', () => {
+    expect(desktopPairingAddress('https://web.synaplan.com')).toBe('https://web.synaplan.com')
+    expect(desktopPairingAddress('http://localhost:8000')).toBe('http://localhost:8000')
+  })
+
+  it('does not rewrite Keycloak on :8080 into a pairing address', () => {
+    expect(desktopPairingAddress('http://localhost:8080')).toBe('http://localhost:8080')
+  })
+})

--- a/frontend/tests/unit/utils/desktopPairingAddress.spec.ts
+++ b/frontend/tests/unit/utils/desktopPairingAddress.spec.ts
@@ -8,6 +8,12 @@ describe('desktopPairingAddress', () => {
     expect(desktopPairingAddress('http://127.0.0.1:4173')).toBe('http://127.0.0.1:8000')
   })
 
+  it('maps a LAN IP or custom hostname on the Vite port to the same host on :8000', () => {
+    expect(desktopPairingAddress('http://192.168.1.42:5173')).toBe('http://192.168.1.42:8000')
+    expect(desktopPairingAddress('http://synaplan.local:4173')).toBe('http://synaplan.local:8000')
+    expect(desktopPairingAddress('http://[::1]:5173')).toBe('http://[::1]:8000')
+  })
+
   it('keeps a production or already-correct API origin', () => {
     expect(desktopPairingAddress('https://web.synaplan.com')).toBe('https://web.synaplan.com')
     expect(desktopPairingAddress('http://localhost:8000')).toBe('http://localhost:8000')


### PR DESCRIPTION
## Summary
Desktop app preps

## Changes
Updated the desktop pairing flow in the documentation to specify the correct API origin address for local installations. Enhanced the user interface by adding a hint for the server address in the DesktopConfiguration component. Translated the new hint into German, Spanish, French, and Turkish to ensure consistency across languages.

## Verification
- [ ] Not tested (explain)
- [X] Manual
- [ ] Tests added/updated
