### PR TITLE
test(frontend): define localStorage via property descriptor in test setup

### DIFF
--- a/frontend/tests/unit/setup-env.ts
+++ b/frontend/tests/unit/setup-env.ts
@@ -58,16 +58,25 @@ const localStorageMock = {
   },
 }
 
-// Set up localStorage on all possible global objects
-;(globalThis as unknown as { localStorage: typeof localStorageMock }).localStorage =
-  localStorageMock
+// Set up localStorage on all possible global objects. happy-dom declares
+// localStorage as a getter-only accessor, so a plain assignment throws as soon as
+// the test environment exposes the real window instead of a writable proxy.
+const defineLocalStorage = (target: object): void => {
+  Object.defineProperty(target, 'localStorage', {
+    value: localStorageMock,
+    writable: true,
+    configurable: true,
+  })
+}
+
+defineLocalStorage(globalThis)
 
 if (typeof window !== 'undefined') {
-  ;(window as unknown as { localStorage: typeof localStorageMock }).localStorage = localStorageMock
+  defineLocalStorage(window)
 }
 
 if (typeof global !== 'undefined') {
-  ;(global as unknown as { localStorage: typeof localStorageMock }).localStorage = localStorageMock
+  defineLocalStorage(global)
 }
 
 // Export to prevent tree-shaking


### PR DESCRIPTION
Prepares the test suite for the Vitest 5 upgrade in #1716, without requiring it.

## Problem

`tests/unit/setup-env.ts` installs its `localStorage` mock by assigning to `globalThis`, `window` and `global`. happy-dom declares `localStorage` as a getter-only accessor. Vitest 4 handed tests a writable proxy of the window, so the assignment silently worked.

Vitest 5 exposes the real `GlobalWindow` instead ([vitest#10373](https://github.com/vitest-dev/vitest/issues/10373)), and the assignment throws before a single test runs. On #1716 that takes out the entire suite:

```
⎯⎯⎯⎯⎯ Failed Suites 200 ⎯⎯⎯⎯⎯⎯
TypeError: Cannot set property localStorage of #<GlobalWindow> which has only a getter
 ❯ tests/unit/setup-env.ts:62:71
 Test Files  200 failed (200)
      Tests  no tests
```

## Change

Install the mock with `Object.defineProperty` instead of a plain assignment. The same file already uses that approach for the `nodeName` fix a few lines above.

## Verification

| Runner | Result |
| --- | --- |
| Vitest 4.1.11 (this branch) | 210 files, 1641 tests passed |
| Vitest 5.0.0 (this change applied onto `renovate/major-5-vitest-monorepo`, isolated worktree) | 200 files, 1583 tests passed |
| Vitest 5.0.0 (that branch unchanged, for comparison) | 200 files failed, no tests ran |

Full frontend gate green: `make -C frontend lint`, `npm run check:types`, `make -C frontend test`. Backend untouched.

## Follow-up for #1716

Vitest 5 also flips `clearMocks` to `true` by default, and we configure it nowhere. Audited against this suite: no `.sequential`, no `toHaveTextContent`, no removed entry points, no snapshots, and only two files use `beforeAll`. The remaining risk is small but belongs in the upgrade PR, not here.