### PR TITLE
feat(iam): leave groups and cascade-delete assistants and saved tasks

### DIFF
--- a/backend/src/Controller/GroupController.php
+++ b/backend/src/Controller/GroupController.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 namespace App\Controller;
 
 use App\Entity\User;
+use App\Service\Iam\Exception\DirectoryGroupReadOnlyException;
+use App\Service\Iam\Exception\GroupMembershipNotFoundException;
 use App\Service\Iam\GroupService;
 use App\Service\Iam\IamConfig;
 use OpenApi\Attributes as OA;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\CurrentUser;
@@ -51,6 +54,8 @@ final class GroupController extends AbstractController
                                     new OA\Property(property: 'externalSource', type: 'string', nullable: true, example: 'oidc:https://idp.example/realms/synaplan'),
                                     new OA\Property(property: 'memberCount', type: 'integer', example: 3),
                                     new OA\Property(property: 'role', type: 'string', enum: ['member', 'manager'], nullable: true),
+                                    new OA\Property(property: 'membershipSource', type: 'string', enum: ['manual', 'directory'], nullable: true),
+                                    new OA\Property(property: 'canLeave', type: 'boolean', example: true),
                                     new OA\Property(property: 'created', type: 'integer', format: 'int64'),
                                     new OA\Property(property: 'updated', type: 'integer', format: 'int64'),
                                 ]
@@ -76,9 +81,63 @@ final class GroupController extends AbstractController
 
         return $this->json([
             'groups' => array_map(
-                fn (array $row) => $this->groupService->serializeGroup($row['group'], null, $row['role']),
+                fn (array $row) => $this->groupService->serializeGroup(
+                    $row['group'],
+                    null,
+                    $row['role'],
+                    $row['source'],
+                ),
                 $rows,
             ),
         ]);
+    }
+
+    #[Route('/{id}/membership', name: 'leave', methods: ['DELETE'], requirements: ['id' => '\d+'])]
+    #[OA\Delete(
+        path: '/api/v1/groups/{id}/membership',
+        operationId: 'leaveMyGroup',
+        summary: 'Leave a group you were added to',
+        description: 'Removes the current user from a manual membership. Directory-synced memberships cannot be left here; they return at the next sign-in.',
+        tags: ['IAM Groups'],
+        parameters: [new OA\Parameter(name: 'id', in: 'path', required: true, schema: new OA\Schema(type: 'integer'))],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Left the group',
+                content: new OA\JsonContent(
+                    required: ['success'],
+                    properties: [
+                        new OA\Property(property: 'success', type: 'boolean', example: true),
+                    ]
+                )
+            ),
+            new OA\Response(response: 401, description: 'Not authenticated'),
+            new OA\Response(response: 404, description: 'Not a member, or feature disabled'),
+            new OA\Response(response: 409, description: 'Directory membership cannot be left here'),
+        ]
+    )]
+    public function leave(int $id, Request $request, #[CurrentUser] ?User $user): JsonResponse
+    {
+        if (!$user instanceof User) {
+            return $this->json(['error' => 'Not authenticated'], Response::HTTP_UNAUTHORIZED);
+        }
+        if (!$this->iamConfig->isGroupsEnabled((int) $user->getId())) {
+            return $this->json(['error' => 'Not found'], Response::HTTP_NOT_FOUND);
+        }
+
+        $group = $this->groupService->get($id);
+        if (null === $group) {
+            return $this->json(['error' => 'Group not found'], Response::HTTP_NOT_FOUND);
+        }
+
+        try {
+            $this->groupService->leave($group, $user, (string) ($request->getClientIp() ?? ''));
+        } catch (GroupMembershipNotFoundException) {
+            return $this->json(['error' => 'You are not a member of this group.'], Response::HTTP_NOT_FOUND);
+        } catch (DirectoryGroupReadOnlyException $e) {
+            return $this->json(['error' => $e->getMessage()], Response::HTTP_CONFLICT);
+        }
+
+        return $this->json(['success' => true]);
     }
 }

--- a/backend/src/Repository/FileRepository.php
+++ b/backend/src/Repository/FileRepository.php
@@ -383,6 +383,20 @@ class FileRepository extends ServiceEntityRepository
         return $map;
     }
 
+    /**
+     * @return list<File>
+     */
+    public function findByUserAndGroupKey(int $userId, string $groupKey): array
+    {
+        return $this->createQueryBuilder('f')
+            ->where('f.userId = :userId')
+            ->andWhere('f.groupKey = :groupKey')
+            ->setParameter('userId', $userId)
+            ->setParameter('groupKey', $groupKey)
+            ->getQuery()
+            ->getResult();
+    }
+
     public function existsForUserAndGroupKey(int $userId, string $groupKey): bool
     {
         $count = (int) $this->createQueryBuilder('f')

--- a/backend/src/Repository/SavedTaskRepository.php
+++ b/backend/src/Repository/SavedTaskRepository.php
@@ -42,6 +42,14 @@ class SavedTaskRepository extends ServiceEntityRepository
         return $this->findOneBy(['promptId' => $promptId, 'ownerId' => $ownerId]);
     }
 
+    /**
+     * @return list<SavedTask>
+     */
+    public function findAllByPromptAndOwner(int $promptId, int $ownerId): array
+    {
+        return $this->findBy(['promptId' => $promptId, 'ownerId' => $ownerId]);
+    }
+
     public function findEnabledChatTaskForPrompt(int $promptId, int $ownerId): ?SavedTask
     {
         return $this->createQueryBuilder('t')

--- a/backend/src/Service/Agent/AgentCascadeCleanup.php
+++ b/backend/src/Service/Agent/AgentCascadeCleanup.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Agent;
+
+use App\Entity\Agent;
+use App\Entity\Prompt;
+use App\Repository\AgentVersionRepository;
+use App\Repository\FileRepository;
+use App\Repository\PromptMetaRepository;
+use App\Repository\PromptRepository;
+use App\Repository\SavedTaskRepository;
+use App\Repository\SavedTaskRunRepository;
+use App\Repository\ShareRepository;
+use App\Service\Document\Persist\DocumentRevisionService;
+use App\Service\File\FileStorageService;
+use App\Service\Iam\ResourceKind\AgentKind;
+use App\Service\Iam\ResourceKind\AssistantKind;
+use App\Service\Iam\ResourceKind\KnowledgeFolderKind;
+use App\Service\Iam\ResourceKind\SavedTaskKind;
+use App\Service\RAG\VectorStorage\VectorStorageFacade;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Removes everything that belongs to an assistant before the BAGENTS row
+ * itself is deleted: shares, versions, the instruction prompt, the own
+ * knowledge folder (files + vectors + folder shares), and saved tasks
+ * bound to that prompt.
+ */
+final readonly class AgentCascadeCleanup
+{
+    public function __construct(
+        private ShareRepository $shares,
+        private AgentVersionRepository $versions,
+        private PromptRepository $prompts,
+        private PromptMetaRepository $promptMeta,
+        private FileRepository $files,
+        private FileStorageService $fileStorage,
+        private VectorStorageFacade $vectorStorage,
+        private DocumentRevisionService $documentRevisions,
+        private SavedTaskRepository $savedTasks,
+        private SavedTaskRunRepository $savedTaskRuns,
+        private EntityManagerInterface $em,
+    ) {
+    }
+
+    public function unshareAndRemoveDependents(Agent $agent): void
+    {
+        $id = $agent->getId();
+        if (null !== $id) {
+            $this->shares->deleteByResource(AgentKind::KEY, (string) $id);
+            $this->versions->deleteForAgent($id);
+        }
+
+        $this->removeOwnKnowledge($agent);
+        $this->removeBoundSavedTasks($agent);
+        $this->removeInstructionPrompt($agent);
+    }
+
+    private function removeOwnKnowledge(Agent $agent): void
+    {
+        $ownerId = $agent->getOwnerId();
+        $groupKey = AgentKnowledgeFolders::ownFolder($agent);
+        $this->shares->deleteByResource(
+            KnowledgeFolderKind::KEY,
+            KnowledgeFolderKind::resourceId($ownerId, $groupKey),
+        );
+        $this->vectorStorage->deleteByGroupKey($ownerId, $groupKey);
+
+        foreach ($this->files->findByUserAndGroupKey($ownerId, $groupKey) as $file) {
+            $this->documentRevisions->deleteForFile($file);
+            $path = $file->getFilePath();
+            if ('' !== $path) {
+                $this->fileStorage->deleteFile($path);
+            }
+            $this->em->remove($file);
+        }
+        $this->em->flush();
+    }
+
+    private function removeBoundSavedTasks(Agent $agent): void
+    {
+        $tasks = $this->savedTasks->findAllByPromptAndOwner(
+            $agent->getPromptId(),
+            $agent->getOwnerId(),
+        );
+        foreach ($tasks as $task) {
+            $taskId = $task->getId();
+            if (null !== $taskId) {
+                $this->shares->deleteByResource(SavedTaskKind::KEY, (string) $taskId);
+                $this->savedTaskRuns->deleteForTask($taskId);
+            }
+            $this->em->remove($task);
+        }
+        $this->em->flush();
+    }
+
+    private function removeInstructionPrompt(Agent $agent): void
+    {
+        $prompt = $this->prompts->find($agent->getPromptId());
+        if (!$prompt instanceof Prompt) {
+            return;
+        }
+        if (!AssistantKind::belongsToAgent($prompt) || $prompt->getOwnerId() !== $agent->getOwnerId()) {
+            return;
+        }
+
+        $promptId = $prompt->getId();
+        if (null !== $promptId) {
+            $this->shares->deleteByResource(AssistantKind::KEY, (string) $promptId);
+            foreach ($this->promptMeta->findByPrompt($promptId) as $meta) {
+                $this->em->remove($meta);
+            }
+        }
+        $this->em->remove($prompt);
+        $this->em->flush();
+    }
+}

--- a/backend/src/Service/Agent/AgentCascadeCleanup.php
+++ b/backend/src/Service/Agent/AgentCascadeCleanup.php
@@ -25,8 +25,9 @@ use Doctrine\ORM\EntityManagerInterface;
 /**
  * Removes everything that belongs to an assistant before the BAGENTS row
  * itself is deleted: shares, versions, the instruction prompt, the own
- * knowledge folder (files + vectors + folder shares), and saved tasks
- * bound to that prompt.
+ * knowledge folder (files + folder shares), and saved tasks bound to that
+ * prompt. Filesystem and Qdrant deletes are returned as
+ * {@see AgentExternalCleanup} and must run after the caller commits.
  */
 final readonly class AgentCascadeCleanup
 {
@@ -45,7 +46,7 @@ final readonly class AgentCascadeCleanup
     ) {
     }
 
-    public function unshareAndRemoveDependents(Agent $agent): void
+    public function unshareAndRemoveDependents(Agent $agent): AgentExternalCleanup
     {
         $id = $agent->getId();
         if (null !== $id) {
@@ -53,12 +54,22 @@ final readonly class AgentCascadeCleanup
             $this->versions->deleteForAgent($id);
         }
 
-        $this->removeOwnKnowledge($agent);
+        $external = $this->detachOwnKnowledge($agent);
         $this->removeBoundSavedTasks($agent);
         $this->removeInstructionPrompt($agent);
+
+        return $external;
     }
 
-    private function removeOwnKnowledge(Agent $agent): void
+    public function purgeExternal(AgentExternalCleanup $cleanup): void
+    {
+        $this->vectorStorage->deleteByGroupKey($cleanup->ownerId, $cleanup->groupKey);
+        foreach ($cleanup->filePaths as $path) {
+            $this->fileStorage->deleteFile($path);
+        }
+    }
+
+    private function detachOwnKnowledge(Agent $agent): AgentExternalCleanup
     {
         $ownerId = $agent->getOwnerId();
         $groupKey = AgentKnowledgeFolders::ownFolder($agent);
@@ -66,17 +77,19 @@ final readonly class AgentCascadeCleanup
             KnowledgeFolderKind::KEY,
             KnowledgeFolderKind::resourceId($ownerId, $groupKey),
         );
-        $this->vectorStorage->deleteByGroupKey($ownerId, $groupKey);
 
+        $filePaths = [];
         foreach ($this->files->findByUserAndGroupKey($ownerId, $groupKey) as $file) {
             $this->documentRevisions->deleteForFile($file);
             $path = $file->getFilePath();
             if ('' !== $path) {
-                $this->fileStorage->deleteFile($path);
+                $filePaths[] = $path;
             }
             $this->em->remove($file);
         }
         $this->em->flush();
+
+        return new AgentExternalCleanup($ownerId, $groupKey, $filePaths);
     }
 
     private function removeBoundSavedTasks(Agent $agent): void

--- a/backend/src/Service/Agent/AgentExternalCleanup.php
+++ b/backend/src/Service/Agent/AgentExternalCleanup.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Agent;
+
+/**
+ * Filesystem and vector deletes that must run after the DB transaction
+ * that removed the assistant has committed. Rolling those back is impossible.
+ */
+final readonly class AgentExternalCleanup
+{
+    /**
+     * @param list<string> $filePaths
+     */
+    public function __construct(
+        public int $ownerId,
+        public string $groupKey,
+        public array $filePaths,
+    ) {
+    }
+}

--- a/backend/src/Service/Agent/AgentService.php
+++ b/backend/src/Service/Agent/AgentService.php
@@ -11,7 +11,6 @@ use App\Entity\User;
 use App\Repository\AgentRepository;
 use App\Repository\AgentVersionRepository;
 use App\Repository\PromptRepository;
-use App\Repository\ShareRepository;
 use App\Repository\UserRepository;
 use App\Service\Agent\Definition\AgentDefinition;
 use App\Service\Agent\Definition\AgentDefinitionValidator;
@@ -34,7 +33,7 @@ final readonly class AgentService
         private EntityManagerInterface $em,
         private AgentAccess $access,
         private ShareService $shareService,
-        private ShareRepository $shares,
+        private AgentCascadeCleanup $cascade,
         private UserRepository $users,
         private AgentSerializer $serializer,
     ) {
@@ -166,11 +165,7 @@ final readonly class AgentService
         if ($agent->isPublished()) {
             throw AgentNotDraftException::cannotDelete($agent->getStatus());
         }
-        $id = $agent->getId();
-        if (null !== $id) {
-            $this->shares->deleteByResource(AgentKind::KEY, (string) $id);
-            $this->versions->deleteForAgent($id);
-        }
+        $this->cascade->unshareAndRemoveDependents($agent);
         $this->agents->remove($agent);
     }
 

--- a/backend/src/Service/Agent/AgentService.php
+++ b/backend/src/Service/Agent/AgentService.php
@@ -165,8 +165,9 @@ final readonly class AgentService
         if ($agent->isPublished()) {
             throw AgentNotDraftException::cannotDelete($agent->getStatus());
         }
-        $this->cascade->unshareAndRemoveDependents($agent);
+        $external = $this->cascade->unshareAndRemoveDependents($agent);
         $this->agents->remove($agent);
+        $this->cascade->purgeExternal($external);
     }
 
     public function requireOwned(int $id, int $ownerId): Agent

--- a/backend/src/Service/Iam/Exception/GroupMembershipNotFoundException.php
+++ b/backend/src/Service/Iam/Exception/GroupMembershipNotFoundException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Iam\Exception;
+
+final class GroupMembershipNotFoundException extends \RuntimeException
+{
+    public function __construct(public readonly int $groupId)
+    {
+        parent::__construct('You are not a member of this group.');
+    }
+}

--- a/backend/src/Service/Iam/GroupService.php
+++ b/backend/src/Service/Iam/GroupService.php
@@ -13,6 +13,7 @@ use App\Repository\GroupRepository;
 use App\Repository\ShareRepository;
 use App\Repository\UserRepository;
 use App\Service\Iam\Exception\DirectoryGroupReadOnlyException;
+use App\Service\Iam\Exception\GroupMembershipNotFoundException;
 
 /**
  * Manual group CRUD + membership. Directory groups cannot be renamed or
@@ -192,7 +193,35 @@ final readonly class GroupService
     }
 
     /**
-     * @return list<array{group: Group, role: string}>
+     * The current user leaves a group they were added to. Directory-synced
+     * memberships stay read-only (they return at the next sign-in).
+     */
+    public function leave(Group $group, User $actor, string $ip = ''): void
+    {
+        $userId = (int) $actor->getId();
+        $groupId = (int) $group->getId();
+        $member = $this->groupMemberRepository->findMembership($groupId, $userId);
+        if (null === $member) {
+            throw new GroupMembershipNotFoundException($groupId);
+        }
+        if (GroupMember::SOURCE_DIRECTORY === $member->getSource()) {
+            throw new DirectoryGroupReadOnlyException($groupId);
+        }
+
+        $this->groupMemberRepository->remove($member);
+
+        $this->auditLogWriter->record(
+            $userId,
+            'group.member_leave',
+            'group',
+            (string) $groupId,
+            ['userId' => $userId],
+            $ip,
+        );
+    }
+
+    /**
+     * @return list<array{group: Group, role: string, source: string}>
      */
     public function groupsOf(int $userId): array
     {
@@ -213,7 +242,11 @@ final readonly class GroupService
             if (null === $group) {
                 continue;
             }
-            $out[] = ['group' => $group, 'role' => $membership->getRole()];
+            $out[] = [
+                'group' => $group,
+                'role' => $membership->getRole(),
+                'source' => $membership->getSource(),
+            ];
         }
 
         return $out;
@@ -282,8 +315,12 @@ final readonly class GroupService
     /**
      * @return array<string, mixed>
      */
-    public function serializeGroup(Group $group, ?int $memberCount = null, ?string $role = null): array
-    {
+    public function serializeGroup(
+        Group $group,
+        ?int $memberCount = null,
+        ?string $role = null,
+        ?string $membershipSource = null,
+    ): array {
         $payload = [
             'id' => $group->getId(),
             'name' => $group->getName(),
@@ -297,6 +334,10 @@ final readonly class GroupService
         ];
         if (null !== $role) {
             $payload['role'] = $role;
+        }
+        if (null !== $membershipSource) {
+            $payload['membershipSource'] = $membershipSource;
+            $payload['canLeave'] = GroupMember::SOURCE_MANUAL === $membershipSource;
         }
 
         return $payload;

--- a/backend/src/Service/UserDeletionService.php
+++ b/backend/src/Service/UserDeletionService.php
@@ -33,6 +33,7 @@ use App\Repository\VerificationTokenRepository;
 use App\Repository\WidgetRepository;
 use App\Repository\WidgetSessionRepository;
 use App\Service\Agent\AgentCascadeCleanup;
+use App\Service\Agent\AgentExternalCleanup;
 use App\Service\File\FileStorageService;
 use App\Service\Iam\ResourceKind\AgentKind;
 use App\Service\Iam\ResourceKind\SavedTaskKind;
@@ -108,7 +109,7 @@ final readonly class UserDeletionService
             $this->deleteUseLogs($userId);
             $this->deleteWidgets($userId);
             $this->deleteShares($userId);
-            $this->deleteAgents($userId);
+            $agentExternal = $this->deleteAgents($userId);
             $this->deleteSavedTasks($userId);
             $this->deleteChats($userId);
             $this->deleteMessages($userId);
@@ -133,6 +134,7 @@ final readonly class UserDeletionService
             $this->em->getConnection()->commit();
 
             // Best-effort cleanup outside transaction (external services & filesystem)
+            $this->purgeAgentExternal($agentExternal);
             $this->purgeMemoryIndex($userId);
             $this->purgeDigestIndex($userId);
             $this->cleanupUserDirectories($userId);
@@ -185,7 +187,7 @@ final readonly class UserDeletionService
             $this->deleteUseLogs($userId);
             $this->deleteWidgets($userId);
             $this->deleteShares($userId);
-            $this->deleteAgents($userId);
+            $agentExternal = $this->deleteAgents($userId);
             $this->deleteSavedTasks($userId);
             $this->deleteChats($userId);
             $this->deleteMessages($userId);
@@ -207,6 +209,7 @@ final readonly class UserDeletionService
             $this->em->getConnection()->commit();
 
             // Best-effort cleanup outside transaction (external services & filesystem)
+            $this->purgeAgentExternal($agentExternal);
             $this->purgeMemoryIndex($userId);
             $this->purgeDigestIndex($userId);
             $this->cleanupUserDirectories($userId);
@@ -483,11 +486,38 @@ final readonly class UserDeletionService
         $this->shareRepository->deleteByPluginDataIds($pluginDataIds);
     }
 
-    private function deleteAgents(int $userId): void
+    /**
+     * @return list<AgentExternalCleanup>
+     */
+    private function deleteAgents(int $userId): array
     {
+        $pending = [];
         foreach ($this->agentRepository->findByOwner($userId) as $agent) {
-            $this->agentCascade->unshareAndRemoveDependents($agent);
+            $pending[] = $this->agentCascade->unshareAndRemoveDependents($agent);
             $this->em->remove($agent);
+        }
+
+        return $pending;
+    }
+
+    /**
+     * Best-effort: MariaDB rows are already gone; a Qdrant or filesystem
+     * failure only leaves orphaned vectors or files.
+     *
+     * @param list<AgentExternalCleanup> $pending
+     */
+    private function purgeAgentExternal(array $pending): void
+    {
+        foreach ($pending as $cleanup) {
+            try {
+                $this->agentCascade->purgeExternal($cleanup);
+            } catch (\Throwable $e) {
+                $this->logger->error('Failed to purge assistant files or vectors after delete', [
+                    'owner_id' => $cleanup->ownerId,
+                    'group_key' => $cleanup->groupKey,
+                    'exception' => $e,
+                ]);
+            }
         }
     }
 

--- a/backend/src/Service/UserDeletionService.php
+++ b/backend/src/Service/UserDeletionService.php
@@ -6,6 +6,7 @@ namespace App\Service;
 
 use App\Entity\SavedTask;
 use App\Entity\User;
+use App\Repository\AgentRepository;
 use App\Repository\ApiKeyRepository;
 use App\Repository\ChatRepository;
 use App\Repository\ConfigRepository;
@@ -21,6 +22,8 @@ use App\Repository\PluginDataRepository;
 use App\Repository\PromptMetaRepository;
 use App\Repository\PromptRepository;
 use App\Repository\RevectorizeRunRepository;
+use App\Repository\SavedTaskRepository;
+use App\Repository\SavedTaskRunRepository;
 use App\Repository\SessionRepository;
 use App\Repository\ShareRepository;
 use App\Repository\TokenRepository;
@@ -29,7 +32,10 @@ use App\Repository\UseLogRepository;
 use App\Repository\VerificationTokenRepository;
 use App\Repository\WidgetRepository;
 use App\Repository\WidgetSessionRepository;
+use App\Service\Agent\AgentCascadeCleanup;
 use App\Service\File\FileStorageService;
+use App\Service\Iam\ResourceKind\AgentKind;
+use App\Service\Iam\ResourceKind\SavedTaskKind;
 use App\Service\RAG\VectorStorage\VectorStorageFacade;
 use App\Service\VectorSearch\QdrantClientInterface;
 use Doctrine\ORM\EntityManagerInterface;
@@ -66,6 +72,10 @@ final readonly class UserDeletionService
         private GroupMemberRepository $groupMemberRepository,
         private ExternalIdentityRepository $externalIdentityRepository,
         private ShareRepository $shareRepository,
+        private AgentRepository $agentRepository,
+        private AgentCascadeCleanup $agentCascade,
+        private SavedTaskRepository $savedTaskRepository,
+        private SavedTaskRunRepository $savedTaskRunRepository,
         private LoggerInterface $logger,
     ) {
     }
@@ -98,6 +108,8 @@ final readonly class UserDeletionService
             $this->deleteUseLogs($userId);
             $this->deleteWidgets($userId);
             $this->deleteShares($userId);
+            $this->deleteAgents($userId);
+            $this->deleteSavedTasks($userId);
             $this->deleteChats($userId);
             $this->deleteMessages($userId);
             $this->deleteEmailVerificationAttempts($email);
@@ -173,6 +185,8 @@ final readonly class UserDeletionService
             $this->deleteUseLogs($userId);
             $this->deleteWidgets($userId);
             $this->deleteShares($userId);
+            $this->deleteAgents($userId);
+            $this->deleteSavedTasks($userId);
             $this->deleteChats($userId);
             $this->deleteMessages($userId);
             $this->deleteEmailVerificationAttempts($email);
@@ -452,6 +466,9 @@ final readonly class UserDeletionService
         foreach ($this->em->getRepository(SavedTask::class)->findBy(['ownerId' => $userId]) as $task) {
             $this->shareRepository->deleteByResource('saved_task', (string) $task->getId());
         }
+        foreach ($this->agentRepository->findByOwner($userId) as $agent) {
+            $this->shareRepository->deleteByResource(AgentKind::KEY, (string) $agent->getId());
+        }
         $this->shareRepository->deleteByOwnerKnowledgeFolders($userId);
 
         // Plugin-declared kinds share by plugin_data.id; a stale row would
@@ -464,6 +481,26 @@ final readonly class UserDeletionService
             }
         }
         $this->shareRepository->deleteByPluginDataIds($pluginDataIds);
+    }
+
+    private function deleteAgents(int $userId): void
+    {
+        foreach ($this->agentRepository->findByOwner($userId) as $agent) {
+            $this->agentCascade->unshareAndRemoveDependents($agent);
+            $this->em->remove($agent);
+        }
+    }
+
+    private function deleteSavedTasks(int $userId): void
+    {
+        foreach ($this->savedTaskRepository->findByOwner($userId) as $task) {
+            $taskId = $task->getId();
+            if (null !== $taskId) {
+                $this->shareRepository->deleteByResource(SavedTaskKind::KEY, (string) $taskId);
+                $this->savedTaskRunRepository->deleteForTask($taskId);
+            }
+            $this->em->remove($task);
+        }
     }
 
     private function deleteRevectorizeRuns(int $userId): void

--- a/backend/tests/Controller/AgentControllerTest.php
+++ b/backend/tests/Controller/AgentControllerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Controller;
 
+use App\Entity\Prompt;
 use App\Entity\User;
 use App\Repository\ConfigRepository;
 use App\Service\Agent\AgentConfig;
@@ -70,8 +71,11 @@ final class AgentControllerTest extends WebTestCase
         self::assertTrue($updated['routable']);
         self::assertSame('anthropic:claude-sonnet-4:chat', $updated['draft']['models']['chat']);
 
+        $promptId = (int) $created['promptId'];
         $this->client->request('DELETE', '/api/v1/agents/'.$id);
         self::assertSame(Response::HTTP_NO_CONTENT, $this->client->getResponse()->getStatusCode());
+        $this->em->clear();
+        self::assertNull($this->em->getRepository(Prompt::class)->find($promptId));
     }
 
     public function testForeignIdIs404(): void

--- a/backend/tests/Controller/AgentPublishFlowTest.php
+++ b/backend/tests/Controller/AgentPublishFlowTest.php
@@ -133,6 +133,10 @@ final class AgentPublishFlowTest extends WebTestCase
         $this->authenticateClient($this->client, $owner);
         $this->client->request('DELETE', '/api/v1/agents/'.$id);
         self::assertSame(Response::HTTP_NO_CONTENT, $this->client->getResponse()->getStatusCode());
+
+        $this->client->request('GET', '/api/v1/shares?kind=agent&resource='.$id);
+        self::assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        self::assertSame([], $this->json()['shares'] ?? null);
     }
 
     public function testDraftCannotBeShared(): void

--- a/backend/tests/Controller/AgentPublishFlowTest.php
+++ b/backend/tests/Controller/AgentPublishFlowTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Controller;
 
 use App\Entity\Group;
 use App\Entity\GroupMember;
+use App\Entity\Share;
 use App\Entity\User;
 use App\Repository\ConfigRepository;
 use App\Service\Agent\AgentConfig;
@@ -134,9 +135,17 @@ final class AgentPublishFlowTest extends WebTestCase
         $this->client->request('DELETE', '/api/v1/agents/'.$id);
         self::assertSame(Response::HTTP_NO_CONTENT, $this->client->getResponse()->getStatusCode());
 
-        $this->client->request('GET', '/api/v1/shares?kind=agent&resource='.$id);
-        self::assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
-        self::assertSame([], $this->json()['shares'] ?? null);
+        $this->client->request('GET', '/api/v1/agents/'.$id);
+        self::assertSame(Response::HTTP_NOT_FOUND, $this->client->getResponse()->getStatusCode());
+
+        $this->em->clear();
+        self::assertSame(
+            [],
+            $this->em->getRepository(Share::class)->findBy([
+                'resourceKind' => 'agent',
+                'resourceId' => (string) $id,
+            ]),
+        );
     }
 
     public function testDraftCannotBeShared(): void

--- a/backend/tests/Controller/GroupControllerTest.php
+++ b/backend/tests/Controller/GroupControllerTest.php
@@ -63,6 +63,8 @@ final class GroupControllerTest extends WebTestCase
         self::assertCount(1, $groups);
         self::assertSame('Sales', $groups[0]['name']);
         self::assertSame('member', $groups[0]['role']);
+        self::assertTrue($groups[0]['canLeave']);
+        self::assertSame('manual', $groups[0]['membershipSource']);
     }
 
     public function testIamReadKeyCanListMine(): void
@@ -96,6 +98,48 @@ final class GroupControllerTest extends WebTestCase
         $groups = json_decode((string) $this->client->getResponse()->getContent(), true)['groups'];
         self::assertCount(1, $groups);
         self::assertSame('Sales', $groups[0]['name']);
+    }
+
+    public function testLeaveRemovesManualMembership(): void
+    {
+        $this->enableFlag();
+        $user = $this->createUser('iam-leave-on@synaplan.internal');
+        $group = new Group();
+        $group->setName('Sales');
+        $group->setSlug('sales-leave-'.uniqid());
+        $this->em->persist($group);
+        $this->em->flush();
+        $member = new GroupMember((int) $group->getId(), (int) $user->getId());
+        $this->em->persist($member);
+        $this->em->flush();
+
+        $this->authenticateClient($this->client, $user);
+        $this->client->request('DELETE', '/api/v1/groups/'.$group->getId().'/membership');
+
+        self::assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode(), (string) $this->client->getResponse()->getContent());
+        $this->em->clear();
+        self::assertNull($this->em->getRepository(GroupMember::class)->findMembership((int) $group->getId(), (int) $user->getId()));
+    }
+
+    public function testLeaveDirectoryMembershipIs409(): void
+    {
+        $this->enableFlag();
+        $user = $this->createUser('iam-leave-dir@synaplan.internal');
+        $group = new Group();
+        $group->setName('From login');
+        $group->setSlug('dir-leave-'.uniqid());
+        $group->setKind(Group::KIND_DIRECTORY);
+        $this->em->persist($group);
+        $this->em->flush();
+        $member = new GroupMember((int) $group->getId(), (int) $user->getId());
+        $member->setSource(GroupMember::SOURCE_DIRECTORY);
+        $this->em->persist($member);
+        $this->em->flush();
+
+        $this->authenticateClient($this->client, $user);
+        $this->client->request('DELETE', '/api/v1/groups/'.$group->getId().'/membership');
+
+        self::assertSame(Response::HTTP_CONFLICT, $this->client->getResponse()->getStatusCode());
     }
 
     private function enableFlag(): void

--- a/backend/tests/Unit/Service/Agent/AgentCascadeCleanupTest.php
+++ b/backend/tests/Unit/Service/Agent/AgentCascadeCleanupTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\Agent;
+
+use App\Entity\Agent;
+use App\Entity\File;
+use App\Repository\AgentVersionRepository;
+use App\Repository\FileRepository;
+use App\Repository\PromptMetaRepository;
+use App\Repository\PromptRepository;
+use App\Repository\SavedTaskRepository;
+use App\Repository\SavedTaskRunRepository;
+use App\Repository\ShareRepository;
+use App\Service\Agent\AgentCascadeCleanup;
+use App\Service\Agent\AgentExternalCleanup;
+use App\Service\Agent\AgentKnowledgeFolders;
+use App\Service\Agent\Definition\AgentDefinition;
+use App\Service\Document\Persist\DocumentRevisionService;
+use App\Service\File\FileStorageService;
+use App\Service\Iam\ResourceKind\AgentKind;
+use App\Service\RAG\VectorStorage\VectorStorageFacade;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class AgentCascadeCleanupTest extends TestCase
+{
+    private ShareRepository&MockObject $shares;
+    private FileRepository&MockObject $files;
+    private FileStorageService&MockObject $fileStorage;
+    private VectorStorageFacade&MockObject $vectorStorage;
+    private DocumentRevisionService&MockObject $revisions;
+    private EntityManagerInterface&MockObject $em;
+    private AgentCascadeCleanup $cleanup;
+
+    protected function setUp(): void
+    {
+        $this->shares = $this->createMock(ShareRepository::class);
+        $this->files = $this->createMock(FileRepository::class);
+        $this->fileStorage = $this->createMock(FileStorageService::class);
+        $this->vectorStorage = $this->createMock(VectorStorageFacade::class);
+        $this->revisions = $this->createMock(DocumentRevisionService::class);
+        $this->em = $this->createMock(EntityManagerInterface::class);
+        $versions = $this->createMock(AgentVersionRepository::class);
+        $prompts = $this->createMock(PromptRepository::class);
+        $promptMeta = $this->createMock(PromptMetaRepository::class);
+        $savedTasks = $this->createMock(SavedTaskRepository::class);
+        $savedTaskRuns = $this->createMock(SavedTaskRunRepository::class);
+        $prompts->method('find')->willReturn(null);
+        $savedTasks->method('findAllByPromptAndOwner')->willReturn([]);
+
+        $this->cleanup = new AgentCascadeCleanup(
+            $this->shares,
+            $versions,
+            $prompts,
+            $promptMeta,
+            $this->files,
+            $this->fileStorage,
+            $this->vectorStorage,
+            $this->revisions,
+            $savedTasks,
+            $savedTaskRuns,
+            $this->em,
+        );
+    }
+
+    public function testDetachDoesNotTouchFilesystemOrQdrant(): void
+    {
+        $agent = $this->agent();
+        $file = (new File())->setFilePath('owner/nda.pdf');
+        $this->files->method('findByUserAndGroupKey')->willReturn([$file]);
+        $this->shares->expects(self::atLeastOnce())->method('deleteByResource');
+        $this->em->expects(self::once())->method('remove')->with($file);
+        $this->fileStorage->expects(self::never())->method('deleteFile');
+        $this->vectorStorage->expects(self::never())->method('deleteByGroupKey');
+
+        $pending = $this->cleanup->unshareAndRemoveDependents($agent);
+
+        self::assertSame(4, $pending->ownerId);
+        self::assertSame(AgentKnowledgeFolders::ownFolder($agent), $pending->groupKey);
+        self::assertSame(['owner/nda.pdf'], $pending->filePaths);
+    }
+
+    public function testPurgeExternalDeletesVectorsAndFiles(): void
+    {
+        $agent = $this->agent();
+        $this->files->method('findByUserAndGroupKey')->willReturn([]);
+        $pending = $this->cleanup->unshareAndRemoveDependents($agent);
+        $pending = new AgentExternalCleanup(
+            $pending->ownerId,
+            $pending->groupKey,
+            ['owner/nda.pdf'],
+        );
+
+        $this->vectorStorage->expects(self::once())->method('deleteByGroupKey')->with(
+            4,
+            AgentKnowledgeFolders::ownFolder($agent),
+        );
+        $this->fileStorage->expects(self::once())->method('deleteFile')->with('owner/nda.pdf');
+
+        $this->cleanup->purgeExternal($pending);
+    }
+
+    public function testUnshareDeletesAgentShares(): void
+    {
+        $this->files->method('findByUserAndGroupKey')->willReturn([]);
+        $kinds = [];
+        $this->shares->expects(self::atLeastOnce())->method('deleteByResource')
+            ->willReturnCallback(static function (string $kind, string $id) use (&$kinds): void {
+                $kinds[] = [$kind, $id];
+            });
+
+        $this->cleanup->unshareAndRemoveDependents($this->agent());
+
+        self::assertContains([AgentKind::KEY, '7'], $kinds);
+    }
+
+    private function agent(): Agent
+    {
+        $agent = new Agent(4, 20, 'contract-review', 'Contract review', AgentDefinition::defaults()->toArray());
+        (new \ReflectionProperty(Agent::class, 'id'))->setValue($agent, 7);
+
+        return $agent;
+    }
+}

--- a/backend/tests/Unit/Service/Iam/GroupServiceTest.php
+++ b/backend/tests/Unit/Service/Iam/GroupServiceTest.php
@@ -142,6 +142,37 @@ final class GroupServiceTest extends TestCase
         $this->service->removeMember($group, 8, $this->actor);
     }
 
+    public function testLeaveRemovesManualMembershipAndAudits(): void
+    {
+        $group = new Group();
+        $ref = new \ReflectionProperty(Group::class, 'id');
+        $ref->setValue($group, 4);
+        $existing = new GroupMember(4, 1);
+        $existing->setSource(GroupMember::SOURCE_MANUAL);
+        $this->members->method('findMembership')->willReturn($existing);
+        $this->members->expects(self::once())->method('remove')->with($existing);
+        $this->audit->expects(self::once())
+            ->method('save')
+            ->with(self::callback(static function (AuditLogEntry $entry): bool {
+                return 'group.member_leave' === $entry->getAction()
+                    && ['userId' => 1] === $entry->getSubject();
+            }));
+
+        $this->service->leave($group, $this->actor);
+    }
+
+    public function testLeaveRejectsDirectoryMembership(): void
+    {
+        $group = $this->directoryGroup(9);
+        $existing = new GroupMember(9, 1);
+        $existing->setSource(GroupMember::SOURCE_DIRECTORY);
+        $this->members->method('findMembership')->willReturn($existing);
+        $this->expectException(DirectoryGroupReadOnlyException::class);
+        $this->members->expects(self::never())->method('remove');
+
+        $this->service->leave($group, $this->actor);
+    }
+
     private function userWithId(int $id): User
     {
         $user = new User();

--- a/frontend/src/components/assistants/AssistantBuilder.vue
+++ b/frontend/src/components/assistants/AssistantBuilder.vue
@@ -23,7 +23,7 @@
       <BuilderInstructions />
       <BuilderModels />
       <BuilderKnowledge />
-      <AssistantPublishSection />
+      <AssistantPublishSection @deleted="emit('deleted')" />
     </div>
     <AssistantTestPanel />
   </div>
@@ -39,6 +39,10 @@ import BuilderModels from './BuilderModels.vue'
 import BuilderKnowledge from './BuilderKnowledge.vue'
 import AssistantTestPanel from './AssistantTestPanel.vue'
 import AssistantPublishSection from './AssistantPublishSection.vue'
+
+const emit = defineEmits<{
+  deleted: []
+}>()
 
 const store = useAgentsStore()
 const { t } = useI18n()

--- a/frontend/src/components/assistants/AssistantCard.vue
+++ b/frontend/src/components/assistants/AssistantCard.vue
@@ -52,6 +52,16 @@
       >
         {{ $t('assistants.edit') }}
       </button>
+      <button
+        v-if="card.origin === 'mine'"
+        type="button"
+        class="btn-danger px-4 py-2.5 rounded-lg text-sm font-medium"
+        data-testid="btn-assistant-delete"
+        :disabled="cardId == null"
+        @click="emitDelete"
+      >
+        {{ $t('assistants.delete') }}
+      </button>
     </div>
   </article>
 </template>
@@ -69,6 +79,7 @@ const emit = defineEmits<{
   'start-chat': [id: number]
   clone: [id: number]
   edit: [id: number]
+  delete: [id: number]
 }>()
 
 const cardId = computed(() =>
@@ -90,6 +101,12 @@ function emitClone(): void {
 function emitEdit(): void {
   if (cardId.value != null) {
     emit('edit', cardId.value)
+  }
+}
+
+function emitDelete(): void {
+  if (cardId.value != null) {
+    emit('delete', cardId.value)
   }
 }
 

--- a/frontend/src/components/assistants/AssistantGallery.vue
+++ b/frontend/src/components/assistants/AssistantGallery.vue
@@ -73,6 +73,7 @@
         @start-chat="$emit('start-chat', $event)"
         @clone="$emit('clone', $event)"
         @edit="$emit('edit', $event)"
+        @delete="$emit('delete', $event)"
       />
     </div>
   </div>
@@ -90,6 +91,7 @@ defineEmits<{
   'start-chat': [id: number]
   clone: [id: number]
   edit: [id: number]
+  delete: [id: number]
 }>()
 
 const { t } = useI18n()

--- a/frontend/src/components/assistants/AssistantPublishSection.vue
+++ b/frontend/src/components/assistants/AssistantPublishSection.vue
@@ -61,6 +61,14 @@
       >
         {{ $t('assistants.unarchive') }}
       </button>
+      <button
+        type="button"
+        class="btn-danger px-4 py-2.5 rounded-lg text-sm font-medium"
+        data-testid="btn-delete-assistant"
+        @click="onDelete"
+      >
+        {{ $t('assistants.delete') }}
+      </button>
     </div>
 
     <ul v-if="versions.length > 0" class="space-y-2" data-testid="list-assistant-versions">
@@ -93,6 +101,10 @@ import { agentsApi, type AgentUsage, type AgentVersionCard } from '@/services/ap
 import { useAgentsStore } from '@/stores/agents'
 import ShareDialog from '@/components/iam/ShareDialog.vue'
 import AssistantUsagePanel from './AssistantUsagePanel.vue'
+
+const emit = defineEmits<{
+  deleted: []
+}>()
 
 const store = useAgentsStore()
 const { t } = useI18n()
@@ -179,6 +191,32 @@ async function onUnarchive(): Promise<void> {
     await store.load(id)
   } catch {
     error(t('assistants.archiveFailed'))
+  }
+}
+
+async function onDelete(): Promise<void> {
+  const agent = store.current
+  if (agent?.id == null) return
+  const published = agent.status === 'published'
+  const ok = await confirm({
+    title: t('assistants.delete'),
+    message: published
+      ? t('assistants.deletePublishedConfirm')
+      : agent.status === 'archived'
+        ? t('assistants.deleteArchivedConfirm')
+        : t('assistants.deleteConfirm'),
+    danger: true,
+  })
+  if (!ok) return
+  try {
+    if (published) {
+      await agentsApi.update(agent.id, { status: 'archived' })
+    }
+    await store.remove(agent.id)
+    success(t('assistants.deleteSuccess'))
+    emit('deleted')
+  } catch {
+    error(t('assistants.deleteFailed'))
   }
 }
 

--- a/frontend/src/components/assistants/BuilderKnowledge.vue
+++ b/frontend/src/components/assistants/BuilderKnowledge.vue
@@ -16,6 +16,14 @@
         class="flex items-center justify-between gap-2 text-sm txt-primary"
       >
         <span class="truncate">{{ file.fileName }}</span>
+        <button
+          type="button"
+          class="btn-danger px-4 py-2.5 rounded-lg text-sm font-medium"
+          :data-testid="`btn-delete-knowledge-file-${file.messageId}`"
+          @click="onDeleteFile(file)"
+        >
+          {{ $t('assistants.deleteFile') }}
+        </button>
       </li>
     </ul>
     <label
@@ -54,11 +62,17 @@
 
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { promptsApi, type PromptFile } from '@/services/api/promptsApi'
 import { emptyAgentDraft } from '@/services/api/agentsApi'
 import { useAgentsStore } from '@/stores/agents'
+import { useDialog } from '@/composables/useDialog'
+import { useNotification } from '@/composables/useNotification'
 
 const store = useAgentsStore()
+const { t } = useI18n()
+const { confirm } = useDialog()
+const { error, success } = useNotification()
 const files = ref<PromptFile[]>([])
 
 const topic = computed(() => {
@@ -75,6 +89,23 @@ async function loadFiles(): Promise<void> {
     return
   }
   files.value = await promptsApi.getPromptFiles(topic.value)
+}
+
+async function onDeleteFile(file: PromptFile): Promise<void> {
+  if (!topic.value) return
+  const ok = await confirm({
+    title: t('assistants.deleteFile'),
+    message: t('assistants.deleteFileConfirm', { name: file.fileName }),
+    danger: true,
+  })
+  if (!ok) return
+  try {
+    await promptsApi.deletePromptFile(topic.value, file.messageId)
+    success(t('assistants.deleteFileSuccess'))
+    await loadFiles()
+  } catch {
+    error(t('assistants.deleteFileFailed'))
+  }
 }
 
 async function onUpload(event: Event): Promise<void> {

--- a/frontend/src/components/config/SavedTaskCard.vue
+++ b/frontend/src/components/config/SavedTaskCard.vue
@@ -22,6 +22,7 @@ const props = defineProps<{
 const emit = defineEmits<{
   updated: [task: SavedTask]
   copied: [task: SavedTask]
+  deleted: [id: number]
 }>()
 
 const { t, te, locale } = useI18n()
@@ -207,6 +208,22 @@ const openResults = () => {
   void router.push({ path: '/', query: { chat: String(props.task.chatId) } })
 }
 
+const onDelete = async () => {
+  const ok = await dialog.confirm({
+    title: t('config.savedTasks.delete'),
+    message: t('config.savedTasks.deleteConfirm', { name: props.task.name }),
+    danger: true,
+  })
+  if (!ok) return
+  try {
+    await savedTasksApi.remove(props.task.id)
+    success(t('config.savedTasks.deleteSuccess'))
+    emit('deleted', props.task.id)
+  } catch {
+    showError(t('config.savedTasks.deleteFailed'))
+  }
+}
+
 const onRunCopy = async () => {
   const ok = await dialog.confirm({
     title: t('iam.runCopy'),
@@ -319,6 +336,15 @@ const onRunCopy = async () => {
         @click="iamShareOpen = true"
       >
         {{ $t('iam.share') }}
+      </button>
+      <button
+        v-if="!sharedView"
+        type="button"
+        class="btn-danger inline-flex items-center px-4 py-2 rounded-lg text-sm font-medium"
+        data-testid="btn-delete-saved-task"
+        @click="onDelete"
+      >
+        {{ $t('config.savedTasks.delete') }}
       </button>
       <select
         v-if="!sharedView"

--- a/frontend/src/components/config/SavedTaskCard.vue
+++ b/frontend/src/components/config/SavedTaskCard.vue
@@ -300,7 +300,7 @@ const onRunCopy = async () => {
       </p>
       <button
         type="button"
-        class="btn-primary inline-flex items-center px-4 py-2 rounded-lg text-sm font-medium mt-2"
+        class="btn-primary inline-flex items-center px-4 py-2.5 rounded-lg text-sm font-medium mt-2"
         @click="onResume"
       >
         {{ $t('config.savedTasks.resume') }}
@@ -311,7 +311,7 @@ const onRunCopy = async () => {
       <button
         v-if="sharedView"
         type="button"
-        class="btn-primary inline-flex items-center px-4 py-2 rounded-lg text-sm font-medium"
+        class="btn-primary inline-flex items-center px-4 py-2.5 rounded-lg text-sm font-medium"
         :disabled="copying"
         data-testid="btn-run-copy"
         @click="onRunCopy"
@@ -321,7 +321,7 @@ const onRunCopy = async () => {
       <button
         v-else
         type="button"
-        class="btn-primary inline-flex items-center px-4 py-2 rounded-lg text-sm font-medium"
+        class="btn-primary inline-flex items-center px-4 py-2.5 rounded-lg text-sm font-medium"
         :disabled="running"
         data-testid="btn-run-now"
         @click="onRunNow"
@@ -331,7 +331,7 @@ const onRunCopy = async () => {
       <button
         v-if="iamSharingEnabled && !sharedView"
         type="button"
-        class="btn-secondary inline-flex items-center px-4 py-2 rounded-lg text-sm font-medium"
+        class="btn-secondary inline-flex items-center px-4 py-2.5 rounded-lg text-sm font-medium"
         data-testid="btn-share-saved-task"
         @click="iamShareOpen = true"
       >
@@ -340,7 +340,7 @@ const onRunCopy = async () => {
       <button
         v-if="!sharedView"
         type="button"
-        class="btn-danger inline-flex items-center px-4 py-2 rounded-lg text-sm font-medium"
+        class="btn-danger inline-flex items-center px-4 py-2.5 rounded-lg text-sm font-medium"
         data-testid="btn-delete-saved-task"
         @click="onDelete"
       >

--- a/frontend/src/components/config/SavedTasksOverview.vue
+++ b/frontend/src/components/config/SavedTasksOverview.vue
@@ -44,6 +44,10 @@ const onCopied = (task: SavedTask) => {
   filterShared.value = false
 }
 
+const onDeleted = (id: number) => {
+  tasks.value = tasks.value.filter((row) => row.id !== id)
+}
+
 const sharedTasks = computed(() =>
   sharedItems.value.map((item) => ({
     task: {
@@ -130,7 +134,7 @@ onMounted(() => {
 
       <ul v-else class="space-y-4">
         <li v-for="task in tasks" :key="task.id">
-          <SavedTaskCard :task="task" @updated="onUpdated" />
+          <SavedTaskCard :task="task" @updated="onUpdated" @deleted="onDeleted" />
         </li>
       </ul>
     </template>

--- a/frontend/src/components/people/AuditTab.vue
+++ b/frontend/src/components/people/AuditTab.vue
@@ -100,6 +100,7 @@ const ACTION_KEYS: Record<string, string> = {
   'group.delete': 'people.audit.action.group_delete',
   'group.member_set': 'people.audit.action.group_member_set',
   'group.member_remove': 'people.audit.action.group_member_remove',
+  'group.member_leave': 'people.audit.action.group_member_leave',
   'directory.sync': 'people.audit.action.directory_sync',
   'impersonation.start': 'people.audit.action.impersonation_start',
   'impersonation.stop': 'people.audit.action.impersonation_stop',

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -1135,7 +1135,9 @@
       "Alle deine Nachrichten und Chats",
       "Alle hochgeladenen Dateien und Wissensdatenbank-Dokumente",
       "Deine persönlichen Daten, Einstellungen und Erinnerungen",
-      "API-Schlüssel, Widgets und Zugangsdaten"
+      "API-Schlüssel, Widgets und Zugangsdaten",
+      "Deine KI-Assistenten und gespeicherten Aufgaben",
+      "Gruppenmitgliedschaften, zu denen du hinzugefügt wurdest"
     ],
     "retention": "Die Löschung ist endgültig und wirkt sofort. Backups mit verbliebenen Daten werden innerhalb von 30 Tagen rotiert. Gesetzlich aufbewahrungspflichtige Daten (z. B. Rechnungen) werden nur so lange aufbewahrt, wie es das Gesetz verlangt.",
     "partialTitle": "Einzelne Daten löschen, ohne das Konto aufzugeben",
@@ -1160,6 +1162,18 @@
       {
         "name": "Verbindungen, Chat-Widgets und API-Schlüssel",
         "how": "Öffne Kanäle und entferne dort die Verbindung, das Widget oder den Schlüssel, den du nicht mehr brauchst."
+      },
+      {
+        "name": "KI-Assistenten",
+        "how": "Öffne KI-Assistenten. Bei deinem eigenen Assistenten wähle Löschen. Ein veröffentlichter Assistent wird zuerst archiviert und dann entfernt, einschließlich Dateien und Freigaben."
+      },
+      {
+        "name": "Gespeicherte Aufgaben",
+        "how": "Öffne Gespeicherte Aufgaben und wähle Löschen bei einer Aufgabe, die du erstellt hast."
+      },
+      {
+        "name": "Gruppen, zu denen du hinzugefügt wurdest",
+        "how": "Öffne Meine Gruppen und wähle Verlassen. Du verlierst den Zugriff auf alles, was mit dieser Gruppe geteilt wurde. Mitgliedschaften aus der Anmeldung können hier nicht verlassen werden."
       }
     ],
     "partialRetention": "Gelöschte Inhalte verschwinden sofort aus deinem Konto. Backups mit verbliebenen Kopien werden innerhalb von 30 Tagen rotiert. Alles andere in deinem Konto bleibt unberührt.",
@@ -2064,6 +2078,10 @@
       "overviewLoading": "Gespeicherte Aufgaben werden geladen…",
       "overviewEmpty": "Noch nichts geplant. Nach einem Chat-Plan das Uhr-Symbol nutzen — oder eine eigene Anweisung speichern unter",
       "loadFailed": "Gespeicherte Aufgaben konnten nicht geladen werden.",
+      "delete": "Löschen",
+      "deleteConfirm": "Die gespeicherte Aufgabe \"{name}\" löschen? Freigaben dieser Aufgabe werden ebenfalls entfernt.",
+      "deleteSuccess": "Gespeicherte Aufgabe gelöscht",
+      "deleteFailed": "Die gespeicherte Aufgabe konnte nicht gelöscht werden.",
       "scheduleThis": "Später erneut ausführen",
       "scheduleThisHint": "Gib der Aufgabe einen Namen. Den Zeitplan setzt du auf der nächsten Seite.",
       "scheduledFromChat": "Gespeichert. Lege fest, wann sie laufen soll.",
@@ -5461,7 +5479,12 @@
     "myGroups": {
       "subtitle": "Gruppen, in denen Sie auf dieser Instanz Mitglied sind.",
       "emptyMember": "Sie sind noch in keiner Gruppe. Ein Administrator kann Sie auf der Seite Personen hinzufügen.",
-      "emptyAdmin": "Noch keine Gruppen. Legen Sie eine auf der Seite Personen an."
+      "emptyAdmin": "Noch keine Gruppen. Legen Sie eine auf der Seite Personen an.",
+      "leave": "Verlassen",
+      "leaveConfirm": "Die Gruppe \"{name}\" verlassen? Sie verlieren den Zugriff auf alles, was mit dieser Gruppe geteilt wurde. Die Gruppe selbst bleibt.",
+      "left": "Sie haben die Gruppe verlassen.",
+      "leaveFailed": "Die Gruppe konnte nicht verlassen werden.",
+      "leaveDirectory": "Diese Mitgliedschaft kommt aus Ihrer Anmeldung und kann hier nicht verlassen werden."
     },
     "users": {
       "groups": "Gruppen",
@@ -5520,6 +5543,7 @@
         "group_delete": "Gruppe gelöscht",
         "group_member_set": "Mitglied hinzugefügt",
         "group_member_remove": "Mitglied entfernt",
+        "group_member_leave": "Gruppe verlassen",
         "directory_sync": "Anmeldegruppe aktualisiert",
         "impersonation_start": "Ansicht als Benutzer gestartet",
         "impersonation_stop": "Ansicht als Benutzer beendet",
@@ -5778,8 +5802,15 @@
     "cloneSuccess": "Als neuer Entwurf kopiert",
     "startChatFailed": "Der Chat konnte nicht gestartet werden",
     "delete": "Löschen",
-    "deleteConfirm": "Diesen Entwurf löschen?",
+    "deleteConfirm": "Diesen Entwurf löschen? Dateien und Freigaben werden ebenfalls entfernt.",
+    "deleteArchivedConfirm": "Diesen archivierten Assistenten endgültig löschen? Dateien und Freigaben werden ebenfalls entfernt.",
+    "deletePublishedConfirm": "Dieser Assistent ist veröffentlicht. Er wird zuerst archiviert und dann endgültig gelöscht, einschließlich Dateien und Freigaben.",
+    "deleteSuccess": "Assistent gelöscht",
     "deleteFailed": "Der Assistent konnte nicht gelöscht werden",
+    "deleteFile": "Datei löschen",
+    "deleteFileConfirm": "\"{name}\" von diesem Assistenten löschen?",
+    "deleteFileSuccess": "Datei gelöscht",
+    "deleteFileFailed": "Die Datei konnte nicht gelöscht werden",
     "sharedEmpty": "Es wurde noch nichts mit dir geteilt",
     "pluginsEmpty": "Noch keine Assistenten aus Plugins",
     "filterArchived": "Archiviert",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -1966,6 +1966,10 @@
       "overviewLoading": "Loading saved tasks…",
       "overviewEmpty": "Nothing scheduled yet. After a chat plan finishes, use the clock — or save a custom instruction under",
       "loadFailed": "Could not load saved tasks.",
+      "delete": "Delete",
+      "deleteConfirm": "Delete the saved task \"{name}\"? Shares of this task are removed too.",
+      "deleteSuccess": "Saved task deleted",
+      "deleteFailed": "Could not delete the saved task.",
       "scheduleThis": "Run this again later",
       "scheduleThisHint": "Name this task. You can set the schedule on the next screen.",
       "scheduledFromChat": "Saved. Set when it should run.",
@@ -4137,7 +4141,9 @@
       "All your messages and chats",
       "All uploaded files and knowledge-base documents",
       "Your personal data, settings and memories",
-      "API keys, widgets and credentials"
+      "API keys, widgets and credentials",
+      "Your AI assistants and saved tasks",
+      "Group memberships you were added to"
     ],
     "retention": "Deletion is permanent and takes effect immediately. Backups containing residual data are rotated out within 30 days. Data we are legally required to retain (e.g. invoices) is kept only as long as the law requires.",
     "partialTitle": "Delete individual data without deleting your account",
@@ -4162,6 +4168,18 @@
       {
         "name": "Connections, chat widgets and API keys",
         "how": "Open Channels and remove the connection, widget or key you no longer need."
+      },
+      {
+        "name": "AI assistants",
+        "how": "Open AI assistants. On your own assistant, choose Delete. A published assistant is archived first, then removed, including its files and shares."
+      },
+      {
+        "name": "Saved tasks",
+        "how": "Open Saved tasks and choose Delete on a task you created."
+      },
+      {
+        "name": "Groups you were added to",
+        "how": "Open My groups and choose Leave. You lose access to anything shared with that group. Memberships that come from your login cannot be left here."
       }
     ],
     "partialRetention": "Deleted items disappear from your account immediately. Backups containing residual copies are rotated out within 30 days. Everything else in your account stays untouched.",
@@ -5527,7 +5545,12 @@
     "myGroups": {
       "subtitle": "Groups you belong to on this instance.",
       "emptyMember": "You are not in a group yet. An administrator can add you on the People page.",
-      "emptyAdmin": "No groups yet. Create one on the People page."
+      "emptyAdmin": "No groups yet. Create one on the People page.",
+      "leave": "Leave",
+      "leaveConfirm": "Leave the group \"{name}\"? You will lose access to anything shared with that group. The group itself stays.",
+      "left": "You left the group.",
+      "leaveFailed": "Could not leave the group.",
+      "leaveDirectory": "This membership comes from your login and cannot be left here."
     },
     "users": {
       "groups": "Groups",
@@ -5586,6 +5609,7 @@
         "group_delete": "Group deleted",
         "group_member_set": "Member added",
         "group_member_remove": "Member removed",
+        "group_member_leave": "Left a group",
         "directory_sync": "Login group updated",
         "impersonation_start": "Started viewing as user",
         "impersonation_stop": "Stopped viewing as user",
@@ -5844,8 +5868,15 @@
     "cloneSuccess": "Copied as a new draft",
     "startChatFailed": "Could not start the chat",
     "delete": "Delete",
-    "deleteConfirm": "Delete this draft assistant?",
+    "deleteConfirm": "Delete this draft assistant? Its files and shares are removed too.",
+    "deleteArchivedConfirm": "Permanently delete this archived assistant? Its files and shares are removed too.",
+    "deletePublishedConfirm": "This assistant is published. It will be archived and then permanently deleted, including files and shares.",
+    "deleteSuccess": "Assistant deleted",
     "deleteFailed": "Could not delete the assistant",
+    "deleteFile": "Delete file",
+    "deleteFileConfirm": "Delete \"{name}\" from this assistant?",
+    "deleteFileSuccess": "File deleted",
+    "deleteFileFailed": "Could not delete the file",
     "sharedEmpty": "Nothing has been shared with you yet",
     "pluginsEmpty": "No assistants from plugins yet",
     "filterArchived": "Archived",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -1767,7 +1767,9 @@
       "Todos tus mensajes y chats",
       "Todos los archivos subidos y documentos de la base de conocimiento",
       "Tus datos personales, ajustes y memorias",
-      "Claves de API, widgets y credenciales"
+      "Claves de API, widgets y credenciales",
+      "Tus asistentes de IA y tareas guardadas",
+      "Pertenencias a grupos a los que te añadieron"
     ],
     "retention": "La eliminación es permanente y surte efecto de inmediato. Las copias de seguridad con datos residuales se rotan en un plazo de 30 días. Los datos que estamos legalmente obligados a conservar (p. ej. facturas) se mantienen solo durante el tiempo que exige la ley.",
     "partialTitle": "Eliminar datos concretos sin borrar tu cuenta",
@@ -1792,6 +1794,18 @@
       {
         "name": "Conexiones, widgets de chat y claves de API",
         "how": "Abre Canales y elimina la conexión, el widget o la clave que ya no necesites."
+      },
+      {
+        "name": "Asistentes de IA",
+        "how": "Abre Asistentes de IA. En tu propio asistente, elige Eliminar. Un asistente publicado se archiva primero y luego se elimina, incluidos sus archivos y usos compartidos."
+      },
+      {
+        "name": "Tareas guardadas",
+        "how": "Abre Tareas guardadas y elige Eliminar en una tarea que hayas creado."
+      },
+      {
+        "name": "Grupos a los que te añadieron",
+        "how": "Abre Mis grupos y elige Salir. Pierdes el acceso a todo lo compartido con ese grupo. Las pertenencias que vienen de tu inicio de sesión no se pueden abandonar aquí."
       }
     ],
     "partialRetention": "Lo que eliminas desaparece de tu cuenta de inmediato. Las copias de seguridad con copias residuales se rotan en un plazo de 30 días. Todo lo demás de tu cuenta permanece intacto.",
@@ -2666,6 +2680,10 @@
       "overviewLoading": "Cargando tareas guardadas…",
       "overviewEmpty": "Aún no hay nada programado. Cuando termine un plan en el chat, usa el reloj — o guarda una instrucción propia en",
       "loadFailed": "No se pudieron cargar las tareas guardadas.",
+      "delete": "Eliminar",
+      "deleteConfirm": "¿Eliminar la tarea guardada \"{name}\"? También se quitan los usos compartidos de esta tarea.",
+      "deleteSuccess": "Tarea guardada eliminada",
+      "deleteFailed": "No se pudo eliminar la tarea guardada.",
       "scheduleThis": "Volver a ejecutar esto más tarde",
       "scheduleThisHint": "Ponle un nombre a esta tarea. El horario lo eliges en la siguiente pantalla.",
       "scheduledFromChat": "Guardada. Elige cuándo debe ejecutarse.",
@@ -4541,7 +4559,12 @@
     "myGroups": {
       "subtitle": "Grupos a los que pertenece en esta instancia.",
       "emptyMember": "Aún no está en ningún grupo. Un administrador puede añadirle en la página Personas.",
-      "emptyAdmin": "Aún no hay grupos. Cree uno en la página Personas."
+      "emptyAdmin": "Aún no hay grupos. Cree uno en la página Personas.",
+      "leave": "Salir",
+      "leaveConfirm": "¿Salir del grupo \"{name}\"? Perderá el acceso a todo lo compartido con ese grupo. El grupo en sí permanece.",
+      "left": "Ha salido del grupo.",
+      "leaveFailed": "No se pudo salir del grupo.",
+      "leaveDirectory": "Esta pertenencia viene de su inicio de sesión y no se puede abandonar aquí."
     },
     "users": {
       "groups": "Grupos",
@@ -4600,6 +4623,7 @@
         "group_delete": "Grupo eliminado",
         "group_member_set": "Miembro añadido",
         "group_member_remove": "Miembro eliminado",
+        "group_member_leave": "Salió de un grupo",
         "directory_sync": "Grupo de inicio de sesión actualizado",
         "impersonation_start": "Empezó a ver como usuario",
         "impersonation_stop": "Dejó de ver como usuario",
@@ -4858,8 +4882,15 @@
     "cloneSuccess": "Copiado como un borrador nuevo",
     "startChatFailed": "No se pudo empezar el chat",
     "delete": "Eliminar",
-    "deleteConfirm": "¿Eliminar este borrador?",
+    "deleteConfirm": "¿Eliminar este borrador? También se quitan sus archivos y usos compartidos.",
+    "deleteArchivedConfirm": "¿Eliminar definitivamente este asistente archivado? También se quitan sus archivos y usos compartidos.",
+    "deletePublishedConfirm": "Este asistente está publicado. Se archivará y luego se eliminará definitivamente, incluidos archivos y usos compartidos.",
+    "deleteSuccess": "Asistente eliminado",
     "deleteFailed": "No se pudo eliminar el asistente",
+    "deleteFile": "Eliminar archivo",
+    "deleteFileConfirm": "¿Eliminar \"{name}\" de este asistente?",
+    "deleteFileSuccess": "Archivo eliminado",
+    "deleteFileFailed": "No se pudo eliminar el archivo",
     "sharedEmpty": "Todavía no han compartido nada contigo",
     "pluginsEmpty": "Aún no hay asistentes de plugins",
     "filterArchived": "Archivados",

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -1964,6 +1964,10 @@
       "overviewLoading": "Chargement des tâches enregistrées…",
       "overviewEmpty": "Rien n’est encore planifié. Après un plan de chat, utilisez l’horloge — ou enregistrez une instruction personnalisée sous",
       "loadFailed": "Impossible de charger les tâches enregistrées.",
+      "delete": "Supprimer",
+      "deleteConfirm": "Supprimer la tâche enregistrée « {name} » ? Les partages de cette tâche sont aussi retirés.",
+      "deleteSuccess": "Tâche enregistrée supprimée",
+      "deleteFailed": "Impossible de supprimer la tâche enregistrée.",
       "scheduleThis": "Relancer plus tard",
       "scheduleThisHint": "Donnez un nom à cette tâche. Vous pourrez définir le planning à l’écran suivant.",
       "scheduledFromChat": "Enregistrée. Indiquez quand elle doit s’exécuter.",
@@ -4137,7 +4141,9 @@
       "Tous vos messages et chats",
       "Tous les fichiers téléversés et documents de la base de connaissances",
       "Vos données personnelles, réglages et mémoires",
-      "Clés API, widgets et identifiants"
+      "Clés API, widgets et identifiants",
+      "Vos assistants IA et tâches enregistrées",
+      "Appartenances à des groupes auxquels vous avez été ajouté"
     ],
     "retention": "La suppression est définitive et prend effet immédiatement. Les sauvegardes contenant des données résiduelles sont renouvelées sous 30 jours. Les données que nous sommes légalement tenus de conserver (p. ex. les factures) ne le sont que le temps exigé par la loi.",
     "partialTitle": "Supprimer des données individuelles sans supprimer votre compte",
@@ -4162,6 +4168,18 @@
       {
         "name": "Connexions, widgets de chat et clés API",
         "how": "Ouvrez Canaux et retirez la connexion, le widget ou la clé dont vous n’avez plus besoin."
+      },
+      {
+        "name": "Assistants IA",
+        "how": "Ouvrez Assistants IA. Sur votre propre assistant, choisissez Supprimer. Un assistant publié est d’abord archivé, puis retiré, y compris ses fichiers et partages."
+      },
+      {
+        "name": "Tâches enregistrées",
+        "how": "Ouvrez Tâches enregistrées et choisissez Supprimer sur une tâche que vous avez créée."
+      },
+      {
+        "name": "Groupes auxquels vous avez été ajouté",
+        "how": "Ouvrez Mes groupes et choisissez Quitter. Vous perdez l’accès à tout ce qui est partagé avec ce groupe. Les appartenances issues de votre connexion ne peuvent pas être quittées ici."
       }
     ],
     "partialRetention": "Les éléments supprimés disparaissent de votre compte immédiatement. Les sauvegardes contenant des copies résiduelles sont renouvelées sous 30 jours. Tout le reste de votre compte reste inchangé.",
@@ -5527,7 +5545,12 @@
     "myGroups": {
       "subtitle": "Groupes auxquels vous appartenez sur cette instance.",
       "emptyMember": "Vous n’êtes encore dans aucun groupe. Un administrateur peut vous ajouter sur la page Personnes.",
-      "emptyAdmin": "Aucun groupe pour le moment. Créez-en un sur la page Personnes."
+      "emptyAdmin": "Aucun groupe pour le moment. Créez-en un sur la page Personnes.",
+      "leave": "Quitter",
+      "leaveConfirm": "Quitter le groupe « {name} » ? Vous perdrez l’accès à tout ce qui est partagé avec ce groupe. Le groupe lui-même reste.",
+      "left": "Vous avez quitté le groupe.",
+      "leaveFailed": "Impossible de quitter le groupe.",
+      "leaveDirectory": "Cette appartenance vient de votre connexion et ne peut pas être quittée ici."
     },
     "users": {
       "groups": "Groupes",
@@ -5586,6 +5609,7 @@
         "group_delete": "Groupe supprimé",
         "group_member_set": "Membre ajouté",
         "group_member_remove": "Membre retiré",
+        "group_member_leave": "A quitté un groupe",
         "directory_sync": "Groupe de connexion mis à jour",
         "impersonation_start": "A commencé à voir en tant qu’utilisateur",
         "impersonation_stop": "A cessé de voir en tant qu’utilisateur",
@@ -5844,8 +5868,15 @@
     "cloneSuccess": "Copié comme nouveau brouillon",
     "startChatFailed": "Impossible de démarrer le chat",
     "delete": "Supprimer",
-    "deleteConfirm": "Supprimer ce brouillon ?",
+    "deleteConfirm": "Supprimer ce brouillon ? Ses fichiers et partages sont aussi retirés.",
+    "deleteArchivedConfirm": "Supprimer définitivement cet assistant archivé ? Ses fichiers et partages sont aussi retirés.",
+    "deletePublishedConfirm": "Cet assistant est publié. Il sera d’abord archivé, puis définitivement supprimé, y compris ses fichiers et partages.",
+    "deleteSuccess": "Assistant supprimé",
     "deleteFailed": "Impossible de supprimer l’assistant",
+    "deleteFile": "Supprimer le fichier",
+    "deleteFileConfirm": "Supprimer « {name} » de cet assistant ?",
+    "deleteFileSuccess": "Fichier supprimé",
+    "deleteFileFailed": "Impossible de supprimer le fichier",
     "sharedEmpty": "Rien n’a encore été partagé avec vous",
     "pluginsEmpty": "Aucun assistant provenant de plugins",
     "filterArchived": "Archivés",

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -1767,7 +1767,9 @@
       "Tüm mesajların ve sohbetlerin",
       "Yüklenen tüm dosyalar ve bilgi tabanı belgeleri",
       "Kişisel verilerin, ayarların ve anıların",
-      "API anahtarları, widget'lar ve kimlik bilgileri"
+      "API anahtarları, widget'lar ve kimlik bilgileri",
+      "AI asistanların ve kayıtlı görevlerin",
+      "Eklenmiş olduğun grup üyelikleri"
     ],
     "retention": "Silme işlemi kalıcıdır ve anında geçerli olur. Artık veri içeren yedekler 30 gün içinde döngüden çıkarılır. Yasal olarak saklamakla yükümlü olduğumuz veriler (ör. faturalar) yalnızca yasanın gerektirdiği süre boyunca tutulur.",
     "partialTitle": "Hesabını silmeden tek tek verileri sil",
@@ -1792,6 +1794,18 @@
       {
         "name": "Bağlantılar, sohbet widget'ları ve API anahtarları",
         "how": "Kanallar'ı aç ve artık ihtiyacın olmayan bağlantıyı, widget'ı veya anahtarı kaldır."
+      },
+      {
+        "name": "AI asistanları",
+        "how": "AI asistanları'nı aç. Kendi asistanında Sil'i seç. Yayınlanmış bir asistan önce arşivlenir, sonra dosyaları ve paylaşımlarıyla birlikte kaldırılır."
+      },
+      {
+        "name": "Kayıtlı görevler",
+        "how": "Kayıtlı görevler'i aç ve oluşturduğun bir görevde Sil'i seç."
+      },
+      {
+        "name": "Eklenmiş olduğun gruplar",
+        "how": "Gruplarım'ı aç ve Ayrıl'ı seç. Bu grupla paylaşılan her şeye erişimini kaybedersin. Girişinden gelen üyelikler burada bırakılamaz."
       }
     ],
     "partialRetention": "Sildiğin ögeler hesabından anında kaybolur. Artık kopya içeren yedekler 30 gün içinde döngüden çıkarılır. Hesabındaki diğer her şey olduğu gibi kalır.",
@@ -2667,6 +2681,10 @@
       "overviewLoading": "Kayıtlı görevler yükleniyor…",
       "overviewEmpty": "Henüz zamanlanmış bir şey yok. Sohbette bir plan bitince saati kullan — veya özel bir talimat kaydet:",
       "loadFailed": "Kayıtlı görevler yüklenemedi.",
+      "delete": "Sil",
+      "deleteConfirm": "\"{name}\" kayıtlı görevi silinsin mi? Bu görevin paylaşımları da kaldırılır.",
+      "deleteSuccess": "Kayıtlı görev silindi",
+      "deleteFailed": "Kayıtlı görev silinemedi.",
       "scheduleThis": "Bunu daha sonra tekrar çalıştır",
       "scheduleThisHint": "Bu göreve bir ad ver. Zamanlamayı sonraki ekranda seçersin.",
       "scheduledFromChat": "Kaydedildi. Ne zaman çalışacağını seç.",
@@ -4542,7 +4560,12 @@
     "myGroups": {
       "subtitle": "Bu kuruluşta üye olduğunuz gruplar.",
       "emptyMember": "Henüz bir grupta değilsiniz. Bir yönetici sizi Kişiler sayfasından ekleyebilir.",
-      "emptyAdmin": "Henüz grup yok. Kişiler sayfasından bir tane oluşturun."
+      "emptyAdmin": "Henüz grup yok. Kişiler sayfasından bir tane oluşturun.",
+      "leave": "Ayrıl",
+      "leaveConfirm": "\"{name}\" grubundan ayrılmak istiyor musunuz? Bu grupla paylaşılan her şeye erişiminizi kaybedersiniz. Grup kalır.",
+      "left": "Gruptan ayrıldınız.",
+      "leaveFailed": "Gruptan ayrılamadı.",
+      "leaveDirectory": "Bu üyelik girişinizden gelir; burada ayrılamazsınız."
     },
     "users": {
       "groups": "Gruplar",
@@ -4601,6 +4624,7 @@
         "group_delete": "Grup silindi",
         "group_member_set": "Üye eklendi",
         "group_member_remove": "Üye kaldırıldı",
+        "group_member_leave": "Gruptan ayrıldı",
         "directory_sync": "Giriş grubu güncellendi",
         "impersonation_start": "Kullanıcı olarak görüntüleme başladı",
         "impersonation_stop": "Kullanıcı olarak görüntüleme bitti",
@@ -4859,8 +4883,15 @@
     "cloneSuccess": "Yeni taslak olarak kopyalandı",
     "startChatFailed": "Sohbet başlatılamadı",
     "delete": "Sil",
-    "deleteConfirm": "Bu taslak asistan silinsin mi?",
+    "deleteConfirm": "Bu taslak asistan silinsin mi? Dosyaları ve paylaşımları da kaldırılır.",
+    "deleteArchivedConfirm": "Bu arşivlenmiş asistan kalıcı olarak silinsin mi? Dosyaları ve paylaşımları da kaldırılır.",
+    "deletePublishedConfirm": "Bu asistan yayınlanmış. Önce arşivlenecek, sonra dosyaları ve paylaşımlarıyla birlikte kalıcı olarak silinecek.",
+    "deleteSuccess": "Asistan silindi",
     "deleteFailed": "Asistan silinemedi",
+    "deleteFile": "Dosyayı sil",
+    "deleteFileConfirm": "\"{name}\" bu asistandan silinsin mi?",
+    "deleteFileSuccess": "Dosya silindi",
+    "deleteFileFailed": "Dosya silinemedi",
     "sharedEmpty": "Henüz sizinle bir şey paylaşılmadı",
     "pluginsEmpty": "Henüz eklentilerden asistan yok",
     "filterArchived": "Arşivlenenler",

--- a/frontend/src/services/api/iamApi.ts
+++ b/frontend/src/services/api/iamApi.ts
@@ -8,6 +8,7 @@ import {
   ListAdminGroupMembersResponseSchema,
   PutAdminGroupMemberResponseSchema,
   DeleteAdminGroupMemberResponseSchema,
+  LeaveMyGroupResponseSchema,
   ListMyGroupsResponseSchema,
   ListSharesResponseSchema,
   GrantShareResponseSchema,
@@ -29,6 +30,7 @@ export type IamAuditEntry = NonNullable<
 >[number]
 
 export type IamGroup = NonNullable<z.infer<typeof ListAdminGroupsResponseSchema>['groups']>[number]
+export type IamMyGroup = NonNullable<z.infer<typeof ListMyGroupsResponseSchema>['groups']>[number]
 export type IamGroupMember = NonNullable<
   z.infer<typeof ListAdminGroupMembersResponseSchema>['members']
 >[number]
@@ -110,12 +112,19 @@ export const iamApi = {
     })
   },
 
-  async listMyGroups(): Promise<IamGroup[]> {
+  async listMyGroups(): Promise<IamMyGroup[]> {
     const data = await httpClient('/api/v1/groups/mine', {
       method: 'GET',
       schema: ListMyGroupsResponseSchema,
     })
     return data.groups ?? []
+  },
+
+  async leaveGroup(id: number): Promise<void> {
+    await httpClient(`/api/v1/groups/${id}/membership`, {
+      method: 'DELETE',
+      schema: LeaveMyGroupResponseSchema,
+    })
   },
 
   async listShares(kind: string, resource: string): Promise<IamShare[]> {

--- a/frontend/src/services/api/savedTasksApi.ts
+++ b/frontend/src/services/api/savedTasksApi.ts
@@ -165,6 +165,10 @@ export const savedTasksApi = {
     return asTask(data.task)
   },
 
+  async remove(id: number): Promise<void> {
+    await httpClient(`/api/v1/saved-tasks/${id}`, { method: 'DELETE' })
+  },
+
   async resume(id: number): Promise<SavedTask> {
     const data = await httpClient(`/api/v1/saved-tasks/${id}/resume`, {
       method: 'POST',

--- a/frontend/src/stores/agents.ts
+++ b/frontend/src/stores/agents.ts
@@ -50,6 +50,14 @@ export const useAgentsStore = defineStore('agents', () => {
     return agent
   }
 
+  async function remove(id: number): Promise<void> {
+    await agentsApi.remove(id)
+    if (current.value?.id === id) {
+      current.value = null
+    }
+    gallery.value = gallery.value.filter((card) => card.id !== id)
+  }
+
   function markDirty(): void {
     dirty.value = true
     scheduleSave()
@@ -141,6 +149,7 @@ export const useAgentsStore = defineStore('agents', () => {
     load,
     create,
     clone,
+    remove,
     markDirty,
     saveDraft,
     clear,

--- a/frontend/src/views/AssistantsView.vue
+++ b/frontend/src/views/AssistantsView.vue
@@ -26,13 +26,14 @@
         </button>
       </PageHeader>
 
-      <AssistantBuilder v-if="builderMode && store.current" />
+      <AssistantBuilder v-if="builderMode && store.current" @deleted="onDeleted" />
       <AssistantGallery
         v-else-if="!builderMode"
         @create="createAssistant"
         @start-chat="startChat"
         @clone="cloneAssistant"
         @edit="editAssistant"
+        @delete="deleteAssistant"
       />
     </div>
   </MainLayout>
@@ -47,12 +48,15 @@ import PageHeader from '@/components/PageHeader.vue'
 import AssistantGallery from '@/components/assistants/AssistantGallery.vue'
 import AssistantBuilder from '@/components/assistants/AssistantBuilder.vue'
 import { useAgentsStore } from '@/stores/agents'
+import { useDialog } from '@/composables/useDialog'
 import { useNotification } from '@/composables/useNotification'
+import { agentsApi } from '@/services/api/agentsApi'
 
 const { t } = useI18n()
 const route = useRoute()
 const router = useRouter()
 const store = useAgentsStore()
+const { confirm } = useDialog()
 const { error, success } = useNotification()
 
 const builderMode = computed(() => route.name === 'ai-assistant-builder')
@@ -94,6 +98,34 @@ function editAssistant(id: number): void {
 
 function startChat(id: number): void {
   void router.push({ name: 'chat', query: { agentId: String(id) } })
+}
+
+async function onDeleted(): Promise<void> {
+  await router.push({ name: 'ai-assistants' })
+}
+
+async function deleteAssistant(id: number): Promise<void> {
+  const card = store.gallery.find((row) => row.id === id)
+  const published = card?.status === 'published'
+  const ok = await confirm({
+    title: t('assistants.delete'),
+    message: published
+      ? t('assistants.deletePublishedConfirm')
+      : card?.status === 'archived'
+        ? t('assistants.deleteArchivedConfirm')
+        : t('assistants.deleteConfirm'),
+    danger: true,
+  })
+  if (!ok) return
+  try {
+    if (published) {
+      await agentsApi.update(id, { status: 'archived' })
+    }
+    await store.remove(id)
+    success(t('assistants.deleteSuccess'))
+  } catch {
+    error(t('assistants.deleteFailed'))
+  }
 }
 
 async function cloneAssistant(id: number): Promise<void> {

--- a/frontend/src/views/MyGroupsView.vue
+++ b/frontend/src/views/MyGroupsView.vue
@@ -58,6 +58,22 @@
           <span class="txt-secondary text-sm">
             {{ $t('people.groups.memberCount', { count: group.memberCount ?? 0 }) }}
           </span>
+          <button
+            v-if="canLeave(group)"
+            type="button"
+            class="btn-danger px-4 py-2.5 rounded-lg text-sm font-medium"
+            :data-testid="`btn-leave-group-${group.id}`"
+            @click="leaveGroup(group)"
+          >
+            {{ $t('people.myGroups.leave') }}
+          </button>
+          <span
+            v-else-if="group.membershipSource === 'directory' || group.kind === 'directory'"
+            class="text-xs txt-secondary"
+            :data-testid="`hint-leave-directory-${group.id}`"
+          >
+            {{ $t('people.myGroups.leaveDirectory') }}
+          </span>
         </li>
       </ul>
     </div>
@@ -71,16 +87,25 @@ import { useI18n } from 'vue-i18n'
 import MainLayout from '@/components/MainLayout.vue'
 import PageHeader from '@/components/PageHeader.vue'
 import { useAuthStore } from '@/stores/auth'
-import { iamApi, type IamGroup } from '@/services/api/iamApi'
+import { iamApi, type IamMyGroup } from '@/services/api/iamApi'
+import { useDialog } from '@/composables/useDialog'
 import { useNotification } from '@/composables/useNotification'
 
 const { t } = useI18n()
 const authStore = useAuthStore()
-const { error } = useNotification()
+const { confirm } = useDialog()
+const { error, success } = useNotification()
 const loading = ref(true)
-const groups = ref<IamGroup[]>([])
+const groups = ref<IamMyGroup[]>([])
 
-onMounted(async () => {
+function canLeave(group: IamMyGroup): boolean {
+  if (group.canLeave === true) return true
+  if (group.canLeave === false) return false
+  return group.kind === 'manual'
+}
+
+async function loadGroups(): Promise<void> {
+  loading.value = true
   try {
     groups.value = await iamApi.listMyGroups()
   } catch {
@@ -88,5 +113,25 @@ onMounted(async () => {
   } finally {
     loading.value = false
   }
+}
+
+async function leaveGroup(group: IamMyGroup): Promise<void> {
+  const ok = await confirm({
+    title: t('people.myGroups.leave'),
+    message: t('people.myGroups.leaveConfirm', { name: group.name }),
+    danger: true,
+  })
+  if (!ok) return
+  try {
+    await iamApi.leaveGroup(group.id)
+    success(t('people.myGroups.left'))
+    groups.value = groups.value.filter((row) => row.id !== group.id)
+  } catch {
+    error(t('people.myGroups.leaveFailed'))
+  }
+}
+
+onMounted(() => {
+  void loadGroups()
 })
 </script>

--- a/frontend/tests/unit/components/assistants/AssistantBuilder.spec.ts
+++ b/frontend/tests/unit/components/assistants/AssistantBuilder.spec.ts
@@ -29,6 +29,7 @@ vi.mock('@/services/api/promptsApi', () => ({
     updatePrompt: vi.fn(),
     getPromptFiles: vi.fn().mockResolvedValue([]),
     uploadPromptFile: vi.fn(),
+    deletePromptFile: vi.fn(),
   },
 }))
 
@@ -45,6 +46,10 @@ vi.mock('@/services/api/chatApi', () => ({
 
 vi.mock('@/composables/useNotification', () => ({
   useNotification: () => ({ error: vi.fn(), success: vi.fn() }),
+}))
+
+vi.mock('@/composables/useDialog', () => ({
+  useDialog: () => ({ confirm: vi.fn().mockResolvedValue(false) }),
 }))
 
 function mountBuilder() {

--- a/frontend/tests/unit/components/assistants/AssistantGallery.spec.ts
+++ b/frontend/tests/unit/components/assistants/AssistantGallery.spec.ts
@@ -70,6 +70,15 @@ describe('AssistantGallery', () => {
     expect(wrapper.emitted('start-chat')).toEqual([[7]])
   })
 
+  it('emits delete for an assistant you own', async () => {
+    const { wrapper, store } = mountGallery()
+    store.gallery = [card]
+    await wrapper.vm.$nextTick()
+
+    await wrapper.get('[data-testid="btn-assistant-delete"]').trigger('click')
+    expect(wrapper.emitted('delete')).toEqual([[7]])
+  })
+
   it('hides archived cards on Mine and shows them on Archived', async () => {
     const { wrapper, store } = mountGallery()
     store.gallery = [{ ...card, status: 'archived' }]

--- a/frontend/tests/unit/components/assistants/AssistantPublishSection.spec.ts
+++ b/frontend/tests/unit/components/assistants/AssistantPublishSection.spec.ts
@@ -17,6 +17,7 @@ vi.mock('@/services/api/agentsApi', async (importOriginal) => {
       publish: vi.fn(),
       update: vi.fn(),
       get: vi.fn(),
+      remove: vi.fn(),
     },
   }
 })
@@ -61,5 +62,6 @@ describe('AssistantPublishSection', () => {
     const share = wrapper.get('[data-testid="btn-share-assistant"]')
     expect(share.text()).toBe('Share')
     expect((share.element as HTMLButtonElement).disabled).toBe(true)
+    expect(wrapper.get('[data-testid="btn-delete-assistant"]').text()).toBe('Delete')
   })
 })

--- a/frontend/tests/unit/components/config/SavedTaskCard.spec.ts
+++ b/frontend/tests/unit/components/config/SavedTaskCard.spec.ts
@@ -3,14 +3,16 @@ import { flushPromises, mount } from '@vue/test-utils'
 import SavedTaskCard from '@/components/config/SavedTaskCard.vue'
 import type { SavedTask, SavedTaskRun } from '@/services/api/savedTasksApi'
 
-const { mockUpdate, mockRun, mockRuns, mockResume, mockRemove, mockPush } = vi.hoisted(() => ({
-  mockUpdate: vi.fn(),
-  mockRun: vi.fn(),
-  mockRuns: vi.fn(),
-  mockResume: vi.fn(),
-  mockRemove: vi.fn(),
-  mockPush: vi.fn(),
-}))
+const { mockUpdate, mockRun, mockRuns, mockResume, mockRemove, mockPush, mockConfirm } =
+  vi.hoisted(() => ({
+    mockUpdate: vi.fn(),
+    mockRun: vi.fn(),
+    mockRuns: vi.fn(),
+    mockResume: vi.fn(),
+    mockRemove: vi.fn(),
+    mockPush: vi.fn(),
+    mockConfirm: vi.fn(),
+  }))
 
 vi.mock('@/services/api/savedTasksApi', () => ({
   savedTasksApi: {
@@ -31,7 +33,7 @@ vi.mock('@/composables/useIamFeature', () => ({
 }))
 
 vi.mock('@/composables/useDialog', () => ({
-  useDialog: () => ({ confirm: vi.fn().mockResolvedValue(false) }),
+  useDialog: () => ({ confirm: (...args: unknown[]) => mockConfirm(...args) }),
 }))
 
 vi.mock('vue-router', () => ({
@@ -88,6 +90,7 @@ const mountCard = (value: SavedTask) =>
 describe('SavedTaskCard', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockConfirm.mockResolvedValue(false)
     mockUpdate.mockImplementation(async (_id: number, patch: Record<string, unknown>) =>
       task({ ...patch } as Partial<SavedTask>)
     )
@@ -245,5 +248,31 @@ describe('SavedTaskCard', () => {
     expect(wrapper.find('[data-testid="btn-run-copy"]').exists()).toBe(false)
     expect(wrapper.find('[data-testid="btn-run-now"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="btn-delete-saved-task"]').exists()).toBe(true)
+  })
+
+  it('deletes after confirm and emits deleted', async () => {
+    mockConfirm.mockResolvedValue(true)
+    mockRemove.mockResolvedValue(undefined)
+    const wrapper = mountCard(task())
+    await wrapper.get('[data-testid="btn-delete-saved-task"]').trigger('click')
+    await flushPromises()
+
+    expect(mockConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Delete',
+        danger: true,
+      })
+    )
+    expect(mockRemove).toHaveBeenCalledWith(7)
+    expect(wrapper.emitted('deleted')).toEqual([[7]])
+  })
+
+  it('does not delete when the confirm is cancelled', async () => {
+    const wrapper = mountCard(task())
+    await wrapper.get('[data-testid="btn-delete-saved-task"]').trigger('click')
+    await flushPromises()
+
+    expect(mockRemove).not.toHaveBeenCalled()
+    expect(wrapper.emitted('deleted')).toBeUndefined()
   })
 })

--- a/frontend/tests/unit/components/config/SavedTaskCard.spec.ts
+++ b/frontend/tests/unit/components/config/SavedTaskCard.spec.ts
@@ -3,8 +3,8 @@ import { flushPromises, mount } from '@vue/test-utils'
 import SavedTaskCard from '@/components/config/SavedTaskCard.vue'
 import type { SavedTask, SavedTaskRun } from '@/services/api/savedTasksApi'
 
-const { mockUpdate, mockRun, mockRuns, mockResume, mockRemove, mockPush, mockConfirm } =
-  vi.hoisted(() => ({
+const { mockUpdate, mockRun, mockRuns, mockResume, mockRemove, mockPush, mockConfirm } = vi.hoisted(
+  () => ({
     mockUpdate: vi.fn(),
     mockRun: vi.fn(),
     mockRuns: vi.fn(),
@@ -12,7 +12,8 @@ const { mockUpdate, mockRun, mockRuns, mockResume, mockRemove, mockPush, mockCon
     mockRemove: vi.fn(),
     mockPush: vi.fn(),
     mockConfirm: vi.fn(),
-  }))
+  })
+)
 
 vi.mock('@/services/api/savedTasksApi', () => ({
   savedTasksApi: {

--- a/frontend/tests/unit/components/config/SavedTaskCard.spec.ts
+++ b/frontend/tests/unit/components/config/SavedTaskCard.spec.ts
@@ -3,11 +3,12 @@ import { flushPromises, mount } from '@vue/test-utils'
 import SavedTaskCard from '@/components/config/SavedTaskCard.vue'
 import type { SavedTask, SavedTaskRun } from '@/services/api/savedTasksApi'
 
-const { mockUpdate, mockRun, mockRuns, mockResume, mockPush } = vi.hoisted(() => ({
+const { mockUpdate, mockRun, mockRuns, mockResume, mockRemove, mockPush } = vi.hoisted(() => ({
   mockUpdate: vi.fn(),
   mockRun: vi.fn(),
   mockRuns: vi.fn(),
   mockResume: vi.fn(),
+  mockRemove: vi.fn(),
   mockPush: vi.fn(),
 }))
 
@@ -17,6 +18,7 @@ vi.mock('@/services/api/savedTasksApi', () => ({
     run: mockRun,
     runs: mockRuns,
     resume: mockResume,
+    remove: mockRemove,
   },
 }))
 
@@ -242,5 +244,6 @@ describe('SavedTaskCard', () => {
     expect(wrapper.find('[data-testid="btn-share-saved-task"]').exists()).toBe(false)
     expect(wrapper.find('[data-testid="btn-run-copy"]').exists()).toBe(false)
     expect(wrapper.find('[data-testid="btn-run-now"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="btn-delete-saved-task"]').exists()).toBe(true)
   })
 })

--- a/frontend/tests/unit/views/MyGroupsView.spec.ts
+++ b/frontend/tests/unit/views/MyGroupsView.spec.ts
@@ -149,7 +149,7 @@ describe('MyGroupsView', () => {
     const wrapper = mountView()
     await flushPromises()
 
-    expect(wrapper.get('[data-testid="btn-leave-group-9"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="btn-leave-group-9"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="hint-leave-directory-9"]').exists()).toBe(false)
   })
 

--- a/frontend/tests/unit/views/MyGroupsView.spec.ts
+++ b/frontend/tests/unit/views/MyGroupsView.spec.ts
@@ -5,15 +5,22 @@ import { createMemoryHistory, createRouter } from 'vue-router'
 import { useAuthStore, type User } from '@/stores/auth'
 
 const listMyGroups = vi.fn()
+const leaveGroup = vi.fn()
+const confirmLeave = vi.fn()
 
 vi.mock('@/services/api/iamApi', () => ({
   iamApi: {
     listMyGroups: (...args: unknown[]) => listMyGroups(...args),
+    leaveGroup: (...args: unknown[]) => leaveGroup(...args),
   },
 }))
 
 vi.mock('@/composables/useNotification', () => ({
   useNotification: () => ({ success: vi.fn(), error: vi.fn() }),
+}))
+
+vi.mock('@/composables/useDialog', () => ({
+  useDialog: () => ({ confirm: (...args: unknown[]) => confirmLeave(...args) }),
 }))
 
 vi.mock('@iconify/vue', () => ({
@@ -52,6 +59,10 @@ function mountView(isAdmin = false) {
 describe('MyGroupsView', () => {
   beforeEach(() => {
     listMyGroups.mockReset()
+    leaveGroup.mockReset()
+    confirmLeave.mockReset()
+    confirmLeave.mockResolvedValue(true)
+    leaveGroup.mockResolvedValue(undefined)
   })
 
   it('lists groups the current user belongs to', async () => {
@@ -72,6 +83,74 @@ describe('MyGroupsView', () => {
     expect(wrapper.get('[data-testid="card-my-group-4"]').text()).toContain('Sales')
     expect(wrapper.get('[data-testid="card-my-group-4"]').text()).toContain('Member')
     expect(wrapper.find('[data-testid="link-my-groups-people"]').exists()).toBe(false)
+    expect(wrapper.get('[data-testid="btn-leave-group-4"]').text()).toContain('Leave')
+  })
+
+  it('lets a member leave a group they were added to', async () => {
+    listMyGroups.mockResolvedValue([
+      {
+        id: 4,
+        name: 'Sales',
+        slug: 'sales',
+        description: '',
+        kind: 'manual',
+        memberCount: 3,
+        role: 'member',
+        canLeave: true,
+        membershipSource: 'manual',
+      },
+    ])
+    const wrapper = mountView()
+    await flushPromises()
+
+    await wrapper.get('[data-testid="btn-leave-group-4"]').trigger('click')
+    await flushPromises()
+
+    expect(confirmLeave).toHaveBeenCalled()
+    expect(leaveGroup).toHaveBeenCalledWith(4)
+    expect(wrapper.find('[data-testid="card-my-group-4"]').exists()).toBe(false)
+  })
+
+  it('hides Leave for a login-synced membership', async () => {
+    listMyGroups.mockResolvedValue([
+      {
+        id: 8,
+        name: 'Everyone',
+        slug: 'everyone',
+        description: '',
+        kind: 'directory',
+        memberCount: 12,
+        role: 'member',
+        canLeave: false,
+        membershipSource: 'directory',
+      },
+    ])
+    const wrapper = mountView()
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="btn-leave-group-8"]').exists()).toBe(false)
+    expect(wrapper.get('[data-testid="hint-leave-directory-8"]').text()).toContain('login')
+  })
+
+  it('still shows Leave when a directory group has a manual membership', async () => {
+    listMyGroups.mockResolvedValue([
+      {
+        id: 9,
+        name: 'IT',
+        slug: 'it',
+        description: '',
+        kind: 'directory',
+        memberCount: 4,
+        role: 'member',
+        canLeave: true,
+        membershipSource: 'manual',
+      },
+    ])
+    const wrapper = mountView()
+    await flushPromises()
+
+    expect(wrapper.get('[data-testid="btn-leave-group-9"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="hint-leave-directory-9"]').exists()).toBe(false)
   })
 
   it('shows an empty state and a People link for admins', async () => {


### PR DESCRIPTION
## Summary
- Members can leave a **manual** group membership (`DELETE /api/v1/groups/{id}/membership`). Directory-synced memberships stay read-only and return at the next sign-in.
- My groups lists `membershipSource` and `canLeave` so the Leave button is only offered when it will work.
- Owners can delete draft assistants and saved tasks. Assistant delete removes shares, versions, the instruction prompt, bound tasks, and the own knowledge folder.
- User deletion collects assistant file paths and Qdrant group keys during the DB transaction and purges them **after** commit, so a rollback cannot leave the store and disk out of sync.

## Test plan
- [ ] Leave a manual group from My groups; confirm it disappears and an audit row is written
- [ ] Directory-synced membership shows the login hint and no Leave button (API 409 if forced)
- [ ] Delete a draft assistant that has a share and a knowledge file; share list and file are gone
- [ ] Delete a saved task after confirm; card disappears
- [ ] Cancel the saved-task delete confirm; the task stays