### PR TITLE
feat(assistant): enhance pinned assistant functionality

### DIFF
--- a/frontend/src/components/assistants/AssistantStarterPrompts.vue
+++ b/frontend/src/components/assistants/AssistantStarterPrompts.vue
@@ -1,0 +1,33 @@
+<template>
+  <div
+    v-if="prompts.length > 0"
+    class="w-full max-w-2xl mx-auto"
+    data-testid="comp-assistant-starters"
+  >
+    <p class="text-center text-xs font-medium txt-muted uppercase tracking-wide mb-3">
+      {{ $t('assistants.suggested') }}
+    </p>
+    <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
+      <button
+        v-for="(prompt, index) in prompts"
+        :key="`${index}-${prompt}`"
+        type="button"
+        class="surface-card hover-surface p-4 rounded-xl text-left text-sm txt-secondary leading-snug transition-all"
+        :data-testid="`btn-assistant-starter-${index}`"
+        @click="emit('pick', prompt)"
+      >
+        {{ prompt }}
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+defineProps<{
+  prompts: string[]
+}>()
+
+const emit = defineEmits<{
+  pick: [prompt: string]
+}>()
+</script>

--- a/frontend/src/composables/usePinnedAssistant.ts
+++ b/frontend/src/composables/usePinnedAssistant.ts
@@ -1,46 +1,183 @@
 import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useRoute } from 'vue-router'
 import { agentsApi } from '@/services/api/agentsApi'
+import { useAgentsStore } from '@/stores/agents'
 import { useHistoryStore } from '@/stores/history'
 import { isAgentsEnabled } from './useAgentsFeature'
 
+export function parseAgentIdQuery(value: unknown): number | null {
+  const raw = Array.isArray(value) ? value[0] : value
+  const id = Number(raw)
+  return Number.isFinite(id) && id > 0 ? id : null
+}
+
+export function resolvePinnedAgentId(
+  enabled: boolean,
+  queryAgentId: number | null,
+  messages: Array<{ agentId?: number | null }>
+): number | null {
+  if (!enabled) {
+    return null
+  }
+  for (const message of messages) {
+    if (message.agentId && message.agentId > 0) {
+      return message.agentId
+    }
+  }
+  if (messages.length > 0) {
+    return null
+  }
+  return queryAgentId
+}
+
+/** True when ?agentId= points at an assistant this thread is not already using. */
+export function shouldOpenFreshAssistantChat(
+  queryAgentId: number | null,
+  messages: Array<{ agentId?: number | null }>
+): boolean {
+  if (queryAgentId == null) {
+    return false
+  }
+  if (messages.length === 0) {
+    return false
+  }
+  return !messages.some((message) => message.agentId === queryAgentId)
+}
+
+function trimmedStrings(values: unknown): string[] {
+  if (!Array.isArray(values)) {
+    return []
+  }
+  const out: string[] = []
+  for (const value of values) {
+    if (typeof value !== 'string') {
+      continue
+    }
+    const text = value.trim()
+    if (text === '') {
+      continue
+    }
+    out.push(text)
+    if (out.length === 3) {
+      break
+    }
+  }
+  return out
+}
+
 export function usePinnedAssistant() {
   const route = useRoute()
+  const { t } = useI18n()
   const historyStore = useHistoryStore()
+  const agentsStore = useAgentsStore()
   const name = ref<string | null>(null)
+  const greeting = ref('')
+  const starterPrompts = ref<string[]>([])
+  let loadSeq = 0
 
-  const agentId = computed(() => {
-    if (!isAgentsEnabled()) {
-      return null
+  const queryAgentId = computed(() => parseAgentIdQuery(route.query.agentId))
+
+  const agentId = computed(() =>
+    resolvePinnedAgentId(isAgentsEnabled(), queryAgentId.value, historyStore.messages)
+  )
+
+  function resetDetails(): void {
+    name.value = null
+    greeting.value = ''
+    starterPrompts.value = []
+  }
+
+  function applyFallbackName(): void {
+    if (!name.value) {
+      name.value = t('assistants.untitled')
     }
-    const fromQuery = Number(route.query.agentId)
-    if (Number.isFinite(fromQuery) && fromQuery > 0) {
-      return fromQuery
+  }
+
+  function applyFromGallery(id: number): boolean {
+    const card = agentsStore.gallery.find((row) => row.id === id)
+    if (!card) {
+      return false
     }
-    for (const message of historyStore.messages) {
-      if (message.agentId && message.agentId > 0) {
-        return message.agentId
-      }
+    if (typeof card.name === 'string' && card.name.trim() !== '') {
+      name.value = card.name
     }
-    return null
-  })
+    const fromCard = trimmedStrings(card.starterPrompts)
+    if (fromCard.length > 0) {
+      starterPrompts.value = fromCard
+    }
+    return true
+  }
+
+  function applyFromCurrent(id: number): boolean {
+    const current = agentsStore.current
+    if (!current || current.id !== id) {
+      return false
+    }
+    if (typeof current.name === 'string' && current.name.trim() !== '') {
+      name.value = current.name
+    }
+    const behaviour = current.draft?.behaviour
+    if (typeof behaviour?.greeting === 'string') {
+      greeting.value = behaviour.greeting.trim()
+    }
+    const fromDraft = trimmedStrings(behaviour?.starterPrompts)
+    if (fromDraft.length > 0) {
+      starterPrompts.value = fromDraft
+    }
+    return true
+  }
 
   watch(
     agentId,
     async (id) => {
+      const seq = ++loadSeq
       if (!id) {
-        name.value = null
+        resetDetails()
         return
       }
+      applyFallbackName()
+      applyFromGallery(id)
+      applyFromCurrent(id)
+      applyFallbackName()
+
       try {
         const agent = await agentsApi.get(id)
-        name.value = agent.name ?? null
+        if (seq !== loadSeq) {
+          return
+        }
+        if (typeof agent.name === 'string' && agent.name.trim() !== '') {
+          name.value = agent.name
+        }
+        const behaviour = agent.draft?.behaviour
+        if (typeof behaviour?.greeting === 'string') {
+          greeting.value = behaviour.greeting.trim()
+        }
+        const fromDraft = trimmedStrings(behaviour?.starterPrompts)
+        if (fromDraft.length > 0) {
+          starterPrompts.value = fromDraft
+        }
+        applyFallbackName()
       } catch {
-        name.value = null
+        if (seq !== loadSeq) {
+          return
+        }
+        if (agentsStore.gallery.length === 0) {
+          try {
+            await agentsStore.loadGallery()
+          } catch {
+            // Banner still shows the fallback name.
+          }
+        }
+        if (seq !== loadSeq) {
+          return
+        }
+        applyFromGallery(id)
+        applyFallbackName()
       }
     },
     { immediate: true }
   )
 
-  return { agentId, name }
+  return { agentId, queryAgentId, name, greeting, starterPrompts }
 }

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -5818,6 +5818,8 @@
     "filterPlugins": "Aus Plugins",
     "searchPlaceholder": "Assistenten suchen",
     "talkingTo": "Im Gespräch mit {name}",
+    "emptyHint": "Dieser Chat verwendet {name}.",
+    "suggested": "Probieren Sie eines davon",
     "save": "Speichern",
     "saving": "Speichern…",
     "saved": "Gespeichert",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -5884,6 +5884,8 @@
     "filterPlugins": "From plugins",
     "searchPlaceholder": "Search assistants",
     "talkingTo": "Talking to {name}",
+    "emptyHint": "This chat uses {name}.",
+    "suggested": "Try one of these",
     "save": "Save",
     "saving": "Saving…",
     "saved": "Saved",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -4898,6 +4898,8 @@
     "filterPlugins": "De plugins",
     "searchPlaceholder": "Buscar asistentes",
     "talkingTo": "Hablando con {name}",
+    "emptyHint": "Este chat usa {name}.",
+    "suggested": "Prueba una de estas",
     "save": "Guardar",
     "saving": "Guardando…",
     "saved": "Guardado",

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -5884,6 +5884,8 @@
     "filterPlugins": "Depuis les plugins",
     "searchPlaceholder": "Rechercher des assistants",
     "talkingTo": "Discussion avec {name}",
+    "emptyHint": "Cette discussion utilise {name}.",
+    "suggested": "Essayez l’une de ces suggestions",
     "save": "Enregistrer",
     "saving": "Enregistrement…",
     "saved": "Enregistré",

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -4899,6 +4899,8 @@
     "filterPlugins": "Eklentilerden",
     "searchPlaceholder": "Asistan ara",
     "talkingTo": "{name} ile konuşuluyor",
+    "emptyHint": "Bu sohbet {name} kullanıyor.",
+    "suggested": "Bunlardan birini deneyin",
     "save": "Kaydet",
     "saving": "Kaydediliyor…",
     "saved": "Kaydedildi",

--- a/frontend/src/views/AssistantsView.vue
+++ b/frontend/src/views/AssistantsView.vue
@@ -48,6 +48,7 @@ import PageHeader from '@/components/PageHeader.vue'
 import AssistantGallery from '@/components/assistants/AssistantGallery.vue'
 import AssistantBuilder from '@/components/assistants/AssistantBuilder.vue'
 import { useAgentsStore } from '@/stores/agents'
+import { useChatsStore } from '@/stores/chats'
 import { useDialog } from '@/composables/useDialog'
 import { useNotification } from '@/composables/useNotification'
 import { agentsApi } from '@/services/api/agentsApi'
@@ -56,6 +57,7 @@ const { t } = useI18n()
 const route = useRoute()
 const router = useRouter()
 const store = useAgentsStore()
+const chatsStore = useChatsStore()
 const { confirm } = useDialog()
 const { error, success } = useNotification()
 
@@ -96,8 +98,17 @@ function editAssistant(id: number): void {
   void router.push({ name: 'ai-assistant-builder', params: { id: String(id) } })
 }
 
-function startChat(id: number): void {
-  void router.push({ name: 'chat', query: { agentId: String(id) } })
+async function startChat(id: number): Promise<void> {
+  try {
+    if (chatsStore.chats.length === 0) {
+      await chatsStore.loadChats()
+    }
+    await chatsStore.findOrCreateEmptyChat()
+  } catch {
+    error(t('assistants.startChatFailed'))
+    return
+  }
+  await router.push({ name: 'chat', query: { agentId: String(id) } })
 }
 
 async function onDeleted(): Promise<void> {

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -167,14 +167,12 @@
                 <Icon icon="mdi:incognito" class="w-6 h-6 txt-brand" aria-hidden="true" />
               </div>
               <h2 class="text-2xl font-semibold txt-primary mb-2">
-                {{ incognitoStore.active ? $t('incognito.emptyTitle') : welcomeGreeting }}
+                {{ emptyLandingTitle }}
               </h2>
               <p class="txt-secondary">
-                {{
-                  incognitoStore.active ? $t('incognito.emptyHint') : $t('chatInput.placeholder')
-                }}
+                {{ emptyLandingHint }}
               </p>
-              <SelfAwareEmptyHint @ask="handleSendMessage" />
+              <SelfAwareEmptyHint v-if="!pinnedAgentId" @ask="handleSendMessage" />
             </div>
 
             <!-- Speed config: the expanded mix card greets the user on every
@@ -189,7 +187,12 @@
               <ModelMixPanel @select="dismissInlineMixPanel" />
             </div>
 
-            <ExamplePrompts v-if="showExamplePrompts" @pick="handleExamplePick" />
+            <AssistantStarterPrompts
+              v-if="pinnedAgentId && pinnedStarterPrompts.length > 0"
+              :prompts="pinnedStarterPrompts"
+              @pick="handleExamplePick"
+            />
+            <ExamplePrompts v-else-if="showExamplePrompts" @pick="handleExamplePick" />
             <MarketingNews v-if="!authStore.isAuthenticated && configStore.marketingNews.enabled" />
           </div>
 
@@ -304,7 +307,11 @@
         ref="chatInputRef"
         :is-streaming="isStreaming"
         :is-guest-mode="isGuestMode"
-        :banner-visible="showPendingPurchaseBanner || (isGuestMode && guestStore.shouldShowBanner)"
+        :banner-visible="
+          showPendingPurchaseBanner ||
+          (isGuestMode && guestStore.shouldShowBanner) ||
+          Boolean(pinnedAgentId)
+        "
         :quote="quoting.pendingQuote.value"
         @send="handleSendMessage"
         @stop="handleUserStop"
@@ -313,22 +320,21 @@
       >
         <!-- Native onboarding: a signed-out store purchase waiting to be
              linked to an account outranks the guest quota banner. -->
-        <template v-if="showPendingPurchaseBanner" #banner>
+        <template #banner>
           <PendingPurchaseBanner
+            v-if="showPendingPurchaseBanner"
             :visible="showPendingPurchaseBanner"
             @dismiss="pendingPurchaseBannerDismissed = true"
           />
-        </template>
-        <template v-else-if="isGuestMode" #banner>
           <GuestBanner
+            v-else-if="isGuestMode"
             :visible="guestStore.shouldShowBanner"
             :remaining="guestStore.remainingMessages"
             :max-messages="guestStore.maxMessages"
             @dismiss="guestStore.dismissBanner()"
           />
-        </template>
-        <template v-else-if="incognitoStore.active" #banner>
           <div
+            v-else-if="incognitoStore.active"
             class="flex items-center justify-center gap-2 px-4 py-2 mb-2 rounded-lg surface-chip text-xs txt-secondary"
             data-testid="banner-incognito"
           >
@@ -338,9 +344,8 @@
               — {{ $t('incognito.bannerText') }}
             </span>
           </div>
-        </template>
-        <template v-else-if="pinnedAssistantName" #banner>
           <div
+            v-else-if="pinnedAgentId && pinnedAssistantName"
             class="flex items-center justify-center gap-2 px-4 py-2 mb-2 rounded-lg surface-chip text-xs txt-secondary"
             data-testid="banner-pinned-assistant"
           >
@@ -499,6 +504,7 @@ import ChatInput from '@/components/ChatInput.vue'
 import ChatMessage from '@/components/ChatMessage.vue'
 import MarketingNews from '@/components/MarketingNews.vue'
 import ExamplePrompts from '@/components/ExamplePrompts.vue'
+import AssistantStarterPrompts from '@/components/assistants/AssistantStarterPrompts.vue'
 import SelfAwareEmptyHint from '@/components/chat/SelfAwareEmptyHint.vue'
 import { parsePlatformDocs } from '@/components/chat/refs/DocRefPill'
 import ConsumptionBar from '@/components/usage/ConsumptionBar.vue'
@@ -531,7 +537,7 @@ import { useMemoriesStore } from '@/stores/userMemories'
 import { useFeedbackStore } from '@/stores/userFeedback'
 import { useMessageDigestsStore } from '@/stores/messageDigests'
 import { useIncognitoStore } from '@/stores/incognito'
-import { usePinnedAssistant } from '@/composables/usePinnedAssistant'
+import { shouldOpenFreshAssistantChat, usePinnedAssistant } from '@/composables/usePinnedAssistant'
 import IncognitoToggle from '@/components/IncognitoToggle.vue'
 import ModelMixControl from '@/components/chat/ModelMixControl.vue'
 import ModelMixPanel from '@/components/chat/ModelMixPanel.vue'
@@ -683,7 +689,13 @@ const memoriesStore = useMemoriesStore()
 const feedbackStore = useFeedbackStore()
 const messageDigestsStore = useMessageDigestsStore()
 const incognitoStore = useIncognitoStore()
-const { agentId: pinnedAgentId, name: pinnedAssistantName } = usePinnedAssistant()
+const {
+  agentId: pinnedAgentId,
+  queryAgentId,
+  name: pinnedAssistantName,
+  greeting: pinnedAssistantGreeting,
+  starterPrompts: pinnedStarterPrompts,
+} = usePinnedAssistant()
 const promoTips = usePromoTips()
 const { getDateLabel } = useDateFormat()
 
@@ -713,6 +725,24 @@ const showPendingPurchaseBanner = computed(
 const welcomeGreeting = computed(() => {
   const firstName = authStore.user?.firstName?.trim()
   return firstName ? t('welcomeUser', { name: firstName }) : t('welcome')
+})
+const emptyLandingTitle = computed(() => {
+  if (incognitoStore.active) {
+    return t('incognito.emptyTitle')
+  }
+  if (pinnedAgentId.value) {
+    return pinnedAssistantGreeting.value || pinnedAssistantName.value || welcomeGreeting.value
+  }
+  return welcomeGreeting.value
+})
+const emptyLandingHint = computed(() => {
+  if (incognitoStore.active) {
+    return t('incognito.emptyHint')
+  }
+  if (pinnedAgentId.value && pinnedAssistantName.value) {
+    return t('assistants.emptyHint', { name: pinnedAssistantName.value })
+  }
+  return t('chatInput.placeholder')
 })
 const showGuestSignupModal = ref(false)
 const featureGateOpen = ref(false)
@@ -1123,7 +1153,8 @@ onMounted(async () => {
   // chat — for a task saved from a chat turn that was the original prompt
   // with the old output.
   const requestedChatId = Number(route.query.chat)
-  if (Number.isInteger(requestedChatId) && requestedChatId > 0) {
+  const openedSpecificChat = Number.isInteger(requestedChatId) && requestedChatId > 0
+  if (openedSpecificChat) {
     chatsStore.setActiveChat(requestedChatId)
     router.replace({ query: { ...route.query, chat: undefined } })
   }
@@ -1137,6 +1168,15 @@ onMounted(async () => {
     // A turn that was still generating when the page was reloaded keeps
     // writing into this bubble instead of being lost.
     void resumeActiveRunIfAny()
+  }
+
+  // Start chat from an assistant must not reopen an unrelated last thread.
+  // A ?chat= deep link (Saved Tasks) keeps that thread even if agentId is set.
+  if (
+    !openedSpecificChat &&
+    shouldOpenFreshAssistantChat(queryAgentId.value, historyStore.messages)
+  ) {
+    await chatsStore.findOrCreateEmptyChat()
   }
 
   // Usage taximeter: seed today's totals once and rebuild the session from the
@@ -1492,6 +1532,15 @@ watch(
     }
   }
 )
+
+watch(queryAgentId, async (id) => {
+  if (!id || !authStore.isAuthenticated) {
+    return
+  }
+  if (shouldOpenFreshAssistantChat(id, historyStore.messages)) {
+    await chatsStore.findOrCreateEmptyChat()
+  }
+})
 
 const userTextBefore = (messageId: string | number): string => {
   const list = historyStore.messages

--- a/frontend/tests/unit/components/assistants/AssistantStarterPrompts.spec.ts
+++ b/frontend/tests/unit/components/assistants/AssistantStarterPrompts.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import AssistantStarterPrompts from '@/components/assistants/AssistantStarterPrompts.vue'
+import en from '@/i18n/en.json'
+
+function mountPrompts(prompts: string[]) {
+  const i18n = createI18n({ legacy: false, locale: 'en', messages: { en } })
+  return mount(AssistantStarterPrompts, {
+    props: { prompts },
+    global: { plugins: [i18n] },
+  })
+}
+
+describe('AssistantStarterPrompts', () => {
+  it('hides when there are no prompts', () => {
+    const wrapper = mountPrompts([])
+    expect(wrapper.find('[data-testid="comp-assistant-starters"]').exists()).toBe(false)
+  })
+
+  it('emits the chosen starter', async () => {
+    const wrapper = mountPrompts(['Review this NDA'])
+    await wrapper.get('[data-testid="btn-assistant-starter-0"]').trigger('click')
+    expect(wrapper.emitted('pick')).toEqual([['Review this NDA']])
+  })
+})

--- a/frontend/tests/unit/composables/usePinnedAssistant.spec.ts
+++ b/frontend/tests/unit/composables/usePinnedAssistant.spec.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import {
+  parseAgentIdQuery,
+  resolvePinnedAgentId,
+  shouldOpenFreshAssistantChat,
+} from '@/composables/usePinnedAssistant'
+
+describe('parseAgentIdQuery', () => {
+  it('reads a positive integer from the query', () => {
+    expect(parseAgentIdQuery('2')).toBe(2)
+    expect(parseAgentIdQuery(2)).toBe(2)
+  })
+
+  it('uses the first value when Vue repeats the param', () => {
+    expect(parseAgentIdQuery(['4', '9'])).toBe(4)
+  })
+
+  it('rejects missing or invalid values', () => {
+    expect(parseAgentIdQuery(undefined)).toBeNull()
+    expect(parseAgentIdQuery('')).toBeNull()
+    expect(parseAgentIdQuery('0')).toBeNull()
+    expect(parseAgentIdQuery(-1)).toBeNull()
+    expect(parseAgentIdQuery('nope')).toBeNull()
+  })
+})
+
+describe('resolvePinnedAgentId', () => {
+  it('is off when the feature flag is off', () => {
+    expect(resolvePinnedAgentId(false, 2, [])).toBeNull()
+    expect(resolvePinnedAgentId(false, 2, [{ agentId: 2 }])).toBeNull()
+  })
+
+  it('uses the query pin only on an empty chat', () => {
+    expect(resolvePinnedAgentId(true, 2, [])).toBe(2)
+  })
+
+  it('prefers a pin already stamped on the thread', () => {
+    expect(resolvePinnedAgentId(true, 9, [{ agentId: null }, { agentId: 2 }])).toBe(2)
+  })
+
+  it('does not pin an unrelated thread just because the URL still has agentId', () => {
+    expect(resolvePinnedAgentId(true, 2, [{ agentId: null }])).toBeNull()
+  })
+})
+
+describe('shouldOpenFreshAssistantChat', () => {
+  it('stays on an empty chat', () => {
+    expect(shouldOpenFreshAssistantChat(2, [])).toBe(false)
+  })
+
+  it('stays when the open thread is already this assistant', () => {
+    expect(shouldOpenFreshAssistantChat(2, [{ agentId: 2 }])).toBe(false)
+  })
+
+  it('opens a new chat when the last thread belongs to someone else', () => {
+    expect(shouldOpenFreshAssistantChat(2, [{ agentId: null }])).toBe(true)
+    expect(shouldOpenFreshAssistantChat(2, [{ agentId: 5 }])).toBe(true)
+  })
+
+  it('does nothing without a query pin', () => {
+    expect(shouldOpenFreshAssistantChat(null, [{ agentId: null }])).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
This commit improves the overall functionality and user interaction with pinned assistants, ensuring a more seamless experience across different languages.

## Changes
- Introduced new utility functions for handling agent IDs and determining when to open a fresh assistant chat.
- Updated the `usePinnedAssistant` composable to manage agent details more effectively, including fallback names and starter prompts.
- Enhanced the `AssistantsView` and `ChatView` components to utilize the new pinned assistant features, improving user experience.
- Added internationalization strings for new assistant chat hints in German, English, Spanish, French, and Turkish.

## Verification
- [ ] Not tested (explain)
- [x] Manual
- [ ] Tests added/updated
