### PR TITLE
fix: latest open bugs — Ollama health, TTS length, merge-to-PDF

### DIFF
--- a/backend/config/services.yaml
+++ b/backend/config/services.yaml
@@ -468,6 +468,13 @@ services:
             $accountId: '%env(CLOUDFLARE_ACCOUNT_ID)%'
             $apiToken: '%env(CLOUDFLARE_API_TOKEN)%'
 
+    # Ollama is always registered as a provider; an empty URL means the
+    # Cloud-AI profile never enabled local AI — that is Unconfigured, not
+    # an outage (#1704).
+    App\AI\Health\Probe\OllamaModelListProbe:
+        arguments:
+            $baseUrl: '%env(OLLAMA_BASE_URL)%'
+
     App\AI\Health\Probe\ModelListProbeRegistry:
         arguments:
             $probes: !tagged_iterator app.model_list_probe

--- a/backend/src/AI/Health/Probe/OllamaModelListProbe.php
+++ b/backend/src/AI/Health/Probe/OllamaModelListProbe.php
@@ -19,8 +19,10 @@ use App\AI\Service\ProviderRegistry;
  */
 final readonly class OllamaModelListProbe implements ModelListProbeInterface
 {
-    public function __construct(private ProviderRegistry $registry)
-    {
+    public function __construct(
+        private ProviderRegistry $registry,
+        private string $baseUrl = '',
+    ) {
     }
 
     public function supports(string $service): bool
@@ -31,8 +33,8 @@ final readonly class OllamaModelListProbe implements ModelListProbeInterface
     public function probe(string $service): ProbeResult
     {
         $provider = $this->ollamaProvider();
-        if (null === $provider) {
-            return ProbeResult::skipped('Ollama is not registered in this installation.');
+        if (null === $provider || '' === trim($this->baseUrl)) {
+            return ProbeResult::skipped('Ollama is not configured.');
         }
 
         try {

--- a/backend/src/AI/Health/Probe/OllamaModelListProbe.php
+++ b/backend/src/AI/Health/Probe/OllamaModelListProbe.php
@@ -33,8 +33,15 @@ final readonly class OllamaModelListProbe implements ModelListProbeInterface
     public function probe(string $service): ProbeResult
     {
         $provider = $this->ollamaProvider();
-        if (null === $provider || '' === trim($this->baseUrl)) {
-            return ProbeResult::skipped('Ollama is not configured.');
+        if (null === $provider) {
+            return ProbeResult::skipped('Ollama is not registered in this installation.');
+        }
+
+        // Ollama is always registered as a provider, so an empty URL is the only
+        // signal that this install never enabled local AI (#1704). Name the
+        // variable — the operator reads this string in the model status list.
+        if ('' === trim($this->baseUrl)) {
+            return ProbeResult::skipped('OLLAMA_BASE_URL is not configured.');
         }
 
         try {

--- a/backend/src/AI/Service/AiFacade.php
+++ b/backend/src/AI/Service/AiFacade.php
@@ -21,6 +21,7 @@ use App\Service\File\FileHelper;
 use App\Service\File\UserUploadPathBuilder;
 use App\Service\InternalEmailService;
 use App\Service\ModelConfigService;
+use App\Service\TtsTextSanitizer;
 use App\Service\Usage\TranscriptionUsageRecorder;
 use Psr\Cache\CacheItemPoolInterface;
 use Psr\Log\LoggerInterface;
@@ -1513,6 +1514,9 @@ class AiFacade
 
         $provider = $this->registry->getTextToSpeechProvider($providerName);
 
+        // Last-line defence for callers that skip TtsTextSanitizer (#1665).
+        $text = TtsTextSanitizer::truncateForSynthesis($text);
+
         $this->logger->info('AI TTS request', [
             'provider' => $provider->getName(),
             'user_id' => $userId,
@@ -1582,6 +1586,8 @@ class AiFacade
         }
 
         $provider = $this->registry->getTextToSpeechProvider($providerName);
+
+        $text = TtsTextSanitizer::truncateForSynthesis($text);
 
         $this->logger->info('AI TTS stream request', [
             'provider' => $provider->getName(),

--- a/backend/src/Controller/StreamController.php
+++ b/backend/src/Controller/StreamController.php
@@ -2211,8 +2211,7 @@ class StreamController extends AbstractController
 
                         $this->sendSSE('tts_generating', ['language' => $language]);
 
-                        $ttsText = TtsTextSanitizer::sanitize($responseText);
-                        $ttsText = mb_substr($ttsText, 0, 4000);
+                        $ttsText = TtsTextSanitizer::prepareForSynthesis($responseText);
 
                         if (!empty(trim($ttsText))) {
                             $ttsResult = $this->aiFacade->synthesize($ttsText, $user->getId(), [

--- a/backend/src/Service/File/Office/DocumentCombineService.php
+++ b/backend/src/Service/File/Office/DocumentCombineService.php
@@ -83,7 +83,7 @@ final readonly class DocumentCombineService
             $pdfPaths[] = $pdf;
         }
 
-        $outputName = $this->sanitizeFilename($filename);
+        $outputName = $this->sanitizeFilename($filename, $ordered);
         $relative = $this->userUploadPathBuilder->buildUserBaseRelativePath($user->getId())
             .'/'.date('Y').'/'.date('m').'/'.$outputName;
         $absolute = $this->uploadDir.'/'.$relative;
@@ -105,7 +105,7 @@ final readonly class DocumentCombineService
         $file->setUserId($user->getId());
         $file->setFilePath($relative);
         $file->setFileType('pdf');
-        $file->setFileName($this->displayName($filename));
+        $file->setFileName(self::resolvedDisplayName($filename, $ordered));
         $file->setFileSize($size);
         $file->setFileMime(GeneratedDocumentStore::mimeTypeForExtension('pdf'));
         $file->setFileText($manifest);
@@ -160,10 +160,25 @@ final readonly class DocumentCombineService
         return implode("\n", $lines);
     }
 
-    private function displayName(?string $filename): string
+    /**
+     * Product filename for a combined PDF. An explicit title wins; otherwise
+     * the first source stem is used so the file chip Combine action and chat
+     * merge do not persist the fallback `combined.pdf` (#1694).
+     *
+     * @param list<File> $sources
+     */
+    public static function resolvedDisplayName(?string $filename, array $sources = []): string
     {
         $base = pathinfo((string) $filename, PATHINFO_FILENAME);
         $base = trim($base);
+        if ('' === $base) {
+            $first = $sources[0] ?? null;
+            $stem = $first instanceof File ? pathinfo($first->getFileName(), PATHINFO_FILENAME) : '';
+            $base = trim($stem);
+            if ('' !== $base) {
+                $base .= '_combined';
+            }
+        }
         if ('' === $base) {
             $base = 'combined';
         }
@@ -171,9 +186,12 @@ final readonly class DocumentCombineService
         return $base.'.pdf';
     }
 
-    private function sanitizeFilename(?string $filename): string
+    /**
+     * @param list<File> $sources
+     */
+    private function sanitizeFilename(?string $filename, array $sources = []): string
     {
-        $base = pathinfo($this->displayName($filename), PATHINFO_FILENAME);
+        $base = pathinfo(self::resolvedDisplayName($filename, $sources), PATHINFO_FILENAME);
         $sanitized = preg_replace('/[^a-zA-Z0-9._-]/', '_', $base) ?? 'combined';
 
         return $sanitized.'_'.time().'.pdf';

--- a/backend/src/Service/File/Office/DocumentCombineService.php
+++ b/backend/src/Service/File/Office/DocumentCombineService.php
@@ -162,8 +162,10 @@ final readonly class DocumentCombineService
 
     /**
      * Product filename for a combined PDF. An explicit title wins; otherwise
-     * the first source stem is used so the file chip Combine action and chat
-     * merge do not persist the fallback `combined.pdf` (#1694).
+     * the first source stem is used, so neither the file chip's Combine action
+     * nor a chat merge persists the bare fallback `combined.pdf` (#1694). Both
+     * callers reach this through {@see combineToPdf()}; it is public only to be
+     * assertable without an office engine.
      *
      * @param list<File> $sources
      */

--- a/backend/src/Service/File/Office/OfficePdfRoutingDecorator.php
+++ b/backend/src/Service/File/Office/OfficePdfRoutingDecorator.php
@@ -19,11 +19,11 @@ final readonly class OfficePdfRoutingDecorator
 
     private const PLANNER_PDF_UNSUPPORTED = 'Real PDFs are NOT supported — say so in a single `chat` node.';
 
-    private const PLANNER_PDF_SUPPORTED = 'Creating a real PDF is supported: plan `document_generation` the same way as a Word file (the server converts the Office source to PDF). Turning a file that ALREADY EXISTS in the conversation into a PDF ("export this as PDF", "hieraus eine PDF") is a single `document_export` node — NOT extract_text + document_generation, which would re-write the file.';
+    private const PLANNER_PDF_SUPPORTED = 'Creating a real PDF is supported: plan `document_generation` the same way as a Word file (the server converts the Office source to PDF). Turning a file that ALREADY EXISTS in the conversation into a PDF ("export this as PDF", "hieraus eine PDF") is a single `document_export` node — NOT extract_text + document_generation, which would re-write the file. Merging two or more existing office/PDF attachments into one PDF ("merge these into one PDF", "führe beide dateien in eine pdf zusammen") is a single `document_combine` node — NOT analyzefile and NOT document_generation.';
 
     private const PLANNER_GENERATOR_NODES = 'document_generation, calendar_event), surfaced through `compose_reply`.';
 
-    private const PLANNER_GENERATOR_NODES_WITH_EXPORT = 'document_generation, document_export, calendar_event), surfaced through `compose_reply`.';
+    private const PLANNER_GENERATOR_NODES_WITH_EXPORT = 'document_generation, document_export, document_combine, calendar_event), surfaced through `compose_reply`.';
 
     private const PLANNER_HARD_RULE_PDF = "If the user asks for output the capability list cannot produce (e.g. a real\n   PDF, a phone call)";
 
@@ -93,7 +93,7 @@ final readonly class OfficePdfRoutingDecorator
         return <<<'PROMPT'
 
 ## OFFICE_PDF_ROUTING
-When the user asks to CREATE a PDF (not "can you make PDFs?"), set BTOPIC to "officemaker". Do not use general or synaplan for produce-a-PDF requests. Turning a file that already exists in the conversation into a PDF is also "officemaker" — the planner then converts that file instead of writing a new one.
+When the user asks to CREATE a PDF (not "can you make PDFs?"), set BTOPIC to "officemaker". Do not use general or synaplan for produce-a-PDF requests. Turning a file that already exists in the conversation into a PDF is also "officemaker" — the planner then converts that file instead of writing a new one. Merging several attached office/PDF files into one PDF is the same topic — the planner then combines those files instead of analysing them.
 PROMPT;
     }
 }

--- a/backend/src/Service/Message/MessageClassifier.php
+++ b/backend/src/Service/Message/MessageClassifier.php
@@ -811,9 +811,6 @@ final readonly class MessageClassifier
     {
         $eligible = [];
         foreach ($message->getFiles() as $file) {
-            if (!$file instanceof File) {
-                continue;
-            }
             $ext = DocumentThumbnailGenerator::extensionOf($file);
             if (DocumentThumbnailGenerator::isOffice($ext) || DocumentThumbnailGenerator::isPdf($ext)) {
                 $eligible[] = $file;

--- a/backend/src/Service/Message/MessageClassifier.php
+++ b/backend/src/Service/Message/MessageClassifier.php
@@ -11,6 +11,7 @@ use App\Service\Document\DocumentKind;
 use App\Service\Document\DocumentToolsConfig;
 use App\Service\File\ConversationFile;
 use App\Service\File\FileTypeResolver;
+use App\Service\File\Office\DocumentThumbnailGenerator;
 use App\Service\File\Office\OfficeConverterClient;
 use App\Service\Message\Capability\SystemCapabilityRegistry;
 use App\Service\Message\Routing\EmbeddingRouterConfig;
@@ -259,6 +260,20 @@ final readonly class MessageClassifier
                     'language' => $message->getLanguage() ?: 'en',
                     'intent' => 'document_generation',
                     'source' => 'attachment_office_edit',
+                    'skip_sorting' => true,
+                ];
+            }
+            $combineRoute = $this->attachmentDocumentFileIntent($message);
+            if (null !== $combineRoute) {
+                $this->logger->info('MessageClassifier: Routing attachment merge/export to '.$combineRoute, [
+                    'message_id' => $messageId,
+                ]);
+
+                return [
+                    'topic' => $combineRoute,
+                    'language' => $message->getLanguage() ?: 'en',
+                    'intent' => $combineRoute,
+                    'source' => 'attachment_'.$combineRoute,
                     'skip_sorting' => true,
                 ];
             }
@@ -690,6 +705,10 @@ final readonly class MessageClassifier
             'analyze' => 'file_analysis',
             'analyzefile' => 'file_analysis',
 
+            // Attachment merge/export of existing files (#1694 / #1691)
+            'document_combine' => 'document_combine',
+            'document_export' => 'document_export',
+
             // Chat alias
             'chat' => 'chat',
 
@@ -731,14 +750,79 @@ final readonly class MessageClassifier
     }
 
     /**
-     * True if the message has at least one attached document, audio, or video
-     * file (i.e. an analyzable non-image attachment). Routes to
-     * FileAnalysisHandler so the ANALYZE default model is used (#595, video
-     * added in #983). Video is included because its audio track is transcribed
-     * to text the chat model can reason about (#722); without this gate a
-     * video-only message fell through to the AI sorter and was answered as a
-     * plain (text-less) chat.
+     * Merge/export-as-PDF of attached office/PDF files must not be forced onto
+     * analyzefile (#1694). Two or more combine-eligible files plus a merge /
+     * combine / export-as-PDF prompt maps to `document_combine`. A single office
+     * file plus export-as-PDF maps to `document_export` (the #1691 conversion).
+     * Read or summarize prompts still return null and take analyzefile.
      */
+    private function attachmentDocumentFileIntent(Message $message): ?string
+    {
+        $text = trim((string) $message->getText());
+        if ('' === $text) {
+            return null;
+        }
+
+        $eligible = $this->combineEligibleAttachments($message);
+        if ([] === $eligible) {
+            return null;
+        }
+
+        $wantsMerge = 1 === preg_match(
+            '/(?:'
+            .'(?:merge|combine|zusammenführen|zusammenfügen|fusionner|combinar|birleştir)\b.{0,80}\bpdfs?\b'
+            .'|'
+            .'\bpdfs?\b.{0,80}\b(?:merge|combine|zusammenführen|zusammenfügen|fusionner|combinar|birleştir)\b'
+            .'|'
+            .'(?:führe|führ)\b.{0,80}\bzusammen\b'
+            .'|'
+            .'\bin\s+(?:eine[nm]?\s+)?pdfs?\s+zusammen\b'
+            .')/iu',
+            $text,
+        );
+        $wantsExport = 1 === preg_match(
+            '/(?:'
+            .'(?:export|convert|speichern|exportar|enregistrer).{0,40}\bpdfs?\b'
+            .'|'
+            .'\b(?:als|as|hieraus)\s+(?:eine[nm]?\s+)?pdfs?\b'
+            .'|'
+            .'\b(?:to|into)\s+(?:a\s+|one\s+|eine[nm]?\s+)?(?:single\s+)?pdfs?\b'
+            .')/iu',
+            $text,
+        );
+
+        if (count($eligible) >= 2 && ($wantsMerge || $wantsExport)) {
+            return 'document_combine';
+        }
+        if (1 === count($eligible) && $wantsExport && !$wantsMerge) {
+            $ext = DocumentThumbnailGenerator::extensionOf($eligible[0]);
+            if (DocumentThumbnailGenerator::isOffice($ext)) {
+                return 'document_export';
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return list<File>
+     */
+    private function combineEligibleAttachments(Message $message): array
+    {
+        $eligible = [];
+        foreach ($message->getFiles() as $file) {
+            if (!$file instanceof File) {
+                continue;
+            }
+            $ext = DocumentThumbnailGenerator::extensionOf($file);
+            if (DocumentThumbnailGenerator::isOffice($ext) || DocumentThumbnailGenerator::isPdf($ext)) {
+                $eligible[] = $file;
+            }
+        }
+
+        return $eligible;
+    }
+
     /**
      * When DOCUMENT_TOOLS.ALLOW_UPLOAD_EDIT is on, an office attachment plus
      * an edit-intent prompt goes to officemaker instead of analyzefile.

--- a/backend/src/Service/Message/MessageClassifier.php
+++ b/backend/src/Service/Message/MessageClassifier.php
@@ -20,6 +20,7 @@ use App\Service\Message\Routing\NativeToolRoutingConfig;
 use App\Service\Message\Routing\RoutingDecision;
 use App\Service\Message\Routing\RoutingLayer;
 use App\Service\ModelConfigService;
+use App\Service\Multitask\MultitaskRoutingConfig;
 use App\Service\SelfAware\SelfAwareConfig;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
@@ -82,6 +83,7 @@ final readonly class MessageClassifier
         private ?SelfAwareConfig $selfAwareConfig = null,
         private ?OfficeConverterClient $officeConverter = null,
         private ?DocumentToolsConfig $documentToolsConfig = null,
+        private ?MultitaskRoutingConfig $multitaskConfig = null,
     ) {
     }
 
@@ -269,8 +271,14 @@ final readonly class MessageClassifier
                     'message_id' => $messageId,
                 ]);
 
+                // BTOPIC stays inside the prompt-topic namespace: `officemaker`
+                // is the topic OFFICE_PDF_ROUTING already assigns to produce-a-PDF
+                // turns, it has a seeded BPROMPTS row, and the chat info popover
+                // links it to a real /ai/instructions entry. The capability is
+                // selected from `intent` + `source`, not from the topic
+                // ({@see TaskPlanExecutor::isDeterministicDocumentFileIntent()}).
                 return [
-                    'topic' => $combineRoute,
+                    'topic' => 'officemaker',
                     'language' => $message->getLanguage() ?: 'en',
                     'intent' => $combineRoute,
                     'source' => 'attachment_'.$combineRoute,
@@ -705,10 +713,6 @@ final readonly class MessageClassifier
             'analyze' => 'file_analysis',
             'analyzefile' => 'file_analysis',
 
-            // Attachment merge/export of existing files (#1694 / #1691)
-            'document_combine' => 'document_combine',
-            'document_export' => 'document_export',
-
             // Chat alias
             'chat' => 'chat',
 
@@ -750,11 +754,66 @@ final readonly class MessageClassifier
     }
 
     /**
+     * Explicit merge lexicon. Only verbs that mean "make ONE file out of
+     * several" — a bare "speichern"/"save" is NOT one of them (see
+     * {@see EXPORT_INTENT_PATTERN}).
+     */
+    private const MERGE_INTENT_PATTERN = '/(?:'
+        .'\b(?:merge|combine|concatenate|zusammenführen|zusammenfügen|zusammenlegen|fusionner|combiner|combinar|fusionar|birleştir\w*)\b'
+        .'|'
+        .'\b(?:führe?|füge?|fügen)\b.{0,80}\bzusammen\b'
+        .')/iu';
+
+    /**
+     * Explicit "turn this INTO a PDF" lexicon. Every alternative pairs a
+     * conversion verb with the target format, so "speichere die PDFs im Ordner
+     * X" (a save_to_folder request) no longer reads as an export.
+     */
+    private const EXPORT_INTENT_PATTERN = '/(?:'
+        .'\b(?:export\w*|exportier\w*|convert\w*|konvertier\w*|umwandel\w*|wandle|exportar|convertir|convierte|enregistrer|dönüştür\w*)\b[^.!?]{0,40}\bpdfs?\b'
+        .'|'
+        .'\b(?:speicher\w*|save|guardar|guarda)\b\s*(?:\w+\s+){0,3}?\b(?:als|as|como|en|comme|olarak)\s+(?:eine[nmr]?\s+)?pdfs?\b'
+        .'|'
+        .'\b(?:als|as|hieraus|daraus)\s+(?:eine[nmr]?\s+)?pdfs?\b'
+        .')/iu';
+
+    /**
+     * "…into ONE pdf". Turns an otherwise ambiguous export phrasing ("mach aus
+     * beiden eine PDF") into a merge when several files are attached, while
+     * "convert both files to PDF" (two separate PDFs) stays with the planner.
+     */
+    private const SINGLE_PDF_TARGET_PATTERN = '/\b(?:one|single|a\s+single|eine[nmr]?|un|una|seule|tek|einzige[nsr]?)\s+(?:\w+\s+){0,2}?pdfs?\b/iu';
+
+    /**
+     * Capabilities that only the planner can deliver alongside a merge. When a
+     * message asks for one of them too ("merge both AND read it aloud"), the
+     * deterministic single-node route would silently drop it (#1192), so we let
+     * the planner see the whole turn instead.
+     */
+    private const COMPETING_INTENT_PATTERN = '/(?:'
+        .'\b(?:aloud|audio|mp3|podcast|voice|vorlesen|vorlies\w*|sprich|audiodatei|sprachnachricht|voz|voix|sesli)\b'
+        .'|\b(?:lies|liest)\b.{0,20}\bvor\b'
+        .'|\bread\b.{0,20}\b(?:aloud|out\s+loud)\b'
+        .'|\b(?:image|picture|photo|illustration|bild|grafik|imagen|foto|resim|görsel)\b'
+        .'|\b(?:e-?mail|mail\s+it|maile?|verschick\w*|correo|courriel|posta)\b'
+        .'|\b(?:folder|ordner|nextcloud|dropbox|carpeta|dossier|klasör)\b'
+        .'|\b(?:translate|translation|übersetz\w*|traduc\w*|traduir\w*|çevir\w*)\b'
+        .'|\b(?:summarize|summary|summarise|zusammenfassung|resum\w*|résum\w*|özetle\w*)\b'
+        .'|\bfasse?\b.{0,40}\bzusammen\b'
+        .')/iu';
+
+    /**
      * Merge/export-as-PDF of attached office/PDF files must not be forced onto
-     * analyzefile (#1694). Two or more combine-eligible files plus a merge /
-     * combine / export-as-PDF prompt maps to `document_combine`. A single office
-     * file plus export-as-PDF maps to `document_export` (the #1691 conversion).
+     * analyzefile (#1694). Two or more combine-eligible files plus an explicit
+     * merge prompt maps to `document_combine`. A single office file plus an
+     * export-as-PDF prompt maps to `document_export` (the #1691 conversion).
      * Read or summarize prompts still return null and take analyzefile.
+     *
+     * Deliberately narrow: this route SKIPS the planner, so anything it claims
+     * is delivered by exactly one server-side node and every other intent in
+     * the same turn would be lost. Whenever the request is ambiguous or
+     * compound we return null and let the planner decide — it knows
+     * `document_combine` too (see {@see OfficePdfRoutingDecorator}).
      */
     private function attachmentDocumentFileIntent(Message $message): ?string
     {
@@ -768,40 +827,57 @@ final readonly class MessageClassifier
             return null;
         }
 
-        $wantsMerge = 1 === preg_match(
-            '/(?:'
-            .'(?:merge|combine|zusammenführen|zusammenfügen|fusionner|combinar|birleştir)\b.{0,80}\bpdfs?\b'
-            .'|'
-            .'\bpdfs?\b.{0,80}\b(?:merge|combine|zusammenführen|zusammenfügen|fusionner|combinar|birleştir)\b'
-            .'|'
-            .'(?:führe|führ)\b.{0,80}\bzusammen\b'
-            .'|'
-            .'\bin\s+(?:eine[nm]?\s+)?pdfs?\s+zusammen\b'
-            .')/iu',
-            $text,
-        );
-        $wantsExport = 1 === preg_match(
-            '/(?:'
-            .'(?:export|convert|speichern|exportar|enregistrer).{0,40}\bpdfs?\b'
-            .'|'
-            .'\b(?:als|as|hieraus)\s+(?:eine[nm]?\s+)?pdfs?\b'
-            .'|'
-            .'\b(?:to|into)\s+(?:a\s+|one\s+|eine[nm]?\s+)?(?:single\s+)?pdfs?\b'
-            .')/iu',
-            $text,
-        );
-
-        if (count($eligible) >= 2 && ($wantsMerge || $wantsExport)) {
-            return 'document_combine';
+        // Neither capability exists without the multi-task engine: the legacy
+        // InferenceRouter has no handler for these intents and would answer
+        // with a plain chat turn that merely CLAIMS a PDF was produced.
+        if (null === $this->multitaskConfig || !$this->multitaskConfig->isRoutingEnabled($message->getUserId())) {
+            return null;
         }
-        if (1 === count($eligible) && $wantsExport && !$wantsMerge) {
-            $ext = DocumentThumbnailGenerator::extensionOf($eligible[0]);
-            if (DocumentThumbnailGenerator::isOffice($ext)) {
-                return 'document_export';
-            }
+
+        if (1 === preg_match(self::COMPETING_INTENT_PATTERN, $text)) {
+            return null;
+        }
+
+        $wantsMerge = 1 === preg_match(self::MERGE_INTENT_PATTERN, $text);
+        $wantsExport = 1 === preg_match(self::EXPORT_INTENT_PATTERN, $text);
+
+        if (count($eligible) >= 2) {
+            $wantsOnePdf = 1 === preg_match(self::SINGLE_PDF_TARGET_PATTERN, $text);
+
+            return ($wantsMerge || ($wantsExport && $wantsOnePdf)) && $this->officeEngineReadyFor($eligible)
+                ? 'document_combine'
+                : null;
+        }
+
+        if ($wantsExport && !$wantsMerge && DocumentThumbnailGenerator::isOffice(DocumentThumbnailGenerator::extensionOf($eligible[0]))) {
+            // Every single-file export runs through the converter, so without
+            // an office engine the node can only fail.
+            return $this->officeEngineReadyFor($eligible) ? 'document_export' : null;
         }
 
         return null;
+    }
+
+    /**
+     * Whether the office engine is available for the conversions these sources
+     * need. PDF-only merges never touch the converter; a single office source
+     * makes it mandatory ({@see DocumentCombineService} throws
+     * `engine_required` otherwise, and {@see DocumentExportRunner} hides its
+     * capability from the planner for the same reason).
+     *
+     * @param list<File> $sources
+     */
+    private function officeEngineReadyFor(array $sources): bool
+    {
+        $needsEngine = false;
+        foreach ($sources as $source) {
+            if (DocumentThumbnailGenerator::isOffice(DocumentThumbnailGenerator::extensionOf($source))) {
+                $needsEngine = true;
+                break;
+            }
+        }
+
+        return !$needsEngine || true === $this->officeConverter?->isEnabled();
     }
 
     /**

--- a/backend/src/Service/Multitask/ClassificationPlanMapper.php
+++ b/backend/src/Service/Multitask/ClassificationPlanMapper.php
@@ -87,6 +87,8 @@ final class ClassificationPlanMapper
         return match ($intent) {
             'file_analysis' => Capability::FileAnalysis,
             'document_generation' => Capability::DocumentGeneration,
+            'document_export' => Capability::DocumentExport,
+            'document_combine' => Capability::DocumentCombine,
             default => Capability::Chat,
         };
     }

--- a/backend/src/Service/Multitask/Execution/Runner/DocumentCombineRunner.php
+++ b/backend/src/Service/Multitask/Execution/Runner/DocumentCombineRunner.php
@@ -40,6 +40,9 @@ final readonly class DocumentCombineRunner implements TaskRunner
 {
     private const SERVE_PREFIX = '/api/v1/files/uploads/';
 
+    /** Merging is only defined for two or more sources. */
+    private const MIN_SOURCES = 2;
+
     public function __construct(
         private DocumentCombineService $combineService,
         private ConversationFileCatalog $conversationFiles,
@@ -75,12 +78,33 @@ final readonly class DocumentCombineRunner implements TaskRunner
         }
 
         $catalog = $this->conversationFiles->build($context->message, $context->thread);
-        $entries = $this->requestedEntries($node, $context, $catalog);
-        if (count($entries) < 2) {
+
+        // An explicit file list is an instruction, not a hint: if one of the
+        // named files cannot be resolved we say so instead of quietly merging
+        // whatever else is lying around in the conversation.
+        $requested = $this->requestedItems($node, $context);
+        if ([] !== $requested) {
+            $entries = [];
+            foreach ($requested as $item) {
+                $entry = $this->resolveItem($item, $catalog);
+                if (null === $entry) {
+                    return NodeResult::failed('document_combine: "'.self::describeItem($item).'" is not an office or PDF file in this conversation');
+                }
+                $entries[] = $entry;
+            }
+        } else {
             $entries = $this->defaultEntries($catalog);
         }
-        if (count($entries) < 2) {
+
+        if (count($entries) < self::MIN_SOURCES) {
             return NodeResult::failed('document_combine: need at least two office or PDF files to merge');
+        }
+
+        if ([] === $requested) {
+            $this->logger->info('DocumentCombineRunner: no file list given, picked the most recent combinable files', [
+                'node_id' => $node->id,
+                'references' => array_map(static fn (ConversationFile $entry): string => $entry->reference, $entries),
+            ]);
         }
 
         $sources = [];
@@ -119,7 +143,11 @@ final readonly class DocumentCombineRunner implements TaskRunner
         $relative = ltrim($combined->getFilePath(), '/');
 
         return NodeResult::ok(
-            'Combined PDF created: '.$combined->getFileName(),
+            // Name the sources: with no explicit file list the runner picked
+            // them itself, and the user can only verify the result if the
+            // answer says what went into it.
+            'Combined PDF created: '.$combined->getFileName()
+                .' (from '.implode(', ', array_map(static fn (File $file): string => (string) $file->getFileName(), $sources)).')',
             [[
                 'path' => self::SERVE_PREFIX.$relative,
                 'type' => 'document',
@@ -137,11 +165,13 @@ final readonly class DocumentCombineRunner implements TaskRunner
     }
 
     /**
-     * @param list<ConversationFile> $catalog
+     * The files the planner (or an upstream node) named, verbatim. Strings are
+     * `file:ID` / `attached:N` references, arrays are upstream file descriptors
+     * — the shape {@see DocumentExportRunner} accepts for a single file.
      *
-     * @return list<ConversationFile>
+     * @return list<mixed>
      */
-    private function requestedEntries(TaskNode $node, NodeContext $context, array $catalog): array
+    private function requestedItems(TaskNode $node, NodeContext $context): array
     {
         $inputs = $context->resolveInputs($node);
         $requested = $node->params['files'] ?? $inputs['files'] ?? null;
@@ -150,23 +180,64 @@ final readonly class DocumentCombineRunner implements TaskRunner
             $requested = null !== $single ? [$single] : [];
         }
 
-        $entries = [];
-        foreach ($requested as $item) {
-            if (is_string($item) && '' !== trim($item)) {
-                $entry = $this->conversationFiles->findByReference($catalog, $item);
-                if (null !== $entry && self::isCombinable($entry)) {
-                    $entries[] = $entry;
+        return array_values(array_filter(
+            $requested,
+            static fn ($item): bool => !is_string($item) || '' !== trim($item),
+        ));
+    }
+
+    /**
+     * @param list<ConversationFile> $catalog
+     */
+    private function resolveItem(mixed $item, array $catalog): ?ConversationFile
+    {
+        if (is_string($item)) {
+            $entry = $this->conversationFiles->findByReference($catalog, $item);
+
+            return null !== $entry && self::isCombinable($entry) ? $entry : null;
+        }
+
+        if (is_array($item)) {
+            $path = $item['local_path'] ?? $item['path'] ?? null;
+            if (!is_string($path) || '' === trim($path)) {
+                return null;
+            }
+            $relative = $this->conversationFiles->normalizeRelativePath($path);
+            foreach ($catalog as $entry) {
+                if ($entry->relativePath === $relative && self::isCombinable($entry)) {
+                    return $entry;
                 }
             }
         }
 
-        return $entries;
+        return null;
+    }
+
+    private static function describeItem(mixed $item): string
+    {
+        if (is_string($item)) {
+            return $item;
+        }
+        if (is_array($item)) {
+            $path = $item['local_path'] ?? $item['path'] ?? null;
+            if (is_string($path) && '' !== trim($path)) {
+                return basename($path);
+            }
+        }
+
+        return 'unknown file';
     }
 
     /**
-     * Current attachments first (the files the user just handed over), then
-     * other combinable conversation files. Two attached office/PDF files is
-     * the #1694 reproduction.
+     * The files to merge when nobody named any: the attachments of this turn,
+     * which is the #1694 reproduction ("führe beide dateien in eine pdf
+     * zusammen" with two files on the message).
+     *
+     * Capped at {@see MIN_SOURCES}. The catalog carries up to
+     * ConversationFileCatalog::MAX_FILES_PER_CATEGORY thread documents, and
+     * folding every document of a long conversation into the user's PDF is
+     * never what "merge these" meant. Thread files are ordered newest-first, so
+     * the fill-up slice is reversed to merge in chronological order.
      *
      * @param list<ConversationFile> $catalog
      *
@@ -187,7 +258,13 @@ final readonly class DocumentCombineRunner implements TaskRunner
             }
         }
 
-        return count($attached) >= 2 ? $attached : array_merge($attached, $rest);
+        if (count($attached) >= self::MIN_SOURCES) {
+            return $attached;
+        }
+
+        $fill = array_slice($rest, 0, self::MIN_SOURCES - count($attached));
+
+        return array_merge($attached, array_reverse($fill));
     }
 
     private static function isCombinable(ConversationFile $entry): bool
@@ -211,10 +288,16 @@ final readonly class DocumentCombineRunner implements TaskRunner
             return $file instanceof File && $file->getUserId() === $userId ? $file : null;
         }
 
+        // `attached:N` entries are the current message's own attachments, in
+        // marker order, and may not have an id yet. Ownership is re-checked
+        // here so both branches enforce the same rule — DocumentCombineService
+        // filters by user as well, but authorization must not depend on a
+        // guarantee two layers down.
         if (1 === preg_match('/^attached:(\d+)$/', $entry->reference, $m)) {
             $attachments = $this->conversationFiles->attachments($context->message);
+            $file = $attachments[(int) $m[1] - 1] ?? null;
 
-            return $attachments[(int) $m[1] - 1] ?? null;
+            return null !== $file && $file->getUserId() === $userId ? $file : null;
         }
 
         return null;

--- a/backend/src/Service/Multitask/Execution/Runner/DocumentCombineRunner.php
+++ b/backend/src/Service/Multitask/Execution/Runner/DocumentCombineRunner.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Multitask\Execution\Runner;
+
+use App\Entity\File;
+use App\Entity\User;
+use App\Repository\FileRepository;
+use App\Repository\UserRepository;
+use App\Service\File\ConversationFile;
+use App\Service\File\ConversationFileCatalog;
+use App\Service\File\Office\DocumentCombineException;
+use App\Service\File\Office\DocumentCombineService;
+use App\Service\File\Office\DocumentThumbnailGenerator;
+use App\Service\Multitask\Execution\NodeContext;
+use App\Service\Multitask\Execution\NodeResult;
+use App\Service\Multitask\Execution\TaskRunner;
+use App\Service\Multitask\Plan\Capability;
+use App\Service\Multitask\Plan\TaskNode;
+use App\Service\Multitask\Skill\SkillDescriptor;
+use Psr\Log\LoggerInterface;
+
+/**
+ * `document_combine` runner — merges two or more office/PDF files that already
+ * exist in the conversation into one PDF (#1694).
+ *
+ * "führe beide dateien in eine pdf zusammen" used to be forced onto
+ * `analyzefile`: the model claimed a named PDF existed and no file was stored.
+ * This node runs the exact merge the file chip's Combine action runs —
+ * {@see DocumentCombineService} — and picks no model.
+ *
+ * Node contract:
+ *   - params.files / inputs.files  optional list of `file:ID` references
+ *   - params.filename              optional product title (without needing .pdf)
+ *   - output                       one PDF file descriptor + `document_combine`
+ *                                  metadata (source ids and the new file id)
+ */
+final readonly class DocumentCombineRunner implements TaskRunner
+{
+    private const SERVE_PREFIX = '/api/v1/files/uploads/';
+
+    public function __construct(
+        private DocumentCombineService $combineService,
+        private ConversationFileCatalog $conversationFiles,
+        private FileRepository $files,
+        private UserRepository $users,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function supportedCapabilities(): array
+    {
+        return [Capability::DocumentCombine];
+    }
+
+    /**
+     * @return list<SkillDescriptor>
+     */
+    public function describe(): array
+    {
+        return [
+            new SkillDescriptor(
+                Capability::DocumentCombine,
+                'Merge two or more office/PDF files that ALREADY EXIST in this conversation into one PDF. The server concatenates the ORIGINAL files (same merge as the file-chip Combine action) — nothing is re-written. Use it for "merge these into one PDF", "führe beide dateien in eine pdf zusammen", "combine the attachments as PDF". Optional params.files: `file:ID` references (defaults to the files the user attached on this turn). Optional params.filename: the product title. A single existing file exported as PDF is document_export. Creating a NEW document delivered as PDF stays document_generation.',
+                available: fn (): bool => $this->serviceWired(),
+            ),
+        ];
+    }
+
+    public function run(TaskNode $node, NodeContext $context): NodeResult
+    {
+        if (!$this->serviceWired()) {
+            return NodeResult::failed('document_combine: combine service is not available');
+        }
+
+        $catalog = $this->conversationFiles->build($context->message, $context->thread);
+        $entries = $this->requestedEntries($node, $context, $catalog);
+        if (count($entries) < 2) {
+            $entries = $this->defaultEntries($catalog);
+        }
+        if (count($entries) < 2) {
+            return NodeResult::failed('document_combine: need at least two office or PDF files to merge');
+        }
+
+        $sources = [];
+        foreach ($entries as $entry) {
+            $source = $this->loadFile($entry, $context);
+            if (null === $source || null === $source->getId()) {
+                return NodeResult::failed('document_combine: file "'.$entry->displayName.'" is not available');
+            }
+            $sources[] = $source;
+        }
+
+        $userId = (int) ($context->userId ?? $context->message->getUserId());
+        $user = $this->users->find($userId);
+        if (!$user instanceof User) {
+            return NodeResult::failed('document_combine: user not found');
+        }
+
+        $filename = is_string($node->params['filename'] ?? null) ? $node->params['filename'] : null;
+
+        try {
+            $combined = $this->combineService->combineToPdf(
+                $user,
+                array_map(static fn (File $file): int => (int) $file->getId(), $sources),
+                $filename,
+            );
+        } catch (DocumentCombineException $e) {
+            return NodeResult::failed('document_combine: '.$e->getMessage());
+        }
+
+        $this->logger->info('DocumentCombineRunner: combined conversation files to PDF', [
+            'node_id' => $node->id,
+            'source_file_ids' => array_map(static fn (File $file): int => (int) $file->getId(), $sources),
+            'pdf_file_id' => $combined->getId(),
+        ]);
+
+        $relative = ltrim($combined->getFilePath(), '/');
+
+        return NodeResult::ok(
+            'Combined PDF created: '.$combined->getFileName(),
+            [[
+                'path' => self::SERVE_PREFIX.$relative,
+                'type' => 'document',
+                'local_path' => $relative,
+            ]],
+            [
+                'media_type' => 'document',
+                'document_combine' => [
+                    'source_file_ids' => array_map(static fn (File $file): int => (int) $file->getId(), $sources),
+                    'pdf_file_id' => $combined->getId(),
+                    'filename' => $combined->getFileName(),
+                ],
+            ],
+        );
+    }
+
+    /**
+     * @param list<ConversationFile> $catalog
+     *
+     * @return list<ConversationFile>
+     */
+    private function requestedEntries(TaskNode $node, NodeContext $context, array $catalog): array
+    {
+        $inputs = $context->resolveInputs($node);
+        $requested = $node->params['files'] ?? $inputs['files'] ?? null;
+        if (!is_array($requested)) {
+            $single = $node->params['file'] ?? $inputs['file'] ?? null;
+            $requested = null !== $single ? [$single] : [];
+        }
+
+        $entries = [];
+        foreach ($requested as $item) {
+            if (is_string($item) && '' !== trim($item)) {
+                $entry = $this->conversationFiles->findByReference($catalog, $item);
+                if (null !== $entry && self::isCombinable($entry)) {
+                    $entries[] = $entry;
+                }
+            }
+        }
+
+        return $entries;
+    }
+
+    /**
+     * Current attachments first (the files the user just handed over), then
+     * other combinable conversation files. Two attached office/PDF files is
+     * the #1694 reproduction.
+     *
+     * @param list<ConversationFile> $catalog
+     *
+     * @return list<ConversationFile>
+     */
+    private function defaultEntries(array $catalog): array
+    {
+        $attached = [];
+        $rest = [];
+        foreach ($catalog as $entry) {
+            if (!self::isCombinable($entry)) {
+                continue;
+            }
+            if (ConversationFile::ORIGIN_ATTACHED === $entry->origin) {
+                $attached[] = $entry;
+            } else {
+                $rest[] = $entry;
+            }
+        }
+
+        return count($attached) >= 2 ? $attached : array_merge($attached, $rest);
+    }
+
+    private static function isCombinable(ConversationFile $entry): bool
+    {
+        if (ConversationFile::CATEGORY_DOCUMENT !== $entry->category) {
+            return false;
+        }
+
+        $ext = strtolower(pathinfo($entry->relativePath, PATHINFO_EXTENSION));
+
+        return DocumentThumbnailGenerator::isOffice($ext) || DocumentThumbnailGenerator::isPdf($ext);
+    }
+
+    private function loadFile(ConversationFile $entry, NodeContext $context): ?File
+    {
+        $userId = (int) ($context->userId ?? $context->message->getUserId());
+
+        if (null !== $entry->fileId) {
+            $file = $this->files->find($entry->fileId);
+
+            return $file instanceof File && $file->getUserId() === $userId ? $file : null;
+        }
+
+        if (1 === preg_match('/^attached:(\d+)$/', $entry->reference, $m)) {
+            $attachments = $this->conversationFiles->attachments($context->message);
+
+            return $attachments[(int) $m[1] - 1] ?? null;
+        }
+
+        return null;
+    }
+
+    /**
+     * SkillCatalogFactory builds runners without constructors for DB-free
+     * planner-prompt tests; an unwired runner has nothing to offer.
+     */
+    private function serviceWired(): bool
+    {
+        return (new \ReflectionProperty($this, 'combineService'))->isInitialized($this);
+    }
+}

--- a/backend/src/Service/Multitask/Execution/Runner/DocumentExportRunner.php
+++ b/backend/src/Service/Multitask/Execution/Runner/DocumentExportRunner.php
@@ -198,11 +198,13 @@ final readonly class DocumentExportRunner implements TaskRunner
         }
 
         // `attached:N` entries are the current message's own attachments, in
-        // marker order, and may not have an id yet.
+        // marker order, and may not have an id yet. Ownership is re-checked so
+        // both branches enforce the same rule.
         if (1 === preg_match('/^attached:(\d+)$/', $entry->reference, $m)) {
             $attachments = $this->conversationFiles->attachments($context->message);
+            $file = $attachments[(int) $m[1] - 1] ?? null;
 
-            return $attachments[(int) $m[1] - 1] ?? null;
+            return null !== $file && $file->getUserId() === $userId ? $file : null;
         }
 
         return null;

--- a/backend/src/Service/Multitask/Execution/Runner/Text2SoundRunner.php
+++ b/backend/src/Service/Multitask/Execution/Runner/Text2SoundRunner.php
@@ -52,9 +52,10 @@ final readonly class Text2SoundRunner implements TaskRunner
         $text = is_string($text) ? $text : (string) $context->message->getText();
 
         // Strip markdown, <think> blocks, [Memory:ID] badges and other
-        // non-speakable artifacts before TTS (issue #1164) — same treatment
-        // TtsController and StreamController already apply before synthesis.
-        $text = TtsTextSanitizer::sanitize($text);
+        // non-speakable artifacts, then cap at the shared TTS input limit
+        // (issues #1164, #1665). StreamController / WhatsAppService use the
+        // same helper so a long essay does not trip OpenAI's 4096-char max.
+        $text = TtsTextSanitizer::prepareForSynthesis($text);
 
         if ('' === trim($text)) {
             return NodeResult::failed('no text to synthesize');

--- a/backend/src/Service/Multitask/Plan/Capability.php
+++ b/backend/src/Service/Multitask/Plan/Capability.php
@@ -71,6 +71,13 @@ enum Capability: string
      */
     case DocumentExport = 'document_export';
 
+    /**
+     * Merge two or more office/PDF files that already exist in the conversation
+     * into one PDF (DocumentCombineService, no model) — the same merge as the
+     * file chip's Combine action (#1694).
+     */
+    case DocumentCombine = 'document_combine';
+
     /** Calendar event / meeting invite as a downloadable .ics file (CalendarEventService, no model). */
     case CalendarEvent = 'calendar_event';
 
@@ -104,7 +111,7 @@ enum Capability: string
             self::ImageGeneration => 'image',
             self::VideoGeneration => 'video',
             self::Text2Sound => 'audio',
-            self::DocumentGeneration, self::DocumentExport => 'document',
+            self::DocumentGeneration, self::DocumentExport, self::DocumentCombine => 'document',
             self::CalendarEvent => 'document',
             self::EmailMe => 'email',
             self::SaveToFolder => 'folder',

--- a/backend/src/Service/Multitask/TaskPlanExecutor.php
+++ b/backend/src/Service/Multitask/TaskPlanExecutor.php
@@ -56,6 +56,7 @@ final readonly class TaskPlanExecutor
     private const DAG_ONLY_CAPABILITIES = [
         Capability::CalendarEvent,
         Capability::DocumentExport,
+        Capability::DocumentCombine,
         Capability::UrlFetch,
         Capability::McpFetch,
         Capability::EmailSearch,
@@ -233,6 +234,19 @@ final readonly class TaskPlanExecutor
     }
 
     /**
+     * @param array<string, mixed> $classification
+     */
+    private function isDeterministicDocumentFileIntent(array $classification): bool
+    {
+        $intent = $classification['intent'] ?? null;
+        $source = $classification['source'] ?? null;
+
+        return in_array($intent, ['document_combine', 'document_export'], true)
+            && is_string($source)
+            && str_starts_with($source, 'attachment_');
+    }
+
+    /**
      * Decide whether to run the planner and, if so, produce a plan. Returns null
      * to mean "use the single-node legacy path" (deterministic/simple branches).
      *
@@ -262,7 +276,9 @@ final readonly class TaskPlanExecutor
         //     about the steps. A single-intent instruction still collapses to a
         //     one-node plan → legacy path, identical to a normal chat turn.
         $source = $classification['source'] ?? null;
-        if (!in_array($source, ['ai_sorting', 'attachment_document_or_audio', 'saved_task'], true)) {
+        $deterministicFileIntent = $this->isDeterministicDocumentFileIntent($classification);
+        if (!in_array($source, ['ai_sorting', 'attachment_document_or_audio', 'saved_task'], true)
+            && !$deterministicFileIntent) {
             return null;
         }
 
@@ -273,6 +289,13 @@ final readonly class TaskPlanExecutor
         // (planning-doc §3.4 invariant).
         if (!empty($classification['is_widget_mode'])) {
             return null;
+        }
+
+        // Attachment merge/export (#1694 / #1691): the classifier already
+        // decided. Do not send these to the planner or the analyzefile legacy
+        // router — neither produces a real PDF.
+        if ($deterministicFileIntent) {
+            return new TaskPlanResult($this->mapper->toSingleNodePlan($classification), fallback: false);
         }
 
         $authored = $this->authoredSavedTaskPlan($message, $classification);

--- a/backend/src/Service/Multitask/TaskPlanExecutor.php
+++ b/backend/src/Service/Multitask/TaskPlanExecutor.php
@@ -141,11 +141,13 @@ final readonly class TaskPlanExecutor
             // "step failed" box sitting above a correct reply.
             $this->discardPlan($progressCallback);
 
+            $fallbackClassification = $this->legacyFallbackClassification($classification);
+
             return $this->withPlanningUsage(
                 $this->runSingleNode(
-                    fn () => $this->router->routeStream($message, $thread, $this->effectiveClassification($classification), $streamCallback, $progressCallback, $options),
+                    fn () => $this->router->routeStream($message, $thread, $this->effectiveClassification($fallbackClassification), $streamCallback, $progressCallback, $options),
                     $message,
-                    $classification,
+                    $fallbackClassification,
                 ),
                 $plan,
             );
@@ -199,11 +201,13 @@ final readonly class TaskPlanExecutor
         if ($assembled['all_failed']) {
             $this->discardPlan($progressCallback);
 
+            $fallbackClassification = $this->legacyFallbackClassification($classification);
+
             return $this->withPlanningUsage(
                 $this->runSingleNode(
-                    fn () => $this->router->route($message, $thread, $this->effectiveClassification($classification), $progressCallback, $options),
+                    fn () => $this->router->route($message, $thread, $this->effectiveClassification($fallbackClassification), $progressCallback, $options),
                     $message,
-                    $classification,
+                    $fallbackClassification,
                 ),
                 $plan,
             );
@@ -244,6 +248,35 @@ final readonly class TaskPlanExecutor
         return in_array($intent, ['document_combine', 'document_export'], true)
             && is_string($source)
             && str_starts_with($source, 'attachment_');
+    }
+
+    /**
+     * Classification the legacy router should run on after a DAG produced
+     * nothing.
+     *
+     * The deterministic merge/export intents (#1694 / #1691) have no legacy
+     * handler — `InferenceRouter::getHandler()` falls through to `chat`, which
+     * would answer a failed merge (no office engine, missing `pdfunite`, a file
+     * that vanished) with a chat turn that happily CLAIMS the PDF exists: the
+     * exact symptom #1694 was about. Hand the router the attachment
+     * classification these turns had before the merge route existed, so the
+     * user gets a real answer about the attached files instead.
+     *
+     * @param array<string, mixed> $classification
+     *
+     * @return array<string, mixed>
+     */
+    private function legacyFallbackClassification(array $classification): array
+    {
+        if (!$this->isDeterministicDocumentFileIntent($classification)) {
+            return $classification;
+        }
+
+        return array_merge($classification, [
+            'topic' => 'analyzefile',
+            'intent' => 'file_analysis',
+            'source' => 'attachment_document_or_audio',
+        ]);
     }
 
     /**

--- a/backend/src/Service/TtsTextSanitizer.php
+++ b/backend/src/Service/TtsTextSanitizer.php
@@ -10,10 +10,15 @@ namespace App\Service;
  * Strips non-speakable artifacts from AI response text before TTS synthesis.
  * Removes: <think> tags, [Memory:ID] badges, code blocks, markdown formatting, HTML tags.
  *
- * Call TtsTextSanitizer::sanitize($text) BEFORE passing text to AiFacade::synthesize().
+ * Call TtsTextSanitizer::prepareForSynthesis($text) BEFORE passing text to
+ * AiFacade::synthesize() so every caller stays inside provider input limits
+ * (OpenAI TTS rejects more than 4096 characters — #1665).
  */
 final readonly class TtsTextSanitizer
 {
+    /** OpenAI TTS input max is 4096; stay under that for every provider. */
+    public const MAX_SYNTHESIS_CHARS = 4000;
+
     /**
      * Strip non-speakable artifacts from AI response text.
      */
@@ -56,5 +61,26 @@ final readonly class TtsTextSanitizer
         $text = trim($text);
 
         return $text;
+    }
+
+    /**
+     * Cap speakable text at the shared TTS input limit. Multibyte-safe, no
+     * ellipsis — the spoken prefix is the content, not a UI snippet.
+     */
+    public static function truncateForSynthesis(string $text, int $maxLength = self::MAX_SYNTHESIS_CHARS): string
+    {
+        if (mb_strlen($text) <= $maxLength) {
+            return $text;
+        }
+
+        return mb_substr($text, 0, $maxLength);
+    }
+
+    /**
+     * Sanitize then cap — the usual pre-synthesize treatment.
+     */
+    public static function prepareForSynthesis(string $text): string
+    {
+        return self::truncateForSynthesis(self::sanitize($text));
     }
 }

--- a/backend/src/Service/TtsTextSanitizer.php
+++ b/backend/src/Service/TtsTextSanitizer.php
@@ -64,8 +64,19 @@ final readonly class TtsTextSanitizer
     }
 
     /**
+     * How far back the cut may search for a natural end. A fifth of the window
+     * is enough for a sentence in normal prose and still leaves the listener
+     * the bulk of the text.
+     */
+    private const BOUNDARY_SEARCH_RATIO = 0.2;
+
+    /**
      * Cap speakable text at the shared TTS input limit. Multibyte-safe, no
      * ellipsis — the spoken prefix is the content, not a UI snippet.
+     *
+     * Cuts on the last sentence end inside the window, falling back to the last
+     * word break and only then to a hard cut: a voice note that stops mid-word
+     * sounds broken, not shortened.
      */
     public static function truncateForSynthesis(string $text, int $maxLength = self::MAX_SYNTHESIS_CHARS): string
     {
@@ -73,7 +84,23 @@ final readonly class TtsTextSanitizer
             return $text;
         }
 
-        return mb_substr($text, 0, $maxLength);
+        $window = mb_substr($text, 0, $maxLength);
+        $earliestCut = (int) ($maxLength * (1 - self::BOUNDARY_SEARCH_RATIO));
+
+        // Drop the trailing run that carries no sentence end, i.e. cut right
+        // after the last '.', '!', '?' or '…' in the window.
+        $sentence = preg_replace('/[^.!?…]*\z/u', '', $window);
+        if (null !== $sentence && mb_strlen($sentence) >= $earliestCut) {
+            return rtrim($sentence);
+        }
+
+        // No sentence end close enough: drop the last (probably cut off) word.
+        $word = preg_replace('/\s+\S*\z/u', '', $window);
+        if (null !== $word && mb_strlen($word) >= $earliestCut) {
+            return rtrim($word);
+        }
+
+        return $window;
     }
 
     /**

--- a/backend/src/Service/WhatsAppService.php
+++ b/backend/src/Service/WhatsAppService.php
@@ -1324,16 +1324,12 @@ final class WhatsAppService
      */
     private function generateTtsResponse(string $text, int $userId, string $language = 'en'): ?array
     {
-        // Sanitize: strip [Memory:ID], markdown, code blocks, <think> tags
-        $text = TtsTextSanitizer::sanitize($text);
-
-        // Limit text length for TTS (max ~4000 chars for most providers)
-        $maxLength = 4000;
-        if (strlen($text) > $maxLength) {
-            $text = substr($text, 0, $maxLength - 3).'...';
+        $originalLength = mb_strlen($text);
+        $text = TtsTextSanitizer::prepareForSynthesis($text);
+        if (mb_strlen($text) < $originalLength) {
             $this->logger->info('WhatsApp: TTS text truncated', [
-                'original_length' => strlen($text),
-                'max_length' => $maxLength,
+                'original_length' => $originalLength,
+                'max_length' => TtsTextSanitizer::MAX_SYNTHESIS_CHARS,
             ]);
         }
 

--- a/backend/src/Service/WhatsAppService.php
+++ b/backend/src/Service/WhatsAppService.php
@@ -1324,11 +1324,14 @@ final class WhatsAppService
      */
     private function generateTtsResponse(string $text, int $userId, string $language = 'en'): ?array
     {
-        $originalLength = mb_strlen($text);
-        $text = TtsTextSanitizer::prepareForSynthesis($text);
-        if (mb_strlen($text) < $originalLength) {
+        // Compare against the SANITIZED length: stripping markdown shortens
+        // almost every answer, so measuring against the raw text would log a
+        // truncation on each one.
+        $speakable = TtsTextSanitizer::sanitize($text);
+        $text = TtsTextSanitizer::truncateForSynthesis($speakable);
+        if (mb_strlen($text) < mb_strlen($speakable)) {
             $this->logger->info('WhatsApp: TTS text truncated', [
-                'original_length' => $originalLength,
+                'original_length' => mb_strlen($speakable),
                 'max_length' => TtsTextSanitizer::MAX_SYNTHESIS_CHARS,
             ]);
         }
@@ -1336,7 +1339,7 @@ final class WhatsAppService
         try {
             $this->logger->info('WhatsApp: Generating TTS response', [
                 'user_id' => $userId,
-                'text_length' => strlen($text),
+                'text_length' => mb_strlen($text),
                 'language' => $language,
             ]);
 

--- a/backend/tests/Characterization/RoutingCharacterizationTest.php
+++ b/backend/tests/Characterization/RoutingCharacterizationTest.php
@@ -11,6 +11,7 @@ use App\Entity\MessageMeta;
 use App\Entity\Model;
 use App\Repository\ConfigRepository;
 use App\Repository\MessageMetaRepository;
+use App\Service\File\Office\OfficeConverterClient;
 use App\Service\Message\Capability\SystemCapabilityRegistry;
 use App\Service\Message\MessageClassifier;
 use App\Service\Message\MessageSorter;
@@ -18,6 +19,7 @@ use App\Service\Message\Routing\EmbeddingRouterConfig;
 use App\Service\Message\Routing\EmbeddingRouterService;
 use App\Service\Message\Routing\NativeToolRoutingConfig;
 use App\Service\ModelConfigService;
+use App\Service\Multitask\MultitaskRoutingConfig;
 use App\Tests\Characterization\Support\RoutingSnapshot;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\EntityManagerInterface;
@@ -143,6 +145,17 @@ final class RoutingCharacterizationTest extends TestCase
             ['id' => 'attach_export_pdf', 'text' => 'hieraus eine pdf', 'language' => 'de', 'files' => [
                 ['type' => 'xlsx', 'name' => 'Finanzmodell.xlsx'],
             ]],
+            // Neither of these is a merge: the first is a save_to_folder
+            // request, the second plausibly wants one PDF per file. Both stay
+            // on analyzefile so the planner can decide.
+            ['id' => 'attach_save_pdfs_to_folder', 'text' => 'Speichere die PDFs im Ordner Projekte', 'language' => 'de', 'files' => [
+                ['type' => 'pdf', 'name' => 'a.pdf'],
+                ['type' => 'pdf', 'name' => 'b.pdf'],
+            ]],
+            ['id' => 'attach_convert_both_to_pdf', 'text' => 'convert both files to PDF', 'language' => 'en', 'files' => [
+                ['type' => 'xlsx', 'name' => 'sheet.xlsx'],
+                ['type' => 'docx', 'name' => 'text.docx'],
+            ]],
 
             // ---- Sorter-driven: media generation params — migration-risk #3 ----
             ['id' => 'sort_image', 'text' => 'make an image of a cat', 'language' => 'en', 'fastPath' => false, 'sorter' => ['topic' => 'mediamaker', 'language' => 'en', 'media_type' => 'image']],
@@ -260,6 +273,13 @@ final class RoutingCharacterizationTest extends TestCase
             }
         );
 
+        // The attachment merge/export layer only routes when the multi-task
+        // engine can execute it and the office engine can convert (#1694), so
+        // both are on here — otherwise those corpus cases would lock the
+        // fallback instead of the contract.
+        $converter = $this->createMock(OfficeConverterClient::class);
+        $converter->method('isEnabled')->willReturn(true);
+
         $classifier = new MessageClassifier(
             $sorter,
             $metaRepo,
@@ -272,6 +292,8 @@ final class RoutingCharacterizationTest extends TestCase
             new EmbeddingRouterConfig($configRepo),
             $this->disabledNativeToolRouting(),
             new ToolCallingCapability(),
+            officeConverter: $converter,
+            multitaskConfig: new MultitaskRoutingConfig($configRepo),
         );
 
         $message = $this->buildMessage($case);

--- a/backend/tests/Characterization/RoutingCharacterizationTest.php
+++ b/backend/tests/Characterization/RoutingCharacterizationTest.php
@@ -136,6 +136,13 @@ final class RoutingCharacterizationTest extends TestCase
             ['id' => 'attach_pdf', 'text' => 'Summarize this', 'language' => 'en', 'files' => [['type' => 'pdf', 'name' => 'report.pdf']]],
             ['id' => 'attach_docx', 'text' => 'What is in here?', 'language' => 'en', 'files' => [['type' => 'docx', 'name' => 'contract.docx']]],
             ['id' => 'attach_audio_mp3', 'text' => 'Transcribe', 'language' => 'de', 'files' => [['type' => 'mp3', 'name' => 'voice.mp3']]],
+            ['id' => 'attach_merge_pdf', 'text' => 'führe beide dateien in eine pdf zusammen', 'language' => 'de', 'files' => [
+                ['type' => 'xlsx', 'name' => 'Finanzmodell.xlsx'],
+                ['type' => 'pdf', 'name' => 'Finanzmodell.pdf'],
+            ]],
+            ['id' => 'attach_export_pdf', 'text' => 'hieraus eine pdf', 'language' => 'de', 'files' => [
+                ['type' => 'xlsx', 'name' => 'Finanzmodell.xlsx'],
+            ]],
 
             // ---- Sorter-driven: media generation params — migration-risk #3 ----
             ['id' => 'sort_image', 'text' => 'make an image of a cat', 'language' => 'en', 'fastPath' => false, 'sorter' => ['topic' => 'mediamaker', 'language' => 'en', 'media_type' => 'image']],

--- a/backend/tests/Characterization/__snapshots__/routing_classification.json
+++ b/backend/tests/Characterization/__snapshots__/routing_classification.json
@@ -51,6 +51,20 @@
         "source": "attachment_document_or_audio",
         "topic": "analyzefile"
     },
+    "attach_export_pdf": {
+        "intent": "document_export",
+        "language": "de",
+        "skip_sorting": true,
+        "source": "attachment_document_export",
+        "topic": "document_export"
+    },
+    "attach_merge_pdf": {
+        "intent": "document_combine",
+        "language": "de",
+        "skip_sorting": true,
+        "source": "attachment_document_combine",
+        "topic": "document_combine"
+    },
     "attach_pdf": {
         "intent": "file_analysis",
         "language": "en",

--- a/backend/tests/Characterization/__snapshots__/routing_classification.json
+++ b/backend/tests/Characterization/__snapshots__/routing_classification.json
@@ -41,6 +41,16 @@
         "source": "attachment_document_or_audio",
         "topic": "analyzefile"
     },
+    "attach_convert_both_to_pdf": {
+        "intent": "file_analysis",
+        "language": "en",
+        "routing_confidence": 1,
+        "routing_discarded_alternatives": [],
+        "routing_fallback_reason": null,
+        "skip_sorting": true,
+        "source": "attachment_document_or_audio",
+        "topic": "analyzefile"
+    },
     "attach_docx": {
         "intent": "file_analysis",
         "language": "en",
@@ -56,18 +66,28 @@
         "language": "de",
         "skip_sorting": true,
         "source": "attachment_document_export",
-        "topic": "document_export"
+        "topic": "officemaker"
     },
     "attach_merge_pdf": {
         "intent": "document_combine",
         "language": "de",
         "skip_sorting": true,
         "source": "attachment_document_combine",
-        "topic": "document_combine"
+        "topic": "officemaker"
     },
     "attach_pdf": {
         "intent": "file_analysis",
         "language": "en",
+        "routing_confidence": 1,
+        "routing_discarded_alternatives": [],
+        "routing_fallback_reason": null,
+        "skip_sorting": true,
+        "source": "attachment_document_or_audio",
+        "topic": "analyzefile"
+    },
+    "attach_save_pdfs_to_folder": {
+        "intent": "file_analysis",
+        "language": "de",
         "routing_confidence": 1,
         "routing_discarded_alternatives": [],
         "routing_fallback_reason": null,

--- a/backend/tests/Support/SkillCatalogFactory.php
+++ b/backend/tests/Support/SkillCatalogFactory.php
@@ -7,6 +7,7 @@ namespace App\Tests\Support;
 use App\Service\Multitask\Execution\Runner\CalendarEventRunner;
 use App\Service\Multitask\Execution\Runner\ChatRunner;
 use App\Service\Multitask\Execution\Runner\ComposeReplyRunner;
+use App\Service\Multitask\Execution\Runner\DocumentCombineRunner;
 use App\Service\Multitask\Execution\Runner\DocumentExportRunner;
 use App\Service\Multitask\Execution\Runner\DocumentGenerationRunner;
 use App\Service\Multitask\Execution\Runner\EmailMeRunner;
@@ -52,6 +53,7 @@ final class SkillCatalogFactory
         Text2SoundRunner::class,
         DocumentGenerationRunner::class,
         DocumentExportRunner::class,
+        DocumentCombineRunner::class,
         CalendarEventRunner::class,
         EmailMeRunner::class,
         SaveToFolderRunner::class,

--- a/backend/tests/Unit/AI/Health/ModelHealthEvaluatorUnconfiguredTest.php
+++ b/backend/tests/Unit/AI/Health/ModelHealthEvaluatorUnconfiguredTest.php
@@ -64,7 +64,7 @@ final class ModelHealthEvaluatorUnconfiguredTest extends TestCase
             self::model(12, 'whisper', 'ollama'),
         ];
 
-        $run = $this->evaluatorFor($models, ProbeResult::skipped('Ollama is not configured.'), 'ollama')
+        $run = $this->evaluatorFor($models, ProbeResult::skipped('OLLAMA_BASE_URL is not configured.'), 'ollama')
             ->run(dryRun: true);
 
         self::assertCount(3, $run->verdicts);
@@ -72,7 +72,7 @@ final class ModelHealthEvaluatorUnconfiguredTest extends TestCase
             self::assertSame(ModelHealthState::Unconfigured, $verdict->state);
             self::assertFalse($verdict->safeToDisable);
         }
-        self::assertSame(['ollama' => 'Ollama is not configured.'], $run->skippedProviders);
+        self::assertSame(['ollama' => 'OLLAMA_BASE_URL is not configured.'], $run->skippedProviders);
         self::assertSame([], $run->alertsRaised, 'Unconfigured Ollama must not page operators');
     }
 

--- a/backend/tests/Unit/AI/Health/ModelHealthEvaluatorUnconfiguredTest.php
+++ b/backend/tests/Unit/AI/Health/ModelHealthEvaluatorUnconfiguredTest.php
@@ -56,19 +56,41 @@ final class ModelHealthEvaluatorUnconfiguredTest extends TestCase
         self::assertSame([], $run->alertsRaised, 'Unconfigured Triton must not page operators');
     }
 
+    public function testUnconfiguredOllamaDoesNotRaiseAnIncident(): void
+    {
+        $models = [
+            self::model(10, 'llama3.2', 'ollama'),
+            self::model(11, 'bge-m3', 'ollama'),
+            self::model(12, 'whisper', 'ollama'),
+        ];
+
+        $run = $this->evaluatorFor($models, ProbeResult::skipped('Ollama is not configured.'), 'ollama')
+            ->run(dryRun: true);
+
+        self::assertCount(3, $run->verdicts);
+        foreach ($run->verdicts as $verdict) {
+            self::assertSame(ModelHealthState::Unconfigured, $verdict->state);
+            self::assertFalse($verdict->safeToDisable);
+        }
+        self::assertSame(['ollama' => 'Ollama is not configured.'], $run->skippedProviders);
+        self::assertSame([], $run->alertsRaised, 'Unconfigured Ollama must not page operators');
+    }
+
     /**
      * @param list<Model> $catalog
      */
-    private function evaluatorFor(array $catalog, ProbeResult $probeResult): ModelHealthEvaluator
+    private function evaluatorFor(array $catalog, ProbeResult $probeResult, string $service = 'triton'): ModelHealthEvaluator
     {
-        $probe = new class($probeResult) implements ModelListProbeInterface {
-            public function __construct(private readonly ProbeResult $result)
-            {
+        $probe = new class($probeResult, $service) implements ModelListProbeInterface {
+            public function __construct(
+                private readonly ProbeResult $result,
+                private readonly string $service,
+            ) {
             }
 
             public function supports(string $service): bool
             {
-                return 'triton' === mb_strtolower($service);
+                return $this->service === mb_strtolower($service);
             }
 
             public function probe(string $service): ProbeResult
@@ -88,7 +110,7 @@ final class ModelHealthEvaluatorUnconfiguredTest extends TestCase
         }
 
         $models = $this->createStub(ModelRepository::class);
-        $models->method('findAllServices')->willReturn(['triton']);
+        $models->method('findAllServices')->willReturn([$service]);
         $models->method('findByServiceIndexedByProviderId')->willReturn($indexed);
 
         $configRepository = $this->createStub(ConfigRepository::class);
@@ -125,10 +147,10 @@ final class ModelHealthEvaluatorUnconfiguredTest extends TestCase
         );
     }
 
-    private static function model(int $id, string $providerId): Model
+    private static function model(int $id, string $providerId, string $service = 'triton'): Model
     {
         $model = new Model();
-        $model->setService('triton')
+        $model->setService($service)
             ->setProviderId($providerId)
             ->setName($providerId)
             ->setTag('chat');

--- a/backend/tests/Unit/AI/Health/Probe/OllamaModelListProbeTest.php
+++ b/backend/tests/Unit/AI/Health/Probe/OllamaModelListProbeTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\AI\Health\Probe;
+
+use App\AI\Health\Probe\OllamaModelListProbe;
+use App\AI\Provider\OllamaProvider;
+use App\AI\Service\ProviderRegistry;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #1704: an empty OLLAMA_BASE_URL is "not configured", not an outage.
+ * The provider is always registered in DI, so the skip must come from the URL.
+ */
+final class OllamaModelListProbeTest extends TestCase
+{
+    public function testEmptyBaseUrlIsSkippedNotFailed(): void
+    {
+        $result = $this->probeFor(baseUrl: '', available: false)->probe('ollama');
+
+        self::assertTrue($result->isSkipped(), 'An empty OLLAMA_BASE_URL must not be treated as an outage');
+        self::assertFalse($result->isFailed());
+        self::assertStringContainsString('not configured', $result->message);
+    }
+
+    public function testWhitespaceBaseUrlIsSkipped(): void
+    {
+        $result = $this->probeFor(baseUrl: "  \n", available: false)->probe('ollama');
+
+        self::assertTrue($result->isSkipped());
+        self::assertFalse($result->isFailed());
+    }
+
+    public function testMissingProviderIsSkipped(): void
+    {
+        $registry = $this->createStub(ProviderRegistry::class);
+        $registry->method('getUniqueProviders')->willReturn([]);
+
+        $result = (new OllamaModelListProbe($registry, 'http://ollama:11434'))->probe('ollama');
+
+        self::assertTrue($result->isSkipped());
+        self::assertStringContainsString('not configured', $result->message);
+    }
+
+    public function testConfiguredUnreachableOllamaIsFailed(): void
+    {
+        $result = $this->probeFor(baseUrl: 'http://ollama:11434', available: false)->probe('ollama');
+
+        self::assertTrue($result->isFailed(), 'A configured Ollama that does not answer is still an outage');
+        self::assertFalse($result->isSkipped());
+        self::assertStringContainsString('not reachable', $result->message);
+    }
+
+    public function testConfiguredReachableOllamaListsModels(): void
+    {
+        $result = $this->probeFor(baseUrl: 'http://ollama:11434', available: true, models: ['llama3.2', 'bge-m3'])->probe('ollama');
+
+        self::assertTrue($result->isOk());
+        self::assertTrue($result->listingAuthoritative);
+        self::assertSame(['llama3.2', 'bge-m3'], $result->modelIds);
+    }
+
+    public function testSupportsOnlyOllama(): void
+    {
+        $probe = new OllamaModelListProbe($this->createStub(ProviderRegistry::class));
+
+        self::assertTrue($probe->supports('ollama'));
+        self::assertTrue($probe->supports('Ollama'));
+        self::assertFalse($probe->supports('triton'));
+        self::assertFalse($probe->supports('openai'));
+    }
+
+    /**
+     * @param list<string> $models
+     */
+    private function probeFor(string $baseUrl, bool $available, array $models = []): OllamaModelListProbe
+    {
+        $provider = $this->createStub(OllamaProvider::class);
+        $provider->method('isAvailable')->willReturn($available);
+        $provider->method('getAvailableModels')->willReturn($models);
+
+        $registry = $this->createStub(ProviderRegistry::class);
+        $registry->method('getUniqueProviders')->willReturn(['ollama' => $provider]);
+
+        return new OllamaModelListProbe($registry, $baseUrl);
+    }
+}

--- a/backend/tests/Unit/AI/Health/Probe/OllamaModelListProbeTest.php
+++ b/backend/tests/Unit/AI/Health/Probe/OllamaModelListProbeTest.php
@@ -21,7 +21,9 @@ final class OllamaModelListProbeTest extends TestCase
 
         self::assertTrue($result->isSkipped(), 'An empty OLLAMA_BASE_URL must not be treated as an outage');
         self::assertFalse($result->isFailed());
-        self::assertStringContainsString('not configured', $result->message);
+        // Names the variable the operator has to set — the two skip reasons are
+        // reported separately because they need different actions.
+        self::assertSame('OLLAMA_BASE_URL is not configured.', $result->message);
     }
 
     public function testWhitespaceBaseUrlIsSkipped(): void
@@ -40,7 +42,7 @@ final class OllamaModelListProbeTest extends TestCase
         $result = (new OllamaModelListProbe($registry, 'http://ollama:11434'))->probe('ollama');
 
         self::assertTrue($result->isSkipped());
-        self::assertStringContainsString('not configured', $result->message);
+        self::assertSame('Ollama is not registered in this installation.', $result->message);
     }
 
     public function testConfiguredUnreachableOllamaIsFailed(): void

--- a/backend/tests/Unit/MessageClassifierTest.php
+++ b/backend/tests/Unit/MessageClassifierTest.php
@@ -387,6 +387,56 @@ class MessageClassifierTest extends TestCase
         $this->assertTrue($result['skip_sorting']);
     }
 
+    public function testMergeAttachmentsIntoPdfRoutesToDocumentCombine(): void
+    {
+        $message = $this->createMock(Message::class);
+        $message->method('getId')->willReturn(483);
+        $message->method('getUserId')->willReturn(10);
+        $message->method('getText')->willReturn('führe beide dateien in eine pdf zusammen');
+        $message->method('getLanguage')->willReturn('de');
+
+        $xlsx = $this->createMock(\App\Entity\File::class);
+        $xlsx->method('getFileType')->willReturn('xlsx');
+        $xlsx->method('getFileName')->willReturn('Finanzmodell_Pro_Forma_Forecast.xlsx');
+        $pdf = $this->createMock(\App\Entity\File::class);
+        $pdf->method('getFileType')->willReturn('pdf');
+        $pdf->method('getFileName')->willReturn('Finanzmodell_Pro_Forma_Forecast.pdf');
+        $message->method('getFiles')->willReturn(new \Doctrine\Common\Collections\ArrayCollection([$xlsx, $pdf]));
+
+        $this->messageMetaRepository->method('findOneBy')->willReturn(null);
+        $this->messageSorter->expects($this->never())->method('classify');
+
+        $result = $this->service->classify($message);
+
+        $this->assertSame('document_combine', $result['topic']);
+        $this->assertSame('document_combine', $result['intent']);
+        $this->assertSame('attachment_document_combine', $result['source']);
+        $this->assertTrue($result['skip_sorting']);
+    }
+
+    public function testExportSingleAttachmentAsPdfRoutesToDocumentExport(): void
+    {
+        $message = $this->createMock(Message::class);
+        $message->method('getId')->willReturn(481);
+        $message->method('getUserId')->willReturn(10);
+        $message->method('getText')->willReturn('hieraus eine pdf');
+        $message->method('getLanguage')->willReturn('de');
+
+        $xlsx = $this->createMock(\App\Entity\File::class);
+        $xlsx->method('getFileType')->willReturn('xlsx');
+        $xlsx->method('getFileName')->willReturn('Finanzmodell.xlsx');
+        $message->method('getFiles')->willReturn(new \Doctrine\Common\Collections\ArrayCollection([$xlsx]));
+
+        $this->messageMetaRepository->method('findOneBy')->willReturn(null);
+        $this->messageSorter->expects($this->never())->method('classify');
+
+        $result = $this->service->classify($message);
+
+        $this->assertSame('document_export', $result['topic']);
+        $this->assertSame('document_export', $result['intent']);
+        $this->assertSame('attachment_document_export', $result['source']);
+    }
+
     public function testAudioAttachmentForcesAnalyzefileRoute(): void
     {
         $message = $this->createMock(Message::class);

--- a/backend/tests/Unit/MessageClassifierTest.php
+++ b/backend/tests/Unit/MessageClassifierTest.php
@@ -3,6 +3,7 @@
 namespace App\Tests\Unit;
 
 use App\AI\ToolCalling\ToolCallingCapability;
+use App\Entity\File;
 use App\Entity\Message;
 use App\Entity\MessageMeta;
 use App\Repository\ConfigRepository;
@@ -16,7 +17,9 @@ use App\Service\Message\Routing\EmbeddingRouterMatch;
 use App\Service\Message\Routing\EmbeddingRouterService;
 use App\Service\Message\Routing\NativeToolRoutingConfig;
 use App\Service\ModelConfigService;
+use App\Service\Multitask\MultitaskRoutingConfig;
 use App\Service\SelfAware\SelfAwareConfig;
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -184,7 +187,7 @@ class MessageClassifierTest extends TestCase
         $message->method('getFileText')->willReturn('');
         $message->method('getFile')->willReturn(0);
         $message->method('getFileType')->willReturn('');
-        $message->method('getFiles')->willReturn(new \Doctrine\Common\Collections\ArrayCollection());
+        $message->method('getFiles')->willReturn(new ArrayCollection());
 
         $this->messageMetaRepository->method('findOneBy')->willReturn(null);
 
@@ -343,9 +346,9 @@ class MessageClassifierTest extends TestCase
         $message->method('getFile')->willReturn(0);
 
         // Mock that the message has files (images)
-        $file = $this->createMock(\App\Entity\File::class);
+        $file = $this->createMock(File::class);
         $file->method('getFileMime')->willReturn('image/png');
-        $files = new \Doctrine\Common\Collections\ArrayCollection([$file]);
+        $files = new ArrayCollection([$file]);
         $message->method('getFiles')->willReturn($files);
 
         $this->messageMetaRepository->method('findOneBy')->willReturn(null);
@@ -369,10 +372,10 @@ class MessageClassifierTest extends TestCase
         $message->method('getText')->willReturn('Summarize this');
         $message->method('getLanguage')->willReturn('en');
 
-        $file = $this->createMock(\App\Entity\File::class);
+        $file = $this->createMock(File::class);
         $file->method('getFileType')->willReturn('pdf');
         $file->method('getFileName')->willReturn('report.pdf');
-        $files = new \Doctrine\Common\Collections\ArrayCollection([$file]);
+        $files = new ArrayCollection([$file]);
         $message->method('getFiles')->willReturn($files);
 
         $this->messageMetaRepository->method('findOneBy')->willReturn(null);
@@ -389,26 +392,12 @@ class MessageClassifierTest extends TestCase
 
     public function testMergeAttachmentsIntoPdfRoutesToDocumentCombine(): void
     {
-        $message = $this->createMock(Message::class);
-        $message->method('getId')->willReturn(483);
-        $message->method('getUserId')->willReturn(10);
-        $message->method('getText')->willReturn('führe beide dateien in eine pdf zusammen');
-        $message->method('getLanguage')->willReturn('de');
+        $message = $this->attachmentMessage(483, 'führe beide dateien in eine pdf zusammen', ['xlsx', 'pdf']);
 
-        $xlsx = $this->createMock(\App\Entity\File::class);
-        $xlsx->method('getFileType')->willReturn('xlsx');
-        $xlsx->method('getFileName')->willReturn('Finanzmodell_Pro_Forma_Forecast.xlsx');
-        $pdf = $this->createMock(\App\Entity\File::class);
-        $pdf->method('getFileType')->willReturn('pdf');
-        $pdf->method('getFileName')->willReturn('Finanzmodell_Pro_Forma_Forecast.pdf');
-        $message->method('getFiles')->willReturn(new \Doctrine\Common\Collections\ArrayCollection([$xlsx, $pdf]));
+        $result = $this->classifierForAttachmentRouting()->classify($message);
 
-        $this->messageMetaRepository->method('findOneBy')->willReturn(null);
-        $this->messageSorter->expects($this->never())->method('classify');
-
-        $result = $this->service->classify($message);
-
-        $this->assertSame('document_combine', $result['topic']);
+        // BTOPIC stays a real prompt topic; the capability comes from the intent.
+        $this->assertSame('officemaker', $result['topic']);
         $this->assertSame('document_combine', $result['intent']);
         $this->assertSame('attachment_document_combine', $result['source']);
         $this->assertTrue($result['skip_sorting']);
@@ -416,25 +405,102 @@ class MessageClassifierTest extends TestCase
 
     public function testExportSingleAttachmentAsPdfRoutesToDocumentExport(): void
     {
-        $message = $this->createMock(Message::class);
-        $message->method('getId')->willReturn(481);
-        $message->method('getUserId')->willReturn(10);
-        $message->method('getText')->willReturn('hieraus eine pdf');
-        $message->method('getLanguage')->willReturn('de');
+        $message = $this->attachmentMessage(481, 'hieraus eine pdf', ['xlsx']);
 
-        $xlsx = $this->createMock(\App\Entity\File::class);
-        $xlsx->method('getFileType')->willReturn('xlsx');
-        $xlsx->method('getFileName')->willReturn('Finanzmodell.xlsx');
-        $message->method('getFiles')->willReturn(new \Doctrine\Common\Collections\ArrayCollection([$xlsx]));
+        $result = $this->classifierForAttachmentRouting()->classify($message);
 
-        $this->messageMetaRepository->method('findOneBy')->willReturn(null);
-        $this->messageSorter->expects($this->never())->method('classify');
-
-        $result = $this->service->classify($message);
-
-        $this->assertSame('document_export', $result['topic']);
+        $this->assertSame('officemaker', $result['topic']);
         $this->assertSame('document_export', $result['intent']);
         $this->assertSame('attachment_document_export', $result['source']);
+    }
+
+    /**
+     * "Save these PDFs to folder X" is a save_to_folder request. The old
+     * `speichern.{0,40}pdf` pattern read it as an export and merged the
+     * attachments instead.
+     */
+    public function testSavingAttachedPdfsToAFolderIsNotAMerge(): void
+    {
+        $message = $this->attachmentMessage(484, 'Speichere die PDFs im Ordner Projekte', ['pdf', 'pdf']);
+
+        $result = $this->classifierForAttachmentRouting()->classify($message);
+
+        $this->assertSame('analyzefile', $result['topic']);
+        $this->assertSame('file_analysis', $result['intent']);
+    }
+
+    /**
+     * Converting two files "to PDF" plausibly means two PDFs. Without an
+     * explicit merge verb or a single-file target the planner decides.
+     */
+    public function testConvertingTwoAttachmentsToPdfIsNotAMerge(): void
+    {
+        $message = $this->attachmentMessage(485, 'convert both files to PDF', ['xlsx', 'docx']);
+
+        $result = $this->classifierForAttachmentRouting()->classify($message);
+
+        $this->assertSame('analyzefile', $result['topic']);
+        $this->assertSame('file_analysis', $result['intent']);
+    }
+
+    public function testExportPhrasingWithAnExplicitSingleTargetStillMerges(): void
+    {
+        $message = $this->attachmentMessage(486, 'convert both files into one pdf', ['xlsx', 'docx']);
+
+        $result = $this->classifierForAttachmentRouting()->classify($message);
+
+        $this->assertSame('document_combine', $result['intent']);
+    }
+
+    /**
+     * The deterministic route skips the planner, so a second intent in the same
+     * turn would be lost (#1192). Compound requests stay with the planner.
+     */
+    public function testMergeCombinedWithAnotherIntentGoesToThePlanner(): void
+    {
+        $message = $this->attachmentMessage(487, 'führe beide dateien in eine pdf zusammen und lies es vor', ['xlsx', 'pdf']);
+
+        $result = $this->classifierForAttachmentRouting()->classify($message);
+
+        $this->assertSame('analyzefile', $result['topic']);
+        $this->assertSame('attachment_document_or_audio', $result['source']);
+    }
+
+    public function testMergeIsNotRoutedWithoutTheOfficeEngine(): void
+    {
+        $message = $this->attachmentMessage(488, 'führe beide dateien in eine pdf zusammen', ['xlsx', 'pdf']);
+
+        $result = $this->classifierForAttachmentRouting(officeEngineOn: false)->classify($message);
+
+        $this->assertSame('analyzefile', $result['topic']);
+        $this->assertSame('file_analysis', $result['intent']);
+    }
+
+    /**
+     * Two PDFs need no converter, so an install without the office engine can
+     * still merge them.
+     */
+    public function testMergingTwoPdfsNeedsNoOfficeEngine(): void
+    {
+        $message = $this->attachmentMessage(489, 'merge these two files', ['pdf', 'pdf']);
+
+        $result = $this->classifierForAttachmentRouting(officeEngineOn: false)->classify($message);
+
+        $this->assertSame('document_combine', $result['intent']);
+    }
+
+    /**
+     * Without the multi-task engine no runner can produce the PDF and the
+     * legacy router would answer with a chat turn that only claims it did.
+     */
+    public function testMergeIsNotRoutedWhenMultitaskRoutingIsDisabled(): void
+    {
+        $message = $this->attachmentMessage(490, 'führe beide dateien in eine pdf zusammen', ['xlsx', 'pdf']);
+
+        $result = $this->classifierForAttachmentRouting(multitaskOn: false)->classify($message);
+
+        $this->assertSame('analyzefile', $result['topic']);
+        $this->assertSame('file_analysis', $result['intent']);
     }
 
     public function testAudioAttachmentForcesAnalyzefileRoute(): void
@@ -445,10 +511,10 @@ class MessageClassifierTest extends TestCase
         $message->method('getText')->willReturn('Transcribe');
         $message->method('getLanguage')->willReturn('de');
 
-        $file = $this->createMock(\App\Entity\File::class);
+        $file = $this->createMock(File::class);
         $file->method('getFileType')->willReturn('mp3');
         $file->method('getFileName')->willReturn('voice.mp3');
-        $files = new \Doctrine\Common\Collections\ArrayCollection([$file]);
+        $files = new ArrayCollection([$file]);
         $message->method('getFiles')->willReturn($files);
 
         $this->messageMetaRepository->method('findOneBy')->willReturn(null);
@@ -474,10 +540,10 @@ class MessageClassifierTest extends TestCase
         $message->method('getText')->willReturn('What is in this clip?');
         $message->method('getLanguage')->willReturn('en');
 
-        $file = $this->createMock(\App\Entity\File::class);
+        $file = $this->createMock(File::class);
         $file->method('getFileType')->willReturn('mp4');
         $file->method('getFileName')->willReturn('clip.mp4');
-        $files = new \Doctrine\Common\Collections\ArrayCollection([$file]);
+        $files = new ArrayCollection([$file]);
         $message->method('getFiles')->willReturn($files);
 
         $this->messageMetaRepository->method('findOneBy')->willReturn(null);
@@ -506,10 +572,10 @@ class MessageClassifierTest extends TestCase
         $message->method('getText')->willReturn('fasse zusammen');
         $message->method('getLanguage')->willReturn('de');
 
-        $file = $this->createMock(\App\Entity\File::class);
+        $file = $this->createMock(File::class);
         $file->method('getFileType')->willReturn('audio'); // generic kind, not 'mp3'
         $file->method('getFileName')->willReturn('tts_123.mp3');
-        $files = new \Doctrine\Common\Collections\ArrayCollection([$file]);
+        $files = new ArrayCollection([$file]);
         $message->method('getFiles')->willReturn($files);
 
         $this->messageMetaRepository->method('findOneBy')->willReturn(null);
@@ -536,10 +602,10 @@ class MessageClassifierTest extends TestCase
         $message->method('getText')->willReturn('was steht drin');
         $message->method('getLanguage')->willReturn('de');
 
-        $file = $this->createMock(\App\Entity\File::class);
+        $file = $this->createMock(File::class);
         $file->method('getFileType')->willReturn('document');
         $file->method('getFileName')->willReturn('generated-doc'); // no extension
-        $files = new \Doctrine\Common\Collections\ArrayCollection([$file]);
+        $files = new ArrayCollection([$file]);
         $message->method('getFiles')->willReturn($files);
 
         $this->messageMetaRepository->method('findOneBy')->willReturn(null);
@@ -597,7 +663,7 @@ class MessageClassifierTest extends TestCase
         $message->method('getText')->willReturn('Hello, how are you today?');
         $message->method('getLanguage')->willReturn('en');
         $message->method('getFile')->willReturn(0);
-        $message->method('getFiles')->willReturn(new \Doctrine\Common\Collections\ArrayCollection());
+        $message->method('getFiles')->willReturn(new ArrayCollection());
 
         $result = $classifier->classify($message);
 
@@ -644,7 +710,7 @@ class MessageClassifierTest extends TestCase
         $message->method('getText')->willReturn('Please draw a sunset over a mountain.');
         $message->method('getLanguage')->willReturn('en');
         $message->method('getFile')->willReturn(0);
-        $message->method('getFiles')->willReturn(new \Doctrine\Common\Collections\ArrayCollection());
+        $message->method('getFiles')->willReturn(new ArrayCollection());
         $message->method('getDateTime')->willReturn('20250116120000');
         $message->method('getFilePath')->willReturn('');
         $message->method('getTopic')->willReturn('');
@@ -673,7 +739,7 @@ class MessageClassifierTest extends TestCase
         $message->method('getTopic')->willReturn('');
         $message->method('getFileText')->willReturn('');
         $message->method('getFile')->willReturn(0);
-        $message->method('getFiles')->willReturn(new \Doctrine\Common\Collections\ArrayCollection());
+        $message->method('getFiles')->willReturn(new ArrayCollection());
 
         $this->messageMetaRepository->method('findOneBy')->willReturn(null);
 
@@ -706,7 +772,7 @@ class MessageClassifierTest extends TestCase
         $message->method('getTopic')->willReturn('');
         $message->method('getFileText')->willReturn('');
         $message->method('getFile')->willReturn(0);
-        $message->method('getFiles')->willReturn(new \Doctrine\Common\Collections\ArrayCollection());
+        $message->method('getFiles')->willReturn(new ArrayCollection());
 
         $this->messageMetaRepository->method('findOneBy')->willReturn(null);
 
@@ -815,7 +881,7 @@ class MessageClassifierTest extends TestCase
         $message->method('getText')->willReturn($text);
         $message->method('getLanguage')->willReturn('de');
         $message->method('getFile')->willReturn(0);
-        $message->method('getFiles')->willReturn(new \Doctrine\Common\Collections\ArrayCollection());
+        $message->method('getFiles')->willReturn(new ArrayCollection());
         $message->method('getDateTime')->willReturn('20260518120000');
         $message->method('getFilePath')->willReturn('');
         $message->method('getTopic')->willReturn('');
@@ -888,7 +954,7 @@ class MessageClassifierTest extends TestCase
         $message->method('getText')->willReturn($text);
         $message->method('getLanguage')->willReturn($lang);
         $message->method('getFile')->willReturn(0);
-        $message->method('getFiles')->willReturn(new \Doctrine\Common\Collections\ArrayCollection());
+        $message->method('getFiles')->willReturn(new ArrayCollection());
         $message->method('getDateTime')->willReturn('20260518120000');
         $message->method('getFilePath')->willReturn('');
         $message->method('getTopic')->willReturn('');
@@ -964,7 +1030,7 @@ class MessageClassifierTest extends TestCase
         $message->method('getText')->willReturn($text);
         $message->method('getLanguage')->willReturn($lang);
         $message->method('getFile')->willReturn(0);
-        $message->method('getFiles')->willReturn(new \Doctrine\Common\Collections\ArrayCollection());
+        $message->method('getFiles')->willReturn(new ArrayCollection());
         $message->method('getDateTime')->willReturn('20260518120000');
         $message->method('getFilePath')->willReturn('');
         $message->method('getTopic')->willReturn('');
@@ -1012,7 +1078,7 @@ class MessageClassifierTest extends TestCase
         $message->method('getText')->willReturn($text);
         $message->method('getLanguage')->willReturn('de');
         $message->method('getFile')->willReturn(0);
-        $message->method('getFiles')->willReturn(new \Doctrine\Common\Collections\ArrayCollection());
+        $message->method('getFiles')->willReturn(new ArrayCollection());
         $message->method('getDateTime')->willReturn('20260518120000');
         $message->method('getFilePath')->willReturn('');
         $message->method('getTopic')->willReturn('');
@@ -1081,7 +1147,7 @@ class MessageClassifierTest extends TestCase
         $message->method('getText')->willReturn($text);
         $message->method('getLanguage')->willReturn('de');
         $message->method('getFile')->willReturn(0);
-        $message->method('getFiles')->willReturn(new \Doctrine\Common\Collections\ArrayCollection());
+        $message->method('getFiles')->willReturn(new ArrayCollection());
         $message->method('getDateTime')->willReturn('20260518120000');
         $message->method('getFilePath')->willReturn('');
         $message->method('getTopic')->willReturn('');
@@ -1139,7 +1205,7 @@ class MessageClassifierTest extends TestCase
         $message->method('getText')->willReturn('Kannst du den Titel bitte fett machen');
         $message->method('getLanguage')->willReturn('de');
         $message->method('getFile')->willReturn(0);
-        $message->method('getFiles')->willReturn(new \Doctrine\Common\Collections\ArrayCollection());
+        $message->method('getFiles')->willReturn(new ArrayCollection());
         $message->method('getDateTime')->willReturn('20260518120000');
         $message->method('getFilePath')->willReturn('');
         $message->method('getTopic')->willReturn('');
@@ -1195,7 +1261,7 @@ class MessageClassifierTest extends TestCase
         $message->method('getText')->willReturn('Thanks, that helps a lot!');
         $message->method('getLanguage')->willReturn('en');
         $message->method('getFile')->willReturn(0);
-        $message->method('getFiles')->willReturn(new \Doctrine\Common\Collections\ArrayCollection());
+        $message->method('getFiles')->willReturn(new ArrayCollection());
 
         $result = $classifier->classify($message, [$previousReply]);
 
@@ -1250,7 +1316,7 @@ class MessageClassifierTest extends TestCase
         $message->method('getText')->willReturn('Kannst du den Titel in der Datei jetzt zentrieren');
         $message->method('getLanguage')->willReturn('de');
         $message->method('getFile')->willReturn(0);
-        $message->method('getFiles')->willReturn(new \Doctrine\Common\Collections\ArrayCollection());
+        $message->method('getFiles')->willReturn(new ArrayCollection());
         $message->method('getDateTime')->willReturn('20260518120000');
         $message->method('getFilePath')->willReturn('');
         $message->method('getTopic')->willReturn('');
@@ -1311,7 +1377,7 @@ class MessageClassifierTest extends TestCase
         $message->method('getText')->willReturn('Super, danke dir vielmals');
         $message->method('getLanguage')->willReturn('de');
         $message->method('getFile')->willReturn(0);
-        $message->method('getFiles')->willReturn(new \Doctrine\Common\Collections\ArrayCollection());
+        $message->method('getFiles')->willReturn(new ArrayCollection());
 
         $result = $classifier->classify($message, [$fileTurn, $interleavedReply]);
 
@@ -1568,7 +1634,7 @@ class MessageClassifierTest extends TestCase
         $message->method('getText')->willReturn('xyzzy plugh');
         $message->method('getLanguage')->willReturn('NN');
         $message->method('getFile')->willReturn(0);
-        $message->method('getFiles')->willReturn(new \Doctrine\Common\Collections\ArrayCollection());
+        $message->method('getFiles')->willReturn(new ArrayCollection());
         $message->method('getDateTime')->willReturn('20260827120000');
         $message->method('getFilePath')->willReturn('');
         $message->method('getTopic')->willReturn('');
@@ -1603,7 +1669,7 @@ class MessageClassifierTest extends TestCase
         $message->method('getText')->willReturn('xyzzy plugh');
         $message->method('getLanguage')->willReturn('NN');
         $message->method('getFile')->willReturn(0);
-        $message->method('getFiles')->willReturn(new \Doctrine\Common\Collections\ArrayCollection());
+        $message->method('getFiles')->willReturn(new ArrayCollection());
         $message->method('getDateTime')->willReturn('20260827120000');
         $message->method('getFilePath')->willReturn('');
         $message->method('getTopic')->willReturn('');
@@ -2012,6 +2078,68 @@ class MessageClassifierTest extends TestCase
         );
     }
 
+    /**
+     * Classifier wired for the attachment merge/export layer: it only routes
+     * when the multi-task engine can execute the node and — for office sources
+     * — the converter is up.
+     */
+    private function classifierForAttachmentRouting(bool $officeEngineOn = true, bool $multitaskOn = true): MessageClassifier
+    {
+        $configRepo = $this->createMock(ConfigRepository::class);
+        $configRepo->method('getValue')->willReturnCallback(
+            static fn (int $owner, string $group, string $setting): string => MultitaskRoutingConfig::CONFIG_GROUP === $group
+                && MultitaskRoutingConfig::KEY_ROUTING_ENABLED === $setting
+                    ? ($multitaskOn ? '1' : '0')
+                    : '0'
+        );
+
+        $converter = $this->createMock(OfficeConverterClient::class);
+        $converter->method('isEnabled')->willReturn($officeEngineOn);
+
+        $this->messageMetaRepository->method('findOneBy')->willReturn(null);
+        $this->messageSorter->expects($this->never())->method('classify');
+
+        return new MessageClassifier(
+            $this->messageSorter,
+            $this->messageMetaRepository,
+            $this->modelConfigService,
+            $configRepo,
+            $this->em,
+            $this->logger,
+            new SystemCapabilityRegistry(),
+            $this->createMock(EmbeddingRouterService::class),
+            new EmbeddingRouterConfig($configRepo),
+            $this->disabledNativeToolRouting(),
+            new ToolCallingCapability(),
+            officeConverter: $converter,
+            multitaskConfig: new MultitaskRoutingConfig($configRepo),
+        );
+    }
+
+    /**
+     * @param list<string> $extensions
+     */
+    private function attachmentMessage(int $id, string $text, array $extensions): Message&MockObject
+    {
+        $files = [];
+        foreach ($extensions as $index => $extension) {
+            $file = $this->createMock(File::class);
+            $file->method('getFileType')->willReturn($extension);
+            $file->method('getFileName')->willReturn('Finanzmodell_'.$index.'.'.$extension);
+            $files[] = $file;
+        }
+
+        $message = $this->createMock(Message::class);
+        $message->method('getId')->willReturn($id);
+        $message->method('getUserId')->willReturn(10);
+        $message->method('getText')->willReturn($text);
+        $message->method('getLanguage')->willReturn('de');
+        $message->method('getFile')->willReturn(0);
+        $message->method('getFiles')->willReturn(new ArrayCollection($files));
+
+        return $message;
+    }
+
     private function plainMessage(int $id, string $text): Message&MockObject
     {
         $message = $this->createMock(Message::class);
@@ -2020,7 +2148,7 @@ class MessageClassifierTest extends TestCase
         $message->method('getText')->willReturn($text);
         $message->method('getLanguage')->willReturn('de');
         $message->method('getFile')->willReturn(0);
-        $message->method('getFiles')->willReturn(new \Doctrine\Common\Collections\ArrayCollection());
+        $message->method('getFiles')->willReturn(new ArrayCollection());
         $message->method('getDateTime')->willReturn('20260827120000');
         $message->method('getFilePath')->willReturn('');
         $message->method('getTopic')->willReturn('');

--- a/backend/tests/Unit/Service/File/Office/DocumentCombineServiceTest.php
+++ b/backend/tests/Unit/Service/File/Office/DocumentCombineServiceTest.php
@@ -53,6 +53,22 @@ final class DocumentCombineServiceTest extends TestCase
         }
     }
 
+    public function testResolvedDisplayNameUsesFirstSourceStemWhenFilenameMissing(): void
+    {
+        $xlsx = $this->file(1, 'Finanzmodell_Pro_Forma_Forecast.xlsx', 'xlsx');
+        $pdf = $this->file(2, 'Finanzmodell_Pro_Forma_Forecast.pdf', 'pdf');
+
+        self::assertSame(
+            'Finanzmodell_Pro_Forma_Forecast_combined.pdf',
+            DocumentCombineService::resolvedDisplayName(null, [$xlsx, $pdf]),
+        );
+        self::assertSame(
+            'Quarterly_Report.pdf',
+            DocumentCombineService::resolvedDisplayName('Quarterly_Report.pdf', [$xlsx, $pdf]),
+        );
+        self::assertSame('combined.pdf', DocumentCombineService::resolvedDisplayName(null, []));
+    }
+
     public function testRejectsUnsupportedTypes(): void
     {
         $png = $this->file(1, 'pic.png', 'png');

--- a/backend/tests/Unit/Service/File/Office/OfficePdfRoutingDecoratorTest.php
+++ b/backend/tests/Unit/Service/File/Office/OfficePdfRoutingDecoratorTest.php
@@ -68,7 +68,8 @@ PROMPT;
         self::assertStringContainsString('Creating a real PDF is supported', $out);
         // #1691: an existing file becomes a PDF through document_export, never by re-authoring it.
         self::assertStringContainsString('single `document_export` node — NOT extract_text + document_generation', $out);
-        self::assertStringContainsString('document_generation, document_export, calendar_event), surfaced through `compose_reply`.', $out);
+        self::assertStringContainsString('document_generation, document_export, document_combine, calendar_event), surfaced through `compose_reply`.', $out);
+        self::assertStringContainsString('single `document_combine` node', $out);
         self::assertStringContainsString('Office document (XLSX, DOCX, PPTX, CSV, PDF)', $out);
         self::assertStringNotContainsString('e.g. a real', $out);
         self::assertStringContainsString('OFFICE_PDF_ROUTING', $out);

--- a/backend/tests/Unit/Service/Multitask/ClassificationPlanMapperTest.php
+++ b/backend/tests/Unit/Service/Multitask/ClassificationPlanMapperTest.php
@@ -95,6 +95,8 @@ final class ClassificationPlanMapperTest extends TestCase
         yield 'audio' => [['intent' => 'image_generation', 'media_type' => 'audio'], Capability::Text2Sound];
         yield 'file analysis' => [['intent' => 'file_analysis'], Capability::FileAnalysis];
         yield 'document generation' => [['intent' => 'document_generation'], Capability::DocumentGeneration];
+        yield 'document export' => [['intent' => 'document_export'], Capability::DocumentExport];
+        yield 'document combine' => [['intent' => 'document_combine'], Capability::DocumentCombine];
         yield 'unknown intent falls back to chat' => [['intent' => 'mystery'], Capability::Chat];
     }
 

--- a/backend/tests/Unit/Service/Multitask/Execution/Runner/DocumentCombineRunnerTest.php
+++ b/backend/tests/Unit/Service/Multitask/Execution/Runner/DocumentCombineRunnerTest.php
@@ -70,7 +70,10 @@ final class DocumentCombineRunnerTest extends TestCase
             ->run(new TaskNode('n1', Capability::DocumentCombine), $this->context($message));
 
         self::assertTrue($result->isSuccessful());
-        self::assertSame('Combined PDF created: Finanzmodell_combined.pdf', $result->text);
+        self::assertSame(
+            'Combined PDF created: Finanzmodell_combined.pdf (from Finanzmodell.xlsx, Finanzmodell.pdf)',
+            $result->text,
+        );
         self::assertSame([[
             'path' => '/api/v1/files/uploads/u/2026/09/Finanzmodell_combined.pdf',
             'type' => 'document',
@@ -92,6 +95,91 @@ final class DocumentCombineRunnerTest extends TestCase
 
         self::assertFalse($result->isSuccessful());
         self::assertStringContainsString('at least two', (string) $result->error);
+    }
+
+    /**
+     * A named file that the catalog does not offer used to leave a too-short
+     * list, which fell through to the defaults — merging files the user never
+     * asked for. An explicit list is an instruction, so it fails loudly.
+     */
+    public function testNamingAFileTheConversationDoesNotHaveFailsInsteadOfMergingOthers(): void
+    {
+        $first = $this->file(101, 'a.pdf');
+        $second = $this->file(102, 'b.pdf');
+        $message = (new Message())->setUserId(7)->setDirection('IN')
+            ->setText('merge them')
+            ->addFile($first)
+            ->addFile($second);
+
+        $combine = $this->createMock(DocumentCombineService::class);
+        $combine->expects(self::never())->method('combineToPdf');
+
+        $node = new TaskNode('n1', Capability::DocumentCombine, params: ['files' => ['file:101', 'file:999']]);
+        $result = $this->runner($combine, $this->repository($first, $second), $this->users())
+            ->run($node, $this->context($message));
+
+        self::assertFalse($result->isSuccessful());
+        self::assertStringContainsString('file:999', (string) $result->error);
+    }
+
+    /**
+     * Without a file list the runner picks its own sources, so it must stop at
+     * two: the catalog carries up to eight thread documents and folding all of
+     * them into the user's PDF is never what "merge these" meant.
+     */
+    public function testDefaultSourcesAreCappedAtTwoMostRecentFiles(): void
+    {
+        $attached = $this->file(101, 'attached.pdf');
+        $message = (new Message())->setUserId(7)->setDirection('IN')
+            ->setText('führe die dateien zusammen')
+            ->addFile($attached);
+
+        $newest = $this->file(203, 'newest.pdf');
+        $older = $this->file(202, 'older.pdf');
+        $oldest = $this->file(201, 'oldest.pdf');
+        $thread = [
+            $this->threadMessage(11, $oldest),
+            $this->threadMessage(12, $older),
+            $this->threadMessage(13, $newest),
+        ];
+
+        $combined = $this->file(104, 'u/2026/09/attached_combined.pdf');
+        $combine = $this->createMock(DocumentCombineService::class);
+        $combine->expects(self::once())
+            ->method('combineToPdf')
+            ->with(self::anything(), [101, 203], null)
+            ->willReturn($combined);
+
+        $result = $this->runner($combine, $this->repository($attached, $newest, $older, $oldest), $this->users())
+            ->run(
+                new TaskNode('n1', Capability::DocumentCombine),
+                new NodeContext($message, $thread, 7, ['language' => 'de']),
+            );
+
+        self::assertTrue($result->isSuccessful());
+    }
+
+    /**
+     * Both reference branches enforce ownership: authorization must not depend
+     * on DocumentCombineService filtering by user two layers down.
+     */
+    public function testAttachmentOfAnotherUserIsRejected(): void
+    {
+        $own = $this->file(101, 'own.pdf');
+        $foreign = $this->file(null, 'foreign.pdf', userId: 8);
+        $message = (new Message())->setUserId(7)->setDirection('IN')
+            ->setText('merge them')
+            ->addFile($own)
+            ->addFile($foreign);
+
+        $combine = $this->createMock(DocumentCombineService::class);
+        $combine->expects(self::never())->method('combineToPdf');
+
+        $result = $this->runner($combine, $this->repository($own), $this->users())
+            ->run(new TaskNode('n1', Capability::DocumentCombine), $this->context($message));
+
+        self::assertFalse($result->isSuccessful());
+        self::assertStringContainsString('foreign.pdf', (string) $result->error);
     }
 
     public function testSurfacesCombineServiceErrors(): void
@@ -177,20 +265,30 @@ final class DocumentCombineRunnerTest extends TestCase
         return $users;
     }
 
-    private function file(int $id, string $name): File
+    private function file(?int $id, string $name, int $userId = 7): File
     {
         file_put_contents($this->uploadDir.'/'.basename($name), 'content');
 
         $file = (new File())
-            ->setUserId(7)
+            ->setUserId($userId)
             ->setFilePath($name)
             ->setFileType(pathinfo($name, PATHINFO_EXTENSION))
             ->setFileName(basename($name))
             ->setFileSize(7)
             ->setFileMime('application/octet-stream')
             ->setStatus('processed');
-        (new \ReflectionProperty(File::class, 'id'))->setValue($file, $id);
+        if (null !== $id) {
+            (new \ReflectionProperty(File::class, 'id'))->setValue($file, $id);
+        }
 
         return $file;
+    }
+
+    private function threadMessage(int $id, File $file): Message
+    {
+        $message = (new Message())->setUserId(7)->setDirection('IN')->setText('here')->addFile($file);
+        (new \ReflectionProperty(Message::class, 'id'))->setValue($message, $id);
+
+        return $message;
     }
 }

--- a/backend/tests/Unit/Service/Multitask/Execution/Runner/DocumentCombineRunnerTest.php
+++ b/backend/tests/Unit/Service/Multitask/Execution/Runner/DocumentCombineRunnerTest.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\Multitask\Execution\Runner;
+
+use App\Entity\File;
+use App\Entity\Message;
+use App\Entity\User;
+use App\Repository\FileRepository;
+use App\Repository\UserRepository;
+use App\Service\File\ConversationFileCatalog;
+use App\Service\File\Office\DocumentCombineException;
+use App\Service\File\Office\DocumentCombineService;
+use App\Service\Multitask\Execution\NodeContext;
+use App\Service\Multitask\Execution\Runner\DocumentCombineRunner;
+use App\Service\Multitask\Plan\Capability;
+use App\Service\Multitask\Plan\TaskNode;
+use App\Service\Multitask\Skill\SkillCatalog;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+/**
+ * #1694: merge attached office/PDF files through DocumentCombineService
+ * instead of answering analyzefile prose that invents a filename.
+ */
+final class DocumentCombineRunnerTest extends TestCase
+{
+    private string $uploadDir;
+
+    protected function setUp(): void
+    {
+        $this->uploadDir = sys_get_temp_dir().'/document-combine-runner-'.bin2hex(random_bytes(6));
+        mkdir($this->uploadDir, 0o775, true);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->uploadDir.'/*') ?: [] as $path) {
+            @unlink($path);
+        }
+        @rmdir($this->uploadDir);
+    }
+
+    public function testMergesAttachedFilesWithTheCombineServiceAndPicksNoModel(): void
+    {
+        $xlsx = $this->file(101, 'Finanzmodell.xlsx');
+        $pdf = $this->file(102, 'Finanzmodell.pdf');
+        $message = (new Message())->setUserId(7)->setDirection('IN')
+            ->setText('führe beide dateien in eine pdf zusammen')
+            ->addFile($xlsx)
+            ->addFile($pdf);
+
+        $combined = $this->file(104, 'u/2026/09/Finanzmodell_combined.pdf');
+        $combined->setFileName('Finanzmodell_combined.pdf');
+
+        $user = $this->createStub(User::class);
+        $user->method('getId')->willReturn(7);
+        $users = $this->createMock(UserRepository::class);
+        $users->method('find')->with(7)->willReturn($user);
+
+        $combine = $this->createMock(DocumentCombineService::class);
+        $combine->expects(self::once())
+            ->method('combineToPdf')
+            ->with($user, [101, 102], null)
+            ->willReturn($combined);
+
+        $result = $this->runner($combine, $this->repository($xlsx, $pdf), $users)
+            ->run(new TaskNode('n1', Capability::DocumentCombine), $this->context($message));
+
+        self::assertTrue($result->isSuccessful());
+        self::assertSame('Combined PDF created: Finanzmodell_combined.pdf', $result->text);
+        self::assertSame([[
+            'path' => '/api/v1/files/uploads/u/2026/09/Finanzmodell_combined.pdf',
+            'type' => 'document',
+            'local_path' => 'u/2026/09/Finanzmodell_combined.pdf',
+        ]], $result->files);
+        self::assertSame([101, 102], $result->metadata['document_combine']['source_file_ids']);
+        self::assertSame(104, $result->metadata['document_combine']['pdf_file_id']);
+    }
+
+    public function testFailsHonestlyWithFewerThanTwoCombinableFiles(): void
+    {
+        $message = (new Message())->setUserId(7)->setDirection('IN')->setText('führe beide zusammen');
+
+        $combine = $this->createMock(DocumentCombineService::class);
+        $combine->expects(self::never())->method('combineToPdf');
+
+        $result = $this->runner($combine, $this->repository(), $this->users())
+            ->run(new TaskNode('n1', Capability::DocumentCombine), $this->context($message));
+
+        self::assertFalse($result->isSuccessful());
+        self::assertStringContainsString('at least two', (string) $result->error);
+    }
+
+    public function testSurfacesCombineServiceErrors(): void
+    {
+        $xlsx = $this->file(101, 'a.xlsx');
+        $pdf = $this->file(102, 'b.pdf');
+        $message = (new Message())->setUserId(7)->setDirection('IN')
+            ->setText('merge into one pdf')
+            ->addFile($xlsx)
+            ->addFile($pdf);
+
+        $combine = $this->createMock(DocumentCombineService::class);
+        $combine->method('combineToPdf')
+            ->willThrowException(new DocumentCombineException('engine_required', 'Combining office documents needs the office engine', 503));
+
+        $result = $this->runner($combine, $this->repository($xlsx, $pdf), $this->users())
+            ->run(new TaskNode('n1', Capability::DocumentCombine), $this->context($message));
+
+        self::assertFalse($result->isSuccessful());
+        self::assertStringContainsString('office engine', (string) $result->error);
+    }
+
+    public function testCapabilityIsOfferedToThePlannerOnlyWhenTheServiceIsWired(): void
+    {
+        $unwired = (new \ReflectionClass(DocumentCombineRunner::class))->newInstanceWithoutConstructor();
+        $wired = $this->runner(
+            $this->createMock(DocumentCombineService::class),
+            $this->repository(),
+            $this->users(),
+        );
+
+        $without = (new SkillCatalog([$unwired]))->renderCapabilityList();
+        $with = (new SkillCatalog([$wired]))->renderCapabilityList();
+
+        self::assertStringNotContainsString('"document_combine": Merge', $without);
+        self::assertStringContainsString('- "document_combine": Merge two or more office/PDF files', $with);
+        self::assertStringContainsString('file-chip Combine action', $with);
+    }
+
+    private function runner(
+        DocumentCombineService $combine,
+        FileRepository&MockObject $repository,
+        UserRepository $users,
+        array $threadFiles = [],
+    ): DocumentCombineRunner {
+        $repository->method('findFilesByMessageIds')->willReturn($threadFiles);
+
+        return new DocumentCombineRunner(
+            $combine,
+            new ConversationFileCatalog($repository, $this->uploadDir),
+            $repository,
+            $users,
+            new NullLogger(),
+        );
+    }
+
+    private function context(Message $message): NodeContext
+    {
+        return new NodeContext($message, [], 7, ['language' => 'de']);
+    }
+
+    private function repository(File ...$files): FileRepository&MockObject
+    {
+        $byId = [];
+        foreach ($files as $file) {
+            $byId[$file->getId()] = $file;
+        }
+
+        $repository = $this->createMock(FileRepository::class);
+        $repository->method('find')->willReturnCallback(static fn (mixed $id): ?File => $byId[(int) $id] ?? null);
+        $repository->method('findOneBy')->willReturn(null);
+
+        return $repository;
+    }
+
+    private function users(): UserRepository
+    {
+        $user = $this->createStub(User::class);
+        $user->method('getId')->willReturn(7);
+        $users = $this->createMock(UserRepository::class);
+        $users->method('find')->willReturn($user);
+
+        return $users;
+    }
+
+    private function file(int $id, string $name): File
+    {
+        file_put_contents($this->uploadDir.'/'.basename($name), 'content');
+
+        $file = (new File())
+            ->setUserId(7)
+            ->setFilePath($name)
+            ->setFileType(pathinfo($name, PATHINFO_EXTENSION))
+            ->setFileName(basename($name))
+            ->setFileSize(7)
+            ->setFileMime('application/octet-stream')
+            ->setStatus('processed');
+        (new \ReflectionProperty(File::class, 'id'))->setValue($file, $id);
+
+        return $file;
+    }
+}

--- a/backend/tests/Unit/Service/Multitask/Execution/Runner/DocumentCombineRunnerTest.php
+++ b/backend/tests/Unit/Service/Multitask/Execution/Runner/DocumentCombineRunnerTest.php
@@ -58,7 +58,7 @@ final class DocumentCombineRunnerTest extends TestCase
         $user = $this->createStub(User::class);
         $user->method('getId')->willReturn(7);
         $users = $this->createMock(UserRepository::class);
-        $users->method('find')->with(7)->willReturn($user);
+        $users->method('find')->willReturn($user);
 
         $combine = $this->createMock(DocumentCombineService::class);
         $combine->expects(self::once())

--- a/backend/tests/Unit/Service/Multitask/Execution/Runner/DocumentExportRunnerTest.php
+++ b/backend/tests/Unit/Service/Multitask/Execution/Runner/DocumentExportRunnerTest.php
@@ -140,6 +140,28 @@ final class DocumentExportRunnerTest extends TestCase
         self::assertStringContainsString('could not convert "book.xlsx"', (string) $result->error);
     }
 
+    /**
+     * Both reference branches enforce ownership — an attachment without an id
+     * is referenced as `attached:N` and must be checked just like `file:ID`.
+     */
+    public function testAttachmentOfAnotherUserIsRejected(): void
+    {
+        $foreign = $this->file(null, 'foreign.xlsx', 'x', userId: 8);
+        $message = (new Message())->setUserId(7)->setDirection('IN')
+            ->setText('hieraus eine pdf')
+            ->addFile($foreign);
+
+        $export = $this->createMock(DocumentExportService::class);
+        $export->method('isEnabled')->willReturn(true);
+        $export->expects(self::never())->method('exportToPdf');
+
+        $result = $this->runner($export, $this->createMock(GeneratedDocumentStore::class), $this->repository())
+            ->run(new TaskNode('n1', Capability::DocumentExport), $this->context($message));
+
+        self::assertFalse($result->isSuccessful());
+        self::assertStringContainsString('foreign.xlsx', (string) $result->error);
+    }
+
     public function testCapabilityIsOfferedToThePlannerOnlyWhenTheEngineIsConfigured(): void
     {
         $off = $this->createMock(DocumentExportService::class);
@@ -206,12 +228,12 @@ final class DocumentExportRunnerTest extends TestCase
         return $message;
     }
 
-    private function file(int $id, string $name, string $text, ?int $messageId = null): File
+    private function file(?int $id, string $name, string $text, ?int $messageId = null, int $userId = 7): File
     {
         file_put_contents($this->uploadDir.'/'.$name, 'content');
 
         $file = (new File())
-            ->setUserId(7)
+            ->setUserId($userId)
             ->setFilePath($name)
             ->setFileType(pathinfo($name, PATHINFO_EXTENSION))
             ->setFileName($name)
@@ -220,7 +242,9 @@ final class DocumentExportRunnerTest extends TestCase
             ->setFileText($text)
             ->setStatus('processed');
         $file->setMessageId($messageId);
-        (new \ReflectionProperty(File::class, 'id'))->setValue($file, $id);
+        if (null !== $id) {
+            (new \ReflectionProperty(File::class, 'id'))->setValue($file, $id);
+        }
 
         return $file;
     }

--- a/backend/tests/Unit/Service/Multitask/Execution/Runner/RunnersTest.php
+++ b/backend/tests/Unit/Service/Multitask/Execution/Runner/RunnersTest.php
@@ -429,6 +429,36 @@ final class RunnersTest extends TestCase
         self::assertFalse($result->isSuccessful());
     }
 
+    public function testText2SoundTruncatesLongTextBeforeSynthesize(): void
+    {
+        $longText = str_repeat('Word ', 1500);
+
+        $aiFacade = $this->createMock(AiFacade::class);
+        $aiFacade
+            ->expects(self::once())
+            ->method('synthesize')
+            ->with(
+                self::callback(static function (string $text): bool {
+                    return mb_strlen($text) <= \App\Service\TtsTextSanitizer::MAX_SYNTHESIS_CHARS;
+                }),
+                self::anything(),
+                self::anything(),
+            )
+            ->willReturn([
+                'relativePath' => '1/000/2026/06/tts_x.mp3',
+                'provider' => 'openai',
+                'model' => 'tts-1',
+            ]);
+
+        $runner = new Text2SoundRunner($aiFacade, $this->createMock(LoggerInterface::class));
+        $node = new TaskNode('n3', Capability::Text2Sound, ['n2'], ['text' => $longText], ['format' => 'mp3']);
+
+        $result = $runner->run($node, $this->context($this->message()));
+
+        self::assertTrue($result->isSuccessful());
+        self::assertLessThanOrEqual(\App\Service\TtsTextSanitizer::MAX_SYNTHESIS_CHARS, mb_strlen((string) $result->files[0]['source_text']));
+    }
+
     public function testMediaGenerationRunnerProducesImageFile(): void
     {
         $handler = $this->createMock(MediaGenerationHandler::class);

--- a/backend/tests/Unit/Service/Multitask/Skill/SkillCatalogTest.php
+++ b/backend/tests/Unit/Service/Multitask/Skill/SkillCatalogTest.php
@@ -84,8 +84,9 @@ final class SkillCatalogTest extends TestCase
         // DYNAMIC blocks (requiresDynamicNote) that additionally need a
         // per-user sub-catalog / availability note — without one they stay
         // invisible regardless of their flags, so those three plus
-        // save_to_folder (also dynamic) are missing. document_export is
-        // engine-gated: without the office converter it is omitted too.
+        // save_to_folder (also dynamic) are missing. document_export and
+        // document_combine are engine/service-gated: without constructors
+        // they are omitted too.
         $default = SkillCatalogFactory::real()->renderCapabilityList();
         self::assertStringContainsString('- "url_fetch": ', $default);
         self::assertStringNotContainsString('"mcp_fetch"', $default);
@@ -93,7 +94,8 @@ final class SkillCatalogTest extends TestCase
         self::assertStringNotContainsString('"email_search"', $default);
         self::assertStringNotContainsString('"save_to_folder"', $default);
         self::assertStringNotContainsString('"document_export"', $default);
-        self::assertCount(count(Capability::cases()) - 5, explode("\n", $default));
+        self::assertStringNotContainsString('"document_combine"', $default);
+        self::assertCount(count(Capability::cases()) - 6, explode("\n", $default));
 
         // Operator kill switch: an explicit URL_FETCH_ENABLED=0 row hides the
         // block from the planner again.

--- a/backend/tests/Unit/Service/Multitask/TaskPlanExecutorTest.php
+++ b/backend/tests/Unit/Service/Multitask/TaskPlanExecutorTest.php
@@ -484,6 +484,32 @@ final class TaskPlanExecutorTest extends TestCase
         self::assertSame('document', $result['metadata']['file']['type']);
     }
 
+    public function testAttachmentDocumentCombineRunsDagWithoutPlannerOrLegacyRouter(): void
+    {
+        $this->planner->expects(self::never())->method('plan');
+        $this->dagExecutor->expects(self::once())->method('execute')->willReturn($this->assembled([
+            'content' => 'Combined PDF created: Finanzmodell_combined.pdf',
+            'files' => [['path' => '/api/v1/files/uploads/combined.pdf', 'type' => 'document']],
+        ]));
+        $this->router->expects(self::never())->method('routeStream');
+
+        $result = $this->executor->executeStream(
+            $this->message(),
+            [],
+            [
+                'topic' => 'document_combine',
+                'intent' => 'document_combine',
+                'language' => 'de',
+                'source' => 'attachment_document_combine',
+                'skip_sorting' => true,
+            ],
+            static function (): void {},
+        );
+
+        self::assertSame('Combined PDF created: Finanzmodell_combined.pdf', $result['content']);
+        self::assertSame('document', $result['metadata']['file']['type']);
+    }
+
     public function testSavedTaskRunPlansAndRunsTheDag(): void
     {
         // Regression: Saved Task runs (source=saved_task) pin their prompt and

--- a/backend/tests/Unit/Service/Multitask/TaskPlanExecutorTest.php
+++ b/backend/tests/Unit/Service/Multitask/TaskPlanExecutorTest.php
@@ -497,7 +497,7 @@ final class TaskPlanExecutorTest extends TestCase
             $this->message(),
             [],
             [
-                'topic' => 'document_combine',
+                'topic' => 'officemaker',
                 'intent' => 'document_combine',
                 'language' => 'de',
                 'source' => 'attachment_document_combine',
@@ -508,6 +508,49 @@ final class TaskPlanExecutorTest extends TestCase
 
         self::assertSame('Combined PDF created: Finanzmodell_combined.pdf', $result['content']);
         self::assertSame('document', $result['metadata']['file']['type']);
+    }
+
+    /**
+     * A failed merge (no office engine, missing pdfunite, file gone) must not
+     * reach the legacy router as `document_combine`: there is no handler for
+     * that intent, so ChatHandler would answer without a matching prompt and
+     * claim a PDF that does not exist (#1694). The fallback is the attachment
+     * analysis these turns had before the merge route existed.
+     */
+    public function testFailedDocumentCombineFallsBackToFileAnalysisNotAPromptlessChat(): void
+    {
+        $this->dagExecutor->method('execute')->willReturn($this->assembled([
+            'all_failed' => true,
+            'node_statuses' => ['n1' => 'failed'],
+        ]));
+
+        $delegated = null;
+        $this->router->expects(self::once())
+            ->method('routeStream')
+            ->willReturnCallback(function (...$args) use (&$delegated): array {
+                $delegated = $args[2];
+
+                return ['content' => 'file analysis answer'];
+            });
+
+        $result = $this->executor->executeStream(
+            $this->message(),
+            [],
+            [
+                'topic' => 'officemaker',
+                'intent' => 'document_combine',
+                'language' => 'de',
+                'source' => 'attachment_document_combine',
+                'skip_sorting' => true,
+            ],
+            static function (): void {},
+        );
+
+        self::assertSame(['content' => 'file analysis answer'], $result);
+        self::assertSame('analyzefile', $delegated['topic'] ?? null);
+        self::assertSame('file_analysis', $delegated['intent'] ?? null);
+        self::assertSame('attachment_document_or_audio', $delegated['source'] ?? null);
+        self::assertSame('de', $delegated['language'] ?? null, 'The rest of the classification survives');
     }
 
     public function testSavedTaskRunPlansAndRunsTheDag(): void

--- a/backend/tests/Unit/Service/TtsTextSanitizerTest.php
+++ b/backend/tests/Unit/Service/TtsTextSanitizerTest.php
@@ -24,6 +24,43 @@ final class TtsTextSanitizerTest extends TestCase
         self::assertSame(str_repeat('ä', TtsTextSanitizer::MAX_SYNTHESIS_CHARS), $truncated);
     }
 
+    public function testTruncateCutsOnTheLastSentenceEnd(): void
+    {
+        $sentence = str_repeat('Ein ganzer Satz. ', 300);
+        $text = $sentence.str_repeat('x', 500);
+
+        $truncated = TtsTextSanitizer::truncateForSynthesis($text);
+
+        self::assertLessThanOrEqual(TtsTextSanitizer::MAX_SYNTHESIS_CHARS, mb_strlen($truncated));
+        self::assertStringEndsWith('Satz.', $truncated, 'A voice note must not stop mid-sentence');
+    }
+
+    public function testTruncateFallsBackToTheLastWordBreak(): void
+    {
+        $text = str_repeat('wortohnesatzende ', 400);
+
+        $truncated = TtsTextSanitizer::truncateForSynthesis($text);
+
+        self::assertLessThanOrEqual(TtsTextSanitizer::MAX_SYNTHESIS_CHARS, mb_strlen($truncated));
+        self::assertStringEndsWith('wortohnesatzende', $truncated, 'A voice note must not stop mid-word');
+    }
+
+    /**
+     * A sentence end in the first 80% is too far back to cut at — the listener
+     * would lose a fifth of the answer.
+     */
+    public function testTruncateIgnoresASentenceEndFarOutsideTheWindow(): void
+    {
+        $text = 'Kurz. '.str_repeat('wort ', 2000);
+
+        $truncated = TtsTextSanitizer::truncateForSynthesis($text);
+
+        self::assertGreaterThan(
+            (int) (TtsTextSanitizer::MAX_SYNTHESIS_CHARS * 0.8),
+            mb_strlen($truncated),
+        );
+    }
+
     public function testPrepareSanitizesThenTruncates(): void
     {
         $text = '**Hello** [Memory:12] '.str_repeat('word ', 2000);

--- a/backend/tests/Unit/Service/TtsTextSanitizerTest.php
+++ b/backend/tests/Unit/Service/TtsTextSanitizerTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service;
+
+use App\Service\TtsTextSanitizer;
+use PHPUnit\Framework\TestCase;
+
+final class TtsTextSanitizerTest extends TestCase
+{
+    public function testTruncateLeavesShortTextUnchanged(): void
+    {
+        self::assertSame('hello', TtsTextSanitizer::truncateForSynthesis('hello'));
+    }
+
+    public function testTruncateCapsAtTheSharedLimit(): void
+    {
+        $text = str_repeat('ä', TtsTextSanitizer::MAX_SYNTHESIS_CHARS + 50);
+
+        $truncated = TtsTextSanitizer::truncateForSynthesis($text);
+
+        self::assertSame(TtsTextSanitizer::MAX_SYNTHESIS_CHARS, mb_strlen($truncated));
+        self::assertSame(str_repeat('ä', TtsTextSanitizer::MAX_SYNTHESIS_CHARS), $truncated);
+    }
+
+    public function testPrepareSanitizesThenTruncates(): void
+    {
+        $text = '**Hello** [Memory:12] '.str_repeat('word ', 2000);
+
+        $prepared = TtsTextSanitizer::prepareForSynthesis($text);
+
+        self::assertStringNotContainsString('Memory', $prepared);
+        self::assertStringNotContainsString('**', $prepared);
+        self::assertLessThanOrEqual(TtsTextSanitizer::MAX_SYNTHESIS_CHARS, mb_strlen($prepared));
+    }
+}

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -1391,7 +1391,7 @@
       "text2sound": "Audio",
       "document_generation": "Dokument",
       "document_export": "PDF-Export",
-      "document_combine": "Zusammengeführte PDF",
+      "document_combine": "Zusammengeführtes PDF",
       "calendar_event": "Kalendereinladung",
       "email_me": "E-Mail-Versand",
       "save_to_folder": "Im Ordner speichern"

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -1381,6 +1381,7 @@
       "text2sound": "Audio",
       "document_generation": "Dokument",
       "document_export": "PDF-Export",
+      "document_combine": "Zusammengeführte PDF",
       "calendar_event": "Kalendereinladung",
       "email_me": "E-Mail-Versand",
       "save_to_folder": "Im Ordner speichern"

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -4226,6 +4226,7 @@
       "text2sound": "Audio",
       "document_generation": "Document",
       "document_export": "PDF export",
+      "document_combine": "Combined PDF",
       "calendar_event": "Calendar invite",
       "email_me": "Email result",
       "save_to_folder": "Save to folder"

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -1863,6 +1863,7 @@
       "text2sound": "Audio",
       "document_generation": "Documento",
       "document_export": "Exportación a PDF",
+      "document_combine": "PDF combinado",
       "calendar_event": "Invitación de calendario",
       "email_me": "Envío por correo",
       "save_to_folder": "Guardar en carpeta"

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -4226,6 +4226,7 @@
       "text2sound": "Audio",
       "document_generation": "Document",
       "document_export": "Export PDF",
+      "document_combine": "PDF fusionné",
       "calendar_event": "Invitation d’agenda",
       "email_me": "Résultat par e-mail",
       "save_to_folder": "Enregistrer dans le dossier"

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -1863,6 +1863,7 @@
       "text2sound": "Ses",
       "document_generation": "Belge",
       "document_export": "PDF dışa aktarma",
+      "document_combine": "Birleştirilmiş PDF",
       "calendar_event": "Takvim daveti",
       "email_me": "E-posta gönderimi",
       "save_to_folder": "Klasöre kaydet"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Fixes the three most recent open bugs: unconfigured Ollama paging operators hourly, OpenAI TTS failing on long multitask scripts, and chat “merge these into one PDF” never producing a file.

## Changes
- **#1704 Model health:** `OllamaModelListProbe` treats an empty `OLLAMA_BASE_URL` as skipped/unconfigured (same rule as Triton/Piper), so Cloud-AI installs no longer raise `KIND_DEGRADED` incidents for local models nobody configured.
- **#1665 Text2Sound:** shared `TtsTextSanitizer::prepareForSynthesis()` caps speakable text at 4000 characters. `Text2SoundRunner`, StreamController, WhatsApp, and `AiFacade::synthesize()` all stay inside OpenAI’s 4096-character input limit.
- **#1694 Chat merge-to-PDF:** document attachments are no longer unconditionally forced onto `analyzefile`. A merge/combine/export-as-PDF prompt with two or more office/PDF files runs `DocumentCombineService` via a new `document_combine` runner and attaches the PDF to the outgoing message. A single office file plus “hieraus eine PDF” takes `document_export`. Combine without an explicit title uses the first source stem (`Finanzmodell_combined.pdf`) instead of `combined.pdf`.

## Verification
- [x] Tests added/updated
- [ ] Manual (office-engine merge and live OpenAI TTS need a configured Collabora / provider key)

Local gate:
- `make -C backend lint` — pass
- `make -C backend phpstan` — pass
- `make -C frontend lint` — pass
- `make -C frontend test` — 1558 passed
- `npm run check:types` — pass
- Targeted PHPUnit for these three bugs — 23 tests / 207 assertions, pass
- Full `make -C backend test` — 5289 tests; the only failures were pre-existing empty `synaplan_test.BUSER` migration fixtures (not this change). After inserting a test user those 7 migration tests pass.

## Notes
- Fixes #1704
- Fixes #1665
- Fixes #1694
- Related: #1691 (single-file export now also escapes the attachment gate)

## Screenshots/Logs
[PHPUnit testdox for the three bug fixes](https://cursor.com/agents/bc-01a06c10-8d41-7314-872c-4da152210e66/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbugfix-phpunit-testdox.log)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a06c10-8d41-7314-872c-4da152210e66?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a06c10-8d41-7314-872c-4da152210e66&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

