### PR TITLE
feat(chat): collapse large pastes into an editable composer card

### DIFF
--- a/backend/src/Controller/ChatController.php
+++ b/backend/src/Controller/ChatController.php
@@ -12,6 +12,7 @@ use App\Service\Digest\MessageDigestMaintenance;
 use App\Service\File\OgImageService;
 use App\Service\Message\MessageApiFormatter;
 use App\Service\Multitask\InProgressTurnResolver;
+use App\Service\PastedContentText;
 use App\Service\WidgetSessionService;
 use Doctrine\ORM\EntityManagerInterface;
 use OpenApi\Attributes as OA;
@@ -141,7 +142,9 @@ class ChatController extends AbstractController
                     // Tool commands (/pic, /vid, …) are kept in the stored message
                     // text for backend routing, but the raw prefix must never leak
                     // into the chat list preview — only the user's actual query.
-                    $content = $this->stripToolCommandPrefix($message->getText() ?? '');
+                    $content = PastedContentText::strip(
+                        $this->stripToolCommandPrefix($message->getText() ?? ''),
+                    );
                     $firstMessagePreview = mb_strlen($content) > 30
                         ? mb_substr($content, 0, 30).'…'
                         : $content;

--- a/backend/src/Controller/SharedChatPageController.php
+++ b/backend/src/Controller/SharedChatPageController.php
@@ -8,6 +8,7 @@ use App\Repository\ChatRepository;
 use App\Repository\MessageRepository;
 use App\Service\Branding\BrandingService;
 use App\Service\File\OgImageService;
+use App\Service\PastedContentText;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -178,7 +179,8 @@ class SharedChatPageController extends AbstractController
         // Use first user message as context
         foreach ($messages as $message) {
             if ('IN' === $message->getDirection()) {
-                $text = strip_tags($message->getText());
+                $text = PastedContentText::strip($message->getText());
+                $text = strip_tags($text);
 
                 // Remove slash commands from description
                 $text = $this->cleanSlashCommands($text);

--- a/backend/src/Service/PastedContentText.php
+++ b/backend/src/Service/PastedContentText.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+final class PastedContentText
+{
+    public static function strip(string $text): string
+    {
+        $stripped = preg_replace('/<pasted-content>[\s\S]*?<\/pasted-content>/', '', $text) ?? $text;
+        $collapsed = preg_replace("/\n{3,}/", "\n\n", $stripped) ?? $stripped;
+
+        return trim($collapsed);
+    }
+}

--- a/backend/tests/Unit/Service/PastedContentTextTest.php
+++ b/backend/tests/Unit/Service/PastedContentTextTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service;
+
+use App\Service\PastedContentText;
+use PHPUnit\Framework\TestCase;
+
+final class PastedContentTextTest extends TestCase
+{
+    public function testStripRemovesWrappedBlocksAndKeepsTypedText(): void
+    {
+        $raw = "<pasted-content>\nstack dump\n</pasted-content>\n\nWhat does this mean?";
+
+        self::assertSame('What does this mean?', PastedContentText::strip($raw));
+    }
+
+    public function testStripReturnsEmptyWhenOnlyPastedContentIsPresent(): void
+    {
+        $raw = "<pasted-content>\nonly paste\n</pasted-content>";
+
+        self::assertSame('', PastedContentText::strip($raw));
+    }
+
+    public function testStripLeavesUnmarkedTextUnchanged(): void
+    {
+        self::assertSame('plain message', PastedContentText::strip('plain message'));
+    }
+}

--- a/frontend/src/components/ChatInput.vue
+++ b/frontend/src/components/ChatInput.vue
@@ -25,9 +25,20 @@
          uses the full width; md+ keeps the roomier px-4. -->
     <div class="max-w-4xl mx-auto px-3 py-2 md:px-4 md:py-4">
       <!-- File and Quote Display (above input) -->
-      <div v-if="uploadedFiles.length > 0 || quote" class="mb-3 flex flex-wrap gap-2">
+      <div
+        v-if="uploadedFiles.length > 0 || quote || pastedBlocks.length > 0"
+        class="mb-3 flex flex-wrap gap-2 max-h-28 overflow-y-auto"
+      >
         <!-- Quoted reference chip -->
         <QuoteChip v-if="quote" :quote="quote" @remove="emit('clearQuote')" />
+
+        <PastedTextCard
+          v-for="block in pastedBlocks"
+          :key="block.id"
+          :content="block.content"
+          @open="openPastedBlock(block.id)"
+          @remove="removePastedBlock(block.id)"
+        />
 
         <!-- Uploaded Files -->
         <div
@@ -394,6 +405,13 @@
       @close="fileSelectionModalVisible = false"
       @select="handleFilesSelected"
     />
+
+    <PastedTextModal
+      :visible="editingPastedBlock !== null"
+      :content="editingPastedBlock?.content ?? ''"
+      @close="closePastedBlock"
+      @save="savePastedBlock"
+    />
   </div>
 </template>
 
@@ -416,6 +434,8 @@ import DesktopJobCard from './DesktopJobCard.vue'
 import ModelDropdown from './ModelDropdown.vue'
 import KnowledgeFolderPicker from './KnowledgeFolderPicker.vue'
 import FileSelectionModal from './FileSelectionModal.vue'
+import PastedTextCard from './chat/PastedTextCard.vue'
+import PastedTextModal from './chat/PastedTextModal.vue'
 import { parseCommand } from '../commands/parse'
 import { type Command, useCommandsStore } from '@/stores/commands'
 import { useAiConfigStore } from '@/stores/aiConfig'
@@ -431,7 +451,11 @@ import { WebSpeechService, isWebSpeechSupported } from '@/services/webSpeechServ
 import { useConfigStore } from '@/stores/config'
 import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
-import { useAutoPersist, useAttachmentPersist } from '@/composables/useInputPersistence'
+import {
+  useAutoPersist,
+  useAttachmentPersist,
+  usePastedBlocksPersist,
+} from '@/composables/useInputPersistence'
 import { useChatsStore } from '@/stores/chats'
 import { useAuthStore } from '@/stores/auth'
 import { useIncognitoStore } from '@/stores/incognito'
@@ -439,6 +463,12 @@ import { useDialog } from '@/composables/useDialog'
 import { desktopApi } from '@/services/api/desktopApi'
 import QuoteChip from './QuoteChip.vue'
 import type { QuotedReference } from '@/composables/useMessageQuoting'
+import {
+  createPastedBlockId,
+  shouldBecomeBlock,
+  wrapPastedBlocks,
+  type PastedTextBlock,
+} from '@/utils/pastedContent'
 
 interface UploadedFile {
   file_id: number
@@ -515,6 +545,8 @@ const message = ref('')
 const originalMessage = ref('')
 const enhancedMessage = ref('')
 const uploadedFiles = ref<UploadedFile[]>([])
+const pastedBlocks = ref<PastedTextBlock[]>([])
+const editingPastedBlockId = ref<string | null>(null)
 const uploading = ref(false)
 const uploadAbortController = ref<AbortController | null>(null)
 const enhanceEnabled = ref(false)
@@ -737,6 +769,17 @@ const { clearAttachments: clearPersistedAttachments } = useAttachmentPersist(
   computed(() => incognitoStore.active)
 )
 
+const { clearPastedBlocks: clearPersistedBlocks } = usePastedBlocksPersist(
+  pastedBlocks,
+  'chat',
+  computed(() => chatsStore.activeChatId),
+  computed(() => incognitoStore.active)
+)
+
+const editingPastedBlock = computed(
+  () => pastedBlocks.value.find((block) => block.id === editingPastedBlockId.value) ?? null
+)
+
 const emit = defineEmits<{
   send: [
     message: string,
@@ -760,25 +803,26 @@ const canSend = computed(() => {
   const trimmedMessage = message.value.trim()
   const hasMessage = trimmedMessage.length > 0
   const hasFiles = uploadedFiles.value.length > 0
+  const hasPastedBlocks = pastedBlocks.value.length > 0
   const filesReady = uploadedFiles.value.every((f) => !f.processing)
 
   // A tool badge (search/image/video) needs a query or description to act on,
   // so an active tool with an empty textarea (and no files) can't be sent.
-  if (activeTool.value && !hasMessage && !hasFiles) {
+  if (activeTool.value && !hasMessage && !hasFiles && !hasPastedBlocks) {
     return false
   }
 
   // Prevent sending if only a raw command is typed (e.g., just "/pic" without arguments).
   // Commands that take no arguments (e.g. /help) are sendable as-is.
   const isOnlyCommand = trimmedMessage.startsWith('/') && !trimmedMessage.includes(' ')
-  if (isOnlyCommand && !hasFiles) {
+  if (isOnlyCommand && !hasFiles && !hasPastedBlocks) {
     const cmd = commandsStore.getCommand(trimmedMessage.slice(1))
     if (!cmd || cmd.requiresArgs) {
       return false
     }
   }
 
-  return (hasMessage || hasFiles) && filesReady && !uploading.value
+  return (hasMessage || hasFiles || hasPastedBlocks) && filesReady && !uploading.value
 })
 
 const currentChatModel = computed(() => {
@@ -931,7 +975,7 @@ const sendMessage = () => {
   // ChatView/backend contract stays identical to the old slash-command flow.
   // The textarea only holds the query; ChatView strips the prefix for display
   // and uses the webSearch flag for /search (see handleSendMessage).
-  const query = message.value
+  const query = wrapPastedBlocks(message.value, pastedBlocks.value)
   let messageToSend = query
   if (activeTool.value === 'pic' || activeTool.value === 'vid') {
     messageToSend = `/${activeTool.value} ${query}`.trim()
@@ -952,6 +996,8 @@ const sendMessage = () => {
   emit('send', messageToSend, options)
   message.value = ''
   uploadedFiles.value = []
+  pastedBlocks.value = []
+  editingPastedBlockId.value = null
   plusMenuOpen.value = false
   paletteVisible.value = false
   mentionPaletteVisible.value = false
@@ -966,6 +1012,7 @@ const sendMessage = () => {
   // Clear persisted input after successful send
   clearPersistedInput()
   clearPersistedAttachments()
+  clearPersistedBlocks()
 }
 
 const toggleThinking = () => {
@@ -1134,61 +1181,114 @@ const handleDragLeave = () => {
   isDragging.value = false
 }
 
-// Clipboard paste handler for images and files
+const isComposerTextarea = (target: EventTarget | null): boolean => {
+  if (!(target instanceof HTMLElement)) {
+    return false
+  }
+  if (target instanceof HTMLTextAreaElement && target.closest('[data-testid="comp-chat-input"]')) {
+    return true
+  }
+  return Boolean(
+    target.closest('[data-testid="input-chat-message"], [data-testid="input-textarea"]')
+  )
+}
+
+const addPastedBlock = (content: string) => {
+  pastedBlocks.value.push({
+    id: createPastedBlockId(),
+    content,
+  })
+  triggerHapticImpact('light')
+}
+
+const removePastedBlock = (id: string) => {
+  pastedBlocks.value = pastedBlocks.value.filter((block) => block.id !== id)
+  if (editingPastedBlockId.value === id) {
+    editingPastedBlockId.value = null
+  }
+  triggerHapticImpact('light')
+}
+
+const openPastedBlock = (id: string) => {
+  editingPastedBlockId.value = id
+}
+
+const closePastedBlock = () => {
+  editingPastedBlockId.value = null
+  if (typeof window !== 'undefined' && window.matchMedia('(min-width: 640px)').matches) {
+    textareaRef.value?.focus()
+  }
+}
+
+const savePastedBlock = (content: string) => {
+  const id = editingPastedBlockId.value
+  if (!id) {
+    return
+  }
+  if (!content.trim()) {
+    removePastedBlock(id)
+    closePastedBlock()
+    return
+  }
+  pastedBlocks.value = pastedBlocks.value.map((block) =>
+    block.id === id ? { ...block, content } : block
+  )
+  closePastedBlock()
+}
+
+// Clipboard paste handler for images, files, and large text
 const handlePaste = async (event: ClipboardEvent) => {
-  if (props.isGuestMode) {
-    const items = event.clipboardData?.items
-    if (items) {
-      for (const item of items) {
-        if (item.type.startsWith('image/') || item.kind === 'file') {
-          event.preventDefault()
-          emit('guestFeatureGate', 'files')
-          return
+  const items = event.clipboardData?.items
+
+  if (items) {
+    const filesToUpload: File[] = []
+
+    for (const item of items) {
+      if (item.type.startsWith('image/')) {
+        const file = item.getAsFile()
+        if (file) {
+          const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, -5)
+          const extension = item.type.split('/')[1] || 'png'
+          const namedFile = new File([file], `pasted-image-${timestamp}.${extension}`, {
+            type: file.type,
+          })
+          filesToUpload.push(namedFile)
+        }
+      } else if (item.kind === 'file') {
+        const file = item.getAsFile()
+        if (file) {
+          filesToUpload.push(file)
         }
       }
     }
+
+    if (filesToUpload.length > 0) {
+      event.preventDefault()
+      if (props.isGuestMode) {
+        emit('guestFeatureGate', 'files')
+        return
+      }
+      try {
+        await uploadFiles(filesToUpload)
+        success(t('chatInput.filesPasted', { count: filesToUpload.length }))
+      } catch {
+        showError(t('chatInput.uploadError'))
+      }
+      return
+    }
+  }
+
+  const pastedText = event.clipboardData?.getData('text/plain') ?? ''
+  if (!pastedText || !shouldBecomeBlock(pastedText)) {
     return
   }
 
-  const items = event.clipboardData?.items
-  if (!items) return
-
-  const filesToUpload: File[] = []
-
-  for (const item of items) {
-    // Handle pasted images (screenshots, copied images)
-    if (item.type.startsWith('image/')) {
-      const file = item.getAsFile()
-      if (file) {
-        // Generate a meaningful filename for pasted images
-        const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, -5)
-        const extension = item.type.split('/')[1] || 'png'
-        const namedFile = new File([file], `pasted-image-${timestamp}.${extension}`, {
-          type: file.type,
-        })
-        filesToUpload.push(namedFile)
-      }
-    }
-    // Handle pasted files (from file manager)
-    else if (item.kind === 'file') {
-      const file = item.getAsFile()
-      if (file) {
-        filesToUpload.push(file)
-      }
-    }
+  if (!isComposerTextarea(event.target) && !isComposerTextarea(document.activeElement)) {
+    return
   }
 
-  if (filesToUpload.length > 0) {
-    // Prevent default paste behavior for files/images
-    event.preventDefault()
-    try {
-      await uploadFiles(filesToUpload)
-      success(t('chatInput.filesPasted', { count: filesToUpload.length }))
-    } catch {
-      showError(t('chatInput.uploadError'))
-    }
-  }
-  // If no files, let the default paste behavior handle text
+  event.preventDefault()
+  addPastedBlock(pastedText)
 }
 
 const uploadFiles = async (files: File[]) => {

--- a/frontend/src/components/MessagePart.vue
+++ b/frontend/src/components/MessagePart.vue
@@ -21,6 +21,7 @@ import MessageLink from './MessageLink.vue'
 import MessageCommandList from './MessageCommandList.vue'
 import MessageThinking from './MessageThinking.vue'
 import MessageTtsLoading from './MessageTtsLoading.vue'
+import MessagePastedText from './MessagePastedText.vue'
 
 interface Props {
   part: Part
@@ -61,6 +62,8 @@ const componentType = computed(() => {
       return MessageThinking
     case 'tts_loading':
       return MessageTtsLoading
+    case 'pastedText':
+      return MessagePastedText
     default:
       return MessageText
   }
@@ -115,6 +118,8 @@ const componentProps = computed(() => {
         thinkingTime: props.part.thinkingTime,
         isStreaming: props.part.isStreaming,
       }
+    case 'pastedText':
+      return { content: props.part.content || '' }
     default:
       return { content: props.part.content || '', memories: props.memories, docs: props.docs }
   }

--- a/frontend/src/components/MessagePastedText.vue
+++ b/frontend/src/components/MessagePastedText.vue
@@ -1,0 +1,18 @@
+<template>
+  <div class="px-3 pt-3 pb-1">
+    <PastedTextCard :content="content" readonly @open="open = true" />
+    <PastedTextModal :visible="open" :content="content" readonly @close="open = false" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import PastedTextCard from '@/components/chat/PastedTextCard.vue'
+import PastedTextModal from '@/components/chat/PastedTextModal.vue'
+
+defineProps<{
+  content: string
+}>()
+
+const open = ref(false)
+</script>

--- a/frontend/src/components/chat/PastedTextCard.vue
+++ b/frontend/src/components/chat/PastedTextCard.vue
@@ -1,0 +1,59 @@
+<template>
+  <div
+    class="pasted-card"
+    role="button"
+    tabindex="0"
+    :aria-label="t('chatInput.pastedText.open')"
+    data-testid="chip-pasted-text"
+    @click="emit('open')"
+    @keydown="handleKeydown"
+  >
+    <p class="pasted-card__preview">{{ preview }}</p>
+    <span class="pasted-card__label">{{ t('chatInput.pastedText.label') }}</span>
+    <button
+      v-if="!readonly"
+      type="button"
+      class="pasted-card__remove icon-ghost"
+      :aria-label="t('chatInput.pastedText.remove')"
+      data-testid="btn-pasted-text-remove"
+      @click.stop="emit('remove')"
+    >
+      <XMarkIcon class="w-3.5 h-3.5" />
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { XMarkIcon } from '@heroicons/vue/24/outline'
+
+const props = withDefaults(
+  defineProps<{
+    content: string
+    readonly?: boolean
+  }>(),
+  {
+    readonly: false,
+  }
+)
+
+const emit = defineEmits<{
+  open: []
+  remove: []
+}>()
+
+const { t } = useI18n()
+
+const preview = computed(() => {
+  const collapsed = props.content.replace(/\s+/g, ' ').trim()
+  return collapsed.length > 160 ? `${collapsed.slice(0, 160)}…` : collapsed
+})
+
+const handleKeydown = (event: KeyboardEvent) => {
+  if (event.key === 'Enter' || event.key === ' ') {
+    event.preventDefault()
+    emit('open')
+  }
+}
+</script>

--- a/frontend/src/components/chat/PastedTextModal.vue
+++ b/frontend/src/components/chat/PastedTextModal.vue
@@ -1,0 +1,215 @@
+<template>
+  <Teleport to="#app">
+    <Transition name="modal">
+      <div
+        v-if="visible"
+        class="modal-overlay fixed inset-0 z-50 flex items-end sm:items-center justify-center sm:p-4 bg-black/50"
+        data-testid="modal-pasted-text-root"
+        @click.self="emit('close')"
+      >
+        <div
+          class="modal-panel pasted-text-modal surface-card w-full sm:max-w-3xl overflow-hidden flex flex-col rounded-t-2xl sm:rounded-xl"
+          data-testid="modal-pasted-text"
+          role="dialog"
+          aria-modal="true"
+          :aria-labelledby="titleId"
+        >
+          <div
+            class="flex items-start justify-between gap-3 px-4 py-3 sm:p-6 border-b border-[var(--border-light)]"
+          >
+            <div class="min-w-0">
+              <h2 :id="titleId" class="text-base sm:text-xl font-semibold txt-primary">
+                {{ t('chatInput.pastedText.modalTitle') }}
+              </h2>
+              <p class="mt-1 text-xs sm:text-sm txt-secondary">
+                {{
+                  t('chatInput.pastedText.meta', {
+                    lines: lineCount,
+                    chars: charCount,
+                  })
+                }}
+              </p>
+            </div>
+            <button
+              type="button"
+              class="icon-ghost p-2 flex-shrink-0"
+              :aria-label="t('common.close')"
+              data-testid="btn-pasted-text-modal-close"
+              @click="emit('close')"
+            >
+              <XMarkIcon class="w-5 h-5" />
+            </button>
+          </div>
+
+          <div class="flex-1 min-h-0 px-4 py-3 sm:px-6 sm:py-4">
+            <textarea
+              ref="textareaRef"
+              v-model="draft"
+              class="pasted-text-modal__editor"
+              :readonly="readonly"
+              :aria-label="t('chatInput.pastedText.title')"
+              data-testid="input-pasted-text-editor"
+              @keydown.esc.stop="emit('close')"
+            />
+          </div>
+
+          <div
+            v-if="!readonly"
+            class="flex items-center justify-end gap-2 px-4 py-3 sm:px-6 sm:py-4 border-t border-[var(--border-light)]"
+          >
+            <button
+              type="button"
+              class="btn-secondary px-3 py-2 sm:px-4 rounded-lg text-sm font-medium"
+              data-testid="btn-pasted-text-cancel"
+              @click="emit('close')"
+            >
+              {{ t('chatInput.pastedText.cancel') }}
+            </button>
+            <button
+              type="button"
+              class="btn-primary px-3 py-2 sm:px-4 rounded-lg text-sm font-medium"
+              data-testid="btn-pasted-text-save"
+              @click="save"
+            >
+              {{ t('chatInput.pastedText.save') }}
+            </button>
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { computed, nextTick, onBeforeUnmount, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { XMarkIcon } from '@heroicons/vue/24/outline'
+import { countLines } from '@/utils/pastedContent'
+
+const props = withDefaults(
+  defineProps<{
+    visible: boolean
+    content: string
+    readonly?: boolean
+  }>(),
+  {
+    readonly: false,
+  }
+)
+
+const emit = defineEmits<{
+  close: []
+  save: [content: string]
+}>()
+
+const { t } = useI18n()
+const textareaRef = ref<HTMLTextAreaElement | null>(null)
+const draft = ref(props.content)
+const titleId = 'pasted-text-modal-title'
+
+const lineCount = computed(() => countLines(draft.value))
+const charCount = computed(() => draft.value.length)
+
+const isDesktopViewport = () =>
+  typeof window !== 'undefined' && window.matchMedia('(min-width: 640px)').matches
+
+watch(
+  () => props.visible,
+  async (open) => {
+    if (!open) {
+      return
+    }
+    draft.value = props.content
+    await nextTick()
+    if (!props.readonly && isDesktopViewport()) {
+      textareaRef.value?.focus()
+    }
+  }
+)
+
+watch(
+  () => props.content,
+  (value) => {
+    if (props.visible) {
+      draft.value = value
+    }
+  }
+)
+
+const handleEscape = (event: KeyboardEvent) => {
+  if (!props.visible || event.key !== 'Escape') {
+    return
+  }
+  event.preventDefault()
+  emit('close')
+}
+
+watch(
+  () => props.visible,
+  (open) => {
+    if (open) {
+      document.addEventListener('keydown', handleEscape)
+      return
+    }
+    document.removeEventListener('keydown', handleEscape)
+  }
+)
+
+onBeforeUnmount(() => {
+  document.removeEventListener('keydown', handleEscape)
+})
+
+const save = () => {
+  emit('save', draft.value)
+}
+</script>
+
+<style scoped>
+.modal-enter-active,
+.modal-leave-active {
+  transition: opacity 0.3s ease;
+}
+
+.modal-enter-from,
+.modal-leave-to {
+  opacity: 0;
+}
+
+.pasted-text-modal {
+  max-height: inherit;
+}
+
+.pasted-text-modal__editor {
+  display: block;
+  width: 100%;
+  min-height: 12rem;
+  height: min(50dvh, 28rem);
+  resize: none;
+  border-radius: 0.75rem;
+  border: 1px solid var(--border-light);
+  background: var(--bg-chip);
+  color: var(--txt-primary);
+  font-family:
+    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
+    monospace;
+  overflow-y: auto;
+  font-size: 1rem;
+  line-height: 1.5;
+  padding: 0.75rem 1rem;
+}
+
+.pasted-text-modal__editor:focus {
+  outline: 2px solid var(--brand);
+  outline-offset: 1px;
+}
+
+.pasted-text-modal__editor[readonly] {
+  cursor: default;
+}
+
+@media (min-width: 640px) {
+  .pasted-text-modal__editor {
+    font-size: 0.875rem;
+  }
+}
+</style>

--- a/frontend/src/composables/useInputPersistence.ts
+++ b/frontend/src/composables/useInputPersistence.ts
@@ -393,3 +393,128 @@ export function useAttachmentPersist<T extends PersistedChatAttachment>(
 
   return { clearAttachments: clear }
 }
+
+export const PASTED_BLOCKS_MAX_BYTES = 100 * 1024
+
+interface PersistedPastedBlocks {
+  blocks: Array<{ id: string; content: string }>
+  timestamp: number
+}
+
+/**
+ * Persist composer pasted-text blocks per chat. Skipped in incognito.
+ * Caps payload size so a multi-megabyte paste cannot blow localStorage.
+ */
+export function usePastedBlocksPersist(
+  blocksRef: Ref<Array<{ id: string; content: string }>>,
+  baseKey: string,
+  chatId?: Ref<number | null>,
+  disabled?: Ref<boolean>
+) {
+  const PASTED_PREFIX = `${STORAGE_KEY_PREFIX}pasted_${baseKey}`
+
+  function storageKey(idOverride?: number | null): string {
+    const id = idOverride !== undefined ? idOverride : chatId?.value
+    if (id !== undefined && id !== null) {
+      return `${PASTED_PREFIX}_${id}`
+    }
+    return PASTED_PREFIX
+  }
+
+  const isDisabled = () => disabled?.value === true
+
+  function payloadBytes(blocks: Array<{ id: string; content: string }>): number {
+    return new Blob([JSON.stringify(blocks)]).size
+  }
+
+  function save(blocks: Array<{ id: string; content: string }>, idOverride?: number | null) {
+    const key = storageKey(idOverride)
+    if (blocks.length === 0 || payloadBytes(blocks) > PASTED_BLOCKS_MAX_BYTES) {
+      try {
+        localStorage.removeItem(key)
+      } catch {
+        /* ignore */
+      }
+      return
+    }
+    const data: PersistedPastedBlocks = { blocks, timestamp: Date.now() }
+    try {
+      localStorage.setItem(key, JSON.stringify(data))
+    } catch (error) {
+      if (error instanceof DOMException && error.name === 'QuotaExceededError') {
+        try {
+          localStorage.removeItem(key)
+        } catch {
+          /* ignore */
+        }
+        return
+      }
+      console.error('Failed to save pasted text blocks:', error)
+    }
+  }
+
+  function load(idOverride?: number | null): Array<{ id: string; content: string }> {
+    try {
+      const stored = localStorage.getItem(storageKey(idOverride))
+      if (!stored) return []
+      const data: PersistedPastedBlocks = JSON.parse(stored)
+      if (Date.now() - data.timestamp > MAX_AGE_MS) {
+        clear(idOverride)
+        return []
+      }
+      if (!Array.isArray(data.blocks)) return []
+      return data.blocks.filter((block): block is { id: string; content: string } =>
+        Boolean(block && typeof block.id === 'string' && typeof block.content === 'string')
+      )
+    } catch {
+      return []
+    }
+  }
+
+  function clear(idOverride?: number | null) {
+    try {
+      localStorage.removeItem(storageKey(idOverride))
+    } catch {
+      /* ignore */
+    }
+  }
+
+  if (!isDisabled()) {
+    const restored = load()
+    if (restored.length > 0 && blocksRef.value.length === 0) {
+      blocksRef.value = restored
+    }
+  }
+
+  if (chatId) {
+    watch(
+      chatId,
+      (newId, oldId) => {
+        if (newId === oldId) return
+        if (isDisabled()) {
+          blocksRef.value = []
+          return
+        }
+        save(blocksRef.value, oldId)
+        blocksRef.value = load(newId)
+      },
+      { immediate: false }
+    )
+  }
+
+  watch(
+    blocksRef,
+    (blocks) => {
+      if (isDisabled()) return
+      save(blocks)
+    },
+    { deep: true }
+  )
+
+  onBeforeUnmount(() => {
+    if (isDisabled()) return
+    save(blocksRef.value)
+  })
+
+  return { clearPastedBlocks: clear }
+}

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -803,7 +803,17 @@
     "modelDropdown": {
       "default": "Standard"
     },
-    "removeTool": "Werkzeug entfernen"
+    "removeTool": "Werkzeug entfernen",
+    "pastedText": {
+      "label": "Eingefügt",
+      "title": "Eingefügter Text",
+      "remove": "Eingefügten Text entfernen",
+      "open": "Eingefügten Text öffnen",
+      "meta": "{lines} Zeilen · {chars} Zeichen",
+      "modalTitle": "Eingefügter Inhalt",
+      "save": "Speichern",
+      "cancel": "Abbrechen"
+    }
   },
   "chatMessage": {
     "again": "Nochmal",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -807,7 +807,17 @@
     "modelDropdown": {
       "default": "Default"
     },
-    "removeTool": "Remove tool"
+    "removeTool": "Remove tool",
+    "pastedText": {
+      "label": "Pasted",
+      "title": "Pasted text",
+      "remove": "Remove pasted text",
+      "open": "Open pasted text",
+      "meta": "{lines} lines · {chars} characters",
+      "modalTitle": "Pasted content",
+      "save": "Save",
+      "cancel": "Cancel"
+    }
   },
   "chatMessage": {
     "again": "Again",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -843,7 +843,17 @@
     "modelDropdown": {
       "default": "Estándar"
     },
-    "removeTool": "Quitar herramienta"
+    "removeTool": "Quitar herramienta",
+    "pastedText": {
+      "label": "Pegado",
+      "title": "Texto pegado",
+      "remove": "Quitar texto pegado",
+      "open": "Abrir texto pegado",
+      "meta": "{lines} líneas · {chars} caracteres",
+      "modalTitle": "Contenido pegado",
+      "save": "Guardar",
+      "cancel": "Cancelar"
+    }
   },
   "chatMessage": {
     "again": "Otra vez",

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -807,7 +807,17 @@
     "modelDropdown": {
       "default": "Par défaut"
     },
-    "removeTool": "Retirer l’outil"
+    "removeTool": "Retirer l’outil",
+    "pastedText": {
+      "label": "Collé",
+      "title": "Texte collé",
+      "remove": "Retirer le texte collé",
+      "open": "Ouvrir le texte collé",
+      "meta": "{lines} lignes · {chars} caractères",
+      "modalTitle": "Contenu collé",
+      "save": "Enregistrer",
+      "cancel": "Annuler"
+    }
   },
   "chatMessage": {
     "again": "Encore",

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -843,7 +843,17 @@
     "modelDropdown": {
       "default": "Standart"
     },
-    "removeTool": "Aracı kaldır"
+    "removeTool": "Aracı kaldır",
+    "pastedText": {
+      "label": "Yapıştırıldı",
+      "title": "Yapıştırılan metin",
+      "remove": "Yapıştırılan metni kaldır",
+      "open": "Yapıştırılan metni aç",
+      "meta": "{lines} satır · {chars} karakter",
+      "modalTitle": "Yapıştırılan içerik",
+      "save": "Kaydet",
+      "cancel": "İptal"
+    }
   },
   "chatMessage": {
     "again": "Tekrar",

--- a/frontend/src/stores/history.ts
+++ b/frontend/src/stores/history.ts
@@ -47,6 +47,7 @@ export type PartType =
   | 'commandList'
   | 'thinking'
   | 'tts_loading'
+  | 'pastedText'
 
 export interface Part {
   /**

--- a/frontend/src/style-v2.css
+++ b/frontend/src/style-v2.css
@@ -913,6 +913,22 @@
     0 0 1px var(--v2-glow);
 }
 
+.design-v2 [data-testid='modal-pasted-text'] {
+  background: rgba(255, 255, 255, 0.97) !important;
+  backdrop-filter: blur(var(--v2-blur-lg));
+  -webkit-backdrop-filter: blur(var(--v2-blur-lg));
+  border: 1px solid var(--v2-border) !important;
+  box-shadow:
+    0 16px 64px rgba(0, 0, 0, 0.12),
+    0 0 1px var(--v2-glow);
+}
+.design-v2.dark [data-testid='modal-pasted-text'] {
+  background: rgba(12, 18, 34, 0.98) !important;
+  box-shadow:
+    0 16px 64px rgba(0, 0, 0, 0.5),
+    0 0 1px var(--v2-glow);
+}
+
 /* ----------------------------------------------------------
    18. Statistics Page — Fancy V2
    ---------------------------------------------------------- */

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1488,6 +1488,114 @@
     border-color: rgba(251, 191, 36, 0.3);
   }
 
+  /* Large pasted-text cards in the composer and sent user bubble. */
+  .pasted-card {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    width: 6rem;
+    min-height: 5.5rem;
+    padding: 0.5rem 0.5rem 0.4rem;
+    border-radius: 0.75rem;
+    background: var(--bg-chip);
+    box-shadow: inset 0 0 0 1px var(--border-light);
+    cursor: pointer;
+    text-align: left;
+  }
+  .pasted-card:focus-visible {
+    outline: 2px solid var(--brand);
+    outline-offset: 2px;
+  }
+  .pasted-card__preview {
+    margin: 0;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 4;
+    overflow: hidden;
+    font-size: 10px;
+    line-height: 1.3;
+    color: var(--txt-secondary);
+    word-break: break-word;
+  }
+  .pasted-card__label {
+    display: inline-flex;
+    align-self: flex-start;
+    margin-top: 0.35rem;
+    padding: 0.1rem 0.35rem;
+    border-radius: 999px;
+    background: rgba(0, 0, 0, 0.06);
+    color: var(--txt-secondary);
+    font-size: 9px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    line-height: 1.2;
+  }
+  .dark .pasted-card__label {
+    background: rgba(255, 255, 255, 0.08);
+  }
+  .pasted-card__remove {
+    position: absolute;
+    top: 0.15rem;
+    right: 0.15rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.25rem;
+    height: 1.25rem;
+    padding: 0;
+    min-width: 0;
+    border-radius: 999px;
+    background: var(--bg-card);
+    opacity: 1;
+  }
+  .pasted-card__remove::before {
+    content: '';
+    position: absolute;
+    inset: 50%;
+    width: 44px;
+    height: 44px;
+    transform: translate(-50%, -50%);
+  }
+  @media (hover: hover) {
+    .pasted-card__remove {
+      opacity: 0;
+    }
+    .pasted-card:hover .pasted-card__remove,
+    .pasted-card:focus-visible .pasted-card__remove,
+    .pasted-card__remove:focus-visible {
+      opacity: 1;
+    }
+  }
+  @media (min-width: 640px) {
+    .pasted-card {
+      width: 7rem;
+    }
+    .pasted-card__preview {
+      -webkit-line-clamp: 5;
+    }
+  }
+
+  .bubble-user .pasted-card {
+    width: 100%;
+    max-width: 100%;
+    background: rgba(255, 255, 255, 0.14);
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.28);
+  }
+  .bubble-user .pasted-card__preview,
+  .bubble-user .pasted-card__label {
+    color: rgba(255, 255, 255, 0.88);
+  }
+  .bubble-user .pasted-card__label {
+    background: rgba(255, 255, 255, 0.16);
+  }
+  @media (min-width: 640px) {
+    .bubble-user .pasted-card {
+      max-width: 20rem;
+    }
+  }
+
   /* Alert/Message Boxes - Compact versions with high contrast */
   .alert-error {
     background: #fee2e2;

--- a/frontend/src/utils/messageMapper.ts
+++ b/frontend/src/utils/messageMapper.ts
@@ -13,6 +13,7 @@ import { parseAIResponse } from '@/utils/responseParser'
 import { normalizeMediaUrl } from '@/utils/urlHelper'
 import { generatePartId, isMediaPartType } from '@/utils/mediaParts'
 import { isChannelSource } from '@/utils/channelSource'
+import { extractPastedBlocks } from '@/utils/pastedContent'
 import {
   buildUploadUrl,
   isAudioFileType,
@@ -250,11 +251,19 @@ export function parseContentWithThinking(
       }
     })
   } else if (content) {
-    // For user messages, just add as text
-    parts.push({
-      type: 'text',
-      content,
+    const extracted = extractPastedBlocks(content)
+    extracted.blocks.forEach((block) => {
+      parts.push({
+        type: 'pastedText',
+        content: block,
+      })
     })
+    if (extracted.text) {
+      parts.push({
+        type: 'text',
+        content: extracted.text,
+      })
+    }
   }
 
   return parts.length > 0 ? parts : [{ type: 'text', content: '' }]

--- a/frontend/src/utils/pastedContent.ts
+++ b/frontend/src/utils/pastedContent.ts
@@ -1,0 +1,79 @@
+export const PASTE_BLOCK_MIN_CHARS = 1200
+export const PASTE_BLOCK_MIN_LINES = 10
+/** A short multi-line address block should stay in the textarea. */
+export const PASTE_BLOCK_MIN_CHARS_FOR_LINE_RULE = 400
+
+export const PASTED_CONTENT_OPEN = '<pasted-content>'
+export const PASTED_CONTENT_CLOSE = '</pasted-content>'
+
+const PASTED_CONTENT_RE = /<pasted-content>([\s\S]*?)<\/pasted-content>/g
+const PASTED_TAG_RE = /<\/?pasted-content>/g
+
+export interface PastedTextBlock {
+  id: string
+  content: string
+}
+
+export function countLines(text: string): number {
+  if (text.length === 0) {
+    return 0
+  }
+  return text.split('\n').length
+}
+
+export function shouldBecomeBlock(text: string): boolean {
+  const chars = text.length
+  if (chars >= PASTE_BLOCK_MIN_CHARS) {
+    return true
+  }
+  return chars >= PASTE_BLOCK_MIN_CHARS_FOR_LINE_RULE && countLines(text) > PASTE_BLOCK_MIN_LINES
+}
+
+export function sanitizePastedBody(text: string): string {
+  return text.replace(PASTED_TAG_RE, '')
+}
+
+export function wrapPastedBlocks(typed: string, blocks: PastedTextBlock[]): string {
+  const wrapped = blocks
+    .map((block) => {
+      const body = sanitizePastedBody(block.content)
+      return `${PASTED_CONTENT_OPEN}\n${body}\n${PASTED_CONTENT_CLOSE}`
+    })
+    .join('\n\n')
+
+  const rest = typed.trim()
+  if (!wrapped) {
+    return typed
+  }
+  if (!rest) {
+    return wrapped
+  }
+  return `${wrapped}\n\n${rest}`
+}
+
+export function extractPastedBlocks(raw: string): { blocks: string[]; text: string } {
+  const blocks: string[] = []
+  const text = raw
+    .replace(PASTED_CONTENT_RE, (_match, body: string) => {
+      blocks.push(body.replace(/^\n/, '').replace(/\n$/, ''))
+      return ''
+    })
+    .replace(/\n{3,}/g, '\n\n')
+    .trim()
+
+  return { blocks, text }
+}
+
+export function stripPastedBlocks(raw: string): string {
+  return raw
+    .replace(PASTED_CONTENT_RE, '')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim()
+}
+
+export function createPastedBlockId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID()
+  }
+  return `paste-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`
+}

--- a/frontend/src/utils/pastedContent.ts
+++ b/frontend/src/utils/pastedContent.ts
@@ -41,9 +41,9 @@ export function wrapPastedBlocks(typed: string, blocks: PastedTextBlock[]): stri
     })
     .join('\n\n')
 
-  const rest = typed.trim()
+  const rest = sanitizePastedBody(typed).trim()
   if (!wrapped) {
-    return typed
+    return sanitizePastedBody(typed)
   }
   if (!rest) {
     return wrapped
@@ -55,7 +55,7 @@ export function extractPastedBlocks(raw: string): { blocks: string[]; text: stri
   const blocks: string[] = []
   const text = raw
     .replace(PASTED_CONTENT_RE, (_match, body: string) => {
-      blocks.push(body.replace(/^\n/, '').replace(/\n$/, ''))
+      blocks.push(body.replace(/^\n+/, '').replace(/\n+$/, ''))
       return ''
     })
     .replace(/\n{3,}/g, '\n\n')

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -525,6 +525,7 @@ import { generatePartId, pushMediaPart, extractMediaParts } from '@/utils/mediaP
 import { buildUploadUrl, isAudioFileType } from '@/utils/mediaTypes'
 import { isChannelSource } from '@/utils/channelSource'
 import { looksLikeFileGenerationEnvelope } from '@/utils/fileGenerationEnvelope'
+import { stripPastedBlocks } from '@/utils/pastedContent'
 import { AudioStreamer } from '@/utils/AudioStreamer'
 import { isRecoverableStreamError, isCancellationError } from '@/utils/streamError'
 import { httpClient } from '@/services/api/httpClient'
@@ -535,6 +536,7 @@ import {
   parseMediaJobPayload,
   applyMediaJobUpdateToMessage,
   mapApiMessageRow,
+  parseContentWithThinking,
   IN_PROGRESS_TURN_ID,
 } from '@/utils/messageMapper'
 import type { UserMemory } from '@/services/api/userMemoriesApi'
@@ -2153,7 +2155,7 @@ const handleSendMessage = async (
   let backendContent = backendMessage
 
   if (messageToSend.startsWith('/')) {
-    const commandMatch = messageToSend.match(/^\/(\w+)\s+(.*)$/)
+    const commandMatch = messageToSend.match(/^\/(\w+)\s+([\s\S]*)$/)
     if (commandMatch) {
       const cmd = commandMatch[1]
       const args = commandMatch[2] || ''
@@ -2186,9 +2188,10 @@ const handleSendMessage = async (
   // badge). Without this the only visible artifact of a voice upload was
   // the transcribed text — there was no way to replay the original
   // recording from the web chat.
-  const optimisticParts: import('@/stores/history').Part[] = [
-    { type: 'text', content: displayContent },
-  ]
+  const optimisticParts: import('@/stores/history').Part[] = parseContentWithThinking(
+    displayContent,
+    'user'
+  )
   if (files && files.length > 0) {
     for (const file of files) {
       if (!isAudioFileType(file.fileType, file.fileMime)) continue
@@ -2223,7 +2226,7 @@ const handleSendMessage = async (
   // Mirrors the backend preview format (30 chars + ellipsis).
   // Incognito: the turn belongs to no chat — never touch the sidebar.
   if (chatsStore.activeChatId && !incognitoStore.active) {
-    const previewSource = displayContent.trim()
+    const previewSource = stripPastedBlocks(displayContent).trim()
     const preview =
       previewSource.length > 30 ? previewSource.slice(0, 30) + '…' : previewSource || undefined
     chatsStore.bumpChatActivity(chatsStore.activeChatId, {

--- a/frontend/tests/unit/components/ChatInputPastedText.spec.ts
+++ b/frontend/tests/unit/components/ChatInputPastedText.spec.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { nextTick } from 'vue'
+import ChatInput from '@/components/ChatInput.vue'
+import { PASTE_BLOCK_MIN_CHARS } from '@/utils/pastedContent'
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ query: {}, fullPath: '/chat' }),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+}))
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key, locale: { value: 'en' } }),
+}))
+
+vi.mock('@/stores/config', () => ({
+  useConfigStore: () => ({
+    speech: {
+      webSpeechEnabled: false,
+      whisperEnabled: false,
+      speechToTextAvailable: false,
+    },
+  }),
+}))
+
+vi.mock('@/services/api/chatApi', () => ({
+  chatApi: {
+    uploadChatFile: vi.fn(),
+    transcribeAudio: vi.fn(),
+  },
+}))
+
+const longPaste = 'L'.repeat(PASTE_BLOCK_MIN_CHARS)
+
+const mountInput = (): VueWrapper =>
+  mount(ChatInput, {
+    attachTo: document.body,
+    global: {
+      mocks: { $t: (key: string) => key },
+      stubs: {
+        Icon: true,
+        Textarea: {
+          template: '<textarea data-testid="input-chat-message" />',
+          methods: { focus() {} },
+        },
+        CommandPalette: true,
+        FileMentionPalette: true,
+        ToolsDropdown: true,
+        ToolBadge: true,
+        ModelDropdown: true,
+        KnowledgeFolderPicker: true,
+        FileSelectionModal: true,
+        PastedTextModal: true,
+        QuoteChip: true,
+      },
+    },
+  })
+
+const pasteIntoComposer = async (wrapper: VueWrapper, text: string) => {
+  const textarea = wrapper.get('[data-testid="input-chat-message"]').element as HTMLTextAreaElement
+  textarea.focus()
+  await wrapper.get('[data-testid="comp-chat-input"]').trigger('paste', {
+    clipboardData: {
+      items: [],
+      getData: (type: string) => (type === 'text/plain' ? text : ''),
+    },
+  })
+  await nextTick()
+  return textarea
+}
+
+describe('ChatInput pasted text blocks', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    setActivePinia(createPinia())
+    document.body.innerHTML = ''
+  })
+
+  it('leaves a short paste in the textarea', async () => {
+    const wrapper = mountInput()
+    const textarea = await pasteIntoComposer(wrapper, 'short note')
+
+    expect(wrapper.find('[data-testid="chip-pasted-text"]').exists()).toBe(false)
+    expect(document.activeElement).toBe(textarea)
+  })
+
+  it('turns a long paste into a card and keeps the textarea focused', async () => {
+    const wrapper = mountInput()
+    const textarea = await pasteIntoComposer(wrapper, longPaste)
+
+    expect(wrapper.find('[data-testid="chip-pasted-text"]').exists()).toBe(true)
+    expect(document.activeElement).toBe(textarea)
+  })
+
+  it('removes the card with the X button', async () => {
+    const wrapper = mountInput()
+    await pasteIntoComposer(wrapper, longPaste)
+
+    await wrapper.get('[data-testid="btn-pasted-text-remove"]').trigger('click')
+    await nextTick()
+
+    expect(wrapper.find('[data-testid="chip-pasted-text"]').exists()).toBe(false)
+  })
+
+  it('enables send from a pasted block alone and wraps the text on send', async () => {
+    const wrapper = mountInput()
+    await pasteIntoComposer(wrapper, longPaste)
+
+    const send = wrapper.get('[data-testid="btn-chat-send"]')
+    expect((send.element as HTMLButtonElement).disabled).toBe(false)
+
+    await send.trigger('click')
+    const emitted = wrapper.emitted('send')
+    expect(emitted).toBeTruthy()
+    expect(String(emitted?.[0]?.[0])).toContain('<pasted-content>')
+    expect(String(emitted?.[0]?.[0])).toContain(longPaste)
+    expect(wrapper.find('[data-testid="chip-pasted-text"]').exists()).toBe(false)
+  })
+})

--- a/frontend/tests/unit/components/ChatInputVoiceActivity.spec.ts
+++ b/frontend/tests/unit/components/ChatInputVoiceActivity.spec.ts
@@ -93,6 +93,8 @@ const mountInput = (): VueWrapper =>
         ModelDropdown: true,
         KnowledgeFolderPicker: true,
         FileSelectionModal: true,
+        PastedTextCard: true,
+        PastedTextModal: true,
         QuoteChip: true,
       },
     },

--- a/frontend/tests/unit/utils/messageMapperPastedText.spec.ts
+++ b/frontend/tests/unit/utils/messageMapperPastedText.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { parseContentWithThinking } from '@/utils/messageMapper'
+import { wrapPastedBlocks } from '@/utils/pastedContent'
+
+describe('parseContentWithThinking pasted text', () => {
+  it('splits user messages into pastedText parts plus remaining text', () => {
+    const raw = wrapPastedBlocks('What is this error?', [
+      { id: '1', content: 'stack trace line 1\nstack trace line 2' },
+    ])
+
+    const parts = parseContentWithThinking(raw, 'user')
+
+    expect(parts).toEqual([
+      { type: 'pastedText', content: 'stack trace line 1\nstack trace line 2' },
+      { type: 'text', content: 'What is this error?' },
+    ])
+  })
+
+  it('keeps a plain user message as a single text part', () => {
+    expect(parseContentWithThinking('hello', 'user')).toEqual([{ type: 'text', content: 'hello' }])
+  })
+})

--- a/frontend/tests/unit/utils/pastedContent.spec.ts
+++ b/frontend/tests/unit/utils/pastedContent.spec.ts
@@ -72,6 +72,30 @@ describe('wrap and extract pasted blocks', () => {
   it('returns typed text unchanged when there are no blocks', () => {
     expect(wrapPastedBlocks('just typing', [])).toBe('just typing')
   })
+
+  it('strips sentinel tags from typed text so they cannot change rendering', () => {
+    const wrapped = wrapPastedBlocks(
+      'Please review <pasted-content>injected</pasted-content> this',
+      [{ id: '1', content: 'log line' }]
+    )
+    const extracted = extractPastedBlocks(wrapped)
+
+    expect(extracted.blocks).toEqual(['log line'])
+    expect(extracted.text).toBe('Please review injected this')
+  })
+
+  it('strips sentinel tags from typed text even without a pasted block', () => {
+    expect(wrapPastedBlocks('see <pasted-content>secret</pasted-content> now', [])).toBe(
+      'see secret now'
+    )
+  })
+
+  it('does not keep a trailing blank line after a stack-trace paste', () => {
+    const wrapped = wrapPastedBlocks('', [{ id: '1', content: 'error\n  at foo.ts:1\n' }])
+    const extracted = extractPastedBlocks(wrapped)
+
+    expect(extracted.blocks).toEqual(['error\n  at foo.ts:1'])
+  })
 })
 
 describe('stripPastedBlocks', () => {

--- a/frontend/tests/unit/utils/pastedContent.spec.ts
+++ b/frontend/tests/unit/utils/pastedContent.spec.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest'
+import {
+  PASTE_BLOCK_MIN_CHARS,
+  PASTE_BLOCK_MIN_CHARS_FOR_LINE_RULE,
+  PASTE_BLOCK_MIN_LINES,
+  countLines,
+  extractPastedBlocks,
+  shouldBecomeBlock,
+  stripPastedBlocks,
+  wrapPastedBlocks,
+} from '@/utils/pastedContent'
+
+const longText = 'a'.repeat(PASTE_BLOCK_MIN_CHARS)
+const shortText = 'hello world'
+
+describe('shouldBecomeBlock', () => {
+  it('keeps short text in the textarea', () => {
+    expect(shouldBecomeBlock(shortText)).toBe(false)
+  })
+
+  it('promotes text at the character threshold', () => {
+    expect(shouldBecomeBlock(longText)).toBe(true)
+  })
+
+  it('does not promote a short multi-line address', () => {
+    const address = ['Name', 'Street 1', 'Street 2', 'City', 'Country', 'Phone', 'Email'].join('\n')
+    expect(countLines(address)).toBeGreaterThan(PASTE_BLOCK_MIN_LINES - 4)
+    expect(shouldBecomeBlock(address)).toBe(false)
+  })
+
+  it('promotes many lines once the line-rule character floor is met', () => {
+    const lines = Array.from(
+      { length: PASTE_BLOCK_MIN_LINES + 1 },
+      () => 'line of pasted notes with enough characters'
+    )
+    const text = lines.join('\n')
+    expect(text.length).toBeGreaterThanOrEqual(PASTE_BLOCK_MIN_CHARS_FOR_LINE_RULE)
+    expect(shouldBecomeBlock(text)).toBe(true)
+  })
+})
+
+describe('wrap and extract pasted blocks', () => {
+  it('round-trips a single block and typed text', () => {
+    const wrapped = wrapPastedBlocks('What does this mean?', [{ id: '1', content: longText }])
+    const extracted = extractPastedBlocks(wrapped)
+
+    expect(extracted.blocks).toEqual([longText])
+    expect(extracted.text).toBe('What does this mean?')
+  })
+
+  it('round-trips several blocks in order', () => {
+    const wrapped = wrapPastedBlocks('summarise', [
+      { id: '1', content: 'first block' },
+      { id: '2', content: 'second block' },
+    ])
+    const extracted = extractPastedBlocks(wrapped)
+
+    expect(extracted.blocks).toEqual(['first block', 'second block'])
+    expect(extracted.text).toBe('summarise')
+  })
+
+  it('strips sentinel tags from the pasted body before wrapping', () => {
+    const wrapped = wrapPastedBlocks('', [
+      { id: '1', content: `before <pasted-content>inner</pasted-content> after` },
+    ])
+    const extracted = extractPastedBlocks(wrapped)
+
+    expect(extracted.blocks).toEqual(['before inner after'])
+    expect(extracted.text).toBe('')
+  })
+
+  it('returns typed text unchanged when there are no blocks', () => {
+    expect(wrapPastedBlocks('just typing', [])).toBe('just typing')
+  })
+})
+
+describe('stripPastedBlocks', () => {
+  it('removes wrapped blocks and leaves the typed remainder', () => {
+    const wrapped = wrapPastedBlocks('Please review', [{ id: '1', content: longText }])
+    expect(stripPastedBlocks(wrapped)).toBe('Please review')
+  })
+
+  it('returns empty when the message is only pasted content', () => {
+    const wrapped = wrapPastedBlocks('', [{ id: '1', content: longText }])
+    expect(stripPastedBlocks(wrapped)).toBe('')
+  })
+})


### PR DESCRIPTION
## Summary
Large pasted text no longer floods the chat input. From about 1,200 characters it becomes a removable card above the field, with an edit modal, while the model still receives the full content.

## Changes
- Turn long pastes into a composer card (preview + PASTED label). Hover shows remove; click opens an editable modal. The textarea stays free for a follow-up.
- Send the pasted body in a `<pasted-content>` marker before the typed text so the AI sees everything.
- Render the same collapsed card in the sent user bubble (and after reload) via a `pastedText` message part.
- Strip the marker from chat-list previews and shared-chat meta descriptions.
- Persist drafts per chat for 30 minutes (skipped in incognito, capped at ~100 KB).
- Mobile: teleported modal (bottom sheet), always-visible 44px remove hit target, no iOS input zoom, focus stays in the textarea after paste.

## Verification
- [x] Manual
- [x] Tests added/updated

- `make lint` — clean
- `make -C backend phpstan` — clean
- Backend PHPUnit: 5271 tests, 0 failures
- Frontend Vitest: 198 files / 1574 tests passed
- `docker compose exec -T frontend npm run check:types` — clean
- Manual: light, dark, V2, and 375px — card, hover/touch X, modal (Cancel/Save use the shared button utilities), textarea stays focused after paste.

## Notes
- Classification is `ota-candidate` (`frontend/**`) + `backend-only` (`backend/**`).
- Do **not** merge until GitHub `CI` / `All Checks Passed` is green. Merge to `main` is left to the reviewer.

## Screenshots/Logs
Composer card above the input with a PASTED label; click opens the “Pasted content” modal (line/character meta, monospace editor, Cancel + Save). On a 375px viewport the remove control stays visible without hover.