### PR TITLE
fix(renovate): remove invalid bare `*` matcher that halted Renovate

### DIFF
--- a/docs/DEPENDENCY_UPDATES.md
+++ b/docs/DEPENDENCY_UPDATES.md
@@ -193,6 +193,8 @@ Rebasing cannot save the group here, and a Dependency Dashboard checkbox does no
 
 If the block will outlast a single PR, the cleaner option is a scoped `allowedVersions` rule in `renovate.json5` so Renovate stays in charge instead of you hand-building branches repeatedly. It must be its own rule — Renovate rejects `allowedVersions` and `matchUpdateTypes` in the same rule, and every group rule here has `matchUpdateTypes`. That has not been needed yet, and it is a deliberate config change, so agree it explicitly before adding one.
 
+When you do touch `renovate.json5`, note that `renovate-config-validator` is a weak gate: it checks option *names* but not matcher semantics. It passes `matchPackageNames: ["*", "!x/**"]`, which Renovate rejects at runtime — and that rejection stops **all** dependency PRs until the default branch is fixed (#1729). Read the matcher rules from Renovate's docs, and expect config errors to surface only after merge.
+
 ## 9. Temporary Pins (revert when upstream releases)
 
 Track dependencies pinned to an untagged/dev branch as a stopgap. Revert each to a

--- a/renovate.json5
+++ b/renovate.json5
@@ -86,14 +86,28 @@
       // major), so they were consuming the prHourlyLimit ahead of the real
       // dependency updates. There is nothing to review per package either -- a
       // digest has no changelog, it is classified by its tag
-      // (docs/DEPENDENCY_UPDATES.md §7). Our own ghcr.io images stay individual:
-      // a digest move on a release artifact of ours is a deployment event, not
-      // third-party noise.
+      // (docs/DEPENDENCY_UPDATES.md §7).
       "description": "Docker digest bumps grouped -- no changelog exists, review is tag-based",
       "groupName": "Docker Digests",
       "matchManagers": ["dockerfile", "docker-compose"],
+      "matchUpdateTypes": ["digest", "pinDigest"]
+    },
+    {
+      // Separates our own release artifacts from the third-party batch above: a
+      // digest move on one of our images is a deployment event, not upstream
+      // noise. Relies on the same "last match wins" ordering as the groups above.
+      //
+      // Do NOT express this as an exclusion on the rule above. Renovate rejects
+      // `matchPackageNames: ["*", "!ghcr.io/metadist/**"]` -- the check is
+      // `(matchers.includes('*') || matchers.includes('**')) && length > 1`, so a
+      // bare `*` may never share the array. It broke Renovate entirely once
+      // (#1729), and `renovate-config-validator` does NOT catch it: the error
+      // surfaces only at runtime, on the default branch, after merge.
+      "description": "Digests of our own images kept out of the third-party batch",
+      "groupName": "Synaplan Image Digests",
+      "matchManagers": ["dockerfile", "docker-compose"],
       "matchUpdateTypes": ["digest", "pinDigest"],
-      "matchPackageNames": ["*", "!ghcr.io/metadist/**"]
+      "matchPackageNames": ["ghcr.io/metadist/**"]
     },
     {
       "description": "Major updates: always individual, manual review",


### PR DESCRIPTION
## Summary

Fixes #1729. #1725 introduced an invalid `matchPackageNames` array; Renovate rejects it and, as a precaution, has **stopped opening all dependency PRs** until the default branch is fixed. This restores the intent with a valid matcher.

## Root cause

The rule tried to keep our own images out of the grouped digest batch with an exclusion:

```json5
"matchPackageNames": ["*", "!ghcr.io/metadist/**"]
```

Renovate forbids that. The check is an element-equality test in `config/validation-helpers/regex-glob-matchers.ts`:

```js
(matchers.includes('*') || matchers.includes('**')) && matchers.length > 1
```

A bare `*` may never share the array with another pattern. The documented negation example is `["@angular/**", "!@angular/abc"]` — a *specific* positive pattern. Generalising it to `*` was the error, and it is mine.

## Changes

The exclusion becomes a second rule matching only `ghcr.io/metadist/**`, relying on the same "last match wins" ordering the other groups already use. That is not a bare `**`, so it does not trip the check, and it is the exact pattern shape that has been live in this file for `symfony/**`, `doctrine/**` and `api-platform/**` for months.

Intent is preserved: third-party digests batch into `Docker Digests`, our own release artifacts get `Synaplan Image Digests` instead of riding along.

## Verification

- [x] Manual

Checked against the source condition rather than a docs example this time — every `match*` array in the file was asserted to contain no bare `*`/`**` element alongside others.

**`renovate-config-validator` cannot catch this class of error.** It reported "validated successfully" for the exact failing array in three configurations:

| Invocation | Result on the broken config |
| --- | --- |
| `renovate-config-validator renovate.json5` | pass (`as global config`) |
| `renovate-config-validator --strict renovate.json5` | pass (`as global config`) |
| `renovate-config-validator` (no arg → repository mode) | pass |
| one-rule minimal repro `{"matchPackageNames": ["*", "!foo/**"]}` | pass |

So the green validator run I cited on #1725 was worthless for this specific risk. Matcher semantics are enforced only at runtime, on the default branch, after merge. That is now recorded in the config comment next to the rule and in `docs/DEPENDENCY_UPDATES.md` §8, which actively advises adding a `packageRules` entry and would otherwise send the next reader into the same false reassurance.

## Notes

Renovate stays halted until this is on `main`, so this wants merging ahead of the open dependency PRs. Nothing else in #1725 is affected — the grouping, the guide corrections and the `AGENTS.md` fix are all independent of this line.
