### PR TITLE
feat(saved-tasks): enhance delete functionality and UI updates

### DIFF
--- a/backend/src/Controller/SavedTaskController.php
+++ b/backend/src/Controller/SavedTaskController.php
@@ -244,7 +244,16 @@ final class SavedTaskController extends AbstractController
         summary: 'Delete a Saved Task',
         tags: ['Saved Tasks'],
         responses: [
-            new OA\Response(response: 200, description: 'Deleted'),
+            new OA\Response(
+                response: 200,
+                description: 'Deleted',
+                content: new OA\JsonContent(
+                    required: ['success'],
+                    properties: [
+                        new OA\Property(property: 'success', type: 'boolean', example: true),
+                    ]
+                )
+            ),
             new OA\Response(response: 404, description: 'Not found'),
         ]
     )]

--- a/backend/tests/Controller/SavedTaskControllerTest.php
+++ b/backend/tests/Controller/SavedTaskControllerTest.php
@@ -29,6 +29,40 @@ final class SavedTaskControllerTest extends WebTestCase
         $this->em = static::getContainer()->get('doctrine')->getManager();
     }
 
+    public function testOwnerCanDeleteTaskAndRuns(): void
+    {
+        $this->enableSharing();
+        $owner = $this->createUser('task-del-owner@synaplan.internal');
+        $prompt = $this->createPrompt((int) $owner->getId(), 'task-del', 'Delete Me');
+        $task = $this->createTask((int) $owner->getId(), (int) $prompt->getId(), 'Delete Me');
+        $taskId = $task->getId();
+        self::assertNotNull($taskId);
+        $this->authenticateClient($this->client, $owner);
+
+        $this->client->request('DELETE', '/api/v1/saved-tasks/'.$taskId);
+
+        self::assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        self::assertTrue($this->json()['success'] ?? false);
+        $this->em->clear();
+        self::assertNull($this->em->find(SavedTask::class, $taskId));
+    }
+
+    public function testForeignTaskDeleteIs404(): void
+    {
+        $this->enableSharing();
+        $owner = $this->createUser('task-del-priv-owner@synaplan.internal');
+        $other = $this->createUser('task-del-priv-other@synaplan.internal');
+        $prompt = $this->createPrompt((int) $owner->getId(), 'task-del-priv', 'Private delete');
+        $task = $this->createTask((int) $owner->getId(), (int) $prompt->getId(), 'Private delete');
+        $this->authenticateClient($this->client, $other);
+
+        $this->client->request('DELETE', '/api/v1/saved-tasks/'.$task->getId());
+
+        self::assertSame(Response::HTTP_NOT_FOUND, $this->client->getResponse()->getStatusCode());
+        $this->em->clear();
+        self::assertInstanceOf(SavedTask::class, $this->em->find(SavedTask::class, $task->getId()));
+    }
+
     public function testForeignTaskIs404(): void
     {
         $this->enableSharing();

--- a/frontend/src/components/config/SavedTaskCard.vue
+++ b/frontend/src/components/config/SavedTaskCard.vue
@@ -212,6 +212,7 @@ const onDelete = async () => {
   const ok = await dialog.confirm({
     title: t('config.savedTasks.delete'),
     message: t('config.savedTasks.deleteConfirm', { name: props.task.name }),
+    confirmText: t('config.savedTasks.delete'),
     danger: true,
   })
   if (!ok) return

--- a/frontend/src/components/config/TaskPromptsConfiguration.vue
+++ b/frontend/src/components/config/TaskPromptsConfiguration.vue
@@ -428,6 +428,7 @@
             class="mb-4"
             :task="currentSavedTask"
             @updated="onSavedTaskUpdated"
+            @deleted="onSavedTaskDeleted"
           />
 
           <!-- Tab nav -->
@@ -1326,6 +1327,10 @@ const loadSavedTasks = async () => {
 
 const onSavedTaskUpdated = (task: SavedTask) => {
   savedTasks.value = savedTasks.value.map((row) => (row.id === task.id ? task : row))
+}
+
+const onSavedTaskDeleted = (id: number) => {
+  savedTasks.value = savedTasks.value.filter((row) => row.id !== id)
 }
 
 const onSaveAsTask = async () => {

--- a/frontend/src/services/api/savedTasksApi.ts
+++ b/frontend/src/services/api/savedTasksApi.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 import { httpClient } from './httpClient'
 import {
+  DeleteApiSavedTasksDeleteResponseSchema,
   GetApiSavedTasksListResponseSchema,
   GetApiSavedTasksRunsResponseSchema,
   PatchApiSavedTasksUpdateResponseSchema,
@@ -166,7 +167,10 @@ export const savedTasksApi = {
   },
 
   async remove(id: number): Promise<void> {
-    await httpClient(`/api/v1/saved-tasks/${id}`, { method: 'DELETE' })
+    await httpClient(`/api/v1/saved-tasks/${id}`, {
+      method: 'DELETE',
+      schema: DeleteApiSavedTasksDeleteResponseSchema,
+    })
   },
 
   async resume(id: number): Promise<SavedTask> {

--- a/frontend/tests/e2e/helpers/selectors.ts
+++ b/frontend/tests/e2e/helpers/selectors.ts
@@ -509,6 +509,7 @@ export const selectors = {
     /** One card per task; rendered on /channels/tasks and inline on the prompt editor */
     card: '[data-testid="saved-task-card"]',
     runNow: '[data-testid="btn-run-now"]',
+    delete: '[data-testid="btn-delete-saved-task"]',
     /** Only rendered once the task has a chat (i.e. after it has run at least once) */
     showResults: '[data-testid="btn-show-results"]',
     viewRuns: '[data-testid="btn-view-runs"]',

--- a/frontend/tests/e2e/tests/saved-task-roundtrip.spec.ts
+++ b/frontend/tests/e2e/tests/saved-task-roundtrip.spec.ts
@@ -88,5 +88,11 @@ test.describe('@ci Saved Task roundtrip', () => {
       await card.locator(TASKS.viewRuns).click()
       await expect(card.locator(TASKS.runsList)).toBeVisible({ timeout: TIMEOUTS.SHORT })
     })
+
+    await test.step('Act: delete the task from the Saved Tasks page', async () => {
+      await card.locator(TASKS.delete).click()
+      await page.locator(selectors.dialog.confirmBtn).click()
+      await expect(card).toHaveCount(0, { timeout: TIMEOUTS.STANDARD })
+    })
   })
 })

--- a/frontend/tests/unit/components/config/SavedTaskCard.spec.ts
+++ b/frontend/tests/unit/components/config/SavedTaskCard.spec.ts
@@ -261,6 +261,7 @@ describe('SavedTaskCard', () => {
     expect(mockConfirm).toHaveBeenCalledWith(
       expect.objectContaining({
         title: 'Delete',
+        confirmText: 'Delete',
         danger: true,
       })
     )

--- a/frontend/tests/unit/components/config/SavedTasksOverview.spec.ts
+++ b/frontend/tests/unit/components/config/SavedTasksOverview.spec.ts
@@ -81,4 +81,25 @@ describe('SavedTasksOverview', () => {
     const wrapper = await mountPage()
     expect(wrapper.find('[data-testid="btn-shared-with-me"]').exists()).toBe(false)
   })
+
+  it('removes a card when the child emits deleted', async () => {
+    mockList.mockResolvedValue([task])
+    const wrapper = mount(SavedTasksOverview, {
+      global: {
+        stubs: {
+          Icon: true,
+          RouterLink: { template: '<a><slot /></a>', props: ['to'] },
+          SavedTaskCard: {
+            props: ['task'],
+            template:
+              '<button type="button" data-testid="emit-deleted" @click="$emit(\'deleted\', task.id)" />',
+          },
+        },
+      },
+    })
+    await flushPromises()
+    await wrapper.get('[data-testid="emit-deleted"]').trigger('click')
+    expect(wrapper.find('[data-testid="emit-deleted"]').exists()).toBe(false)
+    expect(wrapper.get('[data-testid="saved-tasks-empty"]').exists()).toBe(true)
+  })
 })

--- a/frontend/tests/unit/components/config/SavedTasksOverview.spec.ts
+++ b/frontend/tests/unit/components/config/SavedTasksOverview.spec.ts
@@ -100,6 +100,6 @@ describe('SavedTasksOverview', () => {
     await flushPromises()
     await wrapper.get('[data-testid="emit-deleted"]').trigger('click')
     expect(wrapper.find('[data-testid="emit-deleted"]').exists()).toBe(false)
-    expect(wrapper.get('[data-testid="saved-tasks-empty"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="saved-tasks-empty"]').exists()).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary
These changes improve the user experience by providing clear feedback on task deletion and ensuring proper handling of task ownership.

## Changes
- Updated the SavedTaskController to return a JSON response with a success flag upon successful deletion of a saved task.
- Added unit tests to verify that the task owner can delete their tasks and that unauthorized delete attempts return a 404 error.
- Enhanced the SavedTaskCard component to include a confirmation dialog with a custom confirm text for deletion.
- Implemented event handling in the TaskPromptsConfiguration component to remove tasks from the list upon deletion.
- Updated the savedTasksApi to include schema validation for the delete response.
- Added E2E tests to ensure the delete functionality works as expected in the UI.

## Verification
- [ ] Not tested (explain)
- [X] Manual
- [ ] Tests added/updated
