### PR TITLE
fix(catalog): retire TrustedTokens DeepSeek V4 Flash

### DIFF
--- a/backend/src/Model/ModelCatalog.php
+++ b/backend/src/Model/ModelCatalog.php
@@ -315,6 +315,18 @@ class ModelCatalog
             'successor' => 'google:gemini-3.1-flash-image-preview:text2pic',
             'reason' => 'Shut down by Google on 2026-08-17; migrate to Nano Banana (gemini-3.1-flash-image).',
         ],
+
+        // --- 2026-09-08 (TrustedTokens dropped the undated V4 Flash id) ---
+        // Confirmed gone against https://trustedtokens.eu/api/billing/models
+        // on 2026-09-08. The dated Flash-0731 snapshot (BID 336) is still
+        // served at the same price and is the same-family successor; V4 Pro
+        // is still live but is a different (and much more expensive) tier.
+        335 => [
+            'providerId' => 'deepseek-ai/DeepSeek-V4-Flash',
+            'retiredOn' => '2026-09-08',
+            'successor' => 'trustedtokens:deepseek-ai/deepseek-v4-flash-0731:chat',
+            'reason' => 'TrustedTokens no longer serves deepseek-ai/DeepSeek-V4-Flash; migrate to DeepSeek V4 Flash 0731.',
+        ],
     ];
 
     /**
@@ -3504,6 +3516,8 @@ class ModelCatalog
         // Not covered by LiteLLM sync — verify manually against that endpoint.
         // GLM-5.3 / GLM-5.3-Flash / DeepSeek V4 + Chimera added 2026-08-29
         // (BIDs 331–337). Existing 309–312 prices unchanged vs the 07-27 snapshot.
+        // BID 335 (DeepSeek-V4-Flash) dropped by TrustedTokens on 2026-09-08;
+        // see ModelCatalog::RETIREMENTS[335]. Flash-0731 and V4 Pro remain.
         [
             'id' => 309,
             'service' => 'TrustedTokens',
@@ -3731,8 +3745,10 @@ class ModelCatalog
             'service' => 'TrustedTokens',
             'name' => 'DeepSeek V4 Flash',
             'tag' => 'chat',
-            'selectable' => 1,
-            'active' => 1,
+            // Retired: TrustedTokens dropped the undated V4 Flash id on 2026-09-08.
+            // See ModelCatalog::RETIREMENTS[335].
+            'selectable' => 0,
+            'active' => 0,
             'providerId' => 'deepseek-ai/DeepSeek-V4-Flash',
             'priceIn' => 0.15,
             'inUnit' => 'per1M',

--- a/backend/tests/Unit/Model/ModelCatalogTest.php
+++ b/backend/tests/Unit/Model/ModelCatalogTest.php
@@ -587,8 +587,8 @@ class ModelCatalogTest extends TestCase
 
     /**
      * TrustedTokens (TNG, Germany) — chat + vision rows from
-     * https://trustedtokens.eu/api/billing/models (snapshot 2026-08-29;
-     * DeepSeek V4 Flash retired 2026-09-08).
+     * https://trustedtokens.eu/api/billing/models (re-verified 2026-09-08;
+     * prices unchanged from the 2026-08-29 snapshot except BID 335 retired).
      * Provider ids keep the upstream org/name form. Prices are USD/1M.
      */
     public function testTrustedTokensModelsAreAvailableWithExpectedApiIds(): void

--- a/backend/tests/Unit/Model/ModelCatalogTest.php
+++ b/backend/tests/Unit/Model/ModelCatalogTest.php
@@ -587,7 +587,8 @@ class ModelCatalogTest extends TestCase
 
     /**
      * TrustedTokens (TNG, Germany) — chat + vision rows from
-     * https://trustedtokens.eu/api/billing/models (snapshot 2026-08-29).
+     * https://trustedtokens.eu/api/billing/models (snapshot 2026-08-29;
+     * DeepSeek V4 Flash retired 2026-09-08).
      * Provider ids keep the upstream org/name form. Prices are USD/1M.
      */
     public function testTrustedTokensModelsAreAvailableWithExpectedApiIds(): void
@@ -615,6 +616,12 @@ class ModelCatalogTest extends TestCase
         $this->assertCount(1, $qwenChat);
         $this->assertCount(1, $qwenVision);
         $this->assertCount(1, $gptOss);
+
+        $this->assertSame(335, $v4Flash[0]['id']);
+        $this->assertSame(0, $v4Flash[0]['active']);
+        $this->assertSame(0, $v4Flash[0]['selectable']);
+        $this->assertTrue(ModelCatalog::isRetired(335));
+        $this->assertSame(336, ModelCatalog::successorBid(335));
 
         $this->assertSame(331, $glm53[0]['id']);
         $this->assertSame('zai-org/GLM-5.2', $glm[0]['providerId']);

--- a/docs/PRICING_MAINTENANCE.md
+++ b/docs/PRICING_MAINTENANCE.md
@@ -146,6 +146,16 @@ Google deprecated all three Imagen 4 IDs on 2026-06-15 and **hard-shut them down
 
 Retired via the registry (`ModelCatalog::RETIREMENTS`, no migration): the three catalog rows carry `active = selectable = 0` and a `RETIREMENTS` entry, and `ModelRetirementSeeder` stamps `BRETIREDON`/`BSUCCESSORID` on every install. Nano Banana 2 (`gemini-3.1-flash-image-preview`, BID 190) is already the seeded `DEFAULTMODEL.TEXT2PIC`/`PIC2PIC`, so no default binding is orphaned; all three tiers point at it because we do not carry the flat `gemini-3.1-flash-image` / `gemini-3-pro-image` variants Google's migration table names per tier. Google's [deprecations page](https://ai.google.dev/gemini-api/docs/deprecations) is the authority for the shutdown date.
 
+### TrustedTokens DeepSeek V4 Flash shutdown (2026-09-08)
+
+TrustedTokens dropped the undated `deepseek-ai/DeepSeek-V4-Flash` id. The hourly health check confirmed it Gone against `https://trustedtokens.eu/api/billing/models` on 2026-09-08; the dated Flash-0731 snapshot and V4 Pro remain in that catalog.
+
+| BID | Model | `providerId` | Successor |
+| --- | ----- | ------------ | --------- |
+| 335 | DeepSeek V4 Flash | `deepseek-ai/DeepSeek-V4-Flash` | `trustedtokens:deepseek-ai/deepseek-v4-flash-0731:chat` (BID 336) |
+
+Retired via the registry (`ModelCatalog::RETIREMENTS`, no migration): the catalog row carries `active = selectable = 0` and a `RETIREMENTS` entry, and `ModelRetirementSeeder` stamps `BRETIREDON`/`BSUCCESSORID` on every install. No `DEFAULTMODEL` binding points at BID 335, so nothing is orphaned. Flash-0731 is the same-family successor at the same price; V4 Pro is still live but is a different (and much more expensive) tier.
+
 ## Maintenance links
 
 **Official provider price pages** (use these first — step 2 of the playbook):
@@ -182,7 +192,7 @@ Per-provider blocks in `ModelCatalog.php`. Status:
 | Higgsfield | ⚠️ NOT publicly verifiable — see below | dashboard only |
 | **Mistral** | ✅ verified 2026-07-13 — all correct | https://mistral.ai/pricing/api/ |
 | **Cloudflare** | ✅ verified 2026-07-13 — all correct | https://developers.cloudflare.com/workers-ai/platform/pricing/ |
-| **TrustedTokens** | ✅ verified 2026-08-29 | https://trustedtokens.eu/api/billing/models |
+| **TrustedTokens** | ✅ verified 2026-09-08 (V4 Flash retired) | https://trustedtokens.eu/api/billing/models |
 | **xAI Grok Imagine + voice** | ✅ verified 2026-07-29 (chat rows are synced) | https://docs.x.ai/developers/pricing |
 | Piper / Triton | n/a — free/local | — |
 
@@ -222,7 +232,7 @@ The **> 200k long-context tier doubles the whole request**, so it lives in `Mode
 - **The realtime Speech-to-Speech API is deliberately not wired up.** It bills per session minute ($0.05/min, plus $0.004 per text input message) over a WebSocket, and this application has no realtime-voice capability to attach it to. Adding it would need a new capability, a new pricing mode, and session-duration metering.
 - **Embeddings and the server-side tools** (web search, X search, code execution) are intentionally not wired up: xAI publishes no price for `/v1/embeddings`, and without a price there can be no correct usage accounting.
 
-### TrustedTokens (verified 2026-08-29)
+### TrustedTokens (verified 2026-09-08)
 
 German sovereign OpenAI-compatible inference (`https://api.trustedtokens.eu/v1`). Per-token rates come from the public billing catalog (not the JS-rendered marketing page); subscription plans (€50 / €200 / €2,000) are prepaid usage credits that draw down against these rates. Catalog stores **USD per 1M tokens** (same unit as every other cloud provider). Cache-read rates are authored in `json.cache_read_price_per_1M`.
 
@@ -232,7 +242,7 @@ German sovereign OpenAI-compatible inference (`https://api.trustedtokens.eu/v1`)
 | 331 | `zai-org/GLM-5.3` | $1.50 / $4.50 | $1.50 / $4.50 (cache $0.30) | 1M |
 | 332 / 333 | `zai-org/GLM-5.3-Flash` (chat + vision) | $0.15 / $0.30 | $0.15 / $0.30 (cache $0.03) | 1M |
 | 334 | `tngtech/DeepSeek-TNG-R1T2-Chimera` | $1.00 / $3.00 | $1.00 / $3.00 (cache $0.20) | 164k |
-| 335 | `deepseek-ai/DeepSeek-V4-Flash` | $0.15 / $0.30 | $0.15 / $0.30 (cache $0.03) | 400k |
+| 335 | `deepseek-ai/DeepSeek-V4-Flash` | retired 2026-09-08 — see [TrustedTokens DeepSeek V4 Flash shutdown](#trustedtokens-deepseek-v4-flash-shutdown-2026-09-08) | — | — |
 | 336 | `deepseek-ai/DeepSeek-V4-Flash-0731` | $0.15 / $0.30 | $0.15 / $0.30 (cache $0.03) | 400k |
 | 337 | `deepseek-ai/DeepSeek-V4-Pro-0813` | $2.25 / $6.75 | $2.25 / $6.75 (cache $0.45) | 200k |
 | 310 / 311 | `Qwen/Qwen3.6-35B-A3B-FP8` (chat + vision) | $0.25 / $1.50 | $0.25 / $1.50 (cache $0.05) | 262k |

--- a/docs/PRICING_MAINTENANCE.md
+++ b/docs/PRICING_MAINTENANCE.md
@@ -148,7 +148,7 @@ Retired via the registry (`ModelCatalog::RETIREMENTS`, no migration): the three 
 
 ### TrustedTokens DeepSeek V4 Flash shutdown (2026-09-08)
 
-TrustedTokens dropped the undated `deepseek-ai/DeepSeek-V4-Flash` id. The hourly health check confirmed it Gone against `https://trustedtokens.eu/api/billing/models` on 2026-09-08; the dated Flash-0731 snapshot and V4 Pro remain in that catalog.
+TrustedTokens dropped the undated `deepseek-ai/DeepSeek-V4-Flash` id. The hourly health check confirmed the model is gone against `https://trustedtokens.eu/api/billing/models` on 2026-09-08; the dated Flash-0731 snapshot and V4 Pro remain in that catalog.
 
 | BID | Model | `providerId` | Successor |
 | --- | ----- | ------------ | --------- |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
TrustedTokens no longer serves `deepseek-ai/DeepSeek-V4-Flash`. This records the retirement so existing installs stop offering a dead model.

## Changes
- Add `ModelCatalog::RETIREMENTS[335]` (retired 2026-09-08) with successor `trustedtokens:deepseek-ai/deepseek-v4-flash-0731:chat` (BID 336), which is still in the TrustedTokens billing catalog at the same price.
- Switch the catalog row to `active = selectable = 0` so a fresh install never offers it.
- `ModelRetirementSeeder` stamps `BRETIREDON` / `BSUCCESSORID` and forces the row off on every deploy. No migration, no `DEFAULTMODEL` rebinding — nothing seeds BID 335 as a default.
- Document the shutdown in `docs/PRICING_MAINTENANCE.md`.

Confirmed gone against https://trustedtokens.eu/api/billing/models on 2026-09-08. Flash-0731 and V4 Pro remain. V4 Pro is a different, much more expensive tier, so it is not the successor.

## Verification
- [x] Tests added/updated
- Local: `make -C backend lint` and `make -C backend phpstan` green
- Local: `ModelCatalogTest` + `ModelCatalogRetirementTest` + `ModelRetirementSeederTest` — 237 tests, 2854 assertions
- After `app:seed`, BID 335 is `BACTIVE=0`, `BSELECTABLE=0`, `BRETIREDON=2026-09-08`, `BSUCCESSORID=336`; 336 and 337 stay live
- CI Backend (PHP/Symfony) green on this PR
- Follow-up: Copilot wording notes — "confirmed it Gone" → "confirmed the model is gone"; TrustedTokens test docblock dated as re-verified 2026-09-08

## Notes
Triggered by the hourly model-health incident mail: `[INCIDENT][Synaplan] 1 TrustedTokens model(s) no longer available` (2026-09-08 06:31:04 UTC).

## Screenshots/Logs
[Retirement evidence](https://cursor.com/agents/bc-01a07fbc-9a7e-723a-a4ac-ef926e89d782/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdeepseek-v4-flash-retirement.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a07fbc-9a7e-723a-a4ac-ef926e89d782?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a07fbc-9a7e-723a-a4ac-ef926e89d782&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

