### PR TITLE
fix(catalog): retire TrustedTokens DeepSeek V4 Flash

### DIFF
--- a/backend/src/Model/ModelCatalog.php
+++ b/backend/src/Model/ModelCatalog.php
@@ -315,6 +315,16 @@ class ModelCatalog
             'successor' => 'google:gemini-3.1-flash-image-preview:text2pic',
             'reason' => 'Shut down by Google on 2026-08-17; migrate to Nano Banana (gemini-3.1-flash-image).',
         ],
+
+        // --- 2026-09-08 (TrustedTokens dropped the unversioned V4 Flash alias) ---
+        // Confirmed gone from https://trustedtokens.eu/api/billing/models.
+        // The dated Flash snapshot (0731) and V4 Pro remain in that catalog.
+        335 => [
+            'providerId' => 'deepseek-ai/DeepSeek-V4-Flash',
+            'retiredOn' => '2026-09-08',
+            'successor' => 'trustedtokens:deepseek-ai/DeepSeek-V4-Flash-0731:chat',
+            'reason' => 'TrustedTokens no longer serves DeepSeek-V4-Flash; the dated Flash 0731 snapshot remains.',
+        ],
     ];
 
     /**
@@ -3731,8 +3741,11 @@ class ModelCatalog
             'service' => 'TrustedTokens',
             'name' => 'DeepSeek V4 Flash',
             'tag' => 'chat',
-            'selectable' => 1,
-            'active' => 1,
+            // Retired: TrustedTokens no longer serves this unversioned alias
+            // (absent from https://trustedtokens.eu/api/billing/models on
+            // 2026-09-08). See ModelCatalog::RETIREMENTS[335].
+            'selectable' => 0,
+            'active' => 0,
             'providerId' => 'deepseek-ai/DeepSeek-V4-Flash',
             'priceIn' => 0.15,
             'inUnit' => 'per1M',

--- a/backend/tests/Unit/Model/ModelCatalogTest.php
+++ b/backend/tests/Unit/Model/ModelCatalogTest.php
@@ -623,7 +623,14 @@ class ModelCatalogTest extends TestCase
         $this->assertSame('zai-org/GLM-5.3-Flash', $glm53FlashVision[0]['providerId']);
         $this->assertSame('tngtech/DeepSeek-TNG-R1T2-Chimera', $chimera[0]['providerId']);
         $this->assertSame('deepseek-ai/DeepSeek-V4-Flash', $v4Flash[0]['providerId']);
+        $this->assertSame(335, $v4Flash[0]['id']);
+        $this->assertSame(0, $v4Flash[0]['active']);
+        $this->assertSame(0, $v4Flash[0]['selectable']);
+        $this->assertTrue(ModelCatalog::isRetired(335));
+        $this->assertSame(336, ModelCatalog::successorBid(335));
         $this->assertSame('deepseek-ai/DeepSeek-V4-Flash-0731', $v4Flash0731[0]['providerId']);
+        $this->assertSame(1, $v4Flash0731[0]['active']);
+        $this->assertSame(1, $v4Flash0731[0]['selectable']);
         $this->assertSame('deepseek-ai/DeepSeek-V4-Pro-0813', $v4Pro[0]['providerId']);
         $this->assertSame('Qwen/Qwen3.6-35B-A3B-FP8', $qwenChat[0]['providerId']);
         $this->assertSame('openai/gpt-oss-120b', $gptOss[0]['providerId']);

--- a/docs/PRICING_MAINTENANCE.md
+++ b/docs/PRICING_MAINTENANCE.md
@@ -146,6 +146,16 @@ Google deprecated all three Imagen 4 IDs on 2026-06-15 and **hard-shut them down
 
 Retired via the registry (`ModelCatalog::RETIREMENTS`, no migration): the three catalog rows carry `active = selectable = 0` and a `RETIREMENTS` entry, and `ModelRetirementSeeder` stamps `BRETIREDON`/`BSUCCESSORID` on every install. Nano Banana 2 (`gemini-3.1-flash-image-preview`, BID 190) is already the seeded `DEFAULTMODEL.TEXT2PIC`/`PIC2PIC`, so no default binding is orphaned; all three tiers point at it because we do not carry the flat `gemini-3.1-flash-image` / `gemini-3-pro-image` variants Google's migration table names per tier. Google's [deprecations page](https://ai.google.dev/gemini-api/docs/deprecations) is the authority for the shutdown date.
 
+### TrustedTokens DeepSeek V4 Flash retirement (2026-09-08)
+
+TrustedTokens dropped the unversioned `deepseek-ai/DeepSeek-V4-Flash` alias from https://trustedtokens.eu/api/billing/models. The dated Flash snapshot (`deepseek-ai/DeepSeek-V4-Flash-0731`) and V4 Pro remain. BID 335 is not a `ProviderDefaultsService` recommendation, so no default binding is orphaned.
+
+| BID | Model | `providerId` | Successor |
+| --- | ----- | ------------ | --------- |
+| 335 | DeepSeek V4 Flash | `deepseek-ai/DeepSeek-V4-Flash` | `trustedtokens:deepseek-ai/DeepSeek-V4-Flash-0731:chat` (BID 336) |
+
+Retired via the registry (`ModelCatalog::RETIREMENTS`, no migration): the catalog row carries `active = selectable = 0`, and `ModelRetirementSeeder` stamps `BRETIREDON`/`BSUCCESSORID` on every install.
+
 ## Maintenance links
 
 **Official provider price pages** (use these first — step 2 of the playbook):
@@ -232,7 +242,7 @@ German sovereign OpenAI-compatible inference (`https://api.trustedtokens.eu/v1`)
 | 331 | `zai-org/GLM-5.3` | $1.50 / $4.50 | $1.50 / $4.50 (cache $0.30) | 1M |
 | 332 / 333 | `zai-org/GLM-5.3-Flash` (chat + vision) | $0.15 / $0.30 | $0.15 / $0.30 (cache $0.03) | 1M |
 | 334 | `tngtech/DeepSeek-TNG-R1T2-Chimera` | $1.00 / $3.00 | $1.00 / $3.00 (cache $0.20) | 164k |
-| 335 | `deepseek-ai/DeepSeek-V4-Flash` | $0.15 / $0.30 | $0.15 / $0.30 (cache $0.03) | 400k |
+| 335 | `deepseek-ai/DeepSeek-V4-Flash` | $0.15 / $0.30 | **retired 2026-09-08** — unversioned alias gone; successor BID 336 | 400k |
 | 336 | `deepseek-ai/DeepSeek-V4-Flash-0731` | $0.15 / $0.30 | $0.15 / $0.30 (cache $0.03) | 400k |
 | 337 | `deepseek-ai/DeepSeek-V4-Pro-0813` | $2.25 / $6.75 | $2.25 / $6.75 (cache $0.45) | 200k |
 | 310 / 311 | `Qwen/Qwen3.6-35B-A3B-FP8` (chat + vision) | $0.25 / $1.50 | $0.25 / $1.50 (cache $0.05) | 262k |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
TrustedTokens no longer serves the unversioned DeepSeek V4 Flash alias (`deepseek-ai/DeepSeek-V4-Flash`). This retires BID 335 in the catalog so existing installs stop offering a dead model.

## Changes
- Add `ModelCatalog::RETIREMENTS[335]` with successor `trustedtokens:deepseek-ai/DeepSeek-V4-Flash-0731:chat` (BID 336), which is still in the TrustedTokens billing catalog.
- Deactivate the catalog row (`active = selectable = 0`). `ModelRetirementSeeder` stamps `BRETIREDON` / `BSUCCESSORID` on deploy — no migration.
- Update `ModelCatalogTest` to lock the retirement and successor.
- Document the retirement in `docs/PRICING_MAINTENANCE.md`.

Confirmed gone from https://trustedtokens.eu/api/billing/models on 2026-09-08. The dated Flash 0731 snapshot and V4 Pro remain. BID 335 is not a `ProviderDefaultsService` recommendation.

## Verification
- [x] Tests added/updated
- [x] Local `make -C backend lint` — 0 files to fix
- [x] Local `make -C backend phpstan` — no errors
- [x] Local `make -C backend test` — 5574 tests, 0 failures
- [x] Local seed applied: BID 335 `BACTIVE=0`, `BSELECTABLE=0`, `BRETIREDON=2026-09-08`, `BSUCCESSORID=336`
- [x] GitHub CI — All Checks Passed (lint, PHPStan, PHPUnit, frontend, Docker image, E2E)

## Notes
- Backend-only catalog change. No OpenAPI / frontend schema regeneration.
- Rows are never deleted — `BMESSAGES` references the BID.

## Screenshots/Logs
Incident mail: TrustedTokens no longer serves DeepSeek V4 Flash.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a07fbd-da87-74a1-8758-a4a48ab31299?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a07fbd-da87-74a1-8758-a4a48ab31299&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

