### PR TITLE
fix(auth): stop store redirects from cancelling the logout navigation

### DIFF
--- a/frontend/src/services/api/chatApi.ts
+++ b/frontend/src/services/api/chatApi.ts
@@ -8,6 +8,7 @@ import { isNativeApp } from './nativeRuntime'
 import { getNativeAccessToken, hasNativeTokens } from './nativeAuth'
 import { UserMemorySchema } from './userMemoriesApi'
 import { hasSessionHint, clearSessionHint } from '@/services/sessionHint'
+import { isSessionTerminating } from '@/services/sessionTeardown'
 import { GetApiChatsMessagesResponseSchema } from '@/generated/api-schemas'
 import type { StreamUpdatePayload } from '@/types/chatStream'
 
@@ -232,8 +233,14 @@ async function getSseToken(): Promise<string | null> {
 
       return cachedSseToken
     } catch (error) {
-      // If error is "Authentication required", redirect to login
-      if (error instanceof Error && error.message === 'Authentication required') {
+      // If error is "Authentication required", redirect to login — unless a
+      // logout is already under way, whose navigation this would cancel
+      // (see sessionTeardown).
+      if (
+        error instanceof Error &&
+        error.message === 'Authentication required' &&
+        !isSessionTerminating()
+      ) {
         // Trigger auth failure handling (redirect to login)
         window.location.href = `/login?reason=session_expired`
       }

--- a/frontend/src/services/sessionTeardown.ts
+++ b/frontend/src/services/sessionTeardown.ts
@@ -1,0 +1,43 @@
+/**
+ * Session Teardown - marks the window in which the client is giving up its
+ * session but the SPA is still alive.
+ *
+ * Logout is not instant: it awaits POST /api/v1/auth/logout, wipes the
+ * user-scoped stores, disconnects realtime, and only then hands the browser
+ * over to the next page - for OIDC a full-page navigation to the provider's
+ * end-session endpoint, which lands on /logged-out.
+ *
+ * Throughout that window there is no user in memory while requests started
+ * earlier are still resolving. Any code that reacts to "no user" by assigning
+ * `window.location.href` replaces the pending logout navigation instead of
+ * following it: the end-session request dies as `net::ERR_ABORTED`, the user
+ * lands on /login, and the provider session stays open - the user looks
+ * logged out but is not. Store actions firing in the same window also still
+ * write to the API (a chat created after the logout click).
+ *
+ * So the rule is: while a teardown is in progress, an unauthenticated state is
+ * expected, not an error. Do not navigate, do not call protected endpoints -
+ * let the logout reach its own destination.
+ *
+ * Set: when a logout starts through the auth store, silent ones included.
+ * authService's own silent logouts (a refresh that came back 401) stay outside
+ * this: they never request an end-session URL, so there is no navigation to
+ * protect and the ordinary redirect to /login has to keep working.
+ * Cleared: as soon as a principal is signed in again.
+ */
+
+let terminating = false
+
+/** A logout has started; the destination navigation is not committed yet. */
+export function beginSessionTeardown(): void {
+  terminating = true
+}
+
+/** A principal is signed in again; ordinary auth handling applies. */
+export function endSessionTeardown(): void {
+  terminating = false
+}
+
+export function isSessionTerminating(): boolean {
+  return terminating
+}

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -5,6 +5,7 @@ import { ref, computed } from 'vue'
 import { authService, type AuthUser, type ImpersonatorInfo } from '@/services/authService'
 import { useConfigStore } from '@/stores/config'
 import { clearPendingRedirect } from '@/utils/pendingAuthRedirect'
+import { beginSessionTeardown, endSessionTeardown } from '@/services/sessionTeardown'
 import { redeemPendingIapPurchaseAfterAuth } from '@/services/iapPostAuthRedemption'
 
 export type User = AuthUser
@@ -139,6 +140,7 @@ export const useAuthStore = defineStore('auth', () => {
   function syncFromAuthService(): void {
     user.value = authService.getUser().value
     impersonator.value = authService.getImpersonator().value
+    if (user.value) endSessionTeardown()
     publishPrincipal()
   }
 
@@ -259,6 +261,11 @@ export const useAuthStore = defineStore('auth', () => {
   }
 
   async function logout(silent = false): Promise<void> {
+    // Before anything is cleared: from here until the browser leaves this page
+    // an unauthenticated state is the expected state, and nothing may navigate
+    // on its own or keep talking to protected endpoints. See sessionTeardown.
+    beginSessionTeardown()
+
     // Clear user immediately to prevent any auth checks during logout
     user.value = null
     impersonator.value = null

--- a/frontend/src/stores/chats.ts
+++ b/frontend/src/stores/chats.ts
@@ -8,6 +8,7 @@ import { useIncomingStore } from '@/stores/incoming'
 import { isIamSharingEnabled } from '@/composables/useIamFeature'
 import { authService } from '@/services/authService'
 import { hasSessionHint } from '@/services/sessionHint'
+import { isSessionTerminating } from '@/services/sessionTeardown'
 import { getErrorMessage } from '@/utils/errorMessage'
 import { buildChatShareUrl } from '@/utils/urlHelper'
 
@@ -22,6 +23,10 @@ const HISTORY_PAGE_SIZE = 20
 // successful login (session hint) — a never-logged-in guest gets the neutral
 // `auth_required`, so they never see the misleading "session expired" message.
 function checkAuthOrRedirect(): boolean {
+  // A logout in progress owns the next navigation: redirecting here would
+  // cancel it (see sessionTeardown). Bail out silently instead.
+  if (isSessionTerminating()) return false
+
   if (!authService.isAuthenticated()) {
     console.warn('🔒 Not authenticated - redirecting to login')
     const reason = hasSessionHint() ? 'session_expired' : 'auth_required'

--- a/frontend/src/stores/history.ts
+++ b/frontend/src/stores/history.ts
@@ -11,6 +11,7 @@ import {
 } from '@/utils/messageMapper'
 import { authService } from '@/services/authService'
 import { hasSessionHint } from '@/services/sessionHint'
+import { isSessionTerminating } from '@/services/sessionTeardown'
 import type { MessageUsage } from '@/stores/usageTaximeter'
 
 // Re-export so existing consumers keep importing from the store module.
@@ -21,6 +22,10 @@ export { parseContentWithThinking }
 // Helper function to check authentication and redirect if needed
 // Uses authService which holds user info in memory (not localStorage)
 function checkAuthOrRedirect(): boolean {
+  // A logout in progress owns the next navigation: redirecting here would
+  // cancel it (see sessionTeardown). Bail out silently instead.
+  if (isSessionTerminating()) return false
+
   if (!authService.isAuthenticated()) {
     console.warn('🔒 Not authenticated - redirecting to login')
     // Only genuine expired sessions (prior login on this browser) get the

--- a/frontend/tests/unit/stores/auth-impersonation.spec.ts
+++ b/frontend/tests/unit/stores/auth-impersonation.spec.ts
@@ -4,6 +4,7 @@ import { createPinia, setActivePinia } from 'pinia'
 import { useAuthStore } from '@/stores/auth'
 import { useChatsStore } from '@/stores/chats'
 import { useHistoryStore } from '@/stores/history'
+import { endSessionTeardown, isSessionTerminating } from '@/services/sessionTeardown'
 
 const ACTIVE_CHAT_STORAGE_KEY = 'synaplan_active_chat_id'
 
@@ -108,6 +109,8 @@ vi.mock('@/stores/userFeedback', () => ({
 describe('useAuthStore — impersonation', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
+    // Module-scoped and deliberately not cleared by logout itself.
+    endSessionTeardown()
     refreshUserMock.mockClear()
     startApiMock.mockReset()
     stopApiMock.mockReset()
@@ -377,6 +380,8 @@ describe('useAuthStore — impersonation', () => {
     const store = useAuthStore()
     await store.refreshUser()
     expect(store.isImpersonating).toBe(true)
+    // Signing in clears any teardown left over from an earlier session.
+    expect(isSessionTerminating()).toBe(false)
 
     await store.logout()
 
@@ -386,5 +391,8 @@ describe('useAuthStore — impersonation', () => {
     // The realtime client must be torn down before the auth cookie is
     // cleared so it cannot keep retrying with stale credentials.
     expect(realtimeDisconnectMock).toHaveBeenCalledOnce()
+    // Logout owns the next navigation from here on; the stores must not
+    // redirect or keep calling protected endpoints (see sessionTeardown).
+    expect(isSessionTerminating()).toBe(true)
   })
 })

--- a/frontend/tests/unit/stores/logoutNavigationRace.spec.ts
+++ b/frontend/tests/unit/stores/logoutNavigationRace.spec.ts
@@ -1,0 +1,138 @@
+/**
+ * Regression guard for the logout navigation race.
+ *
+ * Logout hands the browser a destination (for OIDC a full-page navigation to
+ * the provider's end-session endpoint). Store code that reacted to the
+ * momentarily missing user by assigning `window.location.href` replaced that
+ * pending navigation: the end-session request died as `net::ERR_ABORTED`, the
+ * user landed on /login instead of /logged-out, and the provider session
+ * stayed open. It also let a chat be created after the logout click.
+ *
+ * The contract asserted here: while a teardown is in progress the stores stay
+ * silent — no navigation, no protected request — and ordinary unauthenticated
+ * handling is untouched outside that window.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { ref } from 'vue'
+import { useChatsStore } from '@/stores/chats'
+import { useHistoryStore } from '@/stores/history'
+import {
+  beginSessionTeardown,
+  endSessionTeardown,
+  isSessionTerminating,
+} from '@/services/sessionTeardown'
+
+const isAuthenticatedMock = vi.hoisted(() => vi.fn(() => true))
+vi.mock('@/services/authService', () => ({
+  authService: {
+    isAuthenticated: () => isAuthenticatedMock(),
+  },
+}))
+
+const httpClientMock = vi.hoisted(() => vi.fn())
+vi.mock('@/services/api/httpClient', () => ({
+  httpClient: httpClientMock,
+}))
+
+vi.mock('@/composables/useIamFeature', () => ({
+  isIamSharingEnabled: () => false,
+  isIamGroupsEnabled: () => false,
+}))
+
+const incomingLoaded = ref(false)
+vi.mock('@/stores/incoming', () => ({
+  useIncomingStore: () => ({
+    get loaded() {
+      return incomingLoaded.value
+    },
+    isOpenable: () => false,
+  }),
+}))
+
+let hrefWrites: string[] = []
+
+describe('logout navigation race', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    localStorage.clear()
+    vi.clearAllMocks()
+    isAuthenticatedMock.mockReturnValue(true)
+    httpClientMock.mockResolvedValue({ chats: [] })
+
+    // The stores navigate by assigning window.location.href; record the
+    // assignments instead of letting the environment act on them.
+    hrefWrites = []
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      writable: true,
+      value: {
+        href: 'http://localhost:5173/',
+        pathname: '/',
+        origin: 'http://localhost:5173',
+      },
+    })
+    Object.defineProperty(window.location, 'href', {
+      configurable: true,
+      get: () => 'http://localhost:5173/',
+      set: (next: string) => {
+        hrefWrites.push(next)
+      },
+    })
+  })
+
+  afterEach(() => {
+    endSessionTeardown()
+  })
+
+  it('keeps the unauthenticated redirect outside a teardown', async () => {
+    isAuthenticatedMock.mockReturnValue(false)
+
+    await useChatsStore().loadChats()
+
+    expect(hrefWrites).toEqual(['/login?reason=auth_required'])
+    expect(httpClientMock).not.toHaveBeenCalled()
+  })
+
+  it('reports a prior session as expired rather than missing', async () => {
+    isAuthenticatedMock.mockReturnValue(false)
+    localStorage.setItem('sh', '1')
+
+    await useChatsStore().loadChats()
+
+    expect(hrefWrites).toEqual(['/login?reason=session_expired'])
+  })
+
+  it('does not navigate while a logout owns the next navigation', async () => {
+    isAuthenticatedMock.mockReturnValue(false)
+    beginSessionTeardown()
+
+    await useChatsStore().loadChats()
+    await useHistoryStore().loadMessages(7)
+
+    expect(hrefWrites).toEqual([])
+    expect(httpClientMock).not.toHaveBeenCalled()
+  })
+
+  it('does not create a chat once a logout has started', async () => {
+    // The logout POST is still in flight, so the client still counts as
+    // authenticated — this is the window in which a stray chat was created.
+    beginSessionTeardown()
+
+    const chat = await useChatsStore().createChat('after logout')
+
+    expect(chat).toBeNull()
+    expect(httpClientMock).not.toHaveBeenCalled()
+  })
+
+  it('restores ordinary handling once a principal is signed in again', async () => {
+    beginSessionTeardown()
+    expect(isSessionTerminating()).toBe(true)
+
+    endSessionTeardown()
+    isAuthenticatedMock.mockReturnValue(false)
+    await useChatsStore().loadChats()
+
+    expect(hrefWrites).toEqual(['/login?reason=auth_required'])
+  })
+})


### PR DESCRIPTION
## Problem

Logout hands the browser a destination. For OIDC that is a full-page navigation to the provider's end-session endpoint, which lands on `/logged-out`. Until that navigation commits, the SPA is still alive with no user in memory while requests started before the click are still resolving.

Three call sites reacted to that momentarily missing user by assigning `window.location.href` themselves:

- `frontend/src/stores/chats.ts:23` `checkAuthOrRedirect()`
- `frontend/src/stores/history.ts:22` `checkAuthOrRedirect()`
- `frontend/src/services/api/chatApi.ts:235` `getSseToken()` catch branch

That assignment replaces the pending logout navigation instead of following it. The end-session request dies as `net::ERR_ABORTED`, the browser lands on `/login`, and the provider session stays open — the user looks logged out but is not. A chat could also still be created after the logout click, because `createChat` passed the same guard while the logout POST was in flight.

## Evidence

Playwright traces of 10 flaky runs: 9 show the chats-store redirect, 1 the SSE-token redirect. The CI list reporter prints the hijack URL in only 6 of 13 cases, which is why `?reason=session_expired` never appears in job logs even though one trace has it.

Job log of the earliest occurrence, run 32979378462, job 98213498814:

```
✘  13 [chromium] › tests/e2e/tests/oidc-auth.spec.ts:16:3 › @auth should logout from OIDC session (19.3s)
✓  14 [chromium] › tests/e2e/tests/oidc-auth.spec.ts:16:3 › @auth should logout from OIDC session (retry #1) (4.0s)
Error: expect(locator).toBeVisible() failed
Locator: locator('[data-testid="page-logged-out"]')
 - navigated to "http://localhost:8001/login?reason=auth_required"
```

Reproduced locally against a CI-like stack: with the provider end-session navigation held open by route interception, a spec forcing this race failed 3/3 without this change and passed 3/3 with it, alongside the rest of the OIDC suite.

Affected specs: `oidc-auth.spec.ts` `@auth should logout from OIDC session`, and `auth.spec.ts`, where the same aborted navigation surfaces as `page.goto: net::ERR_ABORTED at /profile`.

## Timing history

The racing navigations date back to 2026-02-21, when `window.location.href = oidcLogoutUrl` was introduced. The observed failure rate stepped up on 2026-08-26: 0 flakes in 357 consecutive OIDC jobs from 2026-08-08 to 2026-08-26 14:05Z, then 13 of 468 jobs (2.8%, rising to 3.8% in September). No commit in that window touches this path — the push carrying the first flake, `d32416207` (#1573), changes only `phpstan` and `php-cs-fixer` in `composer.lock` and is frontend-identical to a clean job 13 minutes earlier. Job logs older than roughly 30 days are expired, so June and July cannot be checked.

What shifted the timing is undetermined. This change removes the competing navigation rather than widening a wait, so it does not depend on the answer.

## Change

`frontend/src/services/sessionTeardown.ts` marks the window between the start of a logout and the browser leaving the page. Inside it, an unauthenticated state is expected rather than an error: no navigation, no protected requests.

The window opens in the auth store's `logout()` before any state is cleared, and closes when a principal is signed in again. `authService`'s own silent logouts, triggered by a refresh that came back 401, stay outside it deliberately: they never request an end-session URL, so there is no navigation to protect and their ordinary redirect to `/login` has to keep working.

## Tests

`frontend/tests/unit/stores/logoutNavigationRace.spec.ts` asserts both directions: the `auth_required` and `session_expired` redirects still fire outside a teardown, and inside one the stores neither navigate nor call the API, including `createChat` returning `null`. `auth-impersonation.spec.ts` covers the flag's lifecycle across a logout.

Frontend gate green: eslint, `vue-tsc`, 1654 unit tests.

## Mobile impact

`store-required`, from `frontend/src/stores/auth.ts` alone, which `.github/mobile-impact-policy.json:45` lists explicitly. The change there is the two teardown calls; no authentication transport or native seam is touched. The new `frontend/src/services/sessionTeardown.ts` classifies as `ota-candidate` under the existing `services/` rule, so no policy change is needed.
