### PR TITLE
fix(iam): return audit subject as object|null, never an empty array

### DIFF
--- a/backend/src/Controller/AdminAuditController.php
+++ b/backend/src/Controller/AdminAuditController.php
@@ -128,11 +128,13 @@ final class AdminAuditController extends AbstractController
 
     /**
      * Guarantee the wire shape the schema promises (`subject: object|null`).
-     * A legacy row that stored an empty `[]` would otherwise serialize as a
-     * JSON array and fail the client's response validation; cast any non-empty
-     * value to an object so even a stray list is emitted as `{…}`.
+     * An empty or null subject collapses to null, so a legacy row that stored
+     * `[]` no longer serializes as a JSON array and fails the client's response
+     * validation. A well-formed subject is an associative map that stays a JSON
+     * object; a stray non-empty list is cast to an object with numeric string
+     * keys (`{"0": …}`) rather than being emitted as an array.
      *
-     * @param array<string, mixed>|null $subject
+     * @param array<array-key, mixed>|null $subject
      */
     private function normalizeSubject(?array $subject): ?object
     {

--- a/backend/src/Controller/AdminAuditController.php
+++ b/backend/src/Controller/AdminAuditController.php
@@ -106,7 +106,7 @@ final class AdminAuditController extends AbstractController
                 'action' => $row->getAction(),
                 'kind' => $row->getResourceKind(),
                 'resourceId' => $row->getResourceId(),
-                'subject' => $row->getSubject(),
+                'subject' => $this->normalizeSubject($row->getSubject()),
                 'ip' => $row->getIp(),
                 'created' => $row->getCreated(),
             ];
@@ -124,6 +124,19 @@ final class AdminAuditController extends AbstractController
         $value = $request->query->get($key);
 
         return is_string($value) && '' !== $value ? $value : null;
+    }
+
+    /**
+     * Guarantee the wire shape the schema promises (`subject: object|null`).
+     * A legacy row that stored an empty `[]` would otherwise serialize as a
+     * JSON array and fail the client's response validation; cast any non-empty
+     * value to an object so even a stray list is emitted as `{…}`.
+     *
+     * @param array<string, mixed>|null $subject
+     */
+    private function normalizeSubject(?array $subject): ?object
+    {
+        return null === $subject || [] === $subject ? null : (object) $subject;
     }
 
     private function guard(?User $user): ?JsonResponse

--- a/backend/src/Service/Iam/AuditLogWriter.php
+++ b/backend/src/Service/Iam/AuditLogWriter.php
@@ -30,7 +30,10 @@ final readonly class AuditLogWriter
         $entry->setAction($action);
         $entry->setResourceKind($resourceKind);
         $entry->setResourceId($resourceId);
-        $entry->setSubject($subject);
+        // An empty array is stored (and later JSON-encoded) as `[]`, not `{}`.
+        // The subject is a metadata object or nothing, so normalize empty to
+        // null — keeps the persisted shape consistent with the API contract.
+        $entry->setSubject([] === $subject ? null : $subject);
         $entry->setIp($ip);
 
         $this->auditLogEntryRepository->save($entry);

--- a/backend/src/Service/PlatformLink/PlatformLinkExchangeService.php
+++ b/backend/src/Service/PlatformLink/PlatformLinkExchangeService.php
@@ -222,7 +222,7 @@ final readonly class PlatformLinkExchangeService
             'platform_link.disconnected',
             'platform_link',
             (string) $linkId,
-            [],
+            null,
             $ip,
         );
     }

--- a/backend/tests/Controller/AdminAuditControllerTest.php
+++ b/backend/tests/Controller/AdminAuditControllerTest.php
@@ -50,7 +50,9 @@ final class AdminAuditControllerTest extends WebTestCase
         $entry->setActorId((int) $admin->getId());
         $entry->setAction('platform_link.disconnected');
         $entry->setResourceKind('platform_link');
-        $entry->setResourceId('5');
+        // Unique resource id so we can pin the exact row we created.
+        $resourceId = 'empty-subject-'.uniqid('', true);
+        $entry->setResourceId($resourceId);
         $entry->setSubject([]);
         $this->em->persist($entry);
         $this->em->flush();
@@ -63,11 +65,14 @@ final class AdminAuditControllerTest extends WebTestCase
         // The wire form must be `"subject":null`, never `"subject":[]`.
         self::assertStringNotContainsString('"subject":[]', $raw);
         $payload = json_decode($raw, true);
+        self::assertIsArray($payload);
+        self::assertArrayHasKey('entries', $payload);
         $match = array_values(array_filter(
             $payload['entries'],
             static fn (array $e): bool => 'platform_link.disconnected' === $e['action']
+                && $resourceId === $e['resourceId']
         ));
-        self::assertNotEmpty($match);
+        self::assertCount(1, $match);
         self::assertNull($match[0]['subject']);
     }
 

--- a/backend/tests/Controller/AdminAuditControllerTest.php
+++ b/backend/tests/Controller/AdminAuditControllerTest.php
@@ -39,6 +39,38 @@ final class AdminAuditControllerTest extends WebTestCase
         self::assertSame(Response::HTTP_NOT_FOUND, $this->client->getResponse()->getStatusCode());
     }
 
+    public function testEmptySubjectSerializesAsNullNotArray(): void
+    {
+        // A row whose subject was stored as an empty array (e.g. an early
+        // platform_link.disconnected) must not come back as a JSON array, or
+        // the client's `subject: object|null` validation rejects the response.
+        $this->setGroupsFlag('1');
+        $admin = $this->createAdmin('iam-audit-empty-subject@synaplan.internal');
+        $entry = new AuditLogEntry();
+        $entry->setActorId((int) $admin->getId());
+        $entry->setAction('platform_link.disconnected');
+        $entry->setResourceKind('platform_link');
+        $entry->setResourceId('5');
+        $entry->setSubject([]);
+        $this->em->persist($entry);
+        $this->em->flush();
+
+        $this->authenticateClient($this->client, $admin);
+        $this->client->request('GET', '/api/v1/admin/audit?limit=10');
+
+        self::assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        $raw = (string) $this->client->getResponse()->getContent();
+        // The wire form must be `"subject":null`, never `"subject":[]`.
+        self::assertStringNotContainsString('"subject":[]', $raw);
+        $payload = json_decode($raw, true);
+        $match = array_values(array_filter(
+            $payload['entries'],
+            static fn (array $e): bool => 'platform_link.disconnected' === $e['action']
+        ));
+        self::assertNotEmpty($match);
+        self::assertNull($match[0]['subject']);
+    }
+
     public function testListsMetadataOnlyNewestFirst(): void
     {
         $this->setGroupsFlag('1');


### PR DESCRIPTION
## Summary
Fixing API fails

## Changes
The People → Audit page failed with "Invalid API response format: entries.N.subject: expected object, received array". An audit row whose subject was stored as an empty PHP array (platform_link.disconnected passed []) serializes to JSON `[]`, which the generated `subject: object|null` schema rejects.

- AuditLogWriter normalizes an empty subject array to null on write.
- AdminAuditController coerces subject to object|null on read, so existing rows already stored as `[]` render correctly without a data migration.
- disconnect() now records a null subject instead of [].

## Verification
- [ ] Not tested (explain)
- [X] Manual
- [ ] Tests added/updated
