### PR TITLE
fix(frontend): keep office file menu visible outside the chat bubble

### DIFF
--- a/frontend/src/components/files/FileOfficeActions.vue
+++ b/frontend/src/components/files/FileOfficeActions.vue
@@ -1,87 +1,98 @@
 <template>
   <div class="relative" data-testid="file-office-actions">
     <button
+      ref="triggerRef"
       type="button"
       class="shrink-0 px-2 py-1 rounded-md border border-light-border/30 dark:border-dark-border/10 txt-secondary hover:txt-primary transition-colors text-[11px] flex items-center gap-1"
       :aria-expanded="open"
       :aria-label="$t('files.download')"
       data-testid="file-office-actions-trigger"
-      @click.stop="open = !open"
+      @click.stop="toggle"
     >
       <Icon icon="mdi:dots-vertical" class="w-3.5 h-3.5" />
     </button>
-    <div
-      v-if="open"
-      class="absolute right-0 bottom-full mb-1 z-30 w-52 surface-card rounded-xl border border-light-border/30 dark:border-dark-border/20 shadow-xl py-1.5"
-      data-testid="file-office-actions-menu"
-      @click.stop
-    >
-      <button
-        type="button"
-        class="w-full flex items-center gap-2 px-3 py-2 text-xs txt-primary hover:bg-[var(--brand)]/10 transition-colors text-left"
-        data-testid="file-office-actions-download"
-        @click="onDownload"
+    <!--
+      Teleport out of the chat bubble / card. The bubble uses overflow-x-auto,
+      which CSS computes as overflow-y: auto as well, so an absolute menu
+      opening above the trigger is clipped to a sliver. V2 also applies
+      transform on the message row, which would trap position:fixed.
+    -->
+    <Teleport to="body">
+      <div
+        v-if="open"
+        ref="menuRef"
+        class="fixed z-[200] w-52 surface-card rounded-xl border border-light-border/30 dark:border-dark-border/20 shadow-xl py-1.5"
+        :style="menuStyle"
+        data-testid="file-office-actions-menu"
+        @click.stop
       >
-        <Icon icon="mdi:download" class="w-4 h-4 shrink-0" />
-        <span>{{ $t('files.download') }}</span>
-      </button>
-      <button
-        v-if="canExportPdf"
-        type="button"
-        class="w-full flex items-center gap-2 px-3 py-2 text-xs txt-primary hover:bg-[var(--brand)]/10 transition-colors text-left"
-        data-testid="file-office-actions-pdf"
-        @click="onExportPdf"
-      >
-        <Icon icon="mdi:file-pdf-box" class="w-4 h-4 shrink-0" />
-        <span>{{ $t('files.downloadPdf') }}</span>
-      </button>
-      <button
-        v-if="showPreview && canPreview"
-        type="button"
-        class="w-full flex items-center gap-2 px-3 py-2 text-xs txt-primary hover:bg-[var(--brand)]/10 transition-colors text-left"
-        data-testid="file-office-actions-preview"
-        @click="onPreview"
-      >
-        <Icon icon="mdi:eye-outline" class="w-4 h-4 shrink-0" />
-        <span>{{ $t('files.preview.open') }}</span>
-      </button>
-      <button
-        v-if="canCombine"
-        type="button"
-        class="w-full flex items-center gap-2 px-3 py-2 text-xs txt-primary hover:bg-[var(--brand)]/10 transition-colors text-left"
-        data-testid="file-office-actions-combine"
-        @click="onCombine"
-      >
-        <Icon icon="mdi:file-multiple-outline" class="w-4 h-4 shrink-0" />
-        <span>{{ $t('files.combinePdf') }}</span>
-      </button>
-      <button
-        v-if="canCombineOffice"
-        type="button"
-        class="w-full flex items-center gap-2 px-3 py-2 text-xs txt-primary hover:bg-[var(--brand)]/10 transition-colors text-left"
-        data-testid="file-office-actions-combine-office"
-        @click="onCombineOffice"
-      >
-        <Icon icon="mdi:file-multiple" class="w-4 h-4 shrink-0" />
-        <span>{{ $t('files.combineOffice', { format: officeFormatLabel }) }}</span>
-      </button>
-      <button
-        v-if="canShowRevisions"
-        type="button"
-        class="w-full flex items-center gap-2 px-3 py-2 text-xs txt-primary hover:bg-[var(--brand)]/10 transition-colors text-left"
-        data-testid="file-office-actions-revisions"
-        @click="onRevisions"
-      >
-        <Icon icon="mdi:history" class="w-4 h-4 shrink-0" />
-        <span>{{ $t('files.revisions') }}</span>
-      </button>
-    </div>
-    <FileRevisionsPanel v-if="showRevisions" :file-id="fileId" @close="showRevisions = false" />
+        <button
+          type="button"
+          class="w-full flex items-center gap-2 px-3 py-2 text-xs txt-primary hover:bg-[var(--brand)]/10 transition-colors text-left"
+          data-testid="file-office-actions-download"
+          @click="onDownload"
+        >
+          <Icon icon="mdi:download" class="w-4 h-4 shrink-0" />
+          <span>{{ $t('files.download') }}</span>
+        </button>
+        <button
+          v-if="canExportPdf"
+          type="button"
+          class="w-full flex items-center gap-2 px-3 py-2 text-xs txt-primary hover:bg-[var(--brand)]/10 transition-colors text-left"
+          data-testid="file-office-actions-pdf"
+          @click="onExportPdf"
+        >
+          <Icon icon="mdi:file-pdf-box" class="w-4 h-4 shrink-0" />
+          <span>{{ $t('files.downloadPdf') }}</span>
+        </button>
+        <button
+          v-if="showPreview && canPreview"
+          type="button"
+          class="w-full flex items-center gap-2 px-3 py-2 text-xs txt-primary hover:bg-[var(--brand)]/10 transition-colors text-left"
+          data-testid="file-office-actions-preview"
+          @click="onPreview"
+        >
+          <Icon icon="mdi:eye-outline" class="w-4 h-4 shrink-0" />
+          <span>{{ $t('files.preview.open') }}</span>
+        </button>
+        <button
+          v-if="canCombine"
+          type="button"
+          class="w-full flex items-center gap-2 px-3 py-2 text-xs txt-primary hover:bg-[var(--brand)]/10 transition-colors text-left"
+          data-testid="file-office-actions-combine"
+          @click="onCombine"
+        >
+          <Icon icon="mdi:file-multiple-outline" class="w-4 h-4 shrink-0" />
+          <span>{{ $t('files.combinePdf') }}</span>
+        </button>
+        <button
+          v-if="canCombineOffice"
+          type="button"
+          class="w-full flex items-center gap-2 px-3 py-2 text-xs txt-primary hover:bg-[var(--brand)]/10 transition-colors text-left"
+          data-testid="file-office-actions-combine-office"
+          @click="onCombineOffice"
+        >
+          <Icon icon="mdi:file-multiple" class="w-4 h-4 shrink-0" />
+          <span>{{ $t('files.combineOffice', { format: officeFormatLabel }) }}</span>
+        </button>
+        <button
+          v-if="canShowRevisions"
+          type="button"
+          class="w-full flex items-center gap-2 px-3 py-2 text-xs txt-primary hover:bg-[var(--brand)]/10 transition-colors text-left"
+          data-testid="file-office-actions-revisions"
+          @click="onRevisions"
+        >
+          <Icon icon="mdi:history" class="w-4 h-4 shrink-0" />
+          <span>{{ $t('files.revisions') }}</span>
+        </button>
+      </div>
+      <FileRevisionsPanel v-if="showRevisions" :file-id="fileId" @close="showRevisions = false" />
+    </Teleport>
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, ref } from 'vue'
+import { computed, nextTick, onMounted, onUnmounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { Icon } from '@iconify/vue'
 import { isOfficeConvertEnabled } from '@/composables/useOfficeConvertFeature'
@@ -91,6 +102,10 @@ import * as filesService from '@/services/filesService'
 import { useNotification } from '@/composables/useNotification'
 import { ApiError } from '@/services/api/httpClient'
 import FileRevisionsPanel from '@/components/files/FileRevisionsPanel.vue'
+
+const MENU_WIDTH_PX = 208
+const MENU_GAP_PX = 4
+const VIEWPORT_PAD_PX = 8
 
 const props = withDefaults(
   defineProps<{
@@ -109,6 +124,9 @@ const { t } = useI18n()
 const { error: showError, success: showSuccess } = useNotification()
 const open = ref(false)
 const showRevisions = ref(false)
+const triggerRef = ref<HTMLElement | null>(null)
+const menuRef = ref<HTMLElement | null>(null)
+const menuStyle = ref<Record<string, string>>({})
 
 const kind = computed(() => kindFromExtension(extensionOf(props.filename)))
 const canExportPdf = computed(() => isOfficeConvertEnabled() && 'document' === kind.value)
@@ -144,8 +162,35 @@ const canShowRevisions = computed(
   () => isDocumentToolsEnabled() && !props.guestSessionId && null !== officeFormat.value
 )
 
+const updateMenuPosition = () => {
+  if (!triggerRef.value) return
+  const rect = triggerRef.value.getBoundingClientRect()
+  const menuHeight = menuRef.value?.offsetHeight ?? 0
+  const spaceBelow = window.innerHeight - rect.bottom - MENU_GAP_PX
+  const spaceAbove = rect.top - MENU_GAP_PX
+  const openAbove = menuHeight > 0 && spaceBelow < menuHeight && spaceAbove > spaceBelow
+
+  const maxLeft = window.innerWidth - MENU_WIDTH_PX - VIEWPORT_PAD_PX
+  const left = Math.max(VIEWPORT_PAD_PX, Math.min(rect.right - MENU_WIDTH_PX, maxLeft))
+
+  menuStyle.value = {
+    left: `${left}px`,
+    width: `${MENU_WIDTH_PX}px`,
+    ...(openAbove
+      ? { top: 'auto', bottom: `${window.innerHeight - rect.top + MENU_GAP_PX}px` }
+      : { top: `${rect.bottom + MENU_GAP_PX}px`, bottom: 'auto' }),
+  }
+}
+
 const close = () => {
   open.value = false
+}
+
+const toggle = () => {
+  open.value = !open.value
+  if (open.value) {
+    nextTick(updateMenuPosition)
+  }
 }
 
 const onDownload = async () => {
@@ -225,7 +270,32 @@ const onRevisions = () => {
   showRevisions.value = true
 }
 
-const onDocClick = () => close()
-onMounted(() => document.addEventListener('click', onDocClick))
-onUnmounted(() => document.removeEventListener('click', onDocClick))
+const onDocClick = (event: MouseEvent) => {
+  if (!open.value) return
+  const target = event.target as Node
+  if (triggerRef.value?.contains(target) || menuRef.value?.contains(target)) return
+  close()
+}
+
+const onKeydown = (event: KeyboardEvent) => {
+  if ('Escape' === event.key && open.value) close()
+}
+
+const onReposition = () => {
+  if (open.value) updateMenuPosition()
+}
+
+onMounted(() => {
+  document.addEventListener('click', onDocClick)
+  document.addEventListener('keydown', onKeydown)
+  window.addEventListener('scroll', onReposition, true)
+  window.addEventListener('resize', onReposition)
+})
+
+onUnmounted(() => {
+  document.removeEventListener('click', onDocClick)
+  document.removeEventListener('keydown', onKeydown)
+  window.removeEventListener('scroll', onReposition, true)
+  window.removeEventListener('resize', onReposition)
+})
 </script>

--- a/frontend/tests/unit/components/files/FileOfficeActions.spec.ts
+++ b/frontend/tests/unit/components/files/FileOfficeActions.spec.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it, vi } from 'vitest'
-import { mount } from '@vue/test-utils'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { mount, type VueWrapper } from '@vue/test-utils'
 import { createI18n } from 'vue-i18n'
+import { nextTick } from 'vue'
 
 import FileOfficeActions from '@/components/files/FileOfficeActions.vue'
 
@@ -41,24 +42,47 @@ const i18n = createI18n({
   },
 })
 
+const mountActions = (filename: string): VueWrapper =>
+  mount(FileOfficeActions, {
+    props: { fileId: 7, filename },
+    attachTo: document.body,
+    global: { plugins: [i18n], stubs: { Icon: { template: '<i />' } } },
+  })
+
 describe('FileOfficeActions', () => {
+  afterEach(() => {
+    document.body.replaceChildren()
+  })
+
   it('shows PDF export and preview for office files when the engine is on', async () => {
-    const wrapper = mount(FileOfficeActions, {
-      props: { fileId: 7, filename: 'brief.docx' },
-      global: { plugins: [i18n], stubs: { Icon: { template: '<i />' } } },
-    })
+    const wrapper = mountActions('brief.docx')
     await wrapper.find('[data-testid="file-office-actions-trigger"]').trigger('click')
-    expect(wrapper.find('[data-testid="file-office-actions-pdf"]').exists()).toBe(true)
-    expect(wrapper.find('[data-testid="file-office-actions-preview"]').exists()).toBe(true)
+    await nextTick()
+    expect(document.querySelector('[data-testid="file-office-actions-pdf"]')).not.toBeNull()
+    expect(document.querySelector('[data-testid="file-office-actions-preview"]')).not.toBeNull()
+    wrapper.unmount()
   })
 
   it('hides PDF export for plain PDFs', async () => {
-    const wrapper = mount(FileOfficeActions, {
-      props: { fileId: 7, filename: 'report.pdf' },
-      global: { plugins: [i18n], stubs: { Icon: { template: '<i />' } } },
-    })
+    const wrapper = mountActions('report.pdf')
     await wrapper.find('[data-testid="file-office-actions-trigger"]').trigger('click')
-    expect(wrapper.find('[data-testid="file-office-actions-pdf"]').exists()).toBe(false)
-    expect(wrapper.find('[data-testid="file-office-actions-preview"]').exists()).toBe(true)
+    await nextTick()
+    expect(document.querySelector('[data-testid="file-office-actions-pdf"]')).toBeNull()
+    expect(document.querySelector('[data-testid="file-office-actions-preview"]')).not.toBeNull()
+    wrapper.unmount()
+  })
+
+  it('renders the menu as a fixed overlay on the body so bubble overflow cannot clip it', async () => {
+    const wrapper = mountActions('brief.docx')
+    await wrapper.find('[data-testid="file-office-actions-trigger"]').trigger('click')
+    await nextTick()
+
+    const menu = document.querySelector('[data-testid="file-office-actions-menu"]')
+    expect(menu).toBeInstanceOf(HTMLElement)
+    expect(menu?.classList.contains('fixed')).toBe(true)
+    expect(menu?.classList.contains('bottom-full')).toBe(false)
+    expect(document.body.contains(menu)).toBe(true)
+    expect(wrapper.find('[data-testid="file-office-actions"]').element.contains(menu)).toBe(false)
+    wrapper.unmount()
   })
 })


### PR DESCRIPTION
## Summary
- The office file ⋮ menu (`Download as PDF`, preview, combine) opened with `position: absolute` above the trigger. Chat bubbles use `overflow-x-auto`, which CSS computes as `overflow-y: auto` as well, so the menu was clipped to a sliver.
- Teleport the menu to `body` and position it `fixed` (same overlay pattern as `ModelSelectDropdown`), flipping above the trigger only when there is no room below.

## Test plan
- [ ] Open a chat with an attached `.docx` / `.xlsx` / `.pptx` (office engine on).
- [ ] Click the ⋮ on the file chip: the full menu is visible (Download, Download as PDF, Preview), not a grey strip at the top of the bubble.
- [ ] Scroll the thread and resize the window while the menu is open; it stays attached to the trigger.
- [ ] Escape or click outside closes it.
- [ ] Repeat on Quellen → Erzeugt if an office file is there.