### PR TITLE
fix(routing): stop reading a song/lesson request back as TTS audio

### DIFF
--- a/backend/src/Prompt/PromptCatalog.php
+++ b/backend/src/Prompt/PromptCatalog.php
@@ -77,7 +77,7 @@ class PromptCatalog
             [
                 'topic' => 'mediamaker',
                 'language' => 'en',
-                'shortDescription' => 'Media-generation topic that handles all create/edit requests for images, videos and audio — including combined requests that ALSO ask for accompanying text (e.g. "make a video invitation and write the schedule below it").',
+                'shortDescription' => 'Media-generation topic that handles all create/edit requests for images and videos — including combined requests that ALSO ask for accompanying text (e.g. "make a video invitation and write the schedule below it") — and text-to-speech of text that ALREADY EXISTS (typed or quoted in the message, the previous answer, an attached document). NOT for songs, poems, stories or lessons that still have to be written, even "as a song" or "read aloud": those are "general" (with a spoken step only when the user asks to hear the result).',
                 'prompt' => self::mediaMakerPrompt(),
             ],
 

--- a/backend/src/Prompt/PromptCatalog.php
+++ b/backend/src/Prompt/PromptCatalog.php
@@ -396,18 +396,35 @@ This is the list, use only this:
 
 [DYNAMICLIST]
 
-   **Media creation wins over accompanying text work**: A request that
-   COMBINES creating media (a video, image, or audio) with writing text to go
-   with it ("make a video invitation ... and write the schedule below it",
-   "create an image of our logo and write a slogan for it") is a MEDIA
-   request: set BTOPIC "mediamaker" (with the matching BMEDIA, see rule 8).
-   The media wish defines the topic — the accompanying text is produced
-   downstream. NEVER fall back to "general" just because the message also
-   asks for written content.
+   **Image/video creation wins over accompanying text work**: A request that
+   COMBINES creating a picture or video with writing text to go with it
+   ("make a video invitation ... and write the schedule below it", "create an
+   image of our logo and write a slogan for it") is a MEDIA request: set
+   BTOPIC "mediamaker" (with the matching BMEDIA, see rule 8). The media wish
+   defines the topic — the accompanying text is produced downstream. NEVER
+   fall back to "general" just because the message also asks for written
+   content.
    Examples:
    - "Make a video invitation for a company retreat, and write the schedule below it" → BTOPIC: "mediamaker", BMEDIA: "video"
    - "Create an image of a mountain and write a short story about it" → BTOPIC: "mediamaker", BMEDIA: "image"
-   - "Write a poem and read it to me as MP3" → BTOPIC: "mediamaker", BMEDIA: "audio"
+
+   **Audio is the exception — spoken output never wins over the text it
+   speaks**: text-to-speech can only READ text that already exists. A request
+   to write, invent, teach or explain something "as a song / Lied /
+   Kinderlied / rap / poem / Gedicht / story / rhyme / lesson" asks for
+   TEXT — Synaplan cannot compose or perform music, it writes the lyrics or
+   verses. Route it to "general" (BMULTI 0). Only when the user ALSO asks to
+   HEAR the result (read it aloud, vorlesen, as MP3, Sprachnachricht) is it a
+   content step plus a spoken step: BTOPIC "general" with BMULTI 1 (rule 12)
+   — the planner writes the text first and speaks it afterwards. NEVER set
+   BTOPIC "mediamaker" / BMEDIA "audio" for these; that path would speak the
+   user's own request back to them.
+   Examples:
+   - "Bring mir mit einem Kinderlied die persischen Zahlen 0 bis 10 bei" → BTOPIC: "general", BMULTI: 0
+   - "Teach me the first ten Persian numbers with a children's song" → BTOPIC: "general", BMULTI: 0
+   - "Make a song about my cat" → BTOPIC: "general", BMULTI: 0 (lyrics — no music generation exists)
+   - "Schreib ein Kinderlied über die Zahlen und lies es mir als MP3 vor" → BTOPIC: "general", BMULTI: 1
+   - "Write a poem and read it to me as MP3" → BTOPIC: "general", BMULTI: 1
 
    **Questions about Synaplan itself** — whether it can do something
    ("can you make PDFs?", "kannst du Videos erstellen?"), how a feature
@@ -520,10 +537,15 @@ This is the list, use only this:
    - "video" - if user wants a video, film, clip, animation, or moving images
    - "audio" - if user wants audio, sound, voice, speech, TTS, or text-to-speech
    - "image" - if user wants an image, picture, photo, illustration, or any image editing/composition (this is the default)
-   IMPORTANT: "audio" means CREATING speech from text the user provides or asks
-   to be written. If the message asks to DESCRIBE/analyze an ATTACHED image —
-   even when the answer should come "as audio" / "vorgelesen" — rule 7 wins:
-   BTOPIC = "general" and no BMEDIA at all.
+   IMPORTANT: "audio" means READING OUT text that is already there: text the
+   user typed (after a colon, in quotes, "this text"), the previous answer, or
+   an attached document. The message must contain or point at the words to be
+   spoken. If the words still have to be WRITTEN first (a song, poem, story,
+   lesson, explanation, greeting the user only describes), it is NOT
+   "mediamaker"/"audio" — see rule 2: BTOPIC "general", BMULTI 1 when the
+   user also wants to hear it. If the message asks to DESCRIBE/analyze an
+   ATTACHED image — even when the answer should come "as audio" /
+   "vorgelesen" — rule 7 wins: BTOPIC = "general" and no BMEDIA at all.
    Examples:
    - "Create a video of a car" → BMEDIA: "video"
    - "Make a video of a dog running" → BMEDIA: "video"
@@ -533,6 +555,8 @@ This is the list, use only this:
    - "Combine these two photos" → BMEDIA: "image"
    - "Read this text aloud" → BMEDIA: "audio"
    - "Convert to speech" → BMEDIA: "audio"
+   - "Lies mir vor: Guten Morgen zusammen" → BMEDIA: "audio"
+   - "Sing me a song about the sea" → NOT mediamaker → BTOPIC: "general" (the lyrics are the deliverable)
 
 9. **Detect input mode (BINPUTMODE)**: If BTOPIC is "mediamaker" AND BMEDIA is "image", set BINPUTMODE:
    - "reference_images" - if the user attached image(s) to be used as input for editing, composition, or style transfer,
@@ -585,7 +609,9 @@ This is the list, use only this:
    summarize, translate, generate, schreibe, erstelle, fasse zusammen) with a
    SECOND, DIFFERENT deliverable:
    - Content plus a spoken version ("write a poem and read it to me as MP3",
-     "schreib einen Text und lies ihn vor")
+     "schreib einen Text und lies ihn vor", "schreib ein Kinderlied und lies
+     es mir vor") — BTOPIC stays "general": the spoken file is derived from
+     the written text, so the text is the main deliverable
    - Content plus a document or spreadsheet ("summarize this and put it in a DOCX")
    - Content plus a picture or video ("write the invitation and make an image for it")
    - A generated file plus a description of it ("create an image of a cat and
@@ -614,8 +640,10 @@ This is the list, use only this:
    - Any plain question, greeting or smalltalk
    - One deliverable described with several adjectives, constraints or details
      ("write a long, friendly, formal email to my landlord about the heating")
-   - One media request with accompanying text baked into it (rule 2 already
-     routes those to "mediamaker" — the text is produced downstream)
+   - One picture or video request with accompanying text baked into it (rule
+     2 already routes those to "mediamaker" — the text is produced downstream)
+   - A song, poem, story or lesson the user only wants to READ (no spoken
+     version requested) — that is one "general" answer
    - A request to redo, refine or continue the previous answer
    - A general web-search question (that is BWEBSEARCH, not BMULTI)
    - Anything you are unsure about
@@ -1350,9 +1378,12 @@ background", "mach es heller" always refers to the picture that is already there
 - Use the user's language
 
 ### For AUDIO/TTS prompts:
-- Extract ONLY the text that should be spoken
+- The output is exactly what the listener will HEAR — never the user's request itself
+- If the message contains the text to speak, extract ONLY that text
 - Remove instruction words like "read", "speak", "say", "lies vor", "erstelle audio"
-- Keep the actual content to be spoken
+- If the message only DESCRIBES what should be spoken (a greeting, a poem, a song text, a short
+  story, an explanation) and that text does not exist yet, WRITE it in the user's language and
+  return only the written text
 - Preserve original language and punctuation
 
 ## Response Format
@@ -1392,6 +1423,9 @@ Output: Hello World
 
 Input: "Create an audio saying 'Good morning!'"
 Output: Good morning!
+
+Input: "Lies mir ein kurzes Gedicht über den Regen vor"
+Output: Leise fällt der Regen nieder, tropft aufs Dach und singt uns Lieder. Jede Pfütze wird zum Meer, und die Wolken ziehen schwer.
 PROMPT;
     }
 
@@ -1399,11 +1433,15 @@ PROMPT;
     {
         return <<<'PROMPT'
 # Audio text extraction
-You receive a request to create an audio/voice output for the user.
+You receive a request to create an audio/voice output for the user. Your
+output is the script the voice will read — it is exactly what the listener
+hears.
 
 Your task:
-- Extract ONLY the exact text that should be spoken.
+- If the message contains the text to be spoken (after a colon, in quotes, "this text"), extract ONLY that exact text.
 - Remove instruction phrases like "say", "speak", "read", "please create an audio", "generate audio" etc.
+- If the message only DESCRIBES what should be spoken and that text does not exist yet (a greeting, a poem, a song text, a rhyme, a short story, an explanation, a lesson), WRITE that content in the user's language and return only the written text. Keep it short enough to be spoken comfortably.
+- NEVER return the user's request or instruction itself. A script that repeats "bring me ...", "teach me ...", "create an audio ..." is wrong — the listener would hear their own question read back.
 - Preserve the original language, punctuation, emoji, casing.
 - If the user provides quotes, return the quoted text without the quotes (unless they contain mismatched quotes, then return the meaningful text).
 - Do not add introductions like "Audio Prompt:" or explanations.
@@ -1415,6 +1453,8 @@ Examples:
 - Input: "Please say: Hello, how are you?" → Output: Hello, how are you?
 - Input: "Read this aloud: 'Good morning!'" → Output: Good morning!
 - Input: "Create an audio where you say hello" → Output: Hello
+- Input: "Sprich einen kurzen Geburtstagsgruß für Anna" → Output: Alles Liebe zum Geburtstag, Anna! Ich wünsche dir ein wunderbares neues Lebensjahr voller Freude und Gesundheit.
+- Input: "Bring mir mit einem Kinderlied die persischen Zahlen 0 bis 10 bei" → Output: Sefr ist die Null, so fängt es an. Yek ist eins, das kann jeder Mann. Do ist zwei, se ist drei, chahar ist vier, sing mit dabei! Pandsch ist fünf, schesch ist sechs, haft ist sieben, hascht ist acht. Noh ist neun und dah ist zehn — bis Persisch wir verstehen!
 PROMPT;
     }
 

--- a/backend/src/Service/Message/Handler/MediaGenerationHandler.php
+++ b/backend/src/Service/Message/Handler/MediaGenerationHandler.php
@@ -23,6 +23,7 @@ use App\Service\Media\MediaJobDispatcher;
 use App\Service\Media\MediaJobMessageSync;
 use App\Service\Media\MediaJobService;
 use App\Service\Message\MediaPromptExtractor;
+use App\Service\Message\TtsScriptGuard;
 use App\Service\ModelConfigService;
 use App\Service\PerfPipelineFlag;
 use App\Service\PremiumFeatureGate;
@@ -73,6 +74,9 @@ final readonly class MediaGenerationHandler implements MessageHandlerInterface
         #[Autowire('%env(APP_URL)%')]
         private string $publicBaseUrl = '',
         private ?RequestedFolderDelivery $folderDelivery = null,
+        // Answers the turn as normal chat when a sorter-routed audio request
+        // turns out to carry nothing speakable (see TtsScriptGuard).
+        private ?ChatHandler $chatHandler = null,
     ) {
     }
 
@@ -382,6 +386,20 @@ final readonly class MediaGenerationHandler implements MessageHandlerInterface
                     ],
                 ];
             }
+        }
+
+        // A sorter-routed audio turn whose "script" is just the user's request
+        // ("teach me the Persian numbers with a children's song") has nothing
+        // to read out: the sorter mistook a content request for TTS. Speaking
+        // it would play the user's own question back as an MP3, so answer the
+        // request as ordinary chat instead. `/tts` and "Again" re-runs are
+        // exempt — there the user explicitly chose to hear that exact text.
+        if ('audio' === $mediaType
+            && !$isSlashCommand
+            && null === $message->getMeta('media_prompt_override')
+            && TtsScriptGuard::echoesInstruction($prompt, $message->getText())
+        ) {
+            return $this->answerAsChatInstead($message, $thread, $classification, $streamCallback, $progressCallback, $options, $prompt);
         }
 
         // Resolve model ID to provider + model name + config
@@ -1417,6 +1435,74 @@ final readonly class MediaGenerationHandler implements MessageHandlerInterface
         $catalog = $this->conversationFileCatalog->build($message, $thread, [], ConversationFile::CATEGORY_IMAGE);
 
         return $this->conversationFileCatalog->latestImage($catalog);
+    }
+
+    /**
+     * Route a misclassified "audio" turn to the general chat answer.
+     *
+     * The mediamaker classification (topic, BMEDIA, model override, the
+     * pre-resolved mediamaker prompt bundle) is replaced by a plain `general`
+     * chat classification so the reply is written by the chat model with the
+     * user's default prompt — the answer the sorter should have produced.
+     *
+     * @param array<string, mixed> $classification
+     * @param array<string, mixed> $options
+     *
+     * @return array<string, mixed>
+     */
+    private function answerAsChatInstead(
+        Message $message,
+        array $thread,
+        array $classification,
+        callable $streamCallback,
+        ?callable $progressCallback,
+        array $options,
+        string $rejectedScript,
+    ): array {
+        $this->logger->warning('MediaGenerationHandler: audio script only repeats the user request, answering as chat instead', [
+            'message_id' => $message->getId(),
+            'topic' => $classification['topic'] ?? null,
+            'script_preview' => mb_substr($rejectedScript, 0, 120),
+        ]);
+
+        if (null === $this->chatHandler) {
+            $lang = $classification['language'] ?? 'en';
+            $streamCallback('de' === $lang
+                ? 'Ich habe in deiner Nachricht keinen Text gefunden, den ich vorlesen könnte. Formuliere die Anfrage bitte als normale Frage, oder gib den Text an, den ich sprechen soll (z. B. „Lies vor: …“).'
+                : 'I could not find any text in your message to read aloud. Please ask the question as a normal chat message, or tell me the exact text to speak (e.g. "Read aloud: …").');
+
+            return [
+                'metadata' => [
+                    'error' => 'tts_script_echoes_request',
+                    'media_type' => 'audio',
+                ],
+            ];
+        }
+
+        $chatClassification = $classification;
+        $chatClassification['topic'] = 'general';
+        $chatClassification['intent'] = 'chat';
+        $chatClassification['rerouted_from'] = 'mediamaker:audio';
+        unset(
+            $chatClassification['media_type'],
+            $chatClassification['input_mode'],
+            $chatClassification['duration'],
+            $chatClassification['resolution'],
+            $chatClassification['model_id'],
+            $chatClassification['prompt_metadata'],
+        );
+
+        $chatOptions = $options;
+        unset($chatOptions['resolved_prompt_data']);
+
+        $this->notify($progressCallback, 'analyzing', 'Answering your request…');
+
+        $result = $this->chatHandler->handleStream($message, $thread, $chatClassification, $streamCallback, $progressCallback, $chatOptions);
+        $metadata = is_array($result['metadata'] ?? null) ? $result['metadata'] : [];
+        $metadata['rerouted_from'] = 'mediamaker:audio';
+        $result['metadata'] = $metadata;
+
+        return $result;
     }
 
     /**

--- a/backend/src/Service/Message/Handler/MediaGenerationHandler.php
+++ b/backend/src/Service/Message/Handler/MediaGenerationHandler.php
@@ -45,6 +45,9 @@ use Symfony\Component\Messenger\MessageBusInterface;
 #[AutoconfigureTag('app.message.handler')]
 final readonly class MediaGenerationHandler implements MessageHandlerInterface
 {
+    /** Marker stored on a turn that TtsScriptGuard handed to the chat answer. */
+    public const REROUTED_FROM_AUDIO = 'mediamaker:audio';
+
     public function __construct(
         private AiFacade $aiFacade,
         private ModelConfigService $modelConfigService,
@@ -146,14 +149,14 @@ final readonly class MediaGenerationHandler implements MessageHandlerInterface
         // Send initial status based on detected media type (will be refined later)
         $this->notify($progressCallback, 'analyzing', 'Understanding your request...');
 
-        // Dispatch background memory extraction on the user's prompt before
-        // we start the (slow, possibly-failing) provider call. Mirrors the
-        // pattern in ChatHandler::handleStream(): memories must be picked
-        // up from any user turn that carries personal information, not just
-        // text-chat turns (issue #880). Doing it up-front means a failed
-        // image generation still saves "ich liebe Hunde" — and the queue
-        // dispatch is cheap (a few ms) so the user doesn't notice.
-        $this->maybeDispatchMemoryExtraction($message, $thread, $classification, $options);
+        // Background memory extraction on the user's prompt is dispatched
+        // further down, once the turn is confirmed to stay on the media path
+        // (after the TtsScriptGuard re-route decision) but still BEFORE the
+        // slow, possibly-failing provider call. Mirrors ChatHandler: memories
+        // must be picked up from any user turn that carries personal
+        // information (issue #880), and a failed image generation still saves
+        // "ich liebe Hunde". A turn handed to ChatHandler instead is extracted
+        // there — dispatching here as well would queue the same message twice.
 
         // Collect attached image paths for pic2pic. Besides the message's own
         // uploads we also accept reference images passed explicitly via options
@@ -379,6 +382,7 @@ final readonly class MediaGenerationHandler implements MessageHandlerInterface
                         .'Please use one of the following commands: `/pic` for images, `/vid` for videos, `/tts` for audio.';
 
                 $streamCallback($clarification);
+                $this->maybeDispatchMemoryExtraction($message, $thread, $classification, $options);
 
                 return [
                     'metadata' => [
@@ -401,6 +405,10 @@ final readonly class MediaGenerationHandler implements MessageHandlerInterface
         ) {
             return $this->answerAsChatInstead($message, $thread, $classification, $streamCallback, $progressCallback, $options, $prompt);
         }
+
+        // The turn stays on the media path: queue memory extraction now (see
+        // the note at the top of this method).
+        $this->maybeDispatchMemoryExtraction($message, $thread, $classification, $options);
 
         // Resolve model ID to provider + model name + config
         $modelConfig = [];
@@ -1471,10 +1479,11 @@ final readonly class MediaGenerationHandler implements MessageHandlerInterface
                 ? 'Ich habe in deiner Nachricht keinen Text gefunden, den ich vorlesen könnte. Formuliere die Anfrage bitte als normale Frage, oder gib den Text an, den ich sprechen soll (z. B. „Lies vor: …“).'
                 : 'I could not find any text in your message to read aloud. Please ask the question as a normal chat message, or tell me the exact text to speak (e.g. "Read aloud: …").');
 
+            // No `media_type` here on purpose: StreamController bills any
+            // response carrying one as generated media, and nothing was made.
             return [
                 'metadata' => [
                     'error' => 'tts_script_echoes_request',
-                    'media_type' => 'audio',
                 ],
             ];
         }
@@ -1482,7 +1491,7 @@ final readonly class MediaGenerationHandler implements MessageHandlerInterface
         $chatClassification = $classification;
         $chatClassification['topic'] = 'general';
         $chatClassification['intent'] = 'chat';
-        $chatClassification['rerouted_from'] = 'mediamaker:audio';
+        $chatClassification['rerouted_from'] = self::REROUTED_FROM_AUDIO;
         unset(
             $chatClassification['media_type'],
             $chatClassification['input_mode'],
@@ -1499,7 +1508,16 @@ final readonly class MediaGenerationHandler implements MessageHandlerInterface
 
         $result = $this->chatHandler->handleStream($message, $thread, $chatClassification, $streamCallback, $progressCallback, $chatOptions);
         $metadata = is_array($result['metadata'] ?? null) ? $result['metadata'] : [];
-        $metadata['rerouted_from'] = 'mediamaker:audio';
+        $metadata['rerouted_from'] = self::REROUTED_FROM_AUDIO;
+        // MessageProcessor folds this into the classification it hands back,
+        // so the persisted topic / media meta and the voice-reply guard see
+        // the chat answer that was actually produced, not the audio vote.
+        $metadata[MessageHandlerInterface::EFFECTIVE_CLASSIFICATION_KEY] = [
+            'topic' => 'general',
+            'intent' => 'chat',
+            'media_type' => null,
+            'rerouted_from' => self::REROUTED_FROM_AUDIO,
+        ];
         $result['metadata'] = $metadata;
 
         return $result;

--- a/backend/src/Service/Message/Handler/MessageHandlerInterface.php
+++ b/backend/src/Service/Message/Handler/MessageHandlerInterface.php
@@ -10,6 +10,17 @@ use App\Entity\Message;
 interface MessageHandlerInterface
 {
     /**
+     * Result metadata key under which a handler reports that it answered the
+     * turn under a DIFFERENT classification than the one it was dispatched
+     * with (e.g. a misrouted audio request answered as chat). The value is a
+     * partial classification (`topic`, `intent`, `media_type`, …); `null`
+     * entries remove the key. {@see \App\Service\Message\MessageProcessor}
+     * folds it into the classification returned to the persistence layer so
+     * the stored topic and media meta describe what was actually produced.
+     */
+    public const EFFECTIVE_CLASSIFICATION_KEY = 'effective_classification';
+
+    /**
      * Handler Name (für Routing).
      */
     public function getName(): string;

--- a/backend/src/Service/Message/MessageProcessor.php
+++ b/backend/src/Service/Message/MessageProcessor.php
@@ -9,6 +9,7 @@ use App\Repository\SearchResultRepository;
 use App\Service\Agent\AgentConfig;
 use App\Service\Exception\StreamCancelledException;
 use App\Service\Exception\VisionModelRequiredException;
+use App\Service\Message\Handler\MessageHandlerInterface;
 use App\Service\ModelConfigService;
 use App\Service\Multitask\MultitaskRoutingConfig;
 use App\Service\Multitask\TaskPlanExecutor;
@@ -577,6 +578,8 @@ final readonly class MessageProcessor
                 : $this->router->routeStream($message, $conversationHistory, $cls, $streamCallback, $statusCallback, $options);
             $perfTimer->stop('handler_total');
 
+            $classification = $this->applyEffectiveClassification($classification, $response);
+
             // Re-add sorting model info to result (for StreamController to save)
             $classification['sorting_model_id'] = $sortingModelId;
             $classification['sorting_provider'] = $sortingProvider;
@@ -1061,6 +1064,8 @@ final readonly class MessageProcessor
                 'provider' => $response['metadata']['provider'] ?? 'unknown',
                 'model' => $response['metadata']['model'] ?? 'unknown',
             ]);
+
+            $classification = $this->applyEffectiveClassification($classification, $response);
 
             $classification['sorting_model_id'] = $sortingModelId;
             $classification['sorting_provider'] = $sortingProvider;
@@ -1670,6 +1675,47 @@ final readonly class MessageProcessor
         if ($profile instanceof RuntimeProfile) {
             $options['runtime_profile'] = $profile;
         }
+
+        return $classification;
+    }
+
+    /**
+     * Fold a handler's {@see MessageHandlerInterface::EFFECTIVE_CLASSIFICATION_KEY}
+     * report into the classification handed back to the caller.
+     *
+     * The classification returned from here is what StreamController persists
+     * on the IN/OUT rows (topic, `original_media_type`, …) and consults for the
+     * voice-reply guard. When a handler answered under a different route than
+     * it was dispatched with — MediaGenerationHandler handing a misrouted
+     * "audio" request to the chat answer — the stored turn must describe that
+     * chat answer, not the sorter's media vote; otherwise the bubble is
+     * rendered and re-run ("Again") as media that was never generated.
+     *
+     * @param array<string, mixed> $classification
+     * @param array<string, mixed> $response
+     *
+     * @return array<string, mixed>
+     */
+    private function applyEffectiveClassification(array $classification, array $response): array
+    {
+        $effective = $response['metadata'][MessageHandlerInterface::EFFECTIVE_CLASSIFICATION_KEY] ?? null;
+        if (!is_array($effective) || [] === $effective) {
+            return $classification;
+        }
+
+        foreach ($effective as $key => $value) {
+            if (null === $value) {
+                unset($classification[$key]);
+                continue;
+            }
+            $classification[$key] = $value;
+        }
+
+        $this->logger->info('MessageProcessor: handler reported an effective classification', [
+            'topic' => $classification['topic'] ?? null,
+            'intent' => $classification['intent'] ?? null,
+            'rerouted_from' => $classification['rerouted_from'] ?? null,
+        ]);
 
         return $classification;
     }

--- a/backend/src/Service/Message/TtsScriptGuard.php
+++ b/backend/src/Service/Message/TtsScriptGuard.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Message;
+
+/**
+ * Detects a text-to-speech script that merely repeats the user's own request.
+ *
+ * The legacy mediamaker/audio path has no content step: the extractor is asked
+ * for "the text to be spoken" and, when the message carries none ("teach me the
+ * Persian numbers with a children's song"), an LLM tends to hand the instruction
+ * straight back. Synthesizing that produces an MP3 of the user's question —
+ * the exact failure this guard exists to catch before any provider is called.
+ *
+ * Deliberately conservative: a delimited payload ("read aloud: …", quotes) is
+ * always trusted, short messages are never flagged, and a script only counts as
+ * an echo when nearly all of its words come from the request AND it covers most
+ * of the request. A legitimately WRITTEN script (a poem, a greeting) introduces
+ * new words and passes; a legitimately EXTRACTED one is much shorter than the
+ * instruction around it and passes too.
+ */
+final readonly class TtsScriptGuard
+{
+    /** Below this many request words a short extraction cannot be told from an echo. */
+    private const MIN_REQUEST_WORDS = 4;
+
+    /** Share of script words that must also occur in the request to count as copied. */
+    private const MIN_COPIED_WORD_SHARE = 0.9;
+
+    /** Share of the request the script must cover to count as the whole instruction. */
+    private const MIN_REQUEST_COVERAGE = 0.7;
+
+    /**
+     * Whether speaking `$script` would read the user's own request back to them.
+     */
+    public static function echoesInstruction(string $script, string $userText): bool
+    {
+        $normalizedScript = self::normalize($script);
+        $normalizedRequest = self::normalize($userText);
+
+        if ('' === $normalizedScript) {
+            return true;
+        }
+
+        if ('' === $normalizedRequest) {
+            return false;
+        }
+
+        if ($normalizedScript === $normalizedRequest) {
+            return true;
+        }
+
+        // "Lies vor: Guten Morgen" / "Say 'hello world'": the user delimited what
+        // to speak, so any extraction that differs from the whole message is
+        // the payload (or a paraphrase of it) — never the instruction.
+        if (self::hasDelimitedPayload($userText)) {
+            return false;
+        }
+
+        $requestWords = self::words($normalizedRequest);
+        $scriptWords = self::words($normalizedScript);
+
+        if (count($requestWords) < self::MIN_REQUEST_WORDS || [] === $scriptWords) {
+            return false;
+        }
+
+        $requestVocabulary = array_fill_keys($requestWords, true);
+        $copied = 0;
+        foreach ($scriptWords as $word) {
+            if (isset($requestVocabulary[$word])) {
+                ++$copied;
+            }
+        }
+
+        $copiedShare = $copied / count($scriptWords);
+        $requestCoverage = count($scriptWords) / count($requestWords);
+
+        return $copiedShare >= self::MIN_COPIED_WORD_SHARE && $requestCoverage >= self::MIN_REQUEST_COVERAGE;
+    }
+
+    private static function hasDelimitedPayload(string $text): bool
+    {
+        // A colon followed by real content, or a quoted run of at least two characters.
+        if (1 === preg_match('/:\s*\S{2,}/u', $text)) {
+            return true;
+        }
+
+        return 1 === preg_match('/["„“”«»‚‘’\'][^"„“”«»‚‘’\']{2,}["„“”«»‚‘’\']/u', $text);
+    }
+
+    private static function normalize(string $text): string
+    {
+        $lower = mb_strtolower($text);
+        $stripped = preg_replace('/[^\p{L}\p{N}\s]+/u', ' ', $lower) ?? '';
+
+        return trim(preg_replace('/\s+/u', ' ', $stripped) ?? '');
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function words(string $normalized): array
+    {
+        return '' === $normalized ? [] : explode(' ', $normalized);
+    }
+}

--- a/backend/src/Service/Message/TtsScriptGuard.php
+++ b/backend/src/Service/Message/TtsScriptGuard.php
@@ -14,11 +14,14 @@ namespace App\Service\Message;
  * the exact failure this guard exists to catch before any provider is called.
  *
  * Deliberately conservative: a delimited payload ("read aloud: …", quotes) is
- * always trusted, short messages are never flagged, and a script only counts as
- * an echo when nearly all of its words come from the request AND it covers most
- * of the request. A legitimately WRITTEN script (a poem, a greeting) introduces
- * new words and passes; a legitimately EXTRACTED one is much shorter than the
- * instruction around it and passes too.
+ * always trusted, short messages are never flagged, and a script that differs
+ * from the request only counts as an echo when it (a) still OPENS with a
+ * request verb ("teach me…", "bring mir… bei", "erkläre…"), (b) is built
+ * almost entirely from the request's words and (c) covers most of the
+ * request. A legitimately WRITTEN script (a poem, a greeting) introduces new
+ * words and passes; a legitimately EXTRACTED one ("say hello world now" →
+ * "hello world now") no longer starts with the instruction verb and passes
+ * too, however short the surrounding instruction was.
  */
 final readonly class TtsScriptGuard
 {
@@ -30,6 +33,34 @@ final readonly class TtsScriptGuard
 
     /** Share of the request the script must cover to count as the whole instruction. */
     private const MIN_REQUEST_COVERAGE = 0.7;
+
+    /**
+     * Imperatives that ask for content to be produced. A TTS script that still
+     * begins with one of these is the instruction, not the text to speak.
+     * "say"/"read"/"speak" are deliberately absent: those introduce a payload,
+     * and stripping them is exactly what a correct extraction does.
+     *
+     * @var list<string>
+     */
+    private const REQUEST_VERBS = [
+        // en
+        'teach', 'explain', 'write', 'create', 'make', 'generate', 'compose', 'tell', 'give',
+        'show', 'help', 'describe', 'translate', 'summarize', 'summarise', 'invent', 'draft', 'list',
+        // de
+        'bring', 'bringe', 'lehre', 'lehr', 'erkläre', 'erklär', 'schreib', 'schreibe', 'erstelle',
+        'erstell', 'mach', 'mache', 'generiere', 'generier', 'erzähl', 'erzähle', 'gib', 'zeig',
+        'zeige', 'hilf', 'beschreib', 'beschreibe', 'übersetze', 'übersetz', 'fasse', 'erfinde', 'entwirf',
+        // fr / es / tr
+        'apprends', 'explique', 'écris', 'crée', 'fais', 'raconte', 'enséñame', 'explica', 'escribe',
+        'crea', 'haz', 'cuéntame', 'öğret', 'açıkla', 'yaz', 'oluştur', 'anlat',
+    ];
+
+    /**
+     * Politeness openers skipped before looking for the request verb.
+     *
+     * @var list<string>
+     */
+    private const POLITE_OPENERS = ['please', 'bitte', 'kindly', 'lütfen'];
 
     /**
      * Whether speaking `$script` would read the user's own request back to them.
@@ -65,6 +96,14 @@ final readonly class TtsScriptGuard
             return false;
         }
 
+        // "hello world now" for "Say hello world now" is a payload with the
+        // instruction verb removed — the shape a correct extraction has. Only
+        // a script that still opens with a content-producing imperative can be
+        // the instruction itself.
+        if (!self::opensWithRequestVerb($scriptWords)) {
+            return false;
+        }
+
         $requestVocabulary = array_fill_keys($requestWords, true);
         $copied = 0;
         foreach ($scriptWords as $word) {
@@ -77,6 +116,22 @@ final readonly class TtsScriptGuard
         $requestCoverage = count($scriptWords) / count($requestWords);
 
         return $copiedShare >= self::MIN_COPIED_WORD_SHARE && $requestCoverage >= self::MIN_REQUEST_COVERAGE;
+    }
+
+    /**
+     * @param list<string> $scriptWords normalized words of the script
+     */
+    private static function opensWithRequestVerb(array $scriptWords): bool
+    {
+        foreach ($scriptWords as $word) {
+            if (in_array($word, self::POLITE_OPENERS, true)) {
+                continue;
+            }
+
+            return in_array($word, self::REQUEST_VERBS, true);
+        }
+
+        return false;
     }
 
     private static function hasDelimitedPayload(string $text): bool

--- a/backend/tests/Eval/sort_eval_corpus.json
+++ b/backend/tests/Eval/sort_eval_corpus.json
@@ -78,6 +78,30 @@
     "expect": { "topic": "general", "lang": "en", "multi_step": true }
   },
   {
+    "id": "general_song_lesson_de",
+    "text": "Bring mir mit einem Kinderlied die persischen Zahlen 0 bis 10 bei.",
+    "language": "de",
+    "expect": { "topic": "general", "lang": "de", "multi_step": false }
+  },
+  {
+    "id": "general_song_lesson_en",
+    "text": "Teach me the first ten Persian numbers with a children's song.",
+    "language": "en",
+    "expect": { "topic": "general", "lang": "en", "multi_step": false }
+  },
+  {
+    "id": "general_song_lyrics_en",
+    "text": "Make a song about my cat.",
+    "language": "en",
+    "expect": { "topic": "general", "lang": "en", "multi_step": false }
+  },
+  {
+    "id": "general_song_then_mp3_de",
+    "text": "Schreib ein Kinderlied \u00fcber die Zahlen 1 bis 10 und lies es mir als MP3 vor.",
+    "language": "de",
+    "expect": { "topic": "general", "lang": "de", "multi_step": true }
+  },
+  {
     "id": "officemaker_docx_de",
     "text": "Erstelle mir ein Word-Dokument mit einem Anschreiben f\u00fcr eine Bewerbung als Softwareentwickler.",
     "language": "de",

--- a/backend/tests/Unit/MessageProcessorTest.php
+++ b/backend/tests/Unit/MessageProcessorTest.php
@@ -9,6 +9,7 @@ use App\Service\Agent\AgentConfig;
 use App\Service\Exception\StreamCancelledException;
 use App\Service\Message\AttachmentSearchContextResolver;
 use App\Service\Message\ConversationSummaryService;
+use App\Service\Message\Handler\MessageHandlerInterface;
 use App\Service\Message\InferenceRouter;
 use App\Service\Message\MessageClassifier;
 use App\Service\Message\MessagePreProcessor;
@@ -124,6 +125,89 @@ class MessageProcessorTest extends TestCase
         $this->assertTrue($result['success']);
         $this->assertArrayHasKey('response', $result);
         $this->assertArrayHasKey('classification', $result);
+    }
+
+    /**
+     * A handler that answered under a different route (MediaGenerationHandler
+     * handing a misrouted "audio" turn to the chat answer) reports it via
+     * `effective_classification`. The classification returned to the
+     * persistence layer must reflect that — otherwise the stored turn is a
+     * mediamaker/audio row for a chat answer.
+     */
+    public function testProcessFoldsEffectiveClassificationReportedByHandler(): void
+    {
+        $message = $this->createMock(Message::class);
+        $message->method('getUserId')->willReturn(1);
+        $message->method('getTrackingId')->willReturn(123);
+        $message->method('getFile')->willReturn(0);
+
+        $this->preProcessor->method('process')->willReturn($message);
+        $this->messageRepository->method('findConversationHistory')->willReturn([]);
+        $this->modelConfigService->method('getDefaultModel')->willReturn(null);
+
+        $this->classifier->method('classify')->willReturn([
+            'topic' => 'mediamaker',
+            'intent' => 'image_generation',
+            'media_type' => 'audio',
+            'language' => 'de',
+            'source' => 'ai_sorting',
+        ]);
+
+        $this->router->method('route')->willReturn([
+            'content' => 'Sefr, yek, do …',
+            'metadata' => [
+                'provider' => 'test',
+                'model' => 'test',
+                MessageHandlerInterface::EFFECTIVE_CLASSIFICATION_KEY => [
+                    'topic' => 'general',
+                    'intent' => 'chat',
+                    'media_type' => null,
+                    'rerouted_from' => 'mediamaker:audio',
+                ],
+            ],
+        ]);
+
+        $result = $this->processor->process($message);
+
+        $this->assertTrue($result['success']);
+        $this->assertSame('general', $result['classification']['topic']);
+        $this->assertSame('chat', $result['classification']['intent']);
+        $this->assertArrayNotHasKey('media_type', $result['classification']);
+        $this->assertSame('mediamaker:audio', $result['classification']['rerouted_from']);
+        $this->assertSame('de', $result['classification']['language'], 'untouched keys survive');
+    }
+
+    public function testProcessStreamFoldsEffectiveClassificationReportedByHandler(): void
+    {
+        $message = $this->createMock(Message::class);
+        $message->method('getUserId')->willReturn(1);
+        $message->method('getTrackingId')->willReturn(123);
+        $message->method('getFile')->willReturn(0);
+
+        $this->preProcessor->method('process')->willReturn($message);
+        $this->messageRepository->method('findConversationHistory')->willReturn([]);
+        $this->modelConfigService->method('getDefaultModel')->willReturn(null);
+
+        $this->classifier->method('classify')->willReturn([
+            'topic' => 'mediamaker',
+            'intent' => 'image_generation',
+            'media_type' => 'audio',
+            'language' => 'de',
+            'source' => 'ai_sorting',
+        ]);
+
+        $this->router->method('routeStream')->willReturn([
+            'metadata' => [
+                MessageHandlerInterface::EFFECTIVE_CLASSIFICATION_KEY => ['topic' => 'general', 'intent' => 'chat', 'media_type' => null],
+            ],
+        ]);
+
+        $result = $this->processor->processStream($message, static function (string $chunk): void {});
+
+        $this->assertTrue($result['success']);
+        $this->assertSame('general', $result['classification']['topic']);
+        $this->assertSame('chat', $result['classification']['intent']);
+        $this->assertArrayNotHasKey('media_type', $result['classification']);
     }
 
     public function testProcessCallsStatusCallback(): void

--- a/backend/tests/Unit/PromptCatalogTest.php
+++ b/backend/tests/Unit/PromptCatalogTest.php
@@ -114,6 +114,34 @@ final class PromptCatalogTest extends TestCase
     }
 
     /**
+     * The sorter sees the topics through `[DYNAMICLIST]`, which is rendered
+     * from each topic's runtime `shortDescription` — BEFORE the rules above.
+     * A description that still advertises "audio" wholesale hands the model a
+     * contradiction, so the mediamaker description must carry the same
+     * boundary: TTS of existing text only, songs/poems/lessons are `general`.
+     */
+    public function testMediamakerDescriptionLimitsAudioToExistingText(): void
+    {
+        $description = $this->catalogShortDescription('mediamaker');
+
+        $this->assertStringContainsString('images and videos', $description);
+        $this->assertStringContainsString('text-to-speech of text that ALREADY EXISTS', $description);
+        $this->assertStringContainsString('NOT for songs, poems, stories or lessons', $description);
+        $this->assertStringNotContainsString('images, videos and audio', $description);
+    }
+
+    private function catalogShortDescription(string $topic): string
+    {
+        foreach (PromptCatalog::all() as $entry) {
+            if ($topic === $entry['topic']) {
+                return $entry['shortDescription'];
+            }
+        }
+
+        $this->fail(sprintf('catalog has no entry for topic "%s"', $topic));
+    }
+
+    /**
      * When the sorter still mis-votes audio, the extraction prompts are the
      * next line of defence: the script must be what the listener should hear —
      * written on the spot if the message only describes it — and never the

--- a/backend/tests/Unit/PromptCatalogTest.php
+++ b/backend/tests/Unit/PromptCatalogTest.php
@@ -92,6 +92,57 @@ final class PromptCatalogTest extends TestCase
     }
 
     /**
+     * "Teach me the Persian numbers with a children's song" was voted
+     * mediamaker/audio and the legacy TTS path read the request back as an
+     * MP3. Songs, poems and lessons are CONTENT: they route to `general`,
+     * and only an explicit "read it to me" adds a spoken step (BMULTI 1).
+     * Pin the rule and the worked examples the sorter pattern-matches on,
+     * and make sure the old contradictory example (poem+MP3 → mediamaker)
+     * cannot creep back in.
+     */
+    public function testSortPromptKeepsSongAndPoemRequestsOutOfAudioMediamaker(): void
+    {
+        $prompt = $this->catalogPrompt('tools:sort');
+
+        $this->assertStringContainsString('spoken output never wins over the text it', $prompt);
+        $this->assertStringContainsString('"Bring mir mit einem Kinderlied die persischen Zahlen 0 bis 10 bei" → BTOPIC: "general", BMULTI: 0', $prompt);
+        $this->assertStringContainsString('"Make a song about my cat" → BTOPIC: "general", BMULTI: 0', $prompt);
+        $this->assertStringContainsString('"Write a poem and read it to me as MP3" → BTOPIC: "general", BMULTI: 1', $prompt);
+        $this->assertStringNotContainsString('"Write a poem and read it to me as MP3" → BTOPIC: "mediamaker"', $prompt);
+        $this->assertStringContainsString('"audio" means READING OUT text that is already there', $prompt);
+        $this->assertStringContainsString('"Sing me a song about the sea" → NOT mediamaker', $prompt);
+    }
+
+    /**
+     * When the sorter still mis-votes audio, the extraction prompts are the
+     * next line of defence: the script must be what the listener should hear —
+     * written on the spot if the message only describes it — and never the
+     * user's instruction itself.
+     */
+    public function testAudioExtractionPromptsNeverReturnTheInstructionItself(): void
+    {
+        $audioExtract = $this->catalogPrompt('tools:mediamaker_audio_extract');
+        $this->assertStringContainsString('NEVER return the user\'s request or instruction itself', $audioExtract);
+        $this->assertStringContainsString('WRITE that content in the user\'s language', $audioExtract);
+        $this->assertStringContainsString('Bring mir mit einem Kinderlied die persischen Zahlen 0 bis 10 bei', $audioExtract);
+
+        $mediamaker = $this->catalogPrompt('mediamaker');
+        $this->assertStringContainsString('never the user\'s request itself', $mediamaker);
+        $this->assertStringContainsString('WRITE it in the user\'s language', $mediamaker);
+    }
+
+    private function catalogPrompt(string $topic): string
+    {
+        foreach (PromptCatalog::all() as $entry) {
+            if ($topic === $entry['topic']) {
+                return $entry['prompt'];
+            }
+        }
+
+        $this->fail(sprintf('catalog has no prompt for topic "%s"', $topic));
+    }
+
+    /**
      * The search-query prompt must resolve deictic references against the
      * "Attached file content" block SearchQueryGenerator sends — otherwise
      * "what is that?" + photo searches for the literal words again.

--- a/backend/tests/Unit/Service/Message/Handler/MediaGenerationHandlerAudioEchoTest.php
+++ b/backend/tests/Unit/Service/Message/Handler/MediaGenerationHandlerAudioEchoTest.php
@@ -1,0 +1,257 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\Message\Handler;
+
+use App\AI\Service\AiFacade;
+use App\Entity\Message;
+use App\Entity\Model;
+use App\Entity\User;
+use App\Service\BillingService;
+use App\Service\File\ConversationFileCatalog;
+use App\Service\File\ThumbnailService;
+use App\Service\File\UserUploadPathBuilder;
+use App\Service\Media\GeneratedFileRegistrar;
+use App\Service\Media\MediaCancellationStore;
+use App\Service\Media\MediaJobConfig;
+use App\Service\Media\MediaJobDispatcher;
+use App\Service\Media\MediaJobMessageSync;
+use App\Service\Media\MediaJobService;
+use App\Service\Message\Handler\ChatHandler;
+use App\Service\Message\Handler\MediaErrorMessageBuilder;
+use App\Service\Message\Handler\MediaGenerationHandler;
+use App\Service\Message\MediaPromptExtractor;
+use App\Service\ModelConfigService;
+use App\Service\PerfPipelineFlag;
+use App\Service\PremiumFeatureGate;
+use App\Service\RateLimitService;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+/**
+ * A sorter-routed mediamaker/audio turn whose extracted "script" is just the
+ * user's own request must never be synthesized (the MP3 would read the
+ * question back). The handler hands the turn to the general chat answer.
+ */
+final class MediaGenerationHandlerAudioEchoTest extends TestCase
+{
+    private const KINDERLIED_REQUEST = 'Bring mir mit einem Kinderlied die persischen Zahlen 0 bis 10 bei.';
+
+    private AiFacade&MockObject $aiFacade;
+    private MediaPromptExtractor&MockObject $promptExtractor;
+    private ModelConfigService&MockObject $modelConfigService;
+    private EntityManagerInterface&MockObject $em;
+    private RateLimitService&MockObject $rateLimitService;
+    private GeneratedFileRegistrar&MockObject $generatedFileRegistrar;
+    private ChatHandler&MockObject $chatHandler;
+
+    protected function setUp(): void
+    {
+        $this->aiFacade = $this->createMock(AiFacade::class);
+        $this->promptExtractor = $this->createMock(MediaPromptExtractor::class);
+        $this->modelConfigService = $this->createMock(ModelConfigService::class);
+        $this->em = $this->createMock(EntityManagerInterface::class);
+        $this->rateLimitService = $this->createMock(RateLimitService::class);
+        $this->generatedFileRegistrar = $this->createMock(GeneratedFileRegistrar::class);
+        $this->chatHandler = $this->createMock(ChatHandler::class);
+
+        $this->modelConfigService->method('getEffectiveUserIdForMessage')->willReturn(7);
+        $this->modelConfigService->method('getDefaultModel')->with('TEXT2SOUND', 7)->willReturn(42);
+        $this->rateLimitService->method('checkLimit')->willReturn(['allowed' => true]);
+        $this->bootstrapAudioModel();
+    }
+
+    public function testEchoedScriptIsAnsweredAsChatInsteadOfSynthesized(): void
+    {
+        $handler = $this->handler($this->chatHandler);
+        $message = $this->messageStub(self::KINDERLIED_REQUEST);
+
+        $this->promptExtractor->method('extract')->willReturn([
+            'prompt' => self::KINDERLIED_REQUEST,
+            'media_type' => 'audio',
+        ]);
+
+        $this->aiFacade->expects(self::never())->method('synthesize');
+        $this->generatedFileRegistrar->expects(self::never())->method('register');
+
+        $seenClassification = null;
+        $seenOptions = null;
+        $this->chatHandler->expects(self::once())
+            ->method('handleStream')
+            ->willReturnCallback(static function (
+                Message $message,
+                array $thread,
+                array $classification,
+                callable $streamCallback,
+                ?callable $progressCallback,
+                array $options,
+            ) use (&$seenClassification, &$seenOptions): array {
+                $seenClassification = $classification;
+                $seenOptions = $options;
+                $streamCallback('Sefr, yek, do, se …');
+
+                return ['content' => 'Sefr, yek, do, se …', 'metadata' => ['model' => 'chat-model']];
+            });
+
+        $result = $handler->handle(
+            $message,
+            [],
+            ['topic' => 'mediamaker', 'language' => 'de', 'media_type' => 'audio', 'intent' => 'image_generation', 'model_id' => 99, 'prompt_metadata' => ['aiModel' => 0]],
+            null,
+            ['resolved_prompt_data' => ['prompt' => 'mediamaker prompt bundle'], 'channel' => 'web'],
+        );
+
+        self::assertSame('Sefr, yek, do, se …', $result['content']);
+        self::assertSame('mediamaker:audio', $result['metadata']['rerouted_from'] ?? null);
+        self::assertSame('chat-model', $result['metadata']['model'] ?? null);
+
+        self::assertIsArray($seenClassification);
+        self::assertSame('general', $seenClassification['topic']);
+        self::assertSame('chat', $seenClassification['intent']);
+        self::assertSame('de', $seenClassification['language']);
+        self::assertArrayNotHasKey('media_type', $seenClassification);
+        self::assertArrayNotHasKey('model_id', $seenClassification);
+        self::assertArrayNotHasKey('prompt_metadata', $seenClassification);
+
+        self::assertIsArray($seenOptions);
+        self::assertArrayNotHasKey('resolved_prompt_data', $seenOptions, 'the mediamaker prompt bundle must not leak into the chat answer');
+        self::assertSame('web', $seenOptions['channel'] ?? null);
+    }
+
+    public function testExtractedPayloadIsStillSynthesized(): void
+    {
+        $handler = $this->handler($this->chatHandler);
+        $message = $this->messageStub('Lies mir bitte folgenden Text als Sprachnachricht vor: Guten Morgen zusammen.');
+
+        $this->promptExtractor->method('extract')->willReturn([
+            'prompt' => 'Guten Morgen zusammen.',
+            'media_type' => 'audio',
+        ]);
+
+        $this->chatHandler->expects(self::never())->method('handleStream');
+        $this->aiFacade->expects(self::once())
+            ->method('synthesize')
+            ->with('Guten Morgen zusammen.', 7, self::anything())
+            ->willReturn(['relativePath' => '7/tts.mp3', 'provider' => 'openai', 'model' => 'tts-1', 'text_length' => 22]);
+
+        $result = $handler->handle($message, [], ['topic' => 'mediamaker', 'language' => 'de', 'media_type' => 'audio']);
+
+        self::assertSame('__AUDIO_GENERATED__', $result['content']);
+        self::assertSame('audio', $result['metadata']['media_type'] ?? null);
+        self::assertArrayNotHasKey('rerouted_from', $result['metadata']);
+    }
+
+    public function testSlashTtsCommandSpeaksExactlyWhatWasTyped(): void
+    {
+        $handler = $this->handler($this->chatHandler);
+        $message = $this->messageStub('/tts '.self::KINDERLIED_REQUEST);
+
+        $this->promptExtractor->method('extract')->willReturn([
+            'prompt' => self::KINDERLIED_REQUEST,
+            'media_type' => 'audio',
+        ]);
+
+        $this->chatHandler->expects(self::never())->method('handleStream');
+        $this->aiFacade->expects(self::once())
+            ->method('synthesize')
+            ->willReturn(['relativePath' => '7/tts.mp3', 'provider' => 'openai', 'model' => 'tts-1', 'text_length' => 66]);
+
+        $result = $handler->handle($message, [], ['topic' => 'tools:tts', 'language' => 'de']);
+
+        self::assertSame('__AUDIO_GENERATED__', $result['content']);
+    }
+
+    public function testWithoutChatHandlerTheUserGetsAnActionableHintInsteadOfTheirOwnVoiceNote(): void
+    {
+        $handler = $this->handler(null);
+        $message = $this->messageStub(self::KINDERLIED_REQUEST);
+
+        $this->promptExtractor->method('extract')->willReturn([
+            'prompt' => self::KINDERLIED_REQUEST,
+            'media_type' => 'audio',
+        ]);
+
+        $this->aiFacade->expects(self::never())->method('synthesize');
+
+        $result = $handler->handle($message, [], ['topic' => 'mediamaker', 'language' => 'de', 'media_type' => 'audio']);
+
+        self::assertSame('tts_script_echoes_request', $result['metadata']['error'] ?? null);
+        self::assertStringContainsString('Lies vor', $result['content']);
+    }
+
+    private function handler(?ChatHandler $chatHandler): MediaGenerationHandler
+    {
+        $mediaJobConfig = $this->createMock(MediaJobConfig::class);
+        $mediaJobConfig->method('isAsyncJobsEnabled')->willReturn(false);
+
+        return new MediaGenerationHandler(
+            $this->aiFacade,
+            $this->modelConfigService,
+            $this->em,
+            new NullLogger(),
+            $this->promptExtractor,
+            new UserUploadPathBuilder(),
+            $this->createMock(ThumbnailService::class),
+            $this->rateLimitService,
+            new MediaErrorMessageBuilder(),
+            $this->createMock(MessageBusInterface::class),
+            $this->createMock(PerfPipelineFlag::class),
+            $this->createMock(MediaCancellationStore::class),
+            $mediaJobConfig,
+            $this->createMock(MediaJobService::class),
+            $this->createMock(MediaJobDispatcher::class),
+            $this->createMock(MediaJobMessageSync::class),
+            $this->generatedFileRegistrar,
+            new PremiumFeatureGate(new BillingService('', '')),
+            $this->createMock(ConversationFileCatalog::class),
+            sys_get_temp_dir(),
+            'https://app.example.test',
+            null,
+            $chatHandler,
+        );
+    }
+
+    private function bootstrapAudioModel(): void
+    {
+        $user = $this->createMock(User::class);
+        $userRepo = $this->createMock(EntityRepository::class);
+        $userRepo->method('find')->willReturn($user);
+
+        $model = $this->createMock(Model::class);
+        $model->method('getService')->willReturn('OpenAI');
+        $model->method('getProviderId')->willReturn('tts-1');
+        $model->method('getName')->willReturn('TTS 1');
+        $model->method('getTag')->willReturn('text2sound');
+        $model->method('getJson')->willReturn([]);
+
+        $modelRepo = $this->createMock(EntityRepository::class);
+        $modelRepo->method('find')->willReturn($model);
+
+        $this->em->method('getRepository')->willReturnMap([
+            [User::class, $userRepo],
+            [Model::class, $modelRepo],
+        ]);
+    }
+
+    private function messageStub(string $text): Message&MockObject
+    {
+        $message = $this->createMock(Message::class);
+        $message->method('getUserId')->willReturn(7);
+        $message->method('getText')->willReturn($text);
+        $message->method('getLanguage')->willReturn('de');
+        $message->method('getId')->willReturn(1001);
+        $message->method('getChat')->willReturn(null);
+        $message->method('getFile')->willReturn(0);
+        $message->method('getFilePath')->willReturn('');
+        $message->method('getFiles')->willReturn(new ArrayCollection());
+        $message->method('getMeta')->willReturn(null);
+
+        return $message;
+    }
+}

--- a/backend/tests/Unit/Service/Message/Handler/MediaGenerationHandlerAudioEchoTest.php
+++ b/backend/tests/Unit/Service/Message/Handler/MediaGenerationHandlerAudioEchoTest.php
@@ -21,6 +21,7 @@ use App\Service\Media\MediaJobService;
 use App\Service\Message\Handler\ChatHandler;
 use App\Service\Message\Handler\MediaErrorMessageBuilder;
 use App\Service\Message\Handler\MediaGenerationHandler;
+use App\Service\Message\Handler\MessageHandlerInterface;
 use App\Service\Message\MediaPromptExtractor;
 use App\Service\ModelConfigService;
 use App\Service\PerfPipelineFlag;
@@ -32,6 +33,7 @@ use Doctrine\ORM\EntityRepository;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
+use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
 
 /**
@@ -50,6 +52,8 @@ final class MediaGenerationHandlerAudioEchoTest extends TestCase
     private RateLimitService&MockObject $rateLimitService;
     private GeneratedFileRegistrar&MockObject $generatedFileRegistrar;
     private ChatHandler&MockObject $chatHandler;
+    private MessageBusInterface&MockObject $messageBus;
+    private PerfPipelineFlag&MockObject $perfPipelineFlag;
 
     protected function setUp(): void
     {
@@ -60,6 +64,10 @@ final class MediaGenerationHandlerAudioEchoTest extends TestCase
         $this->rateLimitService = $this->createMock(RateLimitService::class);
         $this->generatedFileRegistrar = $this->createMock(GeneratedFileRegistrar::class);
         $this->chatHandler = $this->createMock(ChatHandler::class);
+        $this->messageBus = $this->createMock(MessageBusInterface::class);
+        // Memory extraction fully enabled so the dispatch (or its absence) is observable.
+        $this->perfPipelineFlag = $this->createMock(PerfPipelineFlag::class);
+        $this->perfPipelineFlag->method('isEnabled')->willReturn(true);
 
         $this->modelConfigService->method('getEffectiveUserIdForMessage')->willReturn(7);
         $this->modelConfigService->method('getDefaultModel')->with('TEXT2SOUND', 7)->willReturn(42);
@@ -79,6 +87,9 @@ final class MediaGenerationHandlerAudioEchoTest extends TestCase
 
         $this->aiFacade->expects(self::never())->method('synthesize');
         $this->generatedFileRegistrar->expects(self::never())->method('register');
+        // ChatHandler queues its own extraction for this turn; the media path
+        // must not queue a second ExtractMemoriesCommand for the same message.
+        $this->messageBus->expects(self::never())->method('dispatch');
 
         $seenClassification = null;
         $seenOptions = null;
@@ -110,6 +121,15 @@ final class MediaGenerationHandlerAudioEchoTest extends TestCase
         self::assertSame('Sefr, yek, do, se …', $result['content']);
         self::assertSame('mediamaker:audio', $result['metadata']['rerouted_from'] ?? null);
         self::assertSame('chat-model', $result['metadata']['model'] ?? null);
+        self::assertArrayNotHasKey('media_type', $result['metadata'], 'nothing was generated, so nothing may look billable');
+
+        // The persistence layer must learn that this turn became a chat answer.
+        $effective = $result['metadata'][MessageHandlerInterface::EFFECTIVE_CLASSIFICATION_KEY] ?? null;
+        self::assertIsArray($effective);
+        self::assertSame('general', $effective['topic']);
+        self::assertSame('chat', $effective['intent']);
+        self::assertArrayHasKey('media_type', $effective);
+        self::assertNull($effective['media_type']);
 
         self::assertIsArray($seenClassification);
         self::assertSame('general', $seenClassification['topic']);
@@ -139,12 +159,15 @@ final class MediaGenerationHandlerAudioEchoTest extends TestCase
             ->method('synthesize')
             ->with('Guten Morgen zusammen.', 7, self::anything())
             ->willReturn(['relativePath' => '7/tts.mp3', 'provider' => 'openai', 'model' => 'tts-1', 'text_length' => 22]);
+        // The media path still extracts memories from the user turn — exactly once.
+        $this->messageBus->expects(self::once())->method('dispatch')->willReturn(new Envelope(new \stdClass()));
 
         $result = $handler->handle($message, [], ['topic' => 'mediamaker', 'language' => 'de', 'media_type' => 'audio']);
 
         self::assertSame('__AUDIO_GENERATED__', $result['content']);
         self::assertSame('audio', $result['metadata']['media_type'] ?? null);
         self::assertArrayNotHasKey('rerouted_from', $result['metadata']);
+        self::assertArrayNotHasKey(MessageHandlerInterface::EFFECTIVE_CLASSIFICATION_KEY, $result['metadata']);
     }
 
     public function testSlashTtsCommandSpeaksExactlyWhatWasTyped(): void
@@ -182,6 +205,7 @@ final class MediaGenerationHandlerAudioEchoTest extends TestCase
         $result = $handler->handle($message, [], ['topic' => 'mediamaker', 'language' => 'de', 'media_type' => 'audio']);
 
         self::assertSame('tts_script_echoes_request', $result['metadata']['error'] ?? null);
+        self::assertArrayNotHasKey('media_type', $result['metadata'], 'a failed turn must not be billed as generated audio');
         self::assertStringContainsString('Lies vor', $result['content']);
     }
 
@@ -200,8 +224,8 @@ final class MediaGenerationHandlerAudioEchoTest extends TestCase
             $this->createMock(ThumbnailService::class),
             $this->rateLimitService,
             new MediaErrorMessageBuilder(),
-            $this->createMock(MessageBusInterface::class),
-            $this->createMock(PerfPipelineFlag::class),
+            $this->messageBus,
+            $this->perfPipelineFlag,
             $this->createMock(MediaCancellationStore::class),
             $mediaJobConfig,
             $this->createMock(MediaJobService::class),
@@ -220,6 +244,7 @@ final class MediaGenerationHandlerAudioEchoTest extends TestCase
     private function bootstrapAudioModel(): void
     {
         $user = $this->createMock(User::class);
+        $user->method('isMemoriesEnabled')->willReturn(true);
         $userRepo = $this->createMock(EntityRepository::class);
         $userRepo->method('find')->willReturn($user);
 

--- a/backend/tests/Unit/Service/Message/TtsScriptGuardTest.php
+++ b/backend/tests/Unit/Service/Message/TtsScriptGuardTest.php
@@ -21,9 +21,13 @@ final class TtsScriptGuardTest extends TestCase
             'Bring mir mit einem Kinderlied die persischen Zahlen 0 bis 10 bei.',
             'Bring mir mit einem Kinderlied die persischen Zahlen 0 bis 10 bei.',
         ];
-        yield 'kinderlied request minus the first word' => [
-            'Mit einem Kinderlied die persischen Zahlen 0 bis 10 bei',
-            'Bring mir mit einem Kinderlied die persischen Zahlen 0 bis 10 bei.',
+        yield 'kinderlied request with the politeness word dropped' => [
+            'Bring mir mit einem Kinderlied die persischen Zahlen 0 bis 10 bei',
+            'Bring mir bitte mit einem Kinderlied die persischen Zahlen 0 bis 10 bei.',
+        ];
+        yield 'german explain request lightly rephrased' => [
+            'Erkläre mir die persischen Zahlen in einem Lied',
+            'Erkläre mir bitte die persischen Zahlen in einem Lied!',
         ];
         yield 'english teach request with punctuation and casing changed' => [
             'teach me the first ten persian numbers in a childrens song',
@@ -58,6 +62,18 @@ final class TtsScriptGuardTest extends TestCase
             'Erstelle eine Audio wo du Hallo sagst',
         ];
         yield 'one word from a short message' => ['Hallo Welt', 'Sage Hallo Welt'];
+        // Copilot review: an unquoted payload that is most of a short
+        // instruction must still be spoken — the verb was stripped, so the
+        // script no longer opens with an imperative.
+        yield 'unquoted payload covering most of the request' => ['hello world now', 'Say hello world now'];
+        yield 'unquoted german payload covering most of the request' => ['Hallo Welt wie geht es euch', 'Sag Hallo Welt wie geht es euch'];
+        yield 'payload that itself contains a request verb mid-sentence' => ['we make it happen together', 'Say we make it happen together'];
+        // Accepted trade-off: without its leading verb the remainder cannot be
+        // told from a payload, and never blocking a valid payload wins.
+        yield 'request minus its leading verb is not flagged' => [
+            'mit einem Kinderlied die persischen Zahlen 0 bis 10 bei',
+            'Bring mir mit einem Kinderlied die persischen Zahlen 0 bis 10 bei.',
+        ];
         yield 'content written for the request' => [
             'Sefr ist die Null, so fängt es an. Yek ist eins, das kann jeder Mann. Do ist zwei, se ist drei, chahar ist vier, sing mit dabei!',
             'Bring mir mit einem Kinderlied die persischen Zahlen 0 bis 10 bei.',

--- a/backend/tests/Unit/Service/Message/TtsScriptGuardTest.php
+++ b/backend/tests/Unit/Service/Message/TtsScriptGuardTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\Message;
+
+use App\Service\Message\TtsScriptGuard;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class TtsScriptGuardTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function echoes(): iterable
+    {
+        // The reported bug: no speakable payload, the extractor handed the
+        // instruction straight back and the MP3 read the user's question.
+        yield 'kinderlied request returned verbatim' => [
+            'Bring mir mit einem Kinderlied die persischen Zahlen 0 bis 10 bei.',
+            'Bring mir mit einem Kinderlied die persischen Zahlen 0 bis 10 bei.',
+        ];
+        yield 'kinderlied request minus the first word' => [
+            'Mit einem Kinderlied die persischen Zahlen 0 bis 10 bei',
+            'Bring mir mit einem Kinderlied die persischen Zahlen 0 bis 10 bei.',
+        ];
+        yield 'english teach request with punctuation and casing changed' => [
+            'teach me the first ten persian numbers in a childrens song',
+            "Teach me the first ten Persian numbers in a children's song!",
+        ];
+        yield 'empty script' => ['   ', 'Sing me a song about the sea'];
+        yield 'request wrapped in a leading Please' => [
+            'Please teach me the first ten Persian numbers with a song',
+            'teach me the first ten Persian numbers with a song',
+        ];
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function legitimateScripts(): iterable
+    {
+        yield 'colon-delimited payload extracted' => [
+            'Guten Morgen zusammen.',
+            'Lies mir bitte folgenden Text als Sprachnachricht vor: Guten Morgen zusammen.',
+        ];
+        yield 'quoted payload extracted' => [
+            'Good morning!',
+            "Read this aloud: 'Good morning!'",
+        ];
+        yield 'long colon payload that is most of the message' => [
+            'The quick brown fox jumps over the lazy dog and keeps running through the forest',
+            'Read aloud: The quick brown fox jumps over the lazy dog and keeps running through the forest',
+        ];
+        yield 'short greeting extracted from a longer instruction' => [
+            'Hallo',
+            'Erstelle eine Audio wo du Hallo sagst',
+        ];
+        yield 'one word from a short message' => ['Hallo Welt', 'Sage Hallo Welt'];
+        yield 'content written for the request' => [
+            'Sefr ist die Null, so fängt es an. Yek ist eins, das kann jeder Mann. Do ist zwei, se ist drei, chahar ist vier, sing mit dabei!',
+            'Bring mir mit einem Kinderlied die persischen Zahlen 0 bis 10 bei.',
+        ];
+        yield 'poem written for a read-aloud request' => [
+            'Leise fällt der Regen nieder, tropft aufs Dach und singt uns Lieder.',
+            'Lies mir ein kurzes Gedicht über den Regen vor',
+        ];
+        yield 'empty request never counts as echo' => ['Hello there', ''];
+    }
+
+    #[DataProvider('echoes')]
+    public function testDetectsScriptsThatRepeatTheRequest(string $script, string $userText): void
+    {
+        self::assertTrue(TtsScriptGuard::echoesInstruction($script, $userText));
+    }
+
+    #[DataProvider('legitimateScripts')]
+    public function testAcceptsExtractedOrWrittenScripts(string $script, string $userText): void
+    {
+        self::assertFalse(TtsScriptGuard::echoesInstruction($script, $userText));
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
"Bring mir mit einem Kinderlied die persischen Zahlen 0 bis 10 bei" was answered with an MP3 that spoke the user's own prompt. The sorter voted `mediamaker`/`audio` (BMULTI 0), and the legacy audio path has no content step: the extractor is asked for "the text to speak", finds none, hands the instruction back, and TTS reads the question aloud. This PR fixes the root cause in the routing prompt and adds two fallback layers so the failure can no longer reach the user.

## Changes
- `tools:sort` (`PromptCatalog::sortPrompt`): songs, poems, stories and lessons are content → `general`. `BMEDIA "audio"` now means reading out text that already exists (typed after a colon / in quotes, previous answer, attached document). Content + "read it to me" is `general` with `BMULTI 1` so the planner writes first and speaks second. Removes the rule-2 example that sent "write a poem and read it as MP3" to `mediamaker`/`audio` — it contradicted rule 12 and the sort eval corpus (`mediamaker_combo_poem_mp3` expects `general` + multi-step). Adds worked examples incl. the reported utterance.
- `mediamaker` runtime `shortDescription` (rendered into `[DYNAMICLIST]` before any rule): images/videos plus TTS of text that already exists; explicitly not for songs/poems/lessons that still have to be written.
- `mediamaker` and `tools:mediamaker_audio_extract` prompts: the script is what the listener hears — extract the payload when present, write the content when the message only describes it, never return the instruction itself.
- New `TtsScriptGuard`: deterministic detection of a script that merely repeats the request — exact match, or a script that still opens with a content-producing imperative (`teach`, `erkläre`, `write`, …), is built almost entirely from the request's words and covers ≥70 % of it. Delimited payloads, short messages and verb-stripped payloads ("Say hello world now" → "hello world now") are always trusted.
- `MediaGenerationHandler`: when a sorter-routed audio script trips the guard, the turn is answered as `general` chat via `ChatHandler` (mediamaker prompt bundle, media type and model override stripped) instead of synthesizing. `/tts` and "Again" re-runs are exempt. The fallback reports `metadata.effective_classification`, and `MessageProcessor` folds it into the classification returned to `StreamController`, so the persisted topic/media meta, "Again" and the voice-reply guard describe the chat answer that was actually produced. Memory extraction is dispatched once the turn is confirmed to stay on the media path (no duplicate `ExtractMemoriesCommand` on reroute), and the no-`ChatHandler` error path carries no billable `media_type`.
- `MessageHandlerInterface::EFFECTIVE_CLASSIFICATION_KEY`: small generic seam for handlers that answer under a different route than dispatched.
- Sort eval corpus: `general_song_lesson_de`, `general_song_lesson_en`, `general_song_lyrics_en`, `general_song_then_mp3_de`.
- Tests: `TtsScriptGuardTest`, `MediaGenerationHandlerAudioEchoTest`, `MessageProcessorTest` (effective classification on both paths), pinned prompt rules and description in `PromptCatalogTest`.

## Verification
- [ ] Not tested (explain)
- [ ] Manual
- [x] Tests added/updated

Local gate: `make -C backend lint` (0 fixable), `make -C backend phpstan` (no errors), `make -C backend test` (6385 tests OK after loading fixtures into `synaplan_test`, as CI does). `app:seed` re-seeded the updated prompts into `BPROMPTS`. Mobile impact: `backend-only`. No HTTP/UI contract change, so Playwright was not run. The live `app:sort-eval` needs a chat-capable provider, which this sandbox does not have (Ollama generation segfaults, no API key) — the new corpus cases should be run once against the configured SORT model.

## Notes
Copilot review addressed in dedd4662d (see thread replies and the summary comment). The characterization fixture `sort_audio` ("make a song" → stubbed `mediamaker`/`audio`) is left untouched: it stubs the sorter vote to test wiring, not the prompt.

## Screenshots/Logs
Full PHPUnit output attached to the agent run (`backend_phpunit_full.log`).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a091d7-75e6-77c8-a9ff-d8116bc33782?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a091d7-75e6-77c8-a9ff-d8116bc33782&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

