### PR TITLE
fix(deploy): keep the DLM snapshot description within the allowed pattern

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,7 +182,10 @@ jobs:
       - name: Install cfn-lint
         run: |
           set -euo pipefail
-          pipx install cfn-lint
+          # Pinned: an unpinned install turns every cfn-lint release into an
+          # unannounced red main, because new rules fire on templates that
+          # nobody touched. Bump this deliberately.
+          pipx install 'cfn-lint==1.56.2'
           # pipx links into ~/.local/bin, which the runner does not necessarily
           # export to later steps.
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"

--- a/deploy/aws/cloudformation/synaplan-existing-vpc.yaml
+++ b/deploy/aws/cloudformation/synaplan-existing-vpc.yaml
@@ -477,7 +477,7 @@ Resources:
     Type: AWS::DLM::LifecyclePolicy
     Condition: WantsDailySnapshots
     Properties:
-      Description: !Sub 'Daily snapshots of the Synaplan data volume (${AWS::StackName})'
+      Description: !Sub 'Daily snapshots of the Synaplan data volume - ${AWS::StackName}'
       State: ENABLED
       ExecutionRoleArn: !GetAtt SnapshotRole.Arn
       PolicyDetails:

--- a/deploy/aws/cloudformation/synaplan-new-vpc.yaml
+++ b/deploy/aws/cloudformation/synaplan-new-vpc.yaml
@@ -516,7 +516,7 @@ Resources:
     Type: AWS::DLM::LifecyclePolicy
     Condition: WantsDailySnapshots
     Properties:
-      Description: !Sub 'Daily snapshots of the Synaplan data volume (${AWS::StackName})'
+      Description: !Sub 'Daily snapshots of the Synaplan data volume - ${AWS::StackName}'
       State: ENABLED
       ExecutionRoleArn: !GetAtt SnapshotRole.Arn
       PolicyDetails:

--- a/deploy/aws/marketplace/arm64/synaplan-existing-vpc.yaml
+++ b/deploy/aws/marketplace/arm64/synaplan-existing-vpc.yaml
@@ -475,7 +475,7 @@ Resources:
     Type: AWS::DLM::LifecyclePolicy
     Condition: WantsDailySnapshots
     Properties:
-      Description: !Sub 'Daily snapshots of the Synaplan data volume (${AWS::StackName})'
+      Description: !Sub 'Daily snapshots of the Synaplan data volume - ${AWS::StackName}'
       State: ENABLED
       ExecutionRoleArn: !GetAtt SnapshotRole.Arn
       PolicyDetails:

--- a/deploy/aws/marketplace/arm64/synaplan-new-vpc.yaml
+++ b/deploy/aws/marketplace/arm64/synaplan-new-vpc.yaml
@@ -514,7 +514,7 @@ Resources:
     Type: AWS::DLM::LifecyclePolicy
     Condition: WantsDailySnapshots
     Properties:
-      Description: !Sub 'Daily snapshots of the Synaplan data volume (${AWS::StackName})'
+      Description: !Sub 'Daily snapshots of the Synaplan data volume - ${AWS::StackName}'
       State: ENABLED
       ExecutionRoleArn: !GetAtt SnapshotRole.Arn
       PolicyDetails:

--- a/deploy/aws/marketplace/x86_64/synaplan-existing-vpc.yaml
+++ b/deploy/aws/marketplace/x86_64/synaplan-existing-vpc.yaml
@@ -475,7 +475,7 @@ Resources:
     Type: AWS::DLM::LifecyclePolicy
     Condition: WantsDailySnapshots
     Properties:
-      Description: !Sub 'Daily snapshots of the Synaplan data volume (${AWS::StackName})'
+      Description: !Sub 'Daily snapshots of the Synaplan data volume - ${AWS::StackName}'
       State: ENABLED
       ExecutionRoleArn: !GetAtt SnapshotRole.Arn
       PolicyDetails:

--- a/deploy/aws/marketplace/x86_64/synaplan-new-vpc.yaml
+++ b/deploy/aws/marketplace/x86_64/synaplan-new-vpc.yaml
@@ -514,7 +514,7 @@ Resources:
     Type: AWS::DLM::LifecyclePolicy
     Condition: WantsDailySnapshots
     Properties:
-      Description: !Sub 'Daily snapshots of the Synaplan data volume (${AWS::StackName})'
+      Description: !Sub 'Daily snapshots of the Synaplan data volume - ${AWS::StackName}'
       State: ENABLED
       ExecutionRoleArn: !GetAtt SnapshotRole.Arn
       PolicyDetails:


### PR DESCRIPTION
`Deployment Templates (AWS)` went red on `main` at [fe663cf](https://github.com/metadist/synaplan/commit/fe663cf8b) without anything in that merge touching `deploy/`.

## What broke

`cfn-lint` reported no errors, only two `W1031` warnings — but its exit code is a bit field (2 = error, **4 = warning**), so warnings alone fail the step:

```
W1031 {'Fn::Sub': 'Daily snapshots of the Synaplan data volume (${AWS::StackName})'} does not match '^[0-9A-Za-z _-]+$' when 'Fn::Sub' is resolved
deploy/aws/cloudformation/synaplan-existing-vpc.yaml:480:7
deploy/aws/cloudformation/synaplan-new-vpc.yaml:519:7
```

The step installs `cfn-lint` unpinned. The previous green run on `main` four hours earlier got **1.56.1**; the merge run got **1.56.2**, which resolves `Fn::Sub` before matching the schema pattern. Same templates, same lines, unchanged since #1490 / #1609.

## The warning is correct

`AWS::DLM::LifecyclePolicy.Description` is constrained to `[0-9A-Za-z _-]`. The parentheses around the stack name are outside that set, so the DLM API would have rejected the description at stack-create time for any customer launching the Marketplace template with daily snapshots enabled. The new linter version surfaced a real latent bug rather than inventing a rule.

Replaced the parentheses with ` - `, keeping the stack name in the description.

## Also pinned cfn-lint

An unpinned install makes every upstream release a potential unannounced red `main`. Pinned to `1.56.2` (the version that catches this), to be bumped deliberately.

## Verification

`cfn-lint 1.56.2` against both templates locally: exit **0**, no warnings.