### PR TITLE
feat(multitask): implement task plan persistence in StreamController

### DIFF
--- a/backend/src/Controller/SavedTaskController.php
+++ b/backend/src/Controller/SavedTaskController.php
@@ -107,6 +107,7 @@ final class SavedTaskController extends AbstractController
                 properties: [
                     new OA\Property(property: 'promptId', type: 'integer'),
                     new OA\Property(property: 'name', type: 'string'),
+                    new OA\Property(property: 'sourceMessageId', type: 'integer', nullable: true, description: 'Assistant message of the chat turn being scheduled. Its executed multi-step plan is stored as the task graph so reruns replay the same steps.'),
                 ]
             )
         ),
@@ -163,9 +164,10 @@ final class SavedTaskController extends AbstractController
         if ($promptId < 1 || '' === $name) {
             return $this->json(['error' => 'promptId and name are required'], Response::HTTP_BAD_REQUEST);
         }
+        $sourceMessageId = is_numeric($data['sourceMessageId'] ?? null) ? (int) $data['sourceMessageId'] : null;
 
         try {
-            $task = $this->service->create((int) $user->getId(), $promptId, $name);
+            $task = $this->service->create((int) $user->getId(), $promptId, $name, $sourceMessageId);
         } catch (\InvalidArgumentException $e) {
             return $this->json(['error' => $e->getMessage()], Response::HTTP_BAD_REQUEST);
         }

--- a/backend/src/Controller/StreamController.php
+++ b/backend/src/Controller/StreamController.php
@@ -44,6 +44,7 @@ use App\Service\Message\ChatErrorView;
 use App\Service\Message\MessageForwardingService;
 use App\Service\Message\MessageProcessor;
 use App\Service\ModelConfigService;
+use App\Service\Multitask\TaskPlanExecutor;
 use App\Service\PerfTimer;
 use App\Service\PremiumFeatureGate;
 use App\Service\PromptService;
@@ -1899,6 +1900,7 @@ class StreamController extends AbstractController
                         (string) json_encode($response['metadata']['task_plan_render'], \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE)
                     );
                 }
+                $this->persistTaskPlanDefinition($outgoingMessage, $response['metadata'] ?? []);
 
                 // Multi-task async media (DAG): image/video generation nodes create
                 // their MediaJob with the INCOMING user message id (the runner's
@@ -2833,6 +2835,7 @@ class StreamController extends AbstractController
                     (string) json_encode($metadata['task_plan_render'], \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE)
                 );
             }
+            $this->persistTaskPlanDefinition($outgoingMessage, $metadata);
 
             // Mirror the streaming branch: rebind every async node job to the OUT
             // message, and give a job that already finished while bound to the IN
@@ -3234,6 +3237,30 @@ class StreamController extends AbstractController
         if (!empty($classification['sorting_model_id'])) {
             $message->setMeta('ai_sorting_model_id', (string) $classification['sorting_model_id']);
         }
+    }
+
+    /**
+     * Persist the executed DAG's node definitions (inputs/params, dependencies)
+     * on the OUT message. "Schedule this" turns them into the Saved Task's
+     * authored graph so a rerun replays the very steps the user saw work —
+     * without it a rerun re-plans from the instruction text and can degrade a
+     * `url_fetch → chat → email_me` turn into a single chat answer.
+     *
+     * @param array<string, mixed> $metadata handler-result metadata
+     */
+    private function persistTaskPlanDefinition(Message $message, array $metadata): void
+    {
+        $definition = $metadata[TaskPlanExecutor::PLAN_DEFINITION_KEY] ?? null;
+        if (!is_array($definition) || !is_array($definition['tasks'] ?? null) || [] === $definition['tasks']) {
+            return;
+        }
+
+        $encoded = json_encode($definition, \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE);
+        if (false === $encoded) {
+            return;
+        }
+
+        $message->setMeta(TaskPlanExecutor::PLAN_DEFINITION_META, $encoded);
     }
 
     /**

--- a/backend/src/Service/Message/MessageProcessor.php
+++ b/backend/src/Service/Message/MessageProcessor.php
@@ -335,6 +335,7 @@ final readonly class MessageProcessor
             if (isset($options['rag_min_score'])) {
                 $classification['rag_min_score'] = (float) $options['rag_min_score'];
             }
+            $classification = $this->tagSavedTaskRun($classification, $options);
 
             // Step 2.3: Load Prompt Metadata and apply tool restrictions
             $topic = $classification['topic'] ?? 'general';
@@ -834,6 +835,7 @@ final readonly class MessageProcessor
                 // Inert unless MULTITASK_SHADOW_MODE is on; never affects the turn.
                 $this->maybeShadowPlan($message, $conversationHistory);
             }
+            $classification = $this->tagSavedTaskRun($classification, $options);
 
             $promptMetadata = [];
             if (isset($classification['prompt_metadata']) && is_array($classification['prompt_metadata'])) {
@@ -1145,6 +1147,28 @@ final readonly class MessageProcessor
     }
 
     /**
+     * Mark a Saved Task run on the classification, whichever branch produced
+     * it. A chat-saved task runs through the AI sorter exactly like the turn
+     * the user typed (web-search vote, language, memories, multi-step vote),
+     * so the source is `ai_sorting`; the task id is what lets
+     * TaskPlanExecutor replay the task's pinned steps instead of re-planning.
+     *
+     * @param array<string, mixed> $classification
+     * @param array<string, mixed> $options
+     *
+     * @return array<string, mixed>
+     */
+    private function tagSavedTaskRun(array $classification, array $options): array
+    {
+        $taskId = $options['saved_task_id'] ?? null;
+        if (is_int($taskId) && $taskId > 0) {
+            $classification['saved_task_id'] = $taskId;
+        }
+
+        return $classification;
+    }
+
+    /**
      * Prefetch named URLs into classification['url_content'] so ChatHandler
      * (and UrlFetchRunner reuse) can read the page.
      *
@@ -1160,7 +1184,7 @@ final readonly class MessageProcessor
      */
     private function maybeFetchUrlContent(Message $message, array $promptMetadata, array $classification, ?callable $statusCallback): array
     {
-        $savedTask = 'saved_task' === ($classification['source'] ?? null);
+        $savedTask = 'saved_task' === ($classification['source'] ?? null) || !empty($classification['saved_task_id']);
         if (!$savedTask && empty($promptMetadata['tool_url_screenshot'])) {
             return $classification;
         }

--- a/backend/src/Service/Multitask/TaskPlanExecutor.php
+++ b/backend/src/Service/Multitask/TaskPlanExecutor.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Service\Multitask;
 
 use App\Entity\Message;
+use App\Entity\SavedTask;
 use App\Repository\PromptRepository;
 use App\Repository\SavedTaskRepository;
 use App\Service\Message\InferenceRouter;
@@ -426,11 +427,6 @@ final readonly class TaskPlanExecutor
             return null;
         }
 
-        $topic = $classification['topic'] ?? null;
-        if (!is_string($topic) || '' === $topic) {
-            return null;
-        }
-
         try {
             $userId = $this->modelConfigService->getEffectiveUserIdForMessage($message);
         } catch (\Throwable) {
@@ -448,20 +444,7 @@ final readonly class TaskPlanExecutor
             return null;
         }
 
-        $prompt = $this->prompts->findByTopicAndUser($topic, $userId);
-        if (null === $prompt || null === $prompt->getId()) {
-            return null;
-        }
-
-        // Chat turns pin authored steps only for chat-trigger tasks (typing the
-        // matching instruction re-runs the pinned steps). A Saved Task RUN
-        // (source=saved_task: manual "Run now", scheduler tick, inbound email)
-        // executes the task's own authored graph regardless of trigger type —
-        // falling back to the free-form planner could produce different steps
-        // than the user explicitly authored.
-        $task = 'saved_task' === ($classification['source'] ?? null)
-            ? $this->savedTasks->findEnabledGraphTaskForPrompt($prompt->getId(), $userId)
-            : $this->savedTasks->findEnabledChatTaskForPrompt($prompt->getId(), $userId);
+        $task = $this->savedTaskForClassification($classification, $userId);
         if (null === $task || null === $task->getGraph()) {
             return null;
         }
@@ -485,6 +468,46 @@ final readonly class TaskPlanExecutor
         ]);
 
         return new TaskPlanResult($plan, fallback: false);
+    }
+
+    /**
+     * The Saved Task whose pinned steps this turn should replay, if any.
+     *
+     * A Saved Task RUN (manual "Run now", scheduler tick, inbound email) names
+     * its task directly via `saved_task_id` — the run goes through the AI
+     * sorter like a typed turn, so the classified topic (e.g. `general`) says
+     * nothing about the task. Legacy fixed-prompt runs (source=saved_task)
+     * and ordinary chat turns resolve through the prompt topic: a run picks
+     * the task's graph regardless of trigger type, a chat turn only pins the
+     * steps of a chat-trigger task (typing the matching instruction re-runs
+     * them).
+     *
+     * @param array<string, mixed> $classification
+     */
+    private function savedTaskForClassification(array $classification, int $userId): ?SavedTask
+    {
+        \assert(null !== $this->savedTasks && null !== $this->prompts);
+
+        $taskId = $classification['saved_task_id'] ?? null;
+        if (is_int($taskId) && $taskId > 0) {
+            $task = $this->savedTasks->findByIdAndOwner($taskId, $userId);
+
+            return null !== $task && $task->isEnabled() ? $task : null;
+        }
+
+        $topic = $classification['topic'] ?? null;
+        if (!is_string($topic) || '' === $topic) {
+            return null;
+        }
+
+        $prompt = $this->prompts->findByTopicAndUser($topic, $userId);
+        if (null === $prompt || null === $prompt->getId()) {
+            return null;
+        }
+
+        return 'saved_task' === ($classification['source'] ?? null)
+            ? $this->savedTasks->findEnabledGraphTaskForPrompt($prompt->getId(), $userId)
+            : $this->savedTasks->findEnabledChatTaskForPrompt($prompt->getId(), $userId);
     }
 
     /**

--- a/backend/src/Service/Multitask/TaskPlanExecutor.php
+++ b/backend/src/Service/Multitask/TaskPlanExecutor.php
@@ -49,6 +49,14 @@ use Psr\Log\LoggerInterface;
 final readonly class TaskPlanExecutor
 {
     /**
+     * Handler-result metadata key carrying the executed plan definition
+     * ({@see TaskPlan::toArray()}). Channels persist it as message meta
+     * {@see self::PLAN_DEFINITION_META} on the OUT message.
+     */
+    public const PLAN_DEFINITION_KEY = 'task_plan_definition';
+    public const PLAN_DEFINITION_META = 'task_plan_definition';
+
+    /**
      * Capabilities that have NO legacy InferenceRouter equivalent and therefore
      * must run through the DAG even as a lone single node (see
      * {@see shouldUseLegacyRouter()}).
@@ -673,6 +681,11 @@ final readonly class TaskPlanExecutor
         if (null !== $plan->planningUsage) {
             $assembled['metadata']['planning_usage'] = $plan->planningUsage;
         }
+        // The full node definitions (inputs/params, not just the render cards)
+        // ride along so the channel can persist them on the OUT message. That
+        // is what "Schedule this" copies into a Saved Task graph — a rerun then
+        // replays exactly these steps instead of asking the planner again.
+        $assembled['metadata'][self::PLAN_DEFINITION_KEY] = $plan->plan->toArray();
 
         if (null !== $messageId) {
             try {

--- a/backend/src/Service/SavedTask/Graph/SavedTaskGraphCapture.php
+++ b/backend/src/Service/SavedTask/Graph/SavedTaskGraphCapture.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\SavedTask\Graph;
+
+use App\Entity\Message;
+use App\Repository\MessageRepository;
+use App\Service\Multitask\TaskPlanExecutor;
+
+/**
+ * Turns the plan a chat turn actually executed into a Saved Task graph.
+ *
+ * "Schedule this" used to store only the instruction text, so every rerun
+ * asked the planner again — and a `url_fetch → chat → email_me` turn that
+ * worked in the chat could come back as a lone chat answer. The executed
+ * node definitions are persisted on the OUT message
+ * ({@see TaskPlanExecutor::PLAN_DEFINITION_META}); this class copies them
+ * into the `graph` column so {@see SavedTaskPlanFactory} replays exactly
+ * those steps.
+ */
+final readonly class SavedTaskGraphCapture
+{
+    public function __construct(
+        private MessageRepository $messages,
+    ) {
+    }
+
+    /**
+     * Graph v1 for the plan executed on the given OUT message, or null when
+     * the message is not the owner's, carries no DAG, or ran a single step
+     * (a one-node plan is what the planner produces anyway — nothing to pin).
+     *
+     * @return array<string, mixed>|null
+     */
+    public function fromMessage(int $messageId, int $ownerId, string $triggerType): ?array
+    {
+        $message = $this->messages->find($messageId);
+        if (!$message instanceof Message || $message->getUserId() !== $ownerId) {
+            return null;
+        }
+
+        $raw = $message->getMeta(TaskPlanExecutor::PLAN_DEFINITION_META);
+        if (null === $raw || '' === $raw) {
+            return null;
+        }
+
+        $definition = json_decode($raw, true);
+        if (!is_array($definition)) {
+            return null;
+        }
+
+        return $this->fromDefinition($definition, $triggerType);
+    }
+
+    /**
+     * @param array<string, mixed> $definition {@see \App\Service\Multitask\Plan\TaskPlan::toArray()}
+     *
+     * @return array<string, mixed>|null
+     */
+    public function fromDefinition(array $definition, string $triggerType): ?array
+    {
+        $tasks = $definition['tasks'] ?? null;
+        if (!is_array($tasks) || !array_is_list($tasks)) {
+            return null;
+        }
+
+        $nodes = [];
+        foreach ($tasks as $task) {
+            if (!is_array($task) || !is_string($task['id'] ?? null) || !is_string($task['capability'] ?? null)) {
+                return null;
+            }
+            $dependsOn = is_array($task['depends_on'] ?? null) ? $task['depends_on'] : [];
+            $nodes[] = [
+                'id' => $task['id'],
+                'capability' => $task['capability'],
+                'depends_on' => array_values(array_filter($dependsOn, 'is_string')),
+                'inputs' => is_array($task['inputs'] ?? null) ? $task['inputs'] : [],
+                'params' => is_array($task['params'] ?? null) ? $task['params'] : [],
+            ];
+        }
+
+        // Fewer than two nodes means the turn was a plain answer; the planner
+        // reproduces that on its own and a pinned graph would only add noise.
+        if (count($nodes) < 2) {
+            return null;
+        }
+
+        $graph = [
+            'version' => SavedTaskGraphValidator::VERSION,
+            'trigger' => ['type' => $triggerType],
+            'nodes' => $nodes,
+        ];
+
+        // Keep the answer surface the user saw (a chat step, not the trailing
+        // email_me confirmation) so the rerun's chat reply reads the same.
+        $replyNode = $definition['reply_node'] ?? null;
+        if (is_string($replyNode) && in_array($replyNode, array_column($nodes, 'id'), true)) {
+            $graph['reply_node'] = $replyNode;
+        }
+
+        return $graph;
+    }
+}

--- a/backend/src/Service/SavedTask/Graph/SavedTaskPlanFactory.php
+++ b/backend/src/Service/SavedTask/Graph/SavedTaskPlanFactory.php
@@ -66,6 +66,12 @@ final class SavedTaskPlanFactory
             }
         }
 
+        // A captured plan names its own reply node (the chat answer the user
+        // saw); an authored graph without one replies with the last step.
+        $declaredReply = $graph['reply_node'] ?? null;
+        if (is_string($declaredReply) && in_array($declaredReply, array_column($tasks, 'id'), true)) {
+            $reply = $declaredReply;
+        }
         $reply ??= (string) $tasks[array_key_last($tasks)]['id'];
 
         return TaskPlan::fromArray([

--- a/backend/src/Service/SavedTask/SavedTaskRunner.php
+++ b/backend/src/Service/SavedTask/SavedTaskRunner.php
@@ -97,10 +97,15 @@ final readonly class SavedTaskRunner
 
         try {
             $chat = $this->ensureChat($task, $user);
+            $now = time();
             $message = new Message();
             $message->setUserId($ownerId);
             $message->setChat($chat);
-            $message->setTrackingId(time());
+            $message->setTrackingId($now);
+            // Every channel stamps its own rows; without these the task chat
+            // rendered the run under "01.01.1970" (BUNIXTIMES defaults to 0).
+            $message->setUnixTimestamp($now);
+            $message->setDateTime(date('YmdHis', $now));
             $message->setProviderIndex('WEB');
             $message->setMessageType('WEB');
             $message->setTopic('CHAT');
@@ -204,10 +209,13 @@ final readonly class SavedTaskRunner
             ? $classification['language']
             : 'en';
 
+        $now = time();
         $out = new Message();
         $out->setUserId($incoming->getUserId());
         $out->setChat($chat);
         $out->setTrackingId($incoming->getTrackingId());
+        $out->setUnixTimestamp($now);
+        $out->setDateTime(date('YmdHis', $now));
         $out->setProviderIndex('WEB');
         $out->setMessageType('WEB');
         $out->setTopic('CHAT');

--- a/backend/src/Service/SavedTask/SavedTaskRunner.php
+++ b/backend/src/Service/SavedTask/SavedTaskRunner.php
@@ -18,6 +18,7 @@ use App\Repository\UserRepository;
 use App\Service\InternalEmailService;
 use App\Service\Media\GeneratedFileRegistrar;
 use App\Service\Message\MessageProcessor;
+use App\Service\Multitask\TaskPlanExecutor;
 use App\Service\Multitask\TaskPlanStore;
 use App\Service\RateLimitService;
 use Doctrine\ORM\EntityManagerInterface;
@@ -29,6 +30,13 @@ use Psr\Log\LoggerInterface;
  */
 final readonly class SavedTaskRunner
 {
+    /**
+     * Topic prefix the chat's "Schedule this" gives the prompt it saves the
+     * instruction under (TaskPlanBubble.vue). Everything else is a Task Prompt
+     * the user authored as an assistant.
+     */
+    public const CHAT_INSTRUCTION_TOPIC_PREFIX = 'saved-';
+
     public function __construct(
         private SavedTaskConfig $config,
         private SavedTaskRepository $tasks,
@@ -115,18 +123,20 @@ final readonly class SavedTaskRunner
             $this->em->persist($message);
             $this->em->flush();
 
-            // `saved_task` marks the classification source so TaskPlanExecutor
-            // still PLANS the instruction (multi-step tasks like "make an image
-            // and save it to Nextcloud" must run their DAG, not degrade to chat).
-            $result = $this->processor->process($message, [
-                'fixed_task_prompt' => $prompt->getTopic(),
-                'saved_task' => true,
-            ]);
+            $result = $this->processor->process($message, $this->processorOptions($task, $prompt));
 
             $ok = !empty($result['success']);
             $messageId = $message->getId();
             $snapshot = null !== $messageId ? $this->planStore->loadCards($messageId) : [];
 
+            // Like the web stream: the IN row records what the sorter decided.
+            $classification = is_array($result['classification'] ?? null) ? $result['classification'] : [];
+            if (is_string($classification['topic'] ?? null) && '' !== $classification['topic']) {
+                $message->setTopic($classification['topic']);
+            }
+            if (is_string($classification['language'] ?? null) && '' !== $classification['language']) {
+                $message->setLanguage($classification['language']);
+            }
             $message->setStatus($ok ? 'complete' : 'failed');
             $this->em->flush();
 
@@ -164,6 +174,36 @@ final readonly class SavedTaskRunner
 
             return $this->fail($task, $run, 'The AI step could not complete. Nothing was sent or saved.');
         }
+    }
+
+    /**
+     * A run must behave like the turn the user typed, tool calls included.
+     *
+     * "Schedule this" saves the chat instruction under a `saved-*` prompt. Such
+     * a run goes through the AI sorter exactly like the original turn — web
+     * search vote, memories, language, multi-step vote — and TaskPlanExecutor
+     * replays the task's pinned steps by `saved_task_id`. Pinning the prompt
+     * as a fixed topic instead skipped the sorter, so the rerun lost the web
+     * search and memory lookups the manual request had.
+     *
+     * A task built on a real Task Prompt (an assistant) keeps the fixed topic:
+     * there the prompt IS the behaviour the user wants to run. `saved_task`
+     * keeps the run plannable (multi-step tasks must run their DAG, not
+     * degrade to chat).
+     *
+     * @return array<string, mixed>
+     */
+    private function processorOptions(SavedTask $task, Prompt $prompt): array
+    {
+        $options = [
+            'saved_task' => true,
+            'saved_task_id' => (int) $task->getId(),
+        ];
+        if (!str_starts_with($prompt->getTopic(), self::CHAT_INSTRUCTION_TOPIC_PREFIX)) {
+            $options['fixed_task_prompt'] = $prompt->getTopic();
+        }
+
+        return $options;
     }
 
     /**
@@ -237,10 +277,72 @@ final readonly class SavedTaskRunner
         if (!empty($metadata['model'])) {
             $out->setMeta('ai_chat_model', (string) $metadata['model']);
         }
+        if (!empty($metadata['model_id'])) {
+            $out->setMeta('ai_chat_model_id', (string) $metadata['model_id']);
+        }
+        if (!empty($classification['sorting_model_name'])) {
+            $out->setMeta('ai_sorting_model', (string) $classification['sorting_model_name']);
+        }
+        $this->persistTaskPlanMeta($out, $metadata);
+        $this->persistWebSearchMeta($incoming, $out, $result, $metadata);
 
         $this->em->flush();
 
         $this->registerGeneratedFiles($out, $metadata);
+    }
+
+    /**
+     * Mirror StreamController: the Sources dropdown reads
+     * `web_search_query` / `web_search_results_count` from the message. The
+     * results themselves are already in BSEARCHRESULTS (saved by the
+     * processor or WebSearchRunner); without these metas the task chat showed
+     * the run without the sources the manual turn had.
+     *
+     * @param array<string, mixed> $result   processor result
+     * @param array<string, mixed> $metadata handler response metadata
+     */
+    private function persistWebSearchMeta(Message $incoming, Message $out, array $result, array $metadata): void
+    {
+        $searchResults = $result['search_results'] ?? ($metadata['search_results'] ?? null);
+        if (!is_array($searchResults) || !is_array($searchResults['results'] ?? null) || [] === $searchResults['results']) {
+            return;
+        }
+
+        $query = is_string($searchResults['query'] ?? null) ? $searchResults['query'] : '';
+        $count = (string) count($searchResults['results']);
+        foreach ([$incoming, $out] as $row) {
+            $row->setMeta('web_search_query', $query);
+            $row->setMeta('web_search_results_count', $count);
+        }
+    }
+
+    /**
+     * Mirror what the web stream persists for a DAG turn: the per-step render
+     * cards (`task_plan`), the multitask flag and the executed definition.
+     * Without these the task chat showed the run as a bare text answer even
+     * though every step ran — indistinguishable from a degraded chat reply,
+     * and "Schedule this" from the task chat could not pin the steps again.
+     *
+     * @param array<string, mixed> $metadata handler response metadata
+     */
+    private function persistTaskPlanMeta(Message $out, array $metadata): void
+    {
+        $render = $metadata['task_plan_render'] ?? null;
+        if (is_array($render) && is_array($render['cards'] ?? null) && [] !== $render['cards']) {
+            $encoded = json_encode($render, \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE);
+            if (false !== $encoded) {
+                $out->setMeta('multitask', '1');
+                $out->setMeta('task_plan', $encoded);
+            }
+        }
+
+        $definition = $metadata[TaskPlanExecutor::PLAN_DEFINITION_KEY] ?? null;
+        if (is_array($definition) && is_array($definition['tasks'] ?? null) && [] !== $definition['tasks']) {
+            $encoded = json_encode($definition, \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE);
+            if (false !== $encoded) {
+                $out->setMeta(TaskPlanExecutor::PLAN_DEFINITION_META, $encoded);
+            }
+        }
     }
 
     /**

--- a/backend/src/Service/SavedTask/SavedTaskService.php
+++ b/backend/src/Service/SavedTask/SavedTaskService.php
@@ -15,6 +15,7 @@ use App\Service\Iam\Exception\AssistantNotSharedException;
 use App\Service\Iam\Permission;
 use App\Service\Iam\ResourceKind\AssistantKind;
 use App\Service\Iam\ResourceKind\SavedTaskKind;
+use App\Service\SavedTask\Graph\SavedTaskGraphCapture;
 use App\Service\SavedTask\Graph\SavedTaskGraphValidator;
 use App\Service\SavedTask\Schedule\ScheduleParser;
 
@@ -27,6 +28,7 @@ final readonly class SavedTaskService
         private SavedTaskGraphValidator $graphValidator,
         private ScheduleParser $scheduleParser,
         private AccessGate $accessGate,
+        private SavedTaskGraphCapture $graphCapture,
     ) {
     }
 
@@ -84,8 +86,9 @@ final readonly class SavedTaskService
         }
 
         $copy = new SavedTask($userId, $source->getPromptId(), $source->getName());
-        $copy->setGraph($source->getGraph());
         $copy->setTrigger(SavedTask::TRIGGER_MANUAL, null);
+        $sourceGraph = $source->getGraph();
+        $copy->setGraph(null !== $sourceGraph ? $this->withTriggerType($sourceGraph, SavedTask::TRIGGER_MANUAL) : null);
         $copy->setAllowUnattended(false);
         $this->tasks->save($copy);
 
@@ -97,7 +100,12 @@ final readonly class SavedTaskService
         return $this->tasks->findByPromptAndOwner($promptId, $ownerId);
     }
 
-    public function create(int $ownerId, int $promptId, string $name): SavedTask
+    /**
+     * @param int|null $sourceMessageId OUT message of the chat turn being
+     *                                  scheduled; its executed plan becomes
+     *                                  the task's graph so reruns replay it
+     */
+    public function create(int $ownerId, int $promptId, string $name, ?int $sourceMessageId = null): SavedTask
     {
         $this->assertUsablePrompt($promptId, $ownerId);
         $existing = $this->tasks->findByPromptAndOwner($promptId, $ownerId);
@@ -106,6 +114,12 @@ final readonly class SavedTaskService
         }
 
         $task = new SavedTask($ownerId, $promptId, $name);
+        if (null !== $sourceMessageId && $sourceMessageId > 0) {
+            $graph = $this->graphCapture->fromMessage($sourceMessageId, $ownerId, $task->getTriggerType());
+            if (null !== $graph && [] === $this->graphValidator->validate($graph, $task->getTriggerType(), $task->getTriggerConfig())) {
+                $task->setGraph($graph);
+            }
+        }
         $this->tasks->save($task);
 
         return $task;
@@ -130,6 +144,15 @@ final readonly class SavedTaskService
             $task->setTrigger($data['triggerType'], $config);
         } elseif (isset($data['triggerConfig']) && is_array($data['triggerConfig'])) {
             $task->setTrigger($task->getTriggerType(), $data['triggerConfig']);
+        }
+
+        // The graph carries the trigger it was authored for and the factory
+        // rejects a mismatch — silently, falling back to the planner. Switching
+        // "Run now" → "Every day" must keep the pinned steps, so follow along.
+        $graph = $task->getGraph();
+        if (!array_key_exists('graph', $data) && null !== $graph
+            && ($graph['trigger']['type'] ?? null) !== $task->getTriggerType()) {
+            $task->setGraph($this->withTriggerType($graph, $task->getTriggerType()));
         }
 
         if (array_key_exists('graph', $data)) {
@@ -176,6 +199,18 @@ final readonly class SavedTaskService
         $this->tasks->save($task);
 
         return $task;
+    }
+
+    /**
+     * @param array<string, mixed> $graph
+     *
+     * @return array<string, mixed>
+     */
+    private function withTriggerType(array $graph, string $triggerType): array
+    {
+        $graph['trigger'] = ['type' => $triggerType];
+
+        return $graph;
     }
 
     private function assertUsablePrompt(int $promptId, int $ownerId): void

--- a/backend/tests/Unit/MessageProcessorTest.php
+++ b/backend/tests/Unit/MessageProcessorTest.php
@@ -914,4 +914,48 @@ class MessageProcessorTest extends TestCase
 
         $this->assertTrue($result['success']);
     }
+
+    public function testChatSavedTaskRunGoesThroughTheSorterAndCarriesTheTaskId(): void
+    {
+        // A chat-saved task reruns without a fixed prompt: the AI sorter runs
+        // exactly like for the typed turn (web search vote, language, …) and
+        // the task id rides on the classification so the executor can replay
+        // the pinned steps.
+        $message = $this->createMock(Message::class);
+        $message->method('getUserId')->willReturn(1);
+        $message->method('getTrackingId')->willReturn(123);
+        $message->method('getFile')->willReturn(0);
+        $message->method('getText')->willReturn('Load https://example.com/ and mail me a summary');
+        $message->method('hasFiles')->willReturn(false);
+
+        $this->preProcessor->method('process')->willReturn($message);
+        $this->messageRepository->method('findConversationHistory')->willReturn([]);
+        $this->modelConfigService->method('getDefaultModel')->willReturn(null);
+        $this->classifier->expects($this->once())->method('classify')->willReturn([
+            'topic' => 'general',
+            'language' => 'de',
+            'source' => 'ai_sorting',
+            'web_search' => false,
+        ]);
+        $this->router
+            ->expects($this->once())
+            ->method('route')
+            ->willReturnCallback(function ($msg, $history, $classification) {
+                $this->assertSame('ai_sorting', $classification['source'] ?? null);
+                $this->assertSame(42, $classification['saved_task_id'] ?? null);
+
+                return [
+                    'content' => 'Summary',
+                    'metadata' => ['provider' => 'test', 'model' => 'test'],
+                ];
+            });
+
+        $result = $this->processor->process($message, [
+            'saved_task' => true,
+            'saved_task_id' => 42,
+        ]);
+
+        $this->assertTrue($result['success']);
+        $this->assertSame(42, $result['classification']['saved_task_id'] ?? null);
+    }
 }

--- a/backend/tests/Unit/Service/Multitask/TaskPlanExecutorTest.php
+++ b/backend/tests/Unit/Service/Multitask/TaskPlanExecutorTest.php
@@ -672,6 +672,126 @@ final class TaskPlanExecutorTest extends TestCase
         self::assertSame('image', $result['metadata']['file']['type']);
     }
 
+    public function testAiSortedSavedTaskRunReplaysThePinnedStepsById(): void
+    {
+        // A chat-saved task reruns through the AI sorter like the turn the user
+        // typed, so the classified topic is a plain `general` — the task id on
+        // the classification is what selects the pinned steps.
+        $task = new \App\Entity\SavedTask(9, 4, 'Wochenreport');
+        $this->setTaskId($task, 33);
+        $task->setGraph([
+            'version' => 1,
+            'trigger' => ['type' => 'manual'],
+            'nodes' => [
+                ['id' => 'n1', 'capability' => 'url_fetch', 'params' => ['urls' => ['https://example.com']]],
+                ['id' => 'n2', 'capability' => 'chat', 'depends_on' => ['n1'], 'params' => []],
+            ],
+        ]);
+
+        $configRepo = $this->createMock(ConfigRepository::class);
+        $configRepo->method('getValue')->willReturn('true');
+
+        $prompts = $this->createMock(PromptRepository::class);
+        $prompts->expects(self::never())->method('findByTopicAndUser');
+
+        $savedTasks = $this->createMock(SavedTaskRepository::class);
+        $savedTasks->expects(self::once())->method('findByIdAndOwner')->with(33, 9)->willReturn($task);
+        $savedTasks->expects(self::never())->method('findEnabledGraphTaskForPrompt');
+        $savedTasks->expects(self::never())->method('findEnabledChatTaskForPrompt');
+
+        $this->modelConfigService->method('getEffectiveUserIdForMessage')->willReturn(9);
+
+        $executor = new TaskPlanExecutor(
+            $this->router,
+            new ClassificationPlanMapper(),
+            $this->store,
+            $this->planner,
+            $this->dagExecutor,
+            $this->modelConfigService,
+            $this->multitaskConfig,
+            $this->createMock(LoggerInterface::class),
+            new SavedTaskConfig($configRepo),
+            $savedTasks,
+            $prompts,
+            new SavedTaskPlanFactory(new SavedTaskGraphValidator()),
+        );
+
+        $this->planner->expects(self::never())->method('plan');
+        $this->dagExecutor->expects(self::once())->method('execute')->willReturn($this->assembled([
+            'content' => 'Zusammenfassung.',
+            'node_statuses' => ['n1' => 'done', 'n2' => 'done'],
+        ]));
+        $this->router->expects(self::never())->method('route');
+
+        $result = $executor->execute(
+            $this->message(),
+            [],
+            ['intent' => 'chat', 'topic' => 'general', 'language' => 'de', 'source' => 'ai_sorting', 'multi_step' => true, 'saved_task_id' => 33],
+        );
+
+        self::assertSame('Zusammenfassung.', $result['content']);
+    }
+
+    public function testAiSortedSavedTaskRunWithoutPinnedStepsPlansLikeATypedTurn(): void
+    {
+        // Legacy tasks saved before the plan was captured have no graph: the
+        // run must go through the planner exactly like the manual request did,
+        // not silently fall back to a bare chat answer.
+        $task = new \App\Entity\SavedTask(9, 4, 'Wochenreport');
+        $this->setTaskId($task, 34);
+
+        $configRepo = $this->createMock(ConfigRepository::class);
+        $configRepo->method('getValue')->willReturn('true');
+
+        $savedTasks = $this->createMock(SavedTaskRepository::class);
+        $savedTasks->method('findByIdAndOwner')->with(34, 9)->willReturn($task);
+
+        $this->modelConfigService->method('getEffectiveUserIdForMessage')->willReturn(9);
+
+        $executor = new TaskPlanExecutor(
+            $this->router,
+            new ClassificationPlanMapper(),
+            $this->store,
+            $this->planner,
+            $this->dagExecutor,
+            $this->modelConfigService,
+            $this->multitaskConfig,
+            $this->createMock(LoggerInterface::class),
+            new SavedTaskConfig($configRepo),
+            $savedTasks,
+            $this->createMock(PromptRepository::class),
+            new SavedTaskPlanFactory(new SavedTaskGraphValidator()),
+        );
+
+        $this->planner->expects(self::once())->method('plan')->willReturn(new TaskPlanResult(TaskPlan::fromArray([
+            'version' => 1,
+            'reply_node' => 'n2',
+            'tasks' => [
+                ['id' => 'n1', 'capability' => 'url_fetch', 'params' => ['urls' => ['https://example.com']]],
+                ['id' => 'n2', 'capability' => 'chat', 'depends_on' => ['n1'], 'params' => []],
+            ],
+        ]), fallback: false));
+        $this->dagExecutor->expects(self::once())->method('execute')->willReturn($this->assembled([
+            'content' => 'Geplant und ausgeführt.',
+            'node_statuses' => ['n1' => 'done', 'n2' => 'done'],
+        ]));
+        $this->router->expects(self::never())->method('route');
+
+        $result = $executor->execute(
+            $this->message(),
+            [],
+            ['intent' => 'chat', 'topic' => 'general', 'language' => 'de', 'source' => 'ai_sorting', 'multi_step' => true, 'saved_task_id' => 34],
+        );
+
+        self::assertSame('Geplant und ausgeführt.', $result['content']);
+    }
+
+    private function setTaskId(\App\Entity\SavedTask $task, int $id): void
+    {
+        $ref = new \ReflectionProperty(\App\Entity\SavedTask::class, 'id');
+        $ref->setValue($task, $id);
+    }
+
     public function testSorterVoteOfASingleStepSkipsThePlanner(): void
     {
         // The whole point of the vote: on a one-step turn the planner

--- a/backend/tests/Unit/Service/Multitask/TaskPlanExecutorTest.php
+++ b/backend/tests/Unit/Service/Multitask/TaskPlanExecutorTest.php
@@ -744,7 +744,7 @@ final class TaskPlanExecutorTest extends TestCase
         $configRepo->method('getValue')->willReturn('true');
 
         $savedTasks = $this->createMock(SavedTaskRepository::class);
-        $savedTasks->method('findByIdAndOwner')->with(34, 9)->willReturn($task);
+        $savedTasks->expects(self::once())->method('findByIdAndOwner')->with(34, 9)->willReturn($task);
 
         $this->modelConfigService->method('getEffectiveUserIdForMessage')->willReturn(9);
 

--- a/backend/tests/Unit/Service/SavedTask/SavedTaskGraphCaptureTest.php
+++ b/backend/tests/Unit/Service/SavedTask/SavedTaskGraphCaptureTest.php
@@ -70,7 +70,7 @@ final class SavedTaskGraphCaptureTest extends TestCase
         $message->setMeta(TaskPlanExecutor::PLAN_DEFINITION_META, (string) json_encode(self::DEFINITION));
 
         $messages = $this->createMock(MessageRepository::class);
-        $messages->method('find')->with(4711)->willReturn($message);
+        $messages->method('find')->willReturnCallback(static fn (mixed $id): ?Message => 4711 === $id ? $message : null);
         $capture = new SavedTaskGraphCapture($messages);
 
         $own = $capture->fromMessage(4711, 9, 'manual');

--- a/backend/tests/Unit/Service/SavedTask/SavedTaskGraphCaptureTest.php
+++ b/backend/tests/Unit/Service/SavedTask/SavedTaskGraphCaptureTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\SavedTask;
+
+use App\Entity\Message;
+use App\Repository\MessageRepository;
+use App\Service\Multitask\TaskPlanExecutor;
+use App\Service\SavedTask\Graph\SavedTaskGraphCapture;
+use App\Service\SavedTask\Graph\SavedTaskGraphValidator;
+use PHPUnit\Framework\TestCase;
+
+final class SavedTaskGraphCaptureTest extends TestCase
+{
+    /** @var array<string, mixed> */
+    private const DEFINITION = [
+        'version' => 1,
+        'language' => 'de',
+        'reply_node' => 'n2',
+        'tasks' => [
+            ['id' => 'n1', 'capability' => 'url_fetch', 'depends_on' => [], 'inputs' => ['urls' => ['https://example.com/stock']], 'params' => []],
+            ['id' => 'n2', 'capability' => 'chat', 'depends_on' => ['n1'], 'inputs' => ['text' => '$message.text $n1.text'], 'params' => ['topic_id' => 'general']],
+            ['id' => 'n3', 'capability' => 'email_me', 'depends_on' => ['n2'], 'inputs' => ['text' => '$n2.text'], 'params' => []],
+        ],
+    ];
+
+    public function testExecutedPlanBecomesAValidGraphWithInputsAndReply(): void
+    {
+        $capture = new SavedTaskGraphCapture($this->createStub(MessageRepository::class));
+
+        $graph = $capture->fromDefinition(self::DEFINITION, 'manual');
+
+        self::assertNotNull($graph);
+        self::assertSame(1, $graph['version']);
+        self::assertSame(['type' => 'manual'], $graph['trigger']);
+        self::assertSame('n2', $graph['reply_node']);
+        self::assertCount(3, $graph['nodes']);
+        self::assertSame(['urls' => ['https://example.com/stock']], $graph['nodes'][0]['inputs']);
+        self::assertSame(['topic_id' => 'general'], $graph['nodes'][1]['params']);
+        self::assertSame(['n2'], $graph['nodes'][2]['depends_on']);
+        // The captured graph must pass the same validator authored graphs do.
+        self::assertSame([], (new SavedTaskGraphValidator())->validate($graph, 'manual', null));
+    }
+
+    public function testSingleStepPlanIsNotPinned(): void
+    {
+        $capture = new SavedTaskGraphCapture($this->createStub(MessageRepository::class));
+
+        self::assertNull($capture->fromDefinition([
+            'version' => 1,
+            'reply_node' => 'n1',
+            'tasks' => [['id' => 'n1', 'capability' => 'chat', 'depends_on' => [], 'inputs' => [], 'params' => []]],
+        ], 'manual'));
+    }
+
+    public function testMalformedDefinitionIsRejected(): void
+    {
+        $capture = new SavedTaskGraphCapture($this->createStub(MessageRepository::class));
+
+        self::assertNull($capture->fromDefinition(['tasks' => 'nope'], 'manual'));
+        self::assertNull($capture->fromDefinition(['tasks' => [['capability' => 'chat']]], 'manual'));
+    }
+
+    public function testReadsTheDefinitionFromTheOwnersMessageOnly(): void
+    {
+        $message = new Message();
+        $message->setUserId(9);
+        (new \ReflectionProperty(Message::class, 'id'))->setValue($message, 4711);
+        $message->setMeta(TaskPlanExecutor::PLAN_DEFINITION_META, (string) json_encode(self::DEFINITION));
+
+        $messages = $this->createMock(MessageRepository::class);
+        $messages->method('find')->with(4711)->willReturn($message);
+        $capture = new SavedTaskGraphCapture($messages);
+
+        $own = $capture->fromMessage(4711, 9, 'manual');
+        self::assertNotNull($own);
+        self::assertCount(3, $own['nodes']);
+
+        // Another user's message id must never leak its plan into my task.
+        self::assertNull($capture->fromMessage(4711, 10, 'manual'));
+    }
+
+    public function testMessageWithoutADagYieldsNoGraph(): void
+    {
+        $message = new Message();
+        $message->setUserId(9);
+        (new \ReflectionProperty(Message::class, 'id'))->setValue($message, 4712);
+
+        $messages = $this->createMock(MessageRepository::class);
+        $messages->method('find')->willReturn($message);
+
+        self::assertNull((new SavedTaskGraphCapture($messages))->fromMessage(4712, 9, 'manual'));
+    }
+}

--- a/backend/tests/Unit/Service/SavedTask/SavedTaskPlanFactoryTest.php
+++ b/backend/tests/Unit/Service/SavedTask/SavedTaskPlanFactoryTest.php
@@ -46,4 +46,45 @@ final class SavedTaskPlanFactoryTest extends TestCase
         self::assertSame(['text' => '$n1.text'], $chat->inputs);
         self::assertSame('12', $chat->params['prompt_id'] ?? null);
     }
+
+    public function testDeclaredReplyNodeWinsOverTheLastStep(): void
+    {
+        // A captured chat plan answers with the chat step; the trailing
+        // email_me confirmation must not become the reply just because it is
+        // last in the list.
+        $task = new SavedTask(1, 12, 'Stock mail');
+        $task->setGraph([
+            'version' => 1,
+            'trigger' => ['type' => 'manual'],
+            'reply_node' => 'n2',
+            'nodes' => [
+                ['id' => 'n1', 'capability' => 'url_fetch', 'depends_on' => [], 'inputs' => ['urls' => 'https://example.com/stock']],
+                ['id' => 'n2', 'capability' => 'chat', 'depends_on' => ['n1'], 'inputs' => ['text' => '$n1.text']],
+                ['id' => 'n3', 'capability' => 'email_me', 'depends_on' => ['n2'], 'inputs' => ['text' => '$n2.text']],
+            ],
+        ]);
+
+        $plan = (new SavedTaskPlanFactory(new SavedTaskGraphValidator()))->fromTask($task);
+
+        self::assertSame('n2', $plan->replyNode);
+        self::assertCount(3, $plan->nodes);
+    }
+
+    public function testUnknownDeclaredReplyNodeFallsBackToTheLastStep(): void
+    {
+        $task = new SavedTask(1, 12, 'Stock mail');
+        $task->setGraph([
+            'version' => 1,
+            'trigger' => ['type' => 'manual'],
+            'reply_node' => 'missing',
+            'nodes' => [
+                ['id' => 'n1', 'capability' => 'url_fetch', 'depends_on' => [], 'inputs' => ['urls' => 'https://example.com/stock']],
+                ['id' => 'n2', 'capability' => 'chat', 'depends_on' => ['n1'], 'inputs' => ['text' => '$n1.text']],
+            ],
+        ]);
+
+        $plan = (new SavedTaskPlanFactory(new SavedTaskGraphValidator()))->fromTask($task);
+
+        self::assertSame('n2', $plan->replyNode);
+    }
 }

--- a/backend/tests/Unit/Service/SavedTask/SavedTaskRunnerTest.php
+++ b/backend/tests/Unit/Service/SavedTask/SavedTaskRunnerTest.php
@@ -152,9 +152,29 @@ final class SavedTaskRunnerTest extends TestCase
                         'provider' => 'google',
                         'model' => 'imagen',
                         'file' => ['path' => '/api/v1/files/uploads/01/cat.png', 'type' => 'image'],
+                        'multitask' => true,
+                        'task_plan_render' => [
+                            'reply_node' => 'n2',
+                            'cards' => [
+                                ['nodeId' => 'n1', 'capability' => 'image_generation', 'kind' => 'image', 'state' => 'done'],
+                                ['nodeId' => 'n2', 'capability' => 'save_to_folder', 'kind' => 'text', 'state' => 'done'],
+                            ],
+                        ],
+                        'task_plan_definition' => [
+                            'version' => 1,
+                            'reply_node' => 'n2',
+                            'tasks' => [
+                                ['id' => 'n1', 'capability' => 'image_generation', 'depends_on' => [], 'inputs' => [], 'params' => []],
+                                ['id' => 'n2', 'capability' => 'save_to_folder', 'depends_on' => ['n1'], 'inputs' => [], 'params' => []],
+                            ],
+                        ],
                     ],
                 ],
-                'classification' => ['language' => 'de'],
+                'classification' => ['language' => 'de', 'topic' => 'general', 'sorting_model_name' => 'sorter-x'],
+                'search_results' => [
+                    'query' => 'realistische katze',
+                    'results' => [['url' => 'https://a.example'], ['url' => 'https://b.example']],
+                ],
             ];
         });
 
@@ -207,6 +227,13 @@ final class SavedTaskRunnerTest extends TestCase
         // The classification source must mark this as a Saved Task run so
         // TaskPlanExecutor still plans multi-step instructions.
         $this->assertTrue($capturedOptions['saved_task'] ?? false);
+        // A chat-saved instruction (`saved-*` prompt) reruns like the turn the
+        // user typed: through the AI sorter (web search vote, memories,
+        // language), with the task id so the executor replays the pinned steps.
+        // Pinning the prompt as a fixed topic skipped the sorter and lost the
+        // tool calls the manual request made.
+        $this->assertSame(11, $capturedOptions['saved_task_id'] ?? null);
+        $this->assertArrayNotHasKey('fixed_task_prompt', $capturedOptions);
         // The incoming message must not stay stuck in "processing".
         $this->assertSame('complete', $captured->getStatus());
 
@@ -219,6 +246,25 @@ final class SavedTaskRunnerTest extends TestCase
         $this->assertSame('Bild erstellt und in Nextcloud gespeichert.', $replies[0]->getText());
         $this->assertSame('/api/v1/files/uploads/01/cat.png', $replies[0]->getFilePath());
         $this->assertSame('de', $replies[0]->getLanguage());
+        // The IN row records the sorter's verdict, both rows carry the Sources
+        // metas the chat reads — the rerun looks like the manual turn.
+        $this->assertSame('general', $captured->getTopic());
+        $this->assertSame('de', $captured->getLanguage());
+        $this->assertSame('sorter-x', $replies[0]->getMeta('ai_sorting_model'));
+        foreach ([$captured, $replies[0]] as $row) {
+            $this->assertSame('realistische katze', $row->getMeta('web_search_query'));
+            $this->assertSame('2', $row->getMeta('web_search_results_count'));
+        }
+
+        // The task chat must show the executed steps like the live chat does,
+        // otherwise a replayed DAG is indistinguishable from a bare chat reply.
+        $this->assertSame('1', $replies[0]->getMeta('multitask'));
+        $taskPlan = json_decode((string) $replies[0]->getMeta('task_plan'), true);
+        $this->assertIsArray($taskPlan);
+        $this->assertCount(2, $taskPlan['cards']);
+        $definition = json_decode((string) $replies[0]->getMeta('task_plan_definition'), true);
+        $this->assertIsArray($definition);
+        $this->assertSame('n2', $definition['reply_node']);
 
         // Both rows must carry a real timestamp — BUNIXTIMES defaults to 0 and
         // the task chat rendered every run under "01.01.1970" without these.
@@ -228,6 +274,87 @@ final class SavedTaskRunnerTest extends TestCase
             $this->assertLessThanOrEqual($now, $row->getUnixTimestamp());
             $this->assertMatchesRegularExpression('/^\d{14}$/', $row->getDateTime());
         }
+    }
+
+    public function testTaskPromptRunKeepsTheAssistantPinned(): void
+    {
+        $task = new SavedTask(9, 4, 'Meeting requests');
+        $this->setId($task, 12);
+        $task->setChatId(77);
+
+        $user = $this->createMock(User::class);
+        $user->method('isActive')->willReturn(true);
+        $user->method('getId')->willReturn(9);
+        $user->method('getMail')->willReturn('demo@synaplan.com');
+
+        // A real Task Prompt (an assistant the user authored) — not a chat
+        // instruction saved by "Schedule this".
+        $prompt = $this->createMock(Prompt::class);
+        $prompt->method('isEnabled')->willReturn(true);
+        $prompt->method('getTopic')->willReturn('meetings');
+        $prompt->method('getPrompt')->willReturn('You triage meeting requests.');
+
+        $chat = $this->createMock(Chat::class);
+        $chat->method('getUserId')->willReturn(9);
+        $chat->method('getId')->willReturn(77);
+        $chats = $this->createMock(ChatRepository::class);
+        $chats->method('find')->willReturn($chat);
+
+        $tasks = $this->createMock(SavedTaskRepository::class);
+        $tasks->method('findByIdAndOwner')->willReturn($task);
+        $config = $this->createMock(SavedTaskConfig::class);
+        $config->method('isEnabled')->willReturn(true);
+        $users = $this->createMock(UserRepository::class);
+        $users->method('find')->willReturn($user);
+        $prompts = $this->createMock(PromptRepository::class);
+        $prompts->method('find')->willReturn($prompt);
+        $rateLimits = $this->createMock(RateLimitService::class);
+        $rateLimits->method('checkLimit')->willReturn(['allowed' => true]);
+
+        $capturedOptions = null;
+        $processor = $this->createMock(MessageProcessor::class);
+        $processor->method('process')->willReturnCallback(function (Message $message, array $options) use (&$capturedOptions): array {
+            $capturedOptions = $options;
+
+            return ['success' => true, 'response' => ['content' => 'ok', 'metadata' => []], 'classification' => []];
+        });
+
+        $persisted = [];
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('persist')->willReturnCallback(function (object $entity) use (&$persisted): void {
+            $persisted[] = $entity;
+        });
+        $em->method('flush')->willReturnCallback(function () use (&$persisted): void {
+            foreach ($persisted as $i => $entity) {
+                if ($entity instanceof Message && null === $entity->getId()) {
+                    $ref = new \ReflectionProperty(Message::class, 'id');
+                    $ref->setValue($entity, 2000 + $i);
+                }
+            }
+        });
+
+        $runner = new SavedTaskRunner(
+            $config,
+            $tasks,
+            $this->createStub(SavedTaskRunRepository::class),
+            $prompts,
+            $users,
+            $chats,
+            $em,
+            $processor,
+            $rateLimits,
+            $this->createStub(TaskPlanStore::class),
+            $this->createStub(GeneratedFileRegistrar::class),
+            $this->createStub(InternalEmailService::class),
+            $this->createStub(LoggerInterface::class),
+        );
+
+        $result = $runner->run(9, 12, 'Look into my mail', 'manual');
+
+        $this->assertSame('completed', $result['run']->getStatus(), 'run error: '.(string) $result['run']->getError());
+        $this->assertSame('meetings', $capturedOptions['fixed_task_prompt'] ?? null);
+        $this->assertTrue($capturedOptions['saved_task'] ?? false);
+        $this->assertSame(12, $capturedOptions['saved_task_id'] ?? null);
     }
 
     private function setId(SavedTask $task, int $id): void

--- a/backend/tests/Unit/Service/SavedTask/SavedTaskRunnerTest.php
+++ b/backend/tests/Unit/Service/SavedTask/SavedTaskRunnerTest.php
@@ -219,6 +219,15 @@ final class SavedTaskRunnerTest extends TestCase
         $this->assertSame('Bild erstellt und in Nextcloud gespeichert.', $replies[0]->getText());
         $this->assertSame('/api/v1/files/uploads/01/cat.png', $replies[0]->getFilePath());
         $this->assertSame('de', $replies[0]->getLanguage());
+
+        // Both rows must carry a real timestamp — BUNIXTIMES defaults to 0 and
+        // the task chat rendered every run under "01.01.1970" without these.
+        $now = time();
+        foreach ([$captured, $replies[0]] as $row) {
+            $this->assertGreaterThan($now - 60, $row->getUnixTimestamp());
+            $this->assertLessThanOrEqual($now, $row->getUnixTimestamp());
+            $this->assertMatchesRegularExpression('/^\d{14}$/', $row->getDateTime());
+        }
     }
 
     private function setId(SavedTask $task, int $id): void

--- a/backend/tests/Unit/Service/SavedTask/SavedTaskServiceCopyTest.php
+++ b/backend/tests/Unit/Service/SavedTask/SavedTaskServiceCopyTest.php
@@ -14,6 +14,7 @@ use App\Service\Iam\AccessGate;
 use App\Service\Iam\Exception\AssistantNotSharedException;
 use App\Service\Iam\Permission;
 use App\Service\Iam\ResourceKind\SavedTaskKind;
+use App\Service\SavedTask\Graph\SavedTaskGraphCapture;
 use App\Service\SavedTask\Graph\SavedTaskGraphValidator;
 use App\Service\SavedTask\SavedTaskService;
 use App\Service\SavedTask\Schedule\ScheduleParser;
@@ -62,6 +63,7 @@ final class SavedTaskServiceCopyTest extends TestCase
             $this->createStub(SavedTaskGraphValidator::class),
             $this->createStub(ScheduleParser::class),
             $gate,
+            $this->createStub(SavedTaskGraphCapture::class),
         );
 
         $copy = $service->copyForOwner($source, $user);
@@ -71,7 +73,9 @@ final class SavedTaskServiceCopyTest extends TestCase
         self::assertFalse($copy->allowsUnattended());
         self::assertNull($copy->getChatId());
         self::assertSame(3, $copy->getOwnerId());
-        self::assertSame(['nodes' => []], $copy->getGraph());
+        // The copied graph follows the reset trigger; a schedule-typed graph
+        // on a manual task would be rejected by the factory at run time.
+        self::assertSame(['nodes' => [], 'trigger' => ['type' => SavedTask::TRIGGER_MANUAL]], $copy->getGraph());
     }
 
     public function testCopyWithoutAssistantAccessThrowsConflict(): void
@@ -107,6 +111,7 @@ final class SavedTaskServiceCopyTest extends TestCase
             $this->createStub(SavedTaskGraphValidator::class),
             $this->createStub(ScheduleParser::class),
             $gate,
+            $this->createStub(SavedTaskGraphCapture::class),
         );
 
         $this->expectException(AssistantNotSharedException::class);
@@ -134,6 +139,7 @@ final class SavedTaskServiceCopyTest extends TestCase
             $this->createStub(SavedTaskGraphValidator::class),
             $this->createStub(ScheduleParser::class),
             $gate,
+            $this->createStub(SavedTaskGraphCapture::class),
         );
 
         $this->expectException(\App\Service\SavedTask\SavedTaskNotFoundException::class);

--- a/backend/tests/Unit/Service/SavedTask/SavedTaskServiceGraphTest.php
+++ b/backend/tests/Unit/Service/SavedTask/SavedTaskServiceGraphTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\SavedTask;
+
+use App\Entity\Prompt;
+use App\Entity\SavedTask;
+use App\Repository\PromptRepository;
+use App\Repository\SavedTaskRepository;
+use App\Repository\SavedTaskRunRepository;
+use App\Service\Iam\AccessGate;
+use App\Service\SavedTask\Graph\SavedTaskGraphCapture;
+use App\Service\SavedTask\Graph\SavedTaskGraphValidator;
+use App\Service\SavedTask\SavedTaskService;
+use App\Service\SavedTask\Schedule\ScheduleParser;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * "Schedule this" must pin the executed steps, and changing the trigger must
+ * keep them — otherwise a rerun silently re-plans and can lose url_fetch /
+ * email_me on the way.
+ */
+final class SavedTaskServiceGraphTest extends TestCase
+{
+    /** @var array<string, mixed> */
+    private const GRAPH = [
+        'version' => 1,
+        'trigger' => ['type' => SavedTask::TRIGGER_MANUAL],
+        'reply_node' => 'n2',
+        'nodes' => [
+            ['id' => 'n1', 'capability' => 'url_fetch', 'depends_on' => [], 'inputs' => ['urls' => ['https://example.com/stock']], 'params' => []],
+            ['id' => 'n2', 'capability' => 'chat', 'depends_on' => ['n1'], 'inputs' => ['text' => '$n1.text'], 'params' => []],
+            ['id' => 'n3', 'capability' => 'email_me', 'depends_on' => ['n2'], 'inputs' => ['text' => '$n2.text'], 'params' => []],
+        ],
+    ];
+
+    public function testCreateFromAChatTurnStoresTheExecutedPlanAsGraph(): void
+    {
+        $capture = $this->createMock(SavedTaskGraphCapture::class);
+        $capture->expects(self::once())
+            ->method('fromMessage')
+            ->with(4711, 9, SavedTask::TRIGGER_MANUAL)
+            ->willReturn(self::GRAPH);
+
+        $saved = null;
+        $tasks = $this->createMock(SavedTaskRepository::class);
+        $tasks->method('findByPromptAndOwner')->willReturn(null);
+        $tasks->method('save')->willReturnCallback(static function (SavedTask $task) use (&$saved): void {
+            $saved = $task;
+        });
+
+        $service = $this->service($tasks, $capture);
+
+        $task = $service->create(9, 5, 'RioTinto', 4711);
+
+        self::assertSame($saved, $task);
+        self::assertSame(self::GRAPH, $task->getGraph());
+    }
+
+    public function testCreateWithoutASourceMessageLeavesTheGraphEmpty(): void
+    {
+        $capture = $this->createMock(SavedTaskGraphCapture::class);
+        $capture->expects(self::never())->method('fromMessage');
+
+        $tasks = $this->createMock(SavedTaskRepository::class);
+        $tasks->method('findByPromptAndOwner')->willReturn(null);
+
+        $task = $this->service($tasks, $capture)->create(9, 5, 'Plain');
+
+        self::assertNull($task->getGraph());
+    }
+
+    public function testCreateIgnoresAGraphTheValidatorRejects(): void
+    {
+        $capture = $this->createMock(SavedTaskGraphCapture::class);
+        $capture->method('fromMessage')->willReturn(['version' => 1, 'trigger' => ['type' => 'manual'], 'nodes' => 'broken']);
+
+        $tasks = $this->createMock(SavedTaskRepository::class);
+        $tasks->method('findByPromptAndOwner')->willReturn(null);
+
+        $task = $this->service($tasks, $capture)->create(9, 5, 'Broken', 4711);
+
+        self::assertNull($task->getGraph());
+    }
+
+    public function testSwitchingTheTriggerKeepsThePinnedStepsValid(): void
+    {
+        $task = new SavedTask(9, 5, 'RioTinto');
+        $task->setGraph(self::GRAPH);
+
+        $parser = $this->createMock(ScheduleParser::class);
+        $parser->method('nextRunAt')->willReturn(new \DateTimeImmutable('+1 day', new \DateTimeZone('UTC')));
+
+        $service = $this->service($this->createStub(SavedTaskRepository::class), $this->createStub(SavedTaskGraphCapture::class), $parser);
+
+        // The card sends allowUnattended alongside the schedule: the pinned
+        // email_me step is a mutating action and must be confirmed once.
+        $service->update($task, [
+            'triggerType' => SavedTask::TRIGGER_SCHEDULE,
+            'triggerConfig' => ['kind' => 'daily', 'at' => '09:15', 'tz' => 'Europe/Berlin'],
+            'allowUnattended' => true,
+        ]);
+
+        $graph = $task->getGraph();
+        self::assertNotNull($graph);
+        self::assertSame(['type' => SavedTask::TRIGGER_SCHEDULE], $graph['trigger']);
+        // Only the trigger moved; the steps are untouched.
+        self::assertSame(self::GRAPH['nodes'], $graph['nodes']);
+        self::assertSame('n2', $graph['reply_node']);
+        // And the result is exactly what the run-time factory will validate.
+        self::assertSame([], (new SavedTaskGraphValidator())->validate($graph, $task->getTriggerType(), $task->getTriggerConfig()));
+    }
+
+    public function testSchedulingPinnedMailStepsNeedsTheUnattendedConfirmation(): void
+    {
+        // Before the steps were pinned the graph was empty and this guard never
+        // fired for chat-saved tasks; now the mail step is visible to it.
+        $task = new SavedTask(9, 5, 'RioTinto');
+        $task->setGraph(self::GRAPH);
+
+        $service = $this->service($this->createStub(SavedTaskRepository::class), $this->createStub(SavedTaskGraphCapture::class));
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('runs on its own');
+
+        $service->update($task, [
+            'triggerType' => SavedTask::TRIGGER_SCHEDULE,
+            'triggerConfig' => ['kind' => 'daily', 'at' => '09:15', 'tz' => 'Europe/Berlin'],
+        ]);
+    }
+
+    private function service(SavedTaskRepository $tasks, SavedTaskGraphCapture $capture, ?ScheduleParser $parser = null): SavedTaskService
+    {
+        $prompt = new Prompt();
+        $prompt->setOwnerId(9);
+        $prompt->setTopic('saved-1');
+        $prompt->setPrompt('Look up the stock and mail me.');
+
+        $prompts = $this->createMock(PromptRepository::class);
+        $prompts->method('find')->willReturn($prompt);
+
+        return new SavedTaskService(
+            $tasks,
+            $this->createStub(SavedTaskRunRepository::class),
+            $prompts,
+            new SavedTaskGraphValidator(),
+            $parser ?? $this->createStub(ScheduleParser::class),
+            $this->createStub(AccessGate::class),
+            $capture,
+        );
+    }
+}

--- a/frontend/src/components/ChatMessage.vue
+++ b/frontend/src/components/ChatMessage.vue
@@ -521,6 +521,7 @@
             v-if="displayTaskPlan && displayTaskPlan.cards.length > 0"
             :plan="displayTaskPlan"
             :schedule-source="scheduleSource"
+            :source-message-id="backendMessageId"
             :guest="isGuestMode"
             @retry-task="emit('retryTask', $event)"
             @cancel-task="emit('cancelTask', $event)"

--- a/frontend/src/components/multitask/TaskPlanBubble.vue
+++ b/frontend/src/components/multitask/TaskPlanBubble.vue
@@ -17,6 +17,11 @@ const props = defineProps<{
   plan: TaskPlanState
   /** The user message that produced this plan — used when saving a task. */
   scheduleSource?: string
+  /**
+   * Backend id of the assistant message carrying this plan. Sent along when
+   * saving so the task pins the executed steps instead of re-planning.
+   */
+  sourceMessageId?: number
   guest?: boolean
 }>()
 
@@ -72,7 +77,7 @@ const onSchedule = async () => {
         tool_url_screenshot: instructionHasUrl(instruction),
       },
     })
-    await savedTasksApi.create(prompt.id, name.trim())
+    await savedTasksApi.create(prompt.id, name.trim(), props.sourceMessageId)
     success(t('config.savedTasks.scheduledFromChat'))
     await router.push('/channels/tasks')
   } catch {

--- a/frontend/src/services/api/savedTasksApi.ts
+++ b/frontend/src/services/api/savedTasksApi.ts
@@ -117,10 +117,18 @@ export const savedTasksApi = {
     return (data.tasks ?? []).map((task) => asTask(task))
   },
 
-  async create(promptId: number, name: string): Promise<SavedTask> {
+  /**
+   * `sourceMessageId` is the assistant message whose executed plan the task
+   * should replay; without it a rerun asks the planner again.
+   */
+  async create(promptId: number, name: string, sourceMessageId?: number): Promise<SavedTask> {
     const data = await httpClient('/api/v1/saved-tasks', {
       method: 'POST',
-      body: JSON.stringify({ promptId, name }),
+      body: JSON.stringify({
+        promptId,
+        name,
+        ...(sourceMessageId ? { sourceMessageId } : {}),
+      }),
       schema: PostApiSavedTasksCreateResponseSchema,
     })
     return asTask(data.task)

--- a/frontend/tests/unit/components/multitask/TaskPlanBubble.spec.ts
+++ b/frontend/tests/unit/components/multitask/TaskPlanBubble.spec.ts
@@ -24,8 +24,9 @@ vi.mock('@/services/api/promptsApi', () => ({
   promptsApi: { createPrompt: (...args: unknown[]) => mockCreatePrompt(...args) },
 }))
 
+const mockCreateSavedTask = vi.fn().mockResolvedValue({ id: 1 })
 vi.mock('@/services/api/savedTasksApi', () => ({
-  savedTasksApi: { create: vi.fn().mockResolvedValue({ id: 1 }) },
+  savedTasksApi: { create: (...args: unknown[]) => mockCreateSavedTask(...args) },
 }))
 
 vi.mock('@/composables/useNotification', () => ({
@@ -578,6 +579,36 @@ describe('TaskPlanBubble', () => {
         metadata: expect.objectContaining({ tool_url_screenshot: true }),
       })
     )
+  })
+
+  it('pins the executed plan by sending the assistant message id when saving', async () => {
+    mockSavedTasksEnabled.mockReturnValue(true)
+    mockDialogPrompt.mockResolvedValue('RioTinto')
+    mockCreatePrompt.mockResolvedValue({ id: 9 })
+    mockCreateSavedTask.mockClear()
+    const wrapper = mount(TaskPlanBubble, {
+      props: {
+        plan: {
+          active: false,
+          replyNode: 'n2',
+          cards: [
+            { nodeId: 'n1', capability: 'url_fetch', kind: 'search', state: 'done' },
+            { nodeId: 'n2', capability: 'chat', kind: 'text', state: 'done' },
+            { nodeId: 'n3', capability: 'email_me', kind: 'text', state: 'done' },
+          ],
+        },
+        scheduleSource: 'Look up the price on https://example.com/stock and mail it to me',
+        sourceMessageId: 4711,
+      },
+      ...mountOptions,
+    })
+
+    await wrapper.find('[data-testid="btn-schedule-plan"]').trigger('click')
+    await vi.waitFor(() => expect(mockCreateSavedTask).toHaveBeenCalled())
+
+    // Without the source message the backend cannot copy the executed steps
+    // into the task graph and a rerun degrades to a re-planned chat answer.
+    expect(mockCreateSavedTask).toHaveBeenCalledWith(9, 'RioTinto', 4711)
   })
 
   it('hides the clock while the plan is still running', () => {


### PR DESCRIPTION
## Summary
Fixed the task scheduler with included URLs and other DAG tools!

## Changes
- Added `persistTaskPlanDefinition` method to save executed DAG node definitions on outgoing messages, ensuring reruns accurately reflect user interactions.
- Introduced constants for plan definition keys in `TaskPlanExecutor` to facilitate metadata handling.
- Updated `SavedTaskService` to capture task graphs from source messages, enhancing task scheduling capabilities.
- Enhanced `SavedTaskRunner` to include accurate timestamps for outgoing messages, improving message tracking and consistency.
- Adjusted `SavedTaskPlanFactory` to handle reply nodes correctly, ensuring proper response mapping in task graphs.

## Verification
- [ ] Not tested (explain)
- [X] Manual
- [ ] Tests added/updated

## Notes
<!-- Related issues/links/threads. -->

## Screenshots/Logs
