### PR TITLE
fix(extraction): send Docling convert as multipart form data

### DIFF
--- a/backend/src/Plug/Extraction/Docling/DoclingClient.php
+++ b/backend/src/Plug/Extraction/Docling/DoclingClient.php
@@ -7,6 +7,7 @@ namespace App\Plug\Extraction\Docling;
 use App\Plug\PlugHealth;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Mime\Part\DataPart;
+use Symfony\Component\Mime\Part\Multipart\FormDataPart;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -82,30 +83,34 @@ final class DoclingClient
         }
 
         try {
+            // Symfony HttpClient encodes an array `body` as application/x-www-form-urlencoded.
+            // docling-serve expects multipart/form-data with a real `files` part — a urlencoded
+            // body yields HTTP 422 "Field required" at body.files while GET /health stays green.
+            $formData = new FormDataPart([
+                'files' => DataPart::fromPath($absolutePath, basename($absolutePath)),
+                'to_formats' => 'md',
+                'do_ocr' => 'true',
+                'image_export_mode' => 'placeholder',
+                'table_mode' => 'accurate',
+            ]);
             $response = $this->httpClient->request('POST', $this->endpoint('/v1/convert/file'), [
                 'timeout' => $this->timeoutMs / 1000,
-                'headers' => [
+                'headers' => array_merge($formData->getPreparedHeaders()->toArray(), [
                     'Accept' => 'application/json',
                     'User-Agent' => 'synaplan-docling-client',
-                ],
-                'body' => [
-                    'files' => DataPart::fromPath($absolutePath, basename($absolutePath)),
-                    'to_formats' => 'md',
-                    'do_ocr' => 'true',
-                    'image_export_mode' => 'placeholder',
-                    'table_mode' => 'accurate',
-                ],
+                ]),
+                'body' => $formData->bodyToIterable(),
             ]);
             $status = $response->getStatusCode();
             if ($status >= 500) {
                 throw new DoclingUnavailableException('Docling convert returned HTTP '.$status);
             }
             if ($status >= 400) {
-                throw new DoclingUnavailableException('Docling convert returned HTTP '.$status);
+                throw new DoclingRejectedException('Docling convert returned HTTP '.$status);
             }
 
             $payload = $response->toArray(false);
-        } catch (DoclingUnavailableException $e) {
+        } catch (DoclingUnavailableException|DoclingRejectedException $e) {
             throw $e;
         } catch (TransportExceptionInterface $e) {
             throw new DoclingUnavailableException($this->transportReason($e), $e);

--- a/backend/src/Plug/Extraction/Docling/DoclingRejectedException.php
+++ b/backend/src/Plug/Extraction/Docling/DoclingRejectedException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Plug\Extraction\Docling;
+
+use App\Plug\Extraction\ExtractorRejectedException;
+
+/**
+ * Docling answered the convert request but refused it (HTTP 4xx).
+ * Distinct from {@see DoclingUnavailableException}: the sidecar is reachable.
+ */
+final class DoclingRejectedException extends ExtractorRejectedException
+{
+}

--- a/backend/src/Plug/Extraction/ExtractionProbeService.php
+++ b/backend/src/Plug/Extraction/ExtractionProbeService.php
@@ -68,6 +68,12 @@ final readonly class ExtractionProbeService
                         $winnerKey = $key;
                     }
                 }
+            } catch (ExtractorRejectedException $e) {
+                $this->logger->info('ExtractionProbe: extra extractor refused the file', [
+                    'key' => $key,
+                    'error' => $e->getMessage(),
+                ]);
+                $verdict = 'rejected';
             } catch (\Throwable $e) {
                 $this->logger->info('ExtractionProbe: extra extractor failed', [
                     'key' => $key,

--- a/backend/src/Plug/Extraction/ExtractorRejectedException.php
+++ b/backend/src/Plug/Extraction/ExtractorRejectedException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Plug\Extraction;
+
+/**
+ * The adapter reached its backend and the backend refused the file (HTTP 4xx).
+ * Distinct from "unavailable": health can still be green.
+ */
+class ExtractorRejectedException extends \RuntimeException
+{
+    public function __construct(string $message, ?\Throwable $previous = null)
+    {
+        parent::__construct($message, 0, $previous);
+    }
+}

--- a/backend/tests/Unit/Plug/Extraction/DoclingExtractorContractTest.php
+++ b/backend/tests/Unit/Plug/Extraction/DoclingExtractorContractTest.php
@@ -6,6 +6,8 @@ namespace App\Tests\Unit\Plug\Extraction;
 
 use App\Plug\Extraction\Adapter\DoclingExtractor;
 use App\Plug\Extraction\Docling\DoclingClient;
+use App\Plug\Extraction\Docling\DoclingRejectedException;
+use App\Plug\Extraction\Docling\DoclingUnavailableException;
 use App\Plug\Extraction\ExtractionRequest;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
@@ -56,5 +58,83 @@ final class DoclingExtractorContractTest extends TestCase
         $request = new ExtractionRequest($path, basename($path), 'audio/mpeg', 'mp3', 1, false, 'audio');
         self::assertFalse($extractor->supports($request));
         @unlink($path);
+    }
+
+    public function testConvertFileSendsMultipartFormDataNotUrlencoded(): void
+    {
+        $fixture = (string) file_get_contents(
+            dirname(__DIR__, 3).'/Fixtures/extraction/recorded/docling/invoice-table.json',
+        );
+        $contentType = null;
+        $http = new MockHttpClient(static function (string $method, string $url, array $options) use ($fixture, &$contentType): MockResponse {
+            self::assertSame('POST', $method);
+            self::assertStringEndsWith('/v1/convert/file', $url);
+            $contentType = self::headerLine($options, 'content-type');
+
+            return new MockResponse($fixture, ['http_code' => 200, 'response_headers' => ['content-type' => 'application/json']]);
+        });
+        $client = new DoclingClient($http, new NullLogger(), 'http://docling.test', 120000);
+
+        $path = tempnam(sys_get_temp_dir(), 'docling-multipart-');
+        self::assertNotFalse($path);
+        file_put_contents($path, "%PDF-1.4 recorded\n");
+
+        $converted = $client->convertFile($path);
+        self::assertNotSame('', $converted['text']);
+        self::assertNotNull($contentType);
+        self::assertStringContainsString('multipart/form-data', strtolower($contentType));
+        self::assertStringNotContainsString('application/x-www-form-urlencoded', strtolower($contentType));
+
+        @unlink($path);
+    }
+
+    public function testConvertFileHttp422IsRejectedNotUnavailable(): void
+    {
+        $http = new MockHttpClient([
+            new MockResponse(
+                '{"detail":[{"type":"missing","loc":["body","files"],"msg":"Field required"}]}',
+                ['http_code' => 422],
+            ),
+        ]);
+        $client = new DoclingClient($http, new NullLogger(), 'http://docling.test', 120000);
+
+        $path = tempnam(sys_get_temp_dir(), 'docling-422-');
+        self::assertNotFalse($path);
+        file_put_contents($path, "%PDF-1.4 recorded\n");
+
+        try {
+            $client->convertFile($path);
+            self::fail('HTTP 422 must not be treated as a successful convert');
+        } catch (DoclingRejectedException $e) {
+            self::assertStringContainsString('422', $e->getMessage());
+        } catch (DoclingUnavailableException $e) {
+            self::fail('HTTP 422 means the sidecar answered; must not be DoclingUnavailableException: '.$e->getMessage());
+        } finally {
+            @unlink($path);
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    private static function headerLine(array $options, string $name): string
+    {
+        $normalized = $options['normalized_headers'][$name] ?? null;
+        if (\is_array($normalized) && isset($normalized[0]) && \is_string($normalized[0])) {
+            return $normalized[0];
+        }
+
+        $headers = $options['headers'] ?? [];
+        if (!\is_array($headers)) {
+            return '';
+        }
+        foreach ($headers as $key => $value) {
+            $line = \is_string($key) ? $key.': '.(is_array($value) ? implode(',', $value) : (string) $value) : (string) $value;
+            if (str_starts_with(strtolower($line), $name.':')) {
+                return $line;
+            }
+        }
+
+        return '';
     }
 }

--- a/backend/tests/Unit/Plug/Extraction/ExtractionProbeServiceTest.php
+++ b/backend/tests/Unit/Plug/Extraction/ExtractionProbeServiceTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Plug\Extraction;
+
+use App\Plug\Extraction\ContentExtractorInterface;
+use App\Plug\Extraction\Docling\DoclingRejectedException;
+use App\Plug\Extraction\Docling\DoclingUnavailableException;
+use App\Plug\Extraction\ExtractionProbeService;
+use App\Plug\Extraction\ExtractionQualityGate;
+use App\Plug\Extraction\ExtractionRegistry;
+use App\Plug\Extraction\ExtractionRequest;
+use App\Plug\Extraction\ExtractionResult;
+use App\Plug\PlugConfigService;
+use App\Plug\PlugDescriptor;
+use App\Plug\PlugHealth;
+use App\Service\File\FileProcessor;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+final class ExtractionProbeServiceTest extends TestCase
+{
+    public function testHttp422IsRejectedNotUnavailable(): void
+    {
+        $result = $this->probeWithThrowingDocling(
+            new DoclingRejectedException('Docling convert returned HTTP 422'),
+        );
+
+        $docling = $this->findAttempt($result, 'docling');
+        self::assertSame('rejected', $docling['verdict']);
+        self::assertSame('tika', $result['winner']);
+        self::assertSame('tika', $result['strategy']);
+    }
+
+    public function testUnreachableSidecarStaysUnavailable(): void
+    {
+        $result = $this->probeWithThrowingDocling(
+            new DoclingUnavailableException('Docling unavailable — connection refused'),
+        );
+
+        $docling = $this->findAttempt($result, 'docling');
+        self::assertSame('unavailable', $docling['verdict']);
+        self::assertSame('tika', $result['winner']);
+    }
+
+    /**
+     * @return array{
+     *     winner: string|null,
+     *     strategy: string,
+     *     attempts: list<array{key: string, verdict: string, ms: int}>,
+     *     preview: string,
+     *     markdown: bool
+     * }
+     */
+    private function probeWithThrowingDocling(\Throwable $error): array
+    {
+        $extra = new class($error) implements ContentExtractorInterface {
+            public function __construct(private \Throwable $error)
+            {
+            }
+
+            public function key(): string
+            {
+                return 'docling';
+            }
+
+            public function descriptor(): PlugDescriptor
+            {
+                return new PlugDescriptor('docling', 'Docling', '', [], 'self-hosted');
+            }
+
+            public function supports(ExtractionRequest $request): bool
+            {
+                return '' !== $request->absolutePath;
+            }
+
+            public function extract(ExtractionRequest $request): ExtractionResult
+            {
+                throw $this->error;
+            }
+
+            public function health(): PlugHealth
+            {
+                return PlugHealth::available();
+            }
+        };
+
+        $plugConfig = $this->createMock(PlugConfigService::class);
+        $plugConfig->method('extraExtractorKeys')->willReturn(['docling']);
+
+        $fileProcessor = $this->createMock(FileProcessor::class);
+        $fileProcessor->method('extractText')->willReturn([
+            'Tika fallback body',
+            ['strategy' => 'tika'],
+        ]);
+
+        $uploadDir = sys_get_temp_dir().'/synaplan-probe-'.bin2hex(random_bytes(4));
+        self::assertTrue(mkdir($uploadDir, 0775, true) || is_dir($uploadDir));
+
+        $probe = new ExtractionProbeService(
+            new ExtractionRegistry([$extra], $plugConfig, new NullLogger()),
+            $plugConfig,
+            $this->createStub(ExtractionQualityGate::class),
+            $fileProcessor,
+            new NullLogger(),
+            $uploadDir,
+        );
+
+        $path = tempnam(sys_get_temp_dir(), 'probe-pdf-');
+        self::assertNotFalse($path);
+        file_put_contents($path, "%PDF-1.4 probe\n");
+
+        try {
+            return $probe->testFile($path, 'invoice.pdf');
+        } finally {
+            @unlink($path);
+            foreach (glob($uploadDir.'/*') ?: [] as $leftover) {
+                @unlink($leftover);
+            }
+            @rmdir($uploadDir);
+        }
+    }
+
+    /**
+     * @param array{attempts: list<array{key: string, verdict: string, ms: int}>} $result
+     *
+     * @return array{key: string, verdict: string, ms: int}
+     */
+    private function findAttempt(array $result, string $key): array
+    {
+        foreach ($result['attempts'] as $attempt) {
+            if ($key === $attempt['key']) {
+                return $attempt;
+            }
+        }
+
+        self::fail('Missing attempt for '.$key);
+    }
+}

--- a/frontend/src/components/admin/plugs/ExtractionPlugTab.vue
+++ b/frontend/src/components/admin/plugs/ExtractionPlugTab.vue
@@ -163,6 +163,9 @@ const testSummary = computed(() => {
   const result = testResult.value
   if (!result) return ''
   const docling = result.attempts.find((attempt) => attempt.key === 'docling')
+  if (docling && docling.verdict === 'rejected' && result.strategy === 'tika') {
+    return t('aiInfra.extraction.doclingRejectedTika')
+  }
   if (
     docling &&
     ['unavailable', 'empty', 'low_quality'].includes(docling.verdict) &&

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -3040,6 +3040,7 @@
       "winner": "Gewinner: {winner}",
       "attemptMs": "{ms} ms",
       "doclingUnavailableTika": "Docling nicht verfügbar — stattdessen Tika verwendet",
+      "doclingRejectedTika": "Docling erreichbar, hat die Datei aber abgelehnt — stattdessen Tika verwendet",
       "save": "Kette speichern",
       "saved": "Extraktionskette gespeichert. Der nächste Upload nutzt sie.",
       "saveFailed": "Die Extraktionskette konnte nicht gespeichert werden",
@@ -3051,6 +3052,7 @@
         "empty": "leer",
         "low_quality": "zu wenig brauchbarer Text",
         "unavailable": "nicht verfügbar",
+        "rejected": "erreichbar, Datei abgelehnt",
         "unsupported": "unterstützt diese Datei nicht",
         "unknown": "unbekannter Adapter",
         "skipped": "übersprungen"

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -2948,6 +2948,7 @@
       "winner": "Winner: {winner}",
       "attemptMs": "{ms} ms",
       "doclingUnavailableTika": "Docling unavailable — Tika used instead",
+      "doclingRejectedTika": "Docling reached but refused the file — Tika used instead",
       "save": "Save chain",
       "saved": "Extraction chain saved. The next upload uses it.",
       "saveFailed": "The extraction chain could not be saved",
@@ -2959,6 +2960,7 @@
         "empty": "empty",
         "low_quality": "too little useful text",
         "unavailable": "unavailable",
+        "rejected": "reached but refused the file",
         "unsupported": "does not support this file",
         "unknown": "unknown adapter",
         "skipped": "skipped"

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -1248,6 +1248,7 @@
       "winner": "Ganador: {winner}",
       "attemptMs": "{ms} ms",
       "doclingUnavailableTika": "Docling no disponible — se usó Tika",
+      "doclingRejectedTika": "Docling respondió pero rechazó el archivo — se usó Tika",
       "save": "Guardar cadena",
       "saved": "Cadena de extracción guardada. La próxima carga la usará.",
       "saveFailed": "No se pudo guardar la cadena de extracción",
@@ -1259,6 +1260,7 @@
         "empty": "vacío",
         "low_quality": "demasiado poco texto útil",
         "unavailable": "no disponible",
+        "rejected": "alcanzó el servicio pero rechazó el archivo",
         "unsupported": "no admite este archivo",
         "unknown": "adaptador desconocido",
         "skipped": "omitido"

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -2948,6 +2948,7 @@
       "winner": "Gagnant : {winner}",
       "attemptMs": "{ms} ms",
       "doclingUnavailableTika": "Docling indisponible — Tika a été utilisé",
+      "doclingRejectedTika": "Docling a répondu mais a refusé le fichier — Tika a été utilisé",
       "save": "Enregistrer la chaîne",
       "saved": "Chaîne d’extraction enregistrée. Le prochain envoi l’utilise.",
       "saveFailed": "Impossible d’enregistrer la chaîne d’extraction",
@@ -2959,6 +2960,7 @@
         "empty": "vide",
         "low_quality": "trop peu de texte utile",
         "unavailable": "indisponible",
+        "rejected": "joignable, fichier refusé",
         "unsupported": "ne prend pas en charge ce fichier",
         "unknown": "adaptateur inconnu",
         "skipped": "ignoré"

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -1248,7 +1248,7 @@
       "winner": "Kazanan: {winner}",
       "attemptMs": "{ms} ms",
       "doclingUnavailableTika": "Docling kullanılamıyor — yerine Tika kullanıldı",
-      "doclingRejectedTika": "Docling erişildi ancak dosyayı reddetti — yerine Tika kullanıldı",
+      "doclingRejectedTika": "Docling’e erişildi ancak dosyayı reddetti — yerine Tika kullanıldı",
       "save": "Zinciri kaydet",
       "saved": "Çıkarım zinciri kaydedildi. Sonraki yükleme bunu kullanır.",
       "saveFailed": "Çıkarım zinciri kaydedilemedi",

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -1248,6 +1248,7 @@
       "winner": "Kazanan: {winner}",
       "attemptMs": "{ms} ms",
       "doclingUnavailableTika": "Docling kullanılamıyor — yerine Tika kullanıldı",
+      "doclingRejectedTika": "Docling erişildi ancak dosyayı reddetti — yerine Tika kullanıldı",
       "save": "Zinciri kaydet",
       "saved": "Çıkarım zinciri kaydedildi. Sonraki yükleme bunu kullanır.",
       "saveFailed": "Çıkarım zinciri kaydedilemedi",
@@ -1259,6 +1260,7 @@
         "empty": "boş",
         "low_quality": "çok az yararlı metin",
         "unavailable": "kullanılamıyor",
+        "rejected": "ulaşıldı ancak dosya reddedildi",
         "unsupported": "bu dosyayı desteklemiyor",
         "unknown": "bilinmeyen bağdaştırıcı",
         "skipped": "atlandı"

--- a/frontend/tests/unit/components/admin/plugs/ExtractionPlugTab.spec.ts
+++ b/frontend/tests/unit/components/admin/plugs/ExtractionPlugTab.spec.ts
@@ -24,6 +24,7 @@ vi.mock('@/services/api/adminConfigApi', () => ({
 describe('ExtractionPlugTab', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
+    testExtraction.mockReset()
     getExtractionStatus.mockResolvedValue({
       adapters: [
         {
@@ -74,6 +75,44 @@ describe('ExtractionPlugTab', () => {
     )
     expect(wrapper.get('[data-testid="extraction-test-button"]').text()).toContain(
       'Test with a file'
+    )
+  })
+
+  it('distinguishes a reachable-but-refused Docling convert from a down sidecar', async () => {
+    testExtraction.mockResolvedValue({
+      winner: 'tika',
+      strategy: 'tika',
+      attempts: [
+        { key: 'docling', verdict: 'rejected', ms: 40 },
+        { key: 'tika', verdict: 'quality_ok', ms: 80 },
+      ],
+      preview: 'Tika fallback',
+      markdown: false,
+    })
+
+    const wrapper = mount(ExtractionPlugTab, {
+      global: {
+        stubs: {
+          Icon: true,
+          RouterLink: { template: '<a><slot /></a>', props: ['to'] },
+        },
+      },
+    })
+    await flushPromises()
+
+    const input = wrapper.get('[data-testid="extraction-test-file"]')
+    const file = new File(['%PDF-1.4'], 'invoice.pdf', { type: 'application/pdf' })
+    Object.defineProperty(input.element, 'files', { value: [file] })
+    await input.trigger('change')
+    await wrapper.get('[data-testid="extraction-test-button"]').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.get('[data-testid="extraction-test-summary"]').text()).toContain(
+      'Docling reached but refused the file — Tika used instead'
+    )
+    expect(wrapper.text()).toContain('reached but refused the file')
+    expect(wrapper.get('[data-testid="extraction-test-summary"]').text()).not.toContain(
+      'Docling unavailable'
     )
   })
 })


### PR DESCRIPTION
## Summary
- `DoclingClient::convertFile()` now sends `multipart/form-data` via `FormDataPart` (same pattern as the office converter). Symfony HttpClient was encoding an array `body` as `application/x-www-form-urlencoded`, so docling-serve returned HTTP 422 `Field required` at `body.files` while `GET /health` stayed green.
- HTTP 4xx is `DoclingRejectedException` (sidecar reached, refused the file). Transport / 5xx stay `DoclingUnavailableException`.
- The admin Test button reports `rejected` instead of `unavailable`, so a green health badge is no longer contradicted by “sidecar down”.

Fixes #1786

## Test plan
- [x] `make -C backend lint`
- [x] `make -C backend phpstan`
- [x] `make -C backend test` (5963)
- [x] `make -C frontend lint`
- [x] `docker compose exec -T frontend npm run check:types`
- [x] `make -C frontend test` (1754)
- [ ] Admin → AI infra → Extraction: Test with a file against a live docling-serve. Convert succeeds (multipart). A forced 422 shows “reached but refused the file”, not “unavailable”.