### PR TITLE
fix(frontend): open the office kebab menu above the trigger

### DIFF
--- a/frontend/src/components/files/FileOfficeActions.vue
+++ b/frontend/src/components/files/FileOfficeActions.vue
@@ -21,7 +21,7 @@
       <div
         v-if="open"
         ref="menuRef"
-        class="fixed z-[200] w-52 surface-card rounded-xl border border-light-border/30 dark:border-dark-border/20 shadow-xl py-1.5"
+        class="fixed z-[200] w-52 overflow-y-auto scroll-thin surface-card rounded-xl border border-light-border/30 dark:border-dark-border/20 shadow-xl py-1.5"
         :style="menuStyle"
         data-testid="file-office-actions-menu"
         @click.stop
@@ -102,10 +102,11 @@ import * as filesService from '@/services/filesService'
 import { useNotification } from '@/composables/useNotification'
 import { ApiError } from '@/services/api/httpClient'
 import FileRevisionsPanel from '@/components/files/FileRevisionsPanel.vue'
-
-const MENU_WIDTH_PX = 208
-const MENU_GAP_PX = 4
-const VIEWPORT_PAD_PX = 8
+import {
+  MENU_WIDTH_PX,
+  parseCssPx,
+  placeOfficeActionsMenu,
+} from '@/components/files/officeActionsMenuPlacement'
 
 const props = withDefaults(
   defineProps<{
@@ -162,23 +163,28 @@ const canShowRevisions = computed(
   () => isDocumentToolsEnabled() && !props.guestSessionId && null !== officeFormat.value
 )
 
+const keyboardInsetPx = (): number =>
+  parseCssPx(getComputedStyle(document.documentElement).getPropertyValue('--keyboard-inset-height'))
+
 const updateMenuPosition = () => {
   if (!triggerRef.value) return
   const rect = triggerRef.value.getBoundingClientRect()
-  const menuHeight = menuRef.value?.offsetHeight ?? 0
-  const spaceBelow = window.innerHeight - rect.bottom - MENU_GAP_PX
-  const spaceAbove = rect.top - MENU_GAP_PX
-  const openAbove = menuHeight > 0 && spaceBelow < menuHeight && spaceAbove > spaceBelow
-
-  const maxLeft = window.innerWidth - MENU_WIDTH_PX - VIEWPORT_PAD_PX
-  const left = Math.max(VIEWPORT_PAD_PX, Math.min(rect.right - MENU_WIDTH_PX, maxLeft))
+  const vv = window.visualViewport
+  const placed = placeOfficeActionsMenu({
+    trigger: { top: rect.top, bottom: rect.bottom, right: rect.right },
+    menuHeight: menuRef.value?.offsetHeight ?? 0,
+    innerWidth: window.innerWidth,
+    innerHeight: window.innerHeight,
+    keyboardInsetPx: keyboardInsetPx(),
+    visualViewport: vv ? { offsetTop: vv.offsetTop, height: vv.height } : null,
+  })
 
   menuStyle.value = {
-    left: `${left}px`,
+    left: `${placed.left}px`,
     width: `${MENU_WIDTH_PX}px`,
-    ...(openAbove
-      ? { top: 'auto', bottom: `${window.innerHeight - rect.top + MENU_GAP_PX}px` }
-      : { top: `${rect.bottom + MENU_GAP_PX}px`, bottom: 'auto' }),
+    maxHeight: `${placed.maxHeight}px`,
+    top: placed.top,
+    bottom: placed.bottom,
   }
 }
 
@@ -189,7 +195,10 @@ const close = () => {
 const toggle = () => {
   open.value = !open.value
   if (open.value) {
-    nextTick(updateMenuPosition)
+    nextTick(() => {
+      updateMenuPosition()
+      nextTick(updateMenuPosition)
+    })
   }
 }
 
@@ -290,6 +299,9 @@ onMounted(() => {
   document.addEventListener('keydown', onKeydown)
   window.addEventListener('scroll', onReposition, true)
   window.addEventListener('resize', onReposition)
+  window.addEventListener('synaplan:keyboardinset', onReposition)
+  window.visualViewport?.addEventListener('resize', onReposition)
+  window.visualViewport?.addEventListener('scroll', onReposition)
 })
 
 onUnmounted(() => {
@@ -297,5 +309,8 @@ onUnmounted(() => {
   document.removeEventListener('keydown', onKeydown)
   window.removeEventListener('scroll', onReposition, true)
   window.removeEventListener('resize', onReposition)
+  window.removeEventListener('synaplan:keyboardinset', onReposition)
+  window.visualViewport?.removeEventListener('resize', onReposition)
+  window.visualViewport?.removeEventListener('scroll', onReposition)
 })
 </script>

--- a/frontend/src/components/files/FileOfficeActions.vue
+++ b/frontend/src/components/files/FileOfficeActions.vue
@@ -103,6 +103,10 @@ import { useNotification } from '@/composables/useNotification'
 import { ApiError } from '@/services/api/httpClient'
 import FileRevisionsPanel from '@/components/files/FileRevisionsPanel.vue'
 import {
+  claimOfficeActionsMenu,
+  releaseOfficeActionsMenu,
+} from '@/components/files/officeActionsMenuExclusive'
+import {
   MENU_WIDTH_PX,
   parseCssPx,
   placeOfficeActionsMenu,
@@ -189,17 +193,22 @@ const updateMenuPosition = () => {
 }
 
 const close = () => {
+  if (!open.value) return
   open.value = false
+  releaseOfficeActionsMenu(close)
 }
 
 const toggle = () => {
-  open.value = !open.value
   if (open.value) {
-    nextTick(() => {
-      updateMenuPosition()
-      nextTick(updateMenuPosition)
-    })
+    close()
+    return
   }
+  claimOfficeActionsMenu(close)
+  open.value = true
+  nextTick(() => {
+    updateMenuPosition()
+    nextTick(updateMenuPosition)
+  })
 }
 
 const onDownload = async () => {
@@ -305,6 +314,7 @@ onMounted(() => {
 })
 
 onUnmounted(() => {
+  close()
   document.removeEventListener('click', onDocClick)
   document.removeEventListener('keydown', onKeydown)
   window.removeEventListener('scroll', onReposition, true)

--- a/frontend/src/components/files/officeActionsMenuExclusive.ts
+++ b/frontend/src/components/files/officeActionsMenuExclusive.ts
@@ -1,0 +1,20 @@
+type Closer = () => void
+
+let active: Closer | null = null
+
+/** One kebab menu at a time: opening a second instance closes the first. */
+export function claimOfficeActionsMenu(close: Closer): void {
+  if (active && active !== close) {
+    const previous = active
+    active = close
+    previous()
+    return
+  }
+  active = close
+}
+
+export function releaseOfficeActionsMenu(close: Closer): void {
+  if (active === close) {
+    active = null
+  }
+}

--- a/frontend/src/components/files/officeActionsMenuPlacement.ts
+++ b/frontend/src/components/files/officeActionsMenuPlacement.ts
@@ -1,0 +1,83 @@
+export const MENU_WIDTH_PX = 208
+export const MENU_GAP_PX = 4
+export const VIEWPORT_PAD_PX = 8
+
+export type VisibleViewport = {
+  offsetTop: number
+  height: number
+}
+
+export type MenuPlacement = {
+  left: number
+  maxHeight: number
+  openAbove: boolean
+  top: string
+  bottom: string
+}
+
+export function parseCssPx(raw: string): number {
+  const parsed = Number.parseFloat(raw.trim())
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 0
+}
+
+export function visibleViewportBounds(args: {
+  innerHeight: number
+  keyboardInsetPx: number
+  visualViewport?: VisibleViewport | null
+}): { top: number; bottom: number } {
+  const inset = Math.max(0, args.keyboardInsetPx)
+  let top = 0
+  let bottom = args.innerHeight - inset
+  const vv = args.visualViewport
+  if (vv) {
+    top = Math.max(top, vv.offsetTop)
+    bottom = Math.min(bottom, vv.offsetTop + vv.height)
+  }
+  if (bottom < top) {
+    bottom = top
+  }
+  return { top, bottom }
+}
+
+/**
+ * Prefer opening above the kebab (legacy `bottom-full`). Flip down only when
+ * the menu cannot fit above and there is more room below. Space is the visible
+ * area: native `Keyboard.resize:'none'` does not shrink innerHeight, so the
+ * `--keyboard-inset-height` CSS var must be subtracted; mobile browsers shrink
+ * `visualViewport` instead.
+ */
+export function placeOfficeActionsMenu(args: {
+  trigger: { top: number; bottom: number; right: number }
+  menuHeight: number
+  innerWidth: number
+  innerHeight: number
+  keyboardInsetPx: number
+  visualViewport?: VisibleViewport | null
+}): MenuPlacement {
+  const visible = visibleViewportBounds(args)
+  const spaceAbove = args.trigger.top - visible.top - MENU_GAP_PX
+  const spaceBelow = visible.bottom - args.trigger.bottom - MENU_GAP_PX
+  const menuHeight = Math.max(0, args.menuHeight)
+  const openAbove = !(spaceAbove < menuHeight && spaceBelow > spaceAbove)
+  const maxHeight = Math.max(0, openAbove ? spaceAbove : spaceBelow)
+  const maxLeft = args.innerWidth - MENU_WIDTH_PX - VIEWPORT_PAD_PX
+  const left = Math.max(VIEWPORT_PAD_PX, Math.min(args.trigger.right - MENU_WIDTH_PX, maxLeft))
+
+  if (openAbove) {
+    return {
+      left,
+      maxHeight,
+      openAbove: true,
+      top: 'auto',
+      bottom: `${args.innerHeight - args.trigger.top + MENU_GAP_PX}px`,
+    }
+  }
+
+  return {
+    left,
+    maxHeight,
+    openAbove: false,
+    top: `${args.trigger.bottom + MENU_GAP_PX}px`,
+    bottom: 'auto',
+  }
+}

--- a/frontend/tests/unit/components/files/FileOfficeActions.spec.ts
+++ b/frontend/tests/unit/components/files/FileOfficeActions.spec.ts
@@ -5,16 +5,33 @@ import { nextTick } from 'vue'
 
 import FileOfficeActions from '@/components/files/FileOfficeActions.vue'
 
+const { isDocumentToolsEnabled } = vi.hoisted(() => ({
+  isDocumentToolsEnabled: vi.fn(() => false),
+}))
+
 vi.mock('@/composables/useOfficeConvertFeature', () => ({
   isOfficeConvertEnabled: () => true,
 }))
 
 vi.mock('@/composables/useDocumentToolsFeature', () => ({
-  isDocumentToolsEnabled: () => false,
+  isDocumentToolsEnabled,
 }))
 
 vi.mock('@/composables/useNotification', () => ({
   useNotification: () => ({ error: vi.fn(), success: vi.fn() }),
+}))
+
+vi.mock('@/composables/useDialog', () => ({
+  useDialog: () => ({ confirm: vi.fn() }),
+}))
+
+vi.mock('@/services/filesService', () => ({
+  downloadFile: vi.fn(),
+  downloadGuestFile: vi.fn(),
+  exportFile: vi.fn(),
+  exportGuestFile: vi.fn(),
+  combineFiles: vi.fn(),
+  listFileRevisions: vi.fn().mockResolvedValue({ revisions: [] }),
 }))
 
 const i18n = createI18n({
@@ -24,6 +41,7 @@ const i18n = createI18n({
   fallbackWarn: false,
   messages: {
     en: {
+      common: { close: 'Close' },
       files: {
         download: 'Download',
         downloadPdf: 'Download as PDF',
@@ -37,52 +55,89 @@ const i18n = createI18n({
         combineTooMany: 'too many {count}',
         combineOffice: 'Combine as {format}',
         revisions: 'Version history',
+        revisionsTitle: 'Version history',
+        noRevisions: 'No versions',
+        status_extracting: 'Loading',
       },
     },
   },
 })
 
-const mountActions = (filename: string): VueWrapper =>
-  mount(FileOfficeActions, {
-    props: { fileId: 7, filename },
-    attachTo: document.body,
-    global: { plugins: [i18n], stubs: { Icon: { template: '<i />' } } },
+describe('FileOfficeActions', () => {
+  let wrapper: VueWrapper | null = null
+
+  afterEach(() => {
+    wrapper?.unmount()
+    wrapper = null
+    isDocumentToolsEnabled.mockReturnValue(false)
   })
 
-describe('FileOfficeActions', () => {
-  afterEach(() => {
-    document.body.replaceChildren()
-  })
+  const mountActions = (filename: string): VueWrapper => {
+    wrapper = mount(FileOfficeActions, {
+      props: { fileId: 7, filename },
+      attachTo: document.body,
+      global: { plugins: [i18n], stubs: { Icon: { template: '<i />' } } },
+    })
+    return wrapper
+  }
+
+  const openMenu = async (filename = 'brief.docx'): Promise<VueWrapper> => {
+    const mounted = mountActions(filename)
+    await mounted.find('[data-testid="file-office-actions-trigger"]').trigger('click')
+    await nextTick()
+    await nextTick()
+    return mounted
+  }
 
   it('shows PDF export and preview for office files when the engine is on', async () => {
-    const wrapper = mountActions('brief.docx')
-    await wrapper.find('[data-testid="file-office-actions-trigger"]').trigger('click')
-    await nextTick()
+    await openMenu('brief.docx')
     expect(document.querySelector('[data-testid="file-office-actions-pdf"]')).not.toBeNull()
     expect(document.querySelector('[data-testid="file-office-actions-preview"]')).not.toBeNull()
-    wrapper.unmount()
   })
 
   it('hides PDF export for plain PDFs', async () => {
-    const wrapper = mountActions('report.pdf')
-    await wrapper.find('[data-testid="file-office-actions-trigger"]').trigger('click')
-    await nextTick()
+    await openMenu('report.pdf')
     expect(document.querySelector('[data-testid="file-office-actions-pdf"]')).toBeNull()
     expect(document.querySelector('[data-testid="file-office-actions-preview"]')).not.toBeNull()
-    wrapper.unmount()
   })
 
   it('renders the menu as a fixed overlay on the body so bubble overflow cannot clip it', async () => {
-    const wrapper = mountActions('brief.docx')
-    await wrapper.find('[data-testid="file-office-actions-trigger"]').trigger('click')
-    await nextTick()
-
+    const mounted = await openMenu()
     const menu = document.querySelector('[data-testid="file-office-actions-menu"]')
     expect(menu).toBeInstanceOf(HTMLElement)
     expect(menu?.classList.contains('fixed')).toBe(true)
+    expect(menu?.classList.contains('overflow-y-auto')).toBe(true)
     expect(menu?.classList.contains('bottom-full')).toBe(false)
     expect(document.body.contains(menu)).toBe(true)
-    expect(wrapper.find('[data-testid="file-office-actions"]').element.contains(menu)).toBe(false)
-    wrapper.unmount()
+    expect(mounted.find('[data-testid="file-office-actions"]').element.contains(menu)).toBe(false)
+  })
+
+  it('closes on Escape', async () => {
+    await openMenu()
+    expect(document.querySelector('[data-testid="file-office-actions-menu"]')).not.toBeNull()
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+    await nextTick()
+    expect(document.querySelector('[data-testid="file-office-actions-menu"]')).toBeNull()
+  })
+
+  it('closes on click outside', async () => {
+    await openMenu()
+    expect(document.querySelector('[data-testid="file-office-actions-menu"]')).not.toBeNull()
+    document.body.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await nextTick()
+    expect(document.querySelector('[data-testid="file-office-actions-menu"]')).toBeNull()
+  })
+
+  it('teleports the revisions panel to the body', async () => {
+    isDocumentToolsEnabled.mockReturnValue(true)
+    await openMenu('brief.docx')
+    const revisions = document.querySelector('[data-testid="file-office-actions-revisions"]')
+    expect(revisions).not.toBeNull()
+    await (revisions as HTMLElement).click()
+    await nextTick()
+    const panel = document.querySelector('[data-testid="file-revisions-panel"]')
+    expect(panel).toBeInstanceOf(HTMLElement)
+    expect(document.body.contains(panel)).toBe(true)
+    expect(wrapper?.find('[data-testid="file-office-actions"]').element.contains(panel)).toBe(false)
   })
 })

--- a/frontend/tests/unit/components/files/FileOfficeActions.spec.ts
+++ b/frontend/tests/unit/components/files/FileOfficeActions.spec.ts
@@ -64,20 +64,22 @@ const i18n = createI18n({
 })
 
 describe('FileOfficeActions', () => {
-  let wrapper: VueWrapper | null = null
+  const wrappers: VueWrapper[] = []
 
   afterEach(() => {
-    wrapper?.unmount()
-    wrapper = null
+    while (wrappers.length > 0) {
+      wrappers.pop()?.unmount()
+    }
     isDocumentToolsEnabled.mockReturnValue(false)
   })
 
-  const mountActions = (filename: string): VueWrapper => {
-    wrapper = mount(FileOfficeActions, {
-      props: { fileId: 7, filename },
+  const mountActions = (filename: string, fileId = 7): VueWrapper => {
+    const wrapper = mount(FileOfficeActions, {
+      props: { fileId, filename },
       attachTo: document.body,
       global: { plugins: [i18n], stubs: { Icon: { template: '<i />' } } },
     })
+    wrappers.push(wrapper)
     return wrapper
   }
 
@@ -138,6 +140,31 @@ describe('FileOfficeActions', () => {
     const panel = document.querySelector('[data-testid="file-revisions-panel"]')
     expect(panel).toBeInstanceOf(HTMLElement)
     expect(document.body.contains(panel)).toBe(true)
-    expect(wrapper?.find('[data-testid="file-office-actions"]').element.contains(panel)).toBe(false)
+    expect(wrappers[0]?.find('[data-testid="file-office-actions"]').element.contains(panel)).toBe(
+      false
+    )
+  })
+
+  it('closes the first kebab when a second one opens', async () => {
+    const first = mountActions('brief.docx', 7)
+    const second = mountActions('report.pdf', 8)
+    await first.find('[data-testid="file-office-actions-trigger"]').trigger('click')
+    await nextTick()
+    await nextTick()
+    expect(document.querySelectorAll('[data-testid="file-office-actions-menu"]')).toHaveLength(1)
+    expect(
+      first.find('[data-testid="file-office-actions-trigger"]').attributes('aria-expanded')
+    ).toBe('true')
+
+    await second.find('[data-testid="file-office-actions-trigger"]').trigger('click')
+    await nextTick()
+    await nextTick()
+    expect(document.querySelectorAll('[data-testid="file-office-actions-menu"]')).toHaveLength(1)
+    expect(
+      first.find('[data-testid="file-office-actions-trigger"]').attributes('aria-expanded')
+    ).toBe('false')
+    expect(
+      second.find('[data-testid="file-office-actions-trigger"]').attributes('aria-expanded')
+    ).toBe('true')
   })
 })

--- a/frontend/tests/unit/components/files/officeActionsMenuPlacement.spec.ts
+++ b/frontend/tests/unit/components/files/officeActionsMenuPlacement.spec.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  MENU_GAP_PX,
+  MENU_WIDTH_PX,
+  parseCssPx,
+  placeOfficeActionsMenu,
+  visibleViewportBounds,
+} from '@/components/files/officeActionsMenuPlacement'
+
+const desktop = {
+  innerWidth: 1280,
+  innerHeight: 800,
+  keyboardInsetPx: 0,
+  visualViewport: null,
+}
+
+describe('parseCssPx', () => {
+  it('reads a px custom property', () => {
+    expect(parseCssPx('320px')).toBe(320)
+    expect(parseCssPx(' 48.5px ')).toBe(48.5)
+  })
+
+  it('treats empty, zero, and garbage as no inset', () => {
+    expect(parseCssPx('')).toBe(0)
+    expect(parseCssPx('0px')).toBe(0)
+    expect(parseCssPx('none')).toBe(0)
+  })
+})
+
+describe('visibleViewportBounds', () => {
+  it('subtracts the native keyboard inset from the layout viewport', () => {
+    expect(
+      visibleViewportBounds({ innerHeight: 800, keyboardInsetPx: 300, visualViewport: null })
+    ).toEqual({ top: 0, bottom: 500 })
+  })
+
+  it('uses the visual viewport when it is shorter than the layout viewport', () => {
+    expect(
+      visibleViewportBounds({
+        innerHeight: 800,
+        keyboardInsetPx: 0,
+        visualViewport: { offsetTop: 0, height: 480 },
+      })
+    ).toEqual({ top: 0, bottom: 480 })
+  })
+
+  it('takes the tighter of inset and visual viewport', () => {
+    expect(
+      visibleViewportBounds({
+        innerHeight: 800,
+        keyboardInsetPx: 200,
+        visualViewport: { offsetTop: 40, height: 500 },
+      })
+    ).toEqual({ top: 40, bottom: 540 })
+  })
+})
+
+describe('placeOfficeActionsMenu', () => {
+  const menuHeight = 160
+
+  it('opens above when both sides have room (kebab default)', () => {
+    const placed = placeOfficeActionsMenu({
+      ...desktop,
+      menuHeight,
+      trigger: { top: 400, bottom: 432, right: 240 },
+    })
+    expect(placed.openAbove).toBe(true)
+    expect(placed.bottom).toBe(`${800 - 400 + MENU_GAP_PX}px`)
+    expect(placed.top).toBe('auto')
+    expect(placed.maxHeight).toBe(400 - MENU_GAP_PX)
+  })
+
+  it('flips below only when there is not enough room above', () => {
+    const placed = placeOfficeActionsMenu({
+      ...desktop,
+      menuHeight,
+      trigger: { top: 40, bottom: 72, right: 240 },
+    })
+    expect(placed.openAbove).toBe(false)
+    expect(placed.top).toBe(`${72 + MENU_GAP_PX}px`)
+    expect(placed.bottom).toBe('auto')
+    expect(placed.maxHeight).toBe(800 - 72 - MENU_GAP_PX)
+  })
+
+  it('stays above a last-row kebab instead of covering the composer', () => {
+    const placed = placeOfficeActionsMenu({
+      ...desktop,
+      menuHeight,
+      trigger: { top: 620, bottom: 652, right: 240 },
+    })
+    expect(placed.openAbove).toBe(true)
+    expect(placed.maxHeight).toBe(620 - MENU_GAP_PX)
+  })
+
+  it('does not treat the area behind a native keyboard as free space', () => {
+    const placed = placeOfficeActionsMenu({
+      ...desktop,
+      keyboardInsetPx: 300,
+      menuHeight,
+      trigger: { top: 450, bottom: 482, right: 240 },
+    })
+    expect(placed.openAbove).toBe(true)
+    expect(placed.maxHeight).toBe(450 - MENU_GAP_PX)
+  })
+
+  it('caps height when flipping down toward a native keyboard', () => {
+    const placed = placeOfficeActionsMenu({
+      ...desktop,
+      keyboardInsetPx: 300,
+      menuHeight,
+      trigger: { top: 24, bottom: 56, right: 240 },
+    })
+    expect(placed.openAbove).toBe(false)
+    expect(placed.maxHeight).toBe(500 - 56 - MENU_GAP_PX)
+  })
+
+  it('aligns the menu to the trigger and clamps it inside the viewport', () => {
+    const placed = placeOfficeActionsMenu({
+      ...desktop,
+      menuHeight,
+      trigger: { top: 400, bottom: 432, right: 40 },
+    })
+    expect(placed.left).toBe(8)
+    const wide = placeOfficeActionsMenu({
+      ...desktop,
+      menuHeight,
+      trigger: { top: 400, bottom: 432, right: 1280 },
+    })
+    expect(wide.left).toBe(1280 - MENU_WIDTH_PX - 8)
+  })
+})


### PR DESCRIPTION
## Summary
- Follow-up to #1692: the clip teleport is correct, but opening **below** by default was a regression versus `bottom-full`. Both call sites sit just above the sticky composer (file chip in the last bubble, kebab on a generated card).
- Prefer opening **above**; flip down only when there is not enough room above. Visible space uses `--keyboard-inset-height` (native `Keyboard.resize: 'none'`) and `visualViewport` (mobile web), not `window.innerHeight` alone.
- Cap the menu with `maxHeight` + `overflow-y-auto` so six items cannot spill off a short viewport. Reposition on keyboard-inset and visual-viewport changes.

## Test plan
- [ ] Chat: attach an Office file so the chip sits in the last bubble, open ⋮ — menu appears **above** the kebab and does not cover the composer
- [ ] Chat: scroll that bubble to the top of the viewport, open ⋮ — menu flips **below** and stays on-screen
- [ ] Quellen → Erzeugt: open ⋮ on a generated Office card — menu appears above the kebab
- [ ] Native app with keyboard open: same last-bubble ⋮ — menu stays above the keyboard (not behind it)
- [ ] Short viewport / many actions: menu scrolls inside the remaining visible area
- [ ] Escape and click-outside still close; Version history still opens as a full-viewport overlay