### PR TITLE
fix(iam): close the security review findings before sharing is switched on

### DIFF
--- a/backend/config/packages/rate_limiter.yaml
+++ b/backend/config/packages/rate_limiter.yaml
@@ -48,3 +48,13 @@ framework:
             limit: 10
             interval: '1 minute'
             cache_pool: 'cache.rate_limiter'
+        # People picker (`GET /api/v1/iam/subjects`), keyed per user in
+        # ShareController. A person typing a name fires one request per
+        # keystroke, so 60/minute is generous for real use while making a
+        # scripted walk over the directory (one probe per letter) slow
+        # enough to be pointless.
+        iam_subject_search:
+            policy: 'sliding_window'
+            limit: 60
+            interval: '1 minute'
+            cache_pool: 'cache.rate_limiter'

--- a/backend/src/Controller/FileController.php
+++ b/backend/src/Controller/FileController.php
@@ -24,6 +24,7 @@ use App\Service\File\Office\DocumentExportService;
 use App\Service\File\Office\DocumentThumbnailGenerator;
 use App\Service\File\Office\OfficeConverterClient;
 use App\Service\File\UploadOptions;
+use App\Service\Iam\KnowledgeFolderShareCleanup;
 use App\Service\Iam\SharedFileAccess;
 use App\Service\Media\MediaAccessTokenService;
 use App\Service\RAG\VectorStorage\VectorMigrationService;
@@ -67,6 +68,7 @@ class FileController extends AbstractController
         private DocumentRevisionService $documentRevisionService,
         private DocumentOfficeMergeService $documentOfficeMergeService,
         private SharedFileAccess $sharedFileAccess,
+        private KnowledgeFolderShareCleanup $folderShareCleanup,
     ) {
     }
 
@@ -1148,7 +1150,9 @@ class FileController extends AbstractController
             $this->storageService->deleteFile($file->getFilePath());
         }
 
+        $groupKey = $file->getGroupKey();
         $this->fileRepository->delete($file);
+        $this->folderShareCleanup->forgetIfEmpty($user->getId(), $groupKey);
 
         return $this->json(['success' => true, 'message' => 'File deleted successfully']);
     }
@@ -1405,7 +1409,11 @@ class FileController extends AbstractController
             return $this->json(['error' => 'groupKey is required'], Response::HTTP_BAD_REQUEST);
         }
 
+        $previousGroupKey = $file->getGroupKey();
         $this->fileRepository->updateGroupKey($file, $newGroupKey);
+        if ($previousGroupKey !== $newGroupKey) {
+            $this->folderShareCleanup->forgetIfEmpty($user->getId(), $previousGroupKey);
+        }
 
         $chunksUpdated = $this->vectorStorageFacade->updateGroupKey($user->getId(), $file->getId(), $newGroupKey);
 
@@ -1440,8 +1448,10 @@ class FileController extends AbstractController
             return $this->json(['error' => 'Access denied'], Response::HTTP_FORBIDDEN);
         }
 
+        $previousGroupKey = $file->getGroupKey();
         $file->setGroupKey(null);
         $this->fileRepository->save($file);
+        $this->folderShareCleanup->forgetIfEmpty($user->getId(), $previousGroupKey);
 
         // Keep the vectors — just move them to the ungrouped DEFAULT bucket so
         // the file stays searchable globally but no longer belongs to a folder.

--- a/backend/src/Controller/PromptController.php
+++ b/backend/src/Controller/PromptController.php
@@ -1071,6 +1071,17 @@ class PromptController extends AbstractController
             }
         }
 
+        // The `tools:` namespace is reserved for system prompts on update as
+        // on create — a user-owned prompt renamed into it would be picked up by
+        // internal pipelines once shared (see PromptRepository::findSharedPrompts).
+        if (isset($data['topic']) && is_string($data['topic'])
+            && 0 !== $prompt->getOwnerId() && str_starts_with(trim($data['topic']), 'tools:')
+        ) {
+            return $this->json([
+                'error' => 'Cannot use the "tools:" prefix - reserved for system prompts',
+            ], Response::HTTP_BAD_REQUEST);
+        }
+
         // Update fields if provided
         if (isset($data['shortDescription'])) {
             $prompt->setShortDescription(trim($data['shortDescription']));

--- a/backend/src/Controller/ShareController.php
+++ b/backend/src/Controller/ShareController.php
@@ -17,6 +17,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\CurrentUser;
 
@@ -28,6 +29,7 @@ final class ShareController extends AbstractController
         private readonly ShareService $shareService,
         private readonly AccessGate $accessGate,
         private readonly SharedInbox $sharedInbox,
+        private readonly RateLimiterFactoryInterface $iamSubjectSearchLimiter,
     ) {
     }
 
@@ -282,6 +284,7 @@ final class ShareController extends AbstractController
             ),
             new OA\Response(response: 401, description: 'Not authenticated'),
             new OA\Response(response: 404, description: 'Feature disabled'),
+            new OA\Response(response: 429, description: 'Too many searches — try again in a minute'),
         ]
     )]
     public function subjects(Request $request, #[CurrentUser] ?User $user): JsonResponse
@@ -291,6 +294,11 @@ final class ShareController extends AbstractController
             return $denied;
         }
         \assert($user instanceof User);
+
+        $limit = $this->iamSubjectSearchLimiter->create('user:'.$user->getId())->consume();
+        if (!$limit->isAccepted()) {
+            return $this->json(['error' => 'Too many searches. Try again in a minute.'], Response::HTTP_TOO_MANY_REQUESTS);
+        }
 
         return $this->json([
             'subjects' => $this->shareService->searchSubjects($user, (string) $request->query->get('q', '')),

--- a/backend/src/Controller/WidgetController.php
+++ b/backend/src/Controller/WidgetController.php
@@ -311,7 +311,8 @@ class WidgetController extends AbstractController
         }
 
         // Visitor statistics belong to the owner (like the session list); a
-        // read share shows the configuration only.
+        // read share shows the configuration only — minus the credentials
+        // it carries (Slack webhook, external API token).
         $isOwner = $widget->getOwnerId() === (int) $user->getId();
         $widgetPayload = [
             'id' => $widget->getId(),
@@ -319,7 +320,7 @@ class WidgetController extends AbstractController
             'name' => $widget->getName(),
             'taskPromptTopic' => $widget->getTaskPromptTopic(),
             'status' => $widget->getStatus(),
-            'config' => $widget->getConfig(),
+            'config' => $isOwner ? $widget->getConfig() : self::withoutSecrets($widget->getConfig()),
             'allowedDomains' => $widget->getAllowedDomains(),
             'isActive' => $this->widgetService->isWidgetActive($widget),
             'created' => $widget->getCreated(),
@@ -373,8 +374,10 @@ class WidgetController extends AbstractController
                 $this->widgetService->updateWidgetName($widget, $data['name']);
             }
 
-            if (isset($data['config'])) {
-                $this->widgetService->updateWidget($widget, $data['config']);
+            if (isset($data['config']) && is_array($data['config'])) {
+                // An editor only ever saw the masked credentials; a round-trip
+                // of the mask must not overwrite the owner's real values.
+                $this->widgetService->updateWidget($widget, self::withoutSecretMasks($data['config']));
             }
 
             if (isset($data['status']) && in_array($data['status'], ['active', 'inactive'])) {
@@ -1468,6 +1471,45 @@ class WidgetController extends AbstractController
         }
 
         return ['urls' => $urls, 'promptId' => $prompt->getId()];
+    }
+
+    /**
+     * Config keys that are credentials. They are the owner's alone; a sharee
+     * sees that the integration is configured, never the secret itself.
+     */
+    private const SECRET_CONFIG_KEYS = ['slackWebhookUrl', 'externalApiToken'];
+    private const SECRET_MASK = '***';
+
+    /**
+     * @param array<string, mixed> $config
+     *
+     * @return array<string, mixed>
+     */
+    private static function withoutSecrets(array $config): array
+    {
+        foreach (self::SECRET_CONFIG_KEYS as $key) {
+            if (isset($config[$key]) && is_string($config[$key]) && '' !== $config[$key]) {
+                $config[$key] = self::SECRET_MASK;
+            }
+        }
+
+        return $config;
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     *
+     * @return array<string, mixed>
+     */
+    private static function withoutSecretMasks(array $config): array
+    {
+        foreach (self::SECRET_CONFIG_KEYS as $key) {
+            if (self::SECRET_MASK === ($config[$key] ?? null)) {
+                unset($config[$key]);
+            }
+        }
+
+        return $config;
     }
 
     private function widgetAccess(User $user, Widget $widget): string

--- a/backend/src/Entity/Group.php
+++ b/backend/src/Entity/Group.php
@@ -22,12 +22,15 @@ class Group
     public const KIND_MANUAL = 'manual';
     public const KIND_DIRECTORY = 'directory';
 
+    public const NAME_MAX_LENGTH = 128;
+    public const EXTERNAL_ID_MAX_LENGTH = 191;
+
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(name: 'BID', type: 'bigint')]
     private ?int $id = null;
 
-    #[ORM\Column(name: 'BNAME', length: 128)]
+    #[ORM\Column(name: 'BNAME', length: self::NAME_MAX_LENGTH)]
     private string $name = '';
 
     #[ORM\Column(name: 'BSLUG', length: 128)]
@@ -42,7 +45,7 @@ class Group
     #[ORM\Column(name: 'BEXTERNALSOURCE', length: 191, nullable: true)]
     private ?string $externalSource = null;
 
-    #[ORM\Column(name: 'BEXTERNALID', length: 191, nullable: true)]
+    #[ORM\Column(name: 'BEXTERNALID', length: self::EXTERNAL_ID_MAX_LENGTH, nullable: true)]
     private ?string $externalId = null;
 
     /** Reserved for v2 nested groups; unused in v1. */

--- a/backend/src/Repository/PromptRepository.php
+++ b/backend/src/Repository/PromptRepository.php
@@ -192,6 +192,16 @@ class PromptRepository extends ServiceEntityRepository
             if ($userPrompt) {
                 return $userPrompt;
             }
+        }
+
+        // Global (ownerId = 0) wins over anything another user shared: a share
+        // adds topics, it never replaces a system prompt for the recipient.
+        $global = $this->findByTopic($topic, 0);
+        if ($global instanceof Prompt) {
+            return $global;
+        }
+
+        if ($userId > 0) {
             foreach ($this->findSharedPrompts($userId) as $shared) {
                 if ($shared->getTopic() === $topic) {
                     return $shared;
@@ -199,8 +209,7 @@ class PromptRepository extends ServiceEntityRepository
             }
         }
 
-        // Fallback to global (ownerId = 0)
-        return $this->findByTopic($topic, 0);
+        return null;
     }
 
     /**
@@ -304,6 +313,14 @@ class PromptRepository extends ServiceEntityRepository
     }
 
     /**
+     * Prompts other users shared with this one at `use` or higher.
+     *
+     * A share can only add topics the recipient does not already get from
+     * the system: `tools:*` topics and topics that exist as a system prompt
+     * are dropped here, so a shared prompt can never stand in for the
+     * classifier, memory or default-chat prompt of the person it was shared
+     * with.
+     *
      * @return list<Prompt>
      */
     private function findSharedPrompts(int $userId): array
@@ -316,7 +333,10 @@ class PromptRepository extends ServiceEntityRepository
         /** @var list<Prompt> $rows */
         $rows = $this->createQueryBuilder('p')
             ->where('p.id IN (:ids)')
+            ->andWhere('p.topic NOT LIKE :toolsPrefix')
+            ->andWhere('p.topic NOT IN (SELECT s.topic FROM App\Entity\Prompt s WHERE s.ownerId = 0)')
             ->setParameter('ids', $ids)
+            ->setParameter('toolsPrefix', 'tools:%')
             ->getQuery()
             ->getResult();
 

--- a/backend/src/Repository/UserRepository.php
+++ b/backend/src/Repository/UserRepository.php
@@ -19,26 +19,54 @@ class UserRepository extends ServiceEntityRepository
     }
 
     /**
-     * People picker: match email or the JSON name fields in BUSERDETAILS.
+     * Shortest query the people picker answers. Anything shorter matches too
+     * many accounts to be a lookup and turns the endpoint into an enumerator.
+     */
+    public const SEARCH_MIN_LENGTH = 2;
+
+    /**
+     * BUSERDETAILS keys that hold a person's name. Only these are searched:
+     * the JSON also carries phone, address, provider subjects, Stripe ids and
+     * the pending phone-verification code, none of which may be probed
+     * through a substring match.
+     */
+    private const SEARCHABLE_NAME_KEYS = ['full_name', 'first_name', 'last_name', 'firstName', 'lastName', 'display_name'];
+
+    /**
+     * People picker: match the email address or one of the name fields.
      *
      * @return list<User>
      */
     public function searchByEmailOrName(string $query, int $limit = 20): array
     {
         $query = trim($query);
-        if ('' === $query) {
+        if (mb_strlen($query) < self::SEARCH_MIN_LENGTH) {
             return [];
         }
 
-        $escaped = $this->escapeLike($query);
+        $pattern = '%'.$this->escapeLike($query).'%';
+        $nameMatches = [];
+        foreach (self::SEARCHABLE_NAME_KEYS as $key) {
+            $nameMatches[] = sprintf("JSON_UNQUOTE(JSON_EXTRACT(BUSERDETAILS, '$.%s')) LIKE :q ESCAPE '!'", $key);
+        }
+        $sql = sprintf(
+            "SELECT BID FROM BUSER WHERE BMAIL LIKE :q ESCAPE '!' OR %s ORDER BY BMAIL ASC LIMIT %d",
+            implode(' OR ', $nameMatches),
+            max(1, $limit),
+        );
+
+        $stmt = $this->getEntityManager()->getConnection()->prepare($sql);
+        $stmt->bindValue('q', $pattern);
+        $ids = array_map('intval', $stmt->executeQuery()->fetchFirstColumn());
+        if ([] === $ids) {
+            return [];
+        }
 
         /** @var list<User> $users */
         $users = $this->createQueryBuilder('u')
-            ->where("u.mail LIKE :q ESCAPE '!'")
-            ->orWhere("u.userDetails LIKE :q ESCAPE '!'")
-            ->setParameter('q', '%'.$escaped.'%')
+            ->where('u.id IN (:ids)')
+            ->setParameter('ids', $ids)
             ->orderBy('u.mail', 'ASC')
-            ->setMaxResults($limit)
             ->getQuery()
             ->getResult();
 

--- a/backend/src/Service/Iam/DirectoryGroupSync.php
+++ b/backend/src/Service/Iam/DirectoryGroupSync.php
@@ -10,6 +10,7 @@ use App\Entity\User;
 use App\Repository\GroupMemberRepository;
 use App\Repository\GroupRepository;
 use App\Service\Auth\OidcClaimResolver;
+use Psr\Log\LoggerInterface;
 
 /**
  * Upserts directory groups from an OIDC claim and reconciles this user's
@@ -25,6 +26,7 @@ final readonly class DirectoryGroupSync
         private GroupRepository $groupRepository,
         private GroupMemberRepository $groupMemberRepository,
         private AuditLogWriter $auditLogWriter,
+        private LoggerInterface $logger,
         private string $oidcClientId = '',
         private string $oidcDiscoveryUrl = '',
     ) {
@@ -65,6 +67,16 @@ final readonly class DirectoryGroupSync
 
         $desiredGroupIds = [];
         foreach ($externalIds as $externalId) {
+            // A claim value that does not fit the identity column cannot be
+            // matched reliably on the next login, so it is skipped rather than
+            // truncated into a collision with another group.
+            if ('' === trim($externalId) || mb_strlen($externalId) > Group::EXTERNAL_ID_MAX_LENGTH) {
+                $this->logger->warning('Directory group claim skipped: value empty or too long', [
+                    'source' => $source,
+                    'length' => mb_strlen($externalId),
+                ]);
+                continue;
+            }
             $group = $this->upsertDirectoryGroup($source, $externalId, $names[$externalId] ?? $externalId);
             $desiredGroupIds[(int) $group->getId()] = $group;
         }
@@ -108,9 +120,17 @@ final readonly class DirectoryGroupSync
 
     private function upsertDirectoryGroup(string $source, string $externalId, string $displayName): Group
     {
+        $displayName = trim($displayName);
+        if ('' === $displayName) {
+            $displayName = $externalId;
+        }
+        if (mb_strlen($displayName) > Group::NAME_MAX_LENGTH) {
+            $displayName = rtrim(mb_substr($displayName, 0, Group::NAME_MAX_LENGTH - 1)).'…';
+        }
+
         $existing = $this->groupRepository->findOneByExternal($source, $externalId);
         if ($existing instanceof Group) {
-            if ($existing->getName() !== $displayName && '' !== trim($displayName)) {
+            if ($existing->getName() !== $displayName) {
                 $existing->setName($displayName);
                 $this->groupRepository->save($existing);
             }

--- a/backend/src/Service/Iam/KnowledgeFolderShareCleanup.php
+++ b/backend/src/Service/Iam/KnowledgeFolderShareCleanup.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Iam;
+
+use App\Repository\FileRepository;
+use App\Repository\ShareRepository;
+use App\Service\Iam\ResourceKind\KnowledgeFolderKind;
+
+/**
+ * A knowledge folder has no row of its own — it exists while at least one
+ * non-ephemeral file carries its group key. Its shares therefore have no
+ * cascade to ride on: once the last file leaves, the BSHARES rows would stay
+ * behind and silently apply to the next folder created under the same name.
+ *
+ * Call {@see self::forgetIfEmpty()} after a file is deleted or moved out of
+ * a folder; it removes the shares only when the folder is actually gone.
+ */
+final readonly class KnowledgeFolderShareCleanup
+{
+    public function __construct(
+        private FileRepository $fileRepository,
+        private ShareRepository $shareRepository,
+    ) {
+    }
+
+    public function forgetIfEmpty(int $ownerId, ?string $groupKey): void
+    {
+        if (null === $groupKey || '' === $groupKey) {
+            return;
+        }
+        if ($this->fileRepository->existsForUserAndGroupKey($ownerId, $groupKey)) {
+            return;
+        }
+
+        $this->shareRepository->deleteByResource(
+            KnowledgeFolderKind::KEY,
+            KnowledgeFolderKind::resourceId($ownerId, $groupKey),
+        );
+    }
+}

--- a/backend/src/Service/Iam/ShareService.php
+++ b/backend/src/Service/Iam/ShareService.php
@@ -85,6 +85,16 @@ final readonly class ShareService
             throw new ShareNotAllowedException('Only the owner or someone who can manage this item may share it.');
         }
 
+        // An administrator manages shares on the owner's behalf without holding
+        // a grant of their own. That power must not become a way to read the
+        // content: a subject that includes the actor (themselves, a group they
+        // belong to, everyone) is refused unless the actor already holds access.
+        if (null === $this->accessGate->highestGranted($actor, $kind, $resourceId)
+            && $this->subjectReaches($actor, $subjectType, $subjectId)
+        ) {
+            throw new ShareNotAllowedException('Administrators can share on behalf of the owner, but not with themselves.');
+        }
+
         $share = $this->shareRepository->findOneForSubject($kind, $resourceId, $subjectType, $subjectId);
         if (null === $share) {
             $share = new Share();
@@ -440,6 +450,21 @@ final readonly class ShareService
         }
 
         return $candidateLevel->implies($currentLevel);
+    }
+
+    /**
+     * Would a grant to this subject give the actor access?
+     */
+    private function subjectReaches(User $actor, string $subjectType, int $subjectId): bool
+    {
+        $actorId = (int) $actor->getId();
+
+        return match ($subjectType) {
+            Share::SUBJECT_EVERYONE => true,
+            Share::SUBJECT_USER => $subjectId === $actorId,
+            Share::SUBJECT_GROUP => null !== $this->groupMemberRepository->findMembership($subjectId, $actorId),
+            default => false,
+        };
     }
 
     private static function subjectSpecificity(Share $share): int

--- a/backend/src/Service/OidcUserService.php
+++ b/backend/src/Service/OidcUserService.php
@@ -102,7 +102,16 @@ class OidcUserService
         $lastSeen = $this->lastSeenForClaims($user, $claims);
         $this->upsertExternalIdentity($user, $claims);
         if ($this->directoryGroupSync->shouldRun($user, $refreshToken, $lastSeen)) {
-            $this->directoryGroupSync->sync($user, $claims);
+            // Group reconciliation is best-effort: a malformed claim or a
+            // transient write failure must not turn a valid login into an error.
+            try {
+                $this->directoryGroupSync->sync($user, $claims);
+            } catch (\Throwable $e) {
+                $this->logger->error('Directory group sync failed; login continues without group changes', [
+                    'user_id' => $user->getId(),
+                    'error' => $e->getMessage(),
+                ]);
+            }
         }
 
         if ($isNewUser) {

--- a/backend/src/Service/OidcUserService.php
+++ b/backend/src/Service/OidcUserService.php
@@ -109,7 +109,7 @@ class OidcUserService
             } catch (\Throwable $e) {
                 $this->logger->error('Directory group sync failed; login continues without group changes', [
                     'user_id' => $user->getId(),
-                    'error' => $e->getMessage(),
+                    'exception' => $e,
                 ]);
             }
         }

--- a/backend/tests/Controller/IamHardeningTest.php
+++ b/backend/tests/Controller/IamHardeningTest.php
@@ -1,0 +1,341 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Controller;
+
+use App\Entity\Chat;
+use App\Entity\Group;
+use App\Entity\GroupMember;
+use App\Entity\Prompt;
+use App\Entity\User;
+use App\Entity\Widget;
+use App\Repository\ConfigRepository;
+use App\Repository\PromptRepository;
+use App\Service\Iam\IamConfig;
+use App\Tests\Trait\AuthenticatedTestTrait;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Regression tests for the findings of the 2026-09-07 IAM security review.
+ * Each test names the hole it closes; all of them are only reachable with
+ * sharing switched on, which is why they must stay green before the flag is.
+ */
+final class IamHardeningTest extends WebTestCase
+{
+    use AuthenticatedTestTrait;
+
+    private KernelBrowser $client;
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        self::ensureKernelShutdown();
+        $this->client = static::createClient();
+        $this->em = static::getContainer()->get('doctrine')->getManager();
+        $this->enableSharing();
+    }
+
+    /**
+     * H1 — the people picker used to run a substring LIKE over the whole
+     * BUSERDETAILS JSON, which made phone numbers, provider subjects and the
+     * pending phone-verification code guessable letter by letter.
+     */
+    public function testPeoplePickerMatchesNamesAndEmailOnly(): void
+    {
+        $searcher = $this->createUser('hardening-searcher@synaplan.internal');
+        $target = $this->createUser('hardening-target@synaplan.internal');
+        $target->setUserDetails([
+            'full_name' => 'Hanna Probe',
+            'phone' => '+491701234567',
+            'phone_verification' => ['code' => 'ZQ7XK'],
+            'oidc_sub' => 'sub-zq7xk-secret',
+        ]);
+        $this->em->flush();
+        $this->authenticateClient($this->client, $searcher);
+
+        $this->client->request('GET', '/api/v1/iam/subjects?q=Hanna');
+        self::assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        self::assertContains((int) $target->getId(), $this->userIds(), 'name fields stay searchable');
+
+        $this->client->request('GET', '/api/v1/iam/subjects?q=hardening-target');
+        self::assertContains((int) $target->getId(), $this->userIds(), 'email stays searchable');
+
+        foreach (['ZQ7XK', '49170', 'zq7xk-secret', '"code"'] as $probe) {
+            $this->client->request('GET', '/api/v1/iam/subjects?q='.urlencode($probe));
+            self::assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+            self::assertNotContains(
+                (int) $target->getId(),
+                $this->userIds(),
+                sprintf('probe "%s" must not find a user through non-name JSON fields', $probe),
+            );
+        }
+
+        $this->client->request('GET', '/api/v1/iam/subjects?q=H');
+        self::assertSame([], $this->userIds(), 'a single character is not a lookup');
+    }
+
+    /**
+     * H2 — a shared prompt whose topic collides with a system topic used to
+     * win over the system prompt for every recipient, and an owner could
+     * rename a prompt into the reserved `tools:` namespace after creating it.
+     */
+    public function testSharedPromptCannotShadowSystemOrToolsTopics(): void
+    {
+        $attacker = $this->createUser('hardening-attacker@synaplan.internal');
+        $victim = $this->createUser('hardening-victim@synaplan.internal');
+        $systemTopic = 'hardening-system-'.uniqid();
+        $system = $this->createPrompt(0, $systemTopic, 'System helper');
+        $shadow = $this->createPrompt((int) $attacker->getId(), $systemTopic, 'Shadow helper');
+        $harmless = $this->createPrompt((int) $attacker->getId(), 'hardening-shared-'.uniqid(), 'Shared helper');
+
+        $this->authenticateClient($this->client, $attacker);
+        foreach ([$shadow, $harmless] as $prompt) {
+            $this->postJson('/api/v1/shares', [
+                'kind' => 'assistant',
+                'resource' => (string) $prompt->getId(),
+                'subjectType' => 'user',
+                'subjectId' => (int) $victim->getId(),
+                'permission' => 'use',
+            ]);
+            self::assertSame(Response::HTTP_CREATED, $this->client->getResponse()->getStatusCode());
+        }
+
+        $repo = static::getContainer()->get(PromptRepository::class);
+        $resolved = $repo->findByTopicAndUser($systemTopic, (int) $victim->getId());
+        self::assertInstanceOf(Prompt::class, $resolved);
+        self::assertSame($system->getId(), $resolved->getId(), 'the system prompt wins over a shared one with the same topic');
+
+        $sharedTopics = array_map(
+            static fn (Prompt $p): string => $p->getTopic(),
+            array_filter($repo->findAllForUser((int) $victim->getId()), static fn (Prompt $p): bool => $p->getOwnerId() === (int) $attacker->getId()),
+        );
+        self::assertContains($harmless->getTopic(), $sharedTopics, 'a share on a fresh topic still reaches the recipient');
+        self::assertNotContains($systemTopic, $sharedTopics, 'a share on a system topic is dropped for the recipient');
+
+        $this->client->request(
+            'PUT',
+            '/api/v1/prompts/'.$harmless->getId(),
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: json_encode(['topic' => 'tools:sort'], JSON_THROW_ON_ERROR),
+        );
+        self::assertSame(Response::HTTP_BAD_REQUEST, $this->client->getResponse()->getStatusCode());
+        $fresh = static::getContainer()->get('doctrine')->getManager();
+        $fresh->clear();
+        $reloaded = $fresh->find(Prompt::class, $harmless->getId());
+        self::assertInstanceOf(Prompt::class, $reloaded);
+        self::assertStringStartsNotWith('tools:', $reloaded->getTopic());
+    }
+
+    /**
+     * H3 — an administrator manages shares without holding one, and could use
+     * that to grant a group they belong to (or everyone) read on any private
+     * item, bypassing the impersonation switch.
+     */
+    public function testAdminCannotGrantThemselvesAccessThroughAGroupOrEveryone(): void
+    {
+        $owner = $this->createUser('hardening-owner@synaplan.internal');
+        $admin = $this->createAdmin('hardening-admin@synaplan.internal');
+        $ownGroup = $this->createGroup('Admins circle');
+        $this->addMember($ownGroup, (int) $admin->getId());
+        $otherGroup = $this->createGroup('Sales floor');
+        $chat = $this->createChat((int) $owner->getId(), 'Board minutes');
+
+        $this->authenticateClient($this->client, $admin);
+
+        foreach ([
+            ['subjectType' => 'group', 'subjectId' => (int) $ownGroup->getId()],
+            ['subjectType' => 'everyone', 'subjectId' => 0],
+            ['subjectType' => 'user', 'subjectId' => (int) $admin->getId()],
+        ] as $subject) {
+            $this->postJson('/api/v1/shares', [
+                'kind' => 'conversation',
+                'resource' => (string) $chat->getId(),
+                'permission' => 'read',
+            ] + $subject);
+            self::assertContains(
+                $this->client->getResponse()->getStatusCode(),
+                [Response::HTTP_FORBIDDEN, Response::HTTP_BAD_REQUEST],
+                sprintf('subject %s must be refused for a share-less admin', $subject['subjectType']),
+            );
+
+            $this->client->request('GET', '/api/v1/chats/'.$chat->getId());
+            self::assertSame(Response::HTTP_FORBIDDEN, $this->client->getResponse()->getStatusCode(), 'admin still cannot read the chat');
+        }
+
+        $this->postJson('/api/v1/shares', [
+            'kind' => 'conversation',
+            'resource' => (string) $chat->getId(),
+            'subjectType' => 'group',
+            'subjectId' => (int) $otherGroup->getId(),
+            'permission' => 'read',
+        ]);
+        self::assertSame(Response::HTTP_CREATED, $this->client->getResponse()->getStatusCode(), 'sharing on the owner\'s behalf with a group the admin is not in stays allowed');
+    }
+
+    /**
+     * M2 — a widget shared for reading returned the Slack webhook URL and the
+     * external API token verbatim.
+     */
+    public function testWidgetShareHidesCredentials(): void
+    {
+        $owner = $this->createUser('hardening-widget-owner@synaplan.internal');
+        $reader = $this->createUser('hardening-widget-reader@synaplan.internal');
+        $widget = new Widget();
+        $widget->setOwnerId((int) $owner->getId());
+        $widget->setOwner($owner);
+        $widget->setName('Support');
+        $widget->setTaskPromptTopic('general');
+        $widget->setConfig([
+            'slackWebhookUrl' => 'https://hooks.slack.com/services/T000/B000/secret',
+            'externalApiToken' => 'tok-secret',
+            'primaryColor' => '#123456',
+        ]);
+        $this->em->persist($widget);
+        $this->em->flush();
+
+        $this->authenticateClient($this->client, $owner);
+        $this->postJson('/api/v1/shares', [
+            'kind' => 'widget',
+            'resource' => (string) $widget->getId(),
+            'subjectType' => 'user',
+            'subjectId' => (int) $reader->getId(),
+            'permission' => 'read',
+        ]);
+        self::assertSame(Response::HTTP_CREATED, $this->client->getResponse()->getStatusCode());
+
+        $this->client->request('GET', '/api/v1/widgets/'.$widget->getWidgetId());
+        self::assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        self::assertSame('https://hooks.slack.com/services/T000/B000/secret', $this->json()['widget']['config']['slackWebhookUrl'], 'owner sees the real value');
+
+        $this->authenticateClient($this->client, $reader);
+        $this->client->request('GET', '/api/v1/widgets/'.$widget->getWidgetId());
+        self::assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        $config = $this->json()['widget']['config'];
+        self::assertSame('***', $config['slackWebhookUrl']);
+        self::assertSame('***', $config['externalApiToken']);
+        self::assertSame('#123456', $config['primaryColor'], 'non-secret keys are untouched');
+    }
+
+    /**
+     * @return list<int>
+     */
+    private function userIds(): array
+    {
+        $ids = [];
+        foreach ($this->json()['subjects'] as $subject) {
+            if ('user' === $subject['type']) {
+                $ids[] = (int) $subject['id'];
+            }
+        }
+
+        return $ids;
+    }
+
+    private function enableSharing(): void
+    {
+        $config = static::getContainer()->get(ConfigRepository::class);
+        $config->setValue(0, IamConfig::CONFIG_GROUP, IamConfig::KEY_GROUPS_ENABLED, '1');
+        $config->setValue(0, IamConfig::CONFIG_GROUP, IamConfig::KEY_SHARING_ENABLED, '1');
+        $this->em->flush();
+    }
+
+    private function createAdmin(string $email): User
+    {
+        $user = $this->createUser($email);
+        $user->setUserLevel('ADMIN');
+        $this->em->flush();
+
+        return $user;
+    }
+
+    private function createUser(string $email): User
+    {
+        $existing = $this->em->getRepository(User::class)->findOneBy(['mail' => $email]);
+        if ($existing instanceof User) {
+            return $existing;
+        }
+
+        $user = (new User())
+            ->setMail($email)
+            ->setType('WEB')
+            ->setProviderId('hardening-test-'.uniqid())
+            ->setUserLevel('NEW');
+        $user->setCreated(date('YmdHis'));
+        $user->setEmailVerified(true);
+        $this->em->persist($user);
+        $this->em->flush();
+
+        return $user;
+    }
+
+    private function createGroup(string $name): Group
+    {
+        $group = new Group();
+        $group->setName($name);
+        $group->setSlug(strtolower(str_replace(' ', '-', $name)).'-'.uniqid());
+        $this->em->persist($group);
+        $this->em->flush();
+
+        return $group;
+    }
+
+    private function addMember(Group $group, int $userId): void
+    {
+        $member = new GroupMember((int) $group->getId(), $userId);
+        $this->em->persist($member);
+        $this->em->flush();
+    }
+
+    private function createChat(int $userId, string $title): Chat
+    {
+        $chat = new Chat();
+        $chat->setUserId($userId);
+        $chat->setTitle($title);
+        $this->em->persist($chat);
+        $this->em->flush();
+
+        return $chat;
+    }
+
+    private function createPrompt(int $ownerId, string $topic, string $name): Prompt
+    {
+        $prompt = new Prompt();
+        $prompt->setOwnerId($ownerId);
+        $prompt->setLanguage('en');
+        $prompt->setTopic($topic);
+        $prompt->setShortDescription($name);
+        $prompt->setPrompt('You help with '.$name.'.');
+        $this->em->persist($prompt);
+        $this->em->flush();
+
+        return $prompt;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function postJson(string $uri, array $payload): void
+    {
+        $this->client->request(
+            'POST',
+            $uri,
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: json_encode($payload, JSON_THROW_ON_ERROR),
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function json(): array
+    {
+        $decoded = json_decode((string) $this->client->getResponse()->getContent(), true);
+        self::assertIsArray($decoded, 'Response was not JSON: '.$this->client->getResponse()->getContent());
+
+        return $decoded;
+    }
+}

--- a/backend/tests/Unit/Service/Iam/DirectoryGroupSyncTest.php
+++ b/backend/tests/Unit/Service/Iam/DirectoryGroupSyncTest.php
@@ -15,6 +15,7 @@ use App\Service\Iam\DirectoryGroupSync;
 use App\Service\Iam\IamConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
 
 final class DirectoryGroupSyncTest extends TestCase
 {
@@ -36,6 +37,7 @@ final class DirectoryGroupSyncTest extends TestCase
             $this->groups,
             $this->members,
             $this->audit,
+            new NullLogger(),
             'synaplan',
             'https://idp.example/realms/synaplan/.well-known/openid-configuration',
         );
@@ -135,6 +137,35 @@ final class DirectoryGroupSyncTest extends TestCase
         ]);
 
         self::assertSame('ADMIN', $user->getUserLevel());
+    }
+
+    public function testOversizedClaimIsSkippedAndLongNameIsTruncated(): void
+    {
+        $this->iamConfig->method('isDirectorySyncEnabled')->willReturn(true);
+        $this->iamConfig->method('directoryGroupsClaim')->willReturn('groups');
+        $longName = str_repeat('Vertrieb ', 30);
+        $this->iamConfig->method('directoryGroupNames')->willReturn(['sales' => $longName]);
+        $this->groups->method('findOneByExternal')->willReturn(null);
+        $this->groups->method('findOneBySlug')->willReturn(null);
+
+        $saved = [];
+        $this->groups->method('save')->willReturnCallback(static function (Group $group) use (&$saved): void {
+            $ref = new \ReflectionProperty(Group::class, 'id');
+            $ref->setValue($group, 31);
+            $saved[] = $group;
+        });
+        $this->members->method('findDirectoryByUserId')->willReturn([]);
+        $this->members->method('findMembership')->willReturn(null);
+
+        $this->sync->sync($this->userWithId(4), [
+            'sub' => 's1',
+            'iss' => 'https://idp.example/realms/synaplan',
+            'groups' => ['sales', str_repeat('x', Group::EXTERNAL_ID_MAX_LENGTH + 1), ''],
+        ]);
+
+        self::assertCount(1, $saved, 'only the well-formed claim creates a group');
+        self::assertSame('sales', $saved[0]->getExternalId());
+        self::assertLessThanOrEqual(Group::NAME_MAX_LENGTH, mb_strlen($saved[0]->getName()));
     }
 
     private function userWithId(int $id): User

--- a/backend/tests/Unit/Service/Iam/KnowledgeFolderShareCleanupTest.php
+++ b/backend/tests/Unit/Service/Iam/KnowledgeFolderShareCleanupTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\Iam;
+
+use App\Repository\FileRepository;
+use App\Repository\ShareRepository;
+use App\Service\Iam\KnowledgeFolderShareCleanup;
+use PHPUnit\Framework\TestCase;
+
+final class KnowledgeFolderShareCleanupTest extends TestCase
+{
+    public function testDeletesSharesOnceTheFolderIsEmpty(): void
+    {
+        $files = $this->createMock(FileRepository::class);
+        $files->expects(self::once())->method('existsForUserAndGroupKey')->with(7, 'Q3')->willReturn(false);
+        $shares = $this->createMock(ShareRepository::class);
+        $shares->expects(self::once())->method('deleteByResource')->with('knowledge_folder', '7:Q3');
+
+        (new KnowledgeFolderShareCleanup($files, $shares))->forgetIfEmpty(7, 'Q3');
+    }
+
+    public function testKeepsSharesWhileFilesRemain(): void
+    {
+        $files = $this->createMock(FileRepository::class);
+        $files->method('existsForUserAndGroupKey')->willReturn(true);
+        $shares = $this->createMock(ShareRepository::class);
+        $shares->expects(self::never())->method('deleteByResource');
+
+        (new KnowledgeFolderShareCleanup($files, $shares))->forgetIfEmpty(7, 'Q3');
+    }
+
+    public function testIgnoresFilesWithoutAFolder(): void
+    {
+        $files = $this->createMock(FileRepository::class);
+        $files->expects(self::never())->method('existsForUserAndGroupKey');
+        $shares = $this->createMock(ShareRepository::class);
+        $shares->expects(self::never())->method('deleteByResource');
+
+        $cleanup = new KnowledgeFolderShareCleanup($files, $shares);
+        $cleanup->forgetIfEmpty(7, null);
+        $cleanup->forgetIfEmpty(7, '');
+    }
+}


### PR DESCRIPTION
## Summary

A security review of the IAM work (groups, sharing, directory sync, policies) found three high findings that become exploitable the moment `IAM.SHARING_ENABLED` is on, plus three medium ones. Nothing is reachable on a default (flags-off) install, but all of them must be closed before the flag goes on anywhere.

| # | Finding | Fix |
| - | ------- | --- |
| H1 | People picker ran `BUSERDETAILS LIKE '%q%'` — phone numbers, provider subjects and the live phone-verification code were guessable letter by letter | Match `BMAIL` + JSON name fields only, min. 2 chars, new `iam_subject_search` rate limiter (60/min per user) |
| H2 | A shared prompt with a system topic (`general`, `tools:sort`, …) replaced the system prompt for every recipient; PUT allowed renaming into `tools:` | Shared prompts drop system and `tools:` topics; resolution is own → global → shared; PUT enforces the prefix guard |
| H3 | Admin `manage` let an admin grant a group they belong to / `everyone` / themselves read on any private item, bypassing `ADMIN_IMPERSONATION=disabled` | `ShareService::grant` refuses subjects that reach a share-less actor |
| M1 | Knowledge-folder shares (`{owner}:{groupKey}`) survived the folder and re-activated on a reused name | `KnowledgeFolderShareCleanup` after delete / move / clear group key |
| M2 | Widget `read` share returned `slackWebhookUrl` and `externalApiToken` | Masked for non-owners; mask round-trip on PUT does not overwrite the owner's value |
| M3 | Oversized OIDC group claims broke login with `Data too long`; look-alike names | Skip oversized ids, truncate names, sync is best-effort (logged, login continues) |

## Tests

`tests/Controller/IamHardeningTest.php` (H1, H2, H3, M2 as end-to-end WebTestCase), `KnowledgeFolderShareCleanupTest`, extended `DirectoryGroupSyncTest`.

Full backend gate: lint ✓, PHPStan ✓, PHPUnit 5445 ✓.

## Mobile impact

`backend-only`.