### PR TITLE
fix(frontend): ignore Safari extension errors that wipe the app

### DIFF
--- a/frontend/src/utils/installGlobalErrorHandlers.ts
+++ b/frontend/src/utils/installGlobalErrorHandlers.ts
@@ -18,6 +18,18 @@ const IGNORED_PATTERNS: RegExp[] = [
   /ResizeObserver loop (?:limit exceeded|completed with undelivered notifications)/i,
   // Browser-extension content scripts injecting into our page.
   /^Script error\.?$/i,
+  // Password-managers / Grammarly / ad-blockers on Safari and Chrome inject a
+  // MutationObserver against a node that is not in the document (or already
+  // gone). The stack is always `content.js`, never our bundle. Our own
+  // observers only target `document.body` / `document.documentElement`.
+  /MutationObserver\.observe must be an instance of Node/i,
+  // Extension message-bus leftover. Seen in the wild as
+  // `No Listener: tabs:outgoing.message.ready` — not a Synaplan event. If we
+  // let this through, ErrorView replaces the whole app on an otherwise
+  // healthy Safari tab that happens to have an extension installed.
+  /No Listener: tabs:/i,
+  // Chrome/Safari content script surviving an extension reload/update.
+  /Extension context invalidated/i,
   // Network request aborted by the user (navigation away, slow connection).
   /^The user aborted a request\.?$/i,
   /AbortError/i,
@@ -164,8 +176,14 @@ export function installGlobalErrorHandlers(app: App): void {
   windowRejectionHandler = (event: PromiseRejectionEvent) => {
     const reason = event.reason
     const message = getErrorMessage(reason)
-    if (shouldIgnore(message)) return
+    if (shouldIgnore(message)) {
+      // Stop Safari/Chrome from also logging "Unhandled Promise Rejection"
+      // for noise we have already classified as safe to ignore.
+      event.preventDefault()
+      return
+    }
     if (isTransient(message)) {
+      event.preventDefault()
       reportTransient(message ?? 'unknown', 'window:unhandledrejection')
       return
     }

--- a/frontend/tests/unit/utils/installGlobalErrorHandlers.spec.ts
+++ b/frontend/tests/unit/utils/installGlobalErrorHandlers.spec.ts
@@ -117,6 +117,50 @@ describe('installGlobalErrorHandlers', () => {
     expect(store.hasError).toBe(false)
   })
 
+  // Safari / Mac: password-managers and similar content scripts reject into
+  // our page. The friend's console on web.synaplan.com showed both of these
+  // and ErrorView replaced a healthy session. None of these strings exist in
+  // our own codebase.
+  const extensionNoiseCases: Array<{ label: string; message: string }> = [
+    {
+      label: 'MutationObserver target is not a Node',
+      message: "TypeError: Argument 1 ('target') to MutationObserver.observe must be an instance of Node",
+    },
+    {
+      label: 'extension tab message bus',
+      message: 'No Listener: tabs:outgoing.message.ready',
+    },
+    {
+      label: 'extension context invalidated after reload',
+      message: 'Extension context invalidated.',
+    },
+  ]
+
+  it.each(extensionNoiseCases)(
+    'ignores browser-extension noise ($label) instead of raising ErrorView',
+    ({ message }) => {
+      installGlobalErrorHandlers(app)
+      const store = useGlobalErrorStore()
+      const { notifications } = useNotification()
+
+      const reason = new Error(message)
+      const event = new Event('unhandledrejection') as Event & {
+        reason: unknown
+        promise: Promise<unknown>
+      }
+      event.reason = reason
+      event.promise = Promise.reject(reason)
+      event.promise.catch(() => {})
+      const preventDefault = vi.spyOn(event, 'preventDefault')
+
+      window.dispatchEvent(event)
+
+      expect(store.hasError).toBe(false)
+      expect(notifications.value).toHaveLength(0)
+      expect(preventDefault).toHaveBeenCalledOnce()
+    }
+  )
+
   // -----------------------------------------------------------------------
   // Issue #897 — transient (chunk-load / network) errors must NOT replace
   // the entire UI with the full-screen ErrorView. They should fire a

--- a/frontend/tests/unit/utils/installGlobalErrorHandlers.spec.ts
+++ b/frontend/tests/unit/utils/installGlobalErrorHandlers.spec.ts
@@ -118,13 +118,14 @@ describe('installGlobalErrorHandlers', () => {
   })
 
   // Safari / Mac: password-managers and similar content scripts reject into
-  // our page. The friend's console on web.synaplan.com showed both of these
-  // and ErrorView replaced a healthy session. None of these strings exist in
-  // our own codebase.
+  // our page. Production Safari consoles have shown these exact messages,
+  // after which ErrorView replaced a healthy session. None of these strings
+  // exist in our own codebase.
   const extensionNoiseCases: Array<{ label: string; message: string }> = [
     {
       label: 'MutationObserver target is not a Node',
-      message: "TypeError: Argument 1 ('target') to MutationObserver.observe must be an instance of Node",
+      message:
+        "TypeError: Argument 1 ('target') to MutationObserver.observe must be an instance of Node",
     },
     {
       label: 'extension tab message bus',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Safari/Mac console noise from browser extensions was treated as a fatal app error, so a healthy session got replaced by the full-screen ErrorView. This is not a Cloudflare hard-cache problem.

## Changes
- Ignore known extension rejections in `installGlobalErrorHandlers` (`MutationObserver.observe must be an instance of Node`, `No Listener: tabs:…`, `Extension context invalidated`)
- Call `preventDefault()` on ignored/transient `unhandledrejection` events so Safari does not keep logging them as unhandled
- Cover the new ignore patterns in the existing Vitest suite

## Verification
- [x] Tests added/updated
- Frontend lint, `vue-tsc`, and the full Vitest suite (`221` files / `1677` tests) are green locally, including `18` cases in `installGlobalErrorHandlers.spec.ts`

## Notes
A friend’s Safari console on `web.synaplan.com` mixed four unrelated things:

1. **Real bug (this PR):** `Error: No Listener: tabs:outgoing.message.ready` was caught by our global handler (`Unhandled promise rejection caught:` in `index-*.js`). That string does not exist in Synaplan — it comes from an injected content script. The handler then called `setError()` and ErrorView replaced the app. Same class of failure as issue #897 (extension/transient noise wiping the UI).
2. **`content.js` MutationObserver:** `Argument 1 ('target') to MutationObserver.observe must be an instance of Node` — stack is `content.js` (password-manager / Grammarly / ad-blocker). Our observers only target `document.body` / `document.documentElement`.
3. **Safari PAT 401:** `Failed to load resource: 401 (pat, line 0)` is Safari’s Private Access Token probe, not our `/pat` API.
4. **Viewport warning:** `interactive-widget` is ignored by WebKit. Harmless; Chrome uses it for the virtual keyboard.
5. **German 403s:** `Du bist nicht berechtigt, auf die angeforderte Ressource zuzugreifen.` is Symfony’s Access Denied body. Those are separate HTTP 403s (often follow-on from the ErrorView / an unauthenticated tab), not a stale CF asset. HTML is `Cache-Control: no-cache`; hashed `/assets/` are immutable; `/sw.js` is `no-store`. A CF hard cache would 404 old hashed chunks, not throw MutationObserver / `tabs:outgoing`.

Not a Cloudflare cache purge. After deploy, a hard refresh on the friend’s Mac (or a private window without extensions) is still the fastest confirmation.

## Screenshots/Logs
Console excerpt that triggered this:

```
[Error] Unhandled Promise Rejection: TypeError: Argument 1 ('target') to MutationObserver.observe must be an instance of Node
	observe
	p (content.js:1:283166)
[Error] Viewport argument key "interactive-widget" not recognized and ignored.
[Error] Failed to load resource: Du bist nicht berechtigt, auf die angeforderte Ressource zuzugreifen.
[Error] Failed to load resource: the server responded with a status of 401 () (pat, line 0)
[Error] Unhandled promise rejection caught: Error: No Listener: tabs:outgoing.message.ready
	cs (index-CpbFmsRJ.js:3:616)
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a07cee-58af-7640-bb21-b6ba6bcf5681?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a07cee-58af-7640-bb21-b6ba6bcf5681&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

