### PR TITLE
fix(search): report web search reachability, not just a stored key

### DIFF
--- a/backend/phpunit.xml.dist
+++ b/backend/phpunit.xml.dist
@@ -57,6 +57,9 @@
              when the Collabora sidecar is up; without force=true, kernel tests
              (runtime config, sorter snapshots) would see the live engine. -->
         <env name="OFFICE_CONVERT_URL" value="" force="true" />
+        <!-- Compose injects SEARXNG_BASE_URL=http://searxng:8080. Admin status
+             now live-probes that sidecar; keep the suite off the network. -->
+        <env name="SEARXNG_BASE_URL" value="" force="true" />
         <server name="OFFICE_CONVERT_URL" value="" force="true" />
         <env name="OFFICE_CONVERT_TIMEOUT_MS" value="60000" force="true" />
     </php>

--- a/backend/src/Plug/WebSearch/Adapter/BraveSearchAdapter.php
+++ b/backend/src/Plug/WebSearch/Adapter/BraveSearchAdapter.php
@@ -8,6 +8,7 @@ use App\Plug\PlugDescriptor;
 use App\Plug\PlugHealth;
 use App\Plug\WebSearch\SearchResultSet;
 use App\Plug\WebSearch\WebSearchCapabilities;
+use App\Plug\WebSearch\WebSearchProbe;
 use App\Plug\WebSearch\WebSearchProviderInterface;
 use App\Plug\WebSearch\WebSearchQuery;
 use App\Service\Search\BraveSearchService;
@@ -58,5 +59,16 @@ final readonly class BraveSearchAdapter implements WebSearchProviderInterface
         return $this->braveSearch->isEnabled()
             ? PlugHealth::available()
             : PlugHealth::unavailable('Brave Search is not enabled or has no API key');
+    }
+
+    public function probe(): PlugHealth
+    {
+        return WebSearchProbe::run(
+            $this->braveSearch->isEnabled(),
+            'Brave Search is not enabled or has no API key',
+            function (): void {
+                $this->braveSearch->search('synaplan', ['count' => 1]);
+            },
+        );
     }
 }

--- a/backend/src/Plug/WebSearch/Adapter/BraveSearchAdapter.php
+++ b/backend/src/Plug/WebSearch/Adapter/BraveSearchAdapter.php
@@ -8,6 +8,7 @@ use App\Plug\PlugDescriptor;
 use App\Plug\PlugHealth;
 use App\Plug\WebSearch\SearchResultSet;
 use App\Plug\WebSearch\WebSearchCapabilities;
+use App\Plug\WebSearch\WebSearchLiveProbeInterface;
 use App\Plug\WebSearch\WebSearchProbe;
 use App\Plug\WebSearch\WebSearchProviderInterface;
 use App\Plug\WebSearch\WebSearchQuery;
@@ -19,7 +20,7 @@ use App\Service\Search\BraveSearchService;
  *
  * @internal
  */
-final readonly class BraveSearchAdapter implements WebSearchProviderInterface
+final readonly class BraveSearchAdapter implements WebSearchProviderInterface, WebSearchLiveProbeInterface
 {
     public function __construct(
         private BraveSearchService $braveSearch,

--- a/backend/src/Plug/WebSearch/Adapter/ExaAdapter.php
+++ b/backend/src/Plug/WebSearch/Adapter/ExaAdapter.php
@@ -12,6 +12,7 @@ use App\Plug\WebSearch\SearchResult;
 use App\Plug\WebSearch\SearchResultSet;
 use App\Plug\WebSearch\WebSearchCapabilities;
 use App\Plug\WebSearch\WebSearchOptionMapper;
+use App\Plug\WebSearch\WebSearchProbe;
 use App\Plug\WebSearch\WebSearchProviderInterface;
 use App\Plug\WebSearch\WebSearchQuery;
 
@@ -97,5 +98,14 @@ final readonly class ExaAdapter implements WebSearchProviderInterface
         return $this->client->hasKey()
             ? PlugHealth::available()
             : PlugHealth::unavailable('Exa API key is not configured');
+    }
+
+    public function probe(): PlugHealth
+    {
+        return WebSearchProbe::run(
+            $this->client->hasKey(),
+            'Exa API key is not configured',
+            $this->client->probe(...),
+        );
     }
 }

--- a/backend/src/Plug/WebSearch/Adapter/ExaAdapter.php
+++ b/backend/src/Plug/WebSearch/Adapter/ExaAdapter.php
@@ -11,6 +11,7 @@ use App\Plug\WebSearch\Client\ExaClient;
 use App\Plug\WebSearch\SearchResult;
 use App\Plug\WebSearch\SearchResultSet;
 use App\Plug\WebSearch\WebSearchCapabilities;
+use App\Plug\WebSearch\WebSearchLiveProbeInterface;
 use App\Plug\WebSearch\WebSearchOptionMapper;
 use App\Plug\WebSearch\WebSearchProbe;
 use App\Plug\WebSearch\WebSearchProviderInterface;
@@ -19,7 +20,7 @@ use App\Plug\WebSearch\WebSearchQuery;
 /**
  * @internal
  */
-final readonly class ExaAdapter implements WebSearchProviderInterface
+final readonly class ExaAdapter implements WebSearchProviderInterface, WebSearchLiveProbeInterface
 {
     public function __construct(
         private ExaClient $client,

--- a/backend/src/Plug/WebSearch/Adapter/FirecrawlAdapter.php
+++ b/backend/src/Plug/WebSearch/Adapter/FirecrawlAdapter.php
@@ -11,6 +11,7 @@ use App\Plug\WebSearch\Client\FirecrawlClient;
 use App\Plug\WebSearch\SearchResult;
 use App\Plug\WebSearch\SearchResultSet;
 use App\Plug\WebSearch\WebSearchCapabilities;
+use App\Plug\WebSearch\WebSearchLiveProbeInterface;
 use App\Plug\WebSearch\WebSearchOptionMapper;
 use App\Plug\WebSearch\WebSearchProbe;
 use App\Plug\WebSearch\WebSearchProviderInterface;
@@ -19,7 +20,7 @@ use App\Plug\WebSearch\WebSearchQuery;
 /**
  * @internal
  */
-final readonly class FirecrawlAdapter implements WebSearchProviderInterface
+final readonly class FirecrawlAdapter implements WebSearchProviderInterface, WebSearchLiveProbeInterface
 {
     public function __construct(
         private FirecrawlClient $client,

--- a/backend/src/Plug/WebSearch/Adapter/FirecrawlAdapter.php
+++ b/backend/src/Plug/WebSearch/Adapter/FirecrawlAdapter.php
@@ -12,6 +12,7 @@ use App\Plug\WebSearch\SearchResult;
 use App\Plug\WebSearch\SearchResultSet;
 use App\Plug\WebSearch\WebSearchCapabilities;
 use App\Plug\WebSearch\WebSearchOptionMapper;
+use App\Plug\WebSearch\WebSearchProbe;
 use App\Plug\WebSearch\WebSearchProviderInterface;
 use App\Plug\WebSearch\WebSearchQuery;
 
@@ -86,5 +87,14 @@ final readonly class FirecrawlAdapter implements WebSearchProviderInterface
         return $this->client->hasKey()
             ? PlugHealth::available()
             : PlugHealth::unavailable('Firecrawl API key is not configured');
+    }
+
+    public function probe(): PlugHealth
+    {
+        return WebSearchProbe::run(
+            $this->client->hasKey(),
+            'Firecrawl API key is not configured',
+            $this->client->probe(...),
+        );
     }
 }

--- a/backend/src/Plug/WebSearch/Adapter/PerplexityAdapter.php
+++ b/backend/src/Plug/WebSearch/Adapter/PerplexityAdapter.php
@@ -13,6 +13,7 @@ use App\Plug\WebSearch\ProviderAnswer;
 use App\Plug\WebSearch\SearchResult;
 use App\Plug\WebSearch\SearchResultSet;
 use App\Plug\WebSearch\WebSearchCapabilities;
+use App\Plug\WebSearch\WebSearchLiveProbeInterface;
 use App\Plug\WebSearch\WebSearchOptionMapper;
 use App\Plug\WebSearch\WebSearchProbe;
 use App\Plug\WebSearch\WebSearchProviderInterface;
@@ -27,7 +28,7 @@ use Psr\Log\LoggerInterface;
  *
  * @internal
  */
-final readonly class PerplexityAdapter implements WebSearchProviderInterface
+final readonly class PerplexityAdapter implements WebSearchProviderInterface, WebSearchLiveProbeInterface
 {
     public function __construct(
         private PerplexitySearchClient $client,

--- a/backend/src/Plug/WebSearch/Adapter/PerplexityAdapter.php
+++ b/backend/src/Plug/WebSearch/Adapter/PerplexityAdapter.php
@@ -14,6 +14,7 @@ use App\Plug\WebSearch\SearchResult;
 use App\Plug\WebSearch\SearchResultSet;
 use App\Plug\WebSearch\WebSearchCapabilities;
 use App\Plug\WebSearch\WebSearchOptionMapper;
+use App\Plug\WebSearch\WebSearchProbe;
 use App\Plug\WebSearch\WebSearchProviderInterface;
 use App\Plug\WebSearch\WebSearchQuery;
 use App\Repository\ConfigRepository;
@@ -101,6 +102,15 @@ final readonly class PerplexityAdapter implements WebSearchProviderInterface
         return $this->client->hasKey()
             ? PlugHealth::available()
             : PlugHealth::unavailable('Perplexity API key is not configured');
+    }
+
+    public function probe(): PlugHealth
+    {
+        return WebSearchProbe::run(
+            $this->client->hasKey(),
+            'Perplexity API key is not configured',
+            $this->client->probe(...),
+        );
     }
 
     /**

--- a/backend/src/Plug/WebSearch/Adapter/SearxngAdapter.php
+++ b/backend/src/Plug/WebSearch/Adapter/SearxngAdapter.php
@@ -11,6 +11,7 @@ use App\Plug\WebSearch\SearchResult;
 use App\Plug\WebSearch\SearchResultSet;
 use App\Plug\WebSearch\WebSearchCapabilities;
 use App\Plug\WebSearch\WebSearchOptionMapper;
+use App\Plug\WebSearch\WebSearchProbe;
 use App\Plug\WebSearch\WebSearchProviderInterface;
 use App\Plug\WebSearch\WebSearchQuery;
 
@@ -97,5 +98,14 @@ final readonly class SearxngAdapter implements WebSearchProviderInterface
         return $this->client->isConfigured()
             ? PlugHealth::available()
             : PlugHealth::unavailable('SEARXNG_BASE_URL is unset or disabled');
+    }
+
+    public function probe(): PlugHealth
+    {
+        return WebSearchProbe::run(
+            $this->client->isConfigured(),
+            'SEARXNG_BASE_URL is unset or disabled',
+            $this->client->probe(...),
+        );
     }
 }

--- a/backend/src/Plug/WebSearch/Adapter/SearxngAdapter.php
+++ b/backend/src/Plug/WebSearch/Adapter/SearxngAdapter.php
@@ -10,6 +10,7 @@ use App\Plug\WebSearch\Client\SearxngClient;
 use App\Plug\WebSearch\SearchResult;
 use App\Plug\WebSearch\SearchResultSet;
 use App\Plug\WebSearch\WebSearchCapabilities;
+use App\Plug\WebSearch\WebSearchLiveProbeInterface;
 use App\Plug\WebSearch\WebSearchOptionMapper;
 use App\Plug\WebSearch\WebSearchProbe;
 use App\Plug\WebSearch\WebSearchProviderInterface;
@@ -18,7 +19,7 @@ use App\Plug\WebSearch\WebSearchQuery;
 /**
  * @internal
  */
-final readonly class SearxngAdapter implements WebSearchProviderInterface
+final readonly class SearxngAdapter implements WebSearchProviderInterface, WebSearchLiveProbeInterface
 {
     public function __construct(
         private SearxngClient $client,

--- a/backend/src/Plug/WebSearch/Adapter/TavilyAdapter.php
+++ b/backend/src/Plug/WebSearch/Adapter/TavilyAdapter.php
@@ -11,6 +11,7 @@ use App\Plug\WebSearch\ProviderAnswer;
 use App\Plug\WebSearch\SearchResult;
 use App\Plug\WebSearch\SearchResultSet;
 use App\Plug\WebSearch\WebSearchCapabilities;
+use App\Plug\WebSearch\WebSearchLiveProbeInterface;
 use App\Plug\WebSearch\WebSearchOptionMapper;
 use App\Plug\WebSearch\WebSearchProbe;
 use App\Plug\WebSearch\WebSearchProviderInterface;
@@ -19,7 +20,7 @@ use App\Plug\WebSearch\WebSearchQuery;
 /**
  * @internal
  */
-final readonly class TavilyAdapter implements WebSearchProviderInterface
+final readonly class TavilyAdapter implements WebSearchProviderInterface, WebSearchLiveProbeInterface
 {
     public function __construct(
         private TavilyClient $client,

--- a/backend/src/Plug/WebSearch/Adapter/TavilyAdapter.php
+++ b/backend/src/Plug/WebSearch/Adapter/TavilyAdapter.php
@@ -12,6 +12,7 @@ use App\Plug\WebSearch\SearchResult;
 use App\Plug\WebSearch\SearchResultSet;
 use App\Plug\WebSearch\WebSearchCapabilities;
 use App\Plug\WebSearch\WebSearchOptionMapper;
+use App\Plug\WebSearch\WebSearchProbe;
 use App\Plug\WebSearch\WebSearchProviderInterface;
 use App\Plug\WebSearch\WebSearchQuery;
 
@@ -97,5 +98,14 @@ final readonly class TavilyAdapter implements WebSearchProviderInterface
         return $this->client->hasKey()
             ? PlugHealth::available()
             : PlugHealth::unavailable('Tavily API key is not configured');
+    }
+
+    public function probe(): PlugHealth
+    {
+        return WebSearchProbe::run(
+            $this->client->hasKey(),
+            'Tavily API key is not configured',
+            $this->client->probe(...),
+        );
     }
 }

--- a/backend/src/Plug/WebSearch/Client/ExaClient.php
+++ b/backend/src/Plug/WebSearch/Client/ExaClient.php
@@ -58,4 +58,13 @@ final readonly class ExaClient
 
         return $response->toArray(false);
     }
+
+    public function probe(): void
+    {
+        $this->search([
+            'query' => 'synaplan',
+            'numResults' => 1,
+            'type' => 'auto',
+        ]);
+    }
 }

--- a/backend/src/Plug/WebSearch/Client/FirecrawlClient.php
+++ b/backend/src/Plug/WebSearch/Client/FirecrawlClient.php
@@ -58,4 +58,12 @@ final readonly class FirecrawlClient
 
         return $response->toArray(false);
     }
+
+    public function probe(): void
+    {
+        $this->search([
+            'query' => 'synaplan',
+            'limit' => 1,
+        ]);
+    }
 }

--- a/backend/src/Plug/WebSearch/Client/PerplexitySearchClient.php
+++ b/backend/src/Plug/WebSearch/Client/PerplexitySearchClient.php
@@ -58,4 +58,12 @@ final readonly class PerplexitySearchClient
 
         return $response->toArray(false);
     }
+
+    public function probe(): void
+    {
+        $this->search([
+            'query' => 'synaplan',
+            'max_results' => 1,
+        ]);
+    }
 }

--- a/backend/src/Plug/WebSearch/Client/SearxngClient.php
+++ b/backend/src/Plug/WebSearch/Client/SearxngClient.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Plug\WebSearch\Client;
 
 use App\Plug\PlugConfigService;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
@@ -59,6 +60,43 @@ final readonly class SearxngClient
         }
 
         return $data;
+    }
+
+    /**
+     * Cheap reachability check. A set URL is not enough — a stopped sidecar
+     * still has SEARXNG_BASE_URL.
+     */
+    public function probe(): void
+    {
+        if (!$this->isConfigured()) {
+            throw new \RuntimeException('SEARXNG_BASE_URL is unset or disabled');
+        }
+
+        try {
+            $response = $this->httpClient->request('GET', $this->endpoint('/search'), [
+                'timeout' => 5,
+                'query' => [
+                    'q' => 'synaplan',
+                    'format' => 'json',
+                ],
+                'headers' => ['Accept' => 'application/json'],
+            ]);
+            $status = $response->getStatusCode();
+            if ($status >= 400) {
+                throw new \RuntimeException('SearXNG probe returned HTTP '.$status);
+            }
+            $response->getContent(false);
+        } catch (TransportExceptionInterface $e) {
+            $message = $e->getMessage();
+            if (str_contains(strtolower($message), 'timed out') || str_contains(strtolower($message), 'timeout')) {
+                throw new \RuntimeException('SearXNG request timed out', 0, $e);
+            }
+            if (str_contains(strtolower($message), 'refused') || str_contains(strtolower($message), 'could not resolve')) {
+                throw new \RuntimeException('SearXNG unavailable — connection refused', 0, $e);
+            }
+
+            throw new \RuntimeException('SearXNG unavailable: '.$message, 0, $e);
+        }
     }
 
     private function endpoint(string $path): string

--- a/backend/src/Plug/WebSearch/Client/SearxngClient.php
+++ b/backend/src/Plug/WebSearch/Client/SearxngClient.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Plug\WebSearch\Client;
 
 use App\Plug\PlugConfigService;
+use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -85,13 +86,22 @@ final readonly class SearxngClient
             if ($status >= 400) {
                 throw new \RuntimeException('SearXNG probe returned HTTP '.$status);
             }
-            $response->getContent(false);
+            $data = $response->toArray(false);
+            if (!isset($data['results']) || !\is_array($data['results'])) {
+                throw new \RuntimeException('SearXNG probe returned no results array');
+            }
+        } catch (DecodingExceptionInterface $e) {
+            throw new \RuntimeException('SearXNG probe returned no results array', 0, $e);
         } catch (TransportExceptionInterface $e) {
             $message = $e->getMessage();
-            if (str_contains(strtolower($message), 'timed out') || str_contains(strtolower($message), 'timeout')) {
+            $lower = strtolower($message);
+            if (str_contains($lower, 'timed out') || str_contains($lower, 'timeout')) {
                 throw new \RuntimeException('SearXNG request timed out', 0, $e);
             }
-            if (str_contains(strtolower($message), 'refused') || str_contains(strtolower($message), 'could not resolve')) {
+            if (str_contains($lower, 'could not resolve') || str_contains($lower, 'nodename nor servname') || str_contains($lower, 'name or service not known')) {
+                throw new \RuntimeException('SearXNG unavailable — could not resolve host', 0, $e);
+            }
+            if (str_contains($lower, 'refused')) {
                 throw new \RuntimeException('SearXNG unavailable — connection refused', 0, $e);
             }
 

--- a/backend/src/Plug/WebSearch/Client/TavilyClient.php
+++ b/backend/src/Plug/WebSearch/Client/TavilyClient.php
@@ -58,4 +58,13 @@ final readonly class TavilyClient
 
         return $response->toArray(false);
     }
+
+    public function probe(): void
+    {
+        $this->search([
+            'query' => 'synaplan',
+            'max_results' => 1,
+            'search_depth' => 'basic',
+        ]);
+    }
 }

--- a/backend/src/Plug/WebSearch/WebSearchAdminHealth.php
+++ b/backend/src/Plug/WebSearch/WebSearchAdminHealth.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Plug\WebSearch;
+
+use App\Plug\PlugHealth;
+
+/**
+ * Admin badge health: live probe for SearXNG and the selected providers,
+ * "not verified" for an unused key, config reason when nothing is stored.
+ */
+final readonly class WebSearchAdminHealth
+{
+    public function __construct(
+        private WebSearchHealthCache $cache,
+    ) {
+    }
+
+    public function forAdapter(WebSearchProviderInterface $adapter, string $active, string $fallback): PlugHealth
+    {
+        $configured = $adapter->health();
+        if (!$configured->available) {
+            return $configured;
+        }
+
+        $key = $adapter->key();
+        if ('searxng' !== $key && $key !== $active && $key !== $fallback) {
+            return PlugHealth::unavailable('Key stored — not verified');
+        }
+
+        return $this->cache->remember($key, $adapter->probe(...));
+    }
+
+    public function remember(string $key, PlugHealth $health): PlugHealth
+    {
+        return $this->cache->put($key, $health);
+    }
+}

--- a/backend/src/Plug/WebSearch/WebSearchAdminHealth.php
+++ b/backend/src/Plug/WebSearch/WebSearchAdminHealth.php
@@ -29,11 +29,20 @@ final readonly class WebSearchAdminHealth
             return PlugHealth::unavailable('Key stored — not verified');
         }
 
+        if (!$adapter instanceof WebSearchLiveProbeInterface) {
+            return PlugHealth::unavailable('Key stored — not verified');
+        }
+
         return $this->cache->remember($key, $adapter->probe(...));
     }
 
     public function remember(string $key, PlugHealth $health): PlugHealth
     {
         return $this->cache->put($key, $health);
+    }
+
+    public function forget(string $key): void
+    {
+        $this->cache->forget($key);
     }
 }

--- a/backend/src/Plug/WebSearch/WebSearchAdminService.php
+++ b/backend/src/Plug/WebSearch/WebSearchAdminService.php
@@ -93,7 +93,9 @@ final readonly class WebSearchAdminService
         $started = hrtime(true);
         try {
             $set = $adapter->search(new WebSearchQuery($query));
-            $this->adminHealth->remember($key, PlugHealth::available());
+            if ($adapter->health()->available) {
+                $this->adminHealth->remember($key, PlugHealth::available());
+            }
             $latencyMs = (int) ((hrtime(true) - $started) / 1_000_000);
             $results = [];
             foreach (array_slice($set->results, 0, 5) as $row) {
@@ -129,11 +131,13 @@ final readonly class WebSearchAdminService
         $normalized = strtolower(trim($provider));
         if ($this->plugKeys->supports($normalized)) {
             $this->plugKeys->saveKey($normalized, $key);
+            $this->adminHealth->forget($normalized);
 
             return $this->plugKeys->getStatus($normalized);
         }
         if ('perplexity' === $normalized) {
             $this->providerKeys->saveKey('perplexity', $key);
+            $this->adminHealth->forget('perplexity');
 
             return $this->providerKeys->getStatus('perplexity');
         }
@@ -149,11 +153,13 @@ final readonly class WebSearchAdminService
         $normalized = strtolower(trim($provider));
         if ($this->plugKeys->supports($normalized)) {
             $this->plugKeys->deleteKey($normalized);
+            $this->adminHealth->forget($normalized);
 
             return $this->plugKeys->getStatus($normalized);
         }
         if ('perplexity' === $normalized) {
             $this->providerKeys->deleteKey('perplexity');
+            $this->adminHealth->forget('perplexity');
 
             return $this->providerKeys->getStatus('perplexity');
         }

--- a/backend/src/Plug/WebSearch/WebSearchAdminService.php
+++ b/backend/src/Plug/WebSearch/WebSearchAdminService.php
@@ -6,6 +6,7 @@ namespace App\Plug\WebSearch;
 
 use App\AI\Credential\ProviderKeyStore;
 use App\Plug\PlugConfigService;
+use App\Plug\PlugHealth;
 use App\Plug\PlugKeyStore;
 use App\Service\Search\BraveSearchService;
 
@@ -20,6 +21,7 @@ final readonly class WebSearchAdminService
         private PlugKeyStore $plugKeys,
         private ProviderKeyStore $providerKeys,
         private BraveSearchService $braveSearch,
+        private WebSearchAdminHealth $adminHealth,
     ) {
     }
 
@@ -33,10 +35,12 @@ final readonly class WebSearchAdminService
      */
     public function status(): array
     {
+        $active = $this->plugConfig->webSearchProvider(null);
+        $fallback = $this->plugConfig->webSearchFallback();
         $providers = [];
         foreach ($this->registry->all() as $adapter) {
             $descriptor = $adapter->descriptor();
-            $health = $adapter->health();
+            $health = $this->adminHealth->forAdapter($adapter, $active, $fallback);
             $providers[] = [
                 'key' => $adapter->key(),
                 'label' => $descriptor->label,
@@ -54,8 +58,8 @@ final readonly class WebSearchAdminService
 
         return [
             'providers' => $providers,
-            'active' => $this->plugConfig->webSearchProvider(null),
-            'fallback' => $this->plugConfig->webSearchFallback(),
+            'active' => $active,
+            'fallback' => $fallback,
             'userOverrideAllowed' => $this->plugConfig->isWebSearchUserOverrideAllowed(),
         ];
     }
@@ -89,6 +93,7 @@ final readonly class WebSearchAdminService
         $started = hrtime(true);
         try {
             $set = $adapter->search(new WebSearchQuery($query));
+            $this->adminHealth->remember($key, PlugHealth::available());
             $latencyMs = (int) ((hrtime(true) - $started) / 1_000_000);
             $results = [];
             foreach (array_slice($set->results, 0, 5) as $row) {
@@ -105,6 +110,8 @@ final readonly class WebSearchAdminService
                 'error' => null,
             ];
         } catch (\Throwable $e) {
+            $this->adminHealth->remember($key, PlugHealth::unavailable($e->getMessage()));
+
             return [
                 'results' => [],
                 'answer' => null,

--- a/backend/src/Plug/WebSearch/WebSearchHealthCache.php
+++ b/backend/src/Plug/WebSearch/WebSearchHealthCache.php
@@ -37,4 +37,9 @@ final class WebSearchHealthCache
 
         return $health;
     }
+
+    public function forget(string $key): void
+    {
+        unset($this->items[$key]);
+    }
 }

--- a/backend/src/Plug/WebSearch/WebSearchHealthCache.php
+++ b/backend/src/Plug/WebSearch/WebSearchHealthCache.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Plug\WebSearch;
+
+use App\Plug\PlugHealth;
+
+/**
+ * Process-local TTL cache for live web-search probes (same idea as Docling health).
+ */
+final class WebSearchHealthCache
+{
+    private const TTL_SECONDS = 30;
+
+    /** @var array<string, array{health: PlugHealth, at: int}> */
+    private array $items = [];
+
+    public function remember(string $key, callable $probe): PlugHealth
+    {
+        $hit = $this->items[$key] ?? null;
+        if (null !== $hit && (time() - $hit['at']) < self::TTL_SECONDS) {
+            return $hit['health'];
+        }
+
+        $health = $probe();
+        if (!$health instanceof PlugHealth) {
+            throw new \LogicException('Web search health probe must return PlugHealth');
+        }
+
+        return $this->put($key, $health);
+    }
+
+    public function put(string $key, PlugHealth $health): PlugHealth
+    {
+        $this->items[$key] = ['health' => $health, 'at' => time()];
+
+        return $health;
+    }
+}

--- a/backend/src/Plug/WebSearch/WebSearchLiveProbeInterface.php
+++ b/backend/src/Plug/WebSearch/WebSearchLiveProbeInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Plug\WebSearch;
+
+use App\Plug\PlugHealth;
+
+/**
+ * Optional live reachability check. Built-in adapters implement this;
+ * third-party plugins that only implement {@see WebSearchProviderInterface}
+ * keep loading. Admin badges then show "Key stored — not verified".
+ */
+interface WebSearchLiveProbeInterface
+{
+    public function probe(): PlugHealth;
+}

--- a/backend/src/Plug/WebSearch/WebSearchProbe.php
+++ b/backend/src/Plug/WebSearch/WebSearchProbe.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Plug\WebSearch;
+
+use App\Plug\PlugHealth;
+
+/**
+ * Turns a live ping into {@see PlugHealth}. Config-only checks stay on health().
+ */
+final class WebSearchProbe
+{
+    public static function run(bool $configured, string $notConfiguredReason, callable $ping): PlugHealth
+    {
+        if (!$configured) {
+            return PlugHealth::unavailable($notConfiguredReason);
+        }
+
+        try {
+            $ping();
+        } catch (\Throwable $e) {
+            return PlugHealth::unavailable($e->getMessage());
+        }
+
+        return PlugHealth::available();
+    }
+}

--- a/backend/src/Plug/WebSearch/WebSearchProviderInterface.php
+++ b/backend/src/Plug/WebSearch/WebSearchProviderInterface.php
@@ -22,11 +22,8 @@ interface WebSearchProviderInterface
 
     /**
      * Cheap config check (key / URL present). Used on the chat search path.
+     * Must never throw or perform a paid / networked probe — see
+     * {@see WebSearchLiveProbeInterface} for admin reachability.
      */
     public function health(): PlugHealth;
-
-    /**
-     * Live reachability / credential check. Admin badges use this, not {@see health()}.
-     */
-    public function probe(): PlugHealth;
 }

--- a/backend/src/Plug/WebSearch/WebSearchProviderInterface.php
+++ b/backend/src/Plug/WebSearch/WebSearchProviderInterface.php
@@ -20,5 +20,13 @@ interface WebSearchProviderInterface
 
     public function search(WebSearchQuery $query): SearchResultSet;
 
+    /**
+     * Cheap config check (key / URL present). Used on the chat search path.
+     */
     public function health(): PlugHealth;
+
+    /**
+     * Live reachability / credential check. Admin badges use this, not {@see health()}.
+     */
+    public function probe(): PlugHealth;
 }

--- a/backend/tests/Fixtures/plugins/declared/fixture_search/backend/Plug/FixtureSearchAdapter.php
+++ b/backend/tests/Fixtures/plugins/declared/fixture_search/backend/Plug/FixtureSearchAdapter.php
@@ -47,9 +47,4 @@ final readonly class FixtureSearchAdapter implements WebSearchProviderInterface
     {
         return PlugHealth::available();
     }
-
-    public function probe(): PlugHealth
-    {
-        return $this->health();
-    }
 }

--- a/backend/tests/Fixtures/plugins/declared/fixture_search/backend/Plug/FixtureSearchAdapter.php
+++ b/backend/tests/Fixtures/plugins/declared/fixture_search/backend/Plug/FixtureSearchAdapter.php
@@ -47,4 +47,9 @@ final readonly class FixtureSearchAdapter implements WebSearchProviderInterface
     {
         return PlugHealth::available();
     }
+
+    public function probe(): PlugHealth
+    {
+        return $this->health();
+    }
 }

--- a/backend/tests/Fixtures/plugins/undeclared/undeclared_search/backend/Plug/UndeclaredSearchAdapter.php
+++ b/backend/tests/Fixtures/plugins/undeclared/undeclared_search/backend/Plug/UndeclaredSearchAdapter.php
@@ -41,9 +41,4 @@ final readonly class UndeclaredSearchAdapter implements WebSearchProviderInterfa
     {
         return PlugHealth::available();
     }
-
-    public function probe(): PlugHealth
-    {
-        return $this->health();
-    }
 }

--- a/backend/tests/Fixtures/plugins/undeclared/undeclared_search/backend/Plug/UndeclaredSearchAdapter.php
+++ b/backend/tests/Fixtures/plugins/undeclared/undeclared_search/backend/Plug/UndeclaredSearchAdapter.php
@@ -41,4 +41,9 @@ final readonly class UndeclaredSearchAdapter implements WebSearchProviderInterfa
     {
         return PlugHealth::available();
     }
+
+    public function probe(): PlugHealth
+    {
+        return $this->health();
+    }
 }

--- a/backend/tests/Integration/Plug/SerperSearchAdapterTest.php
+++ b/backend/tests/Integration/Plug/SerperSearchAdapterTest.php
@@ -60,6 +60,19 @@ final class SerperSearchAdapterTest extends TestCase
         self::assertSame([], $adapter->search(new WebSearchQuery('synaplan'))->results);
     }
 
+    public function testGarbageKeyIsUnavailableOnProbe(): void
+    {
+        $adapter = new SerperSearchAdapter(
+            new MockHttpClient([new MockResponse('unauthorized', ['http_code' => 401])]),
+            $this->keyStore('not-a-real-key'),
+        );
+
+        self::assertTrue($adapter->health()->available, 'A stored key is still configured');
+        $probed = $adapter->probe();
+        self::assertFalse($probed->available);
+        self::assertStringContainsString('401', (string) $probed->reason);
+    }
+
     /**
      * @return array<string, mixed>
      */

--- a/backend/tests/Unit/Plug/SearxngAdapterHealthTest.php
+++ b/backend/tests/Unit/Plug/SearxngAdapterHealthTest.php
@@ -19,6 +19,7 @@ use App\Repository\ConfigRepository;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
 
 final class SearxngAdapterHealthTest extends TestCase
 {
@@ -37,6 +38,57 @@ final class SearxngAdapterHealthTest extends TestCase
         $probed = $adapter->probe();
         self::assertFalse($probed->available);
         self::assertStringContainsString('refused', strtolower((string) $probed->reason));
+    }
+
+    public function testUnresolvedHostIsNotReportedAsConnectionRefused(): void
+    {
+        $http = new MockHttpClient(static function (): never {
+            throw new class('Could not resolve host searxng.internal') extends \RuntimeException implements \Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface {};
+        });
+        $adapter = new SearxngAdapter(new SearxngClient(
+            $http,
+            new PlugConfigService($this->repo([])),
+            'http://searxng.internal',
+        ));
+
+        $probed = $adapter->probe();
+        self::assertFalse($probed->available);
+        self::assertStringContainsString('could not resolve host', strtolower((string) $probed->reason));
+        self::assertStringNotContainsString('connection refused', strtolower((string) $probed->reason));
+    }
+
+    public function testHtmlProbeBodyIsNotReportedAvailable(): void
+    {
+        $http = new MockHttpClient([new MockResponse(
+            '<html>login</html>',
+            ['http_code' => 200, 'response_headers' => ['content-type' => 'text/html']],
+        )]);
+        $adapter = new SearxngAdapter(new SearxngClient(
+            $http,
+            new PlugConfigService($this->repo([])),
+            'http://searxng.test',
+        ));
+
+        $probed = $adapter->probe();
+        self::assertFalse($probed->available);
+        self::assertStringContainsString('no results array', strtolower((string) $probed->reason));
+    }
+
+    public function testJsonWithoutResultsArrayIsNotReportedAvailable(): void
+    {
+        $http = new MockHttpClient([new MockResponse(
+            '{"error":"ok"}',
+            ['http_code' => 200, 'response_headers' => ['content-type' => 'application/json']],
+        )]);
+        $adapter = new SearxngAdapter(new SearxngClient(
+            $http,
+            new PlugConfigService($this->repo([])),
+            'http://searxng.test',
+        ));
+
+        $probed = $adapter->probe();
+        self::assertFalse($probed->available);
+        self::assertStringContainsString('no results array', strtolower((string) $probed->reason));
     }
 
     public function testEmptyBaseUrlIsUnavailable(): void

--- a/backend/tests/Unit/Plug/SearxngAdapterHealthTest.php
+++ b/backend/tests/Unit/Plug/SearxngAdapterHealthTest.php
@@ -22,6 +22,23 @@ use Symfony\Component\HttpClient\MockHttpClient;
 
 final class SearxngAdapterHealthTest extends TestCase
 {
+    public function testConfiguredButUnreachableSidecarIsUnavailableOnProbe(): void
+    {
+        $http = new MockHttpClient(static function (): never {
+            throw new class('Connection refused') extends \RuntimeException implements \Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface {};
+        });
+        $adapter = new SearxngAdapter(new SearxngClient(
+            $http,
+            new PlugConfigService($this->repo([])),
+            'http://searxng.test',
+        ));
+
+        self::assertTrue($adapter->health()->available, 'A set URL is still configured');
+        $probed = $adapter->probe();
+        self::assertFalse($probed->available);
+        self::assertStringContainsString('refused', strtolower((string) $probed->reason));
+    }
+
     public function testEmptyBaseUrlIsUnavailable(): void
     {
         $adapter = new SearxngAdapter(new SearxngClient(
@@ -130,6 +147,11 @@ final class SearxngAdapterHealthTest extends TestCase
                 return $this->available
                     ? PlugHealth::available()
                     : PlugHealth::unavailable($this->providerKey.' unavailable');
+            }
+
+            public function probe(): PlugHealth
+            {
+                return $this->health();
             }
         };
     }

--- a/backend/tests/Unit/Plug/WebSearchAdapterContractTest.php
+++ b/backend/tests/Unit/Plug/WebSearchAdapterContractTest.php
@@ -79,6 +79,20 @@ final class WebSearchAdapterContractTest extends TestCase
         $this->assertTrue($adapter->capabilities()->answer);
     }
 
+    public function testExaGarbageKeyIsUnavailableOnProbe(): void
+    {
+        $http = new MockHttpClient([new MockResponse('unauthorized', ['http_code' => 401])]);
+        $adapter = new ExaAdapter(
+            new ExaClient($http, $this->plugKeys('exa'), $this->plugConfig()),
+            $this->plugConfig(),
+        );
+
+        self::assertTrue($adapter->health()->available, 'A stored key is still configured');
+        $probed = $adapter->probe();
+        self::assertFalse($probed->available);
+        self::assertStringContainsString('401', (string) $probed->reason);
+    }
+
     public function testHttpErrorBecomesExceptionForRegistryFallback(): void
     {
         $http = new MockHttpClient([new MockResponse('nope', ['http_code' => 500])]);

--- a/backend/tests/Unit/Plug/WebSearchAdminHealthTest.php
+++ b/backend/tests/Unit/Plug/WebSearchAdminHealthTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Plug;
+
+use App\Plug\PlugDescriptor;
+use App\Plug\PlugHealth;
+use App\Plug\WebSearch\SearchResultSet;
+use App\Plug\WebSearch\WebSearchAdminHealth;
+use App\Plug\WebSearch\WebSearchCapabilities;
+use App\Plug\WebSearch\WebSearchHealthCache;
+use App\Plug\WebSearch\WebSearchProviderInterface;
+use App\Plug\WebSearch\WebSearchQuery;
+use PHPUnit\Framework\TestCase;
+
+final class WebSearchAdminHealthTest extends TestCase
+{
+    public function testUnconfiguredStaysAConfigReasonAndDoesNotProbe(): void
+    {
+        $probes = 0;
+        $adapter = $this->provider('exa', configured: false, probe: static function () use (&$probes): PlugHealth {
+            ++$probes;
+
+            return PlugHealth::available();
+        });
+
+        $health = $this->resolver()->forAdapter($adapter, 'exa', '');
+
+        self::assertFalse($health->available);
+        self::assertSame('Exa API key is not configured', $health->reason);
+        self::assertSame(0, $probes);
+    }
+
+    public function testUnusedKeyIsNotReportedAvailable(): void
+    {
+        $probes = 0;
+        $adapter = $this->provider('exa', configured: true, probe: static function () use (&$probes): PlugHealth {
+            ++$probes;
+
+            return PlugHealth::available();
+        });
+
+        $health = $this->resolver()->forAdapter($adapter, 'brave', '');
+
+        self::assertFalse($health->available);
+        self::assertSame('Key stored — not verified', $health->reason);
+        self::assertSame(0, $probes);
+    }
+
+    public function testActiveProviderUsesLiveProbe(): void
+    {
+        $adapter = $this->provider('exa', configured: true, probe: static function (): PlugHealth {
+            return PlugHealth::unavailable('Exa search returned HTTP 401');
+        });
+
+        $health = $this->resolver()->forAdapter($adapter, 'exa', '');
+
+        self::assertFalse($health->available);
+        self::assertSame('Exa search returned HTTP 401', $health->reason);
+    }
+
+    public function testFallbackProviderUsesLiveProbe(): void
+    {
+        $adapter = $this->provider('exa', configured: true, probe: static function (): PlugHealth {
+            return PlugHealth::unavailable('Exa search returned HTTP 401');
+        });
+
+        $health = $this->resolver()->forAdapter($adapter, 'brave', 'exa');
+
+        self::assertFalse($health->available);
+        self::assertSame('Exa search returned HTTP 401', $health->reason);
+    }
+
+    public function testSearxngIsAlwaysProbedWhenConfigured(): void
+    {
+        $adapter = $this->provider('searxng', configured: true, probe: static function (): PlugHealth {
+            return PlugHealth::unavailable('SearXNG unavailable — connection refused');
+        });
+
+        $health = $this->resolver()->forAdapter($adapter, 'brave', '');
+
+        self::assertFalse($health->available);
+        self::assertStringContainsString('connection refused', (string) $health->reason);
+    }
+
+    public function testProbeResultIsCached(): void
+    {
+        $probes = 0;
+        $adapter = $this->provider('searxng', configured: true, probe: static function () use (&$probes): PlugHealth {
+            ++$probes;
+
+            return PlugHealth::unavailable('SearXNG unavailable — connection refused');
+        });
+        $resolver = $this->resolver();
+
+        $resolver->forAdapter($adapter, 'brave', '');
+        $resolver->forAdapter($adapter, 'brave', '');
+
+        self::assertSame(1, $probes);
+    }
+
+    private function resolver(): WebSearchAdminHealth
+    {
+        return new WebSearchAdminHealth(new WebSearchHealthCache());
+    }
+
+    private function provider(string $key, bool $configured, callable $probe): WebSearchProviderInterface
+    {
+        return new class($key, $configured, $probe) implements WebSearchProviderInterface {
+            /**
+             * @param callable(): PlugHealth $probe
+             */
+            public function __construct(
+                private string $providerKey,
+                private bool $configured,
+                private mixed $probe,
+            ) {
+            }
+
+            public function key(): string
+            {
+                return $this->providerKey;
+            }
+
+            public function descriptor(): PlugDescriptor
+            {
+                return new PlugDescriptor($this->providerKey, $this->providerKey, '', [], 'test');
+            }
+
+            public function capabilities(): WebSearchCapabilities
+            {
+                return WebSearchCapabilities::brave();
+            }
+
+            public function search(WebSearchQuery $query): SearchResultSet
+            {
+                return SearchResultSet::empty($query->query);
+            }
+
+            public function health(): PlugHealth
+            {
+                return $this->configured
+                    ? PlugHealth::available()
+                    : PlugHealth::unavailable('Exa API key is not configured');
+            }
+
+            public function probe(): PlugHealth
+            {
+                return ($this->probe)();
+            }
+        };
+    }
+}

--- a/backend/tests/Unit/Plug/WebSearchAdminHealthTest.php
+++ b/backend/tests/Unit/Plug/WebSearchAdminHealthTest.php
@@ -10,6 +10,7 @@ use App\Plug\WebSearch\SearchResultSet;
 use App\Plug\WebSearch\WebSearchAdminHealth;
 use App\Plug\WebSearch\WebSearchCapabilities;
 use App\Plug\WebSearch\WebSearchHealthCache;
+use App\Plug\WebSearch\WebSearchLiveProbeInterface;
 use App\Plug\WebSearch\WebSearchProviderInterface;
 use App\Plug\WebSearch\WebSearchQuery;
 use PHPUnit\Framework\TestCase;
@@ -100,6 +101,58 @@ final class WebSearchAdminHealthTest extends TestCase
         self::assertSame(1, $probes);
     }
 
+    public function testAdapterWithoutLiveProbeIsNotVerified(): void
+    {
+        $adapter = new class implements WebSearchProviderInterface {
+            public function key(): string
+            {
+                return 'searxng';
+            }
+
+            public function descriptor(): PlugDescriptor
+            {
+                return new PlugDescriptor('searxng', 'Plugin', '', [], 'test');
+            }
+
+            public function capabilities(): WebSearchCapabilities
+            {
+                return WebSearchCapabilities::brave();
+            }
+
+            public function search(WebSearchQuery $query): SearchResultSet
+            {
+                return SearchResultSet::empty($query->query);
+            }
+
+            public function health(): PlugHealth
+            {
+                return PlugHealth::available();
+            }
+        };
+
+        $health = $this->resolver()->forAdapter($adapter, 'searxng', '');
+
+        self::assertFalse($health->available);
+        self::assertSame('Key stored — not verified', $health->reason);
+    }
+
+    public function testForgetDropsCachedProbe(): void
+    {
+        $probes = 0;
+        $adapter = $this->provider('searxng', configured: true, probe: static function () use (&$probes): PlugHealth {
+            ++$probes;
+
+            return PlugHealth::available();
+        });
+        $resolver = $this->resolver();
+
+        $resolver->forAdapter($adapter, 'brave', '');
+        $resolver->forget('searxng');
+        $resolver->forAdapter($adapter, 'brave', '');
+
+        self::assertSame(2, $probes);
+    }
+
     private function resolver(): WebSearchAdminHealth
     {
         return new WebSearchAdminHealth(new WebSearchHealthCache());
@@ -107,7 +160,7 @@ final class WebSearchAdminHealthTest extends TestCase
 
     private function provider(string $key, bool $configured, callable $probe): WebSearchProviderInterface
     {
-        return new class($key, $configured, $probe) implements WebSearchProviderInterface {
+        return new class($key, $configured, $probe) implements WebSearchProviderInterface, WebSearchLiveProbeInterface {
             /**
              * @param callable(): PlugHealth $probe
              */

--- a/backend/tests/Unit/Plug/WebSearchRegistryFallbackTest.php
+++ b/backend/tests/Unit/Plug/WebSearchRegistryFallbackTest.php
@@ -153,6 +153,11 @@ final class WebSearchRegistryFallbackTest extends TestCase
                     ? PlugHealth::available()
                     : PlugHealth::unavailable($this->providerKey.' unavailable');
             }
+
+            public function probe(): PlugHealth
+            {
+                return $this->health();
+            }
         };
     }
 
@@ -189,6 +194,11 @@ final class WebSearchRegistryFallbackTest extends TestCase
             public function health(): PlugHealth
             {
                 return PlugHealth::available();
+            }
+
+            public function probe(): PlugHealth
+            {
+                return $this->health();
             }
         };
     }

--- a/backend/tests/Unit/Plug/WebSearchRegistryTest.php
+++ b/backend/tests/Unit/Plug/WebSearchRegistryTest.php
@@ -89,6 +89,11 @@ final class WebSearchRegistryTest extends TestCase
                     ? PlugHealth::available()
                     : PlugHealth::unavailable($this->providerKey.' unavailable');
             }
+
+            public function probe(): PlugHealth
+            {
+                return $this->health();
+            }
         };
     }
 }

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -29,12 +29,18 @@ Steps:
    `getKey('<key>')`, declare `"plug_keys"` in the manifest `permissions`, and
    never read an env var directly or log the key. Your adapter's key is
    automatically allowed once it is declared in `provides.plugs`.
-4. **`health()` must be cheap and never throw** — a missing key or unreachable
-   service returns `PlugHealth::unavailable('<reason>')`. For the operation
-   itself, return an empty result when there is genuinely nothing to return; a
-   transient upstream failure (timeout, HTTP 5xx/429) may throw — the registry
-   catches it and falls back to another provider, so a down provider never
-   breaks chat or an upload while a recoverable error still triggers a retry.
+4. **`health()` must be cheap, config-only, and never throw** — a missing key
+   or URL returns `PlugHealth::unavailable('<reason>')`. Do not do live I/O
+   here: chat search calls `health()` on every request. For a live
+   reachability / credential check (admin badges, key verification), also
+   implement `App\Plug\WebSearch\WebSearchLiveProbeInterface` (`probe()`).
+   Plugins that skip that interface still load; the admin UI then shows
+   "Key stored — not verified" instead of a live badge. For the search
+   operation itself, return an empty result when there is genuinely nothing
+   to return; a transient upstream failure (timeout, HTTP 5xx/429) may throw
+   — the registry catches it and falls back to another provider, so a down
+   provider never breaks chat or an upload while a recoverable error still
+   triggers a retry.
 5. **Declare the adapter** in `manifest.json` under `provides.plugs` — the
    backend refuses to boot otherwise:
 

--- a/plugins/serper_search/backend/Plug/SerperSearchAdapter.php
+++ b/plugins/serper_search/backend/Plug/SerperSearchAdapter.php
@@ -10,6 +10,7 @@ use App\Plug\PlugKeyStore;
 use App\Plug\WebSearch\SearchResultSet;
 use App\Plug\WebSearch\WebSearchCapabilities;
 use App\Plug\WebSearch\WebSearchOptionMapper;
+use App\Plug\WebSearch\WebSearchLiveProbeInterface;
 use App\Plug\WebSearch\WebSearchProbe;
 use App\Plug\WebSearch\WebSearchProviderInterface;
 use App\Plug\WebSearch\WebSearchQuery;
@@ -27,7 +28,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  * provider — so a down provider never breaks chat, yet a recoverable error
  * still triggers a retry rather than silently returning "no results".
  */
-final readonly class SerperSearchAdapter implements WebSearchProviderInterface
+final readonly class SerperSearchAdapter implements WebSearchProviderInterface, WebSearchLiveProbeInterface
 {
     public const KEY = 'serper';
 

--- a/plugins/serper_search/backend/Plug/SerperSearchAdapter.php
+++ b/plugins/serper_search/backend/Plug/SerperSearchAdapter.php
@@ -10,6 +10,7 @@ use App\Plug\PlugKeyStore;
 use App\Plug\WebSearch\SearchResultSet;
 use App\Plug\WebSearch\WebSearchCapabilities;
 use App\Plug\WebSearch\WebSearchOptionMapper;
+use App\Plug\WebSearch\WebSearchProbe;
 use App\Plug\WebSearch\WebSearchProviderInterface;
 use App\Plug\WebSearch\WebSearchQuery;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -111,6 +112,28 @@ final readonly class SerperSearchAdapter implements WebSearchProviderInterface
         return null !== $key && '' !== $key
             ? PlugHealth::available()
             : PlugHealth::unavailable('Serper API key is not configured');
+    }
+
+    public function probe(): PlugHealth
+    {
+        $key = $this->keys->getKey(self::KEY);
+        $configured = null !== $key && '' !== $key;
+
+        return WebSearchProbe::run(
+            $configured,
+            'Serper API key is not configured',
+            function () use ($key): void {
+                $response = $this->httpClient->request('POST', self::ENDPOINT, [
+                    'timeout' => 5,
+                    'headers' => ['X-API-KEY' => (string) $key, 'Content-Type' => 'application/json'],
+                    'json' => ['q' => 'synaplan', 'num' => 1],
+                ]);
+                if ($response->getStatusCode() >= 400) {
+                    throw new \RuntimeException('Serper HTTP '.$response->getStatusCode());
+                }
+                $response->getContent(false);
+            },
+        );
     }
 
     /**


### PR DESCRIPTION
## Summary
- Admin web-search health no longer treats a stored key or `SEARXNG_BASE_URL` as `available`. `health()` stays a cheap config check for the chat path; `probe()` does a live reachability/credential check.
- Status badges live-probe SearXNG (always, when a URL is set) and the active/fallback providers (30s cache). Unused stored keys report `Key stored — not verified` instead of a green badge. Admin Test writes the same cache.
- Covers all seven adapters, including the `serper_search` plugin. PHPUnit forces `SEARXNG_BASE_URL` empty so the suite does not hit the sidecar.

Fixes #1789

## Test plan
- [x] `make -C backend lint`
- [x] `make -C backend phpstan`
- [x] `make -C backend test` (5968, green)
- [ ] Admin → AI infrastructure → Web search: stop SearXNG, reload — card must not stay `available`
- [ ] Store a garbage Exa key, select Exa as active — badge must show the HTTP 401 (or Test, then reload)
- [ ] Unused provider with a stored key — `Key stored — not verified`, no paid probe on status load

Classification: **backend-only** (`backend/**`, `plugins/**`).