### PR TITLE
fix(frontend): send the app announcement to the store chooser

### DIFF
--- a/frontend/src/composables/useAnnouncements.ts
+++ b/frontend/src/composables/useAnnouncements.ts
@@ -1,4 +1,5 @@
 import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useConfigStore } from '@/stores/config'
 import { isNativeApp } from '@/services/api/nativeRuntime'
 import { detectBrowserOs } from '@/utils/detectBrowserOs'
@@ -79,6 +80,7 @@ const seen = ref<string[]>(loadSeen())
 
 export function useAnnouncements() {
   const config = useConfigStore()
+  const { locale } = useI18n()
 
   const current = computed<ActiveAnnouncement | null>(() => {
     const context: AnnouncementContext = {
@@ -86,6 +88,7 @@ export function useAnnouncements() {
       androidAppUrl: config.mobile.androidAppUrl,
       isNativeApp: isNativeApp(),
       deviceOs: detectBrowserOs(),
+      locale: locale.value,
     }
 
     const announcement = selectAnnouncement(announcements, seen.value, context, Date.now())

--- a/frontend/src/data/announcements.ts
+++ b/frontend/src/data/announcements.ts
@@ -24,11 +24,12 @@ export interface AnnouncementContext {
   /** True inside the native shell, false in a browser. */
   isNativeApp: boolean
   /**
-   * Best-effort OS of the browser itself (not the native shell), used only to
-   * decide which store button leads for this visitor. 'other' covers desktop
-   * and anything we cannot tell apart.
+   * Best-effort OS of the browser itself (not the native shell). Kept on the
+   * context so a later announcement can still order platform-specific actions.
    */
   deviceOs: 'ios' | 'android' | 'other'
+  /** UI locale, used to pick the marketing-site language prefix. */
+  locale: string
 }
 
 /** One call-to-action button the modal renders. */
@@ -64,48 +65,22 @@ export interface Announcement {
   image?: string
 }
 
+const MARKETING_SITE = 'https://www.synaplan.com'
+
 /**
- * Tags a store link so the stores can attribute the install to this
- * campaign. Goes through `URL` rather than string concatenation so a
- * fragment (`#...`) stays after the query instead of swallowing it, and so
- * re-tagging never leaves two `ct` parameters if the operator already set
- * one — it overwrites theirs instead of duplicating it.
+ * Official download chooser on the marketing site. German UI gets `/de/app`;
+ * every other locale lands on the default English page — the website only
+ * ships those two languages.
  */
-function withCampaign(url: string, campaign: string): string {
-  try {
-    const tagged = new URL(url)
-    tagged.searchParams.set('ct', campaign)
-    return tagged.toString()
-  } catch {
-    // Not an absolute URL (e.g. a relative path an operator pasted by
-    // mistake). Falling back to the simple form still gets them a working
-    // link instead of a thrown error breaking the whole announcement.
-    return `${url}${url.includes('?') ? '&' : '?'}ct=${campaign}`
-  }
+function marketingAppUrl(locale: string): string {
+  const prefix = locale.toLowerCase().startsWith('de') ? '/de' : ''
+
+  return `${MARKETING_SITE}${prefix}/app`
 }
 
-/**
- * Store buttons for this visitor: only the stores the operator published,
- * ordered so a visitor's own platform leads — reaching for the wrong store on
- * a phone is the one mistake this ordering exists to avoid. Desktop visitors
- * (`deviceOs: 'other'`) see the App Store first, matching the tie-break used
- * elsewhere (`ForceUpdateScreen`, `SubscriptionView`).
- */
-function storeActions({
-  iosAppUrl,
-  androidAppUrl,
-  deviceOs,
-}: AnnouncementContext): AnnouncementAction[] {
-  const appStore: AnnouncementAction | null = iosAppUrl
-    ? { labelKey: 'appStore', url: withCampaign(iosAppUrl, 'web-announcement') }
-    : null
-  const googlePlay: AnnouncementAction | null = androidAppUrl
-    ? { labelKey: 'googlePlay', url: withCampaign(androidAppUrl, 'web-announcement') }
-    : null
-
-  const ordered = 'android' === deviceOs ? [googlePlay, appStore] : [appStore, googlePlay]
-
-  return ordered.filter((action): action is AnnouncementAction => null !== action)
+/** One button to the chooser page, so nobody is sent to the wrong store. */
+function marketingAppActions({ locale }: AnnouncementContext): AnnouncementAction[] {
+  return [{ labelKey: 'getTheApp', url: marketingAppUrl(locale) }]
 }
 
 export const announcements: Announcement[] = [
@@ -118,7 +93,7 @@ export const announcements: Announcement[] = [
     // inside it.
     applies: ({ iosAppUrl, androidAppUrl, isNativeApp }) =>
       ('' !== iosAppUrl || '' !== androidAppUrl) && !isNativeApp,
-    actions: storeActions,
+    actions: marketingAppActions,
     // No illustration: the one we have is an iPhone-only mockup, which would
     // misrepresent the announcement for an Android visitor. The modal falls
     // back to the instance's own brand mark instead (see `image` above).

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -4,8 +4,7 @@
     "mobileApp": {
       "title": "Synaplan gibt es jetzt für iPhone und Android",
       "body": "Die App bringt deine Chats, Dokumente und Assistenten aufs Handy. Gleicher Zugang, gleiche Daten — unterwegs sprichst du deine Frage einfach ein und setzt jedes Gespräch dort fort, wo du aufgehört hast.",
-      "appStore": "Im App Store laden",
-      "googlePlay": "Bei Google Play laden"
+      "getTheApp": "App laden"
     }
   },
   "updates": {

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -4,8 +4,7 @@
     "mobileApp": {
       "title": "Synaplan is now on iPhone and Android",
       "body": "The app puts your chats, documents and assistants in your pocket. Same account, same data — you can dictate a question on the way and pick up any conversation where you left it.",
-      "appStore": "Get it on the App Store",
-      "googlePlay": "Get it on Google Play"
+      "getTheApp": "Get the app"
     }
   },
   "updates": {

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -4,8 +4,7 @@
     "mobileApp": {
       "title": "Synaplan ya está disponible para iPhone y Android",
       "body": "La app lleva tus chats, documentos y asistentes al móvil. La misma cuenta y los mismos datos: dicta tu pregunta mientras vas de camino y retoma cualquier conversación donde la dejaste.",
-      "appStore": "Descargar en el App Store",
-      "googlePlay": "Descargar en Google Play"
+      "getTheApp": "Descargar la app"
     }
   },
   "updates": {

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -4,8 +4,7 @@
     "mobileApp": {
       "title": "Synaplan est désormais disponible sur iPhone et Android",
       "body": "L’application emporte vos chats, documents et assistants dans votre poche. Même compte, mêmes données — dictez une question en chemin et reprenez n’importe quelle conversation là où vous l’avez laissée.",
-      "appStore": "Télécharger sur l’App Store",
-      "googlePlay": "Télécharger sur Google Play"
+      "getTheApp": "Télécharger l’app"
     }
   },
   "updates": {

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -4,8 +4,7 @@
     "mobileApp": {
       "title": "Synaplan artık iPhone ve Android'de",
       "body": "Uygulama sohbetlerinizi, belgelerinizi ve asistanlarınızı cebinize taşır. Aynı hesap, aynı veriler — yolda sorunuzu sesli olarak söyleyin ve her sohbete kaldığınız yerden devam edin.",
-      "appStore": "App Store'dan indirin",
-      "googlePlay": "Google Play'den indirin"
+      "getTheApp": "Uygulamayı indir"
     }
   },
   "updates": {

--- a/frontend/tests/unit/components/AnnouncementModal.spec.ts
+++ b/frontend/tests/unit/components/AnnouncementModal.spec.ts
@@ -112,28 +112,14 @@ describe('AnnouncementModal', () => {
     expect(wrapper.find(`[data-testid="${modal}"]`).exists()).toBe(true)
   })
 
-  it('greets a web visitor of an instance that has both apps, App Store leading', async () => {
+  it('greets a web visitor of an instance that has an app with a link to the chooser', async () => {
     const wrapper = await mountModal()
 
     expect(wrapper.find(`[data-testid="${modal}"]`).exists()).toBe(true)
     expect(
-      wrapper.find('[data-testid="link-announcement-action-appStore"]').attributes('href')
-    ).toBe('https://apps.apple.com/app/id6784278288?ct=web-announcement')
-    expect(
-      wrapper.find('[data-testid="link-announcement-action-googlePlay"]').attributes('href')
-    ).toBe('https://play.google.com/store/apps/details?id=com.synaplan.app&ct=web-announcement')
-  })
-
-  it('leads with Google Play for a visitor on an Android device', async () => {
-    runtime.deviceOs = 'android'
-
-    const wrapper = await mountModal()
-    const actions = wrapper.findAll('a[data-testid^="link-announcement-action-"]')
-
-    expect(actions.map((action) => action.attributes('data-testid'))).toEqual([
-      'link-announcement-action-googlePlay',
-      'link-announcement-action-appStore',
-    ])
+      wrapper.find('[data-testid="link-announcement-action-getTheApp"]').attributes('href')
+    ).toBe('https://www.synaplan.com/app')
+    expect(wrapper.findAll('a[data-testid^="link-announcement-action-"]')).toHaveLength(1)
   })
 
   it('falls back to the brand mark when the announcement has no illustration', async () => {
@@ -158,8 +144,7 @@ describe('AnnouncementModal', () => {
     const wrapper = await mountModal()
 
     expect(wrapper.find(`[data-testid="${modal}"]`).exists()).toBe(true)
-    expect(wrapper.find('[data-testid="link-announcement-action-appStore"]').exists()).toBe(false)
-    expect(wrapper.find('[data-testid="link-announcement-action-googlePlay"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="link-announcement-action-getTheApp"]').exists()).toBe(true)
   })
 
   it('does not advertise the app inside the app', async () => {
@@ -191,9 +176,9 @@ describe('AnnouncementModal', () => {
     expect((await mountModal()).find(`[data-testid="${modal}"]`).exists()).toBe(false)
   })
 
-  it('counts following a store link as having seen it', async () => {
+  it('counts following the chooser link as having seen it', async () => {
     const wrapper = await mountModal()
-    await wrapper.find('[data-testid="link-announcement-action-appStore"]').trigger('click')
+    await wrapper.find('[data-testid="link-announcement-action-getTheApp"]').trigger('click')
 
     expect(JSON.parse(localStorage.getItem(SEEN_KEY) ?? '[]')).toContain('mobile-apps-launch')
   })

--- a/frontend/tests/unit/composables/useAnnouncements.spec.ts
+++ b/frontend/tests/unit/composables/useAnnouncements.spec.ts
@@ -20,6 +20,7 @@ function visitor(overrides: Partial<AnnouncementContext> = {}): AnnouncementCont
     androidAppUrl: 'https://play.google.com/store/apps/details?id=com.synaplan.app',
     isNativeApp: false,
     deviceOs: 'other',
+    locale: 'en',
     ...overrides,
   }
 }
@@ -88,65 +89,34 @@ describe('the shipped catalogue', () => {
     expect(mobileApp?.applies(visitor())).toBe(true)
   })
 
-  it('offers both stores, App Store first for a desktop or unrecognized visitor', () => {
-    const actions = mobileApp?.actions?.(visitor({ deviceOs: 'other' })) ?? []
-
-    expect(actions.map((action) => action.labelKey)).toEqual(['appStore', 'googlePlay'])
-  })
-
-  it('leads with Google Play for a visitor on an Android device', () => {
-    const actions = mobileApp?.actions?.(visitor({ deviceOs: 'android' })) ?? []
-
-    expect(actions.map((action) => action.labelKey)).toEqual(['googlePlay', 'appStore'])
-  })
-
-  it('offers only the store the operator actually published', () => {
-    const actions = mobileApp?.actions?.(visitor({ androidAppUrl: '' })) ?? []
-
-    expect(actions.map((action) => action.labelKey)).toEqual(['appStore'])
-  })
-
-  it('tags every store link so the installs can be attributed', () => {
+  it('sends every visitor to the marketing chooser instead of a single store', () => {
     const actions = mobileApp?.actions?.(visitor()) ?? []
 
-    expect(actions.map((action) => action.url)).toEqual([
-      'https://apps.apple.com/app/id1?ct=web-announcement',
-      'https://play.google.com/store/apps/details?id=com.synaplan.app&ct=web-announcement',
-    ])
+    expect(actions).toEqual([{ labelKey: 'getTheApp', url: 'https://www.synaplan.com/app' }])
   })
 
-  it('keeps a query string the operator already configured', () => {
-    const actions =
-      mobileApp?.actions?.(
-        visitor({ iosAppUrl: 'https://apps.apple.com/de/app/id1?l=de', androidAppUrl: '' })
-      ) ?? []
+  it('uses the German marketing page when the UI is German', () => {
+    const actions = mobileApp?.actions?.(visitor({ locale: 'de' })) ?? []
 
-    expect(actions[0]?.url).toBe('https://apps.apple.com/de/app/id1?l=de&ct=web-announcement')
+    expect(actions[0]?.url).toBe('https://www.synaplan.com/de/app')
   })
 
-  it('keeps a fragment after the query instead of appending past it', () => {
-    const actions =
-      mobileApp?.actions?.(
-        visitor({ iosAppUrl: 'https://apps.apple.com/app/id1#reviews', androidAppUrl: '' })
-      ) ?? []
+  it('treats regional German locales as German', () => {
+    const actions = mobileApp?.actions?.(visitor({ locale: 'de-AT' })) ?? []
 
-    expect(actions[0]?.url).toBe('https://apps.apple.com/app/id1?ct=web-announcement#reviews')
+    expect(actions[0]?.url).toBe('https://www.synaplan.com/de/app')
   })
 
-  it('overwrites rather than duplicates a ct the operator already configured', () => {
-    const actions =
-      mobileApp?.actions?.(
-        visitor({ iosAppUrl: 'https://apps.apple.com/app/id1?ct=operator', androidAppUrl: '' })
-      ) ?? []
+  it('keeps other locales on the default English marketing page', () => {
+    const actions = mobileApp?.actions?.(visitor({ locale: 'fr' })) ?? []
 
-    expect(actions[0]?.url).toBe('https://apps.apple.com/app/id1?ct=web-announcement')
+    expect(actions[0]?.url).toBe('https://www.synaplan.com/app')
   })
 
-  it('falls back to plain concatenation for a non-absolute store URL', () => {
-    const actions =
-      mobileApp?.actions?.(visitor({ iosAppUrl: '/local-app', androidAppUrl: '' })) ?? []
+  it('still offers the chooser when the operator published only one store', () => {
+    const actions = mobileApp?.actions?.(visitor({ androidAppUrl: '' })) ?? []
 
-    expect(actions[0]?.url).toBe('/local-app?ct=web-announcement')
+    expect(actions.map((action) => action.labelKey)).toEqual(['getTheApp'])
   })
 
   it('gives every entry an id and expiry that the modal can rely on', () => {


### PR DESCRIPTION
## Summary
The first-visit app announcement sent desktop visitors to the App Store. It now opens the marketing `/app` page so both iOS and Android stay visible.

## Changes
- Replace the two store buttons with a single “Get the app” action
- Point that action at `https://www.synaplan.com/app` (`/de/app` when the UI is German)
- Keep the existing audience rules (operator must have published a store URL; never show inside the native app)

## Verification
- [x] Tests added/updated
- [x] `make -C frontend lint`
- [x] `docker compose exec -T frontend npm run check:types`
- [x] `make -C frontend test` (1525 passed)

## Notes
Pairs with the new marketing page on synaplan-website (`/app`). This is an `ota-candidate` frontend change.

## Screenshots/Logs