### PR TITLE
fix(iam): land /admin/people on the Operate user list and gate /groups

### DIFF
--- a/docs/ADMIN.md
+++ b/docs/ADMIN.md
@@ -378,7 +378,9 @@ in **Operate → System configuration → Access → Sharing**
 
 When the flag is off:
 
-- Operate has no People child.
+- The Operate **People** child opens the Operate **Users** tab
+  (`/admin?tab=users`); `/admin/people` redirects there.
+- `/groups` is not routable and shows the not-found page.
 - `/api/v1/admin/groups` and `/api/v1/groups/mine` return 404.
 - The Operate Overview **Users** tab is unchanged.
 

--- a/frontend/src/router/iamGuards.ts
+++ b/frontend/src/router/iamGuards.ts
@@ -2,15 +2,27 @@ import type { RouteLocationNormalized, RouteLocationRaw } from 'vue-router'
 import { isIamGroupsEnabled } from '@/composables/useIamFeature'
 
 /**
- * Flag off: /admin/people is treated as unknown (U5 / U11).
- * Nav already hides the People child; this stops the URL and the
- * `/admin?tab=users` redirect from offering a surface whose APIs 404.
+ * Flag off: People has no groups, policies or audit to show, so the route
+ * lands on the Operate user list instead of a dead end. The Operate nav entry
+ * points there directly.
  */
-export function peopleRouteGuard(to?: RouteLocationNormalized): true | RouteLocationRaw {
+export function peopleRouteGuard(): true | RouteLocationRaw {
   if (isIamGroupsEnabled()) {
     return true
   }
-  const path = to?.path.replace(/^\//, '') ?? 'admin/people'
+  return { name: 'admin', query: { tab: 'users' } }
+}
+
+/**
+ * Flag off: /groups has no data, its APIs 404 (U5 / U11) and its only action
+ * links into People, so the route is treated as unknown. Nav already hides the
+ * entry; this covers a bookmark or a hand-typed URL.
+ */
+export function groupsRouteGuard(to?: RouteLocationNormalized): true | RouteLocationRaw {
+  if (isIamGroupsEnabled()) {
+    return true
+  }
+  const path = to?.path.replace(/^\//, '') ?? 'groups'
   return {
     name: 'not-found',
     params: { pathMatch: path.split('/') },

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -27,7 +27,7 @@ import {
 import { i18n } from '@/i18n'
 import { inferNavContext } from '@/router/navContext'
 import { assistantsRouteGuard, instructionsRouteGuard } from '@/router/assistantGuards'
-import { adminUsersTabRedirect, peopleRouteGuard } from '@/router/iamGuards'
+import { adminUsersTabRedirect, groupsRouteGuard, peopleRouteGuard } from '@/router/iamGuards'
 import { getErrorMessage } from '@/utils/errorMessage'
 import LoadingView from '@/views/LoadingView.vue'
 
@@ -499,6 +499,7 @@ const router = createRouter({
       name: 'my-groups',
       component: () => import('@/views/MyGroupsView.vue'),
       meta: { requiresAuth: true, titleKey: 'pageTitles.myGroups' },
+      beforeEnter: groupsRouteGuard,
     },
     {
       // Conversations other people or groups shared with me ("incoming").

--- a/frontend/tests/e2e/tests/admin-panel.spec.ts
+++ b/frontend/tests/e2e/tests/admin-panel.spec.ts
@@ -115,10 +115,27 @@ test.describe('@ci Admin panel', () => {
         timeout: TIMEOUTS.STANDARD,
       })
     } else {
+      // No groups, policies or audit to show: the old URL lands on the Operate
+      // user list instead of a 404.
+      await expect(page.locator(selectors.pages.admin)).toBeVisible({
+        timeout: TIMEOUTS.STANDARD,
+      })
+      await expect(page.locator(selectors.admin.sectionUsers)).toBeVisible()
+      await expect(page.locator('[data-testid="page-not-found"]')).toHaveCount(0)
+      await expect(page.locator(selectors.pages.people)).toHaveCount(0)
+    }
+
+    await page.goto('/groups')
+    if (iamGroups) {
+      await expect(page.locator('[data-testid="view-my-groups"]')).toBeVisible({
+        timeout: TIMEOUTS.STANDARD,
+      })
+    } else {
+      // Its only action links into People, so the page itself stays unroutable.
       await expect(page.locator('[data-testid="page-not-found"]')).toBeVisible({
         timeout: TIMEOUTS.STANDARD,
       })
-      await expect(page.locator(selectors.pages.people)).toHaveCount(0)
+      await expect(page.locator('[data-testid="view-my-groups"]')).toHaveCount(0)
     }
 
     await page.goto('/admin?tab=users')

--- a/frontend/tests/unit/router/iamGuards.spec.ts
+++ b/frontend/tests/unit/router/iamGuards.spec.ts
@@ -7,7 +7,7 @@ vi.mock('@/services/api/httpClient', () => ({
   getConfigSync: () => getConfigSync(),
 }))
 
-import { adminUsersTabRedirect, peopleRouteGuard } from '@/router/iamGuards'
+import { adminUsersTabRedirect, groupsRouteGuard, peopleRouteGuard } from '@/router/iamGuards'
 
 function routeWithTab(tab?: string): RouteLocationNormalized {
   return {
@@ -17,17 +17,26 @@ function routeWithTab(tab?: string): RouteLocationNormalized {
   } as RouteLocationNormalized
 }
 
+function groupsRoute(): RouteLocationNormalized {
+  return {
+    path: '/groups',
+    query: {},
+    hash: '',
+  } as RouteLocationNormalized
+}
+
 describe('iamGuards', () => {
   beforeEach(() => {
     getConfigSync.mockReset()
   })
 
-  it('hides People and keeps /admin?tab=users on Admin when groups are off', () => {
+  it('sends People to the Operate user list and blocks /groups when groups are off', () => {
     getConfigSync.mockReturnValue({ features: { iamGroups: false } })
 
-    expect(peopleRouteGuard(routeWithTab())).toEqual({
+    expect(peopleRouteGuard()).toEqual({ name: 'admin', query: { tab: 'users' } })
+    expect(groupsRouteGuard(groupsRoute())).toEqual({
       name: 'not-found',
-      params: { pathMatch: ['admin', 'people'] },
+      params: { pathMatch: ['groups'] },
       query: {},
       hash: '',
     })
@@ -35,10 +44,11 @@ describe('iamGuards', () => {
     expect(adminUsersTabRedirect(routeWithTab())).toBe(true)
   })
 
-  it('opens People and redirects ?tab=users when groups are on', () => {
+  it('opens People, /groups and redirects ?tab=users when groups are on', () => {
     getConfigSync.mockReturnValue({ features: { iamGroups: true } })
 
     expect(peopleRouteGuard()).toBe(true)
+    expect(groupsRouteGuard(groupsRoute())).toBe(true)
     expect(adminUsersTabRedirect(routeWithTab('users'))).toEqual({ name: 'admin-people' })
     expect(adminUsersTabRedirect(routeWithTab())).toBe(true)
   })


### PR DESCRIPTION
## Problem

With `IAM.GROUPS_ENABLED` off, two entry points pointed at a route that
deliberately renders the not-found page:

- the Operate nav entry "People" and any bookmark of `/admin/people`
  (`peopleRouteGuard` → `not-found`),
- the "Open People" button on `/groups`, which links to `/admin/people`
  unconditionally.

`/groups` itself was reachable by URL without the flag, although
`/api/v1/groups/mine` returns 404 in that configuration, so the page rendered
empty and its only action was the dead link above.

## Change

- `peopleRouteGuard` redirects `/admin/people` to `/admin?tab=users` when the
  flag is off. That tab is the surface that exists in this configuration; the
  guard no longer produces a 404 for a nav entry the app itself shows.
- `/groups` follows the same flag through the new `groupsRouteGuard`, the way
  the nav entry already did.
- Flag on: unchanged — `/admin/people` opens the People page, `/groups` opens
  My groups.

## Verification

- `make -C frontend lint`, `docker compose exec -T frontend npm run check:types`,
  `make -C frontend test` (253 files, 1829 tests) — green.
- `npx playwright test tests/e2e/tests/admin-panel.spec.ts -g "People route follows the IAM groups flag"` — green.
- `make test-e2e`: the admin, navigation and impersonation specs pass. 19
  failures in this sandbox are unrelated local gaps (MailHog on 8025 instead of
  the 8026 the suite expects, guest session rate cap returning 429, Stripe
  webhook signature from the test stack, WhatsApp stub not running, widget
  bundle not built yet).
- `node scripts/mobile-impact.mjs --base origin/main --head HEAD` → `ota-candidate`.

## Notes

related: #1809, #1795

Still open, not part of this change: with groups off and platform links on, the
"Linked platforms" admin surface has no route at all, because it only exists as
a tab of the People page.
