### PR TITLE
fix(files): skip Imagick when ImageMagick blocks PDF

### DIFF
--- a/backend/src/Service/File/PdfRasterizer.php
+++ b/backend/src/Service/File/PdfRasterizer.php
@@ -7,22 +7,60 @@ use Psr\Log\LoggerInterface;
 /**
  * PDF Rasterizer Service.
  *
- * Converts PDF pages to PNG images using Imagick or pdftoppm as fallback.
- * Used when Tika extraction fails or produces low-quality text.
+ * Converts PDF pages to PNG images. Imagick is used only when the PDF coder
+ * is actually permitted; the shipped ImageMagick policy sets
+ * `rights="none"` for PDF, so we skip that engine after a one-time probe
+ * and go straight to pdftoppm (issue #1794).
  */
 final class PdfRasterizer
 {
+    /**
+     * One-page 1×1 PDF used to probe whether Imagick may read the PDF coder.
+     * Kept tiny so the process-wide probe is cheap.
+     */
+    private const MINIMAL_PDF = <<<'PDF'
+%PDF-1.1
+1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj
+2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj
+3 0 obj<</Type/Page/MediaBox[0 0 1 1]/Parent 2 0 R>>endobj
+trailer<</Root 1 0 R>>
+%%EOF
+PDF;
+
+    private static ?bool $cachedImagickPdfAllowed = null;
+
     private string $lastEngine = '';
     private int $lastDpi = 0;
     private int $lastPages = 0;
 
+    /**
+     * @param bool|null $imagickPdfAllowed When non-null, skip the process-wide
+     *                                     policy probe (tests). Null = detect.
+     */
     public function __construct(
         private LoggerInterface $logger,
         private string $uploadDir,
         private int $rasterizeDpi,
         private int $rasterizePageCap,
         private int $rasterizeTimeoutMs,
+        private ?bool $imagickPdfAllowed = null,
     ) {
+    }
+
+    /**
+     * Reset the process-wide Imagick-PDF probe. Tests only.
+     */
+    public static function resetImagickPdfProbeForTests(): void
+    {
+        self::$cachedImagickPdfAllowed = null;
+    }
+
+    /**
+     * Whether this process will attempt Imagick for PDF reads.
+     */
+    public function willAttemptImagick(): bool
+    {
+        return $this->imagickCanReadPdf();
     }
 
     /**
@@ -47,49 +85,12 @@ final class PdfRasterizer
         $basename = pathinfo($absolutePdfPath, PATHINFO_FILENAME);
         $images = [];
 
-        // Try Imagick first (faster and better quality)
-        if (class_exists('\\Imagick')) {
-            try {
-                $imagick = new \Imagick();
-                $imagick->setResolution($this->rasterizeDpi, $this->rasterizeDpi);
-                $imagick->readImage($absolutePdfPath);
-                $pages = min($cap, $imagick->getNumberImages());
-                $imagick->setIteratorIndex(0);
-
-                for ($i = 0; $i < $pages; ++$i) {
-                    $imagick->setIteratorIndex($i);
-                    $imagick->setImageFormat('png');
-                    $outputPath = $targetDir.'/'.$basename.'-'.($i + 1).'.png';
-
-                    if ($imagick->writeImage($outputPath)) {
-                        if (is_file($outputPath) && filesize($outputPath) > 0) {
-                            $images[] = $outputPath;
-                        } else {
-                            $this->logger->warning('Rasterizer Imagick: write failed', ['output' => $outputPath]);
-                        }
-                    }
-                }
-
-                $imagick->clear();
-                $imagick->destroy();
-
-                if (!empty($images)) {
-                    $this->lastEngine = 'imagick';
-                    $this->lastDpi = $this->rasterizeDpi;
-                    $this->lastPages = count($images);
-
-                    $this->logger->info('Rasterizer success with Imagick', [
-                        'engine' => 'imagick',
-                        'pages' => $this->lastPages,
-                        'dpi' => $this->lastDpi,
-                    ]);
-
-                    return $images;
-                }
-            } catch (\Throwable $e) {
-                $this->logger->warning('Rasterizer Imagick failed, falling back to pdftoppm', [
-                    'error' => $e->getMessage(),
-                ]);
+        // Imagick only when the PDF coder is permitted. The shipped policy
+        // denies it; probing once avoids a warning on every scanned PDF.
+        if ($this->imagickCanReadPdf()) {
+            $images = $this->pdfToPngViaImagick($absolutePdfPath, $targetDir, $basename, $cap);
+            if (!empty($images)) {
+                return $images;
             }
         }
 
@@ -109,6 +110,109 @@ final class PdfRasterizer
         }
 
         return $images;
+    }
+
+    private function imagickCanReadPdf(): bool
+    {
+        if (null !== $this->imagickPdfAllowed) {
+            return $this->imagickPdfAllowed;
+        }
+
+        if (null !== self::$cachedImagickPdfAllowed) {
+            return self::$cachedImagickPdfAllowed;
+        }
+
+        self::$cachedImagickPdfAllowed = $this->probeImagickPdfPolicy();
+
+        return self::$cachedImagickPdfAllowed;
+    }
+
+    private function probeImagickPdfPolicy(): bool
+    {
+        if (!class_exists(\Imagick::class)) {
+            return false;
+        }
+
+        if (\is_callable([\Imagick::class, 'getPolicy'])) {
+            try {
+                $rights = strtolower(trim((string) \Imagick::getPolicy('coder', 'PDF')));
+                if ('none' === $rights) {
+                    $this->logger->info('Rasterizer: skipping Imagick for PDF (coder policy is none)');
+
+                    return false;
+                }
+            } catch (\Throwable) {
+                // Policy query unsupported or unset — fall through to a blob probe.
+            }
+        }
+
+        try {
+            $imagick = new \Imagick();
+            $imagick->setResolution(2, 2);
+            $imagick->readImageBlob(self::MINIMAL_PDF);
+            $imagick->clear();
+            $imagick->destroy();
+
+            return true;
+        } catch (\Throwable $e) {
+            $this->logger->info('Rasterizer: skipping Imagick for PDF', [
+                'reason' => $e->getMessage(),
+            ]);
+
+            return false;
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function pdfToPngViaImagick(string $absolutePdfPath, string $targetDir, string $basename, int $pageCap): array
+    {
+        try {
+            $imagick = new \Imagick();
+            $imagick->setResolution($this->rasterizeDpi, $this->rasterizeDpi);
+            $imagick->readImage($absolutePdfPath);
+            $pages = min($pageCap, $imagick->getNumberImages());
+            $imagick->setIteratorIndex(0);
+
+            $images = [];
+            for ($i = 0; $i < $pages; ++$i) {
+                $imagick->setIteratorIndex($i);
+                $imagick->setImageFormat('png');
+                $outputPath = $targetDir.'/'.$basename.'-'.($i + 1).'.png';
+
+                if ($imagick->writeImage($outputPath)) {
+                    if (is_file($outputPath) && filesize($outputPath) > 0) {
+                        $images[] = $outputPath;
+                    } else {
+                        $this->logger->warning('Rasterizer Imagick: write failed', ['output' => $outputPath]);
+                    }
+                }
+            }
+
+            $imagick->clear();
+            $imagick->destroy();
+
+            if ([] !== $images) {
+                $this->lastEngine = 'imagick';
+                $this->lastDpi = $this->rasterizeDpi;
+                $this->lastPages = count($images);
+
+                $this->logger->info('Rasterizer success with Imagick', [
+                    'engine' => 'imagick',
+                    'pages' => $this->lastPages,
+                    'dpi' => $this->lastDpi,
+                ]);
+            }
+
+            return $images;
+        } catch (\Throwable $e) {
+            $this->logger->warning('Rasterizer Imagick failed, falling back to pdftoppm', [
+                'error' => $e->getMessage(),
+            ]);
+
+            return [];
+        }
     }
 
     /**

--- a/backend/src/Service/File/PdfRasterizer.php
+++ b/backend/src/Service/File/PdfRasterizer.php
@@ -14,20 +14,9 @@ use Psr\Log\LoggerInterface;
  */
 final class PdfRasterizer
 {
-    /**
-     * One-page 1×1 PDF used to probe whether Imagick may read the PDF coder.
-     * Kept tiny so the process-wide probe is cheap.
-     */
-    private const MINIMAL_PDF = <<<'PDF'
-%PDF-1.1
-1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj
-2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj
-3 0 obj<</Type/Page/MediaBox[0 0 1 1]/Parent 2 0 R>>endobj
-trailer<</Root 1 0 R>>
-%%EOF
-PDF;
-
     private static ?bool $cachedImagickPdfAllowed = null;
+
+    private static int $imagickPdfProbeCalls = 0;
 
     private string $lastEngine = '';
     private int $lastDpi = 0;
@@ -53,6 +42,15 @@ PDF;
     public static function resetImagickPdfProbeForTests(): void
     {
         self::$cachedImagickPdfAllowed = null;
+        self::$imagickPdfProbeCalls = 0;
+    }
+
+    /**
+     * How many times this process ran the Imagick-PDF probe. Tests only.
+     */
+    public static function imagickPdfProbeCallCountForTests(): int
+    {
+        return self::$imagickPdfProbeCalls;
     }
 
     /**
@@ -129,6 +127,8 @@ PDF;
 
     private function probeImagickPdfPolicy(): bool
     {
+        ++self::$imagickPdfProbeCalls;
+
         if (!class_exists(\Imagick::class)) {
             return false;
         }
@@ -141,6 +141,11 @@ PDF;
 
                     return false;
                 }
+                if ('' !== $rights) {
+                    // Coder is explicitly permitted. Do not let a probe blob
+                    // override that and disable Imagick for the whole process.
+                    return true;
+                }
             } catch (\Throwable) {
                 // Policy query unsupported or unset — fall through to a blob probe.
             }
@@ -149,7 +154,7 @@ PDF;
         try {
             $imagick = new \Imagick();
             $imagick->setResolution(2, 2);
-            $imagick->readImageBlob(self::MINIMAL_PDF);
+            $imagick->readImageBlob(self::minimalValidPdf());
             $imagick->clear();
             $imagick->destroy();
 
@@ -161,6 +166,34 @@ PDF;
 
             return false;
         }
+    }
+
+    /**
+     * One-page 3×3 PDF with a real xref/startxref so a policy-allowed Imagick
+     * does not reject the probe as malformed and cache "cannot read PDF".
+     */
+    private static function minimalValidPdf(): string
+    {
+        $objects = [
+            '1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj',
+            '2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj',
+            '3 0 obj<</Type/Page/MediaBox[0 0 3 3]/Parent 2 0 R>>endobj',
+        ];
+
+        $body = "%PDF-1.4\n";
+        $offsets = [0];
+        foreach ($objects as $object) {
+            $offsets[] = strlen($body);
+            $body .= $object."\n";
+        }
+
+        $xrefPos = strlen($body);
+        $xref = "xref\n0 4\n".sprintf("%010d 65535 f \n", 0);
+        foreach ([1, 2, 3] as $id) {
+            $xref .= sprintf("%010d 00000 n \n", $offsets[$id]);
+        }
+
+        return $body.$xref."trailer<</Size 4/Root 1 0 R>>\nstartxref\n".$xrefPos."\n%%EOF\n";
     }
 
     /**

--- a/backend/tests/Unit/Service/File/PdfRasterizerTest.php
+++ b/backend/tests/Unit/Service/File/PdfRasterizerTest.php
@@ -56,10 +56,17 @@ final class PdfRasterizerTest extends TestCase
             }
         };
 
-        $rasterizer = new PdfRasterizer($logger, $dir, 72, 1, 5000, false);
-        $rasterizer->pdfToPng($pdf);
+        if (!$this->pdftoppmAvailable()) {
+            self::markTestSkipped('pdftoppm is required to assert the blocked-Imagick fallback');
+        }
 
-        self::assertNotSame('imagick', $rasterizer->getLastEngine());
+        $rasterizer = new PdfRasterizer($logger, $dir, 72, 1, 5000, false);
+        $images = $rasterizer->pdfToPng($pdf);
+
+        self::assertNotSame([], $images);
+        self::assertSame('pdftoppm', $rasterizer->getLastEngine());
+        self::assertFileExists($images[0]);
+        self::assertGreaterThan(0, (int) filesize($images[0]));
         foreach ($logger->warnings as $warning) {
             self::assertStringNotContainsString('Imagick failed', $warning);
         }
@@ -70,14 +77,33 @@ final class PdfRasterizerTest extends TestCase
         @rmdir($dir);
     }
 
+    public function testProbePdfIsStructurallyComplete(): void
+    {
+        $method = new \ReflectionMethod(PdfRasterizer::class, 'minimalValidPdf');
+        $pdf = $method->invoke(null);
+        self::assertIsString($pdf);
+        self::assertStringContainsString("xref\n", $pdf);
+        self::assertStringContainsString("startxref\n", $pdf);
+
+        $marker = "startxref\n";
+        $offsetStart = strpos($pdf, $marker);
+        self::assertNotFalse($offsetStart);
+        $xrefOffset = (int) substr($pdf, $offsetStart + strlen($marker));
+        self::assertSame('xref', substr($pdf, $xrefOffset, 4));
+    }
+
     public function testProbeIsCachedAcrossInstances(): void
     {
         PdfRasterizer::resetImagickPdfProbeForTests();
+        self::assertSame(0, PdfRasterizer::imagickPdfProbeCallCountForTests());
+
         $first = $this->rasterizer();
         $allowed = $first->willAttemptImagick();
-        $second = $this->rasterizer();
+        self::assertSame(1, PdfRasterizer::imagickPdfProbeCallCountForTests());
 
+        $second = $this->rasterizer();
         self::assertSame($allowed, $second->willAttemptImagick());
+        self::assertSame(1, PdfRasterizer::imagickPdfProbeCallCountForTests());
     }
 
     private function rasterizer(?bool $imagickPdfAllowed = null): PdfRasterizer
@@ -98,5 +124,12 @@ final class PdfRasterizerTest extends TestCase
         self::assertFileExists($path);
 
         return $path;
+    }
+
+    private function pdftoppmAvailable(): bool
+    {
+        $path = trim((string) shell_exec('command -v pdftoppm 2>/dev/null'));
+
+        return '' !== $path;
     }
 }

--- a/backend/tests/Unit/Service/File/PdfRasterizerTest.php
+++ b/backend/tests/Unit/Service/File/PdfRasterizerTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\File;
+
+use App\Service\File\PdfRasterizer;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\AbstractLogger;
+use Psr\Log\NullLogger;
+
+/**
+ * Issue #1794 — do not attempt Imagick when the PDF coder is blocked.
+ */
+final class PdfRasterizerTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        PdfRasterizer::resetImagickPdfProbeForTests();
+    }
+
+    public function testOverrideFalseDoesNotAttemptImagick(): void
+    {
+        $rasterizer = $this->rasterizer(imagickPdfAllowed: false);
+
+        self::assertFalse($rasterizer->willAttemptImagick());
+    }
+
+    public function testOverrideTrueAttemptsImagickWhenExtensionExists(): void
+    {
+        $rasterizer = $this->rasterizer(imagickPdfAllowed: true);
+
+        self::assertTrue($rasterizer->willAttemptImagick());
+    }
+
+    public function testBlockedImagickPathDoesNotLogImagickFailedWarning(): void
+    {
+        $dir = sys_get_temp_dir().'/rasterizer-'.bin2hex(random_bytes(4));
+        self::assertTrue(mkdir($dir, 0775, true) || is_dir($dir));
+        $pdf = $dir.'/sample.pdf';
+        copy($this->tinyPdf(), $pdf);
+
+        $logger = new class extends AbstractLogger {
+            /** @var list<string> */
+            public array $warnings = [];
+
+            /**
+             * @param string       $message
+             * @param array<mixed> $context
+             */
+            public function log($level, $message, array $context = []): void
+            {
+                if ('warning' === $level) {
+                    $this->warnings[] = (string) $message;
+                }
+            }
+        };
+
+        $rasterizer = new PdfRasterizer($logger, $dir, 72, 1, 5000, false);
+        $rasterizer->pdfToPng($pdf);
+
+        self::assertNotSame('imagick', $rasterizer->getLastEngine());
+        foreach ($logger->warnings as $warning) {
+            self::assertStringNotContainsString('Imagick failed', $warning);
+        }
+
+        foreach (glob($dir.'/*') ?: [] as $leftover) {
+            @unlink($leftover);
+        }
+        @rmdir($dir);
+    }
+
+    public function testProbeIsCachedAcrossInstances(): void
+    {
+        PdfRasterizer::resetImagickPdfProbeForTests();
+        $first = $this->rasterizer();
+        $allowed = $first->willAttemptImagick();
+        $second = $this->rasterizer();
+
+        self::assertSame($allowed, $second->willAttemptImagick());
+    }
+
+    private function rasterizer(?bool $imagickPdfAllowed = null): PdfRasterizer
+    {
+        return new PdfRasterizer(
+            new NullLogger(),
+            sys_get_temp_dir(),
+            72,
+            1,
+            5000,
+            $imagickPdfAllowed,
+        );
+    }
+
+    private function tinyPdf(): string
+    {
+        $path = dirname(__DIR__, 3).'/Fixtures/extraction/files/tiny.pdf';
+        self::assertFileExists($path);
+
+        return $path;
+    }
+}


### PR DESCRIPTION
## Summary
- `PdfRasterizer` probes Imagick's PDF coder once (policy query, then a tiny blob) and caches the answer for the process.
- When the shipped `rights="none"` PDF policy is in effect, rasterize goes straight to `pdftoppm` — no per-file `Rasterizer Imagick failed` warning.
- Override + unit tests cover the blocked path and the process-wide cache.

Fixes #1794

## Test plan
- [x] `make -C backend lint`
- [x] `make -C backend phpstan`
- [x] `make -C backend test`
- [ ] Upload a text-less PDF in chat and confirm `docker compose logs --since 60s backend | grep -a Rasterizer` has no `Imagick failed` line and names `pdftoppm` (or Imagick only if the policy actually allows it).