### PR TITLE
fix(frontend): keep the composer focused after sending a message

### DIFF
--- a/frontend/src/components/ChatInput.vue
+++ b/frontend/src/components/ChatInput.vue
@@ -1013,6 +1013,11 @@ const sendMessage = () => {
   clearPersistedInput()
   clearPersistedAttachments()
   clearPersistedBlocks()
+
+  // Sending via the button moves focus onto that button, so the next message
+  // would need a click back into the composer. Refocus synchronously — inside
+  // the click gesture — so the mobile keyboard stays open as well.
+  textareaRef.value?.focus()
 }
 
 const toggleThinking = () => {

--- a/frontend/src/components/assistants/AssistantTestPanel.vue
+++ b/frontend/src/components/assistants/AssistantTestPanel.vue
@@ -19,6 +19,7 @@
     </div>
     <form class="flex gap-2" @submit.prevent="send">
       <input
+        ref="draftInputRef"
         v-model="draft"
         type="text"
         class="flex-1 min-w-0 px-3 py-2 rounded-lg surface-card border border-light-border/30 dark:border-dark-border/20 txt-primary text-sm focus:outline-none focus:ring-2 focus:ring-[var(--brand)]"
@@ -46,6 +47,7 @@ import { useAgentsStore } from '@/stores/agents'
 const store = useAgentsStore()
 const authStore = useAuthStore()
 const draft = ref('')
+const draftInputRef = ref<HTMLInputElement | null>(null)
 const sending = ref(false)
 const lines = ref<string[]>([])
 
@@ -62,6 +64,9 @@ function send(): void {
     return
   }
   draft.value = ''
+  // Submitting focuses the send button, which is then disabled while the reply
+  // streams — keep the caret in the field so the next message can just be typed.
+  draftInputRef.value?.focus()
   lines.value.push(message)
   sending.value = true
   let reply = ''

--- a/frontend/src/components/widgets/ChatWidget.vue
+++ b/frontend/src/components/widgets/ChatWidget.vue
@@ -548,6 +548,7 @@
               </button>
             </template>
             <textarea
+              ref="inputRef"
               v-model="inputMessage"
               :disabled="inputDisabled"
               :placeholder="
@@ -822,6 +823,7 @@ const isOpen = ref(false)
 const isFullscreen = ref(props.fullscreenMode)
 const widgetTheme = ref<'light' | 'dark'>(props.defaultTheme)
 const inputMessage = ref('')
+const inputRef = ref<HTMLTextAreaElement | null>(null)
 const privacyStorageKey = `synaplan_privacy_${props.widgetId}`
 const privacyDismissed = ref(
   typeof window !== 'undefined' && window.localStorage.getItem(privacyStorageKey) === '1'
@@ -1573,6 +1575,9 @@ const sendMessage = async () => {
   }
 
   inputMessage.value = ''
+  // Tapping the send button blurs the composer; refocus so the visitor can keep
+  // typing (and the mobile keyboard stays open) without tapping the field again.
+  inputRef.value?.focus()
   await scrollToBottom()
 
   isSending.value = true

--- a/frontend/src/components/widgets/WidgetAiSetupPanel.vue
+++ b/frontend/src/components/widgets/WidgetAiSetupPanel.vue
@@ -544,6 +544,11 @@ async function send() {
   } finally {
     isTyping.value = false
     scrollToBottom()
+
+    // The composer is disabled while the assistant answers, which drops focus.
+    // Restore it once it is enabled again so the next message can just be typed.
+    await nextTick()
+    inputRef.value?.focus()
   }
 }
 

--- a/frontend/src/views/LiveSupportView.vue
+++ b/frontend/src/views/LiveSupportView.vue
@@ -196,6 +196,7 @@
             />
             <div class="flex gap-2">
               <textarea
+                ref="replyInputRef"
                 v-model="replyText"
                 :placeholder="$t('liveSupport.typePlaceholder')"
                 rows="2"
@@ -267,6 +268,7 @@ const loading = ref(false)
 const loadingMessages = ref(false)
 const activeTab = ref<'waiting' | 'active'>('waiting')
 const replyText = ref('')
+const replyInputRef = ref<HTMLTextAreaElement | null>(null)
 const sending = ref(false)
 const messagesContainer = ref<HTMLElement | null>(null)
 const quoting = useMessageQuoting(messagesContainer)
@@ -392,6 +394,11 @@ const sendReply = async () => {
     error(getErrorMessage(err) || 'Failed to send message')
   } finally {
     sending.value = false
+
+    // Clicking the send button takes focus out of the composer, so keep the
+    // agent's cursor in the reply box instead of making them click back in.
+    await nextTick()
+    replyInputRef.value?.focus()
   }
 }
 

--- a/frontend/src/views/WidgetSessionsView.vue
+++ b/frontend/src/views/WidgetSessionsView.vue
@@ -811,6 +811,7 @@
                   <Icon icon="heroicons:paper-clip" class="w-5 h-5 txt-secondary" />
                 </button>
                 <input
+                  ref="messageInputRef"
                   v-model="messageText"
                   type="text"
                   class="flex-1 px-5 py-3 rounded-2xl bg-white/5 dark:bg-white/5 txt-primary text-sm placeholder:txt-secondary focus:outline-none focus:ring-2 focus:ring-[var(--brand)]/30 transition-all"
@@ -1024,6 +1025,7 @@ const selectedSessionIds = ref<Set<string>>(new Set())
 const selectedSessionIdsArray = computed(() => Array.from(selectedSessionIds.value))
 const deletingSessions = ref(false)
 const messageText = ref('')
+const messageInputRef = ref<HTMLInputElement | null>(null)
 const sendingMessage = ref(false)
 const eventSubscription = ref<WidgetSubscription | null>(null)
 // Dedicated typing channel — published from the browser via Centrifugo
@@ -1947,6 +1949,12 @@ const sendMessage = async () => {
     error(err instanceof Error ? err.message : t('widgetSessions.sendFailed'))
   } finally {
     sendingMessage.value = false
+
+    // Submitting moves focus to the send button and the composer stays disabled
+    // for the duration of the request, so the operator would have to click back
+    // into it before typing the next reply. Restore focus once it is enabled again.
+    await nextTick()
+    messageInputRef.value?.focus()
   }
 }
 

--- a/frontend/tests/unit/components/ChatInputFocus.spec.ts
+++ b/frontend/tests/unit/components/ChatInputFocus.spec.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import ChatInput from '@/components/ChatInput.vue'
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ query: {}, fullPath: '/chat' }),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+}))
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key, locale: { value: 'en' } }),
+}))
+
+vi.mock('@/stores/config', () => ({
+  useConfigStore: () => ({
+    speech: {
+      webSpeechEnabled: false,
+      whisperEnabled: false,
+      speechToTextAvailable: false,
+    },
+  }),
+}))
+
+vi.mock('@/services/api/chatApi', () => ({
+  chatApi: {
+    uploadChatFile: vi.fn(),
+    transcribeAudio: vi.fn(),
+  },
+}))
+
+// Mirrors the real Textarea component: v-model plus an exposed focus() that
+// forwards to the underlying element, so document.activeElement is meaningful.
+const TextareaStub = {
+  props: ['modelValue', 'placeholder', 'rows'],
+  emits: ['update:modelValue', 'focus', 'blur'],
+  template:
+    '<textarea data-testid="input-chat-message" :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />',
+  methods: {
+    focus(this: { $el: HTMLTextAreaElement }) {
+      this.$el.focus()
+    },
+  },
+}
+
+const mountInput = (): VueWrapper =>
+  mount(ChatInput, {
+    attachTo: document.body,
+    global: {
+      mocks: { $t: (key: string) => key },
+      stubs: {
+        Icon: true,
+        Textarea: TextareaStub,
+        CommandPalette: true,
+        FileMentionPalette: true,
+        ToolsDropdown: true,
+        ToolBadge: true,
+        ModelDropdown: true,
+        KnowledgeFolderPicker: true,
+        FileSelectionModal: true,
+        PastedTextModal: true,
+        QuoteChip: true,
+      },
+    },
+  })
+
+describe('ChatInput focus handling', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    setActivePinia(createPinia())
+    document.body.innerHTML = ''
+  })
+
+  it('keeps the textarea focused after sending via the send button', async () => {
+    const wrapper = mountInput()
+    const textarea = wrapper.get('[data-testid="input-chat-message"]')
+    await textarea.setValue('hello there')
+
+    await wrapper.get('[data-testid="btn-chat-send"]').trigger('click')
+
+    expect(wrapper.emitted('send')).toBeTruthy()
+    expect(document.activeElement).toBe(textarea.element)
+  })
+
+  it('keeps the textarea focused after sending with Enter', async () => {
+    const wrapper = mountInput()
+    const textarea = wrapper.get('[data-testid="input-chat-message"]')
+    await textarea.setValue('hello there')
+
+    await textarea.trigger('keydown', { key: 'Enter' })
+
+    expect(wrapper.emitted('send')).toBeTruthy()
+    expect(document.activeElement).toBe(textarea.element)
+  })
+})

--- a/frontend/tests/unit/components/assistants/AssistantTestPanel.spec.ts
+++ b/frontend/tests/unit/components/assistants/AssistantTestPanel.spec.ts
@@ -31,7 +31,7 @@ vi.mock('@/services/api/agentsApi', async (importOriginal) => {
   }
 })
 
-function mountPanel() {
+function mountPanel(attach = false) {
   setActivePinia(createPinia())
   const store = useAgentsStore()
   store.current = {
@@ -54,6 +54,7 @@ function mountPanel() {
   auth.user = { id: 1, email: 'ada@test.com', level: 'PRO', isAdmin: false } as never
   const i18n = createI18n({ legacy: false, locale: 'en', messages: { en } })
   return mount(AssistantTestPanel, {
+    attachTo: attach ? document.body : undefined,
     global: {
       plugins: [i18n],
       stubs: { Icon: true },
@@ -75,5 +76,15 @@ describe('AssistantTestPanel', () => {
         message: 'hello draft',
       })
     )
+  })
+
+  it('keeps the input focused after sending', async () => {
+    const wrapper = mountPanel(true)
+    const input = wrapper.get('[data-testid="input-test-message"]')
+    await input.setValue('hello draft')
+    await wrapper.get('form').trigger('submit')
+
+    expect(document.activeElement).toBe(input.element)
+    wrapper.unmount()
   })
 })


### PR DESCRIPTION
## Problem

After sending a message you had to click back into the input field before
you could type the next one — focus was lost on every send.

Two causes, depending on the surface:

1. Submitting a form (or clicking the send button) moves focus **onto that
   button**. The button is then disabled while the request runs, so focus
   falls back to `<body>`.
2. Several composers additionally set `:disabled` on the input for the
   duration of the request, and the browser blurs a disabled element.

Reported for the widget chats inbox (`/channels/widgets/:widgetId/chats`),
but the same bug existed on every send surface.

## Fix

Refocus the input after the send is dispatched.

| Surface | File | When |
| ------- | ---- | ---- |
| Widget chats inbox | `views/WidgetSessionsView.vue` | `finally` + `nextTick` (input is disabled while sending) |
| Live support | `views/LiveSupportView.vue` | `finally` + `nextTick` |
| Widget AI setup panel | `components/widgets/WidgetAiSetupPanel.vue` | `finally` + `nextTick` |
| Main chat composer | `components/ChatInput.vue` | synchronous |
| Embeddable chat widget | `components/widgets/ChatWidget.vue` | synchronous |
| Assistant test panel | `components/assistants/AssistantTestPanel.vue` | synchronous |

Where the field stays enabled during the request, the refocus happens
synchronously inside the click gesture so the **mobile keyboard stays open**
as well. Where the field is disabled, it has to wait for the re-enable —
that is the pattern `components/widgets/SetupChatModal.vue` already used,
which was the only composer that got this right.

## Tests

- New `tests/unit/components/ChatInputFocus.spec.ts` — focus is retained
  after sending via the button and via Enter.
- `tests/unit/components/assistants/AssistantTestPanel.spec.ts` — added a
  focus assertion.

All three new tests were verified to fail without the production change.

## Verification

- `make -C frontend lint` — green (only pre-existing warnings in an
  untouched file)
- `docker compose exec -T frontend npm run check:types` — green
- `make -C frontend test` — 1751 tests, all green
- `make test-e2e` — 17 pre-existing failures in this sandbox (no AI
  provider key: email, subscription, WhatsApp, guest chat, widget). A
  baseline run of the same specs on unmodified `main` produced the same
  failures (18 — one more, flaky), so this change introduces no E2E
  regression.

Mobile impact: `ota-candidate` (all changed source paths are under
`frontend/src/**`; no policy allow-list change needed).
