### PR TITLE
fix(frontend): build chat share links with the platform URL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -448,7 +448,30 @@ jobs:
         # Blocking gate: fail on high/critical advisories in production
         # dependencies only (--omit=dev). Dev tooling and lower severities do
         # not ship to users and would otherwise block PRs without fixes.
-        run: npm audit --omit=dev --audit-level=high
+        # The npm audit API 503s often enough to fail this job before lint
+        # or tests run; retry that transport failure only, never a real finding.
+        run: |
+          set +e
+          attempt=1
+          max_attempts=3
+          while [ "$attempt" -le "$max_attempts" ]; do
+            output="$(npm audit --omit=dev --audit-level=high 2>&1)"
+            status=$?
+            printf '%s\n' "$output"
+            if [ "$status" -eq 0 ]; then
+              exit 0
+            fi
+            if printf '%s\n' "$output" | grep -Eq 'audit endpoint returned an error|503 Service Unavailable|ECONNRESET|ETIMEDOUT'; then
+              if [ "$attempt" -lt "$max_attempts" ]; then
+                echo "npm audit registry unavailable (attempt ${attempt}/${max_attempts}), retrying..."
+                sleep 20
+                attempt=$((attempt + 1))
+                continue
+              fi
+            fi
+            exit "$status"
+          done
+          exit 1
 
       - name: Download OpenAPI spec artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8

--- a/frontend/src/components/ChatShareModal.vue
+++ b/frontend/src/components/ChatShareModal.vue
@@ -230,6 +230,7 @@ import { ref, computed, watch, toRef } from 'vue'
 import { useChatsStore } from '@/stores/chats'
 import { useEscapeKey } from '@/composables/useEscapeKey'
 import { useNotification } from '@/composables/useNotification'
+import { buildChatShareUrl } from '@/utils/urlHelper'
 
 const { success: showSuccess, error: showError } = useNotification()
 const chatsStore = useChatsStore()
@@ -261,9 +262,10 @@ const shareInfo = ref<{
 } | null>(null)
 
 const fullShareUrl = computed(() => {
-  if (!shareInfo.value?.shareUrl) return ''
-  const baseUrl = window.location.origin
-  return `${baseUrl}/shared/${shareInfo.value.shareToken}`
+  const token = shareInfo.value?.shareToken
+  if (!token) return ''
+  // Platform origin, never the Capacitor WebView origin (capacitor://localhost).
+  return buildChatShareUrl(token)
 })
 
 watch(

--- a/frontend/src/components/ChatShareModal.vue
+++ b/frontend/src/components/ChatShareModal.vue
@@ -268,16 +268,6 @@ const fullShareUrl = computed(() => {
   return buildChatShareUrl(token)
 })
 
-watch(
-  () => props.isOpen,
-  async (open) => {
-    if (open && props.chatId) {
-      await loadShareInfo()
-    }
-    copied.value = false
-  }
-)
-
 const loadShareInfo = async () => {
   if (!props.chatId) return
 
@@ -291,6 +281,17 @@ const loadShareInfo = async () => {
     loading.value = false
   }
 }
+
+watch(
+  () => props.isOpen,
+  async (open) => {
+    if (open && props.chatId) {
+      await loadShareInfo()
+    }
+    copied.value = false
+  },
+  { immediate: true }
+)
 
 const makePublic = async () => {
   if (!props.chatId) return

--- a/frontend/src/stores/chats.ts
+++ b/frontend/src/stores/chats.ts
@@ -2,12 +2,12 @@ import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
 import { httpClient } from '@/services/api/httpClient'
 import { GetApiChatsListResponseSchema } from '@/generated/api-schemas'
-import { useConfigStore } from '@/stores/config'
 import { useIncognitoStore } from '@/stores/incognito'
 import { useHistoryStore } from '@/stores/history'
 import { authService } from '@/services/authService'
 import { hasSessionHint } from '@/services/sessionHint'
 import { getErrorMessage } from '@/utils/errorMessage'
+import { buildChatShareUrl } from '@/utils/urlHelper'
 
 const ACTIVE_CHAT_STORAGE_KEY = 'synaplan_active_chat_id'
 
@@ -434,9 +434,6 @@ export const useChatsStore = defineStore('chats', () => {
     try {
       const data = await httpClient<{ chat: Record<string, unknown> }>(`/api/v1/chats/${chatId}`)
 
-      // Import config store for building share URL
-      const config = useConfigStore()
-
       const chat = data.chat
       const shareTok = typeof chat.shareToken === 'string' ? chat.shareToken : null
       const isShared = Boolean(chat.isShared)
@@ -444,7 +441,7 @@ export const useChatsStore = defineStore('chats', () => {
       return {
         isShared,
         shareToken: shareTok,
-        shareUrl: shareTok ? `${config.appBaseUrl}/shared/${shareTok}` : null,
+        shareUrl: shareTok ? buildChatShareUrl(shareTok) : null,
       }
     } catch (err: unknown) {
       error.value = getErrorMessage(err) || 'Failed to get share info'

--- a/frontend/src/utils/urlHelper.ts
+++ b/frontend/src/utils/urlHelper.ts
@@ -1,6 +1,18 @@
 import { useConfigStore } from '@/stores/config'
 
 /**
+ * Public origin for links that leave the app (share URLs, absolute media).
+ *
+ * Never use `window.location.origin` for these: in the native shell that is
+ * `capacitor://localhost` / `https://localhost`, which is not a reachable
+ * platform URL. `appBaseUrl` already remaps the native case to the real
+ * backend/web origin (Epic 3).
+ */
+function publicAppBaseUrl(): string {
+  return useConfigStore().appBaseUrl.replace(/\/$/, '')
+}
+
+/**
  * Normalize media URLs to absolute URLs
  * Converts relative paths to absolute URLs using appBaseUrl
  */
@@ -12,10 +24,17 @@ export function normalizeMediaUrl(url: string | undefined | null): string {
     return url
   }
 
-  const config = useConfigStore()
-
   // Add leading slash if missing
   const normalizedPath = url.startsWith('/') ? url : `/${url}`
 
-  return `${config.appBaseUrl}${normalizedPath}`
+  return `${publicAppBaseUrl()}${normalizedPath}`
+}
+
+/**
+ * HTTPS URL a recipient can open for a publicly shared chat.
+ *
+ * Path is the SPA/crawler page (`/shared/{token}`), not the JSON API route.
+ */
+export function buildChatShareUrl(shareToken: string): string {
+  return `${publicAppBaseUrl()}/shared/${shareToken}`
 }

--- a/frontend/tests/unit/components/ChatShareModal.spec.ts
+++ b/frontend/tests/unit/components/ChatShareModal.spec.ts
@@ -91,4 +91,30 @@ describe('ChatShareModal share URL', () => {
 
     wrapper.unmount()
   })
+
+  it('loads the platform link when the modal is already open on mount', async () => {
+    const wrapper = mount(ChatShareModal, {
+      props: {
+        isOpen: true,
+        chatId: 42,
+        chatTitle: 'Weekly recap',
+      },
+      global: {
+        mocks: {
+          $t: (key: string) => key,
+        },
+        stubs: {
+          Teleport: true,
+          Transition: false,
+        },
+      },
+    })
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="share-link-input"]').text()).toBe(
+      'https://web.synaplan.com/shared/share_tok_1'
+    )
+
+    wrapper.unmount()
+  })
 })

--- a/frontend/tests/unit/components/ChatShareModal.spec.ts
+++ b/frontend/tests/unit/components/ChatShareModal.spec.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+
+const appBaseUrl = vi.hoisted(() => ({ value: 'https://web.synaplan.com' }))
+const getShareInfo = vi.hoisted(() => vi.fn())
+
+vi.mock('@/stores/config', () => ({
+  useConfigStore: () => ({
+    get appBaseUrl() {
+      return appBaseUrl.value
+    },
+  }),
+}))
+
+vi.mock('@/stores/chats', () => ({
+  useChatsStore: () => ({
+    getShareInfo,
+    shareChat: vi.fn(),
+  }),
+}))
+
+vi.mock('@/composables/useNotification', () => ({
+  useNotification: () => ({
+    success: vi.fn(),
+    error: vi.fn(),
+  }),
+}))
+
+vi.mock('@/composables/useEscapeKey', () => ({
+  useEscapeKey: vi.fn(),
+}))
+
+import ChatShareModal from '@/components/ChatShareModal.vue'
+
+async function mountOpenModal() {
+  const wrapper = mount(ChatShareModal, {
+    props: {
+      isOpen: false,
+      chatId: 42,
+      chatTitle: 'Weekly recap',
+    },
+    global: {
+      mocks: {
+        $t: (key: string) => key,
+      },
+      stubs: {
+        Teleport: true,
+        Transition: false,
+      },
+    },
+  })
+  // Share info loads when the modal opens, same as the in-app usage.
+  await wrapper.setProps({ isOpen: true })
+  await flushPromises()
+  return wrapper
+}
+
+describe('ChatShareModal share URL', () => {
+  beforeEach(() => {
+    appBaseUrl.value = 'https://web.synaplan.com'
+    getShareInfo.mockReset()
+    getShareInfo.mockResolvedValue({
+      isShared: true,
+      shareToken: 'share_tok_1',
+      shareUrl: 'https://web.synaplan.com/shared/share_tok_1',
+    })
+  })
+
+  it('shows a platform HTTPS link, not the current page origin', async () => {
+    const wrapper = await mountOpenModal()
+
+    const link = wrapper.find('[data-testid="share-link-input"]')
+    expect(link.exists()).toBe(true)
+    expect(link.text()).toBe('https://web.synaplan.com/shared/share_tok_1')
+    expect(link.text()).not.toContain(window.location.origin)
+    expect(link.text()).not.toContain('capacitor://')
+
+    wrapper.unmount()
+  })
+
+  it('follows a staging platform origin from appBaseUrl', async () => {
+    appBaseUrl.value = 'https://staging.synaplan.com'
+    const wrapper = await mountOpenModal()
+
+    expect(wrapper.find('[data-testid="share-link-input"]').text()).toBe(
+      'https://staging.synaplan.com/shared/share_tok_1'
+    )
+    expect(wrapper.find('[data-testid="share-link-input"]').text()).not.toContain(
+      window.location.origin
+    )
+
+    wrapper.unmount()
+  })
+})

--- a/frontend/tests/unit/stores/configAppBaseUrl.spec.ts
+++ b/frontend/tests/unit/stores/configAppBaseUrl.spec.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const runtime = vi.hoisted(() => ({
+  native: false,
+  baseUrl: 'https://web.synaplan.com',
+}))
+
+vi.mock('@/services/api/nativeRuntime', () => ({
+  isNativeApp: () => runtime.native,
+  getNativeApiBaseUrl: () => runtime.baseUrl,
+}))
+
+vi.mock('@/services/api/httpClient', () => ({
+  getConfig: vi.fn(),
+  getConfigSync: () => ({}),
+  getApiBaseUrl: () => '',
+  reloadConfig: vi.fn(),
+  getUnavailableProviders: () => [],
+}))
+
+vi.mock('@/services/api/configApi', () => ({
+  checkMemoryServiceAvailability: vi.fn(),
+}))
+
+vi.mock('@/i18n', () => ({
+  i18n: { global: { t: (key: string) => key } },
+}))
+
+import { useConfigStore } from '@/stores/config'
+
+describe('config.appBaseUrl', () => {
+  it('uses the page origin on the web', () => {
+    runtime.native = false
+    expect(useConfigStore().appBaseUrl).toBe(window.location.origin)
+  })
+
+  it('uses the platform API origin inside the native shell', () => {
+    runtime.native = true
+    runtime.baseUrl = 'https://web.synaplan.com'
+    expect(useConfigStore().appBaseUrl).toBe('https://web.synaplan.com')
+    expect(useConfigStore().appBaseUrl).not.toMatch(/^capacitor:/)
+    expect(useConfigStore().appBaseUrl).not.toBe(window.location.origin)
+  })
+})

--- a/frontend/tests/unit/utils/urlHelper.spec.ts
+++ b/frontend/tests/unit/utils/urlHelper.spec.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const appBaseUrl = vi.hoisted(() => ({ value: 'https://web.synaplan.com' }))
+
+vi.mock('@/stores/config', () => ({
+  useConfigStore: () => ({
+    get appBaseUrl() {
+      return appBaseUrl.value
+    },
+  }),
+}))
+
+import { buildChatShareUrl, normalizeMediaUrl } from '@/utils/urlHelper'
+
+describe('buildChatShareUrl', () => {
+  it('builds the public chat page on the platform origin', () => {
+    appBaseUrl.value = 'https://web.synaplan.com'
+    expect(buildChatShareUrl('abc123')).toBe('https://web.synaplan.com/shared/abc123')
+  })
+
+  it('does not use the Capacitor WebView origin', () => {
+    appBaseUrl.value = 'https://web.synaplan.com'
+    const url = buildChatShareUrl('tok_native')
+    expect(url).not.toContain('capacitor://')
+    expect(url).not.toBe(`${window.location.origin}/shared/tok_native`)
+    expect(url).toBe('https://web.synaplan.com/shared/tok_native')
+  })
+
+  it('strips a trailing slash from the platform origin', () => {
+    appBaseUrl.value = 'https://web.synaplan.com/'
+    expect(buildChatShareUrl('tok')).toBe('https://web.synaplan.com/shared/tok')
+  })
+})
+
+describe('normalizeMediaUrl', () => {
+  it('prefixes relative media paths with the platform origin', () => {
+    appBaseUrl.value = 'https://web.synaplan.com'
+    expect(normalizeMediaUrl('/up/file.pdf')).toBe('https://web.synaplan.com/up/file.pdf')
+  })
+
+  it('leaves already-absolute http(s) URLs unchanged', () => {
+    expect(normalizeMediaUrl('https://cdn.example.com/a.png')).toBe('https://cdn.example.com/a.png')
+  })
+})


### PR DESCRIPTION
## Summary
Chat share links created in the native app used `capacitor://localhost` because the modal built the URL from `window.location.origin`. They now use the platform origin (`appBaseUrl`), so recipients get a normal `https://…/shared/{token}` link.

This is fixable entirely in this repository. The share URL is built in the Vue SPA that ships OTA to `synaplan-apps`. No change is required in the apps repo.

## Changes
- Build public chat share URLs with `buildChatShareUrl()`, which uses `config.appBaseUrl` (already remapped to the platform in the Capacitor shell).
- Stop reconstructing the link from `window.location.origin` in `ChatShareModal`.
- Load share info immediately when the modal mounts already open.
- Add unit tests for the helper, the modal, and the native `appBaseUrl` remap.
- Retry the Frontend job `npm audit` step on registry HTTP 503 only (real high/critical findings still fail immediately). The previous two CI runs died there before lint or tests ran.

## Verification
- [x] Tests added/updated
- [x] Manual: signed in as `demo@synaplan.com`, opened Share on "New Chat", generated a public link. The modal shows `http://localhost:5173/shared/730352aa83d7bf1822c38ca1` (web/platform origin, not `capacitor://`).
- Frontend gate: lint, `vue-tsc`, and Vitest — 195 files / 1557 tests passed locally.

File sharing already used `config.appBaseUrl` and was not affected.

