### PR TITLE
feat(plugs): add Docling extraction and AI infrastructure Extraction tab

### DIFF
--- a/_devextras/planning/20260903_roadmap.md
+++ b/_devextras/planning/20260903_roadmap.md
@@ -122,7 +122,7 @@ is met, not when the calendar says so.
 | ---- | ----- | -------- |
 | W1 | closed | IAM S0–S2 on `main` (#1708, #1713); groups exist, a folder and a chat can be shared with a group, installs without groups unchanged. |
 | W2 | closed with [#1745](https://github.com/metadist/synaplan/pull/1745) | IAM S3–S5 on `main` (#1714, #1717, #1718, #1719); Agent Builder S1–S3.5 on `main` (#1738): an admin publishes an assistant to a group, OIDC groups sync. More Nextcloud S1 reviewed and gated in #1745: a signed-in user links an existing account from a registered partner instance (`fake-instance.sh` 12/12), Outlook connect unchanged for Synamail. Flags `PLATFORM_LINKS.ENABLED`, `IAM.*`, `AGENTS.ENABLED` stay off by default. |
-| W3 | in progress | AI Plugs S1 on `main` (#1750). Companion **URL watch** on `feat/wave3-url-watch` (one snapshot per URL, compare + mail, Saved Tasks CRUD). Docling / SearXNG / rerank remain S2–S4. Agent Builder S4–S6 and More Nextcloud S2–S3 (`link` mode) still next. |
+| W3 | in progress | AI Plugs S1 + URL watch on `main` (#1750, #1754). AI Plugs S2 (Docling) on `feat/wave3-ai-plugs-s2-docling`. SearXNG / rerank remain S3–S4. Agent Builder S4–S6 and More Nextcloud S2–S3 (`link` mode) still next. |
 
 ---
 

--- a/_devextras/planning/202609_ai_plugs/STATUS.md
+++ b/_devextras/planning/202609_ai_plugs/STATUS.md
@@ -25,6 +25,7 @@ Track 3 of [`../20260903_roadmap.md`](../20260903_roadmap.md). Plan of record:
 | 2026-09-07 | **UX contract.** J-PL-1…3: each admin tab leads with a sentence, health, and Test that shows a human result. A down sidecar never fails an upload. |
 | 2026-09-07 | **S1 implementation.** FileProcessor is **not** rewritten as a full chain runner in S1 — existing `FileProcessor*Test` constructors stay valid. Built-in strategies remain inside FileProcessor. `PlugConfigService::extraExtractorKeys()` is the S2 unlock (empty on the seeded chains). The six Brave callers go through `WebSearchGateway`. `MessagePreProcessor` still talks to `TikaClient` (allow-listed in `PlugBoundaryTest`). No UI, no new env var, no migration. |
 | 2026-09-08 | **S2 implementation.** Docling is a tagged extra extractor; FileProcessor is still not a full chain runner. Quality gate generalizes Tika's PDF `isLowQuality()` and is applied to extras. Markdown chunking is opt-in via `meta.markdown`. Compose profile `docling` uses the CPU image `docling-serve-cpu:v1.32.0` (no `mem_limit` in dev). `DOCLING_BASE_URL` empty = off. |
+| 2026-09-08 | **S2 admin parity.** Docling has the same System configuration → Processing fields and connection test as Tika (`DOCLING_BASE_URL`, timeout, max bytes). Feature status lists Docling like Collabora (disabled when the URL is empty). |
 
 ## Review log
 

--- a/_devextras/planning/202609_ai_plugs/STATUS.md
+++ b/_devextras/planning/202609_ai_plugs/STATUS.md
@@ -8,7 +8,7 @@ Track 3 of [`../20260903_roadmap.md`](../20260903_roadmap.md). Plan of record:
 | Sprint / step | Branch / repo | State | Notes |
 | ------------- | ------------- | ----- | ----- |
 | S1 Ports & refactor | `synaplan/` `main` (#1750) | done | `PL1`–`PL8`: ports, registries, `PLUGS` seeder, Brave gateway, extra-extractor hook. FileProcessor built-in strategies unchanged. |
-| S2 Docling | — | planned | Lands as a tagged extra extractor (`docling`) |
+| S2 Docling | `synaplan/` `feat/wave3-ai-plugs-s2-docling` | implemented | `PL9`–`PL15`: Docling extra extractor, quality gate, markdown chunking, opt-in compose profile, Extraction tab |
 | S3 Web search providers | — | planned | SearXNG (+ later Tavily/Exa/…) on `WebSearchRegistry` |
 | S4 Rerank | — | planned | Port exists; `RERANK.ENABLED=0` |
 | S5 Model import | — | planned | |
@@ -24,6 +24,7 @@ Track 3 of [`../20260903_roadmap.md`](../20260903_roadmap.md). Plan of record:
 | 2026-09-03 | S5 registers the `model_preferences` bundle section with the track-2 registry (roadmap §8.1). |
 | 2026-09-07 | **UX contract.** J-PL-1…3: each admin tab leads with a sentence, health, and Test that shows a human result. A down sidecar never fails an upload. |
 | 2026-09-07 | **S1 implementation.** FileProcessor is **not** rewritten as a full chain runner in S1 — existing `FileProcessor*Test` constructors stay valid. Built-in strategies remain inside FileProcessor. `PlugConfigService::extraExtractorKeys()` is the S2 unlock (empty on the seeded chains). The six Brave callers go through `WebSearchGateway`. `MessagePreProcessor` still talks to `TikaClient` (allow-listed in `PlugBoundaryTest`). No UI, no new env var, no migration. |
+| 2026-09-08 | **S2 implementation.** Docling is a tagged extra extractor; FileProcessor is still not a full chain runner. Quality gate generalizes Tika's PDF `isLowQuality()` and is applied to extras. Markdown chunking is opt-in via `meta.markdown`. Compose profile `docling` uses the CPU image `docling-serve-cpu:v1.32.0` (no `mem_limit` in dev). `DOCLING_BASE_URL` empty = off. |
 
 ## Review log
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -376,9 +376,14 @@ TIKA_MIN_LENGTH=10
 TIKA_MIN_ENTROPY=3.0
 
 # --- Docling (optional document extraction sidecar) ---
-# Empty = off. Compose sets http://docling:5001 when the `docling` profile is
-# used (`docker compose --profile docling up -d`). A down sidecar never fails
-# an upload — Tika stays the fallback.
+# Empty = off. A down sidecar never fails an upload — Tika stays the fallback.
+# After `docker compose --profile docling up -d` the local URL is:
+#   http://docling:5001
+#   http://docling:5001/health
+# Compose injects that into backend/worker unless you override this. There is
+# no published host port (same as Collabora). From the host:
+#   docker compose exec -T backend curl -sS http://docling:5001/health
+# See docs/DEVELOPMENT.md ("Docling extraction").
 DOCLING_BASE_URL=
 DOCLING_TIMEOUT_MS=120000
 DOCLING_MAX_BYTES=52428800

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -375,6 +375,14 @@ TIKA_HTTP_PASS=
 TIKA_MIN_LENGTH=10
 TIKA_MIN_ENTROPY=3.0
 
+# --- Docling (optional document extraction sidecar) ---
+# Empty = off. Compose sets http://docling:5001 when the `docling` profile is
+# used (`docker compose --profile docling up -d`). A down sidecar never fails
+# an upload — Tika stays the fallback.
+DOCLING_BASE_URL=
+DOCLING_TIMEOUT_MS=120000
+DOCLING_MAX_BYTES=52428800
+
 # --- Office conversion (optional Collabora CODE sidecar) ---
 # Empty or "disabled" keeps today's behaviour (no thumbnails / PDF export /
 # preview / combine for office files). Set when the `office` Compose profile

--- a/backend/config/services.yaml
+++ b/backend/config/services.yaml
@@ -141,6 +141,10 @@ parameters:
     env(TIKA_RETRY_BACKOFF_MS): '1000'
     env(TIKA_MIN_LENGTH): '10'
     env(TIKA_MIN_ENTROPY): '3.0'
+    # Docling sidecar. Empty = off (OSS / fresh-install default).
+    env(DOCLING_BASE_URL): ''
+    env(DOCLING_TIMEOUT_MS): '120000'
+    env(DOCLING_MAX_BYTES): '52428800'
     # Office convert (Collabora CODE). Empty = disabled (OSS default).
     env(OFFICE_CONVERT_URL): ''
     env(OFFICE_CONVERT_TIMEOUT_MS): '60000'
@@ -1014,6 +1018,15 @@ services:
             $tikaRetryBackoffMs: '%env(int:TIKA_RETRY_BACKOFF_MS)%'
             $tikaHttpUser: '%env(TIKA_HTTP_USER)%'
             $tikaHttpPass: '%env(TIKA_HTTP_PASS)%'
+
+    App\Plug\Extraction\Docling\DoclingClient:
+        arguments:
+            $baseUrl: '%env(DOCLING_BASE_URL)%'
+            $timeoutMs: '%env(int:DOCLING_TIMEOUT_MS)%'
+
+    App\Plug\Extraction\Adapter\DoclingExtractor:
+        arguments:
+            $maxBytes: '%env(int:DOCLING_MAX_BYTES)%'
 
     App\Service\File\Office\OfficeConverterClient:
         arguments:

--- a/backend/src/Controller/AdminPlugsExtractionController.php
+++ b/backend/src/Controller/AdminPlugsExtractionController.php
@@ -1,0 +1,220 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Entity\User;
+use App\Plug\Extraction\ExtractionAdminService;
+use OpenApi\Attributes as OA;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
+
+#[Route('/api/v1/admin/plugs/extraction')]
+#[OA\Tag(name: 'Admin Plugs Extraction')]
+final class AdminPlugsExtractionController extends AbstractController
+{
+    public function __construct(
+        private readonly ExtractionAdminService $extractionAdmin,
+    ) {
+    }
+
+    #[Route('', name: 'admin_plugs_extraction_status', methods: ['GET'])]
+    #[OA\Get(
+        path: '/api/v1/admin/plugs/extraction',
+        summary: 'List extraction adapters, chains and quality settings',
+        security: [['Bearer' => []]],
+        tags: ['Admin Plugs Extraction']
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'Extraction adapters, configured chains and quality gate',
+        content: new OA\JsonContent(
+            required: ['adapters', 'chains', 'quality'],
+            properties: [
+                new OA\Property(
+                    property: 'adapters',
+                    type: 'array',
+                    items: new OA\Items(
+                        required: ['key', 'label', 'docsUrl', 'sovereignty', 'health'],
+                        properties: [
+                            new OA\Property(property: 'key', type: 'string', example: 'docling'),
+                            new OA\Property(property: 'label', type: 'string', example: 'Docling'),
+                            new OA\Property(property: 'docsUrl', type: 'string', example: 'https://github.com/docling-project/docling-serve'),
+                            new OA\Property(property: 'sovereignty', type: 'string', example: 'self-hosted'),
+                            new OA\Property(
+                                property: 'health',
+                                required: ['available', 'reason'],
+                                properties: [
+                                    new OA\Property(property: 'available', type: 'boolean', example: false),
+                                    new OA\Property(property: 'reason', type: 'string', nullable: true),
+                                ],
+                                type: 'object'
+                            ),
+                        ],
+                        type: 'object'
+                    )
+                ),
+                new OA\Property(
+                    property: 'chains',
+                    type: 'object',
+                    additionalProperties: new OA\AdditionalProperties(type: 'array', items: new OA\Items(type: 'string')),
+                    example: ['document' => ['structured_office', 'office_convert', 'tika', 'pdf_vision']]
+                ),
+                new OA\Property(
+                    property: 'quality',
+                    required: ['minLength', 'minEntropy', 'applyTo'],
+                    properties: [
+                        new OA\Property(property: 'minLength', type: 'integer', example: 10),
+                        new OA\Property(property: 'minEntropy', type: 'number', example: 3.0),
+                        new OA\Property(property: 'applyTo', type: 'array', items: new OA\Items(type: 'string'), example: ['pdf']),
+                    ],
+                    type: 'object'
+                ),
+            ],
+            type: 'object'
+        )
+    )]
+    #[OA\Response(response: 403, description: 'Admin access required')]
+    public function status(#[CurrentUser] ?User $user): JsonResponse
+    {
+        if ($resp = $this->requireAdmin($user)) {
+            return $resp;
+        }
+
+        return $this->json($this->extractionAdmin->status());
+    }
+
+    #[Route('/chains', name: 'admin_plugs_extraction_chains', methods: ['PUT'])]
+    #[OA\Put(
+        path: '/api/v1/admin/plugs/extraction/chains',
+        summary: 'Replace extraction chain order for one or more families',
+        security: [['Bearer' => []]],
+        tags: ['Admin Plugs Extraction']
+    )]
+    #[OA\RequestBody(
+        required: true,
+        content: new OA\JsonContent(
+            required: ['chains'],
+            properties: [
+                new OA\Property(
+                    property: 'chains',
+                    type: 'object',
+                    additionalProperties: new OA\AdditionalProperties(type: 'array', items: new OA\Items(type: 'string')),
+                    example: ['document' => ['docling', 'tika', 'pdf_vision']]
+                ),
+            ],
+            type: 'object'
+        )
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'Updated extraction status',
+        content: new OA\JsonContent(
+            required: ['adapters', 'chains', 'quality'],
+            properties: [
+                new OA\Property(property: 'adapters', type: 'array', items: new OA\Items(type: 'object')),
+                new OA\Property(property: 'chains', type: 'object'),
+                new OA\Property(property: 'quality', type: 'object'),
+            ],
+            type: 'object'
+        )
+    )]
+    #[OA\Response(response: 403, description: 'Admin access required')]
+    #[OA\Response(response: 422, description: 'Unknown family or adapter key')]
+    public function saveChains(Request $request, #[CurrentUser] ?User $user): JsonResponse
+    {
+        if ($resp = $this->requireAdmin($user)) {
+            return $resp;
+        }
+
+        $data = json_decode($request->getContent(), true);
+        if (!\is_array($data) || !\is_array($data['chains'] ?? null)) {
+            return $this->json(['error' => 'chains object is required'], Response::HTTP_BAD_REQUEST);
+        }
+
+        try {
+            return $this->json($this->extractionAdmin->setChains($data['chains']));
+        } catch (\InvalidArgumentException $e) {
+            return $this->json(['error' => $e->getMessage()], Response::HTTP_UNPROCESSABLE_ENTITY);
+        }
+    }
+
+    #[Route('/test', name: 'admin_plugs_extraction_test', methods: ['POST'])]
+    #[OA\Post(
+        path: '/api/v1/admin/plugs/extraction/test',
+        summary: 'Probe every configured extra extractor then the built-in path',
+        security: [['Bearer' => []]],
+        tags: ['Admin Plugs Extraction']
+    )]
+    #[OA\RequestBody(
+        required: true,
+        content: new OA\MediaType(
+            mediaType: 'multipart/form-data',
+            schema: new OA\Schema(
+                required: ['file'],
+                properties: [new OA\Property(property: 'file', type: 'string', format: 'binary')],
+                type: 'object'
+            )
+        )
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'Winner, per-adapter attempts and a text preview',
+        content: new OA\JsonContent(
+            required: ['winner', 'strategy', 'attempts', 'preview', 'markdown'],
+            properties: [
+                new OA\Property(property: 'winner', type: 'string', nullable: true, example: 'tika'),
+                new OA\Property(property: 'strategy', type: 'string', example: 'tika'),
+                new OA\Property(
+                    property: 'attempts',
+                    type: 'array',
+                    items: new OA\Items(
+                        required: ['key', 'verdict', 'ms'],
+                        properties: [
+                            new OA\Property(property: 'key', type: 'string', example: 'docling'),
+                            new OA\Property(property: 'verdict', type: 'string', example: 'unavailable'),
+                            new OA\Property(property: 'ms', type: 'integer', example: 12),
+                        ],
+                        type: 'object'
+                    )
+                ),
+                new OA\Property(property: 'preview', type: 'string'),
+                new OA\Property(property: 'markdown', type: 'boolean', example: false),
+            ],
+            type: 'object'
+        )
+    )]
+    #[OA\Response(response: 400, description: 'Missing file')]
+    #[OA\Response(response: 403, description: 'Admin access required')]
+    public function test(Request $request, #[CurrentUser] ?User $user): JsonResponse
+    {
+        if ($resp = $this->requireAdmin($user)) {
+            return $resp;
+        }
+
+        $file = $request->files->get('file');
+        if (!$file instanceof UploadedFile || !$file->isValid()) {
+            return $this->json(['error' => 'A file is required'], Response::HTTP_BAD_REQUEST);
+        }
+
+        return $this->json($this->extractionAdmin->testFile(
+            $file->getPathname(),
+            $file->getClientOriginalName() ?: $file->getFilename(),
+        ));
+    }
+
+    private function requireAdmin(?User $user): ?JsonResponse
+    {
+        if (!$user || !$user->isAdmin()) {
+            return $this->json(['error' => 'Admin access required'], Response::HTTP_FORBIDDEN);
+        }
+
+        return null;
+    }
+}

--- a/backend/src/Controller/AdminSystemConfigController.php
+++ b/backend/src/Controller/AdminSystemConfigController.php
@@ -208,10 +208,10 @@ final class AdminSystemConfigController extends AbstractController
     )]
     #[OA\Parameter(
         name: 'service',
-        description: 'Service to test (ollama, tika, qdrant, mailer)',
+        description: 'Service to test (ollama, tika, docling, qdrant, mailer)',
         in: 'path',
         required: true,
-        schema: new OA\Schema(type: 'string', enum: ['ollama', 'tika', 'qdrant', 'mailer'])
+        schema: new OA\Schema(type: 'string', enum: ['ollama', 'tika', 'docling', 'qdrant', 'mailer'])
     )]
     #[OA\Response(
         response: 200,

--- a/backend/src/Controller/ConfigController.php
+++ b/backend/src/Controller/ConfigController.php
@@ -2275,6 +2275,25 @@ class ConfigController extends AbstractController
             'version' => $tikaVersion,
         ];
 
+        // Docling (optional document extraction sidecar)
+        $doclingUrl = trim((string) ($_ENV['DOCLING_BASE_URL'] ?? ''));
+        $doclingConfigured = '' !== $doclingUrl && 'disabled' !== strtolower($doclingUrl);
+        $doclingHealthy = $doclingConfigured && $this->checkServiceHealth(rtrim($doclingUrl, '/').'/health');
+        $features['docling'] = [
+            'id' => 'docling',
+            'category' => 'Processing Services',
+            'name' => 'Docling',
+            'enabled' => $doclingConfigured,
+            'status' => $doclingConfigured ? ($doclingHealthy ? 'healthy' : 'unhealthy') : 'disabled',
+            'message' => $doclingConfigured
+                ? ($doclingHealthy
+                    ? 'Document extraction sidecar is running'
+                    : 'Docling is not responding at DOCLING_BASE_URL')
+                : 'Optional. Set DOCLING_BASE_URL and start the docling Compose profile',
+            'setup_required' => !$doclingConfigured,
+            'url' => $doclingConfigured ? $doclingUrl : '',
+        ];
+
         // Collabora CODE convert-to (optional office engine)
         $officeUrl = $this->officeConvertUrl();
         $officeConfigured = $this->isOfficeConvertConfigured();

--- a/backend/src/Plug/Extraction/Adapter/DoclingExtractor.php
+++ b/backend/src/Plug/Extraction/Adapter/DoclingExtractor.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Plug\Extraction\Adapter;
+
+use App\Plug\Extraction\ContentExtractorInterface;
+use App\Plug\Extraction\Docling\DoclingClient;
+use App\Plug\Extraction\ExtractionRequest;
+use App\Plug\Extraction\ExtractionResult;
+use App\Plug\PlugDescriptor;
+use App\Plug\PlugHealth;
+
+/**
+ * docling-serve adapter. Lands in FileProcessor via extraExtractorKeys().
+ *
+ * @internal
+ */
+final readonly class DoclingExtractor implements ContentExtractorInterface
+{
+    private const DOCUMENT_EXT = ['pdf', 'docx', 'pptx', 'xlsx', 'html', 'htm'];
+    private const IMAGE_EXT = ['png', 'jpg', 'jpeg', 'gif', 'webp', 'tiff', 'tif'];
+
+    public function __construct(
+        private DoclingClient $client,
+        private int $maxBytes,
+    ) {
+    }
+
+    public function key(): string
+    {
+        return 'docling';
+    }
+
+    public function descriptor(): PlugDescriptor
+    {
+        return new PlugDescriptor(
+            'docling',
+            'Docling',
+            'https://github.com/docling-project/docling-serve',
+            ['DOCLING_BASE_URL'],
+            'self-hosted',
+        );
+    }
+
+    public function supports(ExtractionRequest $request): bool
+    {
+        if (!$this->client->isEnabled()) {
+            return false;
+        }
+        if (!$this->familyAllowed($request)) {
+            return false;
+        }
+        if (!is_file($request->absolutePath)) {
+            return false;
+        }
+        $size = filesize($request->absolutePath);
+        if (false === $size || $size > $this->maxBytes) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function extract(ExtractionRequest $request): ExtractionResult
+    {
+        $converted = $this->client->convertFile($request->absolutePath);
+
+        return ExtractionResult::of(
+            $converted['text'],
+            'docling',
+            [
+                'mime' => $request->mime,
+                'ext' => $request->ext,
+                'file' => basename($request->absolutePath),
+                'pages' => $converted['pages'],
+            ],
+            '' !== $converted['markdown'] ? $converted['markdown'] : null,
+        );
+    }
+
+    public function health(): PlugHealth
+    {
+        return $this->client->health();
+    }
+
+    private function familyAllowed(ExtractionRequest $request): bool
+    {
+        $ext = strtolower($request->ext);
+        if ('document' === $request->family) {
+            return \in_array($ext, self::DOCUMENT_EXT, true) || '' === $ext;
+        }
+        if ('text' === $request->family && \in_array($ext, ['html', 'htm'], true)) {
+            return true;
+        }
+        if ('image' === $request->family) {
+            return \in_array($ext, self::IMAGE_EXT, true);
+        }
+
+        return false;
+    }
+}

--- a/backend/src/Plug/Extraction/Docling/DoclingClient.php
+++ b/backend/src/Plug/Extraction/Docling/DoclingClient.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Plug\Extraction\Docling;
+
+use App\Plug\PlugHealth;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Mime\Part\DataPart;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * Thin HTTP client for docling-serve. No Python in the PHP image.
+ *
+ * GET  {base}/health
+ * POST {base}/v1/convert/file  multipart files + to_formats=md,text
+ */
+final class DoclingClient
+{
+    private const HEALTH_CACHE_SECONDS = 30;
+
+    private ?PlugHealth $cachedHealth = null;
+    private int $cachedAt = 0;
+
+    public function __construct(
+        private HttpClientInterface $httpClient,
+        private LoggerInterface $logger,
+        private string $baseUrl,
+        private int $timeoutMs,
+    ) {
+    }
+
+    public function isEnabled(): bool
+    {
+        $url = trim($this->baseUrl);
+
+        return '' !== $url && 'disabled' !== strtolower($url);
+    }
+
+    public function health(): PlugHealth
+    {
+        if (null !== $this->cachedHealth && (time() - $this->cachedAt) < self::HEALTH_CACHE_SECONDS) {
+            return $this->cachedHealth;
+        }
+
+        if (!$this->isEnabled()) {
+            return $this->remember(PlugHealth::unavailable('DOCLING_BASE_URL is unset or disabled'));
+        }
+
+        try {
+            $response = $this->httpClient->request('GET', $this->endpoint('/health'), [
+                'timeout' => 5,
+                'headers' => ['Accept' => 'application/json'],
+            ]);
+            $status = $response->getStatusCode();
+            if ($status >= 500) {
+                return $this->remember(PlugHealth::unavailable('Docling health returned HTTP '.$status));
+            }
+            if ($status >= 400) {
+                return $this->remember(PlugHealth::unavailable('Docling health returned HTTP '.$status));
+            }
+
+            return $this->remember(PlugHealth::available());
+        } catch (TransportExceptionInterface $e) {
+            return $this->remember(PlugHealth::unavailable($this->transportReason($e)));
+        } catch (\Throwable $e) {
+            return $this->remember(PlugHealth::unavailable($e->getMessage()));
+        }
+    }
+
+    /**
+     * @return array{text: string, markdown: string, pages: int|null}
+     */
+    public function convertFile(string $absolutePath): array
+    {
+        if (!$this->isEnabled()) {
+            throw new DoclingUnavailableException('DOCLING_BASE_URL is unset or disabled');
+        }
+        if (!is_file($absolutePath) || 0 === filesize($absolutePath)) {
+            throw new DoclingUnavailableException('Input file missing or empty');
+        }
+
+        try {
+            $response = $this->httpClient->request('POST', $this->endpoint('/v1/convert/file'), [
+                'timeout' => $this->timeoutMs / 1000,
+                'headers' => [
+                    'Accept' => 'application/json',
+                    'User-Agent' => 'synaplan-docling-client',
+                ],
+                'body' => [
+                    'files' => DataPart::fromPath($absolutePath, basename($absolutePath)),
+                    'to_formats' => 'md',
+                    'do_ocr' => 'true',
+                    'image_export_mode' => 'placeholder',
+                    'table_mode' => 'accurate',
+                ],
+            ]);
+            $status = $response->getStatusCode();
+            if ($status >= 500) {
+                throw new DoclingUnavailableException('Docling convert returned HTTP '.$status);
+            }
+            if ($status >= 400) {
+                throw new DoclingUnavailableException('Docling convert returned HTTP '.$status);
+            }
+
+            $payload = $response->toArray(false);
+        } catch (DoclingUnavailableException $e) {
+            throw $e;
+        } catch (TransportExceptionInterface $e) {
+            throw new DoclingUnavailableException($this->transportReason($e), $e);
+        } catch (\Throwable $e) {
+            throw new DoclingUnavailableException($e->getMessage(), $e);
+        }
+
+        $document = is_array($payload['document'] ?? null) ? $payload['document'] : [];
+        $markdown = is_string($document['md_content'] ?? null) ? $document['md_content'] : '';
+        $text = is_string($document['text_content'] ?? null) ? $document['text_content'] : '';
+        if ('' === $text) {
+            $text = $markdown;
+        }
+
+        $pages = $document['pages'] ?? $payload['pages'] ?? null;
+        $pageCount = is_int($pages) ? $pages : (is_array($pages) ? count($pages) : null);
+
+        $this->logger->info('Docling: convert succeeded', [
+            'file' => basename($absolutePath),
+            'bytes' => strlen($text),
+            'markdown' => '' !== $markdown,
+        ]);
+
+        return [
+            'text' => $text,
+            'markdown' => $markdown,
+            'pages' => $pageCount,
+        ];
+    }
+
+    private function endpoint(string $path): string
+    {
+        return rtrim($this->baseUrl, '/').$path;
+    }
+
+    private function remember(PlugHealth $health): PlugHealth
+    {
+        $this->cachedHealth = $health;
+        $this->cachedAt = time();
+
+        return $health;
+    }
+
+    private function transportReason(TransportExceptionInterface $e): string
+    {
+        $message = $e->getMessage();
+        if (str_contains(strtolower($message), 'timed out') || str_contains(strtolower($message), 'timeout')) {
+            return 'Docling request timed out';
+        }
+        if (str_contains(strtolower($message), 'refused') || str_contains(strtolower($message), 'could not resolve')) {
+            return 'Docling unavailable — connection refused';
+        }
+
+        return 'Docling unavailable: '.$message;
+    }
+}

--- a/backend/src/Plug/Extraction/Docling/DoclingUnavailableException.php
+++ b/backend/src/Plug/Extraction/Docling/DoclingUnavailableException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Plug\Extraction\Docling;
+
+final class DoclingUnavailableException extends \RuntimeException
+{
+    public function __construct(string $message, ?\Throwable $previous = null)
+    {
+        parent::__construct($message, 0, $previous);
+    }
+}

--- a/backend/src/Plug/Extraction/ExtractionAdminService.php
+++ b/backend/src/Plug/Extraction/ExtractionAdminService.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Plug\Extraction;
+
+use App\Plug\PlugConfigService;
+
+/**
+ * Status + chain writes for the admin Extraction tab.
+ */
+final readonly class ExtractionAdminService
+{
+    private const BUILTIN_LABELS = [
+        'native' => 'Native text',
+        'structured_office' => 'Structured Office',
+        'office_convert' => 'Office convert',
+        'tika' => 'Apache Tika',
+        'pdf_vision' => 'PDF vision fallback',
+        'vision' => 'Vision',
+        'stt_cloud' => 'Cloud speech-to-text',
+        'whisper_local' => 'Local Whisper',
+        'video_analysis' => 'Video analysis',
+    ];
+
+    public function __construct(
+        private ExtractionRegistry $registry,
+        private PlugConfigService $plugConfig,
+        private ExtractionProbeService $probe,
+    ) {
+    }
+
+    /**
+     * @return array{
+     *     adapters: list<array{key: string, label: string, docsUrl: string, sovereignty: string, health: array{available: bool, reason: string|null}}>,
+     *     chains: array<string, list<string>>,
+     *     quality: array{minLength: int, minEntropy: float, applyTo: list<string>}
+     * }
+     */
+    public function status(): array
+    {
+        return [
+            'adapters' => $this->adapters(),
+            'chains' => $this->plugConfig->allChains(),
+            'quality' => [
+                'minLength' => $this->plugConfig->qualityMinLength(),
+                'minEntropy' => $this->plugConfig->qualityMinEntropy(),
+                'applyTo' => $this->plugConfig->qualityApplyTo(),
+            ],
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $chains
+     *
+     * @return array{
+     *     adapters: list<array{key: string, label: string, docsUrl: string, sovereignty: string, health: array{available: bool, reason: string|null}}>,
+     *     chains: array<string, list<string>>,
+     *     quality: array{minLength: int, minEntropy: float, applyTo: list<string>}
+     * }
+     */
+    public function setChains(array $chains): array
+    {
+        $this->plugConfig->setChains($chains, $this->plugConfig->knownExtractorKeys($this->registry));
+
+        return $this->status();
+    }
+
+    /**
+     * @return array{
+     *     winner: string|null,
+     *     strategy: string,
+     *     attempts: list<array{key: string, verdict: string, ms: int}>,
+     *     preview: string,
+     *     markdown: bool
+     * }
+     */
+    public function testFile(string $absolutePath, string $originalName): array
+    {
+        return $this->probe->testFile($absolutePath, $originalName);
+    }
+
+    /**
+     * @return list<array{key: string, label: string, docsUrl: string, sovereignty: string, health: array{available: bool, reason: string|null}}>
+     */
+    private function adapters(): array
+    {
+        $seen = [];
+        $out = [];
+
+        foreach (PlugConfigService::BUILTIN_EXTRACTOR_KEYS as $key) {
+            $adapter = $this->registry->byKey($key);
+            $out[] = null !== $adapter ? $this->serializeAdapter($adapter) : [
+                'key' => $key,
+                'label' => self::BUILTIN_LABELS[$key],
+                'docsUrl' => '',
+                'sovereignty' => 'built-in',
+                'health' => ['available' => true, 'reason' => null],
+            ];
+            $seen[$key] = true;
+        }
+
+        foreach ($this->registry->all() as $adapter) {
+            if (isset($seen[$adapter->key()])) {
+                continue;
+            }
+            $out[] = $this->serializeAdapter($adapter);
+        }
+
+        return $out;
+    }
+
+    /**
+     * @return array{key: string, label: string, docsUrl: string, sovereignty: string, health: array{available: bool, reason: string|null}}
+     */
+    private function serializeAdapter(ContentExtractorInterface $adapter): array
+    {
+        $descriptor = $adapter->descriptor();
+        $health = $adapter->health();
+
+        return [
+            'key' => $adapter->key(),
+            'label' => $descriptor->label,
+            'docsUrl' => $descriptor->docsUrl,
+            'sovereignty' => $descriptor->sovereignty,
+            'health' => [
+                'available' => $health->available,
+                'reason' => $health->reason,
+            ],
+        ];
+    }
+}

--- a/backend/src/Plug/Extraction/ExtractionProbeService.php
+++ b/backend/src/Plug/Extraction/ExtractionProbeService.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Plug\Extraction;
+
+use App\Plug\PlugConfigService;
+use App\Service\File\FileProcessor;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+/**
+ * Walks extra extractors (then FileProcessor) so the admin Test button can
+ * show every attempt: "Docling unavailable — Tika used instead".
+ */
+final readonly class ExtractionProbeService
+{
+    public function __construct(
+        private ExtractionRegistry $registry,
+        private PlugConfigService $plugConfig,
+        private ExtractionQualityGate $qualityGate,
+        private FileProcessor $fileProcessor,
+        private LoggerInterface $logger,
+        #[Autowire('%kernel.project_dir%/var/uploads')]
+        private string $uploadDir,
+    ) {
+    }
+
+    /**
+     * @return array{
+     *     winner: string|null,
+     *     strategy: string,
+     *     attempts: list<array{key: string, verdict: string, ms: int}>,
+     *     preview: string,
+     *     markdown: bool
+     * }
+     */
+    public function testFile(string $absolutePath, string $originalName): array
+    {
+        $ext = strtolower(pathinfo($originalName, PATHINFO_EXTENSION));
+        $mime = mime_content_type($absolutePath) ?: '';
+        $family = ExtractionRequest::familyFrom($mime, $ext);
+        $request = new ExtractionRequest($absolutePath, $originalName, $mime, $ext, null, false, $family);
+
+        $attempts = [];
+        $winnerResult = null;
+        $winnerKey = null;
+
+        foreach ($this->plugConfig->extraExtractorKeys($family) as $key) {
+            $adapter = $this->registry->byKey($key);
+            $started = hrtime(true);
+            if (null === $adapter) {
+                $attempts[] = ['key' => $key, 'verdict' => 'unknown', 'ms' => 0];
+                continue;
+            }
+
+            $verdict = 'skipped';
+            try {
+                if (!$adapter->supports($request)) {
+                    $health = $adapter->health();
+                    $verdict = $health->available ? 'unsupported' : 'unavailable';
+                } else {
+                    $result = $adapter->extract($request);
+                    $gate = $this->qualityGate->verdict($result, $request);
+                    $verdict = $gate->reason;
+                    if ($gate->passed && ($result->hasText() || (null !== $result->markdown && '' !== trim($result->markdown)))) {
+                        $winnerResult = $result;
+                        $winnerKey = $key;
+                    }
+                }
+            } catch (\Throwable $e) {
+                $this->logger->info('ExtractionProbe: extra extractor failed', [
+                    'key' => $key,
+                    'error' => $e->getMessage(),
+                ]);
+                $verdict = 'unavailable';
+            }
+            $attempts[] = [
+                'key' => $key,
+                'verdict' => $verdict,
+                'ms' => (int) ((hrtime(true) - $started) / 1_000_000),
+            ];
+            if (null !== $winnerResult) {
+                break;
+            }
+        }
+
+        if (null === $winnerResult) {
+            $relative = 'plugs-probe-'.bin2hex(random_bytes(8)).('' !== $ext ? '.'.$ext : '');
+            $dest = rtrim($this->uploadDir, '/').'/'.$relative;
+            if (!is_dir(\dirname($dest)) && !mkdir(\dirname($dest), 0775, true) && !is_dir(\dirname($dest))) {
+                throw new \RuntimeException('Unable to create upload directory for extraction probe');
+            }
+            if (!copy($absolutePath, $dest)) {
+                throw new \RuntimeException('Unable to stage file for extraction probe');
+            }
+            $started = hrtime(true);
+            try {
+                [$text, $meta] = $this->fileProcessor->extractText($relative, $ext);
+                $strategy = \is_string($meta['strategy'] ?? null) ? $meta['strategy'] : 'unknown';
+                $attempts[] = [
+                    'key' => $strategy,
+                    'verdict' => '' !== trim($text) ? 'quality_ok' : 'empty',
+                    'ms' => (int) ((hrtime(true) - $started) / 1_000_000),
+                ];
+                $markdown = \is_string($meta['markdown'] ?? null) ? $meta['markdown'] : null;
+                $winnerKey = $strategy;
+                $winnerResult = ExtractionResult::of($text, $strategy, $meta, $markdown);
+            } finally {
+                @unlink($dest);
+            }
+        }
+
+        $previewSource = $winnerResult->markdown ?: $winnerResult->text;
+
+        return [
+            'winner' => $winnerKey,
+            'strategy' => $winnerResult->strategy,
+            'attempts' => $attempts,
+            'preview' => mb_substr($previewSource, 0, 2000),
+            'markdown' => null !== $winnerResult->markdown && '' !== $winnerResult->markdown,
+        ];
+    }
+}

--- a/backend/src/Plug/Extraction/ExtractionQualityGate.php
+++ b/backend/src/Plug/Extraction/ExtractionQualityGate.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Plug\Extraction;
+
+use App\Plug\PlugConfigService;
+use App\Service\File\TextCleaner;
+
+/**
+ * Generalizes FileProcessor's PDF {@see TextCleaner::isLowQuality()} check.
+ * Families in EXTRACTION.QUALITY.apply_to (seeded `pdf`) must meet
+ * min_length / min_entropy; a markdown result with a table or heading
+ * still passes (table-heavy pages are legitimately repetitive).
+ */
+final readonly class ExtractionQualityGate
+{
+    public function __construct(
+        private PlugConfigService $plugConfig,
+        private TextCleaner $textCleaner,
+    ) {
+    }
+
+    public function verdict(ExtractionResult $result, ExtractionRequest $request): GateVerdict
+    {
+        if ('' === trim($result->text) && (null === $result->markdown || '' === trim($result->markdown))) {
+            return GateVerdict::fail('empty');
+        }
+
+        if (!$this->appliesTo($request)) {
+            return GateVerdict::pass('not_applicable');
+        }
+
+        $text = '' !== trim($result->text) ? $result->text : (string) $result->markdown;
+        $lowQuality = $this->textCleaner->isLowQuality(
+            $text,
+            $this->plugConfig->qualityMinLength(),
+            $this->plugConfig->qualityMinEntropy(),
+        );
+        if (!$lowQuality) {
+            return GateVerdict::pass('quality_ok');
+        }
+
+        $markdown = $result->markdown ?? '';
+        if ('' !== $markdown && $this->hasTableOrHeading($markdown)) {
+            return GateVerdict::pass('markdown_structure');
+        }
+
+        return GateVerdict::fail('low_quality');
+    }
+
+    private function appliesTo(ExtractionRequest $request): bool
+    {
+        $ext = strtolower($request->ext);
+        $mime = strtolower($request->mime);
+        foreach ($this->plugConfig->qualityApplyTo() as $token) {
+            if ($token === $ext || $token === $request->family) {
+                return true;
+            }
+            if ('pdf' === $token && ('pdf' === $ext || str_contains($mime, 'pdf'))) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function hasTableOrHeading(string $markdown): bool
+    {
+        foreach (preg_split("/\r\n|\n|\r/", $markdown) ?: [] as $line) {
+            $trim = ltrim($line);
+            if (str_starts_with($trim, '|')) {
+                return true;
+            }
+            if (1 === preg_match('/^#{1,6}\s+\S/', $trim)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/backend/src/Plug/Extraction/ExtractionResult.php
+++ b/backend/src/Plug/Extraction/ExtractionResult.php
@@ -54,6 +54,22 @@ final readonly class ExtractionResult
     }
 
     /**
+     * @param ExtractionMeta $meta
+     */
+    public function withMeta(array $meta): self
+    {
+        return new self(
+            $this->text,
+            $this->markdown,
+            $this->strategy,
+            $meta,
+            $this->pages,
+            $this->rewrittenAbsolutePath,
+            $this->rewrittenExt,
+        );
+    }
+
+    /**
      * FileProcessor::extractText return shape: [text, meta].
      *
      * @return array{0: string, 1: array<string, mixed>}

--- a/backend/src/Plug/Extraction/GateVerdict.php
+++ b/backend/src/Plug/Extraction/GateVerdict.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Plug\Extraction;
+
+/**
+ * Quality-gate outcome for one extraction attempt. Stored in meta.gate.
+ */
+final readonly class GateVerdict
+{
+    public function __construct(
+        public bool $passed,
+        public string $reason,
+    ) {
+    }
+
+    public static function pass(string $reason): self
+    {
+        return new self(true, $reason);
+    }
+
+    public static function fail(string $reason): self
+    {
+        return new self(false, $reason);
+    }
+
+    /**
+     * @return array{passed: bool, reason: string}
+     */
+    public function toArray(): array
+    {
+        return [
+            'passed' => $this->passed,
+            'reason' => $this->reason,
+        ];
+    }
+}

--- a/backend/src/Plug/PlugConfigService.php
+++ b/backend/src/Plug/PlugConfigService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Plug;
 
+use App\Plug\Extraction\ExtractionRegistry;
 use App\Repository\ConfigRepository;
 
 /**
@@ -26,6 +27,7 @@ final readonly class PlugConfigService
     public const KEY_CHAIN_VIDEO = 'EXTRACTION.CHAIN.video';
     public const KEY_QUALITY_MIN_LENGTH = 'EXTRACTION.QUALITY.min_length';
     public const KEY_QUALITY_MIN_ENTROPY = 'EXTRACTION.QUALITY.min_entropy';
+    public const KEY_QUALITY_APPLY_TO = 'EXTRACTION.QUALITY.apply_to';
     public const KEY_WEB_SEARCH_PROVIDER = 'WEB_SEARCH.PROVIDER';
     public const KEY_WEB_SEARCH_FALLBACK = 'WEB_SEARCH.FALLBACK';
     public const KEY_RERANK_ENABLED = 'RERANK.ENABLED';
@@ -40,6 +42,10 @@ final readonly class PlugConfigService
     public const DEFAULT_CHAIN_VIDEO = 'video_analysis';
     public const DEFAULT_MIN_LENGTH = 10;
     public const DEFAULT_MIN_ENTROPY = 3.0;
+    public const DEFAULT_QUALITY_APPLY_TO = 'pdf';
+
+    /** @var list<string> */
+    public const FAMILIES = ['text', 'document', 'image', 'audio', 'audio_no_cloud', 'video'];
     public const DEFAULT_WEB_SEARCH_PROVIDER = 'brave';
     public const DEFAULT_RERANK_ENABLED = false;
     public const DEFAULT_RERANK_MULTIPLIER = 4;
@@ -117,6 +123,101 @@ final readonly class PlugConfigService
     public function qualityMinEntropy(): float
     {
         return $this->readFloat(self::KEY_QUALITY_MIN_ENTROPY, self::DEFAULT_MIN_ENTROPY);
+    }
+
+    /**
+     * Extensions / families the quality gate applies to. Seeded `pdf`.
+     *
+     * @return list<string>
+     */
+    public function qualityApplyTo(): array
+    {
+        return $this->splitList($this->readGlobal(self::KEY_QUALITY_APPLY_TO, self::DEFAULT_QUALITY_APPLY_TO));
+    }
+
+    /**
+     * @return array<string, list<string>>
+     */
+    public function allChains(): array
+    {
+        return [
+            'text' => $this->extractionChain('text'),
+            'document' => $this->extractionChain('document'),
+            'image' => $this->extractionChain('image'),
+            'audio' => $this->extractionChain('audio', true),
+            'audio_no_cloud' => $this->extractionChain('audio', false),
+            'video' => $this->extractionChain('video'),
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function knownExtractorKeys(ExtractionRegistry $registry): array
+    {
+        $keys = self::BUILTIN_EXTRACTOR_KEYS;
+        foreach ($registry->all() as $adapter) {
+            $keys[] = $adapter->key();
+        }
+
+        return array_values(array_unique($keys));
+    }
+
+    /**
+     * Persist one family's adapter order. Unknown family or key → InvalidArgumentException.
+     *
+     * @param list<mixed>  $keys
+     * @param list<string> $knownKeys
+     */
+    public function setChain(string $family, array $keys, array $knownKeys): void
+    {
+        $setting = $this->chainSetting($family);
+        $normalized = [];
+        foreach ($keys as $key) {
+            if (!\is_string($key)) {
+                throw new \InvalidArgumentException('Extractor keys must be strings');
+            }
+            $trimmed = strtolower(trim($key));
+            if ('' === $trimmed) {
+                continue;
+            }
+            if (!\in_array($trimmed, $knownKeys, true)) {
+                throw new \InvalidArgumentException('Unknown extractor key: '.$trimmed);
+            }
+            $normalized[] = $trimmed;
+        }
+
+        $this->configRepository->setValue(0, self::CONFIG_GROUP, $setting, implode(',', $normalized));
+    }
+
+    /**
+     * @param array<mixed, mixed> $chains
+     * @param list<string>        $knownKeys
+     */
+    public function setChains(array $chains, array $knownKeys): void
+    {
+        foreach ($chains as $family => $keys) {
+            if (!\is_string($family)) {
+                throw new \InvalidArgumentException('Unknown extraction family');
+            }
+            if (!\is_array($keys)) {
+                throw new \InvalidArgumentException('Chain for '.$family.' must be a list of keys');
+            }
+            $this->setChain($family, $keys, $knownKeys);
+        }
+    }
+
+    private function chainSetting(string $family): string
+    {
+        return match ($family) {
+            'text' => self::KEY_CHAIN_TEXT,
+            'document' => self::KEY_CHAIN_DOCUMENT,
+            'image' => self::KEY_CHAIN_IMAGE,
+            'audio' => self::KEY_CHAIN_AUDIO,
+            'audio_no_cloud' => self::KEY_CHAIN_AUDIO_NO_CLOUD,
+            'video' => self::KEY_CHAIN_VIDEO,
+            default => throw new \InvalidArgumentException('Unknown extraction family: '.$family),
+        };
     }
 
     public function webSearchProvider(?int $userId): string

--- a/backend/src/Seed/PlugsConfigSeeder.php
+++ b/backend/src/Seed/PlugsConfigSeeder.php
@@ -44,6 +44,7 @@ final readonly class PlugsConfigSeeder
             ['ownerId' => 0, 'group' => $group, 'setting' => PlugConfigService::KEY_CHAIN_VIDEO, 'value' => PlugConfigService::DEFAULT_CHAIN_VIDEO],
             ['ownerId' => 0, 'group' => $group, 'setting' => PlugConfigService::KEY_QUALITY_MIN_LENGTH, 'value' => (string) PlugConfigService::DEFAULT_MIN_LENGTH],
             ['ownerId' => 0, 'group' => $group, 'setting' => PlugConfigService::KEY_QUALITY_MIN_ENTROPY, 'value' => sprintf('%.1f', PlugConfigService::DEFAULT_MIN_ENTROPY)],
+            ['ownerId' => 0, 'group' => $group, 'setting' => PlugConfigService::KEY_QUALITY_APPLY_TO, 'value' => PlugConfigService::DEFAULT_QUALITY_APPLY_TO],
             ['ownerId' => 0, 'group' => $group, 'setting' => PlugConfigService::KEY_WEB_SEARCH_PROVIDER, 'value' => PlugConfigService::DEFAULT_WEB_SEARCH_PROVIDER],
             ['ownerId' => 0, 'group' => $group, 'setting' => PlugConfigService::KEY_WEB_SEARCH_FALLBACK, 'value' => ''],
             ['ownerId' => 0, 'group' => $group, 'setting' => PlugConfigService::KEY_RERANK_ENABLED, 'value' => '0'],

--- a/backend/src/Service/Admin/SystemConfigService.php
+++ b/backend/src/Service/Admin/SystemConfigService.php
@@ -128,6 +128,7 @@ final readonly class SystemConfigService
                 'label' => 'Processing',
                 'sections' => [
                     'tika' => ['label' => 'Apache Tika', 'fields' => ['TIKA_BASE_URL', 'TIKA_TIMEOUT_MS', 'TIKA_RETRIES', 'TIKA_HTTP_USER', 'TIKA_HTTP_PASS']],
+                    'docling' => ['label' => 'Docling', 'fields' => ['DOCLING_BASE_URL', 'DOCLING_TIMEOUT_MS', 'DOCLING_MAX_BYTES']],
                     'rasterize' => ['label' => 'PDF Rasterizer', 'fields' => ['RASTERIZE_DPI', 'RASTERIZE_PAGE_CAP', 'RASTERIZE_TIMEOUT_MS']],
                     'whisper' => ['label' => 'Whisper (Audio)', 'fields' => ['WHISPER_ENABLED', 'WHISPER_DEFAULT_MODEL']],
                     'brave' => ['label' => 'Web Search (Brave)', 'fields' => ['BRAVE_SEARCH_ENABLED', 'BRAVE_SEARCH_API_KEY', 'BRAVE_SEARCH_COUNT']],
@@ -631,6 +632,7 @@ final readonly class SystemConfigService
         return match ($service) {
             'ollama' => $this->testOllama(),
             'tika' => $this->testTika(),
+            'docling' => $this->testDocling(),
             'qdrant' => $this->testQdrant(),
             'mailer' => $this->testMailer(),
             'piper' => $this->testPiperTts(),
@@ -854,6 +856,37 @@ final readonly class SystemConfigService
             }
 
             return ['success' => false, 'message' => 'Tika returned HTTP '.$httpCode];
+        } catch (\Throwable $e) {
+            return ['success' => false, 'message' => 'Connection failed: '.$e->getMessage()];
+        }
+    }
+
+    /**
+     * @return array{success: bool, message: string, details?: array<string, mixed>}
+     */
+    private function testDocling(): array
+    {
+        $url = $this->getEnvValue('DOCLING_BASE_URL');
+        if (!$url || 'disabled' === strtolower($url)) {
+            return ['success' => false, 'message' => 'DOCLING_BASE_URL not configured'];
+        }
+
+        try {
+            $ch = curl_init(rtrim($url, '/').'/health');
+            curl_setopt_array($ch, [
+                CURLOPT_RETURNTRANSFER => true,
+                CURLOPT_TIMEOUT => 5,
+                CURLOPT_CONNECTTIMEOUT => 3,
+            ]);
+            $response = curl_exec($ch);
+            $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+            curl_close($ch);
+
+            if (200 === $httpCode) {
+                return ['success' => true, 'message' => 'Connected to Docling'];
+            }
+
+            return ['success' => false, 'message' => 'Docling returned HTTP '.$httpCode];
         } catch (\Throwable $e) {
             return ['success' => false, 'message' => 'Connection failed: '.$e->getMessage()];
         }
@@ -1893,6 +1926,22 @@ final readonly class SystemConfigService
                 'tab' => 'processing', 'section' => 'tika', 'type' => 'password',
                 'sensitive' => true, 'description' => 'HTTP auth password',
                 'default' => '',
+            ],
+            'DOCLING_BASE_URL' => [
+                'tab' => 'processing', 'section' => 'docling', 'type' => 'url',
+                'sensitive' => false, 'description' => 'Docling serve URL (empty = off)',
+                'default' => '',
+                'placeholder' => 'http://docling:5001',
+            ],
+            'DOCLING_TIMEOUT_MS' => [
+                'tab' => 'processing', 'section' => 'docling', 'type' => 'number',
+                'sensitive' => false, 'description' => 'Request timeout (ms)',
+                'default' => '120000',
+            ],
+            'DOCLING_MAX_BYTES' => [
+                'tab' => 'processing', 'section' => 'docling', 'type' => 'number',
+                'sensitive' => false, 'description' => 'Max file size (bytes)',
+                'default' => '52428800',
             ],
             'RASTERIZE_DPI' => [
                 'tab' => 'processing', 'section' => 'rasterize', 'type' => 'number',

--- a/backend/src/Service/File/FileProcessor.php
+++ b/backend/src/Service/File/FileProcessor.php
@@ -4,8 +4,10 @@ namespace App\Service\File;
 
 use App\AI\Exception\ProviderException;
 use App\AI\Service\AiFacade;
+use App\Plug\Extraction\ExtractionQualityGate;
 use App\Plug\Extraction\ExtractionRegistry;
 use App\Plug\Extraction\ExtractionRequest;
+use App\Plug\Extraction\ExtractionResult;
 use App\Plug\PlugConfigService;
 use App\Service\File\Office\OfficeConverterClient;
 use App\Service\File\Office\StructuredTextExtractor;
@@ -128,6 +130,7 @@ final readonly class FileProcessor
         private ?StructuredTextExtractor $structuredTextExtractor = null,
         private ?ExtractionRegistry $extractionRegistry = null,
         private ?PlugConfigService $plugConfig = null,
+        private ?ExtractionQualityGate $qualityGate = null,
     ) {
     }
 
@@ -237,11 +240,23 @@ final readonly class FileProcessor
             try {
                 $result = $adapter->extract($request);
             } catch (\Throwable $e) {
-                $this->logger->warning('FileProcessor: extra extractor failed, falling through', [
+                $this->logger->info('FileProcessor: extra extractor failed, falling through', [
                     'key' => $key,
                     'error' => $e->getMessage(),
                 ]);
                 continue;
+            }
+
+            if (null !== $this->qualityGate) {
+                $verdict = $this->qualityGate->verdict($result, $request);
+                $result = $result->withMeta(array_merge($result->meta, ['gate' => $verdict->toArray()]));
+                if (!$verdict->passed) {
+                    $this->logger->info('FileProcessor: extra extractor lost quality gate', [
+                        'key' => $key,
+                        'reason' => $verdict->reason,
+                    ]);
+                    continue;
+                }
             }
 
             if ($result->hasText()) {
@@ -251,6 +266,20 @@ final readonly class FileProcessor
                 ]);
 
                 return $result->toLegacyPair();
+            }
+
+            if (null !== $result->markdown && '' !== trim($result->markdown)) {
+                $this->logger->info('FileProcessor: extra extractor succeeded', [
+                    'key' => $key,
+                    'strategy' => $result->strategy,
+                ]);
+
+                return ExtractionResult::of(
+                    $result->markdown,
+                    $result->strategy,
+                    $result->meta,
+                    $result->markdown,
+                )->toLegacyPair();
             }
         }
 
@@ -387,11 +416,27 @@ final readonly class FileProcessor
         if (is_string($tikaText)) {
             $tikaText = $this->textCleaner->clean($tikaText);
             $isPdf = $this->isPdfMime($mime) || 'pdf' === $ext;
+            $tikaMeta = is_array($tikaMeta) ? $tikaMeta : [];
 
-            // Check quality for PDFs
-            $lowQuality = $isPdf
-                ? $this->textCleaner->isLowQuality($tikaText, $this->tikaMinLength, $this->tikaMinEntropy)
-                : false;
+            if (null !== $this->qualityGate) {
+                $tikaResult = ExtractionResult::of($tikaText, 'tika', $meta + $tikaMeta);
+                $gateRequest = new ExtractionRequest(
+                    $absolutePath,
+                    $relativePath,
+                    $mime,
+                    $ext,
+                    $userId,
+                    $describe,
+                    $this->detectFamily($mime, $ext),
+                );
+                $verdict = $this->qualityGate->verdict($tikaResult, $gateRequest);
+                $meta['gate'] = $verdict->toArray();
+                $lowQuality = !$verdict->passed;
+            } else {
+                $lowQuality = $isPdf
+                    ? $this->textCleaner->isLowQuality($tikaText, $this->tikaMinLength, $this->tikaMinEntropy)
+                    : false;
+            }
 
             if (mb_strlen(trim($tikaText)) > 0 && !$lowQuality) {
                 $this->logger->info('FileProcessor: Tika extraction success', [
@@ -443,8 +488,15 @@ final readonly class FileProcessor
             [$tikaText, $tikaMeta] = $this->tikaClient->extractText($pdf, 'application/pdf');
             if (is_string($tikaText)) {
                 $tikaText = $this->textCleaner->clean($tikaText);
-                if (mb_strlen(trim($tikaText)) > 0
-                    && !$this->textCleaner->isLowQuality($tikaText, $this->tikaMinLength, $this->tikaMinEntropy)) {
+                $usable = mb_strlen(trim($tikaText)) > 0;
+                if ($usable && null !== $this->qualityGate) {
+                    $tmp = ExtractionResult::of($tikaText, 'tika_office_pdf', $meta);
+                    $req = new ExtractionRequest($pdf, '', 'application/pdf', 'pdf', $userId, false, 'document');
+                    $usable = $this->qualityGate->verdict($tmp, $req)->passed;
+                } elseif ($usable) {
+                    $usable = !$this->textCleaner->isLowQuality($tikaText, $this->tikaMinLength, $this->tikaMinEntropy);
+                }
+                if ($usable) {
                     $this->logger->info('FileProcessor: Tika extraction after office→PDF convert', [
                         'strategy' => 'tika_office_pdf',
                         'bytes' => strlen($tikaText),

--- a/backend/src/Service/File/FileUploadService.php
+++ b/backend/src/Service/File/FileUploadService.php
@@ -291,7 +291,15 @@ final readonly class FileUploadService
 
         $extractedText = $file->getFileText();
         if (in_array($processLevel, ['vectorize', 'full'], true) && '' !== trim($extractedText)) {
-            $result = $this->vectorize($file, $extractedText, $user, $groupKey, $fileExtension, $result);
+            $result = $this->vectorize(
+                $file,
+                $extractedText,
+                $user,
+                $groupKey,
+                $fileExtension,
+                $result,
+                is_string($result['extraction_markdown'] ?? null) ? $result['extraction_markdown'] : null,
+            );
 
             // Delete-after-embed (CORE-4): when the caller does not want the
             // binary retained, drop it once vectors exist. We keep the row, the
@@ -464,6 +472,7 @@ final readonly class FileUploadService
 
             $result['extracted_text_length'] = strlen($extractedText);
             $result['extraction_strategy'] = $extractMeta['strategy'] ?? 'unknown';
+            $result['extraction_markdown'] = $this->markdownFromMeta($extractMeta);
 
             if ('extract' === $processLevel) {
                 return $result;
@@ -490,6 +499,7 @@ final readonly class FileUploadService
         ?string $groupKey,
         string $fileExtension,
         array $result,
+        ?string $markdown = null,
     ): array {
         try {
             $vectorResult = $this->vectorizationService->vectorizeAndStore(
@@ -498,6 +508,7 @@ final readonly class FileUploadService
                 $file->getId(),
                 $groupKey ?? '',
                 FileHelper::getFileTypeCode($fileExtension),
+                $markdown,
             );
 
             if ($vectorResult['success']) {
@@ -550,6 +561,7 @@ final readonly class FileUploadService
         }
 
         $fileExtension = strtolower($file->getFileType() ?: (string) pathinfo($file->getFilePath(), PATHINFO_EXTENSION));
+        $asyncMarkdown = null;
 
         if ('uploaded' === $file->getStatus()) {
             $file->setStatus('extracting');
@@ -561,6 +573,7 @@ final readonly class FileUploadService
                     $fileExtension,
                     $user->getId(),
                 );
+                $asyncMarkdown = $this->markdownFromMeta($extractMeta);
 
                 $file->setFileText($extractedText);
                 $file->setStatus('extracted');
@@ -617,6 +630,7 @@ final readonly class FileUploadService
                 $file->getId(),
                 $groupKey,
                 FileHelper::getFileTypeCode($fileExtension),
+                $asyncMarkdown,
             );
 
             if ($vectorResult['success']) {
@@ -673,6 +687,7 @@ final readonly class FileUploadService
             $file->getFileName() ?: '',
             $file->getFilePath() ?: '',
         );
+        $markdown = null;
 
         if ('' === trim($extractedText)) {
             $absolutePath = $this->uploadDir.'/'.ltrim($file->getFilePath(), '/');
@@ -681,7 +696,8 @@ final readonly class FileUploadService
             }
 
             try {
-                [$extractedText] = $this->fileProcessor->extractText($file->getFilePath(), $fileExtension, $user->getId());
+                [$extractedText, $extractMeta] = $this->fileProcessor->extractText($file->getFilePath(), $fileExtension, $user->getId());
+                $markdown = $this->markdownFromMeta($extractMeta);
                 $file->setFileText($extractedText);
                 $file->setStatus('extracted');
                 $this->em->flush();
@@ -701,6 +717,7 @@ final readonly class FileUploadService
                 $file->getId(),
                 $groupKey,
                 FileHelper::getFileTypeCode($fileExtension),
+                $markdown,
             );
 
             if ($vectorResult['success']) {
@@ -771,16 +788,18 @@ final readonly class FileUploadService
         // synthesized script into BFILETEXT). Re-running Whisper/Tika would
         // either fail or overwrite that with duration metadata.
         $existingText = trim($file->getFileText());
+        $markdown = null;
         if ('audio' === $category && '' !== $existingText) {
             $extractedText = $file->getFileText();
         } else {
             try {
-                [$extractedText] = $this->fileProcessor->extractText(
+                [$extractedText, $extractMeta] = $this->fileProcessor->extractText(
                     $file->getFilePath(),
                     $fileExtension,
                     $user->getId(),
                     $file->isMedia(),
                 );
+                $markdown = $this->markdownFromMeta($extractMeta);
             } catch (\Throwable $e) {
                 $file->setStatus('error');
                 $this->em->flush();
@@ -823,6 +842,7 @@ final readonly class FileUploadService
                 (int) $file->getId(),
                 $groupKey,
                 FileHelper::getFileTypeCode($fileExtension),
+                $markdown,
             );
         } catch (\Throwable $e) {
             $file->setStatus('extracted');
@@ -914,5 +934,15 @@ final readonly class FileUploadService
             'chunksCreated' => $vectorResult['chunks_created'],
             'groupKey' => $groupKey,
         ];
+    }
+
+    /**
+     * @param array<string, mixed> $meta
+     */
+    private function markdownFromMeta(array $meta): ?string
+    {
+        $markdown = $meta['markdown'] ?? null;
+
+        return \is_string($markdown) && '' !== $markdown ? $markdown : null;
     }
 }

--- a/backend/src/Service/File/TextChunker.php
+++ b/backend/src/Service/File/TextChunker.php
@@ -189,7 +189,14 @@ final readonly class TextChunker
         }
         $content = '' !== $prefix ? $prefix."\n\n".$trimmed : $trimmed;
         if (strlen($content) < $this->minChunkSize && [] !== $chunks) {
-            return;
+            $last = count($chunks) - 1;
+            $merged = $chunks[$last]['content']."\n\n".$content;
+            if (strlen($merged) <= $this->maxChunkSize) {
+                $chunks[$last]['content'] = $merged;
+                $chunks[$last]['end_line'] = $endLine;
+
+                return;
+            }
         }
         $chunks[] = [
             'content' => $content,

--- a/backend/src/Service/File/TextChunker.php
+++ b/backend/src/Service/File/TextChunker.php
@@ -99,6 +99,247 @@ final readonly class TextChunker
     }
 
     /**
+     * Split markdown into heading-aware chunks. Same return shape as chunkify().
+     * Headings `#`–`###` start a new section; each chunk is prefixed with a
+     * breadcrumb (`Report › Q3`). Tables stay together unless larger than
+     * maxChunkSize, in which case they split by row with the header repeated.
+     *
+     * @return list<array{content: string, start_line: int, end_line: int}>
+     */
+    public function chunkifyMarkdown(string $markdown): array
+    {
+        if ('' === $markdown) {
+            return [];
+        }
+
+        $normalized = str_replace(["\r\n", "\r"], "\n", $markdown);
+        $lines = explode("\n", $normalized);
+        $blocks = $this->parseMarkdownBlocks($lines);
+
+        $headingByLevel = [];
+        $chunks = [];
+        $currentBody = '';
+        $chunkStartLine = 0;
+        $chunkEndLine = 0;
+        $currentPrefix = '';
+
+        foreach ($blocks as $block) {
+            if ('heading' === $block['type']) {
+                $this->flushMarkdownChunk($chunks, $currentPrefix, $currentBody, $chunkStartLine, $chunkEndLine);
+                $currentBody = '';
+                $level = $block['level'];
+                foreach (array_keys($headingByLevel) as $lvl) {
+                    if ($lvl >= $level) {
+                        unset($headingByLevel[$lvl]);
+                    }
+                }
+                $headingByLevel[$level] = $block['title'];
+                ksort($headingByLevel);
+                $currentPrefix = implode(' › ', array_values($headingByLevel));
+                $chunkStartLine = $block['start'];
+                $chunkEndLine = $block['end'];
+                continue;
+            }
+
+            if ('table' === $block['type']) {
+                $this->flushMarkdownChunk($chunks, $currentPrefix, $currentBody, $chunkStartLine, $chunkEndLine);
+                $currentBody = '';
+                foreach ($this->chunkMarkdownTable($block, $currentPrefix) as $piece) {
+                    $chunks[] = $piece;
+                }
+                continue;
+            }
+
+            foreach ($block['lines'] as $i => $line) {
+                $lineNum = $block['start'] + $i;
+                $candidate = '' === $currentBody ? $line : $currentBody."\n".$line;
+                $prefixed = '' !== $currentPrefix ? $currentPrefix."\n\n".$candidate : $candidate;
+                if (strlen($prefixed) > $this->maxChunkSize && '' !== $currentBody) {
+                    $this->flushMarkdownChunk($chunks, $currentPrefix, $currentBody, $chunkStartLine, $chunkEndLine);
+                    $currentBody = $line;
+                    $chunkStartLine = $lineNum;
+                } else {
+                    if ('' === $currentBody) {
+                        $chunkStartLine = $lineNum;
+                    }
+                    $currentBody = $candidate;
+                }
+                $chunkEndLine = $lineNum;
+            }
+        }
+
+        $this->flushMarkdownChunk($chunks, $currentPrefix, $currentBody, $chunkStartLine, $chunkEndLine);
+
+        return $chunks;
+    }
+
+    /**
+     * @param list<array{content: string, start_line: int, end_line: int}> $chunks
+     */
+    private function flushMarkdownChunk(
+        array &$chunks,
+        string $prefix,
+        string $body,
+        int $startLine,
+        int $endLine,
+    ): void {
+        $trimmed = trim($body);
+        if ('' === $trimmed) {
+            return;
+        }
+        $content = '' !== $prefix ? $prefix."\n\n".$trimmed : $trimmed;
+        if (strlen($content) < $this->minChunkSize && [] !== $chunks) {
+            return;
+        }
+        $chunks[] = [
+            'content' => $content,
+            'start_line' => $startLine,
+            'end_line' => $endLine,
+        ];
+    }
+
+    /**
+     * @param list<string> $lines
+     *
+     * @return list<array{type: string, lines: list<string>, start: int, end: int, level?: int, title?: string}>
+     */
+    private function parseMarkdownBlocks(array $lines): array
+    {
+        $blocks = [];
+        $i = 0;
+        $n = count($lines);
+        while ($i < $n) {
+            $heading = $this->matchMarkdownHeading($lines[$i]);
+            if (null !== $heading) {
+                $blocks[] = [
+                    'type' => 'heading',
+                    'level' => $heading['level'],
+                    'title' => $heading['title'],
+                    'lines' => [$lines[$i]],
+                    'start' => $i,
+                    'end' => $i,
+                ];
+                ++$i;
+                continue;
+            }
+            if ($this->isMarkdownTableRow($lines[$i])) {
+                $start = $i;
+                $tableLines = [];
+                while ($i < $n && $this->isMarkdownTableRow($lines[$i])) {
+                    $tableLines[] = $lines[$i];
+                    ++$i;
+                }
+                $blocks[] = [
+                    'type' => 'table',
+                    'lines' => $tableLines,
+                    'start' => $start,
+                    'end' => $i - 1,
+                ];
+                continue;
+            }
+            $start = $i;
+            $para = [];
+            while ($i < $n && null === $this->matchMarkdownHeading($lines[$i]) && !$this->isMarkdownTableRow($lines[$i])) {
+                $para[] = $lines[$i];
+                ++$i;
+            }
+            $blocks[] = [
+                'type' => 'text',
+                'lines' => $para,
+                'start' => $start,
+                'end' => max($start, $i - 1),
+            ];
+        }
+
+        return $blocks;
+    }
+
+    /**
+     * @return array{level: int, title: string}|null
+     */
+    private function matchMarkdownHeading(string $line): ?array
+    {
+        if (1 === preg_match('/^(#{1,3})\s+(.+)$/', trim($line), $matches)) {
+            return ['level' => strlen($matches[1]), 'title' => trim($matches[2])];
+        }
+
+        return null;
+    }
+
+    private function isMarkdownTableRow(string $line): bool
+    {
+        return str_starts_with(ltrim($line), '|');
+    }
+
+    private function isMarkdownTableSeparator(string $line): bool
+    {
+        return 1 === preg_match('/^\|?\s*:?-{3,}:?\s*(\|\s*:?-{3,}:?\s*)+\|?$/', trim($line));
+    }
+
+    /**
+     * @param array{type: string, lines: list<string>, start: int, end: int} $block
+     *
+     * @return list<array{content: string, start_line: int, end_line: int}>
+     */
+    private function chunkMarkdownTable(array $block, string $prefix): array
+    {
+        $lines = $block['lines'];
+        if ([] === $lines) {
+            return [];
+        }
+        $full = implode("\n", $lines);
+        $content = '' !== $prefix ? $prefix."\n\n".$full : $full;
+        if (strlen($content) <= $this->maxChunkSize) {
+            return [[
+                'content' => $content,
+                'start_line' => $block['start'],
+                'end_line' => $block['end'],
+            ]];
+        }
+
+        $hasSep = isset($lines[1]) && $this->isMarkdownTableSeparator($lines[1]);
+        $header = $lines[0];
+        $separator = $hasSep ? $lines[1] : '';
+        $headerBlock = $hasSep ? $header."\n".$separator : $header;
+        $dataStart = $hasSep ? 2 : 1;
+
+        $out = [];
+        $currentRows = [];
+        $rowStart = $block['start'] + $dataStart;
+        $rowEnd = $rowStart;
+
+        $emit = function (array $rows, int $start, int $end) use (&$out, $prefix, $headerBlock): void {
+            if ([] === $rows) {
+                return;
+            }
+            $body = $headerBlock."\n".implode("\n", $rows);
+            $text = '' !== $prefix ? $prefix."\n\n".$body : $body;
+            $out[] = ['content' => $text, 'start_line' => $start, 'end_line' => $end];
+        };
+
+        $n = count($lines);
+        for ($i = $dataStart; $i < $n; ++$i) {
+            $row = $lines[$i];
+            $trial = [] === $currentRows ? [$row] : array_merge($currentRows, [$row]);
+            $trialText = ('' !== $prefix ? $prefix."\n\n" : '').$headerBlock."\n".implode("\n", $trial);
+            if (strlen($trialText) > $this->maxChunkSize && [] !== $currentRows) {
+                $emit($currentRows, $rowStart, $rowEnd);
+                $currentRows = [$row];
+                $rowStart = $block['start'] + $i;
+            } else {
+                if ([] === $currentRows) {
+                    $rowStart = $block['start'] + $i;
+                }
+                $currentRows[] = $row;
+            }
+            $rowEnd = $block['start'] + $i;
+        }
+        $emit($currentRows, $rowStart, $rowEnd);
+
+        return $out;
+    }
+
+    /**
      * Get overlap text from the end of current chunk.
      */
     private function getOverlapText(string $text): string

--- a/backend/src/Service/File/VectorizationService.php
+++ b/backend/src/Service/File/VectorizationService.php
@@ -35,11 +35,12 @@ final readonly class VectorizationService
     /**
      * Vectorize file content and store in RAG database.
      *
-     * @param string $fileText  Extracted text from file
-     * @param int    $userId    User ID
-     * @param int    $messageId Message ID
-     * @param string $groupKey  Custom grouping key (e.g., 'PRODUCTHELP', 'DOWNLOADS')
-     * @param int    $fileType  File type (0=text, 1=image, 2=audio/video, 3=pdf, 4=doc, etc.)
+     * @param string      $fileText  Extracted text from file
+     * @param int         $userId    User ID
+     * @param int         $messageId Message ID
+     * @param string      $groupKey  Custom grouping key (e.g., 'PRODUCTHELP', 'DOWNLOADS')
+     * @param int         $fileType  File type (0=text, 1=image, 2=audio/video, 3=pdf, 4=doc, etc.)
+     * @param string|null $markdown  When set, chunks with {@see TextChunker::chunkifyMarkdown()}
      *
      * @return array ['success' => bool, 'chunks_created' => int, 'error' => string|null, 'provider' => string]
      */
@@ -49,6 +50,7 @@ final readonly class VectorizationService
         int $messageId,
         string $groupKey = 'DEFAULT',
         int $fileType = 0,
+        ?string $markdown = null,
     ): array {
         if (empty($fileText)) {
             $this->logger->warning('VectorizationService: Empty text, skipping', [
@@ -106,8 +108,14 @@ final readonly class VectorizationService
                 'storage_provider' => $this->vectorStorage->getProviderName(),
             ]);
 
-            // Chunk the text
-            $chunks = $this->textChunker->chunkify($fileText);
+            // Chunk the text (markdown path when an extractor returned md)
+            $chunks = [];
+            if (null !== $markdown && '' !== trim($markdown)) {
+                $chunks = $this->textChunker->chunkifyMarkdown($markdown);
+            }
+            if ([] === $chunks) {
+                $chunks = $this->textChunker->chunkify($fileText);
+            }
 
             if (empty($chunks)) {
                 $this->logger->warning('VectorizationService: No chunks created');

--- a/backend/tests/Controller/AdminPlugsExtractionControllerTest.php
+++ b/backend/tests/Controller/AdminPlugsExtractionControllerTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Controller;
+
+use App\Entity\User;
+use App\Tests\Trait\AuthenticatedTestTrait;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpFoundation\Response;
+
+final class AdminPlugsExtractionControllerTest extends WebTestCase
+{
+    use AuthenticatedTestTrait;
+
+    private KernelBrowser $client;
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        self::ensureKernelShutdown();
+        $this->client = static::createClient();
+        $this->em = static::getContainer()->get('doctrine')->getManager();
+    }
+
+    public function testNonAdminIsForbidden(): void
+    {
+        $user = $this->createUser('plugs-extraction-user@synaplan.internal', 'NEW');
+        $this->authenticateClient($this->client, $user);
+        $this->client->request('GET', '/api/v1/admin/plugs/extraction');
+
+        self::assertSame(Response::HTTP_FORBIDDEN, $this->client->getResponse()->getStatusCode());
+    }
+
+    public function testAdminGetReturnsAdaptersAndDefaultChains(): void
+    {
+        $this->loginAdmin();
+        $this->client->request('GET', '/api/v1/admin/plugs/extraction');
+
+        self::assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        $body = $this->json();
+        self::assertArrayHasKey('adapters', $body);
+        self::assertArrayHasKey('chains', $body);
+        self::assertSame(['pdf'], $body['quality']['applyTo'] ?? null);
+        self::assertSame(
+            ['structured_office', 'office_convert', 'tika', 'pdf_vision'],
+            $body['chains']['document'] ?? null,
+        );
+        $keys = array_column($body['adapters'], 'key');
+        self::assertContains('docling', $keys);
+        self::assertContains('tika', $keys);
+    }
+
+    public function testPutUnknownAdapterReturns422(): void
+    {
+        $this->loginAdmin();
+        $this->client->request(
+            'PUT',
+            '/api/v1/admin/plugs/extraction/chains',
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: json_encode(['chains' => ['document' => ['not-a-real-adapter']]], JSON_THROW_ON_ERROR),
+        );
+
+        self::assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $this->client->getResponse()->getStatusCode());
+        $body = $this->json();
+        self::assertStringContainsString('Unknown extractor key', (string) ($body['error'] ?? ''));
+    }
+
+    public function testPutKnownChainAndRestoreDefault(): void
+    {
+        $this->loginAdmin();
+        $this->client->request(
+            'PUT',
+            '/api/v1/admin/plugs/extraction/chains',
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: json_encode(['chains' => ['document' => ['docling', 'tika', 'pdf_vision']]], JSON_THROW_ON_ERROR),
+        );
+
+        self::assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        $body = $this->json();
+        self::assertSame(['docling', 'tika', 'pdf_vision'], $body['chains']['document'] ?? null);
+
+        $this->client->request(
+            'PUT',
+            '/api/v1/admin/plugs/extraction/chains',
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: json_encode([
+                'chains' => ['document' => ['structured_office', 'office_convert', 'tika', 'pdf_vision']],
+            ], JSON_THROW_ON_ERROR),
+        );
+        self::assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+    }
+
+    public function testPostTestReturnsAttempts(): void
+    {
+        $this->loginAdmin();
+        $tmp = tempnam(sys_get_temp_dir(), 'plugs-test-');
+        self::assertNotFalse($tmp);
+        file_put_contents($tmp, "Hello extraction probe\n");
+        $upload = new UploadedFile($tmp, 'sample.md', 'text/markdown', null, true);
+
+        $this->client->request('POST', '/api/v1/admin/plugs/extraction/test', files: ['file' => $upload]);
+
+        self::assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        $body = $this->json();
+        self::assertArrayHasKey('attempts', $body);
+        self::assertArrayHasKey('preview', $body);
+        self::assertArrayHasKey('strategy', $body);
+        @unlink($tmp);
+    }
+
+    private function loginAdmin(): void
+    {
+        $admin = $this->createUser('plugs-extraction-admin@synaplan.internal', 'ADMIN');
+        $this->authenticateClient($this->client, $admin);
+    }
+
+    private function createUser(string $email, string $level): User
+    {
+        $existing = $this->em->getRepository(User::class)->findOneBy(['mail' => $email]);
+        if ($existing instanceof User) {
+            $existing->setUserLevel($level);
+            $this->em->flush();
+
+            return $existing;
+        }
+
+        $user = (new User())
+            ->setMail($email)
+            ->setType('WEB')
+            ->setProviderId('plugs-extraction-'.uniqid())
+            ->setUserLevel($level);
+        $user->setCreated(date('YmdHis'));
+        $user->setEmailVerified(true);
+        $this->em->persist($user);
+        $this->em->flush();
+
+        return $user;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function json(): array
+    {
+        $decoded = json_decode((string) $this->client->getResponse()->getContent(), true);
+
+        return \is_array($decoded) ? $decoded : [];
+    }
+}

--- a/backend/tests/Fixtures/extraction/files/tiny.pdf
+++ b/backend/tests/Fixtures/extraction/files/tiny.pdf
@@ -1,0 +1,14 @@
+%PDF-1.4
+1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj
+2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj
+3 0 obj<</Type/Page/MediaBox[0 0 3 3]/Parent 2 0 R>>endobj
+xref
+0 4
+0000000000 65535 f 
+0000000009 00000 n 
+0000000052 00000 n 
+0000000101 00000 n 
+trailer<</Size 4/Root 1 0 R>>
+startxref
+178
+%%EOF

--- a/backend/tests/Fixtures/extraction/recorded/docling/invoice-table.json
+++ b/backend/tests/Fixtures/extraction/recorded/docling/invoice-table.json
@@ -1,0 +1,11 @@
+{
+  "status": "success",
+  "document": {
+    "md_content": "# Invoice\n\n## Revenue by region\n\n| Region | Q3 |\n| --- | --- |\n| EMEA | 4.2 |\n",
+    "text_content": "Invoice\nRevenue by region\nRegion Q3\nEMEA 4.2\n",
+    "pages": 1
+  },
+  "timings": {
+    "total": 0.12
+  }
+}

--- a/backend/tests/Unit/Plug/Extraction/DoclingExtractorContractTest.php
+++ b/backend/tests/Unit/Plug/Extraction/DoclingExtractorContractTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Plug\Extraction;
+
+use App\Plug\Extraction\Adapter\DoclingExtractor;
+use App\Plug\Extraction\Docling\DoclingClient;
+use App\Plug\Extraction\ExtractionRequest;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+final class DoclingExtractorContractTest extends TestCase
+{
+    public function testExtractReturnsMarkdownAndTextFromRecordedResponse(): void
+    {
+        $fixture = (string) file_get_contents(
+            dirname(__DIR__, 3).'/Fixtures/extraction/recorded/docling/invoice-table.json',
+        );
+        $http = new MockHttpClient([
+            new MockResponse($fixture, ['http_code' => 200, 'response_headers' => ['content-type' => 'application/json']]),
+        ]);
+        $extractor = new DoclingExtractor(
+            new DoclingClient($http, new NullLogger(), 'http://docling.test', 120000),
+            50 * 1024 * 1024,
+        );
+
+        $path = tempnam(sys_get_temp_dir(), 'docling-contract-');
+        self::assertNotFalse($path);
+        file_put_contents($path, "%PDF-1.4 recorded\n");
+
+        $request = new ExtractionRequest($path, basename($path), 'application/pdf', 'pdf', 1, false, 'document');
+        self::assertTrue($extractor->supports($request));
+
+        $result = $extractor->extract($request);
+        self::assertSame('docling', $result->strategy);
+        self::assertStringContainsString('EMEA', $result->text);
+        self::assertNotNull($result->markdown);
+        self::assertStringContainsString('| Region | Q3 |', $result->markdown);
+        self::assertSame(1, $result->meta['pages'] ?? null);
+
+        @unlink($path);
+    }
+
+    public function testSupportsRejectsAudioFamily(): void
+    {
+        $extractor = new DoclingExtractor(
+            new DoclingClient(new MockHttpClient(), new NullLogger(), 'http://docling.test', 120000),
+            50 * 1024 * 1024,
+        );
+        $path = tempnam(sys_get_temp_dir(), 'docling-audio-');
+        self::assertNotFalse($path);
+        file_put_contents($path, 'x');
+        $request = new ExtractionRequest($path, basename($path), 'audio/mpeg', 'mp3', 1, false, 'audio');
+        self::assertFalse($extractor->supports($request));
+        @unlink($path);
+    }
+}

--- a/backend/tests/Unit/Plug/Extraction/DoclingExtractorHealthTest.php
+++ b/backend/tests/Unit/Plug/Extraction/DoclingExtractorHealthTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Plug\Extraction;
+
+use App\Plug\Extraction\Docling\DoclingClient;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+use Symfony\Contracts\HttpClient\ResponseStreamInterface;
+
+final class DoclingExtractorHealthTest extends TestCase
+{
+    public function testEmptyUrlIsUnavailable(): void
+    {
+        $client = new DoclingClient(new MockHttpClient(), new NullLogger(), '', 120000);
+
+        self::assertFalse($client->isEnabled());
+        $health = $client->health();
+        self::assertFalse($health->available);
+        self::assertNotNull($health->reason);
+        self::assertStringContainsString('DOCLING_BASE_URL', $health->reason);
+    }
+
+    public function testConnectionRefusedIsUnavailable(): void
+    {
+        $http = new MockHttpClient(static function (): never {
+            throw new class('Connection refused') extends \RuntimeException implements TransportExceptionInterface {};
+        });
+        $client = new DoclingClient($http, new NullLogger(), 'http://docling.test', 120000);
+
+        $health = $client->health();
+        self::assertFalse($health->available);
+        self::assertNotNull($health->reason);
+        self::assertStringContainsString('refused', strtolower($health->reason));
+    }
+
+    public function testTimeoutIsUnavailable(): void
+    {
+        $http = new MockHttpClient(static function (): never {
+            throw new class('Request timed out') extends \RuntimeException implements TransportExceptionInterface {};
+        });
+        $client = new DoclingClient($http, new NullLogger(), 'http://docling.test', 120000);
+
+        $health = $client->health();
+        self::assertFalse($health->available);
+        self::assertNotNull($health->reason);
+        self::assertStringContainsString('timed out', strtolower($health->reason));
+    }
+
+    public function testServerErrorIsUnavailable(): void
+    {
+        $http = new MockHttpClient([
+            new MockResponse('nope', ['http_code' => 503]),
+        ]);
+        $client = new DoclingClient($http, new NullLogger(), 'http://docling.test', 120000);
+
+        $health = $client->health();
+        self::assertFalse($health->available);
+        self::assertNotNull($health->reason);
+        self::assertStringContainsString('503', $health->reason);
+    }
+
+    public function testOkHealthIsAvailableAndCached(): void
+    {
+        $calls = 0;
+        $http = new class($calls) implements HttpClientInterface {
+            public function __construct(private int &$calls)
+            {
+            }
+
+            public function request(string $method, string $url, array $options = []): ResponseInterface
+            {
+                ++$this->calls;
+
+                return new MockResponse('{"status":"ok"}', ['http_code' => 200]);
+            }
+
+            public function stream(ResponseInterface|iterable $responses, ?float $timeout = null): ResponseStreamInterface
+            {
+                throw new \BadMethodCallException('not used');
+            }
+
+            public function withOptions(array $options): static
+            {
+                return $this;
+            }
+        };
+        $client = new DoclingClient($http, new NullLogger(), 'http://docling.test', 120000);
+
+        self::assertTrue($client->health()->available);
+        self::assertTrue($client->health()->available);
+        self::assertSame(1, $calls);
+    }
+}

--- a/backend/tests/Unit/Plug/Extraction/ExtractionQualityGateTest.php
+++ b/backend/tests/Unit/Plug/Extraction/ExtractionQualityGateTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Plug\Extraction;
+
+use App\Plug\Extraction\ExtractionQualityGate;
+use App\Plug\Extraction\ExtractionRequest;
+use App\Plug\Extraction\ExtractionResult;
+use App\Plug\PlugConfigService;
+use App\Service\File\TextCleaner;
+use PHPUnit\Framework\TestCase;
+
+final class ExtractionQualityGateTest extends TestCase
+{
+    public function testEmptyResultFails(): void
+    {
+        $verdict = $this->gate()->verdict(
+            ExtractionResult::of('', 'tika'),
+            $this->pdfRequest(),
+        );
+
+        self::assertFalse($verdict->passed);
+        self::assertSame('empty', $verdict->reason);
+    }
+
+    public function testNonPdfFamilyIsNotApplicable(): void
+    {
+        $text = 'Short but fine for a markdown file.';
+        $verdict = $this->gate()->verdict(
+            ExtractionResult::of($text, 'native'),
+            new ExtractionRequest('/tmp/a.md', 'a.md', 'text/markdown', 'md', 1, false, 'text'),
+        );
+
+        self::assertTrue($verdict->passed);
+        self::assertSame('not_applicable', $verdict->reason);
+    }
+
+    public function testPdfVerdictMatchesTextCleanerIsLowQuality(): void
+    {
+        $cleaner = new TextCleaner();
+        $gate = $this->gate($cleaner);
+
+        $good = 'The quarterly revenue for EMEA was 4.2 million EUR in Q3 2025.';
+        $bad = 'aaaaaaa';
+
+        self::assertFalse($cleaner->isLowQuality($good, 10, 3.0));
+        self::assertTrue($cleaner->isLowQuality($bad, 10, 3.0));
+
+        $goodVerdict = $gate->verdict(ExtractionResult::of($good, 'tika'), $this->pdfRequest());
+        $badVerdict = $gate->verdict(ExtractionResult::of($bad, 'tika'), $this->pdfRequest());
+
+        self::assertTrue($goodVerdict->passed);
+        self::assertSame('quality_ok', $goodVerdict->reason);
+        self::assertFalse($badVerdict->passed);
+        self::assertSame('low_quality', $badVerdict->reason);
+    }
+
+    public function testMarkdownTablePassesEvenWhenEntropyIsLow(): void
+    {
+        $markdown = "# Report\n\n| A | A | A |\n| --- | --- | --- |\n| A | A | A |\n";
+        $verdict = $this->gate()->verdict(
+            ExtractionResult::of('AAAAAAA', 'docling', [], $markdown),
+            $this->pdfRequest(),
+        );
+
+        self::assertTrue($verdict->passed);
+        self::assertSame('markdown_structure', $verdict->reason);
+    }
+
+    private function gate(?TextCleaner $cleaner = null): ExtractionQualityGate
+    {
+        $config = $this->createMock(PlugConfigService::class);
+        $config->method('qualityApplyTo')->willReturn(['pdf']);
+        $config->method('qualityMinLength')->willReturn(10);
+        $config->method('qualityMinEntropy')->willReturn(3.0);
+
+        return new ExtractionQualityGate($config, $cleaner ?? new TextCleaner());
+    }
+
+    private function pdfRequest(): ExtractionRequest
+    {
+        return new ExtractionRequest('/tmp/a.pdf', 'a.pdf', 'application/pdf', 'pdf', 1, false, 'document');
+    }
+}

--- a/backend/tests/Unit/Plug/PlugBoundaryTest.php
+++ b/backend/tests/Unit/Plug/PlugBoundaryTest.php
@@ -27,6 +27,15 @@ final class PlugBoundaryTest extends TestCase
         $this->assertSame([], $violations, "TikaClient imports outside the plug boundary:\n".implode("\n", $violations));
     }
 
+    public function testDoclingClientIsNotImportedOutsideThePlugBoundary(): void
+    {
+        $violations = $this->scan('use App\\Plug\\Extraction\\Docling\\DoclingClient', [
+            '/Plug/',
+        ]);
+
+        $this->assertSame([], $violations, "DoclingClient imports outside the plug boundary:\n".implode("\n", $violations));
+    }
+
     public function testBraveSearchServiceIsNotImportedOutsideThePlugBoundary(): void
     {
         $violations = $this->scan(self::BRAVE_USE, [

--- a/backend/tests/Unit/Plug/PlugConfigServiceTest.php
+++ b/backend/tests/Unit/Plug/PlugConfigServiceTest.php
@@ -25,6 +25,7 @@ final class PlugConfigServiceTest extends TestCase
         $this->assertSame(['video_analysis'], $service->extractionChain('video'));
         $this->assertSame(10, $service->qualityMinLength());
         $this->assertSame(3.0, $service->qualityMinEntropy());
+        $this->assertSame(['pdf'], $service->qualityApplyTo());
         $this->assertSame('brave', $service->webSearchProvider(null));
         $this->assertSame('', $service->webSearchFallback());
         $this->assertFalse($service->isRerankEnabled());
@@ -80,6 +81,29 @@ final class PlugConfigServiceTest extends TestCase
 
         $this->assertSame(25, $service->qualityMinLength());
         $this->assertSame(4.5, $service->qualityMinEntropy());
+    }
+
+    public function testSetChainPersistsKnownKeys(): void
+    {
+        $repo = $this->createMock(ConfigRepository::class);
+        $repo->expects($this->once())->method('setValue')->with(
+            0,
+            PlugConfigService::CONFIG_GROUP,
+            PlugConfigService::KEY_CHAIN_DOCUMENT,
+            'docling,tika,pdf_vision',
+        );
+
+        $service = new PlugConfigService($repo);
+        $service->setChain('document', ['docling', 'tika', 'pdf_vision'], ['docling', 'tika', 'pdf_vision', 'native']);
+    }
+
+    public function testSetChainRejectsUnknownKey(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown extractor key: nope');
+
+        $service = new PlugConfigService($this->repo([]));
+        $service->setChain('document', ['nope'], ['tika']);
     }
 
     /**

--- a/backend/tests/Unit/Seed/PlugsConfigSeederTest.php
+++ b/backend/tests/Unit/Seed/PlugsConfigSeederTest.php
@@ -31,6 +31,7 @@ final class PlugsConfigSeederTest extends TestCase
             PlugConfigService::KEY_CHAIN_VIDEO => 'video_analysis',
             PlugConfigService::KEY_QUALITY_MIN_LENGTH => '10',
             PlugConfigService::KEY_QUALITY_MIN_ENTROPY => sprintf('%.1f', PlugConfigService::DEFAULT_MIN_ENTROPY),
+            PlugConfigService::KEY_QUALITY_APPLY_TO => 'pdf',
             PlugConfigService::KEY_WEB_SEARCH_PROVIDER => 'brave',
             PlugConfigService::KEY_WEB_SEARCH_FALLBACK => '',
             PlugConfigService::KEY_RERANK_ENABLED => '0',

--- a/backend/tests/Unit/Service/Admin/SystemConfigServiceTest.php
+++ b/backend/tests/Unit/Service/Admin/SystemConfigServiceTest.php
@@ -442,4 +442,37 @@ final class SystemConfigServiceTest extends TestCase
             $values['CONVERSATION_SUMMARY_TIERS']['value'],
         );
     }
+
+    public function testDoclingFieldsLiveOnTheProcessingTabNextToTika(): void
+    {
+        $schema = $this->service->getSchema();
+
+        self::assertSame(
+            ['DOCLING_BASE_URL', 'DOCLING_TIMEOUT_MS', 'DOCLING_MAX_BYTES'],
+            $schema['tabs']['processing']['sections']['docling']['fields'],
+        );
+        self::assertSame('processing', $schema['fields']['DOCLING_BASE_URL']['tab']);
+        self::assertSame('url', $schema['fields']['DOCLING_BASE_URL']['type']);
+        self::assertSame('docling', $schema['fields']['DOCLING_TIMEOUT_MS']['section']);
+    }
+
+    public function testDoclingConnectionTestFailsWhenUrlIsEmpty(): void
+    {
+        $envWasSet = \array_key_exists('DOCLING_BASE_URL', $_ENV);
+        $original = $envWasSet ? $_ENV['DOCLING_BASE_URL'] : null;
+        $_ENV['DOCLING_BASE_URL'] = '';
+
+        try {
+            $result = $this->service->testConnection('docling');
+
+            self::assertFalse($result['success']);
+            self::assertStringContainsString('DOCLING_BASE_URL', $result['message']);
+        } finally {
+            if ($envWasSet) {
+                $_ENV['DOCLING_BASE_URL'] = $original;
+            } else {
+                unset($_ENV['DOCLING_BASE_URL']);
+            }
+        }
+    }
 }

--- a/backend/tests/Unit/Service/File/FileProcessorExtraExtractorHookTest.php
+++ b/backend/tests/Unit/Service/File/FileProcessorExtraExtractorHookTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\Service\File;
 
 use App\AI\Service\AiFacade;
 use App\Plug\Extraction\ContentExtractorInterface;
+use App\Plug\Extraction\ExtractionQualityGate;
 use App\Plug\Extraction\ExtractionRegistry;
 use App\Plug\Extraction\ExtractionRequest;
 use App\Plug\Extraction\ExtractionResult;
@@ -127,13 +128,144 @@ final class FileProcessorExtraExtractorHookTest extends TestCase
         @unlink($dir.'/'.$relative);
     }
 
+    public function testExtraExtractorLowQualityPdfFallsThroughWhenGateInjected(): void
+    {
+        $dir = sys_get_temp_dir();
+        $relative = 'plugs-lowq-'.uniqid('', true).'.pdf';
+        copy(dirname(__DIR__, 3).'/Fixtures/extraction/files/tiny.pdf', $dir.'/'.$relative);
+
+        $extra = new class implements ContentExtractorInterface {
+            public function key(): string
+            {
+                return 'docling';
+            }
+
+            public function descriptor(): PlugDescriptor
+            {
+                return new PlugDescriptor('docling', 'Docling', '', [], 'self-hosted');
+            }
+
+            public function supports(ExtractionRequest $request): bool
+            {
+                return 'pdf' === $request->ext;
+            }
+
+            public function extract(ExtractionRequest $request): ExtractionResult
+            {
+                return ExtractionResult::of('aaaaaaa', 'docling', ['file' => basename($request->absolutePath)]);
+            }
+
+            public function health(): PlugHealth
+            {
+                return PlugHealth::available();
+            }
+        };
+
+        $plugConfig = $this->createMock(PlugConfigService::class);
+        $plugConfig->method('extraExtractorKeys')->willReturn(['docling']);
+        $plugConfig->method('qualityApplyTo')->willReturn(['pdf']);
+        $plugConfig->method('qualityMinLength')->willReturn(10);
+        $plugConfig->method('qualityMinEntropy')->willReturn(3.0);
+
+        $tika = $this->createMock(TikaClient::class);
+        $tika->method('isEnabled')->willReturn(true);
+        $tika->method('extractText')->willReturn([
+            'The quarterly revenue for EMEA was 4.2 million EUR in Q3 2025 according to finance.',
+            [],
+        ]);
+
+        $processor = new FileProcessor(
+            $tika,
+            $this->createStub(PdfRasterizer::class),
+            new TextCleaner(),
+            $this->createStub(AiFacade::class),
+            $this->createStub(WhisperService::class),
+            $this->createStub(VideoAnalysisService::class),
+            new HeicConverter(new NullLogger()),
+            new NullLogger(),
+            $dir,
+            10,
+            3.0,
+            '/nonexistent/ffmpeg',
+            null,
+            null,
+            new ExtractionRegistry([$extra], $plugConfig, new NullLogger()),
+            $plugConfig,
+            new ExtractionQualityGate($plugConfig, new TextCleaner()),
+        );
+
+        [$text, $meta] = $processor->extractText($relative, 'pdf');
+
+        $this->assertStringContainsString('EMEA', $text);
+        $this->assertSame('tika', $meta['strategy'] ?? null);
+        @unlink($dir.'/'.$relative);
+    }
+
+    public function testDoclingExceptionFallsThroughToTikaOnPdf(): void
+    {
+        $dir = sys_get_temp_dir();
+        $relative = 'plugs-c7-'.uniqid('', true).'.pdf';
+        copy(dirname(__DIR__, 3).'/Fixtures/extraction/files/tiny.pdf', $dir.'/'.$relative);
+
+        $extra = new class implements ContentExtractorInterface {
+            public function key(): string
+            {
+                return 'docling';
+            }
+
+            public function descriptor(): PlugDescriptor
+            {
+                return new PlugDescriptor('docling', 'Docling', '', [], 'self-hosted');
+            }
+
+            public function supports(ExtractionRequest $request): bool
+            {
+                return 'pdf' === $request->ext;
+            }
+
+            public function extract(ExtractionRequest $request): ExtractionResult
+            {
+                throw new \RuntimeException('sidecar down for '.$request->ext);
+            }
+
+            public function health(): PlugHealth
+            {
+                return PlugHealth::unavailable('connection refused');
+            }
+        };
+
+        $plugConfig = $this->createMock(PlugConfigService::class);
+        $plugConfig->method('extraExtractorKeys')->willReturn(['docling']);
+
+        $tika = $this->createMock(TikaClient::class);
+        $tika->method('isEnabled')->willReturn(true);
+        $tika->method('extractText')->willReturn([
+            'The quarterly revenue for EMEA was 4.2 million EUR in Q3 2025 according to finance.',
+            [],
+        ]);
+
+        $processor = $this->processor(
+            new ExtractionRegistry([$extra], $plugConfig, new NullLogger()),
+            $plugConfig,
+            $dir,
+            $tika,
+        );
+
+        [$text, $meta] = $processor->extractText($relative, 'pdf');
+
+        $this->assertStringContainsString('EMEA', $text);
+        $this->assertSame('tika', $meta['strategy'] ?? null);
+        @unlink($dir.'/'.$relative);
+    }
+
     private function processor(
         ExtractionRegistry $registry,
         PlugConfigService $plugConfig,
         string $uploadDir,
+        ?TikaClient $tika = null,
     ): FileProcessor {
         return new FileProcessor(
-            $this->createStub(TikaClient::class),
+            $tika ?? $this->createStub(TikaClient::class),
             $this->createStub(PdfRasterizer::class),
             new TextCleaner(),
             $this->createStub(AiFacade::class),

--- a/backend/tests/Unit/Service/File/TextChunkerMarkdownTest.php
+++ b/backend/tests/Unit/Service/File/TextChunkerMarkdownTest.php
@@ -58,15 +58,30 @@ MD;
         }
     }
 
+    public function testShortHeadingSectionIsMergedNotDropped(): void
+    {
+        $chunker = new TextChunker(maxChunkSize: 400, overlapSize: 20, minChunkSize: 80);
+        $markdown = <<<'MD'
+# Report
+## Long
+This section has enough text to become its own chunk because it is well above the minimum size.
+## Short
+OK.
+MD;
+        $chunks = $chunker->chunkifyMarkdown($markdown);
+        $all = implode("\n", array_column($chunks, 'content'));
+
+        self::assertNotEmpty($chunks);
+        self::assertStringContainsString('OK.', $all);
+    }
+
     public function testPlainChunkifyPathIsUnchanged(): void
     {
         $chunker = new TextChunker(maxChunkSize: 80, overlapSize: 10, minChunkSize: 20);
         $text = "alpha line one\nbeta line two\ngamma line three\ndelta line four\nepsilon line five";
 
-        self::assertSame(
-            $chunker->chunkify($text),
-            $chunker->chunkify($text),
-        );
+        $plain = $chunker->chunkify($text);
+        self::assertNotEmpty($plain);
         self::assertSame(
             [
                 ['content' => 'alpha line one', 'start_line' => 0, 'end_line' => 0],

--- a/backend/tests/Unit/Service/File/TextChunkerMarkdownTest.php
+++ b/backend/tests/Unit/Service/File/TextChunkerMarkdownTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\File;
+
+use App\Service\File\TextChunker;
+use PHPUnit\Framework\TestCase;
+
+final class TextChunkerMarkdownTest extends TestCase
+{
+    public function testHeadingBreadcrumbPrefixesChunks(): void
+    {
+        $chunker = new TextChunker(maxChunkSize: 200, overlapSize: 20, minChunkSize: 10);
+        $markdown = <<<'MD'
+# Report
+## Q3
+### Revenue by region
+EMEA booked 4.2 million this quarter after a strong September.
+MD;
+        $chunks = $chunker->chunkifyMarkdown($markdown);
+
+        self::assertNotEmpty($chunks);
+        self::assertStringStartsWith('Report › Q3 › Revenue by region', $chunks[0]['content']);
+        self::assertStringContainsString('EMEA booked', $chunks[0]['content']);
+    }
+
+    public function testTableStaysWholeWhenItFits(): void
+    {
+        $chunker = new TextChunker(maxChunkSize: 400, overlapSize: 20, minChunkSize: 10);
+        $markdown = <<<'MD'
+# Report
+| Region | Q3 |
+| --- | --- |
+| EMEA | 4.2 |
+| APAC | 1.1 |
+MD;
+        $chunks = $chunker->chunkifyMarkdown($markdown);
+
+        self::assertCount(1, $chunks);
+        self::assertStringContainsString('| Region | Q3 |', $chunks[0]['content']);
+        self::assertStringContainsString('| APAC | 1.1 |', $chunks[0]['content']);
+    }
+
+    public function testOversizedTableRepeatsHeaderRow(): void
+    {
+        $chunker = new TextChunker(maxChunkSize: 80, overlapSize: 10, minChunkSize: 10);
+        $rows = [];
+        for ($i = 1; $i <= 12; ++$i) {
+            $rows[] = '| R'.$i.' | value-'.$i.' |';
+        }
+        $markdown = "# T\n| Region | Amount |\n| --- | --- |\n".implode("\n", $rows)."\n";
+        $chunks = $chunker->chunkifyMarkdown($markdown);
+
+        self::assertGreaterThan(1, count($chunks));
+        foreach ($chunks as $chunk) {
+            self::assertStringContainsString('| Region | Amount |', $chunk['content']);
+        }
+    }
+
+    public function testPlainChunkifyPathIsUnchanged(): void
+    {
+        $chunker = new TextChunker(maxChunkSize: 80, overlapSize: 10, minChunkSize: 20);
+        $text = "alpha line one\nbeta line two\ngamma line three\ndelta line four\nepsilon line five";
+
+        self::assertSame(
+            $chunker->chunkify($text),
+            $chunker->chunkify($text),
+        );
+        self::assertSame(
+            [
+                ['content' => 'alpha line one', 'start_line' => 0, 'end_line' => 0],
+            ],
+            (new TextChunker(maxChunkSize: 20, overlapSize: 5, minChunkSize: 5))->chunkify('alpha line one'),
+        );
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -308,6 +308,11 @@ services:
       QDRANT_URL: http://qdrant:6333
       TRITON_SERVER_URL: ${TRITON_SERVER_URL:-}
       TIKA_BASE_URL: http://tika:9998
+      # Optional Docling sidecar (profile `docling`). The URL is always set so
+      # enabling the profile needs no extra env; an empty .env value keeps it
+      # off outside compose. A down sidecar is unavailable, never a failed upload.
+      DOCLING_BASE_URL: ${DOCLING_BASE_URL:-http://docling:5001}
+      DOCLING_TIMEOUT_MS: ${DOCLING_TIMEOUT_MS:-120000}
       # Collabora CODE convert-to. Local default is the compose service name.
       # Override with OFFICE_CONVERT_URL for an external CODE, or set
       # OFFICE_CONVERT_URL=disabled to turn the engine off. The sidecar still
@@ -485,6 +490,8 @@ services:
       COMPOSE_PROFILES: ${COMPOSE_PROFILES:-}
       QDRANT_URL: http://qdrant:6333
       TIKA_BASE_URL: http://tika:9998
+      DOCLING_BASE_URL: ${DOCLING_BASE_URL:-http://docling:5001}
+      DOCLING_TIMEOUT_MS: ${DOCLING_TIMEOUT_MS:-120000}
       OFFICE_CONVERT_URL: ${OFFICE_CONVERT_URL:-http://collabora:9980}
       OFFICE_CONVERT_TIMEOUT_MS: ${OFFICE_CONVERT_TIMEOUT_MS:-60000}
       AI_DEFAULT_PROVIDER: ollama
@@ -816,6 +823,27 @@ services:
       retries: 5
       start_period: 60s
     restart: unless-stopped
+    networks:
+      - synaplan-network
+
+  # Optional Docling document extraction — https://github.com/docling-project/docling-serve
+  # CPU image (~4.4 GB) so the sidecar runs without a GPU. Not started by default.
+  # Enable with:  docker compose --profile docling up -d
+  # No mem_limit in dev (cgroup limits break some sandboxes; see frontend-widgets).
+  # Ask-first Docker change: recorded in _devextras/planning/202609_ai_plugs/02_sprint_2_docling.md
+  docling:
+    image: ghcr.io/docling-project/docling-serve-cpu:v1.32.0@sha256:576fc2074ac77bcfbf3fe27633aa0dd89b452a170b2cd31689c8751e94d60f7a
+    container_name: synaplan-docling
+    profiles: [docling]
+    restart: unless-stopped
+    environment:
+      DOCLING_SERVE_ENABLE_UI: "0"
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:5001/health')"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 120s
     networks:
       - synaplan-network
 

--- a/docs/ADMIN.md
+++ b/docs/ADMIN.md
@@ -676,8 +676,11 @@ instance-wide. Rerank stays off (`RERANK.ENABLED=0`).
 
 The Operate page is now **AI infrastructure** (`/admin/setup`). The
 **Extraction** tab shows adapter health, lets an admin reorder a family
-chain, and offers **Test with a file**. Models & keys is the previous
-provider-key UI. Web search and rerank tabs land in later sprints.
+chain, and offers **Test with a file**. Tika and Docling have the same
+sidecar controls: a connection test on that tab, and URL / timeout
+(plus Docling max file size) under **System configuration →
+Processing**. Models & keys is the previous provider-key UI. Web
+search and rerank tabs land in later sprints.
 
 Settings table: [CONFIGURATION.md — AI plugs](CONFIGURATION.md#ai-plugs-plugs).
 

--- a/docs/ADMIN.md
+++ b/docs/ADMIN.md
@@ -662,19 +662,24 @@ Acceptance script: `_devextras/testing/platform-links/fake-instance.sh`
 (`--flag-off` proves the 404 contract). Endpoint reference:
 [Swagger UI](http://localhost:8000/api/doc) → tag *Platform Links*.
 
-### AI plugs (S1)
+### AI plugs (S1–S2)
 
-Extraction, web search and rerank now go through `App\Plug\` registries.
-Nothing user-visible changes: FileProcessor still runs today's built-in
-strategies (native → Tika → vision → STT), and web search still uses Brave
-when `BRAVE_SEARCH_API_KEY` is set. The `PLUGS` BCONFIG group is seeded with
-those defaults. `WEB_SEARCH.PROVIDER` may be overridden per user; everything
-else is instance-wide. Rerank stays off (`RERANK.ENABLED=0`).
+Extraction, web search and rerank go through `App\Plug\` registries.
+FileProcessor still runs today's built-in strategies (native → Tika →
+vision → STT). Extra adapters whose keys are not built-in (today:
+`docling`) run first when an admin adds them to a family chain, and fall
+through if they fail, so a down sidecar never blocks an upload.
 
-A later adapter (Docling, SearXNG, …) is added as a tagged class. Keys that
-FileProcessor does not already implement run first and fall through if they
-fail, so a down sidecar never blocks an upload. Settings table:
-[CONFIGURATION.md — AI plugs](CONFIGURATION.md#ai-plugs-plugs).
+Web search still uses Brave when `BRAVE_SEARCH_API_KEY` is set.
+`WEB_SEARCH.PROVIDER` may be overridden per user; everything else is
+instance-wide. Rerank stays off (`RERANK.ENABLED=0`).
+
+The Operate page is now **AI infrastructure** (`/admin/setup`). The
+**Extraction** tab shows adapter health, lets an admin reorder a family
+chain, and offers **Test with a file**. Models & keys is the previous
+provider-key UI. Web search and rerank tabs land in later sprints.
+
+Settings table: [CONFIGURATION.md — AI plugs](CONFIGURATION.md#ai-plugs-plugs).
 
 ---
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -698,6 +698,7 @@ migration to roll out a new default.
 | `EXTRACTION.CHAIN.video` | `video_analysis` | Transcript + key-frame describe |
 | `EXTRACTION.QUALITY.min_length` | `10` | PDF quality gate (bootstrap from `TIKA_MIN_LENGTH`) |
 | `EXTRACTION.QUALITY.min_entropy` | `3.0` | PDF quality gate (bootstrap from `TIKA_MIN_ENTROPY`) |
+| `EXTRACTION.QUALITY.apply_to` | `pdf` | Families / extensions the quality gate runs on |
 | `WEB_SEARCH.PROVIDER` | `brave` | Active search adapter. Per-user override allowed |
 | `WEB_SEARCH.FALLBACK` | _(empty)_ | Unused until a second provider ships |
 | `RERANK.ENABLED` | `0` | Off. Eval-gated; no adapter in this release |
@@ -705,8 +706,17 @@ migration to roll out a new default.
 | `RERANK.LATENCY_BUDGET_MS` | `800` | Skip rerank if the adapter exceeds this |
 
 Unknown chain keys are skipped. Keys that FileProcessor does not already
-implement (for example a future `docling`) run first, then the built-in
-strategies. A down extra adapter never fails an upload.
+implement (today: `docling`) run first, then the built-in strategies. A
+down extra adapter never fails an upload. Fresh installs do **not** put
+`docling` on the document chain — an admin adds it under **Operate →
+AI infrastructure → Extraction**.
+
+`DOCLING_BASE_URL` (empty = off) points at the optional `docling`
+Compose profile (`docker compose --profile docling up -d`). The CPU
+image needs about 4 GB during OCR; there is no `mem_limit` in dev.
+`DOCLING_TIMEOUT_MS` defaults to `120000`; `DOCLING_MAX_BYTES` defaults
+to 50 MB. Markdown from Docling is chunked heading-aware (tables stay
+together; oversized tables repeat the header row).
 
 See [AI plugs](ADMIN.md#ai-plugs-s1).
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -715,8 +715,10 @@ AI infrastructure → Extraction**.
 Compose profile (`docker compose --profile docling up -d`). The CPU
 image needs about 4 GB during OCR; there is no `mem_limit` in dev.
 `DOCLING_TIMEOUT_MS` defaults to `120000`; `DOCLING_MAX_BYTES` defaults
-to 50 MB. Markdown from Docling is chunked heading-aware (tables stay
-together; oversized tables repeat the header row).
+to 50 MB. Admins edit those the same way as Tika: **System
+configuration → Processing → Docling** (URL, timeout, max bytes, then
+**Test connection**). Markdown from Docling is chunked heading-aware
+(tables stay together; oversized tables repeat the header row).
 
 See [AI plugs](ADMIN.md#ai-plugs-s1).
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -69,6 +69,24 @@ This is **not** host `apt install libreoffice` and **not** the LibreOffice
 binary Desktop looks for on the user’s PC. The PHP app talks only to
 `OFFICE_CONVERT_URL` over HTTP.
 
+### Docling extraction (optional)
+
+PDFs with tables and two-column layouts extract more cleanly when the
+**Docling** sidecar is running. It is **off by default**
+(`profiles: [docling]`). Compose sets `DOCLING_BASE_URL=http://docling:5001`;
+leave that empty in `.env` to keep Docling off. A down sidecar never fails
+an upload — Tika stays the fallback. Enable Docling in
+**Operate → AI infrastructure → Extraction** (add `docling` to the
+document chain), then:
+
+```bash
+docker compose --profile docling up -d
+```
+
+The CPU image is about 4.4 GB and needs a few GB of RAM during OCR. There
+is no `mem_limit` in this compose file (cgroup limits break some
+sandboxes). GPU variants belong in `synaplan-platform`.
+
 #### Troubleshooting stuck media jobs
 
 The chat bubble for an async video shows `Auftrag läuft noch / Job still running` indefinitely:
@@ -260,6 +278,7 @@ make test    # Run tests
 | MailHog | http://localhost:8025 |
 | Ollama | http://localhost:11435 |
 | Collabora CODE (profile `office`, no published port) | `http://collabora:9980` on the compose network |
+| Docling (profile `docling`, no published port) | `http://docling:5001` on the compose network |
 
 ### GPU Support for Local AI Models
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -77,7 +77,8 @@ PDFs with tables and two-column layouts extract more cleanly when the
 leave that empty in `.env` to keep Docling off. A down sidecar never fails
 an upload — Tika stays the fallback. Enable Docling in
 **Operate → AI infrastructure → Extraction** (add `docling` to the
-document chain), then:
+document chain). URL, timeout and **Test connection** match Tika under
+**System configuration → Processing → Docling**. Then:
 
 ```bash
 docker compose --profile docling up -d

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -100,7 +100,7 @@ Extract content from:
 
 | Format | Engine |
 |--------|--------|
-| PDF, Word, Excel, PowerPoint | Apache Tika |
+| PDF, Word, Excel, PowerPoint | Apache Tika (optional Docling for tables and headings) |
 | Images (PNG, JPEG, etc.) | Tesseract OCR |
 | Audio (MP3, WAV, etc.) | Whisper.cpp |
 

--- a/docs/RAG.md
+++ b/docs/RAG.md
@@ -21,7 +21,7 @@ Upload → Extract → Vectorize → Store → Search → Generate
 ```
 
 1. **Upload** - Drop files into the system
-2. **Extract** - Tika extracts text; OCR for images; Whisper for audio
+2. **Extract** - Tika (default) or optional Docling extracts text; OCR for images; Whisper for audio
 3. **Vectorize** - bge-m3 creates 1024-dimensional embeddings
 4. **Store** - MariaDB VECTOR type stores embeddings natively
 5. **Search** - Cosine similarity finds relevant documents
@@ -149,6 +149,6 @@ owner's name. **Can view** alone never adds chunks to a search.
 - **Embedding Model**: bge-m3 (1024 dimensions)
 - **Vector Storage**: MariaDB 11.8 native VECTOR type
 - **Similarity**: VEC_DISTANCE_COSINE function
-- **Text Extraction**: Apache Tika (and future chain adapters via `PLUGS`; see [CONFIGURATION.md](CONFIGURATION.md#ai-plugs-plugs))
-- **OCR**: Tesseract (via Tika)
+- **Text Extraction**: Apache Tika by default. Optional Docling (`docling` Compose profile + Extraction tab) returns markdown with tables and headings; those files are chunked heading-aware. See [CONFIGURATION.md](CONFIGURATION.md#ai-plugs-plugs).
+- **OCR**: Tesseract (via Tika); Docling can OCR when the sidecar is on
 - **Audio**: Whisper.cpp with FFmpeg

--- a/frontend/src/components/admin/plugs/ExtractionPlugTab.vue
+++ b/frontend/src/components/admin/plugs/ExtractionPlugTab.vue
@@ -18,29 +18,7 @@
     </div>
 
     <template v-else>
-      <div class="flex flex-wrap gap-2 mb-6">
-        <span
-          v-for="adapter in adapters"
-          :key="adapter.key"
-          class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs surface-card border border-light-border/30 dark:border-dark-border/20"
-          :data-testid="`extraction-health-${adapter.key}`"
-        >
-          <span
-            class="w-2 h-2 rounded-full"
-            :class="
-              adapter.health.available ? 'bg-[var(--status-success)]' : 'bg-[var(--status-warning)]'
-            "
-          />
-          <span class="txt-primary">{{ adapter.label }}</span>
-          <span class="txt-secondary">
-            {{
-              adapter.health.available
-                ? $t('aiInfra.extraction.healthAvailable')
-                : $t('aiInfra.extraction.healthUnavailable')
-            }}
-          </span>
-        </span>
-      </div>
+      <ExtractionSidecarPanel :adapters="adapters" />
 
       <div v-for="family in families" :key="family" class="surface-card rounded-lg p-4 mb-4">
         <h3 class="text-sm font-semibold txt-primary mb-3">
@@ -157,6 +135,7 @@ import { computed, onMounted, ref } from 'vue'
 import { Icon } from '@iconify/vue'
 import { useI18n } from 'vue-i18n'
 import { useNotification } from '@/composables/useNotification'
+import ExtractionSidecarPanel from '@/components/admin/plugs/ExtractionSidecarPanel.vue'
 import {
   getExtractionStatus,
   saveExtractionChains,

--- a/frontend/src/components/admin/plugs/ExtractionPlugTab.vue
+++ b/frontend/src/components/admin/plugs/ExtractionPlugTab.vue
@@ -1,0 +1,282 @@
+<template>
+  <div data-testid="extraction-plug-tab">
+    <p class="text-sm txt-secondary mb-4">{{ $t('aiInfra.extraction.lead') }}</p>
+
+    <div v-if="loading" class="text-center py-12">
+      <Icon icon="mdi:loading" class="w-8 h-8 animate-spin mx-auto txt-secondary" />
+    </div>
+
+    <div v-else-if="loadFailed" class="surface-card rounded-lg p-8 text-center">
+      <p class="txt-secondary">{{ $t('aiInfra.extraction.loadFailed') }}</p>
+      <button
+        type="button"
+        class="btn-primary px-4 py-2.5 rounded-lg text-sm font-medium mt-4"
+        @click="load"
+      >
+        {{ $t('common.retry') }}
+      </button>
+    </div>
+
+    <template v-else>
+      <div class="flex flex-wrap gap-2 mb-6">
+        <span
+          v-for="adapter in adapters"
+          :key="adapter.key"
+          class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs surface-card border border-light-border/30 dark:border-dark-border/20"
+          :data-testid="`extraction-health-${adapter.key}`"
+        >
+          <span
+            class="w-2 h-2 rounded-full"
+            :class="
+              adapter.health.available ? 'bg-[var(--status-success)]' : 'bg-[var(--status-warning)]'
+            "
+          />
+          <span class="txt-primary">{{ adapter.label }}</span>
+          <span class="txt-secondary">
+            {{
+              adapter.health.available
+                ? $t('aiInfra.extraction.healthAvailable')
+                : $t('aiInfra.extraction.healthUnavailable')
+            }}
+          </span>
+        </span>
+      </div>
+
+      <div v-for="family in families" :key="family" class="surface-card rounded-lg p-4 mb-4">
+        <h3 class="text-sm font-semibold txt-primary mb-3">
+          {{ $t(`aiInfra.extraction.family.${family}`) }}
+        </h3>
+        <ol class="space-y-2">
+          <li
+            v-for="(key, index) in chains[family] ?? []"
+            :key="`${family}-${key}-${index}`"
+            class="flex items-center gap-2"
+          >
+            <span class="flex-1 min-w-0 text-sm txt-primary">{{ labelFor(key) }}</span>
+            <button
+              type="button"
+              class="btn-secondary px-3 py-1.5 rounded-lg text-xs font-medium"
+              :disabled="index === 0"
+              :aria-label="$t('aiInfra.extraction.moveUp')"
+              @click="move(family, index, -1)"
+            >
+              {{ $t('aiInfra.extraction.moveUp') }}
+            </button>
+            <button
+              type="button"
+              class="btn-secondary px-3 py-1.5 rounded-lg text-xs font-medium"
+              :disabled="index === (chains[family]?.length ?? 0) - 1"
+              :aria-label="$t('aiInfra.extraction.moveDown')"
+              @click="move(family, index, 1)"
+            >
+              {{ $t('aiInfra.extraction.moveDown') }}
+            </button>
+            <button
+              type="button"
+              class="btn-danger px-3 py-1.5 rounded-lg text-xs font-medium"
+              @click="removeKey(family, index)"
+            >
+              {{ $t('aiInfra.extraction.remove') }}
+            </button>
+          </li>
+        </ol>
+        <div class="mt-3 flex flex-col sm:flex-row gap-2">
+          <select
+            v-model="addKey[family]"
+            class="flex-1 min-w-0 px-3 py-2 rounded-lg surface-card border border-light-border/30 dark:border-dark-border/20 txt-primary text-sm focus:outline-none focus:ring-2 focus:ring-[var(--brand)]"
+          >
+            <option value="">{{ $t('aiInfra.extraction.addPlaceholder') }}</option>
+            <option v-for="option in unusedKeys(family)" :key="option" :value="option">
+              {{ labelFor(option) }}
+            </option>
+          </select>
+          <button
+            type="button"
+            class="btn-secondary px-4 py-2.5 rounded-lg text-sm font-medium"
+            :disabled="!addKey[family]"
+            @click="add(family)"
+          >
+            {{ $t('aiInfra.extraction.add') }}
+          </button>
+        </div>
+      </div>
+
+      <button
+        type="button"
+        class="btn-primary px-4 py-2.5 rounded-lg text-sm font-medium mb-8"
+        :disabled="saving"
+        data-testid="extraction-save-chains"
+        @click="save"
+      >
+        {{ saving ? $t('common.saving') : $t('aiInfra.extraction.save') }}
+      </button>
+
+      <div class="surface-card rounded-lg p-4">
+        <h3 class="text-sm font-semibold txt-primary">{{ $t('aiInfra.extraction.testTitle') }}</h3>
+        <p class="text-sm txt-secondary mt-1 mb-3">{{ $t('aiInfra.extraction.testHint') }}</p>
+        <input
+          class="block w-full text-sm txt-primary mb-3"
+          type="file"
+          data-testid="extraction-test-file"
+          @change="onFile"
+        />
+        <button
+          type="button"
+          class="btn-primary px-4 py-2.5 rounded-lg text-sm font-medium"
+          :disabled="!testFile || testing"
+          data-testid="extraction-test-button"
+          @click="runTest"
+        >
+          {{ testing ? $t('aiInfra.extraction.testing') : $t('aiInfra.extraction.testButton') }}
+        </button>
+        <p
+          v-if="testSummary"
+          class="text-sm txt-primary mt-3"
+          data-testid="extraction-test-summary"
+        >
+          {{ testSummary }}
+        </p>
+        <ul v-if="testResult" class="mt-3 space-y-1 text-sm txt-secondary">
+          <li v-for="attempt in testResult.attempts" :key="`${attempt.key}-${attempt.ms}`">
+            {{ attempt.key }} — {{ verdictLabel(attempt.verdict) }} ({{
+              $t('aiInfra.extraction.attemptMs', { ms: attempt.ms })
+            }})
+          </li>
+        </ul>
+        <pre
+          v-if="testResult?.preview"
+          class="mt-3 p-3 rounded-lg text-xs txt-primary overflow-x-auto surface-card border border-light-border/30 dark:border-dark-border/20 whitespace-pre-wrap"
+          >{{ testResult.preview }}</pre>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import { Icon } from '@iconify/vue'
+import { useI18n } from 'vue-i18n'
+import { useNotification } from '@/composables/useNotification'
+import {
+  getExtractionStatus,
+  saveExtractionChains,
+  testExtraction,
+  type ExtractionStatus,
+  type ExtractionTestResult,
+} from '@/services/api/adminPlugsApi'
+
+const { t } = useI18n()
+const { success, error: showError } = useNotification()
+
+const families = ['document', 'text', 'image', 'audio', 'audio_no_cloud', 'video'] as const
+
+const loading = ref(true)
+const loadFailed = ref(false)
+const saving = ref(false)
+const testing = ref(false)
+const adapters = ref<ExtractionStatus['adapters']>([])
+const chains = ref<Record<string, string[]>>({})
+const addKey = ref<Record<string, string>>({})
+const testFile = ref<File | null>(null)
+const testResult = ref<ExtractionTestResult | null>(null)
+
+const testSummary = computed(() => {
+  const result = testResult.value
+  if (!result) return ''
+  const docling = result.attempts.find((attempt) => attempt.key === 'docling')
+  if (
+    docling &&
+    ['unavailable', 'empty', 'low_quality'].includes(docling.verdict) &&
+    result.strategy === 'tika'
+  ) {
+    return t('aiInfra.extraction.doclingUnavailableTika')
+  }
+  return t('aiInfra.extraction.winner', { winner: result.winner ?? result.strategy })
+})
+
+function labelFor(key: string): string {
+  return adapters.value.find((adapter) => adapter.key === key)?.label ?? key
+}
+
+function unusedKeys(family: string): string[] {
+  const used = new Set(chains.value[family] ?? [])
+  return adapters.value.map((adapter) => adapter.key).filter((key) => !used.has(key))
+}
+
+function move(family: string, index: number, delta: number) {
+  const list = [...(chains.value[family] ?? [])]
+  const next = index + delta
+  if (next < 0 || next >= list.length) return
+  const swap = list[index]
+  list[index] = list[next]
+  list[next] = swap
+  chains.value = { ...chains.value, [family]: list }
+}
+
+function removeKey(family: string, index: number) {
+  const list = [...(chains.value[family] ?? [])]
+  list.splice(index, 1)
+  chains.value = { ...chains.value, [family]: list }
+}
+
+function add(family: string) {
+  const key = addKey.value[family]
+  if (!key) return
+  chains.value = { ...chains.value, [family]: [...(chains.value[family] ?? []), key] }
+  addKey.value = { ...addKey.value, [family]: '' }
+}
+
+function verdictLabel(verdict: string): string {
+  const key = `aiInfra.extraction.verdict.${verdict}`
+  const translated = t(key)
+  return translated === key ? verdict : translated
+}
+
+function onFile(event: Event) {
+  const input = event.target as HTMLInputElement
+  testFile.value = input.files?.[0] ?? null
+}
+
+async function load() {
+  loading.value = true
+  try {
+    const status = await getExtractionStatus()
+    adapters.value = status.adapters
+    chains.value = { ...status.chains }
+    loadFailed.value = false
+  } catch (err) {
+    loadFailed.value = true
+    showError(err instanceof Error ? err.message : t('aiInfra.extraction.loadFailed'))
+  } finally {
+    loading.value = false
+  }
+}
+
+async function save() {
+  saving.value = true
+  try {
+    const status = await saveExtractionChains(chains.value)
+    adapters.value = status.adapters
+    chains.value = { ...status.chains }
+    success(t('aiInfra.extraction.saved'))
+  } catch (err) {
+    showError(err instanceof Error ? err.message : t('aiInfra.extraction.saveFailed'))
+  } finally {
+    saving.value = false
+  }
+}
+
+async function runTest() {
+  if (!testFile.value) return
+  testing.value = true
+  try {
+    testResult.value = await testExtraction(testFile.value)
+  } catch (err) {
+    showError(err instanceof Error ? err.message : t('aiInfra.extraction.loadFailed'))
+  } finally {
+    testing.value = false
+  }
+}
+
+onMounted(load)
+</script>

--- a/frontend/src/components/admin/plugs/ExtractionSidecarPanel.vue
+++ b/frontend/src/components/admin/plugs/ExtractionSidecarPanel.vue
@@ -1,0 +1,93 @@
+<template>
+  <div class="mb-6">
+    <div class="flex flex-wrap gap-2 mb-3">
+      <span
+        v-for="adapter in adapters"
+        :key="adapter.key"
+        class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs surface-card border border-light-border/30 dark:border-dark-border/20"
+        :data-testid="`extraction-health-${adapter.key}`"
+      >
+        <span
+          class="w-2 h-2 rounded-full"
+          :class="
+            adapter.health.available ? 'bg-[var(--status-success)]' : 'bg-[var(--status-warning)]'
+          "
+        />
+        <span class="txt-primary">{{ adapter.label }}</span>
+        <span class="txt-secondary">
+          {{
+            adapter.health.available
+              ? $t('aiInfra.extraction.healthAvailable')
+              : $t('aiInfra.extraction.healthUnavailable')
+          }}
+        </span>
+        <span
+          v-if="!adapter.health.available && adapter.health.reason"
+          class="txt-secondary max-w-[16rem] truncate"
+          :title="adapter.health.reason"
+        >
+          — {{ adapter.health.reason }}
+        </span>
+      </span>
+    </div>
+    <div class="flex flex-wrap items-center gap-2">
+      <button
+        v-for="service in sidecarServices"
+        :key="service"
+        type="button"
+        class="btn-secondary px-4 py-2.5 rounded-lg text-sm font-medium inline-flex items-center gap-2"
+        :disabled="testing === service"
+        :data-testid="`extraction-test-${service}`"
+        @click="testSidecar(service)"
+      >
+        {{
+          testing === service
+            ? $t('aiInfra.extraction.testingSidecar')
+            : $t(`aiInfra.extraction.testSidecar.${service}`)
+        }}
+      </button>
+      <RouterLink
+        class="text-sm text-[var(--brand)] underline underline-offset-2"
+        :to="{ path: '/admin/config', query: { tab: 'processing', section: 'docling' } }"
+        data-testid="extraction-sidecar-settings"
+      >
+        {{ $t('aiInfra.extraction.sidecarSettingsLink') }}
+      </RouterLink>
+    </div>
+    <p class="text-sm txt-secondary mt-2">{{ $t('aiInfra.extraction.sidecarSettings') }}</p>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useNotification } from '@/composables/useNotification'
+import { testConnection } from '@/services/api/adminConfigApi'
+import type { ExtractionStatus } from '@/services/api/adminPlugsApi'
+
+defineProps<{
+  adapters: ExtractionStatus['adapters']
+}>()
+
+const { t } = useI18n()
+const { success, error: showError } = useNotification()
+
+const sidecarServices = ['tika', 'docling'] as const
+const testing = ref<string | null>(null)
+
+async function testSidecar(service: (typeof sidecarServices)[number]) {
+  testing.value = service
+  try {
+    const result = await testConnection(service)
+    if (result.success) {
+      success(result.message)
+    } else {
+      showError(result.message)
+    }
+  } catch (err) {
+    showError(err instanceof Error ? err.message : t('aiInfra.extraction.loadFailed'))
+  } finally {
+    testing.value = null
+  }
+}
+</script>

--- a/frontend/src/components/admin/plugs/ModelsAndKeysTab.vue
+++ b/frontend/src/components/admin/plugs/ModelsAndKeysTab.vue
@@ -1,0 +1,153 @@
+<template>
+  <div>
+    <LocalAiDownloadCard class="mb-6" />
+
+    <div
+      class="rounded-lg p-4 mb-6 flex items-start gap-3 border"
+      :class="
+        chatReady
+          ? 'bg-[var(--status-success-muted)] border-[var(--status-success)]'
+          : 'bg-[var(--status-warning-muted)] border-[var(--status-warning)]'
+      "
+      data-testid="setup-status"
+    >
+      <Icon
+        :icon="chatReady ? 'mdi:check-circle' : 'mdi:alert-circle-outline'"
+        class="w-6 h-6 shrink-0 mt-0.5"
+        :class="chatReady ? 'text-[var(--status-success)]' : 'text-[var(--status-warning)]'"
+      />
+      <div>
+        <p class="font-semibold txt-primary">
+          {{ chatReady ? $t('adminSetup.statusReadyTitle') : $t('adminSetup.statusNotReadyTitle') }}
+        </p>
+        <p class="text-sm txt-secondary mt-0.5">
+          {{ chatReady ? $t('adminSetup.statusReadyText') : $t('adminSetup.statusNotReadyText') }}
+        </p>
+      </div>
+    </div>
+
+    <div v-if="loading" class="text-center py-12">
+      <Icon icon="mdi:loading" class="w-8 h-8 animate-spin mx-auto txt-secondary" />
+    </div>
+
+    <div
+      v-else-if="loadFailed"
+      class="surface-card rounded-lg p-8 text-center"
+      data-testid="setup-load-error"
+    >
+      <Icon icon="mdi:cloud-alert" class="w-8 h-8 mx-auto text-[var(--status-warning)]" />
+      <p class="txt-secondary mt-3">{{ $t('adminSetup.loadFailed') }}</p>
+      <button
+        type="button"
+        class="btn-primary px-6 py-2.5 rounded-lg font-medium mt-4"
+        data-testid="setup-retry"
+        @click="refresh"
+      >
+        {{ $t('common.retry') }}
+      </button>
+    </div>
+
+    <template v-else>
+      <h2 class="text-xl font-semibold txt-primary mb-3">
+        {{ $t('adminSetup.cloudProviders') }}
+      </h2>
+      <p class="text-sm txt-secondary mb-4">{{ $t('adminSetup.cloudProvidersHint') }}</p>
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-8">
+        <ProviderKeyCard
+          v-for="provider in sortedProviders"
+          :key="provider.name"
+          :provider="provider"
+          :is-default-chat="provider.name === defaultChatProvider"
+          @changed="refresh"
+        />
+      </div>
+
+      <div class="surface-card rounded-lg p-5 flex items-start gap-3 mb-8">
+        <Icon icon="mdi:puzzle-plus-outline" class="w-6 h-6 shrink-0 txt-brand mt-0.5" />
+        <div class="min-w-0 flex-1">
+          <h3 class="text-lg font-semibold txt-primary">
+            {{ $t('adminSetup.ownService.title') }}
+          </h3>
+          <p class="text-sm txt-secondary mt-1">{{ $t('adminSetup.ownService.description') }}</p>
+          <RouterLink
+            :to="{ path: '/ai/models', query: { tab: 'edit' } }"
+            class="inline-flex items-center gap-1.5 mt-3 text-sm font-medium text-[var(--brand)] hover:underline"
+            data-testid="setup-own-service"
+          >
+            {{ $t('adminSetup.ownService.cta') }}
+            <Icon icon="mdi:arrow-right" class="w-4 h-4" aria-hidden="true" />
+          </RouterLink>
+        </div>
+      </div>
+
+      <div class="surface-card rounded-lg p-5 flex items-start gap-3">
+        <Icon icon="mdi:server-outline" class="w-6 h-6 shrink-0 txt-brand mt-0.5" />
+        <div class="min-w-0 flex-1">
+          <div class="flex items-center gap-2">
+            <h3 class="text-lg font-semibold txt-primary">
+              {{ $t('adminSetup.localAi.title') }}
+            </h3>
+            <ProviderHelpHint
+              help-id="ollama"
+              url="https://ollama.com/download"
+              :is-download="true"
+            />
+          </div>
+          <p class="text-sm txt-secondary mt-1">{{ $t('adminSetup.localAi.description') }}</p>
+        </div>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import { Icon } from '@iconify/vue'
+import { RouterLink } from 'vue-router'
+import { useI18n } from 'vue-i18n'
+import ProviderHelpHint from '@/components/admin/ProviderHelpHint.vue'
+import ProviderKeyCard from '@/components/admin/ProviderKeyCard.vue'
+import LocalAiDownloadCard from '@/components/setup/LocalAiDownloadCard.vue'
+import { useNotification } from '@/composables/useNotification'
+import { useConfigStore } from '@/stores/config'
+import { listProviderKeys, type ProviderKeyStatus } from '@/services/api/providerKeysApi'
+
+const { t } = useI18n()
+const { error: showError } = useNotification()
+const config = useConfigStore()
+
+const loading = ref(true)
+const loadFailed = ref(false)
+const providers = ref<ProviderKeyStatus[]>([])
+const defaultChatProvider = ref('')
+
+const chatReady = computed(() => config.setup.chatReady)
+
+const sortedProviders = computed(() =>
+  [...providers.value].sort((a, b) => {
+    if (a.recommended !== b.recommended) return a.recommended ? -1 : 1
+    if (a.configured !== b.configured) return a.configured ? -1 : 1
+    return a.displayName.localeCompare(b.displayName)
+  })
+)
+
+const load = async () => {
+  try {
+    const result = await listProviderKeys()
+    providers.value = result.providers
+    defaultChatProvider.value = result.defaultChatProvider
+    loadFailed.value = false
+  } catch (err) {
+    loadFailed.value = true
+    showError(err instanceof Error ? err.message : t('adminSetup.loadFailed'))
+  } finally {
+    loading.value = false
+  }
+}
+
+const refresh = async () => {
+  await Promise.all([load(), config.reload()])
+}
+
+onMounted(refresh)
+</script>

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -135,7 +135,7 @@
     "adminFeatures": "Feature-Status",
     "adminModelStatus": "Modell-Status",
     "adminConfig": "Systemkonfiguration",
-    "adminSetup": "KI-Anbieter einrichten",
+    "adminSetup": "KI-Infrastruktur",
     "adminPeople": "Personen",
     "myGroups": "Meine Gruppen",
     "incoming": "Eingehende Chats",
@@ -745,7 +745,7 @@
     "adminFeatureStatus": "Feature-Status",
     "adminModelStatus": "Modell-Status",
     "adminSystemConfig": "Systemkonfiguration",
-    "adminProviderSetup": "KI-Anbieter",
+    "adminProviderSetup": "KI-Infrastruktur",
     "adminPeople": "Personen",
     "more": "Mehr",
     "moreDescription": "Weitere Bereiche und Konto",
@@ -2932,7 +2932,11 @@
     }
   },
   "adminSetup": {
-    "title": "KI-Anbieter einrichten",
+    "title": "KI-Infrastruktur",
+    "tabs": {
+      "models": "Modelle & Schlüssel",
+      "extraction": "Extraktion"
+    },
     "description": "Verbinde einen KI-Anbieter, damit dein Team chatten kann. Schlüssel werden verschlüsselt auf deinem Server gespeichert und gelten sofort — kein Neustart nötig.",
     "statusReadyTitle": "Deine KI ist bereit",
     "statusReadyText": "Das Standard-Chat-Modell hat einen funktionierenden Anbieter. Du kannst unten jederzeit weitere Anbieter hinzufügen.",
@@ -2975,6 +2979,48 @@
     "localAi": {
       "title": "Lokale KI (Ollama) — kein Schlüssel nötig",
       "description": "Die Standard-Installation enthält lokale KI-Modelle, die vollständig auf deiner Hardware laufen. Der Modell-Download kann beim ersten Start etwas dauern; die Cloud-Anbieter oben sind sofort verfügbar."
+    }
+  },
+  "aiInfra": {
+    "extraction": {
+      "lead": "Legen Sie fest, wie Dokumente zu Text werden. Docling erhält Tabellen und Überschriften; wenn es nicht läuft, übernimmt Tika — Uploads schlagen nie fehl.",
+      "family": {
+        "document": "Dokumente",
+        "text": "Klartext",
+        "image": "Bilder",
+        "audio": "Audio",
+        "audio_no_cloud": "Audio ohne Cloud-STT",
+        "video": "Video"
+      },
+      "moveUp": "Hoch",
+      "moveDown": "Runter",
+      "remove": "Entfernen",
+      "add": "Hinzufügen",
+      "addPlaceholder": "Adapter hinzufügen…",
+      "healthAvailable": "verfügbar",
+      "healthUnavailable": "nicht verfügbar",
+      "testTitle": "Mit einer Datei testen",
+      "testHint": "Laden Sie eine Beispieldatei hoch. Sie sehen, welcher Adapter gewonnen hat und warum die anderen nicht.",
+      "testButton": "Mit einer Datei testen",
+      "testing": "Test läuft…",
+      "winner": "Gewinner: {winner}",
+      "attemptMs": "{ms} ms",
+      "doclingUnavailableTika": "Docling nicht verfügbar — stattdessen Tika verwendet",
+      "save": "Kette speichern",
+      "saved": "Extraktionskette gespeichert. Der nächste Upload nutzt sie.",
+      "saveFailed": "Die Extraktionskette konnte nicht gespeichert werden",
+      "loadFailed": "Extraktionseinstellungen konnten nicht geladen werden",
+      "verdict": {
+        "quality_ok": "akzeptiert",
+        "not_applicable": "nicht geprüft",
+        "markdown_structure": "akzeptiert (Tabellen oder Überschriften)",
+        "empty": "leer",
+        "low_quality": "zu wenig brauchbarer Text",
+        "unavailable": "nicht verfügbar",
+        "unsupported": "unterstützt diese Datei nicht",
+        "unknown": "unbekannter Adapter",
+        "skipped": "übersprungen"
+      }
     }
   },
   "providerHelp": {

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -2999,6 +2999,13 @@
       "addPlaceholder": "Adapter hinzufügen…",
       "healthAvailable": "verfügbar",
       "healthUnavailable": "nicht verfügbar",
+      "testSidecar": {
+        "tika": "Tika testen",
+        "docling": "Docling testen"
+      },
+      "testingSidecar": "Test läuft…",
+      "sidecarSettings": "URL, Timeout und der Verbindungstest für Tika und Docling liegen unter Systemkonfiguration → Verarbeitung.",
+      "sidecarSettingsLink": "Verarbeitungseinstellungen öffnen",
       "testTitle": "Mit einer Datei testen",
       "testHint": "Laden Sie eine Beispieldatei hoch. Sie sehen, welcher Adapter gewonnen hat und warum die anderen nicht.",
       "testButton": "Mit einer Datei testen",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -134,7 +134,7 @@
     "adminFeatures": "Feature Status",
     "adminModelStatus": "Model Status",
     "adminConfig": "System Configuration",
-    "adminSetup": "AI Provider Setup",
+    "adminSetup": "AI infrastructure",
     "adminPeople": "People",
     "myGroups": "My groups",
     "incoming": "Incoming chats",
@@ -748,7 +748,7 @@
     "adminFeatureStatus": "Feature Status",
     "adminModelStatus": "Model Status",
     "adminSystemConfig": "System configuration",
-    "adminProviderSetup": "AI providers",
+    "adminProviderSetup": "AI infrastructure",
     "adminPeople": "People",
     "more": "More",
     "moreDescription": "More sections and account",
@@ -2838,7 +2838,11 @@
     }
   },
   "adminSetup": {
-    "title": "AI Provider Setup",
+    "title": "AI infrastructure",
+    "tabs": {
+      "models": "Models & keys",
+      "extraction": "Extraction"
+    },
     "description": "Connect an AI provider so your team can chat. Keys are stored encrypted on your server and take effect immediately — no restart needed.",
     "statusReadyTitle": "Your AI is ready",
     "statusReadyText": "The default chat model has a working provider. You can add more providers below at any time.",
@@ -2881,6 +2885,48 @@
     "localAi": {
       "title": "Local AI (Ollama) — no key needed",
       "description": "The standard installation includes local AI models that run entirely on your hardware. Downloading models can take a while on first start; cloud providers above are available instantly."
+    }
+  },
+  "aiInfra": {
+    "extraction": {
+      "lead": "Choose how documents are turned into text. Docling keeps tables and headings; if it is not running, Tika is used instead and uploads never fail.",
+      "family": {
+        "document": "Documents",
+        "text": "Plain text",
+        "image": "Images",
+        "audio": "Audio",
+        "audio_no_cloud": "Audio without cloud STT",
+        "video": "Video"
+      },
+      "moveUp": "Up",
+      "moveDown": "Down",
+      "remove": "Remove",
+      "add": "Add",
+      "addPlaceholder": "Add an adapter…",
+      "healthAvailable": "available",
+      "healthUnavailable": "unavailable",
+      "testTitle": "Test with a file",
+      "testHint": "Upload a sample. You will see which adapter won and why the others did not.",
+      "testButton": "Test with a file",
+      "testing": "Testing…",
+      "winner": "Winner: {winner}",
+      "attemptMs": "{ms} ms",
+      "doclingUnavailableTika": "Docling unavailable — Tika used instead",
+      "save": "Save chain",
+      "saved": "Extraction chain saved. The next upload uses it.",
+      "saveFailed": "The extraction chain could not be saved",
+      "loadFailed": "Could not load extraction settings",
+      "verdict": {
+        "quality_ok": "accepted",
+        "not_applicable": "not gated",
+        "markdown_structure": "accepted (tables or headings)",
+        "empty": "empty",
+        "low_quality": "too little useful text",
+        "unavailable": "unavailable",
+        "unsupported": "does not support this file",
+        "unknown": "unknown adapter",
+        "skipped": "skipped"
+      }
     }
   },
   "providerHelp": {

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -2905,6 +2905,13 @@
       "addPlaceholder": "Add an adapter…",
       "healthAvailable": "available",
       "healthUnavailable": "unavailable",
+      "testSidecar": {
+        "tika": "Test Tika",
+        "docling": "Test Docling"
+      },
+      "testingSidecar": "Testing…",
+      "sidecarSettings": "URL, timeout and a connection test for Tika and Docling live under System configuration → Processing.",
+      "sidecarSettingsLink": "Open Processing settings",
       "testTitle": "Test with a file",
       "testHint": "Upload a sample. You will see which adapter won and why the others did not.",
       "testButton": "Test with a file",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -133,7 +133,7 @@
     "adminFeatures": "Estado de funciones",
     "adminModelStatus": "Estado de modelos",
     "adminConfig": "Configuración del Sistema",
-    "adminSetup": "Configuración de Proveedores de IA",
+    "adminSetup": "Infraestructura de IA",
     "adminPeople": "Personas",
     "myGroups": "Mis grupos",
     "incoming": "Chats entrantes",
@@ -738,7 +738,7 @@
     "adminFeatureStatus": "Estado de Funciones",
     "adminModelStatus": "Estado de Modelos",
     "adminSystemConfig": "Configuración del Sistema",
-    "adminProviderSetup": "Proveedores de IA",
+    "adminProviderSetup": "Infraestructura de IA",
     "adminPeople": "Personas",
     "profile": "Perfil",
     "more": "Más",
@@ -1143,7 +1143,11 @@
     }
   },
   "adminSetup": {
-    "title": "Configuración de Proveedores de IA",
+    "title": "Infraestructura de IA",
+    "tabs": {
+      "models": "Modelos y claves",
+      "extraction": "Extracción"
+    },
     "description": "Conecta un proveedor de IA para que tu equipo pueda chatear. Las claves se guardan cifradas en tu servidor y se aplican al instante — sin reiniciar.",
     "statusReadyTitle": "Tu IA está lista",
     "statusReadyText": "El modelo de chat predeterminado tiene un proveedor funcional. Puedes añadir más proveedores abajo en cualquier momento.",
@@ -1186,6 +1190,48 @@
     "localAi": {
       "title": "IA local (Ollama) — sin clave",
       "description": "La instalación estándar incluye modelos de IA locales que se ejecutan completamente en tu hardware. La descarga de modelos puede tardar en el primer arranque; los proveedores en la nube de arriba están disponibles al instante."
+    }
+  },
+  "aiInfra": {
+    "extraction": {
+      "lead": "Elija cómo se convierte un documento en texto. Docling conserva tablas y títulos; si no está en marcha, se usa Tika y la carga nunca falla.",
+      "family": {
+        "document": "Documentos",
+        "text": "Texto plano",
+        "image": "Imágenes",
+        "audio": "Audio",
+        "audio_no_cloud": "Audio sin STT en la nube",
+        "video": "Vídeo"
+      },
+      "moveUp": "Subir",
+      "moveDown": "Bajar",
+      "remove": "Quitar",
+      "add": "Añadir",
+      "addPlaceholder": "Añadir un adaptador…",
+      "healthAvailable": "disponible",
+      "healthUnavailable": "no disponible",
+      "testTitle": "Probar con un archivo",
+      "testHint": "Suba un ejemplo. Verá qué adaptador ganó y por qué los demás no.",
+      "testButton": "Probar con un archivo",
+      "testing": "Probando…",
+      "winner": "Ganador: {winner}",
+      "attemptMs": "{ms} ms",
+      "doclingUnavailableTika": "Docling no disponible — se usó Tika",
+      "save": "Guardar cadena",
+      "saved": "Cadena de extracción guardada. La próxima carga la usará.",
+      "saveFailed": "No se pudo guardar la cadena de extracción",
+      "loadFailed": "No se pudieron cargar los ajustes de extracción",
+      "verdict": {
+        "quality_ok": "aceptado",
+        "not_applicable": "sin filtro",
+        "markdown_structure": "aceptado (tablas o títulos)",
+        "empty": "vacío",
+        "low_quality": "demasiado poco texto útil",
+        "unavailable": "no disponible",
+        "unsupported": "no admite este archivo",
+        "unknown": "adaptador desconocido",
+        "skipped": "omitido"
+      }
     }
   },
   "providerHelp": {

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -1210,6 +1210,13 @@
       "addPlaceholder": "Añadir un adaptador…",
       "healthAvailable": "disponible",
       "healthUnavailable": "no disponible",
+      "testSidecar": {
+        "tika": "Probar Tika",
+        "docling": "Probar Docling"
+      },
+      "testingSidecar": "Probando…",
+      "sidecarSettings": "La URL, el tiempo de espera y la prueba de conexión de Tika y Docling están en Configuración del sistema → Procesamiento.",
+      "sidecarSettingsLink": "Abrir ajustes de procesamiento",
       "testTitle": "Probar con un archivo",
       "testHint": "Suba un ejemplo. Verá qué adaptador ganó y por qué los demás no.",
       "testButton": "Probar con un archivo",

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -135,7 +135,7 @@
     "adminFeatures": "État des fonctionnalités",
     "adminModelStatus": "État des modèles",
     "adminConfig": "Configuration système",
-    "adminSetup": "Configuration des fournisseurs IA",
+    "adminSetup": "Infrastructure IA",
     "adminPeople": "Personnes",
     "myGroups": "Mes groupes",
     "incoming": "Chats reçus",
@@ -749,7 +749,7 @@
     "adminFeatureStatus": "État des fonctionnalités",
     "adminModelStatus": "État des modèles",
     "adminSystemConfig": "Configuration système",
-    "adminProviderSetup": "Fournisseurs IA",
+    "adminProviderSetup": "Infrastructure IA",
     "adminPeople": "Personnes",
     "more": "Plus",
     "moreDescription": "Autres sections et compte",
@@ -2838,7 +2838,11 @@
     }
   },
   "adminSetup": {
-    "title": "Configuration des fournisseurs IA",
+    "title": "Infrastructure IA",
+    "tabs": {
+      "models": "Modèles et clés",
+      "extraction": "Extraction"
+    },
     "description": "Connectez un fournisseur IA pour que votre équipe puisse discuter. Les clés sont stockées chiffrées sur votre serveur et prennent effet immédiatement — aucun redémarrage n’est nécessaire.",
     "statusReadyTitle": "Votre IA est prête",
     "statusReadyText": "Le modèle de chat par défaut a un fournisseur fonctionnel. Vous pouvez ajouter d’autres fournisseurs ci-dessous à tout moment.",
@@ -2881,6 +2885,48 @@
     "localAi": {
       "title": "IA locale (Ollama) — aucune clé nécessaire",
       "description": "L’installation standard inclut des modèles IA locaux qui s’exécutent entièrement sur votre matériel. Le téléchargement des modèles peut prendre du temps au premier démarrage ; les fournisseurs cloud ci-dessus sont disponibles immédiatement."
+    }
+  },
+  "aiInfra": {
+    "extraction": {
+      "lead": "Choisissez comment un document devient du texte. Docling conserve les tableaux et les titres ; s’il n’est pas lancé, Tika prend le relais et l’envoi n’échoue jamais.",
+      "family": {
+        "document": "Documents",
+        "text": "Texte brut",
+        "image": "Images",
+        "audio": "Audio",
+        "audio_no_cloud": "Audio sans STT cloud",
+        "video": "Vidéo"
+      },
+      "moveUp": "Monter",
+      "moveDown": "Descendre",
+      "remove": "Retirer",
+      "add": "Ajouter",
+      "addPlaceholder": "Ajouter un adaptateur…",
+      "healthAvailable": "disponible",
+      "healthUnavailable": "indisponible",
+      "testTitle": "Tester avec un fichier",
+      "testHint": "Envoyez un exemple. Vous verrez quel adaptateur a gagné et pourquoi les autres n’ont pas été retenus.",
+      "testButton": "Tester avec un fichier",
+      "testing": "Test en cours…",
+      "winner": "Gagnant : {winner}",
+      "attemptMs": "{ms} ms",
+      "doclingUnavailableTika": "Docling indisponible — Tika a été utilisé",
+      "save": "Enregistrer la chaîne",
+      "saved": "Chaîne d’extraction enregistrée. Le prochain envoi l’utilise.",
+      "saveFailed": "Impossible d’enregistrer la chaîne d’extraction",
+      "loadFailed": "Impossible de charger les réglages d’extraction",
+      "verdict": {
+        "quality_ok": "accepté",
+        "not_applicable": "non filtré",
+        "markdown_structure": "accepté (tableaux ou titres)",
+        "empty": "vide",
+        "low_quality": "trop peu de texte utile",
+        "unavailable": "indisponible",
+        "unsupported": "ne prend pas en charge ce fichier",
+        "unknown": "adaptateur inconnu",
+        "skipped": "ignoré"
+      }
     }
   },
   "providerHelp": {

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -2905,6 +2905,13 @@
       "addPlaceholder": "Ajouter un adaptateur…",
       "healthAvailable": "disponible",
       "healthUnavailable": "indisponible",
+      "testSidecar": {
+        "tika": "Tester Tika",
+        "docling": "Tester Docling"
+      },
+      "testingSidecar": "Test en cours…",
+      "sidecarSettings": "L’URL, le délai et le test de connexion de Tika et Docling sont dans Configuration système → Traitement.",
+      "sidecarSettingsLink": "Ouvrir les réglages de traitement",
       "testTitle": "Tester avec un fichier",
       "testHint": "Envoyez un exemple. Vous verrez quel adaptateur a gagné et pourquoi les autres n’ont pas été retenus.",
       "testButton": "Tester avec un fichier",

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -133,7 +133,7 @@
     "adminFeatures": "Özellik Durumu",
     "adminModelStatus": "Model Durumu",
     "adminConfig": "Sistem Yapılandırması",
-    "adminSetup": "AI Sağlayıcı Kurulumu",
+    "adminSetup": "AI altyapısı",
     "adminPeople": "Kişiler",
     "myGroups": "Gruplarım",
     "incoming": "Gelen sohbetler",
@@ -738,7 +738,7 @@
     "adminFeatureStatus": "Özellik Durumu",
     "adminModelStatus": "Model Durumu",
     "adminSystemConfig": "Sistem Yapılandırması",
-    "adminProviderSetup": "AI Sağlayıcıları",
+    "adminProviderSetup": "AI altyapısı",
     "adminPeople": "Kişiler",
     "profile": "Profil",
     "more": "Daha fazla",
@@ -1143,7 +1143,11 @@
     }
   },
   "adminSetup": {
-    "title": "AI Sağlayıcı Kurulumu",
+    "title": "AI altyapısı",
+    "tabs": {
+      "models": "Modeller ve anahtarlar",
+      "extraction": "Çıkarım"
+    },
     "description": "Ekibinizin sohbet edebilmesi için bir AI sağlayıcısı bağlayın. Anahtarlar sunucunuzda şifrelenmiş olarak saklanır ve anında geçerli olur — yeniden başlatma gerekmez.",
     "statusReadyTitle": "AI'nız hazır",
     "statusReadyText": "Varsayılan sohbet modelinin çalışan bir sağlayıcısı var. Aşağıdan istediğiniz zaman başka sağlayıcılar ekleyebilirsiniz.",
@@ -1186,6 +1190,48 @@
     "localAi": {
       "title": "Yerel AI (Ollama) — anahtar gerekmez",
       "description": "Standart kurulum, tamamen kendi donanımınızda çalışan yerel AI modelleri içerir. İlk başlatmada model indirme biraz sürebilir; yukarıdaki bulut sağlayıcıları anında kullanılabilir."
+    }
+  },
+  "aiInfra": {
+    "extraction": {
+      "lead": "Belgelerin nasıl metne dönüşeceğini seçin. Docling tabloları ve başlıkları korur; çalışmıyorsa Tika kullanılır ve yükleme asla başarısız olmaz.",
+      "family": {
+        "document": "Belgeler",
+        "text": "Düz metin",
+        "image": "Görseller",
+        "audio": "Ses",
+        "audio_no_cloud": "Bulut STT olmadan ses",
+        "video": "Video"
+      },
+      "moveUp": "Yukarı",
+      "moveDown": "Aşağı",
+      "remove": "Kaldır",
+      "add": "Ekle",
+      "addPlaceholder": "Bir bağdaştırıcı ekle…",
+      "healthAvailable": "kullanılabilir",
+      "healthUnavailable": "kullanılamıyor",
+      "testTitle": "Bir dosyayla dene",
+      "testHint": "Bir örnek yükleyin. Hangi bağdaştırıcının kazandığını ve diğerlerinin neden kaybettiğini görürsünüz.",
+      "testButton": "Bir dosyayla dene",
+      "testing": "Deneniyor…",
+      "winner": "Kazanan: {winner}",
+      "attemptMs": "{ms} ms",
+      "doclingUnavailableTika": "Docling kullanılamıyor — yerine Tika kullanıldı",
+      "save": "Zinciri kaydet",
+      "saved": "Çıkarım zinciri kaydedildi. Sonraki yükleme bunu kullanır.",
+      "saveFailed": "Çıkarım zinciri kaydedilemedi",
+      "loadFailed": "Çıkarım ayarları yüklenemedi",
+      "verdict": {
+        "quality_ok": "kabul edildi",
+        "not_applicable": "denetlenmedi",
+        "markdown_structure": "kabul edildi (tablo veya başlık)",
+        "empty": "boş",
+        "low_quality": "çok az yararlı metin",
+        "unavailable": "kullanılamıyor",
+        "unsupported": "bu dosyayı desteklemiyor",
+        "unknown": "bilinmeyen bağdaştırıcı",
+        "skipped": "atlandı"
+      }
     }
   },
   "providerHelp": {

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -1210,6 +1210,13 @@
       "addPlaceholder": "Bir bağdaştırıcı ekle…",
       "healthAvailable": "kullanılabilir",
       "healthUnavailable": "kullanılamıyor",
+      "testSidecar": {
+        "tika": "Tika’yı dene",
+        "docling": "Docling’i dene"
+      },
+      "testingSidecar": "Deneniyor…",
+      "sidecarSettings": "Tika ve Docling için URL, zaman aşımı ve bağlantı testi Sistem yapılandırması → İşleme altında.",
+      "sidecarSettingsLink": "İşleme ayarlarını aç",
       "testTitle": "Bir dosyayla dene",
       "testHint": "Bir örnek yükleyin. Hangi bağdaştırıcının kazandığını ve diğerlerinin neden kaybettiğini görürsünüz.",
       "testButton": "Bir dosyayla dene",

--- a/frontend/src/services/api/adminPlugsApi.ts
+++ b/frontend/src/services/api/adminPlugsApi.ts
@@ -1,0 +1,35 @@
+import type { z } from 'zod'
+import {
+  GetAdminPlugsExtractionStatusResponseSchema,
+  PostAdminPlugsExtractionTestResponseSchema,
+} from '@/generated/api-schemas'
+import { httpClient } from './httpClient'
+
+export type ExtractionStatus = z.infer<typeof GetAdminPlugsExtractionStatusResponseSchema>
+export type ExtractionTestResult = z.infer<typeof PostAdminPlugsExtractionTestResponseSchema>
+
+export async function getExtractionStatus(): Promise<ExtractionStatus> {
+  return httpClient('/api/v1/admin/plugs/extraction', {
+    schema: GetAdminPlugsExtractionStatusResponseSchema,
+  })
+}
+
+export async function saveExtractionChains(
+  chains: Record<string, string[]>
+): Promise<ExtractionStatus> {
+  return httpClient('/api/v1/admin/plugs/extraction/chains', {
+    method: 'PUT',
+    body: JSON.stringify({ chains }),
+    schema: GetAdminPlugsExtractionStatusResponseSchema,
+  })
+}
+
+export async function testExtraction(file: File): Promise<ExtractionTestResult> {
+  const body = new FormData()
+  body.append('file', file)
+  return httpClient('/api/v1/admin/plugs/extraction/test', {
+    method: 'POST',
+    body,
+    schema: PostAdminPlugsExtractionTestResponseSchema,
+  })
+}

--- a/frontend/src/views/AdminConfigView.vue
+++ b/frontend/src/views/AdminConfigView.vue
@@ -234,7 +234,7 @@ const currentSections = computed(() => {
 // Service test mapping (multiple services per tab are tested sequentially)
 const testableServices: Record<string, string[]> = {
   ai: ['ollama', 'piper'],
-  processing: ['tika'],
+  processing: ['tika', 'docling'],
   vectordb: ['qdrant'],
   email: ['mailer'],
 }

--- a/frontend/src/views/ProviderSetupView.vue
+++ b/frontend/src/views/ProviderSetupView.vue
@@ -1,175 +1,67 @@
 <template>
   <MainLayout data-testid="view-admin-setup">
     <div class="container mx-auto px-6 py-8 max-w-5xl overflow-x-hidden">
-      <!-- Header -->
       <PageHeader
         :title="$t('adminSetup.title')"
         :subtitle="$t('adminSetup.description')"
         icon="mdi:rocket-launch-outline"
       />
 
-      <LocalAiDownloadCard class="mb-6" />
+      <TabNav
+        v-model="activeTab"
+        class="mb-6"
+        :tabs="tabs"
+        :aria-label="$t('adminSetup.title')"
+        testid="admin-setup-tabs"
+      />
 
-      <!-- Readiness status -->
-      <div
-        class="rounded-lg p-4 mb-6 flex items-start gap-3 border"
-        :class="
-          chatReady
-            ? 'bg-[var(--status-success-muted)] border-[var(--status-success)]'
-            : 'bg-[var(--status-warning-muted)] border-[var(--status-warning)]'
-        "
-        data-testid="setup-status"
-      >
-        <Icon
-          :icon="chatReady ? 'mdi:check-circle' : 'mdi:alert-circle-outline'"
-          class="w-6 h-6 shrink-0 mt-0.5"
-          :class="chatReady ? 'text-[var(--status-success)]' : 'text-[var(--status-warning)]'"
-        />
-        <div>
-          <p class="font-semibold txt-primary">
-            {{
-              chatReady ? $t('adminSetup.statusReadyTitle') : $t('adminSetup.statusNotReadyTitle')
-            }}
-          </p>
-          <p class="text-sm txt-secondary mt-0.5">
-            {{ chatReady ? $t('adminSetup.statusReadyText') : $t('adminSetup.statusNotReadyText') }}
-          </p>
-        </div>
-      </div>
-
-      <!-- Loading -->
-      <div v-if="loading" class="text-center py-12">
-        <Icon icon="mdi:loading" class="w-8 h-8 animate-spin mx-auto txt-secondary" />
-      </div>
-
-      <!-- Load failure: the page is useless without the provider list, so offer a retry -->
-      <div
-        v-else-if="loadFailed"
-        class="surface-card rounded-lg p-8 text-center"
-        data-testid="setup-load-error"
-      >
-        <Icon icon="mdi:cloud-alert" class="w-8 h-8 mx-auto text-[var(--status-warning)]" />
-        <p class="txt-secondary mt-3">{{ $t('adminSetup.loadFailed') }}</p>
-        <button
-          class="btn-primary px-6 py-2.5 rounded-lg font-medium mt-4"
-          data-testid="setup-retry"
-          @click="refresh"
-        >
-          {{ $t('common.retry') }}
-        </button>
-      </div>
-
-      <template v-else>
-        <!-- Provider cards -->
-        <h2 class="text-xl font-semibold txt-primary mb-3">
-          {{ $t('adminSetup.cloudProviders') }}
-        </h2>
-        <p class="text-sm txt-secondary mb-4">{{ $t('adminSetup.cloudProvidersHint') }}</p>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-8">
-          <ProviderKeyCard
-            v-for="provider in sortedProviders"
-            :key="provider.name"
-            :provider="provider"
-            :is-default-chat="provider.name === defaultChatProvider"
-            @changed="refresh"
-          />
-        </div>
-
-        <div class="surface-card rounded-lg p-5 flex items-start gap-3 mb-8">
-          <Icon icon="mdi:puzzle-plus-outline" class="w-6 h-6 shrink-0 txt-brand mt-0.5" />
-          <div class="min-w-0 flex-1">
-            <h3 class="text-lg font-semibold txt-primary">
-              {{ $t('adminSetup.ownService.title') }}
-            </h3>
-            <p class="text-sm txt-secondary mt-1">{{ $t('adminSetup.ownService.description') }}</p>
-            <RouterLink
-              :to="{ path: '/ai/models', query: { tab: 'edit' } }"
-              class="inline-flex items-center gap-1.5 mt-3 text-sm font-medium text-[var(--brand)] hover:underline"
-              data-testid="setup-own-service"
-            >
-              {{ $t('adminSetup.ownService.cta') }}
-              <Icon icon="mdi:arrow-right" class="w-4 h-4" aria-hidden="true" />
-            </RouterLink>
-          </div>
-        </div>
-
-        <!-- Local AI note -->
-        <div class="surface-card rounded-lg p-5 flex items-start gap-3">
-          <Icon icon="mdi:server-outline" class="w-6 h-6 shrink-0 txt-brand mt-0.5" />
-          <div class="min-w-0 flex-1">
-            <div class="flex items-center gap-2">
-              <h3 class="text-lg font-semibold txt-primary">
-                {{ $t('adminSetup.localAi.title') }}
-              </h3>
-              <ProviderHelpHint
-                help-id="ollama"
-                url="https://ollama.com/download"
-                :is-download="true"
-              />
-            </div>
-            <p class="text-sm txt-secondary mt-1">{{ $t('adminSetup.localAi.description') }}</p>
-          </div>
-        </div>
-      </template>
+      <ModelsAndKeysTab v-if="activeTab === 'models'" />
+      <ExtractionPlugTab v-else-if="activeTab === 'extraction'" />
     </div>
   </MainLayout>
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
-import { Icon } from '@iconify/vue'
-import { RouterLink } from 'vue-router'
+import { computed, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import MainLayout from '@/components/MainLayout.vue'
 import PageHeader from '@/components/PageHeader.vue'
-import ProviderHelpHint from '@/components/admin/ProviderHelpHint.vue'
-import ProviderKeyCard from '@/components/admin/ProviderKeyCard.vue'
-import LocalAiDownloadCard from '@/components/setup/LocalAiDownloadCard.vue'
-import { useNotification } from '@/composables/useNotification'
-import { useConfigStore } from '@/stores/config'
-import { listProviderKeys, type ProviderKeyStatus } from '@/services/api/providerKeysApi'
+import TabNav, { type TabNavItem } from '@/components/TabNav.vue'
+import ExtractionPlugTab from '@/components/admin/plugs/ExtractionPlugTab.vue'
+import ModelsAndKeysTab from '@/components/admin/plugs/ModelsAndKeysTab.vue'
 
 const { t } = useI18n()
-const { error: showError } = useNotification()
-const config = useConfigStore()
+const route = useRoute()
+const router = useRouter()
 
-const loading = ref(true)
-const loadFailed = ref(false)
-const providers = ref<ProviderKeyStatus[]>([])
-const defaultChatProvider = ref('')
+const tabFromQuery = (): string => (route.query.tab === 'extraction' ? 'extraction' : 'models')
+const activeTab = ref(tabFromQuery())
 
-const chatReady = computed(() => config.setup.chatReady)
+const tabs = computed<TabNavItem[]>(() => [
+  {
+    id: 'models',
+    label: t('adminSetup.tabs.models'),
+    icon: 'mdi:key-outline',
+    testid: 'admin-setup-tab-models',
+  },
+  {
+    id: 'extraction',
+    label: t('adminSetup.tabs.extraction'),
+    icon: 'mdi:file-document-outline',
+    testid: 'admin-setup-tab-extraction',
+  },
+])
 
-// Recommended first, then configured, then alphabetical — the fresh-install
-// visitor should see the quickest path (free-tier key) at the top.
-const sortedProviders = computed(() =>
-  [...providers.value].sort((a, b) => {
-    if (a.recommended !== b.recommended) return a.recommended ? -1 : 1
-    if (a.configured !== b.configured) return a.configured ? -1 : 1
-    return a.displayName.localeCompare(b.displayName)
-  })
-)
+watch(activeTab, (id) => {
+  if (route.query.tab === id || (id === 'models' && !route.query.tab)) return
+  void router.replace({ query: id === 'models' ? {} : { tab: id } })
+})
 
-const load = async () => {
-  try {
-    const result = await listProviderKeys()
-    providers.value = result.providers
-    defaultChatProvider.value = result.defaultChatProvider
-    loadFailed.value = false
-  } catch (err) {
-    loadFailed.value = true
-    showError(err instanceof Error ? err.message : t('adminSetup.loadFailed'))
-  } finally {
-    loading.value = false
+watch(
+  () => route.query.tab,
+  () => {
+    activeTab.value = tabFromQuery()
   }
-}
-
-// Re-fetch the list AND the runtime config, so the readiness banner (here and in
-// the chat) reflects the current state — also on a direct visit to this URL,
-// where the cached runtime config may predate the last key change.
-const refresh = async () => {
-  await Promise.all([load(), config.reload()])
-}
-
-onMounted(refresh)
+)
 </script>

--- a/frontend/src/views/ProviderSetupView.vue
+++ b/frontend/src/views/ProviderSetupView.vue
@@ -54,8 +54,15 @@ const tabs = computed<TabNavItem[]>(() => [
 ])
 
 watch(activeTab, (id) => {
-  if (route.query.tab === id || (id === 'models' && !route.query.tab)) return
-  void router.replace({ query: id === 'models' ? {} : { tab: id } })
+  const tab = route.query.tab
+  if (tab === id || (id === 'models' && (tab === undefined || tab === ''))) return
+  const query = { ...route.query }
+  if (id === 'models') {
+    delete query.tab
+  } else {
+    query.tab = id
+  }
+  void router.replace({ query })
 })
 
 watch(

--- a/frontend/tests/unit/components/admin/plugs/ExtractionPlugTab.spec.ts
+++ b/frontend/tests/unit/components/admin/plugs/ExtractionPlugTab.spec.ts
@@ -17,6 +17,10 @@ vi.mock('@/composables/useNotification', () => ({
   useNotification: () => ({ error: vi.fn(), success: vi.fn() }),
 }))
 
+vi.mock('@/services/api/adminConfigApi', () => ({
+  testConnection: vi.fn().mockResolvedValue({ success: true, message: 'ok' }),
+}))
+
 describe('ExtractionPlugTab', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
@@ -52,13 +56,22 @@ describe('ExtractionPlugTab', () => {
   it('shows the lead sentence, health pills and the test button', async () => {
     const wrapper = mount(ExtractionPlugTab, {
       global: {
-        stubs: { Icon: true },
+        stubs: {
+          Icon: true,
+          RouterLink: { template: '<a><slot /></a>', props: ['to'] },
+        },
       },
     })
     await flushPromises()
 
     expect(wrapper.text()).toContain('Choose how documents are turned into text')
     expect(wrapper.get('[data-testid="extraction-health-docling"]').text()).toContain('Docling')
+    expect(wrapper.get('[data-testid="extraction-health-docling"]').text()).toContain('down')
+    expect(wrapper.get('[data-testid="extraction-test-docling"]').text()).toContain('Test Docling')
+    expect(wrapper.get('[data-testid="extraction-test-tika"]').text()).toContain('Test Tika')
+    expect(wrapper.get('[data-testid="extraction-sidecar-settings"]').text()).toContain(
+      'Open Processing settings'
+    )
     expect(wrapper.get('[data-testid="extraction-test-button"]').text()).toContain(
       'Test with a file'
     )

--- a/frontend/tests/unit/components/admin/plugs/ExtractionPlugTab.spec.ts
+++ b/frontend/tests/unit/components/admin/plugs/ExtractionPlugTab.spec.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import ExtractionPlugTab from '@/components/admin/plugs/ExtractionPlugTab.vue'
+
+const getExtractionStatus = vi.fn()
+const saveExtractionChains = vi.fn()
+const testExtraction = vi.fn()
+
+vi.mock('@/services/api/adminPlugsApi', () => ({
+  getExtractionStatus: (...args: unknown[]) => getExtractionStatus(...args),
+  saveExtractionChains: (...args: unknown[]) => saveExtractionChains(...args),
+  testExtraction: (...args: unknown[]) => testExtraction(...args),
+}))
+
+vi.mock('@/composables/useNotification', () => ({
+  useNotification: () => ({ error: vi.fn(), success: vi.fn() }),
+}))
+
+describe('ExtractionPlugTab', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    getExtractionStatus.mockResolvedValue({
+      adapters: [
+        {
+          key: 'docling',
+          label: 'Docling',
+          docsUrl: '',
+          sovereignty: 'self-hosted',
+          health: { available: false, reason: 'down' },
+        },
+        {
+          key: 'tika',
+          label: 'Apache Tika',
+          docsUrl: '',
+          sovereignty: 'self-hosted',
+          health: { available: true, reason: null },
+        },
+      ],
+      chains: {
+        document: ['tika', 'pdf_vision'],
+        text: ['native'],
+        image: ['vision'],
+        audio: ['stt_cloud'],
+        audio_no_cloud: ['whisper_local'],
+        video: ['video_analysis'],
+      },
+      quality: { minLength: 10, minEntropy: 3, applyTo: ['pdf'] },
+    })
+  })
+
+  it('shows the lead sentence, health pills and the test button', async () => {
+    const wrapper = mount(ExtractionPlugTab, {
+      global: {
+        stubs: { Icon: true },
+      },
+    })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Choose how documents are turned into text')
+    expect(wrapper.get('[data-testid="extraction-health-docling"]').text()).toContain('Docling')
+    expect(wrapper.get('[data-testid="extraction-test-button"]').text()).toContain(
+      'Test with a file'
+    )
+  })
+})

--- a/frontend/tests/unit/composables/useNavItems.spec.ts
+++ b/frontend/tests/unit/composables/useNavItems.spec.ts
@@ -74,7 +74,7 @@ const navMessages = {
     adminDashboard: 'Overview',
     adminFeatureStatus: 'Feature Status',
     adminModelStatus: 'Model Status',
-    adminProviderSetup: 'AI providers',
+    adminProviderSetup: 'AI infrastructure',
     adminSystemConfig: 'System configuration',
     adminPeople: 'People',
   },

--- a/frontend/tests/unit/views/ProviderSetupView.spec.ts
+++ b/frontend/tests/unit/views/ProviderSetupView.spec.ts
@@ -19,7 +19,7 @@ vi.mock('@/composables/useNotification', () => ({
   useNotification: () => ({ error: vi.fn(), success: vi.fn() }),
 }))
 
-function mountView() {
+async function mountView(path = '/admin/setup') {
   const router = createRouter({
     history: createMemoryHistory(),
     routes: [
@@ -28,7 +28,9 @@ function mountView() {
       { path: '/ai/models', component: { template: '<div />' } },
     ],
   })
-  return mount(ProviderSetupView, {
+  await router.push(path)
+  await router.isReady()
+  const wrapper = mount(ProviderSetupView, {
     global: {
       plugins: [router],
       stubs: {
@@ -42,6 +44,7 @@ function mountView() {
       },
     },
   })
+  return { wrapper, router }
 }
 
 describe('ProviderSetupView own-service link', () => {
@@ -50,7 +53,7 @@ describe('ProviderSetupView own-service link', () => {
   })
 
   it('links to the Edit models tab on /ai/models', async () => {
-    const wrapper = mountView()
+    const { wrapper } = await mountView()
     await flushPromises()
 
     const link = wrapper.get('[data-testid="setup-own-service"]')
@@ -59,12 +62,25 @@ describe('ProviderSetupView own-service link', () => {
   })
 
   it('shows Models and Extraction tabs and hides later plug tabs', async () => {
-    const wrapper = mountView()
+    const { wrapper } = await mountView()
     await flushPromises()
 
     expect(wrapper.get('[data-testid="admin-setup-tab-models"]').text()).toContain('Models')
     expect(wrapper.get('[data-testid="admin-setup-tab-extraction"]').text()).toContain('Extraction')
     expect(wrapper.find('[data-testid="admin-setup-tab-web-search"]').exists()).toBe(false)
     expect(wrapper.find('[data-testid="admin-setup-tab-rerank"]').exists()).toBe(false)
+  })
+
+  it('keeps other query params when switching tabs', async () => {
+    const { wrapper, router } = await mountView('/admin/setup?connected=1')
+    await flushPromises()
+
+    await wrapper.get('[data-testid="admin-setup-tab-extraction"]').trigger('click')
+    await flushPromises()
+    expect(router.currentRoute.value.query).toEqual({ connected: '1', tab: 'extraction' })
+
+    await wrapper.get('[data-testid="admin-setup-tab-models"]').trigger('click')
+    await flushPromises()
+    expect(router.currentRoute.value.query).toEqual({ connected: '1' })
   })
 })

--- a/frontend/tests/unit/views/ProviderSetupView.spec.ts
+++ b/frontend/tests/unit/views/ProviderSetupView.spec.ts
@@ -16,7 +16,7 @@ vi.mock('@/stores/config', () => ({
 }))
 
 vi.mock('@/composables/useNotification', () => ({
-  useNotification: () => ({ error: vi.fn() }),
+  useNotification: () => ({ error: vi.fn(), success: vi.fn() }),
 }))
 
 function mountView() {
@@ -37,6 +37,7 @@ function mountView() {
         LocalAiDownloadCard: true,
         ProviderKeyCard: true,
         ProviderHelpHint: true,
+        ExtractionPlugTab: { template: '<div data-testid="extraction-plug-tab-stub" />' },
         Icon: true,
       },
     },
@@ -55,5 +56,15 @@ describe('ProviderSetupView own-service link', () => {
     const link = wrapper.get('[data-testid="setup-own-service"]')
     expect(link.text()).toContain('Add your own service')
     expect(link.attributes('href')).toBe('/ai/models?tab=edit')
+  })
+
+  it('shows Models and Extraction tabs and hides later plug tabs', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    expect(wrapper.get('[data-testid="admin-setup-tab-models"]').text()).toContain('Models')
+    expect(wrapper.get('[data-testid="admin-setup-tab-extraction"]').text()).toContain('Extraction')
+    expect(wrapper.find('[data-testid="admin-setup-tab-web-search"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="admin-setup-tab-rerank"]').exists()).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary
- Optional **Docling** extra extractor (`docling`) can sit in front of Tika when an admin adds it to a family chain. Fresh installs keep the S1 default (no Docling). A down or unstarted sidecar never fails an upload (C7).
- Quality gate generalizes Tika’s PDF `isLowQuality()` (`EXTRACTION.QUALITY.apply_to=pdf`); markdown with a table or heading can still pass. Markdown from Docling is chunked heading-aware (breadcrumb + tables kept whole / header repeated).
- Opt-in Compose profile `docling` (CPU image `docling-serve-cpu:v1.32.0`, no `mem_limit` in dev). Operate → **AI infrastructure** gains an **Extraction** tab (health, chain edit, Test with a file). Web search / rerank tabs stay hidden until S3/S4.

## Test plan
- [x] `make ci-local` (lint, phpstan, backend + frontend tests, vue-tsc)
- [ ] `docker compose --profile docling up -d`; Operate → AI infrastructure → Extraction; add `docling` to the document chain; upload a PDF with a table; ask for one cell
- [ ] `docker compose stop docling`; same upload succeeds with `strategy=tika`; **Test with a file** shows “Docling unavailable — Tika used instead”
- [ ] Fresh install / default chain: golden corpus unchanged; Models & keys tab matches today’s provider-key page
- [ ] Dark + V2 + 320px on the Extraction tab