### PR TITLE
perf(ci): cache the vendor install and protoc across CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,12 +335,51 @@ jobs:
           key: ${{ runner.os }}-composer-${{ hashFiles('backend/composer.lock') }}
           restore-keys: ${{ runner.os }}-composer-
 
-      - name: Install protoc from base image
+      # `docker create` on the backend base image pulls ~1 GB to extract one
+      # binary, and this job is the head of the critical path. Cache the binary
+      # instead, keyed on the image the Dockerfile pins, so the pull only happens
+      # when that pin moves.
+      #
+      # Deliberately NOT done in the backend job: that one runs the base image
+      # again for the email-contract test, so it pays the pull either way and
+      # caching would move the cost rather than remove it.
+      - name: Resolve the backend base image
+        id: base-image
         run: |
-          BASE_IMAGE=$(grep -oP 'FROM \K\S+' _docker/backend/Dockerfile | head -1)
-          id=$(docker create "$BASE_IMAGE")
-          trap "docker rm $id" EXIT
-          sudo docker cp $id:/usr/local/bin/protoc /usr/local/bin/protoc
+          set -euo pipefail
+          ref="$(grep -oP 'FROM \K\S+' _docker/backend/Dockerfile | head -1)"
+          [ -n "$ref" ] || {
+            echo "::error::Could not resolve the backend base image from _docker/backend/Dockerfile"
+            exit 1
+          }
+          echo "Backend base image: ${ref}"
+          echo "ref=${ref}" >> "$GITHUB_OUTPUT"
+          # The ref contains `/`, `:` and `@`; hash it so the cache key stays a
+          # plain token regardless of how the pin is written.
+          echo "key=$(printf '%s' "$ref" | sha256sum | cut -c1-16)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache protoc
+        id: protoc-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: /tmp/protoc-bin
+          key: ${{ runner.os }}-protoc-${{ steps.base-image.outputs.key }}
+
+      - name: Extract protoc from the base image
+        if: steps.protoc-cache.outputs.cache-hit != 'true'
+        env:
+          BASE_IMAGE: ${{ steps.base-image.outputs.ref }}
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/protoc-bin
+          id="$(docker create "$BASE_IMAGE")"
+          trap 'docker rm "$id" >/dev/null' EXIT
+          docker cp "$id:/usr/local/bin/protoc" /tmp/protoc-bin/protoc
+
+      - name: Install protoc
+        run: |
+          set -euo pipefail
+          sudo install -m 0755 /tmp/protoc-bin/protoc /usr/local/bin/protoc
           protoc --version
 
       - name: Create .env file

--- a/_docker/backend/Dockerfile
+++ b/_docker/backend/Dockerfile
@@ -91,7 +91,29 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=120s --retries=3 \
 # ---------------------------------------------------------------------------
 FROM dev AS prod
 
+# Download and unpack the production dependencies from the lock file ALONE,
+# above the source COPY, so this layer stays cached for as long as composer.lock
+# does. Below it, any one-line edit under backend/ reinstalls the whole tree.
+#
+# Three things belong in this layer and not in the autoloader dump further down:
+# --no-scripts, because post-install-cmd runs cache:clear, which needs a runtime
+# DB connection; COMPOSER_PROCESS_TIMEOUT=0, which lifts the 300s per-process
+# limit so large packages (e.g. google/apiclient-services) still unzip when this
+# stage is built under qemu emulation (amd64 image on an Apple Silicon host); and
+# the recursive chown, which rewrites every file in vendor/ and would therefore
+# copy the whole tree into a new layer on every source change.
+#
+# --no-autoloader is required rather than an optimization: an authoritative
+# classmap has to see src/, the generated gRPC stubs and the plugins, none of
+# which exist yet.
+COPY backend/composer.json backend/composer.lock backend/symfony.lock ./
+RUN COMPOSER_PROCESS_TIMEOUT=0 composer install \
+        --prefer-dist --no-interaction --no-dev --no-scripts --no-autoloader && \
+    chown -R www-data:www-data /var/www/backend/vendor
+
 # Copy application (exclude .env files - use environment variables instead)
+# backend/vendor is excluded by .dockerignore, so this cannot overwrite the
+# vendor tree installed above with a host one.
 COPY --chown=www-data:www-data backend/ .
 RUN rm -f .env .env.example .env.local .env.*.local
 
@@ -107,20 +129,19 @@ RUN mkdir -p /var/www/backend/var/cache /var/www/backend/var/log /var/www/backen
 # Without this, --classmap-authoritative locks the autoloader to only backend classes
 COPY plugins/ /plugins/
 
-# Install dependencies with production optimizations
+# Dump the autoloader now that src/, lib/grpc/ and /plugins/ are all present.
+# The packages themselves are already installed, so this only writes the class
+# maps: it re-runs on every source change but costs a fraction of a full install.
 # Flags explained:
 # --no-dev: Skip dev dependencies (phpunit, fixtures, etc.) for smaller image
-# --no-scripts: Skip post-install scripts (cache:clear requires runtime DB connection)
-# --optimize-autoloader: Generate optimized PSR-4 class maps
+# --optimize: Generate optimized PSR-4 class maps
 # --classmap-authoritative: Never scan filesystem for classes (all classes are in composer.json)
 #   This is safe for Symfony apps where all classes are autoloaded via composer
 #   Provides significant performance improvement by eliminating file_exists() calls
-# Cache is cleared on container startup anyway via docker-entrypoint.sh
-# COMPOSER_PROCESS_TIMEOUT=0 disables the 300s per-process limit so large
-# packages (e.g. google/apiclient-services) still unzip when this stage is built
-# under qemu emulation (e.g. amd64 image on an Apple Silicon host).
-RUN COMPOSER_PROCESS_TIMEOUT=0 composer install --prefer-dist --no-interaction --no-dev --no-scripts --optimize-autoloader --classmap-authoritative && \
-    chown -R www-data:www-data /var/www/backend/vendor
+# Only the files this command writes are chowned; vendor/ as a whole was already
+# handed to www-data in the cached layer above.
+RUN composer dump-autoload --no-interaction --no-dev --optimize --classmap-authoritative && \
+    chown -R www-data:www-data /var/www/backend/vendor/autoload.php /var/www/backend/vendor/composer
 
 # Copy built frontend (built externally in CI, empty in dev)
 COPY frontend/dist /var/www/frontend


### PR DESCRIPTION
## Summary

Two independent build-cache fixes on the critical path of a pull-request run. That path is `frontend-build` → `docker-build` → `e2e` and accounts for ~500s of a typical 480–520s run; every other job finishes inside its slack.

| # | Waste | Fix |
| - | ----- | --- |
| 1 | `composer install --no-dev` re-ran on every backend edit — `COPY backend/ .` sat above it, so the layer was invalidated even when `composer.lock` had not moved | Install from `composer.json`/`composer.lock` alone above the source COPY; dump the authoritative classmap afterwards |
| 2 | `chown -R vendor` beside the autoloader dump rewrote the whole tree into a new layer on every source change | Moved into the same cached install layer; the dump chowns only what it writes |
| 3 | `frontend-build` ran `docker create` against the backend base image, pulling ~1GB to extract one binary, at the head of the critical path | Cache the binary, keyed on the pinned base image |

`--no-autoloader` on the install is required rather than an optimisation: an authoritative classmap has to see `src/`, the generated gRPC stubs and `/plugins/`, none of which exist at that point.

The **`backend` job deliberately keeps** the `docker create` pull — it runs that same base image again for the email-contract test, so caching there would move the cost rather than remove it.

## Measured in CI

Two runs of this branch on the identical tree: the first with a cold cache, the third after the branch had exported one.

| | cold (run 34139152213) | warm (run 34140626972) |
| - | --- | --- |
| `frontend-build` — extract protoc | 29s | **0s** (cache hit) |
| `frontend-build` — job | 139s | **112s** |
| `docker-build` — `composer install` layer | ran | **CACHED** |
| `docker-build` — build step | 80s | **56s** |
| `docker-build` — job | 132s | **108s** |

For reference, protoc extraction on recent `main` runs took 17s, 17s and 22s, and `frontend-build` 107–129s, so the protoc figure is a saving of roughly 20s rather than the full 29s of the cold run above.

## Verification

Built the `prod` target locally and compared against the same target built from `main`:

- Identical image size — 2.57GB both.
- Identical autoloader — 49854 classmap entries, same `ComposerStaticInit` hash, same resolution for `App\Kernel`, `App\Entity\Group`, `App\Service\Iam\ShareService`.
- Identical ownership — `www-data` on `vendor/`, `vendor/composer/`, `src/`.
- E2E stack (`docker-compose.test.yml` + `.ci.yml`) boots healthy on the image: 75 migrations, fixtures, catalog seed, then SPA, `/api/v1/config/runtime`, login, `/api/v1/auth/me` and the widget asset all 200.
- `_docker/backend/tests/test-migrations-bootstrap.sh` 38/38, `test-container-runtime.sh` 67/67, `deploy/scripts/tests/test-lifecycle.sh` green.

No PHP or TypeScript source changed, so the language gates are unaffected.

## Expected effect, and one caveat worth knowing

About 45s off the critical path on a run that does not move `composer.lock` — ~24s in `docker-build` and ~20s in `frontend-build`.

The two halves do **not** warm up the same way, which is worth recording:

- **protoc uses `actions/cache`**, which falls back to the base branch. A pull request restores the entry `main` populated, so this saving applies from a PR's first run.
- **The Docker layer cache does not fall back.** buildx namespaces its gha index per git ref — `index-amd64-1-f921bd05` on `main`, `index-amd64-1-a195eaa9` on this PR — so a branch cannot inherit `main`'s layers and its first `docker-build` is always cold. An intermediate run on this branch also missed while importing a different manifest id than the run that hit, so warmth within a branch is not guaranteed either.

So the reorder pays off reliably on `main` (prod-stage layers are `CACHED` there today, e.g. run 34125654662) and on repeat runs of a branch, but not on a PR's first build.

Follow-ups, not in this PR:

- Adding a registry cache (`type=registry,ref=…:buildcache`) alongside the gha one would remove the per-ref limitation, so every PR's first build could start warm — likely a bigger win than this PR.
- Splitting `docker-build` so it no longer waits on `frontend-build` is worth ~90–110s and is the larger structural change.

## Mobile impact

`no-app-impact` — confirmed with `node scripts/mobile-impact.mjs --base origin/main --head HEAD` for both changed files.