### PR TITLE
fix(saved-tasks): fetch markdown-wrapped URLs on task rerun

### DIFF
--- a/backend/src/Service/Message/MessageProcessor.php
+++ b/backend/src/Service/Message/MessageProcessor.php
@@ -1145,13 +1145,6 @@ final readonly class MessageProcessor
     }
 
     /**
-     * Human-readable reason for the consolidated web-search decision log.
-     *
-     * Mirrors the precedence in {@see WebSearchTopicPolicy::shouldSearch()}
-     * so the log line directly explains the decision without a reader
-     * having to consult two services.
-     */
-    /**
      * Prefetch named URLs into classification['url_content'] so ChatHandler
      * (and UrlFetchRunner reuse) can read the page.
      *
@@ -1190,6 +1183,13 @@ final readonly class MessageProcessor
         return $classification;
     }
 
+    /**
+     * Human-readable reason for the consolidated web-search decision log.
+     *
+     * Mirrors the precedence in {@see WebSearchTopicPolicy::shouldSearch()}
+     * so the log line directly explains the decision without a reader
+     * having to consult two services.
+     */
     private function triggerReasonFor(?string $topic, bool $userRequestedSearch, ?bool $promptToolInternet, ?bool $classifierVote, ?string $messageText, bool $shouldSearch): string
     {
         if (!$shouldSearch) {

--- a/backend/src/Service/Message/MessageProcessor.php
+++ b/backend/src/Service/Message/MessageProcessor.php
@@ -499,21 +499,8 @@ final readonly class MessageProcessor
                 }
             }
 
-            // Step 2.7: URL Content Extraction (if tool_url_screenshot enabled)
-            if ($promptMetadata['tool_url_screenshot'] ?? false) {
-                $urls = $this->urlContentService->extractUrls($message->getText());
-                if (!empty($urls)) {
-                    $this->notify($statusCallback, 'fetching_urls', sprintf('Fetching content from %d URL(s)...', count($urls)));
-
-                    $urlContentResults = $this->urlContentService->fetchMultiple($urls);
-                    $successCount = count(array_filter($urlContentResults, static fn ($r) => $r->success));
-
-                    if ($successCount > 0) {
-                        $classification['url_content'] = $this->urlContentService->formatForPrompt($urlContentResults);
-                        $this->notify($statusCallback, 'urls_fetched', sprintf('Extracted content from %d URL(s)', $successCount));
-                    }
-                }
-            }
+            // Step 2.7: URL Content Extraction (prompt tool or Saved Task rerun)
+            $classification = $this->maybeFetchUrlContent($message, $promptMetadata, $classification, $statusCallback);
 
             // Step 2.9: Rolling conversation summary (read-only on the hot path).
             [$options, $conversationHistory] = $this->applyRollingSummary(
@@ -981,21 +968,8 @@ final readonly class MessageProcessor
                 $classification['search_results'] = $searchResults;
             }
 
-            // Step 2.7: URL Content Extraction (if tool_url_screenshot enabled)
-            if (!empty($promptMetadata['tool_url_screenshot'])) {
-                $urls = $this->urlContentService->extractUrls($message->getText());
-                if (!empty($urls)) {
-                    $this->notify($statusCallback, 'fetching_urls', sprintf('Fetching content from %d URL(s)...', count($urls)));
-
-                    $urlContentResults = $this->urlContentService->fetchMultiple($urls);
-                    $successCount = count(array_filter($urlContentResults, static fn ($r) => $r->success));
-
-                    if ($successCount > 0) {
-                        $classification['url_content'] = $this->urlContentService->formatForPrompt($urlContentResults);
-                        $this->notify($statusCallback, 'urls_fetched', sprintf('Extracted content from %d URL(s)', $successCount));
-                    }
-                }
-            }
+            // Step 2.7: URL Content Extraction (prompt tool or Saved Task rerun)
+            $classification = $this->maybeFetchUrlContent($message, $promptMetadata, $classification, $statusCallback);
 
             // Step 2.9: Rolling conversation summary — the same read-only
             // injection as processStream(), so email / MCP / webhook turns get
@@ -1176,6 +1150,45 @@ final readonly class MessageProcessor
      * so the log line directly explains the decision without a reader
      * having to consult two services.
      */
+    /**
+     * Prefetch named URLs into classification['url_content'] so ChatHandler
+     * (and UrlFetchRunner reuse) can read the page.
+     *
+     * The prompt flag `tool_url_screenshot` is the existing opt-in. Saved Task
+     * reruns also fetch: they pin a user instruction that often wraps the URL
+     * in markdown (`[label](url)`, `**url**`) and skip the sorter, so the
+     * planner can miss `url_fetch` and the page would never be loaded.
+     *
+     * @param array<string, mixed> $promptMetadata
+     * @param array<string, mixed> $classification
+     *
+     * @return array<string, mixed>
+     */
+    private function maybeFetchUrlContent(Message $message, array $promptMetadata, array $classification, ?callable $statusCallback): array
+    {
+        $savedTask = 'saved_task' === ($classification['source'] ?? null);
+        if (!$savedTask && empty($promptMetadata['tool_url_screenshot'])) {
+            return $classification;
+        }
+
+        $urls = $this->urlContentService->extractUrls((string) $message->getText());
+        if ([] === $urls) {
+            return $classification;
+        }
+
+        $this->notify($statusCallback, 'fetching_urls', sprintf('Fetching content from %d URL(s)...', count($urls)));
+
+        $urlContentResults = $this->urlContentService->fetchMultiple($urls);
+        $successCount = count(array_filter($urlContentResults, static fn ($r) => $r->success));
+
+        if ($successCount > 0) {
+            $classification['url_content'] = $this->urlContentService->formatForPrompt($urlContentResults);
+            $this->notify($statusCallback, 'urls_fetched', sprintf('Extracted content from %d URL(s)', $successCount));
+        }
+
+        return $classification;
+    }
+
     private function triggerReasonFor(?string $topic, bool $userRequestedSearch, ?bool $promptToolInternet, ?bool $classifierVote, ?string $messageText, bool $shouldSearch): string
     {
         if (!$shouldSearch) {

--- a/backend/src/Service/Message/MessageProcessor.php
+++ b/backend/src/Service/Message/MessageProcessor.php
@@ -505,7 +505,7 @@ final readonly class MessageProcessor
             // Step 2.9: Rolling conversation summary (read-only on the hot path).
             [$options, $conversationHistory] = $this->applyRollingSummary(
                 $message,
-                $classification ?? [],
+                $classification,
                 $options,
                 $conversationHistory,
                 $perfTimer,
@@ -835,11 +835,12 @@ final readonly class MessageProcessor
                 $this->maybeShadowPlan($message, $conversationHistory);
             }
 
+            $promptMetadata = [];
             if (isset($classification['prompt_metadata']) && is_array($classification['prompt_metadata'])) {
                 $promptMetadata = $classification['prompt_metadata'];
             }
 
-            if (empty($promptMetadata) && !empty($classification['topic'])) {
+            if ([] === $promptMetadata && !empty($classification['topic'])) {
                 $promptData = $this->promptService->getPromptWithMetadata($classification['topic'], $message->getUserId());
                 if ($promptData) {
                     $promptMetadata = $promptData['metadata'] ?? [];

--- a/backend/src/Service/SavedTask/Graph/SavedTaskPlanFactory.php
+++ b/backend/src/Service/SavedTask/Graph/SavedTaskPlanFactory.php
@@ -47,6 +47,7 @@ final class SavedTaskPlanFactory
             $id = (string) $node['id'];
             $capability = (string) $node['capability'];
             $params = is_array($node['params'] ?? null) ? $node['params'] : [];
+            $inputs = is_array($node['inputs'] ?? null) ? $node['inputs'] : [];
             if (Capability::Chat->value === $capability && !isset($params['topic_id']) && isset($graph['prompt_topic'])) {
                 $params['topic_id'] = $graph['prompt_topic'];
             }
@@ -57,6 +58,7 @@ final class SavedTaskPlanFactory
                 'id' => $id,
                 'capability' => $capability,
                 'depends_on' => array_values(array_filter($node['depends_on'] ?? [], 'is_string')),
+                'inputs' => $inputs,
                 'params' => $params,
             ];
             if (Capability::ComposeReply->value === $capability) {

--- a/backend/src/Service/UrlContentService.php
+++ b/backend/src/Service/UrlContentService.php
@@ -48,22 +48,130 @@ final readonly class UrlContentService
     }
 
     /**
-     * Extract URLs from a message text.
+     * Extract http(s) URLs from a message or planner input.
+     *
+     * Handles the shapes a Saved Task / prompt editor actually stores:
+     * bare URLs, markdown links `[label](url)`, GFM autolinks `<url>`,
+     * HTML `href="url"`, and emphasis wrappers (`**url**`) from the
+     * prompt markdown toolbar. Decode HTML entities first so a
+     * formatter round-trip cannot hide `https://`.
      *
      * @return string[]
      */
     public function extractUrls(string $message): array
     {
-        preg_match_all(
-            '/https?:\/\/[^\s<>"{}|\\\\^`\[\]]+/i',
-            $message,
-            $matches
-        );
+        $decoded = html_entity_decode($message, ENT_QUOTES | ENT_HTML5, 'UTF-8');
 
-        $urls = array_unique($matches[0]);
+        $candidates = [];
+        foreach ($this->extractMarkdownLinkUrls($decoded) as $url) {
+            $candidates[] = $url;
+        }
+        foreach ($this->extractHrefUrls($decoded) as $url) {
+            $candidates[] = $url;
+        }
+        if (preg_match_all('/https?:\/\/[^\s<>"{}|\\\\^`\[\]]+/i', $decoded, $matches)) {
+            foreach ($matches[0] as $url) {
+                $candidates[] = $url;
+            }
+        }
 
-        // Clean trailing punctuation that's likely not part of the URL
-        return array_values(array_map(static fn (string $url): string => rtrim($url, '.,;:!?)'), $urls));
+        $urls = [];
+        foreach ($candidates as $raw) {
+            $normalized = $this->normalizeExtractedUrl($raw);
+            if (null !== $normalized) {
+                $urls[$normalized] = $normalized;
+            }
+        }
+
+        return array_values($urls);
+    }
+
+    /**
+     * Markdown `[label](url)` / `![alt](url)` and GFM `<https://…>` autolinks.
+     * Nested parentheses in the destination (Wikipedia `Foo_(bar)`) are kept.
+     *
+     * @return list<string>
+     */
+    private function extractMarkdownLinkUrls(string $message): array
+    {
+        $urls = [];
+        $length = \strlen($message);
+        $offset = 0;
+        while ($offset < $length) {
+            $pos = stripos($message, '](http', $offset);
+            if (false === $pos) {
+                break;
+            }
+            $start = $pos + 2;
+            $depth = 0;
+            $end = $start;
+            while ($end < $length) {
+                $ch = $message[$end];
+                if ('(' === $ch) {
+                    ++$depth;
+                } elseif (')' === $ch) {
+                    if (0 === $depth) {
+                        break;
+                    }
+                    --$depth;
+                } elseif (ctype_space($ch)) {
+                    break;
+                }
+                ++$end;
+            }
+            $urls[] = substr($message, $start, $end - $start);
+            $offset = $end + 1;
+        }
+
+        if (preg_match_all('/<(https?:\/\/[^>\s]+)>/i', $message, $auto)) {
+            foreach ($auto[1] as $url) {
+                $urls[] = $url;
+            }
+        }
+
+        return $urls;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function extractHrefUrls(string $message): array
+    {
+        if (!preg_match_all('/\bhref\s*=\s*["\'](https?:\/\/[^"\']+)["\']/i', $message, $matches)) {
+            return [];
+        }
+
+        return array_values($matches[1]);
+    }
+
+    /**
+     * Strip trailing sentence punctuation and markdown emphasis without
+     * eating a balanced closing `)` that is part of the path.
+     */
+    private function normalizeExtractedUrl(string $url): ?string
+    {
+        $url = trim($url);
+        $url = rtrim($url, '.,;:!?');
+        $url = rtrim($url, '*_~`');
+
+        while (str_ends_with($url, ')')) {
+            $open = substr_count($url, '(');
+            $close = substr_count($url, ')');
+            if ($close <= $open) {
+                break;
+            }
+            $url = substr($url, 0, -1);
+        }
+
+        $parts = parse_url($url);
+        if (!is_array($parts) || empty($parts['scheme']) || empty($parts['host'])) {
+            return null;
+        }
+        if (!\in_array(strtolower((string) $parts['scheme']), ['http', 'https'], true)) {
+            return null;
+        }
+
+        return $url;
     }
 
     /**

--- a/backend/src/Service/UrlContentService.php
+++ b/backend/src/Service/UrlContentService.php
@@ -141,7 +141,7 @@ final readonly class UrlContentService
             return [];
         }
 
-        return array_values($matches[1]);
+        return $matches[1];
     }
 
     /**

--- a/backend/tests/Unit/MessageProcessorTest.php
+++ b/backend/tests/Unit/MessageProcessorTest.php
@@ -845,4 +845,73 @@ class MessageProcessorTest extends TestCase
 
         $this->processor->process($message);
     }
+
+    public function testSavedTaskPrefetchesMarkdownWrappedUrlWithoutScreenshotFlag(): void
+    {
+        $message = $this->createMock(Message::class);
+        $message->method('getUserId')->willReturn(1);
+        $message->method('getTrackingId')->willReturn(123);
+        $message->method('getFile')->willReturn(0);
+        $message->method('getText')->willReturn('Check and summarize [the page](https://example.com/news)');
+        $message->method('hasFiles')->willReturn(false);
+
+        $urlContent = $this->createMock(UrlContentService::class);
+        $urlContent->expects($this->once())
+            ->method('extractUrls')
+            ->with('Check and summarize [the page](https://example.com/news)')
+            ->willReturn(['https://example.com/news']);
+        $urlContent->expects($this->once())
+            ->method('fetchMultiple')
+            ->with(['https://example.com/news'])
+            ->willReturn([]);
+        $urlContent->expects($this->never())->method('formatForPrompt');
+
+        $processor = new MessageProcessor(
+            $this->messageRepository,
+            $this->searchResultRepository,
+            $this->preProcessor,
+            $this->classifier,
+            $this->router,
+            $this->modelConfigService,
+            $this->promptService,
+            WebSearchGatewayFactory::fromBrave($this->braveSearchService),
+            $this->searchQueryGenerator,
+            $this->createMock(AttachmentSearchContextResolver::class),
+            $urlContent,
+            $this->logger,
+            $this->createMock(MultitaskRoutingConfig::class),
+            $this->createMock(TaskPlanner::class),
+            $this->createMock(TaskPlanStore::class),
+            $this->createMock(TaskPlanExecutor::class),
+            $this->conversationSummaryService,
+            $this->createMock(AgentConfig::class),
+        );
+
+        $this->preProcessor->method('process')->willReturn($message);
+        $this->messageRepository->method('findConversationHistory')->willReturn([]);
+        $this->modelConfigService->method('getDefaultModel')->willReturn(null);
+        $this->classifier->expects($this->never())->method('classify');
+        $this->promptService->method('getPromptWithMetadata')->willReturn([
+            'prompt' => 'saved instruction',
+            'metadata' => ['tool_files' => true, 'tool_mcp' => false],
+        ]);
+        $this->router
+            ->expects($this->once())
+            ->method('route')
+            ->willReturnCallback(function ($msg, $history, $classification) {
+                $this->assertSame('saved_task', $classification['source'] ?? null);
+
+                return [
+                    'content' => 'Summary',
+                    'metadata' => ['provider' => 'test', 'model' => 'test'],
+                ];
+            });
+
+        $result = $processor->process($message, [
+            'fixed_task_prompt' => 'saved-123',
+            'saved_task' => true,
+        ]);
+
+        $this->assertTrue($result['success']);
+    }
 }

--- a/backend/tests/Unit/Service/Multitask/Execution/Runner/UrlFetchRunnerTest.php
+++ b/backend/tests/Unit/Service/Multitask/Execution/Runner/UrlFetchRunnerTest.php
@@ -238,6 +238,24 @@ final class UrlFetchRunnerTest extends TestCase
         self::assertStringContainsString('plain body', (string) $result->text);
     }
 
+    public function testExtractsUrlFromMarkdownLinkInPlannerInput(): void
+    {
+        $html = '<html><head><title>News</title></head><body>markdown fetched body</body></html>';
+        $runner = $this->runner([
+            new MockResponse('', ['http_code' => 404]),
+            new MockResponse($html, ['http_code' => 200, 'response_headers' => ['content-type' => 'text/html']]),
+        ]);
+
+        $result = $runner->run(
+            $this->node(['urls' => '[the article](https://example.com/md)']),
+            $this->context('summarize [the article](https://example.com/md)'),
+        );
+
+        self::assertTrue($result->isSuccessful());
+        self::assertSame(['https://example.com/md'], $result->metadata['urls']);
+        self::assertStringContainsString('markdown fetched body', (string) $result->text);
+    }
+
     public function testHttpErrorFailsTheNodeInIsolation(): void
     {
         $runner = $this->runner([

--- a/backend/tests/Unit/Service/SavedTask/SavedTaskPlanFactoryTest.php
+++ b/backend/tests/Unit/Service/SavedTask/SavedTaskPlanFactoryTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\SavedTask;
+
+use App\Entity\SavedTask;
+use App\Service\Multitask\Plan\Capability;
+use App\Service\SavedTask\Graph\SavedTaskGraphValidator;
+use App\Service\SavedTask\Graph\SavedTaskPlanFactory;
+use PHPUnit\Framework\TestCase;
+
+final class SavedTaskPlanFactoryTest extends TestCase
+{
+    public function testAuthoredUrlFetchKeepsInputs(): void
+    {
+        $task = new SavedTask(1, 12, 'Read the page');
+        $task->setGraph([
+            'version' => 1,
+            'trigger' => ['type' => 'manual'],
+            'nodes' => [
+                [
+                    'id' => 'n1',
+                    'capability' => 'url_fetch',
+                    'depends_on' => [],
+                    'inputs' => ['urls' => 'https://example.com/news'],
+                ],
+                [
+                    'id' => 'n2',
+                    'capability' => 'chat',
+                    'depends_on' => ['n1'],
+                    'inputs' => ['text' => '$n1.text'],
+                ],
+            ],
+        ]);
+
+        $plan = (new SavedTaskPlanFactory(new SavedTaskGraphValidator()))->fromTask($task);
+
+        $fetch = $plan->nodeById('n1');
+        self::assertNotNull($fetch);
+        self::assertSame(Capability::UrlFetch, $fetch->capability);
+        self::assertSame(['urls' => 'https://example.com/news'], $fetch->inputs);
+
+        $chat = $plan->nodeById('n2');
+        self::assertNotNull($chat);
+        self::assertSame(['text' => '$n1.text'], $chat->inputs);
+        self::assertSame('12', $chat->params['prompt_id'] ?? null);
+    }
+}

--- a/backend/tests/Unit/Service/UrlContentServiceTest.php
+++ b/backend/tests/Unit/Service/UrlContentServiceTest.php
@@ -131,6 +131,61 @@ HTML;
     }
 
     /**
+     * @dataProvider markdownUrlProvider
+     */
+    public function testExtractUrlsReadsMarkdownAndBareForms(string $message, array $expected): void
+    {
+        self::assertSame($expected, $this->service([])->extractUrls($message));
+    }
+
+    /**
+     * @return iterable<string, array{0: string, 1: list<string>}>
+     */
+    public static function markdownUrlProvider(): iterable
+    {
+        yield 'bare url' => [
+            'summarize https://example.com/article and keep it short',
+            ['https://example.com/article'],
+        ];
+        yield 'markdown link' => [
+            'Check and read [this page](https://example.com/news) then summarize',
+            ['https://example.com/news'],
+        ];
+        yield 'markdown link with wikipedia parens' => [
+            'Read [Foo](https://en.wikipedia.org/wiki/Foo_(bar)) please',
+            ['https://en.wikipedia.org/wiki/Foo_(bar)'],
+        ];
+        yield 'bare wikipedia parens' => [
+            'https://en.wikipedia.org/wiki/Foo_(bar)',
+            ['https://en.wikipedia.org/wiki/Foo_(bar)'],
+        ];
+        yield 'gfm autolink' => [
+            'Load <https://example.com/doc> and summarize',
+            ['https://example.com/doc'],
+        ];
+        yield 'bold-wrapped url from prompt toolbar' => [
+            'Please read **https://example.com/a** now',
+            ['https://example.com/a'],
+        ];
+        yield 'html href after formatter round-trip' => [
+            'See <a href="https://example.com/href">the article</a>',
+            ['https://example.com/href'],
+        ];
+        yield 'html entity encoded slashes' => [
+            'summarize https:&#x2F;&#x2F;example.com/encoded',
+            ['https://example.com/encoded'],
+        ];
+        yield 'trailing sentence punctuation' => [
+            'See https://example.com/end.',
+            ['https://example.com/end'],
+        ];
+        yield 'no url' => [
+            'just summarize my notes',
+            [],
+        ];
+    }
+
+    /**
      * @param list<MockResponse> $responses
      */
     private function service(array $responses): UrlContentService

--- a/backend/tests/Unit/Service/UrlContentServiceTest.php
+++ b/backend/tests/Unit/Service/UrlContentServiceTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\Service;
 
 use App\Service\Security\SsrfGuard;
 use App\Service\UrlContentService;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Symfony\Component\HttpClient\MockHttpClient;
@@ -131,8 +132,9 @@ HTML;
     }
 
     /**
-     * @dataProvider markdownUrlProvider
+     * @param list<string> $expected
      */
+    #[DataProvider('markdownUrlProvider')]
     public function testExtractUrlsReadsMarkdownAndBareForms(string $message, array $expected): void
     {
         self::assertSame($expected, $this->service([])->extractUrls($message));

--- a/frontend/src/components/multitask/TaskPlanBubble.vue
+++ b/frontend/src/components/multitask/TaskPlanBubble.vue
@@ -7,6 +7,7 @@ import type { TaskPlanState } from '@/stores/history'
 import { useDialog } from '@/composables/useDialog'
 import { useNotification } from '@/composables/useNotification'
 import { isSavedTasksEnabled } from '@/composables/useSavedTasksFeature'
+import { instructionHasUrl } from '@/utils/scheduleSource'
 import { promptsApi } from '@/services/api/promptsApi'
 import { savedTasksApi } from '@/services/api/savedTasksApi'
 import TaskCard from '@/components/multitask/TaskCard.vue'
@@ -61,7 +62,15 @@ const onSchedule = async () => {
       shortDescription: name.trim(),
       prompt: instruction,
       language: locale.value || 'en',
-      metadata: { tool_files: true, tool_mcp: false },
+      metadata: {
+        tool_files: true,
+        tool_mcp: false,
+        // Prefetch named pages on rerun. The prompt editor's markdown
+        // toolbar wraps URLs as `[label](url)` / `**url**`; without this
+        // flag a later "Run now" skipped fetch unless the planner re-emitted
+        // url_fetch.
+        tool_url_screenshot: instructionHasUrl(instruction),
+      },
     })
     await savedTasksApi.create(prompt.id, name.trim())
     success(t('config.savedTasks.scheduledFromChat'))

--- a/frontend/src/utils/scheduleSource.ts
+++ b/frontend/src/utils/scheduleSource.ts
@@ -1,0 +1,24 @@
+import type { Part } from '@/stores/history'
+
+const TEXT_PART_TYPES = new Set(['text', 'pastedText'])
+
+/**
+ * Rebuild the user instruction that produced a task plan.
+ *
+ * Pasted blocks are stored as `pastedText` parts (and as
+ * `<pasted-content>` in the persisted row). Dropping them when saving a
+ * Saved Task would lose a URL that only lived in the paste.
+ */
+export function scheduleSourceFromParts(parts: Part[] | undefined): string {
+  if (!parts?.length) return ''
+  return parts
+    .filter((part) => TEXT_PART_TYPES.has(part.type) && typeof part.content === 'string')
+    .map((part) => part.content)
+    .join('\n')
+    .trim()
+}
+
+/** True when the instruction names a concrete http(s) URL, including markdown links. */
+export function instructionHasUrl(text: string): boolean {
+  return /https?:\/\//i.test(text)
+}

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -556,6 +556,7 @@ import { buildUploadUrl, isAudioFileType } from '@/utils/mediaTypes'
 import { isChannelSource } from '@/utils/channelSource'
 import { looksLikeFileGenerationEnvelope } from '@/utils/fileGenerationEnvelope'
 import { stripPastedBlocks } from '@/utils/pastedContent'
+import { scheduleSourceFromParts } from '@/utils/scheduleSource'
 import { AudioStreamer } from '@/utils/AudioStreamer'
 import { isRecoverableStreamError, isCancellationError } from '@/utils/streamError'
 import { httpClient } from '@/services/api/httpClient'
@@ -1547,11 +1548,7 @@ const userTextBefore = (messageId: string | number): string => {
   const idx = list.findIndex((row) => row.id === messageId)
   for (let i = idx - 1; i >= 0; i--) {
     if (list[i].role !== 'user') continue
-    return list[i].parts
-      .filter((part) => part.type === 'text' && typeof part.content === 'string')
-      .map((part) => part.content)
-      .join('\n')
-      .trim()
+    return scheduleSourceFromParts(list[i].parts)
   }
   return ''
 }

--- a/frontend/tests/unit/components/multitask/TaskPlanBubble.spec.ts
+++ b/frontend/tests/unit/components/multitask/TaskPlanBubble.spec.ts
@@ -6,8 +6,10 @@ import type { TaskPlanState } from '@/stores/history'
 import { useAiConfigStore } from '@/stores/aiConfig'
 import type { AIModel } from '@/types/ai-models'
 
-const { mockSavedTasksEnabled } = vi.hoisted(() => ({
+const { mockSavedTasksEnabled, mockDialogPrompt, mockCreatePrompt } = vi.hoisted(() => ({
   mockSavedTasksEnabled: vi.fn(() => false),
+  mockDialogPrompt: vi.fn(),
+  mockCreatePrompt: vi.fn(),
 }))
 
 vi.mock('@/composables/useSavedTasksFeature', () => ({
@@ -15,7 +17,15 @@ vi.mock('@/composables/useSavedTasksFeature', () => ({
 }))
 
 vi.mock('@/composables/useDialog', () => ({
-  useDialog: () => ({ prompt: vi.fn() }),
+  useDialog: () => ({ prompt: mockDialogPrompt }),
+}))
+
+vi.mock('@/services/api/promptsApi', () => ({
+  promptsApi: { createPrompt: (...args: unknown[]) => mockCreatePrompt(...args) },
+}))
+
+vi.mock('@/services/api/savedTasksApi', () => ({
+  savedTasksApi: { create: vi.fn().mockResolvedValue({ id: 1 }) },
 }))
 
 vi.mock('@/composables/useNotification', () => ({
@@ -74,6 +84,8 @@ describe('TaskPlanBubble', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
     mockSavedTasksEnabled.mockReturnValue(false)
+    mockDialogPrompt.mockReset()
+    mockCreatePrompt.mockReset()
   })
   it('renders one card per task node', () => {
     const wrapper = mount(TaskPlanBubble, {
@@ -539,6 +551,33 @@ describe('TaskPlanBubble', () => {
     })
 
     expect(wrapper.find('[data-testid="btn-schedule-plan"]').exists()).toBe(true)
+  })
+
+  it('enables URL prefetch when the saved instruction contains a markdown link', async () => {
+    mockSavedTasksEnabled.mockReturnValue(true)
+    mockDialogPrompt.mockResolvedValue('Daily brief')
+    mockCreatePrompt.mockResolvedValue({ id: 9 })
+    const wrapper = mount(TaskPlanBubble, {
+      props: {
+        plan: {
+          active: false,
+          replyNode: 'n1',
+          cards: [{ nodeId: 'n1', capability: 'url_fetch', kind: 'search', state: 'done' }],
+        },
+        scheduleSource: 'Check and summarize [the page](https://example.com/news)',
+      },
+      ...mountOptions,
+    })
+
+    await wrapper.find('[data-testid="btn-schedule-plan"]').trigger('click')
+    await vi.waitFor(() => expect(mockCreatePrompt).toHaveBeenCalled())
+
+    expect(mockCreatePrompt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: 'Check and summarize [the page](https://example.com/news)',
+        metadata: expect.objectContaining({ tool_url_screenshot: true }),
+      })
+    )
   })
 
   it('hides the clock while the plan is still running', () => {

--- a/frontend/tests/unit/utils/scheduleSource.spec.ts
+++ b/frontend/tests/unit/utils/scheduleSource.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { instructionHasUrl, scheduleSourceFromParts } from '@/utils/scheduleSource'
+import type { Part } from '@/stores/history'
+
+describe('scheduleSourceFromParts', () => {
+  it('joins text and pastedText so a URL in a paste is kept', () => {
+    const parts: Part[] = [
+      { type: 'pastedText', content: 'Read https://example.com/pasted' },
+      { type: 'text', content: 'and summarize it' },
+    ]
+    expect(scheduleSourceFromParts(parts)).toBe('Read https://example.com/pasted\nand summarize it')
+  })
+
+  it('ignores non-text parts', () => {
+    const parts: Part[] = [
+      { type: 'image', url: 'https://cdn.example.com/x.png' },
+      { type: 'text', content: 'hello' },
+    ]
+    expect(scheduleSourceFromParts(parts)).toBe('hello')
+  })
+})
+
+describe('instructionHasUrl', () => {
+  it('detects a bare URL', () => {
+    expect(instructionHasUrl('summarize https://example.com/a')).toBe(true)
+  })
+
+  it('detects a markdown link', () => {
+    expect(instructionHasUrl('read [the page](https://example.com/a)')).toBe(true)
+  })
+
+  it('is false without an http URL', () => {
+    expect(instructionHasUrl('summarize my notes')).toBe(false)
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Saved Tasks created from chat with “check / read / summarize this URL” did not fetch the page on Run now. Yes — markdown formatting was part of the problem: the prompt editor wraps links as `[label](url)` / `**url**`, and URL extraction treated those as unusable.

## Changes
- Make `extractUrls` markdown-aware: `[label](url)`, GFM `<url>`, HTML `href`, emphasis wrappers, HTML entities, and Wikipedia-style `Foo_(bar)` paths.
- Prefetch named URLs on every `saved_task` run, not only when `tool_url_screenshot` is set (chat-saved prompts never had that flag).
- When scheduling from chat, keep pasted text in the instruction and set `tool_url_screenshot` if the instruction contains a URL.
- Pass authored graph `inputs` through `SavedTaskPlanFactory` so a pinned `url_fetch` keeps `inputs.urls`.

## Verification
- [x] Tests added/updated
- [x] `make -C backend phpstan` green
- [x] `make -C backend test` green (5660 tests)
- [x] Frontend lint, Vitest (`scheduleSource`, `TaskPlanBubble`), `vue-tsc`

## Notes
A task saved from a chat turn that successfully fetched the page was re-planned on rerun. The planner often emitted a single `chat`/`summarize` node, step 2.7 did not run, and a markdown-wrapped URL never reached the fetcher.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0810a-bf59-7256-81b2-dd1371345428?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0810a-bf59-7256-81b2-dd1371345428&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

