### PR TITLE
fix(extraction): honour the saved adapter chain and match Test upload to chat

### DIFF
--- a/backend/src/Controller/AdminPlugsExtractionController.php
+++ b/backend/src/Controller/AdminPlugsExtractionController.php
@@ -126,7 +126,7 @@ final class AdminPlugsExtractionController extends AbstractController
         )
     )]
     #[OA\Response(response: 403, description: 'Admin access required')]
-    #[OA\Response(response: 422, description: 'Unknown family or adapter key')]
+    #[OA\Response(response: 422, description: 'Unknown family, adapter key, or empty chain')]
     public function saveChains(Request $request, #[CurrentUser] ?User $user): JsonResponse
     {
         if ($resp = $this->requireAdmin($user)) {
@@ -148,7 +148,7 @@ final class AdminPlugsExtractionController extends AbstractController
     #[Route('/test', name: 'admin_plugs_extraction_test', methods: ['POST'])]
     #[OA\Post(
         path: '/api/v1/admin/plugs/extraction/test',
-        summary: 'Probe every configured extra extractor then the built-in path',
+        summary: 'Probe the configured extraction chain with the same path as a real upload',
         security: [['Bearer' => []]],
         tags: ['Admin Plugs Extraction']
     )]
@@ -206,6 +206,7 @@ final class AdminPlugsExtractionController extends AbstractController
         return $this->json($this->extractionAdmin->testFile(
             $file->getPathname(),
             $file->getClientOriginalName() ?: $file->getFilename(),
+            $user?->getId(),
         ));
     }
 

--- a/backend/src/Controller/MessageController.php
+++ b/backend/src/Controller/MessageController.php
@@ -736,20 +736,17 @@ class MessageController extends AbstractController
             $this->em->flush();
 
             // Extract text synchronously for files the chat handler will analyze
-            // immediately (audio, documents). Image extraction is left to the
-            // vision-model pipeline, which reads the file directly at analyze
-            // time. Doing extraction here closes the race documented in
-            // issue #729: the stream used to run FileAnalysisHandler before
-            // the async/deferred extraction had populated BFILETEXT, yielding
-            // a false "Document text extraction failed" error on the user's
-            // first send. By the time uploadFileForChat returns, the file is
-            // either `extracted` (text available) or `error` (extraction
-            // failed) — never `uploaded` with empty text.
+            // immediately (audio, documents, images). Images used to skip this
+            // and go through MessagePreProcessor::processImageWithVision(), which
+            // ignored the extraction chain (issue #1792). Empty OCR on a photo
+            // is legitimate — only audio/documents treat empty text as failure.
             $extractMeta = [];
             $isAudio = in_array($fileExtension, MessagePreProcessor::AUDIO_EXTENSIONS, true);
             $isDocument = in_array($fileExtension, MessagePreProcessor::DOCUMENT_EXTENSIONS, true);
+            $isImage = in_array($fileExtension, MessagePreProcessor::IMAGE_EXTENSIONS, true);
 
-            if ($isAudio || $isDocument) {
+            if ($isAudio || $isDocument || $isImage) {
+                $kind = $isAudio ? 'audio' : ($isImage ? 'image' : 'document');
                 $messageFile->setStatus('extracting');
                 $this->em->flush();
 
@@ -761,13 +758,14 @@ class MessageController extends AbstractController
                     );
 
                     $messageFile->setFileText($extractedText);
-                    $messageFile->setStatus(empty(trim($extractedText)) ? 'error' : 'extracted');
+                    $emptyIsFailure = !$isImage;
+                    $messageFile->setStatus($emptyIsFailure && empty(trim($extractedText)) ? 'error' : 'extracted');
                     $this->em->flush();
 
                     $this->logger->info('Chat file extracted', [
                         'user_id' => $user->getId(),
                         'file_id' => $messageFile->getId(),
-                        'kind' => $isAudio ? 'audio' : 'document',
+                        'kind' => $kind,
                         'text_length' => strlen($extractedText),
                         'strategy' => $extractMeta['strategy'] ?? 'unknown',
                     ]);
@@ -775,7 +773,7 @@ class MessageController extends AbstractController
                     $this->logger->error('Chat file extraction failed', [
                         'user_id' => $user->getId(),
                         'file_id' => $messageFile->getId(),
-                        'kind' => $isAudio ? 'audio' : 'document',
+                        'kind' => $kind,
                         'error' => $e->getMessage(),
                     ]);
 

--- a/backend/src/Plug/Extraction/Adapter/DoclingExtractor.php
+++ b/backend/src/Plug/Extraction/Adapter/DoclingExtractor.php
@@ -12,7 +12,7 @@ use App\Plug\PlugDescriptor;
 use App\Plug\PlugHealth;
 
 /**
- * docling-serve adapter. Lands in FileProcessor via extraExtractorKeys().
+ * docling-serve adapter. Lands in FileProcessor via the configured family chain.
  *
  * @internal
  */

--- a/backend/src/Plug/Extraction/ExtractionAdminService.php
+++ b/backend/src/Plug/Extraction/ExtractionAdminService.php
@@ -75,9 +75,9 @@ final readonly class ExtractionAdminService
      *     markdown: bool
      * }
      */
-    public function testFile(string $absolutePath, string $originalName): array
+    public function testFile(string $absolutePath, string $originalName, ?int $userId = null): array
     {
-        return $this->probe->testFile($absolutePath, $originalName);
+        return $this->probe->testFile($absolutePath, $originalName, $userId);
     }
 
     /**

--- a/backend/src/Plug/Extraction/ExtractionProbeService.php
+++ b/backend/src/Plug/Extraction/ExtractionProbeService.php
@@ -4,21 +4,17 @@ declare(strict_types=1);
 
 namespace App\Plug\Extraction;
 
-use App\Plug\PlugConfigService;
 use App\Service\File\FileProcessor;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 /**
- * Walks extra extractors (then FileProcessor) so the admin Test button can
- * show every attempt: "Docling unavailable — Tika used instead".
+ * Stages a sample and runs the same FileProcessor chain a real upload uses,
+ * so the admin Test button lists every adapter attempt and the same winner.
  */
 final readonly class ExtractionProbeService
 {
     public function __construct(
-        private ExtractionRegistry $registry,
-        private PlugConfigService $plugConfig,
-        private ExtractionQualityGate $qualityGate,
         private FileProcessor $fileProcessor,
         private LoggerInterface $logger,
         #[Autowire('%kernel.project_dir%/var/uploads')]
@@ -35,96 +31,71 @@ final readonly class ExtractionProbeService
      *     markdown: bool
      * }
      */
-    public function testFile(string $absolutePath, string $originalName): array
+    public function testFile(string $absolutePath, string $originalName, ?int $userId = null): array
     {
         $ext = strtolower(pathinfo($originalName, PATHINFO_EXTENSION));
-        $mime = mime_content_type($absolutePath) ?: '';
-        $family = ExtractionRequest::familyFrom($mime, $ext);
-        $request = new ExtractionRequest($absolutePath, $originalName, $mime, $ext, null, false, $family);
+        $relative = 'plugs-probe-'.bin2hex(random_bytes(8)).('' !== $ext ? '.'.$ext : '');
+        $dest = rtrim($this->uploadDir, '/').'/'.$relative;
+        if (!is_dir(\dirname($dest)) && !mkdir(\dirname($dest), 0775, true) && !is_dir(\dirname($dest))) {
+            throw new \RuntimeException('Unable to create upload directory for extraction probe');
+        }
+        if (!copy($absolutePath, $dest)) {
+            throw new \RuntimeException('Unable to stage file for extraction probe');
+        }
 
-        $attempts = [];
-        $winnerResult = null;
-        $winnerKey = null;
+        try {
+            [$text, $meta] = $this->fileProcessor->extractText($relative, $ext, $userId);
+            $strategy = \is_string($meta['strategy'] ?? null) ? $meta['strategy'] : 'unknown';
+            $markdown = \is_string($meta['markdown'] ?? null) ? $meta['markdown'] : null;
+            $attempts = $this->normalizeAttempts($meta['attempts'] ?? null, $strategy, '' !== trim($text));
+            $previewSource = (null !== $markdown && '' !== $markdown) ? $markdown : $text;
 
-        foreach ($this->plugConfig->extraExtractorKeys($family) as $key) {
-            $adapter = $this->registry->byKey($key);
-            $started = hrtime(true);
-            if (null === $adapter) {
-                $attempts[] = ['key' => $key, 'verdict' => 'unknown', 'ms' => 0];
+            return [
+                'winner' => '' !== $strategy && 'chain_exhausted' !== $strategy ? $strategy : null,
+                'strategy' => $strategy,
+                'attempts' => $attempts,
+                'preview' => mb_substr($previewSource, 0, 2000),
+                'markdown' => null !== $markdown && '' !== $markdown,
+            ];
+        } catch (\Throwable $e) {
+            $this->logger->info('ExtractionProbe: FileProcessor failed', [
+                'error' => $e->getMessage(),
+            ]);
+            throw $e;
+        } finally {
+            @unlink($dest);
+        }
+    }
+
+    /**
+     * @return list<array{key: string, verdict: string, ms: int}>
+     */
+    private function normalizeAttempts(mixed $raw, string $strategy, bool $hasText): array
+    {
+        if (!\is_array($raw)) {
+            return [[
+                'key' => $strategy,
+                'verdict' => $hasText ? 'quality_ok' : 'empty',
+                'ms' => 0,
+            ]];
+        }
+
+        $out = [];
+        foreach ($raw as $row) {
+            if (!\is_array($row) || !\is_string($row['key'] ?? null) || !\is_string($row['verdict'] ?? null)) {
                 continue;
             }
-
-            $verdict = 'skipped';
-            try {
-                if (!$adapter->supports($request)) {
-                    $health = $adapter->health();
-                    $verdict = $health->available ? 'unsupported' : 'unavailable';
-                } else {
-                    $result = $adapter->extract($request);
-                    $gate = $this->qualityGate->verdict($result, $request);
-                    $verdict = $gate->reason;
-                    if ($gate->passed && ($result->hasText() || (null !== $result->markdown && '' !== trim($result->markdown)))) {
-                        $winnerResult = $result;
-                        $winnerKey = $key;
-                    }
-                }
-            } catch (ExtractorRejectedException $e) {
-                $this->logger->info('ExtractionProbe: extra extractor refused the file', [
-                    'key' => $key,
-                    'error' => $e->getMessage(),
-                ]);
-                $verdict = 'rejected';
-            } catch (\Throwable $e) {
-                $this->logger->info('ExtractionProbe: extra extractor failed', [
-                    'key' => $key,
-                    'error' => $e->getMessage(),
-                ]);
-                $verdict = 'unavailable';
-            }
-            $attempts[] = [
-                'key' => $key,
-                'verdict' => $verdict,
-                'ms' => (int) ((hrtime(true) - $started) / 1_000_000),
+            $out[] = [
+                'key' => $row['key'],
+                'verdict' => $row['verdict'],
+                'ms' => \is_int($row['ms'] ?? null) ? $row['ms'] : (int) ($row['ms'] ?? 0),
             ];
-            if (null !== $winnerResult) {
-                break;
-            }
         }
 
-        if (null === $winnerResult) {
-            $relative = 'plugs-probe-'.bin2hex(random_bytes(8)).('' !== $ext ? '.'.$ext : '');
-            $dest = rtrim($this->uploadDir, '/').'/'.$relative;
-            if (!is_dir(\dirname($dest)) && !mkdir(\dirname($dest), 0775, true) && !is_dir(\dirname($dest))) {
-                throw new \RuntimeException('Unable to create upload directory for extraction probe');
-            }
-            if (!copy($absolutePath, $dest)) {
-                throw new \RuntimeException('Unable to stage file for extraction probe');
-            }
-            $started = hrtime(true);
-            try {
-                [$text, $meta] = $this->fileProcessor->extractText($relative, $ext);
-                $strategy = \is_string($meta['strategy'] ?? null) ? $meta['strategy'] : 'unknown';
-                $attempts[] = [
-                    'key' => $strategy,
-                    'verdict' => '' !== trim($text) ? 'quality_ok' : 'empty',
-                    'ms' => (int) ((hrtime(true) - $started) / 1_000_000),
-                ];
-                $markdown = \is_string($meta['markdown'] ?? null) ? $meta['markdown'] : null;
-                $winnerKey = $strategy;
-                $winnerResult = ExtractionResult::of($text, $strategy, $meta, $markdown);
-            } finally {
-                @unlink($dest);
-            }
-        }
-
-        $previewSource = $winnerResult->markdown ?: $winnerResult->text;
-
-        return [
-            'winner' => $winnerKey,
-            'strategy' => $winnerResult->strategy,
-            'attempts' => $attempts,
-            'preview' => mb_substr($previewSource, 0, 2000),
-            'markdown' => null !== $winnerResult->markdown && '' !== $winnerResult->markdown,
-        ];
+        return [] !== $out ? $out : [[
+            'key' => $strategy,
+            'verdict' => $hasText ? 'quality_ok' : 'empty',
+            'ms' => 0,
+        ]];
     }
 }

--- a/backend/src/Plug/PlugConfigService.php
+++ b/backend/src/Plug/PlugConfigService.php
@@ -202,7 +202,54 @@ final readonly class PlugConfigService
      */
     public function setChain(string $family, array $keys, array $knownKeys): void
     {
-        $setting = $this->chainSetting($family);
+        $normalized = $this->normalizeChain($family, $keys, $knownKeys);
+        $this->configRepository->setValue(
+            0,
+            self::CONFIG_GROUP,
+            $this->chainSetting($family),
+            implode(',', $normalized),
+        );
+    }
+
+    /**
+     * Validate every family first, then persist. A later empty/unknown chain
+     * must not leave earlier families written.
+     *
+     * @param array<mixed, mixed> $chains
+     * @param list<string>        $knownKeys
+     */
+    public function setChains(array $chains, array $knownKeys): void
+    {
+        $pending = [];
+        foreach ($chains as $family => $keys) {
+            if (!\is_string($family)) {
+                throw new \InvalidArgumentException('Unknown extraction family');
+            }
+            if (!\is_array($keys)) {
+                throw new \InvalidArgumentException('Chain for '.$family.' must be a list of keys');
+            }
+            $pending[] = [$family, $this->normalizeChain($family, $keys, $knownKeys)];
+        }
+
+        foreach ($pending as [$family, $normalized]) {
+            $this->configRepository->setValue(
+                0,
+                self::CONFIG_GROUP,
+                $this->chainSetting($family),
+                implode(',', $normalized),
+            );
+        }
+    }
+
+    /**
+     * @param list<mixed>  $keys
+     * @param list<string> $knownKeys
+     *
+     * @return list<string>
+     */
+    private function normalizeChain(string $family, array $keys, array $knownKeys): array
+    {
+        $this->chainSetting($family);
         $normalized = [];
         foreach ($keys as $key) {
             if (!\is_string($key)) {
@@ -222,24 +269,7 @@ final readonly class PlugConfigService
             throw new \InvalidArgumentException('Extraction chain for '.$family.' must not be empty');
         }
 
-        $this->configRepository->setValue(0, self::CONFIG_GROUP, $setting, implode(',', $normalized));
-    }
-
-    /**
-     * @param array<mixed, mixed> $chains
-     * @param list<string>        $knownKeys
-     */
-    public function setChains(array $chains, array $knownKeys): void
-    {
-        foreach ($chains as $family => $keys) {
-            if (!\is_string($family)) {
-                throw new \InvalidArgumentException('Unknown extraction family');
-            }
-            if (!\is_array($keys)) {
-                throw new \InvalidArgumentException('Chain for '.$family.' must be a list of keys');
-            }
-            $this->setChain($family, $keys, $knownKeys);
-        }
+        return $normalized;
     }
 
     private function chainSetting(string $family): string

--- a/backend/src/Plug/PlugConfigService.php
+++ b/backend/src/Plug/PlugConfigService.php
@@ -121,7 +121,11 @@ final readonly class PlugConfigService
             default => self::DEFAULT_CHAIN_DOCUMENT,
         };
 
-        return $this->splitList($this->readGlobal($key, $default));
+        $keys = $this->splitList($this->readGlobal($key, $default));
+
+        // A previously accepted empty string must not disable extraction.
+        // New empty saves are rejected in setChain().
+        return [] !== $keys ? $keys : $this->splitList($default);
     }
 
     /**
@@ -212,6 +216,10 @@ final readonly class PlugConfigService
                 throw new \InvalidArgumentException('Unknown extractor key: '.$trimmed);
             }
             $normalized[] = $trimmed;
+        }
+
+        if ([] === $normalized) {
+            throw new \InvalidArgumentException('Extraction chain for '.$family.' must not be empty');
         }
 
         $this->configRepository->setValue(0, self::CONFIG_GROUP, $setting, implode(',', $normalized));

--- a/backend/src/Service/File/FileProcessor.php
+++ b/backend/src/Service/File/FileProcessor.php
@@ -494,9 +494,11 @@ final readonly class FileProcessor
             }
         }
 
+        // Office→PDF here is Tika's own fallback (how it reads a DOCX Tika
+        // could not parse), not the `office_convert` chain step (.doc→.docx).
         $viaPdf = $this->extractTikaViaOfficePdf($request->absolutePath, $request->ext, $meta);
         if (null !== $viaPdf) {
-            return $this->gatePair($viaPdf, $request);
+            return $this->gatePair($viaPdf, $this->asPdfRequest($request));
         }
 
         return $this->gatePair(['', ['strategy' => 'tika_failed'] + $meta], $request);
@@ -516,6 +518,8 @@ final readonly class FileProcessor
             );
         }
 
+        // pdf_vision rasterizes pages. Office files must become a PDF first;
+        // that is this step's input prep, not the `office_convert` rewrite.
         $convertible = isset(self::LEGACY_OFFICE_TARGETS[$request->ext])
             || \in_array($request->ext, ['docx', 'xlsx', 'pptx'], true);
         if (!$convertible || null === $this->officeConverter || !$this->officeConverter->isEnabled()) {
@@ -528,9 +532,10 @@ final readonly class FileProcessor
         }
 
         try {
+            // Rasterize needs a PDF; gate as PDF so qualityApplyTo=['pdf'] applies.
             return $this->gatePair(
                 $this->extractFromPdfViaVision($pdf, $request->userId, $meta),
-                $request,
+                $this->asPdfRequest($request, $pdf),
             );
         } finally {
             @unlink($pdf);
@@ -699,6 +704,15 @@ final readonly class FileProcessor
         $markdown = \is_string($pair[1]['markdown'] ?? null) ? $pair[1]['markdown'] : null;
 
         return $this->gateResult(ExtractionResult::of($pair[0], $strategy, $pair[1], $markdown), $request);
+    }
+
+    /**
+     * Quality apply_to=['pdf'] keys off ext/mime. Converted Office text came
+     * from a PDF, so gate it as one (legacy extractOfficeViaConvertedPdf already does).
+     */
+    private function asPdfRequest(ExtractionRequest $request, ?string $pdfPath = null): ExtractionRequest
+    {
+        return $request->withPath($pdfPath ?? $request->absolutePath, 'pdf', 'application/pdf');
     }
 
     private function detectFamily(string $mime, string $ext): string

--- a/backend/src/Service/File/FileProcessor.php
+++ b/backend/src/Service/File/FileProcessor.php
@@ -4,10 +4,12 @@ namespace App\Service\File;
 
 use App\AI\Exception\ProviderException;
 use App\AI\Service\AiFacade;
+use App\Plug\Extraction\ContentExtractorInterface;
 use App\Plug\Extraction\ExtractionQualityGate;
 use App\Plug\Extraction\ExtractionRegistry;
 use App\Plug\Extraction\ExtractionRequest;
 use App\Plug\Extraction\ExtractionResult;
+use App\Plug\Extraction\ExtractorRejectedException;
 use App\Plug\PlugConfigService;
 use App\Service\File\Office\OfficeConverterClient;
 use App\Service\File\Office\StructuredTextExtractor;
@@ -164,9 +166,16 @@ final readonly class FileProcessor
 
         $this->logger->info('FileProcessor: Starting extraction', $meta);
 
-        $extra = $this->tryExtraExtractors($absolutePath, $relativePath, $mime, $ext, $userId, $describe);
-        if (null !== $extra) {
-            return $extra;
+        if (null !== $this->plugConfig) {
+            return $this->extractViaConfiguredChain(
+                $absolutePath,
+                $relativePath,
+                $mime,
+                $ext,
+                $userId,
+                $describe,
+                $meta,
+            );
         }
 
         $convertedTmp = $this->convertLegacyOffice($absolutePath, $ext);
@@ -194,96 +203,502 @@ final readonly class FileProcessor
     }
 
     /**
-     * Run extraction adapters whose keys are not FileProcessor built-ins.
-     * Empty in S1 (seeded chains only list built-in keys). S2 Docling lands here.
+     * Walk the configured family chain (built-ins and extras) in saved order.
+     * The first quality-ok result wins. Every step is recorded on meta.attempts.
      *
-     * @return array{0: string, 1: array<string, mixed>}|null
+     * @param array<string, mixed> $meta
+     *
+     * @return array{0: string, 1: array<string, mixed>}
      */
-    private function tryExtraExtractors(
+    private function extractViaConfiguredChain(
         string $absolutePath,
         string $relativePath,
         string $mime,
         string $ext,
         ?int $userId,
         bool $describe,
-    ): ?array {
-        if (null === $this->extractionRegistry || null === $this->plugConfig) {
-            return null;
+        array $meta,
+    ): array {
+        if (null === $this->plugConfig) {
+            throw new \LogicException('extractViaConfiguredChain requires PlugConfigService');
         }
 
         $family = $this->detectFamily($mime, $ext);
         $hasCloudStt = 'audio' === $family && $this->aiFacade->hasConfiguredSttProvider($userId);
+        $keys = $this->plugConfig->extractionChain($family, $hasCloudStt);
 
-        foreach ($this->plugConfig->extraExtractorKeys($family, $hasCloudStt) as $key) {
-            $adapter = $this->extractionRegistry->byKey($key);
-            if (null === $adapter) {
-                $this->logger->info('FileProcessor: skipping unknown extra extractor', [
+        $attempts = [];
+        $convertedTmp = null;
+        $workingPath = $absolutePath;
+        $workingExt = $ext;
+        $workingMime = $mime;
+        $workingMeta = $meta;
+
+        try {
+            foreach ($keys as $key) {
+                $started = hrtime(true);
+                $step = $this->runChainStep(
+                    $key,
+                    $workingPath,
+                    $relativePath,
+                    $workingMime,
+                    $workingExt,
+                    $userId,
+                    $describe,
+                    $workingMeta,
+                    $family,
+                );
+                $attempts[] = [
                     'key' => $key,
-                    'family' => $family,
-                ]);
-                continue;
-            }
+                    'verdict' => $step['verdict'],
+                    'ms' => (int) ((hrtime(true) - $started) / 1_000_000),
+                ];
 
-            $request = new ExtractionRequest(
-                $absolutePath,
-                $relativePath,
-                $mime,
-                $ext,
-                $userId,
-                $describe,
-                $family,
-            );
-            if (!$adapter->supports($request)) {
-                continue;
-            }
-
-            try {
-                $result = $adapter->extract($request);
-            } catch (\Throwable $e) {
-                $this->logger->info('FileProcessor: extra extractor failed, falling through', [
-                    'key' => $key,
-                    'error' => $e->getMessage(),
-                ]);
-                continue;
-            }
-
-            if (null !== $this->qualityGate) {
-                $verdict = $this->qualityGate->verdict($result, $request);
-                $result = $result->withMeta(array_merge($result->meta, ['gate' => $verdict->toArray()]));
-                if (!$verdict->passed) {
-                    $this->logger->info('FileProcessor: extra extractor lost quality gate', [
-                        'key' => $key,
-                        'reason' => $verdict->reason,
-                    ]);
+                if (isset($step['converted'])) {
+                    $convertedTmp = $step['converted']['path'];
+                    $workingPath = $step['converted']['path'];
+                    $workingExt = $step['converted']['ext'];
+                    $workingMime = $step['converted']['mime'];
+                    $workingMeta['mime'] = $workingMime;
+                    $workingMeta['ext'] = $workingExt;
+                    $workingMeta['converted_from'] = $ext;
                     continue;
+                }
+
+                if ($step['passed'] && isset($step['pair'])) {
+                    $pair = $step['pair'];
+                    $pair[1]['attempts'] = $attempts;
+                    $this->logger->info('FileProcessor: chain step succeeded', [
+                        'key' => $key,
+                        'strategy' => $pair[1]['strategy'] ?? $key,
+                        'family' => $family,
+                    ]);
+
+                    return $pair;
                 }
             }
 
-            if ($result->hasText()) {
-                $this->logger->info('FileProcessor: extra extractor succeeded', [
+            $this->logger->info('FileProcessor: configured chain exhausted', [
+                'family' => $family,
+                'keys' => $keys,
+            ]);
+
+            return ['', ['strategy' => 'chain_exhausted', 'attempts' => $attempts] + $workingMeta];
+        } finally {
+            if (null !== $convertedTmp && is_file($convertedTmp)) {
+                @unlink($convertedTmp);
+            }
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $meta
+     *
+     * @return array{
+     *     verdict: string,
+     *     passed: bool,
+     *     pair?: array{0: string, 1: array<string, mixed>},
+     *     converted?: array{path: string, ext: string, mime: string}
+     * }
+     */
+    private function runChainStep(
+        string $key,
+        string $absolutePath,
+        string $relativePath,
+        string $mime,
+        string $ext,
+        ?int $userId,
+        bool $describe,
+        array $meta,
+        string $family,
+    ): array {
+        $request = new ExtractionRequest(
+            $absolutePath,
+            $relativePath,
+            $mime,
+            $ext,
+            $userId,
+            $describe,
+            $family,
+        );
+
+        if (
+            null !== $this->extractionRegistry
+            && !\in_array($key, PlugConfigService::BUILTIN_EXTRACTOR_KEYS, true)
+        ) {
+            $adapter = $this->extractionRegistry->byKey($key);
+            if (null === $adapter) {
+                $this->logger->info('FileProcessor: skipping unknown chain key', [
                     'key' => $key,
-                    'strategy' => $result->strategy,
+                    'family' => $family,
                 ]);
 
-                return $result->toLegacyPair();
+                return ['verdict' => 'unknown', 'passed' => false];
             }
 
-            if (null !== $result->markdown && '' !== trim($result->markdown)) {
-                $this->logger->info('FileProcessor: extra extractor succeeded', [
-                    'key' => $key,
-                    'strategy' => $result->strategy,
-                ]);
+            return $this->runExtraAdapter($adapter, $request, $key);
+        }
 
-                return ExtractionResult::of(
+        return $this->runBuiltinStep($key, $request, $meta);
+    }
+
+    /**
+     * @return array{verdict: string, passed: bool, pair?: array{0: string, 1: array<string, mixed>}}
+     */
+    private function runExtraAdapter(
+        ContentExtractorInterface $adapter,
+        ExtractionRequest $request,
+        string $key,
+    ): array {
+        if (!$adapter->supports($request)) {
+            $health = $adapter->health();
+
+            return [
+                'verdict' => $health->available ? 'unsupported' : 'unavailable',
+                'passed' => false,
+            ];
+        }
+
+        try {
+            $result = $adapter->extract($request);
+        } catch (ExtractorRejectedException $e) {
+            $this->logger->info('FileProcessor: extra extractor refused the file', [
+                'key' => $key,
+                'error' => $e->getMessage(),
+            ]);
+
+            return ['verdict' => 'rejected', 'passed' => false];
+        } catch (\Throwable $e) {
+            $this->logger->info('FileProcessor: extra extractor failed, falling through', [
+                'key' => $key,
+                'error' => $e->getMessage(),
+            ]);
+
+            return ['verdict' => 'unavailable', 'passed' => false];
+        }
+
+        return $this->gateResult($result, $request);
+    }
+
+    /**
+     * @param array<string, mixed> $meta
+     *
+     * @return array{
+     *     verdict: string,
+     *     passed: bool,
+     *     pair?: array{0: string, 1: array<string, mixed>},
+     *     converted?: array{path: string, ext: string, mime: string}
+     * }
+     */
+    private function runBuiltinStep(string $key, ExtractionRequest $request, array $meta): array
+    {
+        return match ($key) {
+            'native' => $this->stepNative($request, $meta),
+            'structured_office' => $this->stepStructuredOffice($request, $meta),
+            'office_convert' => $this->stepOfficeConvert($request),
+            'tika' => $this->stepTika($request, $meta),
+            'pdf_vision' => $this->stepPdfVision($request, $meta),
+            'vision' => $this->stepVision($request, $meta),
+            'stt_cloud' => $this->stepSttCloud($request, $meta),
+            'whisper_local' => $this->stepWhisperLocal($request, $meta),
+            'video_analysis' => $this->stepVideoAnalysis($request, $meta),
+            default => ['verdict' => 'unknown', 'passed' => false],
+        };
+    }
+
+    /**
+     * @param array<string, mixed> $meta
+     *
+     * @return array{verdict: string, passed: bool, pair?: array{0: string, 1: array<string, mixed>}}
+     */
+    private function stepNative(ExtractionRequest $request, array $meta): array
+    {
+        if (!$this->isPlainTextMime($request->mime)) {
+            return ['verdict' => 'unsupported', 'passed' => false];
+        }
+
+        $text = $this->textCleaner->clean(@file_get_contents($request->absolutePath) ?: '');
+        $this->logger->info('FileProcessor: Native text extraction', [
+            'strategy' => 'native_text',
+            'bytes' => strlen($text),
+        ]);
+
+        return $this->gatePair([$text, ['strategy' => 'native_text'] + $meta], $request);
+    }
+
+    /**
+     * @param array<string, mixed> $meta
+     *
+     * @return array{verdict: string, passed: bool, pair?: array{0: string, 1: array<string, mixed>}}
+     */
+    private function stepStructuredOffice(ExtractionRequest $request, array $meta): array
+    {
+        $pair = $this->extractStructured($request->absolutePath, $request->ext, $meta);
+        if (null === $pair) {
+            return ['verdict' => 'unsupported', 'passed' => false];
+        }
+
+        return $this->gatePair($pair, $request);
+    }
+
+    /**
+     * @return array{
+     *     verdict: string,
+     *     passed: bool,
+     *     converted?: array{path: string, ext: string, mime: string}
+     * }
+     */
+    private function stepOfficeConvert(ExtractionRequest $request): array
+    {
+        if (!isset(self::LEGACY_OFFICE_TARGETS[$request->ext])) {
+            return ['verdict' => 'unsupported', 'passed' => false];
+        }
+
+        $converted = $this->convertLegacyOffice($request->absolutePath, $request->ext);
+        if (null === $converted) {
+            return ['verdict' => 'empty', 'passed' => false];
+        }
+
+        $newExt = strtolower(pathinfo($converted, PATHINFO_EXTENSION));
+        $newMime = $this->ensureOfficeMime(mime_content_type($converted) ?: $request->mime, $newExt);
+
+        return [
+            'verdict' => 'rewritten',
+            'passed' => false,
+            'converted' => [
+                'path' => $converted,
+                'ext' => $newExt,
+                'mime' => $newMime,
+            ],
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $meta
+     *
+     * @return array{verdict: string, passed: bool, pair?: array{0: string, 1: array<string, mixed>}}
+     */
+    private function stepTika(ExtractionRequest $request, array $meta): array
+    {
+        if (!$this->tikaClient->isEnabled()) {
+            return ['verdict' => 'unavailable', 'passed' => false];
+        }
+
+        [$tikaText, $tikaMeta] = $this->tikaClient->extractText($request->absolutePath, $request->mime);
+        if (\is_string($tikaText)) {
+            $tikaText = $this->textCleaner->clean($tikaText);
+            if (mb_strlen(trim($tikaText)) > 0) {
+                $tikaMeta = \is_array($tikaMeta) ? $tikaMeta : [];
+
+                return $this->gatePair([$tikaText, ['strategy' => 'tika'] + $meta + $tikaMeta], $request);
+            }
+        }
+
+        $viaPdf = $this->extractTikaViaOfficePdf($request->absolutePath, $request->ext, $meta);
+        if (null !== $viaPdf) {
+            return $this->gatePair($viaPdf, $request);
+        }
+
+        return $this->gatePair(['', ['strategy' => 'tika_failed'] + $meta], $request);
+    }
+
+    /**
+     * @param array<string, mixed> $meta
+     *
+     * @return array{verdict: string, passed: bool, pair?: array{0: string, 1: array<string, mixed>}}
+     */
+    private function stepPdfVision(ExtractionRequest $request, array $meta): array
+    {
+        if ($this->isPdfMime($request->mime) || 'pdf' === $request->ext) {
+            return $this->gatePair(
+                $this->extractFromPdfViaVision($request->absolutePath, $request->userId, $meta),
+                $request,
+            );
+        }
+
+        $convertible = isset(self::LEGACY_OFFICE_TARGETS[$request->ext])
+            || \in_array($request->ext, ['docx', 'xlsx', 'pptx'], true);
+        if (!$convertible || null === $this->officeConverter || !$this->officeConverter->isEnabled()) {
+            return ['verdict' => 'unsupported', 'passed' => false];
+        }
+
+        $pdf = $this->officeConverter->convert($request->absolutePath, 'pdf');
+        if (null === $pdf || !is_file($pdf)) {
+            return ['verdict' => 'empty', 'passed' => false];
+        }
+
+        try {
+            return $this->gatePair(
+                $this->extractFromPdfViaVision($pdf, $request->userId, $meta),
+                $request,
+            );
+        } finally {
+            @unlink($pdf);
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $meta
+     *
+     * @return array{verdict: string, passed: bool, pair?: array{0: string, 1: array<string, mixed>}}
+     */
+    private function stepVision(ExtractionRequest $request, array $meta): array
+    {
+        if (!$this->isImageMime($request->mime)) {
+            return ['verdict' => 'unsupported', 'passed' => false];
+        }
+
+        return $this->gatePair(
+            $this->extractFromImage($request->relativePath, $request->userId, $meta, $request->describe),
+            $request,
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $meta
+     *
+     * @return array{verdict: string, passed: bool, pair?: array{0: string, 1: array<string, mixed>}}
+     */
+    private function stepSttCloud(ExtractionRequest $request, array $meta): array
+    {
+        if ($this->isVideo($request->ext) || !$this->isTranscribableMedia($request->ext)) {
+            return ['verdict' => 'unsupported', 'passed' => false];
+        }
+
+        return $this->gatePair(
+            $this->extractFromAudioExternal($request->absolutePath, $meta, $request->userId),
+            $request,
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $meta
+     *
+     * @return array{verdict: string, passed: bool, pair?: array{0: string, 1: array<string, mixed>}}
+     */
+    private function stepWhisperLocal(ExtractionRequest $request, array $meta): array
+    {
+        if ($this->isVideo($request->ext) || !$this->isTranscribableMedia($request->ext)) {
+            return ['verdict' => 'unsupported', 'passed' => false];
+        }
+
+        $pair = $this->transcribeLocally($request->absolutePath, $meta);
+        if (null === $pair) {
+            return ['verdict' => 'unavailable', 'passed' => false];
+        }
+
+        return $this->gatePair($pair, $request);
+    }
+
+    /**
+     * @param array<string, mixed> $meta
+     *
+     * @return array{verdict: string, passed: bool, pair?: array{0: string, 1: array<string, mixed>}}
+     */
+    private function stepVideoAnalysis(ExtractionRequest $request, array $meta): array
+    {
+        if (!$this->isVideo($request->ext)) {
+            return ['verdict' => 'unsupported', 'passed' => false];
+        }
+
+        return $this->gatePair(
+            $this->extractFromVideo($request->relativePath, $request->absolutePath, $meta, $request->userId),
+            $request,
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $meta
+     *
+     * @return array{0: string, 1: array<string, mixed>}|null
+     */
+    private function extractTikaViaOfficePdf(string $absolutePath, string $ext, array $meta): ?array
+    {
+        $convertible = isset(self::LEGACY_OFFICE_TARGETS[$ext])
+            || \in_array($ext, ['docx', 'xlsx', 'pptx'], true);
+        if (!$convertible || null === $this->officeConverter || !$this->officeConverter->isEnabled()) {
+            return null;
+        }
+
+        $pdf = $this->officeConverter->convert($absolutePath, 'pdf');
+        if (null === $pdf || !is_file($pdf)) {
+            return null;
+        }
+
+        try {
+            [$tikaText, $tikaMeta] = $this->tikaClient->extractText($pdf, 'application/pdf');
+            if (!\is_string($tikaText)) {
+                return null;
+            }
+            $tikaText = $this->textCleaner->clean($tikaText);
+            if (mb_strlen(trim($tikaText)) <= 0) {
+                return null;
+            }
+            $tikaMeta = \is_array($tikaMeta) ? $tikaMeta : [];
+
+            return [$tikaText, ['strategy' => 'tika_office_pdf'] + $meta + $tikaMeta];
+        } finally {
+            @unlink($pdf);
+        }
+    }
+
+    /**
+     * @return array{verdict: string, passed: bool, pair?: array{0: string, 1: array<string, mixed>}}
+     */
+    private function gateResult(ExtractionResult $result, ExtractionRequest $request): array
+    {
+        if (null !== $this->qualityGate) {
+            $verdict = $this->qualityGate->verdict($result, $request);
+            $result = $result->withMeta(array_merge($result->meta, ['gate' => $verdict->toArray()]));
+            if (!$verdict->passed) {
+                return ['verdict' => $verdict->reason, 'passed' => false];
+            }
+            if ($result->hasText() || (null !== $result->markdown && '' !== trim($result->markdown))) {
+                $pair = $result->hasText()
+                    ? $result->toLegacyPair()
+                    : ExtractionResult::of(
+                        (string) $result->markdown,
+                        $result->strategy,
+                        $result->meta,
+                        $result->markdown,
+                    )->toLegacyPair();
+
+                return ['verdict' => $verdict->reason, 'passed' => true, 'pair' => $pair];
+            }
+
+            return ['verdict' => 'empty', 'passed' => false];
+        }
+
+        if ($result->hasText()) {
+            return ['verdict' => 'quality_ok', 'passed' => true, 'pair' => $result->toLegacyPair()];
+        }
+        if (null !== $result->markdown && '' !== trim($result->markdown)) {
+            return [
+                'verdict' => 'quality_ok',
+                'passed' => true,
+                'pair' => ExtractionResult::of(
                     $result->markdown,
                     $result->strategy,
                     $result->meta,
                     $result->markdown,
-                )->toLegacyPair();
-            }
+                )->toLegacyPair(),
+            ];
         }
 
-        return null;
+        return ['verdict' => 'empty', 'passed' => false];
+    }
+
+    /**
+     * @param array{0: string, 1: array<string, mixed>} $pair
+     *
+     * @return array{verdict: string, passed: bool, pair?: array{0: string, 1: array<string, mixed>}}
+     */
+    private function gatePair(array $pair, ExtractionRequest $request): array
+    {
+        $strategy = \is_string($pair[1]['strategy'] ?? null) ? $pair[1]['strategy'] : 'unknown';
+        $markdown = \is_string($pair[1]['markdown'] ?? null) ? $pair[1]['markdown'] : null;
+
+        return $this->gateResult(ExtractionResult::of($pair[0], $strategy, $pair[1], $markdown), $request);
     }
 
     private function detectFamily(string $mime, string $ext): string

--- a/backend/src/Service/Message/MessagePreProcessor.php
+++ b/backend/src/Service/Message/MessagePreProcessor.php
@@ -165,9 +165,9 @@ final readonly class MessagePreProcessor
             return;
         }
 
-        // Skip extraction if text already exists (e.g., from FileProcessor in upload endpoint)
-        // This prevents overwriting robust extraction with simple Tika-only extraction
-        if (!empty($messageFile->getFileText())) {
+        // Skip if upload already ran FileProcessor. Empty OCR on a photo is a
+        // real result (status=extracted, fileText='') — do not Vision twice.
+        if (!empty($messageFile->getFileText()) || 'extracted' === $messageFile->getStatus()) {
             $this->logger->info('PreProcessor: File text already extracted, skipping re-extraction', [
                 'file_id' => $messageFile->getId(),
                 'type' => $fileType,

--- a/backend/src/Service/Message/MessagePreProcessor.php
+++ b/backend/src/Service/Message/MessagePreProcessor.php
@@ -299,17 +299,21 @@ final readonly class MessagePreProcessor
             }
         }
 
-        // Image mit Vision AI
+        // Image: same FileProcessor chain as chat upload (issue #1792 / #1793).
         elseif (in_array($fileType, self::IMAGE_EXTENSIONS)) {
             try {
-                // Use file owner as context for Vision AI
                 $userId = $messageFile->getUserId() ?? 0;
-                $text = $this->processImageWithVision($messageFile->getFilePath(), $userId);
-                $messageFile->setFileText($text ?? '');
+                [$text, $extractMeta] = $this->fileProcessor->extractText(
+                    $messageFile->getFilePath(),
+                    $fileType,
+                    $userId,
+                );
+                $messageFile->setFileText($text);
                 $messageFile->setStatus('processed');
                 $this->logger->info('PreProcessor: Image processed with Vision AI', [
                     'file_id' => $messageFile->getId(),
-                    'text_length' => strlen($text ?? ''),
+                    'text_length' => strlen($text),
+                    'strategy' => $extractMeta['strategy'] ?? 'unknown',
                 ]);
 
                 $this->billFileAnalysis($messageFile, $message, 'image');
@@ -506,7 +510,7 @@ final readonly class MessagePreProcessor
             }
         }
 
-        // Image mit Vision AI (wenn Tika nichts extrahiert hat)
+        // Image: FileProcessor so the configured image chain runs (issue #1792).
         if (in_array($fileType, self::IMAGE_EXTENSIONS)) {
             $this->logger->info('PreProcessor: Processing image with Vision AI', [
                 'file' => basename($fullPath),
@@ -514,10 +518,14 @@ final readonly class MessagePreProcessor
             ]);
 
             try {
-                $text = $this->processImageWithVision($message->getFilePath(), $message->getUserId());
-                $message->setFileText($text ?? '');
+                [$text] = $this->fileProcessor->extractText(
+                    $filePath,
+                    $fileType,
+                    $message->getUserId(),
+                );
+                $message->setFileText($text);
                 $this->logger->info('PreProcessor: Image processed successfully', [
-                    'text_length' => strlen($text ?? ''),
+                    'text_length' => strlen($text),
                 ]);
             } catch (\Exception $e) {
                 $this->logger->error('PreProcessor: Vision AI failed', [
@@ -598,35 +606,6 @@ final readonly class MessagePreProcessor
         }
 
         $message->setMeta('ai_transcription_usage', (string) json_encode($usage));
-    }
-
-    /**
-     * Process image with Vision AI.
-     */
-    private function processImageWithVision(string $relativePath, int $userId): ?string
-    {
-        try {
-            $prompt = 'Extract all text visible in this image. '
-                .'Return only the text exactly as it appears, preserving line breaks. '
-                .'Do not add descriptions or commentary. '
-                .'If no text is visible, return an empty string.';
-
-            $result = $this->aiFacade->analyzeImage($relativePath, $prompt, $userId);
-            $text = trim($result['content'] ?? '');
-            if ('' !== $text && str_starts_with(strtolower($text), 'test image description:')) {
-                $text = preg_replace('/^test image description:\s*/i', '', $text);
-                $text = trim($text);
-            }
-
-            return '' !== $text ? $text : null;
-        } catch (\Exception $e) {
-            $this->logger->error("Vision AI analysis failed: {$e->getMessage()}", [
-                'file' => basename($relativePath),
-                'error' => $e->getMessage(),
-            ]);
-
-            return null;
-        }
     }
 
     private function notify(?callable $callback, string $status, string $message): void

--- a/backend/tests/Controller/AdminPlugsExtractionControllerTest.php
+++ b/backend/tests/Controller/AdminPlugsExtractionControllerTest.php
@@ -54,6 +54,21 @@ final class AdminPlugsExtractionControllerTest extends WebTestCase
         self::assertContains('tika', $keys);
     }
 
+    public function testPutEmptyChainReturns422(): void
+    {
+        $this->loginAdmin();
+        $this->client->request(
+            'PUT',
+            '/api/v1/admin/plugs/extraction/chains',
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: json_encode(['chains' => ['document' => []]], JSON_THROW_ON_ERROR),
+        );
+
+        self::assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $this->client->getResponse()->getStatusCode());
+        $body = $this->json();
+        self::assertStringContainsString('must not be empty', (string) ($body['error'] ?? ''));
+    }
+
     public function testPutUnknownAdapterReturns422(): void
     {
         $this->loginAdmin();

--- a/backend/tests/Unit/MessagePreProcessorTest.php
+++ b/backend/tests/Unit/MessagePreProcessorTest.php
@@ -330,7 +330,65 @@ class MessagePreProcessorTest extends TestCase
     }
 
     /**
-     * Issue #1191 — re-attaching an already-vectorized file (BFILETEXT
+     * Issue #1793 — a textless photo is stored as status=extracted with empty
+     * BFILETEXT. The preprocessor must not run Vision a second time.
+     */
+    public function testProcessFileEntityWithExtractedEmptyImageSkipsReExtraction(): void
+    {
+        $tempDir = sys_get_temp_dir();
+        $tempFile = $tempDir.'/test_img_'.uniqid().'.png';
+        touch($tempFile);
+
+        try {
+            $file = $this->createMock(\App\Entity\File::class);
+            $file->method('getId')->willReturn(88);
+            $file->method('getFilePath')->willReturn(basename($tempFile));
+            $file->method('getFileType')->willReturn('png');
+            $file->method('getFileName')->willReturn('photo.png');
+            $file->method('getFileSize')->willReturn(2048);
+            $file->method('getFileText')->willReturn('');
+            $file->method('getStatus')->willReturn('extracted');
+            $file->method('getUserId')->willReturn(7);
+            $file
+                ->expects($this->atLeastOnce())
+                ->method('setStatus')
+                ->with('processed');
+
+            $files = new \Doctrine\Common\Collections\ArrayCollection([$file]);
+            $message = $this->createMock(Message::class);
+            $message->method('getFile')->willReturn(0);
+            $message->method('getFilePath')->willReturn('');
+            $message->method('getFiles')->willReturn($files);
+            $message->method('getUserId')->willReturn(7);
+
+            $this->fileProcessor
+                ->expects($this->never())
+                ->method('extractText');
+
+            $service = new MessagePreProcessor(
+                $this->messageRepository,
+                $this->tikaClient,
+                $this->whisperService,
+                $this->aiFacade,
+                $this->logger,
+                $tempDir,
+                $this->rateLimitService,
+                $this->userRepository,
+                $this->fileProcessor,
+            );
+
+            $this->messageRepository->method('save');
+
+            $service->process($message);
+        } finally {
+            if (file_exists($tempFile)) {
+                unlink($tempFile);
+            }
+        }
+    }
+
+    /**
+     * Issue #1191 — re-attaching an already-vectorized file (BFILETEXT)
      * present) must NOT downgrade its status to 'processed'. The Qdrant
      * vectors are still valid, so flipping the DB status to 'processed' would
      * make the two stores inconsistent.

--- a/backend/tests/Unit/Plug/Extraction/ExtractionProbeServiceTest.php
+++ b/backend/tests/Unit/Plug/Extraction/ExtractionProbeServiceTest.php
@@ -4,115 +4,39 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\Plug\Extraction;
 
-use App\Plug\Extraction\ContentExtractorInterface;
-use App\Plug\Extraction\Docling\DoclingRejectedException;
-use App\Plug\Extraction\Docling\DoclingUnavailableException;
 use App\Plug\Extraction\ExtractionProbeService;
-use App\Plug\Extraction\ExtractionQualityGate;
-use App\Plug\Extraction\ExtractionRegistry;
-use App\Plug\Extraction\ExtractionRequest;
-use App\Plug\Extraction\ExtractionResult;
-use App\Plug\PlugConfigService;
-use App\Plug\PlugDescriptor;
-use App\Plug\PlugHealth;
 use App\Service\File\FileProcessor;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 
 final class ExtractionProbeServiceTest extends TestCase
 {
-    public function testHttp422IsRejectedNotUnavailable(): void
+    public function testForwardsUserIdAndUsesFileProcessorAttempts(): void
     {
-        $result = $this->probeWithThrowingDocling(
-            new DoclingRejectedException('Docling convert returned HTTP 422'),
-        );
-
-        $docling = $this->findAttempt($result, 'docling');
-        self::assertSame('rejected', $docling['verdict']);
-        self::assertSame('tika', $result['winner']);
-        self::assertSame('tika', $result['strategy']);
-    }
-
-    public function testUnreachableSidecarStaysUnavailable(): void
-    {
-        $result = $this->probeWithThrowingDocling(
-            new DoclingUnavailableException('Docling unavailable — connection refused'),
-        );
-
-        $docling = $this->findAttempt($result, 'docling');
-        self::assertSame('unavailable', $docling['verdict']);
-        self::assertSame('tika', $result['winner']);
-    }
-
-    /**
-     * @return array{
-     *     winner: string|null,
-     *     strategy: string,
-     *     attempts: list<array{key: string, verdict: string, ms: int}>,
-     *     preview: string,
-     *     markdown: bool
-     * }
-     */
-    private function probeWithThrowingDocling(\Throwable $error): array
-    {
-        $extra = new class($error) implements ContentExtractorInterface {
-            public function __construct(private \Throwable $error)
-            {
-            }
-
-            public function key(): string
-            {
-                return 'docling';
-            }
-
-            public function descriptor(): PlugDescriptor
-            {
-                return new PlugDescriptor('docling', 'Docling', '', [], 'self-hosted');
-            }
-
-            public function supports(ExtractionRequest $request): bool
-            {
-                return '' !== $request->absolutePath;
-            }
-
-            public function extract(ExtractionRequest $request): ExtractionResult
-            {
-                throw $this->error;
-            }
-
-            public function health(): PlugHealth
-            {
-                return PlugHealth::available();
-            }
-        };
-
-        $plugConfig = $this->createMock(PlugConfigService::class);
-        $plugConfig->method('extraExtractorKeys')->willReturn(['docling']);
-
         $fileProcessor = $this->createMock(FileProcessor::class);
-        $fileProcessor->method('extractText')->willReturn([
-            'Tika fallback body',
-            ['strategy' => 'tika'],
-        ]);
+        $fileProcessor->expects(self::once())
+            ->method('extractText')
+            ->with(self::isString(), 'mp3', 42)
+            ->willReturn([
+                'hello from cloud stt',
+                [
+                    'strategy' => 'whisper_api',
+                    'attempts' => [
+                        ['key' => 'stt_cloud', 'verdict' => 'quality_ok', 'ms' => 12],
+                    ],
+                ],
+            ]);
 
         $uploadDir = sys_get_temp_dir().'/synaplan-probe-'.bin2hex(random_bytes(4));
         self::assertTrue(mkdir($uploadDir, 0775, true) || is_dir($uploadDir));
 
-        $probe = new ExtractionProbeService(
-            new ExtractionRegistry([$extra], $plugConfig, new NullLogger()),
-            $plugConfig,
-            $this->createStub(ExtractionQualityGate::class),
-            $fileProcessor,
-            new NullLogger(),
-            $uploadDir,
-        );
-
-        $path = tempnam(sys_get_temp_dir(), 'probe-pdf-');
+        $probe = new ExtractionProbeService($fileProcessor, new NullLogger(), $uploadDir);
+        $path = tempnam(sys_get_temp_dir(), 'probe-mp3-');
         self::assertNotFalse($path);
-        file_put_contents($path, "%PDF-1.4 probe\n");
+        file_put_contents($path, 'audio');
 
         try {
-            return $probe->testFile($path, 'invoice.pdf');
+            $result = $probe->testFile($path, 'speech.mp3', 42);
         } finally {
             @unlink($path);
             foreach (glob($uploadDir.'/*') ?: [] as $leftover) {
@@ -120,21 +44,40 @@ final class ExtractionProbeServiceTest extends TestCase
             }
             @rmdir($uploadDir);
         }
+
+        self::assertSame('whisper_api', $result['winner']);
+        self::assertSame('whisper_api', $result['strategy']);
+        self::assertSame('stt_cloud', $result['attempts'][0]['key'] ?? null);
+        self::assertSame('hello from cloud stt', $result['preview']);
     }
 
-    /**
-     * @param array{attempts: list<array{key: string, verdict: string, ms: int}>} $result
-     *
-     * @return array{key: string, verdict: string, ms: int}
-     */
-    private function findAttempt(array $result, string $key): array
+    public function testMissingAttemptsFallsBackToStrategyRow(): void
     {
-        foreach ($result['attempts'] as $attempt) {
-            if ($key === $attempt['key']) {
-                return $attempt;
+        $fileProcessor = $this->createMock(FileProcessor::class);
+        $fileProcessor->method('extractText')->willReturn([
+            'Tika body',
+            ['strategy' => 'tika'],
+        ]);
+
+        $uploadDir = sys_get_temp_dir().'/synaplan-probe-'.bin2hex(random_bytes(4));
+        self::assertTrue(mkdir($uploadDir, 0775, true) || is_dir($uploadDir));
+
+        $probe = new ExtractionProbeService($fileProcessor, new NullLogger(), $uploadDir);
+        $path = tempnam(sys_get_temp_dir(), 'probe-md-');
+        self::assertNotFalse($path);
+        file_put_contents($path, 'md');
+
+        try {
+            $result = $probe->testFile($path, 'note.md', 1);
+        } finally {
+            @unlink($path);
+            foreach (glob($uploadDir.'/*') ?: [] as $leftover) {
+                @unlink($leftover);
             }
+            @rmdir($uploadDir);
         }
 
-        self::fail('Missing attempt for '.$key);
+        self::assertSame('tika', $result['attempts'][0]['key'] ?? null);
+        self::assertSame('quality_ok', $result['attempts'][0]['verdict']);
     }
 }

--- a/backend/tests/Unit/Plug/PlugConfigServiceTest.php
+++ b/backend/tests/Unit/Plug/PlugConfigServiceTest.php
@@ -143,6 +143,27 @@ final class PlugConfigServiceTest extends TestCase
         $service->setChain('document', [], ['tika']);
     }
 
+    public function testSetChainsValidatesEveryFamilyBeforePersisting(): void
+    {
+        $repo = $this->createMock(ConfigRepository::class);
+        $repo->expects($this->never())->method('setValue');
+
+        $service = new PlugConfigService($repo);
+
+        try {
+            $service->setChains(
+                [
+                    'document' => ['tika'],
+                    'text' => [],
+                ],
+                ['tika', 'native'],
+            );
+            self::fail('Expected InvalidArgumentException');
+        } catch (\InvalidArgumentException $e) {
+            self::assertStringContainsString('must not be empty', $e->getMessage());
+        }
+    }
+
     public function testStoredEmptyChainFallsBackToDefault(): void
     {
         $service = new PlugConfigService($this->repo([

--- a/backend/tests/Unit/Plug/PlugConfigServiceTest.php
+++ b/backend/tests/Unit/Plug/PlugConfigServiceTest.php
@@ -134,6 +134,27 @@ final class PlugConfigServiceTest extends TestCase
         $service->setChain('document', ['nope'], ['tika']);
     }
 
+    public function testSetChainRejectsEmptyList(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('must not be empty');
+
+        $service = new PlugConfigService($this->repo([]));
+        $service->setChain('document', [], ['tika']);
+    }
+
+    public function testStoredEmptyChainFallsBackToDefault(): void
+    {
+        $service = new PlugConfigService($this->repo([
+            [0, PlugConfigService::KEY_CHAIN_DOCUMENT, ''],
+        ]));
+
+        $this->assertSame(
+            ['structured_office', 'office_convert', 'tika', 'pdf_vision'],
+            $service->extractionChain('document'),
+        );
+    }
+
     /**
      * @param list<array{0: int, 1: string, 2: string}> $rows
      */

--- a/backend/tests/Unit/Service/File/FileProcessorConfiguredChainTest.php
+++ b/backend/tests/Unit/Service/File/FileProcessorConfiguredChainTest.php
@@ -1,0 +1,312 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\File;
+
+use App\AI\Service\AiFacade;
+use App\Plug\Extraction\ContentExtractorInterface;
+use App\Plug\Extraction\Docling\DoclingRejectedException;
+use App\Plug\Extraction\Docling\DoclingUnavailableException;
+use App\Plug\Extraction\ExtractionQualityGate;
+use App\Plug\Extraction\ExtractionRegistry;
+use App\Plug\Extraction\ExtractionRequest;
+use App\Plug\Extraction\ExtractionResult;
+use App\Plug\PlugConfigService;
+use App\Plug\PlugDescriptor;
+use App\Plug\PlugHealth;
+use App\Service\File\FileProcessor;
+use App\Service\File\HeicConverter;
+use App\Service\File\PdfRasterizer;
+use App\Service\File\TextCleaner;
+use App\Service\File\TikaClient;
+use App\Service\File\VideoAnalysisService;
+use App\Service\WhisperService;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+/**
+ * Issue #1792 / #1793 — the saved chain is the execution order, and attempts
+ * are recorded for every built-in step.
+ */
+final class FileProcessorConfiguredChainTest extends TestCase
+{
+    public function testDocumentChainHonoursSingleAdapterAndSkipsTika(): void
+    {
+        $dir = sys_get_temp_dir();
+        $relative = 'chain-pdf-'.uniqid('', true).'.pdf';
+        copy(dirname(__DIR__, 3).'/Fixtures/extraction/files/tiny.pdf', $dir.'/'.$relative);
+
+        $tika = $this->createMock(TikaClient::class);
+        $tika->expects($this->never())->method('extractText');
+        $tika->method('isEnabled')->willReturn(true);
+
+        $png = $dir.'/page-1.png';
+        file_put_contents($png, 'png');
+        $rasterizer = $this->createMock(PdfRasterizer::class);
+        $rasterizer->method('pdfToPng')->willReturn([$png]);
+        $rasterizer->method('getLastEngine')->willReturn('pdftoppm');
+
+        $ai = $this->createMock(AiFacade::class);
+        $ai->expects($this->once())->method('analyzeImage')->willReturn([
+            'content' => 'Vision read this scanned page',
+            'provider' => 'groq',
+        ]);
+
+        $processor = $this->processor(
+            $dir,
+            ['pdf_vision'],
+            tika: $tika,
+            rasterizer: $rasterizer,
+            ai: $ai,
+        );
+
+        [$text, $meta] = $processor->extractText($relative, 'pdf', 7);
+
+        self::assertSame('Vision read this scanned page', $text);
+        self::assertSame('rasterize_vision', $meta['strategy'] ?? null);
+        self::assertSame('pdf_vision', $meta['attempts'][0]['key'] ?? null);
+        @unlink($dir.'/'.$relative);
+        @unlink($png);
+    }
+
+    public function testTikaLowQualityIsRecordedThenVisionWins(): void
+    {
+        $dir = sys_get_temp_dir();
+        $relative = 'chain-lowq-'.uniqid('', true).'.pdf';
+        copy(dirname(__DIR__, 3).'/Fixtures/extraction/files/tiny.pdf', $dir.'/'.$relative);
+
+        $tika = $this->createMock(TikaClient::class);
+        $tika->method('isEnabled')->willReturn(true);
+        $tika->method('extractText')->willReturn(['aaaaaaa', []]);
+
+        $png = $dir.'/page-lowq.png';
+        file_put_contents($png, 'png');
+        $rasterizer = $this->createMock(PdfRasterizer::class);
+        $rasterizer->method('pdfToPng')->willReturn([$png]);
+        $rasterizer->method('getLastEngine')->willReturn('pdftoppm');
+
+        $ai = $this->createMock(AiFacade::class);
+        $ai->method('analyzeImage')->willReturn([
+            'content' => 'Readable vision text from the scan',
+            'provider' => 'groq',
+        ]);
+
+        $plugConfig = $this->createMock(PlugConfigService::class);
+        $plugConfig->method('extractionChain')->willReturn(['tika', 'pdf_vision']);
+        $plugConfig->method('qualityApplyTo')->willReturn(['pdf']);
+        $plugConfig->method('qualityMinLength')->willReturn(10);
+        $plugConfig->method('qualityMinEntropy')->willReturn(3.0);
+
+        $processor = $this->processor(
+            $dir,
+            ['tika', 'pdf_vision'],
+            tika: $tika,
+            rasterizer: $rasterizer,
+            ai: $ai,
+            plugConfig: $plugConfig,
+            qualityGate: new ExtractionQualityGate($plugConfig, new TextCleaner()),
+        );
+
+        [$text, $meta] = $processor->extractText($relative, 'pdf', 1);
+
+        self::assertSame('Readable vision text from the scan', $text);
+        self::assertSame('rasterize_vision', $meta['strategy'] ?? null);
+        $keys = array_column($meta['attempts'] ?? [], 'key');
+        self::assertSame(['tika', 'pdf_vision'], $keys);
+        self::assertSame('low_quality', $meta['attempts'][0]['verdict'] ?? null);
+        self::assertSame('quality_ok', $meta['attempts'][1]['verdict'] ?? null);
+        @unlink($dir.'/'.$relative);
+        @unlink($png);
+    }
+
+    public function testAudioChainPrefersLocalWhisperWhenListedFirst(): void
+    {
+        $dir = sys_get_temp_dir();
+        $relative = 'chain-audio-'.uniqid('', true).'.mp3';
+        file_put_contents($dir.'/'.$relative, 'fake-mp3');
+
+        $ai = $this->createMock(AiFacade::class);
+        $ai->method('hasConfiguredSttProvider')->willReturn(true);
+        $ai->expects($this->never())->method('transcribe');
+
+        $whisper = $this->createMock(WhisperService::class);
+        $whisper->method('isAvailable')->willReturn(true);
+        $whisper->expects($this->once())->method('transcribe')->willReturn([
+            'text' => 'hello from local whisper',
+            'language' => 'en',
+            'duration' => 1.0,
+            'model' => 'base',
+        ]);
+
+        $processor = $this->processor(
+            $dir,
+            ['whisper_local', 'stt_cloud'],
+            ai: $ai,
+            whisper: $whisper,
+        );
+
+        [$text, $meta] = $processor->extractText($relative, 'mp3', 4);
+
+        self::assertSame('hello from local whisper', $text);
+        self::assertSame('whisper_local', $meta['strategy'] ?? null);
+        @unlink($dir.'/'.$relative);
+    }
+
+    public function testDoclingRejectedIsRecordedThenTikaWins(): void
+    {
+        $dir = sys_get_temp_dir();
+        $relative = 'chain-rej-'.uniqid('', true).'.pdf';
+        copy(dirname(__DIR__, 3).'/Fixtures/extraction/files/tiny.pdf', $dir.'/'.$relative);
+
+        $extra = $this->throwingDocling(new DoclingRejectedException('Docling convert returned HTTP 422'));
+        $tika = $this->createMock(TikaClient::class);
+        $tika->method('isEnabled')->willReturn(true);
+        $tika->method('extractText')->willReturn([
+            'The quarterly revenue for EMEA was 4.2 million EUR in Q3 2025 according to finance.',
+            [],
+        ]);
+
+        $processor = $this->processor(
+            $dir,
+            ['docling', 'tika'],
+            tika: $tika,
+            extra: $extra,
+        );
+
+        [$text, $meta] = $processor->extractText($relative, 'pdf', 1);
+
+        self::assertStringContainsString('EMEA', $text);
+        self::assertSame('tika', $meta['strategy'] ?? null);
+        self::assertSame('rejected', $meta['attempts'][0]['verdict'] ?? null);
+        self::assertSame('docling', $meta['attempts'][0]['key'] ?? null);
+        @unlink($dir.'/'.$relative);
+    }
+
+    public function testDoclingUnavailableIsRecordedThenTikaWins(): void
+    {
+        $dir = sys_get_temp_dir();
+        $relative = 'chain-unav-'.uniqid('', true).'.pdf';
+        copy(dirname(__DIR__, 3).'/Fixtures/extraction/files/tiny.pdf', $dir.'/'.$relative);
+
+        $extra = $this->throwingDocling(new DoclingUnavailableException('Docling unavailable — connection refused'));
+        $tika = $this->createMock(TikaClient::class);
+        $tika->method('isEnabled')->willReturn(true);
+        $tika->method('extractText')->willReturn([
+            'The quarterly revenue for EMEA was 4.2 million EUR in Q3 2025 according to finance.',
+            [],
+        ]);
+
+        $processor = $this->processor(
+            $dir,
+            ['docling', 'tika'],
+            tika: $tika,
+            extra: $extra,
+        );
+
+        [, $meta] = $processor->extractText($relative, 'pdf', 1);
+
+        self::assertSame('unavailable', $meta['attempts'][0]['verdict'] ?? null);
+        self::assertSame('tika', $meta['strategy'] ?? null);
+        @unlink($dir.'/'.$relative);
+    }
+
+    public function testDoclingOnlyDoesNotFallThroughToBuiltins(): void
+    {
+        $dir = sys_get_temp_dir();
+        $relative = 'chain-only-'.uniqid('', true).'.md';
+        file_put_contents($dir.'/'.$relative, "Native would have won\n");
+
+        $extra = $this->throwingDocling(new \RuntimeException('sidecar down'));
+        $processor = $this->processor($dir, ['docling'], extra: $extra);
+
+        [$text, $meta] = $processor->extractText($relative, 'md');
+
+        self::assertSame('', $text);
+        self::assertSame('chain_exhausted', $meta['strategy'] ?? null);
+        @unlink($dir.'/'.$relative);
+    }
+
+    /**
+     * @param list<string> $chain
+     */
+    private function processor(
+        string $uploadDir,
+        array $chain,
+        ?TikaClient $tika = null,
+        ?PdfRasterizer $rasterizer = null,
+        ?AiFacade $ai = null,
+        ?WhisperService $whisper = null,
+        ?ContentExtractorInterface $extra = null,
+        ?PlugConfigService $plugConfig = null,
+        ?ExtractionQualityGate $qualityGate = null,
+    ): FileProcessor {
+        $plugConfig ??= $this->plugConfig($chain);
+        $extractors = null !== $extra ? [$extra] : [];
+
+        return new FileProcessor(
+            $tika ?? $this->createStub(TikaClient::class),
+            $rasterizer ?? $this->createStub(PdfRasterizer::class),
+            new TextCleaner(),
+            $ai ?? $this->createStub(AiFacade::class),
+            $whisper ?? $this->createStub(WhisperService::class),
+            $this->createStub(VideoAnalysisService::class),
+            new HeicConverter(new NullLogger()),
+            new NullLogger(),
+            $uploadDir,
+            10,
+            3.0,
+            '/nonexistent/ffmpeg',
+            null,
+            null,
+            new ExtractionRegistry($extractors, $plugConfig, new NullLogger()),
+            $plugConfig,
+            $qualityGate,
+        );
+    }
+
+    /**
+     * @param list<string> $chain
+     */
+    private function plugConfig(array $chain): PlugConfigService
+    {
+        $plugConfig = $this->createMock(PlugConfigService::class);
+        $plugConfig->method('extractionChain')->willReturn($chain);
+
+        return $plugConfig;
+    }
+
+    private function throwingDocling(\Throwable $error): ContentExtractorInterface
+    {
+        return new class($error) implements ContentExtractorInterface {
+            public function __construct(private \Throwable $error)
+            {
+            }
+
+            public function key(): string
+            {
+                return 'docling';
+            }
+
+            public function descriptor(): PlugDescriptor
+            {
+                return new PlugDescriptor('docling', 'Docling', '', [], 'self-hosted');
+            }
+
+            public function supports(ExtractionRequest $request): bool
+            {
+                return '' !== $request->absolutePath;
+            }
+
+            public function extract(ExtractionRequest $request): ExtractionResult
+            {
+                throw $this->error;
+            }
+
+            public function health(): PlugHealth
+            {
+                return PlugHealth::available();
+            }
+        };
+    }
+}

--- a/backend/tests/Unit/Service/File/FileProcessorConfiguredChainTest.php
+++ b/backend/tests/Unit/Service/File/FileProcessorConfiguredChainTest.php
@@ -17,6 +17,7 @@ use App\Plug\PlugDescriptor;
 use App\Plug\PlugHealth;
 use App\Service\File\FileProcessor;
 use App\Service\File\HeicConverter;
+use App\Service\File\Office\OfficeConverterClient;
 use App\Service\File\PdfRasterizer;
 use App\Service\File\TextCleaner;
 use App\Service\File\TikaClient;
@@ -116,6 +117,75 @@ final class FileProcessorConfiguredChainTest extends TestCase
         self::assertSame(['tika', 'pdf_vision'], $keys);
         self::assertSame('low_quality', $meta['attempts'][0]['verdict'] ?? null);
         self::assertSame('quality_ok', $meta['attempts'][1]['verdict'] ?? null);
+        @unlink($dir.'/'.$relative);
+        @unlink($png);
+    }
+
+    public function testTikaOfficePdfIsGatedAsPdfThenVisionWins(): void
+    {
+        $dir = sys_get_temp_dir();
+        $relative = 'chain-docx-'.uniqid('', true).'.docx';
+        file_put_contents($dir.'/'.$relative, "PK\x03\x04");
+
+        $tinyPdf = dirname(__DIR__, 3).'/Fixtures/extraction/files/tiny.pdf';
+        $tika = $this->createMock(TikaClient::class);
+        $tika->method('isEnabled')->willReturn(true);
+        $tika->method('extractText')->willReturnCallback(
+            static function (string $path, string $mime): array {
+                if (str_contains($mime, 'pdf') || str_ends_with($path, '.pdf')) {
+                    return ['aaaaaaa', []];
+                }
+
+                return ['', []];
+            },
+        );
+
+        $office = $this->createMock(OfficeConverterClient::class);
+        $office->method('isEnabled')->willReturn(true);
+        $office->method('convert')->willReturnCallback(
+            static function () use ($dir, $tinyPdf): string {
+                $pdf = $dir.'/converted-'.uniqid('', true).'.pdf';
+                copy($tinyPdf, $pdf);
+
+                return $pdf;
+            },
+        );
+
+        $png = $dir.'/page-docx.png';
+        file_put_contents($png, 'png');
+        $rasterizer = $this->createMock(PdfRasterizer::class);
+        $rasterizer->method('pdfToPng')->willReturn([$png]);
+        $rasterizer->method('getLastEngine')->willReturn('pdftoppm');
+
+        $ai = $this->createMock(AiFacade::class);
+        $ai->method('analyzeImage')->willReturn([
+            'content' => 'Vision read the converted Office page',
+            'provider' => 'groq',
+        ]);
+
+        $plugConfig = $this->createMock(PlugConfigService::class);
+        $plugConfig->method('extractionChain')->willReturn(['tika', 'pdf_vision']);
+        $plugConfig->method('qualityApplyTo')->willReturn(['pdf']);
+        $plugConfig->method('qualityMinLength')->willReturn(10);
+        $plugConfig->method('qualityMinEntropy')->willReturn(3.0);
+
+        $processor = $this->processor(
+            $dir,
+            ['tika', 'pdf_vision'],
+            tika: $tika,
+            rasterizer: $rasterizer,
+            ai: $ai,
+            plugConfig: $plugConfig,
+            qualityGate: new ExtractionQualityGate($plugConfig, new TextCleaner()),
+            officeConverter: $office,
+        );
+
+        [$text, $meta] = $processor->extractText($relative, 'docx', 1);
+
+        self::assertSame('Vision read the converted Office page', $text);
+        self::assertSame('rasterize_vision', $meta['strategy'] ?? null);
+        self::assertSame('low_quality', $meta['attempts'][0]['verdict'] ?? null);
+        self::assertSame('tika', $meta['attempts'][0]['key'] ?? null);
         @unlink($dir.'/'.$relative);
         @unlink($png);
     }
@@ -240,6 +310,7 @@ final class FileProcessorConfiguredChainTest extends TestCase
         ?ContentExtractorInterface $extra = null,
         ?PlugConfigService $plugConfig = null,
         ?ExtractionQualityGate $qualityGate = null,
+        ?OfficeConverterClient $officeConverter = null,
     ): FileProcessor {
         $plugConfig ??= $this->plugConfig($chain);
         $extractors = null !== $extra ? [$extra] : [];
@@ -257,7 +328,7 @@ final class FileProcessorConfiguredChainTest extends TestCase
             10,
             3.0,
             '/nonexistent/ffmpeg',
-            null,
+            $officeConverter,
             null,
             new ExtractionRegistry($extractors, $plugConfig, new NullLogger()),
             $plugConfig,

--- a/backend/tests/Unit/Service/File/FileProcessorExtraExtractorHookTest.php
+++ b/backend/tests/Unit/Service/File/FileProcessorExtraExtractorHookTest.php
@@ -24,7 +24,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 
 /**
- * S2 unlock: keys outside BUILTIN_EXTRACTOR_KEYS run before FileProcessor strategies.
+ * Extra (non-built-in) keys run in the configured chain order.
  */
 final class FileProcessorExtraExtractorHookTest extends TestCase
 {
@@ -64,7 +64,7 @@ final class FileProcessorExtraExtractorHookTest extends TestCase
         };
 
         $plugConfig = $this->createMock(PlugConfigService::class);
-        $plugConfig->method('extraExtractorKeys')->willReturn(['docling']);
+        $plugConfig->method('extractionChain')->willReturn(['docling']);
 
         $processor = $this->processor(
             new ExtractionRegistry([$extra], $plugConfig, new NullLogger()),
@@ -113,7 +113,7 @@ final class FileProcessorExtraExtractorHookTest extends TestCase
         };
 
         $plugConfig = $this->createMock(PlugConfigService::class);
-        $plugConfig->method('extraExtractorKeys')->willReturn(['docling']);
+        $plugConfig->method('extractionChain')->willReturn(['docling', 'native']);
 
         $processor = $this->processor(
             new ExtractionRegistry([$extra], $plugConfig, new NullLogger()),
@@ -162,7 +162,7 @@ final class FileProcessorExtraExtractorHookTest extends TestCase
         };
 
         $plugConfig = $this->createMock(PlugConfigService::class);
-        $plugConfig->method('extraExtractorKeys')->willReturn(['docling']);
+        $plugConfig->method('extractionChain')->willReturn(['docling', 'tika']);
         $plugConfig->method('qualityApplyTo')->willReturn(['pdf']);
         $plugConfig->method('qualityMinLength')->willReturn(10);
         $plugConfig->method('qualityMinEntropy')->willReturn(3.0);
@@ -235,7 +235,7 @@ final class FileProcessorExtraExtractorHookTest extends TestCase
         };
 
         $plugConfig = $this->createMock(PlugConfigService::class);
-        $plugConfig->method('extraExtractorKeys')->willReturn(['docling']);
+        $plugConfig->method('extractionChain')->willReturn(['docling', 'tika']);
 
         $tika = $this->createMock(TikaClient::class);
         $tika->method('isEnabled')->willReturn(true);

--- a/frontend/src/components/admin/plugs/ExtractionPlugTab.vue
+++ b/frontend/src/components/admin/plugs/ExtractionPlugTab.vue
@@ -235,6 +235,10 @@ async function load() {
 }
 
 async function save() {
+  if (families.some((family) => (chains.value[family] ?? []).length === 0)) {
+    showError(t('aiInfra.extraction.emptyChain'))
+    return
+  }
   saving.value = true
   try {
     const status = await saveExtractionChains(chains.value)

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -3046,6 +3046,7 @@
       "save": "Kette speichern",
       "saved": "Extraktionskette gespeichert. Der nächste Upload nutzt sie.",
       "saveFailed": "Die Extraktionskette konnte nicht gespeichert werden",
+      "emptyChain": "Jeder Dateityp braucht mindestens einen Adapter.",
       "loadFailed": "Extraktionseinstellungen konnten nicht geladen werden",
       "verdict": {
         "quality_ok": "akzeptiert",
@@ -3057,7 +3058,8 @@
         "rejected": "erreichbar, Datei abgelehnt",
         "unsupported": "unterstützt diese Datei nicht",
         "unknown": "unbekannter Adapter",
-        "skipped": "übersprungen"
+        "skipped": "übersprungen",
+        "rewritten": "für den nächsten Adapter umgewandelt"
       }
     },
     "webSearch": {

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -2954,6 +2954,7 @@
       "save": "Save chain",
       "saved": "Extraction chain saved. The next upload uses it.",
       "saveFailed": "The extraction chain could not be saved",
+      "emptyChain": "Each file type needs at least one adapter.",
       "loadFailed": "Could not load extraction settings",
       "verdict": {
         "quality_ok": "accepted",
@@ -2965,7 +2966,8 @@
         "rejected": "reached but refused the file",
         "unsupported": "does not support this file",
         "unknown": "unknown adapter",
-        "skipped": "skipped"
+        "skipped": "skipped",
+        "rewritten": "converted for the next adapter"
       }
     },
     "webSearch": {

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -1252,6 +1252,7 @@
       "save": "Guardar cadena",
       "saved": "Cadena de extracción guardada. La próxima carga la usará.",
       "saveFailed": "No se pudo guardar la cadena de extracción",
+      "emptyChain": "Cada tipo de archivo necesita al menos un adaptador.",
       "loadFailed": "No se pudieron cargar los ajustes de extracción",
       "verdict": {
         "quality_ok": "aceptado",
@@ -1263,7 +1264,8 @@
         "rejected": "alcanzó el servicio pero rechazó el archivo",
         "unsupported": "no admite este archivo",
         "unknown": "adaptador desconocido",
-        "skipped": "omitido"
+        "skipped": "omitido",
+        "rewritten": "convertido para el siguiente adaptador"
       }
     },
     "webSearch": {

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -2954,6 +2954,7 @@
       "save": "Enregistrer la chaîne",
       "saved": "Chaîne d’extraction enregistrée. Le prochain envoi l’utilise.",
       "saveFailed": "Impossible d’enregistrer la chaîne d’extraction",
+      "emptyChain": "Chaque type de fichier doit avoir au moins un adaptateur.",
       "loadFailed": "Impossible de charger les réglages d’extraction",
       "verdict": {
         "quality_ok": "accepté",
@@ -2965,7 +2966,8 @@
         "rejected": "joignable, fichier refusé",
         "unsupported": "ne prend pas en charge ce fichier",
         "unknown": "adaptateur inconnu",
-        "skipped": "ignoré"
+        "skipped": "ignoré",
+        "rewritten": "converti pour l’adaptateur suivant"
       }
     },
     "webSearch": {

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -1252,6 +1252,7 @@
       "save": "Zinciri kaydet",
       "saved": "Çıkarım zinciri kaydedildi. Sonraki yükleme bunu kullanır.",
       "saveFailed": "Çıkarım zinciri kaydedilemedi",
+      "emptyChain": "Her dosya türü için en az bir bağdaştırıcı gerekir.",
       "loadFailed": "Çıkarım ayarları yüklenemedi",
       "verdict": {
         "quality_ok": "kabul edildi",
@@ -1263,7 +1264,8 @@
         "rejected": "ulaşıldı ancak dosya reddedildi",
         "unsupported": "bu dosyayı desteklemiyor",
         "unknown": "bilinmeyen bağdaştırıcı",
-        "skipped": "atlandı"
+        "skipped": "atlandı",
+        "rewritten": "sonraki bağdaştırıcı için dönüştürüldü"
       }
     },
     "webSearch": {

--- a/frontend/tests/unit/components/admin/plugs/ExtractionPlugTab.spec.ts
+++ b/frontend/tests/unit/components/admin/plugs/ExtractionPlugTab.spec.ts
@@ -6,6 +6,7 @@ import ExtractionPlugTab from '@/components/admin/plugs/ExtractionPlugTab.vue'
 const getExtractionStatus = vi.fn()
 const saveExtractionChains = vi.fn()
 const testExtraction = vi.fn()
+const notifyError = vi.fn()
 
 vi.mock('@/services/api/adminPlugsApi', () => ({
   getExtractionStatus: (...args: unknown[]) => getExtractionStatus(...args),
@@ -14,7 +15,7 @@ vi.mock('@/services/api/adminPlugsApi', () => ({
 }))
 
 vi.mock('@/composables/useNotification', () => ({
-  useNotification: () => ({ error: vi.fn(), success: vi.fn() }),
+  useNotification: () => ({ error: notifyError, success: vi.fn() }),
 }))
 
 vi.mock('@/services/api/adminConfigApi', () => ({
@@ -25,6 +26,8 @@ describe('ExtractionPlugTab', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
     testExtraction.mockReset()
+    saveExtractionChains.mockReset()
+    notifyError.mockReset()
     getExtractionStatus.mockResolvedValue({
       adapters: [
         {
@@ -114,5 +117,31 @@ describe('ExtractionPlugTab', () => {
     expect(wrapper.get('[data-testid="extraction-test-summary"]').text()).not.toContain(
       'Docling unavailable'
     )
+  })
+
+  it('does not save when a family chain is empty', async () => {
+    const wrapper = mount(ExtractionPlugTab, {
+      global: {
+        stubs: {
+          Icon: true,
+          RouterLink: { template: '<a><slot /></a>', props: ['to'] },
+        },
+      },
+    })
+    await flushPromises()
+
+    const removeDocumentAdapters = async () => {
+      const remove = wrapper.findAll('button').find((button) => button.text() === 'Remove')
+      expect(remove).toBeTruthy()
+      await remove!.trigger('click')
+    }
+    await removeDocumentAdapters()
+    await removeDocumentAdapters()
+
+    await wrapper.get('[data-testid="extraction-save-chains"]').trigger('click')
+    await flushPromises()
+
+    expect(saveExtractionChains).not.toHaveBeenCalled()
+    expect(notifyError).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary
- FileProcessor now walks the **saved** family chain (built-ins and extras) in order. An adapter that is not in the chain does not run.
- `PUT /api/v1/admin/plugs/extraction/chains` rejects an empty family (HTTP 422). The UI blocks the same case. A previously stored empty string falls back to the seeded default so extraction is not bricked.
- Chat image uploads go through FileProcessor (same as documents/audio), so `image = vision` produces a `FileProcessor` / `Chat file extracted` log.
- The Extraction **Test upload** panel passes the admin's user id into `extractText()` and lists every chain step in `attempts` (Tika losing the quality gate, then vision, etc.). Audio/vision therefore use the same STT / PIC2TEXT models as a real upload.

Fixes #1792
Fixes #1793

## Test plan
- [x] `make -C backend lint`
- [x] `make -C backend phpstan`
- [x] `make -C backend test`
- [x] `make -C frontend lint`
- [x] `docker compose exec -T frontend npm run check:types`
- [x] `make -C frontend test`
- [ ] `/admin/setup?tab=extraction`: set `document` to a single adapter, upload a text-layer PDF, confirm logs name that adapter (not always `tika`).
- [ ] Empty a family and Save — rejected; toast explains each file type needs an adapter.
- [ ] Upload a PNG in chat — `FileProcessor: Starting extraction` / `Chat file extracted` with `kind: image`.
- [ ] With cloud STT configured, set `audio = whisper_local,stt_cloud`, upload MP3 — strategy is `whisper_local`.
- [ ] Test upload of the same MP3 / PNG names the same strategy and provider as the chat upload; image-only PDF lists Tika then vision.