### PR TITLE
feat(saved-tasks): Steps editor and webhook trigger behind WORKFLOWS.BUILDER_ENABLED

### DIFF
--- a/_devextras/planning/202609_secure_compute/STATUS.md
+++ b/_devextras/planning/202609_secure_compute/STATUS.md
@@ -27,6 +27,7 @@ Track 5 of [`../20260903_roadmap.md`](../20260903_roadmap.md). Plan of record:
 | 2026-09-07 | **UX contract.** J-CP-1/2: chat-native run card, quota as a sentence, no new page. Wireframe `compute-run-card.md`. |
 | 2026-09-10 | A0–A2 land in this repo under `sidecars/synaplan-compute`. No PHP integration in Wave 4. |
 | 2026-09-10 | A0–A2 merged to `main` as [#1774](https://github.com/metadist/synaplan/pull/1774). |
+| 2026-09-10 | **Wave 5 decisions ticked:** Desktop is not the compute runtime. A3 + B1–B4 stay the next compute strain after this Tools S5 PR. `code_run` is write-class / unattended default `approve`. Cloud stays off until T2 on a compute node. Born as a feature module when B1 starts. |
 
 ## Review log
 

--- a/_devextras/planning/202609_tools_approval_workflows/STATUS.md
+++ b/_devextras/planning/202609_tools_approval_workflows/STATUS.md
@@ -11,7 +11,7 @@ Track 4 of [`../20260903_roadmap.md`](../20260903_roadmap.md). Plan of record:
 | S2 Policy & interactive approval | same | implemented | `ApprovalPolicy` truth table, `ApprovalCard`, inbox at Manage → Automations → Approvals, SSE/realtime, instant/digest notify. Flag off. |
 | S3 Unattended approval | same | implemented | Pause/resume Saved Task runs, 72 h expiry, waiting pill on the task card. |
 | S4 Custom tools | same | implemented | HTTP + OpenAPI import, SSRF, Connections UI, `custom_tools` + `mcp_servers` bundle sections (never tokens). Flag off. |
-| S5 Workflow builder v1 + webhook trigger | — | planned | Wave 5. |
+| S5 Workflow builder v1 + webhook trigger | `feat/wave5-workflow-builder` | in progress | Wave 5 first strain: TL38–TL40, TL42–TL44. Flag `WORKFLOWS.BUILDER_ENABLED` off. |
 
 ## Decisions
 
@@ -24,6 +24,7 @@ Track 4 of [`../20260903_roadmap.md`](../20260903_roadmap.md). Plan of record:
 | 2026-09-07 | **UX contract.** J-TL-1…5 binding. Card + inbox findability is the sharing lesson applied to approvals. Tool/template Share waits on IAM-UX. |
 | 2026-09-10 | Wave 4 S1–S4 implemented behind flags. Registry kill-switch defaults on; approvals and custom HTTP stay off. |
 | 2026-09-10 | Wave 4 S1–S4 merged to `main` as [#1774](https://github.com/metadist/synaplan/pull/1774). |
+| 2026-09-10 | **Wave 5 decisions ticked (roadmap §7.2, first PR):** (1) Recoverable jobs — this strain ships honest per-outcome copy and keeps existing pause/resume; checkpoints and per-run spend limits stay scheduled. (2) Publish ≠ activated — stays on Agent Builder STATUS; not this PR. (3) Approvals on resume — re-check current permissions and hard blocks immediately before execute; bind the approval to tool + arguments (a change voids it). (4) Sovereignty as a job-wide setting — scheduled, not this PR. (5) Complete-workflow packs / For you landing — scheduled. Form-first assistant builder and step-list editor stay the product shape. |
 
 ## Review log
 

--- a/backend/config/packages/messenger.yaml
+++ b/backend/config/packages/messenger.yaml
@@ -121,6 +121,9 @@ framework:
             'App\Message\GenerateDocumentThumbnailMessage': async_index
             'App\Message\ResumeApprovalCommand': async_ai_high
             'App\Message\ResumeSavedTaskRunCommand': async_ai_high
+            # Public webhook → Saved Task run. Accepted on the request path,
+            # executed here so proxy timeouts never trigger duplicate runs.
+            'App\Message\RunSavedTaskCommand': async_ai_high
 
 when@test:
     framework:

--- a/backend/config/packages/rate_limiter.yaml
+++ b/backend/config/packages/rate_limiter.yaml
@@ -58,3 +58,12 @@ framework:
             limit: 60
             interval: '1 minute'
             cache_pool: 'cache.rate_limiter'
+        # Public Saved Task webhook (`POST /api/v1/webhooks/saved-tasks/{token}`,
+        # PUBLIC_ACCESS), keyed per task in SavedTaskWebhookIngress. One start
+        # per second is far beyond any real integration and keeps a leaked
+        # address from flooding the owner's usage quota.
+        saved_task_webhook:
+            policy: 'sliding_window'
+            limit: 60
+            interval: '1 minute'
+            cache_pool: 'cache.rate_limiter'

--- a/backend/config/packages/security.yaml
+++ b/backend/config/packages/security.yaml
@@ -197,6 +197,7 @@ security:
         # Webhook endpoints (email webhook is public, WhatsApp requires verification)
         - { path: ^/api/v1/webhooks/email, roles: PUBLIC_ACCESS }
         - { path: ^/api/v1/webhooks/whatsapp, roles: PUBLIC_ACCESS }
+        - { path: ^/api/v1/webhooks/saved-tasks/, roles: PUBLIC_ACCESS }
 
         # Stripe webhook (public - secured by signature verification)
         - { path: ^/api/v1/stripe/webhook, roles: PUBLIC_ACCESS }

--- a/backend/src/Command/SeedAllCommand.php
+++ b/backend/src/Command/SeedAllCommand.php
@@ -36,6 +36,7 @@ use App\Seed\SubscriptionPlanSeeder;
 use App\Seed\ToolsConfigSeeder;
 use App\Seed\UpdateConfigSeeder;
 use App\Seed\UsageTaximeterConfigSeeder;
+use App\Seed\WorkflowsConfigSeeder;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -77,6 +78,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  *  22. document-tools (BCONFIG: DOCUMENT_TOOLS flags, ownerId=0 — default OFF)
  *  23. plugs         (BCONFIG: PLUGS extraction/search/rerank defaults, ownerId=0)
  *  24. tools         (BCONFIG: TOOLS registry/approvals/custom-HTTP flags, ownerId=0)
+ *  24b. workflows    (BCONFIG: WORKFLOWS.BUILDER_ENABLED, ownerId=0 — default OFF)
  *  25. module-gates  (BCONFIG: MODULES.GATE_<ID> all OFF, ownerId=0)
  *  26. demo-widget   (BCONFIG: example widget for ownerId=2 — dev/test only, no-op in prod)
  *
@@ -120,6 +122,7 @@ final class SeedAllCommand extends Command
         private readonly DocumentToolsConfigSeeder $documentToolsConfigSeeder,
         private readonly PlugsConfigSeeder $plugsConfigSeeder,
         private readonly ToolsConfigSeeder $toolsConfigSeeder,
+        private readonly WorkflowsConfigSeeder $workflowsConfigSeeder,
         private readonly ModuleGateSeeder $moduleGateSeeder,
     ) {
         parent::__construct();
@@ -158,6 +161,7 @@ final class SeedAllCommand extends Command
             "  22. document-tools flags       (BCONFIG, group=DOCUMENT_TOOLS, ownerId=0 — default OFF)\n".
             "  23. plugs defaults             (BCONFIG, group=PLUGS, ownerId=0 — today's FileProcessor + Brave)\n".
             "  24. tools flags                (BCONFIG, group=TOOLS, ownerId=0)\n".
+            "  24b. workflows builder flag    (BCONFIG, group=WORKFLOWS, ownerId=0 — default OFF)\n".
             "  25. module-gates               (BCONFIG, group=MODULES, GATE_<ID>=0 for every declared module)\n".
             "  26. demo widget config         (BCONFIG, group=widget_1, ownerId=2 — dev/test only)\n\n".
             'All steps are idempotent and safe to run on every deploy. The demo-widget step is a no-op in prod.'
@@ -199,6 +203,7 @@ final class SeedAllCommand extends Command
             ['document-tools', fn (): SeedResult => $this->documentToolsConfigSeeder->seed()],
             ['plugs', fn (): SeedResult => $this->plugsConfigSeeder->seed()],
             ['tools', fn (): SeedResult => $this->toolsConfigSeeder->seed()],
+            ['workflows', fn (): SeedResult => $this->workflowsConfigSeeder->seed()],
             ['module-gates', fn (): SeedResult => $this->moduleGateSeeder->seed()],
             ['demo-widget', fn (): SeedResult => $this->demoWidgetConfigSeeder->seed()],
         ];

--- a/backend/src/Controller/ConfigController.php
+++ b/backend/src/Controller/ConfigController.php
@@ -41,6 +41,7 @@ use App\Service\PlatformLink\PlatformLinksConfig;
 use App\Service\Plugin\PluginManager;
 use App\Service\RegistrationConfig;
 use App\Service\SavedTask\SavedTaskConfig;
+use App\Service\SavedTask\WorkflowsConfig;
 use App\Service\SelfAware\CapabilityInventory;
 use App\Service\SelfAware\SelfAwareConfig;
 use App\Service\Setup\SetupStateService;
@@ -106,6 +107,7 @@ class ConfigController extends AbstractController
         private readonly ?GroupPolicyService $groupPolicyService = null,
         private readonly ?BundleConfig $bundleConfig = null,
         private readonly ?ToolsConfig $toolsConfig = null,
+        private readonly ?WorkflowsConfig $workflowsConfig = null,
     ) {
     }
 
@@ -204,6 +206,7 @@ class ConfigController extends AbstractController
                         new OA\Property(property: 'toolsRegistryEnabled', type: 'boolean', example: true, description: 'When true, GET /api/v1/tools lists the tool registry. Kill switch after the Wave 4 registry refactor.'),
                         new OA\Property(property: 'toolsApprovalsEnabled', type: 'boolean', example: false, description: 'When true, write-class tools ask for approval and Manage → Automations → Approvals is shown. Off by default.'),
                         new OA\Property(property: 'toolsCustomHttpEnabled', type: 'boolean', example: false, description: 'When true, Connections shows Custom tools for HTTP/OpenAPI tools. Off by default.'),
+                        new OA\Property(property: 'workflowsBuilderEnabled', type: 'boolean', example: false, description: 'When true, Saved Tasks show a Steps editor and can start from another system. Off by default.'),
                     ]
                 ),
                 new OA\Property(
@@ -530,6 +533,7 @@ class ConfigController extends AbstractController
             'toolsRegistryEnabled' => null !== $this->toolsConfig && $this->toolsConfig->isRegistryEnabled($user?->getId()),
             'toolsApprovalsEnabled' => null !== $this->toolsConfig && $this->toolsConfig->isApprovalsEnabled($user?->getId()),
             'toolsCustomHttpEnabled' => null !== $this->toolsConfig && $this->toolsConfig->isCustomHttpEnabled($user?->getId()),
+            'workflowsBuilderEnabled' => null !== $this->workflowsConfig && $this->workflowsConfig->isBuilderEnabled($user?->getId()),
         ];
 
         // Speech-to-text configuration

--- a/backend/src/Controller/SavedTaskController.php
+++ b/backend/src/Controller/SavedTaskController.php
@@ -216,6 +216,7 @@ final class SavedTaskController extends AbstractController
                                 ]),
                                 new OA\Property(property: 'instructionPreview', type: 'string', nullable: true, description: 'First ~60 characters of the underlying instruction, for the task card.'),
                                 new OA\Property(property: 'waitingApprovalCount', type: 'integer', example: 0, description: 'How many runs are paused waiting for approval.'),
+                                new OA\Property(property: 'webhookSecret', type: 'string', nullable: true, description: 'Only on the response that turned on "Require a signature": the new HMAC secret, shown once. Never returned again.'),
                             ]
                         ),
                     ]
@@ -239,12 +240,15 @@ final class SavedTaskController extends AbstractController
         }
 
         try {
-            $task = $this->service->update($task, $request->toArray());
+            $updated = $this->service->updateAndRevealWebhookSecret($task, $request->toArray());
         } catch (\InvalidArgumentException $e) {
             return $this->json(['error' => $e->getMessage()], Response::HTTP_BAD_REQUEST);
         }
 
-        return $this->json(['success' => true, 'task' => $this->serializer->task($task)]);
+        return $this->json([
+            'success' => true,
+            'task' => $this->serializer->task($updated['task'], $updated['webhookSecret']),
+        ]);
     }
 
     #[Route('/{id}', name: 'delete', methods: ['DELETE'], requirements: ['id' => '\d+'])]

--- a/backend/src/Controller/SavedTaskWebhookController.php
+++ b/backend/src/Controller/SavedTaskWebhookController.php
@@ -16,7 +16,7 @@ use Symfony\Component\Routing\Attribute\Route;
 final class SavedTaskWebhookController extends AbstractController
 {
     public function __construct(
-        private SavedTaskWebhookIngress $ingress,
+        private readonly SavedTaskWebhookIngress $ingress,
     ) {
     }
 

--- a/backend/src/Controller/SavedTaskWebhookController.php
+++ b/backend/src/Controller/SavedTaskWebhookController.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Service\SavedTask\SavedTaskWebhookIngress;
+use OpenApi\Attributes as OA;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[Route('/api/v1/webhooks/saved-tasks', name: 'api_webhooks_saved_tasks_')]
+#[OA\Tag(name: 'Webhooks')]
+final class SavedTaskWebhookController extends AbstractController
+{
+    public function __construct(
+        private SavedTaskWebhookIngress $ingress,
+    ) {
+    }
+
+    #[Route('/{token}', name: 'run', methods: ['POST'])]
+    #[OA\Post(
+        path: '/api/v1/webhooks/saved-tasks/{token}',
+        summary: 'Start a Saved Task from another system',
+        description: 'Public. Unknown, disabled, or turned-off tasks return the same 404. Optional HMAC in X-Synaplan-Signature.',
+        tags: ['Webhooks']
+    )]
+    #[OA\Parameter(name: 'token', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    #[OA\RequestBody(
+        required: false,
+        content: new OA\JsonContent(type: 'object', additionalProperties: true)
+    )]
+    #[OA\Response(response: 202, description: 'Run accepted')]
+    #[OA\Response(response: 401, description: 'Signature missing or wrong')]
+    #[OA\Response(response: 404, description: 'Not found')]
+    #[OA\Response(response: 429, description: 'Too many requests')]
+    public function run(string $token, Request $request): JsonResponse
+    {
+        $result = $this->ingress->handle(
+            $token,
+            $request->getContent(),
+            $request->headers->get('X-Synaplan-Signature'),
+        );
+
+        return $this->json($result['body'], $result['status']);
+    }
+}

--- a/backend/src/Controller/ToolsController.php
+++ b/backend/src/Controller/ToolsController.php
@@ -53,6 +53,7 @@ final class ToolsController extends AbstractController
                                 new OA\Property(property: 'policy', type: 'string', nullable: true, example: null),
                                 new OA\Property(property: 'policyException', type: 'string', nullable: true, example: 'own_artefact'),
                                 new OA\Property(property: 'shared', type: 'boolean', example: false),
+                                new OA\Property(property: 'inputSchema', type: 'object', additionalProperties: true, description: 'JSON Schema of the arguments the tool accepts; the Saved Task Steps editor maps inputs from it.'),
                             ]
                         )),
                     ]

--- a/backend/src/Entity/SavedTask.php
+++ b/backend/src/Entity/SavedTask.php
@@ -19,16 +19,12 @@ class SavedTask
     public const TRIGGER_INBOUND_EMAIL = 'inbound_email';
     public const TRIGGER_WEBHOOK = 'webhook';
 
-    /**
-     * TRIGGER_WEBHOOK is deliberately excluded: no ingress endpoint exists yet
-     * (Sprint 4, work breakdown E22+). Accepting it would store a task that can
-     * never fire. Add it back together with the webhook route.
-     */
     public const TRIGGER_TYPES = [
         self::TRIGGER_MANUAL,
         self::TRIGGER_CHAT,
         self::TRIGGER_SCHEDULE,
         self::TRIGGER_INBOUND_EMAIL,
+        self::TRIGGER_WEBHOOK,
     ];
 
     public const AUTO_PAUSE_AFTER = 3;

--- a/backend/src/Message/RunSavedTaskCommand.php
+++ b/backend/src/Message/RunSavedTaskCommand.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Message;
+
+/**
+ * Starts a Saved Task run off the request path. Dispatched by the public
+ * webhook ingress after it has validated the token, signature and limits.
+ */
+final readonly class RunSavedTaskCommand
+{
+    /**
+     * @param array<string, mixed> $triggerPayload JSON body of the starting event
+     */
+    public function __construct(
+        public int $ownerId,
+        public int $taskId,
+        public string $trigger,
+        public array $triggerPayload = [],
+    ) {
+    }
+}

--- a/backend/src/MessageHandler/RunSavedTaskCommandHandler.php
+++ b/backend/src/MessageHandler/RunSavedTaskCommandHandler.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MessageHandler;
+
+use App\Message\RunSavedTaskCommand;
+use App\Service\SavedTask\SavedTaskDisabledException;
+use App\Service\SavedTask\SavedTaskNotFoundException;
+use App\Service\SavedTask\SavedTaskRunner;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+#[AsMessageHandler]
+final readonly class RunSavedTaskCommandHandler
+{
+    public function __construct(
+        private SavedTaskRunner $runner,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function __invoke(RunSavedTaskCommand $command): void
+    {
+        try {
+            $this->runner->run($command->ownerId, $command->taskId, '', $command->trigger, $command->triggerPayload);
+        } catch (SavedTaskDisabledException|SavedTaskNotFoundException $e) {
+            // The task was turned off or removed between accept and run — nothing to retry.
+            $this->logger->info('RunSavedTask skipped', [
+                'task_id' => $command->taskId,
+                'trigger' => $command->trigger,
+                'reason' => $e->getMessage(),
+            ]);
+        }
+    }
+}

--- a/backend/src/Repository/SavedTaskRepository.php
+++ b/backend/src/Repository/SavedTaskRepository.php
@@ -127,9 +127,26 @@ class SavedTaskRepository extends ServiceEntityRepository
         return $affected > 0;
     }
 
-    /**
-     * @return list<SavedTask>
-     */
+    public function findByWebhookToken(string $token): ?SavedTask
+    {
+        if ('' === $token) {
+            return null;
+        }
+        /** @var list<SavedTask> $tasks */
+        $tasks = $this->createQueryBuilder('t')
+            ->where('t.triggerType = :type')
+            ->setParameter('type', SavedTask::TRIGGER_WEBHOOK)
+            ->getQuery()
+            ->getResult();
+        foreach ($tasks as $task) {
+            if (($task->getTriggerConfig()['token'] ?? null) === $token) {
+                return $task;
+            }
+        }
+
+        return null;
+    }
+
     public function findEnabledInboundEmailTasks(int $ownerId, int $accountId): array
     {
         $tasks = $this->createQueryBuilder('t')

--- a/backend/src/Repository/SavedTaskRepository.php
+++ b/backend/src/Repository/SavedTaskRepository.php
@@ -132,19 +132,22 @@ class SavedTaskRepository extends ServiceEntityRepository
         if ('' === $token) {
             return null;
         }
-        /** @var list<SavedTask> $tasks */
-        $tasks = $this->createQueryBuilder('t')
-            ->where('t.triggerType = :type')
-            ->setParameter('type', SavedTask::TRIGGER_WEBHOOK)
-            ->getQuery()
-            ->getResult();
-        foreach ($tasks as $task) {
-            if (($task->getTriggerConfig()['token'] ?? null) === $token) {
-                return $task;
-            }
+        // Resolve the id in SQL so the lookup stays O(1) as tasks grow; the
+        // constant-time compare afterwards keeps the DB's collation out of it.
+        $id = $this->getEntityManager()->getConnection()->fetchOne(
+            "SELECT BID FROM BSAVEDTASKS WHERE BTRIGGERTYPE = :type AND JSON_UNQUOTE(JSON_EXTRACT(BTRIGGERCONFIG, '$.token')) = :token LIMIT 1",
+            ['type' => SavedTask::TRIGGER_WEBHOOK, 'token' => $token]
+        );
+        if (false === $id || null === $id) {
+            return null;
         }
+        $task = $this->find((int) $id);
+        if (!$task instanceof SavedTask) {
+            return null;
+        }
+        $stored = $task->getTriggerConfig()['token'] ?? null;
 
-        return null;
+        return is_string($stored) && hash_equals($stored, $token) ? $task : null;
     }
 
     public function findEnabledInboundEmailTasks(int $ownerId, int $accountId): array

--- a/backend/src/Seed/WorkflowsConfigSeeder.php
+++ b/backend/src/Seed/WorkflowsConfigSeeder.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Seed;
+
+use App\Service\SavedTask\WorkflowsConfig;
+use Doctrine\DBAL\Connection;
+
+/**
+ * Idempotent seeder for WORKFLOWS.* flags (BCONFIG, ownerId=0).
+ *
+ * Insert-if-missing only. The Steps editor and webhook trigger stay OFF
+ * until an operator enables them.
+ */
+final readonly class WorkflowsConfigSeeder
+{
+    public function __construct(
+        private Connection $connection,
+    ) {
+    }
+
+    public function seed(): SeedResult
+    {
+        $rows = [
+            ['ownerId' => 0, 'group' => WorkflowsConfig::CONFIG_GROUP, 'setting' => WorkflowsConfig::KEY_BUILDER_ENABLED, 'value' => '0'],
+        ];
+
+        return BConfigSeeder::insertIfMissing($this->connection, 'workflows_config', $rows);
+    }
+}

--- a/backend/src/Service/Iam/Policy/PolicyAllowList.php
+++ b/backend/src/Service/Iam/Policy/PolicyAllowList.php
@@ -38,6 +38,7 @@ final class PolicyAllowList
         'TOOLS.REGISTRY_ENABLED',
         'TOOLS.APPROVALS_ENABLED',
         'TOOLS.CUSTOM_HTTP_ENABLED',
+        'WORKFLOWS.BUILDER_ENABLED',
     ];
 
     /**

--- a/backend/src/Service/Multitask/Execution/NodeResult.php
+++ b/backend/src/Service/Multitask/Execution/NodeResult.php
@@ -48,6 +48,14 @@ final readonly class NodeResult
     }
 
     /**
+     * A condition evaluated false. Dependents skip; the run itself completed.
+     */
+    public static function stopped(string $reason = 'Condition was not met'): self
+    {
+        return new self(NodeStatus::Stopped, error: $reason);
+    }
+
+    /**
      * Media detached to a background {@see \App\Service\Media\MediaJob} — no file
      * yet; Sprint C completes the card when the job reaches a terminal state.
      *
@@ -92,7 +100,14 @@ final readonly class NodeResult
 
     public function isSettledUnsuccessful(): bool
     {
-        return NodeStatus::Failed === $this->status || NodeStatus::Skipped === $this->status;
+        return NodeStatus::Failed === $this->status
+            || NodeStatus::Skipped === $this->status
+            || NodeStatus::Stopped === $this->status;
+    }
+
+    public function isStopped(): bool
+    {
+        return NodeStatus::Stopped === $this->status;
     }
 
     public function isWaitingApproval(): bool

--- a/backend/src/Service/Multitask/Execution/NodeStatus.php
+++ b/backend/src/Service/Multitask/Execution/NodeStatus.php
@@ -20,4 +20,9 @@ enum NodeStatus: string
     case Skipped = 'skipped';
     /** A write-class tool is waiting for the owner to approve it. */
     case WaitingApproval = 'waiting_approval';
+    /**
+     * A condition step evaluated false. Dependents are skipped and the run
+     * completes — this is not a failure.
+     */
+    case Stopped = 'stopped';
 }

--- a/backend/src/Service/Multitask/Execution/ResultAssembler.php
+++ b/backend/src/Service/Multitask/Execution/ResultAssembler.php
@@ -60,7 +60,7 @@ final class ResultAssembler
                     $jobKeys[$node->id] = $mediaJob['job_id'];
                 }
             }
-            if (NodeStatus::Done === $status) {
+            if (NodeStatus::Done === $status || NodeStatus::Stopped === $status) {
                 ++$successCount;
             } elseif (NodeStatus::Failed === $status) {
                 ++$failureCount;

--- a/backend/src/Service/Multitask/Execution/Runner/ConditionRunner.php
+++ b/backend/src/Service/Multitask/Execution/Runner/ConditionRunner.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Multitask\Execution\Runner;
+
+use App\Service\Multitask\Execution\NodeContext;
+use App\Service\Multitask\Execution\NodeResult;
+use App\Service\Multitask\Execution\TaskRunner;
+use App\Service\Multitask\Plan\Capability;
+use App\Service\Multitask\Plan\TaskNode;
+use App\Service\Multitask\Skill\SkillDescriptor;
+use App\Service\SavedTask\Graph\StepInputResolver;
+
+/**
+ * Authored condition step. Hidden from the planner. On false the node
+ * {@see NodeResult::stopped()} so dependents skip and the run completes.
+ */
+final readonly class ConditionRunner implements TaskRunner
+{
+    public function __construct(
+        private StepInputResolver $inputs,
+    ) {
+    }
+
+    public function supportedCapabilities(): array
+    {
+        return [Capability::Condition];
+    }
+
+    /**
+     * @return list<SkillDescriptor>
+     */
+    public function describe(): array
+    {
+        return [
+            new SkillDescriptor(
+                Capability::Condition,
+                'Stop later steps when a value does not match.',
+                available: static fn (): bool => false,
+            ),
+        ];
+    }
+
+    public function run(TaskNode $node, NodeContext $context): NodeResult
+    {
+        $params = $node->params;
+        $rawInputs = is_array($params['inputs'] ?? null) ? $params['inputs'] : $node->inputs;
+        $resolved = $this->inputs->resolveAll($rawInputs, $context);
+        $value = $resolved['input'] ?? $this->inputs->resolve($params['input'] ?? null, $context);
+        $operator = is_string($params['operator'] ?? null) ? $params['operator'] : 'not_empty';
+        $expected = $params['value'] ?? $resolved['value'] ?? null;
+
+        $ok = $this->matches($value, $operator, $expected);
+        if ($ok) {
+            $text = is_scalar($value) ? (string) $value : 'Condition matched';
+
+            return NodeResult::ok('' === $text ? 'Condition matched' : $text, [], [
+                'condition' => true,
+                'operator' => $operator,
+            ]);
+        }
+
+        return NodeResult::stopped('Condition was not met');
+    }
+
+    private function matches(mixed $value, string $operator, mixed $expected): bool
+    {
+        $left = $this->stringify($value);
+        $right = $this->stringify($expected);
+
+        return match ($operator) {
+            'equals' => $left === $right,
+            'contains' => '' !== $right && str_contains($left, $right),
+            'matches' => '' !== $right && false !== @preg_match($this->asPattern($right), $left),
+            default => '' !== trim($left),
+        };
+    }
+
+    private function stringify(mixed $value): string
+    {
+        if (null === $value) {
+            return '';
+        }
+        if (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+        if (is_scalar($value)) {
+            return (string) $value;
+        }
+
+        return json_encode($value, \JSON_THROW_ON_ERROR);
+    }
+
+    private function asPattern(string $value): string
+    {
+        if (str_starts_with($value, '/') && 1 === preg_match('/^\/.*\/[imsxuADSUXJ]*$/', $value)) {
+            return $value;
+        }
+
+        return '/'.str_replace('/', '\/', $value).'/u';
+    }
+}

--- a/backend/src/Service/Multitask/Execution/Runner/ConditionRunner.php
+++ b/backend/src/Service/Multitask/Execution/Runner/ConditionRunner.php
@@ -72,7 +72,7 @@ final readonly class ConditionRunner implements TaskRunner
         return match ($operator) {
             'equals' => $left === $right,
             'contains' => '' !== $right && str_contains($left, $right),
-            'matches' => '' !== $right && false !== @preg_match($this->asPattern($right), $left),
+            'matches' => '' !== $right && 1 === @preg_match($this->asPattern($right), $left),
             default => '' !== trim($left),
         };
     }

--- a/backend/src/Service/Multitask/Execution/Runner/OutboundWebhookRunner.php
+++ b/backend/src/Service/Multitask/Execution/Runner/OutboundWebhookRunner.php
@@ -67,7 +67,8 @@ final readonly class OutboundWebhookRunner implements TaskRunner
             'task' => $context->options['saved_task_id'] ?? null,
             'run' => $context->options['saved_task_run_id'] ?? null,
             'step' => $node->id,
-            'result' => $mapped,
+            // No mapping means "send what the previous steps produced" — never an empty result.
+            'result' => [] !== $mapped ? $mapped : $this->dependencyResults($node, $context),
         ];
         $json = json_encode($body, \JSON_THROW_ON_ERROR);
         $headers = [
@@ -106,5 +107,22 @@ final readonly class OutboundWebhookRunner implements TaskRunner
         }
 
         return NodeResult::ok('Sent to the other system', [], ['webhook' => ['status' => $status]]);
+    }
+
+    /**
+     * @return array<string, array{text: string|null, metadata: array<string, mixed>}>
+     */
+    private function dependencyResults(TaskNode $node, NodeContext $context): array
+    {
+        $out = [];
+        foreach ($node->dependsOn as $dependencyId) {
+            $result = $context->getResult($dependencyId);
+            if (null === $result) {
+                continue;
+            }
+            $out[$dependencyId] = ['text' => $result->text, 'metadata' => $result->metadata];
+        }
+
+        return $out;
     }
 }

--- a/backend/src/Service/Multitask/Execution/Runner/OutboundWebhookRunner.php
+++ b/backend/src/Service/Multitask/Execution/Runner/OutboundWebhookRunner.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Multitask\Execution\Runner;
+
+use App\Service\Multitask\Execution\NodeContext;
+use App\Service\Multitask\Execution\NodeResult;
+use App\Service\Multitask\Execution\TaskRunner;
+use App\Service\Multitask\Plan\Capability;
+use App\Service\Multitask\Plan\TaskNode;
+use App\Service\Multitask\Skill\SkillDescriptor;
+use App\Service\SavedTask\Graph\StepInputResolver;
+use App\Service\Security\SsrfGuard;
+use Psr\Log\LoggerInterface;
+use Symfony\Contracts\HttpClient\Exception\ExceptionInterface as HttpClientExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * Sends a signed HTTPS POST of a step result. Hidden from the planner.
+ * No retries — the receiver retries. Never includes credentials.
+ */
+final readonly class OutboundWebhookRunner implements TaskRunner
+{
+    private const TIMEOUT_SECONDS = 10;
+
+    public function __construct(
+        private HttpClientInterface $httpClient,
+        private SsrfGuard $ssrfGuard,
+        private StepInputResolver $inputs,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function supportedCapabilities(): array
+    {
+        return [Capability::OutboundWebhook];
+    }
+
+    /**
+     * @return list<SkillDescriptor>
+     */
+    public function describe(): array
+    {
+        return [
+            new SkillDescriptor(
+                Capability::OutboundWebhook,
+                'Send the result to another system over HTTPS.',
+                available: static fn (): bool => false,
+            ),
+        ];
+    }
+
+    public function run(TaskNode $node, NodeContext $context): NodeResult
+    {
+        $url = is_string($node->params['url'] ?? null) ? trim($node->params['url']) : '';
+        if ('' === $url || !str_starts_with(strtolower($url), 'https://')) {
+            return NodeResult::failed('Send to webhook needs an https address');
+        }
+        if ($this->ssrfGuard->isBlockedUrl($url)) {
+            return NodeResult::failed('That address cannot be reached from here');
+        }
+
+        $rawInputs = is_array($node->params['inputs'] ?? null) ? $node->params['inputs'] : $node->inputs;
+        $mapped = $this->inputs->resolveAll($rawInputs, $context);
+        $body = [
+            'task' => $context->options['saved_task_id'] ?? null,
+            'run' => $context->options['saved_task_run_id'] ?? null,
+            'step' => $node->id,
+            'result' => $mapped,
+        ];
+        $json = json_encode($body, \JSON_THROW_ON_ERROR);
+        $headers = [
+            'Content-Type' => 'application/json',
+            'Accept' => 'application/json',
+        ];
+        $secret = is_string($node->params['secret'] ?? null) ? $node->params['secret'] : '';
+        if ('' !== $secret) {
+            $headers['X-Synaplan-Signature'] = 'sha256='.hash_hmac('sha256', $json, $secret);
+        }
+
+        try {
+            $response = $this->httpClient->request('POST', $url, [
+                'headers' => $headers,
+                'body' => $json,
+                'max_redirects' => 0,
+                'timeout' => self::TIMEOUT_SECONDS,
+                'max_duration' => self::TIMEOUT_SECONDS,
+            ]);
+            $status = $response->getStatusCode();
+            if ($status >= 300 && $status < 400) {
+                $response->cancel();
+
+                return NodeResult::failed('The other system redirected the request — that is not allowed');
+            }
+            if ($status >= 400) {
+                return NodeResult::failed('The other system did not accept the result');
+            }
+        } catch (HttpClientExceptionInterface $e) {
+            $this->logger->info('OutboundWebhookRunner: call failed', [
+                'step' => $node->id,
+                'error' => $e->getMessage(),
+            ]);
+
+            return NodeResult::failed('Could not reach the other system');
+        }
+
+        return NodeResult::ok('Sent to the other system', [], ['webhook' => ['status' => $status]]);
+    }
+}

--- a/backend/src/Service/Multitask/Execution/Runner/ToolCallRunner.php
+++ b/backend/src/Service/Multitask/Execution/Runner/ToolCallRunner.php
@@ -104,8 +104,8 @@ final readonly class ToolCallRunner implements TaskRunner
     {
         $override = is_string($node->params['approval'] ?? null) ? $node->params['approval'] : null;
         if (null === $this->executionGate) {
-            return 'block' === $override
-                ? NodeResult::failed('I cannot do that. This step is set to always ask — and it is blocked.')
+            return PolicyOutcome::Block->value === $override
+                ? NodeResult::failed(ToolExecutionGate::NODE_BLOCK_REFUSAL)
                 : null;
         }
         if ($context->isApproved($node->id)) {

--- a/backend/src/Service/Multitask/Execution/Runner/ToolCallRunner.php
+++ b/backend/src/Service/Multitask/Execution/Runner/ToolCallRunner.php
@@ -1,0 +1,226 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Multitask\Execution\Runner;
+
+use App\Entity\User;
+use App\Repository\CustomToolRepository;
+use App\Repository\McpServerConfigRepository;
+use App\Repository\UserRepository;
+use App\Service\Mcp\McpClient;
+use App\Service\Mcp\McpClientException;
+use App\Service\Multitask\Execution\NodeContext;
+use App\Service\Multitask\Execution\NodeResult;
+use App\Service\Multitask\Execution\TaskRunner;
+use App\Service\Multitask\Plan\Capability;
+use App\Service\Multitask\Plan\TaskNode;
+use App\Service\Multitask\Skill\SkillDescriptor;
+use App\Service\SavedTask\Graph\StepInputResolver;
+use App\Service\Tool\Custom\HttpToolExecutor;
+use App\Service\Tool\Custom\InvalidToolTemplateException;
+use App\Service\Tool\Exception\ToolNotRegisteredException;
+use App\Service\Tool\Policy\PolicyContext;
+use App\Service\Tool\Policy\PolicyOutcome;
+use App\Service\Tool\ToolExecutionGate;
+use App\Service\Tool\ToolRegistry;
+use App\Service\Tool\ToolSource;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Runs a registered custom or MCP tool from an authored Saved Task step.
+ * Hidden from the planner catalog.
+ */
+final readonly class ToolCallRunner implements TaskRunner
+{
+    public function __construct(
+        private ToolRegistry $registry,
+        private StepInputResolver $inputs,
+        private HttpToolExecutor $httpExecutor,
+        private CustomToolRepository $customTools,
+        private McpClient $mcpClient,
+        private McpServerConfigRepository $mcpServers,
+        private UserRepository $users,
+        private LoggerInterface $logger,
+        private ?ToolExecutionGate $executionGate = null,
+    ) {
+    }
+
+    public function supportedCapabilities(): array
+    {
+        return [Capability::ToolCall];
+    }
+
+    /**
+     * @return list<SkillDescriptor>
+     */
+    public function describe(): array
+    {
+        return [
+            new SkillDescriptor(
+                Capability::ToolCall,
+                'Call a connected tool.',
+                available: static fn (): bool => false,
+            ),
+        ];
+    }
+
+    public function run(TaskNode $node, NodeContext $context): NodeResult
+    {
+        $userId = $context->userId ?? $context->message->getUserId();
+        $toolName = is_string($node->params['tool'] ?? null) ? trim($node->params['tool']) : '';
+        if ($userId <= 0 || '' === $toolName) {
+            return NodeResult::failed('This step needs a tool');
+        }
+
+        $descriptor = $this->registry->get((int) $userId, $toolName);
+        if (null === $descriptor) {
+            return NodeResult::failed((new ToolNotRegisteredException($toolName))->getMessage());
+        }
+
+        $rawInputs = is_array($node->params['inputs'] ?? null) ? $node->params['inputs'] : $node->inputs;
+        $arguments = $this->inputs->resolveAll($rawInputs, $context);
+
+        $gated = $this->consultGate($context, $node, $toolName, $arguments, (int) $userId);
+        if (null !== $gated) {
+            return $gated;
+        }
+
+        try {
+            return match ($descriptor->source) {
+                ToolSource::Custom => $this->runCustom($descriptor->meta, $arguments, (int) $userId, $toolName),
+                ToolSource::Mcp => $this->runMcp($descriptor->meta, $arguments, (int) $userId, $toolName),
+                default => NodeResult::failed('This tool cannot run as a Saved Task step'),
+            };
+        } catch (ToolNotRegisteredException $e) {
+            return NodeResult::failed($e->getMessage());
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $arguments
+     */
+    private function consultGate(NodeContext $context, TaskNode $node, string $toolName, array $arguments, int $userId): ?NodeResult
+    {
+        $override = is_string($node->params['approval'] ?? null) ? $node->params['approval'] : null;
+        if (null === $this->executionGate) {
+            return 'block' === $override
+                ? NodeResult::failed('I cannot do that. This step is set to always ask — and it is blocked.')
+                : null;
+        }
+        if ($context->isApproved($node->id)) {
+            return null;
+        }
+        $actor = $this->users->find($userId);
+        if (!$actor instanceof User) {
+            return NodeResult::failed('This account cannot run Saved Tasks');
+        }
+        $runId = is_numeric($context->options['saved_task_run_id'] ?? null) ? (int) $context->options['saved_task_run_id'] : 0;
+        $requestedBy = $runId > 0
+            ? sprintf('task_run:%d:%s', $runId, $node->id)
+            : 'chat:'.(int) $context->message->getId();
+        try {
+            $decision = $this->executionGate->inspect(
+                $userId,
+                $toolName,
+                $arguments,
+                $actor,
+                PolicyContext::Unattended,
+                $requestedBy,
+                null,
+                true === ($context->options['allow_unattended'] ?? false),
+                null,
+                $override,
+            );
+        } catch (ToolNotRegisteredException $e) {
+            return NodeResult::failed($e->getMessage());
+        }
+        if (PolicyOutcome::Block === $decision['outcome']) {
+            return NodeResult::failed((string) $decision['refusal']);
+        }
+        if (PolicyOutcome::Approve === $decision['outcome'] && null !== $decision['approval']) {
+            $approval = $decision['approval'];
+
+            return NodeResult::waitingApproval((int) $approval->getId(), $arguments, [
+                'tool' => $approval->getTool(),
+                'preview' => $approval->getPreview(),
+                'expires_at' => $approval->getExpiresAt(),
+                'side_effect' => $approval->getSideEffect(),
+            ]);
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, mixed> $meta
+     * @param array<string, mixed> $arguments
+     */
+    private function runCustom(array $meta, array $arguments, int $userId, string $toolName): NodeResult
+    {
+        $toolId = $meta['toolId'] ?? null;
+        $tool = is_numeric($toolId) ? $this->customTools->find((int) $toolId) : null;
+        if (null === $tool) {
+            throw new ToolNotRegisteredException($toolName);
+        }
+        try {
+            $result = $this->httpExecutor->execute($tool, $arguments, $userId);
+        } catch (InvalidToolTemplateException $e) {
+            $this->logger->info('ToolCallRunner: custom tool failed', [
+                'tool' => $toolName,
+                'error' => $e->getMessage(),
+            ]);
+
+            return NodeResult::failed($e->getMessage());
+        }
+
+        return NodeResult::ok($result['summary'], [], [
+            'tool' => $toolName,
+            'fields' => $result['fields'],
+            'summary' => $result['summary'],
+        ]);
+    }
+
+    /**
+     * @param array<string, mixed> $meta
+     * @param array<string, mixed> $arguments
+     */
+    private function runMcp(array $meta, array $arguments, int $userId, string $toolName): NodeResult
+    {
+        $serverId = (int) ($meta['serverId'] ?? 0);
+        $mcpTool = is_string($meta['tool'] ?? null) ? $meta['tool'] : '';
+        $server = $serverId > 0 ? $this->mcpServers->findByIdAndUser($serverId, $userId) : null;
+        if (null === $server || !$server->isEnabled() || '' === $mcpTool) {
+            throw new ToolNotRegisteredException($toolName);
+        }
+        try {
+            $call = $this->mcpClient->callTool($server, $mcpTool, $arguments);
+        } catch (McpClientException $e) {
+            return NodeResult::failed('could not reach the connected system: '.$e->getMessage());
+        }
+        $text = $this->formatContent($call['content']);
+        if ($call['isError']) {
+            return NodeResult::failed('the connected system reported an error: '.mb_substr($text, 0, 300));
+        }
+
+        return NodeResult::ok('' !== $text ? $text : 'The tool finished', [], [
+            'tool' => $toolName,
+            'summary' => $text,
+        ]);
+    }
+
+    /**
+     * @param list<array<string, mixed>> $content
+     */
+    private function formatContent(array $content): string
+    {
+        $parts = [];
+        foreach ($content as $item) {
+            if (is_string($item['text'] ?? null) && '' !== $item['text']) {
+                $parts[] = $item['text'];
+            }
+        }
+
+        return trim(implode("\n", $parts));
+    }
+}

--- a/backend/src/Service/Multitask/Plan/Capability.php
+++ b/backend/src/Service/Multitask/Plan/Capability.php
@@ -91,6 +91,38 @@ enum Capability: string
     case ComposeReply = 'compose_reply';
 
     /**
+     * Call a registered tool (custom HTTP or MCP) from an authored Saved Task.
+     * Hidden from the planner catalog ({@see SkillDescriptor::$available}).
+     */
+    case ToolCall = 'tool_call';
+
+    /**
+     * HMAC-signed HTTPS POST of a step result to an external URL.
+     * Hidden from the planner catalog.
+     */
+    case OutboundWebhook = 'outbound_webhook';
+
+    /**
+     * Gate: on false the run stops and dependents are skipped (not failed).
+     * Hidden from the planner catalog.
+     */
+    case Condition = 'condition';
+
+    /**
+     * Capabilities that exist only for the Steps editor (flag-gated at validate).
+     *
+     * @return list<string>
+     */
+    public static function builderOnlyValues(): array
+    {
+        return [
+            self::ToolCall->value,
+            self::OutboundWebhook->value,
+            self::Condition->value,
+        ];
+    }
+
+    /**
      * @return list<string> all capability string values
      */
     public static function values(): array
@@ -116,6 +148,9 @@ enum Capability: string
             self::EmailMe => 'email',
             self::SaveToFolder => 'folder',
             self::ComposeReply => 'hidden',
+            self::ToolCall => 'search',
+            self::OutboundWebhook => 'email',
+            self::Condition => 'text',
         };
     }
 

--- a/backend/src/Service/SavedTask/Graph/SavedTaskGraphValidator.php
+++ b/backend/src/Service/SavedTask/Graph/SavedTaskGraphValidator.php
@@ -151,14 +151,17 @@ final class SavedTaskGraphValidator
             }
         }
 
+        $capability = $node['capability'] ?? null;
         $approval = $params['approval'] ?? null;
         if (null !== $approval) {
             if (!in_array($approval, ['approve', 'block'], true)) {
                 $errors[] = "step[$i] can only tighten approval (ask me, or block)";
+            } elseif (Capability::ToolCall->value !== $capability) {
+                // Only the tool gate pauses a run; promising it elsewhere would be a lie.
+                $errors[] = "step[$i] can only ask before a tool step";
             }
         }
 
-        $capability = $node['capability'] ?? null;
         if (Capability::OutboundWebhook->value === $capability) {
             $url = is_string($params['url'] ?? null) ? trim($params['url']) : '';
             if ('' === $url || !str_starts_with(strtolower($url), 'https://')) {

--- a/backend/src/Service/SavedTask/Graph/SavedTaskGraphValidator.php
+++ b/backend/src/Service/SavedTask/Graph/SavedTaskGraphValidator.php
@@ -5,11 +5,19 @@ declare(strict_types=1);
 namespace App\Service\SavedTask\Graph;
 
 use App\Service\Multitask\Plan\Capability;
+use App\Service\SavedTask\WorkflowsConfig;
+use App\Service\Security\SsrfGuard;
 
 final class SavedTaskGraphValidator
 {
     public const VERSION = 1;
     public const MAX_NODES = 16;
+
+    public function __construct(
+        private readonly ?WorkflowsConfig $workflowsConfig = null,
+        private readonly ?SsrfGuard $ssrfGuard = null,
+    ) {
+    }
 
     /**
      * @param array<string, mixed>      $graph
@@ -17,7 +25,7 @@ final class SavedTaskGraphValidator
      *
      * @return list<string>
      */
-    public function validate(array $graph, string $columnTriggerType, ?array $columnConfig): array
+    public function validate(array $graph, string $columnTriggerType, ?array $columnConfig, ?int $ownerId = null): array
     {
         $errors = [];
         if (($graph['version'] ?? null) !== self::VERSION) {
@@ -41,8 +49,13 @@ final class SavedTaskGraphValidator
             $errors[] = sprintf('too many steps (%d > %d)', count($nodes), self::MAX_NODES);
         }
 
+        $builderOn = null !== $this->workflowsConfig && $this->workflowsConfig->isBuilderEnabled($ownerId);
+        $allowed = Capability::values();
+        if (!$builderOn) {
+            $allowed = array_values(array_diff($allowed, Capability::builderOnlyValues()));
+        }
+
         $ids = [];
-        $capabilities = Capability::values();
         foreach ($nodes as $i => $node) {
             if (!is_array($node)) {
                 $errors[] = "step[$i] must be an object";
@@ -57,8 +70,16 @@ final class SavedTaskGraphValidator
                 $ids[$id] = true;
             }
             $capability = $node['capability'] ?? null;
-            if (!is_string($capability) || !in_array($capability, $capabilities, true)) {
+            if (!is_string($capability) || !in_array($capability, $allowed, true)) {
                 $errors[] = "step[$i] has an unknown action";
+            }
+        }
+
+        if ($builderOn) {
+            foreach ($nodes as $i => $node) {
+                if (is_array($node)) {
+                    array_push($errors, ...$this->validateBuilderNode($i, $node));
+                }
             }
         }
 
@@ -97,6 +118,65 @@ final class SavedTaskGraphValidator
                 if ($value < 1 || $value > 720) {
                     $errors[] = 'approvalExpiryHours must be between 1 and 720';
                 }
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     *
+     * @return list<string>
+     */
+    private function validateBuilderNode(int $i, array $node): array
+    {
+        $errors = [];
+        $depends = is_array($node['depends_on'] ?? null) ? $node['depends_on'] : [];
+        $params = is_array($node['params'] ?? null) ? $node['params'] : [];
+        $inputs = is_array($params['inputs'] ?? null) ? $params['inputs'] : (is_array($node['inputs'] ?? null) ? $node['inputs'] : []);
+        foreach ($inputs as $key => $spec) {
+            if (!is_array($spec)) {
+                continue;
+            }
+            $from = $spec['from'] ?? null;
+            if (!is_string($from) || '' === $from) {
+                continue;
+            }
+            if ('trigger' === $from) {
+                continue;
+            }
+            if (!in_array($from, $depends, true)) {
+                $errors[] = "step[$i] input '$key' must come from an earlier step this step depends on";
+            }
+        }
+
+        $approval = $params['approval'] ?? null;
+        if (null !== $approval) {
+            if (!in_array($approval, ['approve', 'block'], true)) {
+                $errors[] = "step[$i] can only tighten approval (ask me, or block)";
+            }
+        }
+
+        $capability = $node['capability'] ?? null;
+        if (Capability::OutboundWebhook->value === $capability) {
+            $url = is_string($params['url'] ?? null) ? trim($params['url']) : '';
+            if ('' === $url || !str_starts_with(strtolower($url), 'https://')) {
+                $errors[] = "step[$i] needs an https address";
+            } elseif (null !== $this->ssrfGuard && $this->ssrfGuard->isBlockedUrl($url)) {
+                $errors[] = "step[$i] cannot send to that address";
+            }
+        }
+        if (Capability::ToolCall->value === $capability) {
+            $tool = is_string($params['tool'] ?? null) ? trim($params['tool']) : '';
+            if ('' === $tool) {
+                $errors[] = "step[$i] needs a tool";
+            }
+        }
+        if (Capability::Condition->value === $capability) {
+            $operator = $params['operator'] ?? 'not_empty';
+            if (!in_array($operator, ['equals', 'contains', 'matches', 'not_empty'], true)) {
+                $errors[] = "step[$i] has an unknown condition";
             }
         }
 

--- a/backend/src/Service/SavedTask/Graph/SavedTaskPlanFactory.php
+++ b/backend/src/Service/SavedTask/Graph/SavedTaskPlanFactory.php
@@ -28,7 +28,7 @@ final class SavedTaskPlanFactory
             );
         }
 
-        $errors = $this->validator->validate($graph, $task->getTriggerType(), $task->getTriggerConfig());
+        $errors = $this->validator->validate($graph, $task->getTriggerType(), $task->getTriggerConfig(), $task->getOwnerId());
         if ([] !== $errors) {
             throw new \InvalidArgumentException(implode('; ', $errors));
         }

--- a/backend/src/Service/SavedTask/Graph/SavedTaskSummary.php
+++ b/backend/src/Service/SavedTask/Graph/SavedTaskSummary.php
@@ -67,6 +67,9 @@ final class SavedTaskSummary
         if (SavedTask::TRIGGER_CHAT === $task->getTriggerType()) {
             return ['when' => 'chat'];
         }
+        if (SavedTask::TRIGGER_WEBHOOK === $task->getTriggerType()) {
+            return ['when' => 'webhook'];
+        }
         if (SavedTask::TRIGGER_SCHEDULE !== $task->getTriggerType()) {
             return ['when' => 'manual'];
         }

--- a/backend/src/Service/SavedTask/Graph/StepInputResolver.php
+++ b/backend/src/Service/SavedTask/Graph/StepInputResolver.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\SavedTask\Graph;
+
+use App\Service\Multitask\Execution\NodeContext;
+use App\Service\Multitask\Execution\NodeResult;
+
+/**
+ * Resolves authored step inputs: a literal, a field from an earlier step,
+ * or a field from the webhook / trigger payload.
+ *
+ * Shapes:
+ *   { "literal": "…" }
+ *   { "from": "step_2", "field": "summary" }
+ *   { "from": "trigger", "field": "body.title" }
+ */
+final class StepInputResolver
+{
+    /**
+     * @param array<string, mixed> $inputs
+     *
+     * @return array<string, mixed>
+     */
+    public function resolveAll(array $inputs, NodeContext $context): array
+    {
+        $resolved = [];
+        foreach ($inputs as $key => $spec) {
+            $resolved[$key] = $this->resolve($spec, $context);
+        }
+
+        return $resolved;
+    }
+
+    public function resolve(mixed $spec, NodeContext $context): mixed
+    {
+        if (!is_array($spec)) {
+            return $spec;
+        }
+        if (array_key_exists('literal', $spec)) {
+            return $spec['literal'];
+        }
+        $from = $spec['from'] ?? null;
+        if (!is_string($from) || '' === $from) {
+            return $spec;
+        }
+        $field = is_string($spec['field'] ?? null) ? $spec['field'] : 'text';
+        if ('trigger' === $from) {
+            $payload = $context->options['trigger_payload'] ?? [];
+
+            return is_array($payload) ? $this->nested($payload, $field) : null;
+        }
+
+        $result = $context->getResult($from);
+        if (!$result instanceof NodeResult) {
+            return null;
+        }
+
+        return $this->fromResult($result, $field);
+    }
+
+    private function fromResult(NodeResult $result, string $field): mixed
+    {
+        return match ($field) {
+            'text', 'summary' => $result->text,
+            'error' => $result->error,
+            'files' => $result->files,
+            default => $this->nested($result->metadata, $field),
+        };
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function nested(array $data, string $path): mixed
+    {
+        $cursor = $data;
+        foreach (explode('.', $path) as $segment) {
+            if (!is_array($cursor) || !array_key_exists($segment, $cursor)) {
+                return null;
+            }
+            $cursor = $cursor[$segment];
+        }
+
+        return $cursor;
+    }
+}

--- a/backend/src/Service/SavedTask/Graph/StepInputResolver.php
+++ b/backend/src/Service/SavedTask/Graph/StepInputResolver.php
@@ -45,11 +45,15 @@ final class StepInputResolver
         if (!is_string($from) || '' === $from) {
             return $spec;
         }
-        $field = is_string($spec['field'] ?? null) ? $spec['field'] : 'text';
+        $field = is_string($spec['field'] ?? null) ? trim($spec['field']) : '';
         if ('trigger' === $from) {
             $payload = $context->options['trigger_payload'] ?? [];
+            if (!is_array($payload)) {
+                return null;
+            }
 
-            return is_array($payload) ? $this->nested($payload, $field) : null;
+            // No field means the whole starting event.
+            return '' === $field ? $payload : $this->nested($payload, $field);
         }
 
         $result = $context->getResult($from);
@@ -57,7 +61,7 @@ final class StepInputResolver
             return null;
         }
 
-        return $this->fromResult($result, $field);
+        return $this->fromResult($result, '' === $field ? 'text' : $field);
     }
 
     private function fromResult(NodeResult $result, string $field): mixed

--- a/backend/src/Service/SavedTask/SavedTaskOutcomeNarrator.php
+++ b/backend/src/Service/SavedTask/SavedTaskOutcomeNarrator.php
@@ -18,7 +18,7 @@ final class SavedTaskOutcomeNarrator
     {
         $done = [];
         $failed = [];
-        foreach ($this->statuses($result, $cards) as $capability => $status) {
+        foreach ($this->statuses($result, $cards) as [$capability, $status]) {
             $label = $this->label($capability);
             if ('done' === $status || 'stopped' === $status) {
                 $done[$label] = true;
@@ -26,7 +26,8 @@ final class SavedTaskOutcomeNarrator
                 $failed[$label] = true;
             }
         }
-        $doneLabels = array_keys($done);
+        // Two steps of one kind, one of them failed: that kind did not complete.
+        $doneLabels = array_values(array_diff(array_keys($done), array_keys($failed)));
         $failedLabels = array_keys($failed);
         if ([] !== $doneLabels && [] !== $failedLabels) {
             return sprintf(
@@ -50,7 +51,7 @@ final class SavedTaskOutcomeNarrator
      * @param array<string, mixed>       $result
      * @param list<array<string, mixed>> $cards
      *
-     * @return array<string, string> capability => status
+     * @return list<array{0: string, 1: string}> one [capability, status] pair per step
      */
     private function statuses(array $result, array $cards): array
     {
@@ -67,13 +68,13 @@ final class SavedTaskOutcomeNarrator
                 $status = $byNode[$nodeId];
             }
             if ('' !== $status) {
-                $out[$capability] = $status;
+                $out[] = [$capability, $status];
             }
         }
         if ([] === $out && [] !== $byNode) {
             foreach ($byNode as $status) {
                 if (is_string($status)) {
-                    $out['step'] = $status;
+                    $out[] = ['step', $status];
                 }
             }
         }

--- a/backend/src/Service/SavedTask/SavedTaskOutcomeNarrator.php
+++ b/backend/src/Service/SavedTask/SavedTaskOutcomeNarrator.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\SavedTask;
+
+/**
+ * Turns a failed Saved Task run into one honest sentence: what finished,
+ * and what did not. Avoids "Nothing was sent or saved" after a later step fails.
+ */
+final class SavedTaskOutcomeNarrator
+{
+    /**
+     * @param array<string, mixed>       $result
+     * @param list<array<string, mixed>> $cards
+     */
+    public function failureMessage(array $result, array $cards, ?string $processorError = null): string
+    {
+        $done = [];
+        $failed = [];
+        foreach ($this->statuses($result, $cards) as $capability => $status) {
+            $label = $this->label($capability);
+            if ('done' === $status || 'stopped' === $status) {
+                $done[$label] = true;
+            } elseif ('failed' === $status) {
+                $failed[$label] = true;
+            }
+        }
+        $doneLabels = array_keys($done);
+        $failedLabels = array_keys($failed);
+        if ([] !== $doneLabels && [] !== $failedLabels) {
+            return sprintf(
+                '%s finished. %s did not complete.',
+                $this->join($doneLabels),
+                $this->join($failedLabels),
+            );
+        }
+        if ([] !== $doneLabels) {
+            return $this->join($doneLabels).' finished, but the run could not be confirmed as complete.';
+        }
+        if (is_string($processorError) && '' !== trim($processorError)
+            && !str_contains($processorError, 'Nothing was sent or saved')) {
+            return $processorError;
+        }
+
+        return 'This run stopped before anything was sent or saved.';
+    }
+
+    /**
+     * @param array<string, mixed>       $result
+     * @param list<array<string, mixed>> $cards
+     *
+     * @return array<string, string> capability => status
+     */
+    private function statuses(array $result, array $cards): array
+    {
+        $out = [];
+        $response = is_array($result['response'] ?? null) ? $result['response'] : [];
+        $metadata = is_array($response['metadata'] ?? null) ? $response['metadata'] : [];
+        $multitask = is_array($metadata['multitask'] ?? null) ? $metadata['multitask'] : [];
+        $byNode = is_array($multitask['node_statuses'] ?? null) ? $multitask['node_statuses'] : [];
+        foreach ($cards as $card) {
+            $capability = is_string($card['capability'] ?? null) ? $card['capability'] : 'step';
+            $nodeId = is_string($card['nodeId'] ?? $card['node_id'] ?? null) ? (string) ($card['nodeId'] ?? $card['node_id']) : '';
+            $status = is_string($card['state'] ?? $card['status'] ?? null) ? (string) ($card['state'] ?? $card['status']) : '';
+            if ('' !== $nodeId && is_string($byNode[$nodeId] ?? null)) {
+                $status = $byNode[$nodeId];
+            }
+            if ('' !== $status) {
+                $out[$capability] = $status;
+            }
+        }
+        if ([] === $out && [] !== $byNode) {
+            foreach ($byNode as $status) {
+                if (is_string($status)) {
+                    $out['step'] = $status;
+                }
+            }
+        }
+
+        return $out;
+    }
+
+    private function label(string $capability): string
+    {
+        return match ($capability) {
+            'email_me' => 'The email',
+            'save_to_folder' => 'Saving the file',
+            'outbound_webhook' => 'Sending to the other system',
+            'tool_call', 'mcp_action' => 'The connected action',
+            'email_search' => 'The mailbox search',
+            'chat', 'summarize' => 'The written answer',
+            'calendar_event' => 'The calendar entry',
+            default => 'A step',
+        };
+    }
+
+    /**
+     * @param list<string> $parts
+     */
+    private function join(array $parts): string
+    {
+        if (1 === count($parts)) {
+            return $parts[0];
+        }
+        $last = array_pop($parts);
+
+        return implode(', ', $parts).' and '.$last;
+    }
+}

--- a/backend/src/Service/SavedTask/SavedTaskResumeService.php
+++ b/backend/src/Service/SavedTask/SavedTaskResumeService.php
@@ -21,6 +21,8 @@ use App\Service\Multitask\TaskPlanStore;
 use App\Service\RateLimitService;
 use App\Service\SavedTask\Graph\SavedTaskPlanFactory;
 use App\Service\SavedTask\Graph\StepInputResolver;
+use App\Service\Tool\ApprovalArgsRedactor;
+use App\Service\Tool\ApprovalReference;
 use App\Service\Tool\Exception\ToolNotRegisteredException;
 use App\Service\Tool\Policy\ApprovalPolicy;
 use App\Service\Tool\Policy\PolicyContext;
@@ -44,6 +46,7 @@ final readonly class SavedTaskResumeService
         private LoggerInterface $logger,
         private ApprovalPolicy $approvalPolicy,
         private StepInputResolver $inputs,
+        private ApprovalArgsRedactor $redactor = new ApprovalArgsRedactor(),
     ) {
     }
 
@@ -68,6 +71,14 @@ final readonly class SavedTaskResumeService
         if (!$approval instanceof Approval) {
             throw new SavedTaskNotFoundException();
         }
+        // The approval must be the one this run paused for: same owner, decided,
+        // and requested by exactly this run and step. Anything else is not a match.
+        if ($approval->getOwnerId() !== $task->getOwnerId()
+            || Approval::STATUS_APPROVED !== $approval->getStatus()
+            || $approval->getRequestedBy() !== ApprovalReference::taskRun($runId, $nodeId)->raw
+            || $run->getWaitingNode() !== $nodeId) {
+            throw new SavedTaskNotWaitingException();
+        }
 
         $limit = $this->rateLimits->checkLimit($user, 'MESSAGES');
         if (empty($limit['allowed'])) {
@@ -85,10 +96,15 @@ final readonly class SavedTaskResumeService
 
         $plan = $this->planFactory->fromTask($task);
         $node = $plan->nodeById($nodeId);
-        $context = $this->rehydrator->fromRun($run, [
+        $options = [
             'saved_task_run_id' => $runId,
             'allow_unattended' => $task->allowsUnattended(),
-        ]);
+        ];
+        $triggerPayload = $run->getPlanSnapshot()['trigger_payload'] ?? null;
+        if (is_array($triggerPayload) && [] !== $triggerPayload) {
+            $options['trigger_payload'] = $triggerPayload;
+        }
+        $context = $this->rehydrator->fromRun($run, $options);
 
         if (null !== $node && Capability::ToolCall === $node->capability) {
             $bound = $this->recheckToolCall($node, $context, $approval, $task);
@@ -153,7 +169,8 @@ final readonly class SavedTaskResumeService
         }
         $rawInputs = is_array($node->params['inputs'] ?? null) ? $node->params['inputs'] : $node->inputs;
         $args = $this->inputs->resolveAll($rawInputs, $context);
-        if ($this->argsDiffer($args, $approval->getArgs() ?? [])) {
+        // Stored approval arguments are redacted; compare like with like.
+        if ($this->argsDiffer($this->redactor->redact($args), $approval->getArgs() ?? [])) {
             return 'This approval no longer matches the step.';
         }
         $descriptor = $this->registry->get($task->getOwnerId(), $toolName);
@@ -193,9 +210,29 @@ final readonly class SavedTaskResumeService
      */
     private function normalizeArgs(array $args): array
     {
+        foreach ($args as $key => $value) {
+            if (is_array($value)) {
+                $args[$key] = $this->normalizeArgs($this->stringKeyed($value));
+            }
+        }
         ksort($args);
 
         return $args;
+    }
+
+    /**
+     * @param array<mixed> $value
+     *
+     * @return array<string, mixed>
+     */
+    private function stringKeyed(array $value): array
+    {
+        $out = [];
+        foreach ($value as $key => $item) {
+            $out[(string) $key] = $item;
+        }
+
+        return $out;
     }
 
     private function failResume(

--- a/backend/src/Service/SavedTask/SavedTaskResumeService.php
+++ b/backend/src/Service/SavedTask/SavedTaskResumeService.php
@@ -13,11 +13,18 @@ use App\Repository\SavedTaskRepository;
 use App\Repository\SavedTaskRunRepository;
 use App\Repository\UserRepository;
 use App\Service\Multitask\Execution\DagExecutor;
+use App\Service\Multitask\Execution\NodeContext;
 use App\Service\Multitask\Execution\NodeContextRehydrator;
+use App\Service\Multitask\Plan\Capability;
+use App\Service\Multitask\Plan\TaskNode;
 use App\Service\Multitask\TaskPlanStore;
 use App\Service\RateLimitService;
 use App\Service\SavedTask\Graph\SavedTaskPlanFactory;
+use App\Service\SavedTask\Graph\StepInputResolver;
 use App\Service\Tool\Exception\ToolNotRegisteredException;
+use App\Service\Tool\Policy\ApprovalPolicy;
+use App\Service\Tool\Policy\PolicyContext;
+use App\Service\Tool\Policy\PolicyOutcome;
 use App\Service\Tool\ToolRegistry;
 use Psr\Log\LoggerInterface;
 
@@ -35,6 +42,8 @@ final readonly class SavedTaskResumeService
         private RateLimitService $rateLimits,
         private ToolRegistry $registry,
         private LoggerInterface $logger,
+        private ApprovalPolicy $approvalPolicy,
+        private StepInputResolver $inputs,
     ) {
     }
 
@@ -71,20 +80,23 @@ final readonly class SavedTaskResumeService
 
         $descriptor = $this->registry->get($task->getOwnerId(), $approval->getTool());
         if (null === $descriptor) {
-            $run->markFailed((new ToolNotRegisteredException($approval->getTool()))->getMessage());
-            $run->clearWaitingNode();
-            $this->runs->save($run);
-            $approval->markFailed('tool_not_registered');
-            $this->approvals->save($approval);
-
-            throw new ToolNotRegisteredException($approval->getTool());
+            return $this->failResume($run, $task, $approval, (new ToolNotRegisteredException($approval->getTool()))->getMessage(), true);
         }
 
         $plan = $this->planFactory->fromTask($task);
+        $node = $plan->nodeById($nodeId);
         $context = $this->rehydrator->fromRun($run, [
             'saved_task_run_id' => $runId,
             'allow_unattended' => $task->allowsUnattended(),
         ]);
+
+        if (null !== $node && Capability::ToolCall === $node->capability) {
+            $bound = $this->recheckToolCall($node, $context, $approval, $task);
+            if (null !== $bound) {
+                return $this->failResume($run, $task, $approval, $bound);
+            }
+        }
+
         $assembled = $this->dagExecutor->resume($plan, $context, $nodeId, $approval->getArgs() ?? []);
         $messageId = $run->getMessageId();
         $statuses = $assembled['node_statuses'];
@@ -126,6 +138,83 @@ final readonly class SavedTaskResumeService
             'node_id' => $nodeId,
             'approval_id' => $approvalId,
         ]);
+
+        return $run;
+    }
+
+    /**
+     * Re-check the bound tool and arguments, and re-run policy without loosening.
+     */
+    private function recheckToolCall(TaskNode $node, NodeContext $context, Approval $approval, SavedTask $task): ?string
+    {
+        $toolName = is_string($node->params['tool'] ?? null) ? trim($node->params['tool']) : '';
+        if ($toolName !== $approval->getTool()) {
+            return 'This approval no longer matches the step.';
+        }
+        $rawInputs = is_array($node->params['inputs'] ?? null) ? $node->params['inputs'] : $node->inputs;
+        $args = $this->inputs->resolveAll($rawInputs, $context);
+        if ($this->argsDiffer($args, $approval->getArgs() ?? [])) {
+            return 'This approval no longer matches the step.';
+        }
+        $descriptor = $this->registry->get($task->getOwnerId(), $toolName);
+        if (null === $descriptor) {
+            return (new ToolNotRegisteredException($toolName))->getMessage();
+        }
+        $override = PolicyOutcome::tryFrom((string) ($node->params['approval'] ?? ''));
+        $outcome = $this->approvalPolicy->decide(
+            $descriptor,
+            $task->getOwnerId(),
+            PolicyContext::Unattended,
+            null,
+            false,
+            null,
+            $override,
+        );
+        if (PolicyOutcome::Block === $outcome) {
+            return 'I cannot do that. An administrator has turned this off.';
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, mixed> $left
+     * @param array<string, mixed> $right
+     */
+    private function argsDiffer(array $left, array $right): bool
+    {
+        return json_encode($this->normalizeArgs($left)) !== json_encode($this->normalizeArgs($right));
+    }
+
+    /**
+     * @param array<string, mixed> $args
+     *
+     * @return array<string, mixed>
+     */
+    private function normalizeArgs(array $args): array
+    {
+        ksort($args);
+
+        return $args;
+    }
+
+    private function failResume(
+        SavedTaskRun $run,
+        SavedTask $task,
+        Approval $approval,
+        string $error,
+        bool $throwNotRegistered = false,
+    ): SavedTaskRun {
+        $run->markFailed($error, $run->getMessageId(), $run->getPlanSnapshot());
+        $run->clearWaitingNode();
+        $task->recordFailure();
+        $this->runs->save($run);
+        $this->tasks->save($task);
+        $approval->markFailed($error);
+        $this->approvals->save($approval);
+        if ($throwNotRegistered) {
+            throw new ToolNotRegisteredException($approval->getTool());
+        }
 
         return $run;
     }

--- a/backend/src/Service/SavedTask/SavedTaskRunner.php
+++ b/backend/src/Service/SavedTask/SavedTaskRunner.php
@@ -51,6 +51,7 @@ final readonly class SavedTaskRunner
         private GeneratedFileRegistrar $generatedFiles,
         private InternalEmailService $mail,
         private LoggerInterface $logger,
+        private SavedTaskOutcomeNarrator $outcomeNarrator = new SavedTaskOutcomeNarrator(),
     ) {
     }
 
@@ -60,9 +61,11 @@ final readonly class SavedTaskRunner
      * (the pinned prompt body) is used, so "Run now" and scheduled runs never
      * need a synthetic message.
      *
+     * @param array<string, mixed> $triggerPayload JSON body from an inbound webhook, if any
+     *
      * @return array{run: SavedTaskRun, task: SavedTask}
      */
-    public function run(int $ownerId, int $taskId, string $messageText = '', string $trigger = 'manual'): array
+    public function run(int $ownerId, int $taskId, string $messageText = '', string $trigger = 'manual', array $triggerPayload = []): array
     {
         if (!$this->config->isEnabled($ownerId)) {
             throw new SavedTaskDisabledException();
@@ -123,7 +126,7 @@ final readonly class SavedTaskRunner
             $this->em->persist($message);
             $this->em->flush();
 
-            $result = $this->processor->process($message, $this->processorOptions($task, $prompt, (int) $run->getId()));
+            $result = $this->processor->process($message, $this->processorOptions($task, $prompt, (int) $run->getId(), $triggerPayload));
 
             $ok = !empty($result['success']);
             $messageId = $message->getId();
@@ -141,9 +144,11 @@ final readonly class SavedTaskRunner
             $this->em->flush();
 
             if (!$ok) {
-                $reason = is_string($result['error'] ?? null)
-                    ? $result['error']
-                    : 'The AI step could not complete. Nothing was sent or saved.';
+                $reason = $this->outcomeNarrator->failureMessage(
+                    $result,
+                    $snapshot,
+                    is_string($result['error'] ?? null) ? $result['error'] : null,
+                );
 
                 return $this->fail($task, $run, $reason, $messageId, $snapshot);
             }
@@ -180,7 +185,7 @@ final readonly class SavedTaskRunner
                 'error' => $e->getMessage(),
             ]);
 
-            return $this->fail($task, $run, 'The AI step could not complete. Nothing was sent or saved.');
+            return $this->fail($task, $run, 'This run stopped before anything was sent or saved.');
         }
     }
 
@@ -199,14 +204,19 @@ final readonly class SavedTaskRunner
      * keeps the run plannable (multi-step tasks must run their DAG, not
      * degrade to chat).
      *
+     * @param array<string, mixed> $triggerPayload
+     *
      * @return array<string, mixed>
      */
-    private function processorOptions(SavedTask $task, Prompt $prompt, ?int $runId = null): array
+    private function processorOptions(SavedTask $task, Prompt $prompt, ?int $runId = null, array $triggerPayload = []): array
     {
         $options = [
             'saved_task' => true,
             'saved_task_id' => (int) $task->getId(),
         ];
+        if ([] !== $triggerPayload) {
+            $options['trigger_payload'] = $triggerPayload;
+        }
         if (!str_starts_with($prompt->getTopic(), self::CHAT_INSTRUCTION_TOPIC_PREFIX)) {
             $options['fixed_task_prompt'] = $prompt->getTopic();
         }

--- a/backend/src/Service/SavedTask/SavedTaskRunner.php
+++ b/backend/src/Service/SavedTask/SavedTaskRunner.php
@@ -106,6 +106,7 @@ final readonly class SavedTaskRunner
             return $this->fail($task, $run, 'The AI instruction for this task is empty.');
         }
 
+        $messageId = null;
         try {
             $chat = $this->ensureChat($task, $user);
             $now = time();
@@ -125,11 +126,11 @@ final readonly class SavedTaskRunner
             $message->setStatus('processing');
             $this->em->persist($message);
             $this->em->flush();
+            $messageId = $message->getId();
 
             $result = $this->processor->process($message, $this->processorOptions($task, $prompt, (int) $run->getId(), $triggerPayload));
 
             $ok = !empty($result['success']);
-            $messageId = $message->getId();
             $snapshot = null !== $messageId ? $this->planStore->loadCards($messageId) : [];
 
             // Like the web stream: the IN row records what the sorter decided.
@@ -157,7 +158,13 @@ final readonly class SavedTaskRunner
 
             $waitingNode = $this->waitingNodeFromResult($result, $snapshot);
             if (null !== $waitingNode) {
-                $run->markWaitingApproval($waitingNode, $messageId, [] !== $snapshot ? ['cards' => $snapshot] : null);
+                // The resume re-resolves step inputs; a webhook-started run needs
+                // its starting event again or `from: trigger` values come back null.
+                $waitingSnapshot = [] !== $snapshot ? ['cards' => $snapshot] : [];
+                if ([] !== $triggerPayload) {
+                    $waitingSnapshot['trigger_payload'] = $triggerPayload;
+                }
+                $run->markWaitingApproval($waitingNode, $messageId, [] !== $waitingSnapshot ? $waitingSnapshot : null);
                 $this->runs->save($run);
 
                 return ['run' => $run, 'task' => $task];
@@ -185,7 +192,32 @@ final readonly class SavedTaskRunner
                 'error' => $e->getMessage(),
             ]);
 
-            return $this->fail($task, $run, 'This run stopped before anything was sent or saved.');
+            // Steps may already have run before the exception; say so instead of
+            // claiming nothing happened.
+            $snapshot = $this->cardsAfterCrash($messageId);
+
+            return $this->fail(
+                $task,
+                $run,
+                $this->outcomeNarrator->failureMessage([], $snapshot),
+                $messageId,
+                [] !== $snapshot ? $snapshot : null,
+            );
+        }
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function cardsAfterCrash(?int $messageId): array
+    {
+        if (null === $messageId) {
+            return [];
+        }
+        try {
+            return $this->planStore->loadCards($messageId);
+        } catch (\Throwable) {
+            return [];
         }
     }
 

--- a/backend/src/Service/SavedTask/SavedTaskSerializer.php
+++ b/backend/src/Service/SavedTask/SavedTaskSerializer.php
@@ -9,6 +9,7 @@ use App\Entity\SavedTask;
 use App\Entity\SavedTaskRun;
 use App\Repository\PromptRepository;
 use App\Repository\SavedTaskRunRepository;
+use App\Service\Multitask\Plan\Capability;
 use App\Service\SavedTask\Graph\SavedTaskSummary;
 
 final readonly class SavedTaskSerializer
@@ -27,20 +28,23 @@ final readonly class SavedTaskSerializer
     }
 
     /**
+     * @param string|null $revealWebhookSecret a freshly minted HMAC secret, shown on
+     *                                         this one response only — never stored output
+     *
      * @return array<string, mixed>
      */
-    public function task(SavedTask $task): array
+    public function task(SavedTask $task, ?string $revealWebhookSecret = null): array
     {
         $summary = $this->summary->describe($task);
 
-        return [
+        $data = [
             'id' => $task->getId(),
             'promptId' => $task->getPromptId(),
             'name' => $task->getName(),
             'enabled' => $task->isEnabled(),
             'triggerType' => $task->getTriggerType(),
             'triggerConfig' => $this->publicTriggerConfig($task),
-            'graph' => $task->getGraph(),
+            'graph' => $this->publicGraph($task->getGraph()),
             'allowUnattended' => $task->allowsUnattended(),
             'chatId' => $task->getChatId(),
             'nextRunAt' => $task->getNextRunAt()?->format(\DateTimeInterface::ATOM),
@@ -51,6 +55,11 @@ final readonly class SavedTaskSerializer
             'instructionPreview' => $this->instructionPreview($task->getPromptId()),
             'waitingApprovalCount' => $this->waitingApprovalCount($task),
         ];
+        if (null !== $revealWebhookSecret && '' !== $revealWebhookSecret) {
+            $data['webhookSecret'] = $revealWebhookSecret;
+        }
+
+        return $data;
     }
 
     /**
@@ -91,6 +100,33 @@ final readonly class SavedTaskSerializer
         }
 
         return $config;
+    }
+
+    /**
+     * An outbound step's shared secret never leaves the server. The editor sees
+     * `secretConfigured` and sends the step back without a secret to keep it.
+     *
+     * @param array<string, mixed>|null $graph
+     *
+     * @return array<string, mixed>|null
+     */
+    private function publicGraph(?array $graph): ?array
+    {
+        if (null === $graph || !is_array($graph['nodes'] ?? null)) {
+            return $graph;
+        }
+        foreach ($graph['nodes'] as $i => $node) {
+            if (!is_array($node) || Capability::OutboundWebhook->value !== ($node['capability'] ?? null)) {
+                continue;
+            }
+            $params = is_array($node['params'] ?? null) ? $node['params'] : [];
+            $secret = $params['secret'] ?? null;
+            unset($params['secret']);
+            $params['secretConfigured'] = is_string($secret) && '' !== $secret;
+            $graph['nodes'][$i]['params'] = $params;
+        }
+
+        return $graph;
     }
 
     private function instructionPreview(int $promptId): ?string

--- a/backend/src/Service/SavedTask/SavedTaskSerializer.php
+++ b/backend/src/Service/SavedTask/SavedTaskSerializer.php
@@ -39,7 +39,7 @@ final readonly class SavedTaskSerializer
             'name' => $task->getName(),
             'enabled' => $task->isEnabled(),
             'triggerType' => $task->getTriggerType(),
-            'triggerConfig' => $task->getTriggerConfig(),
+            'triggerConfig' => $this->publicTriggerConfig($task),
             'graph' => $task->getGraph(),
             'allowUnattended' => $task->allowsUnattended(),
             'chatId' => $task->getChatId(),
@@ -70,6 +70,27 @@ final readonly class SavedTaskSerializer
             'created' => $run->getCreated(),
             'waitingNode' => $run->getWaitingNode(),
         ];
+    }
+
+    /**
+     * Never expose HMAC secrets. The webhook URL is reconstructed by the client
+     * from the public token.
+     *
+     * @return array<string, mixed>|null
+     */
+    private function publicTriggerConfig(SavedTask $task): ?array
+    {
+        $config = $task->getTriggerConfig();
+        if (null === $config) {
+            return null;
+        }
+        $hasSecret = is_string($config['hmacSecret'] ?? null) && '' !== $config['hmacSecret'];
+        unset($config['hmacSecret']);
+        if (SavedTask::TRIGGER_WEBHOOK === $task->getTriggerType()) {
+            $config['hmacConfigured'] = $hasSecret;
+        }
+
+        return $config;
     }
 
     private function instructionPreview(int $promptId): ?string

--- a/backend/src/Service/SavedTask/SavedTaskService.php
+++ b/backend/src/Service/SavedTask/SavedTaskService.php
@@ -31,6 +31,7 @@ final readonly class SavedTaskService
         private AccessGate $accessGate,
         private SavedTaskGraphCapture $graphCapture,
         private ?ToolsConfig $toolsConfig = null,
+        private ?WorkflowsConfig $workflowsConfig = null,
     ) {
     }
 
@@ -169,7 +170,7 @@ final readonly class SavedTaskService
         $task = new SavedTask($ownerId, $promptId, $name);
         if (null !== $sourceMessageId && $sourceMessageId > 0) {
             $graph = $this->graphCapture->fromMessage($sourceMessageId, $ownerId, $task->getTriggerType());
-            if (null !== $graph && [] === $this->graphValidator->validate($graph, $task->getTriggerType(), $task->getTriggerConfig())) {
+            if (null !== $graph && [] === $this->graphValidator->validate($graph, $task->getTriggerType(), $task->getTriggerConfig(), $ownerId)) {
                 $task->setGraph($graph);
             }
         }
@@ -194,9 +195,11 @@ final readonly class SavedTaskService
         }
         if (isset($data['triggerType']) && is_string($data['triggerType'])) {
             $config = is_array($data['triggerConfig'] ?? null) ? $data['triggerConfig'] : $task->getTriggerConfig();
-            $task->setTrigger($data['triggerType'], $config);
+            $this->applyTrigger($task, $data['triggerType'], $config, $data);
         } elseif (isset($data['triggerConfig']) && is_array($data['triggerConfig'])) {
-            $task->setTrigger($task->getTriggerType(), $data['triggerConfig']);
+            $this->applyTrigger($task, $task->getTriggerType(), $data['triggerConfig'], $data);
+        } elseif (true === ($data['regenerateWebhookToken'] ?? false)) {
+            $this->applyTrigger($task, $task->getTriggerType(), $task->getTriggerConfig(), $data);
         }
 
         // The graph carries the trigger it was authored for and the factory
@@ -215,7 +218,7 @@ final readonly class SavedTaskService
             }
             /** @var array<string, mixed>|null $graph */
             if (null !== $graph) {
-                $errors = $this->graphValidator->validate($graph, $task->getTriggerType(), $task->getTriggerConfig());
+                $errors = $this->graphValidator->validate($graph, $task->getTriggerType(), $task->getTriggerConfig(), $task->getOwnerId());
                 if ([] !== $errors) {
                     throw new \InvalidArgumentException(implode('; ', $errors));
                 }
@@ -266,6 +269,40 @@ final readonly class SavedTaskService
         return $graph;
     }
 
+    /**
+     * @param array<string, mixed>|null $config
+     * @param array<string, mixed>      $data
+     */
+    private function applyTrigger(SavedTask $task, string $type, ?array $config, array $data): void
+    {
+        if (SavedTask::TRIGGER_WEBHOOK === $type) {
+            if (null === $this->workflowsConfig || !$this->workflowsConfig->isBuilderEnabled($task->getOwnerId())) {
+                throw new \InvalidArgumentException('Letting another system start this is turned off');
+            }
+            $config = is_array($config) ? $config : [];
+            unset($config['token'], $config['hmacSecret'], $config['hmacConfigured']);
+            $existing = $task->getTriggerConfig() ?? [];
+            $token = is_string($existing['token'] ?? null) ? $existing['token'] : '';
+            if (true === ($data['regenerateWebhookToken'] ?? false) || '' === $token) {
+                $token = $this->randomToken();
+            }
+            $config['token'] = $token;
+            if (true === ($data['hmacEnabled'] ?? false)) {
+                $secret = is_string($existing['hmacSecret'] ?? null) ? $existing['hmacSecret'] : '';
+                $config['hmacSecret'] = '' !== $secret ? $secret : $this->randomToken();
+            } elseif (!array_key_exists('hmacEnabled', $data) && is_string($existing['hmacSecret'] ?? null) && '' !== $existing['hmacSecret']) {
+                $config['hmacSecret'] = $existing['hmacSecret'];
+            }
+            $config['maxBodyBytes'] = 65536;
+        }
+        $task->setTrigger($type, $config);
+    }
+
+    private function randomToken(): string
+    {
+        return rtrim(strtr(base64_encode(random_bytes(32)), '+/', '-_'), '=');
+    }
+
     private function assertUsablePrompt(int $promptId, int $ownerId): void
     {
         $prompt = $this->prompts->find($promptId);
@@ -290,7 +327,7 @@ final readonly class SavedTaskService
                 continue;
             }
             $capability = (string) ($node['capability'] ?? '');
-            if (in_array($capability, ['email_me', 'save_to_folder', 'outbound_webhook', 'mcp_action'], true)) {
+            if (in_array($capability, ['email_me', 'save_to_folder', 'outbound_webhook', 'mcp_action', 'tool_call'], true)) {
                 $mutating = true;
                 break;
             }

--- a/backend/src/Service/SavedTask/SavedTaskService.php
+++ b/backend/src/Service/SavedTask/SavedTaskService.php
@@ -15,10 +15,13 @@ use App\Service\Iam\Exception\AssistantNotSharedException;
 use App\Service\Iam\Permission;
 use App\Service\Iam\ResourceKind\AssistantKind;
 use App\Service\Iam\ResourceKind\SavedTaskKind;
+use App\Service\Multitask\Plan\Capability;
 use App\Service\SavedTask\Graph\SavedTaskGraphCapture;
 use App\Service\SavedTask\Graph\SavedTaskGraphValidator;
 use App\Service\SavedTask\Schedule\ScheduleParser;
+use App\Service\Tool\ToolRegistry;
 use App\Service\Tool\ToolsConfig;
+use App\Service\Tool\ToolSource;
 
 final readonly class SavedTaskService
 {
@@ -32,6 +35,7 @@ final readonly class SavedTaskService
         private SavedTaskGraphCapture $graphCapture,
         private ?ToolsConfig $toolsConfig = null,
         private ?WorkflowsConfig $workflowsConfig = null,
+        private ?ToolRegistry $toolRegistry = null,
     ) {
     }
 
@@ -90,8 +94,9 @@ final readonly class SavedTaskService
 
         $copy = new SavedTask($userId, $source->getPromptId(), $source->getName());
         $copy->setTrigger(SavedTask::TRIGGER_MANUAL, null);
+        // The recipient gets the steps, never the source owner's shared secrets.
         $sourceGraph = $source->getGraph();
-        $copy->setGraph(null !== $sourceGraph ? $this->withTriggerType($sourceGraph, SavedTask::TRIGGER_MANUAL) : null);
+        $copy->setGraph(null !== $sourceGraph ? $this->withoutOutboundSecrets($this->withTriggerType($sourceGraph, SavedTask::TRIGGER_MANUAL)) : null);
         $copy->setAllowUnattended(false);
         $this->tasks->save($copy);
 
@@ -218,22 +223,42 @@ final readonly class SavedTaskService
             }
             /** @var array<string, mixed>|null $graph */
             if (null !== $graph) {
+                $graph = $this->keepOutboundSecrets($graph, $task->getGraph());
                 $errors = $this->graphValidator->validate($graph, $task->getTriggerType(), $task->getTriggerConfig(), $task->getOwnerId());
                 if ([] !== $errors) {
                     throw new \InvalidArgumentException(implode('; ', $errors));
                 }
+                $this->assertToolsConnected($graph, $task->getOwnerId());
             }
             $task->setGraph($graph);
         }
 
+        $this->assertUnattendedAllowed($task);
         if (SavedTask::TRIGGER_SCHEDULE === $task->getTriggerType()) {
-            $this->assertScheduleAllowed($task);
             $task->setNextRunAt($this->scheduleParser->nextRunAt($task->getTriggerConfig(), new \DateTimeImmutable('now', new \DateTimeZone('UTC'))));
         }
 
         $this->tasks->save($task);
 
         return $task;
+    }
+
+    /**
+     * Like {@see update()}, but also returns a freshly minted HMAC secret exactly
+     * once, on the response that created it. It is never serialized afterwards.
+     *
+     * @param array<string, mixed> $data
+     *
+     * @return array{task: SavedTask, webhookSecret: string|null}
+     */
+    public function updateAndRevealWebhookSecret(SavedTask $task, array $data): array
+    {
+        $before = $task->getTriggerConfig()['hmacSecret'] ?? null;
+        $task = $this->update($task, $data);
+        $after = $task->getTriggerConfig()['hmacSecret'] ?? null;
+        $revealed = is_string($after) && '' !== $after && $after !== $before ? $after : null;
+
+        return ['task' => $task, 'webhookSecret' => $revealed];
     }
 
     public function delete(SavedTask $task): void
@@ -248,8 +273,8 @@ final readonly class SavedTaskService
     public function resume(SavedTask $task): SavedTask
     {
         $task->resume();
+        $this->assertUnattendedAllowed($task);
         if (SavedTask::TRIGGER_SCHEDULE === $task->getTriggerType()) {
-            $this->assertScheduleAllowed($task);
             $task->setNextRunAt($this->scheduleParser->nextRunAt($task->getTriggerConfig(), new \DateTimeImmutable('now', new \DateTimeZone('UTC'))));
         }
         $this->tasks->save($task);
@@ -275,12 +300,15 @@ final readonly class SavedTaskService
      */
     private function applyTrigger(SavedTask $task, string $type, ?array $config, array $data): void
     {
+        // The client never supplies the token or the secret; both are minted here.
+        if (is_array($config)) {
+            unset($config['token'], $config['hmacSecret'], $config['hmacConfigured']);
+        }
         if (SavedTask::TRIGGER_WEBHOOK === $type) {
             if (null === $this->workflowsConfig || !$this->workflowsConfig->isBuilderEnabled($task->getOwnerId())) {
                 throw new \InvalidArgumentException('Letting another system start this is turned off');
             }
             $config = is_array($config) ? $config : [];
-            unset($config['token'], $config['hmacSecret'], $config['hmacConfigured']);
             $existing = $task->getTriggerConfig() ?? [];
             $token = is_string($existing['token'] ?? null) ? $existing['token'] : '';
             if (true === ($data['regenerateWebhookToken'] ?? false) || '' === $token) {
@@ -293,7 +321,6 @@ final readonly class SavedTaskService
             } elseif (!array_key_exists('hmacEnabled', $data) && is_string($existing['hmacSecret'] ?? null) && '' !== $existing['hmacSecret']) {
                 $config['hmacSecret'] = $existing['hmacSecret'];
             }
-            $config['maxBodyBytes'] = 65536;
         }
         $task->setTrigger($type, $config);
     }
@@ -317,8 +344,17 @@ final readonly class SavedTaskService
         }
     }
 
-    private function assertScheduleAllowed(SavedTask $task): void
+    /**
+     * A schedule or an inbound webhook runs with nobody watching. Steps that
+     * send or save need the owner's explicit "runs on its own" — or approvals,
+     * which pause the run instead.
+     */
+    private function assertUnattendedAllowed(SavedTask $task): void
     {
+        $unattended = in_array($task->getTriggerType(), [SavedTask::TRIGGER_SCHEDULE, SavedTask::TRIGGER_WEBHOOK], true);
+        if (!$unattended) {
+            return;
+        }
         $graph = $task->getGraph() ?? [];
         $nodes = is_array($graph['nodes'] ?? null) ? $graph['nodes'] : [];
         $mutating = false;
@@ -336,7 +372,98 @@ final readonly class SavedTaskService
             if (null !== $this->toolsConfig && $this->toolsConfig->isApprovalsEnabled($task->getOwnerId())) {
                 return;
             }
-            throw new \InvalidArgumentException('This schedule would send or save files on its own. Confirm “runs on its own” first.');
+            $who = SavedTask::TRIGGER_WEBHOOK === $task->getTriggerType() ? 'Another system starting this' : 'This schedule';
+
+            throw new \InvalidArgumentException($who.' would send or save files on its own. Confirm “runs on its own” first.');
         }
+    }
+
+    /**
+     * Every "Use a tool" step must point at a tool the owner has connected and
+     * that can run without a chat. Catching this on save beats a failed run.
+     *
+     * @param array<string, mixed> $graph
+     */
+    private function assertToolsConnected(array $graph, int $ownerId): void
+    {
+        if (null === $this->toolRegistry) {
+            return;
+        }
+        $nodes = is_array($graph['nodes'] ?? null) ? $graph['nodes'] : [];
+        foreach (array_values($nodes) as $index => $node) {
+            if (!is_array($node) || Capability::ToolCall->value !== ($node['capability'] ?? null)) {
+                continue;
+            }
+            $params = is_array($node['params'] ?? null) ? $node['params'] : [];
+            $tool = is_string($params['tool'] ?? null) ? trim($params['tool']) : '';
+            $descriptor = '' !== $tool ? $this->toolRegistry->get($ownerId, $tool) : null;
+            if (null === $descriptor) {
+                throw new \InvalidArgumentException(sprintf('Step %d uses a tool that is not connected', $index + 1));
+            }
+            if (!in_array($descriptor->source, [ToolSource::Custom, ToolSource::Mcp], true)) {
+                throw new \InvalidArgumentException(sprintf('Step %d uses a tool that cannot run as a step', $index + 1));
+            }
+        }
+    }
+
+    /**
+     * The serializer never returns an outbound step's shared secret; the editor
+     * sends the step back without it. Keep the stored secret for the same step
+     * unless the owner typed a new one or cleared it.
+     *
+     * @param array<string, mixed>      $graph
+     * @param array<string, mixed>|null $existing
+     *
+     * @return array<string, mixed>
+     */
+    private function keepOutboundSecrets(array $graph, ?array $existing): array
+    {
+        $stored = [];
+        foreach (is_array($existing['nodes'] ?? null) ? $existing['nodes'] : [] as $node) {
+            if (!is_array($node) || Capability::OutboundWebhook->value !== ($node['capability'] ?? null)) {
+                continue;
+            }
+            $secret = $node['params']['secret'] ?? null;
+            if (is_string($node['id'] ?? null) && is_string($secret) && '' !== $secret) {
+                $stored[$node['id']] = $secret;
+            }
+        }
+        if (!is_array($graph['nodes'] ?? null)) {
+            return $graph;
+        }
+        foreach ($graph['nodes'] as $i => $node) {
+            if (!is_array($node) || Capability::OutboundWebhook->value !== ($node['capability'] ?? null)) {
+                continue;
+            }
+            $params = is_array($node['params'] ?? null) ? $node['params'] : [];
+            $keep = true === ($params['secretConfigured'] ?? false) && !array_key_exists('secret', $params);
+            unset($params['secretConfigured']);
+            $id = $node['id'] ?? null;
+            if ($keep && is_string($id) && isset($stored[$id])) {
+                $params['secret'] = $stored[$id];
+            }
+            $graph['nodes'][$i]['params'] = $params;
+        }
+
+        return $graph;
+    }
+
+    /**
+     * @param array<string, mixed> $graph
+     *
+     * @return array<string, mixed>
+     */
+    private function withoutOutboundSecrets(array $graph): array
+    {
+        if (!is_array($graph['nodes'] ?? null)) {
+            return $graph;
+        }
+        foreach ($graph['nodes'] as $i => $node) {
+            if (is_array($node) && Capability::OutboundWebhook->value === ($node['capability'] ?? null) && is_array($node['params'] ?? null)) {
+                unset($graph['nodes'][$i]['params']['secret']);
+            }
+        }
+
+        return $graph;
     }
 }

--- a/backend/src/Service/SavedTask/SavedTaskWebhookIngress.php
+++ b/backend/src/Service/SavedTask/SavedTaskWebhookIngress.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\SavedTask;
+
+use App\Entity\SavedTask;
+use App\Entity\User;
+use App\Repository\SavedTaskRepository;
+use App\Repository\UserRepository;
+use App\Service\RateLimitService;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Public inbound webhook for a Saved Task. Same 404 for unknown, disabled,
+ * or flag-off so tokens cannot be enumerated.
+ */
+final readonly class SavedTaskWebhookIngress
+{
+    public const MAX_BODY_BYTES = 65536;
+    public const RATE_PER_MINUTE = 60;
+
+    public function __construct(
+        private SavedTaskRepository $tasks,
+        private UserRepository $users,
+        private SavedTaskRunner $runner,
+        private WorkflowsConfig $workflows,
+        private RateLimitService $rateLimits,
+        private CacheItemPoolInterface $cache,
+    ) {
+    }
+
+    /**
+     * @return array{status: int, body: array<string, mixed>}
+     */
+    public function handle(string $token, string $rawBody, ?string $signatureHeader): array
+    {
+        $notFound = ['status' => Response::HTTP_NOT_FOUND, 'body' => ['error' => 'Not found']];
+        if ('' === $token || strlen($rawBody) > self::MAX_BODY_BYTES) {
+            return $notFound;
+        }
+
+        $task = $this->tasks->findByWebhookToken($token);
+        if (!$task instanceof SavedTask || !$task->isEnabled()) {
+            return $notFound;
+        }
+        if (!$this->workflows->isBuilderEnabled($task->getOwnerId())) {
+            return $notFound;
+        }
+
+        $secret = $task->getTriggerConfig()['hmacSecret'] ?? null;
+        if (is_string($secret) && '' !== $secret) {
+            $expected = 'sha256='.hash_hmac('sha256', $rawBody, $secret);
+            $given = is_string($signatureHeader) ? $signatureHeader : '';
+            if ('' === $given || !hash_equals($expected, $given)) {
+                return ['status' => Response::HTTP_UNAUTHORIZED, 'body' => ['error' => 'Invalid signature']];
+            }
+        }
+
+        if (!$this->allowTaskRate((int) $task->getId())) {
+            return ['status' => Response::HTTP_TOO_MANY_REQUESTS, 'body' => ['error' => 'Too many requests']];
+        }
+
+        $user = $this->users->find($task->getOwnerId());
+        if (!$user instanceof User || !$user->isActive()) {
+            return $notFound;
+        }
+        $limit = $this->rateLimits->checkLimit($user, 'MESSAGES');
+        if (empty($limit['allowed'])) {
+            return ['status' => Response::HTTP_TOO_MANY_REQUESTS, 'body' => ['error' => 'Too many requests']];
+        }
+
+        $payload = $this->decodeBody($rawBody);
+        try {
+            $this->runner->run($task->getOwnerId(), (int) $task->getId(), '', 'webhook', $payload);
+        } catch (SavedTaskDisabledException|SavedTaskNotFoundException) {
+            return $notFound;
+        }
+
+        return ['status' => Response::HTTP_ACCEPTED, 'body' => ['success' => true]];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeBody(string $rawBody): array
+    {
+        if ('' === trim($rawBody)) {
+            return [];
+        }
+        try {
+            $decoded = json_decode($rawBody, true, 512, \JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            return ['body' => $rawBody];
+        }
+
+        return is_array($decoded) ? $decoded : ['body' => $rawBody];
+    }
+
+    private function allowTaskRate(int $taskId): bool
+    {
+        $minute = (string) intdiv(time(), 60);
+        $key = sprintf('saved_task_wh_%d_%s', $taskId, $minute);
+        $item = $this->cache->getItem($key);
+        $used = is_int($item->get()) ? $item->get() : 0;
+        if ($used >= self::RATE_PER_MINUTE) {
+            return false;
+        }
+        $item->set($used + 1);
+        $item->expiresAfter(70);
+        $this->cache->save($item);
+
+        return true;
+    }
+}

--- a/backend/src/Service/SavedTask/SavedTaskWebhookIngress.php
+++ b/backend/src/Service/SavedTask/SavedTaskWebhookIngress.php
@@ -6,28 +6,33 @@ namespace App\Service\SavedTask;
 
 use App\Entity\SavedTask;
 use App\Entity\User;
+use App\Message\RunSavedTaskCommand;
 use App\Repository\SavedTaskRepository;
 use App\Repository\UserRepository;
 use App\Service\RateLimitService;
-use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
 
 /**
  * Public inbound webhook for a Saved Task. Same 404 for unknown, disabled,
  * or flag-off so tokens cannot be enumerated.
+ *
+ * Everything that can reject the call happens here, on the request path.
+ * The run itself is queued (`RunSavedTaskCommand`) so a slow step can never
+ * outlive the caller's timeout and be retried into a duplicate run.
  */
 final readonly class SavedTaskWebhookIngress
 {
     public const MAX_BODY_BYTES = 65536;
-    public const RATE_PER_MINUTE = 60;
 
     public function __construct(
         private SavedTaskRepository $tasks,
         private UserRepository $users,
-        private SavedTaskRunner $runner,
+        private MessageBusInterface $bus,
         private WorkflowsConfig $workflows,
         private RateLimitService $rateLimits,
-        private CacheItemPoolInterface $cache,
+        private RateLimiterFactoryInterface $savedTaskWebhookLimiter,
     ) {
     }
 
@@ -58,7 +63,8 @@ final readonly class SavedTaskWebhookIngress
             }
         }
 
-        if (!$this->allowTaskRate((int) $task->getId())) {
+        // Atomic per-task limiter (shared storage across web nodes).
+        if (!$this->savedTaskWebhookLimiter->create('task_'.(int) $task->getId())->consume()->isAccepted()) {
             return ['status' => Response::HTTP_TOO_MANY_REQUESTS, 'body' => ['error' => 'Too many requests']];
         }
 
@@ -71,12 +77,12 @@ final readonly class SavedTaskWebhookIngress
             return ['status' => Response::HTTP_TOO_MANY_REQUESTS, 'body' => ['error' => 'Too many requests']];
         }
 
-        $payload = $this->decodeBody($rawBody);
-        try {
-            $this->runner->run($task->getOwnerId(), (int) $task->getId(), '', 'webhook', $payload);
-        } catch (SavedTaskDisabledException|SavedTaskNotFoundException) {
-            return $notFound;
-        }
+        $this->bus->dispatch(new RunSavedTaskCommand(
+            $task->getOwnerId(),
+            (int) $task->getId(),
+            'webhook',
+            $this->decodeBody($rawBody),
+        ));
 
         return ['status' => Response::HTTP_ACCEPTED, 'body' => ['success' => true]];
     }
@@ -96,21 +102,5 @@ final readonly class SavedTaskWebhookIngress
         }
 
         return is_array($decoded) ? $decoded : ['body' => $rawBody];
-    }
-
-    private function allowTaskRate(int $taskId): bool
-    {
-        $minute = (string) intdiv(time(), 60);
-        $key = sprintf('saved_task_wh_%d_%s', $taskId, $minute);
-        $item = $this->cache->getItem($key);
-        $used = is_int($item->get()) ? $item->get() : 0;
-        if ($used >= self::RATE_PER_MINUTE) {
-            return false;
-        }
-        $item->set($used + 1);
-        $item->expiresAfter(70);
-        $this->cache->save($item);
-
-        return true;
     }
 }

--- a/backend/src/Service/SavedTask/WorkflowsConfig.php
+++ b/backend/src/Service/SavedTask/WorkflowsConfig.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\SavedTask;
+
+use App\Repository\ConfigRepository;
+use App\Service\Config\LayeredConfigResolver;
+
+/**
+ * Feature flag for the Saved Task Steps editor, builder-only graph kinds
+ * and the inbound webhook trigger.
+ *
+ * BCONFIG group {@see self::CONFIG_GROUP}. Insert-if-missing default is OFF.
+ */
+final readonly class WorkflowsConfig
+{
+    public const CONFIG_GROUP = 'WORKFLOWS';
+    public const KEY_BUILDER_ENABLED = 'BUILDER_ENABLED';
+
+    private const DEFAULT_BUILDER_ENABLED = false;
+
+    public function __construct(
+        private ConfigRepository $configRepository,
+        private ?LayeredConfigResolver $layeredConfigResolver = null,
+    ) {
+    }
+
+    public function isBuilderEnabled(?int $userId): bool
+    {
+        return $this->resolveFlag(self::KEY_BUILDER_ENABLED, $userId, self::DEFAULT_BUILDER_ENABLED);
+    }
+
+    private function resolveFlag(string $setting, ?int $userId, bool $default): bool
+    {
+        if (null !== $this->layeredConfigResolver) {
+            return $this->layeredConfigResolver->resolveBool($userId, self::CONFIG_GROUP, $setting, $default);
+        }
+        if (null !== $userId && $userId > 0) {
+            $perUser = $this->configRepository->getValue($userId, self::CONFIG_GROUP, $setting);
+            if (null !== $perUser) {
+                return $this->toBool($perUser, $default);
+            }
+        }
+
+        $global = $this->configRepository->getValue(0, self::CONFIG_GROUP, $setting);
+        if (null !== $global) {
+            return $this->toBool($global, $default);
+        }
+
+        return $default;
+    }
+
+    private function toBool(string $value, bool $default): bool
+    {
+        return filter_var($value, \FILTER_VALIDATE_BOOL, \FILTER_NULL_ON_FAILURE) ?? $default;
+    }
+}

--- a/backend/src/Service/Tool/Policy/ApprovalPolicy.php
+++ b/backend/src/Service/Tool/Policy/ApprovalPolicy.php
@@ -35,6 +35,7 @@ final readonly class ApprovalPolicy
         ?array $assistantTools = null,
         bool $allowUnattended = false,
         ?string $assistantKey = null,
+        ?PolicyOutcome $nodeOverride = null,
     ): PolicyOutcome {
         $class = $tool->sideEffect;
         $resolved = $this->mostRestrictive([
@@ -42,6 +43,7 @@ final readonly class ApprovalPolicy
             $this->groupPolicy->outcomeFor($actorId, $tool, $class),
             $this->assistantPolicy->outcomeFor($assistantTools, $tool, $class),
             $this->hardBlock($tool, $class),
+            $nodeOverride,
         ]);
         if (PolicyOutcome::Approve !== $resolved || SideEffect::Write !== $class) {
             return $resolved;

--- a/backend/src/Service/Tool/ToolDescriptor.php
+++ b/backend/src/Service/Tool/ToolDescriptor.php
@@ -65,6 +65,7 @@ final readonly class ToolDescriptor
             'policy' => $policy,
             'policyException' => $this->policyException,
             'shared' => true === ($this->meta['shared'] ?? false),
+            'inputSchema' => $this->inputSchema,
         ];
     }
 }

--- a/backend/src/Service/Tool/ToolExecutionGate.php
+++ b/backend/src/Service/Tool/ToolExecutionGate.php
@@ -40,18 +40,23 @@ final readonly class ToolExecutionGate
         ?array $assistantTools = null,
         bool $allowUnattended = false,
         ?string $assistantKey = null,
+        ?string $nodeApproval = null,
     ): array {
         $descriptor = $this->registry->get($userId, $toolName);
         if (null === $descriptor) {
             throw new ToolNotRegisteredException($toolName);
         }
 
+        $nodeOverride = PolicyOutcome::tryFrom((string) $nodeApproval);
+
         if (!$this->toolsConfig->isApprovalsEnabled($userId)) {
             return [
-                'outcome' => PolicyOutcome::Auto,
+                'outcome' => PolicyOutcome::Block === $nodeOverride ? PolicyOutcome::Block : PolicyOutcome::Auto,
                 'descriptor' => $descriptor,
                 'approval' => null,
-                'refusal' => null,
+                'refusal' => PolicyOutcome::Block === $nodeOverride
+                    ? 'I cannot do that. This step is set to always ask — and it is blocked.'
+                    : null,
             ];
         }
 
@@ -62,6 +67,7 @@ final readonly class ToolExecutionGate
             $assistantTools,
             $allowUnattended,
             $assistantKey,
+            $nodeOverride,
         );
 
         if (PolicyOutcome::Block === $outcome) {

--- a/backend/src/Service/Tool/ToolExecutionGate.php
+++ b/backend/src/Service/Tool/ToolExecutionGate.php
@@ -16,6 +16,12 @@ use App\Service\Tool\Policy\PolicyOutcome;
  */
 final readonly class ToolExecutionGate
 {
+    /**
+     * Refusal when an authored Saved Task step pins `params.approval = block`.
+     * Applies even while the approvals flag is off — a step can only tighten.
+     */
+    public const NODE_BLOCK_REFUSAL = 'I cannot do that. This step is set to never run this tool.';
+
     public function __construct(
         private ToolsConfig $toolsConfig,
         private ToolRegistry $registry,
@@ -54,9 +60,7 @@ final readonly class ToolExecutionGate
                 'outcome' => PolicyOutcome::Block === $nodeOverride ? PolicyOutcome::Block : PolicyOutcome::Auto,
                 'descriptor' => $descriptor,
                 'approval' => null,
-                'refusal' => PolicyOutcome::Block === $nodeOverride
-                    ? 'I cannot do that. This step is set to always ask — and it is blocked.'
-                    : null,
+                'refusal' => PolicyOutcome::Block === $nodeOverride ? self::NODE_BLOCK_REFUSAL : null,
             ];
         }
 

--- a/backend/tests/Support/SkillCatalogFactory.php
+++ b/backend/tests/Support/SkillCatalogFactory.php
@@ -7,6 +7,7 @@ namespace App\Tests\Support;
 use App\Service\Multitask\Execution\Runner\CalendarEventRunner;
 use App\Service\Multitask\Execution\Runner\ChatRunner;
 use App\Service\Multitask\Execution\Runner\ComposeReplyRunner;
+use App\Service\Multitask\Execution\Runner\ConditionRunner;
 use App\Service\Multitask\Execution\Runner\DocumentCombineRunner;
 use App\Service\Multitask\Execution\Runner\DocumentExportRunner;
 use App\Service\Multitask\Execution\Runner\DocumentGenerationRunner;
@@ -17,8 +18,10 @@ use App\Service\Multitask\Execution\Runner\FileAnalysisRunner;
 use App\Service\Multitask\Execution\Runner\McpActionRunner;
 use App\Service\Multitask\Execution\Runner\McpFetchRunner;
 use App\Service\Multitask\Execution\Runner\MediaGenerationRunner;
+use App\Service\Multitask\Execution\Runner\OutboundWebhookRunner;
 use App\Service\Multitask\Execution\Runner\SaveToFolderRunner;
 use App\Service\Multitask\Execution\Runner\Text2SoundRunner;
+use App\Service\Multitask\Execution\Runner\ToolCallRunner;
 use App\Service\Multitask\Execution\Runner\UrlFetchRunner;
 use App\Service\Multitask\Execution\Runner\WebSearchRunner;
 use App\Service\Multitask\Execution\TaskRunner;
@@ -58,6 +61,9 @@ final class SkillCatalogFactory
         EmailMeRunner::class,
         SaveToFolderRunner::class,
         ComposeReplyRunner::class,
+        ToolCallRunner::class,
+        OutboundWebhookRunner::class,
+        ConditionRunner::class,
     ];
 
     public static function real(): SkillCatalog

--- a/backend/tests/Unit/Entity/SavedTaskTriggerTest.php
+++ b/backend/tests/Unit/Entity/SavedTaskTriggerTest.php
@@ -19,17 +19,12 @@ final class SavedTaskTriggerTest extends TestCase
         }
     }
 
-    /**
-     * The webhook ingress endpoint does not exist yet (Sprint 4, E22+). A task
-     * stored with this trigger could never fire, so the entity must reject it
-     * until the route ships.
-     */
-    public function testRejectsWebhookTriggerUntilIngressExists(): void
+    public function testAcceptsWebhookTriggerNowThatIngressExists(): void
     {
         $task = new SavedTask(1, 42, 'Meeting requests from mail');
+        $task->setTrigger(SavedTask::TRIGGER_WEBHOOK, ['token' => 'abc']);
 
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Unsupported trigger type "webhook"');
-        $task->setTrigger(SavedTask::TRIGGER_WEBHOOK, null);
+        self::assertSame(SavedTask::TRIGGER_WEBHOOK, $task->getTriggerType());
+        self::assertContains(SavedTask::TRIGGER_WEBHOOK, SavedTask::TRIGGER_TYPES);
     }
 }

--- a/backend/tests/Unit/Service/Multitask/Execution/Runner/ConditionRunnerTest.php
+++ b/backend/tests/Unit/Service/Multitask/Execution/Runner/ConditionRunnerTest.php
@@ -41,6 +41,42 @@ final class ConditionRunnerTest extends TestCase
         self::assertTrue($result->isSuccessful());
     }
 
+    public function testMatchesOperatorStopsWhenThePatternDoesNotMatch(): void
+    {
+        $runner = new ConditionRunner(new StepInputResolver());
+        $node = new TaskNode('c1', Capability::Condition, [], [], [
+            'operator' => 'matches',
+            'value' => '^INV-\d+$',
+            'inputs' => ['input' => ['literal' => 'hello']],
+        ]);
+
+        self::assertTrue($runner->run($node, $this->context())->isStopped());
+    }
+
+    public function testMatchesOperatorContinuesOnAMatch(): void
+    {
+        $runner = new ConditionRunner(new StepInputResolver());
+        $node = new TaskNode('c1', Capability::Condition, [], [], [
+            'operator' => 'matches',
+            'value' => '^INV-\d+$',
+            'inputs' => ['input' => ['literal' => 'INV-42']],
+        ]);
+
+        self::assertTrue($runner->run($node, $this->context())->isSuccessful());
+    }
+
+    public function testMatchesOperatorTreatsAnInvalidPatternAsNoMatch(): void
+    {
+        $runner = new ConditionRunner(new StepInputResolver());
+        $node = new TaskNode('c1', Capability::Condition, [], [], [
+            'operator' => 'matches',
+            'value' => '(unclosed',
+            'inputs' => ['input' => ['literal' => '(unclosed']],
+        ]);
+
+        self::assertTrue($runner->run($node, $this->context())->isStopped());
+    }
+
     private function context(): NodeContext
     {
         $message = new Message();

--- a/backend/tests/Unit/Service/Multitask/Execution/Runner/ConditionRunnerTest.php
+++ b/backend/tests/Unit/Service/Multitask/Execution/Runner/ConditionRunnerTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\Multitask\Execution\Runner;
+
+use App\Entity\Message;
+use App\Service\Multitask\Execution\NodeContext;
+use App\Service\Multitask\Execution\Runner\ConditionRunner;
+use App\Service\Multitask\Plan\Capability;
+use App\Service\Multitask\Plan\TaskNode;
+use App\Service\SavedTask\Graph\StepInputResolver;
+use PHPUnit\Framework\TestCase;
+
+final class ConditionRunnerTest extends TestCase
+{
+    public function testFalseConditionStopsWithoutFailing(): void
+    {
+        $runner = new ConditionRunner(new StepInputResolver());
+        $node = new TaskNode('c1', Capability::Condition, [], [], [
+            'operator' => 'equals',
+            'value' => 'yes',
+            'inputs' => ['input' => ['literal' => 'no']],
+        ]);
+        $result = $runner->run($node, $this->context());
+
+        self::assertTrue($result->isStopped());
+        self::assertFalse($result->isSuccessful());
+    }
+
+    public function testTrueConditionContinues(): void
+    {
+        $runner = new ConditionRunner(new StepInputResolver());
+        $node = new TaskNode('c1', Capability::Condition, [], [], [
+            'operator' => 'contains',
+            'value' => 'mail',
+            'inputs' => ['input' => ['literal' => 'inbox mail']],
+        ]);
+        $result = $runner->run($node, $this->context());
+
+        self::assertTrue($result->isSuccessful());
+    }
+
+    private function context(): NodeContext
+    {
+        $message = new Message();
+        $message->setUserId(1);
+
+        return new NodeContext($message, [], 1, ['language' => 'en']);
+    }
+}

--- a/backend/tests/Unit/Service/Multitask/Execution/Runner/OutboundWebhookRunnerTest.php
+++ b/backend/tests/Unit/Service/Multitask/Execution/Runner/OutboundWebhookRunnerTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\Multitask\Execution\Runner;
+
+use App\Entity\Message;
+use App\Service\Multitask\Execution\NodeContext;
+use App\Service\Multitask\Execution\Runner\OutboundWebhookRunner;
+use App\Service\Multitask\Plan\Capability;
+use App\Service\Multitask\Plan\TaskNode;
+use App\Service\SavedTask\Graph\StepInputResolver;
+use App\Service\Security\SsrfGuard;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+final class OutboundWebhookRunnerTest extends TestCase
+{
+    public function testRejectsHttpAndBlockedHosts(): void
+    {
+        $ssrf = $this->createMock(SsrfGuard::class);
+        $ssrf->method('isBlockedUrl')->willReturn(true);
+        $runner = new OutboundWebhookRunner(new MockHttpClient(), $ssrf, new StepInputResolver(), new NullLogger());
+        $plain = $runner->run(
+            new TaskNode('w1', Capability::OutboundWebhook, [], [], ['url' => 'http://example.com/hook']),
+            $this->context(),
+        );
+        self::assertFalse($plain->isSuccessful());
+
+        $blocked = $runner->run(
+            new TaskNode('w1', Capability::OutboundWebhook, [], [], ['url' => 'https://127.0.0.1/hook']),
+            $this->context(),
+        );
+        self::assertFalse($blocked->isSuccessful());
+    }
+
+    public function testPostsSignedBodyWithoutCredentials(): void
+    {
+        $captured = [];
+        $client = new MockHttpClient(function (string $method, string $url, array $options) use (&$captured): MockResponse {
+            $captured = ['method' => $method, 'url' => $url, 'options' => $options];
+
+            return new MockResponse('{}', ['http_code' => 200]);
+        });
+        $ssrf = $this->createMock(SsrfGuard::class);
+        $ssrf->method('isBlockedUrl')->willReturn(false);
+        $runner = new OutboundWebhookRunner($client, $ssrf, new StepInputResolver(), new NullLogger());
+        $result = $runner->run(
+            new TaskNode('w1', Capability::OutboundWebhook, [], [], [
+                'url' => 'https://hooks.example/in',
+                'secret' => 'abc',
+                'inputs' => ['text' => ['literal' => 'done']],
+            ]),
+            $this->context(),
+        );
+
+        self::assertTrue($result->isSuccessful());
+        self::assertSame('POST', $captured['method']);
+        $body = is_string($captured['options']['body'] ?? null) ? $captured['options']['body'] : '';
+        self::assertStringContainsString('"result"', $body);
+        self::assertStringNotContainsString('abc', $body);
+        self::assertStringNotContainsString('sk_', $body);
+    }
+
+    private function context(): NodeContext
+    {
+        $message = new Message();
+        $message->setUserId(1);
+
+        return new NodeContext($message, [], 1, ['language' => 'en'], [
+            'saved_task_id' => 3,
+            'saved_task_run_id' => 8,
+        ]);
+    }
+}

--- a/backend/tests/Unit/Service/Multitask/Execution/Runner/OutboundWebhookRunnerTest.php
+++ b/backend/tests/Unit/Service/Multitask/Execution/Runner/OutboundWebhookRunnerTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\Service\Multitask\Execution\Runner;
 
 use App\Entity\Message;
 use App\Service\Multitask\Execution\NodeContext;
+use App\Service\Multitask\Execution\NodeResult;
 use App\Service\Multitask\Execution\Runner\OutboundWebhookRunner;
 use App\Service\Multitask\Plan\Capability;
 use App\Service\Multitask\Plan\TaskNode;
@@ -62,6 +63,32 @@ final class OutboundWebhookRunnerTest extends TestCase
         self::assertStringContainsString('"result"', $body);
         self::assertStringNotContainsString('abc', $body);
         self::assertStringNotContainsString('sk_', $body);
+    }
+
+    public function testWithoutAMappingItSendsWhatTheEarlierStepsProduced(): void
+    {
+        $captured = '';
+        $client = new MockHttpClient(function (string $method, string $url, array $options) use (&$captured): MockResponse {
+            $captured = is_string($options['body'] ?? null) ? $options['body'] : '';
+
+            return new MockResponse('{}', ['http_code' => 200]);
+        });
+        $ssrf = $this->createMock(SsrfGuard::class);
+        $ssrf->method('isBlockedUrl')->willReturn(false);
+        $runner = new OutboundWebhookRunner($client, $ssrf, new StepInputResolver(), new NullLogger());
+        $context = $this->context();
+        $context->setResult('n1', NodeResult::ok('Weekly digest ready', [], ['tool' => 'custom:digest']));
+
+        $result = $runner->run(
+            new TaskNode('w1', Capability::OutboundWebhook, ['n1'], [], ['url' => 'https://hooks.example/in']),
+            $context,
+        );
+
+        self::assertTrue($result->isSuccessful());
+        $decoded = json_decode($captured, true);
+        self::assertIsArray($decoded);
+        self::assertSame('Weekly digest ready', $decoded['result']['n1']['text'] ?? null);
+        self::assertSame('custom:digest', $decoded['result']['n1']['metadata']['tool'] ?? null);
     }
 
     private function context(): NodeContext

--- a/backend/tests/Unit/Service/Multitask/Execution/Runner/ToolCallRunnerTest.php
+++ b/backend/tests/Unit/Service/Multitask/Execution/Runner/ToolCallRunnerTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\Multitask\Execution\Runner;
+
+use App\Entity\Message;
+use App\Repository\CustomToolRepository;
+use App\Repository\McpServerConfigRepository;
+use App\Repository\UserRepository;
+use App\Service\Mcp\McpClient;
+use App\Service\Multitask\Execution\NodeContext;
+use App\Service\Multitask\Execution\Runner\ToolCallRunner;
+use App\Service\Multitask\Plan\Capability;
+use App\Service\Multitask\Plan\TaskNode;
+use App\Service\SavedTask\Graph\StepInputResolver;
+use App\Service\Tool\Custom\HttpToolExecutor;
+use App\Service\Tool\ToolRegistry;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+final class ToolCallRunnerTest extends TestCase
+{
+    public function testUnregisteredToolFailsClearly(): void
+    {
+        $registry = $this->createMock(ToolRegistry::class);
+        $registry->method('get')->willReturn(null);
+        $runner = new ToolCallRunner(
+            $registry,
+            new StepInputResolver(),
+            $this->createMock(HttpToolExecutor::class),
+            $this->createMock(CustomToolRepository::class),
+            $this->createMock(McpClient::class),
+            $this->createMock(McpServerConfigRepository::class),
+            $this->createMock(UserRepository::class),
+            new NullLogger(),
+        );
+        $message = new Message();
+        $message->setUserId(4);
+        $result = $runner->run(
+            new TaskNode('t1', Capability::ToolCall, [], [], ['tool' => 'custom:gone']),
+            new NodeContext($message, [], 4, ['language' => 'en']),
+        );
+
+        self::assertFalse($result->isSuccessful());
+        self::assertNotNull($result->error);
+        self::assertStringContainsString('gone', $result->error);
+    }
+}

--- a/backend/tests/Unit/Service/Multitask/Skill/SkillCatalogTest.php
+++ b/backend/tests/Unit/Service/Multitask/Skill/SkillCatalogTest.php
@@ -95,7 +95,10 @@ final class SkillCatalogTest extends TestCase
         self::assertStringNotContainsString('"save_to_folder"', $default);
         self::assertStringNotContainsString('"document_export"', $default);
         self::assertStringNotContainsString('"document_combine"', $default);
-        self::assertCount(count(Capability::cases()) - 6, explode("\n", $default));
+        self::assertStringNotContainsString('"tool_call"', $default);
+        self::assertStringNotContainsString('"outbound_webhook"', $default);
+        self::assertStringNotContainsString('"condition"', $default);
+        self::assertCount(count(Capability::cases()) - 9, explode("\n", $default));
 
         // Operator kill switch: an explicit URL_FETCH_ENABLED=0 row hides the
         // block from the planner again.

--- a/backend/tests/Unit/Service/SavedTask/SavedTaskGraphValidatorTest.php
+++ b/backend/tests/Unit/Service/SavedTask/SavedTaskGraphValidatorTest.php
@@ -136,6 +136,23 @@ final class SavedTaskGraphValidatorTest extends TestCase
         );
         $this->assertContains('step[0] can only tighten approval (ask me, or block)', $auto);
 
+        // Only the tool gate pauses a run; "ask me" on a webhook step would be an empty promise.
+        $askOnWebhook = $validator->validate(
+            [
+                'version' => 1,
+                'trigger' => ['type' => 'manual'],
+                'nodes' => [[
+                    'id' => 'n1',
+                    'capability' => 'outbound_webhook',
+                    'depends_on' => [],
+                    'params' => ['url' => 'https://example.com/hook', 'approval' => 'approve'],
+                ]],
+            ],
+            'manual',
+            null,
+        );
+        $this->assertContains('step[0] can only ask before a tool step', $askOnWebhook);
+
         $from = $validator->validate(
             [
                 'version' => 1,

--- a/backend/tests/Unit/Service/SavedTask/SavedTaskGraphValidatorTest.php
+++ b/backend/tests/Unit/Service/SavedTask/SavedTaskGraphValidatorTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Tests\Unit\Service\SavedTask;
 
 use App\Service\SavedTask\Graph\SavedTaskGraphValidator;
+use App\Service\SavedTask\WorkflowsConfig;
+use App\Service\Security\SsrfGuard;
 use PHPUnit\Framework\TestCase;
 
 final class SavedTaskGraphValidatorTest extends TestCase
@@ -66,5 +68,94 @@ final class SavedTaskGraphValidatorTest extends TestCase
         );
 
         $this->assertSame([], $errors);
+    }
+
+    public function testFlagOffRejectsBuilderOnlyCapabilitiesAsUnknown(): void
+    {
+        $errors = $this->validator->validate(
+            [
+                'version' => 1,
+                'trigger' => ['type' => 'manual'],
+                'nodes' => [['id' => 'n1', 'capability' => 'tool_call', 'depends_on' => [], 'params' => ['tool' => 'custom:x']]],
+            ],
+            'manual',
+            null,
+        );
+
+        $this->assertContains('step[0] has an unknown action', $errors);
+    }
+
+    public function testFlagOnAcceptsBuilderCapabilitiesAndRejectsAutoOverride(): void
+    {
+        $config = $this->createMock(WorkflowsConfig::class);
+        $config->method('isBuilderEnabled')->willReturn(true);
+        $ssrf = $this->createMock(SsrfGuard::class);
+        $ssrf->method('isBlockedUrl')->willReturn(false);
+        $validator = new SavedTaskGraphValidator($config, $ssrf);
+
+        $ok = $validator->validate(
+            [
+                'version' => 1,
+                'trigger' => ['type' => 'webhook'],
+                'nodes' => [
+                    [
+                        'id' => 'n1',
+                        'capability' => 'tool_call',
+                        'depends_on' => [],
+                        'params' => ['tool' => 'custom:x', 'approval' => 'approve'],
+                    ],
+                    [
+                        'id' => 'n2',
+                        'capability' => 'outbound_webhook',
+                        'depends_on' => ['n1'],
+                        'params' => [
+                            'url' => 'https://example.com/hook',
+                            'inputs' => ['text' => ['from' => 'n1', 'field' => 'text']],
+                        ],
+                    ],
+                ],
+            ],
+            'webhook',
+            ['token' => 't'],
+        );
+        $this->assertSame([], $ok);
+
+        $auto = $validator->validate(
+            [
+                'version' => 1,
+                'trigger' => ['type' => 'manual'],
+                'nodes' => [[
+                    'id' => 'n1',
+                    'capability' => 'tool_call',
+                    'depends_on' => [],
+                    'params' => ['tool' => 'custom:x', 'approval' => 'auto'],
+                ]],
+            ],
+            'manual',
+            null,
+        );
+        $this->assertContains('step[0] can only tighten approval (ask me, or block)', $auto);
+
+        $from = $validator->validate(
+            [
+                'version' => 1,
+                'trigger' => ['type' => 'manual'],
+                'nodes' => [
+                    ['id' => 'n1', 'capability' => 'chat', 'depends_on' => []],
+                    [
+                        'id' => 'n2',
+                        'capability' => 'condition',
+                        'depends_on' => [],
+                        'params' => [
+                            'operator' => 'equals',
+                            'inputs' => ['input' => ['from' => 'n1', 'field' => 'text']],
+                        ],
+                    ],
+                ],
+            ],
+            'manual',
+            null,
+        );
+        $this->assertContains("step[1] input 'input' must come from an earlier step this step depends on", $from);
     }
 }

--- a/backend/tests/Unit/Service/SavedTask/SavedTaskOutcomeNarratorTest.php
+++ b/backend/tests/Unit/Service/SavedTask/SavedTaskOutcomeNarratorTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\SavedTask;
+
+use App\Service\SavedTask\SavedTaskOutcomeNarrator;
+use PHPUnit\Framework\TestCase;
+
+final class SavedTaskOutcomeNarratorTest extends TestCase
+{
+    public function testDoesNotClaimNothingHappenedAfterALaterStepFails(): void
+    {
+        $message = (new SavedTaskOutcomeNarrator())->failureMessage(
+            [
+                'response' => [
+                    'metadata' => [
+                        'multitask' => [
+                            'node_statuses' => [
+                                'n1' => 'done',
+                                'n2' => 'failed',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                ['capability' => 'email_me', 'nodeId' => 'n1', 'state' => 'done'],
+                ['capability' => 'outbound_webhook', 'nodeId' => 'n2', 'state' => 'failed'],
+            ],
+            'The AI step could not complete. Nothing was sent or saved.',
+        );
+
+        self::assertSame('The email finished. Sending to the other system did not complete.', $message);
+        self::assertStringNotContainsString('Nothing was sent or saved', $message);
+    }
+
+    public function testGenericStopWhenNothingFinished(): void
+    {
+        $message = (new SavedTaskOutcomeNarrator())->failureMessage([], [], null);
+
+        self::assertSame('This run stopped before anything was sent or saved.', $message);
+    }
+}

--- a/backend/tests/Unit/Service/SavedTask/SavedTaskOutcomeNarratorTest.php
+++ b/backend/tests/Unit/Service/SavedTask/SavedTaskOutcomeNarratorTest.php
@@ -35,6 +35,20 @@ final class SavedTaskOutcomeNarratorTest extends TestCase
         self::assertStringNotContainsString('Nothing was sent or saved', $message);
     }
 
+    public function testTwoStepsOfOneKindWithOneFailureCountAsNotComplete(): void
+    {
+        $message = (new SavedTaskOutcomeNarrator())->failureMessage(
+            [],
+            [
+                ['capability' => 'save_to_folder', 'nodeId' => 'n1', 'state' => 'done'],
+                ['capability' => 'email_me', 'nodeId' => 'n2', 'state' => 'done'],
+                ['capability' => 'email_me', 'nodeId' => 'n3', 'state' => 'failed'],
+            ],
+        );
+
+        self::assertSame('Saving the file finished. The email did not complete.', $message);
+    }
+
     public function testGenericStopWhenNothingFinished(): void
     {
         $message = (new SavedTaskOutcomeNarrator())->failureMessage([], [], null);

--- a/backend/tests/Unit/Service/SavedTask/SavedTaskResumeServiceTest.php
+++ b/backend/tests/Unit/Service/SavedTask/SavedTaskResumeServiceTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\SavedTask;
+
+use App\Entity\Approval;
+use App\Entity\SavedTask;
+use App\Entity\SavedTaskRun;
+use App\Entity\User;
+use App\Repository\ApprovalRepository;
+use App\Repository\SavedTaskRepository;
+use App\Repository\SavedTaskRunRepository;
+use App\Repository\UserRepository;
+use App\Service\Multitask\Execution\DagExecutor;
+use App\Service\Multitask\Execution\NodeContextRehydrator;
+use App\Service\Multitask\TaskPlanStore;
+use App\Service\RateLimitService;
+use App\Service\SavedTask\Graph\SavedTaskPlanFactory;
+use App\Service\SavedTask\Graph\StepInputResolver;
+use App\Service\SavedTask\SavedTaskNotWaitingException;
+use App\Service\SavedTask\SavedTaskResumeService;
+use App\Service\Tool\Policy\ApprovalPolicy;
+use App\Service\Tool\ToolRegistry;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+/**
+ * Resuming a paused run must only ever accept the approval that run paused for.
+ */
+final class SavedTaskResumeServiceTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{Approval, string}>
+     */
+    public static function mismatchedApprovals(): iterable
+    {
+        yield 'another owner' => [self::approval(ownerId: 77, requestedBy: 'task_run:8:n2', approved: true), 'n2'];
+        yield 'still pending' => [self::approval(ownerId: 9, requestedBy: 'task_run:8:n2', approved: false), 'n2'];
+        yield 'another run' => [self::approval(ownerId: 9, requestedBy: 'task_run:99:n2', approved: true), 'n2'];
+        yield 'another step' => [self::approval(ownerId: 9, requestedBy: 'task_run:8:n2', approved: true), 'n3'];
+        yield 'a chat approval' => [self::approval(ownerId: 9, requestedBy: 'chat:123', approved: true), 'n2'];
+    }
+
+    #[DataProvider('mismatchedApprovals')]
+    public function testAnApprovalThatDoesNotBelongToThisRunAndStepIsRefused(Approval $approval, string $nodeId): void
+    {
+        $run = new SavedTaskRun(5, 'webhook');
+        $run->markWaitingApproval('n2');
+        (new \ReflectionProperty(SavedTaskRun::class, 'id'))->setValue($run, 8);
+        $task = new SavedTask(9, 12, 'Paused');
+
+        $runs = $this->createMock(SavedTaskRunRepository::class);
+        $runs->method('find')->willReturn($run);
+        $tasks = $this->createMock(SavedTaskRepository::class);
+        $tasks->method('find')->willReturn($task);
+        $users = $this->createMock(UserRepository::class);
+        $users->method('find')->willReturn($this->createMock(User::class));
+        $approvals = $this->createMock(ApprovalRepository::class);
+        $approvals->method('find')->willReturn($approval);
+
+        $registry = $this->createMock(ToolRegistry::class);
+        $registry->expects(self::never())->method('get');
+        $executor = $this->createMock(DagExecutor::class);
+        $executor->expects(self::never())->method('resume');
+
+        $service = new SavedTaskResumeService(
+            $runs,
+            $tasks,
+            $users,
+            $approvals,
+            $this->createStub(SavedTaskPlanFactory::class),
+            $this->createStub(NodeContextRehydrator::class),
+            $executor,
+            $this->createStub(TaskPlanStore::class),
+            $this->createStub(RateLimitService::class),
+            $registry,
+            new NullLogger(),
+            $this->createStub(ApprovalPolicy::class),
+            new StepInputResolver(),
+        );
+
+        $this->expectException(SavedTaskNotWaitingException::class);
+
+        $service->resume(8, $nodeId, 1);
+    }
+
+    private static function approval(int $ownerId, string $requestedBy, bool $approved): Approval
+    {
+        $approval = new Approval($ownerId, $requestedBy, 'custom:crm', 'write', time() + 3600);
+        if ($approved) {
+            $approval->markApproved($ownerId);
+        }
+
+        return $approval;
+    }
+}

--- a/backend/tests/Unit/Service/SavedTask/SavedTaskSerializerTest.php
+++ b/backend/tests/Unit/Service/SavedTask/SavedTaskSerializerTest.php
@@ -46,6 +46,24 @@ final class SavedTaskSerializerTest extends TestCase
         self::assertSame('Summarize my inbox', $data['instructionPreview']);
     }
 
+    public function testWebhookTriggerNeverExposesTheHmacSecret(): void
+    {
+        $this->prompts->method('find')->willReturn(null);
+        $task = new SavedTask(1, 12, 'From n8n');
+        $task->setTrigger(SavedTask::TRIGGER_WEBHOOK, [
+            'token' => 'public-token',
+            'hmacSecret' => 'super-secret',
+        ]);
+
+        $data = $this->serializer->task($task);
+        $config = $data['triggerConfig'];
+
+        self::assertIsArray($config);
+        self::assertSame('public-token', $config['token']);
+        self::assertTrue($config['hmacConfigured']);
+        self::assertArrayNotHasKey('hmacSecret', $config);
+    }
+
     public function testMissingPromptYieldsNullPreview(): void
     {
         $this->prompts->method('find')->willReturn(null);

--- a/backend/tests/Unit/Service/SavedTask/SavedTaskSerializerTest.php
+++ b/backend/tests/Unit/Service/SavedTask/SavedTaskSerializerTest.php
@@ -62,6 +62,42 @@ final class SavedTaskSerializerTest extends TestCase
         self::assertSame('public-token', $config['token']);
         self::assertTrue($config['hmacConfigured']);
         self::assertArrayNotHasKey('hmacSecret', $config);
+        self::assertArrayNotHasKey('webhookSecret', $data);
+    }
+
+    public function testFreshHmacSecretIsRevealedOnlyWhenAskedFor(): void
+    {
+        $this->prompts->method('find')->willReturn(null);
+        $task = new SavedTask(1, 12, 'From n8n');
+        $task->setTrigger(SavedTask::TRIGGER_WEBHOOK, [
+            'token' => 'public-token',
+            'hmacSecret' => 'super-secret',
+        ]);
+
+        $revealed = $this->serializer->task($task, 'super-secret');
+
+        self::assertSame('super-secret', $revealed['webhookSecret']);
+        self::assertArrayNotHasKey('hmacSecret', $revealed['triggerConfig']);
+        self::assertArrayNotHasKey('webhookSecret', $this->serializer->task($task));
+    }
+
+    public function testOutboundStepSecretsNeverLeaveTheServer(): void
+    {
+        $this->prompts->method('find')->willReturn(null);
+        $task = new SavedTask(1, 12, 'Outbound');
+        $task->setGraph(['version' => 1, 'trigger' => ['type' => 'manual'], 'nodes' => [
+            ['id' => 'n1', 'capability' => 'outbound_webhook', 'depends_on' => [], 'params' => ['url' => 'https://hooks.example/in', 'secret' => 'shh']],
+            ['id' => 'n2', 'capability' => 'outbound_webhook', 'depends_on' => [], 'params' => ['url' => 'https://hooks.example/open']],
+            ['id' => 'n3', 'capability' => 'chat', 'depends_on' => [], 'params' => ['secret' => 'not-an-outbound-step']],
+        ]]);
+
+        $graph = $this->serializer->task($task)['graph'];
+
+        self::assertIsArray($graph);
+        self::assertSame(['url' => 'https://hooks.example/in', 'secretConfigured' => true], $graph['nodes'][0]['params']);
+        self::assertSame(['url' => 'https://hooks.example/open', 'secretConfigured' => false], $graph['nodes'][1]['params']);
+        self::assertSame(['secret' => 'not-an-outbound-step'], $graph['nodes'][2]['params']);
+        self::assertStringNotContainsString('shh', json_encode($graph, \JSON_THROW_ON_ERROR));
     }
 
     public function testMissingPromptYieldsNullPreview(): void

--- a/backend/tests/Unit/Service/SavedTask/SavedTaskServiceBuilderTest.php
+++ b/backend/tests/Unit/Service/SavedTask/SavedTaskServiceBuilderTest.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\SavedTask;
+
+use App\Entity\Prompt;
+use App\Entity\SavedTask;
+use App\Repository\PromptRepository;
+use App\Repository\SavedTaskRepository;
+use App\Repository\SavedTaskRunRepository;
+use App\Service\Iam\AccessGate;
+use App\Service\SavedTask\Graph\SavedTaskGraphCapture;
+use App\Service\SavedTask\Graph\SavedTaskGraphValidator;
+use App\Service\SavedTask\SavedTaskService;
+use App\Service\SavedTask\Schedule\ScheduleParser;
+use App\Service\SavedTask\WorkflowsConfig;
+use App\Service\Security\SsrfGuard;
+use App\Service\Tool\SideEffect;
+use App\Service\Tool\ToolDescriptor;
+use App\Service\Tool\ToolRegistry;
+use App\Service\Tool\ToolSource;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Builder-specific save rules: an inbound webhook runs unattended, an outbound
+ * step's secret never round-trips through the editor, and a "Use a tool" step
+ * must point at a tool the owner has actually connected.
+ */
+final class SavedTaskServiceBuilderTest extends TestCase
+{
+    public function testAWebhookStartWithSendingStepsNeedsTheUnattendedConfirmation(): void
+    {
+        $task = new SavedTask(9, 5, 'From n8n');
+        $task->setGraph($this->graph([
+            ['id' => 'n1', 'capability' => 'outbound_webhook', 'depends_on' => [], 'params' => ['url' => 'https://hooks.example/in']],
+        ], SavedTask::TRIGGER_WEBHOOK));
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Another system starting this would send or save files on its own');
+
+        $this->service()->update($task, ['triggerType' => SavedTask::TRIGGER_WEBHOOK, 'triggerConfig' => []]);
+    }
+
+    public function testASavedOutboundSecretSurvivesAnEditThatOmitsIt(): void
+    {
+        $task = $this->manualTaskWithSecret('keep-me');
+
+        $edited = $this->graph([
+            ['id' => 'n1', 'capability' => 'outbound_webhook', 'depends_on' => [], 'params' => ['url' => 'https://hooks.example/other', 'secretConfigured' => true]],
+        ]);
+        $this->service()->update($task, ['graph' => $edited]);
+
+        $params = $task->getGraph()['nodes'][0]['params'] ?? [];
+        self::assertSame('https://hooks.example/other', $params['url'] ?? null);
+        self::assertSame('keep-me', $params['secret'] ?? null);
+        self::assertArrayNotHasKey('secretConfigured', $params);
+    }
+
+    public function testTypingANewSecretReplacesItAndClearingRemovesIt(): void
+    {
+        $task = $this->manualTaskWithSecret('old');
+        $service = $this->service();
+
+        $service->update($task, ['graph' => $this->graph([
+            ['id' => 'n1', 'capability' => 'outbound_webhook', 'depends_on' => [], 'params' => ['url' => 'https://hooks.example/in', 'secret' => 'new']],
+        ])]);
+        self::assertSame('new', $task->getGraph()['nodes'][0]['params']['secret'] ?? null);
+
+        $service->update($task, ['graph' => $this->graph([
+            ['id' => 'n1', 'capability' => 'outbound_webhook', 'depends_on' => [], 'params' => ['url' => 'https://hooks.example/in', 'secret' => '']],
+        ])]);
+        self::assertSame('', $task->getGraph()['nodes'][0]['params']['secret'] ?? null);
+    }
+
+    public function testAToolStepMustUseAConnectedToolThatCanRunAsAStep(): void
+    {
+        $task = new SavedTask(9, 5, 'Tools');
+        $registry = $this->createMock(ToolRegistry::class);
+        $registry->method('get')->willReturnCallback(static function (int $userId, string $name): ?ToolDescriptor {
+            return match ($name) {
+                'custom:crm' => new ToolDescriptor('custom:crm', 'CRM', '', [], SideEffect::Write, ToolSource::Custom, $userId),
+                'web_search' => new ToolDescriptor('web_search', 'Search', '', [], SideEffect::Read, ToolSource::Builtin, 0),
+                default => null,
+            };
+        });
+        $service = $this->service($registry);
+
+        $service->update($task, ['graph' => $this->graph([
+            ['id' => 'n1', 'capability' => 'tool_call', 'depends_on' => [], 'params' => ['tool' => 'custom:crm']],
+        ])]);
+        self::assertSame('custom:crm', $task->getGraph()['nodes'][0]['params']['tool'] ?? null);
+
+        try {
+            $service->update($task, ['graph' => $this->graph([
+                ['id' => 'n1', 'capability' => 'tool_call', 'depends_on' => [], 'params' => ['tool' => 'custom:gone']],
+            ])]);
+            self::fail('A tool nobody connected must be rejected');
+        } catch (\InvalidArgumentException $e) {
+            self::assertSame('Step 1 uses a tool that is not connected', $e->getMessage());
+        }
+
+        try {
+            $service->update($task, ['graph' => $this->graph([
+                ['id' => 'n1', 'capability' => 'tool_call', 'depends_on' => [], 'params' => ['tool' => 'web_search']],
+            ])]);
+            self::fail('A built-in chat tool cannot run as a step');
+        } catch (\InvalidArgumentException $e) {
+            self::assertSame('Step 1 uses a tool that cannot run as a step', $e->getMessage());
+        }
+    }
+
+    private function manualTaskWithSecret(string $secret): SavedTask
+    {
+        $task = new SavedTask(9, 5, 'Outbound');
+        $task->setGraph($this->graph([
+            ['id' => 'n1', 'capability' => 'outbound_webhook', 'depends_on' => [], 'params' => ['url' => 'https://hooks.example/in', 'secret' => $secret]],
+        ]));
+
+        return $task;
+    }
+
+    /**
+     * @param list<array<string, mixed>> $nodes
+     *
+     * @return array<string, mixed>
+     */
+    private function graph(array $nodes, string $trigger = SavedTask::TRIGGER_MANUAL): array
+    {
+        return ['version' => 1, 'trigger' => ['type' => $trigger], 'nodes' => $nodes];
+    }
+
+    private function service(?ToolRegistry $registry = null): SavedTaskService
+    {
+        $prompt = new Prompt();
+        $prompt->setOwnerId(9);
+        $prompt->setTopic('saved-1');
+        $prompt->setPrompt('Do the thing.');
+        $prompts = $this->createMock(PromptRepository::class);
+        $prompts->method('find')->willReturn($prompt);
+
+        $workflows = $this->createMock(WorkflowsConfig::class);
+        $workflows->method('isBuilderEnabled')->willReturn(true);
+        $ssrf = $this->createMock(SsrfGuard::class);
+        $ssrf->method('isBlockedUrl')->willReturn(false);
+
+        return new SavedTaskService(
+            $this->createStub(SavedTaskRepository::class),
+            $this->createStub(SavedTaskRunRepository::class),
+            $prompts,
+            new SavedTaskGraphValidator($workflows, $ssrf),
+            $this->createStub(ScheduleParser::class),
+            $this->createStub(AccessGate::class),
+            $this->createStub(SavedTaskGraphCapture::class),
+            null,
+            $workflows,
+            $registry,
+        );
+    }
+}

--- a/backend/tests/Unit/Service/SavedTask/SavedTaskServiceCopyTest.php
+++ b/backend/tests/Unit/Service/SavedTask/SavedTaskServiceCopyTest.php
@@ -27,7 +27,9 @@ final class SavedTaskServiceCopyTest extends TestCase
         $source = new SavedTask(9, 5, 'Weekly');
         $source->setTrigger(SavedTask::TRIGGER_SCHEDULE, ['kind' => 'daily', 'at' => '07:00']);
         $source->setAllowUnattended(true);
-        $source->setGraph(['nodes' => []]);
+        $source->setGraph(['nodes' => [
+            ['id' => 'n1', 'capability' => 'outbound_webhook', 'depends_on' => [], 'params' => ['url' => 'https://hooks.example/in', 'secret' => 'owner-only']],
+        ]]);
         (new \ReflectionProperty(SavedTask::class, 'id'))->setValue($source, 11);
 
         $prompt = new Prompt();
@@ -75,7 +77,13 @@ final class SavedTaskServiceCopyTest extends TestCase
         self::assertSame(3, $copy->getOwnerId());
         // The copied graph follows the reset trigger; a schedule-typed graph
         // on a manual task would be rejected by the factory at run time.
-        self::assertSame(['nodes' => [], 'trigger' => ['type' => SavedTask::TRIGGER_MANUAL]], $copy->getGraph());
+        // The source owner's outbound secret never travels with the copy.
+        self::assertSame([
+            'nodes' => [
+                ['id' => 'n1', 'capability' => 'outbound_webhook', 'depends_on' => [], 'params' => ['url' => 'https://hooks.example/in']],
+            ],
+            'trigger' => ['type' => SavedTask::TRIGGER_MANUAL],
+        ], $copy->getGraph());
     }
 
     public function testCopyWithoutAssistantAccessThrowsConflict(): void

--- a/backend/tests/Unit/Service/SavedTask/SavedTaskWebhookIngressTest.php
+++ b/backend/tests/Unit/Service/SavedTask/SavedTaskWebhookIngressTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\SavedTask;
+
+use App\Entity\SavedTask;
+use App\Entity\User;
+use App\Repository\SavedTaskRepository;
+use App\Repository\UserRepository;
+use App\Service\RateLimitService;
+use App\Service\SavedTask\SavedTaskRunner;
+use App\Service\SavedTask\SavedTaskWebhookIngress;
+use App\Service\SavedTask\WorkflowsConfig;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\HttpFoundation\Response;
+
+final class SavedTaskWebhookIngressTest extends TestCase
+{
+    private SavedTaskRepository&MockObject $tasks;
+    private UserRepository&MockObject $users;
+    private SavedTaskRunner&MockObject $runner;
+    private WorkflowsConfig&MockObject $workflows;
+    private RateLimitService&MockObject $rateLimits;
+    private SavedTaskWebhookIngress $ingress;
+
+    protected function setUp(): void
+    {
+        $this->tasks = $this->createMock(SavedTaskRepository::class);
+        $this->users = $this->createMock(UserRepository::class);
+        $this->runner = $this->createMock(SavedTaskRunner::class);
+        $this->workflows = $this->createMock(WorkflowsConfig::class);
+        $this->rateLimits = $this->createMock(RateLimitService::class);
+        $this->ingress = new SavedTaskWebhookIngress(
+            $this->tasks,
+            $this->users,
+            $this->runner,
+            $this->workflows,
+            $this->rateLimits,
+            new ArrayAdapter(),
+        );
+    }
+
+    public function testUnknownTokenIsNotFound(): void
+    {
+        $this->tasks->method('findByWebhookToken')->willReturn(null);
+
+        $result = $this->ingress->handle('missing', '{}', null);
+
+        self::assertSame(Response::HTTP_NOT_FOUND, $result['status']);
+        $this->runner->expects(self::never())->method('run');
+    }
+
+    public function testDisabledOrFlagOffUsesTheSameNotFound(): void
+    {
+        $task = new SavedTask(9, 12, 'From n8n');
+        $task->setEnabled(false);
+        $task->setTrigger(SavedTask::TRIGGER_WEBHOOK, ['token' => 'tok']);
+        $this->tasks->method('findByWebhookToken')->willReturn($task);
+
+        $result = $this->ingress->handle('tok', '{}', null);
+
+        self::assertSame(Response::HTTP_NOT_FOUND, $result['status']);
+    }
+
+    public function testBadHmacIsUnauthorized(): void
+    {
+        $task = $this->enabledWebhookTask(['token' => 'tok', 'hmacSecret' => 's3cret']);
+        $this->tasks->method('findByWebhookToken')->willReturn($task);
+        $this->workflows->method('isBuilderEnabled')->willReturn(true);
+
+        $result = $this->ingress->handle('tok', '{"a":1}', 'sha256=deadbeef');
+
+        self::assertSame(Response::HTTP_UNAUTHORIZED, $result['status']);
+        $this->runner->expects(self::never())->method('run');
+    }
+
+    public function testValidCallRunsAsOwner(): void
+    {
+        $task = $this->enabledWebhookTask(['token' => 'tok']);
+        $this->tasks->method('findByWebhookToken')->willReturn($task);
+        $this->workflows->method('isBuilderEnabled')->willReturn(true);
+        $user = $this->createMock(User::class);
+        $user->method('isActive')->willReturn(true);
+        $this->users->expects(self::once())->method('find')->with(9)->willReturn($user);
+        $this->rateLimits->method('checkLimit')->willReturn(['allowed' => true]);
+        $this->runner->expects(self::once())->method('run')->with(9, 0, '', 'webhook', ['hello' => 'world']);
+
+        $result = $this->ingress->handle('tok', '{"hello":"world"}', null);
+
+        self::assertSame(Response::HTTP_ACCEPTED, $result['status']);
+    }
+
+    public function testSixtyFirstCallInAMinuteIsRateLimited(): void
+    {
+        $task = $this->enabledWebhookTask(['token' => 'tok']);
+        $this->tasks->method('findByWebhookToken')->willReturn($task);
+        $this->workflows->method('isBuilderEnabled')->willReturn(true);
+        $user = $this->createMock(User::class);
+        $user->method('isActive')->willReturn(true);
+        $this->users->method('find')->willReturn($user);
+        $this->rateLimits->method('checkLimit')->willReturn(['allowed' => true]);
+        $this->runner->method('run')->willReturn([]);
+
+        $last = ['status' => 0, 'body' => []];
+        for ($i = 0; $i < 61; ++$i) {
+            $last = $this->ingress->handle('tok', '{}', null);
+        }
+
+        self::assertSame(Response::HTTP_TOO_MANY_REQUESTS, $last['status']);
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    private function enabledWebhookTask(array $config): SavedTask
+    {
+        $task = new SavedTask(9, 12, 'From n8n');
+        $task->setTrigger(SavedTask::TRIGGER_WEBHOOK, $config);
+
+        return $task;
+    }
+}

--- a/backend/tests/Unit/Service/SavedTask/SavedTaskWebhookIngressTest.php
+++ b/backend/tests/Unit/Service/SavedTask/SavedTaskWebhookIngressTest.php
@@ -6,22 +6,25 @@ namespace App\Tests\Unit\Service\SavedTask;
 
 use App\Entity\SavedTask;
 use App\Entity\User;
+use App\Message\RunSavedTaskCommand;
 use App\Repository\SavedTaskRepository;
 use App\Repository\UserRepository;
 use App\Service\RateLimitService;
-use App\Service\SavedTask\SavedTaskRunner;
 use App\Service\SavedTask\SavedTaskWebhookIngress;
 use App\Service\SavedTask\WorkflowsConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
 
 final class SavedTaskWebhookIngressTest extends TestCase
 {
     private SavedTaskRepository&MockObject $tasks;
     private UserRepository&MockObject $users;
-    private SavedTaskRunner&MockObject $runner;
+    private MessageBusInterface&MockObject $bus;
     private WorkflowsConfig&MockObject $workflows;
     private RateLimitService&MockObject $rateLimits;
     private SavedTaskWebhookIngress $ingress;
@@ -30,27 +33,30 @@ final class SavedTaskWebhookIngressTest extends TestCase
     {
         $this->tasks = $this->createMock(SavedTaskRepository::class);
         $this->users = $this->createMock(UserRepository::class);
-        $this->runner = $this->createMock(SavedTaskRunner::class);
+        $this->bus = $this->createMock(MessageBusInterface::class);
         $this->workflows = $this->createMock(WorkflowsConfig::class);
         $this->rateLimits = $this->createMock(RateLimitService::class);
         $this->ingress = new SavedTaskWebhookIngress(
             $this->tasks,
             $this->users,
-            $this->runner,
+            $this->bus,
             $this->workflows,
             $this->rateLimits,
-            new ArrayAdapter(),
+            new RateLimiterFactory(
+                ['id' => 'saved_task_webhook', 'policy' => 'sliding_window', 'limit' => 60, 'interval' => '1 minute'],
+                new InMemoryStorage(),
+            ),
         );
     }
 
     public function testUnknownTokenIsNotFound(): void
     {
         $this->tasks->method('findByWebhookToken')->willReturn(null);
+        $this->bus->expects(self::never())->method('dispatch');
 
         $result = $this->ingress->handle('missing', '{}', null);
 
         self::assertSame(Response::HTTP_NOT_FOUND, $result['status']);
-        $this->runner->expects(self::never())->method('run');
     }
 
     public function testDisabledOrFlagOffUsesTheSameNotFound(): void
@@ -59,6 +65,7 @@ final class SavedTaskWebhookIngressTest extends TestCase
         $task->setEnabled(false);
         $task->setTrigger(SavedTask::TRIGGER_WEBHOOK, ['token' => 'tok']);
         $this->tasks->method('findByWebhookToken')->willReturn($task);
+        $this->bus->expects(self::never())->method('dispatch');
 
         $result = $this->ingress->handle('tok', '{}', null);
 
@@ -70,14 +77,14 @@ final class SavedTaskWebhookIngressTest extends TestCase
         $task = $this->enabledWebhookTask(['token' => 'tok', 'hmacSecret' => 's3cret']);
         $this->tasks->method('findByWebhookToken')->willReturn($task);
         $this->workflows->method('isBuilderEnabled')->willReturn(true);
+        $this->bus->expects(self::never())->method('dispatch');
 
         $result = $this->ingress->handle('tok', '{"a":1}', 'sha256=deadbeef');
 
         self::assertSame(Response::HTTP_UNAUTHORIZED, $result['status']);
-        $this->runner->expects(self::never())->method('run');
     }
 
-    public function testValidCallRunsAsOwner(): void
+    public function testValidCallQueuesARunAsTheOwner(): void
     {
         $task = $this->enabledWebhookTask(['token' => 'tok']);
         $this->tasks->method('findByWebhookToken')->willReturn($task);
@@ -86,7 +93,14 @@ final class SavedTaskWebhookIngressTest extends TestCase
         $user->method('isActive')->willReturn(true);
         $this->users->expects(self::once())->method('find')->with(9)->willReturn($user);
         $this->rateLimits->method('checkLimit')->willReturn(['allowed' => true]);
-        $this->runner->expects(self::once())->method('run')->with(9, 0, '', 'webhook', ['hello' => 'world']);
+        $this->bus->expects(self::once())->method('dispatch')
+            ->with(self::callback(static function (RunSavedTaskCommand $command): bool {
+                return 9 === $command->ownerId
+                    && 0 === $command->taskId
+                    && 'webhook' === $command->trigger
+                    && ['hello' => 'world'] === $command->triggerPayload;
+            }))
+            ->willReturnCallback(static fn (object $message): Envelope => new Envelope($message));
 
         $result = $this->ingress->handle('tok', '{"hello":"world"}', null);
 
@@ -102,7 +116,8 @@ final class SavedTaskWebhookIngressTest extends TestCase
         $user->method('isActive')->willReturn(true);
         $this->users->method('find')->willReturn($user);
         $this->rateLimits->method('checkLimit')->willReturn(['allowed' => true]);
-        $this->runner->method('run')->willReturn([]);
+        $this->bus->expects(self::exactly(60))->method('dispatch')
+            ->willReturnCallback(static fn (object $message): Envelope => new Envelope($message));
 
         $last = ['status' => 0, 'body' => []];
         for ($i = 0; $i < 61; ++$i) {

--- a/backend/tests/Unit/Service/SavedTask/StepInputResolverTest.php
+++ b/backend/tests/Unit/Service/SavedTask/StepInputResolverTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\SavedTask;
+
+use App\Entity\Message;
+use App\Service\Multitask\Execution\NodeContext;
+use App\Service\Multitask\Execution\NodeResult;
+use App\Service\SavedTask\Graph\StepInputResolver;
+use PHPUnit\Framework\TestCase;
+
+final class StepInputResolverTest extends TestCase
+{
+    public function testResolvesLiteralFromEarlierStepAndTrigger(): void
+    {
+        $message = new Message();
+        $message->setUserId(1);
+        $context = new NodeContext($message, [], 1, ['language' => 'en'], [
+            'trigger_payload' => ['body' => ['title' => 'Hello']],
+        ]);
+        $context->setResult('step_1', NodeResult::ok('Inbox summary', [], ['summary' => 'Inbox summary']));
+
+        $resolver = new StepInputResolver();
+        $resolved = $resolver->resolveAll([
+            'name' => ['literal' => 'Ada'],
+            'text' => ['from' => 'step_1', 'field' => 'text'],
+            'title' => ['from' => 'trigger', 'field' => 'body.title'],
+        ], $context);
+
+        self::assertSame('Ada', $resolved['name']);
+        self::assertSame('Inbox summary', $resolved['text']);
+        self::assertSame('Hello', $resolved['title']);
+    }
+}

--- a/backend/tests/Unit/Service/SavedTask/StepInputResolverTest.php
+++ b/backend/tests/Unit/Service/SavedTask/StepInputResolverTest.php
@@ -32,4 +32,20 @@ final class StepInputResolverTest extends TestCase
         self::assertSame('Inbox summary', $resolved['text']);
         self::assertSame('Hello', $resolved['title']);
     }
+
+    public function testEmptyFieldMeansTheWholeEventOrTheStepText(): void
+    {
+        $message = new Message();
+        $message->setUserId(1);
+        $payload = ['title' => 'Hello', 'count' => 2];
+        $context = new NodeContext($message, [], 1, ['language' => 'en'], ['trigger_payload' => $payload]);
+        $context->setResult('step_1', NodeResult::ok('Inbox summary'));
+
+        $resolver = new StepInputResolver();
+
+        self::assertSame($payload, $resolver->resolve(['from' => 'trigger'], $context));
+        self::assertSame($payload, $resolver->resolve(['from' => 'trigger', 'field' => ''], $context));
+        self::assertSame('Inbox summary', $resolver->resolve(['from' => 'step_1', 'field' => ''], $context));
+        self::assertNull($resolver->resolve(['from' => 'trigger', 'field' => 'missing'], $context));
+    }
 }

--- a/docs/MULTITASK_DATA_NODES.md
+++ b/docs/MULTITASK_DATA_NODES.md
@@ -38,6 +38,15 @@ Every data node obeys the same rules (plan 09 §2):
 | `mcp_action` | `McpActionRunner` | WRITE actions (create/update — e.g. Confluence pages, Jira tickets) on connected MCP servers whose owner enabled **allow write actions** (`BMCPSERVERS.BALLOWWRITE`); destructive tools always refused | `MCP.CLIENT_ENABLED` + `MULTITASK.MCP_ACTION_ENABLED` + per-topic `tool_mcp` + per-server `allow_write` | **on** (seeded), write opt-in per server **off** |
 | `email_search` | `EmailSearchRunner` | Live read-only search over the user's IMAP accounts (`InboundEmailHandler`) **and** Microsoft 365 connections (`GraphMailboxSearcher`, delegated `Mail.Read`) | `MULTITASK.EMAIL_SEARCH_ENABLED` | **on** (seeded) |
 | `rag_query` | `ChatRunner` | User knowledge base (Qdrant) | – | on |
+| `tool_call` | `ToolCallRunner` | A registered custom or MCP tool from an authored Saved Task. Hidden from the planner. | `WORKFLOWS.BUILDER_ENABLED` | **off** |
+| `outbound_webhook` | `OutboundWebhookRunner` | HMAC-signed HTTPS POST of a step result. Hidden from the planner. | `WORKFLOWS.BUILDER_ENABLED` | **off** |
+| `condition` | `ConditionRunner` | Gate: on false the node stops and later steps skip; the run completes. Hidden from the planner. | `WORKFLOWS.BUILDER_ENABLED` | **off** |
+
+Authored step inputs (`params.inputs`) are `{ "literal": "…" }`,
+`{ "from": "step_2", "field": "summary" }`, or
+`{ "from": "trigger", "field": "body.title" }`. Every `from` other than
+`trigger` must be listed in that step’s `depends_on`. `params.approval` may
+only tighten policy (`approve` or `block`).
 
 Flags resolve per-user row → global row → built-in default (see
 `MultitaskRoutingConfig::isFeatureEnabled`).

--- a/docs/N8N.md
+++ b/docs/N8N.md
@@ -1,0 +1,30 @@
+# n8n and Saved Tasks
+
+Synaplan does not embed n8n. Another system starts a Saved Task, or a Saved Task
+sends a result out. Both use ordinary HTTPS.
+
+## Another system starts a Saved Task
+
+1. On the Saved Task card, choose **Let another system start this**.
+2. Copy the address. Optional: turn on **Require a signature**.
+3. In n8n, add an **HTTP Request** node that `POST`s JSON to that address.
+
+When a shared secret is set, send:
+
+`X-Synaplan-Signature: sha256=<hex>`
+
+over the raw request body (HMAC-SHA256). Unknown or disabled tasks return the
+same 404. The body becomes the run’s starting event (`from: trigger`).
+
+## A Saved Task sends a result to n8n
+
+Add a **Send to another system** step. The POST is HTTPS only, no redirects,
+no retries. Body shape:
+
+```json
+{ "task": 1, "run": 2, "step": "step_2", "result": { } }
+```
+
+When the step has a secret, the same `X-Synaplan-Signature` header is sent.
+n8n can receive that with a Webhook node, do its work, then call back to the
+Saved Task inbound address if another run should start.

--- a/docs/N8N.md
+++ b/docs/N8N.md
@@ -6,7 +6,9 @@ sends a result out. Both use ordinary HTTPS.
 ## Another system starts a Saved Task
 
 1. On the Saved Task card, choose **Let another system start this**.
-2. Copy the address. Optional: turn on **Require a signature**.
+2. Copy the address. Optional: turn on **Require a signature** — the shared
+   secret is shown **once**, right then. Copy it into the other system; turn
+   the signature off and on again if you need a new one.
 3. In n8n, add an **HTTP Request** node that `POST`s JSON to that address.
 
 When a shared secret is set, send:
@@ -14,7 +16,15 @@ When a shared secret is set, send:
 `X-Synaplan-Signature: sha256=<hex>`
 
 over the raw request body (HMAC-SHA256). Unknown or disabled tasks return the
-same 404. The body becomes the run’s starting event (`from: trigger`).
+same 404. The JSON body becomes the run’s starting event: a step input
+`{ "from": "trigger", "field": "order.id" }` reads a part of it, and an empty
+`field` passes the whole body. Bodies are limited to 64 KiB, and each task
+accepts at most 60 starts per minute.
+
+The call returns `202` as soon as the event is accepted; the run itself is
+queued and executes in the background. Anything the run produces arrives
+through the task's own steps (an outbound webhook, an email, a saved file) —
+not in this response.
 
 ## A Saved Task sends a result to n8n
 
@@ -22,9 +32,15 @@ Add a **Send to another system** step. The POST is HTTPS only, no redirects,
 no retries. Body shape:
 
 ```json
-{ "task": 1, "run": 2, "step": "step_2", "result": { } }
+{ "task": 1, "run": 2, "step": "step_2", "result": { "result": "…" } }
 ```
 
+`result` holds what you mapped under **What to send** (by default the text of
+the previous step). With no mapping at all it carries the text and details of
+every step this one follows, keyed by step id.
+
 When the step has a secret, the same `X-Synaplan-Signature` header is sent.
+The secret is stored on the server and never shown again after you type it;
+the editor only tells you that one is set.
 n8n can receive that with a Webhook node, do its work, then call back to the
 Saved Task inbound address if another run should start.

--- a/frontend/src/components/config/SavedTaskCard.vue
+++ b/frontend/src/components/config/SavedTaskCard.vue
@@ -5,9 +5,12 @@ import { useRouter } from 'vue-router'
 import { useNotification } from '@/composables/useNotification'
 import { useDialog } from '@/composables/useDialog'
 import { isIamSharingEnabled } from '@/composables/useIamFeature'
+import { isWorkflowsBuilderEnabled } from '@/composables/useWorkflowsFeature'
 import ShareDialog from '@/components/iam/ShareDialog.vue'
 import SharedResourceBanner from '@/components/iam/SharedResourceBanner.vue'
+import SavedTaskStepsEditor from '@/components/config/workflows/SavedTaskStepsEditor.vue'
 import { savedTasksApi, type SavedTask, type SavedTaskRun } from '@/services/api/savedTasksApi'
+import { getApiBaseUrl } from '@/services/api/httpClient'
 import { ApiError } from '@/services/api/httpClient'
 import type { ShareVia } from '@/utils/shareCopy'
 
@@ -30,8 +33,11 @@ const router = useRouter()
 const { success, error: showError } = useNotification()
 const dialog = useDialog()
 const iamSharingEnabled = computed(() => isIamSharingEnabled())
+const workflowsEnabled = computed(() => isWorkflowsBuilderEnabled())
 const iamShareOpen = ref(false)
+const stepsOpen = ref(false)
 const copying = ref(false)
+const hmacSaving = ref(false)
 
 const running = ref(false)
 const showRuns = ref(false)
@@ -51,6 +57,8 @@ watch(
       if (typeof at === 'string') scheduleAt.value = at
       const tz = task.triggerConfig.tz
       if (typeof tz === 'string') scheduleTz.value = tz
+    } else if (task.triggerType === 'webhook') {
+      scheduleKind.value = 'webhook'
     } else {
       scheduleKind.value = 'off'
     }
@@ -139,6 +147,66 @@ const onRunNow = async () => {
   }
 }
 
+const webhookToken = computed(() => {
+  const token = props.task.triggerConfig?.token
+  return typeof token === 'string' ? token : ''
+})
+
+const webhookUrl = computed(() => {
+  if (!webhookToken.value) return ''
+  const base = getApiBaseUrl().replace(/\/$/, '')
+  return `${base}/api/v1/webhooks/saved-tasks/${webhookToken.value}`
+})
+
+const hmacConfigured = computed(() => props.task.triggerConfig?.hmacConfigured === true)
+
+const copyWebhookUrl = async () => {
+  if (!webhookUrl.value) return
+  try {
+    await navigator.clipboard.writeText(webhookUrl.value)
+    success(t('workflows.urlCopied'))
+  } catch {
+    showError(t('config.savedTasks.updateFailed'))
+  }
+}
+
+const regenerateWebhook = async () => {
+  const ok = await dialog.confirm({
+    title: t('workflows.regenerate'),
+    message: t('workflows.regenerateConfirm'),
+    danger: true,
+  })
+  if (!ok) return
+  try {
+    emit(
+      'updated',
+      await savedTasksApi.update(props.task.id, {
+        triggerType: 'webhook',
+        regenerateWebhookToken: true,
+      })
+    )
+  } catch {
+    showError(t('config.savedTasks.updateFailed'))
+  }
+}
+
+const onHmacToggle = async () => {
+  hmacSaving.value = true
+  try {
+    emit(
+      'updated',
+      await savedTasksApi.update(props.task.id, {
+        triggerType: 'webhook',
+        hmacEnabled: !hmacConfigured.value,
+      })
+    )
+  } catch {
+    showError(t('config.savedTasks.updateFailed'))
+  } finally {
+    hmacSaving.value = false
+  }
+}
+
 const onSchedule = async () => {
   try {
     if (scheduleKind.value === 'off') {
@@ -149,6 +217,16 @@ const onSchedule = async () => {
           triggerConfig: null,
         })
       )
+      return
+    }
+    if (scheduleKind.value === 'webhook') {
+      emit(
+        'updated',
+        await savedTasksApi.update(props.task.id, {
+          triggerType: 'webhook',
+        })
+      )
+      success(t('config.savedTasks.scheduleSaved'))
       return
     }
     const triggerConfig: Record<string, unknown> = {
@@ -299,15 +377,11 @@ const onRunCopy = async () => {
       <span class="txt-secondary">{{ task.waitingApprovalCount }}</span>
     </button>
 
-    <div
-      v-if="task.autoPaused"
-      class="p-3 rounded-lg bg-amber-500/10 border border-amber-500/30 text-sm"
-      data-testid="saved-task-auto-pause"
-    >
-      <p class="font-medium text-amber-800 dark:text-amber-200">
+    <div v-if="task.autoPaused" class="alert-warning text-sm" data-testid="saved-task-auto-pause">
+      <p class="alert-warning-text">
         {{ $t('config.savedTasks.autoPauseTitle') }}
       </p>
-      <p class="text-amber-800/80 dark:text-amber-200/80 mt-1">
+      <p class="alert-warning-text mt-1 font-normal">
         {{ $t('config.savedTasks.autoPauseBody') }}
       </p>
       <button
@@ -370,6 +444,9 @@ const onRunCopy = async () => {
         <option value="interval">{{ $t('config.savedTasks.schedule.hourly') }}</option>
         <option value="daily">{{ $t('config.savedTasks.schedule.daily') }}</option>
         <option value="weekly">{{ $t('config.savedTasks.schedule.weekdays') }}</option>
+        <option v-if="workflowsEnabled" value="webhook">
+          {{ $t('config.savedTasks.schedule.webhook') }}
+        </option>
       </select>
       <input
         v-if="!sharedView && (scheduleKind === 'daily' || scheduleKind === 'weekly')"
@@ -403,6 +480,16 @@ const onRunCopy = async () => {
         {{ showRuns ? $t('config.savedTasks.hideRuns') : $t('config.savedTasks.viewRuns') }}
       </button>
       <button
+        v-if="workflowsEnabled && !sharedView"
+        type="button"
+        class="btn-secondary inline-flex items-center px-3 py-1.5 rounded-lg text-sm font-medium"
+        data-testid="btn-saved-task-steps"
+        @click="stepsOpen = true"
+      >
+        {{ $t('workflows.steps') }}
+      </button>
+      <button
+        v-else-if="!workflowsEnabled"
         type="button"
         class="btn-secondary inline-flex items-center px-3 py-1.5 rounded-lg text-sm font-medium"
         data-testid="btn-advanced-steps"
@@ -433,9 +520,65 @@ const onRunCopy = async () => {
       <li v-else class="text-xs txt-secondary">{{ $t('config.savedTasks.runsEmpty') }}</li>
     </ul>
 
-    <p v-if="showAdvanced" class="text-xs txt-secondary">
+    <p v-if="showAdvanced && !workflowsEnabled" class="text-xs txt-secondary">
       {{ $t('config.savedTasks.advancedHint') }}
     </p>
+
+    <div
+      v-if="workflowsEnabled && task.triggerType === 'webhook' && !sharedView"
+      class="surface-card p-4 space-y-3"
+      data-testid="saved-task-webhook"
+    >
+      <p class="text-sm font-medium txt-primary">{{ $t('workflows.webhookCardTitle') }}</p>
+      <p class="text-xs txt-secondary">{{ $t('workflows.webhookCardHint') }}</p>
+      <input
+        class="w-full px-3 py-2 rounded-lg surface-card border border-light-border/30 dark:border-dark-border/20 txt-primary text-sm focus:outline-none focus:ring-2 focus:ring-[var(--brand)]"
+        :value="webhookUrl"
+        readonly
+        data-testid="saved-task-webhook-url"
+      />
+      <div class="flex flex-wrap gap-2">
+        <button
+          type="button"
+          class="btn-secondary px-4 py-2.5 rounded-lg text-sm font-medium"
+          data-testid="btn-copy-webhook-url"
+          @click="copyWebhookUrl"
+        >
+          {{ $t('workflows.copyUrl') }}
+        </button>
+        <button
+          type="button"
+          class="btn-secondary px-4 py-2.5 rounded-lg text-sm font-medium"
+          data-testid="btn-regenerate-webhook"
+          @click="regenerateWebhook"
+        >
+          {{ $t('workflows.regenerate') }}
+        </button>
+      </div>
+      <label class="flex items-start gap-2 text-sm txt-primary">
+        <input
+          type="checkbox"
+          class="mt-1 accent-[var(--brand)]"
+          :checked="hmacConfigured"
+          :disabled="hmacSaving"
+          data-testid="saved-task-webhook-hmac"
+          @change="onHmacToggle"
+        />
+        <span>
+          {{ $t('workflows.hmacEnable') }}
+          <span class="block text-xs txt-secondary mt-0.5">
+            {{ hmacConfigured ? $t('workflows.hmacOn') : $t('workflows.hmacHint') }}
+          </span>
+        </span>
+      </label>
+    </div>
+
+    <SavedTaskStepsEditor
+      :open="stepsOpen"
+      :task="task"
+      @close="stepsOpen = false"
+      @updated="emit('updated', $event)"
+    />
     <ShareDialog
       :is-open="iamShareOpen"
       kind="saved_task"

--- a/frontend/src/components/config/SavedTaskCard.vue
+++ b/frontend/src/components/config/SavedTaskCard.vue
@@ -160,15 +160,25 @@ const webhookUrl = computed(() => {
 
 const hmacConfigured = computed(() => props.task.triggerConfig?.hmacConfigured === true)
 
-const copyWebhookUrl = async () => {
-  if (!webhookUrl.value) return
+// The server mints the shared secret and returns it exactly once; keep it only
+// in memory until the user leaves or turns the signature off.
+const revealedSecret = ref('')
+watch(hmacConfigured, (on) => {
+  if (!on) revealedSecret.value = ''
+})
+
+const copyToClipboard = async (value: string, doneMessage: string) => {
+  if (!value) return
   try {
-    await navigator.clipboard.writeText(webhookUrl.value)
-    success(t('workflows.urlCopied'))
+    await navigator.clipboard.writeText(value)
+    success(doneMessage)
   } catch {
     showError(t('config.savedTasks.updateFailed'))
   }
 }
+
+const copyWebhookUrl = () => copyToClipboard(webhookUrl.value, t('workflows.urlCopied'))
+const copyWebhookSecret = () => copyToClipboard(revealedSecret.value, t('workflows.secretCopied'))
 
 const regenerateWebhook = async () => {
   const ok = await dialog.confirm({
@@ -193,13 +203,13 @@ const regenerateWebhook = async () => {
 const onHmacToggle = async () => {
   hmacSaving.value = true
   try {
-    emit(
-      'updated',
-      await savedTasksApi.update(props.task.id, {
-        triggerType: 'webhook',
-        hmacEnabled: !hmacConfigured.value,
-      })
-    )
+    const { webhookSecret, ...updated } = await savedTasksApi.update(props.task.id, {
+      triggerType: 'webhook',
+      hmacEnabled: !hmacConfigured.value,
+    })
+    // Show it here, once; the list state never carries the secret.
+    revealedSecret.value = webhookSecret ?? ''
+    emit('updated', updated)
   } catch {
     showError(t('config.savedTasks.updateFailed'))
   } finally {
@@ -444,7 +454,7 @@ const onRunCopy = async () => {
         <option value="interval">{{ $t('config.savedTasks.schedule.hourly') }}</option>
         <option value="daily">{{ $t('config.savedTasks.schedule.daily') }}</option>
         <option value="weekly">{{ $t('config.savedTasks.schedule.weekdays') }}</option>
-        <option v-if="workflowsEnabled" value="webhook">
+        <option v-if="workflowsEnabled || scheduleKind === 'webhook'" value="webhook">
           {{ $t('config.savedTasks.schedule.webhook') }}
         </option>
       </select>
@@ -534,6 +544,7 @@ const onRunCopy = async () => {
       <input
         class="w-full px-3 py-2 rounded-lg surface-card border border-light-border/30 dark:border-dark-border/20 txt-primary text-sm focus:outline-none focus:ring-2 focus:ring-[var(--brand)]"
         :value="webhookUrl"
+        :aria-label="$t('workflows.webhookCardTitle')"
         readonly
         data-testid="saved-task-webhook-url"
       />
@@ -571,6 +582,29 @@ const onRunCopy = async () => {
           </span>
         </span>
       </label>
+      <div
+        v-if="revealedSecret"
+        class="alert-warning text-sm space-y-2"
+        data-testid="saved-task-webhook-secret"
+      >
+        <p class="alert-warning-text">{{ $t('workflows.secretRevealTitle') }}</p>
+        <p class="alert-warning-text font-normal">{{ $t('workflows.secretRevealHint') }}</p>
+        <input
+          class="w-full px-3 py-2 rounded-lg surface-card border border-light-border/30 dark:border-dark-border/20 txt-primary text-sm font-mono focus:outline-none focus:ring-2 focus:ring-[var(--brand)]"
+          :value="revealedSecret"
+          :aria-label="$t('workflows.secretRevealTitle')"
+          readonly
+          data-testid="saved-task-webhook-secret-value"
+        />
+        <button
+          type="button"
+          class="btn-secondary px-4 py-2.5 rounded-lg text-sm font-medium"
+          data-testid="btn-copy-webhook-secret"
+          @click="copyWebhookSecret"
+        >
+          {{ $t('workflows.copySecret') }}
+        </button>
+      </div>
     </div>
 
     <SavedTaskStepsEditor

--- a/frontend/src/components/config/workflows/InputSourcePicker.vue
+++ b/frontend/src/components/config/workflows/InputSourcePicker.vue
@@ -1,0 +1,88 @@
+<template>
+  <div class="space-y-2" :data-testid="`input-source-${name}`">
+    <select
+      :id="`${name}-source`"
+      :class="STEP_FIELD_CLASS"
+      :aria-label="$t('workflows.inputSource')"
+      :value="source"
+      @change="onSourceChange(($event.target as HTMLSelectElement).value)"
+    >
+      <option value="literal">{{ $t('workflows.literal') }}</option>
+      <option value="trigger">{{ $t('workflows.fromTrigger') }}</option>
+      <option v-for="(earlier, index) in earlierSteps" :key="earlier.id" :value="earlier.id">
+        {{ $t('workflows.fromStep', { n: index + 1 }) }}
+      </option>
+    </select>
+    <input
+      v-if="source === 'literal'"
+      :class="STEP_FIELD_CLASS"
+      :value="literal"
+      :aria-label="$t('workflows.inputValue')"
+      :placeholder="$t('workflows.inputValue')"
+      @input="setLiteral(($event.target as HTMLInputElement).value)"
+    />
+    <template v-else>
+      <input
+        :class="STEP_FIELD_CLASS"
+        :value="field"
+        :aria-label="$t('workflows.field')"
+        :placeholder="source === 'trigger' ? 'title' : 'text'"
+        @input="setField(($event.target as HTMLInputElement).value)"
+      />
+      <p class="text-xs txt-secondary leading-relaxed">
+        {{
+          source === 'trigger' ? $t('workflows.fieldHintTrigger') : $t('workflows.fieldHintStep')
+        }}
+      </p>
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { STEP_FIELD_CLASS, type AuthoredStep, type InputSpec } from './stepTypes'
+
+const props = defineProps<{
+  /** Input name; also used for test ids and the select id. */
+  name: string
+  modelValue: InputSpec | undefined
+  earlierSteps: AuthoredStep[]
+}>()
+
+const emit = defineEmits<{
+  'update:modelValue': [spec: InputSpec]
+}>()
+
+const spec = computed<InputSpec>(() => props.modelValue ?? { literal: '' })
+
+const source = computed(() => {
+  if ('literal' in spec.value) return 'literal'
+  const from = spec.value.from
+  if (from === 'trigger') return 'trigger'
+  return typeof from === 'string' && props.earlierSteps.some((step) => step.id === from)
+    ? from
+    : 'literal'
+})
+
+const literal = computed(() => (typeof spec.value.literal === 'string' ? spec.value.literal : ''))
+
+const field = computed(() => (typeof spec.value.field === 'string' ? spec.value.field : ''))
+
+const onSourceChange = (next: string) => {
+  if (next === 'literal') {
+    emit('update:modelValue', { literal: literal.value })
+  } else if (next === 'trigger') {
+    emit('update:modelValue', { from: 'trigger', field: '' })
+  } else {
+    emit('update:modelValue', { from: next, field: 'text' })
+  }
+}
+
+const setLiteral = (value: string) => {
+  emit('update:modelValue', { literal: value })
+}
+
+const setField = (value: string) => {
+  emit('update:modelValue', { from: source.value, field: value })
+}
+</script>

--- a/frontend/src/components/config/workflows/SavedTaskStepsEditor.vue
+++ b/frontend/src/components/config/workflows/SavedTaskStepsEditor.vue
@@ -1,0 +1,179 @@
+<template>
+  <Teleport to="body">
+    <div
+      v-if="open"
+      class="modal-overlay fixed inset-0 z-50 flex items-end sm:items-center justify-center p-4 bg-black/50"
+      data-testid="saved-task-steps-editor"
+      @click.self="emit('close')"
+    >
+      <div
+        class="modal-panel surface-card w-full max-w-3xl overflow-y-auto scroll-thin p-4 sm:p-6 space-y-4"
+        role="dialog"
+        aria-modal="true"
+        :aria-label="$t('workflows.stepsTitle')"
+      >
+        <div class="flex items-start justify-between gap-3">
+          <div>
+            <h2 class="text-lg font-semibold txt-primary">{{ $t('workflows.stepsTitle') }}</h2>
+            <p class="text-sm txt-secondary mt-1">{{ $t('workflows.stepsSubtitle') }}</p>
+          </div>
+          <button
+            type="button"
+            class="btn-secondary px-4 py-2.5 rounded-lg text-sm font-medium"
+            @click="emit('close')"
+          >
+            {{ $t('workflows.close') }}
+          </button>
+        </div>
+
+        <p v-if="!steps.length" class="text-sm txt-secondary">{{ $t('workflows.empty') }}</p>
+
+        <div class="space-y-3">
+          <StepRow
+            v-for="(step, index) in steps"
+            :key="step.id"
+            :step="step"
+            :index="index"
+            :total="steps.length"
+            :earlier-steps="steps.slice(0, index)"
+            :tools="tools"
+            @change="onChange(index, $event)"
+            @move="move(index, $event)"
+            @remove="remove(index)"
+          />
+        </div>
+
+        <StepPicker v-model="picked" :tools="tools" />
+        <button
+          type="button"
+          class="btn-secondary px-4 py-2.5 rounded-lg text-sm font-medium"
+          data-testid="btn-add-step"
+          :disabled="!picked"
+          @click="addPicked"
+        >
+          {{ $t('workflows.addStep') }}
+        </button>
+
+        <p v-if="error" class="text-sm text-red-600 dark:text-red-400">{{ error }}</p>
+
+        <div class="flex flex-wrap gap-2">
+          <button
+            type="button"
+            class="btn-primary px-4 py-2.5 rounded-lg text-sm font-medium"
+            data-testid="btn-save-steps"
+            :disabled="saving"
+            @click="save"
+          >
+            {{ $t('workflows.saveSteps') }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useDialog } from '@/composables/useDialog'
+import { useNotification } from '@/composables/useNotification'
+import { savedTasksApi, type SavedTask } from '@/services/api/savedTasksApi'
+import { toolsApi, type RegistryTool } from '@/services/api/toolsApi'
+import StepPicker from './StepPicker.vue'
+import StepRow from './StepRow.vue'
+import { emptyStep, graphFromSteps, stepsFromGraph, type AuthoredStep } from './stepTypes'
+
+const props = defineProps<{
+  open: boolean
+  task: SavedTask
+}>()
+
+const emit = defineEmits<{
+  close: []
+  updated: [task: SavedTask]
+}>()
+
+const { t } = useI18n()
+const dialog = useDialog()
+const { success, error: showError } = useNotification()
+const steps = ref<AuthoredStep[]>([])
+const tools = ref<RegistryTool[]>([])
+const picked = ref('chat')
+const saving = ref(false)
+const error = ref('')
+
+watch(
+  () => [props.open, props.task.id] as const,
+  async ([open]) => {
+    if (!open) return
+    steps.value = stepsFromGraph(props.task.graph)
+    error.value = ''
+    try {
+      tools.value = await toolsApi.list()
+    } catch {
+      tools.value = []
+    }
+  },
+  { immediate: true }
+)
+
+const capabilityFromPick = (key: string): { capability: string; tool?: string } => {
+  if (key.startsWith('tool:')) {
+    return { capability: 'tool_call', tool: key.slice(5) }
+  }
+  return { capability: key }
+}
+
+const addPicked = () => {
+  const chosen = capabilityFromPick(picked.value)
+  const step = emptyStep(chosen.capability, steps.value.length)
+  if (chosen.tool) step.params.tool = chosen.tool
+  steps.value = [...steps.value, step]
+}
+
+const onChange = (index: number, step: AuthoredStep) => {
+  const next = [...steps.value]
+  next[index] = step
+  steps.value = next
+}
+
+const move = (index: number, delta: number) => {
+  const target = index + delta
+  if (target < 0 || target >= steps.value.length) return
+  const next = [...steps.value]
+  const [row] = next.splice(index, 1)
+  next.splice(target, 0, row)
+  steps.value = next.map((step, i) => ({ ...step, id: `step_${i + 1}` }))
+}
+
+const remove = async (index: number) => {
+  const ok = await dialog.confirm({
+    title: t('workflows.deleteStep'),
+    message: t('workflows.deleteStepConfirm', { n: index + 1 }),
+    danger: true,
+  })
+  if (!ok) return
+  steps.value = steps.value
+    .filter((_, i) => i !== index)
+    .map((step, i) => ({ ...step, id: `step_${i + 1}` }))
+}
+
+const save = async () => {
+  saving.value = true
+  error.value = ''
+  try {
+    const updated = await savedTasksApi.update(props.task.id, {
+      graph: graphFromSteps(steps.value, props.task.triggerType),
+    })
+    success(t('workflows.saved'))
+    emit('updated', updated)
+    emit('close')
+  } catch (err) {
+    const message = err instanceof Error ? err.message : t('workflows.saveFailed')
+    error.value = message
+    showError(t('workflows.saveFailed'))
+  } finally {
+    saving.value = false
+  }
+}
+</script>

--- a/frontend/src/components/config/workflows/SavedTaskStepsEditor.vue
+++ b/frontend/src/components/config/workflows/SavedTaskStepsEditor.vue
@@ -81,7 +81,13 @@ import { savedTasksApi, type SavedTask } from '@/services/api/savedTasksApi'
 import { toolsApi, type RegistryTool } from '@/services/api/toolsApi'
 import StepPicker from './StepPicker.vue'
 import StepRow from './StepRow.vue'
-import { emptyStep, graphFromSteps, stepsFromGraph, type AuthoredStep } from './stepTypes'
+import {
+  emptyStep,
+  graphFromSteps,
+  renumberSteps,
+  stepsFromGraph,
+  type AuthoredStep,
+} from './stepTypes'
 
 const props = defineProps<{
   open: boolean
@@ -126,7 +132,11 @@ const capabilityFromPick = (key: string): { capability: string; tool?: string } 
 
 const addPicked = () => {
   const chosen = capabilityFromPick(picked.value)
-  const step = emptyStep(chosen.capability, steps.value.length)
+  const previous = steps.value[steps.value.length - 1]
+  const step = emptyStep(chosen.capability, steps.value.length, {
+    previousStepId: previous?.id,
+    triggerType: props.task.triggerType,
+  })
   if (chosen.tool) step.params.tool = chosen.tool
   steps.value = [...steps.value, step]
 }
@@ -143,7 +153,7 @@ const move = (index: number, delta: number) => {
   const next = [...steps.value]
   const [row] = next.splice(index, 1)
   next.splice(target, 0, row)
-  steps.value = next.map((step, i) => ({ ...step, id: `step_${i + 1}` }))
+  steps.value = renumberSteps(next)
 }
 
 const remove = async (index: number) => {
@@ -153,9 +163,7 @@ const remove = async (index: number) => {
     danger: true,
   })
   if (!ok) return
-  steps.value = steps.value
-    .filter((_, i) => i !== index)
-    .map((step, i) => ({ ...step, id: `step_${i + 1}` }))
+  steps.value = renumberSteps(steps.value.filter((_, i) => i !== index))
 }
 
 const save = async () => {
@@ -163,7 +171,7 @@ const save = async () => {
   error.value = ''
   try {
     const updated = await savedTasksApi.update(props.task.id, {
-      graph: graphFromSteps(steps.value, props.task.triggerType),
+      graph: graphFromSteps(steps.value, props.task.triggerType, props.task.graph),
     })
     success(t('workflows.saved'))
     emit('updated', updated)

--- a/frontend/src/components/config/workflows/StepInputsForm.vue
+++ b/frontend/src/components/config/workflows/StepInputsForm.vue
@@ -1,0 +1,160 @@
+<template>
+  <div class="space-y-3" data-testid="step-inputs">
+    <div v-if="step.capability === 'tool_call'">
+      <label class="text-sm font-medium txt-primary" :for="`${step.id}-tool`">
+        {{ $t('workflows.pickTool') }}
+      </label>
+      <select
+        :id="`${step.id}-tool`"
+        class="mt-1 w-full"
+        :class="STEP_FIELD_CLASS"
+        :value="stringParam('tool')"
+        @change="setParam('tool', ($event.target as HTMLSelectElement).value)"
+      >
+        <option value="">{{ $t('workflows.pickTool') }}</option>
+        <option v-for="tool in tools" :key="tool.name" :value="tool.name">
+          {{ tool.title || tool.name }}
+        </option>
+      </select>
+    </div>
+
+    <div v-if="step.capability === 'outbound_webhook'" class="space-y-3">
+      <label class="block text-sm font-medium txt-primary">
+        {{ $t('workflows.webhookUrl') }}
+        <input
+          :class="STEP_FIELD_CLASS"
+          :value="stringParam('url')"
+          :placeholder="$t('workflows.webhookUrl')"
+          @input="setParam('url', ($event.target as HTMLInputElement).value)"
+        />
+      </label>
+      <label class="block text-sm font-medium txt-primary">
+        {{ $t('workflows.webhookSecret') }}
+        <input
+          :class="STEP_FIELD_CLASS"
+          :value="stringParam('secret')"
+          autocomplete="off"
+          @input="setParam('secret', ($event.target as HTMLInputElement).value)"
+        />
+      </label>
+    </div>
+
+    <div v-if="step.capability === 'condition'" class="space-y-3">
+      <label class="block text-sm font-medium txt-primary">
+        {{ $t('workflows.condition') }}
+        <select
+          :class="STEP_FIELD_CLASS"
+          :value="stringParam('operator') || 'not_empty'"
+          @change="setParam('operator', ($event.target as HTMLSelectElement).value)"
+        >
+          <option value="not_empty">{{ $t('workflows.operator.not_empty') }}</option>
+          <option value="equals">{{ $t('workflows.operator.equals') }}</option>
+          <option value="contains">{{ $t('workflows.operator.contains') }}</option>
+          <option value="matches">{{ $t('workflows.operator.matches') }}</option>
+        </select>
+      </label>
+      <label class="block text-sm font-medium txt-primary">
+        {{ $t('workflows.inputValue') }}
+        <select
+          :class="STEP_FIELD_CLASS"
+          :value="inputSource('input')"
+          @change="onSourceChange('input', ($event.target as HTMLSelectElement).value)"
+        >
+          <option value="literal">{{ $t('workflows.literal') }}</option>
+          <option value="trigger">{{ $t('workflows.fromTrigger') }}</option>
+          <option v-for="(earlier, index) in earlierSteps" :key="earlier.id" :value="earlier.id">
+            {{ $t('workflows.fromStep', { n: index + 1 }) }}
+          </option>
+        </select>
+      </label>
+      <input
+        v-if="inputSource('input') === 'literal'"
+        :class="STEP_FIELD_CLASS"
+        :value="inputLiteral('input')"
+        @input="setLiteral('input', ($event.target as HTMLInputElement).value)"
+      />
+      <input
+        v-if="stringParam('operator') === 'equals' || stringParam('operator') === 'contains'"
+        :class="STEP_FIELD_CLASS"
+        :value="stringParam('value')"
+        :placeholder="$t('workflows.inputValue')"
+        @input="setParam('value', ($event.target as HTMLInputElement).value)"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { STEP_FIELD_CLASS, type AuthoredStep } from './stepTypes'
+import type { RegistryTool } from '@/services/api/toolsApi'
+
+const props = defineProps<{
+  step: AuthoredStep
+  earlierSteps: AuthoredStep[]
+  tools: RegistryTool[]
+}>()
+
+const emit = defineEmits<{
+  change: [step: AuthoredStep]
+}>()
+
+const stringParam = (key: string): string => {
+  const value = props.step.params[key]
+  return typeof value === 'string' ? value : ''
+}
+
+const inputs = (): Record<string, Record<string, unknown>> => {
+  const raw = props.step.params.inputs
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {}
+  const out: Record<string, Record<string, unknown>> = {}
+  for (const [key, spec] of Object.entries(raw as Record<string, unknown>)) {
+    if (spec && typeof spec === 'object' && !Array.isArray(spec)) {
+      out[key] = { ...(spec as Record<string, unknown>) }
+    }
+  }
+  return out
+}
+
+const inputSource = (key: string): string => {
+  const spec = inputs()[key]
+  if (!spec) return 'literal'
+  if (typeof spec.literal === 'string') return 'literal'
+  if (spec.from === 'trigger') return 'trigger'
+  return typeof spec.from === 'string' ? spec.from : 'literal'
+}
+
+const inputLiteral = (key: string): string => {
+  const spec = inputs()[key]
+  return typeof spec?.literal === 'string' ? spec.literal : ''
+}
+
+const patch = (params: Record<string, unknown>) => {
+  emit('change', { ...props.step, params: { ...props.step.params, ...params } })
+}
+
+const setParam = (key: string, value: string) => {
+  patch({ [key]: value })
+}
+
+const setInputs = (next: Record<string, Record<string, unknown>>) => {
+  patch({ inputs: next })
+}
+
+const onSourceChange = (key: string, source: string) => {
+  const next = inputs()
+  if (source === 'literal') {
+    next[key] = { literal: inputLiteral(key) }
+  } else if (source === 'trigger') {
+    next[key] = { from: 'trigger', field: 'body' }
+  } else {
+    next[key] = { from: source, field: 'text' }
+  }
+  setInputs(next)
+}
+
+const setLiteral = (key: string, value: string) => {
+  const next = inputs()
+  next[key] = { literal: value }
+  setInputs(next)
+}
+</script>

--- a/frontend/src/components/config/workflows/StepInputsForm.vue
+++ b/frontend/src/components/config/workflows/StepInputsForm.vue
@@ -1,21 +1,43 @@
 <template>
   <div class="space-y-3" data-testid="step-inputs">
-    <div v-if="step.capability === 'tool_call'">
-      <label class="text-sm font-medium txt-primary" :for="`${step.id}-tool`">
-        {{ $t('workflows.pickTool') }}
-      </label>
-      <select
-        :id="`${step.id}-tool`"
-        class="mt-1 w-full"
-        :class="STEP_FIELD_CLASS"
-        :value="stringParam('tool')"
-        @change="setParam('tool', ($event.target as HTMLSelectElement).value)"
-      >
-        <option value="">{{ $t('workflows.pickTool') }}</option>
-        <option v-for="tool in tools" :key="tool.name" :value="tool.name">
-          {{ tool.title || tool.name }}
-        </option>
-      </select>
+    <div v-if="step.capability === 'tool_call'" class="space-y-3">
+      <div>
+        <label class="text-sm font-medium txt-primary" :for="`${step.id}-tool`">
+          {{ $t('workflows.pickTool') }}
+        </label>
+        <select
+          :id="`${step.id}-tool`"
+          :class="STEP_FIELD_CLASS"
+          :value="stringParam('tool')"
+          @change="setTool(($event.target as HTMLSelectElement).value)"
+        >
+          <option value="">{{ $t('workflows.pickTool') }}</option>
+          <option v-for="tool in tools" :key="tool.name" :value="tool.name">
+            {{ tool.title || tool.name }}
+          </option>
+        </select>
+      </div>
+
+      <template v-if="selectedTool">
+        <p v-if="!toolArguments.length" class="text-xs txt-secondary">
+          {{ $t('workflows.noArguments') }}
+        </p>
+        <div v-else class="space-y-3" data-testid="tool-arguments">
+          <p class="text-sm font-medium txt-primary">{{ $t('workflows.arguments') }}</p>
+          <div v-for="argument in toolArguments" :key="argument.name">
+            <label class="block text-xs font-medium txt-secondary" :for="`${argument.name}-source`">
+              {{ argument.name }}
+              <span v-if="argument.required">· {{ $t('workflows.required') }}</span>
+            </label>
+            <InputSourcePicker
+              :name="argument.name"
+              :model-value="inputs()[argument.name]"
+              :earlier-steps="earlierSteps"
+              @update:model-value="setInput(argument.name, $event)"
+            />
+          </div>
+        </div>
+      </template>
     </div>
 
     <div v-if="step.capability === 'outbound_webhook'" class="space-y-3">
@@ -23,19 +45,37 @@
         {{ $t('workflows.webhookUrl') }}
         <input
           :class="STEP_FIELD_CLASS"
+          type="url"
           :value="stringParam('url')"
-          :placeholder="$t('workflows.webhookUrl')"
+          placeholder="https://"
           @input="setParam('url', ($event.target as HTMLInputElement).value)"
         />
       </label>
+      <div>
+        <label class="block text-sm font-medium txt-primary" for="result-source">
+          {{ $t('workflows.whatToSend') }}
+        </label>
+        <InputSourcePicker
+          name="result"
+          :model-value="inputs().result"
+          :earlier-steps="earlierSteps"
+          @update:model-value="setInput('result', $event)"
+        />
+      </div>
       <label class="block text-sm font-medium txt-primary">
         {{ $t('workflows.webhookSecret') }}
         <input
           :class="STEP_FIELD_CLASS"
+          type="password"
           :value="stringParam('secret')"
-          autocomplete="off"
-          @input="setParam('secret', ($event.target as HTMLInputElement).value)"
+          :placeholder="secretConfigured ? $t('workflows.secretSet') : ''"
+          autocomplete="new-password"
+          data-testid="outbound-secret"
+          @input="setSecret(($event.target as HTMLInputElement).value)"
         />
+        <span v-if="secretConfigured" class="block text-xs txt-secondary mt-1 font-normal">
+          {{ $t('workflows.secretSetHint') }}
+        </span>
       </label>
     </div>
 
@@ -44,7 +84,7 @@
         {{ $t('workflows.condition') }}
         <select
           :class="STEP_FIELD_CLASS"
-          :value="stringParam('operator') || 'not_empty'"
+          :value="operator"
           @change="setParam('operator', ($event.target as HTMLSelectElement).value)"
         >
           <option value="not_empty">{{ $t('workflows.operator.not_empty') }}</option>
@@ -53,31 +93,26 @@
           <option value="matches">{{ $t('workflows.operator.matches') }}</option>
         </select>
       </label>
-      <label class="block text-sm font-medium txt-primary">
-        {{ $t('workflows.inputValue') }}
-        <select
-          :class="STEP_FIELD_CLASS"
-          :value="inputSource('input')"
-          @change="onSourceChange('input', ($event.target as HTMLSelectElement).value)"
-        >
-          <option value="literal">{{ $t('workflows.literal') }}</option>
-          <option value="trigger">{{ $t('workflows.fromTrigger') }}</option>
-          <option v-for="(earlier, index) in earlierSteps" :key="earlier.id" :value="earlier.id">
-            {{ $t('workflows.fromStep', { n: index + 1 }) }}
-          </option>
-        </select>
-      </label>
+      <div>
+        <label class="block text-sm font-medium txt-primary" for="input-source">
+          {{ $t('workflows.inputValue') }}
+        </label>
+        <InputSourcePicker
+          name="input"
+          :model-value="inputs().input"
+          :earlier-steps="earlierSteps"
+          @update:model-value="setInput('input', $event)"
+        />
+      </div>
       <input
-        v-if="inputSource('input') === 'literal'"
-        :class="STEP_FIELD_CLASS"
-        :value="inputLiteral('input')"
-        @input="setLiteral('input', ($event.target as HTMLInputElement).value)"
-      />
-      <input
-        v-if="stringParam('operator') === 'equals' || stringParam('operator') === 'contains'"
+        v-if="operator !== 'not_empty'"
         :class="STEP_FIELD_CLASS"
         :value="stringParam('value')"
-        :placeholder="$t('workflows.inputValue')"
+        :aria-label="$t('workflows.compareWith')"
+        :placeholder="
+          operator === 'matches' ? $t('workflows.patternPlaceholder') : $t('workflows.compareWith')
+        "
+        data-testid="condition-value"
         @input="setParam('value', ($event.target as HTMLInputElement).value)"
       />
     </div>
@@ -85,7 +120,9 @@
 </template>
 
 <script setup lang="ts">
-import { STEP_FIELD_CLASS, type AuthoredStep } from './stepTypes'
+import { computed } from 'vue'
+import InputSourcePicker from './InputSourcePicker.vue'
+import { STEP_FIELD_CLASS, toolArgumentNames, type AuthoredStep, type InputSpec } from './stepTypes'
 import type { RegistryTool } from '@/services/api/toolsApi'
 
 const props = defineProps<{
@@ -103,29 +140,34 @@ const stringParam = (key: string): string => {
   return typeof value === 'string' ? value : ''
 }
 
-const inputs = (): Record<string, Record<string, unknown>> => {
+const operator = computed(() => stringParam('operator') || 'not_empty')
+
+// The server never returns a saved secret, only that one exists. Leaving the
+// field untouched keeps it; typing replaces it; clearing the field removes it.
+const secretConfigured = computed(
+  () => props.step.params.secretConfigured === true && !('secret' in props.step.params)
+)
+
+const setSecret = (value: string) => {
+  const params = { ...props.step.params }
+  delete params.secretConfigured
+  emit('change', { ...props.step, params: { ...params, secret: value } })
+}
+
+const selectedTool = computed(() => props.tools.find((tool) => tool.name === stringParam('tool')))
+
+const toolArguments = computed(() => toolArgumentNames(selectedTool.value?.inputSchema))
+
+const inputs = (): Record<string, InputSpec> => {
   const raw = props.step.params.inputs
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {}
-  const out: Record<string, Record<string, unknown>> = {}
+  const out: Record<string, InputSpec> = {}
   for (const [key, spec] of Object.entries(raw as Record<string, unknown>)) {
     if (spec && typeof spec === 'object' && !Array.isArray(spec)) {
-      out[key] = { ...(spec as Record<string, unknown>) }
+      out[key] = { ...(spec as InputSpec) }
     }
   }
   return out
-}
-
-const inputSource = (key: string): string => {
-  const spec = inputs()[key]
-  if (!spec) return 'literal'
-  if (typeof spec.literal === 'string') return 'literal'
-  if (spec.from === 'trigger') return 'trigger'
-  return typeof spec.from === 'string' ? spec.from : 'literal'
-}
-
-const inputLiteral = (key: string): string => {
-  const spec = inputs()[key]
-  return typeof spec?.literal === 'string' ? spec.literal : ''
 }
 
 const patch = (params: Record<string, unknown>) => {
@@ -136,25 +178,12 @@ const setParam = (key: string, value: string) => {
   patch({ [key]: value })
 }
 
-const setInputs = (next: Record<string, Record<string, unknown>>) => {
-  patch({ inputs: next })
+// A different tool takes different arguments — start its mapping fresh.
+const setTool = (name: string) => {
+  patch({ tool: name, inputs: name === stringParam('tool') ? inputs() : {} })
 }
 
-const onSourceChange = (key: string, source: string) => {
-  const next = inputs()
-  if (source === 'literal') {
-    next[key] = { literal: inputLiteral(key) }
-  } else if (source === 'trigger') {
-    next[key] = { from: 'trigger', field: 'body' }
-  } else {
-    next[key] = { from: source, field: 'text' }
-  }
-  setInputs(next)
-}
-
-const setLiteral = (key: string, value: string) => {
-  const next = inputs()
-  next[key] = { literal: value }
-  setInputs(next)
+const setInput = (key: string, spec: InputSpec) => {
+  patch({ inputs: { ...inputs(), [key]: spec } })
 }
 </script>

--- a/frontend/src/components/config/workflows/StepPicker.vue
+++ b/frontend/src/components/config/workflows/StepPicker.vue
@@ -1,0 +1,101 @@
+<template>
+  <div data-testid="step-picker">
+    <p class="text-sm font-medium txt-primary mb-1">{{ $t('workflows.addStep') }}</p>
+    <div
+      class="grid grid-cols-1 sm:grid-cols-2 gap-2"
+      role="radiogroup"
+      :aria-label="$t('workflows.addStep')"
+    >
+      <button
+        v-for="option in options"
+        :key="option.key"
+        type="button"
+        role="radio"
+        :aria-checked="modelValue === option.key"
+        class="text-left rounded-xl px-3 py-3 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand)]"
+        :class="
+          modelValue === option.key
+            ? 'bg-[var(--brand-alpha-light)] ring-2 ring-[var(--brand)]'
+            : 'surface-card ring-1 ring-[var(--divider)] hover:bg-[var(--brand-alpha-light)]'
+        "
+        :data-testid="`btn-step-kind-${option.key}`"
+        @click="emit('update:modelValue', option.key)"
+      >
+        <span class="flex items-start gap-3">
+          <span
+            class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-[var(--brand-alpha-light)]"
+          >
+            <Icon :icon="option.icon" class="w-4 h-4 text-[var(--brand)]" aria-hidden="true" />
+          </span>
+          <span class="min-w-0 flex-1">
+            <span class="text-sm font-medium txt-primary">{{ option.name }}</span>
+            <span class="block text-xs txt-secondary mt-0.5 leading-relaxed">
+              {{ option.summary }}
+            </span>
+          </span>
+        </span>
+      </button>
+    </div>
+    <p
+      v-if="hint"
+      class="text-xs txt-secondary mt-3 leading-relaxed"
+      data-testid="step-picker-hint"
+    >
+      {{ hint }}
+    </p>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { Icon } from '@iconify/vue'
+import { useI18n } from 'vue-i18n'
+import { BUILTIN_STEP_KINDS } from './stepTypes'
+import type { RegistryTool } from '@/services/api/toolsApi'
+
+const props = defineProps<{
+  modelValue: string
+  tools?: RegistryTool[]
+}>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: string]
+}>()
+
+const { t, te } = useI18n()
+
+const icons: Record<string, string> = {
+  email_search: 'heroicons:envelope',
+  summarize: 'heroicons:document-text',
+  chat: 'heroicons:chat-bubble-left-right',
+  email_me: 'heroicons:paper-airplane',
+  condition: 'heroicons:funnel',
+  outbound_webhook: 'heroicons:arrow-up-right',
+  tool_call: 'heroicons:wrench-screwdriver',
+}
+
+const options = computed(() => {
+  const builtins = BUILTIN_STEP_KINDS.map((key) => ({
+    key,
+    icon: icons[key] ?? 'heroicons:squares-2x2',
+    name: t(`workflows.kinds.${key}`),
+    summary: t(`workflows.kindHints.${key}`),
+  }))
+  const tools = (props.tools ?? [])
+    .filter((tool) => tool.name)
+    .map((tool) => ({
+      key: `tool:${tool.name}`,
+      icon: icons.tool_call,
+      name: tool.title || tool.name,
+      summary: tool.description || t('workflows.kindHints.tool_call'),
+    }))
+  return [...builtins, ...tools]
+})
+
+const hint = computed(() => {
+  const key = props.modelValue.startsWith('tool:')
+    ? 'workflows.kindHints.tool_call'
+    : `workflows.kindHints.${props.modelValue}`
+  return te(key) ? t(key) : ''
+})
+</script>

--- a/frontend/src/components/config/workflows/StepRow.vue
+++ b/frontend/src/components/config/workflows/StepRow.vue
@@ -1,0 +1,104 @@
+<template>
+  <section class="surface-card p-4 space-y-3" :data-testid="`step-row-${index}`">
+    <div class="flex items-start justify-between gap-3">
+      <div class="min-w-0">
+        <h3 class="text-sm font-semibold txt-primary">
+          {{ $t('workflows.stepN', { n: index + 1 }) }}
+        </h3>
+        <p class="text-xs txt-secondary">{{ title }}</p>
+      </div>
+      <div class="flex flex-wrap gap-2">
+        <button
+          type="button"
+          class="btn-secondary px-3 py-1.5 rounded-lg text-sm font-medium"
+          :disabled="index === 0"
+          :aria-label="$t('workflows.moveUp')"
+          @click="emit('move', -1)"
+        >
+          {{ $t('workflows.moveUp') }}
+        </button>
+        <button
+          type="button"
+          class="btn-secondary px-3 py-1.5 rounded-lg text-sm font-medium"
+          :disabled="index >= total - 1"
+          :aria-label="$t('workflows.moveDown')"
+          @click="emit('move', 1)"
+        >
+          {{ $t('workflows.moveDown') }}
+        </button>
+        <button
+          type="button"
+          class="btn-danger px-3 py-1.5 rounded-lg text-sm font-medium"
+          @click="emit('remove')"
+        >
+          {{ $t('workflows.deleteStep') }}
+        </button>
+      </div>
+    </div>
+
+    <StepInputsForm
+      :step="step"
+      :earlier-steps="earlierSteps"
+      :tools="tools"
+      @change="emit('change', $event)"
+    />
+
+    <label class="flex items-start gap-2 text-sm txt-primary">
+      <input
+        type="checkbox"
+        class="mt-1 accent-[var(--brand)]"
+        :checked="step.params.approval === 'approve'"
+        data-testid="step-ask-before"
+        @change="onAskBefore(($event.target as HTMLInputElement).checked)"
+      />
+      <span>
+        {{ $t('workflows.askBefore') }}
+        <span class="block text-xs txt-secondary mt-0.5">{{ $t('workflows.askBeforeHint') }}</span>
+      </span>
+    </label>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import StepInputsForm from './StepInputsForm.vue'
+import type { AuthoredStep } from './stepTypes'
+import type { RegistryTool } from '@/services/api/toolsApi'
+
+const props = defineProps<{
+  step: AuthoredStep
+  index: number
+  total: number
+  earlierSteps: AuthoredStep[]
+  tools: RegistryTool[]
+}>()
+
+const emit = defineEmits<{
+  change: [step: AuthoredStep]
+  move: [delta: number]
+  remove: []
+}>()
+
+const { t, te } = useI18n()
+
+const title = computed(() => {
+  if (props.step.capability === 'tool_call') {
+    const tool = typeof props.step.params.tool === 'string' ? props.step.params.tool : ''
+    const match = props.tools.find((item) => item.name === tool)
+    return match?.title || tool || t('workflows.kinds.tool_call')
+  }
+  const key = `workflows.kinds.${props.step.capability}`
+  return te(key) ? t(key) : props.step.capability
+})
+
+const onAskBefore = (checked: boolean) => {
+  const params = { ...props.step.params }
+  if (checked) {
+    params.approval = 'approve'
+  } else {
+    delete params.approval
+  }
+  emit('change', { ...props.step, params })
+}
+</script>

--- a/frontend/src/components/config/workflows/StepRow.vue
+++ b/frontend/src/components/config/workflows/StepRow.vue
@@ -43,7 +43,11 @@
       @change="emit('change', $event)"
     />
 
-    <label class="flex items-start gap-2 text-sm txt-primary">
+    <!-- Only the tool gate can pause a run; other step kinds never ask. -->
+    <label
+      v-if="step.capability === 'tool_call'"
+      class="flex items-start gap-2 text-sm txt-primary"
+    >
       <input
         type="checkbox"
         class="mt-1 accent-[var(--brand)]"

--- a/frontend/src/components/config/workflows/stepTypes.ts
+++ b/frontend/src/components/config/workflows/stepTypes.ts
@@ -1,0 +1,83 @@
+export const STEP_FIELD_CLASS =
+  'mt-1 w-full px-3 py-2 rounded-lg surface-card border border-light-border/30 dark:border-dark-border/20 txt-primary text-sm focus:outline-none focus:ring-2 focus:ring-[var(--brand)] disabled:opacity-50 disabled:cursor-not-allowed'
+
+export const BUILTIN_STEP_KINDS = [
+  'email_search',
+  'summarize',
+  'chat',
+  'email_me',
+  'condition',
+  'outbound_webhook',
+] as const
+
+export type BuiltinStepKind = (typeof BUILTIN_STEP_KINDS)[number]
+
+export type AuthoredStep = {
+  id: string
+  capability: string
+  depends_on: string[]
+  params: Record<string, unknown>
+}
+
+export function emptyStep(capability: string, index: number): AuthoredStep {
+  const id = `step_${index + 1}`
+  const params: Record<string, unknown> = {}
+  if (capability === 'condition') {
+    params.operator = 'not_empty'
+    params.inputs = { input: { from: 'trigger', field: 'body' } }
+  }
+  if (capability === 'outbound_webhook') {
+    params.url = ''
+  }
+  if (capability === 'tool_call') {
+    params.tool = ''
+    params.inputs = {}
+  }
+  return { id, capability, depends_on: [], params }
+}
+
+export function stepsFromGraph(graph: Record<string, unknown> | null): AuthoredStep[] {
+  const nodes = graph?.nodes
+  if (!Array.isArray(nodes)) return []
+  return nodes.flatMap((node, index) => {
+    if (!node || typeof node !== 'object') return []
+    const row = node as Record<string, unknown>
+    const id = typeof row.id === 'string' && row.id ? row.id : `step_${index + 1}`
+    const capability = typeof row.capability === 'string' ? row.capability : 'chat'
+    const depends = Array.isArray(row.depends_on)
+      ? row.depends_on.filter((item): item is string => typeof item === 'string')
+      : []
+    const params =
+      row.params && typeof row.params === 'object' && !Array.isArray(row.params)
+        ? { ...(row.params as Record<string, unknown>) }
+        : {}
+    return [{ id, capability, depends_on: depends, params }]
+  })
+}
+
+export function graphFromSteps(
+  steps: AuthoredStep[],
+  triggerType: string
+): Record<string, unknown> {
+  const nodes = steps.map((step, index) => {
+    const fromIds = inputFromIds(step)
+    const linear = index === 0 ? [] : [steps[index - 1].id]
+    const depends_on = [...new Set([...linear, ...fromIds])]
+    return { ...step, depends_on }
+  })
+  return {
+    version: 1,
+    trigger: { type: triggerType },
+    nodes,
+  }
+}
+
+function inputFromIds(step: AuthoredStep): string[] {
+  const inputs = step.params.inputs
+  if (!inputs || typeof inputs !== 'object' || Array.isArray(inputs)) return []
+  return Object.values(inputs as Record<string, unknown>).flatMap((spec) => {
+    if (!spec || typeof spec !== 'object' || Array.isArray(spec)) return []
+    const from = (spec as { from?: unknown }).from
+    return typeof from === 'string' && from && from !== 'trigger' ? [from] : []
+  })
+}

--- a/frontend/src/components/config/workflows/stepTypes.ts
+++ b/frontend/src/components/config/workflows/stepTypes.ts
@@ -12,22 +12,40 @@ export const BUILTIN_STEP_KINDS = [
 
 export type BuiltinStepKind = (typeof BUILTIN_STEP_KINDS)[number]
 
+export type InputSpec = Record<string, unknown>
+
 export type AuthoredStep = {
   id: string
   capability: string
   depends_on: string[]
   params: Record<string, unknown>
+  /** Node-level inputs a planner-captured graph may carry (e.g. url_fetch). Kept verbatim. */
+  inputs?: Record<string, unknown>
 }
 
-export function emptyStep(capability: string, index: number): AuthoredStep {
+export type NewStepContext = {
+  /** Id of the step directly before the new one, if any. */
+  previousStepId?: string
+  triggerType?: string
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  !!value && typeof value === 'object' && !Array.isArray(value)
+
+export function emptyStep(
+  capability: string,
+  index: number,
+  context: NewStepContext = {}
+): AuthoredStep {
   const id = `step_${index + 1}`
   const params: Record<string, unknown> = {}
   if (capability === 'condition') {
     params.operator = 'not_empty'
-    params.inputs = { input: { from: 'trigger', field: 'body' } }
+    params.inputs = { input: defaultInputSource(context) }
   }
   if (capability === 'outbound_webhook') {
     params.url = ''
+    params.inputs = { result: defaultInputSource(context) }
   }
   if (capability === 'tool_call') {
     params.tool = ''
@@ -36,48 +54,128 @@ export function emptyStep(capability: string, index: number): AuthoredStep {
   return { id, capability, depends_on: [], params }
 }
 
+/**
+ * A new condition reads the previous step when there is one; a webhook-started
+ * task without earlier steps reads the whole starting event; otherwise a typed value.
+ */
+export function defaultInputSource(context: NewStepContext): InputSpec {
+  if (context.previousStepId) return { from: context.previousStepId, field: 'text' }
+  if (context.triggerType === 'webhook') return { from: 'trigger', field: '' }
+  return { literal: '' }
+}
+
+/**
+ * Argument names a tool accepts, read from its JSON Schema (`properties`),
+ * required ones first. Empty when the tool publishes no schema.
+ */
+export function toolArgumentNames(inputSchema: unknown): { name: string; required: boolean }[] {
+  if (!isRecord(inputSchema) || !isRecord(inputSchema.properties)) return []
+  const required = new Set(
+    Array.isArray(inputSchema.required)
+      ? inputSchema.required.filter((item): item is string => typeof item === 'string')
+      : []
+  )
+  return Object.keys(inputSchema.properties)
+    .map((name) => ({ name, required: required.has(name) }))
+    .sort((a, b) => Number(b.required) - Number(a.required))
+}
+
 export function stepsFromGraph(graph: Record<string, unknown> | null): AuthoredStep[] {
   const nodes = graph?.nodes
   if (!Array.isArray(nodes)) return []
   return nodes.flatMap((node, index) => {
-    if (!node || typeof node !== 'object') return []
-    const row = node as Record<string, unknown>
-    const id = typeof row.id === 'string' && row.id ? row.id : `step_${index + 1}`
-    const capability = typeof row.capability === 'string' ? row.capability : 'chat'
-    const depends = Array.isArray(row.depends_on)
-      ? row.depends_on.filter((item): item is string => typeof item === 'string')
+    if (!isRecord(node)) return []
+    const id = typeof node.id === 'string' && node.id ? node.id : `step_${index + 1}`
+    const capability = typeof node.capability === 'string' ? node.capability : 'chat'
+    const depends = Array.isArray(node.depends_on)
+      ? node.depends_on.filter((item): item is string => typeof item === 'string')
       : []
-    const params =
-      row.params && typeof row.params === 'object' && !Array.isArray(row.params)
-        ? { ...(row.params as Record<string, unknown>) }
-        : {}
-    return [{ id, capability, depends_on: depends, params }]
+    const params = isRecord(node.params) ? { ...node.params } : {}
+    const step: AuthoredStep = { id, capability, depends_on: depends, params }
+    if (isRecord(node.inputs)) step.inputs = { ...node.inputs }
+    return [step]
   })
 }
 
+/**
+ * Builds the graph the backend validates. Steps run in order (each depends on
+ * the previous one) plus on any step they read a value from. Graph-level keys
+ * the planner captured (`prompt_topic`, `settings`, …) are carried over.
+ */
 export function graphFromSteps(
   steps: AuthoredStep[],
-  triggerType: string
+  triggerType: string,
+  existing: Record<string, unknown> | null = null
 ): Record<string, unknown> {
+  const ids = new Set(steps.map((step) => step.id))
   const nodes = steps.map((step, index) => {
-    const fromIds = inputFromIds(step)
+    const fromIds = inputFromIds(step).filter((id) => ids.has(id))
     const linear = index === 0 ? [] : [steps[index - 1].id]
     const depends_on = [...new Set([...linear, ...fromIds])]
     return { ...step, depends_on }
   })
+  const carried: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(existing ?? {})) {
+    if (key === 'version' || key === 'trigger' || key === 'nodes') continue
+    if (key === 'reply_node' && !(typeof value === 'string' && ids.has(value))) continue
+    carried[key] = value
+  }
   return {
+    ...carried,
     version: 1,
     trigger: { type: triggerType },
     nodes,
   }
 }
 
+/**
+ * Re-ids steps as `step_1 … step_n` in their current order and rewrites every
+ * `from:` reference to follow the step it pointed at. A reference to a removed
+ * step, or to a step that now comes later, falls back to a typed value so the
+ * graph stays valid.
+ */
+export function renumberSteps(steps: AuthoredStep[]): AuthoredStep[] {
+  const newIdByOld = new Map(steps.map((step, index) => [step.id, `step_${index + 1}`]))
+  const position = new Map(steps.map((step, index) => [step.id, index]))
+  return steps.map((step, index) => {
+    const remap = (inputs: unknown): Record<string, unknown> | undefined => {
+      if (!isRecord(inputs)) return undefined
+      const out: Record<string, unknown> = {}
+      for (const [key, spec] of Object.entries(inputs)) {
+        if (!isRecord(spec) || typeof spec.from !== 'string' || spec.from === 'trigger') {
+          out[key] = spec
+          continue
+        }
+        const target = position.get(spec.from)
+        if (target === undefined || target >= index) {
+          out[key] = { literal: '' }
+          continue
+        }
+        out[key] = { ...spec, from: newIdByOld.get(spec.from) }
+      }
+      return out
+    }
+    const next: AuthoredStep = {
+      ...step,
+      id: `step_${index + 1}`,
+      params: { ...step.params },
+    }
+    const paramInputs = remap(step.params.inputs)
+    if (paramInputs) next.params.inputs = paramInputs
+    const nodeInputs = remap(step.inputs)
+    if (nodeInputs) next.inputs = nodeInputs
+    return next
+  })
+}
+
 function inputFromIds(step: AuthoredStep): string[] {
-  const inputs = step.params.inputs
-  if (!inputs || typeof inputs !== 'object' || Array.isArray(inputs)) return []
-  return Object.values(inputs as Record<string, unknown>).flatMap((spec) => {
-    if (!spec || typeof spec !== 'object' || Array.isArray(spec)) return []
-    const from = (spec as { from?: unknown }).from
-    return typeof from === 'string' && from && from !== 'trigger' ? [from] : []
+  const sources = [step.params.inputs, step.inputs]
+  return sources.flatMap((inputs) => {
+    if (!isRecord(inputs)) return []
+    return Object.values(inputs).flatMap((spec) => {
+      if (!isRecord(spec)) return []
+      const from = spec.from
+      return typeof from === 'string' && from && from !== 'trigger' ? [from] : []
+    })
   })
 }

--- a/frontend/src/composables/useWorkflowsFeature.ts
+++ b/frontend/src/composables/useWorkflowsFeature.ts
@@ -1,0 +1,11 @@
+import { getConfigSync } from '@/services/api/httpClient'
+
+/**
+ * Saved Task Steps editor and inbound webhook trigger (WORKFLOWS.BUILDER_ENABLED).
+ *
+ * Lives here instead of stores/config.ts so the flag stays OTA-deliverable.
+ */
+export function isWorkflowsBuilderEnabled(): boolean {
+  const features = getConfigSync().features as { workflowsBuilderEnabled?: boolean } | undefined
+  return features?.workflowsBuilderEnabled === true
+}

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -6436,11 +6436,21 @@
       "matches": "entspricht",
       "not_empty": "nicht leer ist"
     },
-    "sendToWebhook": "An ein anderes System senden",
     "webhookUrl": "Adresse (https)",
+    "whatToSend": "Was gesendet wird",
     "webhookSecret": "Gemeinsames Geheimnis (optional)",
+    "secretSet": "Ein Geheimnis ist gespeichert",
+    "secretSetHint": "Es bleibt unverändert. Hier tippen, um es zu ersetzen, oder das Feld leeren, um es zu entfernen.",
     "pickTool": "Werkzeug wählen",
-    "thisAssistant": "Dieser Assistent",
+    "arguments": "Was an das Werkzeug geht",
+    "noArguments": "Dieses Werkzeug braucht keine Eingabe.",
+    "required": "erforderlich",
+    "inputSource": "Woher der Wert kommt",
+    "field": "Feld",
+    "fieldHintTrigger": "Leer lassen für das ganze Startereignis, oder einen Teil nennen wie title oder order.id.",
+    "fieldHintStep": "text ist die Antwort des Schritts. Außerdem: summary, error oder ein Feld seines Ergebnisses.",
+    "compareWith": "Vergleichen mit",
+    "patternPlaceholder": "Muster, z. B. ^INV-\\d+$",
     "kinds": {
       "email_search": "E-Mails durchsuchen",
       "summarize": "Zusammenfassen",
@@ -6469,6 +6479,10 @@
     "regenerateConfirm": "Die alte Adresse funktioniert danach nicht mehr. Fortfahren?",
     "hmacEnable": "Signatur verlangen",
     "hmacHint": "Das andere System muss eine passende Signatur senden. Sicherer, falls die Adresse bekannt wird.",
-    "hmacOn": "Signatur erforderlich. Das Geheimnis liegt auf dem Server und wird nicht erneut angezeigt."
+    "hmacOn": "Signatur erforderlich. Das Geheimnis wurde beim Einschalten einmal angezeigt; für ein neues aus- und wieder einschalten.",
+    "secretRevealTitle": "Dein gemeinsames Geheimnis – jetzt kopieren",
+    "secretRevealHint": "Füge es im anderen System ein. Es wird nur dieses eine Mal angezeigt und kann später nicht abgerufen werden.",
+    "copySecret": "Geheimnis kopieren",
+    "secretCopied": "Geheimnis kopiert."
   }
 }

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -2102,7 +2102,8 @@
         "manual": "von dir gestartet",
         "schedule": "per Zeitplan",
         "chat": "aus dem Chat",
-        "inbound_email": "eingehende E-Mail"
+        "inbound_email": "eingehende E-Mail",
+        "webhook": "von einem anderen System gestartet"
       },
       "advancedSteps": "Erweiterte Schritte",
       "advancedHint": "Nur öffnen, wenn du genaue Schritte festlegen willst. Die meisten Aufgaben brauchen nur „Jetzt ausführen“ und einen Zeitplan.",
@@ -2167,7 +2168,8 @@
         "off": "Kein Zeitplan",
         "hourly": "Jede Stunde",
         "daily": "Jeden Tag",
-        "weekdays": "Jeden Werktag"
+        "weekdays": "Jeden Werktag",
+        "webhook": "Ein anderes System darf dies starten"
       },
       "summary": {
         "simple": "Läuft {when}.",
@@ -2179,7 +2181,8 @@
           "weekly": "an Werktagen um {at} ({tz})",
           "schedule": "nach Zeitplan",
           "inboundEmail": "wenn neue E-Mails eintreffen",
-          "chat": "wenn eine passende Chat-Nachricht eintrifft"
+          "chat": "wenn eine passende Chat-Nachricht eintrifft",
+          "webhook": "wenn ein anderes System es aufruft"
         },
         "reads": {
           "instruction": "diese Anweisung",
@@ -6406,5 +6409,66 @@
       "howToEnable": "So wird sie aktiviert",
       "openFeatureStatus": "Feature-Status öffnen"
     }
+  },
+  "workflows": {
+    "steps": "Schritte",
+    "stepsTitle": "Schritte für diese Aufgabe",
+    "stepsSubtitle": "Jeder Schritt läuft der Reihe nach. Die meisten Aufgaben brauchen nur ein oder zwei.",
+    "addStep": "Schritt hinzufügen",
+    "saveSteps": "Schritte speichern",
+    "saved": "Schritte gespeichert.",
+    "saveFailed": "Diese Schritte konnten nicht gespeichert werden.",
+    "close": "Schließen",
+    "deleteStep": "Diesen Schritt entfernen",
+    "deleteStepConfirm": "Schritt {n} entfernen?",
+    "moveUp": "Nach oben",
+    "moveDown": "Nach unten",
+    "askBefore": "Vor diesem Schritt nachfragen",
+    "askBeforeHint": "Der Schritt wartet auf dein OK. Das macht die Aufgabe nur vorsichtiger, nie weniger.",
+    "fromTrigger": "Vom Startereignis",
+    "fromStep": "Von Schritt {n}",
+    "literal": "Wert eingeben",
+    "inputValue": "Wert",
+    "condition": "Nur fortfahren, wenn",
+    "operator": {
+      "equals": "gleich",
+      "contains": "enthält",
+      "matches": "entspricht",
+      "not_empty": "nicht leer ist"
+    },
+    "sendToWebhook": "An ein anderes System senden",
+    "webhookUrl": "Adresse (https)",
+    "webhookSecret": "Gemeinsames Geheimnis (optional)",
+    "pickTool": "Werkzeug wählen",
+    "thisAssistant": "Dieser Assistent",
+    "kinds": {
+      "email_search": "E-Mails durchsuchen",
+      "summarize": "Zusammenfassen",
+      "chat": "Eine Antwort schreiben",
+      "email_me": "Ergebnis per E-Mail an mich",
+      "tool_call": "Verbundenes Werkzeug nutzen",
+      "condition": "Nur fortfahren, wenn…",
+      "outbound_webhook": "An ein anderes System senden"
+    },
+    "kindHints": {
+      "email_search": "Schaut ins verbundene Postfach.",
+      "summarize": "Kürzt das vorherige Ergebnis.",
+      "chat": "Nutzt den Assistenten dieser Aufgabe.",
+      "email_me": "Schickt dir eine E-Mail.",
+      "tool_call": "Führt ein bereits verbundenes Werkzeug aus.",
+      "condition": "Stoppt spätere Schritte, wenn der Wert nicht passt.",
+      "outbound_webhook": "Sendet das Ergebnis an eine https-Adresse."
+    },
+    "empty": "Noch keine Schritte. Füge einen hinzu.",
+    "stepN": "Schritt {n}",
+    "webhookCardTitle": "Ein anderes System kann dies starten",
+    "webhookCardHint": "Kopiere diese Adresse nach n8n, Make oder ein Skript. Wer die Adresse hat, kann einen Lauf in deinem Namen starten.",
+    "copyUrl": "Adresse kopieren",
+    "urlCopied": "Adresse kopiert.",
+    "regenerate": "Neue Adresse erzeugen",
+    "regenerateConfirm": "Die alte Adresse funktioniert danach nicht mehr. Fortfahren?",
+    "hmacEnable": "Signatur verlangen",
+    "hmacHint": "Das andere System muss eine passende Signatur senden. Sicherer, falls die Adresse bekannt wird.",
+    "hmacOn": "Signatur erforderlich. Das Geheimnis liegt auf dem Server und wird nicht erneut angezeigt."
   }
 }

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -1992,7 +1992,8 @@
         "manual": "started by you",
         "schedule": "scheduled run",
         "chat": "from chat",
-        "inbound_email": "incoming email"
+        "inbound_email": "incoming email",
+        "webhook": "started by another system"
       },
       "advancedSteps": "Advanced steps",
       "advancedHint": "Leave this closed unless you want to pin exact steps. Most tasks only need Run now and a schedule.",
@@ -2057,7 +2058,8 @@
         "off": "No schedule",
         "hourly": "Every hour",
         "daily": "Every day",
-        "weekdays": "Every weekday"
+        "weekdays": "Every weekday",
+        "webhook": "Let another system start this"
       },
       "summary": {
         "simple": "Runs {when}.",
@@ -2069,7 +2071,8 @@
           "weekly": "every weekday at {at} ({tz})",
           "schedule": "on a schedule",
           "inboundEmail": "when new mail arrives",
-          "chat": "when a matching chat message arrives"
+          "chat": "when a matching chat message arrives",
+          "webhook": "when another system calls it"
         },
         "reads": {
           "instruction": "this instruction",
@@ -6472,5 +6475,66 @@
       "howToEnable": "How to enable it",
       "openFeatureStatus": "Open feature status"
     }
+  },
+  "workflows": {
+    "steps": "Steps",
+    "stepsTitle": "Steps for this task",
+    "stepsSubtitle": "Each step runs in order. Most tasks only need one or two.",
+    "addStep": "Add a step",
+    "saveSteps": "Save steps",
+    "saved": "Steps saved.",
+    "saveFailed": "Could not save these steps.",
+    "close": "Close",
+    "deleteStep": "Remove this step",
+    "deleteStepConfirm": "Remove step {n}?",
+    "moveUp": "Move up",
+    "moveDown": "Move down",
+    "askBefore": "Ask me before this step",
+    "askBeforeHint": "The step waits for your OK. This can only make the task more careful, never less.",
+    "fromTrigger": "From the starting event",
+    "fromStep": "From step {n}",
+    "literal": "Type a value",
+    "inputValue": "Value",
+    "condition": "Only continue if",
+    "operator": {
+      "equals": "equals",
+      "contains": "contains",
+      "matches": "matches",
+      "not_empty": "is not empty"
+    },
+    "sendToWebhook": "Send to another system",
+    "webhookUrl": "Address (https)",
+    "webhookSecret": "Shared secret (optional)",
+    "pickTool": "Choose a tool",
+    "thisAssistant": "This assistant",
+    "kinds": {
+      "email_search": "Search mail",
+      "summarize": "Summarize",
+      "chat": "Write an answer",
+      "email_me": "Mail me the result",
+      "tool_call": "Use a connected tool",
+      "condition": "Only continue if…",
+      "outbound_webhook": "Send to another system"
+    },
+    "kindHints": {
+      "email_search": "Looks in the connected mailbox.",
+      "summarize": "Shortens the previous result.",
+      "chat": "Uses this task’s assistant.",
+      "email_me": "Sends you an email.",
+      "tool_call": "Runs a tool you already connected.",
+      "condition": "Stops later steps when the value does not match.",
+      "outbound_webhook": "Posts the result to an https address."
+    },
+    "empty": "No steps yet. Add one to start.",
+    "stepN": "Step {n}",
+    "webhookCardTitle": "Another system can start this",
+    "webhookCardHint": "Copy this address into n8n, Make, or a script. Anyone with the address can start a run as you.",
+    "copyUrl": "Copy address",
+    "urlCopied": "Address copied.",
+    "regenerate": "Create a new address",
+    "regenerateConfirm": "The old address will stop working. Continue?",
+    "hmacEnable": "Require a signature",
+    "hmacHint": "The other system must send a matching signature. Safer if the address might leak.",
+    "hmacOn": "Signature required. The secret is stored on the server and is never shown again."
   }
 }

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -6502,11 +6502,21 @@
       "matches": "matches",
       "not_empty": "is not empty"
     },
-    "sendToWebhook": "Send to another system",
     "webhookUrl": "Address (https)",
+    "whatToSend": "What to send",
     "webhookSecret": "Shared secret (optional)",
+    "secretSet": "A secret is saved",
+    "secretSetHint": "It stays as it is. Type here to replace it, or clear the field to remove it.",
     "pickTool": "Choose a tool",
-    "thisAssistant": "This assistant",
+    "arguments": "What to send to the tool",
+    "noArguments": "This tool takes no input.",
+    "required": "required",
+    "inputSource": "Where the value comes from",
+    "field": "Field",
+    "fieldHintTrigger": "Leave empty for the whole starting event, or name a part like title or order.id.",
+    "fieldHintStep": "text is the step’s answer. Also: summary, error, or a field of its result.",
+    "compareWith": "Compare with",
+    "patternPlaceholder": "Pattern, e.g. ^INV-\\d+$",
     "kinds": {
       "email_search": "Search mail",
       "summarize": "Summarize",
@@ -6535,6 +6545,10 @@
     "regenerateConfirm": "The old address will stop working. Continue?",
     "hmacEnable": "Require a signature",
     "hmacHint": "The other system must send a matching signature. Safer if the address might leak.",
-    "hmacOn": "Signature required. The secret is stored on the server and is never shown again."
+    "hmacOn": "Signature required. The secret was shown once when you turned this on; turn it off and on again for a new one.",
+    "secretRevealTitle": "Your shared secret — copy it now",
+    "secretRevealHint": "Paste it into the other system. It is shown only this once and cannot be retrieved later.",
+    "copySecret": "Copy secret",
+    "secretCopied": "Secret copied."
   }
 }

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -5516,11 +5516,21 @@
       "matches": "coincide con",
       "not_empty": "no está vacío"
     },
-    "sendToWebhook": "Enviar a otro sistema",
     "webhookUrl": "Dirección (https)",
+    "whatToSend": "Qué enviar",
     "webhookSecret": "Secreto compartido (opcional)",
+    "secretSet": "Hay un secreto guardado",
+    "secretSetHint": "Se mantiene tal cual. Escribe aquí para reemplazarlo o vacía el campo para eliminarlo.",
     "pickTool": "Elegir una herramienta",
-    "thisAssistant": "Este asistente",
+    "arguments": "Qué enviar a la herramienta",
+    "noArguments": "Esta herramienta no necesita datos de entrada.",
+    "required": "obligatorio",
+    "inputSource": "De dónde viene el valor",
+    "field": "Campo",
+    "fieldHintTrigger": "Déjalo vacío para todo el evento inicial, o indica una parte como title u order.id.",
+    "fieldHintStep": "text es la respuesta del paso. También: summary, error o un campo de su resultado.",
+    "compareWith": "Comparar con",
+    "patternPlaceholder": "Patrón, p. ej. ^INV-\\d+$",
     "kinds": {
       "email_search": "Buscar correo",
       "summarize": "Resumir",
@@ -5549,6 +5559,10 @@
     "regenerateConfirm": "La dirección anterior dejará de funcionar. ¿Continuar?",
     "hmacEnable": "Exigir una firma",
     "hmacHint": "El otro sistema debe enviar una firma coincidente. Más seguro si la dirección puede filtrarse.",
-    "hmacOn": "Firma exigida. El secreto se guarda en el servidor y no se vuelve a mostrar."
+    "hmacOn": "Firma exigida. El secreto se mostró una sola vez al activarlo; desactívalo y actívalo de nuevo para obtener otro.",
+    "secretRevealTitle": "Tu secreto compartido: cópialo ahora",
+    "secretRevealHint": "Pégalo en el otro sistema. Solo se muestra esta vez y no se podrá recuperar después.",
+    "copySecret": "Copiar secreto",
+    "secretCopied": "Secreto copiado."
   }
 }

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -2891,7 +2891,8 @@
         "manual": "iniciada por ti",
         "schedule": "programada",
         "chat": "desde el chat",
-        "inbound_email": "correo entrante"
+        "inbound_email": "correo entrante",
+        "webhook": "iniciada por otro sistema"
       },
       "advancedSteps": "Pasos avanzados",
       "advancedHint": "Déjalo cerrado salvo que quieras fijar pasos exactos. La mayoría de las tareas solo necesitan Ejecutar ahora y una programación.",
@@ -2956,7 +2957,8 @@
         "off": "Sin programación",
         "hourly": "Cada hora",
         "daily": "Cada día",
-        "weekdays": "Cada día laborable"
+        "weekdays": "Cada día laborable",
+        "webhook": "Que otro sistema lo inicie"
       },
       "summary": {
         "simple": "Se ejecuta {when}.",
@@ -2968,7 +2970,8 @@
           "weekly": "los días laborables a las {at} ({tz})",
           "schedule": "según un horario",
           "inboundEmail": "cuando llega correo nuevo",
-          "chat": "cuando llega un mensaje de chat coincidente"
+          "chat": "cuando llega un mensaje de chat coincidente",
+          "webhook": "cuando otro sistema lo llama"
         },
         "reads": {
           "instruction": "esta instrucción",
@@ -5486,5 +5489,66 @@
       "howToEnable": "Cómo activarla",
       "openFeatureStatus": "Abrir estado de funciones"
     }
+  },
+  "workflows": {
+    "steps": "Pasos",
+    "stepsTitle": "Pasos de esta tarea",
+    "stepsSubtitle": "Cada paso se ejecuta en orden. La mayoría de las tareas solo necesitan uno o dos.",
+    "addStep": "Añadir un paso",
+    "saveSteps": "Guardar pasos",
+    "saved": "Pasos guardados.",
+    "saveFailed": "No se pudieron guardar estos pasos.",
+    "close": "Cerrar",
+    "deleteStep": "Quitar este paso",
+    "deleteStepConfirm": "¿Quitar el paso {n}?",
+    "moveUp": "Subir",
+    "moveDown": "Bajar",
+    "askBefore": "Preguntarme antes de este paso",
+    "askBeforeHint": "El paso espera tu OK. Solo puede hacer la tarea más cuidadosa, nunca menos.",
+    "fromTrigger": "Del evento inicial",
+    "fromStep": "Del paso {n}",
+    "literal": "Escribir un valor",
+    "inputValue": "Valor",
+    "condition": "Continuar solo si",
+    "operator": {
+      "equals": "es igual a",
+      "contains": "contiene",
+      "matches": "coincide con",
+      "not_empty": "no está vacío"
+    },
+    "sendToWebhook": "Enviar a otro sistema",
+    "webhookUrl": "Dirección (https)",
+    "webhookSecret": "Secreto compartido (opcional)",
+    "pickTool": "Elegir una herramienta",
+    "thisAssistant": "Este asistente",
+    "kinds": {
+      "email_search": "Buscar correo",
+      "summarize": "Resumir",
+      "chat": "Escribir una respuesta",
+      "email_me": "Enviarme el resultado",
+      "tool_call": "Usar una herramienta conectada",
+      "condition": "Continuar solo si…",
+      "outbound_webhook": "Enviar a otro sistema"
+    },
+    "kindHints": {
+      "email_search": "Busca en el buzón conectado.",
+      "summarize": "Acorta el resultado anterior.",
+      "chat": "Usa el asistente de esta tarea.",
+      "email_me": "Te envía un correo.",
+      "tool_call": "Ejecuta una herramienta que ya conectaste.",
+      "condition": "Detiene los pasos siguientes si el valor no coincide.",
+      "outbound_webhook": "Envía el resultado a una dirección https."
+    },
+    "empty": "Aún no hay pasos. Añade uno para empezar.",
+    "stepN": "Paso {n}",
+    "webhookCardTitle": "Otro sistema puede iniciar esto",
+    "webhookCardHint": "Copia esta dirección en n8n, Make o un script. Quien tenga la dirección puede iniciar una ejecución en tu nombre.",
+    "copyUrl": "Copiar dirección",
+    "urlCopied": "Dirección copiada.",
+    "regenerate": "Crear una dirección nueva",
+    "regenerateConfirm": "La dirección anterior dejará de funcionar. ¿Continuar?",
+    "hmacEnable": "Exigir una firma",
+    "hmacHint": "El otro sistema debe enviar una firma coincidente. Más seguro si la dirección puede filtrarse.",
+    "hmacOn": "Firma exigida. El secreto se guarda en el servidor y no se vuelve a mostrar."
   }
 }

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -6502,11 +6502,21 @@
       "matches": "correspond à",
       "not_empty": "n’est pas vide"
     },
-    "sendToWebhook": "Envoyer à un autre système",
     "webhookUrl": "Adresse (https)",
+    "whatToSend": "Quoi envoyer",
     "webhookSecret": "Secret partagé (facultatif)",
+    "secretSet": "Un secret est enregistré",
+    "secretSetHint": "Il reste tel quel. Saisissez ici pour le remplacer, ou videz le champ pour le supprimer.",
     "pickTool": "Choisir un outil",
-    "thisAssistant": "Cet assistant",
+    "arguments": "Ce qui est envoyé à l’outil",
+    "noArguments": "Cet outil ne demande aucune donnée.",
+    "required": "obligatoire",
+    "inputSource": "D’où vient la valeur",
+    "field": "Champ",
+    "fieldHintTrigger": "Laissez vide pour tout l’événement de départ, ou indiquez une partie comme title ou order.id.",
+    "fieldHintStep": "text est la réponse de l’étape. Aussi : summary, error ou un champ de son résultat.",
+    "compareWith": "Comparer avec",
+    "patternPlaceholder": "Motif, p. ex. ^INV-\\d+$",
     "kinds": {
       "email_search": "Chercher dans les e-mails",
       "summarize": "Résumer",
@@ -6535,6 +6545,10 @@
     "regenerateConfirm": "L’ancienne adresse ne fonctionnera plus. Continuer ?",
     "hmacEnable": "Exiger une signature",
     "hmacHint": "L’autre système doit envoyer une signature correspondante. Plus sûr si l’adresse fuitait.",
-    "hmacOn": "Signature exigée. Le secret est stocké sur le serveur et n’est plus affiché."
+    "hmacOn": "Signature exigée. Le secret a été affiché une seule fois à l’activation ; désactivez puis réactivez pour en obtenir un nouveau.",
+    "secretRevealTitle": "Votre secret partagé — copiez-le maintenant",
+    "secretRevealHint": "Collez-le dans l’autre système. Il n’est affiché que cette fois et ne pourra pas être récupéré plus tard.",
+    "copySecret": "Copier le secret",
+    "secretCopied": "Secret copié."
   }
 }

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -1990,7 +1990,8 @@
         "manual": "lancée par vous",
         "schedule": "exécution planifiée",
         "chat": "depuis le chat",
-        "inbound_email": "e-mail entrant"
+        "inbound_email": "e-mail entrant",
+        "webhook": "lancée par un autre système"
       },
       "advancedSteps": "Étapes avancées",
       "advancedHint": "Laissez ceci fermé sauf si vous voulez figer des étapes précises. La plupart des tâches n’ont besoin que de Lancer maintenant et d’un planning.",
@@ -2055,7 +2056,8 @@
         "off": "Pas de planning",
         "hourly": "Toutes les heures",
         "daily": "Tous les jours",
-        "weekdays": "Tous les jours ouvrés"
+        "weekdays": "Tous les jours ouvrés",
+        "webhook": "Laisser un autre système le lancer"
       },
       "summary": {
         "simple": "S’exécute {when}.",
@@ -2067,7 +2069,8 @@
           "weekly": "tous les jours ouvrés à {at} ({tz})",
           "schedule": "selon un planning",
           "inboundEmail": "quand un nouveau mail arrive",
-          "chat": "quand un message de chat correspondant arrive"
+          "chat": "quand un message de chat correspondant arrive",
+          "webhook": "lorsqu’un autre système l’appelle"
         },
         "reads": {
           "instruction": "cette instruction",
@@ -6472,5 +6475,66 @@
       "howToEnable": "Comment l’activer",
       "openFeatureStatus": "Ouvrir l’état des fonctionnalités"
     }
+  },
+  "workflows": {
+    "steps": "Étapes",
+    "stepsTitle": "Étapes de cette tâche",
+    "stepsSubtitle": "Chaque étape s’exécute dans l’ordre. La plupart des tâches n’en ont besoin que d’une ou deux.",
+    "addStep": "Ajouter une étape",
+    "saveSteps": "Enregistrer les étapes",
+    "saved": "Étapes enregistrées.",
+    "saveFailed": "Impossible d’enregistrer ces étapes.",
+    "close": "Fermer",
+    "deleteStep": "Retirer cette étape",
+    "deleteStepConfirm": "Retirer l’étape {n} ?",
+    "moveUp": "Monter",
+    "moveDown": "Descendre",
+    "askBefore": "Me demander avant cette étape",
+    "askBeforeHint": "L’étape attend votre accord. Cela ne peut que rendre la tâche plus prudente, jamais moins.",
+    "fromTrigger": "Depuis l’événement de départ",
+    "fromStep": "Depuis l’étape {n}",
+    "literal": "Saisir une valeur",
+    "inputValue": "Valeur",
+    "condition": "Ne continuer que si",
+    "operator": {
+      "equals": "est égal à",
+      "contains": "contient",
+      "matches": "correspond à",
+      "not_empty": "n’est pas vide"
+    },
+    "sendToWebhook": "Envoyer à un autre système",
+    "webhookUrl": "Adresse (https)",
+    "webhookSecret": "Secret partagé (facultatif)",
+    "pickTool": "Choisir un outil",
+    "thisAssistant": "Cet assistant",
+    "kinds": {
+      "email_search": "Chercher dans les e-mails",
+      "summarize": "Résumer",
+      "chat": "Rédiger une réponse",
+      "email_me": "M’envoyer le résultat",
+      "tool_call": "Utiliser un outil connecté",
+      "condition": "Ne continuer que si…",
+      "outbound_webhook": "Envoyer à un autre système"
+    },
+    "kindHints": {
+      "email_search": "Regarde dans la boîte connectée.",
+      "summarize": "Raccourcit le résultat précédent.",
+      "chat": "Utilise l’assistant de cette tâche.",
+      "email_me": "Vous envoie un e-mail.",
+      "tool_call": "Exécute un outil déjà connecté.",
+      "condition": "Arrête les étapes suivantes si la valeur ne correspond pas.",
+      "outbound_webhook": "Envoie le résultat à une adresse https."
+    },
+    "empty": "Pas encore d’étapes. Ajoutez-en une pour commencer.",
+    "stepN": "Étape {n}",
+    "webhookCardTitle": "Un autre système peut lancer ceci",
+    "webhookCardHint": "Copiez cette adresse dans n8n, Make ou un script. Quiconque a l’adresse peut lancer une exécution en votre nom.",
+    "copyUrl": "Copier l’adresse",
+    "urlCopied": "Adresse copiée.",
+    "regenerate": "Créer une nouvelle adresse",
+    "regenerateConfirm": "L’ancienne adresse ne fonctionnera plus. Continuer ?",
+    "hmacEnable": "Exiger une signature",
+    "hmacHint": "L’autre système doit envoyer une signature correspondante. Plus sûr si l’adresse fuitait.",
+    "hmacOn": "Signature exigée. Le secret est stocké sur le serveur et n’est plus affiché."
   }
 }

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -5517,11 +5517,21 @@
       "matches": "eşleşir",
       "not_empty": "boş değil"
     },
-    "sendToWebhook": "Başka bir sisteme gönder",
     "webhookUrl": "Adres (https)",
+    "whatToSend": "Ne gönderilecek",
     "webhookSecret": "Paylaşılan gizli anahtar (isteğe bağlı)",
+    "secretSet": "Bir gizli anahtar kayıtlı",
+    "secretSetHint": "Olduğu gibi kalır. Değiştirmek için buraya yazın veya kaldırmak için alanı boşaltın.",
     "pickTool": "Bir araç seç",
-    "thisAssistant": "Bu asistan",
+    "arguments": "Araca ne gönderilecek",
+    "noArguments": "Bu araç girdi almaz.",
+    "required": "zorunlu",
+    "inputSource": "Değer nereden geliyor",
+    "field": "Alan",
+    "fieldHintTrigger": "Başlangıç olayının tamamı için boş bırak ya da title veya order.id gibi bir bölüm belirt.",
+    "fieldHintStep": "text adımın yanıtıdır. Ayrıca: summary, error veya sonucunun bir alanı.",
+    "compareWith": "Şununla karşılaştır",
+    "patternPlaceholder": "Desen, örn. ^INV-\\d+$",
     "kinds": {
       "email_search": "Postada ara",
       "summarize": "Özetle",
@@ -5550,6 +5560,10 @@
     "regenerateConfirm": "Eski adres çalışmayı durdurur. Devam edilsin mi?",
     "hmacEnable": "İmza iste",
     "hmacHint": "Diğer sistem eşleşen bir imza göndermelidir. Adres sızarsa daha güvenlidir.",
-    "hmacOn": "İmza gerekli. Gizli anahtar sunucuda saklanır ve bir daha gösterilmez."
+    "hmacOn": "İmza gerekli. Gizli anahtar açarken bir kez gösterildi; yenisi için kapatıp tekrar aç.",
+    "secretRevealTitle": "Paylaşılan gizli anahtarın — şimdi kopyala",
+    "secretRevealHint": "Diğer sisteme yapıştır. Yalnızca bu kez gösterilir ve sonradan alınamaz.",
+    "copySecret": "Gizli anahtarı kopyala",
+    "secretCopied": "Gizli anahtar kopyalandı."
   }
 }

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -2892,7 +2892,8 @@
         "manual": "senin tarafından başlatıldı",
         "schedule": "zamanlanmış",
         "chat": "sohbetten",
-        "inbound_email": "gelen e-posta"
+        "inbound_email": "gelen e-posta",
+        "webhook": "başka bir sistem tarafından başlatıldı"
       },
       "advancedSteps": "Gelişmiş adımlar",
       "advancedHint": "Tam adımları sabitlemek istemiyorsan kapalı bırak. Çoğu görev için Şimdi çalıştır ve bir zamanlama yeter.",
@@ -2957,7 +2958,8 @@
         "off": "Zamanlama yok",
         "hourly": "Her saat",
         "daily": "Her gün",
-        "weekdays": "Her iş günü"
+        "weekdays": "Her iş günü",
+        "webhook": "Başka bir sistem başlatsın"
       },
       "summary": {
         "simple": "Ne zaman çalışır: {when}.",
@@ -2969,7 +2971,8 @@
           "weekly": "hafta içi her gün {at} ({tz})",
           "schedule": "zamanlamaya göre",
           "inboundEmail": "yeni e-posta gelince",
-          "chat": "eşleşen bir sohbet mesajı gelince"
+          "chat": "eşleşen bir sohbet mesajı gelince",
+          "webhook": "başka bir sistem çağırınca"
         },
         "reads": {
           "instruction": "bu talimat",
@@ -5487,5 +5490,66 @@
       "howToEnable": "Nasıl etkinleştirilir",
       "openFeatureStatus": "Özellik durumunu aç"
     }
+  },
+  "workflows": {
+    "steps": "Adımlar",
+    "stepsTitle": "Bu görevin adımları",
+    "stepsSubtitle": "Her adım sırayla çalışır. Çoğu görev için bir veya iki adım yeter.",
+    "addStep": "Adım ekle",
+    "saveSteps": "Adımları kaydet",
+    "saved": "Adımlar kaydedildi.",
+    "saveFailed": "Bu adımlar kaydedilemedi.",
+    "close": "Kapat",
+    "deleteStep": "Bu adımı kaldır",
+    "deleteStepConfirm": "{n}. adım kaldırılsın mı?",
+    "moveUp": "Yukarı taşı",
+    "moveDown": "Aşağı taşı",
+    "askBefore": "Bu adımdan önce bana sor",
+    "askBeforeHint": "Adım senin onayını bekler. Görevi yalnızca daha dikkatli yapar, asla daha az.",
+    "fromTrigger": "Başlangıç olayından",
+    "fromStep": "{n}. adımdan",
+    "literal": "Bir değer yaz",
+    "inputValue": "Değer",
+    "condition": "Yalnızca şu durumda devam et",
+    "operator": {
+      "equals": "eşittir",
+      "contains": "içerir",
+      "matches": "eşleşir",
+      "not_empty": "boş değil"
+    },
+    "sendToWebhook": "Başka bir sisteme gönder",
+    "webhookUrl": "Adres (https)",
+    "webhookSecret": "Paylaşılan gizli anahtar (isteğe bağlı)",
+    "pickTool": "Bir araç seç",
+    "thisAssistant": "Bu asistan",
+    "kinds": {
+      "email_search": "Postada ara",
+      "summarize": "Özetle",
+      "chat": "Bir yanıt yaz",
+      "email_me": "Sonucu bana e-postala",
+      "tool_call": "Bağlı bir araç kullan",
+      "condition": "Yalnızca şu durumda devam et…",
+      "outbound_webhook": "Başka bir sisteme gönder"
+    },
+    "kindHints": {
+      "email_search": "Bağlı postakutuya bakar.",
+      "summarize": "Önceki sonucu kısaltır.",
+      "chat": "Bu görevin asistanını kullanır.",
+      "email_me": "Sana bir e-posta gönderir.",
+      "tool_call": "Önceden bağladığın bir aracı çalıştırır.",
+      "condition": "Değer uymazsa sonraki adımları durdurur.",
+      "outbound_webhook": "Sonucu bir https adresine gönderir."
+    },
+    "empty": "Henüz adım yok. Başlamak için bir tane ekle.",
+    "stepN": "Adım {n}",
+    "webhookCardTitle": "Başka bir sistem bunu başlatabilir",
+    "webhookCardHint": "Bu adresi n8n, Make veya bir betiğe kopyala. Adrese sahip herkes senin adına bir çalıştırma başlatabilir.",
+    "copyUrl": "Adresi kopyala",
+    "urlCopied": "Adres kopyalandı.",
+    "regenerate": "Yeni adres oluştur",
+    "regenerateConfirm": "Eski adres çalışmayı durdurur. Devam edilsin mi?",
+    "hmacEnable": "İmza iste",
+    "hmacHint": "Diğer sistem eşleşen bir imza göndermelidir. Adres sızarsa daha güvenlidir.",
+    "hmacOn": "İmza gerekli. Gizli anahtar sunucuda saklanır ve bir daha gösterilmez."
   }
 }

--- a/frontend/src/services/api/savedTasksApi.ts
+++ b/frontend/src/services/api/savedTasksApi.ts
@@ -43,6 +43,11 @@ export interface SavedTask {
   /** First ~60 characters of the underlying instruction ("what runs"). */
   instructionPreview: string | null
   waitingApprovalCount: number
+  /**
+   * Present only on the update response that turned on "Require a signature":
+   * the new HMAC secret, shown once. Never returned by list/get.
+   */
+  webhookSecret?: string
 }
 
 export interface SavedTaskRun {
@@ -144,7 +149,9 @@ export const savedTasksApi = {
       body: JSON.stringify(patch),
       schema: PatchApiSavedTasksUpdateResponseSchema,
     })
-    return asTask(data.task)
+    const task = asTask(data.task)
+    const secret = data.task?.webhookSecret
+    return typeof secret === 'string' && secret ? { ...task, webhookSecret: secret } : task
   },
 
   /**

--- a/frontend/src/services/api/toolsApi.ts
+++ b/frontend/src/services/api/toolsApi.ts
@@ -1,0 +1,25 @@
+import { httpClient } from './httpClient'
+import { GetApiToolsListResponseSchema } from '@/generated/api-schemas'
+
+export type RegistryTool = {
+  name: string
+  title: string
+  description: string
+  sideEffect: string
+  source: string
+}
+
+export const toolsApi = {
+  async list(): Promise<RegistryTool[]> {
+    const data = await httpClient('/api/v1/tools', {
+      schema: GetApiToolsListResponseSchema,
+    })
+    return (data.tools ?? []).map((tool) => ({
+      name: tool.name ?? '',
+      title: tool.title ?? tool.name ?? '',
+      description: tool.description ?? '',
+      sideEffect: tool.sideEffect ?? 'read',
+      source: tool.source ?? 'custom',
+    }))
+  },
+}

--- a/frontend/src/services/api/toolsApi.ts
+++ b/frontend/src/services/api/toolsApi.ts
@@ -7,6 +7,8 @@ export type RegistryTool = {
   description: string
   sideEffect: string
   source: string
+  /** JSON Schema of the tool's arguments, when the tool publishes one. */
+  inputSchema?: Record<string, unknown>
 }
 
 export const toolsApi = {
@@ -20,6 +22,9 @@ export const toolsApi = {
       description: tool.description ?? '',
       sideEffect: tool.sideEffect ?? 'read',
       source: tool.source ?? 'custom',
+      ...(tool.inputSchema && typeof tool.inputSchema === 'object'
+        ? { inputSchema: tool.inputSchema as Record<string, unknown> }
+        : {}),
     }))
   },
 }

--- a/frontend/tests/unit/components/config/SavedTaskCard.spec.ts
+++ b/frontend/tests/unit/components/config/SavedTaskCard.spec.ts
@@ -305,6 +305,35 @@ describe('SavedTaskCard', () => {
     expect(wrapper.find('[data-testid="btn-advanced-steps"]').exists()).toBe(false)
   })
 
+  it('shows the webhook address and reveals a fresh shared secret exactly once', async () => {
+    mockWorkflowsEnabled.mockReturnValue(true)
+    const webhookTask = task({
+      triggerType: 'webhook',
+      triggerConfig: { token: 'tok-123', hmacConfigured: false },
+    })
+    mockUpdate.mockResolvedValueOnce({
+      ...webhookTask,
+      triggerConfig: { token: 'tok-123', hmacConfigured: true },
+      webhookSecret: 'shh-once',
+    })
+    const wrapper = mountCard(webhookTask)
+
+    const url = wrapper.get('[data-testid="saved-task-webhook-url"]').element as HTMLInputElement
+    expect(url.value).toContain('/api/v1/webhooks/saved-tasks/tok-123')
+    expect(wrapper.find('[data-testid="saved-task-webhook-secret"]').exists()).toBe(false)
+
+    await wrapper.get('[data-testid="saved-task-webhook-hmac"]').trigger('change')
+    await flushPromises()
+
+    expect(mockUpdate).toHaveBeenCalledWith(7, { triggerType: 'webhook', hmacEnabled: true })
+    const secret = wrapper.get('[data-testid="saved-task-webhook-secret-value"]')
+      .element as HTMLInputElement
+    expect(secret.value).toBe('shh-once')
+    const emitted = wrapper.emitted('updated')?.[0]?.[0] as SavedTask
+    expect(emitted.webhookSecret).toBeUndefined()
+    expect(emitted.triggerConfig).toEqual({ token: 'tok-123', hmacConfigured: true })
+  })
+
   it('does not delete when the confirm is cancelled', async () => {
     const wrapper = mountCard(task())
     await wrapper.get('[data-testid="btn-delete-saved-task"]').trigger('click')

--- a/frontend/tests/unit/components/config/SavedTaskCard.spec.ts
+++ b/frontend/tests/unit/components/config/SavedTaskCard.spec.ts
@@ -3,17 +3,25 @@ import { flushPromises, mount } from '@vue/test-utils'
 import SavedTaskCard from '@/components/config/SavedTaskCard.vue'
 import type { SavedTask, SavedTaskRun } from '@/services/api/savedTasksApi'
 
-const { mockUpdate, mockRun, mockRuns, mockResume, mockRemove, mockPush, mockConfirm } = vi.hoisted(
-  () => ({
-    mockUpdate: vi.fn(),
-    mockRun: vi.fn(),
-    mockRuns: vi.fn(),
-    mockResume: vi.fn(),
-    mockRemove: vi.fn(),
-    mockPush: vi.fn(),
-    mockConfirm: vi.fn(),
-  })
-)
+const {
+  mockUpdate,
+  mockRun,
+  mockRuns,
+  mockResume,
+  mockRemove,
+  mockPush,
+  mockConfirm,
+  mockWorkflowsEnabled,
+} = vi.hoisted(() => ({
+  mockUpdate: vi.fn(),
+  mockRun: vi.fn(),
+  mockRuns: vi.fn(),
+  mockResume: vi.fn(),
+  mockRemove: vi.fn(),
+  mockPush: vi.fn(),
+  mockConfirm: vi.fn(),
+  mockWorkflowsEnabled: vi.fn(() => false),
+}))
 
 vi.mock('@/services/api/savedTasksApi', () => ({
   savedTasksApi: {
@@ -31,6 +39,10 @@ vi.mock('@/composables/useNotification', () => ({
 
 vi.mock('@/composables/useIamFeature', () => ({
   isIamSharingEnabled: () => false,
+}))
+
+vi.mock('@/composables/useWorkflowsFeature', () => ({
+  isWorkflowsBuilderEnabled: () => mockWorkflowsEnabled(),
 }))
 
 vi.mock('@/composables/useDialog', () => ({
@@ -86,13 +98,14 @@ const mountCard = (value: SavedTask) =>
   mount(SavedTaskCard, {
     props: { task: value },
     global: {
-      stubs: { Icon: true, ShareDialog: true },
+      stubs: { Icon: true, ShareDialog: true, SavedTaskStepsEditor: true },
     },
   })
 
 describe('SavedTaskCard', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockWorkflowsEnabled.mockReturnValue(false)
     mockConfirm.mockResolvedValue(false)
     mockUpdate.mockImplementation(async (_id: number, patch: Record<string, unknown>) =>
       task({ ...patch } as Partial<SavedTask>)
@@ -276,6 +289,20 @@ describe('SavedTaskCard', () => {
     )
     expect(mockRemove).toHaveBeenCalledWith(7)
     expect(wrapper.emitted('deleted')).toEqual([[7]])
+  })
+
+  it('hides Steps when the builder flag is off', () => {
+    const wrapper = mountCard(task())
+    expect(wrapper.find('[data-testid="btn-saved-task-steps"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="btn-advanced-steps"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="saved-task-webhook"]').exists()).toBe(false)
+  })
+
+  it('shows Steps when the builder flag is on', () => {
+    mockWorkflowsEnabled.mockReturnValue(true)
+    const wrapper = mountCard(task())
+    expect(wrapper.find('[data-testid="btn-saved-task-steps"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="btn-advanced-steps"]').exists()).toBe(false)
   })
 
   it('does not delete when the confirm is cancelled', async () => {

--- a/frontend/tests/unit/components/config/SavedTaskStepsEditor.spec.ts
+++ b/frontend/tests/unit/components/config/SavedTaskStepsEditor.spec.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+import SavedTaskStepsEditor from '@/components/config/workflows/SavedTaskStepsEditor.vue'
+import type { SavedTask } from '@/services/api/savedTasksApi'
+
+const { mockUpdate, mockListTools, mockConfirm } = vi.hoisted(() => ({
+  mockUpdate: vi.fn(),
+  mockListTools: vi.fn(),
+  mockConfirm: vi.fn(),
+}))
+
+vi.mock('@/services/api/savedTasksApi', () => ({
+  savedTasksApi: { update: mockUpdate },
+}))
+
+vi.mock('@/services/api/toolsApi', () => ({
+  toolsApi: { list: mockListTools },
+}))
+
+vi.mock('@/composables/useNotification', () => ({
+  useNotification: () => ({ success: vi.fn(), error: vi.fn() }),
+}))
+
+vi.mock('@/composables/useDialog', () => ({
+  useDialog: () => ({ confirm: (...args: unknown[]) => mockConfirm(...args) }),
+}))
+
+function task(): SavedTask {
+  return {
+    id: 7,
+    promptId: 12,
+    name: 'Meeting requests',
+    enabled: true,
+    triggerType: 'manual',
+    triggerConfig: null,
+    graph: null,
+    allowUnattended: false,
+    chatId: null,
+    nextRunAt: null,
+    lastRunAt: null,
+    consecutiveFailures: 0,
+    autoPaused: false,
+    summary: { key: 'config.savedTasks.summary.simple', params: { when: 'manual' } },
+    instructionPreview: null,
+    waitingApprovalCount: 0,
+  }
+}
+
+describe('SavedTaskStepsEditor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockListTools.mockResolvedValue([])
+    mockUpdate.mockResolvedValue(task())
+    mockConfirm.mockResolvedValue(true)
+  })
+
+  it('adds a step and saves a linear graph', async () => {
+    const wrapper = mount(SavedTaskStepsEditor, {
+      props: { open: true, task: task() },
+      attachTo: document.body,
+    })
+    await flushPromises()
+    const root = document.body
+    const add = root.querySelector('[data-testid="btn-add-step"]')
+    expect(add).toBeTruthy()
+    await (add as HTMLButtonElement).click()
+    await flushPromises()
+    expect(root.querySelector('[data-testid="step-row-0"]')?.textContent).toContain('Step 1')
+    const save = root.querySelector('[data-testid="btn-save-steps"]') as HTMLButtonElement
+    save.click()
+    await flushPromises()
+    expect(mockUpdate).toHaveBeenCalledWith(
+      7,
+      expect.objectContaining({
+        graph: expect.objectContaining({
+          version: 1,
+          trigger: { type: 'manual' },
+          nodes: [
+            expect.objectContaining({
+              id: 'step_1',
+              capability: 'chat',
+              depends_on: [],
+            }),
+          ],
+        }),
+      })
+    )
+    wrapper.unmount()
+  })
+})

--- a/frontend/tests/unit/components/config/StepInputsForm.spec.ts
+++ b/frontend/tests/unit/components/config/StepInputsForm.spec.ts
@@ -3,21 +3,19 @@ import { mount } from '@vue/test-utils'
 import StepInputsForm from '@/components/config/workflows/StepInputsForm.vue'
 import type { AuthoredStep } from '@/components/config/workflows/stepTypes'
 
-const conditionStep = (): AuthoredStep => ({
+const conditionStep = (operator = 'equals'): AuthoredStep => ({
   id: 'step_2',
   capability: 'condition',
   depends_on: ['step_1'],
-  params: { operator: 'equals', value: 'yes', inputs: { input: { literal: '' } } },
+  params: { operator, value: 'yes', inputs: { input: { literal: '' } } },
 })
+
+const earlier: AuthoredStep[] = [{ id: 'step_1', capability: 'chat', depends_on: [], params: {} }]
 
 describe('StepInputsForm', () => {
   it('lets a condition pick a typed value or an earlier step', async () => {
     const wrapper = mount(StepInputsForm, {
-      props: {
-        step: conditionStep(),
-        earlierSteps: [{ id: 'step_1', capability: 'chat', depends_on: [], params: {} }],
-        tools: [],
-      },
+      props: { step: conditionStep(), earlierSteps: earlier, tools: [] },
     })
     expect(wrapper.text()).toContain('Only continue if')
     expect(wrapper.text()).toContain('From step 1')
@@ -25,5 +23,107 @@ describe('StepInputsForm', () => {
     await selects[1].setValue('step_1')
     const change = wrapper.emitted('change')?.[0]?.[0] as AuthoredStep
     expect(change.params.inputs).toEqual({ input: { from: 'step_1', field: 'text' } })
+  })
+
+  it('shows the compare field for equals, contains and matches — not for not_empty', () => {
+    for (const operator of ['equals', 'contains', 'matches']) {
+      const wrapper = mount(StepInputsForm, {
+        props: { step: conditionStep(operator), earlierSteps: earlier, tools: [] },
+      })
+      expect(wrapper.find('[data-testid="condition-value"]').exists(), operator).toBe(true)
+    }
+    const wrapper = mount(StepInputsForm, {
+      props: { step: conditionStep('not_empty'), earlierSteps: earlier, tools: [] },
+    })
+    expect(wrapper.find('[data-testid="condition-value"]').exists()).toBe(false)
+  })
+
+  it('maps tool arguments from the tool schema, required first', async () => {
+    const wrapper = mount(StepInputsForm, {
+      props: {
+        step: {
+          id: 'step_2',
+          capability: 'tool_call',
+          depends_on: ['step_1'],
+          params: { tool: 'crm.create', inputs: {} },
+        },
+        earlierSteps: earlier,
+        tools: [
+          {
+            name: 'crm.create',
+            title: 'Create contact',
+            description: '',
+            sideEffect: 'write',
+            source: 'custom',
+            inputSchema: {
+              type: 'object',
+              properties: { note: { type: 'string' }, name: { type: 'string' } },
+              required: ['name'],
+            },
+          },
+        ],
+      },
+    })
+    const labels = wrapper.findAll('[data-testid="tool-arguments"] label').map((l) => l.text())
+    expect(labels[0]).toContain('name')
+    expect(labels[0]).toContain('required')
+    expect(labels[1]).toContain('note')
+
+    await wrapper.find('[data-testid="input-source-name"] select').setValue('trigger')
+    const change = wrapper.emitted('change')?.[0]?.[0] as AuthoredStep
+    expect(change.params.inputs).toEqual({ name: { from: 'trigger', field: '' } })
+  })
+
+  it('starts the argument mapping fresh when the tool changes', async () => {
+    const wrapper = mount(StepInputsForm, {
+      props: {
+        step: {
+          id: 'step_1',
+          capability: 'tool_call',
+          depends_on: [],
+          params: { tool: 'a', inputs: { x: { literal: '1' } } },
+        },
+        earlierSteps: [],
+        tools: [
+          { name: 'a', title: 'A', description: '', sideEffect: 'read', source: 'custom' },
+          { name: 'b', title: 'B', description: '', sideEffect: 'read', source: 'custom' },
+        ],
+      },
+    })
+    await wrapper.find('select').setValue('b')
+    const change = wrapper.emitted('change')?.[0]?.[0] as AuthoredStep
+    expect(change.params).toEqual({ tool: 'b', inputs: {} })
+  })
+
+  it('keeps a saved outbound secret untouched until the owner types or clears it', async () => {
+    const step: AuthoredStep = {
+      id: 'step_2',
+      capability: 'outbound_webhook',
+      depends_on: ['step_1'],
+      params: { url: 'https://hooks.example/in', secretConfigured: true },
+    }
+    const wrapper = mount(StepInputsForm, {
+      props: { step, earlierSteps: earlier, tools: [] },
+    })
+    const secret = wrapper.find('[data-testid="outbound-secret"]')
+    expect(secret.attributes('type')).toBe('password')
+    expect(secret.attributes('placeholder')).toBe('A secret is saved')
+    expect(wrapper.text()).toContain('What to send')
+
+    await secret.setValue('new-secret')
+    const change = wrapper.emitted('change')?.[0]?.[0] as AuthoredStep
+    expect(change.params).toEqual({ url: 'https://hooks.example/in', secret: 'new-secret' })
+  })
+
+  it('says so when the chosen tool takes no input', () => {
+    const wrapper = mount(StepInputsForm, {
+      props: {
+        step: { id: 'step_1', capability: 'tool_call', depends_on: [], params: { tool: 'a' } },
+        earlierSteps: [],
+        tools: [{ name: 'a', title: 'A', description: '', sideEffect: 'read', source: 'custom' }],
+      },
+    })
+    expect(wrapper.text()).toContain('This tool takes no input.')
+    expect(wrapper.find('[data-testid="tool-arguments"]').exists()).toBe(false)
   })
 })

--- a/frontend/tests/unit/components/config/StepInputsForm.spec.ts
+++ b/frontend/tests/unit/components/config/StepInputsForm.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import StepInputsForm from '@/components/config/workflows/StepInputsForm.vue'
+import type { AuthoredStep } from '@/components/config/workflows/stepTypes'
+
+const conditionStep = (): AuthoredStep => ({
+  id: 'step_2',
+  capability: 'condition',
+  depends_on: ['step_1'],
+  params: { operator: 'equals', value: 'yes', inputs: { input: { literal: '' } } },
+})
+
+describe('StepInputsForm', () => {
+  it('lets a condition pick a typed value or an earlier step', async () => {
+    const wrapper = mount(StepInputsForm, {
+      props: {
+        step: conditionStep(),
+        earlierSteps: [{ id: 'step_1', capability: 'chat', depends_on: [], params: {} }],
+        tools: [],
+      },
+    })
+    expect(wrapper.text()).toContain('Only continue if')
+    expect(wrapper.text()).toContain('From step 1')
+    const selects = wrapper.findAll('select')
+    await selects[1].setValue('step_1')
+    const change = wrapper.emitted('change')?.[0]?.[0] as AuthoredStep
+    expect(change.params.inputs).toEqual({ input: { from: 'step_1', field: 'text' } })
+  })
+})

--- a/frontend/tests/unit/components/config/StepPicker.spec.ts
+++ b/frontend/tests/unit/components/config/StepPicker.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import StepPicker from '@/components/config/workflows/StepPicker.vue'
+
+describe('StepPicker', () => {
+  it('lists built-in steps without developer jargon', () => {
+    const wrapper = mount(StepPicker, { props: { modelValue: 'chat', tools: [] } })
+    const text = wrapper.text()
+    expect(text).toContain('Write an answer')
+    expect(text).toContain('Only continue if')
+    expect(text).toContain('Send to another system')
+    expect(text).not.toContain('DAG')
+    expect(text).not.toContain('node')
+    expect(text).not.toContain('side effect')
+  })
+
+  it('emits the selected kind', async () => {
+    const wrapper = mount(StepPicker, { props: { modelValue: 'chat', tools: [] } })
+    await wrapper.get('[data-testid="btn-step-kind-condition"]').trigger('click')
+    expect(wrapper.emitted('update:modelValue')).toEqual([['condition']])
+  })
+})

--- a/frontend/tests/unit/components/config/stepTypes.spec.ts
+++ b/frontend/tests/unit/components/config/stepTypes.spec.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest'
+import {
+  defaultInputSource,
+  emptyStep,
+  graphFromSteps,
+  renumberSteps,
+  stepsFromGraph,
+  toolArgumentNames,
+  type AuthoredStep,
+} from '@/components/config/workflows/stepTypes'
+
+const step = (
+  id: string,
+  capability: string,
+  params: Record<string, unknown> = {}
+): AuthoredStep => ({
+  id,
+  capability,
+  depends_on: [],
+  params,
+})
+
+describe('stepTypes', () => {
+  it('keeps planner-captured node inputs and graph-level keys when saving', () => {
+    const existing = {
+      version: 1,
+      trigger: { type: 'manual' },
+      prompt_topic: 'tools:inbox',
+      reply_node: 'step_2',
+      settings: { language: 'en' },
+      nodes: [
+        {
+          id: 'step_1',
+          capability: 'url_fetch',
+          inputs: { url: { literal: 'https://a.example' } },
+        },
+        { id: 'step_2', capability: 'summarize', params: {} },
+      ],
+    }
+    const steps = stepsFromGraph(existing)
+    expect(steps[0].inputs).toEqual({ url: { literal: 'https://a.example' } })
+
+    const graph = graphFromSteps(steps, 'schedule', existing)
+    expect(graph.prompt_topic).toBe('tools:inbox')
+    expect(graph.settings).toEqual({ language: 'en' })
+    expect(graph.reply_node).toBe('step_2')
+    expect(graph.trigger).toEqual({ type: 'schedule' })
+    const nodes = graph.nodes as Array<Record<string, unknown>>
+    expect(nodes[0].inputs).toEqual({ url: { literal: 'https://a.example' } })
+    expect(nodes[1].depends_on).toEqual(['step_1'])
+  })
+
+  it('drops a reply_node that no longer points at a step', () => {
+    const graph = graphFromSteps([step('step_1', 'chat')], 'manual', {
+      reply_node: 'step_9',
+    })
+    expect(graph).not.toHaveProperty('reply_node')
+  })
+
+  it('follows from: references when steps move', () => {
+    const steps = [
+      step('step_1', 'chat'),
+      step('step_2', 'email_search'),
+      step('step_3', 'condition', {
+        operator: 'not_empty',
+        inputs: { input: { from: 'step_2', field: 'text' } },
+      }),
+    ]
+    // Move the search first: step_2 → step_1; the condition must follow it.
+    const moved = renumberSteps([steps[1], steps[0], steps[2]])
+    expect(moved.map((row) => row.id)).toEqual(['step_1', 'step_2', 'step_3'])
+    expect(moved[0].capability).toBe('email_search')
+    expect(moved[2].params.inputs).toEqual({ input: { from: 'step_1', field: 'text' } })
+  })
+
+  it('falls back to a typed value when the referenced step is removed or comes later', () => {
+    const condition = step('step_2', 'condition', {
+      inputs: { input: { from: 'step_1', field: 'text' } },
+    })
+    const removed = renumberSteps([condition])
+    expect(removed[0].params.inputs).toEqual({ input: { literal: '' } })
+
+    const later = renumberSteps([condition, step('step_1', 'chat')])
+    expect(later[0].params.inputs).toEqual({ input: { literal: '' } })
+    expect(later[1].id).toBe('step_2')
+  })
+
+  it('leaves trigger and literal inputs untouched when renumbering', () => {
+    const [row] = renumberSteps([
+      step('step_7', 'tool_call', {
+        tool: 'crm.create',
+        inputs: { name: { literal: 'Ada' }, title: { from: 'trigger', field: 'title' } },
+      }),
+    ])
+    expect(row.id).toBe('step_1')
+    expect(row.params.inputs).toEqual({
+      name: { literal: 'Ada' },
+      title: { from: 'trigger', field: 'title' },
+    })
+  })
+
+  it('reads the previous step by default, else the whole starting event of a webhook task', () => {
+    expect(defaultInputSource({ previousStepId: 'step_1' })).toEqual({
+      from: 'step_1',
+      field: 'text',
+    })
+    expect(defaultInputSource({ triggerType: 'webhook' })).toEqual({ from: 'trigger', field: '' })
+    expect(defaultInputSource({ triggerType: 'manual' })).toEqual({ literal: '' })
+    expect(emptyStep('condition', 0, { triggerType: 'webhook' }).params.inputs).toEqual({
+      input: { from: 'trigger', field: '' },
+    })
+    expect(emptyStep('outbound_webhook', 1, { previousStepId: 'step_1' }).params.inputs).toEqual({
+      result: { from: 'step_1', field: 'text' },
+    })
+  })
+
+  it('lists tool arguments from the JSON Schema, required first', () => {
+    expect(
+      toolArgumentNames({
+        type: 'object',
+        properties: { note: { type: 'string' }, id: { type: 'integer' } },
+        required: ['id'],
+      })
+    ).toEqual([
+      { name: 'id', required: true },
+      { name: 'note', required: false },
+    ])
+    expect(toolArgumentNames(undefined)).toEqual([])
+    expect(toolArgumentNames({ type: 'object' })).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary
- Adds a **Steps** editor and a **webhook** trigger for Saved Tasks, gated by `WORKFLOWS.BUILDER_ENABLED` (default **off**). Flag-off cards, the planner catalog, and existing scheduled/manual runs stay unchanged.
- New builder step kinds (`tool_call`, `condition`, `outbound_webhook`) stay out of the planner (`available: false`). Public ingress is `POST /api/v1/webhooks/saved-tasks/{token}` with the same 404 for unknown / disabled / flag-off tokens; HMAC is optional; the secret is never serialized.
- Honest run outcomes replace the blanket “Nothing was sent or saved” copy. Resume re-checks permission and binds approval to the tool plus args.

## Test plan
- [ ] Flag **off**: Saved Task card has no Steps button / webhook trigger; webhook URL returns 404; planner snapshots unchanged.
- [ ] Flag **on**: Steps editor can add a condition / tool / outbound HTTPS call; webhook URL copies; regenerate token; HMAC checkbox.
- [ ] Webhook HMAC: missing/wrong signature → 401; correct signature starts a run.
- [ ] Condition false → run stops cleanly; failure copy names what actually failed.
- [ ] Resume of a `tool_call` step voids approval if the tool or args changed.
- [ ] Dark + light + V2: card, Steps modal, webhook fields.