### PR TITLE
fix: chat delete orphans, Operate back nav, URL-watch diff and failures

### DIFF
--- a/backend/migrations/Version20260910200000.php
+++ b/backend/migrations/Version20260910200000.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Persist the last URL-watch diff and the last failed check (#1805, #1806).
+ *
+ * Galera-safe: raw addSql only, ADD COLUMN IF NOT EXISTS, no Schema API.
+ */
+final class Version20260910200000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add last-diff and last-failure columns to BURLWATCHES';
+    }
+
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE BURLWATCHES ADD COLUMN IF NOT EXISTS BLASTDIFFTEXT LONGTEXT NULL');
+        $this->addSql('ALTER TABLE BURLWATCHES ADD COLUMN IF NOT EXISTS BLASTERROR VARCHAR(512) NULL');
+        $this->addSql('ALTER TABLE BURLWATCHES ADD COLUMN IF NOT EXISTS BLASTFAILEDAT BIGINT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE BURLWATCHES DROP COLUMN IF EXISTS BLASTDIFFTEXT');
+        $this->addSql('ALTER TABLE BURLWATCHES DROP COLUMN IF EXISTS BLASTERROR');
+        $this->addSql('ALTER TABLE BURLWATCHES DROP COLUMN IF EXISTS BLASTFAILEDAT');
+    }
+}

--- a/backend/src/Controller/ChatController.php
+++ b/backend/src/Controller/ChatController.php
@@ -5,12 +5,10 @@ namespace App\Controller;
 use App\Entity\Chat;
 use App\Entity\User;
 use App\Repository\ChatRepository;
-use App\Repository\ChatSummaryRepository;
 use App\Repository\MessageRepository;
-use App\Repository\ShareRepository;
 use App\Repository\UserRepository;
+use App\Service\Chat\ChatDeletionService;
 use App\Service\Chat\Run\ChatRunService;
-use App\Service\Digest\MessageDigestMaintenance;
 use App\Service\File\OgImageService;
 use App\Service\Iam\AccessGate;
 use App\Service\Iam\ConversationCopyService;
@@ -38,8 +36,7 @@ class ChatController extends AbstractController
     public function __construct(
         private EntityManagerInterface $em,
         private ChatRepository $chatRepository,
-        private ChatSummaryRepository $chatSummaryRepository,
-        private MessageDigestMaintenance $digestMaintenance,
+        private ChatDeletionService $chatDeletionService,
         private MessageRepository $messageRepository,
         private WidgetSessionService $widgetSessionService,
         private OgImageService $ogImageService,
@@ -50,7 +47,6 @@ class ChatController extends AbstractController
         private AccessGate $accessGate,
         private IamConfig $iamConfig,
         private ConversationCopyService $conversationCopyService,
-        private ShareRepository $shareRepository,
         private ShareService $shareService,
         private UserRepository $userRepository,
     ) {
@@ -463,16 +459,7 @@ class ChatController extends AbstractController
             return $this->json(['error' => 'Chat not found'], Response::HTTP_NOT_FOUND);
         }
 
-        // No FK cascade on BCHATSUMMARIES (Galera rule) — clean up explicitly.
-        $this->chatSummaryRepository->deleteByChatId($id);
-
-        // Deep-memory hygiene: digests of this chat stop resolving and their
-        // vectors leave the search index.
-        $this->digestMaintenance->deactivateForChat($user->getId(), $id);
-
-        $this->shareRepository->deleteByResource(ConversationKind::KEY, (string) $id);
-        $this->em->remove($chat);
-        $this->em->flush();
+        $this->chatDeletionService->deleteOwnedChat($user->getId(), $chat);
 
         $this->logger->info('Chat deleted', [
             'chat_id' => $id,

--- a/backend/src/Controller/UrlWatchController.php
+++ b/backend/src/Controller/UrlWatchController.php
@@ -51,6 +51,9 @@ final class UrlWatchController extends AbstractController
                                 new OA\Property(property: 'fetchedAt', type: 'string', nullable: true),
                                 new OA\Property(property: 'created', type: 'string', nullable: true),
                                 new OA\Property(property: 'updated', type: 'string', nullable: true),
+                                new OA\Property(property: 'lastDiffText', type: 'string', nullable: true),
+                                new OA\Property(property: 'lastError', type: 'string', nullable: true),
+                                new OA\Property(property: 'lastFailedAt', type: 'string', nullable: true),
                             ]
                         )),
                     ]
@@ -95,9 +98,10 @@ final class UrlWatchController extends AbstractController
                 response: 200,
                 description: 'Existing or newly registered watch',
                 content: new OA\JsonContent(
-                    required: ['success', 'watch'],
+                    required: ['success', 'created', 'watch'],
                     properties: [
                         new OA\Property(property: 'success', type: 'boolean', example: true),
+                        new OA\Property(property: 'created', type: 'boolean', example: true),
                         new OA\Property(
                             property: 'watch',
                             type: 'object',
@@ -111,12 +115,15 @@ final class UrlWatchController extends AbstractController
                                 new OA\Property(property: 'created', type: 'string', nullable: true),
                                 new OA\Property(property: 'updated', type: 'string', nullable: true),
                                 new OA\Property(property: 'body', type: 'string'),
+                                new OA\Property(property: 'lastDiffText', type: 'string', nullable: true),
+                                new OA\Property(property: 'lastError', type: 'string', nullable: true),
+                                new OA\Property(property: 'lastFailedAt', type: 'string', nullable: true),
                             ]
                         ),
                     ]
                 )
             ),
-            new OA\Response(response: 400, description: 'Invalid URL'),
+            new OA\Response(response: 400, description: 'Invalid or blocked URL'),
             new OA\Response(response: 401, description: 'Not authenticated'),
             new OA\Response(response: 404, description: 'Feature disabled'),
         ]
@@ -132,12 +139,23 @@ final class UrlWatchController extends AbstractController
         $payload = $request->toArray();
         $url = trim((string) ($payload['url'] ?? ''));
         try {
-            $watch = $this->service->register((int) $user->getId(), $url);
-        } catch (\InvalidArgumentException) {
+            $result = $this->service->register((int) $user->getId(), $url);
+        } catch (\InvalidArgumentException $e) {
+            if ('blocked_url' === $e->getMessage()) {
+                return $this->json(
+                    ['error' => 'URL points to a private/blocked address'],
+                    Response::HTTP_BAD_REQUEST,
+                );
+            }
+
             return $this->json(['error' => 'invalid_url'], Response::HTTP_BAD_REQUEST);
         }
 
-        return $this->json(['success' => true, 'watch' => $this->service->toDetail($watch)]);
+        return $this->json([
+            'success' => true,
+            'created' => $result['created'],
+            'watch' => $this->service->toDetail($result['watch']),
+        ]);
     }
 
     #[Route('/{id}', name: 'get', methods: ['GET'], requirements: ['id' => '\d+'])]
@@ -166,6 +184,9 @@ final class UrlWatchController extends AbstractController
                                 new OA\Property(property: 'created', type: 'string', nullable: true),
                                 new OA\Property(property: 'updated', type: 'string', nullable: true),
                                 new OA\Property(property: 'body', type: 'string'),
+                                new OA\Property(property: 'lastDiffText', type: 'string', nullable: true),
+                                new OA\Property(property: 'lastError', type: 'string', nullable: true),
+                                new OA\Property(property: 'lastFailedAt', type: 'string', nullable: true),
                             ]
                         ),
                     ]
@@ -217,6 +238,9 @@ final class UrlWatchController extends AbstractController
                                 new OA\Property(property: 'created', type: 'string', nullable: true),
                                 new OA\Property(property: 'updated', type: 'string', nullable: true),
                                 new OA\Property(property: 'body', type: 'string'),
+                                new OA\Property(property: 'lastDiffText', type: 'string', nullable: true),
+                                new OA\Property(property: 'lastError', type: 'string', nullable: true),
+                                new OA\Property(property: 'lastFailedAt', type: 'string', nullable: true),
                             ]
                         ),
                         new OA\Property(

--- a/backend/src/Controller/UrlWatchController.php
+++ b/backend/src/Controller/UrlWatchController.php
@@ -143,7 +143,10 @@ final class UrlWatchController extends AbstractController
         } catch (\InvalidArgumentException $e) {
             if ('blocked_url' === $e->getMessage()) {
                 return $this->json(
-                    ['error' => 'URL points to a private/blocked address'],
+                    [
+                        'error' => 'blocked_url',
+                        'message' => 'URL points to a private/blocked address',
+                    ],
                     Response::HTTP_BAD_REQUEST,
                 );
             }

--- a/backend/src/Controller/WidgetSessionController.php
+++ b/backend/src/Controller/WidgetSessionController.php
@@ -7,10 +7,10 @@ namespace App\Controller;
 use App\Entity\User;
 use App\Entity\WidgetSession;
 use App\Repository\ChatRepository;
-use App\Repository\ChatSummaryRepository;
 use App\Repository\MessageRepository;
 use App\Repository\WidgetRepository;
 use App\Repository\WidgetSessionRepository;
+use App\Service\Chat\ChatDeletionService;
 use App\Service\WidgetService;
 use App\Service\WidgetSessionService;
 use Doctrine\ORM\EntityManagerInterface;
@@ -36,7 +36,7 @@ class WidgetSessionController extends AbstractController
         private WidgetRepository $widgetRepository,
         private WidgetSessionRepository $sessionRepository,
         private ChatRepository $chatRepository,
-        private ChatSummaryRepository $chatSummaryRepository,
+        private ChatDeletionService $chatDeletionService,
         private MessageRepository $messageRepository,
         private LoggerInterface $logger,
         private EntityManagerInterface $em,
@@ -658,19 +658,8 @@ class WidgetSessionController extends AbstractController
                 }
             }
 
-            // Delete messages associated with the chats
-            if (!empty($chatIds)) {
-                $this->messageRepository->deleteByChatIds($chatIds);
-            }
-
-            // Delete chats (+ their rolling-summary rows — no FK cascade on
-            // BCHATSUMMARIES per the Galera rule, so clean up explicitly)
-            foreach ($chatIds as $chatId) {
-                $this->chatSummaryRepository->deleteByChatId((int) $chatId);
-                $chat = $this->chatRepository->find($chatId);
-                if ($chat) {
-                    $this->chatRepository->remove($chat);
-                }
+            if ([] !== $chatIds) {
+                $this->chatDeletionService->deleteOwnedChats($user->getId(), array_map('intval', $chatIds));
             }
 
             // Delete sessions

--- a/backend/src/Entity/UrlWatch.php
+++ b/backend/src/Entity/UrlWatch.php
@@ -45,6 +45,15 @@ class UrlWatch
     #[ORM\Column(name: 'BUPDATED', type: 'bigint')]
     private int $updated;
 
+    #[ORM\Column(name: 'BLASTDIFFTEXT', type: 'text', nullable: true)]
+    private ?string $lastDiffText = null;
+
+    #[ORM\Column(name: 'BLASTERROR', length: 512, nullable: true)]
+    private ?string $lastError = null;
+
+    #[ORM\Column(name: 'BLASTFAILEDAT', type: 'bigint', nullable: true)]
+    private ?int $lastFailedAt = null;
+
     public function __construct(int $ownerId, string $url, string $urlHash)
     {
         $now = time();
@@ -105,6 +114,33 @@ class UrlWatch
         return $this->updated;
     }
 
+    public function getLastDiffText(): ?string
+    {
+        return $this->lastDiffText;
+    }
+
+    public function getLastError(): ?string
+    {
+        return $this->lastError;
+    }
+
+    public function getLastFailedAt(): ?int
+    {
+        return $this->lastFailedAt;
+    }
+
+    public function setLastDiffText(?string $diff): void
+    {
+        $this->lastDiffText = (null === $diff || '' === $diff) ? null : $diff;
+    }
+
+    public function recordFailure(string $error): void
+    {
+        $this->lastError = mb_substr($error, 0, 512);
+        $this->lastFailedAt = time();
+        $this->updated = $this->lastFailedAt;
+    }
+
     public function replaceSnapshot(string $title, string $body, string $contentHash, int $fetchedAt): void
     {
         if ('' !== $title) {
@@ -114,5 +150,7 @@ class UrlWatch
         $this->contentHash = $contentHash;
         $this->fetchedAt = $fetchedAt;
         $this->updated = $fetchedAt;
+        $this->lastError = null;
+        $this->lastFailedAt = null;
     }
 }

--- a/backend/src/Repository/MessageRepository.php
+++ b/backend/src/Repository/MessageRepository.php
@@ -4,6 +4,7 @@ namespace App\Repository;
 
 use App\Entity\Chat;
 use App\Entity\Message;
+use App\Entity\MessageMeta;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -689,7 +690,10 @@ class MessageRepository extends ServiceEntityRepository
     }
 
     /**
-     * Delete all messages for the given chat IDs.
+     * Delete all messages for the given chat IDs, and their BMESSAGEMETA rows.
+     *
+     * Bulk DQL skips Doctrine orphanRemoval, and BMESSAGEMETA has no
+     * ON DELETE CASCADE, so meta must be removed first (#1811).
      *
      * @param array<int> $chatIds
      *
@@ -697,8 +701,25 @@ class MessageRepository extends ServiceEntityRepository
      */
     public function deleteByChatIds(array $chatIds): int
     {
-        if (empty($chatIds)) {
+        if ([] === $chatIds) {
             return 0;
+        }
+
+        $ids = $this->createQueryBuilder('m')
+            ->select('m.id')
+            ->where('m.chatId IN (:chatIds)')
+            ->setParameter('chatIds', $chatIds)
+            ->getQuery()
+            ->getSingleColumnResult();
+
+        $messageIds = array_values(array_map(static fn (mixed $id): int => (int) $id, $ids));
+        if ([] !== $messageIds) {
+            $this->getEntityManager()->createQueryBuilder()
+                ->delete(MessageMeta::class, 'meta')
+                ->where('meta.messageId IN (:ids)')
+                ->setParameter('ids', $messageIds)
+                ->getQuery()
+                ->execute();
         }
 
         $qb = $this->getEntityManager()->createQueryBuilder();

--- a/backend/src/Repository/MessageRepository.php
+++ b/backend/src/Repository/MessageRepository.php
@@ -10,6 +10,8 @@ use Doctrine\Persistence\ManagerRegistry;
 
 class MessageRepository extends ServiceEntityRepository
 {
+    private const DELETE_ID_BATCH = 500;
+
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, Message::class);
@@ -705,29 +707,33 @@ class MessageRepository extends ServiceEntityRepository
             return 0;
         }
 
-        $ids = $this->createQueryBuilder('m')
-            ->select('m.id')
-            ->where('m.chatId IN (:chatIds)')
-            ->setParameter('chatIds', $chatIds)
-            ->getQuery()
-            ->getSingleColumnResult();
+        $deleted = 0;
+        foreach (array_chunk(array_values(array_unique($chatIds)), self::DELETE_ID_BATCH) as $chatBatch) {
+            $ids = $this->createQueryBuilder('m')
+                ->select('m.id')
+                ->where('m.chatId IN (:chatIds)')
+                ->setParameter('chatIds', $chatBatch)
+                ->getQuery()
+                ->getSingleColumnResult();
 
-        $messageIds = array_values(array_map(static fn (mixed $id): int => (int) $id, $ids));
-        if ([] !== $messageIds) {
-            $this->getEntityManager()->createQueryBuilder()
-                ->delete(MessageMeta::class, 'meta')
-                ->where('meta.messageId IN (:ids)')
-                ->setParameter('ids', $messageIds)
+            $messageIds = array_values(array_map(static fn (mixed $id): int => (int) $id, $ids));
+            foreach (array_chunk($messageIds, self::DELETE_ID_BATCH) as $idBatch) {
+                $this->getEntityManager()->createQueryBuilder()
+                    ->delete(MessageMeta::class, 'meta')
+                    ->where('meta.messageId IN (:ids)')
+                    ->setParameter('ids', $idBatch)
+                    ->getQuery()
+                    ->execute();
+            }
+
+            $qb = $this->getEntityManager()->createQueryBuilder();
+            $deleted += $qb->delete(Message::class, 'm')
+                ->where($qb->expr()->in('m.chatId', ':chatIds'))
+                ->setParameter('chatIds', $chatBatch)
                 ->getQuery()
                 ->execute();
         }
 
-        $qb = $this->getEntityManager()->createQueryBuilder();
-
-        return $qb->delete(Message::class, 'm')
-            ->where($qb->expr()->in('m.chatId', ':chatIds'))
-            ->setParameter('chatIds', $chatIds)
-            ->getQuery()
-            ->execute();
+        return $deleted;
     }
 }

--- a/backend/src/Service/Chat/ChatDeletionService.php
+++ b/backend/src/Service/Chat/ChatDeletionService.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Chat;
+
+use App\Entity\Chat;
+use App\Repository\ChatRepository;
+use App\Repository\ChatSummaryRepository;
+use App\Repository\FileRepository;
+use App\Repository\MessageRepository;
+use App\Repository\ShareRepository;
+use App\Service\Digest\MessageDigestMaintenance;
+use App\Service\File\FileStorageService;
+use App\Service\File\OgImageService;
+use App\Service\Iam\ResourceKind\ConversationKind;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Deletes a chat and the conversation it owned: messages, metadata, plan
+ * rows, message-bound files, summary, digests and shares.
+ *
+ * The BMESSAGES.BCHATID FK is ON DELETE SET NULL, so removing the chat row
+ * alone detaches the conversation instead of deleting it (#1811).
+ */
+final readonly class ChatDeletionService
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private ChatRepository $chatRepository,
+        private ChatSummaryRepository $chatSummaryRepository,
+        private MessageRepository $messageRepository,
+        private FileRepository $fileRepository,
+        private FileStorageService $fileStorage,
+        private MessageDigestMaintenance $digestMaintenance,
+        private ShareRepository $shareRepository,
+        private OgImageService $ogImageService,
+    ) {
+    }
+
+    public function deleteOwnedChat(int $userId, Chat $chat): void
+    {
+        if ($chat->getUserId() !== $userId) {
+            return;
+        }
+
+        $this->purgeConversation($userId, $chat);
+        $this->em->flush();
+    }
+
+    /**
+     * @param list<int> $chatIds
+     */
+    public function deleteOwnedChats(int $userId, array $chatIds): void
+    {
+        $seen = [];
+        foreach ($chatIds as $chatId) {
+            $id = (int) $chatId;
+            if (isset($seen[$id])) {
+                continue;
+            }
+            $seen[$id] = true;
+            $chat = $this->chatRepository->find($id);
+            if (!$chat instanceof Chat || $chat->getUserId() !== $userId) {
+                continue;
+            }
+            $this->purgeConversation($userId, $chat);
+        }
+        $this->em->flush();
+    }
+
+    private function purgeConversation(int $userId, Chat $chat): void
+    {
+        $chatId = (int) $chat->getId();
+        $messages = $this->messageRepository->findAllByChatId($userId, $chatId);
+        $messageIds = [];
+        foreach ($messages as $message) {
+            $id = $message->getId();
+            if (null !== $id) {
+                $messageIds[] = (int) $id;
+            }
+            $legacyPath = $message->getFilePath();
+            if ('' !== $legacyPath) {
+                $this->fileStorage->deleteFile($legacyPath);
+            }
+        }
+
+        if ([] !== $messageIds) {
+            $files = $this->fileRepository->findFilesByMessageIds($userId, $messageIds, 10_000);
+            foreach ($files as $file) {
+                $path = $file->getFilePath();
+                if ('' !== $path) {
+                    $this->fileStorage->deleteFile($path);
+                }
+                $this->em->remove($file);
+            }
+        }
+
+        // Meta first — BMESSAGEMETA has no ON DELETE CASCADE. Plan rows on
+        // BMESSAGE_TASKS cascade with the message delete that follows.
+        $this->messageRepository->deleteByChatIds([$chatId]);
+
+        $this->chatSummaryRepository->deleteByChatId($chatId);
+        $this->digestMaintenance->deactivateForChat($userId, $chatId);
+        $this->shareRepository->deleteByResource(ConversationKind::KEY, (string) $chatId);
+        $this->ogImageService->deleteOgImage($chat);
+        $this->em->remove($chat);
+    }
+}

--- a/backend/src/Service/UrlWatch/UrlWatchService.php
+++ b/backend/src/Service/UrlWatch/UrlWatchService.php
@@ -6,8 +6,11 @@ namespace App\Service\UrlWatch;
 
 use App\Entity\UrlWatch;
 use App\Repository\UrlWatchRepository;
+use App\Service\File\FileHelper;
+use App\Service\Security\SsrfGuard;
 use App\Service\UrlContentService;
 use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * One saved page per owner+URL. Each remember()/refresh() overwrites.
@@ -23,6 +26,8 @@ final readonly class UrlWatchService
         private EntityManagerInterface $em,
         private UrlContentService $urlContent,
         private TextDiff $diff,
+        private SsrfGuard $ssrfGuard,
+        private LoggerInterface $logger,
     ) {
     }
 
@@ -39,25 +44,34 @@ final readonly class UrlWatchService
         return $this->watches->findOneForOwner($id, $ownerId);
     }
 
-    public function register(int $ownerId, string $url): UrlWatch
+    /**
+     * @return array{watch: UrlWatch, created: bool}
+     */
+    public function register(int $ownerId, string $url): array
     {
         $normalized = $this->canonicalize($url);
+        if ($this->ssrfGuard->isBlockedUrl($normalized)) {
+            throw new \InvalidArgumentException('blocked_url');
+        }
         $hash = self::hashUrl($normalized);
         $existing = $this->watches->findOneByOwnerAndHash($ownerId, $hash);
         if ($existing instanceof UrlWatch) {
-            return $existing;
+            return ['watch' => $existing, 'created' => false];
         }
 
         $watch = new UrlWatch($ownerId, $normalized, $hash);
         $this->em->persist($watch);
         $this->em->flush();
 
-        return $watch;
+        return ['watch' => $watch, 'created' => true];
     }
 
     public function remember(int $ownerId, string $url, string $title, string $body): UrlWatchCompareResult
     {
         $normalized = $this->canonicalize($url);
+        if ($this->ssrfGuard->isBlockedUrl($normalized)) {
+            throw new \InvalidArgumentException('blocked_url');
+        }
         $hash = self::hashUrl($normalized);
         $body = $this->clip($body, self::MAX_BODY_CHARS);
         $contentHash = hash('sha256', $body);
@@ -81,6 +95,7 @@ final readonly class UrlWatchService
         }
 
         $watch->replaceSnapshot($title, $body, $contentHash, $now);
+        $watch->setLastDiffText(UrlWatchCompareResult::CHANGED === $status ? $diff : null);
         $this->em->flush();
 
         return new UrlWatchCompareResult(
@@ -100,7 +115,16 @@ final readonly class UrlWatchService
 
         $result = $this->urlContent->fetchForCrawling($watch->getUrl());
         if (!$result->success) {
-            throw new UrlWatchFetchFailedException($result->error ?? 'fetch failed');
+            $reason = $result->error ?? 'fetch failed';
+            $this->logger->warning('URL watch fetch failed', [
+                'watch_id' => $watch->getId(),
+                'owner_id' => $ownerId,
+                'url' => FileHelper::redactUrlForLogging($watch->getUrl()),
+                'error' => $reason,
+            ]);
+            $watch->recordFailure($reason);
+            $this->em->flush();
+            throw new UrlWatchFetchFailedException($reason);
         }
 
         return $this->remember($ownerId, $watch->getUrl(), $result->title, $result->extractedText);
@@ -132,6 +156,9 @@ final readonly class UrlWatchService
             'fetchedAt' => $this->iso($watch->getFetchedAt()),
             'created' => $this->iso($watch->getCreated()),
             'updated' => $this->iso($watch->getUpdated()),
+            'lastDiffText' => $watch->getLastDiffText(),
+            'lastError' => $watch->getLastError(),
+            'lastFailedAt' => $this->iso($watch->getLastFailedAt()),
         ];
     }
 

--- a/backend/tests/Controller/ChatControllerTest.php
+++ b/backend/tests/Controller/ChatControllerTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Controller;
 
 use App\Entity\Chat;
 use App\Entity\Message;
+use App\Entity\MessageMeta;
 use App\Entity\User;
 use App\Service\TokenService;
 use App\Tests\Trait\AuthenticatedTestTrait;
@@ -415,6 +416,22 @@ class ChatControllerTest extends WebTestCase
 
         $chatId = $chat->getId();
 
+        $message = new Message();
+        $message->setUserId($this->user->getId());
+        $message->setChat($chat);
+        $message->setTrackingId(time());
+        $message->setUnixTimestamp(time());
+        $message->setDateTime(date('YmdHis'));
+        $message->setText('Please summarize this note.');
+        $message->setDirection('IN');
+        $message->setProviderIndex('WEB');
+        $this->em->persist($message);
+        $this->em->flush();
+
+        $messageId = (int) $message->getId();
+        $message->setMeta('ai_chat_model', 'test-model');
+        $this->em->flush();
+
         $this->client->request(
             'DELETE',
             '/api/v1/chats/'.$chatId,
@@ -425,9 +442,14 @@ class ChatControllerTest extends WebTestCase
 
         $this->assertResponseIsSuccessful();
 
-        // Verify deletion in database
-        $deletedChat = $this->em->getRepository(Chat::class)->find($chatId);
-        $this->assertNull($deletedChat);
+        $this->em->clear();
+
+        $this->assertNull($this->em->getRepository(Chat::class)->find($chatId));
+        $this->assertNull($this->em->getRepository(Message::class)->find($messageId));
+        $this->assertSame(
+            [],
+            $this->em->getRepository(MessageMeta::class)->findBy(['messageId' => $messageId]),
+        );
     }
 
     /**

--- a/backend/tests/Controller/UrlWatchControllerTest.php
+++ b/backend/tests/Controller/UrlWatchControllerTest.php
@@ -108,7 +108,9 @@ final class UrlWatchControllerTest extends WebTestCase
         $this->postJson('/api/v1/url-watches', ['url' => 'http://127.0.0.1/page.html']);
 
         self::assertSame(Response::HTTP_BAD_REQUEST, $this->client->getResponse()->getStatusCode());
-        self::assertSame('URL points to a private/blocked address', $this->json()['error'] ?? null);
+        $body = $this->json();
+        self::assertSame('blocked_url', $body['error'] ?? null);
+        self::assertSame('URL points to a private/blocked address', $body['message'] ?? null);
     }
 
     private function createUser(string $email): User

--- a/backend/tests/Controller/UrlWatchControllerTest.php
+++ b/backend/tests/Controller/UrlWatchControllerTest.php
@@ -95,8 +95,20 @@ final class UrlWatchControllerTest extends WebTestCase
         $second = (int) ($this->json()['watch']['id'] ?? 0);
 
         self::assertSame($first, $second);
+        self::assertFalse($this->json()['created'] ?? true);
         $this->client->request('GET', '/api/v1/url-watches');
         self::assertCount(1, $this->json()['watches'] ?? []);
+    }
+
+    public function testPrivateUrlIsRejectedAtCreate(): void
+    {
+        $owner = $this->createUser('url-watch-ssrf@synaplan.internal');
+        $this->authenticateClient($this->client, $owner);
+
+        $this->postJson('/api/v1/url-watches', ['url' => 'http://127.0.0.1/page.html']);
+
+        self::assertSame(Response::HTTP_BAD_REQUEST, $this->client->getResponse()->getStatusCode());
+        self::assertSame('URL points to a private/blocked address', $this->json()['error'] ?? null);
     }
 
     private function createUser(string $email): User

--- a/backend/tests/Unit/Service/UrlWatch/UrlWatchServiceTest.php
+++ b/backend/tests/Unit/Service/UrlWatch/UrlWatchServiceTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\Service\UrlWatch;
 
 use App\Entity\UrlWatch;
 use App\Repository\UrlWatchRepository;
+use App\Service\Security\SsrfGuard;
 use App\Service\UrlContentResult;
 use App\Service\UrlContentService;
 use App\Service\UrlWatch\TextDiff;
@@ -15,6 +16,7 @@ use App\Service\UrlWatch\UrlWatchNotFoundException;
 use App\Service\UrlWatch\UrlWatchService;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 
 final class UrlWatchServiceTest extends TestCase
 {
@@ -53,6 +55,7 @@ final class UrlWatchServiceTest extends TestCase
         self::assertStringContainsString('- line two', $changed->diffText);
         self::assertStringContainsString('+ line three', $changed->diffText);
         self::assertSame("line one\nline three", $changed->watch->getBody());
+        self::assertSame($changed->diffText, $changed->watch->getLastDiffText());
     }
 
     public function testRegisterIsIdempotentPerOwnerAndUrl(): void
@@ -62,9 +65,18 @@ final class UrlWatchServiceTest extends TestCase
         $b = $service->register(7, 'https://example.com/a/');
         $other = $service->register(8, 'https://example.com/a');
 
-        self::assertSame($a, $b);
-        self::assertNotSame($a, $other);
-        self::assertSame('https://example.com/a', $a->getUrl());
+        self::assertTrue($a['created']);
+        self::assertFalse($b['created']);
+        self::assertSame($a['watch'], $b['watch']);
+        self::assertNotSame($a['watch'], $other['watch']);
+        self::assertSame('https://example.com/a', $a['watch']->getUrl());
+    }
+
+    public function testRegisterRejectsPrivateUrl(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('blocked_url');
+        $this->service(blocked: true)->register(7, 'http://127.0.0.1/page.html');
     }
 
     public function testRegisterRejectsNonUrl(): void
@@ -82,7 +94,7 @@ final class UrlWatchServiceTest extends TestCase
             hostname: 'example.com',
             success: true,
         )));
-        $watch = $service->register(7, 'https://example.com/a');
+        $watch = $service->register(7, 'https://example.com/a')['watch'];
         self::assertNotNull($watch->getId());
 
         $result = $service->refresh((int) $watch->getId(), 7);
@@ -107,16 +119,24 @@ final class UrlWatchServiceTest extends TestCase
             success: false,
             error: 'HTTP 500',
         )));
-        $watch = $service->register(7, 'https://example.com/a');
+        $watch = $service->register(7, 'https://example.com/a')['watch'];
 
-        $this->expectException(UrlWatchFetchFailedException::class);
-        $service->refresh((int) $watch->getId(), 7);
+        try {
+            $service->refresh((int) $watch->getId(), 7);
+            self::fail('expected UrlWatchFetchFailedException');
+        } catch (UrlWatchFetchFailedException $e) {
+            self::assertStringContainsString('HTTP 500', $e->getMessage());
+        }
+
+        self::assertSame('HTTP 500', $watch->getLastError());
+        self::assertNotNull($watch->getLastFailedAt());
+        self::assertNull($watch->getFetchedAt());
     }
 
     public function testDeleteOnlyForOwner(): void
     {
         $service = $this->service();
-        $watch = $service->register(7, 'https://example.com/a');
+        $watch = $service->register(7, 'https://example.com/a')['watch'];
         $id = (int) $watch->getId();
 
         self::assertFalse($service->delete($id, 8));
@@ -124,7 +144,7 @@ final class UrlWatchServiceTest extends TestCase
         self::assertNull($service->get($id, 7));
     }
 
-    private function service(?UrlContentService $urlContent = null): UrlWatchService
+    private function service(?UrlContentService $urlContent = null, bool $blocked = false): UrlWatchService
     {
         $urlContent ??= $this->urlContentMock();
         /** @var array<string, UrlWatch> $store */
@@ -180,7 +200,17 @@ final class UrlWatchServiceTest extends TestCase
             },
         );
 
-        return new UrlWatchService($repo, $em, $urlContent, new TextDiff());
+        $ssrf = $this->createMock(SsrfGuard::class);
+        $ssrf->method('isBlockedUrl')->willReturn($blocked);
+
+        return new UrlWatchService(
+            $repo,
+            $em,
+            $urlContent,
+            new TextDiff(),
+            $ssrf,
+            $this->createMock(LoggerInterface::class),
+        );
     }
 
     private function urlContentMock(?UrlContentResult $fetchResult = null): UrlContentService

--- a/frontend/src/components/config/UrlWatchPanel.vue
+++ b/frontend/src/components/config/UrlWatchPanel.vue
@@ -74,7 +74,7 @@ const onAdd = async () => {
   } catch (err) {
     if (err instanceof ApiError && err.status === 400) {
       showError(
-        err.message.includes('private/blocked')
+        err.code === 'blocked_url'
           ? t('config.savedTasks.watches.blockedUrl')
           : t('config.savedTasks.watches.invalidUrl')
       )

--- a/frontend/src/components/config/UrlWatchPanel.vue
+++ b/frontend/src/components/config/UrlWatchPanel.vue
@@ -30,6 +30,17 @@ const formatWhen = (iso: string | null): string => {
   })
 }
 
+const rowStatus = (watch: UrlWatch): string => {
+  if (watch.lastError && watch.lastFailedAt) {
+    const failed = Date.parse(watch.lastFailedAt)
+    const fetched = watch.fetchedAt ? Date.parse(watch.fetchedAt) : 0
+    if (!Number.isNaN(failed) && failed >= fetched) {
+      return t('config.savedTasks.watches.lastCheckFailed', { reason: watch.lastError })
+    }
+  }
+  return formatWhen(watch.fetchedAt)
+}
+
 const load = async () => {
   loading.value = true
   try {
@@ -52,13 +63,21 @@ const onAdd = async () => {
   if (!value) return
   adding.value = true
   try {
-    const watch = await urlWatchesApi.create(value)
+    const { watch, created } = await urlWatchesApi.create(value)
     watches.value = [watch, ...watches.value.filter((row) => row.id !== watch.id)]
     url.value = ''
-    success(t('config.savedTasks.watches.added'))
+    success(
+      created
+        ? t('config.savedTasks.watches.added')
+        : t('config.savedTasks.watches.alreadyWatching')
+    )
   } catch (err) {
     if (err instanceof ApiError && err.status === 400) {
-      showError(t('config.savedTasks.watches.invalidUrl'))
+      showError(
+        err.message.includes('private/blocked')
+          ? t('config.savedTasks.watches.blockedUrl')
+          : t('config.savedTasks.watches.invalidUrl')
+      )
     } else {
       showError(t('config.savedTasks.watches.addFailed'))
     }
@@ -91,8 +110,13 @@ const onCheck = async (id: number) => {
       viewing.value = result.watch
     }
     toastCompare(result.compare)
-  } catch {
-    showError(t('config.savedTasks.watches.checkFailed'))
+  } catch (err) {
+    showError(
+      err instanceof ApiError && err.message
+        ? err.message
+        : t('config.savedTasks.watches.checkFailed')
+    )
+    await load()
   } finally {
     checkingId.value = null
   }
@@ -180,7 +204,7 @@ onMounted(() => {
             {{ watch.title || $t('config.savedTasks.watches.untitled') }}
           </p>
           <p class="text-sm txt-secondary break-all">{{ watch.url }}</p>
-          <p class="text-xs txt-secondary">{{ formatWhen(watch.fetchedAt) }}</p>
+          <p class="text-xs txt-secondary" data-testid="url-watch-status">{{ rowStatus(watch) }}</p>
         </div>
         <div class="flex flex-wrap items-center gap-2">
           <button
@@ -230,9 +254,19 @@ onMounted(() => {
             {{ viewing.title || $t('config.savedTasks.watches.untitled') }}
           </h3>
           <p class="text-sm txt-secondary break-all">{{ viewing.url }}</p>
-          <p class="text-xs txt-secondary">{{ formatWhen(viewing.fetchedAt) }}</p>
+          <p class="text-xs txt-secondary">{{ rowStatus(viewing) }}</p>
+          <div v-if="viewing.lastDiffText" class="space-y-1">
+            <p class="text-sm font-medium txt-primary">
+              {{ $t('config.savedTasks.watches.lastDiff') }}
+            </p>
+            <pre
+              class="whitespace-pre-wrap text-sm txt-primary surface-card border border-light-border/30 dark:border-dark-border/20 rounded-lg p-3 max-h-80 overflow-y-auto"
+              data-testid="url-watch-diff"
+              >{{ viewing.lastDiffText }}</pre>
+          </div>
           <pre
             class="whitespace-pre-wrap text-sm txt-primary surface-card border border-light-border/30 dark:border-dark-border/20 rounded-lg p-3 max-h-80 overflow-y-auto"
+            data-testid="url-watch-body"
             >{{ viewing.body || $t('config.savedTasks.watches.neverFetched') }}</pre>
           <button
             type="button"

--- a/frontend/src/composables/useNavItems.ts
+++ b/frontend/src/composables/useNavItems.ts
@@ -392,13 +392,11 @@ export function useNavItems() {
         path: '/admin/config',
         label: t('nav.adminSystemConfig'),
       })
-      if (isIamGroupsEnabled()) {
-        adminChildren.push({
-          key: 'admin-people',
-          path: '/admin/people',
-          label: t('nav.adminPeople'),
-        })
-      }
+      adminChildren.push({
+        key: 'admin-people',
+        path: isIamGroupsEnabled() ? '/admin/people' : '/admin?tab=users',
+        label: t('nav.adminPeople'),
+      })
 
       items.push({
         key: 'admin',

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -2127,8 +2127,10 @@
         "add": "Seite beobachten",
         "adding": "Wird gespeichert…",
         "added": "Seite gespeichert. Mit „Jetzt prüfen“ die erste Kopie anlegen.",
+        "alreadyWatching": "Diese Seite wird bereits beobachtet.",
         "addFailed": "Diese Seite konnte nicht beobachtet werden.",
         "invalidUrl": "Gib eine Webadresse ein, die mit http:// oder https:// beginnt.",
+        "blockedUrl": "Diese Adresse kann nicht beobachtet werden (privat oder gesperrt).",
         "loading": "Beobachtete Seiten werden geladen…",
         "loadFailed": "Beobachtete Seiten konnten nicht geladen werden.",
         "empty": "Noch keine Seiten beobachtet.",
@@ -2146,6 +2148,8 @@
         "deleteFailed": "Die beobachtete Seite konnte nicht entfernt werden.",
         "neverFetched": "Noch nicht abgerufen",
         "lastFetched": "Zuletzt gespeichert {when}",
+        "lastCheckFailed": "Letzte Prüfung fehlgeschlagen: {reason}",
+        "lastDiff": "Was sich geändert hat",
         "untitled": "Seite ohne Titel"
       },
       "scheduleThis": "Später erneut ausführen",
@@ -5731,6 +5735,7 @@
       "audit": "Protokoll"
     },
     "openPeople": "Personen öffnen",
+    "backToOperate": "Zurück zu Betrieb",
     "myGroups": {
       "subtitle": "Gruppen, in denen Sie auf dieser Instanz Mitglied sind.",
       "emptyMember": "Sie sind noch in keiner Gruppe. Ein Administrator kann Sie auf der Seite Personen hinzufügen.",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -2017,8 +2017,10 @@
         "add": "Watch this page",
         "adding": "Saving…",
         "added": "Page saved. Check now to store the first copy.",
+        "alreadyWatching": "This page is already watched.",
         "addFailed": "Could not watch this page.",
         "invalidUrl": "Enter a web address starting with http:// or https://.",
+        "blockedUrl": "That address cannot be watched (private or blocked).",
         "loading": "Loading watched pages…",
         "loadFailed": "Could not load watched pages.",
         "empty": "No pages watched yet.",
@@ -2036,6 +2038,8 @@
         "deleteFailed": "Could not remove this watched page.",
         "neverFetched": "Not fetched yet",
         "lastFetched": "Last saved {when}",
+        "lastCheckFailed": "Last check failed: {reason}",
+        "lastDiff": "What changed",
         "untitled": "Untitled page"
       },
       "scheduleThis": "Run this again later",
@@ -5797,6 +5801,7 @@
       "audit": "Audit"
     },
     "openPeople": "Open People",
+    "backToOperate": "Back to Operate",
     "myGroups": {
       "subtitle": "Groups you belong to on this instance.",
       "emptyMember": "You are not in a group yet. An administrator can add you on the People page.",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -2911,8 +2911,10 @@
         "add": "Vigilar esta página",
         "adding": "Guardando…",
         "added": "Página guardada. Pulsa Comprobar ahora para guardar la primera copia.",
+        "alreadyWatching": "Esta página ya está vigilada.",
         "addFailed": "No se pudo vigilar esta página.",
         "invalidUrl": "Introduce una dirección web que empiece por http:// o https://.",
+        "blockedUrl": "Esa dirección no se puede vigilar (privada o bloqueada).",
         "loading": "Cargando páginas vigiladas…",
         "loadFailed": "No se pudieron cargar las páginas vigiladas.",
         "empty": "Aún no hay páginas vigiladas.",
@@ -2930,6 +2932,8 @@
         "deleteFailed": "No se pudo quitar esta página vigilada.",
         "neverFetched": "Aún no se ha obtenido",
         "lastFetched": "Último guardado {when}",
+        "lastCheckFailed": "La última comprobación falló: {reason}",
+        "lastDiff": "Qué cambió",
         "untitled": "Página sin título"
       },
       "scheduleThis": "Volver a ejecutar esto más tarde",
@@ -4811,6 +4815,7 @@
       "audit": "Auditoría"
     },
     "openPeople": "Abrir Personas",
+    "backToOperate": "Volver a Operar",
     "myGroups": {
       "subtitle": "Grupos a los que pertenece en esta instancia.",
       "emptyMember": "Aún no está en ningún grupo. Un administrador puede añadirle en la página Personas.",

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -2015,8 +2015,10 @@
         "add": "Surveiller cette page",
         "adding": "Enregistrement…",
         "added": "Page enregistrée. Cliquez sur Vérifier maintenant pour stocker la première copie.",
+        "alreadyWatching": "Cette page est déjà surveillée.",
         "addFailed": "Impossible de surveiller cette page.",
         "invalidUrl": "Saisissez une adresse web commençant par http:// ou https://.",
+        "blockedUrl": "Cette adresse ne peut pas être surveillée (privée ou bloquée).",
         "loading": "Chargement des pages surveillées…",
         "loadFailed": "Impossible de charger les pages surveillées.",
         "empty": "Aucune page surveillée pour le moment.",
@@ -2034,6 +2036,8 @@
         "deleteFailed": "Impossible de retirer cette page surveillée.",
         "neverFetched": "Pas encore récupérée",
         "lastFetched": "Dernier enregistrement {when}",
+        "lastCheckFailed": "Dernière vérification échouée : {reason}",
+        "lastDiff": "Ce qui a changé",
         "untitled": "Page sans titre"
       },
       "scheduleThis": "Relancer plus tard",
@@ -5797,6 +5801,7 @@
       "audit": "Journal"
     },
     "openPeople": "Ouvrir Personnes",
+    "backToOperate": "Retour à Exploitation",
     "myGroups": {
       "subtitle": "Groupes auxquels vous appartenez sur cette instance.",
       "emptyMember": "Vous n’êtes encore dans aucun groupe. Un administrateur peut vous ajouter sur la page Personnes.",

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -2912,8 +2912,10 @@
         "add": "Bu sayfayı izle",
         "adding": "Kaydediliyor…",
         "added": "Sayfa kaydedildi. İlk kopyayı saklamak için Şimdi kontrol et.",
+        "alreadyWatching": "Bu sayfa zaten izleniyor.",
         "addFailed": "Bu sayfa izlenemedi.",
         "invalidUrl": "http:// veya https:// ile başlayan bir web adresi gir.",
+        "blockedUrl": "Bu adres izlenemez (özel veya engelli).",
         "loading": "İzlenen sayfalar yükleniyor…",
         "loadFailed": "İzlenen sayfalar yüklenemedi.",
         "empty": "Henüz izlenen sayfa yok.",
@@ -2931,6 +2933,8 @@
         "deleteFailed": "Bu izlenen sayfa kaldırılamadı.",
         "neverFetched": "Henüz alınmadı",
         "lastFetched": "Son kayıt {when}",
+        "lastCheckFailed": "Son kontrol başarısız: {reason}",
+        "lastDiff": "Ne değişti",
         "untitled": "Başlıksız sayfa"
       },
       "scheduleThis": "Bunu daha sonra tekrar çalıştır",
@@ -4812,6 +4816,7 @@
       "audit": "Kayıt"
     },
     "openPeople": "Kişiler’i aç",
+    "backToOperate": "İşlet’e dön",
     "myGroups": {
       "subtitle": "Bu kuruluşta üye olduğunuz gruplar.",
       "emptyMember": "Henüz bir grupta değilsiniz. Bir yönetici sizi Kişiler sayfasından ekleyebilir.",

--- a/frontend/src/services/api/urlWatchesApi.ts
+++ b/frontend/src/services/api/urlWatchesApi.ts
@@ -22,6 +22,9 @@ export interface UrlWatch {
   created: string | null
   updated: string | null
   body: string
+  lastDiffText: string | null
+  lastError: string | null
+  lastFailedAt: string | null
 }
 
 export interface UrlWatchCompare {
@@ -42,6 +45,11 @@ function asWatch(raw: RawListWatch | RawDetailWatch | undefined): UrlWatch {
     created: raw.created ?? null,
     updated: raw.updated ?? null,
     body: 'body' in raw && typeof raw.body === 'string' ? raw.body : '',
+    lastDiffText:
+      'lastDiffText' in raw && typeof raw.lastDiffText === 'string' ? raw.lastDiffText : null,
+    lastError: 'lastError' in raw && typeof raw.lastError === 'string' ? raw.lastError : null,
+    lastFailedAt:
+      'lastFailedAt' in raw && typeof raw.lastFailedAt === 'string' ? raw.lastFailedAt : null,
   }
 }
 
@@ -53,13 +61,13 @@ export const urlWatchesApi = {
     return (data.watches ?? []).map((watch) => asWatch(watch))
   },
 
-  async create(url: string): Promise<UrlWatch> {
+  async create(url: string): Promise<{ watch: UrlWatch; created: boolean }> {
     const data = await httpClient('/api/v1/url-watches', {
       method: 'POST',
       body: JSON.stringify({ url }),
       schema: PostApiUrlWatchesCreateResponseSchema,
     })
-    return asWatch(data.watch)
+    return { watch: asWatch(data.watch), created: data.created === true }
   },
 
   async get(id: number): Promise<UrlWatch> {

--- a/frontend/src/views/AdminView.vue
+++ b/frontend/src/views/AdminView.vue
@@ -480,7 +480,7 @@
 
 <script setup lang="ts">
 import { defineAsyncComponent, ref, computed, onMounted, watch } from 'vue'
-import { useRoute } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import { Icon } from '@iconify/vue'
 import MainLayout from '@/components/MainLayout.vue'
 import PageHeader from '@/components/PageHeader.vue'
@@ -518,6 +518,7 @@ const { t } = useI18n()
 const { formatDateTime } = useDateFormat()
 const config = useConfigStore()
 const route = useRoute()
+const router = useRouter()
 const iamGroupsEnabled = computed(() => isIamGroupsEnabled())
 
 type TabId =
@@ -528,8 +529,28 @@ interface AdminTab {
   icon: string
 }
 
+const isValidTab = (tab: unknown): tab is TabId =>
+  tab === 'overview' ||
+  tab === 'users' ||
+  tab === 'prompts' ||
+  tab === 'usage' ||
+  tab === 'subscriptions' ||
+  tab === 'moderation' ||
+  tab === 'appServer'
+
+const tabFromQuery = (): TabId => {
+  const tab = route.query.tab
+  if (isValidTab(tab)) {
+    if (tab === 'appServer' && !isNativeApp()) {
+      return 'overview'
+    }
+    return tab
+  }
+  return 'overview'
+}
+
 // Tabs
-const activeTab = ref<TabId>('overview')
+const activeTab = ref<TabId>(tabFromQuery())
 const tabs = computed<AdminTab[]>(() => {
   const baseTabs: AdminTab[] = [
     { id: 'overview', label: t('admin.tabs.overview'), icon: 'mdi:view-dashboard' },
@@ -564,6 +585,23 @@ function onTabNavChange(id: string) {
   }
   activeTab.value = id as TabId
 }
+
+watch(activeTab, (id) => {
+  if (id === 'users' && iamGroupsEnabled.value) {
+    return
+  }
+  const tab = route.query.tab
+  if (tab === id || (id === 'overview' && (tab === undefined || tab === ''))) {
+    return
+  }
+  const query = { ...route.query }
+  if (id === 'overview') {
+    delete query.tab
+  } else {
+    query.tab = id
+  }
+  void router.replace({ query })
+})
 
 // Overview
 const overview = ref<SystemOverview | null>(null)
@@ -743,12 +781,9 @@ function formatDate(dateStr: string): string {
 // Initialize
 watch(
   () => route.query.tab,
-  (tab) => {
-    if (!iamGroupsEnabled.value && tab === 'users') {
-      activeTab.value = 'users'
-    }
-  },
-  { immediate: true }
+  () => {
+    activeTab.value = tabFromQuery()
+  }
 )
 
 onMounted(() => {

--- a/frontend/src/views/PeopleView.vue
+++ b/frontend/src/views/PeopleView.vue
@@ -1,6 +1,15 @@
 <template>
   <MainLayout data-testid="view-people">
     <div class="container mx-auto px-6 py-8 max-w-7xl overflow-x-hidden">
+      <button
+        type="button"
+        class="text-xs txt-secondary hover:txt-primary transition-colors mb-3 inline-flex items-center gap-1.5"
+        data-testid="link-people-back-operate"
+        @click="router.push({ name: 'admin' })"
+      >
+        <Icon icon="heroicons:arrow-left" class="w-3.5 h-3.5" />
+        {{ $t('people.backToOperate') }}
+      </button>
       <PageHeader
         :title="$t('people.title')"
         :subtitle="$t('people.subtitle')"
@@ -27,6 +36,8 @@
 
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { Icon } from '@iconify/vue'
 import MainLayout from '@/components/MainLayout.vue'
 import PageHeader from '@/components/PageHeader.vue'
 import TabNav, { type TabNavItem } from '@/components/TabNav.vue'
@@ -40,6 +51,7 @@ import { isPlatformLinksEnabled } from '@/composables/usePlatformLinksFeature'
 import { useI18n } from 'vue-i18n'
 
 const { t } = useI18n()
+const router = useRouter()
 const activeTab = ref<'users' | 'groups' | 'policies' | 'linked-platforms' | 'audit'>('users')
 
 const tabNavItems = computed<TabNavItem[]>(() => {

--- a/frontend/tests/e2e/helpers/selectors.ts
+++ b/frontend/tests/e2e/helpers/selectors.ts
@@ -525,6 +525,9 @@ export const selectors = {
     people: '[data-testid="view-people"]',
     tools: '[data-testid="page-tools"]',
   },
+  people: {
+    backToOperate: '[data-testid="link-people-back-operate"]',
+  },
   dialog: {
     confirmBtn: '[data-testid="btn-dialog-confirm"]',
     cancelBtn: '[data-testid="btn-dialog-cancel"]',

--- a/frontend/tests/e2e/tests/admin-panel.spec.ts
+++ b/frontend/tests/e2e/tests/admin-panel.spec.ts
@@ -109,6 +109,11 @@ test.describe('@ci Admin panel', () => {
       })
       await expect(page.locator('[data-testid="tab-groups"]')).toBeVisible()
       await expect(page.locator('[data-testid="page-not-found"]')).toHaveCount(0)
+      await expect(page.locator(selectors.people.backToOperate)).toBeVisible()
+      await page.locator(selectors.people.backToOperate).click()
+      await expect(page.locator(selectors.pages.admin)).toBeVisible({
+        timeout: TIMEOUTS.STANDARD,
+      })
     } else {
       await expect(page.locator('[data-testid="page-not-found"]')).toBeVisible({
         timeout: TIMEOUTS.STANDARD,

--- a/frontend/tests/unit/components/config/UrlWatchPanel.spec.ts
+++ b/frontend/tests/unit/components/config/UrlWatchPanel.spec.ts
@@ -143,6 +143,18 @@ describe('UrlWatchPanel', () => {
     expect(buttons[1].attributes('disabled')).toBeUndefined()
   })
 
+  it('toasts the blocked-URL copy when create returns blocked_url', async () => {
+    mockList.mockResolvedValue([])
+    mockCreate.mockRejectedValue(
+      new ApiError(400, 'URL points to a private/blocked address', 'blocked_url')
+    )
+    const wrapper = await mountPanel()
+    await wrapper.get('[data-testid="url-watch-input"]').setValue('http://127.0.0.1/page.html')
+    await wrapper.get('form').trigger('submit')
+    await flushPromises()
+    expect(mockError).toHaveBeenCalledWith('That address cannot be watched (private or blocked).')
+  })
+
   it('reports an existing watch instead of a first save', async () => {
     mockList.mockResolvedValue([watch])
     mockCreate.mockResolvedValue({ watch, created: false })

--- a/frontend/tests/unit/components/config/UrlWatchPanel.spec.ts
+++ b/frontend/tests/unit/components/config/UrlWatchPanel.spec.ts
@@ -1,14 +1,27 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { flushPromises, mount } from '@vue/test-utils'
 import UrlWatchPanel from '@/components/config/UrlWatchPanel.vue'
+import { ApiError } from '@/services/api/httpClient'
 import type { UrlWatch } from '@/services/api/urlWatchesApi'
 
-const { mockList, mockCreate, mockRemove, mockConfirm, mockRefresh } = vi.hoisted(() => ({
+const {
+  mockList,
+  mockCreate,
+  mockRemove,
+  mockConfirm,
+  mockRefresh,
+  mockGet,
+  mockSuccess,
+  mockError,
+} = vi.hoisted(() => ({
   mockList: vi.fn(),
   mockCreate: vi.fn(),
   mockRemove: vi.fn(),
   mockConfirm: vi.fn(),
   mockRefresh: vi.fn(),
+  mockGet: vi.fn(),
+  mockSuccess: vi.fn(),
+  mockError: vi.fn(),
 }))
 
 vi.mock('@/services/api/urlWatchesApi', () => ({
@@ -16,13 +29,13 @@ vi.mock('@/services/api/urlWatchesApi', () => ({
     list: mockList,
     create: mockCreate,
     remove: mockRemove,
-    get: vi.fn(),
+    get: mockGet,
     refresh: mockRefresh,
   },
 }))
 
 vi.mock('@/composables/useNotification', () => ({
-  useNotification: () => ({ success: vi.fn(), error: vi.fn() }),
+  useNotification: () => ({ success: mockSuccess, error: mockError }),
 }))
 
 vi.mock('@/composables/useDialog', () => ({
@@ -38,6 +51,9 @@ const watch: UrlWatch = {
   created: '2026-09-08T08:00:00+00:00',
   updated: '2026-09-08T09:00:00+00:00',
   body: '',
+  lastDiffText: null,
+  lastError: null,
+  lastFailedAt: null,
 }
 
 const mountPanel = async () => {
@@ -69,7 +85,7 @@ describe('UrlWatchPanel', () => {
 
   it('creates a watch from the form', async () => {
     mockList.mockResolvedValue([])
-    mockCreate.mockResolvedValue(watch)
+    mockCreate.mockResolvedValue({ watch, created: true })
     const wrapper = await mountPanel()
     await wrapper.get('[data-testid="url-watch-input"]').setValue('https://example.com/news')
     await wrapper.get('form').trigger('submit')
@@ -125,5 +141,56 @@ describe('UrlWatchPanel', () => {
     await flushPromises()
     expect(buttons[0].attributes('disabled')).toBeUndefined()
     expect(buttons[1].attributes('disabled')).toBeUndefined()
+  })
+
+  it('reports an existing watch instead of a first save', async () => {
+    mockList.mockResolvedValue([watch])
+    mockCreate.mockResolvedValue({ watch, created: false })
+    const wrapper = await mountPanel()
+    await wrapper.get('[data-testid="url-watch-input"]').setValue('https://example.com/news')
+    await wrapper.get('form').trigger('submit')
+    await flushPromises()
+    expect(mockSuccess).toHaveBeenCalledWith('This page is already watched.')
+  })
+
+  it('shows the API reason when a check fails', async () => {
+    mockList.mockResolvedValue([watch])
+    mockRefresh.mockRejectedValue(
+      new ApiError(400, 'could not read the page: HTTP 404', 'HTTP_400')
+    )
+    const wrapper = await mountPanel()
+    await wrapper.get('[data-testid="url-watch-check"]').trigger('click')
+    await flushPromises()
+    expect(mockError).toHaveBeenCalledWith('could not read the page: HTTP 404')
+    expect(wrapper.get('[data-testid="url-watch-status"]').text()).toContain('Last saved')
+  })
+
+  it('renders the last diff in the saved-copy dialog', async () => {
+    const changed: UrlWatch = {
+      ...watch,
+      lastDiffText: '- old uuid\n+ new uuid',
+      body: '{ "uuid": "new" }',
+    }
+    mockList.mockResolvedValue([changed])
+    mockGet.mockResolvedValue(changed)
+    const wrapper = await mountPanel()
+    await wrapper.get('[data-testid="url-watch-view"]').trigger('click')
+    await flushPromises()
+    expect(wrapper.get('[data-testid="url-watch-diff"]').text()).toContain('- old uuid')
+    expect(wrapper.get('[data-testid="url-watch-body"]').text()).toContain('new')
+  })
+
+  it('labels a failed check instead of Not fetched yet', async () => {
+    const failed: UrlWatch = {
+      ...watch,
+      fetchedAt: null,
+      lastError: 'URL points to a private/blocked address',
+      lastFailedAt: '2026-09-10T17:00:00+00:00',
+    }
+    mockList.mockResolvedValue([failed])
+    const wrapper = await mountPanel()
+    expect(wrapper.get('[data-testid="url-watch-status"]').text()).toContain(
+      'Last check failed: URL points to a private/blocked address'
+    )
   })
 })

--- a/frontend/tests/unit/composables/useNavItems.spec.ts
+++ b/frontend/tests/unit/composables/useNavItems.spec.ts
@@ -243,16 +243,22 @@ describe('useNavItems rail', () => {
     expect(keys).toContain('admin')
     const operate = wrapper.vm.navItems.find((item: { key: string }) => item.key === 'admin')
     expect(operate?.label).toBe('Operate')
-    const childKeys = (operate?.children ?? []).map((child: { key: string }) => child.key)
-    expect(childKeys).not.toContain('admin-people')
+    const children = operate?.children ?? []
+    const childKeys = children.map((child: { key: string }) => child.key)
+    expect(childKeys).toContain('admin-people')
+    expect(children.find((child: { key: string }) => child.key === 'admin-people')?.path).toBe(
+      '/admin?tab=users'
+    )
   })
 
-  it('shows People under Operate only when IAM groups are enabled', () => {
+  it('sends People to /admin/people when IAM groups are enabled', () => {
     runtimeFeatures.iamGroups = true
     const wrapper = mountNav({ email: 'admin@test.com', level: 'ADMIN', isAdmin: true })
     const operate = wrapper.vm.navItems.find((item: { key: string }) => item.key === 'admin')
-    const childKeys = (operate?.children ?? []).map((child: { key: string }) => child.key)
-    expect(childKeys).toContain('admin-people')
+    const people = (operate?.children ?? []).find(
+      (child: { key: string }) => child.key === 'admin-people'
+    )
+    expect(people?.path).toBe('/admin/people')
   })
 
   it('plugins stay a top-level rail entry when installed', () => {

--- a/frontend/tests/unit/views/PeopleView.spec.ts
+++ b/frontend/tests/unit/views/PeopleView.spec.ts
@@ -64,7 +64,10 @@ function mountView() {
   setActivePinia(createPinia())
   const router = createRouter({
     history: createMemoryHistory(),
-    routes: [{ path: '/', component: { template: '<div />' } }],
+    routes: [
+      { path: '/', component: { template: '<div />' } },
+      { path: '/admin', name: 'admin', component: { template: '<div />' } },
+    ],
   })
   return mount(PeopleView, {
     global: {
@@ -113,6 +116,36 @@ describe('PeopleView', () => {
         updated: 1,
       },
     ])
+  })
+
+  it('offers a back link to Operate', async () => {
+    setActivePinia(createPinia())
+    const router = createRouter({
+      history: createMemoryHistory(),
+      routes: [
+        { path: '/', component: { template: '<div />' } },
+        { path: '/admin', name: 'admin', component: { template: '<div />' } },
+      ],
+    })
+    await router.push('/')
+    await router.isReady()
+    const wrapper = mount(PeopleView, {
+      global: {
+        plugins: [router],
+        stubs: {
+          MainLayout: { template: '<div><slot /></div>' },
+          PageHeader: { template: '<div><slot /></div>' },
+          Teleport: true,
+        },
+      },
+    })
+    await flushPromises()
+
+    const back = wrapper.get('[data-testid="link-people-back-operate"]')
+    expect(back.text()).toContain('Back to Operate')
+    await back.trigger('click')
+    await flushPromises()
+    expect(router.currentRoute.value.name).toBe('admin')
   })
 
   it('hides Groups and Audit tabs when IAM groups are off', async () => {


### PR DESCRIPTION
## Summary

Fixes four bugs filed in the last 90 minutes.

- **#1811** — Chat delete now purges messages, `BMESSAGEMETA`, plan rows and message-bound files before removing the chat. `BMESSAGES.BCHATID` is `ON DELETE SET NULL`, so the previous path only detached the conversation. Shared `ChatDeletionService` is used by both `ChatController` and widget session delete. Bulk `deleteByChatIds()` removes meta first (no cascade on `BMESSAGEMETA`).
- **#1809** — Operate syncs `?tab=` so browser back restores the previous panel. People has a **Back to Operate** control. The sidebar People item is always listed (`/admin/people` with IAM groups, `/admin?tab=users` without).
- **#1806** — Last unified diff is persisted on `BURLWATCHES.BLASTDIFFTEXT` and shown in the saved-copy dialog. Re-adding an existing watch toasts “already watched”, not a first save.
- **#1805** — Failed checks persist `BLASTERROR` / `BLASTFAILEDAT`, log a redacted warning, and show the API reason on the row and in the toast. Private/SSRF-blocked URLs are rejected at create.

## Test plan

- [x] `make -C backend lint` / `phpstan` / affected PHPUnit (Chat + UrlWatch). Full suite green after clearing leftover Redis `platform_link:register_attempt` keys (unrelated 429).
- [x] `make -C frontend lint` / `vue-tsc` / Vitest
- [x] Playwright: `admin-panel` (People back link) and `chat-manage` (delete). Local `@ci` also hit env-only misses (MailHog `:8026`, WhatsApp stub `:3999`, Stripe webhook signature) and a pre-existing `/ai/instructions` overview miss — not caused by this change.
- [ ] After merge: apply `Version20260910200000` (Galera-safe `ADD COLUMN IF NOT EXISTS` on `BURLWATCHES`)

Fixes #1811
Fixes #1809
Fixes #1806
Fixes #1805