### PR TITLE
refactor(admin): drop the redundant string assertion in the password getter

### DIFF
--- a/backend/src/Service/Admin/BootstrapAdminConfiguration.php
+++ b/backend/src/Service/Admin/BootstrapAdminConfiguration.php
@@ -70,10 +70,7 @@ final readonly class BootstrapAdminConfiguration
      */
     public function password(): string
     {
-        $password = $this->password->getValue();
-        \assert(\is_string($password));
-
-        return $password;
+        return $this->password->getValue();
     }
 
     /**


### PR DESCRIPTION
Unblocks the PHPStan bump in #1662, without requiring it.

## Problem

PHPStan 2.2.13 narrows `\SensitiveParameterValue::getValue()` to the type the constructor put in. Both the `assert()` and the `is_string()` inside it are therefore always true, and #1662 fails on them:

```
 ------ -----------------------------------------------------------------------
  Line   src/Service/Admin/BootstrapAdminConfiguration.php
 ------ -----------------------------------------------------------------------
  74     Call to function assert() with true will always evaluate to true.
         function.alreadyNarrowedType
  74     Call to function is_string() with string will always evaluate to true.
         function.alreadyNarrowedType
 ------ -----------------------------------------------------------------------

 [ERROR] Found 2 errors
```

## Change

The assertion was redundant at runtime as well. `__construct` only accepts `string $acceptedPassword` (`BootstrapAdminConfiguration.php:60`), and the `string` return type of `password()` would raise a TypeError on anything else.

## Verification

Backward compatibility was measured, not assumed — the analyser on `main` accepts the change too:

| Analyser | Result |
| --- | --- |
| 2.2.9 (currently on `main`, via `make -C backend phpstan`) | `[OK] No errors` |
| 2.2.13 (the version #1662 upgrades to, run from the release phar against the same `phpstan.neon`) | `[OK] No errors` |

Full backend gate green: `make -C backend lint` (0 of 1693 files to fix), `make -C backend phpstan`, `make -C backend test` (5435 tests, no failures). Frontend untouched.

After this merges, #1662 needs a rebase; `friendsofphp/php-cs-fixer` and `happy-dom` in that PR were never the blocker.