### PR TITLE
feat(frontend): native iOS Shortcuts seam for dictation and camera

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -31,7 +31,7 @@
 
 <script setup lang="ts">
 import { watch, computed } from 'vue'
-import { useRoute } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { useTheme } from './composables/useTheme'
 import { useAuthStore } from '@/stores/auth'
@@ -55,6 +55,7 @@ import { initNativeStatusBar } from '@/services/nativeStatusBar'
 import { initNativeBackButton } from '@/services/nativeBackButton'
 import { initKeyboardScrollAssist } from '@/services/keyboardScrollAssist'
 import { isNativeApp } from '@/services/api/nativeRuntime'
+import { initNativeShortcuts } from '@/services/api/nativeShortcuts'
 import type { CookieConsent as CookieConsentType } from '@/composables/useCookieConsent'
 
 useTheme()
@@ -131,6 +132,16 @@ void initNativeBackButton()
 // the WebView does not shrink, so ordinary form/dialog fields would otherwise
 // stay hidden behind it). No-op on web.
 initKeyboardScrollAssist()
+
+// MOBILE-APP SEAM: iOS Shortcuts that need the composer (dictate / photo)
+// navigate to chat. The pending action itself is consumed in ChatView once
+// the input is mounted. No-op on web / when the bridge is absent.
+const router = useRouter()
+initNativeShortcuts(() => {
+  if ('chat' !== String(router.currentRoute.value.name ?? '')) {
+    void router.push({ name: 'chat' })
+  }
+})
 
 // Update page title when language changes
 const route = useRoute()

--- a/frontend/src/components/ChatInput.vue
+++ b/frontend/src/components/ChatInput.vue
@@ -1760,6 +1760,23 @@ const submitText = (text: string) => {
   nextTick(() => sendMessage())
 }
 
+/**
+ * MOBILE-APP SEAM: start voice dictation for the iOS Shortcuts "Start
+ * dictation" action. No-op when already recording. Returns false (and a
+ * toast) when this server has no speech-to-text path.
+ */
+const startDictation = async (): Promise<boolean> => {
+  if (isRecording.value) {
+    return true
+  }
+  if (!showMicrophoneButton.value) {
+    showError(t('chatInput.dictationUnavailable'))
+    return false
+  }
+  await toggleRecording()
+  return isRecording.value
+}
+
 // Expose textarea ref, uploadFiles, setInputText, submitText for parent component
 // ATTENTION: needs to be typed when using vue-tsc -b
 defineExpose<{
@@ -1767,11 +1784,13 @@ defineExpose<{
   uploadFiles: (files: File[]) => Promise<void>
   setInputText: (text: string) => void
   submitText: (text: string) => void
+  startDictation: () => Promise<boolean>
 }>({
   textareaRef,
   uploadFiles,
   setInputText,
   submitText,
+  startDictation,
 })
 </script>
 

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -775,6 +775,8 @@
       "notSupported": "Spracheingabe ist hier nicht verfügbar.",
       "unknown": "Das Mikrofon konnte nicht gestartet werden. Bitte versuche es erneut."
     },
+    "dictationUnavailable": "Sprachdiktat ist auf diesem Server nicht verfügbar.",
+    "cameraUnavailable": "Die Kamera konnte nicht geöffnet werden. Du kannst ein Foto weiterhin über das +-Menü anhängen.",
     "dropFiles": "Dateien hier ablegen",
     "dropFilesHint": "Bilder, Dokumente, Audiodateien...",
     "filesPasted": "{count} Datei eingefügt | {count} Dateien eingefügt",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -774,6 +774,8 @@
       "notSupported": "Voice input is not available here.",
       "unknown": "The microphone could not be started. Please try again."
     },
+    "dictationUnavailable": "Voice dictation is not available on this server.",
+    "cameraUnavailable": "The camera could not be opened. You can still attach a photo from the + menu.",
     "dropFiles": "Drop files here",
     "dropFilesHint": "Images, documents, audio files...",
     "filesPasted": "{count} file pasted | {count} files pasted",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -810,6 +810,8 @@
       "notSupported": "La entrada de voz no está disponible aquí.",
       "unknown": "No se pudo iniciar el micrófono. Inténtalo de nuevo."
     },
+    "dictationUnavailable": "El dictado por voz no está disponible en este servidor.",
+    "cameraUnavailable": "No se pudo abrir la cámara. Aún puedes adjuntar una foto desde el menú +.",
     "dropFiles": "Suelta los archivos aquí",
     "dropFilesHint": "Imágenes, documentos, archivos de audio...",
     "filesPasted": "{count} archivo pegado | {count} archivos pegados",

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -774,6 +774,8 @@
       "notSupported": "La saisie vocale n’est pas disponible ici.",
       "unknown": "Le microphone n’a pas pu être démarré. Veuillez réessayer."
     },
+    "dictationUnavailable": "La dictée vocale n’est pas disponible sur ce serveur.",
+    "cameraUnavailable": "L’appareil photo n’a pas pu être ouvert. Vous pouvez toujours joindre une photo depuis le menu +.",
     "dropFiles": "Déposez les fichiers ici",
     "dropFilesHint": "Images, documents, fichiers audio…",
     "filesPasted": "{count} fichier collé | {count} fichiers collés",

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -810,6 +810,8 @@
       "notSupported": "Sesli giriş burada kullanılamıyor.",
       "unknown": "Mikrofon başlatılamadı. Lütfen tekrar dene."
     },
+    "dictationUnavailable": "Sesli dikte bu sunucuda kullanılamıyor.",
+    "cameraUnavailable": "Kamera açılamadı. Fotoğrafı yine + menüsünden ekleyebilirsin.",
     "dropFiles": "Dosyaları buraya bırakın",
     "dropFilesHint": "Resimler, belgeler, ses dosyaları...",
     "filesPasted": "{count} dosya yapıştırıldı",

--- a/frontend/src/services/api/nativeCamera.ts
+++ b/frontend/src/services/api/nativeCamera.ts
@@ -1,0 +1,83 @@
+/**
+ * SPA-side seam for native photo capture (iOS Analyze-photo shortcut).
+ *
+ * The native shell exposes `window.SynaplanCamera`, which wraps
+ * `@capacitor/camera` so this submodule stays Capacitor-free. On the plain
+ * web build the bridge is absent and every accessor is a no-op.
+ *
+ * MOBILE-APP SEAM: default-off. Web file-input capture is unchanged.
+ */
+
+interface NativePhoto {
+  dataUrl: string
+  mimeType: string
+  fileName: string
+}
+
+interface NativeCameraApi {
+  isAvailable: () => boolean
+  capturePhoto: () => Promise<NativePhoto | null>
+}
+
+function getApi(): NativeCameraApi | null {
+  const api = (globalThis as { SynaplanCamera?: unknown }).SynaplanCamera
+  if (
+    api &&
+    'object' === typeof api &&
+    'function' === typeof (api as NativeCameraApi).isAvailable &&
+    'function' === typeof (api as NativeCameraApi).capturePhoto
+  ) {
+    return api as NativeCameraApi
+  }
+  return null
+}
+
+/** True when the app-owned Camera bridge can present a capture UI. */
+export function isNativeCameraAvailable(): boolean {
+  const api = getApi()
+  try {
+    return !!api && true === api.isAvailable()
+  } catch {
+    return false
+  }
+}
+
+function dataUrlToFile(photo: NativePhoto): File | null {
+  const comma = photo.dataUrl.indexOf(',')
+  const encoded = comma >= 0 ? photo.dataUrl.slice(comma + 1) : photo.dataUrl
+  try {
+    const binary = atob(encoded)
+    const bytes = new Uint8Array(binary.length)
+    for (let i = 0; i < binary.length; i += 1) {
+      bytes[i] = binary.charCodeAt(i)
+    }
+    return new File([bytes], photo.fileName, { type: photo.mimeType || 'image/jpeg' })
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Open the native camera (photo library on the Simulator) and return a File
+ * ready for `ChatInput.uploadFiles()`. Resolves null on cancel, missing
+ * bridge, or a failed capture — never throws.
+ */
+export async function captureNativePhoto(): Promise<File | null> {
+  const api = getApi()
+  if (!api) {
+    return null
+  }
+  try {
+    const photo = await api.capturePhoto()
+    if (!photo || 'string' !== typeof photo.dataUrl || '' === photo.dataUrl) {
+      return null
+    }
+    return dataUrlToFile({
+      dataUrl: photo.dataUrl,
+      mimeType: 'string' === typeof photo.mimeType ? photo.mimeType : 'image/jpeg',
+      fileName: 'string' === typeof photo.fileName ? photo.fileName : 'photo.jpg',
+    })
+  } catch {
+    return null
+  }
+}

--- a/frontend/src/services/api/nativeShortcuts.ts
+++ b/frontend/src/services/api/nativeShortcuts.ts
@@ -1,5 +1,5 @@
 /**
- * SPA-side seam for iOS App Shortcuts (Kurzbefehle).
+ * SPA-side seam for iOS App Shortcuts.
  *
  * The native shell (synaplan-apps) injects `app/synaplan-native.js` BEFORE the
  * SPA bundle and exposes `window.SynaplanShortcuts`. That API wraps the
@@ -60,7 +60,10 @@ export function isShortcutBridgeAvailable(): boolean {
 
 /**
  * Pull (and clear) any Shortcuts action that arrived before the SPA mounted.
- * Returns the first pending action, or null.
+ * Returns the first action this build understands, or null.
+ *
+ * The queue is scanned rather than only its head: an action added by a newer
+ * app binary must not swallow the tap the user actually made.
  */
 export async function consumePendingShortcut(): Promise<ShortcutActionPayload | null> {
   const api = getApi()
@@ -69,10 +72,16 @@ export async function consumePendingShortcut(): Promise<ShortcutActionPayload | 
   }
   try {
     const pending = await api.consumePending()
-    if (!Array.isArray(pending) || 0 === pending.length) {
+    if (!Array.isArray(pending)) {
       return null
     }
-    return normalizePayload(pending[0])
+    for (const raw of pending) {
+      const payload = normalizePayload(raw)
+      if (payload) {
+        return payload
+      }
+    }
+    return null
   } catch {
     return null
   }

--- a/frontend/src/services/api/nativeShortcuts.ts
+++ b/frontend/src/services/api/nativeShortcuts.ts
@@ -1,0 +1,118 @@
+/**
+ * SPA-side seam for iOS App Shortcuts (Kurzbefehle).
+ *
+ * The native shell (synaplan-apps) injects `app/synaplan-native.js` BEFORE the
+ * SPA bundle and exposes `window.SynaplanShortcuts`. That API wraps the
+ * app-owned Capacitor plugin so this submodule stays Capacitor-free — the same
+ * pattern as `nativeHaptics.ts` / `nativeServer.ts`.
+ *
+ * MOBILE-APP SEAM: every accessor is a no-op when the bridge is absent (plain
+ * web build, Android, or an older app binary). Web/self-host behaviour is
+ * unchanged.
+ */
+
+export type ShortcutActionName = 'open' | 'dictate' | 'photo'
+
+export interface ShortcutActionPayload {
+  action: ShortcutActionName
+  token: string
+}
+
+interface NativeShortcutsApi {
+  consumePending: () => Promise<ShortcutActionPayload[]>
+  subscribe: (fn: (payload: ShortcutActionPayload) => void) => () => void
+}
+
+const KNOWN_ACTIONS = new Set<ShortcutActionName>(['open', 'dictate', 'photo'])
+
+function getApi(): NativeShortcutsApi | null {
+  const api = (globalThis as { SynaplanShortcuts?: unknown }).SynaplanShortcuts
+  if (
+    api &&
+    'object' === typeof api &&
+    'function' === typeof (api as NativeShortcutsApi).consumePending &&
+    'function' === typeof (api as NativeShortcutsApi).subscribe
+  ) {
+    return api as NativeShortcutsApi
+  }
+  return null
+}
+
+function normalizePayload(raw: unknown): ShortcutActionPayload | null {
+  if (!raw || 'object' !== typeof raw) {
+    return null
+  }
+  const action = (raw as { action?: unknown }).action
+  if ('string' !== typeof action || !KNOWN_ACTIONS.has(action as ShortcutActionName)) {
+    return null
+  }
+  const token = (raw as { token?: unknown }).token
+  return {
+    action: action as ShortcutActionName,
+    token: 'string' === typeof token ? token : '',
+  }
+}
+
+/** True when the app-owned Shortcuts bridge is present. */
+export function isShortcutBridgeAvailable(): boolean {
+  return null !== getApi()
+}
+
+/**
+ * Pull (and clear) any Shortcuts action that arrived before the SPA mounted.
+ * Returns the first pending action, or null.
+ */
+export async function consumePendingShortcut(): Promise<ShortcutActionPayload | null> {
+  const api = getApi()
+  if (!api) {
+    return null
+  }
+  try {
+    const pending = await api.consumePending()
+    if (!Array.isArray(pending) || 0 === pending.length) {
+      return null
+    }
+    return normalizePayload(pending[0])
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Listen for live Shortcuts taps while the app is already open.
+ * Returns an unsubscribe function. No-op when the bridge is absent.
+ */
+export function onShortcutAction(cb: (payload: ShortcutActionPayload) => void): () => void {
+  const api = getApi()
+  if (!api) {
+    return () => {}
+  }
+  try {
+    return api.subscribe((raw) => {
+      const payload = normalizePayload(raw)
+      if (payload) {
+        cb(payload)
+      }
+    })
+  } catch {
+    return () => {}
+  }
+}
+
+/**
+ * Route dictate/photo Shortcuts onto the chat surface. `open` leaves the
+ * current screen alone. No-op on web.
+ *
+ * MOBILE-APP SEAM: the listener does not consume the pending action — ChatView
+ * owns that so the composer is mounted before dictation/camera run.
+ */
+export function initNativeShortcuts(navigateToChat: () => void): () => void {
+  if (!isShortcutBridgeAvailable()) {
+    return () => {}
+  }
+  return onShortcutAction((payload) => {
+    if ('dictate' === payload.action || 'photo' === payload.action) {
+      navigateToChat()
+    }
+  })
+}

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -566,6 +566,13 @@ import GuestHintPopover from '@/components/guest/GuestHintPopover.vue'
 import SubscriptionPaywallModal from '@/components/subscription/SubscriptionPaywallModal.vue'
 import { paywallReasonForLimit, usePaywallPrompt } from '@/composables/usePaywallPrompt'
 import { hasPendingIapRedemption } from '@/services/nativeIap'
+import { isNativeApp } from '@/services/api/nativeRuntime'
+import {
+  consumePendingShortcut,
+  onShortcutAction,
+  type ShortcutActionName,
+} from '@/services/api/nativeShortcuts'
+import { captureNativePhoto, isNativeCameraAvailable } from '@/services/api/nativeCamera'
 import { usePromoTips } from '@/composables/usePromoTips'
 import { useDateFormat } from '@/composables/useDateFormat'
 
@@ -777,6 +784,71 @@ function handleGuestFeatureGate(key: string) {
   featureGateOpen.value = true
 }
 
+// MOBILE-APP SEAM: iOS Shortcuts (Kurzbefehle) land here after the native
+// bootstrap pulls/pushes the pending action. `open` is a no-op (the app is
+// already visible). Photos are attached, never auto-sent.
+let stopShortcutListen: (() => void) | null = null
+const handledShortcutTokens = new Set<string>()
+
+async function waitForChatInput(): Promise<InstanceType<typeof ChatInput> | null> {
+  if (chatInputRef.value) {
+    return chatInputRef.value
+  }
+  await nextTick()
+  if (chatInputRef.value) {
+    return chatInputRef.value
+  }
+  await new Promise((resolve) => setTimeout(resolve, 300))
+  return chatInputRef.value
+}
+
+async function handleNativeShortcut(action: ShortcutActionName, token: string): Promise<void> {
+  if (token && handledShortcutTokens.has(token)) {
+    return
+  }
+  if (token) {
+    handledShortcutTokens.add(token)
+  }
+  if ('open' === action) {
+    return
+  }
+
+  const input = await waitForChatInput()
+  if ('dictate' === action) {
+    await input?.startDictation()
+    return
+  }
+  if ('photo' !== action) {
+    return
+  }
+  if (isGuestMode.value) {
+    handleGuestFeatureGate('attach')
+    return
+  }
+  if (!isNativeCameraAvailable()) {
+    showErrorToast(t('chatInput.cameraUnavailable'))
+    return
+  }
+  const file = await captureNativePhoto()
+  if (file && chatInputRef.value) {
+    await chatInputRef.value.uploadFiles([file])
+  }
+}
+
+function initChatShortcuts(): void {
+  if (!isNativeApp()) {
+    return
+  }
+  stopShortcutListen = onShortcutAction((payload) => {
+    void handleNativeShortcut(payload.action, payload.token)
+  })
+  void consumePendingShortcut().then((pending) => {
+    if (pending) {
+      void handleNativeShortcut(pending.action, pending.token)
+    }
+  })
+}
+
 function handleExamplePick(prompt: string) {
   chatInputRef.value?.submitText(prompt)
 }
@@ -903,6 +975,7 @@ const isStreaming = computed(() => {
 
 // Init on mount
 onMounted(async () => {
+  initChatShortcuts()
   // Subscribe to the per-user realtime channel so finished renders resolve
   // their banner instantly (push primary). No-op for guests / when realtime is
   // disabled; the 25s banner poll remains the fallback.
@@ -1234,6 +1307,10 @@ onBeforeUnmount(() => {
   window.removeEventListener('open-feedback-dialog', handleOpenFeedbackDialogEvent)
   window.removeEventListener('open-first-run-setup', handleOpenFirstRunSetupEvent)
   window.removeEventListener('open-message-reference', handleOpenMessageReferenceEvent)
+  if (stopShortcutListen) {
+    stopShortcutListen()
+    stopShortcutListen = null
+  }
   window.removeEventListener('focus', prefetchSseToken)
   document.removeEventListener('visibilitychange', handleVisibilityChangeForToken)
   clearDeleteDialogTimer()

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -784,41 +784,24 @@ function handleGuestFeatureGate(key: string) {
   featureGateOpen.value = true
 }
 
-// MOBILE-APP SEAM: iOS Shortcuts (Kurzbefehle) land here after the native
-// bootstrap pulls/pushes the pending action. `open` is a no-op (the app is
-// already visible). Photos are attached, never auto-sent.
+// MOBILE-APP SEAM: iOS App Shortcuts land here after the native bootstrap
+// pulls (cold start) or pushes (warm start) the pending action. `open` is a
+// no-op — the app is already visible. Photos are attached, never auto-sent.
 let stopShortcutListen: (() => void) | null = null
 const handledShortcutTokens = new Set<string>()
+// The composer is `v-if`-gated behind provider setup, so a shortcut can arrive
+// before it exists. The action is parked here and run by the watcher below
+// once the composer is mounted, instead of polling for the ref: dictation and
+// the camera are useless without an input to hand their result to, and a
+// captured photo with nowhere to go would be silently discarded.
+const queuedShortcut = ref<Exclude<ShortcutActionName, 'open'> | null>(null)
 
-async function waitForChatInput(): Promise<InstanceType<typeof ChatInput> | null> {
-  if (chatInputRef.value) {
-    return chatInputRef.value
-  }
-  await nextTick()
-  if (chatInputRef.value) {
-    return chatInputRef.value
-  }
-  await new Promise((resolve) => setTimeout(resolve, 300))
-  return chatInputRef.value
-}
-
-async function handleNativeShortcut(action: ShortcutActionName, token: string): Promise<void> {
-  if (token && handledShortcutTokens.has(token)) {
-    return
-  }
-  if (token) {
-    handledShortcutTokens.add(token)
-  }
-  if ('open' === action) {
-    return
-  }
-
-  const input = await waitForChatInput()
+async function runNativeShortcut(
+  input: InstanceType<typeof ChatInput>,
+  action: Exclude<ShortcutActionName, 'open'>
+): Promise<void> {
   if ('dictate' === action) {
-    await input?.startDictation()
-    return
-  }
-  if ('photo' !== action) {
+    await input.startDictation()
     return
   }
   if (isGuestMode.value) {
@@ -830,21 +813,45 @@ async function handleNativeShortcut(action: ShortcutActionName, token: string): 
     return
   }
   const file = await captureNativePhoto()
-  if (file && chatInputRef.value) {
-    await chatInputRef.value.uploadFiles([file])
+  if (file) {
+    await chatInputRef.value?.uploadFiles([file])
   }
 }
+
+function handleNativeShortcut(action: ShortcutActionName, token: string): void {
+  if (token && handledShortcutTokens.has(token)) {
+    return
+  }
+  if (token) {
+    handledShortcutTokens.add(token)
+  }
+  if ('open' !== action) {
+    queuedShortcut.value = action
+  }
+}
+
+watch(
+  [chatInputRef, queuedShortcut],
+  ([input, action]) => {
+    if (!input || !action) {
+      return
+    }
+    queuedShortcut.value = null
+    void runNativeShortcut(input, action)
+  },
+  { flush: 'post' }
+)
 
 function initChatShortcuts(): void {
   if (!isNativeApp()) {
     return
   }
   stopShortcutListen = onShortcutAction((payload) => {
-    void handleNativeShortcut(payload.action, payload.token)
+    handleNativeShortcut(payload.action, payload.token)
   })
   void consumePendingShortcut().then((pending) => {
     if (pending) {
-      void handleNativeShortcut(pending.action, pending.token)
+      handleNativeShortcut(pending.action, pending.token)
     }
   })
 }

--- a/frontend/tests/unit/components/ChatInputDictation.spec.ts
+++ b/frontend/tests/unit/components/ChatInputDictation.spec.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import ChatInput from '@/components/ChatInput.vue'
+
+// MOBILE-APP SEAM: `startDictation()` is exposed for the iOS "Start dictation"
+// App Shortcut, so it is reached from outside the component and never through
+// the microphone button these specs otherwise exercise. It has to stay safe on
+// a server without speech-to-text and on a second tap while already recording.
+
+let speechToTextAvailable = true
+let recorderOptions: { onStart?: () => void } = {}
+const startRecording = vi.fn(async () => {
+  recorderOptions.onStart?.()
+})
+const showError = vi.fn()
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ query: {}, fullPath: '/chat' }),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+}))
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key, locale: { value: 'en' } }),
+}))
+
+vi.mock('@/composables/useNotification', () => ({
+  useNotification: () => ({
+    error: showError,
+    success: vi.fn(),
+    warning: vi.fn(),
+    info: vi.fn(),
+    push: vi.fn(),
+    remove: vi.fn(),
+    notifications: { value: [] },
+  }),
+}))
+
+vi.mock('@/stores/config', () => ({
+  useConfigStore: () => ({
+    speech: {
+      webSpeechEnabled: false,
+      whisperEnabled: speechToTextAvailable,
+      speechToTextAvailable,
+    },
+  }),
+}))
+
+vi.mock('@/services/webSpeechService', () => ({
+  isWebSpeechSupported: () => false,
+  WebSpeechService: class {
+    start = vi.fn().mockResolvedValue(undefined)
+    stop = vi.fn()
+    abort = vi.fn()
+  },
+}))
+
+vi.mock('@/services/audioRecorder', () => ({
+  AudioRecorder: class {
+    startRecording: () => Promise<void>
+    constructor(options: { onStart?: () => void }) {
+      recorderOptions = options
+      // Assigned here rather than as a class field: the mock factory runs
+      // while the outer `const` is still in its temporal dead zone.
+      this.startRecording = startRecording
+    }
+    checkSupport = vi.fn().mockResolvedValue({ supported: true, hasDevices: true })
+    stopRecording = vi.fn()
+  },
+}))
+
+vi.mock('@/services/api/chatApi', () => ({
+  chatApi: {
+    uploadChatFile: vi.fn(),
+    transcribeAudio: vi.fn().mockResolvedValue({ text: '', file_id: 1 }),
+  },
+}))
+
+interface DictationInput {
+  startDictation: () => Promise<boolean>
+}
+
+const mountInput = (): VueWrapper =>
+  mount(ChatInput, {
+    global: {
+      mocks: { $t: (key: string) => key },
+      stubs: {
+        Icon: true,
+        Textarea: { template: '<textarea />', methods: { focus() {} } },
+        CommandPalette: true,
+        FileMentionPalette: true,
+        ToolsDropdown: true,
+        ToolBadge: true,
+        ModelDropdown: true,
+        KnowledgeFolderPicker: true,
+        FileSelectionModal: true,
+        PastedTextCard: true,
+        PastedTextModal: true,
+        QuoteChip: true,
+      },
+    },
+  })
+
+const dictationOf = (wrapper: VueWrapper): DictationInput => wrapper.vm as unknown as DictationInput
+
+describe('ChatInput.startDictation', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    speechToTextAvailable = true
+    recorderOptions = {}
+    startRecording.mockClear()
+    showError.mockClear()
+  })
+
+  it('starts recording when the server can transcribe', async () => {
+    const wrapper = mountInput()
+
+    await expect(dictationOf(wrapper).startDictation()).resolves.toBe(true)
+    expect(startRecording).toHaveBeenCalledTimes(1)
+    expect(showError).not.toHaveBeenCalled()
+  })
+
+  it('leaves a running recording alone instead of stopping it', async () => {
+    // The shortcut can be fired again while the microphone is already live.
+    // Forwarding that to `toggleRecording()` would end the dictation the user
+    // just asked for, so the second call has to be a no-op.
+    const wrapper = mountInput()
+    await dictationOf(wrapper).startDictation()
+
+    await expect(dictationOf(wrapper).startDictation()).resolves.toBe(true)
+    expect(startRecording).toHaveBeenCalledTimes(1)
+  })
+
+  it('explains itself instead of opening a dead microphone without a transcription path', async () => {
+    speechToTextAvailable = false
+    const wrapper = mountInput()
+
+    await expect(dictationOf(wrapper).startDictation()).resolves.toBe(false)
+    expect(showError).toHaveBeenCalledWith('chatInput.dictationUnavailable')
+    expect(startRecording).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
Add a default-off native seam so the iOS Shortcuts app can start chat dictation or attach a photo once the companion app binary donates those actions.

## Changes
- Add `nativeShortcuts.ts` and `nativeCamera.ts` wrappers over the app-owned `window.SynaplanShortcuts` / `window.SynaplanCamera` bridges (this repo stays Capacitor-free).
- Expose `startDictation()` on `ChatInput` and handle pending/live shortcut actions in `ChatView` (`dictate` starts the mic, `photo` captures and attaches — never auto-sends).
- `App.vue` routes dictate/photo taps onto the chat surface. Guest photo taps reuse the existing attach feature-gate.
- Additive i18n keys in `en` / `de` / `es` / `fr` / `tr`.

## Verification
- [ ] Not tested (explain)
- [x] Manual — exercised with the companion `synaplan-apps` Simulator build (Shortcuts donation + chat composer).
- [x] Tests added/updated — `make -C frontend lint`, `docker compose exec -T frontend npm run check:types`, `make -C frontend test` (198 files / 1577 tests).

## Notes
- **Release classification: `store-required`.** `frontend/src/services/api/native*.ts` is a native seam in `.github/mobile-impact-policy.json`. The handlers are a no-op on web. Companion native PR: `synaplan-apps` `feat/ios-app-shortcuts`.
- Do not merge this as if it were backend-only or an OTA-only ship. The first useful delivery needs the new iOS binary.

## Screenshots/Logs
See the companion app PR for the Simulator Kurzbefehle screenshot.

## Merge blockers (do not merge until every box is checked)
The author will merge `main` themselves.

- [x] Feature branch only — never commit or push to `main`
- [x] Conventional Commit, no AI attribution
- [x] Frontend gate green (lint, vue-tsc, unfiltered Vitest)
- [ ] Platform CI on this PR is green (`All Checks Passed`)
- [ ] Review confirms every shared hook is marked `MOBILE-APP SEAM` and default-off