### PR TITLE
fix(billing): meter rerank calls and price Cohere per search

### DIFF
--- a/backend/migrations/Version20260910190000.php
+++ b/backend/migrations/Version20260910190000.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Set Cohere Rerank v3.5 (BID 346) to per-search pricing on existing installs.
+ *
+ * The row was seeded at $2.00 / 1,000 searches with no `BJSON.pricing_mode`.
+ * CostCalculationService then treated `per1K` as $0.002/token (~1000× the real
+ * price) as soon as rerank usage started being recorded (#1778). A catalog-only
+ * edit does not reach an un-fingerprinted legacy row: ModelSeeder preserves it.
+ *
+ * Guarded on a missing / non-per_request pricing_mode so an operator who already
+ * set the mode (or a later catalog shape) is left alone. Operator-owned flags
+ * stay out of the SET clause.
+ *
+ * Idempotent and Galera-safe: raw addSql, no Schema API access.
+ *
+ * @see \App\Model\ModelCatalog
+ */
+final class Version20260910190000 extends AbstractMigration
+{
+    /** Must match ModelCatalog::FINGERPRINT_FLOAT_PRECISION. */
+    private const FINGERPRINT_FLOAT_PRECISION = 6;
+
+    private const BID = 346;
+
+    public function getDescription(): string
+    {
+        return 'Set Cohere Rerank v3.5 (BID 346) to per_request pricing and write a matching '
+            .'BJSON fingerprint so ModelSeeder keeps managing the row.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $model = $this->cohereRerankRow();
+        $json = $model['json'];
+        $json['__catalog_fingerprint'] = $this->fingerprint($model);
+
+        $this->addSql(<<<'SQL'
+            UPDATE BMODELS
+               SET BSERVICE = :service,
+                   BNAME = :name,
+                   BTAG = :tag,
+                   BPROVID = :providerId,
+                   BPRICEIN = :priceIn,
+                   BINUNIT = :inUnit,
+                   BPRICEOUT = :priceOut,
+                   BOUTUNIT = :outUnit,
+                   BQUALITY = :quality,
+                   BRATING = :rating,
+                   BJSON = :json
+             WHERE BID = :id
+               AND BPROVID = :providerId
+               AND (
+                    JSON_EXTRACT(COALESCE(BJSON, '{}'), '$.pricing_mode') IS NULL
+                    OR JSON_UNQUOTE(JSON_EXTRACT(COALESCE(BJSON, '{}'), '$.pricing_mode')) <> 'per_request'
+               )
+            SQL, [
+            'service' => $model['service'],
+            'name' => $model['name'],
+            'tag' => $model['tag'],
+            'providerId' => $model['providerId'],
+            'priceIn' => $model['priceIn'],
+            'inUnit' => $model['inUnit'],
+            'priceOut' => $model['priceOut'],
+            'outUnit' => $model['outUnit'],
+            'quality' => $model['quality'],
+            'rating' => $model['rating'],
+            'json' => json_encode($json, \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE | \JSON_THROW_ON_ERROR),
+            'id' => self::BID,
+        ]);
+    }
+
+    public function down(Schema $schema): void
+    {
+        // Deliberately empty. Reinstating per-token billing would overcharge.
+    }
+
+    /**
+     * Snapshot of BID 346 exactly as authored in ModelCatalog on 2026-09-10 —
+     * values AND json key order, because the fingerprint hashes the encoded
+     * payload.
+     *
+     * @return array<string, mixed>
+     */
+    private function cohereRerankRow(): array
+    {
+        return [
+            'id' => 346,
+            'service' => 'cohere',
+            'name' => 'Cohere Rerank v3.5',
+            'tag' => 'rerank',
+            'selectable' => 0,
+            'active' => 1,
+            'providerId' => 'rerank-v3.5',
+            'priceIn' => 2.00,
+            'inUnit' => 'per1K',
+            'priceOut' => 0,
+            'outUnit' => '-',
+            'quality' => 9,
+            'rating' => 1,
+            'json' => [
+                'description' => 'Cohere rerank v2 API. Seeded unselectable; enable after adding a Cohere key on the Reranking tab.',
+                'params' => ['model' => 'rerank-v3.5'],
+                'features' => ['rerank'],
+                'pricing_mode' => 'per_request',
+            ],
+        ];
+    }
+
+    /**
+     * Local copy of ModelCatalog::fingerprint() frozen at authoring time.
+     *
+     * @param array<string, mixed> $row
+     */
+    private function fingerprint(array $row): string
+    {
+        $payload = [
+            'service' => (string) $row['service'],
+            'name' => (string) $row['name'],
+            'tag' => (string) $row['tag'],
+            'providerId' => (string) $row['providerId'],
+            'priceIn' => round((float) $row['priceIn'], self::FINGERPRINT_FLOAT_PRECISION),
+            'inUnit' => (string) $row['inUnit'],
+            'priceOut' => round((float) $row['priceOut'], self::FINGERPRINT_FLOAT_PRECISION),
+            'outUnit' => (string) $row['outUnit'],
+            'quality' => round((float) $row['quality'], self::FINGERPRINT_FLOAT_PRECISION),
+            'rating' => round((float) $row['rating'], self::FINGERPRINT_FLOAT_PRECISION),
+            'json' => $row['json'],
+        ];
+
+        return hash(
+            'sha256',
+            (string) json_encode($payload, \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE | \JSON_THROW_ON_ERROR)
+        );
+    }
+}

--- a/backend/src/Command/SyncModelPricesCommand.php
+++ b/backend/src/Command/SyncModelPricesCommand.php
@@ -230,7 +230,7 @@ class SyncModelPricesCommand extends Command
             }
 
             // Case 2 — same non-per-token mode on both sides (per_second, per_image,
-            // per_character). The prices ARE comparable once normalised to a single
+            // per_character, per_request). The prices ARE comparable once normalised to a single
             // unit, so we DETECT drift here (this is what makes whisper/tts/veo/imagen
             // checkable at all, #1318). Resolution-tiered rows are compared tier by
             // tier, because a provider can reprice 1080p or 4K while the headline
@@ -704,8 +704,9 @@ class SyncModelPricesCommand extends Command
         // output side — LiteLLM nevertheless mirrors the input rate into
         // `output_cost_per_token` on some entries (Jina), which compared against
         // the catalog's unbilled output read as drift. Cohere bills per request
-        // (`input_cost_per_query`); billing has no such mode, so that is reported
-        // as a structural mismatch rather than squeezed into per-token.
+        // (`input_cost_per_query`); that is the same `per_request` mode the
+        // catalog authors on BID 346, so the row is compared (never auto-written)
+        // instead of flagged as a structural mismatch.
         if ('rerank' === $mode) {
             $perQuery = (float) ($litellmModel['input_cost_per_query'] ?? 0.0);
 

--- a/backend/src/Controller/UsageStatsController.php
+++ b/backend/src/Controller/UsageStatsController.php
@@ -38,7 +38,7 @@ class UsageStatsController extends AbstractController
      * - Breakdown by source (WhatsApp, Email, Web)
      * - Breakdown by time period (today, this week, this month)
      * - Recent usage history
-     * - total_requests (sum across all actions) and total_messages (BACTION=MESSAGES only)
+     * - total_requests (sum across all tracked actions, including RERANK) and total_messages (BACTION=MESSAGES only)
      * - cost_budget and cost_summary
      *
      * TODO: the OpenAPI schema for the `data` property is currently `object`, which

--- a/backend/src/Model/ModelCatalog.php
+++ b/backend/src/Model/ModelCatalog.php
@@ -4468,6 +4468,9 @@ class ModelCatalog
                 'description' => 'Cohere rerank v2 API. Seeded unselectable; enable after adding a Cohere key on the Reranking tab.',
                 'params' => ['model' => 'rerank-v3.5'],
                 'features' => ['rerank'],
+                // $2.00 per 1,000 searches. Without this mode the token path
+                // would treat per1K as $0.002/token (~1000× the real price).
+                'pricing_mode' => 'per_request',
             ],
         ],
         [

--- a/backend/src/Plug/Rerank/Adapter/HttpRerankAdapter.php
+++ b/backend/src/Plug/Rerank/Adapter/HttpRerankAdapter.php
@@ -64,10 +64,10 @@ final readonly class HttpRerankAdapter implements RerankProviderInterface
             $texts[] = $this->truncate($candidate->text, $options->maxCandidateChars);
         }
 
-        $ranked = $this->request($model, $query, $texts, $topK, $options->latencyBudgetMs);
+        $outcome = $this->request($model, $query, $texts, $topK, $options->latencyBudgetMs);
         $ms = (int) ((hrtime(true) - $started) / 1_000_000);
         $hits = [];
-        foreach ($ranked as $row) {
+        foreach ($outcome['ranks'] as $row) {
             $index = $row['index'];
             if (!isset($candidates[$index])) {
                 continue;
@@ -83,7 +83,15 @@ final readonly class HttpRerankAdapter implements RerankProviderInterface
             }
         }
 
-        return new RerankResult($hits, self::KEY.':'.strtolower($model->getService()), $ms);
+        return new RerankResult(
+            $hits,
+            self::KEY.':'.strtolower($model->getService()),
+            $ms,
+            $model->getId() ?? $this->modelConfig->getDefaultModel('RERANK'),
+            true,
+            $outcome['tokens'],
+            $outcome['requests'],
+        );
     }
 
     public function health(): PlugHealth
@@ -147,7 +155,7 @@ final readonly class HttpRerankAdapter implements RerankProviderInterface
     /**
      * @param list<string> $texts
      *
-     * @return list<array{index: int, score: float}>
+     * @return array{ranks: list<array{index: int, score: float}>, tokens: int, requests: int}
      */
     private function request(Model $model, string $query, array $texts, int $topK, int $budgetMs): array
     {
@@ -174,7 +182,7 @@ final readonly class HttpRerankAdapter implements RerankProviderInterface
                 'raw_scores' => false,
             ], $timeout);
 
-            return $this->mapIndexed($payload, 'score');
+            return $this->withUsage($this->mapIndexed($payload, 'score'), $payload);
         }
 
         $key = $this->keys->getKey($service);
@@ -182,27 +190,68 @@ final readonly class HttpRerankAdapter implements RerankProviderInterface
             throw new \RuntimeException(ucfirst($service).' API key is not configured');
         }
 
-        return match ($service) {
-            'jina' => $this->mapResults($this->client->postJson(
+        $payload = match ($service) {
+            'jina' => $this->client->postJson(
                 'https://api.jina.ai/v1/rerank',
                 ['Authorization' => 'Bearer '.$key],
                 ['model' => $providerId, 'query' => $query, 'documents' => $texts, 'top_n' => $topK],
                 $timeout,
-            ), 'relevance_score'),
-            'cohere' => $this->mapResults($this->client->postJson(
+            ),
+            'cohere' => $this->client->postJson(
                 'https://api.cohere.com/v2/rerank',
                 ['Authorization' => 'Bearer '.$key],
                 ['model' => $providerId, 'query' => $query, 'documents' => $texts, 'top_n' => $topK],
                 $timeout,
-            ), 'relevance_score'),
-            'voyage' => $this->mapVoyage($this->client->postJson(
+            ),
+            'voyage' => $this->client->postJson(
                 'https://api.voyageai.com/v1/rerank',
                 ['Authorization' => 'Bearer '.$key],
                 ['model' => $providerId, 'query' => $query, 'documents' => $texts, 'top_k' => $topK],
                 $timeout,
-            )),
+            ),
             default => throw new \RuntimeException('Unsupported rerank service: '.$model->getService()),
         };
+
+        $ranks = match ($service) {
+            'voyage' => $this->mapVoyage($payload),
+            default => $this->mapResults($payload, 'relevance_score'),
+        };
+
+        return $this->withUsage($ranks, $payload);
+    }
+
+    /**
+     * Jina/Voyage report `usage.total_tokens`. Cohere bills `meta.billed_units.search_units`.
+     * TEI typically returns a bare list and is treated as one unbilled request.
+     *
+     * @param list<array{index: int, score: float}> $ranks
+     * @param array<int|string, mixed>              $payload
+     *
+     * @return array{ranks: list<array{index: int, score: float}>, tokens: int, requests: int}
+     */
+    private function withUsage(array $ranks, array $payload): array
+    {
+        $tokens = 0;
+        $usage = $payload['usage'] ?? null;
+        if (\is_array($usage)) {
+            if (is_numeric($usage['total_tokens'] ?? null)) {
+                $tokens = (int) $usage['total_tokens'];
+            } elseif (is_numeric($usage['prompt_tokens'] ?? null)) {
+                $tokens = (int) $usage['prompt_tokens'];
+            }
+        }
+
+        $requests = 1;
+        $meta = $payload['meta'] ?? null;
+        if (\is_array($meta)) {
+            $billed = $meta['billed_units'] ?? null;
+            $units = \is_array($billed) ? ($billed['search_units'] ?? null) : null;
+            if (is_numeric($units) && (int) $units > 0) {
+                $requests = (int) $units;
+            }
+        }
+
+        return ['ranks' => $ranks, 'tokens' => $tokens, 'requests' => $requests];
     }
 
     /**

--- a/backend/src/Plug/Rerank/Adapter/HttpRerankAdapter.php
+++ b/backend/src/Plug/Rerank/Adapter/HttpRerankAdapter.php
@@ -85,12 +85,13 @@ final readonly class HttpRerankAdapter implements RerankProviderInterface
 
         return new RerankResult(
             $hits,
-            self::KEY.':'.strtolower($model->getService()),
+            strtolower($model->getService()),
             $ms,
             $model->getId() ?? $this->modelConfig->getDefaultModel('RERANK'),
             true,
             $outcome['tokens'],
             $outcome['requests'],
+            $model->getProviderId(),
         );
     }
 

--- a/backend/src/Plug/Rerank/RerankMetrics.php
+++ b/backend/src/Plug/Rerank/RerankMetrics.php
@@ -35,6 +35,13 @@ final class RerankMetrics
         $this->logger->info('synaplan_plugs_rerank_fallback_total', ['reason' => $reason]);
     }
 
+    public function recordBillingFailure(\Throwable $error): void
+    {
+        $this->logger->warning('synaplan_plugs_rerank_billing_failed', [
+            'error' => $error->getMessage(),
+        ]);
+    }
+
     public function fallbackCount(string $reason): int
     {
         return $this->fallbacks[$reason] ?? 0;

--- a/backend/src/Plug/Rerank/RerankResult.php
+++ b/backend/src/Plug/Rerank/RerankResult.php
@@ -18,6 +18,10 @@ final readonly class RerankResult
         public array $hits,
         public string $provider = '',
         public int $ms = 0,
+        public ?int $modelId = null,
+        public bool $meter = false,
+        public int $promptTokens = 0,
+        public int $requests = 1,
     ) {
     }
 }

--- a/backend/src/Plug/Rerank/RerankResult.php
+++ b/backend/src/Plug/Rerank/RerankResult.php
@@ -22,6 +22,7 @@ final readonly class RerankResult
         public bool $meter = false,
         public int $promptTokens = 0,
         public int $requests = 1,
+        public string $model = '',
     ) {
     }
 }

--- a/backend/src/Plug/Rerank/RerankStage.php
+++ b/backend/src/Plug/Rerank/RerankStage.php
@@ -70,16 +70,6 @@ final readonly class RerankStage
         $started = hrtime(true);
         try {
             $ranked = $provider->rerank($query, $candidates, $k, $options);
-            $ms = $ranked->ms > 0 ? $ranked->ms : (int) ((hrtime(true) - $started) / 1_000_000);
-            $this->metrics->observeLatency($ms);
-            if ($ms > $options->latencyBudgetMs) {
-                return $this->fallback($results, $k, 'timeout');
-            }
-            if ([] === $ranked->hits) {
-                return $this->fallback($results, $k, 'empty');
-            }
-
-            $out = $this->reorder($results, $ranked, $k);
         } catch (\Throwable) {
             $ms = (int) ((hrtime(true) - $started) / 1_000_000);
             $this->metrics->observeLatency($ms);
@@ -87,12 +77,21 @@ final readonly class RerankStage
             return $this->fallback($results, $k, 'exception');
         }
 
-        // After a successful reorder only. A billing failure must not rewind
-        // the ranking into the embedding-order fallback, and the LLM adapter
-        // already bills through the summarize model's chat path (#1778).
+        $ms = $ranked->ms > 0 ? $ranked->ms : (int) ((hrtime(true) - $started) / 1_000_000);
+        $this->metrics->observeLatency($ms);
+        // The provider already ran (and may have billed us). Record that
+        // before the local timeout / empty-hit fallbacks, and never let a
+        // usage-row failure rewind a successful reorder (#1778).
         $this->recordUsage($user, $ranked);
 
-        return $out;
+        if ($ms > $options->latencyBudgetMs) {
+            return $this->fallback($results, $k, 'timeout');
+        }
+        if ([] === $ranked->hits) {
+            return $this->fallback($results, $k, 'empty');
+        }
+
+        return $this->reorder($results, $ranked, $k);
     }
 
     private function recordUsage(?User $user, RerankResult $ranked): void
@@ -101,19 +100,24 @@ final readonly class RerankStage
             return;
         }
 
-        $this->rateLimit->recordUsage($user, 'RERANK', [
-            'usage' => [
-                'prompt_tokens' => $ranked->promptTokens,
-                'completion_tokens' => 0,
-                'total_tokens' => $ranked->promptTokens,
-            ],
-            'media_usage' => [
-                'requests' => max(1, $ranked->requests),
-            ],
-            'provider' => $ranked->provider,
-            'model_id' => $ranked->modelId,
-            'source' => 'RAG_RERANK',
-        ]);
+        try {
+            $this->rateLimit->recordUsage($user, 'RERANK', [
+                'usage' => [
+                    'prompt_tokens' => $ranked->promptTokens,
+                    'completion_tokens' => 0,
+                    'total_tokens' => $ranked->promptTokens,
+                ],
+                'media_usage' => [
+                    'requests' => max(1, $ranked->requests),
+                ],
+                'provider' => $ranked->provider,
+                'model' => $ranked->model,
+                'model_id' => $ranked->modelId,
+                'source' => 'RAG_RERANK',
+            ]);
+        } catch (\Throwable $error) {
+            $this->metrics->recordBillingFailure($error);
+        }
     }
 
     /**

--- a/backend/src/Plug/Rerank/RerankStage.php
+++ b/backend/src/Plug/Rerank/RerankStage.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Plug\Rerank;
 
+use App\Entity\User;
 use App\Plug\PlugConfigService;
+use App\Service\RateLimitService;
 
 /**
  * Reorders RAG hits when a rerank adapter is active. On timeout, empty
@@ -18,6 +20,7 @@ final readonly class RerankStage
         private RerankRegistry $registry,
         private PlugConfigService $config,
         private RerankMetrics $metrics,
+        private RateLimitService $rateLimit,
     ) {
     }
 
@@ -44,7 +47,7 @@ final readonly class RerankStage
      *
      * @return list<RagHit>
      */
-    public function apply(string $query, array $results, int $k): array
+    public function apply(string $query, array $results, int $k, ?User $user = null): array
     {
         $provider = $this->registry->active();
         if (null === $provider || [] === $results || $k < 1 || '' === trim($query)) {
@@ -76,13 +79,41 @@ final readonly class RerankStage
                 return $this->fallback($results, $k, 'empty');
             }
 
-            return $this->reorder($results, $ranked, $k);
+            $out = $this->reorder($results, $ranked, $k);
         } catch (\Throwable) {
             $ms = (int) ((hrtime(true) - $started) / 1_000_000);
             $this->metrics->observeLatency($ms);
 
             return $this->fallback($results, $k, 'exception');
         }
+
+        // After a successful reorder only. A billing failure must not rewind
+        // the ranking into the embedding-order fallback, and the LLM adapter
+        // already bills through the summarize model's chat path (#1778).
+        $this->recordUsage($user, $ranked);
+
+        return $out;
+    }
+
+    private function recordUsage(?User $user, RerankResult $ranked): void
+    {
+        if (null === $user || !$ranked->meter || null === $ranked->modelId) {
+            return;
+        }
+
+        $this->rateLimit->recordUsage($user, 'RERANK', [
+            'usage' => [
+                'prompt_tokens' => $ranked->promptTokens,
+                'completion_tokens' => 0,
+                'total_tokens' => $ranked->promptTokens,
+            ],
+            'media_usage' => [
+                'requests' => max(1, $ranked->requests),
+            ],
+            'provider' => $ranked->provider,
+            'model_id' => $ranked->modelId,
+            'source' => 'RAG_RERANK',
+        ]);
     }
 
     /**

--- a/backend/src/Service/CostCalculationService.php
+++ b/backend/src/Service/CostCalculationService.php
@@ -80,6 +80,12 @@ final readonly class CostCalculationService
             );
         }
 
+        // Per-search rows (Cohere rerank) must never go through convertToPerToken —
+        // a $2.00/1K-searches price would be read as $0.002/token (#1778).
+        if ('per_request' === ($model->getJson()['pricing_mode'] ?? 'per_token')) {
+            return $this->calculateMediaCost($modelId, 1.0, 0.0, $timestamp);
+        }
+
         // Long-context tier: several providers bill the WHOLE request at a
         // higher per-token rate once the prompt crosses a token threshold
         // (Gemini/Claude >200k, GPT-5.x / GPT-6 >272k). Switch both input and output to
@@ -338,7 +344,7 @@ final readonly class CostCalculationService
             'perhour' => $price / 3_600,
             // Flat per-clip / per-call billing (#1317): the authored price is
             // already the price for one whole generation, so no scaling.
-            'per1', 'perchar', 'perpic', 'perimage', 'persec', 'persecond', 'per_generation', 'pergeneration' => $price,
+            'per1', 'perchar', 'perpic', 'perimage', 'persec', 'persecond', 'per_generation', 'pergeneration', 'perrequest', 'per_request' => $price,
             '-', '', 'free' => 0.0,
             default => $price,
         };

--- a/backend/src/Service/RAG/VectorSearchService.php
+++ b/backend/src/Service/RAG/VectorSearchService.php
@@ -126,7 +126,9 @@ final readonly class VectorSearchService
             }, $results);
 
             if (null !== $queryText && '' !== trim($queryText)) {
-                return $this->rerankStage->apply($queryText, $mapped, $limit);
+                $user = $this->userRepository->find($userId);
+
+                return $this->rerankStage->apply($queryText, $mapped, $limit, $user instanceof User ? $user : null);
             }
 
             return $mapped;

--- a/backend/src/Service/RateLimitService.php
+++ b/backend/src/Service/RateLimitService.php
@@ -380,6 +380,7 @@ final class RateLimitService
             $inputQty = match ($pricingMode) {
                 'per_character' => (float) ($mediaUsage['characters'] ?? 0),
                 'per_second' => (float) ($mediaUsage['duration_seconds'] ?? 0),
+                'per_request' => (float) ($mediaUsage['requests'] ?? 1),
                 default => 0.0,
             };
             $outputQty = match ($pricingMode) {
@@ -805,7 +806,7 @@ final class RateLimitService
     public function getUserLimits(User $user): array
     {
         $level = $user->getRateLimitLevel();
-        $actions = ['MESSAGES', 'IMAGES', 'VIDEOS', 'AUDIOS', 'FILE_ANALYSIS', 'EMBEDDINGS'];
+        $actions = ['MESSAGES', 'IMAGES', 'VIDEOS', 'AUDIOS', 'FILE_ANALYSIS', 'EMBEDDINGS', 'RERANK'];
 
         $result = [
             'level' => $level,

--- a/backend/src/Service/UsageStatsService.php
+++ b/backend/src/Service/UsageStatsService.php
@@ -21,6 +21,7 @@ final readonly class UsageStatsService
         'AUDIOS',
         'FILE_ANALYSIS',
         'EMBEDDINGS',
+        'RERANK',
     ];
 
     public function __construct(

--- a/backend/tests/Command/SyncModelPricesCommandTest.php
+++ b/backend/tests/Command/SyncModelPricesCommandTest.php
@@ -744,10 +744,10 @@ class SyncModelPricesCommandTest extends TestCase
 
     public function testRerankPerQueryPricingIsAStructuralMismatch(): void
     {
-        // Cohere bills rerank per request (input_cost_per_query). Billing has no
-        // per-request mode, so the row can neither be compared nor written: it is
-        // a structural mismatch — visible, never drift, and no longer misfiled as
-        // "null-price protected" (LiteLLM's per-token rate is 0 by construction).
+        // A catalog row still on implicit per_token (no json.pricing_mode)
+        // cannot be compared to LiteLLM's per_request query rate — that stays
+        // a structural mismatch. BID 346 now authors per_request; see the
+        // same-mode test below.
         $model = $this->createModelMock('cohere', 'rerank-v3.5', 2.0, 0.0, id: 346);
 
         $this->mockLiteLLMResponse([
@@ -772,6 +772,42 @@ class SyncModelPricesCommandTest extends TestCase
         $output = $this->commandTester->getDisplay();
         $this->assertStringContainsString('litellm=per_request', $output);
         $this->assertStringNotContainsString('Null-price protected', $output);
+    }
+
+    public function testRerankPerQueryPricingMatchesCatalogPerRequest(): void
+    {
+        $model = $this->createMock(Model::class);
+        $model->method('getId')->willReturn(346);
+        $model->method('getService')->willReturn('cohere');
+        $model->method('getProviderId')->willReturn('rerank-v3.5');
+        $model->method('getPriceIn')->willReturn(2.0);
+        $model->method('getPriceOut')->willReturn(0.0);
+        $model->method('getInUnit')->willReturn('per1K');
+        $model->method('getOutUnit')->willReturn('-');
+        $model->method('getJson')->willReturn(['pricing_mode' => 'per_request']);
+
+        $this->mockLiteLLMResponse([
+            'rerank-v3.5' => [
+                'mode' => 'rerank',
+                'input_cost_per_query' => 0.002,
+                'input_cost_per_token' => 0.0,
+                'output_cost_per_token' => 0.0,
+            ],
+        ]);
+
+        // @phpstan-ignore-next-line
+        $this->modelRepository->method('findAll')->willReturn([$model]);
+        // @phpstan-ignore-next-line
+        $this->priceHistoryRepository->method('findCurrentPrice')->willReturn(null);
+
+        $this->em->expects($this->never())->method('persist');
+
+        $this->commandTester->execute(['--dry-run' => true, '--fail-on-drift' => true]);
+
+        $this->assertSame(Command::SUCCESS, $this->commandTester->getStatusCode());
+        $output = $this->commandTester->getDisplay();
+        $this->assertStringContainsString('1 unchanged', $output);
+        $this->assertStringNotContainsString('Pricing-mode mismatch', $output);
     }
 
     public function testKnownDeviationIsReportedButIsNotDrift(): void

--- a/backend/tests/Fixtures/rerank/cohere/rerank.json
+++ b/backend/tests/Fixtures/rerank/cohere/rerank.json
@@ -3,5 +3,6 @@
     {"index": 1, "relevance_score": 0.91},
     {"index": 0, "relevance_score": 0.22},
     {"index": 2, "relevance_score": 0.04}
-  ]
+  ],
+  "meta": {"billed_units": {"search_units": 2}}
 }

--- a/backend/tests/Fixtures/rerank/jina/rerank.json
+++ b/backend/tests/Fixtures/rerank/jina/rerank.json
@@ -3,5 +3,6 @@
     {"index": 1, "relevance_score": 0.88},
     {"index": 0, "relevance_score": 0.33},
     {"index": 2, "relevance_score": 0.05}
-  ]
+  ],
+  "usage": {"total_tokens": 42, "prompt_tokens": 42}
 }

--- a/backend/tests/Fixtures/rerank/voyage/rerank.json
+++ b/backend/tests/Fixtures/rerank/voyage/rerank.json
@@ -3,5 +3,6 @@
     {"index": 1, "relevance_score": 0.87},
     {"index": 0, "relevance_score": 0.29},
     {"index": 2, "relevance_score": 0.08}
-  ]
+  ],
+  "usage": {"total_tokens": 17}
 }

--- a/backend/tests/Unit/Model/ModelCatalogTest.php
+++ b/backend/tests/Unit/Model/ModelCatalogTest.php
@@ -1224,4 +1224,40 @@ class ModelCatalogTest extends TestCase
 
         ModelCatalog::upsert($connection, $model);
     }
+
+    /**
+     * #1778: a per1K catalog price on the implicit per_token mode is read by
+     * convertToPerToken as $price/1000 per token. Cohere's $2.00/1K searches
+     * would then bill ~1000×. Any per1K/per1000 row must author pricing_mode.
+     */
+    public function testPer1kRowsAuthorAnExplicitPricingMode(): void
+    {
+        foreach (ModelCatalog::all() as $row) {
+            $unit = strtolower((string) ($row['inUnit'] ?? ''));
+            if (!\in_array($unit, ['per1k', 'per1000'], true)) {
+                continue;
+            }
+
+            $this->assertArrayHasKey(
+                'pricing_mode',
+                $row['json'] ?? [],
+                sprintf(
+                    'BID %d (%s/%s) authors inUnit=%s and must set json.pricing_mode so it is not billed per token',
+                    $row['id'] ?? 0,
+                    $row['service'] ?? '',
+                    $row['providerId'] ?? '',
+                    $row['inUnit'] ?? '',
+                ),
+            );
+        }
+
+        $cohere = array_values(array_filter(
+            ModelCatalog::all(),
+            static fn (array $m): bool => 346 === ($m['id'] ?? null),
+        ));
+        $this->assertCount(1, $cohere);
+        $this->assertSame('per_request', $cohere[0]['json']['pricing_mode'] ?? null);
+        $this->assertSame('per1K', $cohere[0]['inUnit'] ?? null);
+        $this->assertEqualsWithDelta(2.0, (float) ($cohere[0]['priceIn'] ?? 0.0), 1e-9);
+    }
 }

--- a/backend/tests/Unit/Plug/HttpRerankAdapterContractTest.php
+++ b/backend/tests/Unit/Plug/HttpRerankAdapterContractTest.php
@@ -41,7 +41,8 @@ final class HttpRerankAdapterContractTest extends TestCase
         $result = $adapter->rerank('invoice total', $this->candidates(), 2, new RerankOptions());
 
         $this->assertSame(['b', 'a'], array_column($result->hits, 'id'));
-        $this->assertStringStartsWith('http:', $result->provider);
+        $this->assertSame(strtolower($service), $result->provider);
+        $this->assertSame($providerId, $result->model);
         $this->assertTrue($result->meter);
         $this->assertSame(347, $result->modelId);
         if ('Jina' === $service) {

--- a/backend/tests/Unit/Plug/HttpRerankAdapterContractTest.php
+++ b/backend/tests/Unit/Plug/HttpRerankAdapterContractTest.php
@@ -42,6 +42,15 @@ final class HttpRerankAdapterContractTest extends TestCase
 
         $this->assertSame(['b', 'a'], array_column($result->hits, 'id'));
         $this->assertStringStartsWith('http:', $result->provider);
+        $this->assertTrue($result->meter);
+        $this->assertSame(347, $result->modelId);
+        if ('Jina' === $service) {
+            $this->assertSame(42, $result->promptTokens);
+        } elseif ('Voyage' === $service) {
+            $this->assertSame(17, $result->promptTokens);
+        } elseif ('Cohere' === $service) {
+            $this->assertSame(2, $result->requests);
+        }
     }
 
     public function testUnreachableTeiIsUnavailable(): void

--- a/backend/tests/Unit/Plug/RerankStageFallbackTest.php
+++ b/backend/tests/Unit/Plug/RerankStageFallbackTest.php
@@ -142,7 +142,9 @@ final class RerankStageFallbackTest extends TestCase
                 return 346 === ($metadata['model_id'] ?? null)
                     && 12 === ($metadata['usage']['prompt_tokens'] ?? null)
                     && 1 === ($metadata['media_usage']['requests'] ?? null)
-                    && 'RAG_RERANK' === ($metadata['source'] ?? null);
+                    && 'RAG_RERANK' === ($metadata['source'] ?? null)
+                    && 'cohere' === ($metadata['provider'] ?? null)
+                    && 'rerank-v3.5' === ($metadata['model'] ?? null);
             }),
         );
 
@@ -162,12 +164,13 @@ final class RerankStageFallbackTest extends TestCase
                 {
                     return new RerankResult(
                         [['id' => '1', 'text' => 'first', 'score' => 0.9]],
-                        'http:cohere',
+                        'cohere',
                         8,
                         346,
                         true,
                         12,
                         1,
+                        'rerank-v3.5',
                     );
                 }
 
@@ -227,6 +230,146 @@ final class RerankStageFallbackTest extends TestCase
         $stage->apply('question', [
             ['chunk_id' => '1', 'chunk_text' => 'first', 'score' => 0.9],
         ], 1, $this->createMock(User::class));
+    }
+
+    public function testBillableTimeoutStillRecordsUsage(): void
+    {
+        $user = $this->createMock(User::class);
+        $rateLimit = $this->createMock(RateLimitService::class);
+        $rateLimit->expects($this->once())->method('recordUsage');
+
+        $stage = new RerankStage(
+            $this->registry(new class implements RerankProviderInterface {
+                public function key(): string
+                {
+                    return 'http';
+                }
+
+                public function descriptor(): PlugDescriptor
+                {
+                    return new PlugDescriptor('http', 'HTTP', '', [], 'mixed');
+                }
+
+                public function rerank(string $query, array $candidates, int $topK, RerankOptions $options): RerankResult
+                {
+                    return new RerankResult(
+                        [['id' => '1', 'text' => 'first', 'score' => 0.9]],
+                        'cohere',
+                        50_000,
+                        346,
+                        true,
+                        12,
+                        1,
+                        'rerank-v3.5',
+                    );
+                }
+
+                public function health(): PlugHealth
+                {
+                    return PlugHealth::available();
+                }
+            }),
+            $this->config(),
+            new RerankMetrics(new NullLogger()),
+            $rateLimit,
+        );
+
+        $out = $stage->apply('question', [
+            ['chunk_id' => '1', 'chunk_text' => 'first', 'score' => 0.9],
+        ], 1, $user);
+
+        $this->assertFalse($out[0]['rerank']['applied']);
+        $this->assertSame('timeout', $out[0]['rerank']['reason']);
+    }
+
+    public function testBillableEmptyHitsStillRecordsUsage(): void
+    {
+        $user = $this->createMock(User::class);
+        $rateLimit = $this->createMock(RateLimitService::class);
+        $rateLimit->expects($this->once())->method('recordUsage');
+
+        $stage = new RerankStage(
+            $this->registry(new class implements RerankProviderInterface {
+                public function key(): string
+                {
+                    return 'http';
+                }
+
+                public function descriptor(): PlugDescriptor
+                {
+                    return new PlugDescriptor('http', 'HTTP', '', [], 'mixed');
+                }
+
+                public function rerank(string $query, array $candidates, int $topK, RerankOptions $options): RerankResult
+                {
+                    return new RerankResult([], 'cohere', 8, 346, true, 12, 1, 'rerank-v3.5');
+                }
+
+                public function health(): PlugHealth
+                {
+                    return PlugHealth::available();
+                }
+            }),
+            $this->config(),
+            new RerankMetrics(new NullLogger()),
+            $rateLimit,
+        );
+
+        $out = $stage->apply('question', [
+            ['chunk_id' => '1', 'chunk_text' => 'first', 'score' => 0.9],
+        ], 1, $user);
+
+        $this->assertFalse($out[0]['rerank']['applied']);
+        $this->assertSame('empty', $out[0]['rerank']['reason']);
+    }
+
+    public function testBillingFailureDoesNotDiscardRankedHits(): void
+    {
+        $rateLimit = $this->createMock(RateLimitService::class);
+        $rateLimit->method('recordUsage')->willThrowException(new \RuntimeException('buselog down'));
+
+        $stage = new RerankStage(
+            $this->registry(new class implements RerankProviderInterface {
+                public function key(): string
+                {
+                    return 'http';
+                }
+
+                public function descriptor(): PlugDescriptor
+                {
+                    return new PlugDescriptor('http', 'HTTP', '', [], 'mixed');
+                }
+
+                public function rerank(string $query, array $candidates, int $topK, RerankOptions $options): RerankResult
+                {
+                    return new RerankResult(
+                        [['id' => '1', 'text' => 'first', 'score' => 0.9]],
+                        'cohere',
+                        8,
+                        346,
+                        true,
+                        12,
+                        1,
+                        'rerank-v3.5',
+                    );
+                }
+
+                public function health(): PlugHealth
+                {
+                    return PlugHealth::available();
+                }
+            }),
+            $this->config(),
+            new RerankMetrics(new NullLogger()),
+            $rateLimit,
+        );
+
+        $out = $stage->apply('question', [
+            ['chunk_id' => '1', 'chunk_text' => 'first', 'score' => 0.9],
+        ], 1, $this->createMock(User::class));
+
+        $this->assertTrue($out[0]['rerank']['applied']);
+        $this->assertSame('1', $out[0]['chunk_id']);
     }
 
     private function registry(RerankProviderInterface $provider): RerankRegistry

--- a/backend/tests/Unit/Plug/RerankStageFallbackTest.php
+++ b/backend/tests/Unit/Plug/RerankStageFallbackTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\Plug;
 
+use App\Entity\User;
 use App\Plug\PlugConfigService;
 use App\Plug\PlugDescriptor;
 use App\Plug\PlugHealth;
@@ -15,6 +16,7 @@ use App\Plug\Rerank\RerankResult;
 use App\Plug\Rerank\RerankStage;
 use App\Repository\ConfigRepository;
 use App\Service\ModelConfigService;
+use App\Service\RateLimitService;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 
@@ -47,6 +49,7 @@ final class RerankStageFallbackTest extends TestCase
             }),
             $this->config(),
             $metrics,
+            $this->createMock(RateLimitService::class),
         );
 
         $results = [
@@ -88,6 +91,7 @@ final class RerankStageFallbackTest extends TestCase
             }),
             $this->config(),
             new RerankMetrics(new NullLogger()),
+            $this->createMock(RateLimitService::class),
         );
 
         $results = [
@@ -113,13 +117,116 @@ final class RerankStageFallbackTest extends TestCase
         $models = $this->createMock(ModelConfigService::class);
         $models->method('getDefaultModel')->willReturn(null);
         $registry = new RerankRegistry([], new PlugConfigService($repo), $models);
-        $stage = new RerankStage($registry, new PlugConfigService($repo), new RerankMetrics(new NullLogger()));
+        $stage = new RerankStage(
+            $registry,
+            new PlugConfigService($repo),
+            new RerankMetrics(new NullLogger()),
+            $this->createMock(RateLimitService::class),
+        );
 
         $this->assertSame(5, $stage->storageLimit(5, 'a question'));
         $this->assertSame(
             [['chunk_id' => '1', 'chunk_text' => 'x', 'score' => 1.0]],
             $stage->apply('q', [['chunk_id' => '1', 'chunk_text' => 'x', 'score' => 1.0]], 5),
         );
+    }
+
+    public function testSuccessfulHttpRerankRecordsUsage(): void
+    {
+        $user = $this->createMock(User::class);
+        $rateLimit = $this->createMock(RateLimitService::class);
+        $rateLimit->expects($this->once())->method('recordUsage')->with(
+            $user,
+            'RERANK',
+            $this->callback(static function (array $metadata): bool {
+                return 346 === ($metadata['model_id'] ?? null)
+                    && 12 === ($metadata['usage']['prompt_tokens'] ?? null)
+                    && 1 === ($metadata['media_usage']['requests'] ?? null)
+                    && 'RAG_RERANK' === ($metadata['source'] ?? null);
+            }),
+        );
+
+        $stage = new RerankStage(
+            $this->registry(new class implements RerankProviderInterface {
+                public function key(): string
+                {
+                    return 'http';
+                }
+
+                public function descriptor(): PlugDescriptor
+                {
+                    return new PlugDescriptor('http', 'HTTP', '', [], 'mixed');
+                }
+
+                public function rerank(string $query, array $candidates, int $topK, RerankOptions $options): RerankResult
+                {
+                    return new RerankResult(
+                        [['id' => '1', 'text' => 'first', 'score' => 0.9]],
+                        'http:cohere',
+                        8,
+                        346,
+                        true,
+                        12,
+                        1,
+                    );
+                }
+
+                public function health(): PlugHealth
+                {
+                    return PlugHealth::available();
+                }
+            }),
+            $this->config(),
+            new RerankMetrics(new NullLogger()),
+            $rateLimit,
+        );
+
+        $out = $stage->apply('question', [
+            ['chunk_id' => '1', 'chunk_text' => 'first', 'score' => 0.9],
+        ], 1, $user);
+
+        $this->assertTrue($out[0]['rerank']['applied']);
+    }
+
+    public function testLlmRerankDoesNotRecordUsage(): void
+    {
+        $rateLimit = $this->createMock(RateLimitService::class);
+        $rateLimit->expects($this->never())->method('recordUsage');
+
+        $stage = new RerankStage(
+            $this->registry(new class implements RerankProviderInterface {
+                public function key(): string
+                {
+                    return 'llm';
+                }
+
+                public function descriptor(): PlugDescriptor
+                {
+                    return new PlugDescriptor('llm', 'LLM', '', [], 'mixed');
+                }
+
+                public function rerank(string $query, array $candidates, int $topK, RerankOptions $options): RerankResult
+                {
+                    return new RerankResult(
+                        [['id' => '1', 'text' => 'first', 'score' => 0.9]],
+                        'llm',
+                        20,
+                    );
+                }
+
+                public function health(): PlugHealth
+                {
+                    return PlugHealth::available();
+                }
+            }),
+            $this->config(),
+            new RerankMetrics(new NullLogger()),
+            $rateLimit,
+        );
+
+        $stage->apply('question', [
+            ['chunk_id' => '1', 'chunk_text' => 'first', 'score' => 0.9],
+        ], 1, $this->createMock(User::class));
     }
 
     private function registry(RerankProviderInterface $provider): RerankRegistry

--- a/backend/tests/Unit/Service/CostCalculationServiceTest.php
+++ b/backend/tests/Unit/Service/CostCalculationServiceTest.php
@@ -405,6 +405,26 @@ class CostCalculationServiceTest extends TestCase
         $this->assertSame('2.500000', $result->outputCost);
     }
 
+    public function testPerRequestRerankIsOneSearchNotTokens(): void
+    {
+        $model = $this->createModelMock('cohere', 2.0, 0.0, 'per1K', '-', [
+            'pricing_mode' => 'per_request',
+        ], 'rerank-v3.5');
+
+        // @phpstan-ignore-next-line
+        $this->modelRepository->method('find')->willReturn($model);
+        // @phpstan-ignore-next-line
+        $this->priceHistoryRepository->method('findPriceAtTimestamp')->willReturn(null);
+
+        $viaMedia = $this->service->calculateMediaCost(346, 1.0, 0.0);
+        $this->assertSame('0.002000', $viaMedia->totalCost);
+
+        // The token path must not treat $2.00/per1K as $0.002/token (25000
+        // tokens would have billed ≈ $50). It now delegates to per_request.
+        $viaTokens = $this->service->calculateCost(25000, 0, 0, 0, 346);
+        $this->assertSame('0.002000', $viaTokens->totalCost);
+    }
+
     public function testCalculateMediaCostPerGenerationScalesWithClipCount(): void
     {
         $model = $this->createModelMock('Higgsfield', 0.0, 1.75, '-', 'per_generation', [

--- a/backend/tests/Unit/Service/VectorSearchServiceRerankOffTest.php
+++ b/backend/tests/Unit/Service/VectorSearchServiceRerankOffTest.php
@@ -53,6 +53,7 @@ final class VectorSearchServiceRerankOffTest extends TestCase
             new RerankRegistry([], new PlugConfigService($repo), $models),
             new PlugConfigService($repo),
             new RerankMetrics(new NullLogger()),
+            $this->createMock(RateLimitService::class),
         );
 
         $service = new VectorSearchService(

--- a/frontend/src/api/usageApi.ts
+++ b/frontend/src/api/usageApi.ts
@@ -109,8 +109,8 @@ export interface UsageStats {
     status: string
   }>
   /**
-   * Sum across all six tracked action types (MESSAGES + IMAGES + VIDEOS + AUDIOS
-   * + FILE_ANALYSIS + EMBEDDINGS). Do NOT use for the headline "chat messages
+   * Sum across all tracked action types (MESSAGES + IMAGES + VIDEOS + AUDIOS
+   * + FILE_ANALYSIS + EMBEDDINGS + RERANK). Do NOT use for the headline "chat messages"
    * used" number — use `total_messages` instead so it matches the free-tier
    * limit (50/50) surfaced in LimitReachedModal.
    */

--- a/frontend/src/components/config/UsageStatistics.vue
+++ b/frontend/src/components/config/UsageStatistics.vue
@@ -300,6 +300,7 @@
             <option value="SORTING">{{ $t('config.usage.actions.sorting') }}</option>
             <option value="SEARCH_QUERY">{{ $t('config.usage.actions.search_query') }}</option>
             <option value="EMBEDDINGS">{{ $t('config.usage.actions.embeddings') }}</option>
+            <option value="RERANK">{{ $t('config.usage.actions.rerank') }}</option>
           </select>
 
           <input

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -2654,7 +2654,8 @@
         "sorting": "Klassifikation",
         "search_query": "Suchanfrage",
         "embeddings": "Embeddings",
-        "api_chat": "API-Chat"
+        "api_chat": "API-Chat",
+        "rerank": "Rerank"
       },
       "sources": {
         "whatsapp": "WhatsApp",
@@ -2669,7 +2670,8 @@
         "openai_api": "API (OpenAI-kompatibel)",
         "api_summary": "API-Sitzungszusammenfassung",
         "mcp": "MCP",
-        "mcp_tool": "MCP-Tools"
+        "mcp_tool": "MCP-Tools",
+        "rag_rerank": "Dokument-Rerank"
       },
       "periods": {
         "today": "Heute",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -2557,7 +2557,8 @@
         "sorting": "Classification",
         "search_query": "Search Query",
         "embeddings": "Embeddings",
-        "api_chat": "API Chat"
+        "api_chat": "API Chat",
+        "rerank": "Rerank"
       },
       "sources": {
         "whatsapp": "WhatsApp",
@@ -2572,7 +2573,8 @@
         "openai_api": "API (OpenAI-compatible)",
         "api_summary": "API Session Summary",
         "mcp": "MCP",
-        "mcp_tool": "MCP Tools"
+        "mcp_tool": "MCP Tools",
+        "rag_rerank": "Document rerank"
       },
       "periods": {
         "today": "Today",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -3599,7 +3599,8 @@
         "file_analysis": "Análisis de Archivos",
         "sorting": "Clasificación",
         "search_query": "Consulta de búsqueda",
-        "api_chat": "Chat de API"
+        "api_chat": "Chat de API",
+        "rerank": "Rerank"
       },
       "sources": {
         "whatsapp": "WhatsApp",
@@ -3614,7 +3615,8 @@
         "openai_api": "API (compatible con OpenAI)",
         "api_summary": "Resumen de sesión de API",
         "mcp": "MCP",
-        "mcp_tool": "Herramientas MCP"
+        "mcp_tool": "Herramientas MCP",
+        "rag_rerank": "Rerank de documentos"
       },
       "periods": {
         "today": "Hoy",

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -2555,7 +2555,8 @@
         "sorting": "Classification",
         "search_query": "Requête de recherche",
         "embeddings": "Embeddings",
-        "api_chat": "Chat API"
+        "api_chat": "Chat API",
+        "rerank": "Rerank"
       },
       "sources": {
         "whatsapp": "WhatsApp",
@@ -2570,7 +2571,8 @@
         "openai_api": "API (compatible OpenAI)",
         "api_summary": "Résumé de session API",
         "mcp": "MCP",
-        "mcp_tool": "Outils MCP"
+        "mcp_tool": "Outils MCP",
+        "rag_rerank": "Rerank de documents"
       },
       "periods": {
         "today": "Aujourd’hui",

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -3600,7 +3600,8 @@
         "file_analysis": "Dosya Analizi",
         "sorting": "Sınıflandırma",
         "search_query": "Arama Sorgusu",
-        "api_chat": "API Sohbeti"
+        "api_chat": "API Sohbeti",
+        "rerank": "Yeniden sıralama"
       },
       "sources": {
         "whatsapp": "WhatsApp",
@@ -3615,7 +3616,8 @@
         "openai_api": "API (OpenAI uyumlu)",
         "api_summary": "API oturum özeti",
         "mcp": "MCP",
-        "mcp_tool": "MCP Araçları"
+        "mcp_tool": "MCP Araçları",
+        "rag_rerank": "Belge yeniden sıralama"
       },
       "periods": {
         "today": "Bugün",


### PR DESCRIPTION
## Summary
- Record a `RERANK` usage row after a successful HTTP rerank (Jina/Cohere/Voyage/TEI). The LLM fallback still bills only through the summarize chat path.
- Add `per_request` pricing so Cohere BID 346 (`$2.00 / 1K searches`) is charged per search (~$0.002), not as `$0.002/token`.
- `app:sync-model-prices` now compares that catalog mode to LiteLLM `input_cost_per_query` instead of flagging a permanent structural mismatch.

Fixes #1778

## Test plan
- [x] `make -C backend lint`
- [x] `make -C backend phpstan`
- [x] `make -C backend test` (5964)
- [ ] Enable rerank, bind Jina or Cohere, run a RAG search, confirm a `BUSELOG` row with `BACTION=RERANK`
- [ ] `calculateCost(346, promptTokens: 25000)` / one Cohere search ≈ `$0.002`, not ~`$50`