### PR TITLE
chore(vscode): point Intelephense at PHP 8.4

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
-    // PHP Version for Intelephense (must match Docker container PHP 8.3)
+    // PHP Version for Intelephense (must match Docker container PHP 8.4)
     // Note: Reload Cursor window after changing this setting
-    "intelephense.environment.phpVersion": "8.3.0",
+    "intelephense.environment.phpVersion": "8.4.0",
 
     // PHP CS Fixer
     "php-cs-fixer.executablePath": "${workspaceFolder}/backend/vendor/bin/php-cs-fixer",


### PR DESCRIPTION
## Summary
- The committed `.vscode/settings.json` still told Intelephense the container was PHP 8.3. The stack is PHP 8.4; this updates the workspace setting so editors and readers stop treating 8.3 as current.

## Test plan
- [ ] Open the repo in Cursor/VS Code and confirm Intelephense reports PHP 8.4.0
- [ ] Reload the window after pulling so the language server picks up the new version