### PR TITLE
fix(iam): hide People and dead Groups tab when groups flag is off

### DIFF
--- a/frontend/src/components/ImpersonationBanner.vue
+++ b/frontend/src/components/ImpersonationBanner.vue
@@ -78,7 +78,9 @@ import { useRouter } from 'vue-router'
 import { Icon } from '@iconify/vue'
 
 import { useAuth } from '@/composables/useAuth'
+import { isIamGroupsEnabled } from '@/composables/useIamFeature'
 import { useNotification } from '@/composables/useNotification'
+import { getConfig } from '@/services/api/httpClient'
 
 /**
  * Persistent impersonation indicator.
@@ -124,11 +126,18 @@ async function onExit(): Promise<void> {
     const result = await stopImpersonation()
     if (result.success) {
       success(t('admin.impersonate.stopped'))
+      // stopImpersonation() kicks off config reload without awaiting it and
+      // that reload nulls the runtime-config cache first. Reading the IAM
+      // flag against the empty default would send a groups-on install to
+      // Admin, and a subsequent /admin/people push would 404 in the guard.
+      await getConfig()
       // Send the admin back to the user list so they can either pick another
       // impersonation target or continue admin work without a stale view.
       // Do not swallow navigation failures — a silent `.catch` left CI on
       // `/` after the banner hid, waiting 15s for the admin users page.
-      await router.push({ name: 'admin-people' })
+      await router.push(
+        isIamGroupsEnabled() ? { name: 'admin-people' } : { name: 'admin', query: { tab: 'users' } }
+      )
     } else {
       error(result.error ?? t('admin.impersonate.stopFailed'))
     }

--- a/frontend/src/router/iamGuards.ts
+++ b/frontend/src/router/iamGuards.ts
@@ -1,0 +1,31 @@
+import type { RouteLocationNormalized, RouteLocationRaw } from 'vue-router'
+import { isIamGroupsEnabled } from '@/composables/useIamFeature'
+
+/**
+ * Flag off: /admin/people is treated as unknown (U5 / U11).
+ * Nav already hides the People child; this stops the URL and the
+ * `/admin?tab=users` redirect from offering a surface whose APIs 404.
+ */
+export function peopleRouteGuard(to?: RouteLocationNormalized): true | RouteLocationRaw {
+  if (isIamGroupsEnabled()) {
+    return true
+  }
+  const path = to?.path.replace(/^\//, '') ?? 'admin/people'
+  return {
+    name: 'not-found',
+    params: { pathMatch: path.split('/') },
+    query: to?.query,
+    hash: to?.hash,
+  }
+}
+
+/**
+ * Legacy `/admin?tab=users` only becomes a People landing when IAM groups
+ * are on. Otherwise AdminView keeps its own Users table.
+ */
+export function adminUsersTabRedirect(to: RouteLocationNormalized): true | RouteLocationRaw {
+  if (to.query.tab === 'users' && isIamGroupsEnabled()) {
+    return { name: 'admin-people' }
+  }
+  return true
+}

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -27,6 +27,7 @@ import {
 import { i18n } from '@/i18n'
 import { inferNavContext } from '@/router/navContext'
 import { assistantsRouteGuard, instructionsRouteGuard } from '@/router/assistantGuards'
+import { adminUsersTabRedirect, peopleRouteGuard } from '@/router/iamGuards'
 import { getErrorMessage } from '@/utils/errorMessage'
 import LoadingView from '@/views/LoadingView.vue'
 
@@ -521,11 +522,7 @@ const router = createRouter({
       name: 'admin',
       component: () => import('@/views/AdminView.vue'),
       meta: { requiresAuth: true, requiresAdmin: true, titleKey: 'pageTitles.admin' },
-      beforeEnter: (to) => {
-        if (to.query.tab === 'users') {
-          return { name: 'admin-people' }
-        }
-      },
+      beforeEnter: adminUsersTabRedirect,
     },
     {
       path: '/admin/features',
@@ -556,6 +553,7 @@ const router = createRouter({
       name: 'admin-people',
       component: () => import('@/views/PeopleView.vue'),
       meta: { requiresAuth: true, requiresAdmin: true, titleKey: 'pageTitles.adminPeople' },
+      beforeEnter: peopleRouteGuard,
     },
     {
       path: '/subscription',

--- a/frontend/src/views/AdminView.vue
+++ b/frontend/src/views/AdminView.vue
@@ -143,6 +143,9 @@
           </div>
         </div>
 
+        <!-- Users stay on this page while IAM groups are off (U5 / sprint 1). -->
+        <UsersTab v-if="activeTab === 'users'" />
+
         <!-- Prompts Tab -->
         <div v-if="activeTab === 'prompts'" data-testid="section-prompts">
           <div v-if="promptsLoading" class="text-center py-12">
@@ -477,10 +480,12 @@
 
 <script setup lang="ts">
 import { defineAsyncComponent, ref, computed, onMounted, watch } from 'vue'
+import { useRoute } from 'vue-router'
 import { Icon } from '@iconify/vue'
 import MainLayout from '@/components/MainLayout.vue'
 import PageHeader from '@/components/PageHeader.vue'
 import TabNav, { type TabNavItem } from '@/components/TabNav.vue'
+import { isIamGroupsEnabled } from '@/composables/useIamFeature'
 import RegistrationChart from '@/components/admin/RegistrationChart.vue'
 import UsageChart from '@/components/admin/UsageChart.vue'
 import {
@@ -502,6 +507,7 @@ const AdminSystemInfoPanel = defineAsyncComponent(
 const NativeServerControl = defineAsyncComponent(
   () => import('@/components/NativeServerControl.vue')
 )
+const UsersTab = defineAsyncComponent(() => import('@/components/people/UsersTab.vue'))
 
 import { useConfigStore } from '@/stores/config'
 import { useI18n } from 'vue-i18n'
@@ -511,6 +517,8 @@ import { isNativeApp } from '@/services/api/nativeRuntime'
 const { t } = useI18n()
 const { formatDateTime } = useDateFormat()
 const config = useConfigStore()
+const route = useRoute()
+const iamGroupsEnabled = computed(() => isIamGroupsEnabled())
 
 type TabId =
   'overview' | 'users' | 'prompts' | 'usage' | 'subscriptions' | 'moderation' | 'appServer'
@@ -545,13 +553,13 @@ const tabNavItems = computed<TabNavItem[]>(() =>
     label: tab.label,
     icon: tab.icon,
     testid: `tab-${tab.id}`,
-    ...(tab.id === 'users' ? { to: '/admin/people' } : {}),
+    ...(tab.id === 'users' && iamGroupsEnabled.value ? { to: '/admin/people' } : {}),
   }))
 )
 
 function onTabNavChange(id: string) {
-  // Users is a navigation link to People, not a panel on this page.
-  if (id === 'users') {
+  // With IAM groups on, Users is a link to People, not a panel here.
+  if (id === 'users' && iamGroupsEnabled.value) {
     return
   }
   activeTab.value = id as TabId
@@ -733,6 +741,16 @@ function formatDate(dateStr: string): string {
 }
 
 // Initialize
+watch(
+  () => route.query.tab,
+  (tab) => {
+    if (!iamGroupsEnabled.value && tab === 'users') {
+      activeTab.value = 'users'
+    }
+  },
+  { immediate: true }
+)
+
 onMounted(() => {
   loadOverview()
   loadRegistrationAnalytics()

--- a/frontend/src/views/PeopleView.vue
+++ b/frontend/src/views/PeopleView.vue
@@ -20,7 +20,7 @@
       <GroupsTab v-else-if="activeTab === 'groups'" />
       <PoliciesTab v-else-if="activeTab === 'policies'" />
       <PlatformInstancesTab v-else-if="activeTab === 'linked-platforms'" />
-      <AuditTab v-else />
+      <AuditTab v-else-if="activeTab === 'audit'" />
     </div>
   </MainLayout>
 </template>
@@ -35,7 +35,7 @@ import GroupsTab from '@/components/people/GroupsTab.vue'
 import PoliciesTab from '@/components/people/PoliciesTab.vue'
 import AuditTab from '@/components/people/AuditTab.vue'
 import PlatformInstancesTab from '@/components/people/PlatformInstancesTab.vue'
-import { isIamPoliciesEnabled } from '@/composables/useIamFeature'
+import { isIamGroupsEnabled, isIamPoliciesEnabled } from '@/composables/useIamFeature'
 import { isPlatformLinksEnabled } from '@/composables/usePlatformLinksFeature'
 import { useI18n } from 'vue-i18n'
 
@@ -50,13 +50,15 @@ const tabNavItems = computed<TabNavItem[]>(() => {
       icon: 'mdi:account-multiple',
       testid: 'tab-users',
     },
-    {
+  ]
+  if (isIamGroupsEnabled()) {
+    tabs.push({
       id: 'groups',
       label: t('people.tabs.groups'),
       icon: 'mdi:account-group',
       testid: 'tab-groups',
-    },
-  ]
+    })
+  }
   if (isIamPoliciesEnabled()) {
     tabs.push({
       id: 'policies',
@@ -73,12 +75,14 @@ const tabNavItems = computed<TabNavItem[]>(() => {
       testid: 'tab-linked-platforms',
     })
   }
-  tabs.push({
-    id: 'audit',
-    label: t('people.tabs.audit'),
-    icon: 'mdi:clipboard-text-clock',
-    testid: 'tab-audit',
-  })
+  if (isIamGroupsEnabled()) {
+    tabs.push({
+      id: 'audit',
+      label: t('people.tabs.audit'),
+      icon: 'mdi:clipboard-text-clock',
+      testid: 'tab-audit',
+    })
+  }
   return tabs
 })
 

--- a/frontend/tests/e2e/tests/admin-impersonation-chat.spec.ts
+++ b/frontend/tests/e2e/tests/admin-impersonation-chat.spec.ts
@@ -96,14 +96,29 @@ test.describe('@ci @smoke Admin impersonation + chat', () => {
       expect(aiText.length).toBeGreaterThan(0)
     })
 
-    await test.step('Act: exit impersonation and land on People', async () => {
+    await test.step('Act: exit impersonation and land on the admin user list', async () => {
+      const runtimeRes = await request.get(`${getApiUrl()}/api/v1/config/runtime`)
+      expect(runtimeRes.ok()).toBeTruthy()
+      const runtime = (await runtimeRes.json()) as { features?: { iamGroups?: boolean } }
+      const iamGroups = runtime.features?.iamGroups === true
+
       await page.locator(selectors.impersonation.exitBtn).click()
       // Terminal state is the user list, not the banner disappearing.
       // refreshUser() hides the banner before onExit's router.push.
-      await expect(page.locator(selectors.pages.people)).toBeVisible({
-        timeout: TIMEOUTS.LONG,
-      })
-      await expect(page.locator(selectors.admin.sectionUsers)).toBeVisible()
+      // Flag off: that list stays on Admin. Flag on: it lives on People.
+      if (iamGroups) {
+        await expect(page.locator(selectors.pages.people)).toBeVisible({
+          timeout: TIMEOUTS.LONG,
+        })
+        await expect(page.locator(selectors.admin.sectionUsers)).toBeVisible()
+        await expect(page.locator(selectors.pages.admin)).toHaveCount(0)
+      } else {
+        await expect(page.locator(selectors.pages.admin)).toBeVisible({
+          timeout: TIMEOUTS.LONG,
+        })
+        await expect(page.locator(selectors.admin.sectionUsers)).toBeVisible()
+        await expect(page.locator(selectors.pages.people)).toHaveCount(0)
+      }
       await expect(page.locator(selectors.impersonation.banner)).toBeHidden()
     })
   })

--- a/frontend/tests/e2e/tests/admin-impersonation-chat.spec.ts
+++ b/frontend/tests/e2e/tests/admin-impersonation-chat.spec.ts
@@ -18,9 +18,10 @@ test.describe('@ci @smoke Admin impersonation + chat', () => {
     const chat = new ChatHelper(page)
     const adminCreds = CREDENTIALS.getAdminCredentials()
     let targetUserId: number
+    let adminCookie: string
 
     await test.step('Arrange: look up the worker user ID via admin API', async () => {
-      const adminCookie = await loginViaApi(request, adminCreds)
+      adminCookie = await loginViaApi(request, adminCreds)
       const usersRes = await request.get(
         `${getApiUrl()}/api/v1/admin/users?search=${encodeURIComponent(credentials.user)}`,
         { headers: { Cookie: adminCookie } }
@@ -97,7 +98,11 @@ test.describe('@ci @smoke Admin impersonation + chat', () => {
     })
 
     await test.step('Act: exit impersonation and land on the admin user list', async () => {
-      const runtimeRes = await request.get(`${getApiUrl()}/api/v1/config/runtime`)
+      // iamGroups is user-scoped. The unauthenticated request fixture would
+      // see only the global default; onExit routes as the restored admin.
+      const runtimeRes = await request.get(`${getApiUrl()}/api/v1/config/runtime`, {
+        headers: { Cookie: adminCookie },
+      })
       expect(runtimeRes.ok()).toBeTruthy()
       const runtime = (await runtimeRes.json()) as { features?: { iamGroups?: boolean } }
       const iamGroups = runtime.features?.iamGroups === true

--- a/frontend/tests/e2e/tests/admin-panel.spec.ts
+++ b/frontend/tests/e2e/tests/admin-panel.spec.ts
@@ -92,4 +92,42 @@ test.describe('@ci Admin panel', () => {
       })
     })
   })
+
+  test('People route follows the IAM groups flag', async ({ page, request }) => {
+    const adminCookie = await loginViaApi(request, CREDENTIALS.getAdminCredentials())
+    const runtimeRes = await request.get(`${getApiUrl()}/api/v1/config/runtime`, {
+      headers: { Cookie: adminCookie },
+    })
+    expect(runtimeRes.ok()).toBeTruthy()
+    const runtime = (await runtimeRes.json()) as { features?: { iamGroups?: boolean } }
+    const iamGroups = runtime.features?.iamGroups === true
+
+    await page.goto('/admin/people')
+    if (iamGroups) {
+      await expect(page.locator(selectors.pages.people)).toBeVisible({
+        timeout: TIMEOUTS.STANDARD,
+      })
+      await expect(page.locator('[data-testid="tab-groups"]')).toBeVisible()
+      await expect(page.locator('[data-testid="page-not-found"]')).toHaveCount(0)
+    } else {
+      await expect(page.locator('[data-testid="page-not-found"]')).toBeVisible({
+        timeout: TIMEOUTS.STANDARD,
+      })
+      await expect(page.locator(selectors.pages.people)).toHaveCount(0)
+    }
+
+    await page.goto('/admin?tab=users')
+    if (iamGroups) {
+      await expect(page.locator(selectors.pages.people)).toBeVisible({
+        timeout: TIMEOUTS.STANDARD,
+      })
+      await expect(page.locator(selectors.pages.admin)).toHaveCount(0)
+    } else {
+      await expect(page.locator(selectors.pages.admin)).toBeVisible({
+        timeout: TIMEOUTS.STANDARD,
+      })
+      await expect(page.locator(selectors.admin.sectionUsers)).toBeVisible()
+      await expect(page.locator(selectors.pages.people)).toHaveCount(0)
+    }
+  })
 })

--- a/frontend/tests/unit/components/ImpersonationBanner.spec.ts
+++ b/frontend/tests/unit/components/ImpersonationBanner.spec.ts
@@ -25,12 +25,16 @@ vi.mock('@/services/api/impersonationApi', () => ({
   },
 }))
 
+const getConfigSync = vi.fn()
+
 vi.mock('@/services/api/httpClient', () => ({
   getApiBaseUrl: () => 'http://localhost:8000',
   refreshAccessToken: vi.fn().mockResolvedValue(true),
   beginAuthMutation: vi.fn(),
   endAuthMutation: vi.fn(),
   getInFlightRefresh: vi.fn().mockReturnValue(null),
+  getConfigSync: () => getConfigSync(),
+  getConfig: () => Promise.resolve(getConfigSync()),
 }))
 
 vi.mock('@/services/authService', async () => {
@@ -118,6 +122,8 @@ describe('ImpersonationBanner', () => {
     setActivePinia(createPinia())
     successMock.mockClear()
     errorMock.mockClear()
+    getConfigSync.mockReset()
+    getConfigSync.mockReturnValue({ features: {} })
     stopImpersonationMock.mockReset()
   })
 
@@ -173,6 +179,27 @@ describe('ImpersonationBanner', () => {
 
     expect(stopImpersonationMock).toHaveBeenCalledTimes(1)
     expect(successMock).toHaveBeenCalledWith('Admin session restored.')
+    expect(wrapper.vm.$router.currentRoute.value.name).toBe('admin')
+    expect(wrapper.vm.$router.currentRoute.value.path).toBe('/admin')
+    expect(wrapper.vm.$router.currentRoute.value.query).toEqual({ tab: 'users' })
+  })
+
+  it('returns to People after Exit when IAM groups are enabled', async () => {
+    getConfigSync.mockReturnValue({ features: { iamGroups: true } })
+    const store = useAuthStore()
+    store.user = { id: 99, email: 'normal-user@example.com', level: 'PRO' }
+    store.impersonator = { id: 1, email: 'admin@example.com', level: 'ADMIN' }
+
+    stopImpersonationMock.mockResolvedValueOnce({
+      success: true,
+      data: { success: true, user: { id: 1, email: 'admin@example.com', level: 'ADMIN' } },
+      status: 200,
+    })
+
+    const wrapper = await mountBanner()
+    await wrapper.find('[data-testid="btn-impersonation-exit"]').trigger('click')
+    await flushPromises()
+
     expect(wrapper.vm.$router.currentRoute.value.name).toBe('admin-people')
     expect(wrapper.vm.$router.currentRoute.value.path).toBe('/admin/people')
   })

--- a/frontend/tests/unit/router/iamGuards.spec.ts
+++ b/frontend/tests/unit/router/iamGuards.spec.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RouteLocationNormalized } from 'vue-router'
+
+const getConfigSync = vi.fn()
+
+vi.mock('@/services/api/httpClient', () => ({
+  getConfigSync: () => getConfigSync(),
+}))
+
+import { adminUsersTabRedirect, peopleRouteGuard } from '@/router/iamGuards'
+
+function routeWithTab(tab?: string): RouteLocationNormalized {
+  return {
+    path: '/admin/people',
+    query: tab === undefined ? {} : { tab },
+    hash: '',
+  } as RouteLocationNormalized
+}
+
+describe('iamGuards', () => {
+  beforeEach(() => {
+    getConfigSync.mockReset()
+  })
+
+  it('hides People and keeps /admin?tab=users on Admin when groups are off', () => {
+    getConfigSync.mockReturnValue({ features: { iamGroups: false } })
+
+    expect(peopleRouteGuard(routeWithTab())).toEqual({
+      name: 'not-found',
+      params: { pathMatch: ['admin', 'people'] },
+      query: {},
+      hash: '',
+    })
+    expect(adminUsersTabRedirect(routeWithTab('users'))).toBe(true)
+    expect(adminUsersTabRedirect(routeWithTab())).toBe(true)
+  })
+
+  it('opens People and redirects ?tab=users when groups are on', () => {
+    getConfigSync.mockReturnValue({ features: { iamGroups: true } })
+
+    expect(peopleRouteGuard()).toBe(true)
+    expect(adminUsersTabRedirect(routeWithTab('users'))).toEqual({ name: 'admin-people' })
+    expect(adminUsersTabRedirect(routeWithTab())).toBe(true)
+  })
+})

--- a/frontend/tests/unit/views/PeopleView.spec.ts
+++ b/frontend/tests/unit/views/PeopleView.spec.ts
@@ -115,7 +115,21 @@ describe('PeopleView', () => {
     ])
   })
 
-  it('renders Users and Groups tabs', async () => {
+  it('hides Groups and Audit tabs when IAM groups are off', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="tab-users"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="tab-groups"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="tab-audit"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="tab-policies"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="tab-linked-platforms"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="section-users"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="section-audit"]').exists()).toBe(false)
+  })
+
+  it('renders Users, Groups and Audit tabs when IAM groups are on', async () => {
+    getConfigSync.mockReturnValue({ features: { iamGroups: true } })
     const wrapper = mountView()
     await flushPromises()
 
@@ -145,6 +159,7 @@ describe('PeopleView', () => {
   })
 
   it('lists audit events on the Audit tab', async () => {
+    getConfigSync.mockReturnValue({ features: { iamGroups: true } })
     const wrapper = mountView()
     await flushPromises()
 
@@ -157,6 +172,7 @@ describe('PeopleView', () => {
   })
 
   it('lists groups on the Groups tab', async () => {
+    getConfigSync.mockReturnValue({ features: { iamGroups: true } })
     const wrapper = mountView()
     await flushPromises()
 


### PR DESCRIPTION
## Summary
- Gate `/admin/people` and the `/admin?tab=users` redirect on `IAM.GROUPS_ENABLED`, so a seeded-default install no longer offers a People surface whose Groups/Audit APIs 404 (U5 / U11).
- Restore the Admin Users table while the flag is off; keep People + Groups/Audit when it is on.
- Exit impersonation lands on that same user list, after waiting for runtime config so a groups-on install is not sent to a 404.

Fixes #1777

## Test plan
- [x] `make -C frontend lint` (prettier + eslint)
- [x] `docker compose exec -T frontend npm run check:types`
- [x] `make -C frontend test` (1757)
- [x] Playwright `admin-panel` + `admin-impersonation-chat` (flag-aware)
- [ ] On a seeded `IAM.GROUPS_ENABLED=0` install: `/admin/people` is 404, `/admin?tab=users` shows Admin Users, Groups/Create group are absent
- [ ] On a groups-on install: People stays reachable, Groups/Audit remain, Exit impersonation returns to People