### PR TITLE
fix(files): add support for .jar files as store-only archives

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
-    // PHP Version for Intelephense (must match Docker container PHP 8.3)
+    // PHP Version for Intelephense (must match Docker container PHP 8.4)
     // Note: Reload Cursor window after changing this setting
-    "intelephense.environment.phpVersion": "8.3.0",
+    "intelephense.environment.phpVersion": "8.4.0",
 
     // PHP CS Fixer
     "php-cs-fixer.executablePath": "${workspaceFolder}/backend/vendor/bin/php-cs-fixer",

--- a/backend/src/Controller/FileController.php
+++ b/backend/src/Controller/FileController.php
@@ -452,7 +452,7 @@ class FileController extends AbstractController
         $statusCode = match ($result['errorType'] ?? null) {
             'not_found' => Response::HTTP_NOT_FOUND,
             'rate_limited' => Response::HTTP_TOO_MANY_REQUESTS,
-            'empty_content' => Response::HTTP_UNPROCESSABLE_ENTITY,
+            'empty_content', 'not_extractable' => Response::HTTP_UNPROCESSABLE_ENTITY,
             default => Response::HTTP_INTERNAL_SERVER_ERROR,
         };
 
@@ -526,7 +526,7 @@ class FileController extends AbstractController
         $statusCode = match ($result['errorType'] ?? null) {
             'not_found' => Response::HTTP_NOT_FOUND,
             'rate_limited' => Response::HTTP_TOO_MANY_REQUESTS,
-            'empty_content' => Response::HTTP_UNPROCESSABLE_ENTITY,
+            'empty_content', 'not_extractable' => Response::HTTP_UNPROCESSABLE_ENTITY,
             default => Response::HTTP_INTERNAL_SERVER_ERROR,
         };
 
@@ -1687,7 +1687,7 @@ class FileController extends AbstractController
 
         $statusCode = match ($result['errorType'] ?? null) {
             'not_found' => Response::HTTP_NOT_FOUND,
-            'empty_content' => Response::HTTP_UNPROCESSABLE_ENTITY,
+            'empty_content', 'not_extractable' => Response::HTTP_UNPROCESSABLE_ENTITY,
             default => Response::HTTP_INTERNAL_SERVER_ERROR,
         };
 

--- a/backend/src/Service/Capability/CapabilityService.php
+++ b/backend/src/Service/Capability/CapabilityService.php
@@ -35,6 +35,7 @@ final readonly class CapabilityService
         'audio' => ['mp3', 'wav', 'ogg', 'm4a'],
         'video' => ['mp4', 'webm', 'mov', 'avi', 'mkv'],
         'calendar' => ['ics'],
+        'archives' => ['jar'],
     ];
 
     /**

--- a/backend/src/Service/File/FileProcessor.php
+++ b/backend/src/Service/File/FileProcessor.php
@@ -153,9 +153,18 @@ final readonly class FileProcessor
      */
     public function extractText(string $relativePath, string $fileExtension, ?int $userId = null, bool $describe = false): array
     {
+        $ext = strtolower($fileExtension);
+        if (FileStorageService::skipsExtraction($ext)) {
+            $this->logger->info('FileProcessor: skipping extraction for store-only type', [
+                'ext' => $ext,
+                'file' => basename($relativePath),
+            ]);
+
+            return ['', ['strategy' => 'skipped_store_only', 'ext' => $ext]];
+        }
+
         $absolutePath = $this->resolveAbsolutePath($relativePath);
         $mime = mime_content_type($absolutePath) ?: '';
-        $ext = strtolower($fileExtension);
         $mime = $this->ensureOfficeMime($mime, $ext);
 
         $meta = [

--- a/backend/src/Service/File/FileStorageService.php
+++ b/backend/src/Service/File/FileStorageService.php
@@ -26,6 +26,18 @@ final readonly class FileStorageService
         'mp3', 'mp4', 'wav', 'ogg', 'm4a', 'webm',
         // Video formats analysable via audio transcription + key-frame vision (#983)
         'mov', 'avi', 'mkv',
+        // Minecraft / Java archives: store and attach, never extract (Tika would unzip).
+        'jar',
+    ];
+
+    /**
+     * Uploads that may be stored and attached to a chat, but must never be
+     * unpacked or sent through Tika / Whisper / Vision.
+     *
+     * @var list<string>
+     */
+    public const STORE_ONLY_EXTENSIONS = [
+        'jar',
     ];
 
     /**
@@ -44,6 +56,11 @@ final readonly class FileStorageService
     public static function getAllowedExtensions(): array
     {
         return self::ALLOWED_EXTENSIONS;
+    }
+
+    public static function skipsExtraction(string $extension): bool
+    {
+        return in_array(strtolower($extension), self::STORE_ONLY_EXTENSIONS, true);
     }
 
     public function __construct(

--- a/backend/src/Service/File/FileUploadService.php
+++ b/backend/src/Service/File/FileUploadService.php
@@ -284,6 +284,14 @@ final readonly class FileUploadService
             return $result;
         }
 
+        // Archives such as .jar may be stored and attached to a chat, but
+        // Tika would unzip them. Never extract or vectorize.
+        if (FileStorageService::skipsExtraction($fileExtension)) {
+            $result['extraction_skipped'] = true;
+
+            return $result;
+        }
+
         $result = $this->extractText($file, $storageResult['path'], $fileExtension, $user, $processLevel, $result);
         if (!$result['success'] || 'extract' === $processLevel) {
             return $result;
@@ -539,7 +547,7 @@ final readonly class FileUploadService
     /**
      * Run extraction + vectorization for a stored file (used for async processing after fast upload).
      *
-     * @return array{success: bool, status: string, error?: string, extracted_text_length?: int, chunks_created?: int}
+     * @return array{success: bool, status: string, error?: string, extracted_text_length?: int, chunks_created?: int, extraction_skipped?: bool, message?: string}
      */
     public function processFile(File $file, User $user): array
     {
@@ -561,6 +569,14 @@ final readonly class FileUploadService
         }
 
         $fileExtension = strtolower($file->getFileType() ?: (string) pathinfo($file->getFilePath(), PATHINFO_EXTENSION));
+        if (FileStorageService::skipsExtraction($fileExtension)) {
+            return [
+                'success' => true,
+                'status' => $file->getStatus(),
+                'extraction_skipped' => true,
+            ];
+        }
+
         $asyncMarkdown = null;
 
         if ('uploaded' === $file->getStatus()) {
@@ -687,6 +703,14 @@ final readonly class FileUploadService
             $file->getFileName() ?: '',
             $file->getFilePath() ?: '',
         );
+        if (FileStorageService::skipsExtraction($fileExtension)) {
+            return [
+                'success' => false,
+                'error' => 'This file type is stored as-is and cannot be extracted.',
+                'errorType' => 'not_extractable',
+            ];
+        }
+
         $markdown = null;
 
         if ('' === trim($extractedText)) {
@@ -775,6 +799,14 @@ final readonly class FileUploadService
             $file->getFileName() ?: '',
             $file->getFilePath() ?: '',
         );
+        if (FileStorageService::skipsExtraction($fileExtension)) {
+            return [
+                'success' => false,
+                'error' => 'This file type is stored as-is and cannot be extracted.',
+                'errorType' => 'not_extractable',
+            ];
+        }
+
         $category = FileTypeResolver::resolveCategory(
             $file->getFileType() ?: '',
             $file->getFileName() ?: '',

--- a/backend/src/Service/File/FileUploadService.php
+++ b/backend/src/Service/File/FileUploadService.php
@@ -285,11 +285,10 @@ final readonly class FileUploadService
         }
 
         // Archives such as .jar may be stored and attached to a chat, but
-        // Tika would unzip them. Never extract or vectorize.
+        // Tika would unzip them. Never extract or vectorize. Mark extracted
+        // so the file picker's post-upload poll treats the upload as finished.
         if (FileStorageService::skipsExtraction($fileExtension)) {
-            $result['extraction_skipped'] = true;
-
-            return $result;
+            return array_merge($result, $this->completeStoreOnly($file));
         }
 
         $result = $this->extractText($file, $storageResult['path'], $fileExtension, $user, $processLevel, $result);
@@ -334,6 +333,27 @@ final readonly class FileUploadService
         ]);
 
         return $result;
+    }
+
+    /**
+     * Store-only types never get text or vectors. Persist a terminal status so
+     * FileSelectionModal's poll (vectorized / processed / extracted / error)
+     * can stop instead of spinning on `uploaded`.
+     *
+     * @return array{success: true, status: 'extracted', extraction_skipped: true}
+     */
+    private function completeStoreOnly(File $file): array
+    {
+        if ('extracted' !== $file->getStatus()) {
+            $file->setStatus('extracted');
+            $this->em->flush();
+        }
+
+        return [
+            'success' => true,
+            'status' => 'extracted',
+            'extraction_skipped' => true,
+        ];
     }
 
     private function createFileEntity(
@@ -559,21 +579,17 @@ final readonly class FileUploadService
             return ['success' => false, 'status' => 'error', 'error' => 'File is in error state'];
         }
 
+        $fileExtension = strtolower($file->getFileType() ?: (string) pathinfo($file->getFilePath(), PATHINFO_EXTENSION));
+        if (FileStorageService::skipsExtraction($fileExtension)) {
+            return $this->completeStoreOnly($file);
+        }
+
         $rateLimitCheck = $this->rateLimitService->checkLimit($user, 'FILE_ANALYSIS');
         if (!$rateLimitCheck['allowed']) {
             return [
                 'success' => false,
                 'status' => $file->getStatus(),
                 'error' => "Rate limit exceeded for FILE_ANALYSIS. Used: {$rateLimitCheck['used']}/{$rateLimitCheck['limit']}",
-            ];
-        }
-
-        $fileExtension = strtolower($file->getFileType() ?: (string) pathinfo($file->getFilePath(), PATHINFO_EXTENSION));
-        if (FileStorageService::skipsExtraction($fileExtension)) {
-            return [
-                'success' => true,
-                'status' => $file->getStatus(),
-                'extraction_skipped' => true,
             ];
         }
 

--- a/backend/tests/Service/File/FileStorageServiceTest.php
+++ b/backend/tests/Service/File/FileStorageServiceTest.php
@@ -86,6 +86,29 @@ class FileStorageServiceTest extends TestCase
         $this->assertStringContainsString('not allowed', $result['error']);
     }
 
+    public function testJarUploadsAreAllowedAndNeverExtracted(): void
+    {
+        $this->assertContains('jar', FileStorageService::getAllowedExtensions());
+        $this->assertTrue(FileStorageService::skipsExtraction('jar'));
+        $this->assertTrue(FileStorageService::skipsExtraction('JAR'));
+        $this->assertFalse(FileStorageService::skipsExtraction('pdf'));
+
+        $testFile = $this->createTestFile('mod.jar', "PK\x03\x04store-only");
+        $uploadedFile = new UploadedFile(
+            $testFile,
+            'mod.jar',
+            'application/java-archive',
+            null,
+            true
+        );
+
+        $result = $this->service->storeUploadedFile($uploadedFile, 123);
+
+        $this->assertTrue($result['success']);
+        $this->assertNull($result['error']);
+        $this->assertTrue($this->service->fileExists($result['path']));
+    }
+
     public function testStoreUploadedFileWithLargeSize(): void
     {
         // Create a file that reports as larger than allowed

--- a/backend/tests/Service/File/FileUploadServiceCheckUploadTest.php
+++ b/backend/tests/Service/File/FileUploadServiceCheckUploadTest.php
@@ -77,6 +77,7 @@ class FileUploadServiceCheckUploadTest extends TestCase
         $this->assertArrayNotHasKey('reason', $result);
         $this->assertSame(FileStorageService::getMaxFileSize(), $result['max_file_size']);
         $this->assertContains('pdf', $result['allowed_extensions']);
+        $this->assertContains('jar', $result['allowed_extensions']);
     }
 
     public function testBlocksUploadWhenStorageExceeded(): void

--- a/backend/tests/Service/File/FileUploadServiceStoreOnlyTest.php
+++ b/backend/tests/Service/File/FileUploadServiceStoreOnlyTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Service\File;
+
+use App\Entity\File;
+use App\Entity\User;
+use App\Repository\FileRepository;
+use App\Service\File\FileGroupSorter;
+use App\Service\File\FileProcessor;
+use App\Service\File\FileStorageService;
+use App\Service\File\FileUploadService;
+use App\Service\File\VectorizationService;
+use App\Service\RAG\VectorStorage\VectorStorageFacade;
+use App\Service\RateLimitService;
+use App\Service\StorageQuotaService;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+/**
+ * Store-only uploads (.jar) must reach a terminal file status so the
+ * file picker's post-upload poll can stop. They must not hit Tika or
+ * consume a FILE_ANALYSIS slot.
+ */
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
+final class FileUploadServiceStoreOnlyTest extends TestCase
+{
+    private FileProcessor&MockObject $fileProcessor;
+    private EntityManagerInterface&MockObject $em;
+    private RateLimitService&MockObject $rateLimitService;
+
+    protected function setUp(): void
+    {
+        $this->fileProcessor = $this->createMock(FileProcessor::class);
+        $this->em = $this->createMock(EntityManagerInterface::class);
+        $this->rateLimitService = $this->createMock(RateLimitService::class);
+    }
+
+    private function makeService(): FileUploadService
+    {
+        return new FileUploadService(
+            $this->createStub(FileStorageService::class),
+            $this->fileProcessor,
+            $this->createStub(VectorizationService::class),
+            $this->createStub(VectorStorageFacade::class),
+            $this->createStub(StorageQuotaService::class),
+            $this->rateLimitService,
+            $this->createStub(FileGroupSorter::class),
+            $this->createStub(FileRepository::class),
+            $this->em,
+            new NullLogger(),
+            '/tmp/uploads',
+        );
+    }
+
+    private function makeJarFile(): File&MockObject
+    {
+        $file = $this->createMock(File::class);
+        $file->method('getStatus')->willReturn('uploaded');
+        $file->method('getFileType')->willReturn('jar');
+        $file->method('getFilePath')->willReturn('user/1/mod.jar');
+        $file->method('getFileName')->willReturn('mod.jar');
+        $file->method('getId')->willReturn(42);
+
+        return $file;
+    }
+
+    private function makeUser(): User&MockObject
+    {
+        $user = $this->createMock(User::class);
+        $user->method('getId')->willReturn(1);
+
+        return $user;
+    }
+
+    public function testProcessFileMarksJarExtractedWithoutTikaOrRateLimit(): void
+    {
+        $file = $this->makeJarFile();
+        $file->expects(self::once())->method('setStatus')->with('extracted');
+        $this->em->expects(self::once())->method('flush');
+        $this->fileProcessor->expects(self::never())->method('extractText');
+        $this->rateLimitService->expects(self::never())->method('checkLimit');
+
+        $result = $this->makeService()->processFile($file, $this->makeUser());
+
+        $this->assertTrue($result['success']);
+        $this->assertSame('extracted', $result['status']);
+        $this->assertTrue($result['extraction_skipped']);
+    }
+
+    public function testProcessFileLeavesAlreadyExtractedJarUnchanged(): void
+    {
+        $file = $this->createMock(File::class);
+        $file->method('getStatus')->willReturn('extracted');
+        $file->method('getFileType')->willReturn('jar');
+        $file->method('getFilePath')->willReturn('user/1/mod.jar');
+        $file->expects(self::never())->method('setStatus');
+        $this->em->expects(self::never())->method('flush');
+        $this->fileProcessor->expects(self::never())->method('extractText');
+
+        $result = $this->makeService()->processFile($file, $this->makeUser());
+
+        $this->assertTrue($result['success']);
+        $this->assertSame('extracted', $result['status']);
+        $this->assertTrue($result['extraction_skipped']);
+    }
+}

--- a/backend/tests/Unit/Service/Capability/CapabilityServiceTest.php
+++ b/backend/tests/Unit/Service/Capability/CapabilityServiceTest.php
@@ -67,5 +67,6 @@ class CapabilityServiceTest extends TestCase
         $this->assertContains('pptx', $formats['presentations']);
         $this->assertContains('png', $formats['images']);
         $this->assertContains('mp4', $formats['video']);
+        $this->assertContains('jar', $formats['archives']);
     }
 }

--- a/backend/tests/Unit/Service/File/FileProcessorStoreOnlyTest.php
+++ b/backend/tests/Unit/Service/File/FileProcessorStoreOnlyTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\File;
+
+use App\AI\Service\AiFacade;
+use App\Service\File\FileProcessor;
+use App\Service\File\HeicConverter;
+use App\Service\File\PdfRasterizer;
+use App\Service\File\TextCleaner;
+use App\Service\File\TikaClient;
+use App\Service\File\VideoAnalysisService;
+use App\Service\WhisperService;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+/**
+ * Store-only uploads (.jar) may be kept and attached, but Tika must never
+ * unpack them — a JAR is a ZIP and Tika would extract class files and assets.
+ */
+final class FileProcessorStoreOnlyTest extends TestCase
+{
+    private TikaClient&MockObject $tikaClient;
+    private FileProcessor $processor;
+
+    protected function setUp(): void
+    {
+        $this->tikaClient = $this->createMock(TikaClient::class);
+
+        $this->processor = new FileProcessor(
+            $this->tikaClient,
+            $this->createStub(PdfRasterizer::class),
+            new TextCleaner(),
+            $this->createStub(AiFacade::class),
+            $this->createStub(WhisperService::class),
+            $this->createStub(VideoAnalysisService::class),
+            new HeicConverter(new NullLogger()),
+            new NullLogger(),
+            sys_get_temp_dir(),
+            100,
+            0.5,
+            '/nonexistent/ffmpeg',
+        );
+    }
+
+    public function testJarExtractionIsSkippedAndNeverSentToTika(): void
+    {
+        $this->tikaClient->expects(self::never())->method('extractText');
+
+        [$text, $meta] = $this->processor->extractText('does-not-need-to-exist.jar', 'jar', 1);
+
+        self::assertSame('', $text);
+        self::assertSame('skipped_store_only', $meta['strategy']);
+        self::assertSame('jar', $meta['ext']);
+    }
+
+    public function testJarExtensionIsCaseInsensitive(): void
+    {
+        $this->tikaClient->expects(self::never())->method('extractText');
+
+        [, $meta] = $this->processor->extractText('Mod.JAR', 'JAR', 1);
+
+        self::assertSame('skipped_store_only', $meta['strategy']);
+    }
+}

--- a/frontend/src/components/ChatInput.vue
+++ b/frontend/src/components/ChatInput.vue
@@ -301,7 +301,7 @@
                 type="file"
                 multiple
                 class="hidden"
-                accept="image/*,.heic,.heif,video/*,audio/*,.pdf,.doc,.docx,.txt,.xlsx,.xls,.pptx,.ppt"
+                accept="image/*,.heic,.heif,video/*,audio/*,.pdf,.doc,.docx,.txt,.xlsx,.xls,.pptx,.ppt,.jar"
                 data-testid="input-chat-file"
                 @change="handleFileSelect"
               />

--- a/frontend/src/components/FileSelectionModal.vue
+++ b/frontend/src/components/FileSelectionModal.vue
@@ -58,7 +58,7 @@
                 type="file"
                 multiple
                 class="hidden"
-                accept="image/*,.heic,.heif,video/*,audio/*,.pdf,.doc,.docx,.rtf,.txt,.md,.csv,.xlsx,.xls,.pptx,.ppt,.odt,.ods,.odp,.pages,.numbers,.key,.ics"
+                accept="image/*,.heic,.heif,video/*,audio/*,.pdf,.doc,.docx,.rtf,.txt,.md,.csv,.xlsx,.xls,.pptx,.ppt,.odt,.ods,.odp,.pages,.numbers,.key,.ics,.jar"
                 data-testid="input-file-selection-upload"
                 @change="handleFileUpload"
               />
@@ -250,7 +250,10 @@
                   @click.stop
                 >
                   <button
-                    v-if="!['vectorized', 'extracting', 'vectorizing'].includes(file.status)"
+                    v-if="
+                      !['vectorized', 'extracting', 'vectorizing'].includes(file.status) &&
+                      !skipsExtraction(extensionOf(file.filename) || file.file_type)
+                    "
                     class="p-1 sm:p-1.5 rounded hover:bg-purple-500/10 text-purple-600 dark:text-purple-400 transition-colors"
                     :title="$t('fileSelection.reVectorize')"
                     data-testid="btn-file-revectorize"
@@ -365,6 +368,7 @@ import filesService, {
   UploadBlockedError,
   UploadFailedError,
 } from '@/services/filesService'
+import { extensionOf, skipsExtraction } from '@/services/filePreview'
 import { getApiBaseUrl } from '@/services/api/httpClient'
 import { useMediaSrc } from '@/services/api/mediaAuth'
 import { useNotification } from '@/composables/useNotification'

--- a/frontend/src/components/files/FileMakeSearchableButton.vue
+++ b/frontend/src/components/files/FileMakeSearchableButton.vue
@@ -1,6 +1,6 @@
 <template>
   <button
-    v-if="vectorStateOf(file) !== 'vectorized'"
+    v-if="vectorStateOf(file) !== 'vectorized' && !skipsExtraction(extensionOf(file.filename) || file.file_type)"
     type="button"
     class="p-1.5 rounded-lg hover:bg-black/5 dark:hover:bg-white/5 txt-secondary hover:text-[var(--brand)] transition-colors disabled:opacity-50"
     :title="t('files.describeSortAction')"
@@ -21,6 +21,7 @@
 import { useI18n } from 'vue-i18n'
 import { Icon } from '@iconify/vue'
 import type { FileItem } from '@/services/filesService'
+import { extensionOf, skipsExtraction } from '@/services/filePreview'
 import { vectorStateOf } from '@/utils/fileDisplayName'
 
 defineProps<{

--- a/frontend/src/components/files/FileMakeSearchableButton.vue
+++ b/frontend/src/components/files/FileMakeSearchableButton.vue
@@ -1,6 +1,6 @@
 <template>
   <button
-    v-if="vectorStateOf(file) !== 'vectorized' && !skipsExtraction(extensionOf(file.filename) || file.file_type)"
+    v-if="canMakeSearchable(file)"
     type="button"
     class="p-1.5 rounded-lg hover:bg-black/5 dark:hover:bg-white/5 txt-secondary hover:text-[var(--brand)] transition-colors disabled:opacity-50"
     :title="t('files.describeSortAction')"
@@ -34,4 +34,8 @@ const emit = defineEmits<{
 }>()
 
 const { t } = useI18n()
+
+const canMakeSearchable = (file: FileItem): boolean =>
+  vectorStateOf(file) !== 'vectorized' &&
+  !skipsExtraction(extensionOf(file.filename) || file.file_type)
 </script>

--- a/frontend/src/services/filePreview.ts
+++ b/frontend/src/services/filePreview.ts
@@ -35,6 +35,12 @@ const DOCUMENT_EXTENSIONS = [
 export const extensionOf = (name: string | undefined | null): string =>
   (name ?? '').split('.').pop()?.toLowerCase() ?? ''
 
+/** Uploads that may be stored and attached, but must never be extracted. */
+const STORE_ONLY_EXTENSIONS = ['jar']
+
+export const skipsExtraction = (ext: string): boolean =>
+  STORE_ONLY_EXTENSIONS.includes(ext.toLowerCase())
+
 /** Map a bare file extension to a preview kind. */
 export const kindFromExtension = (ext: string): PreviewKind => {
   if (IMAGE_EXTENSIONS.includes(ext)) return 'image'

--- a/frontend/src/views/FilesView.vue
+++ b/frontend/src/views/FilesView.vue
@@ -66,7 +66,7 @@
             ref="fileInputRef"
             type="file"
             multiple
-            accept=".pdf,.docx,.doc,.xlsx,.xls,.pptx,.ppt,.txt,.md,.csv,.odt,.ods,.odp,.odg,.odf,.rtf,.pages,.numbers,.key,.ics,.jpg,.jpeg,.png,.gif,.webp,.heic,.heif,.mp3,.mp4,.wav,.ogg,.m4a,.webm,.mov,.avi,.mkv"
+            accept=".pdf,.docx,.doc,.xlsx,.xls,.pptx,.ppt,.txt,.md,.csv,.odt,.ods,.odp,.odg,.odf,.rtf,.pages,.numbers,.key,.ics,.jpg,.jpeg,.png,.gif,.webp,.heic,.heif,.mp3,.mp4,.wav,.ogg,.m4a,.webm,.mov,.avi,.mkv,.jar"
             class="hidden"
             data-testid="input-files"
             @change="handleFileSelect"

--- a/frontend/tests/unit/components/files/FileMakeSearchableButton.spec.ts
+++ b/frontend/tests/unit/components/files/FileMakeSearchableButton.spec.ts
@@ -59,6 +59,11 @@ describe('FileMakeSearchableButton', () => {
     expect(generated.find('button').attributes('data-testid')).toBe('btn-index-prompt')
   })
 
+  it('is hidden for store-only archives that must not be extracted', () => {
+    const wrapper = mountButton({ filename: 'sodium.jar', file_type: 'jar' })
+    expect(wrapper.find('button').exists()).toBe(false)
+  })
+
   it('emits activate when clicked', async () => {
     const wrapper = mountButton()
     await wrapper.find('button').trigger('click')

--- a/frontend/tests/unit/services/filePreview.spec.ts
+++ b/frontend/tests/unit/services/filePreview.spec.ts
@@ -9,6 +9,7 @@ import {
   previewIconForName,
   previewKindForFile,
   previewSnippet,
+  skipsExtraction,
 } from '@/services/filePreview'
 import type { FileItem } from '@/services/filesService'
 
@@ -44,6 +45,13 @@ describe('filePreview helpers', () => {
     expect(kindFromExtension('docx')).toBe('document')
     expect(kindFromExtension('ics')).toBe('calendar')
     expect(kindFromExtension('bin')).toBe('unknown')
+    expect(kindFromExtension('jar')).toBe('unknown')
+  })
+
+  it('treats jar as store-only (never extract)', () => {
+    expect(skipsExtraction('jar')).toBe(true)
+    expect(skipsExtraction('JAR')).toBe(true)
+    expect(skipsExtraction('pdf')).toBe(false)
   })
 
   it('prefers the filename extension over the coarse origin_kind', () => {


### PR DESCRIPTION
## Summary
Update extraction logic and handle jar files

## Changes
- Updated Intelephense PHP version in VSCode settings from 8.3 to 8.4.
- Modified error handling in FileController to include 'not_extractable' for .jar files.
- Enhanced FileStorageService to recognize .jar files as store-only and prevent extraction.
- Updated FileUploadService to skip extraction for .jar files and return appropriate status.
- Added tests to ensure .jar files are allowed for upload and are not extracted.
- Updated frontend components to accept .jar files in file uploads.

## Verification
- [ ] Not tested (explain)
- [X] Manual
- [ ] Tests added/updated
