### PR TITLE
chore(renovate): correct stale review-guide facts and group Docker digest bumps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ description: AI-powered knowledge management system with RAG, chat widgets, and 
 
 Full-stack AI knowledge management platform: RAG with MariaDB VECTOR + Qdrant, embeddable chat widgets, WhatsApp/Email integration, multiple AI providers (Ollama, OpenAI, Anthropic, Groq, Gemini, xAI).
 
-**Stack:** PHP 8.3/Symfony 7, Vue 3/TypeScript/Vite, Docker Compose, frankenphp/caddy.
+**Stack:** PHP 8.4/Symfony 8.1, Vue 3/TypeScript/Vite, Docker Compose, frankenphp/caddy.
 
 ## Repository Architecture
 

--- a/docs/DEPENDENCY_UPDATES.md
+++ b/docs/DEPENDENCY_UPDATES.md
@@ -180,7 +180,7 @@ Rebasing cannot save the group here, and a Dependency Dashboard checkbox does no
 
 **Land the rest by hand.** Precedent: #942 (Frontend Core) was blocked by vite 8.0.13 (Rolldown minification bug). The remedy was a human branch `chore/frontend-core-safe` that applied the safe bumps with vite held at 8.0.11, merged as #967, after which #942 was closed pointing at it. Reuse that shape — human branch, a `chore(deps):` subject naming the skipped package and the reason, then close the group PR with that reason. Renovate reopens the skipped package by itself once a fixed version exists.
 
-If the block will outlast a single PR, the cleaner option is a scoped `allowedVersions` rule in `renovate.json5` so Renovate stays in charge instead of you hand-building branches repeatedly. That has not been needed here yet — it is a deliberate config change, so agree it explicitly before adding one.
+If the block will outlast a single PR, the cleaner option is a scoped `allowedVersions` rule in `renovate.json5` so Renovate stays in charge instead of you hand-building branches repeatedly. It must be its own rule — Renovate rejects `allowedVersions` and `matchUpdateTypes` in the same rule, and every group rule here has `matchUpdateTypes`. That has not been needed yet, and it is a deliberate config change, so agree it explicitly before adding one.
 
 ## 9. Temporary Pins (revert when upstream releases)
 

--- a/docs/DEPENDENCY_UPDATES.md
+++ b/docs/DEPENDENCY_UPDATES.md
@@ -8,17 +8,18 @@ How to review, merge, and close Renovate dependency update PRs.
 
 For each open Renovate PR, work through these steps **in order**. Stop at the first "no".
 
-1. **Superseded?** → close (§1)
-2. **Read diff + changelog + PR comments** → understand what changed and what reviewers/bots flagged (Review Checklist)
-3. **Dashboard (entire):** superseded by pending/rate-limited PR? → close. Partner needed? → blocked (§2)
-4. **Majors — peer deps OK against `main`?** → if unclear or not, blocked (§4)
-5. **Majors — peers OK against each other?** → if not, coordinate (§4)
-6. **Conflict analysis:** shared files? lockfile? overlapping hunks? → decide parallel vs. sequential (§3)
-7. **CI green?** → if not, don't merge
-8. **Security fix?** → prioritize (§6)
-9. **What does it affect?** → CI-infra / test-infra → merge directly. Build / runtime → test locally (§7)
-10. **Major?** → check manual steps beyond Renovate (§5)
-11. **Merge order:** security first, then independent, then sequential hotspots, blocked last (§6)
+1. **Which update type?** `digest`, `pin` and `lockFileMaintenance` bumps have no changelog to read — they follow the CI-infra path, not the changelog review below (§7)
+2. **Superseded?** → close (§1)
+3. **Read diff + changelog + PR comments** → understand what changed and what reviewers/bots flagged (Review Checklist)
+4. **Dashboard (entire):** superseded by pending/rate-limited PR? → close. Partner needed? → blocked (§2)
+5. **Majors — peer deps OK against `main`?** → if unclear or not, blocked (§4)
+6. **Majors — peers OK against each other?** → if not, coordinate (§4)
+7. **Conflict analysis:** shared files? lockfile? overlapping hunks? → decide parallel vs. sequential (§3)
+8. **CI green?** → if not, don't merge. If one package is blocking a whole group, don't just close it (§8)
+9. **Security fix?** → prioritize (§6)
+10. **What does it affect?** → CI-infra / test-infra → merge directly. Build / runtime → test locally (§7)
+11. **Major?** → check manual steps beyond Renovate (§5)
+12. **Merge order:** security first, then independent, then sequential hotspots, blocked last (§6)
 
 ---
 
@@ -27,7 +28,7 @@ For each open Renovate PR, work through these steps **in order**. Stop at the fi
 For **every** open PR, do all four:
 
 1. **Read the diff:** `gh pr diff <NR> --repo metadist/synaplan` (incl. `--name-only`). Understand what changes — including lockfile collateral.
-2. **Check changelogs / release notes** for affected versions: breaking changes, deprecations, migration steps. Compare against the diff. If release notes are unavailable, state it explicitly and assess risk from diff + peer dependencies.
+2. **Check changelogs / release notes** for affected versions: breaking changes, deprecations, migration steps. Compare against the diff. If release notes are unavailable, state it explicitly and assess risk from diff + peer dependencies. Digest bumps have no release notes *by construction* — classify them by their tag (§7) instead of blocking them for missing notes.
 3. **Read PR comments and review threads:** `gh pr view <NR> --repo metadist/synaplan --comments`. Look for:
    - Reviewer concerns, blockers, or required follow-ups not yet resolved.
    - Renovate bot notes about conflicts, rebases, dependency-dashboard links, or "depends on" markers.
@@ -48,12 +49,14 @@ Always add a short reason when closing.
 
 ## 2. Dependency Dashboard
 
-Read the **entire** dashboard at <https://github.com/metadist/synaplan/issues/30> — not just the "Open" section. Check all of these:
+Read the **entire** dashboard at <https://github.com/metadist/synaplan/issues/30> — not just the "Open" section. These are the headings it actually carries; walk all of them:
 
-- **Rate-limited updates:** if a coordinated partner upgrade is rate-limited (e.g. Vitest 4 while Vite 8 is open), the open PR is **blocked** until its partner is also available. Don't merge one half of a coordinated upgrade alone.
-- **Pending status checks:** a newer group PR may be waiting that already includes bumps from an open PR → the open PR is **superseded**, close it.
-- **Blocked / closed PRs:** understand why they were blocked. If an open PR depends on a blocked one, it is blocked too.
-- **Deprecations & abandoned packages:** note them — they may need replacement rather than updating.
+- **Repository Problems:** Renovate's own config and extraction errors. If this section is not empty, everything below it may be incomplete — deal with it before trusting the rest of the page.
+- **Rate-Limited:** if a coordinated partner upgrade is rate-limited (e.g. Vitest 4 while Vite 8 is open), the open PR is **blocked** until its partner is also available. Don't merge one half of a coordinated upgrade alone.
+- **Open:** a newer group PR listed here may already include bumps from an older open PR → the older one is **superseded**, close it.
+- **PR Closed (Blocked):** understand why they were blocked. If an open PR depends on a blocked one, it is blocked too.
+- **Deprecations / Replacements** and **Abandoned Dependencies:** note them — they may need replacement rather than updating.
+- **Detected Dependencies:** ground truth for what Renovate manages. Use it to check whether a file or manager is covered at all — several update types and managers fall outside every group rule in `renovate.json5`.
 
 ## 3. Conflict Analysis
 
@@ -88,10 +91,11 @@ For each major PR:
 5. If CI is green despite a known incompatibility (e.g. tests pass by luck), **still treat as blocked** — a green CI does not override a documented peer dependency mismatch.
 6. **Check compatibility between open PRs:** if multiple majors are being reviewed in the same session, verify they are compatible with each other, not just with `main`. Merging one major changes the baseline for the next.
 
-**Runtime versions:**
+**Runtime versions — read them from the repo, never from this file:**
 
-- **Node.js:** Only **LTS** lines (even numbers). Odd-numbered releases → close. Current: **Node 22 LTS**.
-- **PHP:** Check tool majors against `composer.json` minimum PHP version (currently `>=8.3`).
+- **Node.js:** `.nvmrc` and `frontend/package.json` (`engines.node`) are the source of truth.
+- **PHP:** `backend/composer.json` (`require.php`) is the source of truth. Check tool majors against it.
+- **Policy:** Node follows **LTS lines only**. "Even-numbered" is not the test — an even major is not LTS on release day. Node 24 was correctly closed as not-yet-LTS in #873 and only landed months later in #1210.
 
 ## 5. Major Upgrades: Manual Steps Beyond Renovate
 
@@ -106,11 +110,17 @@ Renovate only bumps version numbers — it does not fix code, configuration, CI 
 - **Security advisories:** Composer/npm may block packages with known CVEs. Check audit config if dependency resolution fails unexpectedly.
 - **Polyfill replace section:** When bumping the minimum PHP/Node version, add the corresponding polyfill to the `replace` section.
 
-**Strategy:** Create a backward-compatible compatibility PR first (code changes that work on both old and new version), then push infrastructure fixes (CI, Dockerfile, config) directly into the Renovate PR branch.
+**Strategy** — three destinations, and mixing them up is the usual failure:
+
+1. **Compatibility PR first:** only changes that also work on the version currently on `main`. Replace a deprecated API with a successor that already exists there, and verify from the changelog *when* the successor was introduced — don't assume it was always available.
+2. **The Renovate PR itself:** changes that require the new version (removed config keys, new-only APIs). These must never go into the compatibility PR — they would break `main`.
+3. **The Renovate branch, pushed directly:** infrastructure fixes (CI runtime, Dockerfile, framework meta-constraints, lockfile regeneration).
+
+Nothing of the above may carry local testing artifacts — removed Dockerfile digests, `docker-compose.yml` env tweaks, temporary dependency swaps.
 
 ## 6. Merge Order
 
-Goal: minimize rebase cycles.
+Goal: minimize rebase cycles. This is the expensive part of the process, not a stylistic preference: `ci.yml` has no path filters, so every force-push replays the full pipeline (~7 min, ~7 concurrent jobs, 8-way E2E matrix) on runners shared across the org. Grouped PRs have averaged roughly a dozen CI runs each — median 11 force-pushes, 54 in #1615 — because Renovate rewrites the branch whenever *any* package in the group gets a new release. An idling group PR therefore keeps costing pipelines: merge it or mark it blocked, but don't leave it open to accumulate.
 
 1. **Security fixes first** — regardless of major/minor/patch, regardless of hotspot group.
 2. **Independent PRs and safe parallel groups:** PRs with no shared files, plus PRs that share a file but qualify for parallel merge (see section 3).
@@ -126,10 +136,19 @@ Decide based on **what the update affects**, not just whether it's a major.
 ### Merge directly (CI is sufficient)
 
 - **Patch/minor bumps:** lockfile-only, no constraint changes, no changelog risk.
-- **CI-infrastructure majors** (GitHub Actions, Docker digests): CI has already validated itself by running green. Local testing is not possible or useful.
+- **CI-infrastructure majors** (GitHub Actions): CI has already validated itself by running green. Local testing is not possible or useful.
+- **Docker digests:** depends on the tag — see "Digest bumps" below.
 - **Test-infrastructure majors** (happy-dom, Vitest, PHPUnit) when CI is fully green incl. E2E: the CI run *is* the test — it ran the entire test suite with the new version.
 
 All of the above still require: CI fully green (incl. E2E), no peer dependency conflicts (verified in step 4), no known risk from changelog.
+
+### Digest bumps
+
+Digest updates are the single largest stream of dependency PRs and there is no changelog to read. What a digest actually carries depends on the tag it sits on, so check the tag first:
+
+- **Exact tag** (`mariadb:12.3.3@sha256:…`, `qdrant/qdrant:v1.19.0@sha256:…`, `apache/tika:3.3.1.0@sha256:…`): a rebuild of the same declared version, i.e. base-OS patches. Green CI is sufficient evidence — merge.
+- **Floating tag** (`node:24@sha256:…`, `redis:7.4-alpine@sha256:…`, `quay.io/keycloak/keycloak:26.7@sha256:…`): the digest can hide a real version move inside that line. Establish what changed (the image's own version label, or the upstream release notes for that line) and review it as a minor bump.
+- **`:latest` tag** (`ollama/ollama`, `mailhog/mailhog`, `phpmyadmin/phpmyadmin`, `ghcr.io/metadist/synaplan-tts`): genuinely opaque — the tag guarantees nothing. All of these are dev tooling or optional companions, so green CI plus a working local stack is the only evidence available, and that is enough. Never extend this exemption to an image on the production path.
 
 ### Test locally
 
@@ -141,11 +160,29 @@ All of the above still require: CI fully green (incl. E2E), no peer dependency c
 ### Local test commands
 
 - **Backend only:** `make -C backend lint && make -C backend phpstan && make -C backend test`
-- **Frontend lockfile:** `cd frontend && rm -rf node_modules && npm ci` → `make -C frontend lint && docker compose exec -T frontend npm run check:types && make -C frontend test`
-- **Cloudflare lockfile:** `cd cloudflare && rm -rf node_modules && npm ci`
+- **Frontend lockfile:** reinstall **inside the container** — `docker compose exec -T frontend npm ci` (or `docker compose restart frontend`, whose entrypoint runs `npm ci`). A host-side `npm ci` proves nothing here: `docker-compose.yml` mounts an anonymous volume over `/app/node_modules` on purpose, so the container never sees host `node_modules`. Then `make -C frontend lint && docker compose exec -T frontend npm run check:types && make -C frontend test`.
+- **Cloudflare lockfile:** `cd cloudflare && rm -rf node_modules && npm ci` — there is no container for `cloudflare/`, so the host install is the right one.
 - **Playwright changes:** `npx playwright install`
 
-## 8. Temporary Pins (revert when upstream releases)
+## 8. When One Package Blocks a Group
+
+A group PR is all-or-nothing — Renovate cannot drop a single failing member from it. Two different causes, two different remedies. Neither of them is "close the PR": closing only defers the work to the next group PR.
+
+### The bumped tool got stricter
+
+A static-analysis or formatter bump (PHPStan, php-cs-fixer, ESLint) can turn CI red while the dependency itself is perfectly fine — the new version simply reports issues in code that was already there. #580 (PHPStan 2.1.40, `Call to an undefined method ::expects()` in `ProcessMailHandlersCommandTest.php`) was autoclosed within half an hour, that version never landed, and the work reappeared later. #1662 is the open instance (`function.alreadyNarrowedType` in `BootstrapAdminConfiguration.php:74`).
+
+**Push the code fix onto the Renovate branch.** That is the established practice here: #680 carried the mock-typing fix together with the PHPStan bump it needed, and #551 pushed `phpstan.neon` plus lint fixes onto `renovate/api-platform`. Do **not** widen the baseline — new ignores, a lowered level, a broader exclude — to make the bump pass; that hides the finding instead of fixing it.
+
+### One member version is genuinely broken
+
+Rebasing cannot save the group here, and a Dependency Dashboard checkbox does not help either: it recreates the branch with the same bad version still in it.
+
+**Land the rest by hand.** Precedent: #942 (Frontend Core) was blocked by vite 8.0.13 (Rolldown minification bug). The remedy was a human branch `chore/frontend-core-safe` that applied the safe bumps with vite held at 8.0.11, merged as #967, after which #942 was closed pointing at it. Reuse that shape — human branch, a `chore(deps):` subject naming the skipped package and the reason, then close the group PR with that reason. Renovate reopens the skipped package by itself once a fixed version exists.
+
+If the block will outlast a single PR, the cleaner option is a scoped `allowedVersions` rule in `renovate.json5` so Renovate stays in charge instead of you hand-building branches repeatedly. That has not been needed here yet — it is a deliberate config change, so agree it explicitly before adding one.
+
+## 9. Temporary Pins (revert when upstream releases)
 
 Track dependencies pinned to an untagged/dev branch as a stopgap. Revert each to a
 proper tagged constraint as soon as the upstream release lands (Renovate will open

--- a/docs/DEPENDENCY_UPDATES.md
+++ b/docs/DEPENDENCY_UPDATES.md
@@ -27,9 +27,9 @@ For each open Renovate PR, work through these steps **in order**. Stop at the fi
 
 For **every** open PR, do all four:
 
-1. **Read the diff:** `gh pr diff <NR> --repo metadist/synaplan` (incl. `--name-only`). Understand what changes — including lockfile collateral.
+1. **Read the diff:** `gh pr diff <NR>` (incl. `--name-only`). Understand what changes — including lockfile collateral.
 2. **Check changelogs / release notes** for affected versions: breaking changes, deprecations, migration steps. Compare against the diff. If release notes are unavailable, state it explicitly and assess risk from diff + peer dependencies. Digest bumps have no release notes *by construction* — classify them by their tag (§7) instead of blocking them for missing notes.
-3. **Read PR comments and review threads:** `gh pr view <NR> --repo metadist/synaplan --comments`. Look for:
+3. **Read PR comments and review threads:** `gh pr view <NR> --comments`. Look for:
    - Reviewer concerns, blockers, or required follow-ups not yet resolved.
    - Renovate bot notes about conflicts, rebases, dependency-dashboard links, or "depends on" markers.
    - Cross-references to issues or other PRs (e.g. "blocked by #123", "supersedes #456").
@@ -60,13 +60,13 @@ Read the **entire** dashboard at <https://github.com/metadist/synaplan/issues/30
 
 ## 3. Conflict Analysis
 
-Group changed paths per PR. When multiple PRs touch the **same file**, decide:
+Group changed paths per PR with `gh pr diff <NR> --name-only`. PRs that share no file merge independently. When two PRs touch the **same file**, decide:
 
 **Rebase between merges** (sequential) when:
 
 - The shared file is a **lockfile** (`package-lock.json`, `composer.lock`) — integrity hashes make text conflicts inevitable.
 - The changes touch **overlapping or adjacent lines** (check hunk headers with `gh pr diff <NR> | grep "^@@"`).
-- The changes are **semantically coupled** — e.g. one PR changes a function signature, another calls it.
+- The changes are **semantically coupled**. This happens because Renovate branches here carry source fixes, not just manifests (§5 and §8 tell you to push them there): #680 landed a test fix, #967 touched `stores/auth.ts`. Two such branches editing the same source file are coupled even if the hunks are far apart.
 
 **Parallel merge is safe** when all of these are true:
 
@@ -74,15 +74,26 @@ Group changed paths per PR. When multiple PRs touch the **same file**, decide:
 - Each PR changes a **single, isolated line** in a **different region** of the file (hunks don't overlap, ≥10 lines apart).
 - The changes are **semantically independent** — e.g. different Docker action versions, different service digests, different CI job configs.
 
-PRs that share **no files at all** can always be merged independently.
-
 ## 4. Peer Dependency & Ecosystem Compatibility
 
 **Every major update** must pass this check before it can be merged or even recommended for local testing. No PR moves forward without it. **If peer dependency information cannot be found or is ambiguous, mark the PR as blocked.**
 
 For each major PR:
 
-1. **Check the new version against `main`:** look up peer dependencies in the npm registry, packagist, or the package's own `package.json` / `composer.json`. Verify every peer is satisfied by the versions currently on `main`.
+1. **Check the new version against `main`** with commands, not from memory. Query the *specific* version — an aggregated lookup shows the union of all versions and proves nothing. Check the **first and the latest** version in the range; requirements change between minors.
+
+   ```bash
+   # Composer
+   docker compose exec -T backend composer show -a <vendor/package> <version>
+   docker compose exec -T backend composer why-not <vendor/package> <version>
+
+   # npm
+   npm view <package>@<version> peerDependencies --json
+   npm view <package>@<version> engines --json
+   npm view <package> versions --json | tail -20
+   ```
+
+   Verify every peer is satisfied by the versions currently on `main`. "Probably compatible" is not an outcome — either the command output shows it, or the PR is blocked.
 2. **Walk the ecosystem chains** — one major often requires others. Common chains:
    - Frontend: **Vite ↔ Vitest ↔ @vitejs/plugin-vue ↔ vue-tsc ↔ TypeScript**
    - Backend: **PHPUnit ↔ PHP version ↔ Symfony ↔ Doctrine**
@@ -120,7 +131,7 @@ Nothing of the above may carry local testing artifacts — removed Dockerfile di
 
 ## 6. Merge Order
 
-Goal: minimize rebase cycles. This is the expensive part of the process, not a stylistic preference: `ci.yml` has no path filters, so every force-push replays the full pipeline (~7 min, ~7 concurrent jobs, 8-way E2E matrix) on runners shared across the org. Grouped PRs have averaged roughly a dozen CI runs each — median 11 force-pushes, 54 in #1615 — because Renovate rewrites the branch whenever *any* package in the group gets a new release. An idling group PR therefore keeps costing pipelines: merge it or mark it blocked, but don't leave it open to accumulate.
+Goal: minimize rebase cycles. This is the expensive part of the process, not a stylistic preference, and the mechanism is structural: `ci.yml` has no path filters, so every force-push replays the *entire* pipeline including the E2E matrix — and Renovate force-pushes a group branch whenever **any** package in that group gets a new release. A group PR left open therefore keeps buying full pipelines for as long as it idles (measured over the first five months of grouping: about a dozen CI runs per grouped PR). Merge it or mark it blocked; don't let it sit.
 
 1. **Security fixes first** — regardless of major/minor/patch, regardless of hotspot group.
 2. **Independent PRs and safe parallel groups:** PRs with no shared files, plus PRs that share a file but qualify for parallel merge (see section 3).
@@ -135,12 +146,12 @@ Decide based on **what the update affects**, not just whether it's a major.
 
 ### Merge directly (CI is sufficient)
 
-- **Patch/minor bumps:** lockfile-only, no constraint changes, no changelog risk.
+- **Patch/minor bumps** where `gh pr diff <NR> --name-only` lists only lockfiles — no `composer.json` / `package.json` constraint change, no source file.
 - **CI-infrastructure majors** (GitHub Actions): CI has already validated itself by running green. Local testing is not possible or useful.
 - **Docker digests:** depends on the tag — see "Digest bumps" below.
 - **Test-infrastructure majors** (happy-dom, Vitest, PHPUnit) when CI is fully green incl. E2E: the CI run *is* the test — it ran the entire test suite with the new version.
 
-All of the above still require: CI fully green (incl. E2E), no peer dependency conflicts (verified in step 4), no known risk from changelog.
+All of the above still require: CI fully green (incl. E2E), and no peer dependency conflict (§4, by command output). They do **not** waive the changelog review — you still do checklist item 2 and it has to come back empty. "No changelog risk" is the *result* of reading the changelog, never a reason to skip it.
 
 ### Digest bumps
 
@@ -152,8 +163,8 @@ Digest updates are the single largest stream of dependency PRs and there is no c
 
 ### Test locally
 
-- **Build-affecting majors** (Vite, TypeScript, Webpack): changes how production output is generated. CI covers build + E2E but may miss subtle runtime differences. Check out the branch, build, and manually verify.
-- **Runtime/framework majors** (Symfony, Doctrine, Vue, vue-router): affects application behavior. Test locally beyond what CI covers.
+- **Build-affecting majors** (Vite, TypeScript, Webpack): changes how production output is generated, which CI's build+E2E does not fully cover. Run `make -C frontend build` (app **and** widget), then load the app and check: browser console free of new errors, chat streaming still arrives (SSE), and the widget still boots from `dist-widget/` against a different origin. Name what you checked.
+- **Runtime/framework majors** (Symfony, Doctrine, Vue, vue-router): affects application behavior. Exercise the paths CI does not: send a chat message end to end, upload and search a document (RAG), and open one page per changed area. Name the pages and features you exercised — "tested locally" without that list is not a result.
 - **Coordinated upgrades:** check out a fresh branch, apply all related PRs, install dependencies, run full test suite.
 - **Any PR with source code changes** or version constraint changes in `package.json` / `composer.json`.
 

--- a/renovate.json5
+++ b/renovate.json5
@@ -9,7 +9,8 @@
   "timezone": "Europe/Berlin",
   "prHourlyLimit": 2,
   // Make the implicit Renovate default (10) explicit. Grouping already collapses
-  // minor/patch into ~6 buckets, so this is a backlog cap, not a per-dependency knob.
+  // minor/patch into ~6 buckets plus one for Docker digests, so this is a backlog
+  // cap, not a per-dependency knob.
   "prConcurrentLimit": 10,
   "prCreation": "immediate",
   "dependencyDashboard": true,
@@ -76,6 +77,23 @@
       "groupName": "Docker Images",
       "matchManagers": ["dockerfile", "docker-compose"],
       "matchUpdateTypes": ["minor", "patch"]
+    },
+    {
+      // Digest bumps matched NO rule above (every group is minor/patch only), so
+      // each one opened its own PR: ~12 per month, each replaying the full CI
+      // pipeline because ci.yml has no path filters. They also sort FIRST in
+      // Renovate's creation order (pinDigest > pin > digest > patch > minor >
+      // major), so they were consuming the prHourlyLimit ahead of the real
+      // dependency updates. There is nothing to review per package either -- a
+      // digest has no changelog, it is classified by its tag
+      // (docs/DEPENDENCY_UPDATES.md §7). Our own ghcr.io images stay individual:
+      // a digest move on a release artifact of ours is a deployment event, not
+      // third-party noise.
+      "description": "Docker digest bumps grouped -- no changelog exists, review is tag-based",
+      "groupName": "Docker Digests",
+      "matchManagers": ["dockerfile", "docker-compose"],
+      "matchUpdateTypes": ["digest", "pinDigest"],
+      "matchPackageNames": ["*", "!ghcr.io/metadist/**"]
     },
     {
       "description": "Major updates: always individual, manual review",


### PR DESCRIPTION
## Summary

Verified every hard claim in the Renovate review guide against the repo and the PR history; five were stale or contradictory enough to produce wrong review decisions. Adds the missing playbook for a single package blocking a group, and closes the one config gap that survived scrutiny.

## Changes

**`docs/DEPENDENCY_UPDATES.md` — corrections**

| Claim | Reality |
| --- | --- |
| PHP minimum `>=8.3` | `backend/composer.json` requires `>=8.4`; CI's lint job installs `php-version: "8.4"`. The old value would wrongly block any tool needing `^8.4`. |
| "Node 22 LTS, odd-numbered releases → close" | `.nvmrc` is `24`, `frontend/package.json` `engines.node` is `>=24`. Parity was never the real test either: Node 24 (an even major) was correctly closed as not-yet-LTS in #873 and landed in #1210. |
| Dashboard section "Pending status checks" | Does not exist on #30. Replaced with the headings actually rendered there, incl. `Repository Problems` and `Detected Dependencies`. |
| Frontend lockfile test: `cd frontend && npm ci` | `docker-compose.yml` mounts an anonymous volume over `/app/node_modules` on purpose, so the container never sees host `node_modules` — the recipe verified nothing. Now reinstalls inside the container. |
| Docker digests blanket-approved as CI-infra | The review rule simultaneously demanded blocking opaque digests. Contradiction over the largest single PR stream; digests are now classified by tag (exact / floating / `:latest`). |

Runtime versions no longer appear as literals in prose — the guide points at `.nvmrc` and `composer.json` as the source of truth, since hardcoding them is exactly how it went stale.

**`docs/DEPENDENCY_UPDATES.md` — additions**

- New §8 for a single package blocking a whole group, with both causes separated: a stricter analyser gets its code fix pushed onto the Renovate branch (#680, #551 — versus the autoclosed #580 and the currently red #1662), a genuinely broken member version gets the rest landed by hand (#942 → #967). Includes the non-obvious trap that a Dependency Dashboard checkbox recreates the branch with the bad version still in it.
- §6 now states why rebase cycles are the expensive part: `ci.yml` has no path filters, so every force-push replays the full pipeline, and grouped PRs have averaged roughly a dozen runs each (median 11 force-pushes, 54 in #1615).
- §5 splits the three destinations for major-upgrade changes explicitly.

**`renovate.json5`**

Groups Docker digest bumps. Every group rule matches minor/patch only, so digests matched none of them and each opened its own PR — ~12 per month, roughly a third of all Renovate traffic. They also sort first in Renovate's creation order (`pinDigest > pin > digest > patch > minor > major`), so they consumed the `prHourlyLimit` ahead of the real dependency updates. Our own `ghcr.io/metadist/**` images are excluded and stay individual: a digest move on a release artifact of ours is a deployment event, not third-party noise.

GitHub Action digests are deliberately **not** grouped. Their version comment stays put while the SHA changes (#1556, #1377: `# v4` before and after), meaning the upstream major tag was moved — exactly the mutable-tag event that pinning digests exists to surface. Batching those would dilute a security signal for one or two PRs a month. A `github-actions` minor/patch group was rejected too: 13 of 14 actions are pinned to major-only comments (`# v7`), so such a group would match exactly one package.

**`AGENTS.md`**

Header advertised PHP 8.3/Symfony 7; `composer.json` requires `php >=8.4` and pins `symfony/*` to `8.1.*`.

## Verification

- [x] Manual

- `renovate.json5` passes `renovate-config-validator`. Because it reports "as global config", I gegen-tested it with a deliberately broken copy: it catches unknown option names (`grupName`) but **not** invalid enum values, so `pinDigest` and the negation syntax `["*", "!ghcr.io/metadist/**"]` were confirmed against the Renovate docs instead (which document exactly `["@angular/**", "!@angular/abc"]`).
- Every corrected fact checked against the file it claims to describe (`composer.json`, `.nvmrc`, `docker-compose.yml`, `ci.yml`) or against the PR/issue cited.
- `node scripts/mobile-impact.mjs --base origin/main --head HEAD` → `no-app-impact`; all three paths are already on the `noAppImpact` allow-list, no policy change needed.
- No test/lint gate applies: markdown is not linted anywhere, the CI `lint` job is PHP-only, and no workflow validates `renovate.json5`.

## Notes

Expected transition on the first Renovate run after merge: the open individual digest PRs (e.g. #1698, ollama) get replaced by one collected "Docker Digests" PR. That first one will be unusually large because it picks up the accumulated backlog.

Two findings left untouched here: `AGENTS.md:277` still qualifies `eraseCredentials()` with "Symfony 7.3+" (harmless, we are past it), and the repo root carries a 93-byte `package-lock.json` with no `package.json` next to it.


---

## Follow-up: hardening pass

A second round after reviewing the guide from the perspective of the agent that has to follow it. The finding: it was followable exactly where it named a concrete test, and guesswork everywhere it used a soft predicate. Soft predicates are worse than redundancy — a reader does not notice them as a gap, they fill them in plausibly and produce a judgement that looks like process.

| Was | Now |
| --- | --- |
| §7 "no changelog risk" (circular — the review's outcome used as a precondition for skipping it) | The `--name-only` diff test decides the path; the changelog review is explicitly never waived |
| §7 "check out the branch, build, and manually verify" (violated the review rule's own anti-pattern against unspecified local testing) | Names the build command and what to look at |
| §4 "look up peer dependencies in the npm registry" | Carries the actual commands, moved in from `.cursor/rules/` so the guide is self-contained, incl. the trap that an aggregated `composer show -a` proves nothing |
| §3 "semantically coupled — one PR changes a signature, another calls it" (does not occur for Renovate PRs) | The real case: Renovate branches here carry source fixes (#680, #967), so two of them can touch the same source file |
| §6's five measurements | One anchor number. The mechanism is durable, the numbers were a fresh staleness liability of exactly the kind this branch set out to fix |

Also removed a trivially true line in §3 and the redundant `--repo metadist/synaplan` flag from four commands.

**Not in this PR, because `.cursor/` is gitignored:** the local review rule lost its copy of the gate list (83 → 58 lines). It had compressed the guide's twelve ordered steps into eight and silently dropped four of them while still calling itself "the critical gates" — three representations of one procedure is what let the digest contradiction survive in the first place. The rule now points at the guide's Quick Reference and keeps only what the guide cannot carry: the approval boundary for an agent, and the anti-patterns.
